### PR TITLE
feat: rename commands to manage encryption keys (add/remove)

### DIFF
--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsAddCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsAddCommand.cs
@@ -6,12 +6,12 @@ using KSail.Utils;
 
 namespace KSail.Commands.Secrets.Commands;
 
-sealed class KSailSecretsGenerateCommand : Command
+sealed class KSailSecretsAddCommand : Command
 {
   readonly ExceptionHandler _exceptionHandler = new();
   readonly ProjectSecretManagerOption _projectSecretManagerOption = new() { Arity = ArgumentArity.ZeroOrOne };
 
-  internal KSailSecretsGenerateCommand() : base("gen", "Generate a new encryption key")
+  internal KSailSecretsAddCommand() : base("add", "Add a new encryption key")
   {
     AddOption(_projectSecretManagerOption);
     this.SetHandler(async (context) =>
@@ -21,7 +21,7 @@ sealed class KSailSecretsGenerateCommand : Command
         var config = await KSailClusterConfigLoader.LoadAsync().ConfigureAwait(false);
         config.UpdateConfig("Spec.Project.SecretManager", context.ParseResult.GetValueForOption(_projectSecretManagerOption));
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsGenerateCommandHandler handler;
+        KSailSecretsAddCommandHandler handler;
         switch (config.Spec.Project.SecretManager)
         {
           default:
@@ -30,7 +30,7 @@ sealed class KSailSecretsGenerateCommand : Command
             context.ExitCode = 1;
             return;
           case Models.Project.KSailSecretManager.SOPS:
-            handler = new KSailSecretsGenerateCommandHandler(new SOPSLocalAgeSecretManager());
+            handler = new KSailSecretsAddCommandHandler(new SOPSLocalAgeSecretManager());
             break;
         }
 

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsRemoveCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsRemoveCommand.cs
@@ -7,12 +7,12 @@ using KSail.Utils;
 
 namespace KSail.Commands.Secrets.Commands;
 
-sealed class KSailSecretsDeleteCommand : Command
+sealed class KSailSecretsRemoveCommand : Command
 {
   readonly ExceptionHandler _exceptionHandler = new();
-  readonly PublicKeyArgument _publicKeyArgument = new("The public key for the encryption key to delete") { Arity = ArgumentArity.ExactlyOne };
+  readonly PublicKeyArgument _publicKeyArgument = new("Public key matching existing encryption key") { Arity = ArgumentArity.ExactlyOne };
   readonly ProjectSecretManagerOption _projectSecretManagerOption = new() { Arity = ArgumentArity.ZeroOrOne };
-  internal KSailSecretsDeleteCommand() : base("del", "Delete an existing encryption key")
+  internal KSailSecretsRemoveCommand() : base("rm", "Remove an existing encryption key")
   {
     AddArgument(_publicKeyArgument);
     AddOption(_projectSecretManagerOption);
@@ -24,7 +24,7 @@ sealed class KSailSecretsDeleteCommand : Command
         config.UpdateConfig("Spec.Project.SecretManager", context.ParseResult.GetValueForOption(_projectSecretManagerOption));
         string publicKey = context.ParseResult.GetValueForArgument(_publicKeyArgument);
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsDeleteCommandHandler handler;
+        KSailSecretsRemoveCommandHandler handler;
         switch (config.Spec.Project.SecretManager)
         {
           default:
@@ -33,7 +33,7 @@ sealed class KSailSecretsDeleteCommand : Command
             context.ExitCode = 1;
             return;
           case Models.Project.KSailSecretManager.SOPS:
-            handler = new KSailSecretsDeleteCommandHandler(config, publicKey, new SOPSLocalAgeSecretManager());
+            handler = new KSailSecretsRemoveCommandHandler(config, publicKey, new SOPSLocalAgeSecretManager());
             break;
         }
 

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsGenerateCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsGenerateCommandHandler.cs
@@ -3,7 +3,7 @@ using Devantler.SecretManager.Core;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsGenerateCommandHandler(ISecretManager<AgeKey> secretManager)
+class KSailSecretsAddCommandHandler(ISecretManager<AgeKey> secretManager)
 {
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsRemoveCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsRemoveCommandHandler.cs
@@ -4,7 +4,7 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsDeleteCommandHandler(KSailCluster config, string publicKey, ISecretManager<AgeKey> secretManager)
+class KSailSecretsRemoveCommandHandler(KSailCluster config, string publicKey, ISecretManager<AgeKey> secretManager)
 {
   readonly KSailCluster _config = config;
   readonly string _publicKey = publicKey;
@@ -12,9 +12,9 @@ class KSailSecretsDeleteCommandHandler(KSailCluster config, string publicKey, IS
 
   internal async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
-    Console.WriteLine($"► deleting '{_publicKey}' from '{_config.Spec.Project.SecretManager}'");
+    Console.WriteLine($"► removing '{_publicKey}' from '{_config.Spec.Project.SecretManager}'");
     _ = await _secretManager.DeleteKeyAsync(_publicKey, cancellationToken).ConfigureAwait(false);
-    Console.WriteLine($"✔ key deleted");
+    Console.WriteLine($"✔ key removed");
     return 0;
   }
 }

--- a/src/KSail/Commands/Secrets/KSailSecretsCommand.cs
+++ b/src/KSail/Commands/Secrets/KSailSecretsCommand.cs
@@ -21,8 +21,8 @@ sealed class KSailSecretsCommand : Command
     AddCommand(new KSailSecretsDecryptCommand());
     // TODO: Include `ksail secrets edit` command when pseudo-terminal support is added to CLIWrap. See https://github.com/Tyrrrz/CliWrap/issues/225.
     //AddCommand(new KSailSecretsEditCommand());
-    AddCommand(new KSailSecretsGenerateCommand());
-    AddCommand(new KSailSecretsDeleteCommand());
+    AddCommand(new KSailSecretsAddCommand());
+    AddCommand(new KSailSecretsRemoveCommand());
     AddCommand(new KSailSecretsListCommand());
     AddCommand(new KSailSecretsImportCommand());
     AddCommand(new KSailSecretsExportCommand());

--- a/tests/KSail.Tests/Commands/Secrets/KSailSecretsCommandTests.KSailSecretsHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/KSailSecretsCommandTests.KSailSecretsHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -11,8 +11,8 @@ Options:
 Commands:
   encrypt <path>       Encrypt a file
   decrypt <path>       Decrypt a file
-  gen                  Generate a new encryption key
-  del <public-key>     Delete an existing encryption key
+  add                  Add a new encryption key
+  rm <public-key>      Remove an existing encryption key
   list                 List keys
   import <key>         Import a key from stdin or a file
   export <public-key>  Export a key to a file


### PR DESCRIPTION
Rename commands related to managing encryption keys to better reflect their functionality, changing "generate" to "add" and "delete" to "remove." Update associated handlers and command registrations accordingly.