### PR TITLE
feat: change secret manager configuration to boolean flag

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -61,7 +61,7 @@ Options:
   -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
   -mr, --mirror-registries                          Enable mirror registries for the project. [default: True]
-  -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
+  -sm, --secret-manager                             Whether to use a secret manager. [default: False]
   -l, --lint                                        Lit manifests. [default: True'
   -r, --reconcile                                   Reconcile manifests. [default: True]
   -?, -h, --help                                    Show help and usage information
@@ -155,7 +155,7 @@ Options:
   -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
   -mr, --mirror-registries                          Enable mirror registries for the project. [default: True]
-  -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
+  -sm, --secret-manager                             Whether to use a secret manager. [default: False]
   -?, -h, --help                                    Show help and usage information
 ```
 
@@ -828,8 +828,8 @@ Usage:
   ksail secrets [command] [options]
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 
 Commands:
   encrypt <path>       Encrypt a file
@@ -855,11 +855,11 @@ Arguments:
   <path>  The path to the file to encrypt.
 
 Options:
-  -pk, --public-key <public-key>     The public key.
-  -ip, --in-place                    In-place decryption/encryption. [default: False]
-  -o, --output <output>              A file or directory path. []
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -pk, --public-key <public-key>  The public key.
+  -ip, --in-place                 In-place decryption/encryption. [default: False]
+  -o, --output <output>           A file or directory path. []
+  -sm, --secret-manager           Whether to use a secret manager. [default: False]
+  -?, -h, --help                  Show help and usage information
 ```
 
 ## `ksail secrets decrypt`
@@ -875,10 +875,10 @@ Arguments:
   <path>  The path to the file to decrypt.
 
 Options:
-  -ip, --in-place                    In-place decryption/encryption. [default: False]
-  -o, --output <output>              A file or directory path. []
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -ip, --in-place        In-place decryption/encryption. [default: False]
+  -o, --output <output>  A file or directory path. []
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 ```
 
 ## `ksail secrets edit`
@@ -894,9 +894,9 @@ Arguments:
   <path>  The path to the file to edit.
 
 Options:
-  -e, --editor <Nano|Vim>            Editor to use. [default: Nano]
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -e, --editor <Nano|Vim>  Editor to use. [default: Nano]
+  -sm, --secret-manager    Whether to use a secret manager. [default: False]
+  -?, -h, --help           Show help and usage information
 ```
 
 ## `ksail secrets add`
@@ -909,8 +909,8 @@ Usage:
   ksail secrets add [options]
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 ```
 
 ## `ksail secrets rm`
@@ -926,8 +926,8 @@ Arguments:
   <public-key>  Public key matching existing encryption key
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 ```
 
 ## `ksail secrets list`
@@ -940,10 +940,10 @@ Usage:
   ksail secrets list [options]
 
 Options:
-  -spk, --show-private-keys          Show private keys. [default: False]
-  -a, --all                          Show all keys. [default: False]
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -spk, --show-private-keys  Show private keys. [default: False]
+  -a, --all                  Show all keys. [default: False]
+  -sm, --secret-manager      Whether to use a secret manager. [default: False]
+  -?, -h, --help             Show help and usage information
 ```
 
 ## `ksail secrets import`
@@ -959,8 +959,8 @@ Arguments:
   <key>  The encryption key to import
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 ```
 
 ## `ksail secrets export`
@@ -976,7 +976,7 @@ Arguments:
   <public-key>  The public key for the encryption key to export
 
 Options:
-  -o, --output <output>              A file or directory path. []
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -o, --output <output>  A file or directory path. []
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 ```

--- a/docs/configuration/declarative-config.md
+++ b/docs/configuration/declarative-config.md
@@ -53,8 +53,8 @@ spec:
     distribution: Native
     # The Deployment tool to use. [default: Flux]
     deploymentTool: Flux
-    # The secret manager to use. [default: None]
-    secretManager: None
+    # Whether to use a secret manager. [default: false]
+    secretManager: false
     # The CNI to use. [default: Default]
     cni: Default
     # The editor to use for viewing files while debugging. [default: Nano]

--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -77,11 +77,8 @@
               ]
             },
             "secretManager": {
-              "description": "The secret manager to use. [default: None]",
-              "enum": [
-                "None",
-                "SOPS"
-              ]
+              "description": "Whether to use a secret manager. [default: false]",
+              "type": "boolean"
             },
             "cni": {
               "description": "The CNI to use. [default: Default]",

--- a/src/KSail.Models/Project/KSailProject.cs
+++ b/src/KSail.Models/Project/KSailProject.cs
@@ -20,8 +20,8 @@ public class KSailProject
   [Description("The Deployment tool to use. [default: Flux]")]
   public KSailDeploymentToolType DeploymentTool { get; set; } = KSailDeploymentToolType.Flux;
 
-  [Description("The secret manager to use. [default: None]")]
-  public KSailSecretManagerType SecretManager { get; set; } = KSailSecretManagerType.None;
+  [Description("Whether to use a secret manager. [default: false]")]
+  public bool SecretManager { get; set; } = false;
 
   [Description("The CNI to use. [default: Default]")]
   [YamlMember(Alias = "cni")]

--- a/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
+++ b/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
@@ -42,7 +42,7 @@ class KSailDownCommandHandler
     bool ksailRegistryExists = await _containerEngineProvisioner.CheckContainerExistsAsync(containerName, cancellationToken).ConfigureAwait(false);
     if (ksailRegistryExists)
     {
-      Console.WriteLine("► Deleting OCI source registry");
+      Console.WriteLine("► Deleting local registry");
       await _containerEngineProvisioner.DeleteRegistryAsync(containerName, cancellationToken).ConfigureAwait(false);
       Console.WriteLine($"✓ '{containerName}' deleted.");
     }

--- a/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
+++ b/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
@@ -25,7 +25,7 @@ class KSailInitCommandHandler(KSailCluster config)
       cancellationToken
     ).ConfigureAwait(false);
 
-    if (_config.Spec.Project.SecretManager == KSailSecretManagerType.SOPS)
+    if (_config.Spec.Project.SecretManager)
     {
       await _sopsConfigFileGenerator.GenerateAsync(
         _config,

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsAddCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsAddCommand.cs
@@ -18,20 +18,8 @@ sealed class KSailSecretsAddCommand : Command
       {
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsAddCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsAddCommandHandler(new SOPSLocalAgeSecretManager());
-            break;
-        }
-
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
+        var handler = new KSailSecretsAddCommandHandler(new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsDecryptCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsDecryptCommand.cs
@@ -26,19 +26,8 @@ sealed class KSailSecretsDecryptCommand : Command
         string path = context.ParseResult.GetValueForArgument(_pathArgument);
         string? output = context.ParseResult.GetValueForOption(_outputOption);
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsDecryptCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsDecryptCommandHandler(config, path, output, new SOPSLocalAgeSecretManager());
-            break;
-        }
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
+        var handler = new KSailSecretsDecryptCommandHandler(config, path, output, new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
         Console.WriteLine();
       }
       catch (Exception ex)

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsEditCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsEditCommand.cs
@@ -24,19 +24,8 @@ sealed class KSailSecretsEditCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         string path = context.ParseResult.GetValueForArgument(_pathArgument);
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsEditCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsEditCommandHandler(config, path, new SOPSLocalAgeSecretManager());
-            break;
-        }
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
+        var handler = new KSailSecretsEditCommandHandler(config, path, new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
         Console.WriteLine();
       }
       catch (Exception ex)

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsEncryptCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsEncryptCommand.cs
@@ -26,19 +26,8 @@ sealed class KSailSecretsEncryptCommand : Command
         string path = context.ParseResult.GetValueForArgument(_pathArgument);
         string? output = context.ParseResult.GetValueForOption(_outputOption);
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsEncryptCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsEncryptCommandHandler(config, path, output, new SOPSLocalAgeSecretManager());
-            break;
-        }
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
+        var handler = new KSailSecretsEncryptCommandHandler(config, path, output, new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
         Console.WriteLine();
       }
       catch (Exception ex)

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsExportCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsExportCommand.cs
@@ -39,19 +39,8 @@ sealed class KSailSecretsExportCommand : Command
         string outputPath = context.ParseResult.GetValueForOption(_outputFilePathOption) ?? throw new KSailException("output path is required");
 
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsExportCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsExportCommandHandler(config, publicKey, outputPath, new SOPSLocalAgeSecretManager());
-            break;
-        }
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
+        var handler = new KSailSecretsExportCommandHandler(config, publicKey, outputPath, new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsImportCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsImportCommand.cs
@@ -21,19 +21,8 @@ sealed class KSailSecretsImportCommand : Command
         string key = context.ParseResult.GetValueForArgument(_keyArgument);
 
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsImportCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsImportCommandHandler(config, key, new SOPSLocalAgeSecretManager());
-            break;
-        }
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
+        var handler = new KSailSecretsImportCommandHandler(config, key, new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
@@ -21,19 +21,8 @@ sealed class KSailSecretsListCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
 
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsListCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsListCommandHandler(config, new SOPSLocalAgeSecretManager());
-            break;
-        }
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        var handler = new KSailSecretsListCommandHandler(config, new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false) ? 0 : 1;
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsRemoveCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsRemoveCommand.cs
@@ -21,20 +21,8 @@ sealed class KSailSecretsRemoveCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         string publicKey = context.ParseResult.GetValueForArgument(_publicKeyArgument);
         var cancellationToken = context.GetCancellationToken();
-        KSailSecretsRemoveCommandHandler handler;
-        switch (config.Spec.Project.SecretManager)
-        {
-          default:
-          case KSailSecretManagerType.None:
-            _ = _exceptionHandler.HandleException(new KSailException("no secret manager configured"));
-            context.ExitCode = 1;
-            return;
-          case KSailSecretManagerType.SOPS:
-            handler = new KSailSecretsRemoveCommandHandler(config, publicKey, new SOPSLocalAgeSecretManager());
-            break;
-        }
-
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
+        var handler = new KSailSecretsRemoveCommandHandler(config, publicKey, new SOPSLocalAgeSecretManager());
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -359,7 +359,6 @@ class KSailUpCommandHandler
     }
   }
 
-  // TODO: Move to generic method on KubernetesResourceProvisioner
   static async Task CreateFluxSystemNamespace(KubernetesResourceProvisioner resourceProvisioner, CancellationToken cancellationToken)
   {
     var namespaceList = await resourceProvisioner.ListNamespaceAsync(cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -326,7 +326,7 @@ class KSailUpCommandHandler
   async Task BootstrapSecretManager(KSailCluster config, CancellationToken cancellationToken)
   {
     using var resourceProvisioner = new KubernetesResourceProvisioner(config.Spec.Connection.Kubeconfig, config.Spec.Connection.Context);
-    if (config.Spec.Project.SecretManager == KSailSecretManagerType.SOPS)
+    if (config.Spec.Project.SecretManager)
     {
       Console.WriteLine("🔼 Bootstrapping SOPS secret manager");
       Console.WriteLine($"► creating 'flux-system' namespace");

--- a/src/KSail/Options/Project/ProjectSecretManagerOption.cs
+++ b/src/KSail/Options/Project/ProjectSecretManagerOption.cs
@@ -5,9 +5,9 @@ using KSail.Models.Project.Enums;
 namespace KSail.Options.Project;
 
 
-class ProjectSecretManagerOption(KSailCluster config) : Option<KSailSecretManagerType>(
+class ProjectSecretManagerOption(KSailCluster config) : Option<bool>(
   ["-sm", "--secret-manager"],
-  $"Configure which secret manager to use. [default: {config.Spec.Project.SecretManager}]"
+  $"Whether to use a secret manager. [default: {config.Spec.Project.SecretManager}]"
 )
 {
 }

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -15,7 +15,7 @@
       DistributionConfigPath: k3d.yaml,
       Distribution: K3s,
       DeploymentTool: Flux,
-      SecretManager: None,
+      SecretManager: false,
       CNI: Default,
       Editor: Nano,
       Provider: Docker,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -15,7 +15,7 @@
       DistributionConfigPath: k3d.yaml,
       Distribution: K3s,
       DeploymentTool: Flux,
-      SecretManager: None,
+      SecretManager: false,
       CNI: Default,
       Editor: Nano,
       Provider: Docker,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -15,7 +15,7 @@
       DistributionConfigPath: kind.yaml,
       Distribution: Native,
       DeploymentTool: Flux,
-      SecretManager: None,
+      SecretManager: false,
       CNI: Default,
       Editor: Nano,
       Provider: Docker,

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -15,7 +15,7 @@
       DistributionConfigPath: kind.yaml,
       Distribution: Native,
       DeploymentTool: Flux,
-      SecretManager: None,
+      SecretManager: false,
       CNI: Default,
       Editor: Nano,
       Provider: Docker,

--- a/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterJSONSchemaGenerationTests.GenerateJSONSchemaFromKSailCluster_ShouldReturnJSONSchema.verified.txt
@@ -77,11 +77,8 @@
               ]
             },
             "secretManager": {
-              "description": "The secret manager to use. [default: None]",
-              "enum": [
-                "None",
-                "SOPS"
-              ]
+              "description": "Whether to use a secret manager. [default: false]",
+              "type": "boolean"
             },
             "cni": {
               "description": "The CNI to use. [default: Default]",

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -14,7 +14,7 @@ Options:
   -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
   -mr, --mirror-registries                          Enable mirror registries for the project. [default: True]
-  -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
+  -sm, --secret-manager                             Whether to use a secret manager. [default: False]
   -?, -h, --help                                    Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.cs
+++ b/tests/KSail.Tests/Commands/Init/KSailInitCommandTests.cs
@@ -33,9 +33,9 @@ public partial class KSailInitCommandTests : IAsyncLifetime
 
   [Theory]
   [InlineData("ksail-init-native-simple", new string[] { "init" })]
-  [InlineData("ksail-init-native-advanced", new string[] { "init", "--name", "ksail-advanced-native", "--secret-manager", "sops", "--cni", "cilium" })]
+  [InlineData("ksail-init-native-advanced", new string[] { "init", "--name", "ksail-advanced-native", "--secret-manager", "--cni", "cilium" })]
   [InlineData("ksail-init-k3s-simple", new string[] { "init", "--distribution", "k3s" })]
-  [InlineData("ksail-init-k3s-advanced", new string[] { "init", "--name", "ksail-advanced-k3s", "--distribution", "k3s", "--secret-manager", "sops", "--cni", "cilium" })]
+  [InlineData("ksail-init-k3s-advanced", new string[] { "init", "--name", "ksail-advanced-k3s", "--distribution", "k3s", "--secret-manager", "--cni", "cilium" })]
   public async Task KSailInit_WithVariousOptions_SucceedsAndGeneratesKSailProject(string outputDirName, string[] args)
   {
     // TODO: Add support for Windows at a later time.

--- a/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
@@ -16,8 +16,8 @@ spec:
     distributionConfigPath: k3d.yaml
     # The Kubernetes distribution to use. [default: Native]
     distribution: K3s
-    # The secret manager to use. [default: None]
-    secretManager: SOPS
+    # Whether to use a secret manager. [default: false]
+    secretManager: true
     # The CNI to use. [default: Default]
     cni: Cilium
   # The options for the deployment tool.

--- a/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
@@ -12,8 +12,8 @@ spec:
     context: kind-ksail-advanced-native
   # The options for the KSail project.
   project:
-    # The secret manager to use. [default: None]
-    secretManager: SOPS
+    # Whether to use a secret manager. [default: false]
+    secretManager: true
     # The CNI to use. [default: Default]
     cni: Cilium
   # The options for the deployment tool.

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets --help.verified.txt
@@ -5,8 +5,8 @@ Usage:
   testhost secrets [command] [options]
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 
 Commands:
   encrypt <path>       Encrypt a file

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets add --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets add --help.verified.txt
@@ -5,7 +5,7 @@ Usage:
   testhost secrets add [options]
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets decrypt --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets decrypt --help.verified.txt
@@ -8,10 +8,10 @@ Arguments:
   <path>  The path to the file to decrypt.
 
 Options:
-  -ip, --in-place                    In-place decryption/encryption. [default: False]
-  -o, --output <output>              A file or directory path. []
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -ip, --in-place        In-place decryption/encryption. [default: False]
+  -o, --output <output>  A file or directory path. []
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets encrypt --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets encrypt --help.verified.txt
@@ -8,11 +8,11 @@ Arguments:
   <path>  The path to the file to encrypt.
 
 Options:
-  -pk, --public-key <public-key>     The public key.
-  -ip, --in-place                    In-place decryption/encryption. [default: False]
-  -o, --output <output>              A file or directory path. []
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -pk, --public-key <public-key>  The public key.
+  -ip, --in-place                 In-place decryption/encryption. [default: False]
+  -o, --output <output>           A file or directory path. []
+  -sm, --secret-manager           Whether to use a secret manager. [default: False]
+  -?, -h, --help                  Show help and usage information
 
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets export --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets export --help.verified.txt
@@ -8,9 +8,9 @@ Arguments:
   <public-key>  The public key for the encryption key to export
 
 Options:
-  -o, --output <output>              A file or directory path. []
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -o, --output <output>  A file or directory path. []
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets import --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets import --help.verified.txt
@@ -8,8 +8,8 @@ Arguments:
   <key>  The encryption key to import
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets list --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets list --help.verified.txt
@@ -5,9 +5,9 @@ Usage:
   testhost secrets list [options]
 
 Options:
-  -spk, --show-private-keys          Show private keys. [default: False]
-  -a, --all                          Show all keys. [default: False]
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -spk, --show-private-keys  Show private keys. [default: False]
+  -a, --all                  Show all keys. [default: False]
+  -sm, --secret-manager      Whether to use a secret manager. [default: False]
+  -?, -h, --help             Show help and usage information
 
 

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets rm --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets rm --help.verified.txt
@@ -8,8 +8,8 @@ Arguments:
   <public-key>  Public key matching existing encryption key
 
 Options:
-  -sm, --secret-manager <None|SOPS>  Configure which secret manager to use. [default: None]
-  -?, -h, --help                     Show help and usage information
+  -sm, --secret-manager  Whether to use a secret manager. [default: False]
+  -?, -h, --help         Show help and usage information
 
 
 

--- a/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -17,7 +17,7 @@ Options:
   -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
   -mr, --mirror-registries                          Enable mirror registries for the project. [default: True]
-  -sm, --secret-manager <None|SOPS>                 Configure which secret manager to use. [default: None]
+  -sm, --secret-manager                             Whether to use a secret manager. [default: False]
   -l, --lint                                        Lit manifests. [default: True'
   -r, --reconcile                                   Reconcile manifests. [default: True]
   -?, -h, --help                                    Show help and usage information


### PR DESCRIPTION
Refactor the secret manager configuration from a type-based option to a boolean flag indicating usage. Update CLI options, help documentation, and internal models to reflect this change, ensuring consistency across the application.