### PR TITLE
refactor: rename cipher rotate flags from --new-key/--old-key to --add-key/--remove-key

### DIFF
--- a/docs/src/content/docs/cli-flags/cipher/cipher-rotate.mdx
+++ b/docs/src/content/docs/cli-flags/cipher/cipher-rotate.mdx
@@ -17,8 +17,8 @@ folder, all SOPS-encrypted YAML and JSON files in the folder are rotated.
 Use --recursive to include subdirectories.
 
 Optionally, master key recipients can be added or removed during rotation:
-  --new-key adds a new master key recipient
-  --old-key removes an existing master key recipient
+  --add-key adds a new master key recipient
+  --remove-key removes an existing master key recipient
 
 By default, the command shows which files will be affected and prompts for
 confirmation. Use --force to skip the confirmation prompt. In non-interactive
@@ -41,22 +41,22 @@ Examples:
   ksail cipher rotate secrets.yaml
 
   # Add a new age recipient during rotation
-  ksail cipher rotate ./k8s --new-key age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+  ksail cipher rotate ./k8s --add-key age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
 
   # Remove an old age recipient during rotation
-  ksail cipher rotate ./k8s --old-key age1oldkey...
+  ksail cipher rotate ./k8s --remove-key age1oldkey...
 
   # Replace a recipient (add new, remove old)
-  ksail cipher rotate ./k8s --new-key age1newkey... --old-key age1oldkey...
+  ksail cipher rotate ./k8s --add-key age1newkey... --remove-key age1oldkey...
 
 Usage:
   ksail cipher rotate <file/folder> [flags]
 
 Flags:
-  -f, --force            skip confirmation prompt and rotate immediately
-      --new-key string   public key to add as a master key recipient
-      --old-key string   public key to remove from master key recipients
-  -r, --recursive        scan subdirectories when target is a folder
+      --add-key string      public key to add as a master key recipient
+  -f, --force               skip confirmation prompt and rotate immediately
+  -r, --recursive           scan subdirectories when target is a folder
+      --remove-key string   public key to remove from master key recipients
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/pkg/cli/cmd/cipher/__snapshots__/cipher_test.snap
+++ b/pkg/cli/cmd/cipher/__snapshots__/cipher_test.snap
@@ -165,8 +165,8 @@ folder, all SOPS-encrypted YAML and JSON files in the folder are rotated.
 Use --recursive to include subdirectories.
 
 Optionally, master key recipients can be added or removed during rotation:
-  --new-key adds a new master key recipient
-  --old-key removes an existing master key recipient
+  --add-key adds a new master key recipient
+  --remove-key removes an existing master key recipient
 
 By default, the command shows which files will be affected and prompts for
 confirmation. Use --force to skip the confirmation prompt. In non-interactive
@@ -189,22 +189,22 @@ Examples:
   ksail cipher rotate secrets.yaml
 
   # Add a new age recipient during rotation
-  ksail cipher rotate ./k8s --new-key age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+  ksail cipher rotate ./k8s --add-key age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
 
   # Remove an old age recipient during rotation
-  ksail cipher rotate ./k8s --old-key age1oldkey...
+  ksail cipher rotate ./k8s --remove-key age1oldkey...
 
   # Replace a recipient (add new, remove old)
-  ksail cipher rotate ./k8s --new-key age1newkey... --old-key age1oldkey...
+  ksail cipher rotate ./k8s --add-key age1newkey... --remove-key age1oldkey...
 
 Usage:
   cipher rotate <file/folder> [flags]
 
 Flags:
-  -f, --force            skip confirmation prompt and rotate immediately
-  -h, --help             help for rotate
-      --new-key string   public key to add as a master key recipient
-      --old-key string   public key to remove from master key recipients
-  -r, --recursive        scan subdirectories when target is a folder
+      --add-key string      public key to add as a master key recipient
+  -f, --force               skip confirmation prompt and rotate immediately
+  -h, --help                help for rotate
+  -r, --recursive           scan subdirectories when target is a folder
+      --remove-key string   public key to remove from master key recipients
 
 ---

--- a/pkg/cli/cmd/cipher/cipher.go
+++ b/pkg/cli/cmd/cipher/cipher.go
@@ -485,8 +485,8 @@ folder, all SOPS-encrypted YAML and JSON files in the folder are rotated.
 Use --recursive to include subdirectories.
 
 Optionally, master key recipients can be added or removed during rotation:
-  --new-key adds a new master key recipient
-  --old-key removes an existing master key recipient
+  --add-key adds a new master key recipient
+  --remove-key removes an existing master key recipient
 
 By default, the command shows which files will be affected and prompts for
 confirmation. Use --force to skip the confirmation prompt. In non-interactive
@@ -509,19 +509,19 @@ Examples:
   ksail cipher rotate secrets.yaml
 
   # Add a new age recipient during rotation
-  ksail cipher rotate ./k8s --new-key age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+  ksail cipher rotate ./k8s --add-key age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
 
   # Remove an old age recipient during rotation
-  ksail cipher rotate ./k8s --old-key age1oldkey...
+  ksail cipher rotate ./k8s --remove-key age1oldkey...
 
   # Replace a recipient (add new, remove old)
-  ksail cipher rotate ./k8s --new-key age1newkey... --old-key age1oldkey...`
+  ksail cipher rotate ./k8s --add-key age1newkey... --remove-key age1oldkey...`
 
 // NewRotateCmd creates and returns the rotate command.
 func NewRotateCmd() *cobra.Command {
 	var (
-		newKey    string
-		oldKey    string
+		addKey    string
+		removeKey string
 		recursive bool
 		force     bool
 	)
@@ -533,15 +533,15 @@ func NewRotateCmd() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return handleRotateRunE(cmd, args[0], newKey, oldKey, recursive, force)
+			return handleRotateRunE(cmd, args[0], addKey, removeKey, recursive, force)
 		},
 		Annotations: map[string]string{
 			annotations.AnnotationPermission: "write",
 		},
 	}
 
