### PR TITLE
Refactor validation logic and add unit tests for ConfigurationValidator

### DIFF
--- a/src/KSail/Commands/Validate/Handlers/KSailValidateCommandHandler.cs
+++ b/src/KSail/Commands/Validate/Handlers/KSailValidateCommandHandler.cs
@@ -17,9 +17,7 @@ class KSailValidateCommandHandler(KSailCluster config)
       throw new KSailException($"no manifest files found in '{path}'.");
 
     Console.WriteLine("► validating configuration");
-    var (configIsValid, configMessage) = await _configValidator.ValidateAsync(path, cancellationToken: cancellationToken).ConfigureAwait(false);
-    if (!configIsValid)
-      throw new KSailException(configMessage);
+    await _configValidator.ValidateAsync(path, cancellationToken: cancellationToken).ConfigureAwait(false);
     Console.WriteLine("✔ configuration is valid");
 
     Console.WriteLine("► validating yaml syntax");
@@ -33,6 +31,6 @@ class KSailValidateCommandHandler(KSailCluster config)
     if (!schemasAreValid)
       throw new KSailException(schemasMessage);
     Console.WriteLine("✔ schemas are valid");
-    return configIsValid && yamlIsValid && schemasAreValid;
+    return yamlIsValid && schemasAreValid;
   }
 }

--- a/src/KSail/Commands/Validate/Validators/ConfigurationValidator.cs
+++ b/src/KSail/Commands/Validate/Validators/ConfigurationValidator.cs
@@ -10,66 +10,57 @@ namespace KSail.Commands.Validate.Validators;
 
 class ConfigurationValidator(KSailCluster config)
 {
-  public async Task<(bool, string)> ValidateAsync(string path, CancellationToken cancellationToken = default)
+  public async Task ValidateAsync(string path, CancellationToken cancellationToken = default)
   {
     string projectRootPath = path;
     try
     {
-      while (!File.Exists(Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)))
-      {
-        projectRootPath = Directory.GetParent(projectRootPath)?.FullName ?? throw new KSailException($"not a valid ksail project directory or subdirectory: '{path}'.");
-      }
+      projectRootPath = GetProjectRootPath(path, projectRootPath);
     }
     catch (Exception)
     {
-      return (true, string.Empty);
+      return;
     }
 
-    var (isValid, message) = CheckContextName(projectRootPath, config.Spec.Project.Distribution, config.Metadata.Name, config.Spec.Connection.Context);
-    if (!isValid)
-      return (false, message);
-
-
-    (isValid, message) = CheckOCISourceUri(projectRootPath, config.Spec.Project.Distribution);
-    if (!isValid)
-      return (false, message);
+    CheckContextName(projectRootPath, config.Spec.Project.Distribution, config.Metadata.Name, config.Spec.Connection.Context);
+    CheckOCISourceUri(projectRootPath, config.Spec.Project.Distribution);
 
     var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
-    if (config.Spec.Project.Distribution == KSailDistributionType.K3s)
+    switch (config.Spec.Project.Distribution)
     {
-      var distributionConfig = deserializer.Deserialize<K3dConfig>(await File.ReadAllTextAsync(Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath), cancellationToken).ConfigureAwait(false));
+      case KSailDistributionType.K3s:
+        {
+          var distributionConfig = deserializer.Deserialize<K3dConfig>(await File.ReadAllTextAsync(Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath), cancellationToken).ConfigureAwait(false));
+          CheckClusterName(projectRootPath, config.Metadata.Name, distributionConfig.Metadata.Name);
+          CheckK3dCNI(projectRootPath, distributionConfig);
+          CheckK3dMirrorRegistries(projectRootPath, distributionConfig);
+          break;
+        }
 
-      (isValid, message) = CheckClusterName(projectRootPath, config.Metadata.Name, distributionConfig.Metadata.Name);
-      if (!isValid)
-        return (false, message);
+      case KSailDistributionType.Native:
+        {
+          var distributionConfig = deserializer.Deserialize<KindConfig>(await File.ReadAllTextAsync(Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath), cancellationToken).ConfigureAwait(false));
+          CheckClusterName(projectRootPath, config.Metadata.Name, distributionConfig.Name);
+          CheckKindCNI(projectRootPath, distributionConfig);
+          break;
+        }
 
-      (isValid, message) = CheckK3dCNI(projectRootPath, distributionConfig);
-      if (!isValid)
-        return (false, message);
-
-      (isValid, message) = CheckK3dMirrorRegistries(projectRootPath, distributionConfig);
-      if (!isValid)
-        return (false, message);
+      default:
+        throw new KSailException($"unsupported distribution '{config.Spec.Project.Distribution}'.");
     }
