### PR TITLE
Potential fix for code scanning alert no. 67: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/67](https://github.com/devantler-tech/ksail/security/code-scanning/67)

To fix the problem, add a `permissions` block to the workflow or the specific job(s) to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since most steps that require write access use custom tokens, the minimal permission required for the default `GITHUB_TOKEN` is likely `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `publish-binaries` job). The best practice is to set it at the workflow level unless there are jobs with different requirements. Add the following at the top level of the workflow, just after the `name` field and before `on:`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
