### PR TITLE
chore: remove deadcode, sync-modules, and coverage CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,96 +139,6 @@ jobs:
           source-hash: ${{ hashFiles('go.mod', 'go.sum', '**/*.go') }}
           output-path: /usr/local/bin/ksail
 
-  deadcode:
-    name: 🔍 Dead Code Analysis
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.code == 'true'
-    permissions:
-      contents: read
-    steps:
-      - name: 📄 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: ⚙️ Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-
-      - name: 📥 Install deadcode
-        run: go install golang.org/x/tools/cmd/deadcode@v0.43.0
-
-      - name: 🔍 Check for dead code
-        run: |
-          output_file="$(mktemp)"
-          trap 'rm -f "$output_file"' EXIT
-
-          deadcode -test ./... >"$output_file"
-
-          if [ -s "$output_file" ]; then
-            echo "::error::Dead code detected. Remove unreachable functions before merging."
-            cat "$output_file"
-            exit 1
-          fi
-          echo "No dead code found ✅"
-
-  sync-modules:
-    name: 🔄 Sync Module Dependencies
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: github.event_name != 'merge_group' && needs.changes.outputs.code == 'true'
-    permissions:
-      contents: read
-    steps:
-      - name: 📄 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
-      - name: ⚙️ Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-
-      - name: 🔄 Sync all Go modules
-        run: |
-          echo "Syncing module dependencies..."
-          go mod tidy
-          echo "✅ Module dependencies synced"
-
-      - name: 📤 Upload patch
-        run: |
-          git add -N .
-          git diff > /tmp/sync-modules.patch
-          if [ -s /tmp/sync-modules.patch ]; then
-            echo "Changes detected"
-          else
-            echo "No changes"
-          fi
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: sync-modules-patch
-          path: /tmp/sync-modules.patch
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: ❌ Fail if generated files are out of date (fork PR)
-        if: >-
-          github.event_name == 'pull_request'
-          && github.event.pull_request.head.repo.full_name != github.repository
-        shell: bash
-        run: |
-          if [ -s /tmp/sync-modules.patch ]; then
-            echo "::error::Generated files are out of date. Please run 'go mod tidy' locally and commit the results."
-            echo ""
-            cat /tmp/sync-modules.patch
-            exit 1
-          fi
-
   generate-schema:
     name: 📝 Generate JSON Schema
     runs-on: ubuntu-latest
@@ -335,13 +245,12 @@ jobs:
   auto-commit:
     name: 📤 Auto-Commit Generated Changes
     runs-on: ubuntu-latest
-    needs: [changes, sync-modules, generate-schema, generate-docs]
+    needs: [changes, generate-schema, generate-docs]
     if: >-
       always()
       && github.event_name != 'merge_group'
       && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      && (needs.sync-modules.result == 'success'
-        || needs.generate-schema.result == 'success'
+      && (needs.generate-schema.result == 'success'
         || needs.generate-docs.result == 'success')
     permissions:
       contents: write
@@ -410,40 +319,6 @@ jobs:
           commit_user_name: generator-bot
           commit_user_email: generator-bot@users.noreply.github.com
           branch: ${{ github.head_ref || github.ref_name }}
-
-  coverage:
-    name: 📊 Code Coverage
-    runs-on: ubuntu-latest
-    needs: [changes]
-    # Only run on push to main, skip if no code files changed
-    if: |
-      github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
-      && needs.changes.outputs.code == 'true'
-    permissions:
-      contents: write
-    steps:
-      - name: 📑 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: ⚙️ Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-
-      - name: 👨🏻‍🔧 Enable covdata (temp) see https://github.com/golang/go/issues/75031
-        run: go env -w GOTOOLCHAIN=go1.26.0+auto
-
-      - name: 📄 Generate coverage
-        run: |
-          go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-      - name: 📄 Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env] - third-party action input, no environment scoping available
 
   audit-docs:
     name: 🔍 Audit Docs Dependencies
@@ -750,11 +625,9 @@ jobs:
         rate-limit-gate,
         changes,
         build-artifact,
-        sync-modules,
         generate-schema,
         generate-docs,
         auto-commit,
-        coverage,
         warm-helm-cache,
         system-test,
         cleanup-hetzner,
@@ -774,11 +647,9 @@ jobs:
             ${{ needs.rate-limit-gate.result }}
             ${{ needs.changes.result }}
             ${{ needs.build-artifact.result }}
-            ${{ needs.sync-modules.result }}
             ${{ needs.generate-schema.result }}
             ${{ needs.generate-docs.result }}
             ${{ needs.auto-commit.result }}
-            ${{ needs.coverage.result }}
             ${{ needs.warm-helm-cache.result }}
             ${{ needs.system-test.result }}
             ${{ needs.cleanup-hetzner.result }}


### PR DESCRIPTION
## Summary

Removes three generic Go CI jobs from `.github/workflows/ci.yaml` that are now handled by the [CI-GO reusable workflow](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/ci-go.yaml):

| Removed ksail job | CI-GO equivalent |
|---|---|
| `deadcode` | `deadcode` |
| `sync-modules` | `tidy` |
| `coverage` | `coverage` |

Also updates the `auto-commit` and `status` jobs to remove references to the removed jobs.

Fixes #3709