### PR TITLE
feat: implement image verification for Kind (Vanilla) via containerd image verifier plugin

### DIFF
--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -21,7 +21,7 @@ Flags:
       --distribution-config string             Configuration file for the distribution
   -f, --force                                  Overwrite existing files
   -g, --gitops-engine GitOpsEngine             GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --image-verification ImageVerification   Talos image verification (Enabled: scaffold ImageVerificationConfig template, Disabled: skip)
+      --image-verification ImageVerification   Image verification (Enabled: scaffold verification config, Disabled: skip)
       --import-images string                   Path to tar archive with container images to import after cluster creation but before component installation
   -k, --kubeconfig string                      Path to kubeconfig file (default "~/.kube/config")
       --kustomization-file string              Relative directory within sourceDirectory used as the kustomize entry point (e.g., clusters/local)

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -21,7 +21,7 @@ Flags:
       --distribution-config string             Configuration file for the distribution
   -f, --force                                  Overwrite existing files
   -g, --gitops-engine GitOpsEngine             GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --image-verification ImageVerification   Image verification (Enabled: scaffold verification config, Disabled: skip)
+      --image-verification ImageVerification   Image verification (Talos: scaffold ImageVerificationConfig template; Vanilla/Kind: inject containerd verifier plugin patch, requires verifier binaries/policy; Disabled: skip)
       --import-images string                   Path to tar archive with container images to import after cluster creation but before component installation
   -k, --kubeconfig string                      Path to kubeconfig file (default "~/.kube/config")
       --kustomization-file string              Relative directory within sourceDirectory used as the kustomize entry point (e.g., clusters/local)

--- a/pkg/apis/cluster/v1alpha1/imageverification.go
+++ b/pkg/apis/cluster/v1alpha1/imageverification.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 )
 
-// ImageVerification defines image verification options for Talos distributions.
+// ImageVerification defines image verification options for supported distributions.
+// Talos uses a native ImageVerificationConfig document; Kind uses containerd config patches.
 type ImageVerification string
 
 const (

--- a/pkg/fsutil/configmanager/kind/helpers.go
+++ b/pkg/fsutil/configmanager/kind/helpers.go
@@ -111,7 +111,14 @@ per_verifier_timeout = "10s"
 
 // ApplyImageVerificationPatches adds a containerd config patch to enable the image verifier plugin.
 // The patch is applied at the cluster level and affects every node's containerd configuration.
+// This function is idempotent — it skips appending if the patch is already present.
 func ApplyImageVerificationPatches(kindConfig *kindv1alpha4.Cluster) {
+	for _, patch := range kindConfig.ContainerdConfigPatches {
+		if strings.Contains(patch, `io.containerd.image-verifier.v1.bindir`) {
+			return
+		}
+	}
+
 	kindConfig.ContainerdConfigPatches = append(
 		kindConfig.ContainerdConfigPatches,
 		ImageVerificationPatch,

--- a/pkg/fsutil/configmanager/kind/helpers.go
+++ b/pkg/fsutil/configmanager/kind/helpers.go
@@ -84,3 +84,36 @@ func ApplyKubeletCertRotationPatches(kindConfig *kindv1alpha4.Cluster) {
 		)
 	}
 }
+
+// ImageVerificationPatch is a TOML containerd config patch that enables the image verifier plugin.
+// This requires containerd 2.x (Kind v0.31.0+ / kindest/node:v1.35.1+).
+// Verifier binaries (e.g., Cosign, Notation) must be pre-installed in the Kind node image
+// at the configured bin_dir path.
+// See: https://github.com/containerd/containerd/blob/main/docs/image-verification.md
+const ImageVerificationPatch = `# Enable the containerd image verifier plugin (requires containerd 2.x).
+# Verifier binaries must be pre-installed in the Kind node image at bin_dir.
+# If bin_dir is empty or missing, image pulls proceed without verification.
+# See: https://github.com/containerd/containerd/blob/main/docs/image-verification.md
+[plugins."io.containerd.image-verifier.v1.bindir"]
+bin_dir = "/opt/image-verifier/bin"
+max_verifiers = 10
+per_verifier_timeout = "10s"
+
+# --- Example: Cosign keyless verification (OIDC / Sigstore) ---
+# Install the cosign verifier binary into /opt/image-verifier/bin/ in a custom Kind node image.
+# Cosign will verify signatures using the Sigstore public good instance by default.
+# See: https://docs.sigstore.dev/cosign/
+
+# --- Example: Notation verification ---
+# Install the notation verifier binary into /opt/image-verifier/bin/ in a custom Kind node image.
+# Configure trust policies and certificates in the notation config directory.
+# See: https://notaryproject.dev/docs/`
+
+// ApplyImageVerificationPatches adds a containerd config patch to enable the image verifier plugin.
+// The patch is applied at the cluster level and affects every node's containerd configuration.
+func ApplyImageVerificationPatches(kindConfig *kindv1alpha4.Cluster) {
+	kindConfig.ContainerdConfigPatches = append(
+		kindConfig.ContainerdConfigPatches,
+		ImageVerificationPatch,
+	)
+}

--- a/pkg/fsutil/configmanager/kind/helpers_test.go
+++ b/pkg/fsutil/configmanager/kind/helpers_test.go
@@ -280,4 +280,16 @@ func TestApplyImageVerificationPatches(t *testing.T) {
 
 		assert.Equal(t, kind.ImageVerificationPatch, kindConfig.ContainerdConfigPatches[0])
 	})
