### PR TITLE
Refactor CLI options to include default values for public key

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -887,7 +887,7 @@ Arguments:
   <path>  The path to the file to encrypt.
 
 Options:
-  -pk, --public-key <public-key>  The public key.
+  -pk, --public-key <public-key>  The public key. [default: ]
   -ip, --in-place                 In-place decryption/encryption. [default: False]
   -o, --output <output>           A file or directory path. []
   -?, -h, --help                  Show help and usage information

--- a/src/KSail/Options/Connection/ConnectionContextOption.cs
+++ b/src/KSail/Options/Connection/ConnectionContextOption.cs
@@ -4,9 +4,7 @@ using KSail.Models;
 namespace KSail.Options.Connection;
 
 
-class ConnectionContextOption(KSailCluster config) : Option<string>(
+class ConnectionContextOption(KSailCluster config) : Option<string?>(
   ["-c", "--context"],
   $"The kubernetes context to use. [default: {config.Spec.Connection.Context}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Connection/ConnectionKubeconfigOption.cs
+++ b/src/KSail/Options/Connection/ConnectionKubeconfigOption.cs
@@ -4,9 +4,7 @@ using KSail.Models;
 namespace KSail.Options.Connection;
 
 
-class ConnectionKubeconfigOption(KSailCluster config) : Option<string>(
+class ConnectionKubeconfigOption(KSailCluster config) : Option<string?>(
   ["-k", "--kubeconfig"],
   $"Path to kubeconfig file. [default: {config.Spec.Connection.Kubeconfig}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Connection/ConnectionOptions.cs
+++ b/src/KSail/Options/Connection/ConnectionOptions.cs
@@ -6,12 +6,7 @@ namespace KSail.Options.Connection;
 
 class ConnectionOptions(KSailCluster config)
 {
-
   public readonly ConnectionContextOption ContextOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
-
-
   public readonly ConnectionKubeconfigOption KubeconfigOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
-
-
   public readonly ConnectionTimeoutOption TimeoutOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
 }

--- a/src/KSail/Options/Connection/ConnectionTimeoutOption.cs
+++ b/src/KSail/Options/Connection/ConnectionTimeoutOption.cs
@@ -4,9 +4,7 @@ using KSail.Models;
 namespace KSail.Options.Connection;
 
 
-class ConnectionTimeoutOption(KSailCluster config) : Option<string>(
+class ConnectionTimeoutOption(KSailCluster config) : Option<string?>(
   ["-t", "--timeout"],
   $"The time to wait for each kustomization to become ready. [default: {config.Spec.Connection.Timeout}]"
-)
-{
-}
+);

--- a/src/KSail/Options/DeploymentTool/DeploymentToolFluxOptions.cs
+++ b/src/KSail/Options/DeploymentTool/DeploymentToolFluxOptions.cs
@@ -6,6 +6,5 @@ namespace KSail.Options.DeploymentTool;
 
 class DeploymentToolFluxOptions(KSailCluster config)
 {
-
   public readonly DeploymentToolFluxSourceUrlOption SourceOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
 }

--- a/src/KSail/Options/DeploymentTool/DeploymentToolOptions.cs
+++ b/src/KSail/Options/DeploymentTool/DeploymentToolOptions.cs
@@ -6,7 +6,5 @@ namespace KSail.Options.DeploymentTool;
 
 class DeploymentToolOptions(KSailCluster config)
 {
-
   public DeploymentToolFluxOptions Flux { get; set; } = new(config);
-
 }

--- a/src/KSail/Options/Distribution/DistributionOptions.cs
+++ b/src/KSail/Options/Distribution/DistributionOptions.cs
@@ -6,6 +6,5 @@ namespace KSail.Options.Distribution;
 
 class DistributionOptions(KSailCluster config)
 {
-
   public DistributionShowAllClustersInListingsOption ShowAllClustersInListings { get; set; } = new(config);
 }

--- a/src/KSail/Options/Generator/GeneratorOverwriteOption.cs
+++ b/src/KSail/Options/Generator/GeneratorOverwriteOption.cs
@@ -6,6 +6,4 @@ namespace KSail.Options.Generator;
 class GeneratorOverwriteOption(KSailCluster config) : Option<bool?>(
   ["-o", "--overwrite"],
   $"Overwrite existing files. [default: {config.Spec.Generator.Overwrite}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Metadata/MetadataNameOption.cs
+++ b/src/KSail/Options/Metadata/MetadataNameOption.cs
@@ -4,9 +4,7 @@ using KSail.Models;
 namespace KSail.Options.Metadata;
 
 
-class MetadataNameOption(KSailCluster config) : Option<string>(
+class MetadataNameOption(KSailCluster config) : Option<string?>(
   ["-n", "--name"],
   $"The name of the cluster. [default: {config.Metadata.Name}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Project/ProjectCNIOption.cs
+++ b/src/KSail/Options/Project/ProjectCNIOption.cs
@@ -7,5 +7,4 @@ namespace KSail.Options.Project;
 class ProjectCNIOption(KSailCluster config) : Option<KSailCNIType>(
   ["--cni"],
   $"The CNI to use. [default: {config.Spec.Project.CNI}]"
-)
-{ }
+);

--- a/src/KSail/Options/Project/ProjectConfigPathOption.cs
+++ b/src/KSail/Options/Project/ProjectConfigPathOption.cs
@@ -7,5 +7,4 @@ namespace KSail.Options.Project;
 class ProjectConfigPathOption(KSailCluster config) : Option<string?>(
   ["--config", "-c"],
   $"The path to the ksail configuration file. [default: {config.Spec.Project.ConfigPath}]"
-)
-{ }
+);

--- a/src/KSail/Options/Project/ProjectDeploymentToolOption.cs
+++ b/src/KSail/Options/Project/ProjectDeploymentToolOption.cs
@@ -9,6 +9,4 @@ namespace KSail.Options.Project;
 class ProjectDeploymentToolOption(KSailCluster config) : Option<KSailDeploymentToolType>(
   ["-dt", "--deployment-tool"],
   $"The Deployment tool to use for updating the state of the cluster. [default: {config.Spec.Project.DeploymentTool}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Project/ProjectDistributionConfigPathOption.cs
+++ b/src/KSail/Options/Project/ProjectDistributionConfigPathOption.cs
@@ -8,5 +8,4 @@ namespace KSail.Options.Project;
 class ProjectDistributionConfigPathOption(KSailCluster config) : Option<string?>(
   ["--distribution-config", "-dc"],
   $"Path to the distribution configuration file. [default: {config.Spec.Project.DistributionConfigPath}]"
-)
-{ }
+);

--- a/src/KSail/Options/Project/ProjectDistributionOption.cs
+++ b/src/KSail/Options/Project/ProjectDistributionOption.cs
@@ -5,10 +5,7 @@ using KSail.Models.Project.Enums;
 namespace KSail.Options.Project;
 
 
-class ProjectDistributionOption(KSailCluster config)
- : Option<KSailDistributionType>(
-    ["-d", "--distribution"],
-    $"The distribution to use for the cluster. [default: {config.Spec.Project.Distribution}]"
-  )
-{
-}
+class ProjectDistributionOption(KSailCluster config) : Option<KSailDistributionType>(
+  ["-d", "--distribution"],
+  $"The distribution to use for the cluster. [default: {config.Spec.Project.Distribution}]"
+);

--- a/src/KSail/Options/Project/ProjectKustomizationPathOption.cs
+++ b/src/KSail/Options/Project/ProjectKustomizationPathOption.cs
@@ -6,6 +6,4 @@ namespace KSail.Options.Project;
 class ProjectKustomizationPathOption(KSailCluster config) : Option<string?>(
   ["--kustomization-path", "-kp"],
   $"The path to the root kustomization directory. [default: {config.Spec.Project.KustomizationPath}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Project/ProjectMirrorRegistriesOption.cs
+++ b/src/KSail/Options/Project/ProjectMirrorRegistriesOption.cs
@@ -9,6 +9,4 @@ class ProjectMirrorRegistriesOption(KSailCluster config) : Option<bool?>
 (
   ["-mr", "--mirror-registries"],
   $"Enable mirror registries for the project. [default: {config.Spec.Project.MirrorRegistries}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Project/ProjectProviderOption.cs
+++ b/src/KSail/Options/Project/ProjectProviderOption.cs
@@ -5,10 +5,7 @@ using KSail.Models.Project.Enums;
 namespace KSail.Options.Project;
 
 
-class ProjectProviderOption(KSailCluster config)
- : Option<KSailProviderType>(
-    ["-p", "--provider"],
-    $"The provider to use for provisioning the cluster. [default: {config.Spec.Project.Provider}]"
-  )
-{
-}
+class ProjectProviderOption(KSailCluster config) : Option<KSailProviderType>(
+  ["-p", "--provider"],
+  $"The provider to use for provisioning the cluster. [default: {config.Spec.Project.Provider}]"
+);

--- a/src/KSail/Options/Project/ProjectSecretManagerOption.cs
+++ b/src/KSail/Options/Project/ProjectSecretManagerOption.cs
@@ -5,9 +5,7 @@ using KSail.Models.Project.Enums;
 namespace KSail.Options.Project;
 
 
-class ProjectSecretManagerOption(KSailCluster config) : Option<bool>(
+class ProjectSecretManagerOption(KSailCluster config) : Option<bool?>(
   ["-sm", "--secret-manager"],
   $"Whether to use a secret manager. [default: {config.Spec.Project.SecretManager}]"
-)
-{
-}
+);

--- a/src/KSail/Options/SecretManager/SecretManagerSOPSInPlaceOption.cs
+++ b/src/KSail/Options/SecretManager/SecretManagerSOPSInPlaceOption.cs
@@ -5,9 +5,7 @@ namespace KSail.Options.SecretManager;
 
 
 
-class SecretManagerSOPSInPlaceOption(KSailCluster config) : Option<bool>(
+class SecretManagerSOPSInPlaceOption(KSailCluster config) : Option<bool?>(
   ["--in-place", "-ip"],
   $"In-place decryption/encryption. [default: {config.Spec.SecretManager.SOPS.InPlace}]"
-)
-{
-}
+);

--- a/src/KSail/Options/SecretManager/SecretManagerSOPSOptions.cs
+++ b/src/KSail/Options/SecretManager/SecretManagerSOPSOptions.cs
@@ -7,15 +7,8 @@ namespace KSail.Options.SecretManager;
 
 class SecretManagerSOPSOptions(KSailCluster config)
 {
-
-  public readonly SecretManagerSOPSPublicKeyOption PublicKeyOption = new() { Arity = ArgumentArity.ZeroOrOne };
-
-
+  public readonly SecretManagerSOPSPublicKeyOption PublicKeyOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
   public readonly SecretManagerSOPSInPlaceOption InPlaceOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
-
-
   public readonly SecretManagerSOPSShowPrivateKeysInListingsOption ShowPrivateKeysInListingsOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
-
-
   public readonly SecretManagerSOPSShowAllKeysInListingsOption ShowAllKeysInListingsOption = new(config) { Arity = ArgumentArity.ZeroOrOne };
 }

--- a/src/KSail/Options/SecretManager/SecretManagerSOPSPublicKeyOption.cs
+++ b/src/KSail/Options/SecretManager/SecretManagerSOPSPublicKeyOption.cs
@@ -1,11 +1,10 @@
 using System.CommandLine;
+using KSail.Models;
 
 namespace KSail.Options.SecretManager;
 
 
-class SecretManagerSOPSPublicKeyOption() : Option<string?>(
+class SecretManagerSOPSPublicKeyOption(KSailCluster cluster) : Option<string?>(
   ["--public-key", "-pk"],
-  $"The public key."
-)
-{
-}
+  $"The public key. [default: {cluster.Spec.SecretManager.SOPS.PublicKey}]"
+);

--- a/src/KSail/Options/SecretManager/SecretManagerSOPSShowPrivateKeysInListingsOption.cs
+++ b/src/KSail/Options/SecretManager/SecretManagerSOPSShowPrivateKeysInListingsOption.cs
@@ -8,5 +8,4 @@ namespace KSail.Options.SecretManager;
 class SecretManagerSOPSShowPrivateKeysInListingsOption(KSailCluster config) : Option<bool?>(
   ["--show-private-keys", "-spk"],
   $"Show private keys. [default: {config.Spec.SecretManager.SOPS.ShowPrivateKeysInListings}]"
-)
-{ }
+);

--- a/src/KSail/Options/Validation/ValidationOptions.cs
+++ b/src/KSail/Options/Validation/ValidationOptions.cs
@@ -12,5 +12,4 @@ class ValidationOptions(KSailCluster config)
   public ValidationValidateOnUpdateOption ValidateOnUpdateOption { get; } = new(config) { Arity = ArgumentArity.ZeroOrOne };
   public ValidationReconcileOnUpdateOption ReconcileOnUpdateOption { get; } = new(config) { Arity = ArgumentArity.ZeroOrOne };
   public ValidationVerboseOption VerboseOption { get; } = new(config) { Arity = ArgumentArity.ZeroOrOne };
-
 }

--- a/src/KSail/Options/Validation/ValidationReconcileOnUpOption.cs
+++ b/src/KSail/Options/Validation/ValidationReconcileOnUpOption.cs
@@ -8,6 +8,4 @@ namespace KSail.Options.Validation;
 class ValidationReconcileOnUpOption(KSailCluster config) : Option<bool?>(
   ["--reconcile", "-r"],
   $"Reconcile manifests. [default: {config.Spec.Validation.ReconcileOnUp}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Validation/ValidationReconcileOnUpdateOption.cs
+++ b/src/KSail/Options/Validation/ValidationReconcileOnUpdateOption.cs
@@ -8,6 +8,4 @@ namespace KSail.Options.Validation;
 class ValidationReconcileOnUpdateOption(KSailCluster config) : Option<bool?>(
   ["--reconcile", "-r"],
   $"Reconcile manifests. [default: {config.Spec.Validation.ReconcileOnUpdate}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Validation/ValidationValidateOnUpOption.cs
+++ b/src/KSail/Options/Validation/ValidationValidateOnUpOption.cs
@@ -8,6 +8,4 @@ namespace KSail.Options.Validation;
 class ValidationValidateOnUpOption(KSailCluster config) : Option<bool?>(
   ["--validate", "-v"],
   $"Validate project files before creating a new cluster. [default: {config.Spec.Validation.ValidateOnUp}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Validation/ValidationValidateOnUpdateOption.cs
+++ b/src/KSail/Options/Validation/ValidationValidateOnUpdateOption.cs
@@ -8,6 +8,4 @@ namespace KSail.Options.Validation;
 class ValidationValidateOnUpdateOption(KSailCluster config) : Option<bool?>(
   ["--validate", "-v"],
   $"Validate project files before applying changes to an existing cluster. [default: {config.Spec.Validation.ValidateOnUpdate}]"
-)
-{
-}
+);

--- a/src/KSail/Options/Validation/ValidationVerboseOption.cs
+++ b/src/KSail/Options/Validation/ValidationVerboseOption.cs
@@ -6,6 +6,4 @@ namespace KSail.Options.Validation;
 class ValidationVerboseOption(KSailCluster config) : Option<bool?>(
   ["--verbose"],
   $"Verbose output for validation or status checks. [default: {config.Spec.Validation.Verbose}]"
-)
-{
-}
+);

--- a/src/KSail/Utils/KSailClusterConfigLoader.cs
+++ b/src/KSail/Utils/KSailClusterConfigLoader.cs
@@ -21,7 +21,7 @@ static class KSailClusterConfigLoader
   internal static async Task<KSailCluster> LoadWithoptionsAsync(InvocationContext context)
   {
     var config = await LoadAsync(
-      context.ParseResult.GetValueForOption(CLIOptions.Project.ConfigPathOption),
+      context.ParseResult.GetValueForOption(CLIOptions.Project.ConfigPathOption) ?? "ksail.yaml",
       context.ParseResult.GetValueForOption(CLIOptions.Metadata.NameOption),
       context.ParseResult.GetValueForOption(CLIOptions.Project.DistributionOption)
     ).ConfigureAwait(false);
@@ -84,7 +84,7 @@ static class KSailClusterConfigLoader
     return config;
   }
 
-  internal static async Task<KSailCluster> LoadAsync(string? configFilePath = "ksail.yaml", string? name = default, KSailDistributionType distribution = default)
+  internal static async Task<KSailCluster> LoadAsync(string configFilePath, string? name = default, KSailDistributionType distribution = default)
   {
     // Create default KSailClusterConfig
     var ksailClusterConfig = string.IsNullOrEmpty(name) ?
@@ -93,9 +93,7 @@ static class KSailClusterConfigLoader
 
     // Locate KSail YAML file
     string startDirectory = Directory.GetCurrentDirectory();
-    string? ksailYaml = string.IsNullOrEmpty(configFilePath) ?
-      FindConfigFile(startDirectory, "ksail.yaml") :
-      FindConfigFile(startDirectory, configFilePath);
+    string? ksailYaml = FindConfigFile(startDirectory, configFilePath);
 
 
     // If no KSail YAML file is found, return the default KSailClusterConfig

--- a/tests/KSail.Tests/Commands/Secrets/ksail secrets encrypt --help.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/ksail secrets encrypt --help.verified.txt
@@ -8,7 +8,7 @@ Arguments:
   <path>  The path to the file to encrypt.
 
 Options:
-  -pk, --public-key <public-key>  The public key.
+  -pk, --public-key <public-key>  The public key. [default: ]
   -ip, --in-place                 In-place decryption/encryption. [default: False]
   -o, --output <output>           A file or directory path. []
   -?, -h, --help                  Show help and usage information


### PR DESCRIPTION
Update CLI options to provide default values for the public key and refactor related classes for improved clarity and consistency.