### PR TITLE
fix(config): add config path option and improve validation

### DIFF
--- a/src/KSail/Commands/Init/KSailInitCommand.cs
+++ b/src/KSail/Commands/Init/KSailInitCommand.cs
@@ -36,6 +36,7 @@ sealed class KSailInitCommand : Command
     AddOption(CLIOptions.Generator.OverwriteOption);
     AddOption(CLIOptions.Metadata.NameOption);
     AddOption(CLIOptions.Project.CNIOption);
+    AddOption(CLIOptions.Project.ConfigPathOption);
     AddOption(CLIOptions.Project.DistributionConfigPathOption);
     AddOption(CLIOptions.Project.DistributionOption);
     AddOption(CLIOptions.Project.EngineOption);

--- a/src/KSail/Commands/Lint/ConfigurationValidator.cs
+++ b/src/KSail/Commands/Lint/ConfigurationValidator.cs
@@ -28,7 +28,7 @@ internal class ConfigurationValidator(KSailCluster config)
     var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
     if (config.Spec.Project.Distribution == KSailKubernetesDistributionType.K3s)
     {
-      var distributionConfig = deserializer.Deserialize<K3dConfig>(await File.ReadAllTextAsync("k3d.yaml", cancellationToken).ConfigureAwait(false));
+      var distributionConfig = deserializer.Deserialize<K3dConfig>(await File.ReadAllTextAsync(config.Spec.Project.DistributionConfigPath, cancellationToken).ConfigureAwait(false));
 
       (isValid, message) = CheckClusterName(config.Metadata.Name, distributionConfig.Metadata.Name);
       if (!isValid)
@@ -44,7 +44,7 @@ internal class ConfigurationValidator(KSailCluster config)
     }
     else if (config.Spec.Project.Distribution == KSailKubernetesDistributionType.Native)
     {
-      var distributionConfig = deserializer.Deserialize<KindConfig>(await File.ReadAllTextAsync("kind.yaml", cancellationToken).ConfigureAwait(false));
+      var distributionConfig = deserializer.Deserialize<KindConfig>(await File.ReadAllTextAsync(config.Spec.Project.DistributionConfigPath, cancellationToken).ConfigureAwait(false));
       (isValid, message) = CheckClusterName(config.Metadata.Name, distributionConfig.Name);
       if (!isValid)
       {

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -8,6 +8,7 @@ Options:
   -o, --overwrite                                   Overwrite existing files. [default: False]
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]
   --cni <Cilium|Default>                            The CNI to use. [default: Default]
+  -c, --config <config>                             The path to the ksail configuration file. [default: ksail.yaml]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. [default: Docker]


### PR DESCRIPTION
Introduce a configuration path option in `KSailInitCommand` and enhance the configuration validation to utilize this path for loading distribution configurations.