### PR TITLE
Refactor: remove unused CNI, Ingress Controller, and Waypoint Controller options

### DIFF
--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -177,18 +177,6 @@
             }
           }
         },
-        "cni": {
-          "description": "The options for the CNI.",
-          "type": "object"
-        },
-        "ingressController": {
-          "description": "The options for the Ingress Controller.",
-          "type": "object"
-        },
-        "waypointController": {
-          "description": "The options for the Waypoint Controller.",
-          "type": "object"
-        },
         "localRegistry": {
           "description": "The local registry for storing deployment artifacts.",
           "type": "object",

--- a/src/KSail.Models/KSailClusterSpec.cs
+++ b/src/KSail.Models/KSailClusterSpec.cs
@@ -35,15 +35,15 @@ public class KSailClusterSpec
   [Description("The options for the Secret Manager.")]
   public KSailSecretManager SecretManager { get; set; } = new();
 
-  [Description("The options for the CNI.")]
-  [YamlMember(Alias = "cni")]
-  public KSailCNI CNI { get; set; } = new();
+  // [Description("The options for the CNI.")]
+  // [YamlMember(Alias = "cni")]
+  // public KSailCNI CNI { get; set; } = new();
 
-  [Description("The options for the Ingress Controller.")]
-  public KSailIngressController IngressController { get; set; } = new();
+  // [Description("The options for the Ingress Controller.")]
+  // public KSailIngressController IngressController { get; set; } = new();
 
-  [Description("The options for the Waypoint Controller.")]
-  public KSailWaypointController WaypointController { get; set; } = new();
+  // [Description("The options for the Waypoint Controller.")]
+  // public KSailWaypointController WaypointController { get; set; } = new();
 
   [Description("The local registry for storing deployment artifacts.")]
   public KSailLocalRegistry LocalRegistry { get; set; } = new();

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
@@ -16,9 +16,6 @@ spec:
   distribution: {}
   secretManager:
     sops: {}
-  cni: {}
-  ingressController: {}
-  waypointController: {}
   localRegistry: {}
   generator: {}
   mirrorRegistries:

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
@@ -12,9 +12,6 @@ spec:
   distribution: {}
   secretManager:
     sops: {}
-  cni: {}
-  ingressController: {}
-  waypointController: {}
   localRegistry: {}
   generator: {}
   mirrorRegistries:

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -40,9 +40,6 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: {},
-    IngressController: {},
-    WaypointController: {},
     LocalRegistry: {
       Name: ksail-registry,
       HostPort: 5555,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -40,9 +40,6 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: {},
-    IngressController: {},
-    WaypointController: {},
     LocalRegistry: {
       Name: ksail-registry,
       HostPort: 5555,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -40,9 +40,6 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: {},
-    IngressController: {},
-    WaypointController: {},
     LocalRegistry: {
       Name: ksail-registry,
       HostPort: 5555,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -40,9 +40,6 @@
         ShowPrivateKeysInListings: false
       }
     },
-    CNI: {},
-    IngressController: {},
-    WaypointController: {},
     LocalRegistry: {
       Name: ksail-registry,
       HostPort: 5555,

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -177,18 +177,6 @@
             }
           }
         },
-        "cni": {
-          "description": "The options for the CNI.",
-          "type": "object"
-        },
-        "ingressController": {
-          "description": "The options for the Ingress Controller.",
-          "type": "object"
-        },
-        "waypointController": {
-          "description": "The options for the Waypoint Controller.",
-          "type": "object"
-        },
         "localRegistry": {
           "description": "The local registry for storing deployment artifacts.",
           "type": "object",

--- a/tests/KSail.Tests/Commands/Gen/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Gen/ksail.yaml.verified.yaml
@@ -12,9 +12,6 @@ spec:
   distribution: {}
   secretManager:
     sops: {}
-  cni: {}
-  ingressController: {}
-  waypointController: {}
   localRegistry: {}
   generator: {}
   mirrorRegistries:

--- a/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
@@ -18,9 +18,6 @@ spec:
   distribution: {}
   secretManager:
     sops: {}
-  cni: {}
-  ingressController: {}
-  waypointController: {}
   localRegistry: {}
   generator: {}
   mirrorRegistries:

--- a/tests/KSail.Tests/Commands/Init/ksail-init-k3s-simple/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-k3s-simple/ksail.yaml.verified.yaml
@@ -16,9 +16,6 @@ spec:
   distribution: {}
   secretManager:
     sops: {}
-  cni: {}
-  ingressController: {}
-  waypointController: {}
   localRegistry: {}
   generator: {}
   mirrorRegistries:

--- a/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
@@ -15,9 +15,6 @@ spec:
   distribution: {}
   secretManager:
     sops: {}
-  cni: {}
-  ingressController: {}
-  waypointController: {}
   localRegistry: {}
   generator: {}
   mirrorRegistries:

--- a/tests/KSail.Tests/Commands/Init/ksail-init-native-simple/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-native-simple/ksail.yaml.verified.yaml
@@ -12,9 +12,6 @@ spec:
   distribution: {}
   secretManager:
     sops: {}
-  cni: {}
-  ingressController: {}
-  waypointController: {}
   localRegistry: {}
   generator: {}
   mirrorRegistries:


### PR DESCRIPTION
Eliminate unused options from the schema and models to streamline the codebase and improve maintainability.