### PR TITLE
fix: Simplify schema description attribute handling in SchemaGenerator

### DIFF
--- a/src/KSail.Docs/SchemaGenerator.cs
+++ b/src/KSail.Docs/SchemaGenerator.cs
@@ -54,12 +54,7 @@ static class SchemaGenerator
         // Apply description attribute to the generated schema.
         if (descriptionAttr != null)
         {
-          if (schema is not JsonObject jObj)
-          {
-            var valueKind = schema.GetValueKind();
-            schema = jObj = [];
-          }
-
+          var jObj = schema.AsObject();
           jObj.Insert(0, "description", descriptionAttr.Description);
         }
 


### PR DESCRIPTION
Streamline the handling of the description attribute in the schema generation process by directly converting the schema to a JsonObject, reducing unnecessary checks and improving code clarity.