### PR TITLE
fix: refactor command handlers to return exit codes

### DIFF
--- a/src/KSail/Commands/Connect/KSailConnectCommand.cs
+++ b/src/KSail/Commands/Connect/KSailConnectCommand.cs
@@ -21,11 +21,12 @@ sealed class KSailConnectCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailConnectCommandHandler(config);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Down/KSailDownCommand.cs
+++ b/src/KSail/Commands/Down/KSailDownCommand.cs
@@ -19,11 +19,12 @@ sealed class KSailDownCommand : Command
 
         var handler = new KSailDownCommandHandler(config);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Gen/Commands/CertManager/KSailGenCertManagerCertificateCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/CertManager/KSailGenCertManagerCertificateCommand.cs
@@ -26,15 +26,16 @@ class KSailGenCertManagerCertificateCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenCertManagerCertificateCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/CertManager/KSailGenCertManagerClusterIssuerCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/CertManager/KSailGenCertManagerClusterIssuerCommand.cs
@@ -27,15 +27,16 @@ class KSailGenCertManagerClusterIssuerCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenCertManagerClusterIssuerCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Config/KSailGenConfigK3dCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Config/KSailGenConfigK3dCommand.cs
@@ -26,11 +26,12 @@ class KSailGenConfigK3dCommand : Command
           $"✚ generating '{outputFile}'");
         var handler = new KSailGenConfigK3dCommandHandler(outputFile, overwrite);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Gen/Commands/Config/KSailGenConfigKSailCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Config/KSailGenConfigKSailCommand.cs
@@ -25,15 +25,16 @@ class KSailGenConfigKSailCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenConfigKSailCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Config/KSailGenConfigSOPSCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Config/KSailGenConfigSOPSCommand.cs
@@ -25,15 +25,16 @@ class KSailGenConfigSOPSCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenConfigSOPSCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Flux/KSailGenFluxHelmReleaseCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Flux/KSailGenFluxHelmReleaseCommand.cs
@@ -26,15 +26,16 @@ class KSailGenFluxHelmReleaseCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenFluxHelmReleaseCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Flux/KSailGenFluxHelmRepositoryCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Flux/KSailGenFluxHelmRepositoryCommand.cs
@@ -26,15 +26,16 @@ class KSailGenFluxHelmRepositoryCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenFluxHelmRepositoryCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Flux/KSailGenFluxKustomizationCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Flux/KSailGenFluxKustomizationCommand.cs
@@ -26,15 +26,16 @@ sealed class KSailGenFluxKustomizationCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenFluxKustomizationCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Kustomize/KSailGenKustomizeComponentCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Kustomize/KSailGenKustomizeComponentCommand.cs
@@ -25,15 +25,16 @@ class KSailGenKustomizeComponentCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenKustomizeComponentCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Kustomize/KSailGenKustomizeKustomizationCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Kustomize/KSailGenKustomizeKustomizationCommand.cs
@@ -25,15 +25,16 @@ class KSailGenKustomizeKustomizationCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           var handler = new KSailGenKustomizeKustomizationCommandHandler(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeClusterRoleBindingCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeClusterRoleBindingCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeClusterRoleBindingCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeClusterRoleBindingCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeClusterRoleCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeClusterRoleCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeClusterRoleCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeClusterRoleCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeConfigMapCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeConfigMapCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeConfigMapCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeConfigMapCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeCronJobCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeCronJobCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeWorkloadsCronJobCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeWorkloadsCronJobCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeDaemonSetCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeDaemonSetCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeWorkloadsDaemonSetCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeWorkloadsDaemonSetCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeDeploymentCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeDeploymentCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeWorkloadsDeploymentCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeWorkloadsDeploymentCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeHorizontalPodAutoscalerCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeHorizontalPodAutoscalerCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeHorizontalPodAutoscalerCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeHorizontalPodAutoscalerCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeIngressCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeIngressCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeIngressCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeIngressCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeJobCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeJobCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeWorkloadsJobCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeWorkloadsJobCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeNamespaceCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeNamespaceCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeNamespaceCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeNamespaceCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeNetworkPolicyCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeNetworkPolicyCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeNetworkPolicyCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeNetworkPolicyCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePersistentVolumeClaimCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePersistentVolumeClaimCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativePersistentVolumeClaimCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativePersistentVolumeClaimCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePersistentVolumeCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePersistentVolumeCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativePersistentVolumeCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativePersistentVolumeCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePodDisruptionBudgetCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePodDisruptionBudgetCommand.cs
@@ -26,15 +26,16 @@ class KSailGenNativePodDisruptionBudgetCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativePodDisruptionBudgetCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePriorityClassCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativePriorityClassCommand.cs
@@ -26,15 +26,16 @@ class KSailGenNativePriorityClassCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativePriorityClassCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeResourceQuotaCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeResourceQuotaCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeResourceQuotaCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeResourceQuotaCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeRoleBindingCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeRoleBindingCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeRoleBindingCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeRoleBindingCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeRoleCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeRoleCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeRoleCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeRoleCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeSecretCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeSecretCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeSecretCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeSecretCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeServiceAccountCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeServiceAccountCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeAccountCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeAccountCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeServiceCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeServiceCommand.cs
@@ -25,11 +25,12 @@ class KSailGenNativeServiceCommand : Command
             $"✚ generating '{outputFile}'");
           KSailGenNativeServiceCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeStatefulSetCommand.cs
