### PR TITLE
fix: Add publication options for manifest publishing

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -116,6 +116,7 @@ Options:
   -c, --context <context>                         The kubernetes context to use. [default: kind-ksail-default]
   -k, --kubeconfig <kubeconfig>                   Path to kubeconfig file. [default: ~/.kube/config]
   -kp, --kustomization-path <kustomization-path>  The path to the root kustomization directory. [default: k8s]
+  -p, --publish                                   Publish manifests. [default: True]
   -v, --validate                                  Validate project files before applying changes to an existing cluster. [default: True]
   -r, --reconcile                                 Reconcile manifests. [default: True]
   --helpz                                         Show help and usage information

--- a/docs/configuration/declarative-config.md
+++ b/docs/configuration/declarative-config.md
@@ -171,6 +171,10 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Docker
+  # Options for publication of manifests.
+  publication:
+    # Publish manifests before applying changes to an existing cluster. [default: true]
+    publishOnUpdate: true
   # Options for validating the KSail cluster.
   validation:
     # Validate the project files and configuration before creating a new cluster. [default: true]

--- a/schemas/ksail-cluster-schema.json
+++ b/schemas/ksail-cluster-schema.json
@@ -273,6 +273,16 @@
             }
           }
         },
+        "publication": {
+          "description": "Options for publication of manifests.",
+          "type": "object",
+          "properties": {
+            "publishOnUpdate": {
+              "description": "Publish manifests before applying changes to an existing cluster. [default: true]",
+              "type": "boolean"
+            }
+          }
+        },
         "validation": {
           "description": "Options for validating the KSail cluster.",
           "type": "object",

--- a/src/KSail.Models/KSailClusterSpec.cs
+++ b/src/KSail.Models/KSailClusterSpec.cs
@@ -10,6 +10,7 @@ using KSail.Models.LocalRegistry;
 using KSail.Models.MirrorRegistry;
 using KSail.Models.Project;
 using KSail.Models.Project.Enums;
+using KSail.Models.Publication;
 using KSail.Models.SecretManager;
 using KSail.Models.Validation;
 using YamlDotNet.Serialization;
@@ -60,6 +61,9 @@ public class KSailClusterSpec
     new KSailMirrorRegistry { Name = "mcr.microsoft.com-proxy", HostPort = 5560, Proxy = new KSailMirrorRegistryProxy { Url = new("https://mcr.microsoft.com") } },
     new KSailMirrorRegistry { Name = "quay.io-proxy", HostPort = 5561, Proxy = new KSailMirrorRegistryProxy { Url = new("https://quay.io") } }
   ];
+
+  [Description("Options for publication of manifests.")]
+  public KSailPublication Publication { get; set; } = new();
 
   [Description("Options for validating the KSail cluster.")]
   public KSailValidation Validation { get; set; } = new();

--- a/src/KSail.Models/Publication/KSailPublication.cs
+++ b/src/KSail.Models/Publication/KSailPublication.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel;
+
+namespace KSail.Models.Publication;
+
+public class KSailPublication
+{
+
+  [Description("Publish manifests before applying changes to an existing cluster. [default: true]")]
+  public bool PublishOnUpdate { get; set; } = true;
+}

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -35,6 +35,7 @@ sealed class KSailUpdateCommand : Command
     AddOption(CLIOptions.Connection.ContextOption);
     AddOption(CLIOptions.Connection.KubeconfigOption);
     AddOption(CLIOptions.Project.KustomizationPathOption);
+    AddOption(CLIOptions.Publication.PublishOnUpdateOption);
     AddOption(CLIOptions.Validation.ValidateOnUpdateOption);
     AddOption(CLIOptions.Validation.ReconcileOnUpdateOption);
   }

--- a/src/KSail/Options/CLIOptions.cs
+++ b/src/KSail/Options/CLIOptions.cs
@@ -9,6 +9,7 @@ using KSail.Options.LocalRegistry;
 using KSail.Options.Metadata;
 using KSail.Options.MirrorRegistries;
 using KSail.Options.Project;
+using KSail.Options.Publication;
 using KSail.Options.SecretManager;
 using KSail.Options.Validation;
 using KSail.Options.WaypointController;
@@ -44,6 +45,6 @@ static class CLIOptions
 
   public static readonly GeneratorOptions Generator = new(_config);
 
+  public static readonly PublicationOptions Publication = new(_config);
   public static readonly ValidationOptions Validation = new(_config);
-
 }

--- a/src/KSail/Options/Publication/PublicationOptions.cs
+++ b/src/KSail/Options/Publication/PublicationOptions.cs
@@ -1,0 +1,13 @@
+using System.CommandLine;
+using KSail.Models;
+using KSail.Options.Validation;
+
+namespace KSail.Options.Publication;
+
+class PublicationOptions(KSailCluster config)
+{
+  public PublicationPublishOnUpdateOption PublishOnUpdateOption { get; } = new(config)
+  {
+    Arity = ArgumentArity.ZeroOrOne
+  };
+}

