### PR TITLE
Potential fix for code scanning alert no. 68: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-pages.yaml
+++ b/.github/workflows/test-pages.yaml
@@ -1,4 +1,6 @@
 name: Test - Pages
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/68](https://github.com/devantler-tech/ksail/security/code-scanning/68)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and builds with Jekyll, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
