### PR TITLE
feat: add Talos OS version upgrade via LifecycleService API

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -34,4 +34,10 @@ var (
 	ErrEtcdLeaveCluster = errors.New("failed to remove etcd member")
 	// ErrNoConfigForRole is returned when no Talos machine config is available for a role.
 	ErrNoConfigForRole = errors.New("no config available for role")
+	// ErrUpgradeFailed is returned when a Talos OS upgrade fails on a node.
+	ErrUpgradeFailed = errors.New("talos upgrade failed")
+	// ErrNodeNotReady is returned when a node does not become ready within the timeout.
+	ErrNodeNotReady = errors.New("node did not become ready within timeout")
+	// ErrEmptyVersionResponse is returned when a Talos node returns an empty version response.
+	ErrEmptyVersionResponse = errors.New("empty version response from node")
 )

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -127,3 +127,13 @@ func (p *Provisioner) ApplyNodeScalingChangesForTest(
 ) error {
 	return p.applyNodeScalingChanges(ctx, clusterName, oldSpec, newSpec, result)
 }
+
+// ExtractTagFromImageForTest exposes extractTagFromImage for unit testing.
+func ExtractTagFromImageForTest(image string) string {
+	return extractTagFromImage(image)
+}
+
+// InstallerImageFromTagForTest exposes installerImageFromTag for unit testing.
+func InstallerImageFromTagForTest(tag string) string {
+	return installerImageFromTag(tag)
+}

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -65,12 +65,9 @@ func (p *Provisioner) Update(
 		}
 	}
 
-	// Handle Talos OS version upgrade.
-	// Omni manages upgrades externally through its own API.
-	if p.omniOpts == nil {
-		if upgradeErr := p.applyTalosVersionUpgrade(ctx, clusterName, result); upgradeErr != nil {
-			return result, fmt.Errorf("failed to apply Talos version upgrade: %w", upgradeErr)
-		}
+	// Handle Talos OS version upgrade (skipped internally for Omni clusters).
+	if upgradeErr := p.applyTalosVersionUpgrade(ctx, clusterName, result); upgradeErr != nil {
+		return result, fmt.Errorf("failed to apply Talos version upgrade: %w", upgradeErr)
 	}
 
 	return result, nil
@@ -278,14 +275,20 @@ func (p *Provisioner) applyNodeConfig(
 	}
 }
 
