### PR TITLE
fix: add default ingress and gateway controllers

### DIFF
--- a/docs/configuration/declarative-config.md
+++ b/docs/configuration/declarative-config.md
@@ -49,20 +49,24 @@ spec:
     configPath: ksail.yaml
     # The path to the distribution configuration file. [default: kind.yaml]
     distributionConfigPath: kind.yaml
+    # The path to the root kustomization directory. [default: k8s]
+    kustomizationPath: k8s
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Docker
     # The Kubernetes distribution to use. [default: Native]
     distribution: Native
     # The Deployment tool to use. [default: Kubectl]
     deploymentTool: Kubectl
-    # Whether to use a secret manager. [default: false]
-    secretManager: false
     # The CNI to use. [default: Default]
     cni: Default
+    # The Ingress Controller to use. [default: Default]
+    ingressController: Default
+    # The Gateway Controller to use. [default: Default]
+    gatewayController: Default
+    # Whether to use a secret manager. [default: false]
+    secretManager: false
     # The editor to use for viewing files while debugging. [default: Nano]
     editor: Nano
-    # The provider to use for running the KSail cluster. [default: Docker]
-    provider: Docker
-    # The path to the root kustomization directory. [default: k8s]
-    kustomizationPath: k8s
     # Whether to set up mirror registries for the project. [default: true]
     mirrorRegistries: true
   # The options for the deployment tool.

--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -63,6 +63,16 @@
               "description": "The path to the distribution configuration file. [default: kind.yaml]",
               "type": "string"
             },
+            "kustomizationPath": {
+              "description": "The path to the root kustomization directory. [default: k8s]",
+              "type": "string"
+            },
+            "provider": {
+              "description": "The provider to use for running the KSail cluster. [default: Docker]",
+              "enum": [
+                "Docker"
+              ]
+            },
             "distribution": {
               "description": "The Kubernetes distribution to use. [default: Native]",
               "enum": [
@@ -77,10 +87,6 @@
                 "Flux"
               ]
             },
-            "secretManager": {
-              "description": "Whether to use a secret manager. [default: false]",
-              "type": "boolean"
-            },
             "cni": {
               "description": "The CNI to use. [default: Default]",
               "enum": [
@@ -88,22 +94,28 @@
                 "Cilium"
               ]
             },
+            "ingressController": {
+              "description": "The Ingress Controller to use. [default: Default]",
+              "enum": [
+                "Default"
+              ]
+            },
+            "gatewayController": {
+              "description": "The Gateway Controller to use. [default: Default]",
+              "enum": [
+                "Default"
+              ]
+            },
+            "secretManager": {
+              "description": "Whether to use a secret manager. [default: false]",
+              "type": "boolean"
+            },
             "editor": {
               "description": "The editor to use for viewing files while debugging. [default: Nano]",
               "enum": [
                 "Nano",
                 "Vim"
               ]
-            },
-            "provider": {
-              "description": "The provider to use for running the KSail cluster. [default: Docker]",
-              "enum": [
-                "Docker"
-              ]
-            },
-            "kustomizationPath": {
-              "description": "The path to the root kustomization directory. [default: k8s]",
-              "type": "string"
             },
             "mirrorRegistries": {
               "description": "Whether to set up mirror registries for the project. [default: true]",

--- a/src/KSail.Models/Project/Enums/KSailGatewayControllerType.cs
+++ b/src/KSail.Models/Project/Enums/KSailGatewayControllerType.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel;
+
+namespace KSail.Models.Project.Enums;
+
+public enum KSailGatewayControllerType
+{
+  [Description("Use the default Gateway Controller that comes with the chosen Kubernetes distribution.")]
+  Default
+}

--- a/src/KSail.Models/Project/Enums/KSailIngressControllerType.cs
+++ b/src/KSail.Models/Project/Enums/KSailIngressControllerType.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel;
+
+namespace KSail.Models.Project.Enums;
+
+public enum KSailIngressControllerType
+{
+  [Description("Use the default Ingress Controller that comes with the chosen Kubernetes distribution.")]
+  Default
+}

--- a/src/KSail.Models/Project/KSailProject.cs
+++ b/src/KSail.Models/Project/KSailProject.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using KSail.Models.GatewayController;
 using KSail.Models.Project.Enums;
 using YamlDotNet.Serialization;
 
@@ -14,27 +15,33 @@ public class KSailProject
   [Description("The path to the distribution configuration file. [default: kind.yaml]")]
   public string DistributionConfigPath { get; set; } = "kind.yaml";
 
+  [Description("The path to the root kustomization directory. [default: k8s]")]
+  public string KustomizationPath { get; set; } = "k8s";
+
+  [Description("The provider to use for running the KSail cluster. [default: Docker]")]
+  public KSailProviderType Provider { get; set; } = KSailProviderType.Docker;
+
   [Description("The Kubernetes distribution to use. [default: Native]")]
   public KSailDistributionType Distribution { get; set; } = KSailDistributionType.Native;
 
   [Description("The Deployment tool to use. [default: Kubectl]")]
   public KSailDeploymentToolType DeploymentTool { get; set; } = KSailDeploymentToolType.Kubectl;
 
-  [Description("Whether to use a secret manager. [default: false]")]
-  public bool SecretManager { get; set; } = false;
-
   [Description("The CNI to use. [default: Default]")]
   [YamlMember(Alias = "cni")]
   public KSailCNIType CNI { get; set; } = KSailCNIType.Default;
 
+  [Description("The Ingress Controller to use. [default: Default]")]
+  public KSailIngressControllerType IngressController { get; set; } = KSailIngressControllerType.Default;
+
+  [Description("The Gateway Controller to use. [default: Default]")]
+  public KSailGatewayControllerType GatewayController { get; set; } = KSailGatewayControllerType.Default;
+
+  [Description("Whether to use a secret manager. [default: false]")]
+  public bool SecretManager { get; set; } = false;
+
   [Description("The editor to use for viewing files while debugging. [default: Nano]")]
   public KSailEditorType Editor { get; set; } = KSailEditorType.Nano;
-
-  [Description("The provider to use for running the KSail cluster. [default: Docker]")]
-  public KSailProviderType Provider { get; set; } = KSailProviderType.Docker;
-
-  [Description("The path to the root kustomization directory. [default: k8s]")]
-  public string KustomizationPath { get; set; } = "k8s";
 
   [Description("Whether to set up mirror registries for the project. [default: true]")]
   public bool MirrorRegistries { get; set; } = true;

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -342,13 +342,12 @@ class KSailUpCommandHandler
       }
     }
 
