### PR TITLE
fix: allow 'insecure' option to be nullable in mirror registry configuration

### DIFF
--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -267,7 +267,10 @@
                   },
                   "insecure": {
                     "description": "Connect to the upstream registry over HTTPS. [default: false]",
-                    "type": "boolean"
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
                   }
                 }
               },

--- a/src/KSail.Models/MirrorRegistry/MirrorRegistryProxy.cs
+++ b/src/KSail.Models/MirrorRegistry/MirrorRegistryProxy.cs
@@ -17,5 +17,5 @@ public class KSailMirrorRegistryProxy
 
 
   [Description("Connect to the upstream registry over HTTPS. [default: false]")]
-  public bool Insecure { get; set; }
+  public bool? Insecure { get; set; }
 }

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
@@ -24,32 +24,26 @@ spec:
   mirrorRegistries:
   - proxy:
       url: <url>
-      insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
   - proxy:
       url: <url>
-      insecure: false
     name: docker.io-proxy
     hostPort: 5557
   - proxy:
       url: <url>
-      insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
   - proxy:
       url: <url>
-      insecure: false
     name: gcr.io-proxy
     hostPort: 5559
   - proxy:
       url: <url>
-      insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
   - proxy:
       url: <url>
-      insecure: false
     name: quay.io-proxy
     hostPort: 5561
   validation: {}

--- a/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
@@ -20,32 +20,26 @@ spec:
   mirrorRegistries:
   - proxy:
       url: <url>
-      insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
   - proxy:
       url: <url>
-      insecure: false
     name: docker.io-proxy
     hostPort: 5557
   - proxy:
       url: <url>
-      insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
   - proxy:
       url: <url>
-      insecure: false
     name: gcr.io-proxy
     hostPort: 5559
   - proxy:
       url: <url>
-      insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
   - proxy:
       url: <url>
-      insecure: false
     name: quay.io-proxy
     hostPort: 5561
   validation: {}

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -59,7 +59,7 @@
           Url: https://registry.k8s.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
@@ -72,7 +72,7 @@
           Url: https://registry-1.docker.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: docker.io-proxy,
         HostPort: 5557,
@@ -85,7 +85,7 @@
           Url: https://ghcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: ghcr.io-proxy,
         HostPort: 5558,
@@ -98,7 +98,7 @@
           Url: https://gcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: gcr.io-proxy,
         HostPort: 5559,
@@ -111,7 +111,7 @@
           Url: https://mcr.microsoft.com,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
@@ -124,7 +124,7 @@
           Url: https://quay.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: quay.io-proxy,
         HostPort: 5561,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -59,7 +59,7 @@
           Url: https://registry.k8s.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
@@ -72,7 +72,7 @@
           Url: https://registry-1.docker.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: docker.io-proxy,
         HostPort: 5557,
@@ -85,7 +85,7 @@
           Url: https://ghcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: ghcr.io-proxy,
         HostPort: 5558,
@@ -98,7 +98,7 @@
           Url: https://gcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: gcr.io-proxy,
         HostPort: 5559,
@@ -111,7 +111,7 @@
           Url: https://mcr.microsoft.com,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
@@ -124,7 +124,7 @@
           Url: https://quay.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: quay.io-proxy,
         HostPort: 5561,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -59,7 +59,7 @@
           Url: https://registry.k8s.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
@@ -72,7 +72,7 @@
           Url: https://registry-1.docker.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: docker.io-proxy,
         HostPort: 5557,
@@ -85,7 +85,7 @@
           Url: https://ghcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: ghcr.io-proxy,
         HostPort: 5558,
@@ -98,7 +98,7 @@
           Url: https://gcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: gcr.io-proxy,
         HostPort: 5559,
@@ -111,7 +111,7 @@
           Url: https://mcr.microsoft.com,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
@@ -124,7 +124,7 @@
           Url: https://quay.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: quay.io-proxy,
         HostPort: 5561,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -59,7 +59,7 @@
           Url: https://registry.k8s.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: registry.k8s.io-proxy,
         HostPort: 5556,
@@ -72,7 +72,7 @@
           Url: https://registry-1.docker.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: docker.io-proxy,
         HostPort: 5557,
@@ -85,7 +85,7 @@
           Url: https://ghcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: ghcr.io-proxy,
         HostPort: 5558,
