### PR TITLE
feat(vsce): add AI category and mcp-server keyword for @mcp discoverability

### DIFF
--- a/vsce/package.json
+++ b/vsce/package.json
@@ -18,7 +18,7 @@
     "vscode": "^1.110.0"
   },
   "categories": [
-    "AI",
+    "Machine Learning",
     "Other"
   ],
   "keywords": [


### PR DESCRIPTION
## Summary

Ensure the KSail VS Code extension appears when users filter by `@mcp` in the Extensions view.

## Changes

**`vsce/package.json`:**
- Add `"AI"` to `categories` (was only `["Other"]`) — aligns with marketplace expectations for AI/MCP extensions
- Add `"mcp-server"` to `keywords` — improves gallery indexing alongside existing `"mcp"` keyword

## Context

The extension already contributes `mcpServerDefinitionProviders` (the technical contribution point for MCP server definitions). These metadata changes ensure the extension is properly indexed in the VS Code Marketplace for MCP-related searches and the `@mcp` gallery filter.