### PR TITLE
Refactor mirror registries option to enum type

### DIFF
--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -109,7 +109,10 @@
             },
             "mirrorRegistries": {
               "description": "Whether to set up mirror registries for the project. [default: true]",
-              "type": "boolean"
+              "enum": [
+                "None",
+                "DockerRegistry"
+              ]
             }
           }
         },

--- a/src/KSail.Models/Project/Enums/KSailCNIType.cs
+++ b/src/KSail.Models/Project/Enums/KSailCNIType.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel;
+
 namespace KSail.Models.Project.Enums;
 
 
 public enum KSailCNIType
 {
+  [Description("Use the default CNI that comes with the chosen Kubernetes distribution.")]
   Default,
+
+  [Description("Use Cilium as the CNI.")]
   Cilium,
 }

--- a/src/KSail.Models/Project/Enums/KSailDeploymentToolType.cs
+++ b/src/KSail.Models/Project/Enums/KSailDeploymentToolType.cs
@@ -1,9 +1,11 @@
+using System.ComponentModel;
+
 namespace KSail.Models.Project.Enums;
 
 
 public enum KSailDeploymentToolType
 {
-
+  [Description("Use Flux GitOps to deploy manifests.")]
   Flux
 
   //

--- a/src/KSail.Models/Project/Enums/KSailEditorType.cs
+++ b/src/KSail.Models/Project/Enums/KSailEditorType.cs
@@ -1,12 +1,14 @@
+using System.ComponentModel;
+
 namespace KSail.Models.Project.Enums;
 
 
 
 public enum KSailEditorType
 {
-
+  [Description("Use Nano as the editor.")]
   Nano,
 
-
+  [Description("Use Vim as the editor.")]
   Vim
 }

--- a/src/KSail.Models/Project/Enums/KSailEngineType.cs
+++ b/src/KSail.Models/Project/Enums/KSailEngineType.cs
@@ -1,10 +1,12 @@
+using System.ComponentModel;
+
 namespace KSail.Models.Project.Enums;
 
 
 public enum KSailEngineType
 {
-
-  Docker
+  [Description("Use Docker as the engine.")]
+  Docker,
 
   //
   //Podman

--- a/src/KSail.Models/Project/Enums/KSailKubernetesDistributionType.cs
+++ b/src/KSail.Models/Project/Enums/KSailKubernetesDistributionType.cs
@@ -1,14 +1,15 @@
+using System.ComponentModel;
+
 namespace KSail.Models.Project.Enums;
 
 
 public enum KSailKubernetesDistributionType
 {
-
+  [Description("Use the native Kubernetes distribution.")]
   Native,
 
-
+  [Description("Use K3s as the Kubernetes distribution.")]
   K3s
-
   //
   // Talos
 }

--- a/src/KSail.Models/Project/Enums/KSailMirrorRegistriesType.cs
+++ b/src/KSail.Models/Project/Enums/KSailMirrorRegistriesType.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+
+namespace KSail.Models.Project.Enums;
+
+public enum KSailMirrorRegistriesType
+{
+  [Description("Do not set up mirror registries for the project.")]
+  None,
+  [Description("Set up mirror registries for the project using 'registry:2'")]
+  DockerRegistry
+}

--- a/src/KSail.Models/Project/Enums/KSailSecretManagerType.cs
+++ b/src/KSail.Models/Project/Enums/KSailSecretManagerType.cs
@@ -1,11 +1,12 @@
+using System.ComponentModel;
+
 namespace KSail.Models.Project.Enums;
 
 
 public enum KSailSecretManagerType
 {
-
+  [Description("Do not use a secret manager.")]
   None,
-
-
+  [Description("Use SOPS to manage sensitive data in the project.")]
   SOPS
 }

--- a/src/KSail.Models/Project/Enums/KSailTemplateType.cs
+++ b/src/KSail.Models/Project/Enums/KSailTemplateType.cs
@@ -1,8 +1,0 @@
-namespace KSail.Models.Project.Enums;
-
-
-public enum KSailTemplateType
-{
-
-  Kustomize
-}

--- a/src/KSail.Models/Project/KSailProject.cs
+++ b/src/KSail.Models/Project/KSailProject.cs
@@ -37,5 +37,5 @@ public class KSailProject
   public string KustomizationPath { get; set; } = "k8s";
 
   [Description("Whether to set up mirror registries for the project. [default: true]")]
-  public bool MirrorRegistries { get; set; } = true;
+  public KSailMirrorRegistriesType MirrorRegistries { get; set; } = KSailMirrorRegistriesType.DockerRegistry;
 }

--- a/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
+++ b/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
@@ -53,7 +53,7 @@ class KSailDownCommandHandler
       default:
         throw new KSailException($"deployment tool '{_config.Spec.Project.DeploymentTool}' is not supported.");
     }
