### PR TITLE
feat: add support for Podman as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Getting started with KSail is straightforward. Begin by initializing a new KSail
   --distribution <★Native★|K3s> \
   --deployment-tool <★Kubectl★|Flux> \
   --cni <★Default★|Cilium> \
+  --csi <★Default★> \
   --ingress-controller <★Default★> \
   --gateway-controller <★Default★> \
   --secret-manager <★None★|SOPS> \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Getting started with KSail is straightforward. Begin by initializing a new KSail
 > ksail init # to create a new default project
 
 > ksail init \ # to create a new custom project (★ is default)
-  --provider <★Docker★> \
+  --provider <★Docker★|Podman> \
   --distribution <★Native★|K3s> \
   --deployment-tool <★Kubectl★|Flux> \
   --cni <★Default★|Cilium> \

--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -56,7 +56,7 @@ Options:
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>                    The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a kustomization. [default: Kubectl]
   --cni <Cilium|Default>                            The CNI to use. [default: Default]
@@ -84,7 +84,7 @@ Options:
   -fsu, --flux-source-url <flux-source-url>  Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
   -n, --name <name>                          The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>            The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>                    The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>             The provider to use for provisioning the cluster. [default: Docker]
   -mr, --mirror-registries                   Enable mirror registries for the project. [default: True]
   -?, -h, --help                             Show help and usage information
 ```
@@ -120,7 +120,7 @@ Options:
   -c, --context <context>          The kubernetes context to use. [default: kind-ksail-default]
   -n, --name <name>                The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -?, -h, --help                   Show help and usage information
 ```
 
