### PR TITLE
fix: whitespace handling in secrets import

### DIFF
--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
@@ -13,12 +13,12 @@ class KSailSecretsImportCommandHandler(KSailCluster config, string key, ISecretM
   internal async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Console.WriteLine($"► importing '{_key}' to '{_config.Spec.Project.SecretManager}'");
-    string key = File.ReadAllText(_key);
+    string key = _key;
     if (File.Exists(key))
     {
       key = File.ReadAllText(key);
     }
-    var ageKey = new AgeKey(key);
+    var ageKey = new AgeKey(key.Trim());
     _ = await _secretManager.ImportKeyAsync(ageKey, cancellationToken).ConfigureAwait(false);
     Console.WriteLine("✔ key imported");
     return 0;


### PR DESCRIPTION
Trim whitespace from the key during the import process to ensure it meets the requirement of having exactly 3 lines. This change addresses the issue reported in #647.

Fixes #647