+
+	t.Run("idempotent_does_not_duplicate_patch", func(t *testing.T) {
+		t.Parallel()
+
+		kindConfig := &kindv1alpha4.Cluster{}
+
+		kind.ApplyImageVerificationPatches(kindConfig)
+		kind.ApplyImageVerificationPatches(kindConfig)
+
+		assert.Len(t, kindConfig.ContainerdConfigPatches, 1,
+			"calling ApplyImageVerificationPatches twice should not duplicate the patch")
+	})
 }

--- a/pkg/fsutil/configmanager/kind/helpers_test.go
+++ b/pkg/fsutil/configmanager/kind/helpers_test.go
@@ -235,3 +235,45 @@ func TestApplyKubeletCertRotationPatches(t *testing.T) {
 		assert.Equal(t, kind.KubeletCertRotationPatch, kindConfig.Nodes[0].KubeadmConfigPatches[1])
 	})
 }
+
+func TestApplyImageVerificationPatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds_containerd_config_patch_to_empty_cluster", func(t *testing.T) {
+		t.Parallel()
+
+		kindConfig := &kindv1alpha4.Cluster{}
+
+		kind.ApplyImageVerificationPatches(kindConfig)
+
+		assert.Len(t, kindConfig.ContainerdConfigPatches, 1)
+		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `io.containerd.image-verifier.v1.bindir`)
+		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `bin_dir`)
+		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `max_verifiers`)
+		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `per_verifier_timeout`)
+	})
+
+	t.Run("appends_to_existing_containerd_patches", func(t *testing.T) {
+		t.Parallel()
+
+		kindConfig := &kindv1alpha4.Cluster{
+			ContainerdConfigPatches: []string{"existing-patch"},
+		}
+
+		kind.ApplyImageVerificationPatches(kindConfig)
+
+		assert.Len(t, kindConfig.ContainerdConfigPatches, 2)
+		assert.Equal(t, "existing-patch", kindConfig.ContainerdConfigPatches[0])
+		assert.Equal(t, kind.ImageVerificationPatch, kindConfig.ContainerdConfigPatches[1])
+	})
+
+	t.Run("patch_equals_exported_constant", func(t *testing.T) {
+		t.Parallel()
+
+		kindConfig := &kindv1alpha4.Cluster{}
+
+		kind.ApplyImageVerificationPatches(kindConfig)
+
+		assert.Equal(t, kind.ImageVerificationPatch, kindConfig.ContainerdConfigPatches[0])
+	})
+}

