### PR TITLE
fix: correct cluster listing logic in KSailListCommandHandler

### DIFF
--- a/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
+++ b/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
@@ -17,12 +17,12 @@ sealed class KSailListCommandHandler(KSailCluster config)
     if (_config.Spec.Distribution.ShowAllClustersInListings)
     {
       Console.WriteLine("---- K3d ----");
-      clusters = [.. clusters, .. await _k3dProvisioner.ListAsync(cancellationToken).ConfigureAwait(false)];
+      clusters = [.. await _k3dProvisioner.ListAsync(cancellationToken).ConfigureAwait(false)];
       PrintClusters(clusters);
       Console.WriteLine();
 
       Console.WriteLine("---- Kind ----");
-      clusters = [.. clusters, .. await _kindProvisioner.ListAsync(cancellationToken).ConfigureAwait(false)];
+      clusters = [.. await _kindProvisioner.ListAsync(cancellationToken).ConfigureAwait(false)];
       clusters = clusters.Where(cluster => !cluster.Contains("No kind clusters found.", StringComparison.Ordinal));
       PrintClusters(clusters);
       return true;

--- a/tests/KSail.Tests.System/E2ETests.cs
+++ b/tests/KSail.Tests.System/E2ETests.cs
@@ -73,8 +73,10 @@ public class E2ETests
     Assert.Equal(0, upExitCode);
     int statusExitCode = await statusCommand.InvokeAsync(["status"], console).ConfigureAwait(false);
     Assert.Equal(0, statusExitCode);
-    int listExitCode = await listCommand.InvokeAsync(["list"], console).ConfigureAwait(false);
-    Assert.Equal(0, listExitCode);
+    int listExitCode1 = await listCommand.InvokeAsync(["list"], console).ConfigureAwait(false);
+    Assert.Equal(0, listExitCode1);
+    int listExitCode2 = await listCommand.InvokeAsync(["list", "--all"], console).ConfigureAwait(false);
+    Assert.Equal(0, listExitCode2);
     int stopExitCode = await stopCommand.InvokeAsync(["stop"], console).ConfigureAwait(false);
     Assert.Equal(0, stopExitCode);
     int startExitCode = await startCommand.InvokeAsync(["start"], console).ConfigureAwait(false);


### PR DESCRIPTION
Refactor the cluster listing logic to ensure accurate retrieval of clusters from K3d and Kind provisioners. This change improves the handling of cluster listings when the configuration specifies to show all clusters.