### PR TITLE
fix: add kubeconfig option to ksail update

### DIFF
--- a/src/KSail.Models/Connection/KSailConnection.cs
+++ b/src/KSail.Models/Connection/KSailConnection.cs
@@ -7,7 +7,7 @@ public class KSailConnection
 {
 
   [Description("The path to the kubeconfig file. [default: ~/.kube/config]")]
-  public string Kubeconfig { get; set; } = "~/.kube/config";
+  public string Kubeconfig { get; set; } = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}/.kube/config";
 
 
   [Description("The kube context. [default: kind-ksail-default]")]

--- a/src/KSail/Commands/Init/Generators/SubGenerators/TemplateKustomizeGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/TemplateKustomizeGenerator.cs
@@ -1,6 +1,5 @@
 using Devantler.KubernetesGenerator.Kustomize;
 using Devantler.KubernetesGenerator.Kustomize.Models;
-using Docker.DotNet.Models;
 using KSail.Models;
 
 namespace KSail.Commands.Init.Generators.SubGenerators;
@@ -21,6 +20,11 @@ class TemplateKustomizeGenerator
 
   async Task GenerateKustomization(KSailCluster config, string outputPath, CancellationToken cancellationToken = default)
   {
+    FileAttributes attr = File.GetAttributes(outputPath);
+    if (!attr.HasFlag(FileAttributes.Directory))
+    {
+      throw new KSailException($"'{nameof(config.Spec.Project.KustomizationPath)}' must be a directory. It was '{outputPath}'.");
+    }
     outputPath = Path.Combine(outputPath, "kustomization.yaml");
     bool overwrite = config.Spec.Generator.Overwrite;
     Console.WriteLine(File.Exists(outputPath) ? (overwrite ?

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -288,7 +288,7 @@ class KSailUpCommandHandler
   {
     Console.WriteLine($"🔼 Bootstrapping {config.Spec.Project.DeploymentTool}");
     using var resourceProvisioner = new KubernetesResourceProvisioner(config.Spec.Connection.Kubeconfig, config.Spec.Connection.Context);
-    Console.WriteLine($"► creating 'flux-system' namespace (--context={config.Spec.Connection.Context})");
+    Console.WriteLine($"► creating 'flux-system' namespace");
     await CreateFluxSystemNamespace(resourceProvisioner, cancellationToken).ConfigureAwait(false);
 
     string scheme = config.Spec.DeploymentTool.Flux.Source.Url.Scheme;
@@ -326,7 +326,7 @@ class KSailUpCommandHandler
     if (config.Spec.Project.SecretManager == KSailSecretManagerType.SOPS)
     {
       Console.WriteLine("🔼 Bootstrapping SOPS secret manager");
-      Console.WriteLine($"► creating 'flux-system' namespace (--context={config.Spec.Connection.Context})");
+      Console.WriteLine($"► creating 'flux-system' namespace");
       await CreateFluxSystemNamespace(resourceProvisioner, cancellationToken).ConfigureAwait(false);
 
       var sopsConfig = await SopsConfigLoader.LoadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -44,13 +44,13 @@ class KSailUpCommandHandler
     };
     _cniProvisioner = config.Spec.Project.CNI switch
     {
-      KSailCNIType.Cilium => new CiliumProvisioner(),
+      KSailCNIType.Cilium => new CiliumProvisioner(config.Spec.Connection.Kubeconfig, config.Spec.Connection.Context),
       KSailCNIType.Default => null,
       _ => throw new NotSupportedException($"The CNI '{config.Spec.Project.CNI}' is not supported.")
     };
     _deploymentTool = config.Spec.Project.DeploymentTool switch
     {
-      KSailDeploymentToolType.Flux => new FluxProvisioner(config.Spec.Connection.Context),
+      KSailDeploymentToolType.Flux => new FluxProvisioner(config.Spec.Connection.Kubeconfig, config.Spec.Connection.Context),
       _ => throw new NotSupportedException($"The Deployment tool '{config.Spec.Project.DeploymentTool}' is not supported.")
     };
     _config = config;
@@ -287,7 +287,7 @@ class KSailUpCommandHandler
   async Task BootstrapDeploymentTool(KSailCluster config, CancellationToken cancellationToken = default)
   {
     Console.WriteLine($"🔼 Bootstrapping {config.Spec.Project.DeploymentTool}");
-    using var resourceProvisioner = new KubernetesResourceProvisioner(config.Spec.Connection.Context);
+    using var resourceProvisioner = new KubernetesResourceProvisioner(config.Spec.Connection.Kubeconfig, config.Spec.Connection.Context);
     Console.WriteLine($"► creating 'flux-system' namespace (--context={config.Spec.Connection.Context})");
     await CreateFluxSystemNamespace(resourceProvisioner, cancellationToken).ConfigureAwait(false);
 
@@ -322,7 +322,7 @@ class KSailUpCommandHandler
 
   async Task BootstrapSecretManager(KSailCluster config, CancellationToken cancellationToken)
   {
-    using var resourceProvisioner = new KubernetesResourceProvisioner(config.Spec.Connection.Context);
+    using var resourceProvisioner = new KubernetesResourceProvisioner(config.Spec.Connection.Kubeconfig, config.Spec.Connection.Context);
     if (config.Spec.Project.SecretManager == KSailSecretManagerType.SOPS)
     {
       Console.WriteLine("🔼 Bootstrapping SOPS secret manager");

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -315,7 +315,7 @@ class KSailUpCommandHandler
     }
 
     Console.WriteLine($"⬡ Installing {config.Spec.Project.CNI} CNI");
-    await _cniProvisioner.InstallAsync(config.Spec.Connection.Context, cancellationToken).ConfigureAwait(false);
+    await _cniProvisioner.InstallAsync(cancellationToken).ConfigureAwait(false);
     Console.WriteLine("✔ Cilium CNI installed");
     Console.WriteLine();
   }

--- a/src/KSail/Commands/Up/KSailUpCommand.cs
+++ b/src/KSail/Commands/Up/KSailUpCommand.cs
@@ -31,6 +31,7 @@ sealed class KSailUpCommand : Command
   void AddOptions()
   {
     AddOption(CLIOptions.Connection.ContextOption);
+    AddOption(CLIOptions.Connection.KubeconfigOption);
     AddOption(CLIOptions.Connection.TimeoutOption);
     AddOption(CLIOptions.DeploymentTool.Flux.SourceOption);
     //AddOption(CLIOptions.LocalRegistry.LocalRegistryOption);

--- a/src/KSail/Commands/Update/Handlers/KSailUpdateCommandHandler.cs
+++ b/src/KSail/Commands/Update/Handlers/KSailUpdateCommandHandler.cs
@@ -15,7 +15,7 @@ class KSailUpdateCommandHandler
     _ksailLintCommandHandler = new KSailLintCommandHandler(config);
     _deploymentTool = config.Spec.Project.DeploymentTool switch
     {
-      KSailDeploymentToolType.Flux => new FluxProvisioner(config.Spec.Connection.Context),
+      KSailDeploymentToolType.Flux => new FluxProvisioner(config.Spec.Connection.Kubeconfig, config.Spec.Connection.Context),
       _ => throw new NotSupportedException($"The deployment tool '{config.Spec.Project.DeploymentTool}' is not supported.")
     };
     _config = config;

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -32,6 +32,8 @@ sealed class KSailUpdateCommand : Command
 
   void AddOptions()
   {
+    AddOption(CLIOptions.Connection.ContextOption);
+    AddOption(CLIOptions.Connection.KubeconfigOption);
     AddOption(CLIOptions.Project.KustomizationPathOption);
     AddOption(CLIOptions.Validation.LintOnUpdateOption);
     AddOption(CLIOptions.Validation.ReconcileOnUpdateOption);

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -25,10 +25,10 @@
     <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.5.15" />
     <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.5.15" />
     <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.5.15" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.4.0" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.4.0" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.4.0" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.4.0" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.5.0" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.5.0" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.5.0" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.5.0" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.1.2" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.1.2" />
     <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.3.6" />

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -25,10 +25,10 @@
     <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.5.15" />
     <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.5.15" />
     <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.5.15" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.3.3" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.3.3" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.3.3" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.3.3" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.4.0" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.4.0" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.4.0" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.4.0" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.1.2" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.1.2" />
     <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.3.6" />

--- a/src/KSail/Options/Project/ProjectKustomizationPathOption.cs
+++ b/src/KSail/Options/Project/ProjectKustomizationPathOption.cs
@@ -4,7 +4,7 @@ using KSail.Models;
 namespace KSail.Options.Project;
 
 class ProjectKustomizationPathOption(KSailCluster config) : Option<string?>(
-  ["--kustomization", "-k"],
+  ["--kustomization-path", "-kp"],
   $"The path to the root kustomization directory. [default: {config.Spec.Project.KustomizationPath}]"
 )
 {

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -6,7 +6,7 @@
   },
   Spec: {
     Connection: {
-      Kubeconfig: ~/.kube/config,
+      Kubeconfig: {UserProfile}/.kube/config,
       Context: k3d-ksail-default,
       Timeout: 5m
     },

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -6,7 +6,7 @@
   },
   Spec: {
     Connection: {
-      Kubeconfig: ~/.kube/config,
+      Kubeconfig: {UserProfile}/.kube/config,
       Context: k3d-my-cluster,
       Timeout: 5m
     },

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -6,7 +6,7 @@
   },
   Spec: {
     Connection: {
-      Kubeconfig: ~/.kube/config,
+      Kubeconfig: {UserProfile}/.kube/config,
       Context: kind-my-cluster,
       Timeout: 5m
     },

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -6,7 +6,7 @@
   },
   Spec: {
     Connection: {
-      Kubeconfig: ~/.kube/config,
+      Kubeconfig: {UserProfile}/.kube/config,
       Context: kind-ksail-default,
       Timeout: 5m
     },

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -12,7 +12,7 @@ Options:
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. [default: Docker]
-  -k, --kustomization <kustomization>               The path to the root kustomization directory. [default: k8s]
+  -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
   -mr, --mirror-registries                          Enable mirror registries. [default: True]
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
   -?, -h, --help                                    Show help and usage information

--- a/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.KSailLintHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Lint/KSailLintCommandTests.KSailLintHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,7 +5,7 @@ Usage:
   testhost lint [options]
 
 Options:
-  -k, --kustomization <kustomization>  The path to the root kustomization directory. [default: k8s]
-  -?, -h, --help                       Show help and usage information
+  -kp, --kustomization-path <kustomization-path>  The path to the root kustomization directory. [default: k8s]
+  -?, -h, --help                                  Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -6,6 +6,7 @@ Usage:
 
 Options:
   -c, --context <context>                           The kubernetes context to use. [default: kind-ksail-default]
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. [default: ~/.kube/config]
   -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. [default: 5m]
   -fsu, --flux-source-url <flux-source-url>         Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]
@@ -14,7 +15,7 @@ Options:
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. [default: Docker]
-  -k, --kustomization <kustomization>               The path to the root kustomization directory. [default: k8s]
+  -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
   -mr, --mirror-registries                          Enable mirror registries. [default: True]
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
   -l, --lint                                        Lit manifests. [default: True'

--- a/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -6,7 +6,7 @@ Usage:
 
 Options:
   -c, --context <context>                           The kubernetes context to use. [default: kind-ksail-default]
-  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. [default: ~/.kube/config]
+  -k, --kubeconfig <kubeconfig>                     Path to kubeconfig file. [default: {UserProfile}/.kube/config]
   -t, --timeout <timeout>                           The time to wait for each kustomization to become ready. [default: 5m]
   -fsu, --flux-source-url <flux-source-url>         Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]

--- a/tests/KSail.Tests/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -6,7 +6,7 @@ Usage:
 
 Options:
   -c, --context <context>                         The kubernetes context to use. [default: kind-ksail-default]
-  -k, --kubeconfig <kubeconfig>                   Path to kubeconfig file. [default: ~/.kube/config]
+  -k, --kubeconfig <kubeconfig>                   Path to kubeconfig file. [default: {UserProfile}/.kube/config]
   -kp, --kustomization-path <kustomization-path>  The path to the root kustomization directory. [default: k8s]
   -l, --lint                                      Lit manifests. [default: True]
   -r, --reconcile                                 Reconcile manifests. [default: True]

--- a/tests/KSail.Tests/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,9 +5,11 @@ Usage:
   testhost update [options]
 
 Options:
-  -k, --kustomization <kustomization>  The path to the root kustomization directory. [default: k8s]
-  -l, --lint                           Lit manifests. [default: True]
-  -r, --reconcile                      Reconcile manifests. [default: True]
-  -?, -h, --help                       Show help and usage information
+  -c, --context <context>                         The kubernetes context to use. [default: kind-ksail-default]
+  -k, --kubeconfig <kubeconfig>                   Path to kubeconfig file. [default: ~/.kube/config]
+  -kp, --kustomization-path <kustomization-path>  The path to the root kustomization directory. [default: k8s]
+  -l, --lint                                      Lit manifests. [default: True]
+  -r, --reconcile                                 Reconcile manifests. [default: True]
+  -?, -h, --help                                  Show help and usage information
 
 


### PR DESCRIPTION
Introduce a kubeconfig option for the ksail update command to enhance configuration flexibility. This change allows the FluxProvisioner to utilize the kubeconfig directly from the connection settings.