### PR TITLE
fix: Improve null handling and error messages in UpdateConfig method

### DIFF
--- a/src/KSail/Utils/KSailClusterExtensions.cs
+++ b/src/KSail/Utils/KSailClusterExtensions.cs
@@ -15,26 +15,28 @@ static class KSailClusterExtensions
     for (int i = 0; i < properties.Length; i++)
     {
       string propertyName = properties[i];
-      var property = (currentObject?.GetType().GetProperty(propertyName)) ?? throw new ArgumentException($"Property '{propertyName}' not found on type '{currentObject?.GetType().FullName}'");
-      var defaultProperty = (defaultObject?.GetType().GetProperty(propertyName)) ?? throw new ArgumentException($"Property '{propertyName}' not found on type '{defaultObject?.GetType().FullName}'");
+      var property = currentObject?.GetType().GetProperty(propertyName);
+      var defaultProperty = defaultObject?.GetType().GetProperty(propertyName);
       if (i == properties.Length - 1)
       {
-        // If it's the last property in the path, set the value
-        object? currentValue = property.GetValue(currentObject);
-        object? defaultValue = defaultProperty.GetValue(defaultObject);
+        object? currentValue = property?.GetValue(currentObject);
+        object? defaultValue = defaultProperty?.GetValue(defaultObject);
 
         if (value != null && !Equals(currentValue, value) && !Equals(value, defaultValue))
         {
           if (value is IEnumerable<string> enumerableValue && !enumerableValue.Any())
             continue;
-          property.SetValue(currentObject, value);
+          property?.SetValue(currentObject, value);
         }
       }
       else
       {
-        // Traverse to the next object in the path
-        object? nextObject = property.GetValue(currentObject);
-        object? nextDefaultObject = defaultProperty.GetValue(defaultObject);
+        object? nextObject = property?.GetValue(currentObject);
+        object? nextDefaultObject = defaultProperty?.GetValue(defaultObject);
+        if (property == null || defaultProperty == null)
+        {
+          throw new KSailException($"Property '{propertyName}' not found in {currentObject?.GetType().Name}");
+        }
         nextObject ??= Activator.CreateInstance(property.PropertyType);
         nextDefaultObject ??= Activator.CreateInstance(defaultProperty.PropertyType);
         property.SetValue(currentObject, nextObject);


### PR DESCRIPTION
Enhance error handling in the UpdateConfig method by improving null checks and providing clearer error messages when properties are not found.