+++ b/src/KSail/Commands/Gen/Commands/Native/KSailGenNativeStatefulSetCommand.cs
@@ -25,15 +25,16 @@ class KSailGenNativeWorkloadsStatefulSetCommand : Command
             $"✚ generating '{outputFile}'");
           if (File.Exists(outputFile) && !overwrite)
           {
-            return;
+            return 0;
           }
           KSailGenNativeWorkloadsStatefulSetCommandHandler handler = new(outputFile, overwrite);
           await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
-
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Init/KSailInitCommand.cs
+++ b/src/KSail/Commands/Init/KSailInitCommand.cs
@@ -25,11 +25,12 @@ sealed class KSailInitCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailInitCommandHandler(outputPath, config);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/List/KsailListCommand.cs
+++ b/src/KSail/Commands/List/KsailListCommand.cs
@@ -18,11 +18,12 @@ sealed class KSailListCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailListCommandHandler(config, parseResult);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Root/KSailRootCommand.cs
+++ b/src/KSail/Commands/Root/KSailRootCommand.cs
@@ -41,12 +41,13 @@ sealed class KSailRootCommand : RootCommand
               }
             );
             _ = await helpResult.InvokeAsync(cancellationToken).ConfigureAwait(false);
-
           }
+          return 0;
         }
         catch (Exception ex)
         {
           _ = _exceptionHandler.HandleException(ex);
+          return 1;
         }
       }
     );

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsAddCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsAddCommand.cs
@@ -19,10 +19,12 @@ sealed class KSailSecretsAddCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailSecretsAddCommandHandler(new SOPSLocalAgeSecretManager(), parseResult);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsDecryptCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsDecryptCommand.cs
@@ -28,11 +28,12 @@ sealed class KSailSecretsDecryptCommand : Command
         var handler = new KSailSecretsDecryptCommandHandler(config, path, output, new SOPSLocalAgeSecretManager());
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
         Console.WriteLine();
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsEditCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsEditCommand.cs
@@ -28,11 +28,12 @@ sealed class KSailSecretsEditCommand : Command
         var handler = new KSailSecretsEditCommandHandler(config, path, new SOPSLocalAgeSecretManager());
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
         Console.WriteLine();
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsEncryptCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsEncryptCommand.cs
@@ -28,11 +28,12 @@ sealed class KSailSecretsEncryptCommand : Command
         var handler = new KSailSecretsEncryptCommandHandler(config, path, output, new SOPSLocalAgeSecretManager());
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
         Console.WriteLine();
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsExportCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsExportCommand.cs
@@ -28,10 +28,12 @@ sealed class KSailSecretsExportCommand : Command
 
         var handler = new KSailSecretsExportCommandHandler(publicKey, outputPath, new SOPSLocalAgeSecretManager());
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsImportCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsImportCommand.cs
@@ -22,11 +22,12 @@ sealed class KSailSecretsImportCommand : Command
 
         var handler = new KSailSecretsImportCommandHandler(key, new SOPSLocalAgeSecretManager());
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsListCommand.cs
@@ -22,11 +22,12 @@ sealed class KSailSecretsListCommand : Command
 
         var handler = new KSailSecretsListCommandHandler(config, new SOPSLocalAgeSecretManager(), parseResult);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Secrets/Commands/KSailSecretsRemoveCommand.cs
+++ b/src/KSail/Commands/Secrets/Commands/KSailSecretsRemoveCommand.cs
@@ -22,11 +22,12 @@ sealed class KSailSecretsRemoveCommand : Command
         string publicKey = parseResult.GetValue(_publicKeyArgument) ?? throw new KSailException("Public key argument is required.");
         var handler = new KSailSecretsRemoveCommandHandler(publicKey, new SOPSLocalAgeSecretManager());
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Start/KSailStartCommand.cs
+++ b/src/KSail/Commands/Start/KSailStartCommand.cs
@@ -19,11 +19,12 @@ sealed class KSailStartCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailStartCommandHandler(config);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Status/KSailStatusCommand.cs
+++ b/src/KSail/Commands/Status/KSailStatusCommand.cs
@@ -19,11 +19,12 @@ sealed class KSailStatusCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailStatusCommandHandler(config, parseResult);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Stop/KSailStopCommand.cs
+++ b/src/KSail/Commands/Stop/KSailStopCommand.cs
@@ -20,10 +20,12 @@ sealed class KSailStopCommand : Command
       try
       {
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Up/KSailUpCommand.cs
+++ b/src/KSail/Commands/Up/KSailUpCommand.cs
@@ -19,11 +19,12 @@ sealed class KSailUpCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailUpCommandHandler(config);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -21,11 +21,12 @@ sealed class KSailUpdateCommand : Command
         var config = await KSailClusterConfigLoader.LoadWithoptionsAsync(parseResult).ConfigureAwait(false);
         var handler = new KSailUpdateCommandHandler(config);
         await handler.HandleAsync(cancellationToken).ConfigureAwait(false);
+        return 0;
       }
       catch (Exception ex)
       {
         _ = _exceptionHandler.HandleException(ex);
-
+        return 1;
       }
     });
   }

--- a/src/KSail/Utils/ExceptionHandler.cs
+++ b/src/KSail/Utils/ExceptionHandler.cs
@@ -1,3 +1,4 @@
+using System.CommandLine;
 using System.Globalization;
 using System.Text;
 using CliWrap.Exceptions;


### PR DESCRIPTION
Refactor command handlers to return exit codes for success and failure, enhancing error handling and robustness in command execution.

- Fixed #1248 