### PR TITLE
ci(goreleaser): use PR mode for homebrew-tap cask updates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,6 +39,9 @@ homebrew_casks:
       owner: devantler-tech
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_GITHUB_API_TOKEN }}"
+      branch: "goreleaser/{{ .ProjectName }}-{{ .Tag }}"
+      pull_request:
+        enabled: true
     hooks:
       post:
         install: |


### PR DESCRIPTION
## Problem

The CD workflow fails when GoReleaser tries to push `Casks/ksail.rb` directly to `devantler-tech/homebrew-tap` main branch via the GitHub Contents API:

```
homebrew cask: could not update "Casks/ksail.rb": PUT https://api.github.com/repos/devantler-tech/homebrew-tap/contents/Casks/ksail.rb: 409 Repository rule violations found
Required workflows 'CI - Auto-merge, CI - Auto-merge, Zizmor, Zizmor' are not satisfied
```

Org-level required workflow rulesets block direct commits to protected branches.

## Solution

Configure GoReleaser to use **pull request mode** instead of direct push:
- Push the cask file to a feature branch (`goreleaser/ksail-v<version>`)
- Open a PR from that branch to main
- Required workflows (Zizmor, CI - Auto-merge) run on the PR
- Auto-merge handles merging once checks pass

## Changes

- Added `branch` and `pull_request.enabled: true` to `homebrew_casks[0].repository` in `.goreleaser.yaml`