--- a/pkg/fsutil/configmanager/kind/helpers_test.go
+++ b/pkg/fsutil/configmanager/kind/helpers_test.go
@@ -247,7 +247,11 @@ func TestApplyImageVerificationPatches(t *testing.T) {
 		kind.ApplyImageVerificationPatches(kindConfig)
 
 		assert.Len(t, kindConfig.ContainerdConfigPatches, 1)
-		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `io.containerd.image-verifier.v1.bindir`)
+		assert.Contains(
+			t,
+			kindConfig.ContainerdConfigPatches[0],
+			`io.containerd.image-verifier.v1.bindir`,
+		)
 		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `bin_dir`)
 		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `max_verifiers`)
 		assert.Contains(t, kindConfig.ContainerdConfigPatches[0], `per_verifier_timeout`)

--- a/pkg/fsutil/configmanager/ksail/binding.go
+++ b/pkg/fsutil/configmanager/ksail/binding.go
@@ -191,7 +191,7 @@ func (m *ConfigManager) getFieldMappings() map[any]string {
 		&m.Config.Spec.Cluster.LocalRegistry.Registry: "local-registry",
 		&m.Config.Spec.Cluster.ImportImages:           "import-images",
 
-		// Unified node counts for all distributions
+		// Unified options for all distributions (stored in Talos struct for historical reasons)
 		&m.Config.Spec.Cluster.Talos.ControlPlanes:     "control-planes",
 		&m.Config.Spec.Cluster.Talos.Workers:           "workers",
 		&m.Config.Spec.Cluster.Talos.ImageVerification: "image-verification",

--- a/pkg/fsutil/configmanager/ksail/field_selector.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector.go
@@ -203,13 +203,13 @@ func DefaultImportImagesFieldSelector() FieldSelector[v1alpha1.Cluster] {
 	}
 }
 
-// ImageVerificationFieldSelector creates a field selector for Talos image verification.
+// ImageVerificationFieldSelector creates a field selector for image verification.
 func ImageVerificationFieldSelector() FieldSelector[v1alpha1.Cluster] {
 	return FieldSelector[v1alpha1.Cluster]{
 		Selector: func(c *v1alpha1.Cluster) any {
 			return &c.Spec.Cluster.Talos.ImageVerification
 		},
-		Description:  "Talos image verification (Enabled: scaffold ImageVerificationConfig template, Disabled: skip)",
+		Description:  "Image verification (Enabled: scaffold verification config, Disabled: skip)",
 		DefaultValue: v1alpha1.ImageVerificationDisabled,
 	}
 }

--- a/pkg/fsutil/configmanager/ksail/field_selector.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector.go
@@ -209,7 +209,9 @@ func ImageVerificationFieldSelector() FieldSelector[v1alpha1.Cluster] {
 		Selector: func(c *v1alpha1.Cluster) any {
 			return &c.Spec.Cluster.Talos.ImageVerification
 		},
-		Description:  "Image verification (Enabled: scaffold verification config, Disabled: skip)",
+		Description: "Image verification (Talos: scaffold ImageVerificationConfig template; " +
+			"Vanilla/Kind: inject containerd verifier plugin patch, requires verifier binaries/policy; " +
+			"Disabled: skip)",
 		DefaultValue: v1alpha1.ImageVerificationDisabled,
 	}
 }

--- a/pkg/fsutil/scaffolder/scaffolder_kind.go
+++ b/pkg/fsutil/scaffolder/scaffolder_kind.go
@@ -71,6 +71,11 @@ func (s *Scaffolder) buildKindConfig(output string) *v1alpha4.Cluster {
 		kindconfigmanager.ApplyKubeletCertRotationPatches(kindConfig)
 	}
 
