### PR TITLE
fix: retry cloud provider cluster creation with exponential backoff

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -344,7 +344,9 @@ runs:
             if [ "$INIT" = "true" ]; then
               ksail ${CONFIG:+--config "$CONFIG"} cluster delete --force 2>/dev/null || true
             elif [ -n "$CLUSTER_NAME" ]; then
-              ksail cluster delete --name "$CLUSTER_NAME" --provider "$PROVIDER" --force 2>/dev/null || true
+              ksail ${CONFIG:+--config "$CONFIG"} cluster delete --name "$CLUSTER_NAME" --provider "$PROVIDER" --force 2>/dev/null || true
+            elif [ -n "$CONFIG" ]; then
+              ksail --config "$CONFIG" cluster delete --force 2>/dev/null || true
             fi
             sleep "$BACKOFF"
           fi


### PR DESCRIPTION
## Summary

Add retry logic with exponential backoff to the `🚀 Create Cluster` step in the `ksail-cluster` composite action for cloud providers (Omni, Hetzner).

## Changes

- **Docker provider**: 1 attempt (no retry — local, deterministic)
- **Cloud providers (Omni, Hetzner)**: 3 attempts with exponential backoff (10s, 20s)
- **Between retries**: `ksail cluster delete --force` cleans up partial cluster state
- **After all retries exhausted**: error propagates with a clear failure message

This follows the existing retry pattern already used in `ksail-system-test/action.yaml` for `workload create`, `workload install`, and `cluster start`.

## Motivation

Transient Omni API failures caused 2 consecutive merge queue failures for PR #3689 ([#9338](https://github.com/devantler-tech/ksail/actions/runs/24003229086), [#9358](https://github.com/devantler-tech/ksail/actions/runs/24004412928)). The test failed in ~5 seconds — indicative of a transient connection/API issue, not a code regression. A retry mechanism handles transient failures while still propagating persistent ones.

Fixes #3692