### PR TITLE
Refactor command handlers and add run commands for various tools

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -38,6 +38,7 @@ Commands:
   connect   Connect to a cluster with K9s
   gen       Generate a resource
   secrets   Manage secrets
+  run       Run a command
 ```
 
 ## `ksail up`
@@ -199,6 +200,7 @@ Commands:
   connect   Connect to a cluster with K9s
   gen       Generate a resource
   secrets   Manage secrets
+  run       Run a command
 ```
 
 ## `ksail status`

--- a/src/KSail/Commands/Connect/Handlers/KSailDebugCommandHandler.cs
+++ b/src/KSail/Commands/Connect/Handlers/KSailDebugCommandHandler.cs
@@ -6,19 +6,19 @@ using KSail.Models;
 namespace KSail.Commands.Connect.Handlers;
 
 [ExcludeFromCodeCoverage]
-class KSailConnectCommandHandler
+class KSailConnectCommandHandler : ICommandHandler
 {
   readonly KSailCluster _config;
 
   internal KSailConnectCommandHandler(KSailCluster config) => _config = config;
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     string[] args = ["--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context];
     // TODO: Update k9s call when pseudo-terminal support is added to CLIWrap. See https://github.com/Tyrrrz/CliWrap/issues/225.
     Environment.SetEnvironmentVariable("EDITOR", _config.Spec.Project.Editor.ToString().ToLower(CultureInfo.CurrentCulture));
     int exitCode = await K9s.RunAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
     Environment.SetEnvironmentVariable("EDITOR", null);
-    return exitCode == 0;
+    return exitCode;
   }
 }

--- a/src/KSail/Commands/Connect/KSailConnectCommand.cs
+++ b/src/KSail/Commands/Connect/KSailConnectCommand.cs
@@ -20,7 +20,7 @@ sealed class KSailConnectCommand : Command
       {
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var handler = new KSailConnectCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
+++ b/src/KSail/Commands/Down/Handlers/KsailDownCommandHandler.cs
@@ -12,16 +12,16 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Down.Handlers;
 
-class KSailDownCommandHandler(KSailCluster config)
+class KSailDownCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly ClusterManager _clusterManager = new(config);
   readonly MirrorRegistryManager _mirrorRegistryManager = new(config);
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine($"🔥 Destroying cluster...");
     await _clusterManager.CleanupAsync(cancellationToken).ConfigureAwait(false);
     await _mirrorRegistryManager.CleanupAsync(cancellationToken).ConfigureAwait(false);
-    return true;
+    return 0;
   }
 }

--- a/src/KSail/Commands/Down/KSailDownCommand.cs
+++ b/src/KSail/Commands/Down/KSailDownCommand.cs
@@ -18,7 +18,7 @@ sealed class KSailDownCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
 
         var handler = new KSailDownCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerCertificateCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerCertificateCommandHandler.cs
@@ -5,11 +5,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.CertManager;
 