-    if (_cniProvisioner == null)
+    if (_cniProvisioner != null)
     {
-      throw new KSailException($"CNI '{config.Spec.Project.CNI}' is not supported.");
+      Console.WriteLine($"► installing '{config.Spec.Project.CNI}' CNI");
+      await _cniProvisioner.InstallAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    Console.WriteLine($"► installing '{config.Spec.Project.CNI}' CNI");
-    await _cniProvisioner.InstallAsync(cancellationToken).ConfigureAwait(false);
     Console.WriteLine($"✔ '{config.Spec.Project.CNI}' CNI installed");
     Console.WriteLine();
   }

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -83,6 +83,8 @@ class KSailUpCommandHandler
     await BootstrapOCISourceRegistry(_config, cancellationToken).ConfigureAwait(false);
     await BootstrapMirrorRegistries(_config, cancellationToken).ConfigureAwait(false);
     await BootstrapCNI(_config, cancellationToken).ConfigureAwait(false);
+    BootstrapIngressController(_config);
+    BootstrapGatewayController(_config);
     await BootstrapSecretManager(_config, cancellationToken).ConfigureAwait(false);
     await BootstrapDeploymentTool(_config, cancellationToken).ConfigureAwait(false);
 
@@ -324,14 +326,72 @@ class KSailUpCommandHandler
 
   async Task BootstrapCNI(KSailCluster config, CancellationToken cancellationToken)
   {
-    if (config.Spec.Project.CNI == KSailCNIType.Default || _cniProvisioner == null)
+    Console.WriteLine("🔼 Bootstrapping CNI");
+    if (config.Spec.Project.CNI == KSailCNIType.Default)
     {
-      return;
+      switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
+      {
+        case (KSailProviderType.Docker, KSailDistributionType.Native):
+          Console.WriteLine("► Kind deploys the kindnetd CNI by default");
+          break;
+        case (KSailProviderType.Docker, KSailDistributionType.K3s):
+          Console.WriteLine("► K3d deploys the Flannel CNI by default");
+          break;
+        default:
+          break;
+      }
     }
 
-    Console.WriteLine($"⬡ Installing {config.Spec.Project.CNI} CNI");
+    if (_cniProvisioner == null)
+    {
+      throw new KSailException($"CNI '{config.Spec.Project.CNI}' is not supported.");
+    }
+
+    Console.WriteLine($"► installing '{config.Spec.Project.CNI}' CNI");
     await _cniProvisioner.InstallAsync(cancellationToken).ConfigureAwait(false);
-    Console.WriteLine("✔ Cilium CNI installed");
+    Console.WriteLine($"✔ '{config.Spec.Project.CNI}' CNI installed");
+    Console.WriteLine();
+  }
+
+  static void BootstrapIngressController(KSailCluster config)
+  {
+    Console.WriteLine("🔼 Bootstrapping Ingress Controller");
+    if (config.Spec.Project.IngressController == KSailIngressControllerType.Default)
+    {
+      switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
+      {
+        case (KSailProviderType.Docker, KSailDistributionType.Native):
+          Console.WriteLine("► Kind does not deploy an Ingress Controller by default");
+          break;
+        case (KSailProviderType.Docker, KSailDistributionType.K3s):
+          Console.WriteLine("► K3d deploys the Traefik Ingress Controller by default");
+          break;
+        default:
+          break;
+      }
+    }
+    Console.WriteLine("✔ Ingress Controller bootstrapped");
+    Console.WriteLine();
+  }
+
+  static void BootstrapGatewayController(KSailCluster config)
+  {
+    Console.WriteLine("🔼 Bootstrapping Gateway Controller");
+    if (config.Spec.Project.GatewayController == KSailGatewayControllerType.Default)
+    {
+      switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
+      {
+        case (KSailProviderType.Docker, KSailDistributionType.Native):
+          Console.WriteLine("► Kind does not deploy a Gateway Controller by default");
+          break;
+        case (KSailProviderType.Docker, KSailDistributionType.K3s):
+          Console.WriteLine("► K3d does not deploy a Gateway Controller by default");
+          break;
+        default:
+          break;
+      }
+    }
+    Console.WriteLine("✔ Gateway Controller bootstrapped");
     Console.WriteLine();
   }
 

