### PR TITLE
fix: add image pull in MirrorRegistryManager

### DIFF
--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -20,17 +20,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.5.3" />
-    <PackageReference Include="Devantler.ContainerEngineProvisioner.Podman" Version="1.5.3" />
+    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.6.0" />
+    <PackageReference Include="Devantler.ContainerEngineProvisioner.Podman" Version="1.6.0" />
     <PackageReference Include="Devantler.KubernetesGenerator.CertManager" Version="1.7.13" />
     <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.7.13" />
     <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.7.13" />
     <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.7.13" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.8.40" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.8.40" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.8.40" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Deployment.Kubectl" Version="1.8.40" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.8.40" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.8.42" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.8.42" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.CNI.Cilium" Version="1.8.42" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Deployment.Kubectl" Version="1.8.42" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.8.42" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.1.16" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.1.16" />
     <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.4.24" />

--- a/src/KSail/Managers/MirrorRegistryManager.cs
+++ b/src/KSail/Managers/MirrorRegistryManager.cs
@@ -35,6 +35,8 @@ class MirrorRegistryManager(KSailCluster config) : IBootstrapManager, ICleanupMa
   async Task CreateMirrorRegistries(KSailCluster config, CancellationToken cancellationToken)
   {
     Console.WriteLine("🧮 Creating mirror registries");
+
+    await _containerEngineProvisioner.PullImageAsync("registry:3", cancellationToken).ConfigureAwait(false);
     var tasks = config.Spec.MirrorRegistries.Select(async mirrorRegistry =>
     {
       Console.WriteLine($"► creating mirror registry '{mirrorRegistry.Name}' for '{mirrorRegistry.Proxy.Url}'");


### PR DESCRIPTION
Implement image pulling in the MirrorRegistryManager to ensure the necessary registry image is available during the creation of mirror registries. Update package references to their latest versions for improved functionality.