### PR TITLE
chore(ci): Standardize runner environment to ubuntu-latest in CI and CD workflows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   goreleaser:
     name: Release with GoReleaser
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
 
   build-artifact:
     name: 🏗️ Build KSail Binary
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     needs: [changes]
     if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.outputs.code == 'true' || needs.changes.outputs.cli == 'true')
     permissions:
@@ -196,7 +196,7 @@ jobs:
 
   generate-docs:
     name: 📚 Generate Reference Docs
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     needs: [changes]
     if: github.event_name != 'merge_group' && needs.changes.outputs.cli == 'true'
     permissions:


### PR DESCRIPTION
Standardize the runner environment to `ubuntu-latest` across all CI and CD workflows for consistency and improved compatibility. 