@@ -136,7 +136,7 @@ Usage:
 Options:
   -n, --name <name>                The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -?, -h, --help                   Show help and usage information
 ```
 
@@ -155,7 +155,7 @@ Options:
   -c, --config <config>                             The path to the ksail configuration file. [default: ksail.yaml]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>                    The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a kustomization. [default: Kubectl]
   --cni <Cilium|Default>                            The CNI to use. [default: Default]
@@ -225,7 +225,7 @@ Usage:
   ksail list [options]
 
 Options:
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
   -a, --all                        List clusters from all distributions. [default: False]
   -?, -h, --help                   Show help and usage information

--- a/docs/overview/core-concepts/cnis.md
+++ b/docs/overview/core-concepts/cnis.md
@@ -22,6 +22,8 @@ Because the `Native` distribution varies depending on the `Provider`, the CNI is
 | -------- | ------------- | ----------------------------------------------------------------------------- |
 | Docker   | Native (Kind) | [kindnetd](https://github.com/kubernetes-sigs/kind/tree/main/images/kindnetd) |
 | Docker   | K3s (K3d)     | [flannel](https://github.com/flannel-io/flannel)                              |
+| Podman   | Native (Kind) | [kindnetd](https://github.com/kubernetes-sigs/kind/tree/main/images/kindnetd) |
+| Podman   | K3s (K3d)     | [flannel](https://github.com/flannel-io/flannel)                              |
 
 ## Cilium
 

--- a/docs/overview/core-concepts/csis.md
+++ b/docs/overview/core-concepts/csis.md
@@ -1,0 +1,26 @@
+---
+title: Container Storage Interfaces (CSIs)
+parent: Core Concepts
+layout: default
+nav_order: 3
+---
+
+# Container Storage Interfaces (CSIs)
+
+## None
+
+> [!WARNING]
+> This option is not supported yet.
+
+## Default
+
+The `Default` CSI is the default Container Storage Interface plugin that is bundled with the Kubernetes distribution you are using. It is often a basic CSI plugin with limited features.
+
+Because the `Native` distribution varies depending on the `Provider`, the CSI is determined by the `Provider` and `Distribution` you are using.
+
+| Provider | Distribution  | Default CSI                                                                 |
+| -------- | ------------- | --------------------------------------------------------------------------- |
+| Docker   | Native (Kind) | [local-path-provisioner](https://github.com/rancher/local-path-provisioner) |
+| Docker   | K3s (K3d)     | [local-path-provisioner](https://github.com/rancher/local-path-provisioner) |
+| Podman   | Native (Kind) | [local-path-provisioner](https://github.com/rancher/local-path-provisioner) |
+| Podman   | K3s (K3d)     | [local-path-provisioner](https://github.com/rancher/local-path-provisioner) |

--- a/docs/overview/core-concepts/deployment-tools.md
+++ b/docs/overview/core-concepts/deployment-tools.md
@@ -2,7 +2,7 @@
 title: Deployment Tools
 parent: Core Concepts
 layout: default
-nav_order: 5
+nav_order: 6
 ---
 
 # Deployment Tools

--- a/docs/overview/core-concepts/distributions.md
+++ b/docs/overview/core-concepts/distributions.md
@@ -18,6 +18,7 @@ Below is the actual distribution used when using the `Native` distribution with 
 | Provider | Distribution | Actual Distribution                 |
 | -------- | ------------ | ----------------------------------- |
 | Docker   | Native       | [`kind`](https://kind.sigs.k8s.io/) |
+| Podman   | Native       | [`kind`](https://kind.sigs.k8s.io/) |
 
 ## [K3s](https://k3s.io/)
 
@@ -26,3 +27,4 @@ The `K3s` distribution is a lightweight Kubernetes distribution that is designed
 | Provider | Distribution | Actual Distribution      |
 | -------- | ------------ | ------------------------ |
 | Docker   | K3s          | [`k3d`](https://k3d.io/) |
+| Podman   | K3s          | [`k3d`](https://k3d.io/) |

--- a/docs/overview/core-concepts/gateway-controllers.md
+++ b/docs/overview/core-concepts/gateway-controllers.md
@@ -2,7 +2,7 @@
 title: Gateway Controllers
 parent: Core Concepts
 layout: default
-nav_order: 4
+nav_order: 5
 ---
 
 # Gateway Controllers

--- a/docs/overview/core-concepts/gateway-controllers.md
+++ b/docs/overview/core-concepts/gateway-controllers.md
@@ -23,3 +23,5 @@ nav_order: 4
 | -------- | ------------- | ------------------ |
 | Docker   | Native (kind) | None               |
 | Docker   | K3s (k3d)     | None               |
+| Podman   | Native (kind) | None               |
+| Podman   | K3s (k3d)     | None               |

--- a/docs/overview/core-concepts/index.md
+++ b/docs/overview/core-concepts/index.md
@@ -30,7 +30,11 @@ By understanding the foundational concepts of cloud-native technologies and how 
   <tbody>
     <tr>
       <td><a href="https://docs.docker.com/">Docker</a></td>
-      <td>A platform for developing, shipping, and running containerized applications.</td>
+      <td>A platform and container engine for developing, shipping, and running containerized applications.</td>
+    </tr>
+    <tr>
+      <td><a href="https://podman.io/">Podman</a></td>
+      <td>A daemonless container engine for developing, managing, and running containers on your system.</td>
     </tr>
     <tr>
       <td><a href="https://kubernetes.io/docs/home/">Kubernetes</a></td>

--- a/docs/overview/core-concepts/index.md
+++ b/docs/overview/core-concepts/index.md
@@ -78,6 +78,10 @@ By understanding the foundational concepts of cloud-native technologies and how 
       <td><code>CNIs</code> refers to Container Network Interface plugins that facilitate networking for containers in a Kubernetes cluster.</td>
     </tr>
     <tr>
+      <td><strong>Container Storage Interfaces (CSIs)</strong></td>
+      <td><code>CSIs</code> refers to Container Storage Interface plugins that facilitate storage for containers in a Kubernetes cluster.</td>
+    </tr>
+    <tr>
       <td><strong>Ingress Controllers</strong></td>
       <td><code>Ingress Controllers</code> refers to the controllers that manage ingress resources in a Kubernetes cluster. They are responsible for routing external traffic to the appropriate services within the cluster.</td>
     </tr>

--- a/docs/overview/core-concepts/ingress-controllers.md
+++ b/docs/overview/core-concepts/ingress-controllers.md
@@ -20,3 +20,5 @@ nav_order: 3
 | -------- | ------------- | ------------------ |
 | Docker   | Native (kind) | None               |
 | Docker   | K3s (k3d)     | Traefik            |
+| Podman   | Native (kind) | None               |
+| Podman   | K3s (k3d)     | Traefik            |

--- a/docs/overview/core-concepts/ingress-controllers.md
+++ b/docs/overview/core-concepts/ingress-controllers.md
@@ -2,7 +2,7 @@
 title: Ingress Controllers
 parent: Core Concepts
 layout: default
-nav_order: 3
+nav_order: 4
 ---
 
 # Ingress Controllers

--- a/docs/overview/core-concepts/local-registry.md
+++ b/docs/overview/core-concepts/local-registry.md
@@ -2,7 +2,7 @@
 title: Local Registry
 parent: Core Concepts
 layout: default
-nav_order: 7
+nav_order: 8
 ---
 
 # Local Registry

--- a/docs/overview/core-concepts/mirror-registries.md
+++ b/docs/overview/core-concepts/mirror-registries.md
@@ -2,7 +2,7 @@
 title: Mirror Registries
 parent: Core Concepts
 layout: default
-nav_order: 8
+nav_order: 9
 ---
 
 # Mirror Registries

--- a/docs/overview/core-concepts/providers.md
+++ b/docs/overview/core-concepts/providers.md
@@ -8,18 +8,18 @@ nav_order: 0
 # Providers
 
 > [!NOTE]
-> KSail is designed to be extensible and support multiple providers. However, at the moment, only the `Docker` provider is supported.
+> KSail is designed to be extensible and support multiple providers. However, at the moment, only local providers are supported.
 
 `Providers` refer to the underlying infrastructure that is used to create the Kubernetes cluster. This can be a local provider, on-premises provider or a cloud provider. The `Provider` is responsible for creating and managing the underlying infrastructure that is used to run the Kubernetes cluster.
 
-## [Docker](https://www.docker.com/)
+## Docker
 
-The `Docker` provider is a container runtime that is used to create and manage containers. It is the most widely used container runtime and it is supported on all major operating systems.
+The [`Docker`](<https://www.docker.com/>) provider is a container runtime that is used to create and manage containers. It is the most widely used container runtime and it is supported on all major operating systems.
 
 Using `Docker` as a provider will create a Kubernetes cluster as container(s).
 
-## [Podman](https://podman.io/)
+## Podman
 
-The `Podman` provider is a container runtime that is used to create and manage containers. It is a daemonless container runtime that is compatible with Docker. It is supported on all major operating systems.
+The [`Podman`](https://podman.io/) provider is a container runtime that is used to create and manage containers. It is a daemonless container runtime that is compatible with Docker. It is supported on all major operating systems.
 
 Using `Podman` as a provider will create a Kubernetes cluster as container(s).

--- a/docs/overview/core-concepts/providers.md
+++ b/docs/overview/core-concepts/providers.md
@@ -12,8 +12,14 @@ nav_order: 0
 
 `Providers` refer to the underlying infrastructure that is used to create the Kubernetes cluster. This can be a local provider, on-premises provider or a cloud provider. The `Provider` is responsible for creating and managing the underlying infrastructure that is used to run the Kubernetes cluster.
 
-### [Docker](https://www.docker.com/)
+## [Docker](https://www.docker.com/)
 
 The `Docker` provider is a container runtime that is used to create and manage containers. It is the most widely used container runtime and it is supported on all major operating systems.
 
 Using `Docker` as a provider will create a Kubernetes cluster as container(s).
+
+## [Podman](https://podman.io/)
+
+The `Podman` provider is a container runtime that is used to create and manage containers. It is a daemonless container runtime that is compatible with Docker. It is supported on all major operating systems.
+
+Using `Podman` as a provider will create a Kubernetes cluster as container(s).

--- a/docs/overview/core-concepts/secret-manager.md
+++ b/docs/overview/core-concepts/secret-manager.md
@@ -14,5 +14,15 @@ KSail uses [`SOPS`](https://getsops.io) as the secret manager. This is a tool th
 
 KSail ensures that a private key is securely stored in the cluster, allowing for seamless decryption of secrets when they are applied to the cluster.
 
-> [!NOTE]
-> `SOPS` supports both `PGP` and `Age` key pairs, but for now, KSail only supports `Age` key pairs. This is because `Age` is a newer and simpler encryption format that is designed to be easy to use and understand. It is also more secure than `PGP` because it solely uses modern cryptography and does not rely on any legacy algorithms or protocols.
+> [!NOTE] > `SOPS` supports both `PGP` and `Age` key pairs, but for now, KSail only supports `Age` key pairs. This is because `Age` is a newer and simpler encryption format that is designed to be easy to use and understand. It is also more secure than `PGP` because it solely uses modern cryptography and does not rely on any legacy algorithms or protocols.
+
+## None
+
+No secret manager is used. This means that encryption secrets are not bootstrapped into the cluster, and that encrypted secrets cannot be applied to the cluster. This is the default option.
+
+## SOPS
+
+SOPS is used as the secret manager. This ensures a `.sops.yaml` config file is created in the project root, and that an encryption key is bootstrapped into the cluster, for the deployment tools that support encrypting secrets as part of the deployment process.
+
+> [!IMPORTANT]
+> KSail only supports decryption of secrets as part of the deployment process with the `Flux` deployment tool. For other deployment tools, it is still possible to enable, with tooling like [`ksops`](https://github.com/viaduct-ai/kustomize-sops). Setting this up is currently deemed out of scope for KSail. This is a feature that may be added in the future, but as `ksops` is a binary tool that is called by via a `kustomize` plugin, it is not a simple task to implement in KSail. I am interested in using upstream functionality, instead of creating another solution to solve the same problem. As such, I will continue to monitor developments in this area.

--- a/docs/overview/core-concepts/secret-manager.md
+++ b/docs/overview/core-concepts/secret-manager.md
@@ -14,7 +14,8 @@ KSail uses [`SOPS`](https://getsops.io) as the secret manager. This is a tool th
 
 KSail ensures that a private key is securely stored in the cluster, allowing for seamless decryption of secrets when they are applied to the cluster.
 
-> [!NOTE] > `SOPS` supports both `PGP` and `Age` key pairs, but for now, KSail only supports `Age` key pairs. This is because `Age` is a newer and simpler encryption format that is designed to be easy to use and understand. It is also more secure than `PGP` because it solely uses modern cryptography and does not rely on any legacy algorithms or protocols.
+> [!NOTE]
+> The secret manager `SOPS` supports both `PGP` and `Age` key pairs, but for now, KSail only supports `Age` key pairs. This is because `Age` is a newer and simpler encryption format that is designed to be easy to use and understand. It is also more secure than `PGP` because it solely uses modern cryptography and does not rely on any legacy algorithms or protocols.
 
 ## None
 

--- a/docs/overview/core-concepts/secret-manager.md
+++ b/docs/overview/core-concepts/secret-manager.md
@@ -2,7 +2,7 @@
 title: Secret Manager
 parent: Core Concepts
 layout: default
-nav_order: 6
+nav_order: 7
 ---
 
 # Secret Manager

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -6,9 +6,6 @@ nav_order: 1
 
 # Overview
 
-> [!NOTE]
-> Currently, KSail supports `Docker` as a provider for local development. Support for other providers is planned for the future.
-
 KSail is an SDK for Kubernetes allowing you to easily create, manage, and dismantle Kubernetes clusters in various providers. It is built on top of popular Kubernetes tools with the goal of improving the developer experience (DX) when working with Kubernetes.
 
 ![KSail Architecture](../images/architecture.drawio.png)

--- a/docs/overview/support-matrix.md
+++ b/docs/overview/support-matrix.md
@@ -18,7 +18,7 @@ KSail aims to support a wide range of use cases by providing the flexibility to 
   </thead>
   <tbody>
     <tr>
-      <td><strong>Binary OS Support</strong></td>
+      <td><strong>CLI</strong></td>
       <td>
         Linux (amd64 and arm64),<br>
         macOS (amd64 and arm64)

--- a/docs/overview/support-matrix.md
+++ b/docs/overview/support-matrix.md
@@ -18,7 +18,7 @@ KSail aims to support a wide range of use cases by providing the flexibility to 
   </thead>
   <tbody>
     <tr>
-      <td><strong>Operating Systems</strong></td>
+      <td><strong>Binary OS Support</strong></td>
       <td>
         Linux (amd64 and arm64),<br>
         macOS (amd64 and arm64)
@@ -26,13 +26,32 @@ KSail aims to support a wide range of use cases by providing the flexibility to 
     </tr>
     <tr>
       <td><strong>Providers</strong></td>
-      <td><a href="https://www.docker.com">Docker</a></td>
+      <td><a href="https://www.docker.com">Docker</a>, <a href="https://podman.io">Podman</a></td>
     </tr>
     <tr>
       <td><strong>Distributions</strong></td>
       <td>
         Native,
         <a href="https://k3d.io">K3s</a>
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Container Network Interfaces (CNI)</strong></td>
+      <td>
+        Default,
+        <a href="https://cilium.io">Cilium</a>
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Ingress Controllers</strong></td>
+      <td>
+        Default
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Gateway Controllers</strong></td>
+      <td>
+        Default
       </td>
     </tr>
     <tr>
@@ -46,13 +65,6 @@ KSail aims to support a wide range of use cases by providing the flexibility to 
       <td><strong>Secret Manager</strong></td>
       <td>
         <a href="https://github.com/getsops/sops">SOPS</a>
-      </td>
-    </tr>
-    <tr>
-      <td><strong>Container Network Interfaces (CNI)</strong></td>
-      <td>
-        Default,
-        <a href="https://cilium.io">Cilium</a>
       </td>
     </tr>
     <tr>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,6 +22,7 @@ The roadmap for KSail details the planned features and improvements for the proj
 - [x] Mirror registry support for kind.
 - [x] Cilium support to enable users to create clusters with Cilium as the default CNI.
 - [x] Traefik.me support to enable users to make services accessible through ingresses without having to set up a DNS server locally.
+- [x] Podman support to enable users to create and manage GitOps-enabled Kubernetes clusters provisioned with Podman. This is important for users that prefer to use Podman over Docker.
 - [ ] The `ksail diff` command to show the the differences between the current state of the cluster and the desired state before applying the changes. This can be useful to see all the hidden changes that are applied by e.g. HelmRelease resources.
 - [ ] Talos in Docker support to enable users to create and manage GitOps-enabled Kubernetes clusters provisioned with Talos Linux in Docker. This is important for users that prefer to use Talos over K3d.
 - [ ] ArgoCD support to enable users to manage their clusters through ArgoCDs GitOps engine. This is important to support a wide range of use cases.

--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -70,7 +70,8 @@
             "provider": {
               "description": "The provider to use for running the KSail cluster. [default: Docker]",
               "enum": [
-                "Docker"
+                "Docker",
+                "Podman"
               ]
             },
             "distribution": {

--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -209,7 +209,8 @@
             "provider": {
               "description": "The registry provider. [default: Docker]",
               "enum": [
-                "Docker"
+                "Docker",
+                "Podman"
               ]
             }
           }
@@ -255,7 +256,8 @@
               "provider": {
                 "description": "The registry provider. [default: Docker]",
                 "enum": [
-                  "Docker"
+                  "Docker",
+                  "Podman"
                 ]
               }
             }

--- a/src/KSail.Models/LocalRegistry/KSailLocalRegistry.cs
+++ b/src/KSail.Models/LocalRegistry/KSailLocalRegistry.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using KSail.Models.Project.Enums;
 
 namespace KSail.Models.LocalRegistry;
 
@@ -19,5 +20,5 @@ public class KSailLocalRegistry
   // public string? Password { get; set; }
 
   [Description("The registry provider. [default: Docker]")]
-  public KSailLocalRegistryProvider Provider { get; set; } = KSailLocalRegistryProvider.Docker;
+  public KSailProviderType Provider { get; set; } = KSailProviderType.Docker;
 }

--- a/src/KSail.Models/LocalRegistry/KSailLocalRegistryProvider.cs
+++ b/src/KSail.Models/LocalRegistry/KSailLocalRegistryProvider.cs
@@ -3,6 +3,6 @@ namespace KSail.Models.LocalRegistry;
 
 public enum KSailLocalRegistryProvider
 {
-
-  Docker
+  Docker,
+  Podman
 }

--- a/src/KSail.Models/LocalRegistry/KSailLocalRegistryProvider.cs
+++ b/src/KSail.Models/LocalRegistry/KSailLocalRegistryProvider.cs
@@ -1,8 +1,0 @@
-namespace KSail.Models.LocalRegistry;
-
-
-public enum KSailLocalRegistryProvider
-{
-  Docker,
-  Podman
-}

--- a/src/KSail.Models/Project/Enums/KSailProviderType.cs
+++ b/src/KSail.Models/Project/Enums/KSailProviderType.cs
@@ -8,8 +8,8 @@ public enum KSailProviderType
   [Description("Use Docker as the engine.")]
   Docker,
 
-  //
-  //Podman
+  [Description("Use Podman as the engine.")]
+  Podman
 
   //
   // ClusterAPI

--- a/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
+++ b/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
@@ -19,13 +19,13 @@ class KSailDownCommandHandler
     _containerEngineProvisioner = _config.Spec.Project.Provider switch
     {
       KSailProviderType.Docker or KSailProviderType.Podman => new DockerProvisioner(),
-      _ => throw new KSailException($"Provider '{_config.Spec.Project.Provider}' is not supported.")
+      _ => throw new NotSupportedException($"Provider '{_config.Spec.Project.Provider}' is not supported.")
     };
     _kubernetesDistributionProvisioner = _config.Spec.Project.Distribution switch
     {
       KSailDistributionType.K3s => new K3dProvisioner(),
       KSailDistributionType.Native => new KindProvisioner(),
-      _ => throw new KSailException($"Kubernetes distribution '{_config.Spec.Project.Provider}' is not supported.")
+      _ => throw new NotSupportedException($"Kubernetes distribution '{_config.Spec.Project.Provider}' is not supported.")
     };
   }
 

--- a/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
+++ b/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
@@ -18,7 +18,7 @@ class KSailDownCommandHandler
     _config = config;
     _containerEngineProvisioner = _config.Spec.Project.Provider switch
     {
-      KSailProviderType.Docker => new DockerProvisioner(),
+      KSailProviderType.Docker or KSailProviderType.Podman => new DockerProvisioner(),
       _ => throw new KSailException($"Provider '{_config.Spec.Project.Provider}' is not supported.")
     };
     _kubernetesDistributionProvisioner = _config.Spec.Project.Distribution switch

--- a/src/KSail/Commands/Init/Generators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/DistributionConfigFileGenerator.cs
@@ -19,10 +19,10 @@ class DistributionConfigFileGenerator
     string configPath = Path.Combine(outputPath, config.Spec.Project.DistributionConfigPath);
     switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
     {
-      case (KSailProviderType.Docker, KSailDistributionType.Native):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native):
         await GenerateKindConfigFile(config, configPath, cancellationToken).ConfigureAwait(false);
         break;
-      case (KSailProviderType.Docker, KSailDistributionType.K3s):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s):
         await GenerateK3DConfigFile(config, configPath, cancellationToken).ConfigureAwait(false);
         break;
       default:

--- a/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
+++ b/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
@@ -40,7 +40,7 @@ class KSailInitCommandHandler(string outputPath, KSailCluster config)
       case KSailSecretManagerType.None:
         break;
       default:
-        throw new KSailException($"Secret manager '{_config.Spec.Project.SecretManager}' is not supported.");
+        throw new NotSupportedException($"Secret manager '{_config.Spec.Project.SecretManager}' is not supported.");
     }
 
     await _projectGenerator.GenerateAsync(

--- a/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
+++ b/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
@@ -31,8 +31,8 @@ sealed class KSailListCommandHandler(KSailCluster config)
     {
       clusters = (_config.Spec.Project.Provider, _config.Spec.Project.Distribution) switch
       {
-        (KSailProviderType.Docker, KSailDistributionType.K3s) => await _k3dProvisioner.ListAsync(cancellationToken).ConfigureAwait(false),
-        (KSailProviderType.Docker, KSailDistributionType.Native) => await _kindProvisioner.ListAsync(cancellationToken).ConfigureAwait(false),
+        (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s) => await _k3dProvisioner.ListAsync(cancellationToken).ConfigureAwait(false),
+        (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native) => await _kindProvisioner.ListAsync(cancellationToken).ConfigureAwait(false),
         _ => throw new NotSupportedException($"The container engine '{_config.Spec.Project.Provider}' and distribution '{_config.Spec.Project.Distribution}' combination is not supported.")
       };
       clusters = clusters.Where(cluster => !cluster.Contains("No kind clusters found.", StringComparison.Ordinal));

--- a/src/KSail/Commands/Start/Handlers/KSailStartCommandHandler.cs
+++ b/src/KSail/Commands/Start/Handlers/KSailStartCommandHandler.cs
@@ -16,8 +16,8 @@ class KSailStartCommandHandler
     _config = config;
     _clusterProvisioner = (_config.Spec.Project.Provider, _config.Spec.Project.Distribution) switch
     {
-      (KSailProviderType.Docker, KSailDistributionType.Native) => new KindProvisioner(),
-      (KSailProviderType.Docker, KSailDistributionType.K3s) => new K3dProvisioner(),
+      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native) => new KindProvisioner(),
+      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s) => new K3dProvisioner(),
       _ => throw new NotSupportedException($"The engine '{_config.Spec.Project.Provider}' and distribution '{_config.Spec.Project.Distribution}' combination is not supported")
     };
   }

--- a/src/KSail/Commands/Stop/Handlers/KSailStopCommandHandler.cs
+++ b/src/KSail/Commands/Stop/Handlers/KSailStopCommandHandler.cs
@@ -16,8 +16,8 @@ class KSailStopCommandHandler
     _config = config;
     _clusterProvisioner = (_config.Spec.Project.Provider, _config.Spec.Project.Distribution) switch
     {
-      (KSailProviderType.Docker, KSailDistributionType.Native) => new KindProvisioner(),
-      (KSailProviderType.Docker, KSailDistributionType.K3s) => new K3dProvisioner(),
+      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native) => new KindProvisioner(),
+      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s) => new K3dProvisioner(),
       _ => throw new NotSupportedException($"The distribution '{_config.Spec.Project.Distribution}' is not supported.")
     };
   }

--- a/src/KSail/Commands/Up/Bootstrappers/CNIBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/CNIBootstrapper.cs
@@ -21,7 +21,7 @@ class CNIBootstrapper(KSailCluster config) : IBootstrapper
         HandleDefaultCNI();
         break;
       default:
-        throw new KSailException($"the '{config.Spec.Project.CNI}' CNI is not supported.");
+        throw new NotSupportedException($"the '{config.Spec.Project.CNI}' CNI is not supported.");
     }
     Console.WriteLine();
   }

--- a/src/KSail/Commands/Up/Bootstrappers/CNIBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/CNIBootstrapper.cs
@@ -40,10 +40,10 @@ class CNIBootstrapper(KSailCluster config) : IBootstrapper
   {
     switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
     {
-      case (KSailProviderType.Docker, KSailDistributionType.Native):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native):
         Console.WriteLine("► Kind deploys the kindnetd CNI by default");
         break;
-      case (KSailProviderType.Docker, KSailDistributionType.K3s):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s):
         Console.WriteLine("► K3d deploys the Flannel CNI by default");
         break;
       default:

--- a/src/KSail/Commands/Up/Bootstrappers/CSIBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/CSIBootstrapper.cs
@@ -14,7 +14,7 @@ class CSIBootstrapper(KSailCluster config) : IBootstrapper
         HandleDefaultCSI();
         break;
       default:
-        throw new KSailException($"the '{config.Spec.Project.CSI}' CSI is not supported.");
+        throw new NotSupportedException($"the '{config.Spec.Project.CSI}' CSI is not supported.");
     }
     Console.WriteLine();
     return Task.CompletedTask;
@@ -31,7 +31,7 @@ class CSIBootstrapper(KSailCluster config) : IBootstrapper
         Console.WriteLine("► K3d deploys the local-path-provisioner CSI by default");
         break;
       default:
-        throw new KSailException($"the '{config.Spec.Project.CSI}' CSI is not supported.");
+        throw new NotSupportedException($"the '{config.Spec.Project.CSI}' CSI is not supported.");
     }
   }
 }

--- a/src/KSail/Commands/Up/Bootstrappers/CSIBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/CSIBootstrapper.cs
@@ -24,10 +24,10 @@ class CSIBootstrapper(KSailCluster config) : IBootstrapper
   {
     switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
     {
-      case (KSailProviderType.Docker, KSailDistributionType.Native):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native):
         Console.WriteLine("► Kind deploys the local-path-provisioner CSI by default");
         break;
-      case (KSailProviderType.Docker, KSailDistributionType.K3s):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s):
         Console.WriteLine("► K3d deploys the local-path-provisioner CSI by default");
         break;
       default:

--- a/src/KSail/Commands/Up/Bootstrappers/ClusterBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/ClusterBootstrapper.cs
@@ -71,9 +71,6 @@ class ClusterBootstrapper(KSailCluster config) : IBootstrapper
   {
     Console.WriteLine($"☸️ Provisioning cluster '{config.Spec.Project.Distribution.ToString().ToLower(System.Globalization.CultureInfo.CurrentCulture)}-{config.Metadata.Name}'");
     await _clusterProvisioner.CreateAsync(config.Metadata.Name, config.Spec.Project.DistributionConfigPath, cancellationToken).ConfigureAwait(false);
-    if (config.Spec.Project.Distribution == KSailDistributionType.K3s)
-    {
-      Console.WriteLine();
-    }
+    Console.WriteLine();
   }
 }

--- a/src/KSail/Commands/Up/Bootstrappers/ClusterBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/ClusterBootstrapper.cs
@@ -37,7 +37,19 @@ class ClusterBootstrapper(KSailCluster config) : IBootstrapper
         + "  - if you want to update the cluster, use 'ksail update' instead.");
     }
     Console.WriteLine("✔ cluster does not exist");
+    // TODO: Remove 'TemporaryMacOSPodmanK3sCompatabilityErrorHandling()' when the issue is resolved.
+    TemporaryMacOSPodmanK3sCompatabilityErrorHandling();
     Console.WriteLine();
+  }
+
+  void TemporaryMacOSPodmanK3sCompatabilityErrorHandling()
+  {
+    if (OperatingSystem.IsMacOS() && config.Spec.Project.Provider == KSailProviderType.Podman && config.Spec.Project.Distribution == KSailDistributionType.K3s)
+    {
+      throw new KSailException("Podman + K3s is not supported on MacOS yet." + Environment.NewLine
+        + "  - 'host-gateway' is not working with 'podman machine' VMs." + Environment.NewLine
+        + "    see https://github.com/containers/podman/issues/21681 for more details.");
+    }
   }
 
   async Task CheckProviderIsRunning(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Up/Bootstrappers/GatewayControllerBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/GatewayControllerBootstrapper.cs
@@ -13,7 +13,7 @@ class GatewayControllerBootstrapper(KSailCluster config) : IBootstrapper
         HandleDefaultGatewayController();
         break;
       default:
-        throw new KSailException($"the '{config.Spec.Project.GatewayController}' Gateway Controller is not supported.");
+        throw new NotSupportedException($"the '{config.Spec.Project.GatewayController}' Gateway Controller is not supported.");
     }
     Console.WriteLine();
     return Task.CompletedTask;

--- a/src/KSail/Commands/Up/Bootstrappers/GatewayControllerBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/GatewayControllerBootstrapper.cs
@@ -23,10 +23,10 @@ class GatewayControllerBootstrapper(KSailCluster config) : IBootstrapper
   {
     switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
     {
-      case (KSailProviderType.Docker, KSailDistributionType.Native):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native):
         Console.WriteLine("► Kind does not deploy a Gateway Controller by default");
         break;
-      case (KSailProviderType.Docker, KSailDistributionType.K3s):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s):
         Console.WriteLine("► K3d does not deploy a Gateway Controller by default");
         break;
       default:

--- a/src/KSail/Commands/Up/Bootstrappers/GitOpsSourceBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/GitOpsSourceBootstrapper.cs
@@ -1,6 +1,7 @@
 
 using Devantler.ContainerEngineProvisioner.Core;
 using Devantler.ContainerEngineProvisioner.Docker;
+using KSail;
 using KSail.Factories;
 using KSail.Models;
 using KSail.Models.Project.Enums;
@@ -13,12 +14,16 @@ class GitOpsSourceBootstrapper(KSailCluster config) : IBootstrapper
   {
     if (config.Spec.Project.DeploymentTool == KSailDeploymentToolType.Flux)
     {
-      if (config.Spec.Project.Provider == KSailProviderType.Docker)
+      switch (config.Spec.Project.Provider)
       {
-        Console.WriteLine("📦 Bootstrapping GitOps source...");
-        await CreateOCISourceRegistry(config, cancellationToken).ConfigureAwait(false);
-        await BootstrapOCISource(cancellationToken).ConfigureAwait(false);
-        Console.WriteLine();
+        case KSailProviderType.Docker or KSailProviderType.Podman:
+          Console.WriteLine("📦 Bootstrapping GitOps source...");
+          await CreateOCISourceRegistry(config, cancellationToken).ConfigureAwait(false);
+          await BootstrapOCISource(cancellationToken).ConfigureAwait(false);
+          Console.WriteLine();
+          break;
+        default:
+          throw new KSailException($"unsupported provider '{config.Spec.Project.Provider}'.");
       }
     }
   }

--- a/src/KSail/Commands/Up/Bootstrappers/GitOpsSourceBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/GitOpsSourceBootstrapper.cs
@@ -23,7 +23,7 @@ class GitOpsSourceBootstrapper(KSailCluster config) : IBootstrapper
           Console.WriteLine();
           break;
         default:
-          throw new KSailException($"unsupported provider '{config.Spec.Project.Provider}'.");
+          throw new NotSupportedException($"unsupported provider '{config.Spec.Project.Provider}'.");
       }
     }
   }

--- a/src/KSail/Commands/Up/Bootstrappers/IngressControllerBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/IngressControllerBootstrapper.cs
@@ -13,7 +13,7 @@ class IngressControllerBootstrapper(KSailCluster config) : IBootstrapper
         HandleDefaultIngressController();
         break;
       default:
-        throw new KSailException($"the '{config.Spec.Project.IngressController}' Ingress Controller is not supported.");
+        throw new NotSupportedException($"the '{config.Spec.Project.IngressController}' Ingress Controller is not supported.");
     }
     Console.WriteLine();
     return Task.CompletedTask;

--- a/src/KSail/Commands/Up/Bootstrappers/IngressControllerBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/IngressControllerBootstrapper.cs
@@ -23,10 +23,10 @@ class IngressControllerBootstrapper(KSailCluster config) : IBootstrapper
   {
     switch (config.Spec.Project.Provider, config.Spec.Project.Distribution)
     {
-      case (KSailProviderType.Docker, KSailDistributionType.Native):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native):
         Console.WriteLine("► Kind does not deploy an Ingress Controller by default");
         break;
-      case (KSailProviderType.Docker, KSailDistributionType.K3s):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s):
         Console.WriteLine("► K3d deploys the Traefik Ingress Controller by default");
         break;
       default:

--- a/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
@@ -42,7 +42,7 @@ class MirrorRegistryBootstrapper(KSailCluster config) : IBootstrapper
   {
     switch ((config.Spec.Project.Provider, config.Spec.Project.Distribution))
     {
-      case (KSailProviderType.Docker, KSailDistributionType.Native):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native):
         Console.WriteLine("🔼 Bootstrapping mirror registries");
         string[] args = [
         "get",
@@ -82,7 +82,7 @@ class MirrorRegistryBootstrapper(KSailCluster config) : IBootstrapper
         Console.WriteLine($"✔ mirror registries connected to 'kind' networks");
         Console.WriteLine();
         break;
-      case (KSailProviderType.Docker, KSailDistributionType.K3s):
+      case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s):
         break;
       default:
         break;

--- a/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
@@ -55,6 +55,8 @@ class MirrorRegistryBootstrapper(KSailCluster config) : IBootstrapper
           throw new KSailException(output);
         }
         string[] nodes = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        // TODO: Remove this workaround when Kind CLI no longer outputs the experimental podman provider message
+        nodes = [.. nodes.Where(line => !line.Contains("enabling experimental podman provider", StringComparison.OrdinalIgnoreCase))];
         foreach (string node in nodes)
         {
           foreach (var mirrorRegistry in config.Spec.MirrorRegistries)

--- a/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
@@ -35,7 +35,7 @@ class MirrorRegistryBootstrapper(KSailCluster config) : IBootstrapper
             cancellationToken).ConfigureAwait(false);
           break;
         default:
-          throw new KSailException($"Provider '{mirrorRegistry.Provider}' is not supported.");
+          throw new NotSupportedException($"Provider '{mirrorRegistry.Provider}' is not supported.");
       }
     });
     await Task.WhenAll(tasks).ConfigureAwait(false);

--- a/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/MirrorRegistryBootstrapper.cs
@@ -90,7 +90,7 @@ class MirrorRegistryBootstrapper(KSailCluster config) : IBootstrapper
       case (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s):
         break;
       default:
-        break;
+        throw new NotSupportedException($"Provider '{config.Spec.Project.Provider}' with distribution '{config.Spec.Project.Distribution}' is not supported.");
     }
   }
 

--- a/src/KSail/Commands/Up/Bootstrappers/SecretManagerBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/SecretManagerBootstrapper.cs
@@ -24,7 +24,7 @@ class SecretManagerBootstrapper(KSailCluster config) : IBootstrapper
       case KSailSecretManagerType.None:
         return;
       default:
-        throw new KSailException($"the '{config.Spec.Project.SecretManager}' Secret Manager is not supported.");
+        throw new NotSupportedException($"the '{config.Spec.Project.SecretManager}' Secret Manager is not supported.");
     }
   }
 
@@ -40,7 +40,7 @@ class SecretManagerBootstrapper(KSailCluster config) : IBootstrapper
         await BootstrapSOPSForFluxAsync(cancellationToken).ConfigureAwait(false);
         break;
       default:
-        throw new KSailException($"the '{config.Spec.Project.DeploymentTool}' Deployment Tool is not supported.");
+        throw new NotSupportedException($"the '{config.Spec.Project.DeploymentTool}' Deployment Tool is not supported.");
     }
     Console.WriteLine();
   }

--- a/src/KSail/Commands/Validate/Validators/ConfigurationValidator.cs
+++ b/src/KSail/Commands/Validate/Validators/ConfigurationValidator.cs
@@ -50,7 +50,7 @@ class ConfigurationValidator(KSailCluster config)
         }
 
       default:
-        throw new KSailException($"unsupported distribution '{config.Spec.Project.Distribution}'.");
+        throw new NotSupportedException($"unsupported distribution '{config.Spec.Project.Distribution}'.");
     }
     Console.WriteLine("✔ configuration is valid");
   }
@@ -84,7 +84,7 @@ class ConfigurationValidator(KSailCluster config)
     {
       KSailDistributionType.K3s => $"k3d-{name}",
       KSailDistributionType.Native => $"kind-{name}",
-      _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+      _ => throw new NotSupportedException($"unsupported distribution '{distribution}'.")
     };
     if (!string.Equals(expectedContextName, context, StringComparison.Ordinal))
     {
@@ -98,7 +98,7 @@ class ConfigurationValidator(KSailCluster config)
     {
       KSailDistributionType.Native => new Uri("oci://ksail-registry:5000/ksail-registry"),
       KSailDistributionType.K3s => new Uri("oci://host.k3d.internal:5555/ksail-registry"),
-      _ => throw new KSailException($"unsupported distribution '{distribution}'.")
+      _ => throw new NotSupportedException($"unsupported distribution '{distribution}'.")
     };
     if (!Equals(expectedOCISourceUri, config.Spec.DeploymentTool.Flux.Source.Url))
     {

--- a/src/KSail/Factories/ClusterProvisionerFactory.cs
+++ b/src/KSail/Factories/ClusterProvisionerFactory.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Devantler.KubernetesProvisioner.Cluster.Core;
 using Devantler.KubernetesProvisioner.Cluster.K3d;
 using Devantler.KubernetesProvisioner.Cluster.Kind;
@@ -10,11 +11,31 @@ class ClusterProvisionerFactory
 {
   internal static IKubernetesClusterProvisioner Create(KSailCluster config)
   {
-    return (config.Spec.Project.Provider, config.Spec.Project.Distribution) switch
+    switch (config.Spec.Project.Provider)
     {
-      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native) => new KindProvisioner(),
-      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s) => new K3dProvisioner(),
-      _ => throw new NotSupportedException($"The distribution '{config.Spec.Project.Distribution}' is not supported.")
+      case KSailProviderType.Podman:
+        string dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST") ?? "unix:var/run/docker.sock";
+        string podmanSocket = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && File.Exists(@"\\.\pipe\docker_engine") ?
+          "npipe://./pipe/docker_engine" : File.Exists($"/run/podman/podman.sock") ?
+          $"unix:///run/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock") ?
+          $"unix:///run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock") ?
+          $"unix:///run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : dockerHost;
+        Environment.SetEnvironmentVariable("DOCKER_HOST", podmanSocket);
+        return GetClusterProvisioner(config);
+      case KSailProviderType.Docker:
+        return GetClusterProvisioner(config);
+      default:
+        throw new NotSupportedException($"The provider '{config.Spec.Project.Provider}' is not supported.");
+    }
+  }
+
+  static IKubernetesClusterProvisioner GetClusterProvisioner(KSailCluster config)
+  {
+    return config.Spec.Project.Distribution switch
+    {
+      KSailDistributionType.Native => new KindProvisioner(),
+      KSailDistributionType.K3s => new K3dProvisioner(),
+      _ => throw new NotSupportedException($"The distribution '{config.Spec.Project.Distribution}' is not supported."),
     };
   }
 }

--- a/src/KSail/Factories/ClusterProvisionerFactory.cs
+++ b/src/KSail/Factories/ClusterProvisionerFactory.cs
@@ -12,8 +12,8 @@ class ClusterProvisionerFactory
   {
     return (config.Spec.Project.Provider, config.Spec.Project.Distribution) switch
     {
-      (KSailProviderType.Docker, KSailDistributionType.Native) => new KindProvisioner(),
-      (KSailProviderType.Docker, KSailDistributionType.K3s) => new K3dProvisioner(),
+      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.Native) => new KindProvisioner(),
+      (KSailProviderType.Docker or KSailProviderType.Podman, KSailDistributionType.K3s) => new K3dProvisioner(),
       _ => throw new NotSupportedException($"The distribution '{config.Spec.Project.Distribution}' is not supported.")
     };
   }

--- a/src/KSail/Factories/ContainerEngineProvisionerFactory.cs
+++ b/src/KSail/Factories/ContainerEngineProvisionerFactory.cs
@@ -11,10 +11,15 @@ class ContainerEngineProvisionerFactory
 {
   internal static DockerProvisioner Create(KSailCluster config)
   {
-    return config.Spec.Project.Provider switch
+    switch (config.Spec.Project.Provider)
     {
-      KSailProviderType.Docker or KSailProviderType.Podman => new DockerProvisioner(),
-      _ => throw new NotSupportedException($"The container engine '{config.Spec.Project.Provider}' is not supported.")
-    };
+      case KSailProviderType.Docker:
+        return new DockerProvisioner();
+      case KSailProviderType.Podman:
+        string socketPath = PodmanHelper.GetPodmanSocket();
+        return new DockerProvisioner(socketPath);
+      default:
+        throw new NotSupportedException($"The provider '{config.Spec.Project.Provider}' is not supported.");
+    }
   }
 }

--- a/src/KSail/Factories/ContainerEngineProvisionerFactory.cs
+++ b/src/KSail/Factories/ContainerEngineProvisionerFactory.cs
@@ -13,7 +13,7 @@ class ContainerEngineProvisionerFactory
   {
     return config.Spec.Project.Provider switch
     {
-      KSailProviderType.Docker => new DockerProvisioner(),
+      KSailProviderType.Docker or KSailProviderType.Podman => new DockerProvisioner(),
       _ => throw new NotSupportedException($"The container engine '{config.Spec.Project.Provider}' is not supported.")
     };
   }

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.3.0" />
+    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.4.0" />
     <PackageReference Include="Devantler.KubernetesGenerator.CertManager" Version="1.7.2" />
     <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.7.2" />
     <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.7.2" />

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.4.0" />
+    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.4.1" />
     <PackageReference Include="Devantler.KubernetesGenerator.CertManager" Version="1.7.2" />
     <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.7.2" />
     <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.7.2" />

--- a/src/KSail/Utils/KSailClusterConfigLoader.cs
+++ b/src/KSail/Utils/KSailClusterConfigLoader.cs
@@ -2,6 +2,7 @@ using System.CommandLine.Invocation;
 using Devantler.KubernetesGenerator.Core.Converters;
 using Devantler.KubernetesGenerator.Core.Inspectors;
 using KSail.Models;
+using KSail.Models.LocalRegistry;
 using KSail.Models.Project.Enums;
 using KSail.Options;
 using YamlDotNet.Serialization;
@@ -79,6 +80,14 @@ static class KSailClusterConfigLoader
 
     // MirrorRegistries
     // TODO: Implement MirrorRegistries CLIOptions
+    for (int i = 0; i < config.Spec.MirrorRegistries.Count(); i++)
+    {
+      var mirrorRegistry = config.Spec.MirrorRegistries.ElementAt(i);
+      if (mirrorRegistry.Provider == KSailProviderType.Docker)
+      {
+        config.Spec.MirrorRegistries.ElementAt(i).Provider = context.ParseResult.GetValueForOption(CLIOptions.Project.ProviderOption);
+      }
+    }
 
     // Generator
     config.UpdateConfig(c => c.Spec.Generator.Overwrite, context.ParseResult.GetValueForOption(CLIOptions.Generator.OverwriteOption));

--- a/src/KSail/Utils/PodmanHelper.cs
+++ b/src/KSail/Utils/PodmanHelper.cs
@@ -1,0 +1,12 @@
+using System.Runtime.InteropServices;
+
+class PodmanHelper
+{
+  internal static string GetPodmanSocket()
+  {
+    return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+      "npipe://./pipe/docker_engine" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock") ?
+      $"unix:/run/user/${Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock") ?
+      $"unix:/run/user/${Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : "unix:/var/run/docker.sock";
+  }
+}

--- a/src/KSail/Utils/PodmanHelper.cs
+++ b/src/KSail/Utils/PodmanHelper.cs
@@ -6,6 +6,7 @@ class PodmanHelper
   {
     return File.Exists($"/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock") ?
       $"unix:///run/user/${Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock") ?
-      $"unix:///run/user/${Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : "unix:///var/run/docker.sock";
+      $"unix:///run/user/${Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : File.Exists("/run/podman/podman.sock") ?
+      "unix:///run/podman/podman.sock" : "unix:///var/run/docker.sock";
   }
 }

--- a/src/KSail/Utils/PodmanHelper.cs
+++ b/src/KSail/Utils/PodmanHelper.cs
@@ -4,8 +4,7 @@ class PodmanHelper
 {
   internal static string GetPodmanSocket()
   {
-    return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-      "npipe://./pipe/docker_engine" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock") ?
+    return File.Exists($"/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock") ?
       $"unix:///run/user/${Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock") ?
       $"unix:///run/user/${Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : "unix:///var/run/docker.sock";
   }

--- a/src/KSail/Utils/PodmanHelper.cs
+++ b/src/KSail/Utils/PodmanHelper.cs
@@ -6,7 +6,7 @@ class PodmanHelper
   {
     return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
       "npipe://./pipe/docker_engine" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock") ?
-      $"unix:/run/user/${Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock") ?
-      $"unix:/run/user/${Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : "unix:/var/run/docker.sock";
+      $"unix:///run/user/${Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock") ?
+      $"unix:///run/user/${Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : "unix:///var/run/docker.sock";
   }
 }

--- a/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
+++ b/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
@@ -56,7 +56,7 @@ Options:
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>                    The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a kustomization. [default: Kubectl]
   --cni <Cilium|Default>                            The CNI to use. [default: Default]
@@ -84,7 +84,7 @@ Options:
   -fsu, --flux-source-url <flux-source-url>  Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
   -n, --name <name>                          The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>            The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>                    The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>             The provider to use for provisioning the cluster. [default: Docker]
   -mr, --mirror-registries                   Enable mirror registries for the project. [default: True]
   -?, -h, --help                             Show help and usage information
 ```
