### PR TITLE
[docs] docs: add workload reconcile to copilot-instructions CLI reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -213,6 +213,7 @@ ksail cluster switch <cluster-name>    # Switch active kubeconfig context
 ksail cluster backup                   # Backup cluster resources to .tar.gz
 ksail cluster restore                  # Restore cluster resources from .tar.gz
 ksail workload apply                   # Apply workloads
+ksail workload reconcile               # Trigger reconciliation for GitOps workloads
 ksail workload gen <resource>          # Generate resources
 ksail workload watch [--path <dir>]    # Watch a directory (defaults to k8s/ or spec.workload.sourceDirectory) and auto-apply on change
 ksail cipher <command>                 # Manage secrets with SOPS


### PR DESCRIPTION
The `ksail workload reconcile` command exists in the codebase (pkg/cli/cmd/workload/reconcile.go) but was missing from the CLI Commands Reference in copilot-instructions.md.

Fixes https://github.com/devantler-tech/ksail/issues/3044