### PR TITLE
refactor: Standardize command handler implementations with ICommandHandler interface

### DIFF
--- a/src/KSail/Commands/Connect/Handlers/KSailDebugCommandHandler.cs
+++ b/src/KSail/Commands/Connect/Handlers/KSailDebugCommandHandler.cs
@@ -6,19 +6,19 @@ using KSail.Models;
 namespace KSail.Commands.Connect.Handlers;
 
 [ExcludeFromCodeCoverage]
-class KSailConnectCommandHandler
+class KSailConnectCommandHandler : ICommandHandler
 {
   readonly KSailCluster _config;
 
   internal KSailConnectCommandHandler(KSailCluster config) => _config = config;
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     string[] args = ["--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context];
     // TODO: Update k9s call when pseudo-terminal support is added to CLIWrap. See https://github.com/Tyrrrz/CliWrap/issues/225.
     Environment.SetEnvironmentVariable("EDITOR", _config.Spec.Project.Editor.ToString().ToLower(CultureInfo.CurrentCulture));
     int exitCode = await K9s.RunAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
     Environment.SetEnvironmentVariable("EDITOR", null);
-    return exitCode == 0;
+    return exitCode;
   }
 }

--- a/src/KSail/Commands/Connect/KSailConnectCommand.cs
+++ b/src/KSail/Commands/Connect/KSailConnectCommand.cs
@@ -20,7 +20,7 @@ sealed class KSailConnectCommand : Command
       {
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var handler = new KSailConnectCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
+++ b/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
@@ -12,16 +12,16 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Down.Handlers;
 
-class KSailDownCommandHandler(KSailCluster config)
+class KSailDownCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly ClusterManager _clusterManager = new(config);
   readonly MirrorRegistryManager _mirrorRegistryManager = new(config);
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine($"🔥 Destroying cluster...");
     await _clusterManager.CleanupAsync(cancellationToken).ConfigureAwait(false);
     await _mirrorRegistryManager.CleanupAsync(cancellationToken).ConfigureAwait(false);
-    return true;
+    return 0;
   }
 }

--- a/src/KSail/Commands/Down/KSailDownCommand.cs
+++ b/src/KSail/Commands/Down/KSailDownCommand.cs
@@ -18,7 +18,7 @@ sealed class KSailDownCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
 
         var handler = new KSailDownCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerCertificateCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerCertificateCommandHandler.cs
@@ -5,11 +5,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.CertManager;
 
