### PR TITLE
test: add tests for KSailCluster initialization with name and unnamed distribution

### DIFF
--- a/src/KSail.Models/KSailClusterSpec.cs
+++ b/src/KSail.Models/KSailClusterSpec.cs
@@ -3,6 +3,7 @@ using KSail.Models.CNI;
 using KSail.Models.Connection;
 using KSail.Models.DeploymentTool;
 using KSail.Models.Distribution;
+using KSail.Models.GatewayController;
 using KSail.Models.Generator;
 using KSail.Models.IngressController;
 using KSail.Models.LocalRegistry;
@@ -11,7 +12,6 @@ using KSail.Models.Project;
 using KSail.Models.Project.Enums;
 using KSail.Models.SecretManager;
 using KSail.Models.Validation;
-using KSail.Models.GatewayController;
 using YamlDotNet.Serialization;
 
 namespace KSail.Models;
@@ -72,6 +72,20 @@ public class KSailClusterSpec
     Connection = new KSailConnection
     {
       Context = $"kind-{name}"
+    };
+  }
+
+  public KSailClusterSpec(KSailDistributionType distribution)
+  {
+    SetOCISourceUri(distribution);
+    Connection = new KSailConnection
+    {
+      Context = distribution switch
+      {
+        KSailDistributionType.Native => $"kind-{distribution}",
+        KSailDistributionType.K3s => $"k3d-{distribution}",
+        _ => $"kind-{distribution}"
+      }
     };
   }
 

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndUnnamedDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndUnnamedDistribution_ShouldReturnValidConfig.verified.txt
@@ -1,0 +1,109 @@
+﻿{
+  ApiVersion: ksail.io/v1alpha1,
+  Kind: Cluster,
+  Metadata: {
+    Name: ksail-default
+  },
+  Spec: {
+    Connection: {
+      Kubeconfig: {UserProfile}/.kube/config,
+      Context: kind-ksail-default,
+      Timeout: 5m
+    },
+    Project: {
+      ConfigPath: ksail.yaml,
+      DistributionConfigPath: kind.yaml,
+      Distribution: 8,
+      DeploymentTool: Flux,
+      SecretManager: false,
+      CNI: Default,
+      Editor: Nano,
+      Provider: Docker,
+      KustomizationPath: k8s,
+      MirrorRegistries: true
+    },
+    DeploymentTool: {
+      Flux: {
+        Source: {
+          Url: oci://testhost:5555/ksail-registry
+        }
+      }
+    },
+    Distribution: {
+      ShowAllClustersInListings: false
+    },
+    SecretManager: {
+      SOPS: {
+        PublicKey: null,
+        InPlace: false,
+        ShowAllKeysInListings: false,
+        ShowPrivateKeysInListings: false
+      }
+    },
+    LocalRegistry: {
+      Name: ksail-registry,
+      HostPort: 5555,
+      Provider: Docker
+    },
+    Generator: {
+      Overwrite: false
+    },
+    MirrorRegistries: [
+      {
+        Proxy: {
+          Url: https://registry.k8s.io
+        },
+        Name: registry.k8s.io-proxy,
+        HostPort: 5556,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://registry-1.docker.io
+        },
+        Name: docker.io-proxy,
+        HostPort: 5557,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://ghcr.io
+        },
+        Name: ghcr.io-proxy,
+        HostPort: 5558,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://gcr.io
+        },
+        Name: gcr.io-proxy,
+        HostPort: 5559,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://mcr.microsoft.com
+        },
+        Name: mcr.microsoft.com-proxy,
+        HostPort: 5560,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://quay.io
+        },
+        Name: quay.io-proxy,
+        HostPort: 5561,
+        Provider: Docker
+      }
+    ],
+    Validation: {
+      ValidateOnUp: true,
+      ReconcileOnUp: true,
+      ValidateOnUpdate: true,
+      ReconcileOnUpdate: true,
+      Verbose: false
+    }
+  }
+}

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithUnnamedDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.InitializeKSailCluster_WithUnnamedDistribution_ShouldReturnValidConfig.verified.txt
@@ -1,0 +1,109 @@
+﻿{
+  ApiVersion: ksail.io/v1alpha1,
+  Kind: Cluster,
+  Metadata: {
+    Name: my-cluster
+  },
+  Spec: {
+    Connection: {
+      Kubeconfig: {UserProfile}/.kube/config,
+      Context: kind-my-cluster,
+      Timeout: 5m
+    },
+    Project: {
+      ConfigPath: ksail.yaml,
+      DistributionConfigPath: kind.yaml,
+      Distribution: 8,
+      DeploymentTool: Flux,
+      SecretManager: false,
+      CNI: Default,
+      Editor: Nano,
+      Provider: Docker,
+      KustomizationPath: k8s,
+      MirrorRegistries: true
+    },
+    DeploymentTool: {
+      Flux: {
+        Source: {
+          Url: oci://testhost:5555/ksail-registry
+        }
+      }
+    },
+    Distribution: {
+      ShowAllClustersInListings: false
+    },
+    SecretManager: {
+      SOPS: {
+        PublicKey: null,
+        InPlace: false,
+        ShowAllKeysInListings: false,
+        ShowPrivateKeysInListings: false
+      }
+    },
+    LocalRegistry: {
+      Name: ksail-registry,
+      HostPort: 5555,
+      Provider: Docker
+    },
+    Generator: {
+      Overwrite: false
+    },
+    MirrorRegistries: [
+      {
+        Proxy: {
+          Url: https://registry.k8s.io
+        },
+        Name: registry.k8s.io-proxy,
+        HostPort: 5556,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://registry-1.docker.io
+        },
+        Name: docker.io-proxy,
+        HostPort: 5557,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://ghcr.io
+        },
+        Name: ghcr.io-proxy,
+        HostPort: 5558,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://gcr.io
+        },
+        Name: gcr.io-proxy,
+        HostPort: 5559,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://mcr.microsoft.com
+        },
+        Name: mcr.microsoft.com-proxy,
+        HostPort: 5560,
+        Provider: Docker
+      },
+      {
+        Proxy: {
+          Url: https://quay.io
+        },
+        Name: quay.io-proxy,
+        HostPort: 5561,
+        Provider: Docker
+      }
+    ],
+    Validation: {
+      ValidateOnUp: true,
+      ReconcileOnUp: true,
+      ValidateOnUpdate: true,
+      ReconcileOnUpdate: true,
+      Verbose: false
+    }
+  }
+}