--- a/tests/KSail.Docs.Tests.Unit/declarative-config.verified.md
+++ b/tests/KSail.Docs.Tests.Unit/declarative-config.verified.md
@@ -26,20 +26,24 @@ spec:
     configPath: ksail.yaml
     # The path to the distribution configuration file. [default: kind.yaml]
     distributionConfigPath: kind.yaml
+    # The path to the root kustomization directory. [default: k8s]
+    kustomizationPath: k8s
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Docker
     # The Kubernetes distribution to use. [default: Native]
     distribution: Native
     # The Deployment tool to use. [default: Kubectl]
     deploymentTool: Kubectl
-    # Whether to use a secret manager. [default: false]
-    secretManager: false
     # The CNI to use. [default: Default]
     cni: Default
+    # The Ingress Controller to use. [default: Default]
+    ingressController: Default
+    # The Gateway Controller to use. [default: Default]
+    gatewayController: Default
+    # Whether to use a secret manager. [default: false]
+    secretManager: false
     # The editor to use for viewing files while debugging. [default: Nano]
     editor: Nano
-    # The provider to use for running the KSail cluster. [default: Docker]
-    provider: Docker
-    # The path to the root kustomization directory. [default: k8s]
-    kustomizationPath: k8s
     # Whether to set up mirror registries for the project. [default: true]
     mirrorRegistries: true
   # The options for the deployment tool.

--- a/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
+++ b/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
@@ -63,6 +63,16 @@
               "description": "The path to the distribution configuration file. [default: kind.yaml]",
               "type": "string"
             },
+            "kustomizationPath": {
+              "description": "The path to the root kustomization directory. [default: k8s]",
+              "type": "string"
+            },
+            "provider": {
+              "description": "The provider to use for running the KSail cluster. [default: Docker]",
+              "enum": [
+                "Docker"
+              ]
+            },
             "distribution": {
               "description": "The Kubernetes distribution to use. [default: Native]",
               "enum": [
@@ -77,10 +87,6 @@
                 "Flux"
               ]
             },
-            "secretManager": {
-              "description": "Whether to use a secret manager. [default: false]",
-              "type": "boolean"
-            },
             "cni": {
               "description": "The CNI to use. [default: Default]",
               "enum": [
@@ -88,22 +94,28 @@
                 "Cilium"
               ]
             },
