### PR TITLE
chore: remove GitHub environments

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,7 +22,6 @@ jobs:
   goreleaser:
     name: Release with GoReleaser
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
       packages: write
@@ -78,7 +77,6 @@ jobs:
   vscode-extension:
     name: 🧩 Release VSCode Extension
     runs-on: ubuntu-latest
-    environment: release
     needs: [goreleaser]
     permissions:
       contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,7 +237,6 @@ jobs:
   auto-commit:
     name: 📤 Auto-Commit Generated Changes
     runs-on: ubuntu-latest
-    environment: ci
     needs: [changes, sync-modules, generate-schema, generate-docs]
     if: >-
       always()
@@ -316,7 +315,6 @@ jobs:
   coverage:
     name: 📊 Code Coverage
     runs-on: ubuntu-latest
-    environment: ci
     needs: [changes]
     # Only run on push to main, skip if no code files changed
     if: |
@@ -351,7 +349,6 @@ jobs:
   audit-docs:
     name: 🔍 Audit Docs Dependencies
     runs-on: ubuntu-latest
-    environment: ci
     needs: [changes]
     if: github.event_name != 'merge_group' && needs.changes.outputs.docs-deps == 'true'
     permissions:
@@ -373,7 +370,6 @@ jobs:
   audit-vsce:
     name: 🔍 Audit VSCode Extension Dependencies
     runs-on: ubuntu-latest
-    environment: ci
     needs: [changes]
     if: github.event_name != 'merge_group' && needs.changes.outputs.vsce-deps == 'true'
     permissions:
@@ -505,7 +501,6 @@ jobs:
   system-test:
     name: 🧪 System Test
     runs-on: ubuntu-latest
-    environment: ci
     timeout-minutes: 30
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
     if: github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true'
@@ -580,7 +575,6 @@ jobs:
   cleanup-hetzner:
     name: 🧹 Cleanup Hetzner Resources
     runs-on: ubuntu-latest
-    environment: ci
     needs: [system-test]
     if: ${{ always() && github.event_name == 'merge_group' && needs.system-test.result != 'skipped' }}
     permissions:

--- a/.github/workflows/publish-pages.yaml
+++ b/.github/workflows/publish-pages.yaml
@@ -49,9 +49,6 @@ jobs:
           path: docs/dist
 
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

Removes all GitHub environment declarations from CI/CD workflows and deletes the environments from the repository. KSail does not deploy to running environments from this repo, so these deployment environments are unnecessary.

## Changes

- **ci.yaml**: Removed `environment: ci` from 6 jobs (auto-commit, coverage, audit-docs, audit-vsce, system-test, cleanup-hetzner)
- **cd.yaml**: Removed `environment: release` from 2 jobs (goreleaser, vscode-extension)
- **publish-pages.yaml**: Removed `environment: { name: github-pages, url: ... }` block from deploy job
- **GitHub API**: Deleted all 4 environments (ci, copilot, github-pages, release) from the repository