### PR TITLE
chore: add age key cleanup in KSailSecretsList_ListsKeys test

### DIFF
--- a/tests/KSail.Tests.Unit/Commands/Secrets/KSailSecretsCommandTests.cs
+++ b/tests/KSail.Tests.Unit/Commands/Secrets/KSailSecretsCommandTests.cs
@@ -189,6 +189,7 @@ public class KSailSecretsCommandTests
     string? key = _console.Out?.ToString()?.Trim();
     Assert.NotNull(key);
     Assert.NotEmpty(key);
+    var ageKey = new AgeKey(key);
 
     // Act
     int listExitCode = await _ksailCommand.InvokeAsync(["secrets", "list", "--all"], _console);
@@ -196,5 +197,9 @@ public class KSailSecretsCommandTests
     // Assert
     Assert.Equal(0, addExitCode);
     Assert.Equal(0, listExitCode);
+
+    // Cleanup
+    int rmExitCode = await _ksailCommand.InvokeAsync(["secrets", "rm", ageKey.PublicKey], _console);
+    Assert.Equal(0, rmExitCode);
   }
 }


### PR DESCRIPTION
Implement cleanup for age keys in the KSailSecretsList_ListsKeys test to ensure proper resource management after test execution.