+            "ingressController": {
+              "description": "The Ingress Controller to use. [default: Default]",
+              "enum": [
+                "Default"
+              ]
+            },
+            "gatewayController": {
+              "description": "The Gateway Controller to use. [default: Default]",
+              "enum": [
+                "Default"
+              ]
+            },
+            "secretManager": {
+              "description": "Whether to use a secret manager. [default: false]",
+              "type": "boolean"
+            },
             "editor": {
               "description": "The editor to use for viewing files while debugging. [default: Nano]",
               "enum": [
                 "Nano",
                 "Vim"
               ]
-            },
-            "provider": {
-              "description": "The provider to use for running the KSail cluster. [default: Docker]",
-              "enum": [
-                "Docker"
-              ]
-            },
-            "kustomizationPath": {
-              "description": "The path to the root kustomization directory. [default: k8s]",
-              "type": "string"
             },
             "mirrorRegistries": {
               "description": "Whether to set up mirror registries for the project. [default: true]",

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -13,13 +13,15 @@
     Project: {
       ConfigPath: ksail.yaml,
       DistributionConfigPath: k3d.yaml,
+      KustomizationPath: k8s,
+      Provider: Docker,
       Distribution: K3s,
       DeploymentTool: Kubectl,
-      SecretManager: false,
       CNI: Default,
+      IngressController: Default,
+      GatewayController: Default,
+      SecretManager: false,
       Editor: Nano,
-      Provider: Docker,
-      KustomizationPath: k8s,
       MirrorRegistries: true
     },
     DeploymentTool: {

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -13,13 +13,15 @@
     Project: {
       ConfigPath: ksail.yaml,
       DistributionConfigPath: k3d.yaml,
+      KustomizationPath: k8s,
+      Provider: Docker,
       Distribution: K3s,
       DeploymentTool: Kubectl,
-      SecretManager: false,
       CNI: Default,
+      IngressController: Default,
+      GatewayController: Default,
+      SecretManager: false,
       Editor: Nano,
-      Provider: Docker,
-      KustomizationPath: k8s,
       MirrorRegistries: true
     },
     DeploymentTool: {

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndUnnamedDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndUnnamedDistribution_ShouldReturnValidConfig.verified.txt
@@ -13,13 +13,15 @@
     Project: {
       ConfigPath: ksail.yaml,
       DistributionConfigPath: kind.yaml,
+      KustomizationPath: k8s,
+      Provider: Docker,
       Distribution: 8,
       DeploymentTool: Kubectl,
-      SecretManager: false,
       CNI: Default,
+      IngressController: Default,
+      GatewayController: Default,
+      SecretManager: false,
       Editor: Nano,
-      Provider: Docker,
-      KustomizationPath: k8s,
       MirrorRegistries: true
     },
     DeploymentTool: {

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -13,13 +13,15 @@
     Project: {
       ConfigPath: ksail.yaml,
       DistributionConfigPath: kind.yaml,
+      KustomizationPath: k8s,
+      Provider: Docker,
       Distribution: Native,
       DeploymentTool: Kubectl,
-      SecretManager: false,
       CNI: Default,
+      IngressController: Default,
+      GatewayController: Default,
+      SecretManager: false,
       Editor: Nano,
-      Provider: Docker,
-      KustomizationPath: k8s,
       MirrorRegistries: true
     },
     DeploymentTool: {

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -13,13 +13,15 @@
     Project: {
       ConfigPath: ksail.yaml,
       DistributionConfigPath: kind.yaml,
+      KustomizationPath: k8s,
+      Provider: Docker,
       Distribution: Native,
       DeploymentTool: Kubectl,
-      SecretManager: false,
       CNI: Default,
+      IngressController: Default,
+      GatewayController: Default,
+      SecretManager: false,
       Editor: Nano,
-      Provider: Docker,
-      KustomizationPath: k8s,
       MirrorRegistries: true
     },
     DeploymentTool: {

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithUnnamedDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithUnnamedDistribution_ShouldReturnValidConfig.verified.txt
@@ -13,13 +13,15 @@
     Project: {
       ConfigPath: ksail.yaml,
       DistributionConfigPath: kind.yaml,
+      KustomizationPath: k8s,
+      Provider: Docker,
       Distribution: 8,
       DeploymentTool: Kubectl,
-      SecretManager: false,
       CNI: Default,
+      IngressController: Default,
+      GatewayController: Default,
+      SecretManager: false,
       Editor: Nano,
-      Provider: Docker,
-      KustomizationPath: k8s,
       MirrorRegistries: true
     },
     DeploymentTool: {

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-k3s-advanced/ksail.yaml.verified.yaml
@@ -16,10 +16,10 @@ spec:
     distributionConfigPath: k3d.yaml
     # The Kubernetes distribution to use. [default: Native]
     distribution: K3s
-    # Whether to use a secret manager. [default: false]
-    secretManager: true
     # The CNI to use. [default: Default]
     cni: Cilium
+    # Whether to use a secret manager. [default: false]
+    secretManager: true
   # The options for the deployment tool.
   deploymentTool:
     # The options for the Flux deployment tool.

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-native-advanced/ksail.yaml.verified.yaml
@@ -12,10 +12,10 @@ spec:
     context: kind-ksail-advanced-native
   # The options for the KSail project.
   project:
-    # Whether to use a secret manager. [default: false]
-    secretManager: true
     # The CNI to use. [default: Default]
     cni: Cilium
+    # Whether to use a secret manager. [default: false]
+    secretManager: true
   # The options for the deployment tool.
   deploymentTool:
     # The options for the Flux deployment tool.


### PR DESCRIPTION
Introduce default ingress and gateway controller options to enhance user clarity on the configurations being utilized. Update relevant project settings and descriptions accordingly.

- Fixes #854 
- Fixes #855 