-// applyTalosVersionUpgrade checks whether the running Talos version differs from
-// the desired version (derived from Options.TalosImage) and performs a rolling
-// upgrade if needed.
+// applyTalosVersionUpgrade checks whether any node's running Talos version
+// differs from the desired version (derived from Options.TalosImage) and
+// performs a rolling upgrade of all mismatched nodes.
+// Omni-managed clusters are skipped since Omni handles upgrades externally.
 func (p *Provisioner) applyTalosVersionUpgrade(
 	ctx context.Context,
 	clusterName string,
 	result *clusterupdate.UpdateResult,
 ) error {
+	// Omni manages Talos upgrades through its own API.
+	if p.omniOpts != nil {
+		return nil
+	}
+
 	desiredTag := extractTagFromImage(p.options.TalosImage)
 	if desiredTag == "" {
 		return nil // No tag to compare — skip
@@ -300,27 +303,41 @@ func (p *Provisioner) applyTalosVersionUpgrade(
 		return nil
 	}
 
-	// Check the first node's running version to decide if an upgrade is needed.
-	runningTag, err := p.getRunningTalosVersion(ctx, nodes[0].IP)
-	if err != nil {
-		return fmt.Errorf("checking running Talos version: %w", err)
+	// Check all nodes for version mismatch to handle partial upgrades.
+	needsUpgrade := false
+
+	var firstRunningTag string
+
+	for _, node := range nodes {
+		tag, versionErr := p.getRunningTalosVersion(ctx, node.IP)
+		if versionErr != nil {
+			return fmt.Errorf("checking running Talos version on %s: %w", node.IP, versionErr)
+		}
+
+		if firstRunningTag == "" {
+			firstRunningTag = tag
+		}
+
+		if tag != desiredTag {
+			needsUpgrade = true
+		}
 	}
 
-	if runningTag == desiredTag {
-		return nil // Already at desired version
+	if !needsUpgrade {
+		return nil // All nodes at desired version
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter,
-		"  Talos version mismatch: running %s, desired %s — starting rolling upgrade\n",
-		runningTag, desiredTag,
+		"  Talos version mismatch detected (desired %s) — starting rolling upgrade\n",
+		desiredTag,
 	)
 
 	installerImage := installerImageFromTag(desiredTag)
 
-	if upgradeErr := p.rollingUpgradeNodes(ctx, clusterName, installerImage); upgradeErr != nil {
+	if upgradeErr := p.rollingUpgradeNodes(ctx, clusterName, installerImage, desiredTag); upgradeErr != nil {
 		result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
 			Field:    "talos.version",
-			OldValue: runningTag,
+			OldValue: firstRunningTag,
 			NewValue: desiredTag,
 			Category: clusterupdate.ChangeCategoryRebootRequired,
 			Reason:   "Talos OS version upgrade via LifecycleService failed: " + upgradeErr.Error(),
@@ -331,7 +348,7 @@ func (p *Provisioner) applyTalosVersionUpgrade(
 
 	result.AppliedChanges = append(result.AppliedChanges, clusterupdate.Change{
 		Field:    "talos.version",
-		OldValue: runningTag,
+		OldValue: firstRunningTag,
 		NewValue: desiredTag,
 		Category: clusterupdate.ChangeCategoryRebootRequired,
 		Reason:   "Talos OS upgraded via LifecycleService API",

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -65,6 +65,14 @@ func (p *Provisioner) Update(
 		}
 	}
 
+	// Handle Talos OS version upgrade.
+	// Omni manages upgrades externally through its own API.
+	if p.omniOpts == nil {
+		if upgradeErr := p.applyTalosVersionUpgrade(ctx, clusterName, result); upgradeErr != nil {
+			return result, fmt.Errorf("failed to apply Talos version upgrade: %w", upgradeErr)
+		}
+	}
+
 	return result, nil
 }
 
@@ -268,6 +276,68 @@ func (p *Provisioner) applyNodeConfig(
 			Reason:   node.Role + " config applied successfully",
 		})
 	}
+}
+
+// applyTalosVersionUpgrade checks whether the running Talos version differs from
+// the desired version (derived from Options.TalosImage) and performs a rolling
+// upgrade if needed.
+func (p *Provisioner) applyTalosVersionUpgrade(
+	ctx context.Context,
+	clusterName string,
+	result *clusterupdate.UpdateResult,
+) error {
+	desiredTag := extractTagFromImage(p.options.TalosImage)
+	if desiredTag == "" {
+		return nil // No tag to compare — skip
+	}
+
+	nodes, err := p.getNodesByRole(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("listing nodes for version check: %w", err)
+	}
+
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	// Check the first node's running version to decide if an upgrade is needed.
+	runningTag, err := p.getRunningTalosVersion(ctx, nodes[0].IP)
+	if err != nil {
+		return fmt.Errorf("checking running Talos version: %w", err)
+	}
+
+	if runningTag == desiredTag {
+		return nil // Already at desired version
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter,
+		"  Talos version mismatch: running %s, desired %s — starting rolling upgrade\n",
+		runningTag, desiredTag,
+	)
+
+	installerImage := installerImageFromTag(desiredTag)
+
+	if upgradeErr := p.rollingUpgradeNodes(ctx, clusterName, installerImage); upgradeErr != nil {
+		result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
+			Field:    "talos.version",
+			OldValue: runningTag,
+			NewValue: desiredTag,
+			Category: clusterupdate.ChangeCategoryRebootRequired,
+			Reason:   "Talos OS version upgrade via LifecycleService failed: " + upgradeErr.Error(),
+		})
+
+		return fmt.Errorf("rolling upgrade: %w", upgradeErr)
+	}
+
+	result.AppliedChanges = append(result.AppliedChanges, clusterupdate.Change{
+		Field:    "talos.version",
+		OldValue: runningTag,
+		NewValue: desiredTag,
+		Category: clusterupdate.ChangeCategoryRebootRequired,
+		Reason:   "Talos OS upgraded via LifecycleService API",
+	})
+
+	return nil
 }
 
 // applyRebootRequiredChanges applies changes that require node reboots.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -341,6 +341,7 @@ func (p *Provisioner) applyTalosVersionUpgrade(
 }
 
 // checkNodesNeedUpgrade checks all nodes for version mismatch to handle partial upgrades.
+// Returns the first mismatched tag so the update result accurately reflects the old version.
 func (p *Provisioner) checkNodesNeedUpgrade(
 	ctx context.Context,
 	nodes []nodeWithRole,
@@ -349,8 +350,6 @@ func (p *Provisioner) checkNodesNeedUpgrade(
 	if len(nodes) == 0 {
 		return false, "", nil
 	}
-
-	var firstRunningTag string
 
 	for _, node := range nodes {
 		tag, versionErr := p.getRunningTalosVersion(ctx, node.IP)
@@ -362,16 +361,12 @@ func (p *Provisioner) checkNodesNeedUpgrade(
 			)
 		}
 
-		if firstRunningTag == "" {
-			firstRunningTag = tag
-		}
-
 		if tag != desiredTag {
-			return true, firstRunningTag, nil
+			return true, tag, nil
 		}
 	}
 
-	return false, firstRunningTag, nil
+	return false, desiredTag, nil
 }
 
 // applyRebootRequiredChanges applies changes that require node reboots.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -299,28 +299,9 @@ func (p *Provisioner) applyTalosVersionUpgrade(
 		return fmt.Errorf("listing nodes for version check: %w", err)
 	}
 
-	if len(nodes) == 0 {
-		return nil
-	}
-
-	// Check all nodes for version mismatch to handle partial upgrades.
-	needsUpgrade := false
-
-	var firstRunningTag string
-
-	for _, node := range nodes {
-		tag, versionErr := p.getRunningTalosVersion(ctx, node.IP)
-		if versionErr != nil {
-			return fmt.Errorf("checking running Talos version on %s: %w", node.IP, versionErr)
-		}
-
-		if firstRunningTag == "" {
-			firstRunningTag = tag
-		}
-
-		if tag != desiredTag {
-			needsUpgrade = true
-		}
+	needsUpgrade, firstRunningTag, err := p.checkNodesNeedUpgrade(ctx, nodes, desiredTag)
+	if err != nil {
+		return err
 	}
 
 	if !needsUpgrade {
@@ -355,6 +336,36 @@ func (p *Provisioner) applyTalosVersionUpgrade(
 	})
 
 	return nil
+}
+
+// checkNodesNeedUpgrade checks all nodes for version mismatch to handle partial upgrades.
+func (p *Provisioner) checkNodesNeedUpgrade(
+	ctx context.Context,
+	nodes []nodeWithRole,
+	desiredTag string,
+) (bool, string, error) {
+	if len(nodes) == 0 {
+		return false, "", nil
+	}
+
+	var firstRunningTag string
+
+	for _, node := range nodes {
+		tag, versionErr := p.getRunningTalosVersion(ctx, node.IP)
+		if versionErr != nil {
+			return false, "", fmt.Errorf("checking running Talos version on %s: %w", node.IP, versionErr)
+		}
+
+		if firstRunningTag == "" {
+			firstRunningTag = tag
+		}
+
+		if tag != desiredTag {
+			return true, firstRunningTag, nil
+		}
+	}
+
+	return false, firstRunningTag, nil
 }
 
 // applyRebootRequiredChanges applies changes that require node reboots.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -66,7 +66,8 @@ func (p *Provisioner) Update(
 	}
 
 	// Handle Talos OS version upgrade (skipped internally for Omni clusters).
