### PR TITLE
fix(ci): pass explicit flags to cluster delete cleanup for reliable teardown

### DIFF
--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -337,5 +337,16 @@ runs:
     - name: 🧪 ksail cluster delete
       if: always()
       shell: bash
+      env:
+        PROVIDER: ${{ inputs.provider }}
+        ARGS: ${{ steps.resolve-args.outputs.args }}
       run: |
-        ksail cluster delete || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
+        # Extract --name value from args for reliable cleanup even when no kubeconfig exists
+        CLUSTER_NAME=$(echo "$ARGS" | grep -oP '(?<=--name\s)\S+' || true)
+        if [ -n "$CLUSTER_NAME" ]; then
+          ksail cluster delete --provider "$PROVIDER" --name "$CLUSTER_NAME" --force \
+            || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
+        else
+          ksail cluster delete \
+            || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
+        fi


### PR DESCRIPTION
The system-test cleanup step (Phase 7) ran a bare `ksail cluster delete` with no flags, relying entirely on the kubeconfig context to identify the cluster. When cluster creation failed or the kubeconfig was not configured, the cleanup silently failed to delete the cluster.

This updates the cleanup step to extract `--name` from `$ARGS` and pass `--provider`, `--name`, and `--force` to `ksail cluster delete`, enabling reliable teardown even when no kubeconfig context exists.

## Type of change

- [x] 🐞 Bug fix