### PR TITLE
test(e2e): expand backup coverage with exclude-types, metadata, and cross-validation

### DIFF
--- a/.github/actions/ksail-test-backup-restore/action.yaml
+++ b/.github/actions/ksail-test-backup-restore/action.yaml
@@ -90,7 +90,7 @@ runs:
           echo "❌ resourceCount should be an integer > 0"
           exit 1
         fi
-        if ! TYPE_COUNT=$(echo "$METADATA" | jq -re '.resourceTypes | arrays | length | select(. > 0)'); then
+        if ! RESOURCE_TYPE_COUNT=$(echo "$METADATA" | jq -re '.resourceTypes | arrays | length | select(. > 0)'); then
           echo "❌ resourceTypes should be a non-empty array"
           exit 1
         fi
@@ -106,7 +106,7 @@ runs:
           echo "❌ resourceCount ($COUNT) should be greater than or equal to YAML file count ($YAML_COUNT)"
           exit 1
         fi
-        echo "✅ Backup metadata is valid (resourceCount=$COUNT, resourceTypes=$TYPE_COUNT, yamlFiles=$YAML_COUNT)"
+        echo "✅ Backup metadata is valid (resourceCount=$COUNT, resourceTypeCount=$RESOURCE_TYPE_COUNT, yamlFiles=$YAML_COUNT)"
 
     - name: 🧪 Namespace-filtered backup
       id: backup-ns


### PR DESCRIPTION
## Summary

Add missing E2E coverage for `ksail cluster backup` to address remaining gaps after #3792.

### Changes

- **Exclude-types test**: Exercises `--exclude-types deployments` and verifies excluded types are absent from both backup metadata (`resourceTypes` array) and archive contents
- **Enhanced metadata validation**: Validates `clusterName`, `version`, `ksailVersion` as required fields; logs `distribution` and `provider` as best-effort (detection may fail for some kubeconfig context patterns, e.g. Omni)
- **`resourceTypes` validation**: Asserts `resourceTypes` is a non-empty array using robust `jq -re` with `arrays` filter
- **`resourceCount` cross-validation**: Verifies `resourceCount >= YAML file count` in the archive (resources may exceed files due to multi-document YAML)
- **SIGPIPE fix**: Uses here-strings (`grep -q <<< "$VAR"`) instead of `echo "$VAR" | grep -q` to avoid broken pipe under `bash -o pipefail`

### Testing

All changes are in `.github/actions/ksail-test-backup-restore/action.yaml` and are exercised by the existing system test matrix across all distributions (Vanilla, K3s, Talos, VCluster) and providers (Docker, Hetzner, Omni).

Closes #3783