### PR TITLE
refactor(docs): improve benchmark chart navigation with package grouping

### DIFF
--- a/docs/src/components/BenchmarkChart.astro
+++ b/docs/src/components/BenchmarkChart.astro
@@ -176,7 +176,6 @@
       hierarchy[p.pkg][p.stem][p.metric].push(p);
     }
 
-    const theme = detectTheme();
     const sortedPkgs = Object.keys(hierarchy).sort();
 
     // Build TOC
@@ -293,12 +292,13 @@
               });
 
             if (activeChart) activeChart.destroy();
-            activeChart = createChart(canvas, datasets, metric, theme);
+            activeChart = createChart(canvas, datasets, metric, detectTheme());
           }
 
           for (const metric of METRICS) {
             if (!metricsData[metric]) continue;
             const tab = document.createElement("button");
+            tab.type = "button";
             tab.className = "benchmark-tab";
             tab.textContent = metric;
             tab.addEventListener("click", () => {


### PR DESCRIPTION
The benchmark "Performance Trends" page rendered ~487 separate charts in a flat, unscrollable list. Each Go benchmark produced 8 data entries (bare + package-qualified × combined + 3 metric suffixes), and the grouping logic treated each variant as its own chart — resulting in bloated legends with 6-8 duplicate entries per benchmark.

This rewrites the `BenchmarkChart.astro` component to organize benchmarks hierarchically:

- **Canonical filtering** — only package-qualified metric-specific entries are used (1464 → 549 entries), discarding 5 redundant variants per benchmark
- **Package grouping** — 16 collapsible `<details>` sections by Go package (e.g., `client/docker`, `k8s/readiness`)
- **Function stem charts** — sub-test variants become datasets on one chart (119 charts total, max 7 legend entries)
- **Metric tabs** — ns/op | B/op | allocs/op toggle per chart instead of separate charts per metric
- **Table of contents** — anchor links with benchmark count badges; clicking auto-opens the target section
- **Lazy rendering** — charts are created only when a section is expanded (better initial page load)

## Type of change

- [x] 🧹 Refactor
- [x] 📚 Documentation update