### PR TITLE
fix: improve Helm installation stability with retry and caching

### DIFF
--- a/.github/actions/cache-helm-charts/action.yaml
+++ b/.github/actions/cache-helm-charts/action.yaml
@@ -1,0 +1,24 @@
+name: Cache Helm Charts
+description: |
+  Caches the Helm repository index and chart data to reduce external HTTP
+  requests during CI, mitigating 429 rate-limit errors when many parallel
+  system test jobs hit the same chart registries.
+
+outputs:
+  cache-hit:
+    description: Whether the cache was found and restored
+    value: ${{ steps.restore-cache.outputs.cache-hit || 'false' }}
+
+runs:
+  using: composite
+  steps:
+    - name: 📥 Restore Helm chart cache
+      id: restore-cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: |
+          ~/.cache/helm/repository
+          ~/.config/helm/registry
+        key: helm-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod') }}
+        restore-keys: |
+          helm-cache-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -143,6 +143,9 @@ runs:
           echo "✅ All 4 mirror cache volumes present"
         fi
 
+    - name: 📥 Restore Helm chart cache
+      uses: ./.github/actions/cache-helm-charts
+
     - name: 📥 Pre-pull registry image
       if: inputs.provider == 'Docker'
       shell: bash

--- a/pkg/client/helm/repository.go
+++ b/pkg/client/helm/repository.go
@@ -19,10 +19,11 @@ const (
 	repoFileMode = 0o640
 
 	// Retry configuration for repository index downloads.
-	// External Helm repositories may experience transient 5xx errors.
-	repoIndexMaxRetries    = 3
-	repoIndexRetryBaseWait = 2 * time.Second
-	repoIndexRetryMaxWait  = 15 * time.Second
+	// External Helm repositories may experience transient 429/5xx errors,
+	// especially in CI with many parallel jobs hitting the same chart servers.
+	repoIndexMaxRetries    = 5
+	repoIndexRetryBaseWait = 3 * time.Second
+	repoIndexRetryMaxWait  = 30 * time.Second
 )
 
 var (

--- a/pkg/client/netretry/netretry_test.go
+++ b/pkg/client/netretry/netretry_test.go
@@ -42,6 +42,15 @@ var (
 	errNoSuchHost    = errors.New(
 		"dial tcp: lookup charts.example.com: no such host",
 	)
+	errRateLimit429 = errors.New(
+		"failed to fetch index: 429",
+	)
+	errTooManyRequests = errors.New(
+		"response: Too Many Requests - rate limit exceeded",
+	)
+	errContextDeadline = errors.New(
+		"context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+	)
 )
 
 func TestIsRetryable(t *testing.T) {
@@ -76,6 +85,11 @@ func TestIsRetryable(t *testing.T) {
 		{name: "TLS handshake timeout", err: errTLSTimeout, expected: true},
 		{name: "unexpected EOF", err: errUnexpectedEOF, expected: true},
 		{name: "no such host", err: errNoSuchHost, expected: true},
+		// HTTP 429 rate-limit errors.
+		{name: "429 code", err: errRateLimit429, expected: true},
+		{name: "429 text", err: errTooManyRequests, expected: true},
+		// Context deadline exceeded.
+		{name: "context deadline exceeded", err: errContextDeadline, expected: true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -240,6 +240,26 @@ func (d *ComponentDetector) detectLoadBalancer(
 		}
 	}
 
+	// Talos: check for MetalLB Helm release (used by Talos × Docker;
+	// Talos × Hetzner also resolves correctly via ProvidesLoadBalancerByDefault).
+	if distribution == v1alpha1.DistributionTalos {
+		return d.detectMetalLB(ctx)
+	}
+
+	return v1alpha1.LoadBalancerDefault, nil
+}
+
+// detectMetalLB checks for a MetalLB Helm release.
+func (d *ComponentDetector) detectMetalLB(ctx context.Context) (v1alpha1.LoadBalancer, error) {
+	exists, err := d.helmClient.ReleaseExists(ctx, ReleaseMetalLB, NamespaceMetalLB)
+	if err != nil {
+		return v1alpha1.LoadBalancerDefault, fmt.Errorf("check metallb release: %w", err)
+	}
+
+	if exists {
+		return v1alpha1.LoadBalancerEnabled, nil
+	}
+
 	return v1alpha1.LoadBalancerDefault, nil
 }
 

--- a/pkg/svc/detector/releases.go
+++ b/pkg/svc/detector/releases.go
@@ -50,6 +50,11 @@ const (
 	// NamespaceLocalPathStorage is the namespace where local-path-provisioner is installed.
 	NamespaceLocalPathStorage = "local-path-storage"
 
+	// ReleaseMetalLB is the Helm release name for MetalLB.
+	ReleaseMetalLB = "metallb"
+	// NamespaceMetalLB is the namespace where MetalLB is installed.
+	NamespaceMetalLB = "metallb-system"
+
 	// ContainerCloudProviderKind is the Docker container name for cloud-provider-kind.
 	ContainerCloudProviderKind = "ksail-cloud-provider-kind"
 

--- a/pkg/svc/installer/argocd/installer.go
+++ b/pkg/svc/installer/argocd/installer.go
@@ -81,18 +81,14 @@ func (a *Installer) helmInstallOrUpgrade(ctx context.Context) error {
 	// Set context deadline longer than Helm timeout to ensure Helm has
 	// sufficient time to complete its kstatus-based wait operation.
 	// Add 5 minutes buffer to the Helm timeout.
-	//
-	// Note: This installer calls client.InstallOrUpgradeChart directly (not the
-	// helm.InstallOrUpgradeChart helper) because OCI charts don't require repository
-	// registration. Therefore, we must apply the context timeout buffer here.
 	contextTimeout := a.timeout + helm.ContextTimeoutBuffer
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, contextTimeout)
 	defer cancel()
 
-	_, err := a.client.InstallOrUpgradeChart(timeoutCtx, spec)
+	err := helm.InstallChartWithRetry(timeoutCtx, a.client, spec, "argocd")
 	if err != nil {
-		return fmt.Errorf("failed to install Argo CD chart: %w", err)
+		return fmt.Errorf("installing argocd chart: %w", err)
 	}
 
 	return nil

--- a/pkg/svc/installer/flux/installer.go
+++ b/pkg/svc/installer/flux/installer.go
@@ -81,18 +81,14 @@ func (b *Installer) helmInstallOrUpgrade(ctx context.Context) error {
 	// Set context deadline longer than Helm timeout to ensure Helm has
 	// sufficient time to complete its kstatus-based wait operation.
 	// Add 5 minutes buffer to the Helm timeout.
-	//
-	// Note: This installer calls client.InstallOrUpgradeChart directly (not the
-	// helm.InstallOrUpgradeChart helper) because OCI charts don't require repository
-	// registration. Therefore, we must apply the context timeout buffer here.
 	contextTimeout := b.timeout + helm.ContextTimeoutBuffer
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, contextTimeout)
 	defer cancel()
 
-	_, err := b.client.InstallOrUpgradeChart(timeoutCtx, spec)
+	err := helm.InstallChartWithRetry(timeoutCtx, b.client, spec, "flux-operator")
 	if err != nil {
-		return fmt.Errorf("failed to install flux operator chart: %w", err)
+		return fmt.Errorf("installing flux operator chart: %w", err)
 	}
 
 	return nil

--- a/pkg/svc/installer/internal/helmutil/base.go
+++ b/pkg/svc/installer/internal/helmutil/base.go
@@ -55,9 +55,9 @@ func (b *Base) Install(ctx context.Context) error {
 	installCtx, cancel := context.WithTimeout(ctx, b.timeout+helm.ContextTimeoutBuffer)
 	defer cancel()
 
-	_, err = b.client.InstallOrUpgradeChart(installCtx, b.spec)
+	err = helm.InstallChartWithRetry(installCtx, b.client, b.spec, b.name)
 	if err != nil {
-		return fmt.Errorf("failed to install %s chart: %w", b.name, err)
+		return fmt.Errorf("installing %s chart: %w", b.name, err)
 	}
 
 	return nil


### PR DESCRIPTION
Helm installations in CI fail intermittently due to HTTP 429 rate limits and transient 5xx errors when 40 parallel system test jobs hit the same chart registries (~400-600 HTTP requests per CI run). Most installers lacked retry logic entirely, and rate-limit responses were not recognized as retryable.

This PR:
- Adds HTTP 429 (Too Many Requests) and `context deadline exceeded` to retryable error patterns in `netretry.IsRetryable()`
- Exports `InstallChartWithRetry` so all Helm-based installers can use it (previously only Calico/Cilium had retry logic)
- Uses `InstallChartWithRetry` in `helmutil.Base` (7 installers), Flux, and ArgoCD
- Increases chart install and repo index max retries from 3 to 5, and raises backoff timing (base 2s→3s, max 15s→30s)
- Adds `cache-helm-charts` CI action to cache Helm repository index/registry data across parallel jobs
- Detects MetalLB Helm release for Talos load-balancer component detection

## Type of change

- [x] 🪲 Bug fix