### PR TITLE
fix(ci): anchor grep pattern in mcp-publisher checksum verification

### DIFF
--- a/.github/workflows/publish-mcp.yaml
+++ b/.github/workflows/publish-mcp.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/mcp-publisher_linux_amd64.tar.gz"
           curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/registry_1.5.0_checksums.txt"
-          grep "mcp-publisher_linux_amd64.tar.gz" registry_1.5.0_checksums.txt | sha256sum --check
+          grep "mcp-publisher_linux_amd64.tar.gz$" registry_1.5.0_checksums.txt | sha256sum --check
           tar -xzf mcp-publisher_linux_amd64.tar.gz mcp-publisher
           rm mcp-publisher_linux_amd64.tar.gz registry_1.5.0_checksums.txt
 


### PR DESCRIPTION
## Summary

The `grep` pattern in the "Install mcp-publisher" step of `publish-mcp.yaml` matched both the tarball and the `.sbom.json` entry in the checksums file, causing `sha256sum --check` to fail on the non-existent SBOM file.

## Changes

Added a `$` anchor to the grep pattern so it only matches the exact tarball filename at end of line:

```diff
- grep "mcp-publisher_linux_amd64.tar.gz" registry_1.5.0_checksums.txt | sha256sum --check
+ grep "mcp-publisher_linux_amd64.tar.gz$" registry_1.5.0_checksums.txt | sha256sum --check
```

## Root Cause

The checksums file contains entries for both `mcp-publisher_linux_amd64.tar.gz` and `mcp-publisher_linux_amd64.tar.gz.sbom.json`. The unanchored grep matched both lines, but only the tarball was downloaded.