### PR TITLE
[docs] sync copilot instructions with Flux distribution images parser

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -167,7 +167,7 @@ go run main.go --help
 │       │   └── gitops/     # Detects existing GitOps CRs (FluxInstance, ArgoCD Application) in source dir
 │       ├── diff/           # Computes ClusterSpec config diffs and classifies update impact
 │       ├── image/          # Container image export/import services
-│       │   └── parser/     # Parses image references from Dockerfiles and manifests
+│       │   └── parser/     # Parses image references from Dockerfiles
 │       ├── installer/      # Component installers (CNI, CSI, metrics-server, etc.)
 │       ├── mcp/            # Model Context Protocol server
 │       ├── provider/       # Infrastructure providers (docker, hetzner, omni)


### PR DESCRIPTION
- Add pkg/svc/image/parser/ sub-package to project tree (parses image references from Dockerfiles and manifests)
- Expand pkg/svc/image/ description to mention ParseAllImagesFromDockerfile and its role in mirror cache warming
- Expand pkg/svc/installer/ description to document Dockerfile.distribution convention for tracking Flux distribution controller images

Follows feat: include Flux distribution controller images in mirror cache warming (#3014)

Please include a summary of the changes. **What** has changed and **why**?.

Fixes [url OR #issue]

## Type of change

Select the appropriate options and delete the rest:

- [ ] 🧹 Refactor
- [ ] 🪲 Bug fix
- [ ] 🚀 New feature
- [ ] ⛓️‍💥 Breaking change
- [ ] 📚 Documentation update
