### PR TITLE
test: Add unit test for SopsConfigLoader exception handling

### DIFF
--- a/tests/KSail.Tests/Utils/SopsConfigLoaderTests.cs
+++ b/tests/KSail.Tests/Utils/SopsConfigLoaderTests.cs
@@ -1,0 +1,33 @@
+using KSail.Utils;
+
+namespace KSail.Tests.Utils;
+
+/// <summary>
+/// Tests for <see cref="SopsConfigLoader"/>.
+/// </summary>
+public class SopsConfigLoaderTest
+{
+  /// <summary>
+  /// Test that <see cref="SopsConfigLoader.LoadAsync"/> throws <see cref="KSailException"/> when no '.sops.yaml' file is found.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task LoadAsync_NoSopsYamlFile_ThrowsKSailException()
+  {
+    // Arrange
+    string testDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    _ = Directory.CreateDirectory(testDirectory);
+
+    try
+    {
+      // Act & Assert
+      var exception = await Assert.ThrowsAsync<KSailException>(() => SopsConfigLoader.LoadAsync(testDirectory));
+      Assert.Equal("'.sops.yaml' file not found in the current or parent directories", exception.Message);
+    }
+    finally
+    {
+      // Cleanup
+      Directory.Delete(testDirectory, true);
+    }
+  }
+}


### PR DESCRIPTION
Introduce a unit test to verify that the SopsConfigLoader throws a KSailException when the .sops.yaml file is missing.