### PR TITLE
fix: Simplify Boolean schema handling in SchemaGenerator

### DIFF
--- a/src/KSail.Docs/SchemaGenerator.cs
+++ b/src/KSail.Docs/SchemaGenerator.cs
@@ -56,11 +56,8 @@ static class SchemaGenerator
         {
           if (schema is not JsonObject jObj)
           {
-            // Handle the case where the schema is a Boolean.
             var valueKind = schema.GetValueKind();
             schema = jObj = [];
-            if (valueKind is JsonValueKind.False)
-              jObj.Add("not", true);
           }
 
           jObj.Insert(0, "description", descriptionAttr.Description);


### PR DESCRIPTION
Remove unnecessary handling for Boolean schema values to streamline the schema generation process.