### PR TITLE
fix: update Kubernetes provisioner dependencies to version 1.8.3

### DIFF
--- a/docs/overview/core-concepts/distributions.md
+++ b/docs/overview/core-concepts/distributions.md
@@ -11,6 +11,8 @@ nav_order: 1
 
 ## Native
 
+> [!NOTE] > `kind` uses `cloud-provider-kind` to support LoadBalancer services. To access these services, you can use the ExternalIP on Linux, and on MacOS, you use localhost followed by the port number that is mapped to the host by the Envoy container `kindccm-*`. See [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) for more information.
+
 The `Native` distribution is the default Kubernetes distribution provided by a specific `Provider`. In most cases this is a distribution that is optimized for the provider and is designed to work seamlessly with the provider's infrastructure.
 
 Below is the actual distribution used when using the `Native` distribution with the various engines.

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.7.2" />
     <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.7.2" />
     <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.7.2" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.8.2" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.7.8" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.7.8" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Deployment.Kubectl" Version="1.7.8" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.7.8" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.8.3" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.8.3" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.8.3" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Deployment.Kubectl" Version="1.8.3" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.8.3" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.1.2" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.1.2" />
     <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.3.11" />


### PR DESCRIPTION
Update the Kubernetes provisioner dependencies to the latest version for improved functionality and compatibility.