### PR TITLE
chore: update dependabot.yaml to simplify configurations

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,6 +3,8 @@ updates:
   # Go modules (main application)
   - package-ecosystem: gomod
     directory: /
+    schedule:
+      interval: daily
     # Wait for releases to stabilize before updating
     cooldown:
       default-days: 7
@@ -20,10 +22,14 @@ updates:
   # Note: cooldown not supported for github-actions ecosystem
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: daily
 
   # npm (documentation site)
   - package-ecosystem: npm
     directory: /docs
+    schedule:
+      interval: daily
     # Wait for releases to stabilize before updating
     cooldown:
       default-days: 7
@@ -37,9 +43,15 @@ updates:
   # Note: cooldown not supported for docker ecosystem
   - package-ecosystem: docker
     directory: / # Dockerfile (build image)
+    schedule:
+      interval: daily
 
   - package-ecosystem: docker
     directory: /.github/fixtures/reconcile-test # Kubernetes deployment manifest
+    schedule:
+      interval: daily
 
   - package-ecosystem: docker
     directory: /pkg/io/config-manager/talos # Talos image (embedded in Go via go:embed)
+    schedule:
+      interval: daily


### PR DESCRIPTION
Removed schedule and open-pull-requests-limit for various package ecosystems in dependabot configuration.

## Type of change

Select the appropriate options and delete the rest:

- [x] 🧹 Refactor
- [ ] 🪲 Bug fix
- [ ] 🚀 New feature
- [ ] ⛓️‍💥 Breaking change
- [ ] 📚 Documentation update
