### PR TITLE
fix: Remove working directory option and add project deployment tool to global options

### DIFF
--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -51,10 +51,6 @@
           "description": "The options for the KSail project.",
           "type": "object",
           "properties": {
-            "workingDirectory": {
-              "description": "The working directory for the project.",
-              "type": "string"
-            },
             "configPath": {
               "description": "The path to the ksail configuration file.",
               "type": "string"

--- a/src/KSail.Models/Project/KSailProject.cs
+++ b/src/KSail.Models/Project/KSailProject.cs
@@ -10,12 +10,6 @@ namespace KSail.Models.Project;
 public class KSailProject
 {
   /// <summary>
-  /// The working directory for the project.
-  /// </summary>
-  [Description("The working directory for the project.")]
-  public string WorkingDirectory { get; set; } = ".";
-
-  /// <summary>
   /// The path to the ksail configuration file.
   /// </summary>
   [Description("The path to the ksail configuration file.")]

--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -17,7 +17,7 @@ class DistributionConfigFileGenerator
 
   internal async Task GenerateAsync(KSailCluster config, CancellationToken cancellationToken = default)
   {
-    string configPath = config.Spec.Project.DistributionConfigPath;
+    string configPath = Path.Combine(Directory.GetCurrentDirectory(), config.Spec.Project.DistributionConfigPath);
     if (File.Exists(configPath))
     {
       Console.WriteLine($"✔ skipping '{configPath}', as it already exists.");

--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -17,7 +17,7 @@ class DistributionConfigFileGenerator
 
   internal async Task GenerateAsync(KSailCluster config, CancellationToken cancellationToken = default)
   {
-    string configPath = Path.Combine(config.Spec.Project.WorkingDirectory, config.Spec.Project.DistributionConfigPath);
+    string configPath = config.Spec.Project.DistributionConfigPath;
     if (File.Exists(configPath))
     {
       Console.WriteLine($"✔ skipping '{configPath}', as it already exists.");

--- a/src/KSail/Commands/Init/Generators/SubGenerators/FluxSystemGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/FluxSystemGenerator.cs
@@ -14,7 +14,7 @@ class FluxSystemGenerator
   readonly FluxKustomizationGenerator _fluxKustomizationGenerator = new();
   internal async Task GenerateAsync(KSailCluster config, CancellationToken cancellationToken = default)
   {
-    string outputDirectory = Path.Combine(config.Spec.Project.WorkingDirectory, "k8s", "clusters", config.Metadata.Name, "flux-system");
+    string outputDirectory = Path.Combine("k8s", "clusters", config.Metadata.Name, "flux-system");
     if (!Directory.Exists(outputDirectory))
       _ = Directory.CreateDirectory(outputDirectory);
     await GenerateFluxSystemKustomization(config, outputDirectory, cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Init/Generators/SubGenerators/KSailClusterConfigGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/KSailClusterConfigGenerator.cs
@@ -8,7 +8,7 @@ class KSailClusterConfigGenerator
   readonly KSailClusterGenerator _ksailClusterGenerator = new();
   internal async Task GenerateAsync(KSailCluster config, CancellationToken cancellationToken = default)
   {
-    string ksailConfigPath = Path.Combine(config.Spec.Project.WorkingDirectory, "ksail-config.yaml");
+    string ksailConfigPath = Path.Combine("ksail-config.yaml");
     if (File.Exists(ksailConfigPath))
     {
       Console.WriteLine($"✔ skipping '{ksailConfigPath}', as it already exists.");

--- a/src/KSail/Commands/Init/Generators/SubGenerators/KSailClusterConfigGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/KSailClusterConfigGenerator.cs
@@ -8,7 +8,7 @@ class KSailClusterConfigGenerator
   readonly KSailClusterGenerator _ksailClusterGenerator = new();
   internal async Task GenerateAsync(KSailCluster config, CancellationToken cancellationToken = default)
   {
-    string ksailConfigPath = Path.Combine("ksail-config.yaml");
+    string ksailConfigPath = Path.Combine(Directory.GetCurrentDirectory(), "ksail-config.yaml");
     if (File.Exists(ksailConfigPath))
     {
       Console.WriteLine($"✔ skipping '{ksailConfigPath}', as it already exists.");

--- a/src/KSail/Commands/Init/Generators/SubGenerators/KustomizeFlowGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/KustomizeFlowGenerator.cs
@@ -58,8 +58,8 @@ class KustomizeFlowGenerator
       kustomization = new KustomizeKustomization
       {
         Resources = [
-          Path.Combine($"variables.yaml"),
-          Path.Combine($"variables-sensitive.enc.yaml")
+          "variables.yaml",
+          "variables-sensitive.enc.yaml"
         ]
       };
       if (!string.IsNullOrEmpty(pathToNextFlow))

--- a/src/KSail/Commands/Init/Generators/SubGenerators/KustomizeFlowGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/KustomizeFlowGenerator.cs
@@ -32,7 +32,7 @@ class KustomizeFlowGenerator
 
   async Task GenerateKustomizeFlowHook(KSailCluster config, string currentHook, string currentFlow, CancellationToken cancellationToken = default)
   {
-    string outputPath = Path.Combine(config.Spec.Project.WorkingDirectory, "k8s", currentHook, currentFlow);
+    string outputPath = Path.Combine("k8s", currentHook, currentFlow);
     if (!Directory.Exists(outputPath))
       _ = Directory.CreateDirectory(outputPath);
     string outputDirectory = Path.Combine(outputPath, "kustomization.yaml");

--- a/src/KSail/Commands/Init/Generators/SubGenerators/SOPSConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/SOPSConfigFileGenerator.cs
@@ -13,7 +13,7 @@ class SOPSConfigFileGenerator
 
   internal async Task GenerateAsync(KSailCluster config, CancellationToken cancellationToken = default)
   {
-    string sopsConfigPath = Path.Combine(".sops.yaml");
+    string sopsConfigPath = ".sops.yaml";
     if (!File.Exists(sopsConfigPath) || string.IsNullOrEmpty(await File.ReadAllTextAsync(sopsConfigPath, cancellationToken).ConfigureAwait(false)))
     {
       await GenerateNewSOPSConfigFile(

--- a/src/KSail/Commands/Init/Generators/SubGenerators/SOPSConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/SOPSConfigFileGenerator.cs
@@ -13,7 +13,7 @@ class SOPSConfigFileGenerator
 
   internal async Task GenerateAsync(KSailCluster config, CancellationToken cancellationToken = default)
   {
-    string sopsConfigPath = Path.Combine(config.Spec.Project.WorkingDirectory, ".sops.yaml");
+    string sopsConfigPath = Path.Combine(".sops.yaml");
     if (!File.Exists(sopsConfigPath) || string.IsNullOrEmpty(await File.ReadAllTextAsync(sopsConfigPath, cancellationToken).ConfigureAwait(false)))
     {
       await GenerateNewSOPSConfigFile(

--- a/src/KSail/Commands/Init/Generators/SubGenerators/VariablesGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/VariablesGenerator.cs
@@ -12,7 +12,7 @@ class VariablesGenerator
   {
     foreach (string hook in config.Spec.KustomizeTemplate.Hooks)
     {
-      string hookPath = Path.Combine(config.Spec.Project.WorkingDirectory, "k8s", hook, "variables");
+      string hookPath = Path.Combine("k8s", hook, "variables");
       string name = hook.Replace("/", "-", StringComparison.Ordinal);
       await GenerateVariables(hookPath, name, cancellationToken).ConfigureAwait(false);
     }

--- a/src/KSail/Commands/Init/KSailInitCommand.cs
+++ b/src/KSail/Commands/Init/KSailInitCommand.cs
@@ -26,7 +26,7 @@ sealed class KSailInitCommand : Command
         config.UpdateConfig("Spec.KustomizeTemplate.Flows", context.ParseResult.GetValueForOption(_kustomizeTemplateKustomizationsOption));
         config.UpdateConfig("Spec.KustomizeTemplate.Hooks", context.ParseResult.GetValueForOption(_kustomizeTemplateKustomizationHooksOption));
         var handler = new KSailInitCommandHandler(config);
-        Console.WriteLine($"📁 Initializing new cluster '{config.Metadata.Name}' in '{config.Spec.Project.WorkingDirectory}' with the '{config.Spec.Project.Template}' template.");
+        Console.WriteLine($"📁 Initializing new cluster '{config.Metadata.Name}' in './' with the '{config.Spec.Project.Template}' template.");
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
         Console.WriteLine();
       }

--- a/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
+++ b/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
@@ -16,12 +16,6 @@ class KSailLintCommandHandler()
       throw new KSailException($"no manifest files found in '{kubernetesDirectory}'.");
     }
 
-    if (!Directory.Exists(kubernetesDirectory) || Directory.GetFiles(kubernetesDirectory, "*.yaml", SearchOption.AllDirectories).Length == 0)
-    {
-      Console.WriteLine($"✔ skipping, as '{kubernetesDirectory}' directory does not exist or is empty");
-      return true;
-    }
-
     Console.WriteLine("► validating yaml syntax");
     bool yamlIsValid = await _yamlSyntaxValidator.ValidateAsync(kubernetesDirectory, cancellationToken).ConfigureAwait(false);
     Console.WriteLine("✔ yaml syntax is valid");

--- a/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
+++ b/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
@@ -10,7 +10,7 @@ class KSailLintCommandHandler()
 
   internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
   {
-    string kubernetesDirectory = "k8s";
+    string kubernetesDirectory = Path.Combine(Directory.GetCurrentDirectory(), "k8s");
     if (!Directory.Exists(kubernetesDirectory) || Directory.GetFiles(kubernetesDirectory, "*.yaml", SearchOption.AllDirectories).Length == 0)
     {
       throw new KSailException($"no manifest files found in '{kubernetesDirectory}'.");

--- a/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
+++ b/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
@@ -1,6 +1,5 @@
 using Devantler.KubernetesValidator.ClientSide.Schemas;
 using Devantler.KubernetesValidator.ClientSide.YamlSyntax;
-using KSail.Models;
 
 namespace KSail.Commands.Lint.Handlers;
 
@@ -9,14 +8,12 @@ class KSailLintCommandHandler()
   readonly YamlSyntaxValidator _yamlSyntaxValidator = new();
   readonly SchemaValidator _schemaValidator = new();
 
-  internal async Task<bool> HandleAsync(KSailCluster config, CancellationToken cancellationToken = default)
+  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
   {
-    string kubernetesDirectory = Path.Combine(config.Spec.Project.WorkingDirectory, "k8s");
-    // if the k8s directory does not exist or is empty, use the working directory instead
+    string kubernetesDirectory = "k8s";
     if (!Directory.Exists(kubernetesDirectory) || Directory.GetFiles(kubernetesDirectory, "*.yaml", SearchOption.AllDirectories).Length == 0)
     {
-      Console.WriteLine($"► no manifest files found in '{kubernetesDirectory}', using '{config.Spec.Project.WorkingDirectory}' instead");
-      kubernetesDirectory = config.Spec.Project.WorkingDirectory;
+      throw new KSailException($"no manifest files found in '{kubernetesDirectory}'.");
     }
 
     if (!Directory.Exists(kubernetesDirectory) || Directory.GetFiles(kubernetesDirectory, "*.yaml", SearchOption.AllDirectories).Length == 0)

--- a/src/KSail/Commands/Lint/KSailLintCommand.cs
+++ b/src/KSail/Commands/Lint/KSailLintCommand.cs
@@ -20,7 +20,7 @@ sealed class KSailLintCommand : Command
 
         Console.WriteLine("🧹 Linting manifest files");
         var handler = new KSailLintCommandHandler();
-        context.ExitCode = await handler.HandleAsync(config, context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
         Console.WriteLine();
       }
       catch (Exception ex)

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -141,7 +141,7 @@ class KSailUpCommandHandler
     if (config.Spec.CLI.Up.Lint)
     {
       Console.WriteLine("🔍 Linting manifests");
-      bool success = await _ksailLintCommandHandler.HandleAsync(config, cancellationToken).ConfigureAwait(false);
+      bool success = await _ksailLintCommandHandler.HandleAsync(cancellationToken).ConfigureAwait(false);
       Console.WriteLine();
       return success;
     }

--- a/src/KSail/Commands/Update/Handlers/KSailUpdateCommandHandler.cs
+++ b/src/KSail/Commands/Update/Handlers/KSailUpdateCommandHandler.cs
@@ -27,7 +27,7 @@ class KSailUpdateCommandHandler
     {
       return false;
     }
-    string manifestDirectory = Path.Combine(_config.Spec.Project.WorkingDirectory, "k8s");
+    string manifestDirectory = "k8s";
     if (!Directory.Exists(manifestDirectory) || Directory.GetFiles(manifestDirectory, "*.yaml", SearchOption.AllDirectories).Length == 0)
     {
       throw new KSailException($"a '{manifestDirectory}' directory does not exist or is empty.");
@@ -42,7 +42,7 @@ class KSailUpdateCommandHandler
         var ociRegistryFromHost = new Uri($"{scheme}://{host}:{port}{absolutePath}");
         Console.WriteLine($"📥 Pushing manifests to '{ociRegistryFromHost}'");
         // TODO: Make some form of abstraction around GitOps tools, so it is easier to support apply-based tools like kubectl
-        await _deploymentTool.PushManifestsAsync(ociRegistryFromHost, Path.Combine(_config.Spec.Project.WorkingDirectory, "k8s"), cancellationToken: cancellationToken).ConfigureAwait(false);
+        await _deploymentTool.PushManifestsAsync(ociRegistryFromHost, "k8s", cancellationToken: cancellationToken).ConfigureAwait(false);
         Console.WriteLine();
         if (_config.Spec.CLI.Update.Reconcile)
         {
@@ -64,7 +64,7 @@ class KSailUpdateCommandHandler
     if (config.Spec.CLI.Update.Lint)
     {
       Console.WriteLine("🔍 Linting manifests");
-      bool success = await _ksailLintCommandHandler.HandleAsync(config, cancellationToken).ConfigureAwait(false);
+      bool success = await _ksailLintCommandHandler.HandleAsync(cancellationToken).ConfigureAwait(false);
       Console.WriteLine();
       return success;
     }

--- a/src/KSail/Options/GlobalOptions.cs
+++ b/src/KSail/Options/GlobalOptions.cs
@@ -16,19 +16,19 @@ public class GlobalOptions : IReadOnlyList<Option>
   /// </summary>
   public List<Option> Options { get; } =
   [
+    new ConnectionContextOption(new()) { Arity = ArgumentArity.ZeroOrOne },
+    new ConnectionKubeconfigOption(new()) { Arity = ArgumentArity.ZeroOrOne },
+    new ConnectionTimeoutOption(new()) { Arity = ArgumentArity.ZeroOrOne },
     new MetadataNameOption(new()) { Arity = ArgumentArity.ZeroOrOne },
+    new PathOption("The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)", ["--config", "-c"]) { Arity = ArgumentArity.ZeroOrOne },
+    new ProjectDeploymentToolOption(new()) { Arity = ArgumentArity.ZeroOrOne },
     new ProjectDistributionOption(new()) { Arity = ArgumentArity.ZeroOrOne },
+    new PathOption($"Path to the distribution configuration file. Default: 'kind-config.yaml' (G)", ["--distribution-config", "-dc"]) { Arity = ArgumentArity.ZeroOrOne },
+    new ProjectEditorOption(new()) { Arity = ArgumentArity.ZeroOrOne },
     new ProjectEngineOption(new()) { Arity = ArgumentArity.ZeroOrOne },
     new ProjectMirrorRegistriesOption(new()) { Arity = ArgumentArity.ZeroOrOne },
     new ProjectSecretManagerOption(new()) { Arity = ArgumentArity.ZeroOrOne },
-    new PathOption($"Path to the distribution configuration file. Default: 'kind-config.yaml' (G)", ["--distribution-config", "-dc"]) { Arity = ArgumentArity.ZeroOrOne },
-    new PathOption("The root directory of the project. Default: '.' (G)", ["--working-directory", "-wd"]) { Arity = ArgumentArity.ZeroOrOne },
-    new PathOption("The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)", ["--config", "-c"]) { Arity = ArgumentArity.ZeroOrOne },
-    new ProjectTemplateOption(new()) { Arity = ArgumentArity.ZeroOrOne },
-    new ProjectEditorOption(new()) { Arity = ArgumentArity.ZeroOrOne },
-    new ConnectionKubeconfigOption(new()) { Arity = ArgumentArity.ZeroOrOne },
-    new ConnectionContextOption(new()) { Arity = ArgumentArity.ZeroOrOne },
-    new ConnectionTimeoutOption(new()) { Arity = ArgumentArity.ZeroOrOne }
+    new ProjectTemplateOption(new()) { Arity = ArgumentArity.ZeroOrOne }
   ];
 
 

--- a/src/KSail/Options/ProjectDeploymentToolOption.cs
+++ b/src/KSail/Options/ProjectDeploymentToolOption.cs
@@ -1,11 +1,12 @@
 using System.CommandLine;
+using KSail.Models;
 using KSail.Models.Project;
 
 namespace KSail.Options;
 
-class ProjectDeploymentToolOption() : Option<KSailDeploymentTool>(
+class ProjectDeploymentToolOption(KSailCluster config) : Option<KSailDeploymentTool>(
   ["-dt", "--deployment-tool"],
-  "The Deployment tool to use for updating the state of the cluster."
+  $"The Deployment tool to use for updating the state of the cluster. Default: '{config.Spec.Project.DeploymentTool}' (G)"
 )
 {
 }

--- a/src/KSail/Utils/KSailClusterConfigLoader.cs
+++ b/src/KSail/Utils/KSailClusterConfigLoader.cs
@@ -23,10 +23,9 @@ static class KSailClusterConfigLoader
     var metadataNameOption = (MetadataNameOption)globalOptions.Options.First(o => o is MetadataNameOption);
     var projectConfigOption = (PathOption)globalOptions.Options.First(o => o is PathOption && o.Aliases.Contains("--config"));
     var projectDistributionOption = (ProjectDistributionOption)globalOptions.Options.First(o => o is ProjectDistributionOption);
-    var projectWorkingDirectoryOption = (PathOption)globalOptions.Options.First(o => o is PathOption && o.Aliases.Contains("--working-directory"));
     var config = await LoadAsync(
       context.ParseResult.GetValueForOption(projectConfigOption),
-      context.ParseResult.GetValueForOption(projectWorkingDirectoryOption),
+      "./",
       context.ParseResult.GetValueForOption(metadataNameOption),
       context.ParseResult.GetValueForOption(projectDistributionOption)
     ).ConfigureAwait(false);
@@ -34,7 +33,6 @@ static class KSailClusterConfigLoader
     config.UpdateConfig("Spec.Connection.Kubeconfig", context.ParseResult.GetValueForOption((ConnectionKubeconfigOption)globalOptions.Options.First(o => o is ConnectionKubeconfigOption)));
     config.UpdateConfig("Spec.Connection.Context", context.ParseResult.GetValueForOption((ConnectionContextOption)globalOptions.Options.First(o => o is ConnectionContextOption)));
     config.UpdateConfig("Spec.Connection.Timeout", context.ParseResult.GetValueForOption((ConnectionTimeoutOption)globalOptions.Options.First(o => o is ConnectionTimeoutOption)));
-    config.UpdateConfig("Spec.Project.WorkingDirectory", context.ParseResult.GetValueForOption(projectWorkingDirectoryOption));
     config.UpdateConfig("Spec.Project.ConfigPath", context.ParseResult.GetValueForOption(projectConfigOption));
     config.UpdateConfig("Spec.Project.Distribution", context.ParseResult.GetValueForOption(projectDistributionOption));
     config.UpdateConfig("Spec.Project.DistributionConfigPath", context.ParseResult.GetValueForOption((PathOption)globalOptions.Options.First(o => o is PathOption && o.Aliases.Contains("--distribution-config"))));

--- a/src/KSail/Utils/KSailClusterConfigLoader.cs
+++ b/src/KSail/Utils/KSailClusterConfigLoader.cs
@@ -25,7 +25,6 @@ static class KSailClusterConfigLoader
     var projectDistributionOption = (ProjectDistributionOption)globalOptions.Options.First(o => o is ProjectDistributionOption);
     var config = await LoadAsync(
       context.ParseResult.GetValueForOption(projectConfigOption),
-      "./",
       context.ParseResult.GetValueForOption(metadataNameOption),
       context.ParseResult.GetValueForOption(projectDistributionOption)
     ).ConfigureAwait(false);
@@ -44,7 +43,7 @@ static class KSailClusterConfigLoader
     return config;
   }
 
-  internal static async Task<KSailCluster> LoadAsync(string? configFilePath = "ksail-config.yaml", string? directory = default, string? name = default, KSailKubernetesDistribution distribution = default)
+  internal static async Task<KSailCluster> LoadAsync(string? configFilePath = "ksail-config.yaml", string? name = default, KSailKubernetesDistribution distribution = default)
   {
     // Create default KSailClusterConfig
     var ksailClusterConfig = string.IsNullOrEmpty(name) ?
@@ -52,7 +51,7 @@ static class KSailClusterConfigLoader
       new KSailCluster(name, distribution: distribution);
 
     // Locate KSail YAML file
-    string startDirectory = directory ?? Directory.GetCurrentDirectory();
+    string startDirectory = Directory.GetCurrentDirectory();
     string? ksailYaml = string.IsNullOrEmpty(configFilePath) ?
       FindConfigFile(startDirectory, "ksail-config.yaml") :
       FindConfigFile(startDirectory, configFilePath);

--- a/src/KSail/Utils/SopsConfigLoader.cs
+++ b/src/KSail/Utils/SopsConfigLoader.cs
@@ -6,10 +6,10 @@ namespace KSail.Utils;
 static class SopsConfigLoader
 {
   static readonly SOPSConfigHelper _sopsConfigHelper = new();
-  internal static async Task<SOPSConfig> LoadAsync(string? directory = default, CancellationToken cancellationToken = default)
+  internal static async Task<SOPSConfig> LoadAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine("► searching for a '.sops.yaml' file");
-    directory ??= Directory.GetCurrentDirectory();
+    string directory = Directory.GetCurrentDirectory();
     string sopsConfigPath = string.Empty;
     while (!string.IsNullOrEmpty(directory))
     {

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.full.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.full.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: k3d-my-cluster
     timeout: 5m
   project:
-    workingDirectory: .
     configPath: ksail-config.yaml
     distributionConfigPath: k3d-config.yaml
     template: Kustomize

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.minimal.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.minimal.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-ksail-default
     timeout: 5m
   project:
-    workingDirectory: .
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -11,7 +11,6 @@
       Timeout: 5m
     },
     Project: {
-      WorkingDirectory: .,
       ConfigPath: ksail-config.yaml,
       DistributionConfigPath: k3d-config.yaml,
       Template: Kustomize,

--- a/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -11,7 +11,6 @@
       Timeout: 5m
     },
     Project: {
-      WorkingDirectory: .,
       ConfigPath: ksail-config.yaml,
       DistributionConfigPath: k3d-config.yaml,
       Template: Kustomize,

--- a/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -11,7 +11,6 @@
       Timeout: 5m
     },
     Project: {
-      WorkingDirectory: .,
       ConfigPath: ksail-config.yaml,
       DistributionConfigPath: kind-config.yaml,
       Template: Kustomize,

--- a/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitialization.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -11,7 +11,6 @@
       Timeout: 5m
     },
     Project: {
-      WorkingDirectory: .,
       ConfigPath: ksail-config.yaml,
       DistributionConfigPath: kind-config.yaml,
       Template: Kustomize,

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGeneration.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGeneration.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -51,10 +51,6 @@
           "description": "The options for the KSail project.",
           "type": "object",
           "properties": {
-            "workingDirectory": {
-              "description": "The working directory for the project.",
-              "type": "string"
-            },
             "configPath": {
               "description": "The path to the ksail configuration file.",
               "type": "string"

--- a/tests/KSail.Tests/Commands/Debug/KSailDebugCommandTests.KSailDebugHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Debug/KSailDebugCommandTests.KSailDebugHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost debug [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Down/KSailDownCommandTests.KSailDownHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Down/KSailDownCommandTests.KSailDownHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost down [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost gen [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 Commands:

--- a/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost gen cert-manager [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 Commands:

--- a/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager certificate --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager certificate --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./certificate.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager cluster-issuer --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager cluster-issuer --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./cluster-issuer.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen cert-manager.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
 
 Commands:
   certificate     Generate a 'cert-manager.io/v1/Certificate' resource.

--- a/tests/KSail.Tests/Commands/Gen/ksail gen config --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen config --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost gen config [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 Commands:

--- a/tests/KSail.Tests/Commands/Gen/ksail gen config k3d --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen config k3d --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./k3d-config.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen config ksail --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen config ksail --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./ksail-config.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen config sops --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen config sops --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./.sops.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen config.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen config.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
 
 Commands:
   k3d    Generate a 'k3d.io/v1alpha5/Simple' resource.

--- a/tests/KSail.Tests/Commands/Gen/ksail gen flux --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen flux --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost gen flux [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 Commands:

--- a/tests/KSail.Tests/Commands/Gen/ksail gen flux helm-release --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen flux helm-release --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./helm-release.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen flux helm-repository --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen flux helm-repository --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./helm-repository.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen flux kustomization --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen flux kustomization --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./flux-kustomization.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen flux.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen flux.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
 
 Commands:
   helm-release     Generate a 'helm.toolkit.fluxcd.io/v2/HelmRelease' resource.

--- a/tests/KSail.Tests/Commands/Gen/ksail gen kustomize --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen kustomize --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost gen kustomize [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 Commands:

--- a/tests/KSail.Tests/Commands/Gen/ksail gen kustomize component --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen kustomize component --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./kustomization.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen kustomize kustomization --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen kustomize kustomization --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./kustomization.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen kustomize.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen kustomize.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
 
 Commands:
   component      Generate a 'kustomize.config.k8s.io/v1alpha1/Component' resource.

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost gen native [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 Commands:

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native cluster-role-binding --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native cluster-role-binding --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./cluster-role-binding.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native config-map --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native config-map --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./config-map.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native cron-job --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native cron-job --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./cron-job.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native daemon-set --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native daemon-set --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./daemon-set.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native deployment --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native deployment --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./deployment.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native horizontal-pod-autoscaler --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native horizontal-pod-autoscaler --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./horizontal-pod-autoscaler.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native ingress --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native ingress --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./ingress.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native job --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native job --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./job.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native namespace --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native namespace --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./namespace.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native network-policy --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native network-policy --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./network-policy.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native persistent-volume --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native persistent-volume --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./persistent-volume.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native persistent-volume-claim --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native persistent-volume-claim --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./persistent-volume-claim.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native pod-disruption-budget --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native pod-disruption-budget --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./pod-disruption-budget.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native resource-quota --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native resource-quota --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./resource-quota.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native role --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native role --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./role.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native role-binding --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native role-binding --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./role-binding.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native secret --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native secret --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./secret.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native service --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native service --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./service.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native service-account --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native service-account --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./service-account.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native stateful-set --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native stateful-set --help.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -o, --output <output>                             The output file to write the resource to. [default: ./stateful-set.yaml]
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Gen/ksail gen native.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen native.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
 
 Commands:
   cluster-role-binding       Generate a 'rbac.authorization.k8s.io/v1/ClusterRoleBinding' resource.

--- a/tests/KSail.Tests/Commands/Gen/ksail gen.verified.txt
+++ b/tests/KSail.Tests/Commands/Gen/ksail gen.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
 
 Commands:
   cert-manager  Generate a CertManager resource.

--- a/tests/KSail.Tests/Commands/Gen/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Gen/ksail-config.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-ksail-default
     timeout: 5m
   project:
-    workingDirectory: .
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -8,19 +8,19 @@ Options:
   -fpbv, --flux-post-build-variables                Generate ConfigMaps and Secrets for flux post-build-variables.
   -kh, --kustomize-hooks <kustomize-hooks>          The kustomize hooks to include in the initialized cluster.
   -kf, --kustomize-flows <kustomize-flows>          The flows to include. The first depends on the next, and so on.
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.cs
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.cs
@@ -54,9 +54,8 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     _ = Directory.CreateDirectory(outputDir);
 
     //Act
-    int exitCode = await ksailCommand.InvokeAsync(["init",
-      "--working-directory", outputDir
-    ]);
+    Directory.SetCurrentDirectory(outputDir);
+    int exitCode = await ksailCommand.InvokeAsync(["init"]);
 
     //Assert
     Assert.Equal(0, exitCode);
@@ -93,12 +92,9 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     _ = Directory.CreateDirectory(outputDir);
 
     //Act
-    int exitCodeRun1 = await ksailCommand.InvokeAsync(["init",
-      "--working-directory", outputDir
-    ]);
-    int exitCodeRun2 = await ksailCommand.InvokeAsync(["init",
-      "--working-directory", outputDir
-    ]);
+    Directory.SetCurrentDirectory(outputDir);
+    int exitCodeRun1 = await ksailCommand.InvokeAsync(["init"]);
+    int exitCodeRun2 = await ksailCommand.InvokeAsync(["init"]);
 
     //Assert
     Assert.Equal(0, exitCodeRun1);
@@ -136,15 +132,14 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     _ = Directory.CreateDirectory(outputDir);
 
     //Act
+    Directory.SetCurrentDirectory(outputDir);
     int exitCodeRun1 = await ksailCommand.InvokeAsync(["init",
       "--name", "cluster1",
-      "--distribution", "native",
-      "--working-directory", outputDir
+      "--distribution", "native"
     ]);
     int exitCodeRun2 = await ksailCommand.InvokeAsync(["init",
       "--name", "cluster2",
-      "--distribution", "k3s",
-      "--working-directory", outputDir
+      "--distribution", "k3s"
     ]);
 
     //Assert
@@ -184,9 +179,9 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     _ = Directory.CreateDirectory(outputDir);
 
     //Act
+    Directory.SetCurrentDirectory(outputDir);
     int exitCode = await ksailCommand.InvokeAsync(["init",
       "--name", "ksail-advanced-native",
-      "--working-directory", outputDir,
       "--secret-manager", "sops",
       "--flux-post-build-variables",
       "--kustomize-hooks", "clusters/ksail-advanced-native", "distributions/native", "shared"
@@ -231,16 +226,16 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     _ = Directory.CreateDirectory(outputDir);
 
     //Act
+    Directory.SetCurrentDirectory(outputDir);
     int exitCodeRun1 = await ksailCommand.InvokeAsync(["init",
       "--name", "ksail-advanced-native",
-      "--working-directory", outputDir,
       "--secret-manager", "sops",
       "--flux-post-build-variables",
       "--kustomize-hooks", "clusters/ksail-advanced-native", "distributions/native", "shared"
     ]);
     int exitCodeRun2 = await ksailCommand.InvokeAsync(["init",
       "--name", "ksail-advanced-native",
-      "--working-directory", outputDir, "--secret-manager", "sops",
+      "--secret-manager", "sops",
       "--flux-post-build-variables",
       "--kustomize-hooks", "clusters/ksail-advanced-native","distributions/native", "shared"
     ]);
@@ -285,9 +280,9 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     _ = Directory.CreateDirectory(outputDir);
 
     //Act
+    Directory.SetCurrentDirectory(outputDir);
     int exitCodeRun1 = await ksailCommand.InvokeAsync(["init",
       "--name", "cluster1",
-      "--working-directory", outputDir,
       "--secret-manager", "sops",
       "--flux-post-build-variables",
       "--distribution", "native",
@@ -295,7 +290,6 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     ]);
     int exitCodeRun2 = await ksailCommand.InvokeAsync(["init",
       "--name", "cluster2",
-      "--working-directory", outputDir,
       "--secret-manager", "sops",
       "--flux-post-build-variables",
       "--distribution", "k3s",

--- a/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/ksail-config.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-cluster1
     timeout: 5m
   project:
-    workingDirectory: {TempPath}ksail-init-mixed-advanced-multi
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Tests/Commands/Init/mixed-simple-multi/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-simple-multi/ksail-config.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-cluster1
     timeout: 5m
   project:
-    workingDirectory: {TempPath}ksail-init-mixed-simple-multi
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Tests/Commands/Init/native-advanced-existing/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced-existing/ksail-config.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-ksail-advanced-native
     timeout: 5m
   project:
-    workingDirectory: {TempPath}ksail-init-native-advanced-existing
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Tests/Commands/Init/native-advanced/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced/ksail-config.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-ksail-advanced-native
     timeout: 5m
   project:
-    workingDirectory: {TempPath}ksail-init-native-advanced
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Tests/Commands/Init/native-simple-existing/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-simple-existing/ksail-config.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-ksail-default
     timeout: 5m
   project:
-    workingDirectory: {TempPath}ksail-init-native-simple-existing
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Tests/Commands/Init/native-simple/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-simple/ksail-config.yaml.verified.yaml
@@ -9,7 +9,6 @@ spec:
     context: kind-ksail-default
     timeout: 5m
   project:
-    workingDirectory: {TempPath}ksail-init-native-simple
     configPath: ksail-config.yaml
     distributionConfigPath: kind-config.yaml
     template: Kustomize

--- a/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.KSailLintHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.KSailLintHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost lint [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.cs
+++ b/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.cs
@@ -42,10 +42,12 @@ public class KSailLintCommandTests : IAsyncLifetime
     string path = Path.Combine(Path.GetTempPath(), "ksail-lint-test-cluster");
     var console = new TestConsole();
     var ksailCommand = new KSailRootCommand(console);
+    _ = Directory.CreateDirectory(path);
+    Directory.SetCurrentDirectory(path);
 
     //Act
-    int initExitCode = await ksailCommand.InvokeAsync(["init", "--name", "test-cluster", "--working-directory", path], console);
-    int lintExitCode = await ksailCommand.InvokeAsync(["lint", "--working-directory", path], console);
+    int initExitCode = await ksailCommand.InvokeAsync(["init", "--name", "test-cluster"], console);
+    int lintExitCode = await ksailCommand.InvokeAsync(["lint"], console);
 
     //Assert
     Assert.Equal(0, initExitCode);
@@ -65,7 +67,8 @@ public class KSailLintCommandTests : IAsyncLifetime
     _ = Directory.CreateDirectory(path);
 
     //Act
-    int lintExitCode = await ksailCommand.InvokeAsync(["lint", "--working-directory", path], console);
+    Directory.SetCurrentDirectory(path);
+    int lintExitCode = await ksailCommand.InvokeAsync(["lint"], console);
 
     //Assert
     Assert.Equal(0, lintExitCode);
@@ -95,7 +98,8 @@ public class KSailLintCommandTests : IAsyncLifetime
     await File.WriteAllTextAsync(Path.Combine(path, "invalid.yaml"), invalidYaml);
 
     //Act
-    int lintExitCode = await ksailCommand.InvokeAsync(["lint", "--working-directory", path], console);
+    Directory.SetCurrentDirectory(path);
+    int lintExitCode = await ksailCommand.InvokeAsync(["lint"], console);
 
     //Assert
     Assert.Equal(1, lintExitCode);

--- a/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.cs
+++ b/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.cs
@@ -9,11 +9,8 @@ namespace KSail.Tests.Commands.Lint;
 /// Tests for the <see cref="KSailLintCommand"/> class.
 /// </summary>
 [Collection("KSail.Tests")]
-public class KSailLintCommandTests : IAsyncLifetime
+public class KSailLintCommandTests : IDisposable
 {
-  /// <inheritdoc/>
-  public Task InitializeAsync() => Task.CompletedTask;
-
   /// <summary>
   /// Tests that the 'ksail lint --help'
   /// </summary>
@@ -39,11 +36,8 @@ public class KSailLintCommandTests : IAsyncLifetime
   public async Task KSailLint_GivenValidPath_Succeeds()
   {
     //Arrange
-    string path = Path.Combine(Path.GetTempPath(), "ksail-lint-test-cluster");
     var console = new TestConsole();
     var ksailCommand = new KSailRootCommand(console);
-    _ = Directory.CreateDirectory(path);
-    Directory.SetCurrentDirectory(path);
 
     //Act
     int initExitCode = await ksailCommand.InvokeAsync(["init", "--name", "test-cluster"], console);
@@ -58,20 +52,17 @@ public class KSailLintCommandTests : IAsyncLifetime
   /// Tests that the 'ksail lint' command skips when given an invalid path or a path with no YAML files.
   /// </summary>
   [Fact]
-  public async Task KSailLint_GivenInvalidPathOrNoYaml_Succeeds()
+  public async Task KSailLint_GivenInvalidPathOrNoYaml_ThrowsKSailException()
   {
     //Arrange
-    string path = Path.Combine(Path.GetTempPath(), "ksail-lint-invalid-path");
     var console = new TestConsole();
     var ksailCommand = new KSailRootCommand(console);
-    _ = Directory.CreateDirectory(path);
 
     //Act
-    Directory.SetCurrentDirectory(path);
     int lintExitCode = await ksailCommand.InvokeAsync(["lint"], console);
 
     //Assert
-    Assert.Equal(0, lintExitCode);
+    Assert.Equal(1, lintExitCode);
   }
 
   /// <summary>
@@ -81,7 +72,6 @@ public class KSailLintCommandTests : IAsyncLifetime
   public async Task KSailLint_GivenInvalidYaml_Fails()
   {
     //Arrange
-    string path = Path.Combine(Path.GetTempPath(), "ksail-lint-invalid-yaml");
     var console = new TestConsole();
     var ksailCommand = new KSailRootCommand(console);
     string invalidYaml = """
@@ -94,44 +84,37 @@ public class KSailLintCommandTests : IAsyncLifetime
         - name: my-container
           image: my-image
     """;
-    _ = Directory.CreateDirectory(path);
-    await File.WriteAllTextAsync(Path.Combine(path, "invalid.yaml"), invalidYaml);
+    await File.WriteAllTextAsync(Path.Combine(Directory.GetCurrentDirectory(), "invalid.yaml"), invalidYaml);
 
     //Act
-    Directory.SetCurrentDirectory(path);
     int lintExitCode = await ksailCommand.InvokeAsync(["lint"], console);
 
     //Assert
     Assert.Equal(1, lintExitCode);
   }
 
-  // TODO: Fix flakyness in this test on Windows, requiring waiting for the active processes to finish.
   /// <inheritdoc/>
-  public async Task DisposeAsync()
+  public void Dispose()
   {
-    var directories = new List<string> {
-      Path.Combine(Path.GetTempPath(), "ksail-lint-test-cluster"),
-      Path.Combine(Path.GetTempPath(), "ksail-lint-invalid-path"),
-      Path.Combine(Path.GetTempPath(), "ksail-lint-invalid-yaml")
-    };
-    foreach (string directory in directories)
+    if (Directory.Exists("k8s"))
     {
-      if (Directory.Exists(directory))
+      Directory.Delete("k8s", true);
+    }
+
+    string[] filePaths =
+    [
+      "ksail-config.yaml",
+      "kind-config.yaml",
+      "k3d-config.yaml",
+      ".sops.yaml"
+    ];
+    foreach (string filePath in filePaths)
+    {
+      if (File.Exists(filePath))
       {
-        bool directoryDeleted = false;
-        while (!directoryDeleted)
-        {
-          try
-          {
-            Directory.Delete(directory, true);
-            directoryDeleted = true;
-          }
-          catch (IOException)
-          {
-            await Task.Delay(100);
-          }
-        }
+        File.Delete(filePath);
       }
     }
+    GC.SuppressFinalize(this);
   }
 }

--- a/tests/KSail.Tests/Commands/List/KSailListCommandTests.KSailListHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/List/KSailListCommandTests.KSailListHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -6,19 +6,19 @@ Usage:
 
 Options:
   -a, --all                                         List clusters from all distributions
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSailHelp_SucceedsAndPrintsHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSailHelp_SucceedsAndPrintsHelp.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
 

--- a/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSail_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSail_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -16,19 +16,19 @@ Usage:
   testhost [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   --version                                         Show version information
   -?, -h, --help                                    Show help and usage information
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost secrets [command] [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 Commands:

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets add --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets add --help.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost secrets add [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets decrypt --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets decrypt --help.verified.txt
@@ -10,19 +10,19 @@ Arguments:
 Options:
   -ip, --in-place                                   Decrypt the file in place.
   -o, --output <output>                             The path to output the decrypted file. []
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets encrypt --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets encrypt --help.verified.txt
@@ -11,19 +11,19 @@ Options:
   -pk, --public-key <public-key>                    The public key to encrypt the file with.
   -ip, --in-place                                   Encrypt the file in place.
   -o, --output <output>                             The path to output the encrypted file. []
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets export --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets export --help.verified.txt
@@ -9,19 +9,19 @@ Arguments:
 
 Options:
   -o, --output <output>                             Path to the output file
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets import --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets import --help.verified.txt
@@ -8,19 +8,19 @@ Arguments:
   <key>  The encryption key to import
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets list --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets list --help.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   -spk, --show-private-keys                         Show private keys
   -spko, --show-project-keys-only                   Only show keys used in the current project
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets rm --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets rm --help.verified.txt
@@ -8,19 +8,19 @@ Arguments:
   <public-key>  Public key matching existing encryption key
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Start/KSailStartCommandTests.KSailStartHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Start/KSailStartCommandTests.KSailStartHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost start [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Stop/KSailStopCommandTests.KSailStopHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Stop/KSailStopCommandTests.KSailStopHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,19 +5,19 @@ Usage:
   testhost stop [options]
 
 Options:
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -8,19 +8,19 @@ Options:
   -fsu, --flux-source-url <flux-source-url>         Flux source URL for reconciling GitOps resources
   -l, --lint                                        Lint manifests before pushing an update
   -r, --reconcile                                   Reconcile manifests after pushing an update
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -7,19 +7,19 @@ Usage:
 Options:
   -l, --lint                                        Lint manifests before pushing an update
   -r, --reconcile                                   Reconcile manifests after pushing an update
+  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
+  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -n, --name <name>                                 The name of the cluster. Default: 'ksail-default' (G)
+  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
+  -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. Default: 'Flux' (G)
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. Default: 'Native' (G)
+  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
+  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. Default: 'Docker' (G)
   -mr, --mirror-registries                          Enable mirror registries. Default: 'True' (G)
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. Default: 'None' (G)
-  -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. Default: 'kind-config.yaml' (G)
-  -wd, --working-directory <working-directory>      The root directory of the project. Default: '.' (G)
-  -c, --config <config>                             The path to the ksail configuration file. Default: 'ksail-config.yaml' (G)
   -t, --template <Kustomize>                        The template to use for the initialized cluster. Default: 'Kustomize' (G)
-  -e, --editor <Nano|Vim>                           Editor to use. Default: 'Nano' (G)
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. Default: '~/.kube/config' (G)
-  -c, --context <context>                           The kubernetes context to use. Default: 'kind-ksail-default' (G)
-  -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. Default: '5m' (G)
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Utils/SopsConfigLoaderTests.cs
+++ b/tests/KSail.Tests/Utils/SopsConfigLoaderTests.cs
@@ -5,6 +5,7 @@ namespace KSail.Tests.Utils;
 /// <summary>
 /// Tests for <see cref="SopsConfigLoader"/>.
 /// </summary>
+[Collection("KSail.Tests")]
 public class SopsConfigLoaderTest
 {
   /// <summary>
@@ -14,20 +15,10 @@ public class SopsConfigLoaderTest
   [Fact]
   public async Task LoadAsync_NoSopsYamlFile_ThrowsKSailException()
   {
-    // Arrange
-    string testDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-    _ = Directory.CreateDirectory(testDirectory);
+    // Act
+    var exception = await Assert.ThrowsAsync<KSailException>(() => SopsConfigLoader.LoadAsync());
 
-    try
-    {
-      // Act & Assert
-      var exception = await Assert.ThrowsAsync<KSailException>(() => SopsConfigLoader.LoadAsync(testDirectory));
-      Assert.Equal("'.sops.yaml' file not found in the current or parent directories", exception.Message);
-    }
-    finally
-    {
-      // Cleanup
-      Directory.Delete(testDirectory, true);
-    }
+    // Assert
+    Assert.Equal("'.sops.yaml' file not found in the current or parent directories", exception.Message);
   }
 }


### PR DESCRIPTION
Eliminate the working directory option from the project configuration and adjust related file paths accordingly. Introduce the project deployment tool as a global option for enhanced deployment management.