--- a/src/KSail/Options/Publication/PublicationPublishOnUpdateOption.cs
+++ b/src/KSail/Options/Publication/PublicationPublishOnUpdateOption.cs
@@ -1,0 +1,10 @@
+using System.CommandLine;
+using KSail.Models;
+
+namespace KSail.Options.Publication;
+
+class PublicationPublishOnUpdateOption(KSailCluster config) : Option<bool?>(
+  ["--publish", "-p"],
+  $"Publish manifests. [default: {config.Spec.Publication.PublishOnUpdate}]"
+);
+

--- a/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
+++ b/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
@@ -116,6 +116,7 @@ Options:
   -c, --context <context>                         The kubernetes context to use. [default: kind-ksail-default]
   -k, --kubeconfig <kubeconfig>                   Path to kubeconfig file. [default: ~/.kube/config]
   -kp, --kustomization-path <kustomization-path>  The path to the root kustomization directory. [default: k8s]
+  -p, --publish                                   Publish manifests. [default: True]
   -v, --validate                                  Validate project files before applying changes to an existing cluster. [default: True]
   -r, --reconcile                                 Reconcile manifests. [default: True]
   --helpz                                         Show help and usage information

--- a/tests/KSail.Docs.Tests.Unit/declarative-config.verified.md
+++ b/tests/KSail.Docs.Tests.Unit/declarative-config.verified.md
@@ -148,6 +148,10 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Docker
+  # Options for publication of manifests.
+  publication:
+    # Publish manifests before applying changes to an existing cluster. [default: true]
+    publishOnUpdate: true
   # Options for validating the KSail cluster.
   validation:
     # Validate the project files and configuration before creating a new cluster. [default: true]

--- a/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
+++ b/tests/KSail.Docs.Tests.Unit/ksail-cluster-schema.verified.json
@@ -273,6 +273,16 @@
             }
           }
         },
+        "publication": {
+          "description": "Options for publication of manifests.",
+          "type": "object",
+          "properties": {
+            "publishOnUpdate": {
+              "description": "Publish manifests before applying changes to an existing cluster. [default: true]",
+              "type": "boolean"
+            }
+          }
+        },
         "validation": {
           "description": "Options for validating the KSail cluster.",
           "type": "object",

--- a/tests/KSail.Generator.Tests.Unit/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests.Unit/KSailClusterGeneratorTests/ksail.full.yaml.verified.yaml
@@ -84,5 +84,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Generator.Tests.Unit/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
+++ b/tests/KSail.Generator.Tests.Unit/KSailClusterGeneratorTests/ksail.minimal.yaml.verified.yaml
@@ -76,5 +76,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithDistribution_ShouldReturnValidConfig.verified.txt
@@ -102,6 +102,9 @@
         Provider: Docker
       }
     ],
+    Publication: {
+      PublishOnUpdate: true
+    },
     Validation: {
       ValidateOnUp: true,
       ReconcileOnUp: true,

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndDistribution_ShouldReturnValidConfig.verified.txt
@@ -102,6 +102,9 @@
         Provider: Docker
       }
     ],
+    Publication: {
+      PublishOnUpdate: true
+    },
     Validation: {
       ValidateOnUp: true,
       ReconcileOnUp: true,

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndUnnamedDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNameAndUnnamedDistribution_ShouldReturnValidConfig.verified.txt
@@ -102,6 +102,9 @@
         Provider: Docker
       }
     ],
+    Publication: {
+      PublishOnUpdate: true
+    },
     Validation: {
       ValidateOnUp: true,
       ReconcileOnUp: true,

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithName_ShouldReturnValidConfig.verified.txt
@@ -102,6 +102,9 @@
         Provider: Docker
       }
     ],
+    Publication: {
+      PublishOnUpdate: true
+    },
     Validation: {
       ValidateOnUp: true,
       ReconcileOnUp: true,

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithNoInput_ShouldReturnValidConfig.verified.txt
@@ -102,6 +102,9 @@
         Provider: Docker
       }
     ],
+    Publication: {
+      PublishOnUpdate: true
+    },
     Validation: {
       ValidateOnUp: true,
       ReconcileOnUp: true,

--- a/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithUnnamedDistribution_ShouldReturnValidConfig.verified.txt
+++ b/tests/KSail.Models.Tests.Unit/KSailClusterInitializationTests.InitializeKSailCluster_WithUnnamedDistribution_ShouldReturnValidConfig.verified.txt
@@ -102,6 +102,9 @@
         Provider: Docker
       }
     ],
