### PR TITLE
feat(ci): extend ksail-cluster action with GitOps CI support for end-users

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -232,7 +232,14 @@ runs:
       shell: bash
       env:
         SOPS_AGE_KEY: ${{ inputs.sops-age-key }}
-      run: ksail cipher import "$SOPS_AGE_KEY"
+      run: |
+        # Extract the AGE-SECRET-KEY line from the input (supports both bare keys and key files with comments)
+        AGE_KEY=$(echo "$SOPS_AGE_KEY" | grep -oE 'AGE-SECRET-KEY-[A-Za-z0-9]+' | head -1)
+        if [ -z "$AGE_KEY" ]; then
+          echo "❌ No valid AGE-SECRET-KEY found in sops-age-key input"
+          exit 1
+        fi
+        ksail cipher import "$AGE_KEY"
 
     - name: 🏗️ Initialize Project
       if: inputs.init == 'true'
@@ -292,9 +299,10 @@ runs:
       env:
         SOPS_AGE_KEY: ${{ inputs.sops-age-key }}
       run: |
+        AGE_KEY=$(echo "$SOPS_AGE_KEY" | grep -oE 'AGE-SECRET-KEY-[A-Za-z0-9]+' | head -1)
         kubectl create secret generic sops-age \
           --namespace=flux-system \
-          --from-literal=sops.agekey="$SOPS_AGE_KEY"
+          --from-literal=sops.agekey="$AGE_KEY"
 
     - name: 📦 Push manifests
       if: inputs.push == 'true'


### PR DESCRIPTION
## Summary

Extends the `ksail-cluster` composite action with 6 new optional inputs and 7 new steps to support end-user GitOps CI workflows (e.g., the platform repo), in addition to KSail's own system tests.

## New Inputs

All inputs default to empty/`"false"` for **full backward compatibility** — existing callers like `ksail-system-test` are unaffected.

| Input | Default | Description |
|---|---|---|
| `sops-age-key` | `""` | SOPS Age private key — imports key and creates K8s secret |
| `hosts-file` | `""` | Path to hosts file to append to `/etc/hosts` |
| `root-ca-cert-file` | `""` | Root CA cert to install as trusted |
| `push` | `"false"` | Push manifests after cluster creation |
| `reconcile` | `"false"` | Reconcile workloads after push |
| `delete` | `"false"` | Delete cluster at the end (runs even on failure) |

## New Steps

Inserted in the correct order within the existing step flow:

1. **🌐 Add hosts** — before cluster init/create
2. **🔐 Install root CA** — before cluster init/create
3. **🔑 Import SOPS Age key** — before cluster init/create (KSail reads Age keys during creation)
4. **🔐 Create SOPS Age K8s secret** — after cluster create (needs running cluster)
5. **📦 Push manifests** — after cluster create
6. **🔁 Reconcile workloads** — after push
7. **🔥 Delete cluster** — at the very end with `if: always()`

## Motivation

The `ci-gitops-test.yaml` reusable workflow currently reimplements cluster setup, SOPS handling, push/reconcile, and delete as individual steps. By moving these into `ksail-cluster`, the reusable workflow becomes a thin wrapper, and the action becomes a complete GitOps CI solution for any repo using KSail.