### PR TITLE
feat: add cleanup logic for old KSail .NET directories

### DIFF
--- a/src/KSail.Docs/RegexHelpers.cs
+++ b/src/KSail.Docs/RegexHelpers.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 
 namespace KSail.Docs;
+
 static partial class RegexHelpers
 {
   [GeneratedRegex(@"```yaml[\s\S]+```", RegexOptions.Multiline)]

--- a/tests/KSail.Tests.Unit/Commands/Validate/KSailValidateCommandTests.cs
+++ b/tests/KSail.Tests.Unit/Commands/Validate/KSailValidateCommandTests.cs
@@ -3,6 +3,7 @@ using System.CommandLine.IO;
 using KSail.Commands.Root;
 
 namespace KSail.Tests.Unit.Commands.Validate;
+
 public class KSailValidateCommandTests
 {
   readonly TestConsole _console;

--- a/tests/KSail.Tests.Unit/StartupTests.cs
+++ b/tests/KSail.Tests.Unit/StartupTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 
 namespace KSail.Tests.Unit;
+
 public class StartupTests
 {
   [Fact]


### PR DESCRIPTION
Implement a method to clean up old KSail .NET directories in `~/.net/ksail`, ensuring that unnecessary directories are removed during execution. This enhances the application's directory management.