### PR TITLE
fix(ci): filter sub-microsecond benchmarks from regression gate

### DIFF
--- a/.github/workflows/benchmark-regression.yaml
+++ b/.github/workflows/benchmark-regression.yaml
@@ -99,21 +99,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Remove benchmark lines with ns/op < 100 to avoid false positives
-          # from CPU clock jitter on shared CI runners (see #3698).
+          # Create a filtered copy excluding benchmark lines with ns/op < 100
+          # to avoid false positives from CPU clock jitter on shared CI runners
+          # (see #3698). The original bench.txt is preserved for artifact upload
+          # and historical storage.
           awk '/^Benchmark/ && /ns\/op/ {
             for (i = 1; i <= NF; i++) {
               if ($(i+1) == "ns/op" && $i + 0 < 100) next
             }
           } {print}' "$RUNNER_TEMP/bench.txt" > "$RUNNER_TEMP/bench-filtered.txt"
-          mv "$RUNNER_TEMP/bench-filtered.txt" "$RUNNER_TEMP/bench.txt"
 
       - name: 📊 Compare benchmark results
         if: steps.discover.outputs.skip == 'false'
         uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           tool: go
-          output-file-path: ${{ runner.temp }}/bench.txt
+          output-file-path: ${{ runner.temp }}/bench-filtered.txt
           gh-pages-branch: benchmark-data
           benchmark-data-dir-path: dev/bench
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add an `awk` filtering step in the Benchmark Regression workflow that removes benchmark result lines with `ns/op < 100` before feeding output to the comparison action. This prevents false positives from CPU clock jitter on shared CI runners for trivial benchmarks like struct initialization (~2-8 ns/op).

Benchmarks below the threshold still run and appear in CI logs but are excluded from the regression comparison.

Fixes #3698

## Changes

- `.github/workflows/benchmark-regression.yaml`: Added "🔍 Filter sub-microsecond benchmarks" step between "Run benchmarks" and "Compare benchmark results"

## Why 100 ns/op?

Operations below ~100 ns/op are dominated by measurement overhead (timer resolution, branch predictor state, CPU cache effects, runner load) rather than the benchmark code itself. The threshold is consistent with the investigation protocol referenced in #3698.