### PR TITLE
fix: Add Apple code signing to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,8 @@ jobs:
   publish-binaries-old:
     name: Publish binaries
     runs-on: macos-latest
+    env:
+      APPLE_TEAM_ID: F2NXL88V7B
     steps:
       - name: Generate GitHub App Token
         uses: actions/create-github-app-token@v1
@@ -45,16 +47,55 @@ jobs:
 
           dotnet publish -c Release -r linux-arm64 src/KSail/KSail.csproj /p:Version=$version
           mv src/KSail/bin/Release/net9.0/linux-arm64/publish/ksail ksail-linux-arm64
-
-          dotnet publish -c Release -r win-x64 src/KSail/KSail.csproj /p:Version=$version
-          mv src/KSail/bin/Release/net9.0/win-x64/publish/ksail.exe ksail-windows-amd64.exe
-      - name: 🔐 Sign binaries
-        run: |
-          codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime ksail-darwin-amd64
-          codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime ksail-darwin-arm64 
-          codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime ksail-linux-amd64 
-          codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime ksail-linux-arm64 
-          codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime ksail-windows-amd64.exe 
+      # https://docs.github.com/en/actions/use-cases-and-examples/deploying/installing-an-apple-certificate-on-macos-runners-for-xcode-development#creating-secrets-for-your-certificate-and-provisioning-profile
+      - name: 🔐 Sign binary (ksail-darwin-amd64)
+        uses: lando/code-sign-action@v3
+        with:
+          file: ksail-darwin-amd64
+          certificate-id: ${{ env.APPLE_TEAM_ID }}
+          certificate-data: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          certificate-password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+          apple-notary-user: ${{ secrets.APPLE_NOTARY_USER }}
+          apple-notary-password: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          apple-notary-tool: altool
+          apple-product-id: dev.lando.code-sign-action
+          options: --options runtime --entitlements entitlements.xml
+      - name: 🔐 Sign binary (ksail-darwin-arm64)
+        uses: lando/code-sign-action@v3
+        with:
+          file: ksail-darwin-arm64
+          certificate-id: ${{ env.APPLE_TEAM_ID }}
+          certificate-data: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          certificate-password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+          apple-notary-user: ${{ secrets.APPLE_NOTARY_USER }}
+          apple-notary-password: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          apple-notary-tool: altool
+          apple-product-id: dev.lando.code-sign-action
+          options: --options runtime --entitlements entitlements.xml
+      - name: 🔐 Sign binary (ksail-linux-amd64)
+        uses: lando/code-sign-action@v3
+        with:
+          file: ksail-linux-amd64
+          certificate-id: ${{ env.APPLE_TEAM_ID }}
+          certificate-data: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          certificate-password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+          apple-notary-user: ${{ secrets.APPLE_NOTARY_USER }}
+          apple-notary-password: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          apple-notary-tool: altool
+          apple-product-id: dev.lando.code-sign-action
+          options: --options runtime --entitlements entitlements.xml
+      - name: 🔐 Sign binary (ksail-linux-arm64)
+        uses: lando/code-sign-action@v3
+        with:
+          file: ksail-linux-arm64
+          certificate-id: ${{ env.APPLE_TEAM_ID }}
+          certificate-data: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          certificate-password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+          apple-notary-user: ${{ secrets.APPLE_NOTARY_USER }}
+          apple-notary-password: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          apple-notary-tool: altool
+          apple-product-id: dev.lando.code-sign-action
+          options: --options runtime --entitlements entitlements.xml
       - name: 📦 Tar binaries
         run: tar -czf ksail.tar.gz ksail-darwin-amd64 ksail-darwin-arm64 ksail-linux-amd64 ksail-linux-arm64 ksail-windows-amd64.exe
       - name: 🎉 Release
@@ -65,7 +106,6 @@ jobs:
             ksail-darwin-arm64
             ksail-linux-amd64
             ksail-linux-arm64
-            ksail-windows-amd64.exe
             ksail.tar.gz
           token: ${{ steps.app-token.outputs.token }}
       - name: 🍺 Brew tap formulas


### PR DESCRIPTION
Integrate Apple code signing into the publish workflow to ensure binaries are properly signed for macOS and Linux environments. This enhancement improves the security and compliance of the published binaries.

Fixes #645 