-    if (_config.Spec.Project.MirrorRegistries)
+    if (_config.Spec.Project.MirrorRegistries == KSailMirrorRegistriesType.DockerRegistry)
     {
       Console.WriteLine("► Deleting mirror registries");
       var deleteTasks = _config.Spec.MirrorRegistries.Select(async mirrorRegistry =>

--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -44,7 +44,7 @@ class DistributionConfigFileGenerator
     var kindConfig = new KindConfig
     {
       Name = config.Metadata.Name,
-      ContainerdConfigPatches = config.Spec.Project.MirrorRegistries ? [
+      ContainerdConfigPatches = config.Spec.Project.MirrorRegistries == KSailMirrorRegistriesType.DockerRegistry ? [
         """
         [plugins."io.containerd.grpc.v1.cri".registry]
           config_path = "/etc/containerd/certs.d"

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -139,7 +139,7 @@ class KSailUpCommandHandler
 
   async Task CreateMirrorRegistries(KSailCluster config, CancellationToken cancellationToken)
   {
-    if (config.Spec.Project.MirrorRegistries)
+    if (config.Spec.Project.MirrorRegistries == KSailMirrorRegistriesType.DockerRegistry)
     {
       Console.WriteLine("🧮 Creating mirror registries");
       var tasks = config.Spec.MirrorRegistries.Select(async mirrorRegistry =>
@@ -210,7 +210,7 @@ class KSailUpCommandHandler
 
   async Task BootstrapMirrorRegistries(KSailCluster config, CancellationToken cancellationToken)
   {
-    if (config.Spec.Project.MirrorRegistries)
+    if (config.Spec.Project.MirrorRegistries == KSailMirrorRegistriesType.DockerRegistry)
     {
       switch ((config.Spec.Project.Engine, config.Spec.Project.Distribution))
       {

--- a/src/KSail/Options/Project/ProjectMirrorRegistriesOption.cs
+++ b/src/KSail/Options/Project/ProjectMirrorRegistriesOption.cs
@@ -1,13 +1,14 @@
 using System.CommandLine;
 using KSail.Models;
+using KSail.Models.Project.Enums;
 
 namespace KSail.Options.Project;
 
 
-class ProjectMirrorRegistriesOption(KSailCluster config) : Option<bool?>
+class ProjectMirrorRegistriesOption(KSailCluster config) : Option<KSailMirrorRegistriesType?>
 (
   ["-mr", "--mirror-registries"],
-  $"Enable mirror registries. [default: {config.Spec.Project.MirrorRegistries}]"
+  $"Configure how to handle mirror registries. [default: {config.Spec.Project.MirrorRegistries}]"
 )
 {
 }

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -20,7 +20,7 @@
       Editor: Nano,
       Engine: Docker,
       KustomizationPath: k8s,
-      MirrorRegistries: true
+      MirrorRegistries: DockerRegistry
     },
     DeploymentTool: {
       Flux: {

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -20,7 +20,7 @@
       Editor: Nano,
       Engine: Docker,
       KustomizationPath: k8s,
-      MirrorRegistries: true
+      MirrorRegistries: DockerRegistry
     },
     DeploymentTool: {
       Flux: {

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -20,7 +20,7 @@
       Editor: Nano,
       Engine: Docker,
       KustomizationPath: k8s,
-      MirrorRegistries: true
+      MirrorRegistries: DockerRegistry
     },
     DeploymentTool: {
       Flux: {

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -20,7 +20,7 @@
       Editor: Nano,
       Engine: Docker,
       KustomizationPath: k8s,
-      MirrorRegistries: true
+      MirrorRegistries: DockerRegistry
     },
     DeploymentTool: {
       Flux: {

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -109,7 +109,10 @@
             },
             "mirrorRegistries": {
               "description": "Whether to set up mirror registries for the project. [default: true]",
-              "type": "boolean"
+              "enum": [
+                "None",
+                "DockerRegistry"
+              ]
             }
           }
         },

--- a/tests/KSail.Tests/Commands/Down/KSailDownCommandTests.KSailDownHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Down/KSailDownCommandTests.KSailDownHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,12 +5,12 @@ Usage:
   testhost down [options]
 
 Options:
-  -fsu, --flux-source-url <flux-source-url>  Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
-  -n, --name <name>                          The name of the cluster. [default: ksail-default]
-  -dt, --deployment-tool <Flux>              The Deployment tool to use for updating the state of the cluster. [default: Flux]
-  -d, --distribution <K3s|Native>            The distribution to use for the cluster. [default: Native]
-  -e, --engine <Docker>                      The engine to use for provisioning the cluster. [default: Docker]
-  -mr, --mirror-registries                   Enable mirror registries. [default: True]
-  -?, -h, --help                             Show help and usage information
+  -fsu, --flux-source-url <flux-source-url>       Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
+  -n, --name <name>                               The name of the cluster. [default: ksail-default]
+  -dt, --deployment-tool <Flux>                   The Deployment tool to use for updating the state of the cluster. [default: Flux]
+  -d, --distribution <K3s|Native>                 The distribution to use for the cluster. [default: Native]
+  -e, --engine <Docker>                           The engine to use for provisioning the cluster. [default: Docker]
+  -mr, --mirror-registries <DockerRegistry|None>  Configure how to handle mirror registries. [default: DockerRegistry]
+  -?, -h, --help                                  Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -13,7 +13,7 @@ Options:
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. [default: Docker]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -mr, --mirror-registries                          Enable mirror registries. [default: True]
+  -mr, --mirror-registries <DockerRegistry|None>    Configure how to handle mirror registries. [default: DockerRegistry]
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
   -?, -h, --help                                    Show help and usage information
 

--- a/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -16,7 +16,7 @@ Options:
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -e, --engine <Docker>                             The engine to use for provisioning the cluster. [default: Docker]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -mr, --mirror-registries                          Enable mirror registries. [default: True]
+  -mr, --mirror-registries <DockerRegistry|None>    Configure how to handle mirror registries. [default: DockerRegistry]
   -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
   -l, --lint                                        Lit manifests. [default: True'
   -r, --reconcile                                   Reconcile manifests. [default: True]


### PR DESCRIPTION
Replace the boolean mirror registries option with an enum to provide clearer configuration options. Update related configurations and usages throughout the codebase.