+	// Enable containerd image verifier plugin when image verification is enabled.
+	if s.KSailConfig.Spec.Cluster.Talos.ImageVerification == v1alpha1.ImageVerificationEnabled {
+		kindconfigmanager.ApplyImageVerificationPatches(kindConfig)
+	}
+
 	// Apply node counts from CLI flags (stored in Talos options)
 	s.applyKindNodeCounts(kindConfig)
 

--- a/pkg/fsutil/scaffolder/scaffolder_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_test.go
@@ -572,7 +572,11 @@ func TestGenerateKindConfigHandlesImageVerification(t *testing.T) {
 		captured := captureKindConfigForImageVerification(t, v1alpha1.ImageVerificationEnabled)
 
 		assert.NotEmpty(t, captured.ContainerdConfigPatches)
-		assert.Contains(t, captured.ContainerdConfigPatches[0], `io.containerd.image-verifier.v1.bindir`)
+		assert.Contains(
+			t,
+			captured.ContainerdConfigPatches[0],
+			`io.containerd.image-verifier.v1.bindir`,
+		)
 	})
 
 	t.Run("disabled_has_no_containerd_config_patch", func(t *testing.T) {

--- a/pkg/fsutil/scaffolder/scaffolder_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_test.go
@@ -563,6 +563,27 @@ func TestGenerateKindConfigHandlesCNI(t *testing.T) {
 	}
 }
 
+func TestGenerateKindConfigHandlesImageVerification(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enabled_adds_containerd_config_patch", func(t *testing.T) {
+		t.Parallel()
+
+		captured := captureKindConfigForImageVerification(t, v1alpha1.ImageVerificationEnabled)
+
+		assert.NotEmpty(t, captured.ContainerdConfigPatches)
+		assert.Contains(t, captured.ContainerdConfigPatches[0], `io.containerd.image-verifier.v1.bindir`)
+	})
+
+	t.Run("disabled_has_no_containerd_config_patch", func(t *testing.T) {
+		t.Parallel()
+
+		captured := captureKindConfigForImageVerification(t, v1alpha1.ImageVerificationDisabled)
+
+		assert.Empty(t, captured.ContainerdConfigPatches)
+	})
+}
+
 func TestGenerateK3dConfigHandlesCNI(t *testing.T) {
 	t.Parallel()
 
@@ -702,6 +723,38 @@ func captureK3dConfigForCNI(t *testing.T, cni v1alpha1.CNI) *k3dv1alpha5.SimpleC
 		},
 	)
 
