### PR TITLE
fix: increase cluster readiness and system test timeouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,6 +331,7 @@ jobs:
   system-test:
     name: 🧪 System Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [changes, build-artifact, warm-mirror-cache]
     if: github.event_name == 'merge_group' && needs.changes.outputs.code == 'true'
     permissions:

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -50,8 +50,8 @@ const (
 	// kubeconfigFileMode is the file mode for kubeconfig files.
 	kubeconfigFileMode = 0o600
 	// clusterReadinessTimeout is the timeout for waiting for the cluster to become ready.
-	// This matches the upstream talosctl default of 10 minutes.
-	clusterReadinessTimeout = 10 * time.Minute
+	// This matches the upstream talosctl default of 20 minutes.
+	clusterReadinessTimeout = 20 * time.Minute
 	// talosAPIWaitTimeout is the timeout for waiting for Talos API to be reachable.
 	talosAPIWaitTimeout = 5 * time.Minute
 	// bootstrapTimeout is the timeout for bootstrap operations.


### PR DESCRIPTION
Increase the cluster readiness timeout to 20 minutes and set the system test timeout to 30 minutes to ensure adequate time for operations to complete.

## Type of change

- [ ] 🧹 Refactor
- [x] 🪲 Bug fix
- [ ] 🚀 New feature
- [ ] ⛓️‍💥 Breaking change
- [ ] 📚 Documentation update