@@ -98,7 +98,7 @@
           Url: https://gcr.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: gcr.io-proxy,
         HostPort: 5559,
@@ -111,7 +111,7 @@
           Url: https://mcr.microsoft.com,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: mcr.microsoft.com-proxy,
         HostPort: 5560,
@@ -124,7 +124,7 @@
           Url: https://quay.io,
           Username: null,
           Password: null,
-          Insecure: false
+          Insecure: null
         },
         Name: quay.io-proxy,
         HostPort: 5561,

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -267,7 +267,10 @@
                   },
                   "insecure": {
                     "description": "Connect to the upstream registry over HTTPS. [default: false]",
-                    "type": "boolean"
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
                   }
                 }
               },

--- a/tests/KSail.Tests/Commands/Gen/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Gen/ksail.yaml.verified.yaml
@@ -20,32 +20,26 @@ spec:
   mirrorRegistries:
   - proxy:
       url: <url>
-      insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
   - proxy:
       url: <url>
-      insecure: false
     name: docker.io-proxy
     hostPort: 5557
   - proxy:
       url: <url>
-      insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
   - proxy:
       url: <url>
-      insecure: false
     name: gcr.io-proxy
     hostPort: 5559
   - proxy:
       url: <url>
-      insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
   - proxy:
       url: <url>
-      insecure: false
     name: quay.io-proxy
     hostPort: 5561
   validation: {}

--- a/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
@@ -26,32 +26,26 @@ spec:
   mirrorRegistries:
   - proxy:
       url: <url>
-      insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
   - proxy:
       url: <url>
-      insecure: false
     name: docker.io-proxy
     hostPort: 5557
   - proxy:
       url: <url>
-      insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
   - proxy:
       url: <url>
-      insecure: false
     name: gcr.io-proxy
     hostPort: 5559
   - proxy:
       url: <url>
-      insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
   - proxy:
       url: <url>
-      insecure: false
     name: quay.io-proxy
     hostPort: 5561
   validation: {}

--- a/tests/KSail.Tests/Commands/Init/ksail-init-k3s-simple/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-k3s-simple/ksail.yaml.verified.yaml
@@ -24,32 +24,26 @@ spec:
   mirrorRegistries:
   - proxy:
       url: <url>
-      insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
   - proxy:
       url: <url>
-      insecure: false
     name: docker.io-proxy
     hostPort: 5557
   - proxy:
       url: <url>
-      insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
   - proxy:
       url: <url>
-      insecure: false
     name: gcr.io-proxy
     hostPort: 5559
   - proxy:
       url: <url>
-      insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
   - proxy:
       url: <url>
-      insecure: false
     name: quay.io-proxy
     hostPort: 5561
   validation: {}

--- a/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
@@ -23,32 +23,26 @@ spec:
   mirrorRegistries:
   - proxy:
       url: <url>
-      insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
   - proxy:
       url: <url>
-      insecure: false
     name: docker.io-proxy
     hostPort: 5557
   - proxy:
       url: <url>
-      insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
   - proxy:
       url: <url>
-      insecure: false
     name: gcr.io-proxy
     hostPort: 5559
   - proxy:
       url: <url>
-      insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
   - proxy:
       url: <url>
-      insecure: false
     name: quay.io-proxy
     hostPort: 5561
   validation: {}

--- a/tests/KSail.Tests/Commands/Init/ksail-init-native-simple/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-native-simple/ksail.yaml.verified.yaml
@@ -20,32 +20,26 @@ spec:
   mirrorRegistries:
   - proxy:
       url: <url>
-      insecure: false
     name: registry.k8s.io-proxy
     hostPort: 5556
   - proxy:
       url: <url>
-      insecure: false
     name: docker.io-proxy
     hostPort: 5557
   - proxy:
       url: <url>
-      insecure: false
     name: ghcr.io-proxy
     hostPort: 5558
   - proxy:
       url: <url>
-      insecure: false
     name: gcr.io-proxy
     hostPort: 5559
   - proxy:
       url: <url>
-      insecure: false
     name: mcr.microsoft.com-proxy
     hostPort: 5560
   - proxy:
       url: <url>
-      insecure: false
     name: quay.io-proxy
     hostPort: 5561
   validation: {}


### PR DESCRIPTION
Update the 'insecure' option in the mirror registry configuration to accept null values, enhancing flexibility in registry connections.