### PR TITLE
build: migrate Node.js 22 to 24

### DIFF
--- a/.github/actions/npm-audit-and-fix/action.yaml
+++ b/.github/actions/npm-audit-and-fix/action.yaml
@@ -53,7 +53,7 @@ runs:
     - name: ⚙️ Setup Node.js
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
-        node-version: "22"
+        node-version: "24"
         cache: "npm"
         cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ KSail is a Go-based CLI application that provides a unified SDK for spinning up 
 
 ```bash
 # Node.js for documentation builds
-# CI uses Node.js 22 (see .github/workflows/ci.yaml)
+# CI uses Node.js 24 (see .github/workflows/ci.yaml)
 cd /path/to/repo/docs
 npm ci
 ```

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: ⚙️ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: 🏷️ Extract version from tag
         id: get_version
@@ -189,7 +189,7 @@ jobs:
       - name: ⚙️ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: docs/package-lock.json
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,7 +389,7 @@ jobs:
       - name: ⚙️ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: docs/package-lock.json
 
@@ -420,7 +420,7 @@ jobs:
       - name: ⚙️ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: "vsce/package-lock.json"
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,6 +35,6 @@ jobs:
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          node-version: "24"
       - name: 🔧 Install jscpd
         run: npm install -g jscpd@4.0.8

--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: ⚙️ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: 🔄 Update Copilot skills
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Before you begin developing, ensure you have the following installed:
 - [mockery (v3.5+)](https://vektra.github.io/mockery/v3.5/installation/)
 - [golangci-lint](https://golangci-lint.run/docs/welcome/install/)
 - [mega-linter](https://github.com/oxsecurity/megalinter/tree/main/mega-linter-runner#installation)
-- [Node.js (v22+)](https://nodejs.org/en/download/) — Required for building documentation (matches CI)
+- [Node.js (v24+)](https://nodejs.org/en/download/) — Required for building documentation (matches CI)
 
 ### Lint
 

--- a/docs/src/content/docs/development.mdx
+++ b/docs/src/content/docs/development.mdx
@@ -7,7 +7,7 @@ description: Guide for setting up KSail development environment and contributing
 
 **Required:** [Go 1.26.0+](https://go.dev/dl/) (`go version` ≥ 1.26.0), [Docker](https://docs.docker.com/get-started/) (`docker ps` without errors), [Git](https://git-scm.com/).
 
-**Optional:** Node.js 22 (docs), golangci-lint, VSCode with Go extension.
+**Optional:** Node.js 24 (docs), golangci-lint, VSCode with Go extension.
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary

Migrates all Node.js version references from 22 to 24 across GitHub Actions workflows, composite actions, and documentation.

## Changes

**Workflows** (6 occurrences of `node-version`):
- `.github/workflows/ci.yaml` — docs build + vsce build
- `.github/workflows/cd.yaml` — publish docs + vsce
- `.github/workflows/update-skills.yaml`
- `.github/workflows/copilot-setup-steps.yml`

**Composite action** (1 occurrence):
- `.github/actions/npm-audit-and-fix/action.yaml`

**Documentation** (3 files):
- `.github/copilot-instructions.md`
- `CONTRIBUTING.md`
- `docs/src/content/docs/development.mdx`

## Validation

- ✅ `docs/` build passes (`npm ci && npm run build`)
- ✅ `vsce/` build passes (`npm ci && npm run compile`)
- ✅ No remaining Node.js 22 references in workflows/actions/docs

## Notes

- Lock files (`docs/package-lock.json`, `vsce/package-lock.json`) contain upstream dependency engine constraints like `"node": ">=20"` — these are satisfied by Node.js 24 and require no changes.
- `.lock.yml` workflows are managed by GitHub Agentics and excluded per repo policy.
- The Dockerfile uses distroless (no Node.js) — no changes needed.