### PR TITLE
fix: add timeout option to update command

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -50,32 +50,37 @@ Usage:
   ksail init [options]
 
 Options:
-  -o, --output                                      Output directory for the project files. [default: ./]
-  -n, --name                                        The name of the cluster. [default: ksail-default]
-  -c, --config                                      The path to the ksail configuration file. [default: 
-                                                    ksail.yaml]
-  -dc, --distribution-config                        The path to the distribution configuration file. 
-                                                    [default: kind.yaml]
-  -kp, --kustomization-path                         The path to the root kustomization directory. 
-                                                    [default: k8s]
-  -ce, --container-engine <Docker|Podman>           The container engine in which to provision the 
-                                                    cluster. [default: Docker]
-  -d, --distribution <K3d|Kind>                     The distribution to use for the cluster. [default: 
-                                                    Kind]
-  -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a 
-                                                    kustomization. [default: Kubectl]
-  --cni <Cilium|Default|None>                       The CNI to use. [default: Default]
-  --csi <Default|LocalPathProvisioner|None>         The CSI to use. [default: Default]
-  -ic, --ingress-controller <Default|None|Traefik>  The Ingress Controller to use. [default: Default]
-  -gc, --gateway-controller <Default|None>          The Gateway Controller to use. [default: Default]
-  -ms, --metrics-server                             Whether to install Metrics Server. [default: True]
-  -mr, --mirror-registries                          Enable mirror registries for the project. [default: 
-                                                    True]
-  -sm, --secret-manager <None|SOPS>                 Whether to use a secret manager. [default: None]
-  -e, --editor <Nano|Vim>                           The editor to use for editing files from the CLI. 
-                                                    [default: Nano]
-  --overwrite                                       Overwrite existing files. [default: False]
-  -?, -h, --help                                    Show help and usage information
+  -o, --output                               Output directory for the project files. 
+                                             [default: ./]
+  -n, --name                                 The name of the cluster. [default: 
+                                             ksail-default]
+  -c, --config                               The path to the ksail configuration file. 
+                                             [default: ksail.yaml]
+  -dc, --distribution-config                 The path to the distribution configuration 
+                                             file. [default: kind.yaml]
+  -kp, --kustomization-path                  The path to the root kustomization directory. 
+                                             [default: k8s]
+  -ce, --container-engine <Docker|Podman>    The container engine in which to provision the 
+                                             cluster. [default: Docker]
+  -d, --distribution <K3d|Kind>              The distribution to use for the cluster. 
+                                             [default: Kind]
+  -dt, --deployment-tool <Flux|Kubectl>      The Deployment tool to use for applying a 
+                                             kustomization. [default: Kubectl]
+  --cni <Cilium|Default|None>                The CNI to use. [default: Default]
+  --csi <Default|LocalPathProvisioner|None>  The CSI to use. [default: Default]
+  -ic, --ingress-controller                  The Ingress Controller to use. [default: 
+  <Default|None|Traefik>                     Default]
+  -gc, --gateway-controller <Default|None>   The Gateway Controller to use. [default: 
+                                             Default]
+  -ms, --metrics-server                      Whether to install Metrics Server. [default: 
+                                             True]
+  -mr, --mirror-registries                   Enable mirror registries for the project. 
+                                             [default: True]
+  -sm, --secret-manager <None|SOPS>          Whether to use a secret manager. [default: None]
+  -e, --editor <Nano|Vim>                    The editor to use for editing files from the 
+                                             CLI. [default: Nano]
+  --overwrite                                Overwrite existing files. [default: False]
+  -?, -h, --help                             Show help and usage information
 ```
 
 ## `ksail up`
@@ -88,36 +93,41 @@ Usage:
   ksail up [options]
 
 Options:
-  -c, --context                                     The kubernetes context to use. [default: 
-                                                    kind-ksail-default]
-  -k, --kubeconfig                                  Path to kubeconfig file. [default: 
-                                                    ~/.kube/config]
-  -t, --timeout                                     The time to wait for each kustomization to become 
-                                                    ready. [default: 5m]
-  -n, --name                                        The name of the cluster. [default: ksail-default]
-  -dc, --distribution-config                        The path to the distribution configuration file. 
-                                                    [default: kind.yaml]
-  -kp, --kustomization-path                         The path to the root kustomization directory. 
-                                                    [default: k8s]
-  -ce, --container-engine <Docker|Podman>           The container engine in which to provision the 
-                                                    cluster. [default: Docker]
-  -d, --distribution <K3d|Kind>                     The distribution to use for the cluster. [default: 
-                                                    Kind]
-  -dt, --deployment-tool <Flux|Kubectl>             The Deployment tool to use for applying a 
-                                                    kustomization. [default: Kubectl]
-  --cni <Cilium|Default|None>                       The CNI to use. [default: Default]
-  --csi <Default|LocalPathProvisioner|None>         The CSI to use. [default: Default]
-  -ic, --ingress-controller <Default|None|Traefik>  The Ingress Controller to use. [default: Default]
-  -gc, --gateway-controller <Default|None>          The Gateway Controller to use. [default: Default]
-  -ms, --metrics-server                             Whether to install Metrics Server. [default: True]
-  -mr, --mirror-registries                          Enable mirror registries for the project. [default: 
-                                                    True]
-  -sm, --secret-manager <None|SOPS>                 Whether to use a secret manager. [default: None]
-  -fsu, --flux-source-url                           Flux source URL for reconciling GitOps resources. 
-                                                    [default: oci://ksail-registry:5000/ksail-registry]
-  -v, --validate                                    Validate project files on up. [default: True]
-  -r, --reconcile                                   Reconcile manifests on up. [default: True]
-  -?, -h, --help                                    Show help and usage information
+  -c, --context                              The kubernetes context to use. [default: 
+                                             kind-ksail-default]
+  -k, --kubeconfig                           Path to kubeconfig file. [default: 
+                                             ~/.kube/config]
+  -t, --timeout                              The time to wait for each kustomization to 
+                                             become ready. [default: 5m]
+  -n, --name                                 The name of the cluster. [default: 
+                                             ksail-default]
+  -dc, --distribution-config                 The path to the distribution configuration 
+                                             file. [default: kind.yaml]
+  -kp, --kustomization-path                  The path to the root kustomization directory. 
+                                             [default: k8s]
+  -ce, --container-engine <Docker|Podman>    The container engine in which to provision the 
+                                             cluster. [default: Docker]
+  -d, --distribution <K3d|Kind>              The distribution to use for the cluster. 
+                                             [default: Kind]
+  -dt, --deployment-tool <Flux|Kubectl>      The Deployment tool to use for applying a 
+                                             kustomization. [default: Kubectl]
+  --cni <Cilium|Default|None>                The CNI to use. [default: Default]
+  --csi <Default|LocalPathProvisioner|None>  The CSI to use. [default: Default]
+  -ic, --ingress-controller                  The Ingress Controller to use. [default: 
+  <Default|None|Traefik>                     Default]
+  -gc, --gateway-controller <Default|None>   The Gateway Controller to use. [default: 
+                                             Default]
+  -ms, --metrics-server                      Whether to install Metrics Server. [default: 
+                                             True]
+  -mr, --mirror-registries                   Enable mirror registries for the project. 
+                                             [default: True]
+  -sm, --secret-manager <None|SOPS>          Whether to use a secret manager. [default: None]
+  -fsu, --flux-source-url                    Flux source URL for reconciling GitOps 
+                                             resources. [default: 
+                                             oci://ksail-registry:5000/ksail-registry]
+  -v, --validate                             Validate project files on up. [default: True]
+  -r, --reconcile                            Reconcile manifests on up. [default: True]
+  -?, -h, --help                             Show help and usage information
 ```
 
 ## `ksail update`
