### PR TITLE
fix(ci): upsert benchmark PR comments with comment-always

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -639,7 +639,7 @@ jobs:
 
       - name: 📊 Compare benchmark results
         if: steps.discover.outputs.skip == 'false'
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           tool: go
           output-file-path: ${{ runner.temp }}/bench-filtered.txt
@@ -650,7 +650,7 @@ jobs:
           alert-threshold: "150%"
           fail-threshold: "200%"
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
-          comment-on-alert: ${{ github.event_name == 'pull_request' }}
+          comment-always: ${{ github.event_name == 'pull_request' }}
           summary-always: true
 
       - name: 📤 Upload benchmark results
@@ -685,7 +685,7 @@ jobs:
           path: ${{ runner.temp }}
 
       - name: 📊 Store benchmark data
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           tool: go
           output-file-path: ${{ runner.temp }}/bench.txt


### PR DESCRIPTION
The `benchmark-action/github-action-benchmark` action's `comment-on-alert` only fires when a regression exceeds the alert threshold. Runs with no regression skip commenting entirely, leaving stale PR reviews and increasing the chance of duplicates when the action's internal review search (`findExistingPRReviewId`) misses an older entry.

Switching to `comment-always` uses the same native `leavePRComment` upsert mechanism but updates the comment on **every** PR benchmark run, keeping the review current and more reliably found for in-place updates. The action is also bumped to v1.22.0 for latest upstream fixes.

## Type of change

- [x] 🪲 Bug fix