### PR TITLE
feat(mirror-registry): support multiple proxies per mirror registry

### DIFF
--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -242,32 +242,38 @@
               "null"
             ],
             "properties": {
-              "proxy": {
+              "proxies": {
                 "description": "A proxy for the registry to use to proxy and cache images.",
-                "type": "object",
-                "properties": {
-                  "url": {
-                    "description": "The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]",
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "username": {
-                    "description": "The username to authenticate with the upstream registry. [default: null]",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "password": {
-                    "description": "The password to authenticate with the upstream registry. [default: null]",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "insecure": {
-                    "description": "Connect to the upstream registry over HTTPS. [default: false]",
-                    "type": "boolean"
+                "type": "array",
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "url": {
+                      "description": "The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]",
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "username": {
+                      "description": "The username to authenticate with the upstream registry. [default: null]",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "password": {
+                      "description": "The password to authenticate with the upstream registry. [default: null]",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "insecure": {
+                      "description": "Connect to the upstream registry over HTTPS. [default: false]",
+                      "type": "boolean"
+                    }
                   }
                 }
               },

--- a/src/KSail.Models/KSailClusterSpec.cs
+++ b/src/KSail.Models/KSailClusterSpec.cs
@@ -53,12 +53,12 @@ public class KSailClusterSpec
 
   [Description("The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]")]
   public IEnumerable<KSailMirrorRegistry> MirrorRegistries { get; set; } = [
-    new KSailMirrorRegistry { Name = "registry.k8s.io-proxy", HostPort = 5556, Proxy = new KSailMirrorRegistryProxy { Url = new Uri("https://registry.k8s.io") } },
-    new KSailMirrorRegistry { Name = "docker.io-proxy", HostPort = 5557,  Proxy = new KSailMirrorRegistryProxy { Url = new Uri("https://registry-1.docker.io") } },
-    new KSailMirrorRegistry { Name = "ghcr.io-proxy", HostPort = 5558, Proxy = new KSailMirrorRegistryProxy { Url = new Uri("https://ghcr.io") } },
-    new KSailMirrorRegistry { Name = "gcr.io-proxy", HostPort = 5559, Proxy = new KSailMirrorRegistryProxy { Url = new Uri("https://gcr.io") } },
-    new KSailMirrorRegistry { Name = "mcr.microsoft.com-proxy", HostPort = 5560, Proxy = new KSailMirrorRegistryProxy { Url = new Uri("https://mcr.microsoft.com") } },
-    new KSailMirrorRegistry { Name = "quay.io-proxy", HostPort = 5561, Proxy = new KSailMirrorRegistryProxy { Url = new Uri("https://quay.io") } },
+    new KSailMirrorRegistry { Name = "registry.k8s.io-proxy", HostPort = 5556, Proxies = [new KSailMirrorRegistryProxy { Url = new Uri("https://registry.k8s.io") }] },
+    new KSailMirrorRegistry { Name = "docker.io-proxy", HostPort = 5557,  Proxies = [new KSailMirrorRegistryProxy { Url = new Uri("https://registry-1.docker.io") }] },
+    new KSailMirrorRegistry { Name = "ghcr.io-proxy", HostPort = 5558, Proxies = [new KSailMirrorRegistryProxy { Url = new Uri("https://ghcr.io") }] },
+    new KSailMirrorRegistry { Name = "gcr.io-proxy", HostPort = 5559, Proxies = [new KSailMirrorRegistryProxy { Url = new Uri("https://gcr.io") }] },
+    new KSailMirrorRegistry { Name = "mcr.microsoft.com-proxy", HostPort = 5560, Proxies = [new KSailMirrorRegistryProxy { Url = new Uri("https://mcr.microsoft.com") }] },
+    new KSailMirrorRegistry { Name = "quay.io-proxy", HostPort = 5561, Proxies = [new KSailMirrorRegistryProxy { Url = new Uri("https://quay.io") }] },
   ];
 
   [Description("Options for validating the KSail cluster.")]

--- a/src/KSail.Models/MirrorRegistry/MirrorRegistry.cs
+++ b/src/KSail.Models/MirrorRegistry/MirrorRegistry.cs
@@ -8,5 +8,5 @@ public class KSailMirrorRegistry : KSailLocalRegistry
 {
 
   [Description("A proxy for the registry to use to proxy and cache images.")]
-  public KSailMirrorRegistryProxy Proxy { get; set; } = new();
+  public IEnumerable<KSailMirrorRegistryProxy> Proxies { get; set; } = [];
 }

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
@@ -22,33 +22,33 @@ spec:
   localRegistry: {}
   generator: {}
   mirrorRegistries:
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: docker.io-proxy
     hostPort: 5557
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: gcr.io-proxy
     hostPort: 5559
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: quay.io-proxy
     hostPort: 5561

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
@@ -18,33 +18,33 @@ spec:
   localRegistry: {}
   generator: {}
   mirrorRegistries:
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: docker.io-proxy
     hostPort: 5557
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: gcr.io-proxy
     hostPort: 5559
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: quay.io-proxy
     hostPort: 5561

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -55,12 +55,14 @@
     },
     MirrorRegistries: [
       {
-        Proxy: {
-          Url: https://registry.k8s.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry.k8s.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
         Username: null,
@@ -68,12 +70,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://registry-1.docker.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry-1.docker.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: docker.io-proxy,
         HostPort: 5557,
         Username: null,
@@ -81,12 +85,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://ghcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://ghcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: ghcr.io-proxy,
         HostPort: 5558,
         Username: null,
@@ -94,12 +100,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://gcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://gcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: gcr.io-proxy,
         HostPort: 5559,
         Username: null,
@@ -107,12 +115,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://mcr.microsoft.com,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://mcr.microsoft.com,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
         Username: null,
@@ -120,12 +130,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://quay.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://quay.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: quay.io-proxy,
         HostPort: 5561,
         Username: null,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -55,12 +55,14 @@
     },
     MirrorRegistries: [
       {
-        Proxy: {
-          Url: https://registry.k8s.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry.k8s.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
         Username: null,
@@ -68,12 +70,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://registry-1.docker.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry-1.docker.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: docker.io-proxy,
         HostPort: 5557,
         Username: null,
@@ -81,12 +85,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://ghcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://ghcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: ghcr.io-proxy,
         HostPort: 5558,
         Username: null,
@@ -94,12 +100,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://gcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://gcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: gcr.io-proxy,
         HostPort: 5559,
         Username: null,
@@ -107,12 +115,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://mcr.microsoft.com,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://mcr.microsoft.com,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
         Username: null,
@@ -120,12 +130,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://quay.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://quay.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: quay.io-proxy,
         HostPort: 5561,
         Username: null,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -55,12 +55,14 @@
     },
     MirrorRegistries: [
       {
-        Proxy: {
-          Url: https://registry.k8s.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry.k8s.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
         Username: null,
@@ -68,12 +70,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://registry-1.docker.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry-1.docker.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: docker.io-proxy,
         HostPort: 5557,
         Username: null,
@@ -81,12 +85,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://ghcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://ghcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: ghcr.io-proxy,
         HostPort: 5558,
         Username: null,
@@ -94,12 +100,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://gcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://gcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: gcr.io-proxy,
         HostPort: 5559,
         Username: null,
@@ -107,12 +115,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://mcr.microsoft.com,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://mcr.microsoft.com,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
         Username: null,
@@ -120,12 +130,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://quay.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://quay.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: quay.io-proxy,
         HostPort: 5561,
         Username: null,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -55,12 +55,14 @@
     },
     MirrorRegistries: [
       {
-        Proxy: {
-          Url: https://registry.k8s.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry.k8s.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
         Username: null,
@@ -68,12 +70,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://registry-1.docker.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://registry-1.docker.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: docker.io-proxy,
         HostPort: 5557,
         Username: null,
@@ -81,12 +85,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://ghcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://ghcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: ghcr.io-proxy,
         HostPort: 5558,
         Username: null,
@@ -94,12 +100,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://gcr.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://gcr.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: gcr.io-proxy,
         HostPort: 5559,
         Username: null,
@@ -107,12 +115,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://mcr.microsoft.com,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://mcr.microsoft.com,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
         Username: null,
@@ -120,12 +130,14 @@
         Provider: Docker
       },
       {
-        Proxy: {
-          Url: https://quay.io,
-          Username: null,
-          Password: null,
-          Insecure: false
-        },
+        Proxies: [
+          {
+            Url: https://quay.io,
+            Username: null,
+            Password: null,
+            Insecure: false
+          }
+        ],
         Name: quay.io-proxy,
         HostPort: 5561,
         Username: null,

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -242,32 +242,38 @@
               "null"
             ],
             "properties": {
-              "proxy": {
+              "proxies": {
                 "description": "A proxy for the registry to use to proxy and cache images.",
-                "type": "object",
-                "properties": {
-                  "url": {
-                    "description": "The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]",
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "username": {
-                    "description": "The username to authenticate with the upstream registry. [default: null]",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "password": {
-                    "description": "The password to authenticate with the upstream registry. [default: null]",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "insecure": {
-                    "description": "Connect to the upstream registry over HTTPS. [default: false]",
-                    "type": "boolean"
+                "type": "array",
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "url": {
+                      "description": "The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]",
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "username": {
+                      "description": "The username to authenticate with the upstream registry. [default: null]",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "password": {
+                      "description": "The password to authenticate with the upstream registry. [default: null]",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "insecure": {
+                      "description": "Connect to the upstream registry over HTTPS. [default: false]",
+                      "type": "boolean"
+                    }
                   }
                 }
               },

--- a/tests/KSail.Tests/Commands/Gen/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Gen/ksail.yaml.verified.yaml
@@ -18,33 +18,33 @@ spec:
   localRegistry: {}
   generator: {}
   mirrorRegistries:
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: docker.io-proxy
     hostPort: 5557
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: gcr.io-proxy
     hostPort: 5559
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: quay.io-proxy
     hostPort: 5561

--- a/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
@@ -24,33 +24,33 @@ spec:
   localRegistry: {}
   generator: {}
   mirrorRegistries:
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: docker.io-proxy
     hostPort: 5557
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: gcr.io-proxy
     hostPort: 5559
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: quay.io-proxy
     hostPort: 5561

--- a/tests/KSail.Tests/Commands/Init/ksail-init-k3s-simple/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-k3s-simple/ksail.yaml.verified.yaml
@@ -22,33 +22,33 @@ spec:
   localRegistry: {}
   generator: {}
   mirrorRegistries:
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: docker.io-proxy
     hostPort: 5557
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: gcr.io-proxy
     hostPort: 5559
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: quay.io-proxy
     hostPort: 5561

--- a/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
@@ -21,33 +21,33 @@ spec:
   localRegistry: {}
   generator: {}
   mirrorRegistries:
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: docker.io-proxy
     hostPort: 5557
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: gcr.io-proxy
     hostPort: 5559
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: quay.io-proxy
     hostPort: 5561

--- a/tests/KSail.Tests/Commands/Init/ksail-init-native-simple/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-native-simple/ksail.yaml.verified.yaml
@@ -18,33 +18,33 @@ spec:
   localRegistry: {}
   generator: {}
   mirrorRegistries:
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: docker.io-proxy
     hostPort: 5557
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: gcr.io-proxy
     hostPort: 5559
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
-  - proxy:
-      url: <url>
+  - proxies:
+    - url: <url>
       insecure: false
     name: quay.io-proxy
     hostPort: 5561


### PR DESCRIPTION
Change the Proxy property to Proxies to allow multiple proxy configurations for the registry. Update related data structures and documentation accordingly.

This is in preperation for supporting Zot as the mirror registry in Docker, and it fits well with remote registries like Harbor, so it will become the default.