### PR TITLE
feat: Add support for Cilium CNI in cluster configuration

### DIFF
--- a/docs/5-supported-tooling.md
+++ b/docs/5-supported-tooling.md
@@ -2,28 +2,27 @@
 
 KSail wants to support a wide range of use cases, as such it is important that it provides the flexibility to work on the Container Engines and Kubernetes distributions that you enjoy using. Below is a list of the supported tooling that KSail can work with. If you have a tool that you would like to see supported, please open an issue or a pull request, and why this tool is necessary for your use case.
 
-## Container engines
+## Engines
 
 - [Docker](https://www.docker.com)
-- [Podman](https://podman.io) - WIP
 
 ## Kubernetes distributions
 
 - [Kind](https://kind.sigs.k8s.io)
 - [K3d](https://k3d.io)
-- [Talos Docker](https://www.talos.dev/v1.8/talos-guides/install/local-platforms/docker/) - WIP
+- [Talos Docker](https://www.talos.dev/v1.8/talos-guides/install/local-platforms/docker/) - Coming Soon
 
-## GitOps tools
+## Deployment tools
 
 - [Flux](https://fluxcd.io)
-- [ArgoCD](https://argoproj.github.io/argo-cd) - WIP
+- [ArgoCD](https://argoproj.github.io/argo-cd) - Coming Soon
+- [Kubectl](https://argoproj.github.io/argo-cd) - Coming Soon
 
 ## Container Network Interfaces (CNI)
 
-- [Cilium](https://cilium.io) - WIP
+- [Cilium](https://cilium.io)
 
 ## Client-side validation
 
 - [YAML syntax via YamlDotNet](https://github.com/aaubry/YamlDotNet)
 - [Schema validation via Kubeconform and Kustomize](https://github.com/yannh/kubeconform)
-- [Polaris best-practice checks](https://polaris.docs.fairwinds.com/infrastructure-as-code/) - WIP

--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -82,7 +82,8 @@
             "cni": {
               "description": "The CNI to use.",
               "enum": [
-                "Default"
+                "Default",
+                "Cilium"
               ]
             },
             "editor": {
@@ -174,7 +175,8 @@
         "cni": {
           "description": "The options for the CNI.",
           "enum": [
-            "Default"
+            "Default",
+            "Cilium"
           ]
         },
         "ingressController": {

--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -174,10 +174,7 @@
         },
         "cni": {
           "description": "The options for the CNI.",
-          "enum": [
-            "Default",
-            "Cilium"
-          ]
+          "type": "object"
         },
         "ingressController": {
           "description": "The options for the Ingress Controller.",

--- a/src/KSail.Models/KSailClusterSpec.cs
+++ b/src/KSail.Models/KSailClusterSpec.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using KSail.Models.CNI;
 using KSail.Models.Connection;
 using KSail.Models.DeploymentTool;
 using KSail.Models.Distribution;
@@ -35,7 +36,7 @@ public class KSailClusterSpec
 
   [Description("The options for the CNI.")]
   [YamlMember(Alias = "cni")]
-  public KSailCNIType CNI { get; set; } = new();
+  public KSailCNI CNI { get; set; } = new();
 
   [Description("The options for the Ingress Controller.")]
   public KSailIngressController IngressController { get; set; } = new();

--- a/src/KSail.Models/Project/Enums/KSailCNIType.cs
+++ b/src/KSail.Models/Project/Enums/KSailCNIType.cs
@@ -3,10 +3,6 @@ namespace KSail.Models.Project.Enums;
 
 public enum KSailCNIType
 {
-
   Default,
-
-  //
-  // Cilium,
-
+  Cilium,
 }

--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -103,7 +103,10 @@ class DistributionConfigFileGenerator
           [
             new K3dOptionsK3sExtraArg
             {
-              Arg = "--flannel-backend=none"
+              Arg = "--flannel-backend=none",
+              NodeFilters = [
+                "server:*"
+              ]
             }
           ]
         }

--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -1,9 +1,12 @@
 using System.Text;
 using Devantler.KubernetesGenerator.K3d;
 using Devantler.KubernetesGenerator.K3d.Models;
+using Devantler.KubernetesGenerator.K3d.Models.Options;
+using Devantler.KubernetesGenerator.K3d.Models.Options.K3s;
 using Devantler.KubernetesGenerator.K3d.Models.Registries;
 using Devantler.KubernetesGenerator.Kind;
 using Devantler.KubernetesGenerator.Kind.Models;
+using Devantler.KubernetesGenerator.Kind.Models.Networking;
 using k8s.Models;
 using KSail.Models;
 using KSail.Models.Project.Enums;
@@ -50,6 +53,14 @@ class DistributionConfigFileGenerator
       ] : null
     };
 
+    if (config.Spec.Project.CNI != KSailCNIType.Default)
+    {
+      kindConfig.Networking = new KindNetworking
+      {
+        DisableDefaultCNI = true
+      };
+    }
+
     await _kindConfigKubernetesGenerator.GenerateAsync(kindConfig, outputPath, cancellationToken: cancellationToken).ConfigureAwait(false);
   }
 
@@ -81,6 +92,23 @@ class DistributionConfigFileGenerator
         """
       }
     };
+
+    if (config.Spec.Project.CNI != KSailCNIType.Default)
+    {
+      k3dConfig.Options = new K3dOptions
+      {
+        K3s = new K3dOptionsK3s
+        {
+          ExtraArgs =
+          [
+            new K3dOptionsK3sExtraArg
+            {
+              Arg = "--flannel-backend=none"
+            }
+          ]
+        }
+      };
+    }
 
     await _k3dConfigKubernetesGenerator.GenerateAsync(k3dConfig, outputPath, cancellationToken: cancellationToken).ConfigureAwait(false);
   }

--- a/src/KSail/Commands/Init/Generators/SubGenerators/SOPSConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/SOPSConfigFileGenerator.cs
@@ -16,10 +16,11 @@ class SOPSConfigFileGenerator
     string sopsConfigPath = Path.Combine(".sops.yaml");
     if (!File.Exists(sopsConfigPath) || string.IsNullOrEmpty(await File.ReadAllTextAsync(sopsConfigPath, cancellationToken).ConfigureAwait(false)))
     {
+      var ageKey = await SOPSLocalAgeSecretManager.CreateKeyAsync(cancellationToken).ConfigureAwait(false);
       await GenerateNewSOPSConfigFile(
         sopsConfigPath,
         config.Metadata.Name,
-        await SOPSLocalAgeSecretManager.CreateKeyAsync(cancellationToken).ConfigureAwait(false),
+        ageKey,
         cancellationToken
       ).ConfigureAwait(false);
     }

--- a/src/KSail/Commands/Init/KSailInitCommand.cs
+++ b/src/KSail/Commands/Init/KSailInitCommand.cs
@@ -34,6 +34,7 @@ sealed class KSailInitCommand : Command
   void AddOptions()
   {
     AddOption(CLIOptions.Metadata.NameOption);
+    AddOption(CLIOptions.Project.CNIOption);
     AddOption(CLIOptions.Project.DistributionConfigPathOption);
     AddOption(CLIOptions.Project.DistributionOption);
     AddOption(CLIOptions.Project.EngineOption);

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -290,7 +290,7 @@ class KSailUpCommandHandler
     switch (config.Spec.Project.CNI)
     {
       case KSailCNIType.Cilium:
-        Console.WriteLine("🔼 Bootstrapping Cilium CNI");
+        Console.WriteLine("🐝 Installing Cilium CNI");
         await _cniProvisioner.InstallAsync(config.Spec.Connection.Context, cancellationToken).ConfigureAwait(false);
         Console.WriteLine("✔ Cilium CNI installed");
         Console.WriteLine();

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -3,6 +3,7 @@ using Devantler.ContainerEngineProvisioner.Docker;
 using Devantler.KubernetesProvisioner.Cluster.Core;
 using Devantler.KubernetesProvisioner.Cluster.K3d;
 using Devantler.KubernetesProvisioner.Cluster.Kind;
+using Devantler.KubernetesProvisioner.CNI.Cilium;
 using Devantler.KubernetesProvisioner.GitOps.Flux;
 using Devantler.KubernetesProvisioner.Resources.Native;
 using Devantler.SecretManager.SOPS.LocalAge;
@@ -19,12 +20,11 @@ namespace KSail.Commands.Up.Handlers;
 
 class KSailUpCommandHandler
 {
-  //TODO: readonly CiliumProvisioner _cniProvisioner = new();
   readonly SOPSLocalAgeSecretManager _secretManager = new();
   readonly DockerProvisioner _engineProvisioner;
   readonly FluxProvisioner _deploymentTool;
   readonly IKubernetesClusterProvisioner _clusterProvisioner;
-  readonly IKubernetesCNIProvisioner _cniProvisioner;
+  readonly CiliumProvisioner _cniProvisioner;
   readonly KSailCluster _config;
   readonly KSailLintCommandHandler _ksailLintCommandHandler;
 
@@ -41,6 +41,11 @@ class KSailUpCommandHandler
       (KSailEngineType.Docker, KSailKubernetesDistributionType.Native) => new KindProvisioner(),
       (KSailEngineType.Docker, KSailKubernetesDistributionType.K3s) => new K3dProvisioner(),
       _ => throw new NotSupportedException($"The distribution '{config.Spec.Project.Distribution}' is not supported.")
+    };
+    _cniProvisioner = config.Spec.Project.CNI switch
+    {
+      KSailCNIType.Cilium => new CiliumProvisioner(),
+      _ => throw new NotSupportedException($"The CNI '{config.Spec.Project.CNI}' is not supported.")
     };
     _deploymentTool = config.Spec.Project.DeploymentTool switch
     {

--- a/src/KSail/Commands/Up/KSailUpCommand.cs
+++ b/src/KSail/Commands/Up/KSailUpCommand.cs
@@ -36,6 +36,7 @@ sealed class KSailUpCommand : Command
     //AddOption(CLIOptions.LocalRegistry.LocalRegistryOption);
     AddOption(CLIOptions.Metadata.NameOption);
     //AddOption(CLIOptions.MirrorRegistries.MirrorRegistryOption);
+    AddOption(CLIOptions.Project.CNIOption);
     AddOption(CLIOptions.Project.DeploymentToolOption);
     AddOption(CLIOptions.Project.DistributionConfigPathOption);
     AddOption(CLIOptions.Project.DistributionOption);

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.5.3" />
     <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.2.14" />
     <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.2.14" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.3.0" />
     <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.2.14" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.0.34" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.0.34" />

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -21,14 +21,14 @@
 
   <ItemGroup>
     <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.1.4" />
-    <PackageReference Include="Devantler.KubernetesGenerator.CertManager" Version="1.5.3" />
-    <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.5.3" />
-    <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.5.3" />
-    <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.5.3" />
+    <PackageReference Include="Devantler.KubernetesGenerator.CertManager" Version="1.5.4" />
+    <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.5.4" />
+    <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.5.4" />
+    <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.5.4" />
     <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.3.1" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.2.14" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.3.0" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.2.14" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.3.1" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.3.1" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.3.1" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.0.34" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.0.34" />
     <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.3.5" />

--- a/src/KSail/Options/DeploymentTool/DeploymentToolFluxSourceUrlOption.cs
+++ b/src/KSail/Options/DeploymentTool/DeploymentToolFluxSourceUrlOption.cs
@@ -4,7 +4,7 @@ using KSail.Models;
 namespace KSail.Options.DeploymentTool;
 
 
-class DeploymentToolFluxSourceUrlOption(KSailCluster config) : Option<string>(
+class DeploymentToolFluxSourceUrlOption(KSailCluster config) : Option<Uri?>(
  ["--flux-source-url", "-fsu"],
   $"Flux source URL for reconciling GitOps resources. [default: {config.Spec.DeploymentTool.Flux.Source.Url}]"
 );

--- a/src/KSail/Options/Project/ProjectCNIOption.cs
+++ b/src/KSail/Options/Project/ProjectCNIOption.cs
@@ -1,0 +1,11 @@
+using System.CommandLine;
+using KSail.Models;
+using KSail.Models.Project.Enums;
+
+namespace KSail.Options.Project;
+
+class ProjectCNIOption(KSailCluster config) : Option<KSailCNIType?>(
+  ["--cni"],
+  $"The CNI to use. [default: {config.Spec.Project.CNI}]"
+)
+{ }

--- a/src/KSail/Options/Project/ProjectOptions.cs
+++ b/src/KSail/Options/Project/ProjectOptions.cs
@@ -7,6 +7,7 @@ namespace KSail.Options.Project;
 
 class ProjectOptions(KSailCluster config)
 {
+  public readonly ProjectCNIOption CNIOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
   public readonly ProjectConfigPathOption ConfigPathOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
   public readonly ProjectDeploymentToolOption DeploymentToolOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
   public readonly ProjectDistributionConfigPathOption DistributionConfigPathOption = new(config) { Arity = ArgumentArity.ZeroOrOne };

--- a/src/KSail/Utils/KSailClusterConfigLoader.cs
+++ b/src/KSail/Utils/KSailClusterConfigLoader.cs
@@ -26,21 +26,21 @@ static class KSailClusterConfigLoader
       context.ParseResult.GetValueForOption(CLIOptions.Project.DistributionOption)
     ).ConfigureAwait(false);
     // Metadata
-    config.UpdateConfig("Metadata.Name", context.ParseResult.GetValueForOption(CLIOptions.Metadata.NameOption));
+    config.UpdateConfig(c => c.Metadata.Name, context.ParseResult.GetValueForOption(CLIOptions.Metadata.NameOption));
 
     // CNI
     // TODO: Implement CNI CLIOptions
 
     // Connection
-    config.UpdateConfig("Spec.Connection.Context", context.ParseResult.GetValueForOption(CLIOptions.Connection.ContextOption));
-    config.UpdateConfig("Spec.Connection.Kubeconfig", context.ParseResult.GetValueForOption(CLIOptions.Connection.KubeconfigOption));
-    config.UpdateConfig("Spec.Connection.Timeout", context.ParseResult.GetValueForOption(CLIOptions.Connection.TimeoutOption));
+    config.UpdateConfig(c => c.Spec.Connection.Context, context.ParseResult.GetValueForOption(CLIOptions.Connection.ContextOption));
+    config.UpdateConfig(c => c.Spec.Connection.Kubeconfig, context.ParseResult.GetValueForOption(CLIOptions.Connection.KubeconfigOption));
+    config.UpdateConfig(c => c.Spec.Connection.Timeout, context.ParseResult.GetValueForOption(CLIOptions.Connection.TimeoutOption));
 
     // DeploymentTool
-    config.UpdateConfig("Spec.DeploymentTool.Flux.Source", context.ParseResult.GetValueForOption(CLIOptions.DeploymentTool.Flux.SourceOption));
+    config.UpdateConfig(c => c.Spec.DeploymentTool.Flux.Source.Url, context.ParseResult.GetValueForOption(CLIOptions.DeploymentTool.Flux.SourceOption));
 
     // Distribution
-    config.UpdateConfig("Spec.Distribution.ShowAllClustersInListings", context.ParseResult.GetValueForOption(CLIOptions.Distribution.ShowAllClustersInListings));
+    config.UpdateConfig(c => c.Spec.Distribution.ShowAllClustersInListings, context.ParseResult.GetValueForOption(CLIOptions.Distribution.ShowAllClustersInListings));
 
     // IngressController
     // TODO: Implement IngressController CLIOptions
@@ -52,28 +52,28 @@ static class KSailClusterConfigLoader
     // TODO: Implement MirrorRegistries CLIOptions
 
     // Project
-    config.UpdateConfig("Spec.Project.CNI", context.ParseResult.GetValueForOption(CLIOptions.Project.CNIOption));
-    config.UpdateConfig("Spec.Project.ConfigPath", context.ParseResult.GetValueForOption(CLIOptions.Project.ConfigPathOption));
-    config.UpdateConfig("Spec.Project.DeploymentTool", context.ParseResult.GetValueForOption(CLIOptions.Project.DeploymentToolOption));
-    config.UpdateConfig("Spec.Project.Distribution", context.ParseResult.GetValueForOption(CLIOptions.Project.DistributionOption));
-    config.UpdateConfig("Spec.Project.DistributionConfigPath", context.ParseResult.GetValueForOption(CLIOptions.Project.DistributionConfigPathOption));
-    config.UpdateConfig("Spec.Project.Editor", context.ParseResult.GetValueForOption(CLIOptions.Project.EditorOption));
-    config.UpdateConfig("Spec.Project.Engine", context.ParseResult.GetValueForOption(CLIOptions.Project.EngineOption));
-    config.UpdateConfig("Spec.Project.KustomizationPath", context.ParseResult.GetValueForOption(CLIOptions.Project.KustomizationPathOption));
-    config.UpdateConfig("Spec.Project.MirrorRegistries", context.ParseResult.GetValueForOption(CLIOptions.Project.MirrorRegistriesOption));
-    config.UpdateConfig("Spec.Project.SecretManager", context.ParseResult.GetValueForOption(CLIOptions.Project.SecretManagerOption));
+    config.UpdateConfig(c => c.Spec.Project.CNI, context.ParseResult.GetValueForOption(CLIOptions.Project.CNIOption));
+    config.UpdateConfig(c => c.Spec.Project.ConfigPath, context.ParseResult.GetValueForOption(CLIOptions.Project.ConfigPathOption));
+    config.UpdateConfig(c => c.Spec.Project.DeploymentTool, context.ParseResult.GetValueForOption(CLIOptions.Project.DeploymentToolOption));
+    config.UpdateConfig(c => c.Spec.Project.Distribution, context.ParseResult.GetValueForOption(CLIOptions.Project.DistributionOption));
+    config.UpdateConfig(c => c.Spec.Project.DistributionConfigPath, context.ParseResult.GetValueForOption(CLIOptions.Project.DistributionConfigPathOption));
+    config.UpdateConfig(c => c.Spec.Project.Editor, context.ParseResult.GetValueForOption(CLIOptions.Project.EditorOption));
+    config.UpdateConfig(c => c.Spec.Project.Engine, context.ParseResult.GetValueForOption(CLIOptions.Project.EngineOption));
+    config.UpdateConfig(c => c.Spec.Project.KustomizationPath, context.ParseResult.GetValueForOption(CLIOptions.Project.KustomizationPathOption));
+    config.UpdateConfig(c => c.Spec.Project.MirrorRegistries, context.ParseResult.GetValueForOption(CLIOptions.Project.MirrorRegistriesOption));
+    config.UpdateConfig(c => c.Spec.Project.SecretManager, context.ParseResult.GetValueForOption(CLIOptions.Project.SecretManagerOption));
 
     // SecretManager
-    config.UpdateConfig("Spec.SecretManager.SOPS.InPlace", context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.InPlaceOption));
-    config.UpdateConfig("Spec.SecretManager.SOPS.PublicKey", context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.PublicKeyOption));
-    config.UpdateConfig("Spec.SecretManager.SOPS.ShowAllKeysInListings", context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.ShowAllKeysInListingsOption));
-    config.UpdateConfig("Spec.SecretManager.SOPS.ShowPrivateKeysInListings", context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.ShowPrivateKeysInListingsOption));
+    config.UpdateConfig(c => c.Spec.SecretManager.SOPS.InPlace, context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.InPlaceOption));
+    config.UpdateConfig(c => c.Spec.SecretManager.SOPS.PublicKey, context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.PublicKeyOption));
+    config.UpdateConfig(c => c.Spec.SecretManager.SOPS.ShowAllKeysInListings, context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.ShowAllKeysInListingsOption));
+    config.UpdateConfig(c => c.Spec.SecretManager.SOPS.ShowPrivateKeysInListings, context.ParseResult.GetValueForOption(CLIOptions.SecretManager.SOPS.ShowPrivateKeysInListingsOption));
 
     // Validation
-    config.UpdateConfig("Spec.Validation.LintOnUp", context.ParseResult.GetValueForOption(CLIOptions.Validation.LintOnUpOption));
-    config.UpdateConfig("Spec.Validation.LintOnUpdate", context.ParseResult.GetValueForOption(CLIOptions.Validation.LintOnUpdateOption));
-    config.UpdateConfig("Spec.Validation.ReconcileOnUp", context.ParseResult.GetValueForOption(CLIOptions.Validation.ReconcileOnUpOption));
-    config.UpdateConfig("Spec.Validation.ReconcileOnUpdate", context.ParseResult.GetValueForOption(CLIOptions.Validation.ReconcileOnUpdateOption));
+    config.UpdateConfig(c => c.Spec.Validation.LintOnUp, context.ParseResult.GetValueForOption(CLIOptions.Validation.LintOnUpOption));
+    config.UpdateConfig(c => c.Spec.Validation.LintOnUpdate, context.ParseResult.GetValueForOption(CLIOptions.Validation.LintOnUpdateOption));
+    config.UpdateConfig(c => c.Spec.Validation.ReconcileOnUp, context.ParseResult.GetValueForOption(CLIOptions.Validation.ReconcileOnUpOption));
+    config.UpdateConfig(c => c.Spec.Validation.ReconcileOnUpdate, context.ParseResult.GetValueForOption(CLIOptions.Validation.ReconcileOnUpdateOption));
 
     // WaypointController
     // TODO: Implement WaypointController CLIOptions

--- a/src/KSail/Utils/KSailClusterConfigLoader.cs
+++ b/src/KSail/Utils/KSailClusterConfigLoader.cs
@@ -52,6 +52,7 @@ static class KSailClusterConfigLoader
     // TODO: Implement MirrorRegistries CLIOptions
 
     // Project
+    config.UpdateConfig("Spec.Project.CNI", context.ParseResult.GetValueForOption(CLIOptions.Project.CNIOption));
     config.UpdateConfig("Spec.Project.ConfigPath", context.ParseResult.GetValueForOption(CLIOptions.Project.ConfigPathOption));
     config.UpdateConfig("Spec.Project.DeploymentTool", context.ParseResult.GetValueForOption(CLIOptions.Project.DeploymentToolOption));
     config.UpdateConfig("Spec.Project.Distribution", context.ParseResult.GetValueForOption(CLIOptions.Project.DistributionOption));

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.full.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.full.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.minimal.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail-config.minimal.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -40,7 +40,7 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: Default,
+    CNI: {},
     IngressController: {},
     WaypointController: {},
     LocalRegistry: {

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -40,7 +40,7 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: Default,
+    CNI: {},
     IngressController: {},
     WaypointController: {},
     LocalRegistry: {

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -40,7 +40,7 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: Default,
+    CNI: {},
     IngressController: {},
     WaypointController: {},
     LocalRegistry: {

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -40,7 +40,7 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: Default,
+    CNI: {},
     IngressController: {},
     WaypointController: {},
     LocalRegistry: {

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -82,7 +82,8 @@
             "cni": {
               "description": "The CNI to use.",
               "enum": [
-                "Default"
+                "Default",
+                "Cilium"
               ]
             },
             "editor": {
@@ -174,7 +175,8 @@
         "cni": {
           "description": "The options for the CNI.",
           "enum": [
-            "Default"
+            "Default",
+            "Cilium"
           ]
         },
         "ingressController": {

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -174,10 +174,7 @@
         },
         "cni": {
           "description": "The options for the CNI.",
-          "enum": [
-            "Default",
-            "Cilium"
-          ]
+          "type": "object"
         },
         "ingressController": {
           "description": "The options for the Ingress Controller.",

--- a/tests/KSail.Tests/Commands/Gen/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Gen/ksail-config.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -6,6 +6,7 @@ Usage:
 
 Options:
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]
+  --cni <Cilium|Default>                            The CNI to use. [default: Default]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind-config.yaml]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. [default: Docker]

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.cs
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.cs
@@ -171,7 +171,8 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     Directory.SetCurrentDirectory(outputDir);
     int exitCode = await ksailCommand.InvokeAsync(["init",
       "--name", "ksail-advanced-native",
-      "--secret-manager", "sops"
+      "--secret-manager", "sops",
+      "--cni", "cilium"
     ]);
 
     //Assert
@@ -214,11 +215,13 @@ public partial class KSailInitCommandTests : IAsyncLifetime
     Directory.SetCurrentDirectory(outputDir);
     int exitCodeRun1 = await ksailCommand.InvokeAsync(["init",
       "--name", "ksail-advanced-native",
-      "--secret-manager", "sops"
+      "--secret-manager", "sops",
+      "--cni", "cilium"
     ]);
     int exitCodeRun2 = await ksailCommand.InvokeAsync(["init",
       "--name", "ksail-advanced-native",
-      "--secret-manager", "sops"
+      "--secret-manager", "sops",
+      "--cni", "cilium"
     ]);
 
     //Assert
@@ -264,13 +267,15 @@ public partial class KSailInitCommandTests : IAsyncLifetime
       "--name", "cluster1",
       "--kustomization", "k8s/cluster1",
       "--secret-manager", "sops",
-      "--distribution", "native"
+      "--distribution", "native",
+      "--cni", "cilium"
     ]);
     int exitCodeRun2 = await ksailCommand.InvokeAsync(["init",
       "--name", "cluster2",
       "--kustomization", "k8s/cluster2",
       "--secret-manager", "sops",
-      "--distribution", "k3s"
+      "--distribution", "k3s",
+      "--cni", "cilium"
     ]);
 
     //Assert

--- a/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/kind-config.yaml.verified.yaml
@@ -2,6 +2,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: cluster1
+networking:
+  disableDefaultCNI: true
 containerdConfigPatches:
 - >-
   [plugins."io.containerd.grpc.v1.cri".registry]

--- a/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/ksail-config.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/ksail-config.yaml.verified.yaml
@@ -14,7 +14,7 @@ spec:
     distribution: Native
     deploymentTool: Flux
     secretManager: SOPS
-    cni: Default
+    cni: Cilium
     editor: Nano
     engine: Docker
     kustomizationPath: k8s/cluster1

--- a/tests/KSail.Tests/Commands/Init/mixed-simple-multi/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-simple-multi/ksail-config.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Tests/Commands/Init/native-advanced-existing/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced-existing/kind-config.yaml.verified.yaml
@@ -2,6 +2,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: ksail-advanced-native
+networking:
+  disableDefaultCNI: true
 containerdConfigPatches:
 - >-
   [plugins."io.containerd.grpc.v1.cri".registry]

--- a/tests/KSail.Tests/Commands/Init/native-advanced-existing/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced-existing/ksail-config.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Tests/Commands/Init/native-advanced-existing/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced-existing/ksail-config.yaml.verified.yaml
@@ -14,7 +14,7 @@ spec:
     distribution: Native
     deploymentTool: Flux
     secretManager: SOPS
-    cni: Default
+    cni: Cilium
     editor: Nano
     engine: Docker
     kustomizationPath: k8s

--- a/tests/KSail.Tests/Commands/Init/native-advanced/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced/kind-config.yaml.verified.yaml
@@ -2,6 +2,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: ksail-advanced-native
+networking:
+  disableDefaultCNI: true
 containerdConfigPatches:
 - >-
   [plugins."io.containerd.grpc.v1.cri".registry]

--- a/tests/KSail.Tests/Commands/Init/native-advanced/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced/ksail-config.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Tests/Commands/Init/native-advanced/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced/ksail-config.yaml.verified.yaml
@@ -14,7 +14,7 @@ spec:
     distribution: Native
     deploymentTool: Flux
     secretManager: SOPS
-    cni: Default
+    cni: Cilium
     editor: Nano
     engine: Docker
     kustomizationPath: k8s

--- a/tests/KSail.Tests/Commands/Init/native-simple-existing/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-simple-existing/ksail-config.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Tests/Commands/Init/native-simple/ksail-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-simple/ksail-config.yaml.verified.yaml
@@ -30,7 +30,7 @@ spec:
       inPlace: false
       showAllKeysInListings: false
       showPrivateKeysInListings: false
-  cni: Default
+  cni: {}
   ingressController: {}
   waypointController: {}
   localRegistry:

--- a/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -9,6 +9,7 @@ Options:
   -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. [default: 5m]
   -fsu, --flux-source-url <flux-source-url>         Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]
+  --cni <Cilium|Default>                            The CNI to use. [default: Default]
   -dt, --deployment-tool <Flux>                     The Deployment tool to use for updating the state of the cluster. [default: Flux]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind-config.yaml]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]

--- a/tests/KSail.Tests/E2E/E2ETests.cs
+++ b/tests/KSail.Tests/E2E/E2ETests.cs
@@ -17,9 +17,9 @@ public class E2ETests : IAsyncLifetime
 
   [Theory]
   [InlineData(["init", "-d", "native"])]
-  [InlineData(["init", "--name", "ksail-advanced-native", "--distribution", "native", "--secret-manager", "sops"])]
+  [InlineData(["init", "--name", "ksail-advanced-native", "--distribution", "native", "--secret-manager", "sops", "--cni", "cilium"])]
   [InlineData(["init", "-d", "k3s"])]
-  [InlineData(["init", "--name", "ksail-advanced-k3s", "--distribution", "k3s", "--secret-manager", "sops"])]
+  [InlineData(["init", "--name", "ksail-advanced-k3s", "--distribution", "k3s", "--secret-manager", "sops", "--cni", "cilium"])]
   public async Task KSailUp_WithVariousConfigurations_Succeeds(params string[] initArgs)
   {
     // TODO: Add support for Windows and macOS in GitHub Runners when GitHub Actions runners support dind on Windows and macOS runners.


### PR DESCRIPTION
Introduce Cilium as an option for the Container Network Interface (CNI) in the cluster configuration, enabling users to select it instead of the distributions default option. Update relevant configurations and tests to accommodate this new CNI support.

- Closes #628 
- Closes #335