@@ -130,12 +140,18 @@ Usage:
   ksail update [options]
 
 Options:
-  -c, --context                          The kubernetes context to use. [default: kind-ksail-default]
-  -k, --kubeconfig                       Path to kubeconfig file. [default: ~/.kube/config]
-  -kp, --kustomization-path              The path to the root kustomization directory. [default: k8s]
-  -dt, --deployment-tool <Flux|Kubectl>  The Deployment tool to use for applying a kustomization. 
-                                         [default: Kubectl]
-  -p, --publish                          Whether to publish manifests on update. [default: True]
+  -c, --context                          The kubernetes context to use. [default: 
+                                         kind-ksail-default]
+  -k, --kubeconfig                       Path to kubeconfig file. [default: 
+                                         ~/.kube/config]
+  -t, --timeout                          The time to wait for each kustomization to become 
+                                         ready. [default: 5m]
+  -kp, --kustomization-path              The path to the root kustomization directory. 
+                                         [default: k8s]
+  -dt, --deployment-tool <Flux|Kubectl>  The Deployment tool to use for applying a 
+                                         kustomization. [default: Kubectl]
+  -p, --publish                          Whether to publish manifests on update. [default: 
+                                         True]
   -v, --validate                         Validate project files on update. [default: True]
   -r, --reconcile                        Reconcile manifests on update. [default: True]
   -?, -h, --help                         Show help and usage information