+	require.NotNil(t, captured)
+
+	return captured
+}
+
+func captureKindConfigForImageVerification(
+	t *testing.T,
+	iv v1alpha1.ImageVerification,
+) *v1alpha4.Cluster {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	buffer := &bytes.Buffer{}
+	instance, mocks := newScaffolderWithMocks(t, buffer)
+	instance.KSailConfig.Spec.Cluster.Distribution = v1alpha1.DistributionVanilla
+	instance.KSailConfig.Spec.Cluster.Talos.ImageVerification = iv
+
+	var captured *v1alpha4.Cluster
+
+	mocks.kind.ExpectedCalls = nil
+	mocks.kind.On(
+		"Generate",
+		mock.MatchedBy(func(cfg *v1alpha4.Cluster) bool {
+			captured = cfg
+
+			return true
+		}),
+		mock.Anything,
+	).Return("", nil).Once()
+
+	err := instance.Scaffold(tempDir, true)
+	require.NoError(t, err)
 	require.NotNil(t, captured)
 
 	return captured

--- a/pkg/fsutil/scaffolder/scaffolder_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_test.go
@@ -730,7 +730,7 @@ func captureK3dConfigForCNI(t *testing.T, cni v1alpha1.CNI) *k3dv1alpha5.SimpleC
 
 func captureKindConfigForImageVerification(
 	t *testing.T,
-	iv v1alpha1.ImageVerification,
+	imageVerification v1alpha1.ImageVerification,
 ) *v1alpha4.Cluster {
 	t.Helper()
 
@@ -738,7 +738,7 @@ func captureKindConfigForImageVerification(
 	buffer := &bytes.Buffer{}
 	instance, mocks := newScaffolderWithMocks(t, buffer)
 	instance.KSailConfig.Spec.Cluster.Distribution = v1alpha1.DistributionVanilla
-	instance.KSailConfig.Spec.Cluster.Talos.ImageVerification = iv
+	instance.KSailConfig.Spec.Cluster.Talos.ImageVerification = imageVerification
 
 	var captured *v1alpha4.Cluster
 

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -138,6 +138,11 @@ func (f DefaultFactory) createKindProvisioner(
 		kindconfigmanager.ApplyKubeletCertRotationPatches(kindConfig)
 	}
 
+	// Apply containerd image verifier plugin patch when image verification is enabled.
+	if cluster.Spec.Cluster.Talos.ImageVerification == v1alpha1.ImageVerificationEnabled {
+		kindconfigmanager.ApplyImageVerificationPatches(kindConfig)
+	}
+
 	provisioner, err := kindprovisioner.CreateProvisioner(
 		kindConfig,
 		cluster.Spec.Cluster.Connection.Kubeconfig,

--- a/pkg/svc/provisioner/cluster/factory_test.go
+++ b/pkg/svc/provisioner/cluster/factory_test.go
@@ -253,7 +253,7 @@ func TestCreateKindProvisioner_DockerClientError(t *testing.T) {
 }
 
 func TestCreateKindProvisioner_ImageVerificationPatchApplied(t *testing.T) {
-	t.Parallel()
+	t.Setenv("DOCKER_HOST", "://invalid")
 
 	kindConfig := &v1alpha4.Cluster{
 		Name: "test-kind",
@@ -276,8 +276,8 @@ func TestCreateKindProvisioner_ImageVerificationPatchApplied(t *testing.T) {
 		},
 	}
 
-	// factory.Create may fail due to Docker not being available,
-	// but image verification patches are applied before Docker client creation.
+	// factory.Create will fail on Docker client creation,
+	// but image verification patches are applied before that.
 	//nolint:dogsled // only testing side effects on kindConfig, return values irrelevant
 	_, _, _ = factory.Create(context.Background(), cluster)
 
@@ -288,7 +288,7 @@ func TestCreateKindProvisioner_ImageVerificationPatchApplied(t *testing.T) {
 }
 
 func TestCreateKindProvisioner_ImageVerificationDisabledNoPatch(t *testing.T) {
-	t.Parallel()
+	t.Setenv("DOCKER_HOST", "://invalid")
 
 	kindConfig := &v1alpha4.Cluster{
 		Name: "test-kind",

--- a/pkg/svc/provisioner/cluster/factory_test.go
+++ b/pkg/svc/provisioner/cluster/factory_test.go
@@ -251,3 +251,67 @@ func TestCreateKindProvisioner_DockerClientError(t *testing.T) {
 	assert.Nil(t, provisioner)
 	assert.Contains(t, err.Error(), "failed to create Docker client")
 }
+
+func TestCreateKindProvisioner_ImageVerificationPatchApplied(t *testing.T) {
+	t.Parallel()
+
+	kindConfig := &v1alpha4.Cluster{
+		Name: "test-kind",
+	}
+
+	factory := clusterprovisioner.DefaultFactory{
+		DistributionConfig: &clusterprovisioner.DistributionConfig{
+			Kind: kindConfig,
+		},
+	}
+
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionVanilla,
+				Talos: v1alpha1.OptionsTalos{
+					ImageVerification: v1alpha1.ImageVerificationEnabled,
+				},
+			},
+		},
+	}
+
+	// factory.Create may fail due to Docker not being available,
+	// but image verification patches are applied before Docker client creation.
+	_, _, _ = factory.Create(context.Background(), cluster)
+
+	assert.NotEmpty(t, kindConfig.ContainerdConfigPatches,
+		"image verification containerd config patch should be applied")
+	assert.Contains(t, kindConfig.ContainerdConfigPatches[0],
+		`io.containerd.image-verifier.v1.bindir`)
+}
+
+func TestCreateKindProvisioner_ImageVerificationDisabledNoPatch(t *testing.T) {
+	t.Parallel()
+
+	kindConfig := &v1alpha4.Cluster{
+		Name: "test-kind",
+	}
+
+	factory := clusterprovisioner.DefaultFactory{
+		DistributionConfig: &clusterprovisioner.DistributionConfig{
+			Kind: kindConfig,
+		},
+	}
+
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionVanilla,
+				Talos: v1alpha1.OptionsTalos{
+					ImageVerification: v1alpha1.ImageVerificationDisabled,
+				},
+			},
+		},
+	}
+
+	_, _, _ = factory.Create(context.Background(), cluster)
+
+	assert.Empty(t, kindConfig.ContainerdConfigPatches,
+		"no containerd config patch should be applied when image verification is disabled")
+}

--- a/pkg/svc/provisioner/cluster/factory_test.go
+++ b/pkg/svc/provisioner/cluster/factory_test.go
@@ -278,6 +278,7 @@ func TestCreateKindProvisioner_ImageVerificationPatchApplied(t *testing.T) {
 
 	// factory.Create may fail due to Docker not being available,
 	// but image verification patches are applied before Docker client creation.
+	//nolint:dogsled // only testing side effects on kindConfig, return values irrelevant
 	_, _, _ = factory.Create(context.Background(), cluster)
 
 	assert.NotEmpty(t, kindConfig.ContainerdConfigPatches,
@@ -310,6 +311,7 @@ func TestCreateKindProvisioner_ImageVerificationDisabledNoPatch(t *testing.T) {
 		},
 	}
 
+	//nolint:dogsled // only testing side effects on kindConfig, return values irrelevant
 	_, _, _ = factory.Create(context.Background(), cluster)
 
 	assert.Empty(t, kindConfig.ContainerdConfigPatches,


### PR DESCRIPTION
## Summary

Implements containerd image verifier configuration for the Kind (Vanilla) distribution using `containerdConfigPatches` in `kind.yaml`. When `--image-verification Enabled` is set, a TOML containerd config patch is injected that enables the `io.containerd.image-verifier.v1.bindir` plugin.

## Changes

- **`pkg/fsutil/configmanager/kind/helpers.go`** — Added `ImageVerificationPatch` constant (TOML config with plugin enablement, `bin_dir`, timeouts, and commented Cosign/Notation examples) and `ApplyImageVerificationPatches()` function
- **`pkg/fsutil/scaffolder/scaffolder_kind.go`** — Wired into `buildKindConfig()` for scaffolded path (`ksail cluster init --image-verification Enabled`)
- **`pkg/svc/provisioner/cluster/factory.go`** — Wired into `createKindProvisioner()` for non-scaffolded path (`ksail cluster create --image-verification Enabled`)
- **`pkg/apis/cluster/v1alpha1/imageverification.go`** — Updated doc comment to be distribution-agnostic
- **`pkg/fsutil/configmanager/ksail/field_selector.go`** + **`binding.go`** — Updated descriptions from "Talos-specific" to distribution-agnostic
- **Tests** — Added tests in `helpers_test.go`, `scaffolder_test.go`, and `factory_test.go`

## References

- containerd image verification docs: https://github.com/containerd/containerd/blob/main/docs/image-verification.md
- Requires containerd 2.x (Kind v0.31.0+ / `kindest/node:v1.35.1+`)

Fixes #3608