-    else if (config.Spec.Project.Distribution == KSailDistributionType.Native)
-    {
-      var distributionConfig = deserializer.Deserialize<KindConfig>(await File.ReadAllTextAsync(Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath), cancellationToken).ConfigureAwait(false));
-      (isValid, message) = CheckClusterName(projectRootPath, config.Metadata.Name, distributionConfig.Name);
-      if (!isValid)
-        return (false, message);
-
-      (isValid, message) = CheckKindCNI(projectRootPath, distributionConfig);
-      if (!isValid)
-        return (false, message);
-    }
-    else
-    {
-      throw new KSailException($"unsupported distribution '{config.Spec.Project.Distribution}'.");
-    }
-    return (true, string.Empty);
   }
 
-  (bool isValid, string message) CheckK3dMirrorRegistries(string projectRootPath, K3dConfig distributionConfig)
+  string GetProjectRootPath(string path, string projectRootPath)
+  {
+    while (!File.Exists(Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)))
+    {
+      projectRootPath = Directory.GetParent(projectRootPath)?.FullName ?? throw new KSailException($"not a valid ksail project directory or subdirectory: '{path}'.");
+    }
+
+    return projectRootPath;
+  }
+
+  void CheckK3dMirrorRegistries(string projectRootPath, K3dConfig distributionConfig)
   {
     // check that k3d config includes all mirrors from the ksail config
     var expectedMirrors = config.Spec.MirrorRegistries.Select(x => x.Proxy.Url.Host.Contains("docker.io", StringComparison.Ordinal) ? "docker.io" : x.Proxy.Url.Host);
@@ -77,14 +68,13 @@ class ConfigurationValidator(KSailCluster config)
     {
       if (!(distributionConfig.Registries?.Config?.Contains(expectedMirror, StringComparison.Ordinal) ?? false))
       {
-        return (false, $"'registries.config' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}' does not contain the expected mirror '{expectedMirror}'." + Environment.NewLine +
+        throw new KSailException($"'registries.config' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}' does not contain the expected mirror '{expectedMirror}'." + Environment.NewLine +
           $"  - please add the mirror to 'registries.config' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'.");
       }
     }
-    return (true, string.Empty);
   }
 
-  (bool isValid, string message) CheckContextName(string projectRootPath, KSailDistributionType distribution, string name, string context)
+  void CheckContextName(string projectRootPath, KSailDistributionType distribution, string name, string context)
   {
     string expectedContextName = distribution switch
     {
@@ -92,12 +82,13 @@ class ConfigurationValidator(KSailCluster config)
       KSailDistributionType.Native => $"kind-{name}",
       _ => throw new KSailException($"unsupported distribution '{distribution}'.")
     };
-    return !string.Equals(expectedContextName, context, StringComparison.Ordinal)
-      ? (false, $"'config.spec.connection.context' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match the expected value '{expectedContextName}'.")
-      : (true, string.Empty);
+    if (!string.Equals(expectedContextName, context, StringComparison.Ordinal))
+    {
+      throw new KSailException($"'config.spec.connection.context' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match the expected value '{expectedContextName}'.");
+    }
   }
 
-  (bool isValid, string message) CheckOCISourceUri(string projectRootPath, KSailDistributionType distribution)
+  void CheckOCISourceUri(string projectRootPath, KSailDistributionType distribution)
   {
     var expectedOCISourceUri = distribution switch
     {
@@ -105,20 +96,22 @@ class ConfigurationValidator(KSailCluster config)
       KSailDistributionType.K3s => new Uri("oci://host.k3d.internal:5555/ksail-registry"),
       _ => throw new KSailException($"unsupported distribution '{distribution}'.")
     };
-    return !Equals(expectedOCISourceUri, config.Spec.DeploymentTool.Flux.Source.Url)
-      ? (false, $"'config.spec.deploymentTool.flux.source.url' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match the expected value '{expectedOCISourceUri}'.")
-      : (true, string.Empty);
+    if (!Equals(expectedOCISourceUri, config.Spec.DeploymentTool.Flux.Source.Url))
+    {
+      throw new KSailException($"'config.spec.deploymentTool.flux.source.url' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match the expected value '{expectedOCISourceUri}'.");
+    }
   }
 
-  (bool, string) CheckClusterName(string projectRootPath, string ksailClusterName, string distributionClusterName)
+  void CheckClusterName(string projectRootPath, string ksailClusterName, string distributionClusterName)
   {
-    return !string.Equals(ksailClusterName, distributionClusterName, StringComparison.Ordinal)
-      ? (false, $"'metadata.name' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match cluster name in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
-        $"  - please set cluster name to '{ksailClusterName}' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'.")
-      : (true, string.Empty);
+    if (!string.Equals(ksailClusterName, distributionClusterName, StringComparison.Ordinal))
+    {
+      throw new KSailException($"'metadata.name' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match cluster name in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
+        $"  - please set cluster name to '{ksailClusterName}' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'.");
+    }
   }
 
-  (bool, string) CheckK3dCNI(string projectRootPath, K3dConfig distributionConfig)
+  void CheckK3dCNI(string projectRootPath, K3dConfig distributionConfig)
   {
     var expectedWithCustomCNIK3sExtraArgs = new List<K3dOptionsK3sExtraArg>
       {
@@ -141,29 +134,27 @@ class ConfigurationValidator(KSailCluster config)
     var actual = distributionConfig.Options?.K3s?.ExtraArgs?.Select(x => x.Arg + ":" + (x.NodeFilters?.First() ?? "server:*")) ?? [];
     if (config.Spec.Project.CNI == KSailCNIType.Default && actual.Intersect(expectedWithCustomCNI).Any())
     {
-      return (false, $"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
+      throw new KSailException($"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
         $"  - please remove '--flannel-backend=none' and '--disable-network-policy' from 'options.k3s.extraArgs' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'.");
     }
     else if (config.Spec.Project.CNI != KSailCNIType.Default && !actual.All(expectedWithCustomCNI.Contains))
     {
-      return (false, $"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
+      throw new KSailException($"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
         $"  - please set 'options.k3s.extraArgs' to '--flannel-backend=none' and '--disable-network-policy' for 'server:*' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'.");
     }
-    return (true, string.Empty);
   }
 
-  (bool isValid, string message) CheckKindCNI(string projectRootPath, KindConfig distributionConfig)
+  void CheckKindCNI(string projectRootPath, KindConfig distributionConfig)
   {
     if (config.Spec.Project.CNI == KSailCNIType.Default && distributionConfig.Networking?.DisableDefaultCNI == true)
     {
-      return (false, $"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
+      throw new KSailException($"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
         $"  - please set 'networking.disableDefaultCNI: false' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'.");
     }
     else if (config.Spec.Project.CNI != KSailCNIType.Default && distributionConfig.Networking?.DisableDefaultCNI != true)
     {
-      return (false, $"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
+      throw new KSailException($"'spec.project.cni={config.Spec.Project.CNI}' in '{Path.Combine(projectRootPath, config.Spec.Project.ConfigPath)}' does not match expected values in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'." + Environment.NewLine +
         $"  - please set 'networking.disableDefaultCNI: true' in '{Path.Combine(projectRootPath, config.Spec.Project.DistributionConfigPath)}'.");
     }
-    return (true, string.Empty);
   }
 }

--- a/tests/KSail.Tests.Unit/Commands/Validate/Validators/ConfigurationValidatorTests.cs
+++ b/tests/KSail.Tests.Unit/Commands/Validate/Validators/ConfigurationValidatorTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Devantler.KubernetesGenerator.K3d.Models;
+using Devantler.KubernetesGenerator.Kind.Models;
+using KSail.Commands.Root;
+using KSail.Commands.Validate.Validators;
+using KSail.Models;
+using KSail.Models.Connection;
+using KSail.Models.DeploymentTool;
+using KSail.Models.MirrorRegistry;
+using KSail.Models.Project;
+using KSail.Models.Project.Enums;
+using Xunit;
+using YamlDotNet.Serialization;
+
+namespace KSail.Tests.Unit.Commands.Validate.Validators;
+
+public class ConfigurationValidatorTest
+{
+  readonly IConsole _console;
+  readonly KSailRootCommand _rootCommand;
+
+  public ConfigurationValidatorTest()
+  {
+    _console = new TestConsole();
+    _rootCommand = new KSailRootCommand(_console);
+  }
+
+  [Fact]
+  public async Task ValidateAsync_UnsupportedDistribution_ThrowsKSailException()
+  {
+    // Arrange
+    string tempDir = Path.Combine(Path.GetTempPath(), "ksail-validate-unsupported-distribution");
+    _ = await _rootCommand.InvokeAsync(["init", "--output", tempDir], _console);
+    var config = new KSailCluster
+    {
+      Spec = new KSailClusterSpec
+      {
+        Project = new KSailProject
+        {
+          Distribution = (KSailDistributionType)999
+        }
+      }
+    };
+    var validator = new ConfigurationValidator(config);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<KSailException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
+    Assert.Contains("unsupported distribution", exception.Message, StringComparison.Ordinal);
+
+    //Cleanup
+    Directory.Delete(tempDir, true);
+  }
+
+  [Theory]
+  [InlineData(KSailDistributionType.Native)]
+  [InlineData(KSailDistributionType.K3s)]
+  public async Task ValidateAsync_InvalidContextName_ThrowsKSailException(KSailDistributionType distribution)
+  {
+    // Arrange
+    string tempDir = Path.Combine(Path.GetTempPath(), "ksail-validate-invalid-context-name");
+    _ = await _rootCommand.InvokeAsync(["init", "--output", tempDir, "--distribution", distribution.ToString()], _console);
+    var config = new KSailCluster
+    {
+      Spec = new KSailClusterSpec
+      {
+        Project = new KSailProject
+        {
+          Distribution = distribution
+        },
+        Connection = new KSailConnection
+        {
+          Context = "invalid-context"
+        }
+      }
+    };
+    var validator = new ConfigurationValidator(config);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<KSailException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
+    Assert.Contains("'config.spec.connection.context' in", exception.Message, StringComparison.Ordinal);
+
+    //Cleanup
+    Directory.Delete(tempDir, true);
+  }
+
+  [Theory]
+  [InlineData(KSailDistributionType.Native)]
+  [InlineData(KSailDistributionType.K3s)]
+  public async Task ValidateAsync_InvalidOCISourceUri_ThrowsKSailException(KSailDistributionType distribution)
+  {
+
+    string tempDir = Path.Combine(Path.GetTempPath(), "ksail-validate-invalid-oci-source-uri");
+    _ = await _rootCommand.InvokeAsync(["init", "--output", tempDir, "--distribution", distribution.ToString()], _console);
+    var config = new KSailCluster
+    {
+      Spec = new KSailClusterSpec
+      {
+        Project = new KSailProject
+        {
+          Distribution = distribution
+        },
+        Connection = new KSailConnection
+        {
+          Context = distribution switch
+          {
+            KSailDistributionType.K3s => "k3d-ksail-default",
+            KSailDistributionType.Native => "kind-ksail-default",
+            _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+          }
+        },
+        DeploymentTool = new KSailDeploymentTool
+        {
+          Flux = new KSailFluxDeploymentTool
+          {
+            Source = new KSailFluxDeploymentToolRepository
+            {
+              Url = new Uri("oci://invalid-oci-source-uri")
+            }
+          }
+        },
+      }
+    };
+    var validator = new ConfigurationValidator(config);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<KSailException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
+    Assert.Contains("'config.spec.deploymentTool.flux.source.url' in", exception.Message, StringComparison.Ordinal);
+
+    //Cleanup
+    Directory.Delete(tempDir, true);
+  }
+
+  [Theory]
+  [InlineData(KSailDistributionType.Native)]
+  [InlineData(KSailDistributionType.K3s)]
+  public async Task ValidateAsync_InvalidClusterName_ThrowsKSailException(KSailDistributionType distribution)
+  {
+
+    string tempDir = Path.Combine(Path.GetTempPath(), "ksail-validate-invalid-cluster-name");
+    _ = await _rootCommand.InvokeAsync(["init", "--output", tempDir, "--distribution", distribution.ToString()], _console);
+    var config = new KSailCluster
+    {
+      Metadata = new KSailMetadata
+      {
+        Name = "invalid"
+      },
+      Spec = new KSailClusterSpec
+      {
+        Project = new KSailProject
+        {
+          Distribution = distribution,
+          DistributionConfigPath = distribution switch
+          {
+            KSailDistributionType.K3s => "k3d.yaml",
+            KSailDistributionType.Native => "kind.yaml",
+            _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+          }
+        },
+        Connection = new KSailConnection
+        {
+          Context = distribution switch
+          {
+            KSailDistributionType.K3s => "k3d-invalid",
+            KSailDistributionType.Native => "kind-invalid",
+            _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+          }
+        },
+        DeploymentTool = new KSailDeploymentTool
+        {
+          Flux = new KSailFluxDeploymentTool
+          {
+            Source = new KSailFluxDeploymentToolRepository
+            {
+              Url = distribution switch
+              {
+                KSailDistributionType.Native => new Uri("oci://ksail-registry:5000/ksail-registry"),
+                KSailDistributionType.K3s => new Uri("oci://host.k3d.internal:5555/ksail-registry"),
+                _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+              }
+            }
+          }
+        },
+      }
+    };
+    var validator = new ConfigurationValidator(config);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<KSailException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
+    Assert.Contains("'metadata.name' in '", exception.Message, StringComparison.Ordinal);
+
+    //Cleanup
+    Directory.Delete(tempDir, true);
+  }
+
+  [Theory]
+  [InlineData(KSailDistributionType.Native, KSailCNIType.Default, KSailCNIType.Cilium)]
+  [InlineData(KSailDistributionType.Native, KSailCNIType.Cilium, KSailCNIType.Default)]
+  [InlineData(KSailDistributionType.K3s, KSailCNIType.Default, KSailCNIType.Cilium)]
+  [InlineData(KSailDistributionType.K3s, KSailCNIType.Cilium, KSailCNIType.Default)]
+  public async Task ValidateAsync_InvalidCNI_ThrowsKSailException(KSailDistributionType distribution, KSailCNIType actualCNI, KSailCNIType expectedCNI)
+  {
+    string tempDir = Path.Combine(Path.GetTempPath(), "ksail-validate-invalid-cni");
+    _ = await _rootCommand.InvokeAsync(["init", "--output", tempDir, "--distribution", distribution.ToString(), "--cni", expectedCNI.ToString()], _console);
+    var config = new KSailCluster
+    {
+      Spec = new KSailClusterSpec
+      {
+        Project = new KSailProject
+        {
+          Distribution = distribution,
+          CNI = actualCNI,
+          DistributionConfigPath = distribution switch
+          {
+            KSailDistributionType.K3s => "k3d.yaml",
+            KSailDistributionType.Native => "kind.yaml",
+            _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+          }
+        },
+        Connection = new KSailConnection
+        {
+          Context = distribution switch
+          {
+            KSailDistributionType.K3s => "k3d-ksail-default",
+            KSailDistributionType.Native => "kind-ksail-default",
+            _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+          }
+        },
+        DeploymentTool = new KSailDeploymentTool
+        {
+          Flux = new KSailFluxDeploymentTool
+          {
+            Source = new KSailFluxDeploymentToolRepository
+            {
+              Url = distribution switch
+              {
+                KSailDistributionType.Native => new Uri("oci://ksail-registry:5000/ksail-registry"),
+                KSailDistributionType.K3s => new Uri("oci://host.k3d.internal:5555/ksail-registry"),
+                _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+              }
+            }
+          }
+        },
+      }
+    };
+    var validator = new ConfigurationValidator(config);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<KSailException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
+    Assert.Contains($"'spec.project.cni={actualCNI}' in '", exception.Message, StringComparison.Ordinal);
+
+    //Cleanup
+    Directory.Delete(tempDir, true);
+  }
+
+  [Theory]
+  [InlineData(KSailDistributionType.K3s)]
+  public async Task ValidateAsync_InvalidMirrorRegistries_ThrowsKSailException(KSailDistributionType distribution)
+  {
+    string tempDir = Path.Combine(Path.GetTempPath(), "ksail-validate-invalid-mirror-registries");
+    _ = await _rootCommand.InvokeAsync(["init", "--output", tempDir, "--distribution", distribution.ToString(), "--mirror-registries"], _console);
+    var config = new KSailCluster
+    {
+      Spec = new KSailClusterSpec
+      {
+        Project = new KSailProject
+        {
+          Distribution = distribution,
+          DistributionConfigPath = "k3d.yaml",
+          MirrorRegistries = false
+        },
+        Connection = new KSailConnection
+        {
+          Context = "k3d-ksail-default"
+        },
+        DeploymentTool = new KSailDeploymentTool
+        {
+          Flux = new KSailFluxDeploymentTool
+          {
+            Source = new KSailFluxDeploymentToolRepository
+            {
+              Url = new Uri("oci://host.k3d.internal:5555/ksail-registry")
+            }
+          }
+        },
+        MirrorRegistries = [
+          new KSailMirrorRegistry
+          {
+            Name = "random.io-proxy",
+            HostPort = 7654,
+            Proxy = new KSailMirrorRegistryProxy
+            {
+              Url = new Uri("https://random.io")
+            }
+          }
+        ]
+      }
+    };
+    var validator = new ConfigurationValidator(config);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<KSailException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
+    Assert.Contains("'registries.config' in", exception.Message, StringComparison.Ordinal);
+
+    //Cleanup
+    Directory.Delete(tempDir, true);
+  }
+}


### PR DESCRIPTION
Simplify the validation logic in the ConfigurationValidator and KSailValidateCommandHandler. Introduce unit tests to ensure proper validation of distribution and context name.