-class KSailGenCertManagerCertificateCommandHandler(string outputFile, bool overwrite)
+class KSailGenCertManagerCertificateCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly CertManagerCertificateGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var certificate = new CertManagerCertificate
     {

--- a/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerClusterIssuerCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerClusterIssuerCommandHandler.cs
@@ -4,11 +4,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.CertManager;
 
-class KSailGenCertManagerClusterIssuerCommandHandler(string outputFile, bool overwrite)
+class KSailGenCertManagerClusterIssuerCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly CertManagerClusterIssuerGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var clusterIssuer = new CertManagerClusterIssuer
     {

--- a/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigK3dCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigK3dCommandHandler.cs
@@ -4,7 +4,7 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Config;
 
-class KSailGenConfigK3dCommandHandler(string outputFile, bool overwrite)
+class KSailGenConfigK3dCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly K3dConfigGenerator _generator = new();
 

--- a/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigKSailCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigKSailCommandHandler.cs
@@ -3,10 +3,10 @@ using KSail.Models;
 
 namespace KSail.Commands.Gen.Handlers.Config;
 
-class KSailGenConfigKSailCommandHandler(string outputFile, bool overwrite)
+class KSailGenConfigKSailCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly KSailClusterGenerator _ksailClusterGenerator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var ksailCluster = new KSailCluster();
     await _ksailClusterGenerator.GenerateAsync(ksailCluster, outputFile, overwrite, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigSOPSCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigSOPSCommandHandler.cs
@@ -3,10 +3,10 @@ using Devantler.SecretManager.SOPS.LocalAge.Utils;
 
 namespace KSail.Commands.Gen.Handlers.Config;
 
-class KSailGenConfigSOPSCommandHandler(string outputFile, bool overwrite)
+class KSailGenConfigSOPSCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly SOPSConfigHelper _configHelper = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var sopsConfig = new SOPSConfig
     {

--- a/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmReleaseCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmReleaseCommandHandler.cs
@@ -4,10 +4,10 @@ using Devantler.KubernetesGenerator.Flux.Models.HelmRelease;
 
 namespace KSail.Commands.Gen.Handlers.Flux;
 
-class KSailGenFluxHelmReleaseCommandHandler(string outputFile, bool overwrite)
+class KSailGenFluxHelmReleaseCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly FluxHelmReleaseGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var helmRelease = new FluxHelmRelease()
     {

--- a/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmRepositoryCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmRepositoryCommandHandler.cs
@@ -4,10 +4,10 @@ using Devantler.KubernetesGenerator.Flux.Models.HelmRepository;
 
 namespace KSail.Commands.Gen.Handlers.Flux;
 
-class KSailGenFluxHelmRepositoryCommandHandler(string outputFile, bool overwrite)
+class KSailGenFluxHelmRepositoryCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly FluxHelmRepositoryGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var helmRepository = new FluxHelmRepository()
     {

--- a/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxKustomizationCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxKustomizationCommandHandler.cs
@@ -4,7 +4,7 @@ using Devantler.KubernetesGenerator.Flux.Models.Kustomization;
 
 namespace KSail.Commands.Gen.Handlers.Flux;
 
-class KSailGenFluxKustomizationCommandHandler(string outputFile, bool overwrite)
+class KSailGenFluxKustomizationCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly FluxKustomizationGenerator _generator = new();
   public async Task<int> HandleAsync(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeComponentCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeComponentCommandHandler.cs
@@ -3,7 +3,7 @@ using Devantler.KubernetesGenerator.Kustomize.Models;
 
 namespace KSail.Commands.Gen.Handlers.Kustomize;
 
-class KSailGenKustomizeComponentCommandHandler(string outputFile, bool overwrite)
+class KSailGenKustomizeComponentCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly KustomizeComponentGenerator _generator = new();
   public async Task<int> HandleAsync(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeKustomizationCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeKustomizationCommandHandler.cs
@@ -3,7 +3,7 @@ using Devantler.KubernetesGenerator.Kustomize.Models;
 
 namespace KSail.Commands.Gen.Handlers.Kustomize;
 
-class KSailGenKustomizeKustomizationCommandHandler(string outputFile, bool overwrite)
+class KSailGenKustomizeKustomizationCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly KustomizeKustomizationGenerator _generator = new();
   public async Task<int> HandleAsync(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleBindingCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleBindingCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeClusterRoleBindingCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeClusterRoleBindingCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ClusterRoleBindingGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ClusterRoleBinding()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeClusterRoleCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeClusterRoleCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ClusterRoleGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ClusterRole()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeConfigMapCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeConfigMapCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeConfigMapCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeConfigMapCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ConfigMapGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ConfigMap()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeCronJobCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeCronJobCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsCronJobCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsCronJobCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly CronJobGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1CronJob
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDaemonSetCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDaemonSetCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsDaemonSetCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsDaemonSetCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly DaemonSetGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1DaemonSet
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDeploymentCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDeploymentCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsDeploymentCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsDeploymentCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly DeploymentGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Deployment
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeHorizontalPodAutoscalerCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeHorizontalPodAutoscalerCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeHorizontalPodAutoscalerCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeHorizontalPodAutoscalerCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly HorizontalPodAutoscalerGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V2HorizontalPodAutoscaler()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeIngressCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeIngressCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeIngressCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeIngressCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly IngressGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Ingress
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeJobCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeJobCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsJobCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsJobCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly JobGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Job
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNamespaceCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNamespaceCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeNamespaceCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeNamespaceCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly NamespaceGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Namespace()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNetworkPolicyCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNetworkPolicyCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeNetworkPolicyCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeNetworkPolicyCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly NetworkPolicyGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1NetworkPolicy()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeClaimCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeClaimCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePersistentVolumeClaimCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePersistentVolumeClaimCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PersistentVolumeClaimGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PersistentVolumeClaim
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePersistentVolumeCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePersistentVolumeCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PersistentVolumeGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PersistentVolume()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePodDisruptionBudgetCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePodDisruptionBudgetCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePodDisruptionBudgetCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePodDisruptionBudgetCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PodDisruptionBudgetGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PodDisruptionBudget()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePriorityClassCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePriorityClassCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePriorityClassCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePriorityClassCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PriorityClassGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PriorityClass()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeResourceQuotaCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeResourceQuotaCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeResourceQuotaCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeResourceQuotaCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ResourceQuotaGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ResourceQuota()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleBindingCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleBindingCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeRoleBindingCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeRoleBindingCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly RoleBindingGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1RoleBinding()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeRoleCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeRoleCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly RoleGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Role()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeSecretCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeSecretCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeSecretCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeSecretCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly SecretGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Secret
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceAccountCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceAccountCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeAccountCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeAccountCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ServiceAccountGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ServiceAccount()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeServiceCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeServiceCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ServiceGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Service
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeStatefulSetCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeStatefulSetCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsStatefulSetCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsStatefulSetCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly StatefulSetGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1StatefulSet
     {

--- a/src/KSail/Commands/ICommandHandler.cs
+++ b/src/KSail/Commands/ICommandHandler.cs
@@ -1,0 +1,6 @@
+namespace KSail.Commands;
+
+interface ICommandHandler
+{
+  Task<int> HandleAsync(CancellationToken cancellationToken = default);
+}

--- a/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
+++ b/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
@@ -4,7 +4,7 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Init.Handlers;
 
-class KSailInitCommandHandler(string outputPath, KSailCluster config)
+class KSailInitCommandHandler(string outputPath, KSailCluster config) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly string _outputPath = outputPath;

--- a/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
+++ b/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
@@ -5,13 +5,13 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.List.Handlers;
 
-sealed class KSailListCommandHandler(KSailCluster config)
+sealed class KSailListCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly K3dProvisioner _k3dProvisioner = new();
   readonly KindProvisioner _kindProvisioner = new();
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     IEnumerable<string> clusters;
     if (_config.Spec.Distribution.ShowAllClustersInListings)
@@ -24,7 +24,7 @@ sealed class KSailListCommandHandler(KSailCluster config)
       Console.WriteLine("---- Kind ----");
       clusters = [.. await _kindProvisioner.ListAsync(cancellationToken).ConfigureAwait(false)];
       PrintClusters(clusters);
-      return true;
+      return 0;
     }
     else
     {
@@ -35,7 +35,7 @@ sealed class KSailListCommandHandler(KSailCluster config)
         _ => throw new NotSupportedException($"The container engine '{_config.Spec.Project.ContainerEngine}' and distribution '{_config.Spec.Project.Distribution}' combination is not supported.")
       };
       PrintClusters(clusters);
-      return true;
+      return 0;
     }
   }
 

--- a/src/KSail/Commands/List/KsailListCommand.cs
+++ b/src/KSail/Commands/List/KsailListCommand.cs
@@ -18,7 +18,7 @@ sealed class KSailListCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var cancellationToken = context.GetCancellationToken();
         var handler = new KSailListCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Root/Handlers/KSailRootCommandHandler.cs
+++ b/src/KSail/Commands/Root/Handlers/KSailRootCommandHandler.cs
@@ -3,14 +3,12 @@ using System.CommandLine;
 namespace KSail.Commands.Root.Handlers;
 
 
-class KSailRootCommandHandler
+class KSailRootCommandHandler(IConsole console) : ICommandHandler
 {
-
-
-  internal static bool Handle(IConsole console)
+  public Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     PrintIntroduction(console);
-    return true;
+    return Task.FromResult(0);
   }
 
   static void PrintIntroduction(IConsole console)

--- a/src/KSail/Commands/Root/KSailRootCommand.cs
+++ b/src/KSail/Commands/Root/KSailRootCommand.cs
@@ -20,6 +20,7 @@ namespace KSail.Commands.Root;
 sealed class KSailRootCommand : RootCommand
 {
   readonly ExceptionHandler _exceptionHandler = new();
+
   internal KSailRootCommand(IConsole console) : base("KSail is an SDK for Kubernetes. Ship k8s with ease!")
   {
     AddCommands(console);
@@ -27,8 +28,13 @@ sealed class KSailRootCommand : RootCommand
       {
         try
         {
-          bool exitCode = KSailRootCommandHandler.Handle(console) && await this.InvokeAsync("--help", console).ConfigureAwait(false) == 0;
-          context.ExitCode = exitCode ? 0 : 1;
+          var ksailRootCommandHandler = new KSailRootCommandHandler(console);
+          int exitCode = await ksailRootCommandHandler.HandleAsync().ConfigureAwait(false);
+          if (exitCode == 0)
+          {
+            exitCode = await this.InvokeAsync("--help", console).ConfigureAwait(false);
+          }
+          context.ExitCode = exitCode;
         }
         catch (Exception ex)
         {

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
@@ -22,7 +22,7 @@ sealed class KSailSecretsListCommand : Command
 
         var cancellationToken = context.GetCancellationToken();
         var handler = new KSailSecretsListCommandHandler(config, new SOPSLocalAgeSecretManager());
-        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsAddCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsAddCommandHandler.cs
@@ -4,11 +4,11 @@ using Devantler.SecretManager.Core;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsAddCommandHandler(ISecretManager<AgeKey> secretManager, IConsole console)
+class KSailSecretsAddCommandHandler(ISecretManager<AgeKey> secretManager, IConsole console) : ICommandHandler
 {
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     var key = await _secretManager.CreateKeyAsync(cancellationToken).ConfigureAwait(false);
     console.WriteLine(key.ToString());

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsDecryptCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsDecryptCommandHandler.cs
@@ -4,13 +4,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsDecryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager)
+class KSailSecretsDecryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _path = path;
   readonly string? _output = output;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     string encrypted = await _secretManager.DecryptAsync(_path, cancellationToken).ConfigureAwait(false);
     if (config.Spec.SecretManager.SOPS.InPlace)

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsEditCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsEditCommandHandler.cs
@@ -7,13 +7,13 @@ using KSail.Models;
 namespace KSail.Commands.Secrets.Handlers;
 
 [ExcludeFromCodeCoverage]
-class KSailSecretsEditCommandHandler(KSailCluster config, string path, ISecretManager<AgeKey> secretManager)
+class KSailSecretsEditCommandHandler(KSailCluster config, string path, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly string _path = path;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Environment.SetEnvironmentVariable("EDITOR", _config.Spec.Project.Editor.ToString().ToLower(CultureInfo.CurrentCulture));
     await _secretManager.EditAsync(_path, cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsEncryptCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsEncryptCommandHandler.cs
@@ -4,13 +4,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsEncryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager)
+class KSailSecretsEncryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _path = path;
   readonly string? _output = output;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     string encrypted = await _secretManager.EncryptAsync(_path, config.Spec.SecretManager.SOPS.PublicKey, cancellationToken).ConfigureAwait(false);
     if (config.Spec.SecretManager.SOPS.InPlace)

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsExportCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsExportCommandHandler.cs
@@ -4,13 +4,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsExportCommandHandler(string publicKey, string outputPath, ISecretManager<AgeKey> secretManager)
+class KSailSecretsExportCommandHandler(string publicKey, string outputPath, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _publicKey = publicKey;
   readonly string _outputPath = outputPath;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Console.WriteLine($"► exporting '{_publicKey}' from SOPS to '{_outputPath}'");
     var key = await _secretManager.GetKeyAsync(_publicKey, cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
@@ -4,12 +4,12 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsImportCommandHandler(string key, ISecretManager<AgeKey> secretManager)
+class KSailSecretsImportCommandHandler(string key, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _key = key;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Console.WriteLine($"► importing '{_key}' to SOPS");
     string key = _key;

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsListCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsListCommandHandler.cs
@@ -5,12 +5,12 @@ using KSail.Utils;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey> secretManager)
+class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     var keys = await _secretManager.ListKeysAsync(cancellationToken).ConfigureAwait(false);
 
@@ -20,7 +20,7 @@ class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey>
       if (!keys.Any(key => sopsConfig.CreationRules.Any(rule => rule.Age == key.PublicKey)))
       {
         Console.WriteLine("► no keys found");
-        return true;
+        return 0;
       }
       foreach (var key in keys.Where(key => sopsConfig.CreationRules.Any(rule => rule.Age == key.PublicKey)))
       {
@@ -40,7 +40,7 @@ class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey>
       if (!keys.Any())
       {
         Console.WriteLine("► no keys found");
-        return true;
+        return 0;
       }
       foreach (var key in keys)
       {
@@ -55,7 +55,7 @@ class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey>
         Console.WriteLine();
       }
     }
-    return true;
+    return 0;
   }
 
   static string Obscure(AgeKey key)

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsRemoveCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsRemoveCommandHandler.cs
@@ -4,12 +4,12 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsRemoveCommandHandler(string publicKey, ISecretManager<AgeKey> secretManager)
+class KSailSecretsRemoveCommandHandler(string publicKey, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _publicKey = publicKey;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Console.WriteLine($"► removing '{_publicKey}' from SOPS key file");
     _ = await _secretManager.DeleteKeyAsync(_publicKey, cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Start/Handlers/KSailStartCommandHandler.cs
+++ b/src/KSail/Commands/Start/Handlers/KSailStartCommandHandler.cs
@@ -6,7 +6,7 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Start.Handlers;
 
-class KSailStartCommandHandler
+class KSailStartCommandHandler : ICommandHandler
 {
   readonly KSailCluster _config;
   readonly IKubernetesClusterProvisioner _clusterProvisioner;
@@ -22,7 +22,7 @@ class KSailStartCommandHandler
     };
   }
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine($"▶️ Starting cluster...");
     Console.WriteLine($"► starting cluster '{_config.Spec.Connection.Context}'");

--- a/src/KSail/Commands/Status/Handlers/KSailStatusCommandHandler.cs
+++ b/src/KSail/Commands/Status/Handlers/KSailStatusCommandHandler.cs
@@ -6,11 +6,11 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Status.Handlers;
 
-sealed class KSailStatusCommandHandler(KSailCluster config)
+sealed class KSailStatusCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly KSailCluster _config = config;
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var (LiveCheckExitCode, LiveCheckMessage) = await Devantler.KubectlCLI.Kubectl.RunAsync(
       ["get", "--raw", $"/livez{(_config.Spec.Validation.Verbose ? "?verbose" : "")}", "--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context],
@@ -32,6 +32,6 @@ sealed class KSailStatusCommandHandler(KSailCluster config)
       Console.WriteLine($"Live: {LiveCheckMessage}");
       Console.WriteLine($"Ready: {ReadyCheckMessage}");
     }
-    return LiveCheckExitCode == 0 && ReadyCheckExitCode == 0;
+    return (LiveCheckExitCode == 0 && ReadyCheckExitCode == 0) ? 0 : 1;
   }
 }

--- a/src/KSail/Commands/Status/KSailStatusCommand.cs
+++ b/src/KSail/Commands/Status/KSailStatusCommand.cs
@@ -19,7 +19,7 @@ sealed class KSailStatusCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var cancellationToken = context.GetCancellationToken();
         var handler = new KSailStatusCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Stop/Handlers/KSailStopCommandHandler.cs
+++ b/src/KSail/Commands/Stop/Handlers/KSailStopCommandHandler.cs
@@ -6,7 +6,7 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Stop.Handlers;
 
-class KSailStopCommandHandler
+class KSailStopCommandHandler : ICommandHandler
 {
   readonly KSailCluster _config;
   readonly IKubernetesClusterProvisioner _clusterProvisioner;
@@ -22,7 +22,7 @@ class KSailStopCommandHandler
     };
   }
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine($"⏹️ Stopping cluster...");
     Console.WriteLine($"► stopping cluster '{_config.Spec.Connection.Context}'");

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -18,7 +18,7 @@ using KSail.Utils;
 
 namespace KSail.Commands.Up.Handlers;
 
-class KSailUpCommandHandler(KSailCluster config)
+class KSailUpCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly ClusterManager _clusterBootstrapper = new(config);
   readonly GitOpsSourceManager _gitOpsSourceBootstrapper = new(config);
@@ -30,7 +30,7 @@ class KSailUpCommandHandler(KSailCluster config)
   readonly MetricsServerManager _metricsServerBootstrapper = new(config);
   readonly SecretManager _secretManagerBootstrapper = new(config);
   readonly DeploymentToolManager _deploymentToolBootstrapper = new(config);
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     await _clusterBootstrapper.BootstrapAsync(cancellationToken).ConfigureAwait(false);
     await _gitOpsSourceBootstrapper.BootstrapAsync(cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -20,7 +20,7 @@ sealed class KSailUpdateCommand : Command
       {
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var handler = new KSailUpdateCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Validate/Handlers/KSailValidateCommandHandler.cs
+++ b/src/KSail/Commands/Validate/Handlers/KSailValidateCommandHandler.cs
@@ -5,13 +5,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Validate.Handlers;
 
-class KSailValidateCommandHandler(KSailCluster config)
+class KSailValidateCommandHandler(KSailCluster config, string path) : ICommandHandler
 {
   readonly ConfigurationValidator _configValidator = new(config);
   readonly YamlSyntaxValidator _yamlSyntaxValidator = new();
   readonly SchemaValidator _schemaValidator = new();
 
-  internal async Task<bool> HandleAsync(string path, CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine("🔍 Validating project files and configuration...");
     if (!Directory.Exists(path) || Directory.GetFiles(path, "*.yaml", SearchOption.AllDirectories).Length == 0)
@@ -33,6 +33,6 @@ class KSailValidateCommandHandler(KSailCluster config)
     if (!schemasAreValid)
       throw new KSailException(schemasMessage);
     Console.WriteLine("✔ schemas are valid");
-    return yamlIsValid && schemasAreValid;
+    return yamlIsValid && schemasAreValid ? 0 : 1;
   }
 }

--- a/src/KSail/Commands/Validate/KSailValidateCommand.cs
+++ b/src/KSail/Commands/Validate/KSailValidateCommand.cs
@@ -24,8 +24,8 @@ sealed class KSailValidateCommand : Command
       {
         string path = context.ParseResult.GetValueForOption(_pathOption) ?? "./";
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context, path).ConfigureAwait(false);
-        var handler = new KSailValidateCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(path, context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        var handler = new KSailValidateCommandHandler(config, path);
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Managers/ClusterManager.cs
+++ b/src/KSail/Managers/ClusterManager.cs
@@ -12,7 +12,7 @@ class ClusterManager(KSailCluster config) : IBootstrapManager, ICleanupManager
 {
   readonly IKubernetesClusterProvisioner _clusterProvisioner = ClusterProvisionerFactory.Create(config);
   readonly IContainerEngineProvisioner _containerEngineProvisioner = ContainerEngineProvisionerFactory.Create(config);
-  readonly KSailValidateCommandHandler _ksailValidateCommandHandler = new(config);
+  readonly KSailValidateCommandHandler _ksailValidateCommandHandler = new(config, "./");
   public async Task BootstrapAsync(CancellationToken cancellationToken = default)
   {
     await CheckPrerequisites(cancellationToken).ConfigureAwait(false);
@@ -62,7 +62,7 @@ class ClusterManager(KSailCluster config) : IBootstrapManager, ICleanupManager
   {
     if (config.Spec.Validation.ValidateOnUp)
     {
-      bool success = await _ksailValidateCommandHandler.HandleAsync("./", cancellationToken).ConfigureAwait(false);
+      bool success = (await _ksailValidateCommandHandler.HandleAsync(cancellationToken).ConfigureAwait(false)) == 0;
       Console.WriteLine();
       return success;
     }


### PR DESCRIPTION
Refactor command handlers to implement the ICommandHandler interface, ensuring consistent method signatures and improved accessibility. Adjust exit code handling to return integers instead of booleans for better clarity in command execution results.

- Fixes #938