### PR TITLE
fix: suppress exception messages for CommandExecutionException

### DIFF
--- a/src/KSail/Utils/ExceptionHandler.cs
+++ b/src/KSail/Utils/ExceptionHandler.cs
@@ -23,9 +23,9 @@ class ExceptionHandler
       var message = new StringBuilder();
       message = message.AppendLine(CultureInfo.InvariantCulture, $"✗ {ex.Message}");
       Console.ForegroundColor = ConsoleColor.Red;
-      Console.WriteLine($"✗ {ex.Message}");
       if (ex is not CommandExecutionException)
       {
+        Console.WriteLine($"✗ {ex.Message}");
         for (var inner = ex.InnerException; inner is not null; inner = inner.InnerException)
         {
           Console.WriteLine($"  {inner.Message}");


### PR DESCRIPTION
Prevent outputting exception messages for CommandExecutionException while still logging messages for other exceptions.