@@ -120,7 +120,7 @@ Options:
   -c, --context <context>          The kubernetes context to use. [default: kind-ksail-default]
   -n, --name <name>                The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -?, -h, --help                   Show help and usage information
 ```
 
@@ -136,7 +136,7 @@ Usage:
 Options:
   -n, --name <name>                The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -?, -h, --help                   Show help and usage information
 ```
 
@@ -155,7 +155,7 @@ Options:
   -c, --config <config>                             The path to the ksail configuration file. [default: ksail.yaml]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>                    The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a kustomization. [default: Kubectl]
   --cni <Cilium|Default>                            The CNI to use. [default: Default]
@@ -225,7 +225,7 @@ Usage:
   ksail list [options]
 
 Options:
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
   -a, --all                        List clusters from all distributions. [default: False]
   -?, -h, --help                   Show help and usage information

--- a/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
+++ b/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
@@ -70,7 +70,8 @@
             "provider": {
               "description": "The provider to use for running the KSail cluster. [default: Docker]",
               "enum": [
-                "Docker"
+                "Docker",
+                "Podman"
               ]
             },
             "distribution": {

--- a/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
+++ b/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
@@ -209,7 +209,8 @@
             "provider": {
               "description": "The registry provider. [default: Docker]",
               "enum": [
-                "Docker"
+                "Docker",
+                "Podman"
               ]
             }
           }