+    Publication: {
+      PublishOnUpdate: true
+    },
     Validation: {
       ValidateOnUp: true,
       ReconcileOnUp: true,

--- a/tests/KSail.Tests.Unit/Commands/Gen/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Gen/ksail.yaml.verified.yaml
@@ -76,5 +76,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-default/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-default/ksail.yaml.verified.yaml
@@ -76,5 +76,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-flux-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-flux-cilium-sops/ksail.yaml.verified.yaml
@@ -90,5 +90,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-flux-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-flux-cilium/ksail.yaml.verified.yaml
@@ -88,5 +88,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-flux/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-flux/ksail.yaml.verified.yaml
@@ -86,5 +86,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-kubectl-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-kubectl-cilium-sops/ksail.yaml.verified.yaml
@@ -88,5 +88,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-kubectl-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-kubectl-cilium/ksail.yaml.verified.yaml
@@ -86,5 +86,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-kubectl/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-kubectl/ksail.yaml.verified.yaml
@@ -84,5 +84,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-no-metrics-server/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-no-metrics-server/ksail.yaml.verified.yaml
@@ -86,5 +86,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-none/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d-none/ksail.yaml.verified.yaml
@@ -86,5 +86,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-k3d/ksail.yaml.verified.yaml
@@ -84,5 +84,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-flux-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-flux-cilium-sops/ksail.yaml.verified.yaml
@@ -82,5 +82,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-flux-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-flux-cilium/ksail.yaml.verified.yaml
@@ -80,5 +80,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-flux/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-flux/ksail.yaml.verified.yaml
@@ -78,5 +78,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-kubectl-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-kubectl-cilium-sops/ksail.yaml.verified.yaml
@@ -80,5 +80,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-kubectl-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-kubectl-cilium/ksail.yaml.verified.yaml
@@ -78,5 +78,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-kubectl/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-kubectl/ksail.yaml.verified.yaml
@@ -76,5 +76,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-metrics-server/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind-metrics-server/ksail.yaml.verified.yaml
@@ -76,5 +76,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-kind/ksail.yaml.verified.yaml
@@ -76,5 +76,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-none/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker-none/ksail.yaml.verified.yaml
@@ -78,5 +78,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-docker/ksail.yaml.verified.yaml
@@ -76,5 +76,7 @@ spec:
     name: quay.io-proxy
     # The host port of the registry (if applicable). [default: 5555]
     hostPort: 5561
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-flux-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-flux-cilium-sops/ksail.yaml.verified.yaml
@@ -104,5 +104,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-flux-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-flux-cilium/ksail.yaml.verified.yaml
@@ -102,5 +102,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-flux/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-flux/ksail.yaml.verified.yaml
@@ -100,5 +100,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-kubectl-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-kubectl-cilium-sops/ksail.yaml.verified.yaml
@@ -102,5 +102,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-kubectl-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-kubectl-cilium/ksail.yaml.verified.yaml
@@ -100,5 +100,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-kubectl/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-kubectl/ksail.yaml.verified.yaml
@@ -98,5 +98,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-none/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d-none/ksail.yaml.verified.yaml
@@ -100,5 +100,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-k3d/ksail.yaml.verified.yaml
@@ -98,5 +98,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-flux-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-flux-cilium-sops/ksail.yaml.verified.yaml
@@ -96,5 +96,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-flux-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-flux-cilium/ksail.yaml.verified.yaml
@@ -94,5 +94,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-flux/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-flux/ksail.yaml.verified.yaml
@@ -92,5 +92,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-kubectl-cilium-sops/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-kubectl-cilium-sops/ksail.yaml.verified.yaml
@@ -94,5 +94,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-kubectl-cilium/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-kubectl-cilium/ksail.yaml.verified.yaml
@@ -92,5 +92,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-kubectl/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind-kubectl/ksail.yaml.verified.yaml
@@ -90,5 +90,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-kind/ksail.yaml.verified.yaml
@@ -90,5 +90,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-none/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman-none/ksail.yaml.verified.yaml
@@ -92,5 +92,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/ksail.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Init/ksail-init-podman/ksail.yaml.verified.yaml
@@ -90,5 +90,7 @@ spec:
     hostPort: 5561
     # The registry provider. [default: Docker]
     provider: Podman
+  # Options for publication of manifests.
+  publication: {}
   # Options for validating the KSail cluster.
   validation: {}

--- a/tests/KSail.Tests.Unit/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -8,6 +8,7 @@ Options:
   -c, --context <context>                         The kubernetes context to use. [default: kind-ksail-default]
   -k, --kubeconfig <kubeconfig>                   Path to kubeconfig file. [default: {UserProfile}/.kube/config]
   -kp, --kustomization-path <kustomization-path>  The path to the root kustomization directory. [default: k8s]
+  -p, --publish                                   Publish manifests. [default: True]
   -v, --validate                                  Validate project files before applying changes to an existing cluster. [default: True]
   -r, --reconcile                                 Reconcile manifests. [default: True]
   -?, -h, --help                                  Show help and usage information


### PR DESCRIPTION
Introduce `PublicationOptions` to manage publication settings, including a `PublishOnUpdate` flag. Update documentation and tests to reflect these changes.

This allows using `ksail update --publish false` to reconcile a cluster without publishing new manifests. This is useful for using KSail to check cluster reconciliation in CD workflows.