@@ -151,11 +167,13 @@ Usage:
   ksail start [options]
 
 Options:
-  -c, --context                            The kubernetes context to use. [default: kind-ksail-default]
+  -c, --context                            The kubernetes context to use. [default: 
+                                           kind-ksail-default]
   -n, --name                               The name of the cluster. [default: ksail-default]
-  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the cluster. 
-                                           [default: Docker]
-  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. [default: Kind]
+  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the 
+                                           cluster. [default: Docker]
+  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. 
+                                           [default: Kind]
   -?, -h, --help                           Show help and usage information
 ```
 
@@ -170,9 +188,10 @@ Usage:
 
 Options:
   -n, --name                               The name of the cluster. [default: ksail-default]
-  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the cluster. 
-                                           [default: Docker]
-  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. [default: Kind]
+  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the 
+                                           cluster. [default: Docker]
+  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. 
+                                           [default: Kind]
   -?, -h, --help                           Show help and usage information
 ```
 
@@ -186,13 +205,16 @@ Usage:
   ksail down [options]
 
 Options:
-  -fsu, --flux-source-url                  Flux source URL for reconciling GitOps resources. [default: 
+  -fsu, --flux-source-url                  Flux source URL for reconciling GitOps resources. 
+                                           [default: 
                                            oci://ksail-registry:5000/ksail-registry]
   -n, --name                               The name of the cluster. [default: ksail-default]
-  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. [default: Kind]
-  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the cluster. 
-                                           [default: Docker]
-  -mr, --mirror-registries                 Enable mirror registries for the project. [default: True]
+  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. 
+                                           [default: Kind]
+  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the 
+                                           cluster. [default: Docker]
+  -mr, --mirror-registries                 Enable mirror registries for the project. 
+                                           [default: True]
   -?, -h, --help                           Show help and usage information
 ```
 
@@ -222,10 +244,12 @@ Usage:
   ksail list [options]
 
 Options:
-  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the cluster. 
-                                           [default: Docker]
-  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. [default: Kind]
-  -a, --all                                List clusters from all distributions. [default: False]
+  -ce, --container-engine <Docker|Podman>  The container engine in which to provision the 
+                                           cluster. [default: Docker]
+  -d, --distribution <K3d|Kind>            The distribution to use for the cluster. 
+                                           [default: Kind]
+  -a, --all                                List clusters from all distributions. [default: 
+                                           False]
   -?, -h, --help                           Show help and usage information
 ```
 
@@ -512,7 +536,8 @@ Options:
   -?, -h, --help  Show help and usage information
 
 Commands:
-  cluster-role-binding       Generate a 'rbac.authorization.k8s.io/v1/ClusterRoleBinding' resource.
+  cluster-role-binding       Generate a 'rbac.authorization.k8s.io/v1/ClusterRoleBinding' 
+                             resource.
   cluster-role               Generate a 'rbac.authorization.k8s.io/v1/ClusterRole' resource.
   namespace                  Generate a 'core/v1/Namespace' resource.
   network-policy             Generate a 'networking.k8s.io/v1/NetworkPolicy' resource.

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -35,6 +35,7 @@ sealed class KSailUpdateCommand : Command
   {
     Options.Add(CLIOptions.Connection.ContextOption);
     Options.Add(CLIOptions.Connection.KubeconfigOption);
+    Options.Add(CLIOptions.Connection.TimeoutOption);
     Options.Add(CLIOptions.Project.KustomizationPathOption);
     Options.Add(CLIOptions.Project.DeploymentToolOption);
     Options.Add(CLIOptions.Publication.PublishOnUpdateOption);

--- a/tests/KSail.Docs.Tests.Unit/CLIOptionsGeneratorTests.cs
+++ b/tests/KSail.Docs.Tests.Unit/CLIOptionsGeneratorTests.cs
@@ -17,24 +17,10 @@ public partial class CLIOptionsGeneratorTests
   {
     // Arrange & Act
     string expectedMarkdown = await CLIOptionsGenerator.GenerateAsync();
-    expectedMarkdown = expectedMarkdown
-      .Replace("testhost", "ksail", StringComparison.Ordinal)
-      .Replace("\\", "/", StringComparison.Ordinal);
-    string actualMarkdown = await File.ReadAllTextAsync("../../../../../../docs/configuration/cli-options.md");
+    expectedMarkdown = expectedMarkdown.Replace("testhost", "ksail", StringComparison.Ordinal);
 
     // Assert
     _ = await Verify(expectedMarkdown.ToString(), extension: "md").UseFileName("cli-options");
-    Assert.Equal(
-      ReplaceWhitespace(Normalize(expectedMarkdown), ""),
-      ReplaceWhitespace(Normalize(actualMarkdown), "")
-    );
   }
-
-  static readonly Regex _sWhitespace = WhiteSpaceRegex();
-  public static string ReplaceWhitespace(string input, string replacement) => _sWhitespace.Replace(input, replacement);
-
-  static string Normalize(string s) => s.Replace("\r", "", StringComparison.Ordinal).Replace("\n", "", StringComparison.Ordinal);
-  [GeneratedRegex(@"\s+")]
-  private static partial Regex WhiteSpaceRegex();
 }
 

--- a/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
+++ b/tests/KSail.Docs.Tests.Unit/cli-options.verified.md
@@ -114,6 +114,7 @@ Usage:
 Options:
   -c, --context                          The kubernetes context to use. [default: kind-ksail-default]
   -k, --kubeconfig                       Path to kubeconfig file. [default: ~/.kube/config]
+  -t, --timeout                          The time to wait for each kustomization to become ready. [default: 5m]
   -kp, --kustomization-path              The path to the root kustomization directory. [default: k8s]
   -dt, --deployment-tool <Flux|Kubectl>  The Deployment tool to use for applying a kustomization. [default: Kubectl]
   -p, --publish                          Whether to publish manifests on update. [default: True]

--- a/tests/KSail.Tests.Unit/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests.Unit/Commands/Update/KSailUpdateCommandTests.KSailUpdateHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -7,6 +7,7 @@ Usage:
 Options:
   -c, --context                          The kubernetes context to use. [default: kind-ksail-default]
   -k, --kubeconfig                       Path to kubeconfig file. [default: {UserProfile}/.kube/config]
+  -t, --timeout                          The time to wait for each kustomization to become ready. [default: 5m]
   -kp, --kustomization-path              The path to the root kustomization directory. [default: k8s]
   -dt, --deployment-tool <Flux|Kubectl>  The Deployment tool to use for applying a kustomization. [default: Kubectl]
   -p, --publish                          Whether to publish manifests on update. [default: True]


### PR DESCRIPTION
Introduce a timeout option for the update command to specify the wait time for each kustomization to become ready, along with corresponding documentation updates.