### PR TITLE
chore: update issuer name from 'selfsigned-cluster-issuer' to 'selfsigned'

### DIFF
--- a/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerCertificateCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerCertificateCommandHandler.cs
@@ -26,7 +26,7 @@ class KSailGenCertManagerCertificateCommandHandler(string outputFile, bool overw
         ],
         IssuerRef = new CertManagerIssuerRef
         {
-          Name = "selfsigned-cluster-issuer",
+          Name = "selfsigned",
           Kind = "ClusterIssuer",
         }
       }

--- a/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerClusterIssuerCommandHandler.cs
+++ b/src/KSail/Commands/Gen/Handlers/CertManager/KSailGenCertManagerClusterIssuerCommandHandler.cs
@@ -14,7 +14,7 @@ class KSailGenCertManagerClusterIssuerCommandHandler(string outputFile, bool ove
     {
       Metadata = new V1ObjectMeta
       {
-        Name = "selfsigned-cluster-issuer",
+        Name = "selfsigned",
         NamespaceProperty = "cert-manager"
       },
       Spec = new CertManagerClusterIssuerSpec

--- a/tests/KSail.Tests.Unit/Commands/Gen/cert-manager-certificate.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Gen/cert-manager-certificate.yaml.verified.yaml
@@ -9,5 +9,5 @@ spec:
   dnsNames:
   - k8s.local
   issuerRef:
-    name: selfsigned-cluster-issuer
+    name: selfsigned
     kind: ClusterIssuer

--- a/tests/KSail.Tests.Unit/Commands/Gen/cert-manager-cluster-issuer.yaml.verified.yaml
+++ b/tests/KSail.Tests.Unit/Commands/Gen/cert-manager-cluster-issuer.yaml.verified.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: selfsigned-cluster-issuer
+  name: selfsigned
   namespace: cert-manager
 spec:
   selfSigned: {}


### PR DESCRIPTION
Update the issuer name in certificate and cluster issuer configurations for consistency.