### PR TITLE
ci: only comment on benchmark alerts instead of always

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -692,7 +692,7 @@ jobs:
           alert-threshold: "150%"
           fail-threshold: "200%"
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
-          comment-always: ${{ github.event_name == 'pull_request' }}
+          comment-on-alert: ${{ github.event_name == 'pull_request' }}
           summary-always: true
 
       - name: 📤 Upload benchmark results


### PR DESCRIPTION
## Summary

Changes the benchmark comparison step to use `comment-on-alert` instead of `comment-always`, so PR comments are only posted when benchmarks cross the 150% alert threshold — reducing noise on PRs with no performance regressions.

## Changes

- `.github/workflows/ci.yaml`: Replace `comment-always` with `comment-on-alert` in the benchmark comparison step