### PR TITLE
fix(ci): add environment declarations to resolve secrets-outside-env warnings

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,6 +22,7 @@ jobs:
   goreleaser:
     name: Release with GoReleaser
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -77,6 +78,7 @@ jobs:
   vscode-extension:
     name: 🧩 Release VSCode Extension
     runs-on: ubuntu-latest
+    environment: release
     needs: [goreleaser]
     permissions:
       contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,6 +237,7 @@ jobs:
   auto-commit:
     name: 📤 Auto-Commit Generated Changes
     runs-on: ubuntu-latest
+    environment: ci
     needs: [changes, sync-modules, generate-schema, generate-docs]
     if: >-
       always()
@@ -315,6 +316,7 @@ jobs:
   coverage:
     name: 📊 Code Coverage
     runs-on: ubuntu-latest
+    environment: ci
     needs: [changes]
     # Only run on push to main, skip if no code files changed
     if: |
@@ -349,6 +351,7 @@ jobs:
   audit-docs:
     name: 🔍 Audit Docs Dependencies
     runs-on: ubuntu-latest
+    environment: ci
     needs: [changes]
     if: github.event_name != 'merge_group' && needs.changes.outputs.docs-deps == 'true'
     permissions:
@@ -370,6 +373,7 @@ jobs:
   audit-vsce:
     name: 🔍 Audit VSCode Extension Dependencies
     runs-on: ubuntu-latest
+    environment: ci
     needs: [changes]
     if: github.event_name != 'merge_group' && needs.changes.outputs.vsce-deps == 'true'
     permissions:
@@ -501,6 +505,7 @@ jobs:
   system-test:
     name: 🧪 System Test
     runs-on: ubuntu-latest
+    environment: ci
     timeout-minutes: 30
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
     if: github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true'
@@ -575,6 +580,7 @@ jobs:
   cleanup-hetzner:
     name: 🧹 Cleanup Hetzner Resources
     runs-on: ubuntu-latest
+    environment: ci
     needs: [system-test]
     if: ${{ always() && github.event_name == 'merge_group' && needs.system-test.result != 'skipped' }}
     permissions:


### PR DESCRIPTION
## Summary

Adds `environment:` declarations to CI/CD workflow jobs that reference non-`GITHUB_TOKEN` secrets, resolving [zizmor `secrets-outside-env`](https://docs.zizmor.sh/audits/#secrets-outside-env) audit findings.

## Changes

### CI jobs → `environment: ci`
| Job | Secrets |
|---|---|
| `auto-commit` | `APP_PRIVATE_KEY` |
| `coverage` | `CODECOV_TOKEN` |
| `audit-docs` | `APP_PRIVATE_KEY` |
| `audit-vsce` | `APP_PRIVATE_KEY` |
| `system-test` | `DOCKERHUB_TOKEN`, `HCLOUD_TOKEN` |
| `cleanup-hetzner` | `HCLOUD_TOKEN` |

### CD jobs → `environment: release`
| Job | Secrets |
|---|---|
| `goreleaser` | `DOCKERHUB_TOKEN`, `HOMEBREW_GITHUB_API_TOKEN`, `GPG_PRIVATE_KEY` |
| `vscode-extension` | `VSCE_PAT` |

## Required Setup

Two GitHub Environments need to be created in the repository settings and their secrets configured:

1. **`ci`** — with secrets: `APP_PRIVATE_KEY`, `CODECOV_TOKEN`, `DOCKERHUB_TOKEN`, `HCLOUD_TOKEN`
2. **`release`** — with secrets: `DOCKERHUB_TOKEN`, `HOMEBREW_GITHUB_API_TOKEN`, `GPG_PRIVATE_KEY`, `VSCE_PAT`

> **Note**: `secrets.GITHUB_TOKEN` is automatically available in all environments and does not need to be configured.