### PR TITLE
fix: move Podman + K3s compatibility check to validation

### DIFF
--- a/src/KSail/Commands/Up/Bootstrappers/ClusterBootstrapper.cs
+++ b/src/KSail/Commands/Up/Bootstrappers/ClusterBootstrapper.cs
@@ -37,19 +37,7 @@ class ClusterBootstrapper(KSailCluster config) : IBootstrapper
         + "  - if you want to update the cluster, use 'ksail update' instead.");
     }
     Console.WriteLine("✔ cluster does not exist");
-    // TODO: Remove 'TemporaryMacOSPodmanK3sCompatabilityErrorHandling()' when the issue is resolved.
-    TemporaryMacOSPodmanK3sCompatabilityErrorHandling();
     Console.WriteLine();
-  }
-
-  void TemporaryMacOSPodmanK3sCompatabilityErrorHandling()
-  {
-    if (OperatingSystem.IsMacOS() && config.Spec.Project.Provider == KSailProviderType.Podman && config.Spec.Project.Distribution == KSailDistributionType.K3s)
-    {
-      throw new KSailException("Podman + K3s is not supported on MacOS yet." + Environment.NewLine
-        + "  - 'host-gateway' is not working with 'podman machine' VMs." + Environment.NewLine
-        + "    see https://github.com/containers/podman/issues/21681 for more details.");
-    }
   }
 
   async Task CheckProviderIsRunning(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Validate/Validators/ConfigurationValidator.cs
+++ b/src/KSail/Commands/Validate/Validators/ConfigurationValidator.cs
@@ -26,6 +26,7 @@ class ConfigurationValidator(KSailCluster config)
     }
     Console.WriteLine($"✔ configuration files located");
     Console.WriteLine("► validating configuration");
+    CheckCompatibility(config);
     CheckContextName(projectRootPath, config.Spec.Project.Distribution, config.Metadata.Name, config.Spec.Connection.Context);
     CheckOCISourceUri(projectRootPath, config.Spec.Project.Distribution);
 
@@ -53,6 +54,17 @@ class ConfigurationValidator(KSailCluster config)
         throw new NotSupportedException($"unsupported distribution '{config.Spec.Project.Distribution}'.");
     }
     Console.WriteLine("✔ configuration is valid");
+  }
+
+  static void CheckCompatibility(KSailCluster config)
+  {
+    // TODO: Remove temporary MacOS + Podman + K3s compatability check when the issue is resolved.
+    if (OperatingSystem.IsMacOS() && config.Spec.Project.Provider == KSailProviderType.Podman && config.Spec.Project.Distribution == KSailDistributionType.K3s)
+    {
+      throw new KSailException("Podman + K3s is not supported on MacOS yet." + Environment.NewLine
+        + "  - 'host-gateway' is not working with 'podman machine' VMs." + Environment.NewLine
+        + "    see https://github.com/containers/podman/issues/21681 for more details.");
+    }
   }
 
   string GetProjectRootPath(string path, string projectRootPath)


### PR DESCRIPTION
Relocate the compatibility check for Podman and K3s on MacOS to the validation process, removing the temporary error handling method. This change streamlines the validation workflow and maintains clarity regarding compatibility issues.

- Fixes #870 