--- a/tests/KSail.Models.Tests/KSailClusterInitializationTests.cs
+++ b/tests/KSail.Models.Tests/KSailClusterInitializationTests.cs
@@ -75,4 +75,38 @@ public class KSailClusterInitializationTests
     settings.DontIgnoreEmptyCollections();
     _ = await Verify(cluster, settings);
   }
+
+  [Fact]
+  public async Task InitializeKSailCluster_WithNameAndUnnamedDistribution_ShouldReturnValidConfig()
+  {
+    // Arrange
+    var cluster = new KSailCluster((KSailDistributionType)8);
+
+    // Act & Assert
+    var settings = new VerifySettings();
+    settings.AddExtraSettings(s =>
+    {
+      s.DefaultValueHandling = DefaultValueHandling.Include;
+    });
+    cluster.Spec.DeploymentTool.Flux.Source.Url = new Uri("oci://testhost:5555/ksail-registry");
+    settings.DontIgnoreEmptyCollections();
+    _ = await Verify(cluster, settings);
+  }
+
+  [Fact]
+  public async Task InitializeKSailCluster_WithUnnamedDistribution_ShouldReturnValidConfig()
+  {
+    // Arrange
+    var cluster = new KSailCluster("my-cluster", (KSailDistributionType)8);
+
+    // Act & Assert
+    var settings = new VerifySettings();
+    settings.AddExtraSettings(s =>
+    {
+      s.DefaultValueHandling = DefaultValueHandling.Include;
+    });
+    cluster.Spec.DeploymentTool.Flux.Source.Url = new Uri("oci://testhost:5555/ksail-registry");
+    settings.DontIgnoreEmptyCollections();
+    _ = await Verify(cluster, settings);
+  }
 }


### PR DESCRIPTION
Introduce tests to validate the initialization of KSailCluster with both named and unnamed distributions. These tests ensure the correct configuration is generated for different cluster setups.