### PR TITLE
feat: Implement `ksail status` to check the health of a cluster

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -32,6 +32,7 @@ Commands:
   start     Start a cluster
   stop      Stop a cluster
   down      Destroy a cluster
+  status    Show the status of a cluster
   list      List active clusters
   validate  Validate project files
   debug     Debug a cluster (❤️ K9s)
@@ -181,11 +182,27 @@ Commands:
   start     Start a cluster
   stop      Stop a cluster
   down      Destroy a cluster
+  status    Show the status of a cluster
   list      List active clusters
   validate  Validate project files
   debug     Debug a cluster (❤️ K9s)
   gen       Generate a resource
   secrets   Manage secrets
+```
+
+## `ksail status`
+
+```text
+Description:
+  Show the status of a cluster
+
+Usage:
+  ksail status [options]
+
+Options:
+  -k, --kubeconfig <kubeconfig>  Path to kubeconfig file. [default: /Users/nikolaiemildamm/.kube/config]
+  -c, --context <context>        The kubernetes context to use. [default: kind-ksail-default]
+  -?, -h, --help                 Show help and usage information
 ```
 
 ## `ksail list`

--- a/src/KSail/Commands/Root/KSailRootCommand.cs
+++ b/src/KSail/Commands/Root/KSailRootCommand.cs
@@ -8,6 +8,7 @@ using KSail.Commands.List;
 using KSail.Commands.Root.Handlers;
 using KSail.Commands.Secrets;
 using KSail.Commands.Start;
+using KSail.Commands.Status;
 using KSail.Commands.Stop;
 using KSail.Commands.Up;
 using KSail.Commands.Update;
@@ -46,6 +47,7 @@ sealed class KSailRootCommand : RootCommand
     AddCommand(new KSailStartCommand());
     AddCommand(new KSailStopCommand());
     AddCommand(new KSailDownCommand());
+    AddCommand(new KSailStatusCommand());
     AddCommand(new KSailListCommand());
     AddCommand(new KSailValidateCommand());
     AddCommand(new KSailDebugCommand());

--- a/src/KSail/Commands/Status/Handlers/KSailListCommandHandler.cs
+++ b/src/KSail/Commands/Status/Handlers/KSailListCommandHandler.cs
@@ -1,0 +1,21 @@
+using Devantler.KubernetesProvisioner.Cluster.K3d;
+using Devantler.KubernetesProvisioner.Cluster.Kind;
+using Devantler.KubernetesProvisioner.Resources.Native;
+using KSail.Models;
+using KSail.Models.Project.Enums;
+
+namespace KSail.Commands.Status.Handlers;
+
+sealed class KSailStatusCommandHandler(KSailCluster config)
+{
+  readonly KSailCluster _config = config;
+
+  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  {
+    var (ExitCode, _) = await Devantler.KubectlCLI.Kubectl.RunAsync(
+      ["cluster-info", "--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context],
+      cancellationToken: cancellationToken
+    ).ConfigureAwait(false);
+    return ExitCode == 0;
+  }
+}

--- a/src/KSail/Commands/Status/Handlers/KSailListCommandHandler.cs
+++ b/src/KSail/Commands/Status/Handlers/KSailListCommandHandler.cs
@@ -12,10 +12,21 @@ sealed class KSailStatusCommandHandler(KSailCluster config)
 
   internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
   {
-    var (ExitCode, _) = await Devantler.KubectlCLI.Kubectl.RunAsync(
+    var (ExitCode0, _) = await Devantler.KubectlCLI.Kubectl.RunAsync(
+      ["version", "--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context],
+      cancellationToken: cancellationToken
+    ).ConfigureAwait(false);
+    Console.WriteLine("---");
+    var (ExitCode1, _) = await Devantler.KubectlCLI.Kubectl.RunAsync(
+      ["get", "nodes", "-o", "wide", "--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context],
+      cancellationToken: cancellationToken
+    ).ConfigureAwait(false);
+    Console.WriteLine("---");
+    var (ExitCode2, _) = await Devantler.KubectlCLI.Kubectl.RunAsync(
       ["cluster-info", "--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context],
       cancellationToken: cancellationToken
     ).ConfigureAwait(false);
-    return ExitCode == 0;
+    //TODO: Check status of etcd
+    return ExitCode0 == 0 && ExitCode1 == 0 && ExitCode2 == 0;
   }
 }

--- a/src/KSail/Commands/Status/KSailStatusCommand.cs
+++ b/src/KSail/Commands/Status/KSailStatusCommand.cs
@@ -1,0 +1,37 @@
+using System.CommandLine;
+using KSail.Commands.List.Handlers;
+using KSail.Commands.Status.Handlers;
+using KSail.Options;
+using KSail.Utils;
+
+namespace KSail.Commands.Status;
+
+sealed class KSailStatusCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  internal KSailStatusCommand() : base("status", "Show the status of a cluster")
+  {
+    AddOptions();
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
+        var cancellationToken = context.GetCancellationToken();
+        var handler = new KSailStatusCommandHandler(config);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false) ? 0 : 1;
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  internal void AddOptions()
+  {
+    AddOption(CLIOptions.Connection.KubeconfigOption);
+    AddOption(CLIOptions.Connection.ContextOption);
+  }
+}

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.1.2" />
     <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.3.8" />
     <PackageReference Include="Devantler.K9sCLI" Version="1.8.0" />
+    <PackageReference Include="Devantler.KubectlCLI" Version="1.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSailHelp_SucceedsAndPrintsHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSailHelp_SucceedsAndPrintsHelp.verified.txt
@@ -15,6 +15,7 @@ Commands:
   start     Start a cluster
   stop      Stop a cluster
   down      Destroy a cluster
+  status    Show the status of a cluster
   list      List active clusters
   validate  Validate project files
   debug     Debug a cluster (❤️ K9s)

--- a/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSail_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Root/KSailRootCommandTests.KSail_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -26,6 +26,7 @@ Commands:
   start     Start a cluster
   stop      Stop a cluster
   down      Destroy a cluster
+  status    Show the status of a cluster
   list      List active clusters
   validate  Validate project files
   debug     Debug a cluster (❤️ K9s)

--- a/tests/KSail.Tests/Commands/Status/KSailStatusCommandTests.KSailStatusHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Status/KSailStatusCommandTests.KSailStatusHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -1,0 +1,12 @@
+﻿Description:
+  Show the status of a cluster
+
+Usage:
+  testhost status [options]
+
+Options:
+  -k, --kubeconfig <kubeconfig>  Path to kubeconfig file. [default: {UserProfile}/.kube/config]
+  -c, --context <context>        The kubernetes context to use. [default: kind-ksail-default]
+  -?, -h, --help                 Show help and usage information
+
+

--- a/tests/KSail.Tests/Commands/Status/KSailStatusCommandTests.cs
+++ b/tests/KSail.Tests/Commands/Status/KSailStatusCommandTests.cs
@@ -1,0 +1,30 @@
+using System.CommandLine;
+using System.CommandLine.IO;
+using KSail.Commands.Root;
+
+namespace KSail.Tests.Commands.Status;
+
+
+public class KSailStatusCommandTests : IAsyncLifetime
+{
+  /// <inheritdoc/>
+  public Task DisposeAsync() => Task.CompletedTask;
+  /// <inheritdoc/>
+  public Task InitializeAsync() => Task.CompletedTask;
+
+
+  [Fact]
+  public async Task KSailStatusHelp_SucceedsAndPrintsIntroductionAndHelp()
+  {
+    //Arrange
+    var console = new TestConsole();
+    var ksailCommand = new KSailRootCommand(console);
+
+    //Act
+    int exitCode = await ksailCommand.InvokeAsync(["status", "--help"], console);
+
+    //Assert
+    Assert.Equal(0, exitCode);
+    _ = await Verify(console.Error.ToString() + console.Out);
+  }
+}

--- a/tests/KSail.Tests/E2E/E2ETests.cs
+++ b/tests/KSail.Tests/E2E/E2ETests.cs
@@ -52,6 +52,8 @@ public class E2ETests : IAsyncLifetime
     Assert.Equal(0, initExitCode);
     int upExitCode = await upCommand.InvokeAsync(["up"], console).ConfigureAwait(false);
     Assert.Equal(0, upExitCode);
+    int statusExitCode = await upCommand.InvokeAsync(["status"], console).ConfigureAwait(false);
+    Assert.Equal(0, statusExitCode);
     int listExitCode = await listCommand.InvokeAsync(["list"], console).ConfigureAwait(false);
     Assert.Equal(0, listExitCode);
     int stopExitCode = await stopCommand.InvokeAsync(["stop"], console).ConfigureAwait(false);

--- a/tests/KSail.Tests/E2E/E2ETests.cs
+++ b/tests/KSail.Tests/E2E/E2ETests.cs
@@ -8,6 +8,7 @@ using KSail.Commands.Init;
 using KSail.Commands.List;
 using KSail.Commands.Root;
 using KSail.Commands.Start;
+using KSail.Commands.Status;
 using KSail.Commands.Stop;
 using KSail.Commands.Up;
 using KSail.Commands.Update;
@@ -40,6 +41,7 @@ public class E2ETests : IAsyncLifetime
     var console = new TestConsole();
     var initCommand = new KSailInitCommand();
     var upCommand = new KSailUpCommand();
+    var statusCommand = new KSailStatusCommand();
     var listCommand = new KSailListCommand();
     var stopCommand = new KSailStopCommand();
     var startCommand = new KSailStartCommand();
@@ -52,7 +54,7 @@ public class E2ETests : IAsyncLifetime
     Assert.Equal(0, initExitCode);
     int upExitCode = await upCommand.InvokeAsync(["up"], console).ConfigureAwait(false);
     Assert.Equal(0, upExitCode);
-    int statusExitCode = await upCommand.InvokeAsync(["status"], console).ConfigureAwait(false);
+    int statusExitCode = await statusCommand.InvokeAsync(["status"], console).ConfigureAwait(false);
     Assert.Equal(0, statusExitCode);
     int listExitCode = await listCommand.InvokeAsync(["list"], console).ConfigureAwait(false);
     Assert.Equal(0, listExitCode);

--- a/tests/KSail.Tests/KSailCLIOptionsDocsGenTests.cs
+++ b/tests/KSail.Tests/KSailCLIOptionsDocsGenTests.cs
@@ -23,6 +23,7 @@ public class KSailCLIOptionsDocsGenTests
       { "ksail stop", await GetHelpTextAsync(ksailCommand, "stop", "--help") },
       { "ksail init", await GetHelpTextAsync(ksailCommand, "init", "--help") },
       { "ksail lint", await GetHelpTextAsync(ksailCommand, "lint", "--help") },
+      { "ksail status", await GetHelpTextAsync(ksailCommand, "status", "--help") },
       { "ksail list", await GetHelpTextAsync(ksailCommand, "list", "--help") },
       { "ksail debug", await GetHelpTextAsync(ksailCommand, "debug", "--help") },
       { "ksail gen", await GetHelpTextAsync(ksailCommand, "gen", "--help") },


### PR DESCRIPTION
The `ksail status` command has been added to allow users to check the health of a cluster. This includes options for specifying the kubeconfig file and the Kubernetes context. The command integrates with the existing command structure and includes tests to ensure functionality.

Fixes #809