### PR TITLE
ci: add rate-limit gate to prevent cascade failures from API exhaustion

### DIFF
--- a/.github/actions/rate-limit-gate/action.yaml
+++ b/.github/actions/rate-limit-gate/action.yaml
@@ -31,8 +31,7 @@ runs:
         elapsed=0
 
         while true; do
-          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
-            https://api.github.com/rate_limit | jq '.resources.core.remaining')
+          remaining=$(gh api /rate_limit --jq '.resources.core.remaining')
 
           if [ "$remaining" -ge "$MIN_REMAINING" ]; then
             echo "✅ GitHub API rate limit OK — $remaining remaining (minimum: $MIN_REMAINING)"
@@ -40,15 +39,21 @@ runs:
           fi
 
           if [ "$elapsed" -ge "$MAX_WAIT" ]; then
-            reset_at=$(curl -sf -H "Authorization: token $GH_TOKEN" \
-              https://api.github.com/rate_limit | jq -r '.resources.core.reset | todate')
+            reset_at=$(gh api /rate_limit --jq '.resources.core.reset | todate')
             echo "::error::GitHub API rate limit exhausted ($remaining remaining, need $MIN_REMAINING). Waited ${elapsed}s (max ${MAX_WAIT}s). Resets at $reset_at."
             exit 1
           fi
 
-          echo "⏳ Rate limit low ($remaining remaining, need $MIN_REMAINING) — retrying in ${interval}s (elapsed: ${elapsed}s / ${MAX_WAIT}s)"
-          sleep "$interval"
-          elapsed=$((elapsed + interval))
+          # Cap sleep to remaining budget so we don't overshoot MAX_WAIT
+          budget=$((MAX_WAIT - elapsed))
+          sleep_time=$interval
+          if [ "$sleep_time" -gt "$budget" ]; then
+            sleep_time=$budget
+          fi
+
+          echo "⏳ Rate limit low ($remaining remaining, need $MIN_REMAINING) — retrying in ${sleep_time}s (elapsed: ${elapsed}s / ${MAX_WAIT}s)"
+          sleep "$sleep_time"
+          elapsed=$((elapsed + sleep_time))
           interval=$((interval * 2))
           if [ "$interval" -gt "$max_interval" ]; then
             interval=$max_interval

--- a/.github/workflows/benchmark-regression.yaml
+++ b/.github/workflows/benchmark-regression.yaml
@@ -20,6 +20,8 @@ jobs:
   rate-limit-gate:
     name: ⏳ Rate Limit Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
   rate-limit-gate:
     name: ⏳ Rate Limit Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Adds a rate-limit gate job to CI workflows that blocks pipeline execution until sufficient GitHub API quota is available, preventing cascade failures from `dorny/paths-filter` API rate-limit exhaustion.

## Changes

### New: `.github/actions/rate-limit-gate/action.yaml`
Reusable composite action that:
- Checks `core.remaining` via the `/rate_limit` endpoint (free — doesn't count against quota)
- Proceeds immediately if ≥ 100 remaining
- Waits with exponential backoff (30s → 60s → 120s → 240s → 300s cap) if exhausted
- Times out after 30 minutes with a clear error message

### Modified: `.github/workflows/ci.yaml`
- Added `rate-limit-gate` as the first job
- `changes` job now depends on `rate-limit-gate` (transitively gates all downstream jobs)
- `status` job includes `rate-limit-gate` in `needs` and `job-results`

### Modified: `.github/workflows/benchmark-regression.yaml`
- Same pattern: `rate-limit-gate` job added, `changes` depends on it

## Context

See [Run #9424](https://github.com/devantler-tech/ksail/actions/runs/24006707028) — the `dorny/paths-filter` action failed with `API rate limit exceeded`, cascading to skip all downstream jobs and failing the summary.

Fixes #3703