-class KSailGenCertManagerCertificateCommandHandler(string outputFile, bool overwrite)
+class KSailGenCertManagerCertificateCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly CertManagerCertificateGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var certificate = new CertManagerCertificate
     {

--- a/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerClusterIssuerCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerClusterIssuerCommandHandler.cs
@@ -4,11 +4,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.CertManager;
 
-class KSailGenCertManagerClusterIssuerCommandHandler(string outputFile, bool overwrite)
+class KSailGenCertManagerClusterIssuerCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly CertManagerClusterIssuerGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var clusterIssuer = new CertManagerClusterIssuer
     {

--- a/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigK3dCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigK3dCommandHandler.cs
@@ -4,7 +4,7 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Config;
 
-class KSailGenConfigK3dCommandHandler(string outputFile, bool overwrite)
+class KSailGenConfigK3dCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly K3dConfigGenerator _generator = new();
 

--- a/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigKSailCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigKSailCommandHandler.cs
@@ -3,10 +3,10 @@ using KSail.Models;
 
 namespace KSail.Commands.Gen.Handlers.Config;
 
-class KSailGenConfigKSailCommandHandler(string outputFile, bool overwrite)
+class KSailGenConfigKSailCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly KSailClusterGenerator _ksailClusterGenerator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var ksailCluster = new KSailCluster();
     await _ksailClusterGenerator.GenerateAsync(ksailCluster, outputFile, overwrite, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigSOPSCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Config/KSailGenConfigSOPSCommandHandler.cs
@@ -3,10 +3,10 @@ using Devantler.SecretManager.SOPS.LocalAge.Utils;
 
 namespace KSail.Commands.Gen.Handlers.Config;
 
-class KSailGenConfigSOPSCommandHandler(string outputFile, bool overwrite)
+class KSailGenConfigSOPSCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly SOPSConfigHelper _configHelper = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var sopsConfig = new SOPSConfig
     {

--- a/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmReleaseCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmReleaseCommandHandler.cs
@@ -4,10 +4,10 @@ using Devantler.KubernetesGenerator.Flux.Models.HelmRelease;
 
 namespace KSail.Commands.Gen.Handlers.Flux;
 
-class KSailGenFluxHelmReleaseCommandHandler(string outputFile, bool overwrite)
+class KSailGenFluxHelmReleaseCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly FluxHelmReleaseGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var helmRelease = new FluxHelmRelease()
     {

--- a/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmRepositoryCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxHelmRepositoryCommandHandler.cs
@@ -4,10 +4,10 @@ using Devantler.KubernetesGenerator.Flux.Models.HelmRepository;
 
 namespace KSail.Commands.Gen.Handlers.Flux;
 
-class KSailGenFluxHelmRepositoryCommandHandler(string outputFile, bool overwrite)
+class KSailGenFluxHelmRepositoryCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly FluxHelmRepositoryGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var helmRepository = new FluxHelmRepository()
     {

--- a/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxKustomizationCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Flux/KSailGenFluxKustomizationCommandHandler.cs
@@ -4,7 +4,7 @@ using Devantler.KubernetesGenerator.Flux.Models.Kustomization;
 
 namespace KSail.Commands.Gen.Handlers.Flux;
 
-class KSailGenFluxKustomizationCommandHandler(string outputFile, bool overwrite)
+class KSailGenFluxKustomizationCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly FluxKustomizationGenerator _generator = new();
   public async Task<int> HandleAsync(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeComponentCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeComponentCommandHandler.cs
@@ -3,7 +3,7 @@ using Devantler.KubernetesGenerator.Kustomize.Models;
 
 namespace KSail.Commands.Gen.Handlers.Kustomize;
 
-class KSailGenKustomizeComponentCommandHandler(string outputFile, bool overwrite)
+class KSailGenKustomizeComponentCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly KustomizeComponentGenerator _generator = new();
   public async Task<int> HandleAsync(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeKustomizationCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Kustomize/KSailGenKustomizeKustomizationCommandHandler.cs
@@ -3,7 +3,7 @@ using Devantler.KubernetesGenerator.Kustomize.Models;
 
 namespace KSail.Commands.Gen.Handlers.Kustomize;
 
-class KSailGenKustomizeKustomizationCommandHandler(string outputFile, bool overwrite)
+class KSailGenKustomizeKustomizationCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly KustomizeKustomizationGenerator _generator = new();
   public async Task<int> HandleAsync(CancellationToken cancellationToken = default)

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleBindingCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleBindingCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeClusterRoleBindingCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeClusterRoleBindingCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ClusterRoleBindingGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ClusterRoleBinding()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeClusterRoleCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeClusterRoleCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeClusterRoleCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ClusterRoleGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ClusterRole()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeConfigMapCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeConfigMapCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeConfigMapCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeConfigMapCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ConfigMapGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ConfigMap()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeCronJobCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeCronJobCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsCronJobCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsCronJobCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly CronJobGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1CronJob
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDaemonSetCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDaemonSetCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsDaemonSetCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsDaemonSetCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly DaemonSetGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1DaemonSet
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDeploymentCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeDeploymentCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsDeploymentCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsDeploymentCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly DeploymentGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Deployment
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeHorizontalPodAutoscalerCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeHorizontalPodAutoscalerCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeHorizontalPodAutoscalerCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeHorizontalPodAutoscalerCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly HorizontalPodAutoscalerGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V2HorizontalPodAutoscaler()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeIngressCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeIngressCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeIngressCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeIngressCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly IngressGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Ingress
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeJobCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeJobCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsJobCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsJobCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly JobGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Job
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNamespaceCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNamespaceCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeNamespaceCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeNamespaceCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly NamespaceGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Namespace()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNetworkPolicyCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeNetworkPolicyCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeNetworkPolicyCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeNetworkPolicyCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly NetworkPolicyGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1NetworkPolicy()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeClaimCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeClaimCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePersistentVolumeClaimCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePersistentVolumeClaimCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PersistentVolumeClaimGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PersistentVolumeClaim
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePersistentVolumeCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePersistentVolumeCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePersistentVolumeCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PersistentVolumeGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PersistentVolume()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePodDisruptionBudgetCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePodDisruptionBudgetCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePodDisruptionBudgetCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePodDisruptionBudgetCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PodDisruptionBudgetGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PodDisruptionBudget()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePriorityClassCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativePriorityClassCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativePriorityClassCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativePriorityClassCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly PriorityClassGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1PriorityClass()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeResourceQuotaCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeResourceQuotaCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeResourceQuotaCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeResourceQuotaCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ResourceQuotaGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ResourceQuota()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleBindingCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleBindingCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeRoleBindingCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeRoleBindingCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly RoleBindingGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1RoleBinding()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeRoleCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeRoleCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeRoleCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly RoleGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Role()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeSecretCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeSecretCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeSecretCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeSecretCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly SecretGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Secret
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceAccountCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceAccountCommandHandler.cs
@@ -3,11 +3,11 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeAccountCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeAccountCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ServiceAccountGenerator _generator = new();
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1ServiceAccount()
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeServiceCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeServiceCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeServiceCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly ServiceGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1Service
     {

--- a/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeStatefulSetCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/Native/KSailGenNativeStatefulSetCommandHandler.cs
@@ -3,10 +3,10 @@ using k8s.Models;
 
 namespace KSail.Commands.Gen.Handlers.Native;
 
-class KSailGenNativeWorkloadsStatefulSetCommandHandler(string outputFile, bool overwrite)
+class KSailGenNativeWorkloadsStatefulSetCommandHandler(string outputFile, bool overwrite) : ICommandHandler
 {
   readonly StatefulSetGenerator _generator = new();
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var model = new V1StatefulSet
     {

--- a/src/KSail/Commands/ICommandHandler.cs
+++ b/src/KSail/Commands/ICommandHandler.cs
@@ -1,0 +1,6 @@
+namespace KSail.Commands;
+
+interface ICommandHandler
+{
+  Task<int> HandleAsync(CancellationToken cancellationToken = default);
+}

--- a/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
+++ b/src/KSail/Commands/Init/Handlers/KSailInitCommandHandler.cs
@@ -4,7 +4,7 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Init.Handlers;
 
-class KSailInitCommandHandler(string outputPath, KSailCluster config)
+class KSailInitCommandHandler(string outputPath, KSailCluster config) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly string _outputPath = outputPath;

--- a/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
+++ b/src/KSail/Commands/List/Handlers/KSailListCommandHandler.cs
@@ -5,13 +5,13 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.List.Handlers;
 
-sealed class KSailListCommandHandler(KSailCluster config)
+sealed class KSailListCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly K3dProvisioner _k3dProvisioner = new();
   readonly KindProvisioner _kindProvisioner = new();
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     IEnumerable<string> clusters;
     if (_config.Spec.Distribution.ShowAllClustersInListings)
@@ -24,7 +24,7 @@ sealed class KSailListCommandHandler(KSailCluster config)
       Console.WriteLine("---- Kind ----");
       clusters = [.. await _kindProvisioner.ListAsync(cancellationToken).ConfigureAwait(false)];
       PrintClusters(clusters);
-      return true;
+      return 0;
     }
     else
     {
@@ -35,7 +35,7 @@ sealed class KSailListCommandHandler(KSailCluster config)
         _ => throw new NotSupportedException($"The container engine '{_config.Spec.Project.ContainerEngine}' and distribution '{_config.Spec.Project.Distribution}' combination is not supported.")
       };
       PrintClusters(clusters);
-      return true;
+      return 0;
     }
   }
 

--- a/src/KSail/Commands/List/KsailListCommand.cs
+++ b/src/KSail/Commands/List/KsailListCommand.cs
@@ -18,7 +18,7 @@ sealed class KSailListCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var cancellationToken = context.GetCancellationToken();
         var handler = new KSailListCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Root/Handlers/KSailRootCommandHandler.cs
+++ b/src/KSail/Commands/Root/Handlers/KSailRootCommandHandler.cs
@@ -3,14 +3,12 @@ using System.CommandLine;
 namespace KSail.Commands.Root.Handlers;
 
 
-class KSailRootCommandHandler
+class KSailRootCommandHandler(IConsole console) : ICommandHandler
 {
-
-
-  internal static bool Handle(IConsole console)
+  public Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     PrintIntroduction(console);
-    return true;
+    return Task.FromResult(0);
   }
 
   static void PrintIntroduction(IConsole console)

--- a/src/KSail/Commands/Root/KSailRootCommand.cs
+++ b/src/KSail/Commands/Root/KSailRootCommand.cs
@@ -6,6 +6,7 @@ using KSail.Commands.Gen;
 using KSail.Commands.Init;
 using KSail.Commands.List;
 using KSail.Commands.Root.Handlers;
+using KSail.Commands.Run;
 using KSail.Commands.Secrets;
 using KSail.Commands.Start;
 using KSail.Commands.Status;
@@ -53,5 +54,6 @@ sealed class KSailRootCommand : RootCommand
     AddCommand(new KSailConnectCommand());
     AddCommand(new KSailGenCommand(console));
     AddCommand(new KSailSecretsCommand(console));
+    AddCommand(new KSailRunCommand(console));
   }
 }

--- a/src/KSail/Commands/Root/KSailRootCommand.cs
+++ b/src/KSail/Commands/Root/KSailRootCommand.cs
@@ -21,6 +21,7 @@ namespace KSail.Commands.Root;
 sealed class KSailRootCommand : RootCommand
 {
   readonly ExceptionHandler _exceptionHandler = new();
+
   internal KSailRootCommand(IConsole console) : base("KSail is an SDK for Kubernetes. Ship k8s with ease!")
   {
     AddCommands(console);
@@ -28,8 +29,13 @@ sealed class KSailRootCommand : RootCommand
       {
         try
         {
-          bool exitCode = KSailRootCommandHandler.Handle(console) && await this.InvokeAsync("--help", console).ConfigureAwait(false) == 0;
-          context.ExitCode = exitCode ? 0 : 1;
+          var ksailRootCommandHandler = new KSailRootCommandHandler(console);
+          int exitCode = await ksailRootCommandHandler.HandleAsync().ConfigureAwait(false);
+          if (exitCode == 0)
+          {
+            exitCode = await this.InvokeAsync("--help", console).ConfigureAwait(false);
+          }
+          context.ExitCode = exitCode;
         }
         catch (Exception ex)
         {

--- a/src/KSail/Commands/Run/Arguments/ArgsArgument.cs
+++ b/src/KSail/Commands/Run/Arguments/ArgsArgument.cs
@@ -1,0 +1,8 @@
+using System.CommandLine;
+
+namespace KSail.Commands.Run.Arguments;
+
+class CLIArguments() : Argument<string[]>(
+  "args",
+  "Arguments to pass to a binary"
+);

--- a/src/KSail/Commands/Run/Commands/KSailRunAgeKeygenCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunAgeKeygenCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunAgeKeygenCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunAgeKeygenCommand() : base("age-keygen", "Run 'age-keygen' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunAgeKeygenCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunCiliumCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunCiliumCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunCiliumCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunCiliumCommand() : base("cilium", "Run 'cilium' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunCiliumCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunFluxCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunFluxCommand.cs
@@ -1,0 +1,38 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunFluxCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+  internal KSailRunFluxCommand() : base("flux", "Run 'flux' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunFluxCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunHelmCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunHelmCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunHelmCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunHelmCommand() : base("helm", "Run 'helm' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunHelmCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunK3dCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunK3dCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunK3dCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunK3dCommand() : base("k3d", "Run 'k3d' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunK3dCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunK9sCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunK9sCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunK9sCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunK9sCommand() : base("k9s", "Run 'k9s' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunK9sCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunKindCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunKindCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunKindCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunKindCommand() : base("kind", "Run 'kind' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunKindCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunKubeconformCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunKubeconformCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunKubeconformCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunKubeconformCommand() : base("kubeconform", "Run 'kubeconform' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunKubeconformCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunKubectlCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunKubectlCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunKubectlCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunKubectlCommand() : base("kubectl", "Run 'kubectl' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunKubectlCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunKustomizeCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunKustomizeCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunKustomizeCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunKustomizeCommand() : base("kustomize", "Run 'kustomize' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunKustomizeCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Commands/KSailRunSopsCommand.cs
+++ b/src/KSail/Commands/Run/Commands/KSailRunSopsCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Devantler.SecretManager.SOPS.LocalAge;
+using KSail.Commands.Run.Arguments;
+using KSail.Commands.Run.Handlers;
+using KSail.Commands.Secrets.Handlers;
+using KSail.Models.Project.Enums;
+using KSail.Utils;
+
+namespace KSail.Commands.Run.Commands;
+
+sealed class KSailRunSopsCommand : Command
+{
+  readonly ExceptionHandler _exceptionHandler = new();
+  readonly Argument<string[]> _argsArgument = new CLIArguments();
+
+  internal KSailRunSopsCommand() : base("sops", "Run 'sops' command")
+  {
+    AddArguments();
+
+    this.SetHandler(async (context) =>
+    {
+      try
+      {
+        var cancellationToken = context.GetCancellationToken();
+        string[] args = context.ParseResult.GetValueForArgument(_argsArgument);
+
+        var handler = new KSailRunSopsCommandHandler(args);
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _ = _exceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+    });
+  }
+
+  void AddArguments() => AddArgument(_argsArgument);
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunAgeKeygenCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunAgeKeygenCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.AgeCLI;
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunAgeKeygenCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await AgeKeygen.RunAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunCiliumCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunCiliumCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.CiliumCLI;
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunCiliumCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await Cilium.RunAsync(args, input: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunFluxCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunFluxCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.FluxCLI;
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunFluxCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await Flux.RunAsync(args, input: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunHelmCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunHelmCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.HelmCLI;
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunHelmCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await Helm.RunAsync(args, input: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunK3dCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunK3dCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.K3dCLI;
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunK3dCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await K3d.RunAsync(args, input: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunK9sCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunK9sCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.K9sCLI;
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunK9sCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await K9s.RunAsync(args, cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunKindCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunKindCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.Keys.Age;
+using Devantler.KindCLI;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunKindCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await Kind.RunAsync(args, input: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunKubeconformCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunKubeconformCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.Keys.Age;
+using Devantler.KubeconformCLI;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunKubeconformCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await Kubeconform.RunAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunKubectlCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunKubectlCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.Keys.Age;
+using Devantler.KubectlCLI;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunKubectlCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await Kubectl.RunAsync(args, input: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunKustomizeCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunKustomizeCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.Keys.Age;
+using Devantler.KustomizeCLI;
+using Devantler.SecretManager.Core;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunKustomizeCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await Kustomize.RunAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/Handlers/KSailRunSopsCommandHandler.cs
+++ b/src/KSail/Commands/Run/Handlers/KSailRunSopsCommandHandler.cs
@@ -1,0 +1,15 @@
+using System.CommandLine;
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+using Devantler.SOPSCLI;
+
+namespace KSail.Commands.Run.Handlers;
+
+class KSailRunSopsCommandHandler(string[] args) : ICommandHandler
+{
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    _ = await SOPS.RunAsync(args, input: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Run/KSailRunCommand.cs
+++ b/src/KSail/Commands/Run/KSailRunCommand.cs
@@ -1,0 +1,35 @@
+using System.CommandLine;
+using System.CommandLine.IO;
+using KSail.Commands.Run.Commands;
+using KSail.Commands.Secrets.Commands;
+using KSail.Options;
+
+namespace KSail.Commands.Run;
+
+sealed class KSailRunCommand : Command
+{
+  internal KSailRunCommand(IConsole? console = default) : base("run", "Run a command")
+  {
+    console ??= new SystemConsole();
+    AddCommands();
+    this.SetHandler(async (context) =>
+      {
+        context.ExitCode = await this.InvokeAsync("--help", console).ConfigureAwait(false);
+      }
+    );
+  }
+  void AddCommands()
+  {
+    AddCommand(new KSailRunKindCommand());
+    AddCommand(new KSailRunK3dCommand());
+    AddCommand(new KSailRunKubectlCommand());
+    AddCommand(new KSailRunFluxCommand());
+    AddCommand(new KSailRunHelmCommand());
+    AddCommand(new KSailRunCiliumCommand());
+    AddCommand(new KSailRunKustomizeCommand());
+    AddCommand(new KSailRunKubeconformCommand());
+    AddCommand(new KSailRunSopsCommand());
+    AddCommand(new KSailRunAgeKeygenCommand());
+    AddCommand(new KSailRunK9sCommand());
+  }
+}

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
@@ -22,7 +22,7 @@ sealed class KSailSecretsListCommand : Command
 
         var cancellationToken = context.GetCancellationToken();
         var handler = new KSailSecretsListCommandHandler(config, new SOPSLocalAgeSecretManager());
-        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsAddCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsAddCommandHandler.cs
@@ -4,11 +4,11 @@ using Devantler.SecretManager.Core;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsAddCommandHandler(ISecretManager<AgeKey> secretManager, IConsole console)
+class KSailSecretsAddCommandHandler(ISecretManager<AgeKey> secretManager, IConsole console) : ICommandHandler
 {
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     var key = await _secretManager.CreateKeyAsync(cancellationToken).ConfigureAwait(false);
     console.WriteLine(key.ToString());

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsDecryptCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsDecryptCommandHandler.cs
@@ -4,13 +4,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsDecryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager)
+class KSailSecretsDecryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _path = path;
   readonly string? _output = output;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     string encrypted = await _secretManager.DecryptAsync(_path, cancellationToken).ConfigureAwait(false);
     if (config.Spec.SecretManager.SOPS.InPlace)

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsEditCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsEditCommandHandler.cs
@@ -7,13 +7,13 @@ using KSail.Models;
 namespace KSail.Commands.Secrets.Handlers;
 
 [ExcludeFromCodeCoverage]
-class KSailSecretsEditCommandHandler(KSailCluster config, string path, ISecretManager<AgeKey> secretManager)
+class KSailSecretsEditCommandHandler(KSailCluster config, string path, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly string _path = path;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Environment.SetEnvironmentVariable("EDITOR", _config.Spec.Project.Editor.ToString().ToLower(CultureInfo.CurrentCulture));
     await _secretManager.EditAsync(_path, cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsEncryptCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsEncryptCommandHandler.cs
@@ -4,13 +4,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsEncryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager)
+class KSailSecretsEncryptCommandHandler(KSailCluster config, string path, string? output, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _path = path;
   readonly string? _output = output;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     string encrypted = await _secretManager.EncryptAsync(_path, config.Spec.SecretManager.SOPS.PublicKey, cancellationToken).ConfigureAwait(false);
     if (config.Spec.SecretManager.SOPS.InPlace)

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsExportCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsExportCommandHandler.cs
@@ -4,13 +4,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsExportCommandHandler(string publicKey, string outputPath, ISecretManager<AgeKey> secretManager)
+class KSailSecretsExportCommandHandler(string publicKey, string outputPath, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _publicKey = publicKey;
   readonly string _outputPath = outputPath;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Console.WriteLine($"► exporting '{_publicKey}' from SOPS to '{_outputPath}'");
     var key = await _secretManager.GetKeyAsync(_publicKey, cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
@@ -4,12 +4,12 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsImportCommandHandler(string key, ISecretManager<AgeKey> secretManager)
+class KSailSecretsImportCommandHandler(string key, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _key = key;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Console.WriteLine($"► importing '{_key}' to SOPS");
     string key = _key;

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsListCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsListCommandHandler.cs
@@ -5,12 +5,12 @@ using KSail.Utils;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey> secretManager)
+class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly KSailCluster _config = config;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     var keys = await _secretManager.ListKeysAsync(cancellationToken).ConfigureAwait(false);
 
@@ -20,7 +20,7 @@ class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey>
       if (!keys.Any(key => sopsConfig.CreationRules.Any(rule => rule.Age == key.PublicKey)))
       {
         Console.WriteLine("► no keys found");
-        return true;
+        return 0;
       }
       foreach (var key in keys.Where(key => sopsConfig.CreationRules.Any(rule => rule.Age == key.PublicKey)))
       {
@@ -40,7 +40,7 @@ class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey>
       if (!keys.Any())
       {
         Console.WriteLine("► no keys found");
-        return true;
+        return 0;
       }
       foreach (var key in keys)
       {
@@ -55,7 +55,7 @@ class KSailSecretsListCommandHandler(KSailCluster config, ISecretManager<AgeKey>
         Console.WriteLine();
       }
     }
-    return true;
+    return 0;
   }
 
   static string Obscure(AgeKey key)

--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsRemoveCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsRemoveCommandHandler.cs
@@ -4,12 +4,12 @@ using KSail.Models;
 
 namespace KSail.Commands.Secrets.Handlers;
 
-class KSailSecretsRemoveCommandHandler(string publicKey, ISecretManager<AgeKey> secretManager)
+class KSailSecretsRemoveCommandHandler(string publicKey, ISecretManager<AgeKey> secretManager) : ICommandHandler
 {
   readonly string _publicKey = publicKey;
   readonly ISecretManager<AgeKey> _secretManager = secretManager;
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken)
   {
     Console.WriteLine($"► removing '{_publicKey}' from SOPS key file");
     _ = await _secretManager.DeleteKeyAsync(_publicKey, cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Start/Handlers/KSailStartCommandHandler.cs
+++ b/src/KSail/Commands/Start/Handlers/KSailStartCommandHandler.cs
@@ -6,7 +6,7 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Start.Handlers;
 
-class KSailStartCommandHandler
+class KSailStartCommandHandler : ICommandHandler
 {
   readonly KSailCluster _config;
   readonly IKubernetesClusterProvisioner _clusterProvisioner;
@@ -22,7 +22,7 @@ class KSailStartCommandHandler
     };
   }
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine($"▶️ Starting cluster...");
     Console.WriteLine($"► starting cluster '{_config.Spec.Connection.Context}'");

--- a/src/KSail/Commands/Status/Handlers/KSailStatusCommandHandler.cs
+++ b/src/KSail/Commands/Status/Handlers/KSailStatusCommandHandler.cs
@@ -6,11 +6,11 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Status.Handlers;
 
-sealed class KSailStatusCommandHandler(KSailCluster config)
+sealed class KSailStatusCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly KSailCluster _config = config;
 
-  internal async Task<bool> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     var (LiveCheckExitCode, LiveCheckMessage) = await Devantler.KubectlCLI.Kubectl.RunAsync(
       ["get", "--raw", $"/livez{(_config.Spec.Validation.Verbose ? "?verbose" : "")}", "--kubeconfig", _config.Spec.Connection.Kubeconfig, "--context", _config.Spec.Connection.Context],
@@ -32,6 +32,6 @@ sealed class KSailStatusCommandHandler(KSailCluster config)
       Console.WriteLine($"Live: {LiveCheckMessage}");
       Console.WriteLine($"Ready: {ReadyCheckMessage}");
     }
-    return LiveCheckExitCode == 0 && ReadyCheckExitCode == 0;
+    return (LiveCheckExitCode == 0 && ReadyCheckExitCode == 0) ? 0 : 1;
   }
 }

--- a/src/KSail/Commands/Status/KSailStatusCommand.cs
+++ b/src/KSail/Commands/Status/KSailStatusCommand.cs
@@ -19,7 +19,7 @@ sealed class KSailStatusCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var cancellationToken = context.GetCancellationToken();
         var handler = new KSailStatusCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Stop/Handlers/KSailStopCommandHandler.cs
+++ b/src/KSail/Commands/Stop/Handlers/KSailStopCommandHandler.cs
@@ -6,7 +6,7 @@ using KSail.Models.Project.Enums;
 
 namespace KSail.Commands.Stop.Handlers;
 
-class KSailStopCommandHandler
+class KSailStopCommandHandler : ICommandHandler
 {
   readonly KSailCluster _config;
   readonly IKubernetesClusterProvisioner _clusterProvisioner;
@@ -22,7 +22,7 @@ class KSailStopCommandHandler
     };
   }
 
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine($"⏹️ Stopping cluster...");
     Console.WriteLine($"► stopping cluster '{_config.Spec.Connection.Context}'");

--- a/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
+++ b/src/KSail/Commands/Up/Handlers/KSailUpCommandHandler.cs
@@ -18,7 +18,7 @@ using KSail.Utils;
 
 namespace KSail.Commands.Up.Handlers;
 
-class KSailUpCommandHandler(KSailCluster config)
+class KSailUpCommandHandler(KSailCluster config) : ICommandHandler
 {
   readonly ClusterManager _clusterBootstrapper = new(config);
   readonly GitOpsSourceManager _gitOpsSourceBootstrapper = new(config);
@@ -30,7 +30,7 @@ class KSailUpCommandHandler(KSailCluster config)
   readonly MetricsServerManager _metricsServerBootstrapper = new(config);
   readonly SecretManager _secretManagerBootstrapper = new(config);
   readonly DeploymentToolManager _deploymentToolBootstrapper = new(config);
-  internal async Task<int> HandleAsync(CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     await _clusterBootstrapper.BootstrapAsync(cancellationToken).ConfigureAwait(false);
     await _gitOpsSourceBootstrapper.BootstrapAsync(cancellationToken).ConfigureAwait(false);

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -20,7 +20,7 @@ sealed class KSailUpdateCommand : Command
       {
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context).ConfigureAwait(false);
         var handler = new KSailUpdateCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/Commands/Validate/Handlers/KSailValidateCommandHandler.cs
+++ b/src/KSail/Commands/Validate/Handlers/KSailValidateCommandHandler.cs
@@ -5,13 +5,13 @@ using KSail.Models;
 
 namespace KSail.Commands.Validate.Handlers;
 
-class KSailValidateCommandHandler(KSailCluster config)
+class KSailValidateCommandHandler(KSailCluster config, string path) : ICommandHandler
 {
   readonly ConfigurationValidator _configValidator = new(config);
   readonly YamlSyntaxValidator _yamlSyntaxValidator = new();
   readonly SchemaValidator _schemaValidator = new();
 
-  internal async Task<bool> HandleAsync(string path, CancellationToken cancellationToken = default)
+  public async Task<int> HandleAsync(CancellationToken cancellationToken = default)
   {
     Console.WriteLine("🔍 Validating project files and configuration...");
     if (!Directory.Exists(path) || Directory.GetFiles(path, "*.yaml", SearchOption.AllDirectories).Length == 0)
@@ -33,6 +33,6 @@ class KSailValidateCommandHandler(KSailCluster config)
     if (!schemasAreValid)
       throw new KSailException(schemasMessage);
     Console.WriteLine("✔ schemas are valid");
-    return yamlIsValid && schemasAreValid;
+    return yamlIsValid && schemasAreValid ? 0 : 1;
   }
 }

--- a/src/KSail/Commands/Validate/KSailValidateCommand.cs
+++ b/src/KSail/Commands/Validate/KSailValidateCommand.cs
@@ -24,8 +24,8 @@ sealed class KSailValidateCommand : Command
       {
         string path = context.ParseResult.GetValueForOption(_pathOption) ?? "./";
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(context, path).ConfigureAwait(false);
-        var handler = new KSailValidateCommandHandler(config);
-        context.ExitCode = await handler.HandleAsync(path, context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
+        var handler = new KSailValidateCommandHandler(config, path);
+        context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
       }
       catch (Exception ex)
       {

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.8.12" />
     <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.8.12" />
     <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.8.12" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Deployment.Kubectl" Version="1.8.11" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Deployment.Kubectl" Version="1.8.12" />
     <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.8.12" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.1.6" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.1.6" />

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.8.12" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.1.6" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.1.6" />
-    <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.4.7" />
+    <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.4.8" />
     <PackageReference Include="Devantler.K9sCLI" Version="1.9.1" />
     <PackageReference Include="Devantler.HelmCLI" Version="1.3.1" />
     <PackageReference Include="Devantler.KubectlCLI" Version="1.3.1" />

--- a/src/KSail/Managers/ClusterManager.cs
+++ b/src/KSail/Managers/ClusterManager.cs
@@ -12,7 +12,7 @@ class ClusterManager(KSailCluster config) : IBootstrapManager, ICleanupManager
 {
   readonly IKubernetesClusterProvisioner _clusterProvisioner = ClusterProvisionerFactory.Create(config);
   readonly IContainerEngineProvisioner _containerEngineProvisioner = ContainerEngineProvisionerFactory.Create(config);
-  readonly KSailValidateCommandHandler _ksailValidateCommandHandler = new(config);
+  readonly KSailValidateCommandHandler _ksailValidateCommandHandler = new(config, "./");
   public async Task BootstrapAsync(CancellationToken cancellationToken = default)
   {
     await CheckPrerequisites(cancellationToken).ConfigureAwait(false);
@@ -62,7 +62,7 @@ class ClusterManager(KSailCluster config) : IBootstrapManager, ICleanupManager
   {
     if (config.Spec.Validation.ValidateOnUp)
     {
-      bool success = await _ksailValidateCommandHandler.HandleAsync("./", cancellationToken).ConfigureAwait(false);
+      bool success = (await _ksailValidateCommandHandler.HandleAsync(cancellationToken).ConfigureAwait(false)) == 0;
       Console.WriteLine();
       return success;
     }

--- a/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
+++ b/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
@@ -38,6 +38,7 @@ Commands:
   connect   Connect to a cluster with K9s
   gen       Generate a resource
   secrets   Manage secrets
+  run       Run a command
 ```
 
 ## `ksail up`
@@ -199,6 +200,7 @@ Commands:
   connect   Connect to a cluster with K9s
   gen       Generate a resource
   secrets   Manage secrets
+  run       Run a command
 ```
 
 ## `ksail status`

--- a/tests/KSail.Tests.Unit/Commands/Root/KSailRootCommandTests.KSailHelp_SucceedsAndPrintsHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Root/KSailRootCommandTests.KSailHelp_SucceedsAndPrintsHelp.verified.txt
@@ -21,4 +21,5 @@ Commands:
   connect   Connect to a cluster with K9s
   gen       Generate a resource
   secrets   Manage secrets
+  run       Run a command
 

--- a/tests/KSail.Tests.Unit/Commands/Root/KSailRootCommandTests.KSail_SucceedsAndPrintsIntroduction.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Root/KSailRootCommandTests.KSail_SucceedsAndPrintsIntroduction.verified.txt
@@ -32,4 +32,5 @@ Commands:
   connect   Connect to a cluster with K9s
   gen       Generate a resource
   secrets   Manage secrets
+  run       Run a command
 

--- a/tests/KSail.Tests.Unit/Commands/Run/KSailRunCommandTests.cs
+++ b/tests/KSail.Tests.Unit/Commands/Run/KSailRunCommandTests.cs
@@ -1,0 +1,31 @@
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using KSail.Commands.Root;
+
+namespace KSail.Tests.Unit.Commands.Run;
+
+public partial class KSailRunCommandTests
+{
+  readonly TestConsole _console;
+  readonly KSailRootCommand _ksailCommand;
+
+  public KSailRunCommandTests()
+  {
+    _console = new TestConsole();
+    _ksailCommand = new KSailRootCommand(_console);
+  }
+
+  [Theory]
+  [MemberData(nameof(KSailRunCommandTestsTheoryData.HelpTheoryData), MemberType = typeof(KSailRunCommandTestsTheoryData))]
+  public async Task KSailRun_SucceedsAndPrintsHelp(string[] command)
+  {
+    //Act
+    int exitCode = await _ksailCommand.InvokeAsync(command, _console);
+
+    //Assert
+    Assert.Equal(0, exitCode);
+    _ = await Verify(_console.Error.ToString() + _console.Out).UseFileName($"ksail {string.Join(" ", command)}");
+  }
+}

--- a/tests/KSail.Tests.Unit/Commands/Run/KSailRunCommandTestsTheoryData.cs
+++ b/tests/KSail.Tests.Unit/Commands/Run/KSailRunCommandTestsTheoryData.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KSail.Tests.Unit.Commands.Run;
+
+static class KSailRunCommandTestsTheoryData
+{
+  public static TheoryData<string[]> HelpTheoryData =>
+    [
+      ["run"],
+      ["run", "--help"],
+      ["run", "age-keygen", "--help"],
+      ["run", "cilium", "--help"],
+      ["run", "flux", "--help"],
+      ["run", "helm", "--help"],
+      ["run", "k3d", "--help"],
+      ["run", "k9s", "--help"],
+      ["run", "kind", "--help"],
+      ["run", "kubeconform", "--help"],
+      ["run", "kubectl", "--help"],
+      ["run", "kustomize", "--help"],
+      ["run", "sops", "--help"]
+    ];
+}

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run --help.verified.txt
@@ -1,0 +1,22 @@
+﻿Description:
+  Run a command
+
+Usage:
+  testhost run [command] [options]
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+Commands:
+  kind <args>         Run 'kind' command
+  k3d <args>          Run 'k3d' command
+  kubectl <args>      Run 'kubectl' command
+  flux <args>         Run 'flux' command
+  helm <args>         Run 'helm' command
+  cilium <args>       Run 'cilium' command
+  kustomize <args>    Run 'kustomize' command
+  kubeconform <args>  Run 'kubeconform' command
+  sops <args>         Run 'sops' command
+  age-keygen <args>   Run 'age-keygen' command
+  k9s <args>          Run 'k9s' command
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run age-keygen --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run age-keygen --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'age-keygen' command
+
+Usage:
+  testhost run age-keygen [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run cilium --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run cilium --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'cilium' command
+
+Usage:
+  testhost run cilium [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run flux --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run flux --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'flux' command
+
+Usage:
+  testhost run flux [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run helm --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run helm --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'helm' command
+
+Usage:
+  testhost run helm [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run k3d --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run k3d --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'k3d' command
+
+Usage:
+  testhost run k3d [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run k9s --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run k9s --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'k9s' command
+
+Usage:
+  testhost run k9s [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run kind --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run kind --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'kind' command
+
+Usage:
+  testhost run kind [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run kubeconform --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run kubeconform --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'kubeconform' command
+
+Usage:
+  testhost run kubeconform [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run kubectl --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run kubectl --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'kubectl' command
+
+Usage:
+  testhost run kubectl [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run kustomize --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run kustomize --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'kustomize' command
+
+Usage:
+  testhost run kustomize [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run sops --help.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run sops --help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  Run 'sops' command
+
+Usage:
+  testhost run sops [<args>...] [options]
+
+Arguments:
+  <args>  Arguments to pass to a binary
+
+Options:
+  -?, -h, --help  Show help and usage information
+
+
+

--- a/tests/KSail.Tests.Unit/Commands/Run/ksail run.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Run/ksail run.verified.txt
@@ -1,0 +1,23 @@
+﻿Description:
+  Run a command
+
+Usage:
+  testhost run [command] [options]
+
+Options:
+  --version       Show version information
+  -?, -h, --help  Show help and usage information
+
+Commands:
+  kind <args>         Run 'kind' command
+  k3d <args>          Run 'k3d' command
+  kubectl <args>      Run 'kubectl' command
+  flux <args>         Run 'flux' command
+  helm <args>         Run 'helm' command
+  cilium <args>       Run 'cilium' command
+  kustomize <args>    Run 'kustomize' command
+  kubeconform <args>  Run 'kubeconform' command
+  sops <args>         Run 'sops' command
+  age-keygen <args>   Run 'age-keygen' command
+  k9s <args>          Run 'k9s' command
+


### PR DESCRIPTION
Refactor command handlers to implement a standardized interface, enhancing consistency and accessibility. Introduce new 'run' commands for various tools, complete with help documentation and tests.

- Fixes #939
- Fixes #941
- Fixes #948
- Fixes #949
- Fixes #949
- Fixes #950