@@ -255,7 +256,8 @@
               "provider": {
                 "description": "The registry provider. [default: Docker]",
                 "enum": [
-                  "Docker"
+                  "Docker",
+                  "Podman"
                 ]
               }
             }

--- a/tests/KSail.Tests.System/E2ETests.cs
+++ b/tests/KSail.Tests.System/E2ETests.cs
@@ -43,7 +43,7 @@ public class E2ETests
   // Docker + K3s + Flux + Cilium
   [InlineData(["init", "--name", "d-k-f-cilium", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
   // Docker + K3s + Flux  + SOPS
-  [InlineData(["init", "--name", "d-k-f-sops", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "SOPS"])]
+  [InlineData(["init", "--name", "d-k-f-sops", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
   // Podman + Native + Kubectl + Defaults
   [InlineData(["init", "--name", "p-n-k-defaults", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
   // Podman + Native + Kubectl + Cilium

--- a/tests/KSail.Tests.System/E2ETests.cs
+++ b/tests/KSail.Tests.System/E2ETests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CommandLine;
 using System.CommandLine.IO;
 using System.Runtime.InteropServices;
@@ -69,11 +70,20 @@ public class E2ETests
   [InlineData(["init", "--name", "p-k-f-sops", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
   public async Task KSailUp_WithVariousConfigurations_Succeeds(params string[] initArgs)
   {
+    // Validate that initArgs is not null
+    ArgumentNullException.ThrowIfNull(initArgs);
+
     // TODO: Add support for Windows and macOS in GitHub Runners when GitHub Actions runners support dind on Windows and macOS runners.
     Skip.If(
       RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
       (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true"),
       "Skipping test on Windows OS or macOS in GitHub Actions.");
+
+    string provider = initArgs.Contains("--provider") ? initArgs[Array.IndexOf(initArgs, "--provider") + 1] : string.Empty;
+    string distribution = initArgs.Contains("--distribution") ? initArgs[Array.IndexOf(initArgs, "--distribution") + 1] : string.Empty;
+    Skip.If(
+      RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && provider.Equals("Podman", StringComparison.Ordinal) && distribution.Equals("K3s", StringComparison.Ordinal),
+      "Skipping test on macOS with Podman and K3s.");
 
     //Arrange
     var console = new TestConsole();

--- a/tests/KSail.Tests.System/E2ETests.cs
+++ b/tests/KSail.Tests.System/E2ETests.cs
@@ -19,67 +19,54 @@ namespace KSail.Tests.System;
 public class E2ETests
 {
   [SkippableTheory]
-  [InlineData(["init", "--name", "default"])]
-  // Docker
-  [InlineData(["init", "--name", "d", "--provider", "Docker"])]
-  // Docker + Native
-  [InlineData(["init", "--name", "d-n", "--provider", "Docker", "--distribution", "Native"])]
-  // Docker + Native + Kubectl
-  [InlineData(["init", "--name", "d-n-k", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
+  // Docker + Native + Kubectl + Defaults
+  [InlineData(["init", "--name", "d-n-k-defaults", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
   // Docker + Native + Kubectl + Cilium
-  [InlineData(["init", "--name", "d-n-k-c", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
-  // Docker + Native + Kubectl + Cilium + SOPS
-  [InlineData(["init", "--name", "d-n-k-c-s", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
-  // Docker + Native + Flux
-  [InlineData(["init", "--name", "d-n-f", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux"])]
+  [InlineData(["init", "--name", "d-n-k-cilium", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Docker + Native + Kubectl + SOPS
+  [InlineData(["init", "--name", "d-n-k-sops", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
+  // Docker + Native + Flux + Defaults
+  [InlineData(["init", "--name", "d-n-f-defaults", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux"])]
   // Docker + Native + Flux + Cilium
-  [InlineData(["init", "--name", "d-n-f-c", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
-  // Docker + Native + Flux + Cilium + SOPS
-  [InlineData(["init", "--name", "d-n-f-c-s", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
-  // Docker + K3s
-  [InlineData(["init", "--name", "d-k", "--provider", "Docker", "--distribution", "K3s"])]
-  // Docker + K3s + Kubectl
-  [InlineData(["init", "--name", "d-k-k", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
+  [InlineData(["init", "--name", "d-n-f-cilium", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  // Docker + Native + Flux + SOPS
+  [InlineData(["init", "--name", "d-n-f-sops", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
+  // Docker + K3s + Kubectl + Defaults
+  [InlineData(["init", "--name", "d-k-k-defaults", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
   // Docker + K3s + Kubectl + Cilium
-  [InlineData(["init", "--name", "d-k-k-c", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
-  // Docker + K3s + Kubectl + Cilium + SOPS
-  [InlineData(["init", "--name", "d-k-k-c-s", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
-  // Docker + K3s + Flux
-  [InlineData(["init", "--name", "d-k-f", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux"])]
+  [InlineData(["init", "--name", "d-k-k-cilium", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Docker + K3s + Kubectl + SOPS
+  [InlineData(["init", "--name", "d-k-k-sops", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
+  // Docker + K3s + Flux + Defaults
+  [InlineData(["init", "--name", "d-k-f-defaults", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux"])]
   // Docker + K3s + Flux + Cilium
-  [InlineData(["init", "--name", "d-k-f-c", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
-  // Docker + K3s + Flux + Cilium + SOPS
-  [InlineData(["init", "--name", "d-k-f-c-s", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
-  // Podman
-  [InlineData(["init", "--name", "p", "--provider", "Podman"])]
-  // Podman + Native
-  [InlineData(["init", "--name", "p-n", "--provider", "Podman", "--distribution", "Native"])]
-  // Podman + Native + Kubectl
-  [InlineData(["init", "--name", "p-n-k", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
+  [InlineData(["init", "--name", "d-k-f-cilium", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  // Docker + K3s + Flux  + SOPS
+  [InlineData(["init", "--name", "d-k-f-sops", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "SOPS"])]
+  // Podman + Native + Kubectl + Defaults
+  [InlineData(["init", "--name", "p-n-k-defaults", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
   // Podman + Native + Kubectl + Cilium
-  [InlineData(["init", "--name", "p-n-k-c", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
-  // Podman + Native + Kubectl + Cilium + SOPS
-  [InlineData(["init", "--name", "p-n-k-c-s", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
-  // Podman + Native + Flux
-  [InlineData(["init", "--name", "p-n-f", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux"])]
+  [InlineData(["init", "--name", "p-n-k-cilium", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Podman + Native + Kubectl + SOPS
+  [InlineData(["init", "--name", "p-n-k-sops", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
+  // Podman + Native + Flux + Defaults
+  [InlineData(["init", "--name", "p-n-f-defaults", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux"])]
   // Podman + Native + Flux + Cilium
-  [InlineData(["init", "--name", "p-n-f-c", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
-  // Podman + Native + Flux + Cilium + SOPS
-  [InlineData(["init", "--name", "p-n-f-c-s", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
-  // Podman + K3s
-  [InlineData(["init", "--name", "p-k", "--provider", "Podman", "--distribution", "K3s"])]
-  // Podman + K3s + Kubectl
-  [InlineData(["init", "--name", "p-k-k", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
+  [InlineData(["init", "--name", "p-n-f-cilium", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  // Podman + Native + Flux + SOPS
+  [InlineData(["init", "--name", "p-n-f-sops", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
+  // Podman + K3s + Kubectl + Defaults
+  [InlineData(["init", "--name", "p-k-k-defaults", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
   // Podman + K3s + Kubectl + Cilium
-  [InlineData(["init", "--name", "p-k-k-c", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
-  // Podman + K3s + Kubectl + Cilium + SOPS
-  [InlineData(["init", "--name", "p-k-k-c-s", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
-  // Podman + K3s + Flux
-  [InlineData(["init", "--name", "p-k-f", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux"])]
+  [InlineData(["init", "--name", "p-k-k-cilium", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Podman + K3s + Kubectl + SOPS
+  [InlineData(["init", "--name", "p-k-k-sops", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
+  // Podman + K3s + Flux + Defaults
+  [InlineData(["init", "--name", "p-k-f-defaults", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux"])]
   // Podman + K3s + Flux + Cilium
-  [InlineData(["init", "--name", "p-k-f-c", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
-  // Podman + K3s + Flux + Cilium + SOPS
-  [InlineData(["init", "--name", "p-k-f-c-s", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  [InlineData(["init", "--name", "p-k-f-cilium", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  // Podman + K3s + Flux + SOPS
+  [InlineData(["init", "--name", "p-k-f-sops", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
   public async Task KSailUp_WithVariousConfigurations_Succeeds(params string[] initArgs)
   {
     // TODO: Add support for Windows and macOS in GitHub Runners when GitHub Actions runners support dind on Windows and macOS runners.

--- a/tests/KSail.Tests.System/E2ETests.cs
+++ b/tests/KSail.Tests.System/E2ETests.cs
@@ -20,54 +20,30 @@ namespace KSail.Tests.System;
 public class E2ETests
 {
   [SkippableTheory]
-  // Docker + Native + Kubectl + Defaults
-  [InlineData(["init", "--name", "d-n-k-defaults", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
-  // Docker + Native + Kubectl + Cilium
-  [InlineData(["init", "--name", "d-n-k-cilium", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Docker + Native + Defaults
+  [InlineData(["init", "--name", "d-n-defaults", "--provider", "Docker", "--distribution", "Native"])]
+  // Docker + Native + Cilium
+  [InlineData(["init", "--name", "d-n-cilium", "--provider", "Docker", "--distribution", "Native", "--cni", "Cilium"])]
   // Docker + Native + Kubectl + SOPS
   [InlineData(["init", "--name", "d-n-k-sops", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
   // Docker + Native + Flux + Defaults
   [InlineData(["init", "--name", "d-n-f-defaults", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux"])]
-  // Docker + Native + Flux + Cilium
-  [InlineData(["init", "--name", "d-n-f-cilium", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
   // Docker + Native + Flux + SOPS
   [InlineData(["init", "--name", "d-n-f-sops", "--provider", "Docker", "--distribution", "Native", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
-  // Docker + K3s + Kubectl + Defaults
-  [InlineData(["init", "--name", "d-k-k-defaults", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
-  // Docker + K3s + Kubectl + Cilium
-  [InlineData(["init", "--name", "d-k-k-cilium", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Docker + K3s + Defaults
+  [InlineData(["init", "--name", "d-k-defaults", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
+  // Docker + K3s + Cilium
+  [InlineData(["init", "--name", "d-k-cilium", "--provider", "Docker", "--distribution", "K3s", "--cni", "Cilium"])]
   // Docker + K3s + Kubectl + SOPS
   [InlineData(["init", "--name", "d-k-k-sops", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
   // Docker + K3s + Flux + Defaults
   [InlineData(["init", "--name", "d-k-f-defaults", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux"])]
-  // Docker + K3s + Flux + Cilium
-  [InlineData(["init", "--name", "d-k-f-cilium", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
-  // Docker + K3s + Flux  + SOPS
+  // Docker + K3s + Flux + SOPS
   [InlineData(["init", "--name", "d-k-f-sops", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
-  // Podman + Native + Kubectl + Defaults
-  [InlineData(["init", "--name", "p-n-k-defaults", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
-  // Podman + Native + Kubectl + Cilium
-  [InlineData(["init", "--name", "p-n-k-cilium", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
-  // Podman + Native + Kubectl + SOPS
-  [InlineData(["init", "--name", "p-n-k-sops", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
-  // Podman + Native + Flux + Defaults
-  [InlineData(["init", "--name", "p-n-f-defaults", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux"])]
-  // Podman + Native + Flux + Cilium
-  [InlineData(["init", "--name", "p-n-f-cilium", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
-  // Podman + Native + Flux + SOPS
-  [InlineData(["init", "--name", "p-n-f-sops", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
-  // Podman + K3s + Kubectl + Defaults
-  [InlineData(["init", "--name", "p-k-k-defaults", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
-  // Podman + K3s + Kubectl + Cilium
-  [InlineData(["init", "--name", "p-k-k-cilium", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
-  // Podman + K3s + Kubectl + SOPS
-  [InlineData(["init", "--name", "p-k-k-sops", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--secret-manager", "SOPS"])]
-  // Podman + K3s + Flux + Defaults
-  [InlineData(["init", "--name", "p-k-f-defaults", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux"])]
-  // Podman + K3s + Flux + Cilium
-  [InlineData(["init", "--name", "p-k-f-cilium", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
-  // Podman + K3s + Flux + SOPS
-  [InlineData(["init", "--name", "p-k-f-sops", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--secret-manager", "SOPS"])]
+  // Podman + Native + Defaults
+  [InlineData(["init", "--name", "p-n-defaults", "--provider", "Podman", "--distribution", "Native"])]
+  // Podman + K3s + Defaults
+  [InlineData(["init", "--name", "p-k-defaults", "--provider", "Podman", "--distribution", "K3s"])]
   public async Task KSailUp_WithVariousConfigurations_Succeeds(params string[] initArgs)
   {
     // Validate that initArgs is not null

--- a/tests/KSail.Tests.System/E2ETests.cs
+++ b/tests/KSail.Tests.System/E2ETests.cs
@@ -50,6 +50,36 @@ public class E2ETests
   [InlineData(["init", "--name", "d-k-f-c", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
   // Docker + K3s + Flux + Cilium + SOPS
   [InlineData(["init", "--name", "d-k-f-c-s", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  // Podman
+  [InlineData(["init", "--name", "p", "--provider", "Podman"])]
+  // Podman + Native
+  [InlineData(["init", "--name", "p-n", "--provider", "Podman", "--distribution", "Native"])]
+  // Podman + Native + Kubectl
+  [InlineData(["init", "--name", "p-n-k", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
+  // Podman + Native + Kubectl + Cilium
+  [InlineData(["init", "--name", "p-n-k-c", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Podman + Native + Kubectl + Cilium + SOPS
+  [InlineData(["init", "--name", "p-n-k-c-s", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  // Podman + Native + Flux
+  [InlineData(["init", "--name", "p-n-f", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux"])]
+  // Podman + Native + Flux + Cilium
+  [InlineData(["init", "--name", "p-n-f-c", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  // Podman + Native + Flux + Cilium + SOPS
+  [InlineData(["init", "--name", "p-n-f-c-s", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  // Podman + K3s
+  [InlineData(["init", "--name", "p-k", "--provider", "Podman", "--distribution", "K3s"])]
+  // Podman + K3s + Kubectl
+  [InlineData(["init", "--name", "p-k-k", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
+  // Podman + K3s + Kubectl + Cilium
+  [InlineData(["init", "--name", "p-k-k-c", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  // Podman + K3s + Kubectl + Cilium + SOPS
+  [InlineData(["init", "--name", "p-k-k-c-s", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  // Podman + K3s + Flux
+  [InlineData(["init", "--name", "p-k-f", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux"])]
+  // Podman + K3s + Flux + Cilium
+  [InlineData(["init", "--name", "p-k-f-c", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  // Podman + K3s + Flux + Cilium + SOPS
+  [InlineData(["init", "--name", "p-k-f-c-s", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
   public async Task KSailUp_WithVariousConfigurations_Succeeds(params string[] initArgs)
   {
     // TODO: Add support for Windows and macOS in GitHub Runners when GitHub Actions runners support dind on Windows and macOS runners.

--- a/tests/KSail.Tests.Unit/Commands/Down/KSailDownCommandTests.KSailDownHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Down/KSailDownCommandTests.KSailDownHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -8,7 +8,7 @@ Options:
   -fsu, --flux-source-url <flux-source-url>  Flux source URL for reconciling GitOps resources. [default: oci://ksail-registry:5000/ksail-registry]
   -n, --name <name>                          The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>            The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>                    The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>             The provider to use for provisioning the cluster. [default: Docker]
   -mr, --mirror-registries                   Enable mirror registries for the project. [default: True]
   -?, -h, --help                             Show help and usage information
 

--- a/tests/KSail.Tests.Unit/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Init/KSailInitCommandTests.KSailInitHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -10,7 +10,7 @@ Options:
   -c, --config <config>                             The path to the ksail configuration file. [default: ksail.yaml]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>                    The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a kustomization. [default: Kubectl]
   --cni <Cilium|Default>                            The CNI to use. [default: Default]

--- a/tests/KSail.Tests.Unit/Commands/Init/KSailInitCommandTests.cs
+++ b/tests/KSail.Tests.Unit/Commands/Init/KSailInitCommandTests.cs
@@ -48,6 +48,21 @@ public partial class KSailInitCommandTests
   [InlineData(["init", "--output", "ksail-init-docker-k3s-flux", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux"])]
   [InlineData(["init", "--output", "ksail-init-docker-k3s-flux-cilium", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
   [InlineData(["init", "--output", "ksail-init-docker-k3s-flux-cilium-sops", "--provider", "Docker", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  [InlineData(["init", "--output", "ksail-init-podman", "--provider", "Podman"])]
+  [InlineData(["init", "--output", "ksail-init-podman-native", "--provider", "Podman", "--distribution", "Native"])]
+  [InlineData(["init", "--output", "ksail-init-podman-native-kubectl", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl"])]
+  [InlineData(["init", "--output", "ksail-init-podman-native-kubectl-cilium", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  [InlineData(["init", "--output", "ksail-init-podman-native-kubectl-cilium-sops", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  [InlineData(["init", "--output", "ksail-init-podman-native-flux", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux"])]
+  [InlineData(["init", "--output", "ksail-init-podman-native-flux-cilium", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  [InlineData(["init", "--output", "ksail-init-podman-native-flux-cilium-sops", "--provider", "Podman", "--distribution", "Native", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  [InlineData(["init", "--output", "ksail-init-podman-k3s", "--provider", "Podman", "--distribution", "K3s"])]
+  [InlineData(["init", "--output", "ksail-init-podman-k3s-kubectl", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl"])]
+  [InlineData(["init", "--output", "ksail-init-podman-k3s-kubectl-cilium", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium"])]
+  [InlineData(["init", "--output", "ksail-init-podman-k3s-kubectl-cilium-sops", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Kubectl", "--cni", "Cilium", "--secret-manager", "SOPS"])]
+  [InlineData(["init", "--output", "ksail-init-podman-k3s-flux", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux"])]
+  [InlineData(["init", "--output", "ksail-init-podman-k3s-flux-cilium", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium"])]
+  [InlineData(["init", "--output", "ksail-init-podman-k3s-flux-cilium-sops", "--provider", "Podman", "--distribution", "K3s", "--deployment-tool", "Flux", "--cni", "Cilium", "--secret-manager", "SOPS"])]
   public async Task KSailInit_WithVariousOptions_SucceedsAndGeneratesKSailProject(params string[] args)
   {
     //TODO: Add support for Windows at a later time.

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium-sops/k3d.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium-sops/k3d.yaml.verified.yaml
@@ -1,0 +1,35 @@
+﻿---
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ksail-default
+registries:
+  config: >2
+      mirrors:
+        "registry.k8s.io":
+          endpoint:
+            - http://host.k3d.internal:5556
+        "docker.io":
+          endpoint:
+            - http://host.k3d.internal:5557
+        "ghcr.io":
+          endpoint:
+            - http://host.k3d.internal:5558
+        "gcr.io":
+          endpoint:
+            - http://host.k3d.internal:5559
+        "mcr.microsoft.com":
+          endpoint:
+            - http://host.k3d.internal:5560
+        "quay.io":
+          endpoint:
+            - http://host.k3d.internal:5561
+options:
+  k3s:
+    extraArgs:
+    - arg: --flannel-backend=none
+      nodeFilters:
+      - server:*
+    - arg: --disable-network-policy
+      nodeFilters:
+      - server:*

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium-sops/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium-sops/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium-sops/ksail.yaml.verified.yaml
@@ -1,0 +1,108 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection:
+    # The kube context. [default: kind-ksail-default]
+    context: k3d-ksail-default
+  # The options for the KSail project.
+  project:
+    # The path to the distribution configuration file. [default: kind.yaml]
+    distributionConfigPath: k3d.yaml
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Kubernetes distribution to use. [default: Native]
+    distribution: K3s
+    # The Deployment tool to use. [default: Kubectl]
+    deploymentTool: Flux
+    # The CNI to use. [default: Default]
+    cni: Cilium
+    # Whether to use a secret manager. [default: None]
+    secretManager: SOPS
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source:
+        # The URL of the repository. [default: oci://ksail-registry:5000/ksail-registry]
+        url: <url>
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium/k3d.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium/k3d.yaml.verified.yaml
@@ -1,0 +1,35 @@
+﻿---
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ksail-default
+registries:
+  config: >2
+      mirrors:
+        "registry.k8s.io":
+          endpoint:
+            - http://host.k3d.internal:5556
+        "docker.io":
+          endpoint:
+            - http://host.k3d.internal:5557
+        "ghcr.io":
+          endpoint:
+            - http://host.k3d.internal:5558
+        "gcr.io":
+          endpoint:
+            - http://host.k3d.internal:5559
+        "mcr.microsoft.com":
+          endpoint:
+            - http://host.k3d.internal:5560
+        "quay.io":
+          endpoint:
+            - http://host.k3d.internal:5561
+options:
+  k3s:
+    extraArgs:
+    - arg: --flannel-backend=none
+      nodeFilters:
+      - server:*
+    - arg: --disable-network-policy
+      nodeFilters:
+      - server:*

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux-cilium/ksail.yaml.verified.yaml
@@ -1,0 +1,106 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection:
+    # The kube context. [default: kind-ksail-default]
+    context: k3d-ksail-default
+  # The options for the KSail project.
+  project:
+    # The path to the distribution configuration file. [default: kind.yaml]
+    distributionConfigPath: k3d.yaml
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Kubernetes distribution to use. [default: Native]
+    distribution: K3s
+    # The Deployment tool to use. [default: Kubectl]
+    deploymentTool: Flux
+    # The CNI to use. [default: Default]
+    cni: Cilium
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source:
+        # The URL of the repository. [default: oci://ksail-registry:5000/ksail-registry]
+        url: <url>
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux/k3d.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux/k3d.yaml.verified.yaml
@@ -1,0 +1,26 @@
+﻿---
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ksail-default
+registries:
+  config: >2
+      mirrors:
+        "registry.k8s.io":
+          endpoint:
+            - http://host.k3d.internal:5556
+        "docker.io":
+          endpoint:
+            - http://host.k3d.internal:5557
+        "ghcr.io":
+          endpoint:
+            - http://host.k3d.internal:5558
+        "gcr.io":
+          endpoint:
+            - http://host.k3d.internal:5559
+        "mcr.microsoft.com":
+          endpoint:
+            - http://host.k3d.internal:5560
+        "quay.io":
+          endpoint:
+            - http://host.k3d.internal:5561

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-flux/ksail.yaml.verified.yaml
@@ -1,0 +1,104 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection:
+    # The kube context. [default: kind-ksail-default]
+    context: k3d-ksail-default
+  # The options for the KSail project.
+  project:
+    # The path to the distribution configuration file. [default: kind.yaml]
+    distributionConfigPath: k3d.yaml
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Kubernetes distribution to use. [default: Native]
+    distribution: K3s
+    # The Deployment tool to use. [default: Kubectl]
+    deploymentTool: Flux
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source:
+        # The URL of the repository. [default: oci://ksail-registry:5000/ksail-registry]
+        url: <url>
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium-sops/k3d.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium-sops/k3d.yaml.verified.yaml
@@ -1,0 +1,35 @@
+﻿---
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ksail-default
+registries:
+  config: >2
+      mirrors:
+        "registry.k8s.io":
+          endpoint:
+            - http://host.k3d.internal:5556
+        "docker.io":
+          endpoint:
+            - http://host.k3d.internal:5557
+        "ghcr.io":
+          endpoint:
+            - http://host.k3d.internal:5558
+        "gcr.io":
+          endpoint:
+            - http://host.k3d.internal:5559
+        "mcr.microsoft.com":
+          endpoint:
+            - http://host.k3d.internal:5560
+        "quay.io":
+          endpoint:
+            - http://host.k3d.internal:5561
+options:
+  k3s:
+    extraArgs:
+    - arg: --flannel-backend=none
+      nodeFilters:
+      - server:*
+    - arg: --disable-network-policy
+      nodeFilters:
+      - server:*

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium-sops/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium-sops/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium-sops/ksail.yaml.verified.yaml
@@ -1,0 +1,106 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection:
+    # The kube context. [default: kind-ksail-default]
+    context: k3d-ksail-default
+  # The options for the KSail project.
+  project:
+    # The path to the distribution configuration file. [default: kind.yaml]
+    distributionConfigPath: k3d.yaml
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Kubernetes distribution to use. [default: Native]
+    distribution: K3s
+    # The CNI to use. [default: Default]
+    cni: Cilium
+    # Whether to use a secret manager. [default: None]
+    secretManager: SOPS
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source:
+        # The URL of the repository. [default: oci://ksail-registry:5000/ksail-registry]
+        url: <url>
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium/k3d.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium/k3d.yaml.verified.yaml
@@ -1,0 +1,35 @@
+﻿---
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ksail-default
+registries:
+  config: >2
+      mirrors:
+        "registry.k8s.io":
+          endpoint:
+            - http://host.k3d.internal:5556
+        "docker.io":
+          endpoint:
+            - http://host.k3d.internal:5557
+        "ghcr.io":
+          endpoint:
+            - http://host.k3d.internal:5558
+        "gcr.io":
+          endpoint:
+            - http://host.k3d.internal:5559
+        "mcr.microsoft.com":
+          endpoint:
+            - http://host.k3d.internal:5560
+        "quay.io":
+          endpoint:
+            - http://host.k3d.internal:5561
+options:
+  k3s:
+    extraArgs:
+    - arg: --flannel-backend=none
+      nodeFilters:
+      - server:*
+    - arg: --disable-network-policy
+      nodeFilters:
+      - server:*

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl-cilium/ksail.yaml.verified.yaml
@@ -1,0 +1,104 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection:
+    # The kube context. [default: kind-ksail-default]
+    context: k3d-ksail-default
+  # The options for the KSail project.
+  project:
+    # The path to the distribution configuration file. [default: kind.yaml]
+    distributionConfigPath: k3d.yaml
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Kubernetes distribution to use. [default: Native]
+    distribution: K3s
+    # The CNI to use. [default: Default]
+    cni: Cilium
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source:
+        # The URL of the repository. [default: oci://ksail-registry:5000/ksail-registry]
+        url: <url>
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl/k3d.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl/k3d.yaml.verified.yaml
@@ -1,0 +1,26 @@
+﻿---
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ksail-default
+registries:
+  config: >2
+      mirrors:
+        "registry.k8s.io":
+          endpoint:
+            - http://host.k3d.internal:5556
+        "docker.io":
+          endpoint:
+            - http://host.k3d.internal:5557
+        "ghcr.io":
+          endpoint:
+            - http://host.k3d.internal:5558
+        "gcr.io":
+          endpoint:
+            - http://host.k3d.internal:5559
+        "mcr.microsoft.com":
+          endpoint:
+            - http://host.k3d.internal:5560
+        "quay.io":
+          endpoint:
+            - http://host.k3d.internal:5561

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s-kubectl/ksail.yaml.verified.yaml
@@ -1,0 +1,102 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection:
+    # The kube context. [default: kind-ksail-default]
+    context: k3d-ksail-default
+  # The options for the KSail project.
+  project:
+    # The path to the distribution configuration file. [default: kind.yaml]
+    distributionConfigPath: k3d.yaml
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Kubernetes distribution to use. [default: Native]
+    distribution: K3s
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source:
+        # The URL of the repository. [default: oci://ksail-registry:5000/ksail-registry]
+        url: <url>
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s/k3d.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s/k3d.yaml.verified.yaml
@@ -1,0 +1,26 @@
+﻿---
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ksail-default
+registries:
+  config: >2
+      mirrors:
+        "registry.k8s.io":
+          endpoint:
+            - http://host.k3d.internal:5556
+        "docker.io":
+          endpoint:
+            - http://host.k3d.internal:5557
+        "ghcr.io":
+          endpoint:
+            - http://host.k3d.internal:5558
+        "gcr.io":
+          endpoint:
+            - http://host.k3d.internal:5559
+        "mcr.microsoft.com":
+          endpoint:
+            - http://host.k3d.internal:5560
+        "quay.io":
+          endpoint:
+            - http://host.k3d.internal:5561

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3s/ksail.yaml.verified.yaml
@@ -1,0 +1,102 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection:
+    # The kube context. [default: kind-ksail-default]
+    context: k3d-ksail-default
+  # The options for the KSail project.
+  project:
+    # The path to the distribution configuration file. [default: kind.yaml]
+    distributionConfigPath: k3d.yaml
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Kubernetes distribution to use. [default: Native]
+    distribution: K3s
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source:
+        # The URL of the repository. [default: oci://ksail-registry:5000/ksail-registry]
+        url: <url>
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium-sops/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium-sops/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium-sops/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium-sops/kind.yaml.verified.yaml
@@ -1,0 +1,10 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+networking:
+  disableDefaultCNI: true
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium-sops/ksail.yaml.verified.yaml
@@ -1,0 +1,100 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Deployment tool to use. [default: Kubectl]
+    deploymentTool: Flux
+    # The CNI to use. [default: Default]
+    cni: Cilium
+    # Whether to use a secret manager. [default: None]
+    secretManager: SOPS
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium/kind.yaml.verified.yaml
@@ -1,0 +1,10 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+networking:
+  disableDefaultCNI: true
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux-cilium/ksail.yaml.verified.yaml
@@ -1,0 +1,98 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Deployment tool to use. [default: Kubectl]
+    deploymentTool: Flux
+    # The CNI to use. [default: Default]
+    cni: Cilium
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux/kind.yaml.verified.yaml
@@ -1,0 +1,8 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-flux/ksail.yaml.verified.yaml
@@ -1,0 +1,96 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The Deployment tool to use. [default: Kubectl]
+    deploymentTool: Flux
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium-sops/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium-sops/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium-sops/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium-sops/kind.yaml.verified.yaml
@@ -1,0 +1,10 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+networking:
+  disableDefaultCNI: true
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium-sops/ksail.yaml.verified.yaml
@@ -1,0 +1,98 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The CNI to use. [default: Default]
+    cni: Cilium
+    # Whether to use a secret manager. [default: None]
+    secretManager: SOPS
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium/kind.yaml.verified.yaml
@@ -1,0 +1,10 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+networking:
+  disableDefaultCNI: true
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl-cilium/ksail.yaml.verified.yaml
@@ -1,0 +1,96 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+    # The CNI to use. [default: Default]
+    cni: Cilium
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl/kind.yaml.verified.yaml
@@ -1,0 +1,8 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native-kubectl/ksail.yaml.verified.yaml
@@ -1,0 +1,94 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native/kind.yaml.verified.yaml
@@ -1,0 +1,8 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-native/ksail.yaml.verified.yaml
@@ -1,0 +1,94 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/k8s/kustomization.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/k8s/kustomization.yaml.verified.yaml
@@ -1,0 +1,4 @@
+﻿---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/kind.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/kind.yaml.verified.yaml
@@ -1,0 +1,8 @@
+﻿---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ksail-default
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/ksail.yaml.verified.yaml
@@ -1,0 +1,94 @@
+﻿---
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  # The name of the KSail object. [default: ksail-default]
+  name: ksail-default
+# The spec of the KSail Cluster object.
+spec:
+  # The options for connecting to the KSail cluster.
+  connection: {}
+  # The options for the KSail project.
+  project:
+    # The provider to use for running the KSail cluster. [default: Docker]
+    provider: Podman
+  # The options for the deployment tool.
+  deploymentTool:
+    # The options for the Flux deployment tool.
+    flux:
+      # The source for reconciling GitOps resources.
+      source: {}
+  # The options for the distribution.
+  distribution: {}
+  # The options for the Secret Manager.
+  secretManager:
+    # The options for the SOPS secret manager.
+    sops: {}
+  # The local registry for storing deployment artifacts.
+  localRegistry: {}
+  # The options for the generator.
+  generator: {}
+  # The mirror registries to create for the KSail cluster. [default: registry.k8s.io-proxy, docker.io-proxy, ghcr.io-proxy, gcr.io-proxy, mcr.microsoft.com-proxy, quay.io-proxy]
+  mirrorRegistries:
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: registry.k8s.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5556
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: docker.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5557
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: ghcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5558
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: gcr.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5559
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: mcr.microsoft.com-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5560
+    # The registry provider. [default: Docker]
+    provider: Podman
+  - # A proxy for the registry to use to proxy and cache images.
+    proxy:
+      # The URL of the upstream registry to proxy and cache images from. [default: https://registry-1.docker.io]
+      url: <url>
+    # The name of the registry. [default: ksail-registry]
+    name: quay.io-proxy
+    # The host port of the registry (if applicable). [default: 5555]
+    hostPort: 5561
+    # The registry provider. [default: Docker]
+    provider: Podman
+  # Options for validating the KSail cluster.
+  validation: {}

--- a/tests/KSail.Tests.Unit/Commands/List/KSailListCommandTests.KSailListHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/List/KSailListCommandTests.KSailListHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -5,7 +5,7 @@ Usage:
   testhost list [options]
 
 Options:
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
   -a, --all                        List clusters from all distributions. [default: False]
   -?, -h, --help                   Show help and usage information

--- a/tests/KSail.Tests.Unit/Commands/Start/KSailStartCommandTests.KSailStartHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Start/KSailStartCommandTests.KSailStartHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -8,7 +8,7 @@ Options:
   -c, --context <context>          The kubernetes context to use. [default: kind-ksail-default]
   -n, --name <name>                The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -?, -h, --help                   Show help and usage information
 
 

--- a/tests/KSail.Tests.Unit/Commands/Stop/KSailStopCommandTests.KSailStopHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Stop/KSailStopCommandTests.KSailStopHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -7,7 +7,7 @@ Usage:
 Options:
   -n, --name <name>                The name of the cluster. [default: ksail-default]
   -d, --distribution <K3s|Native>  The distribution to use for the cluster. [default: Native]
-  -p, --provider <Docker>          The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>   The provider to use for provisioning the cluster. [default: Docker]
   -?, -h, --help                   Show help and usage information
 
 

--- a/tests/KSail.Tests.Unit/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Up/KSailUpCommandTests.KSailUpHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -11,7 +11,7 @@ Options:
   -n, --name <name>                                 The name of the cluster. [default: ksail-default]
   -dc, --distribution-config <distribution-config>  Path to the distribution configuration file. [default: kind.yaml]
   -kp, --kustomization-path <kustomization-path>    The path to the root kustomization directory. [default: k8s]
-  -p, --provider <Docker>                           The provider to use for provisioning the cluster. [default: Docker]
+  -p, --provider <Docker|Podman>                    The provider to use for provisioning the cluster. [default: Docker]
   -d, --distribution <K3s|Native>                   The distribution to use for the cluster. [default: Native]
   -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a kustomization. [default: Kubectl]
   --cni <Cilium|Default>                            The CNI to use. [default: Default]

--- a/tests/KSail.Tests.Unit/Commands/Validate/Validators/ConfigurationValidatorTests.cs
+++ b/tests/KSail.Tests.Unit/Commands/Validate/Validators/ConfigurationValidatorTests.cs
@@ -31,7 +31,7 @@ public class ConfigurationValidatorTest
   }
 
   [Fact]
-  public async Task ValidateAsync_UnsupportedDistribution_ThrowsKSailException()
+  public async Task ValidateAsync_UnsupportedDistribution_ThrowsNotSupportedException()
   {
     // Arrange
     string tempDir = Path.Combine(Path.GetTempPath(), "ksail-validate-unsupported-distribution");
@@ -49,7 +49,7 @@ public class ConfigurationValidatorTest
     var validator = new ConfigurationValidator(config);
 
     // Act & Assert
-    var exception = await Assert.ThrowsAsync<KSailException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
+    var exception = await Assert.ThrowsAsync<NotSupportedException>(async () => await validator.ValidateAsync(tempDir, CancellationToken.None).ConfigureAwait(false));
     Assert.Contains("unsupported distribution", exception.Message, StringComparison.Ordinal);
 
     //Cleanup


### PR DESCRIPTION
Introduce Podman as an additional provider for running KSail clusters, enhancing flexibility in container management alongside Docker. Update documentation and command options to reflect this new capability.

- Fixes #802
- Fixes #801
- Fixes #794