-	if upgradeErr := p.applyTalosVersionUpgrade(ctx, clusterName, result); upgradeErr != nil {
+	upgradeErr := p.applyTalosVersionUpgrade(ctx, clusterName, result)
+	if upgradeErr != nil {
 		return result, fmt.Errorf("failed to apply Talos version upgrade: %w", upgradeErr)
 	}
 
@@ -315,7 +316,8 @@ func (p *Provisioner) applyTalosVersionUpgrade(
 
 	installerImage := installerImageFromTag(desiredTag)
 
-	if upgradeErr := p.rollingUpgradeNodes(ctx, clusterName, installerImage, desiredTag); upgradeErr != nil {
+	upgradeErr := p.rollingUpgradeNodes(ctx, clusterName, installerImage, desiredTag)
+	if upgradeErr != nil {
 		result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
 			Field:    "talos.version",
 			OldValue: firstRunningTag,
@@ -353,7 +355,11 @@ func (p *Provisioner) checkNodesNeedUpgrade(
 	for _, node := range nodes {
 		tag, versionErr := p.getRunningTalosVersion(ctx, node.IP)
 		if versionErr != nil {
-			return false, "", fmt.Errorf("checking running Talos version on %s: %w", node.IP, versionErr)
+			return false, "", fmt.Errorf(
+				"checking running Talos version on %s: %w",
+				node.IP,
+				versionErr,
+			)
 		}
 
 		if firstRunningTag == "" {

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -139,6 +139,36 @@ func TestUpdateSkipsOmniInPlaceConfigApply(t *testing.T) {
 	}
 }
 
+// TestUpdateSkipsOmniVersionUpgrade verifies the omniOpts guard in applyTalosVersionUpgrade
+// prevents Talos OS upgrade attempts on Omni-managed clusters.
+// Without the guard, Update() would try to query node versions via the Talos API and fail.
+func TestUpdateSkipsOmniVersionUpgrade(t *testing.T) {
+	t.Parallel()
+
+	talosConfigs, err := talosconfigmanager.NewDefaultConfigs()
+	if err != nil {
+		t.Fatalf("NewDefaultConfigs() error = %v", err)
+	}
+
+	provisioner := talosprovisioner.NewProvisioner(talosConfigs, nil).
+		WithOmniOptions(v1alpha1.OptionsOmni{}).
+		WithLogWriter(io.Discard)
+
+	// Identical specs: only the version upgrade step runs (no scaling/config changes).
+	spec := &v1alpha1.ClusterSpec{}
+	spec.Talos.ControlPlanes = 1
+
+	result, err := provisioner.Update(
+		context.Background(),
+		"demo",
+		spec,
+		spec,
+		clusterupdate.UpdateOptions{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, result.FailedChanges)
+}
+
 // TestApplyNodeScalingChanges_NilSpecs verifies that nil specs short-circuit scaling without error.
 // The implementation short-circuits when either spec is nil, so all three nil combinations are tested.
 func TestApplyNodeScalingChanges_NilSpecs(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -1,0 +1,233 @@
+package talosprovisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+)
+
+// Upgrade timeouts and retry intervals.
+const (
+	// upgradeNodeReadinessTimeout is the maximum time to wait for a node to
+	// become reachable after a reboot following an upgrade.
+	upgradeNodeReadinessTimeout = 10 * time.Minute
+	// upgradeReadinessInterval is the poll interval for node readiness checks.
+	upgradeReadinessInterval = 5 * time.Second
+)
+
+// upgradeNodeTalosVersion performs a Talos OS upgrade on a single node using the
+// LifecycleService API. The flow is:
+//  1. Pull the installer image onto the node's containerd.
+//  2. Call LifecycleService.Upgrade to write the new OS image.
+//  3. Reboot the node.
+//  4. Wait for the node to come back online.
+func (p *Provisioner) upgradeNodeTalosVersion(
+	ctx context.Context,
+	nodeIP, installerImage string,
+) error {
+	talosClient, err := p.createTalosClient(ctx, nodeIP)
+	if err != nil {
+		return fmt.Errorf("creating talos client: %w", err)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	containerd := &common.ContainerdInstance{
+		Driver:    common.ContainerDriver_CONTAINERD,
+		Namespace: common.ContainerdNamespace_NS_SYSTEM,
+	}
+
+	// Step 1: Pull the installer image on the node.
+	if pullErr := p.pullInstallerImage(ctx, talosClient, containerd, nodeIP, installerImage); pullErr != nil {
+		return pullErr
+	}
+
+	// Step 2: Upgrade via LifecycleService.
+	if upgradeErr := p.lifecycleUpgrade(ctx, talosClient, containerd, nodeIP, installerImage); upgradeErr != nil {
+		return upgradeErr
+	}
+
+	// Step 3: Reboot.
+	_, _ = fmt.Fprintf(p.logWriter, "    Rebooting %s...\n", nodeIP)
+
+	if rebootErr := talosClient.Reboot(ctx); rebootErr != nil {
+		return fmt.Errorf("rebooting node %s: %w", nodeIP, rebootErr)
+	}
+
+	// Step 4: Wait for the node to come back.
+	_, _ = fmt.Fprintf(p.logWriter, "    Waiting for %s to become ready...\n", nodeIP)
+
+	if waitErr := p.waitForNodeReadyAfterUpgrade(ctx, nodeIP); waitErr != nil {
+		return fmt.Errorf("waiting for node %s readiness: %w", nodeIP, waitErr)
+	}
+
+	return nil
+}
+
+// pullInstallerImage pulls the Talos installer image on the remote node via the
+// ImageService.Pull streaming RPC.
+func (p *Provisioner) pullInstallerImage(
+	ctx context.Context,
+	talosClient *talosclient.Client,
+	containerd *common.ContainerdInstance,
+	nodeIP, installerImage string,
+) error {
+	_, _ = fmt.Fprintf(p.logWriter, "    Pulling installer image %s on %s...\n", installerImage, nodeIP)
+
+	stream, err := talosClient.ImageClient.Pull(ctx, &machineapi.ImageServicePullRequest{
+		Containerd: containerd,
+		ImageRef:   installerImage,
+	})
+	if err != nil {
+		return fmt.Errorf("pulling installer image on %s: %w", nodeIP, err)
+	}
+
+	for {
+		_, recvErr := stream.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+
+		if recvErr != nil {
+			return fmt.Errorf("pulling installer image on %s: %w", nodeIP, recvErr)
+		}
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "    ✓ Installer image pulled on %s\n", nodeIP)
+
+	return nil
+}
+
+// lifecycleUpgrade calls LifecycleService.Upgrade on the node and drains the
+// streaming progress response.
+func (p *Provisioner) lifecycleUpgrade(
+	ctx context.Context,
+	talosClient *talosclient.Client,
+	containerd *common.ContainerdInstance,
+	nodeIP, installerImage string,
+) error {
+	_, _ = fmt.Fprintf(p.logWriter, "    Upgrading %s via LifecycleService...\n", nodeIP)
+
+	stream, err := talosClient.LifecycleClient.Upgrade(ctx, &machineapi.LifecycleServiceUpgradeRequest{
+		Containerd: containerd,
+		Source: &machineapi.InstallArtifactsSource{
+			ImageName: installerImage,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("lifecycle upgrade on %s: %w", nodeIP, err)
+	}
+
+	for {
+		resp, recvErr := stream.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+
+		if recvErr != nil {
+			return fmt.Errorf("lifecycle upgrade on %s: %w", nodeIP, recvErr)
+		}
+
+		progress := resp.GetProgress()
+		if progress == nil {
+			continue
+		}
+
+		switch msg := progress.GetResponse().(type) {
+		case *machineapi.LifecycleServiceInstallProgress_Message:
+			_, _ = fmt.Fprintf(p.logWriter, "      %s: %s\n", nodeIP, msg.Message)
+		case *machineapi.LifecycleServiceInstallProgress_ExitCode:
+			if msg.ExitCode != 0 {
+				return fmt.Errorf("upgrade on %s failed with exit code %d", nodeIP, msg.ExitCode)
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "    ✓ Upgrade completed on %s\n", nodeIP)
+
+	return nil
+}
+
+// waitForNodeReadyAfterUpgrade polls a node's Talos API until it responds,
+// indicating the node has rebooted and is reachable again after an upgrade.
+func (p *Provisioner) waitForNodeReadyAfterUpgrade(ctx context.Context, nodeIP string) error {
+	deadline := time.Now().Add(upgradeNodeReadinessTimeout)
+
+	// Short delay to allow the node to begin rebooting before we start polling.
+	select {
+	case <-time.After(upgradeReadinessInterval):
+	case <-ctx.Done():
+		return ctx.Err() //nolint:wrapcheck
+	}
+
+	for time.Now().Before(deadline) {
+		_, err := p.getRunningTalosVersion(ctx, nodeIP)
+		if err == nil {
+			return nil
+		}
+
+		select {
+		case <-time.After(upgradeReadinessInterval):
+		case <-ctx.Done():
+			return ctx.Err() //nolint:wrapcheck
+		}
+	}
+
+	return fmt.Errorf("node %s did not become ready within %s", nodeIP, upgradeNodeReadinessTimeout)
+}
+
+// rollingUpgradeNodes performs a rolling Talos OS upgrade across all cluster
+// nodes. Workers are upgraded first, then control-planes, one node at a time.
+func (p *Provisioner) rollingUpgradeNodes(
+	ctx context.Context,
+	clusterName, installerImage string,
+) error {
+	nodes, err := p.getNodesByRole(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("listing nodes for upgrade: %w", err)
+	}
+
+	// Partition into workers and control-planes.
+	var workers, controlPlanes []nodeWithRole
+
+	for _, n := range nodes {
+		switch n.Role {
+		case RoleWorker:
+			workers = append(workers, n)
+		case RoleControlPlane:
+			controlPlanes = append(controlPlanes, n)
+		}
+	}
+
+	// Sort for deterministic ordering.
+	sort.Slice(workers, func(i, j int) bool { return workers[i].IP < workers[j].IP })
+	sort.Slice(controlPlanes, func(i, j int) bool { return controlPlanes[i].IP < controlPlanes[j].IP })
+
+	// Upgrade workers first, then control-planes.
+	ordered := append(workers, controlPlanes...) //nolint:gocritic // intentional append to new slice
+
+	for i, node := range ordered {
+		_, _ = fmt.Fprintf(p.logWriter,
+			"  [%d/%d] Upgrading %s (%s)...\n",
+			i+1, len(ordered), node.IP, node.Role,
+		)
+
+		if upgradeErr := p.upgradeNodeTalosVersion(ctx, node.IP, installerImage); upgradeErr != nil {
+			return fmt.Errorf("upgrading node %s (%s): %w", node.IP, node.Role, upgradeErr)
+		}
+
+		_, _ = fmt.Fprintf(p.logWriter,
+			"  ✓ Node %s (%s) upgraded successfully\n",
+			node.IP, node.Role,
+		)
+	}
+
+	return nil
+}

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -36,26 +36,30 @@ func (p *Provisioner) upgradeNodeTalosVersion(
 	}
 
 	// Step 1: Pull the installer image on the node.
-	if pullErr := p.pullInstallerImage(ctx, talosClient, containerd, nodeIP, installerImage); pullErr != nil {
+	pullErr := p.pullInstallerImage(ctx, talosClient, containerd, nodeIP, installerImage)
+	if pullErr != nil {
 		return pullErr
 	}
 
 	// Step 2: Upgrade via LifecycleService.
-	if upgradeErr := p.lifecycleUpgrade(ctx, talosClient, containerd, nodeIP, installerImage); upgradeErr != nil {
+	upgradeErr := p.lifecycleUpgrade(ctx, talosClient, containerd, nodeIP, installerImage)
+	if upgradeErr != nil {
 		return upgradeErr
 	}
 
 	// Step 3: Reboot.
 	_, _ = fmt.Fprintf(p.logWriter, "    Rebooting %s...\n", nodeIP)
 
-	if rebootErr := talosClient.Reboot(ctx); rebootErr != nil {
+	rebootErr := talosClient.Reboot(ctx)
+	if rebootErr != nil {
 		return fmt.Errorf("rebooting node %s: %w", nodeIP, rebootErr)
 	}
 
 	// Step 4: Wait for the node to come back with the desired version.
 	_, _ = fmt.Fprintf(p.logWriter, "    Waiting for %s to become ready...\n", nodeIP)
 
-	if waitErr := p.waitForNodeReadyAfterUpgrade(ctx, nodeIP, desiredTag); waitErr != nil {
+	waitErr := p.waitForNodeReadyAfterUpgrade(ctx, nodeIP, desiredTag)
+	if waitErr != nil {
 		return fmt.Errorf("waiting for node %s readiness: %w", nodeIP, waitErr)
 	}
 
@@ -70,7 +74,12 @@ func (p *Provisioner) pullInstallerImage(
 	containerd *common.ContainerdInstance,
 	nodeIP, installerImage string,
 ) error {
-	_, _ = fmt.Fprintf(p.logWriter, "    Pulling installer image %s on %s...\n", installerImage, nodeIP)
+	_, _ = fmt.Fprintf(
+		p.logWriter,
+		"    Pulling installer image %s on %s...\n",
+		installerImage,
+		nodeIP,
+	)
 
 	stream, err := talosClient.ImageClient.Pull(ctx, &machineapi.ImageServicePullRequest{
 		Containerd: containerd,
@@ -106,17 +115,21 @@ func (p *Provisioner) lifecycleUpgrade(
 ) error {
 	_, _ = fmt.Fprintf(p.logWriter, "    Upgrading %s via LifecycleService...\n", nodeIP)
 
-	stream, err := talosClient.LifecycleClient.Upgrade(ctx, &machineapi.LifecycleServiceUpgradeRequest{
-		Containerd: containerd,
-		Source: &machineapi.InstallArtifactsSource{
-			ImageName: installerImage,
+	stream, err := talosClient.LifecycleClient.Upgrade(
+		ctx,
+		&machineapi.LifecycleServiceUpgradeRequest{
+			Containerd: containerd,
+			Source: &machineapi.InstallArtifactsSource{
+				ImageName: installerImage,
+			},
 		},
-	})
+	)
 	if err != nil {
 		return fmt.Errorf("lifecycle upgrade on %s: %w", nodeIP, err)
 	}
 
-	if drainErr := drainUpgradeStream(stream, p.logWriter, nodeIP); drainErr != nil {
+	drainErr := drainUpgradeStream(stream, p.logWriter, nodeIP)
+	if drainErr != nil {
 		return drainErr
 	}
 
@@ -152,7 +165,12 @@ func drainUpgradeStream(
 			_, _ = fmt.Fprintf(logWriter, "      %s: %s\n", nodeIP, msg.Message)
 		case *machineapi.LifecycleServiceInstallProgress_ExitCode:
 			if msg.ExitCode != 0 {
-				return fmt.Errorf("node %s exit code %d: %w", nodeIP, msg.ExitCode, ErrUpgradeFailed)
+				return fmt.Errorf(
+					"node %s exit code %d: %w",
+					nodeIP,
+					msg.ExitCode,
+					ErrUpgradeFailed,
+				)
 			}
 		}
 	}
@@ -160,7 +178,10 @@ func drainUpgradeStream(
 
 // waitForNodeReadyAfterUpgrade polls a node's Talos API until it responds with
 // the desired version tag, indicating the node has rebooted into the new OS.
-func (p *Provisioner) waitForNodeReadyAfterUpgrade(ctx context.Context, nodeIP, desiredTag string) error {
+func (p *Provisioner) waitForNodeReadyAfterUpgrade(
+	ctx context.Context,
+	nodeIP, desiredTag string,
+) error {
 	deadline := time.Now().Add(clusterReadinessTimeout)
 
 	// Short delay to allow the node to begin rebooting before we start polling.
@@ -211,10 +232,15 @@ func (p *Provisioner) rollingUpgradeNodes(
 
 	// Sort for deterministic ordering.
 	sort.Slice(workers, func(i, j int) bool { return workers[i].IP < workers[j].IP })
-	sort.Slice(controlPlanes, func(i, j int) bool { return controlPlanes[i].IP < controlPlanes[j].IP })
+	sort.Slice(
+		controlPlanes,
+		func(i, j int) bool { return controlPlanes[i].IP < controlPlanes[j].IP },
+	)
 
 	// Upgrade workers first, then control-planes.
-	ordered := append(workers, controlPlanes...) //nolint:gocritic // intentional append to new slice
+	ordered := append(
+		workers,
+		controlPlanes...) //nolint:gocritic // intentional append to new slice
 
 	for i, node := range ordered {
 		_, _ = fmt.Fprintf(p.logWriter,
@@ -222,7 +248,8 @@ func (p *Provisioner) rollingUpgradeNodes(
 			i+1, len(ordered), node.IP, node.Role,
 		)
 
-		if upgradeErr := p.upgradeNodeTalosVersion(ctx, node.IP, installerImage, desiredTag); upgradeErr != nil {
+		upgradeErr := p.upgradeNodeTalosVersion(ctx, node.IP, installerImage, desiredTag)
+		if upgradeErr != nil {
 			return fmt.Errorf("upgrading node %s (%s): %w", node.IP, node.Role, upgradeErr)
 		}
 

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -243,9 +243,9 @@ func (p *Provisioner) rollingUpgradeNodes(
 	)
 
 	// Upgrade workers first, then control-planes.
-	ordered := append(
-		workers,
-		controlPlanes...) //nolint:gocritic // intentional append to new slice
+	ordered := make([]nodeWithRole, 0, len(workers)+len(controlPlanes))
+	ordered = append(ordered, workers...)
+	ordered = append(ordered, controlPlanes...)
 
 	for i, node := range ordered {
 		_, _ = fmt.Fprintf(p.logWriter,

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -25,7 +25,7 @@ func (p *Provisioner) upgradeNodeTalosVersion(
 ) error {
 	talosClient, err := p.createTalosClient(ctx, nodeIP)
 	if err != nil {
-		return fmt.Errorf("creating talos client: %w", err)
+		return fmt.Errorf("creating talos client for node %s: %w", nodeIP, err)
 	}
 
 	defer talosClient.Close() //nolint:errcheck
@@ -192,7 +192,12 @@ func (p *Provisioner) waitForNodeReadyAfterUpgrade(
 	}
 
 	for time.Now().Before(deadline) {
-		tag, err := p.getRunningTalosVersion(ctx, nodeIP)
+		pollCtx, pollCancel := context.WithTimeout(ctx, retryInterval)
+
+		tag, err := p.getRunningTalosVersion(pollCtx, nodeIP)
+
+		pollCancel()
+
 		if err == nil && tag == desiredTag {
 			return nil
 		}

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -13,24 +13,15 @@ import (
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 )
 
-// Upgrade timeouts and retry intervals.
-const (
-	// upgradeNodeReadinessTimeout is the maximum time to wait for a node to
-	// become reachable after a reboot following an upgrade.
-	upgradeNodeReadinessTimeout = 10 * time.Minute
-	// upgradeReadinessInterval is the poll interval for node readiness checks.
-	upgradeReadinessInterval = 5 * time.Second
-)
-
 // upgradeNodeTalosVersion performs a Talos OS upgrade on a single node using the
 // LifecycleService API. The flow is:
 //  1. Pull the installer image onto the node's containerd.
 //  2. Call LifecycleService.Upgrade to write the new OS image.
 //  3. Reboot the node.
-//  4. Wait for the node to come back online.
+//  4. Wait for the node to come back online with the expected version.
 func (p *Provisioner) upgradeNodeTalosVersion(
 	ctx context.Context,
-	nodeIP, installerImage string,
+	nodeIP, installerImage, desiredTag string,
 ) error {
 	talosClient, err := p.createTalosClient(ctx, nodeIP)
 	if err != nil {
@@ -61,10 +52,10 @@ func (p *Provisioner) upgradeNodeTalosVersion(
 		return fmt.Errorf("rebooting node %s: %w", nodeIP, rebootErr)
 	}
 
-	// Step 4: Wait for the node to come back.
+	// Step 4: Wait for the node to come back with the desired version.
 	_, _ = fmt.Fprintf(p.logWriter, "    Waiting for %s to become ready...\n", nodeIP)
 
-	if waitErr := p.waitForNodeReadyAfterUpgrade(ctx, nodeIP); waitErr != nil {
+	if waitErr := p.waitForNodeReadyAfterUpgrade(ctx, nodeIP, desiredTag); waitErr != nil {
 		return fmt.Errorf("waiting for node %s readiness: %w", nodeIP, waitErr)
 	}
 
@@ -125,14 +116,30 @@ func (p *Provisioner) lifecycleUpgrade(
 		return fmt.Errorf("lifecycle upgrade on %s: %w", nodeIP, err)
 	}
 
+	if drainErr := drainUpgradeStream(stream, p.logWriter, nodeIP); drainErr != nil {
+		return drainErr
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "    ✓ Upgrade completed on %s\n", nodeIP)
+
+	return nil
+}
+
+// drainUpgradeStream reads all messages from a LifecycleService.Upgrade stream,
+// logging progress messages and checking the exit code.
+func drainUpgradeStream(
+	stream machineapi.LifecycleService_UpgradeClient,
+	logWriter io.Writer,
+	nodeIP string,
+) error {
 	for {
-		resp, recvErr := stream.Recv()
-		if errors.Is(recvErr, io.EOF) {
-			break
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
 		}
 
-		if recvErr != nil {
-			return fmt.Errorf("lifecycle upgrade on %s: %w", nodeIP, recvErr)
+		if err != nil {
+			return fmt.Errorf("lifecycle upgrade on %s: %w", nodeIP, err)
 		}
 
 		progress := resp.GetProgress()
@@ -142,52 +149,48 @@ func (p *Provisioner) lifecycleUpgrade(
 
 		switch msg := progress.GetResponse().(type) {
 		case *machineapi.LifecycleServiceInstallProgress_Message:
-			_, _ = fmt.Fprintf(p.logWriter, "      %s: %s\n", nodeIP, msg.Message)
+			_, _ = fmt.Fprintf(logWriter, "      %s: %s\n", nodeIP, msg.Message)
 		case *machineapi.LifecycleServiceInstallProgress_ExitCode:
 			if msg.ExitCode != 0 {
-				return fmt.Errorf("upgrade on %s failed with exit code %d", nodeIP, msg.ExitCode)
+				return fmt.Errorf("node %s exit code %d: %w", nodeIP, msg.ExitCode, ErrUpgradeFailed)
 			}
 		}
 	}
-
-	_, _ = fmt.Fprintf(p.logWriter, "    ✓ Upgrade completed on %s\n", nodeIP)
-
-	return nil
 }
 
-// waitForNodeReadyAfterUpgrade polls a node's Talos API until it responds,
-// indicating the node has rebooted and is reachable again after an upgrade.
-func (p *Provisioner) waitForNodeReadyAfterUpgrade(ctx context.Context, nodeIP string) error {
-	deadline := time.Now().Add(upgradeNodeReadinessTimeout)
+// waitForNodeReadyAfterUpgrade polls a node's Talos API until it responds with
+// the desired version tag, indicating the node has rebooted into the new OS.
+func (p *Provisioner) waitForNodeReadyAfterUpgrade(ctx context.Context, nodeIP, desiredTag string) error {
+	deadline := time.Now().Add(clusterReadinessTimeout)
 
 	// Short delay to allow the node to begin rebooting before we start polling.
 	select {
-	case <-time.After(upgradeReadinessInterval):
+	case <-time.After(retryInterval):
 	case <-ctx.Done():
 		return ctx.Err() //nolint:wrapcheck
 	}
 
 	for time.Now().Before(deadline) {
-		_, err := p.getRunningTalosVersion(ctx, nodeIP)
-		if err == nil {
+		tag, err := p.getRunningTalosVersion(ctx, nodeIP)
+		if err == nil && tag == desiredTag {
 			return nil
 		}
 
 		select {
-		case <-time.After(upgradeReadinessInterval):
+		case <-time.After(retryInterval):
 		case <-ctx.Done():
 			return ctx.Err() //nolint:wrapcheck
 		}
 	}
 
-	return fmt.Errorf("node %s did not become ready within %s", nodeIP, upgradeNodeReadinessTimeout)
+	return fmt.Errorf("node %s: %w", nodeIP, ErrNodeNotReady)
 }
 
 // rollingUpgradeNodes performs a rolling Talos OS upgrade across all cluster
 // nodes. Workers are upgraded first, then control-planes, one node at a time.
 func (p *Provisioner) rollingUpgradeNodes(
 	ctx context.Context,
-	clusterName, installerImage string,
+	clusterName, installerImage, desiredTag string,
 ) error {
 	nodes, err := p.getNodesByRole(ctx, clusterName)
 	if err != nil {
@@ -219,7 +222,7 @@ func (p *Provisioner) rollingUpgradeNodes(
 			i+1, len(ordered), node.IP, node.Role,
 		)
 
-		if upgradeErr := p.upgradeNodeTalosVersion(ctx, node.IP, installerImage); upgradeErr != nil {
+		if upgradeErr := p.upgradeNodeTalosVersion(ctx, node.IP, installerImage, desiredTag); upgradeErr != nil {
 			return fmt.Errorf("upgrading node %s (%s): %w", node.IP, node.Role, upgradeErr)
 		}
 

--- a/pkg/svc/provisioner/cluster/talos/utils.go
+++ b/pkg/svc/provisioner/cluster/talos/utils.go
@@ -103,9 +103,9 @@ func (p *Provisioner) getRunningTalosVersion(ctx context.Context, nodeIP string)
 		return "", fmt.Errorf("querying Talos version on %s: %w", nodeIP, err)
 	}
 
-	if len(resp.Messages) == 0 || resp.Messages[0].Version == nil {
+	if len(resp.GetMessages()) == 0 || resp.GetMessages()[0].GetVersion() == nil {
 		return "", fmt.Errorf("node %s: %w", nodeIP, ErrEmptyVersionResponse)
 	}
 
-	return resp.Messages[0].Version.Tag, nil
+	return resp.GetMessages()[0].GetVersion().GetTag(), nil
 }

--- a/pkg/svc/provisioner/cluster/talos/utils.go
+++ b/pkg/svc/provisioner/cluster/talos/utils.go
@@ -93,18 +93,18 @@ func installerImageFromTag(tag string) string {
 func (p *Provisioner) getRunningTalosVersion(ctx context.Context, nodeIP string) (string, error) {
 	talosClient, err := p.createTalosClient(ctx, nodeIP)
 	if err != nil {
-		return "", fmt.Errorf("failed to create client for version check: %w", err)
+		return "", fmt.Errorf("version check for node %s: %w", nodeIP, err)
 	}
 
 	defer talosClient.Close() //nolint:errcheck
 
 	resp, err := talosClient.Version(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to query Talos version: %w", err)
+		return "", fmt.Errorf("querying Talos version on %s: %w", nodeIP, err)
 	}
 
 	if len(resp.Messages) == 0 || resp.Messages[0].Version == nil {
-		return "", fmt.Errorf("empty version response from node %s", nodeIP)
+		return "", fmt.Errorf("node %s: %w", nodeIP, ErrEmptyVersionResponse)
 	}
 
 	return resp.Messages[0].Version.Tag, nil

--- a/pkg/svc/provisioner/cluster/talos/utils.go
+++ b/pkg/svc/provisioner/cluster/talos/utils.go
@@ -1,10 +1,12 @@
 package talosprovisioner
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // nthIPInNetwork returns the nth IP in the network (1-indexed).
@@ -54,4 +56,56 @@ func getStateDirectory() (string, error) {
 	}
 
 	return stateDir, nil
+}
+
+// extractTagFromImage extracts the tag from a container image reference.
+// For example, "ghcr.io/siderolabs/talos:v1.13.0-beta.1" returns "v1.13.0-beta.1".
+// Returns empty string if no tag is present.
+func extractTagFromImage(image string) string {
+	// Handle digest references (image@sha256:...)
+	if idx := strings.LastIndex(image, "@"); idx != -1 {
+		image = image[:idx]
+	}
+
+	if idx := strings.LastIndex(image, ":"); idx != -1 {
+		tag := image[idx+1:]
+		// Ensure we're not splitting on a port number (e.g., "localhost:5000/image")
+		if !strings.Contains(tag, "/") {
+			return tag
+		}
+	}
+
+	return ""
+}
+
+// installerImageRepository is the OCI repository for the Talos installer image.
+// The installer is distinct from the node image and contains the OS assets used
+// by the LifecycleService API to perform in-place upgrades.
+const installerImageRepository = "ghcr.io/siderolabs/installer"
+
+// installerImageFromTag constructs a Talos installer image reference from a version tag.
+// The installer image is used by the LifecycleService API for upgrades.
+func installerImageFromTag(tag string) string {
+	return installerImageRepository + ":" + tag
+}
+
+// getRunningTalosVersion queries a Talos node for its running version tag.
+func (p *Provisioner) getRunningTalosVersion(ctx context.Context, nodeIP string) (string, error) {
+	talosClient, err := p.createTalosClient(ctx, nodeIP)
+	if err != nil {
+		return "", fmt.Errorf("failed to create client for version check: %w", err)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	resp, err := talosClient.Version(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to query Talos version: %w", err)
+	}
+
+	if len(resp.Messages) == 0 || resp.Messages[0].Version == nil {
+		return "", fmt.Errorf("empty version response from node %s", nodeIP)
+	}
+
+	return resp.Messages[0].Version.Tag, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/utils_test.go
+++ b/pkg/svc/provisioner/cluster/talos/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//nolint:funlen // Table-driven test with comprehensive image tag scenarios
 func TestExtractTagFromImage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/talos/utils_test.go
+++ b/pkg/svc/provisioner/cluster/talos/utils_test.go
@@ -1,0 +1,106 @@
+package talosprovisioner_test
+
+import (
+	"testing"
+
+	talosprovisioner "github.com/devantler-tech/ksail/v5/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractTagFromImage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		image string
+		want  string
+	}{
+		{
+			name:  "standard image with tag",
+			image: "ghcr.io/siderolabs/talos:v1.13.0-beta.1",
+			want:  "v1.13.0-beta.1",
+		},
+		{
+			name:  "installer image with tag",
+			image: "ghcr.io/siderolabs/installer:v1.13.0",
+			want:  "v1.13.0",
+		},
+		{
+			name:  "image without tag",
+			image: "ghcr.io/siderolabs/talos",
+			want:  "",
+		},
+		{
+			name:  "image with digest only",
+			image: "ghcr.io/siderolabs/talos@sha256:abc123",
+			want:  "",
+		},
+		{
+			name:  "image with tag and digest",
+			image: "ghcr.io/siderolabs/talos:v1.13.0@sha256:abc123",
+			want:  "v1.13.0",
+		},
+		{
+			name:  "image with port in registry",
+			image: "localhost:5000/siderolabs/talos:v1.13.0",
+			want:  "v1.13.0",
+		},
+		{
+			name:  "image with port in registry and no tag",
+			image: "localhost:5000/siderolabs/talos",
+			want:  "",
+		},
+		{
+			name:  "simple image with tag",
+			image: "talos:latest",
+			want:  "latest",
+		},
+		{
+			name:  "empty string",
+			image: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := talosprovisioner.ExtractTagFromImageForTest(tt.image)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInstallerImageFromTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{
+			name: "release version",
+			tag:  "v1.13.0",
+			want: "ghcr.io/siderolabs/installer:v1.13.0",
+		},
+		{
+			name: "beta version",
+			tag:  "v1.13.0-beta.1",
+			want: "ghcr.io/siderolabs/installer:v1.13.0-beta.1",
+		},
+		{
+			name: "alpha version",
+			tag:  "v1.13.0-alpha.0",
+			want: "ghcr.io/siderolabs/installer:v1.13.0-alpha.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := talosprovisioner.InstallerImageFromTagForTest(tt.tag)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/talos/utils_test.go
+++ b/pkg/svc/provisioner/cluster/talos/utils_test.go
@@ -66,6 +66,7 @@ func TestExtractTagFromImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			got := talosprovisioner.ExtractTagFromImageForTest(tt.image)
 			assert.Equal(t, tt.want, got)
 		})
@@ -100,6 +101,7 @@ func TestInstallerImageFromTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			got := talosprovisioner.InstallerImageFromTagForTest(tt.tag)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
## Summary

Adds rolling Talos OS upgrade support to `ksail cluster update` using the Talos 1.13 `LifecycleService.Upgrade` streaming RPC.

## Problem

KSail lacked any Talos OS version upgrade capability — when KSail ships a newer Talos version, `ksail cluster update` could not upgrade running clusters' Talos OS. Issue #3574 requested migrating to the new `LifecycleService` API. An audit confirmed KSail had **zero** calls to the deprecated `MachineService.Upgrade` API, so this is a new feature built directly on the non-deprecated API.

## Changes

When the compiled-in Talos version (from `Options.TalosImage`) differs from the running cluster's version, the update path now:

1. Detects the version mismatch via `client.Version()`
2. Pulls the installer image on each node via `ImageService.Pull()` (streaming)
3. Upgrades via `LifecycleService.Upgrade()` (streaming progress)
4. Reboots each node and waits for readiness
5. Rolls through workers first, then control-planes (one at a time)

Omni-managed clusters are skipped (Omni handles upgrades externally).

### New files
- `upgrade.go` — `upgradeNodeTalosVersion`, `rollingUpgradeNodes`, `pullInstallerImage`, `lifecycleUpgrade`, `waitForNodeReadyAfterUpgrade`
- `utils_test.go` — Tests for `extractTagFromImage`, `installerImageFromTag`

### Modified files
- `utils.go` — Added `extractTagFromImage`, `installerImageFromTag`, `getRunningTalosVersion`
- `update.go` — Added `applyTalosVersionUpgrade`, integrated into `Update()` after in-place config changes
- `export_test.go` — Added test helpers for new utils

## Validation

- ✅ `go build ./...` passes
- ✅ `go test ./pkg/svc/provisioner/cluster/talos/...` — all tests pass (including new unit tests)
- ✅ `go test ./...` — full suite passes (only pre-existing k3d failure due to Docker not running)

Fixes #3574