-	cmd.Flags().StringVar(&newKey, "new-key", "", "public key to add as a master key recipient")
-	cmd.Flags().StringVar(&oldKey, "old-key", "", "public key to remove from master key recipients")
+	cmd.Flags().StringVar(&addKey, "add-key", "", "public key to add as a master key recipient")
+	cmd.Flags().StringVar(&removeKey, "remove-key", "", "public key to remove from master key recipients")
 	cmd.Flags().
 		BoolVarP(&recursive, "recursive", "r", false, "scan subdirectories when target is a folder")
 	cmd.Flags().
@@ -553,7 +553,7 @@ func NewRotateCmd() *cobra.Command {
 // handleRotateRunE is the main handler for the rotate command.
 func handleRotateRunE(
 	cmd *cobra.Command,
-	target, newKey, oldKey string,
+	target, addKey, removeKey string,
 	recursive, force bool,
 ) error {
 	writer := cmd.OutOrStdout()
@@ -563,7 +563,7 @@ func handleRotateRunE(
 		return fmt.Errorf("resolve target path %q: %w", target, err)
 	}
 
-	opts, err := buildRotateOpts(newKey, oldKey)
+	opts, err := buildRotateOpts(addKey, removeKey)
 	if err != nil {
 		return err
 	}
@@ -647,23 +647,23 @@ func collectRotateTargets(
 }
 
 // buildRotateOpts constructs RotateOpts from CLI flag values.
-func buildRotateOpts(newKey, oldKey string) (sopsclient.RotateOpts, error) {
+func buildRotateOpts(addKey, removeKey string) (sopsclient.RotateOpts, error) {
 	opts := sopsclient.RotateOpts{
 		KeyServices:     []keyservice.KeyServiceClient{keyservice.NewLocalClient()},
 		DecryptionOrder: []string{},
 	}
 
-	if newKey != "" {
-		masterKey, err := sopsclient.ParseKeyType(newKey)
+	if addKey != "" {
+		masterKey, err := sopsclient.ParseKeyType(addKey)
 		if err != nil {
-			return opts, fmt.Errorf("parsing --new-key: %w", err)
+			return opts, fmt.Errorf("parsing --add-key: %w", err)
 		}
 
 		opts.AddKeys = []keys.MasterKey{masterKey}
 	}
 
-	if oldKey != "" {
-		opts.RemoveKeys = []string{oldKey}
+	if removeKey != "" {
+		opts.RemoveKeys = []string{removeKey}
 	}
 
 	return opts, nil

--- a/pkg/cli/cmd/cipher/cipher.go
+++ b/pkg/cli/cmd/cipher/cipher.go
@@ -541,7 +541,8 @@ func NewRotateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&addKey, "add-key", "", "public key to add as a master key recipient")
-	cmd.Flags().StringVar(&removeKey, "remove-key", "", "public key to remove from master key recipients")
+	cmd.Flags().
+		StringVar(&removeKey, "remove-key", "", "public key to remove from master key recipients")
 	cmd.Flags().
 		BoolVarP(&recursive, "recursive", "r", false, "scan subdirectories when target is a folder")
 	cmd.Flags().

--- a/pkg/cli/cmd/cipher/cipher_test.go
+++ b/pkg/cli/cmd/cipher/cipher_test.go
@@ -933,13 +933,13 @@ func TestNewRotateCmd(t *testing.T) {
 	}
 
 	// Verify flags are registered
-	newKeyFlag := cmd.Flags().Lookup("add-key")
-	if newKeyFlag == nil {
+	addKeyFlag := cmd.Flags().Lookup("add-key")
+	if addKeyFlag == nil {
 		t.Error("expected add-key flag to be registered")
 	}
 
-	oldKeyFlag := cmd.Flags().Lookup("remove-key")
-	if oldKeyFlag == nil {
+	removeKeyFlag := cmd.Flags().Lookup("remove-key")
+	if removeKeyFlag == nil {
 		t.Error("expected remove-key flag to be registered")
 	}
 

--- a/pkg/cli/cmd/cipher/cipher_test.go
+++ b/pkg/cli/cmd/cipher/cipher_test.go
@@ -933,14 +933,14 @@ func TestNewRotateCmd(t *testing.T) {
 	}
 
 	// Verify flags are registered
-	newKeyFlag := cmd.Flags().Lookup("new-key")
+	newKeyFlag := cmd.Flags().Lookup("add-key")
 	if newKeyFlag == nil {
-		t.Error("expected new-key flag to be registered")
+		t.Error("expected add-key flag to be registered")
 	}
 
-	oldKeyFlag := cmd.Flags().Lookup("old-key")
+	oldKeyFlag := cmd.Flags().Lookup("remove-key")
 	if oldKeyFlag == nil {
-		t.Error("expected old-key flag to be registered")
+		t.Error("expected remove-key flag to be registered")
 	}
 
 	recursiveFlag := cmd.Flags().Lookup("recursive")


### PR DESCRIPTION
The `--new-key` and `--old-key` flags on `ksail cipher rotate` don't clearly describe their actions. This renames them to `--add-key` and `--remove-key` to better reflect their purpose of adding and removing master key recipients during key rotation.

The rename is applied across the flag definitions, help text, examples, error messages, tests, snapshots, and the auto-generated docs page.

## Type of change

- [x] 🧹 Refactor
- [x] ⛓️‍💥 Breaking change