### PR TITLE
fix: resolve Omni cluster create timeout when CNI is not yet installed

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -4959,10 +4959,18 @@ func runClusterCreationWorkflow(
 	// the correct kubeconfig context. This MUST happen after local registry operations
 	// (which resolve cluster name from distribution configs, not from context) but before
 	// post-CNI setup (which needs the kubectl context name like "kind-kind").
-	clusterName := resolveClusterNameFromContext(ctx)
-	ctx.ClusterCfg.Spec.Cluster.Connection.Context = ctx.ClusterCfg.Spec.Cluster.Distribution.ContextName(
-		clusterName,
-	)
+	//
+	// Omni-generated kubeconfigs use a service-account context name that differs from
+	// the talosctl "admin@<name>" convention. Use empty context (= kubeconfig's
+	// current-context) so helm/kubectl pick the right context automatically.
+	if ctx.ClusterCfg.Spec.Cluster.Provider == v1alpha1.ProviderOmni {
+		ctx.ClusterCfg.Spec.Cluster.Connection.Context = ""
+	} else {
+		clusterName := resolveClusterNameFromContext(ctx)
+		ctx.ClusterCfg.Spec.Cluster.Connection.Context = ctx.ClusterCfg.Spec.Cluster.Distribution.ContextName(
+			clusterName,
+		)
+	}
 
 	maybeImportCachedImages(cmd, ctx, deps.Timer)
 

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -508,8 +508,8 @@ func countReadyNodes(nodes []provider.NodeInfo) (int, int) {
 	return total, ready
 }
 
-// clusterReadyPollInterval is the interval between cluster readiness polls.
-const clusterReadyPollInterval = 10 * time.Second
+// clusterStatusPollInterval is the interval between cluster status polls.
+const clusterStatusPollInterval = 10 * time.Second
 
 // clusterCheckFunc checks a cluster condition and returns true when the condition is met.
 type clusterCheckFunc func(ctx context.Context, st state.State, clusterName string) (bool, error)
@@ -529,7 +529,7 @@ func (p *Provider) waitForCluster(
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(clusterReadyPollInterval)
+	ticker := time.NewTicker(clusterStatusPollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -228,59 +228,6 @@ func (p *Provider) CreateCluster(
 	return nil
 }
 
-// clusterReadyPollInterval is the interval between cluster readiness polls.
-const clusterReadyPollInterval = 10 * time.Second
-
-// clusterCheckFunc checks a cluster condition and returns true when the condition is met.
-type clusterCheckFunc func(ctx context.Context, st state.State, clusterName string) (bool, error)
-
-// waitForCluster polls a cluster condition until it is met or the timeout expires.
-func (p *Provider) waitForCluster(
-	ctx context.Context,
-	clusterName string,
-	timeout time.Duration,
-	check clusterCheckFunc,
-	conditionLabel string,
-) error {
-	if p.st == nil {
-		return provider.ErrProviderUnavailable
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(clusterReadyPollInterval)
-	defer ticker.Stop()
-
-	for {
-		ok, err := check(ctx, p.st, clusterName)
-		if err != nil {
-			return err
-		}
-
-		if ok {
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			ctxErr := ctx.Err()
-			if errors.Is(ctxErr, context.Canceled) {
-				return fmt.Errorf(
-					"cancelled waiting for cluster %q to %s: %w",
-					clusterName, conditionLabel, ctxErr,
-				)
-			}
-
-			return fmt.Errorf(
-				"timed out waiting for cluster %q to %s: %w",
-				clusterName, conditionLabel, ctxErr,
-			)
-		case <-ticker.C:
-		}
-	}
-}
-
 // WaitForClusterReady polls the ClusterStatus resource until the cluster is ready
 // (Phase == RUNNING and Ready == true) or the timeout expires.
 func (p *Provider) WaitForClusterReady(
@@ -302,63 +249,6 @@ func (p *Provider) WaitForClusterRunning(
 	timeout time.Duration,
 ) error {
 	return p.waitForCluster(ctx, clusterName, timeout, isClusterRunning, "reach RUNNING phase")
-}
-
-// getClusterStatus retrieves the ClusterStatus resource for the given cluster.
-// It returns (nil, nil) when the resource is not found or the context is done,
-// allowing the caller to retry or handle the context via ctx.Done().
-func getClusterStatus(
-	ctx context.Context,
-	omniState state.State,
-	clusterName string,
-) (*omnires.ClusterStatus, error) {
-	status, err := safe.StateGet[*omnires.ClusterStatus](
-		ctx,
-		omniState,
-		omnires.NewClusterStatus(clusterName).Metadata(),
-	)
-	if err != nil {
-		if state.IsNotFoundError(err) ||
-			errors.Is(err, context.DeadlineExceeded) ||
-			errors.Is(err, context.Canceled) {
-			return nil, nil
-		}
-
-		return nil, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
-	}
-
-	return status, nil
-}
-
-// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
-func isClusterRunningAndReady(
-	ctx context.Context,
-	omniState state.State,
-	clusterName string,
-) (bool, error) {
-	status, err := getClusterStatus(ctx, omniState, clusterName)
-	if err != nil || status == nil {
-		return false, err
-	}
-
-	phase := status.TypedSpec().Value.GetPhase()
-	ready := status.TypedSpec().Value.GetReady()
-
-	return phase == specs.ClusterStatusSpec_RUNNING && ready, nil
-}
-
-// isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
-func isClusterRunning(
-	ctx context.Context,
-	omniState state.State,
-	clusterName string,
-) (bool, error) {
-	status, err := getClusterStatus(ctx, omniState, clusterName)
-	if err != nil || status == nil {
-		return false, err
-	}
-
-	return status.TypedSpec().Value.GetPhase() == specs.ClusterStatusSpec_RUNNING, nil
 }
 
 // DefaultKubeconfigTTL is the default time-to-live for Omni service-account
@@ -616,4 +506,114 @@ func countReadyNodes(nodes []provider.NodeInfo) (int, int) {
 	}
 
 	return total, ready
+}
+
+// clusterReadyPollInterval is the interval between cluster readiness polls.
+const clusterReadyPollInterval = 10 * time.Second
+
+// clusterCheckFunc checks a cluster condition and returns true when the condition is met.
+type clusterCheckFunc func(ctx context.Context, st state.State, clusterName string) (bool, error)
+
+// waitForCluster polls a cluster condition until it is met or the timeout expires.
+func (p *Provider) waitForCluster(
+	ctx context.Context,
+	clusterName string,
+	timeout time.Duration,
+	check clusterCheckFunc,
+	conditionLabel string,
+) error {
+	if p.st == nil {
+		return provider.ErrProviderUnavailable
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(clusterReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		ok, err := check(ctx, p.st, clusterName)
+		if err != nil {
+			return err
+		}
+
+		if ok {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			ctxErr := ctx.Err()
+			if errors.Is(ctxErr, context.Canceled) {
+				return fmt.Errorf(
+					"cancelled waiting for cluster %q to %s: %w",
+					clusterName, conditionLabel, ctxErr,
+				)
+			}
+
+			return fmt.Errorf(
+				"timed out waiting for cluster %q to %s: %w",
+				clusterName, conditionLabel, ctxErr,
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+// getClusterStatus retrieves the ClusterStatus resource for the given cluster.
+// It returns (nil, nil) when the resource is not found or the context is done,
+// allowing the caller to retry or handle the context via ctx.Done().
+func getClusterStatus(
+	ctx context.Context,
+	omniState state.State,
+	clusterName string,
+) (*omnires.ClusterStatus, error) {
+	status, err := safe.StateGet[*omnires.ClusterStatus](
+		ctx,
+		omniState,
+		omnires.NewClusterStatus(clusterName).Metadata(),
+	)
+	if err != nil {
+		if state.IsNotFoundError(err) ||
+			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, context.Canceled) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
+	}
+
+	return status, nil
+}
+
+// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
+func isClusterRunningAndReady(
+	ctx context.Context,
+	omniState state.State,
+	clusterName string,
+) (bool, error) {
+	status, err := getClusterStatus(ctx, omniState, clusterName)
+	if err != nil || status == nil {
+		return false, err
+	}
+
+	phase := status.TypedSpec().Value.GetPhase()
+	ready := status.TypedSpec().Value.GetReady()
+
+	return phase == specs.ClusterStatusSpec_RUNNING && ready, nil
+}
+
+// isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
+func isClusterRunning(
+	ctx context.Context,
+	omniState state.State,
+	clusterName string,
+) (bool, error) {
+	status, err := getClusterStatus(ctx, omniState, clusterName)
+	if err != nil || status == nil {
+		return false, err
+	}
+
+	return status.TypedSpec().Value.GetPhase() == specs.ClusterStatusSpec_RUNNING, nil
 }

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -561,57 +561,57 @@ func (p *Provider) waitForCluster(
 	}
 }
 
-// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
-// It returns (false, nil) when the cluster resource is not yet found or when the context
+// clusterStatusPredicate evaluates a condition on a ClusterStatusSpec.
+type clusterStatusPredicate func(phase specs.ClusterStatusSpec_Phase, ready bool) bool
+
+// checkClusterStatus fetches the ClusterStatus and evaluates the predicate.
+// It returns (false, nil) when the resource is not yet found or when the context
 // is cancelled/expired, allowing the caller to retry or handle the context via ctx.Done().
+func checkClusterStatus(
+	ctx context.Context,
+	omniState state.State,
+	clusterName string,
+	predicate clusterStatusPredicate,
+) (bool, error) {
+	status, err := safe.StateGet[*omnires.ClusterStatus](
+		ctx,
+		omniState,
+		omnires.NewClusterStatus(clusterName).Metadata(),
+	)
+	if err != nil {
+		if state.IsNotFoundError(err) ||
+			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, context.Canceled) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
+	}
+
+	return predicate(
+		status.TypedSpec().Value.GetPhase(),
+		status.TypedSpec().Value.GetReady(),
+	), nil
+}
+
+// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
 func isClusterRunningAndReady(
 	ctx context.Context,
 	omniState state.State,
 	clusterName string,
 ) (bool, error) {
-	status, err := safe.StateGet[*omnires.ClusterStatus](
-		ctx,
-		omniState,
-		omnires.NewClusterStatus(clusterName).Metadata(),
-	)
-	if err != nil {
-		if state.IsNotFoundError(err) ||
-			errors.Is(err, context.DeadlineExceeded) ||
-			errors.Is(err, context.Canceled) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
-	}
-
-	phase := status.TypedSpec().Value.GetPhase()
-	ready := status.TypedSpec().Value.GetReady()
-
-	return phase == specs.ClusterStatusSpec_RUNNING && ready, nil
+	return checkClusterStatus(ctx, omniState, clusterName, func(phase specs.ClusterStatusSpec_Phase, ready bool) bool {
+		return phase == specs.ClusterStatusSpec_RUNNING && ready
+	})
 }
 
 // isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
-// It returns (false, nil) when the cluster resource is not yet found or when the context
-// is cancelled/expired, allowing the caller to retry or handle the context via ctx.Done().
 func isClusterRunning(
 	ctx context.Context,
 	omniState state.State,
 	clusterName string,
 ) (bool, error) {
-	status, err := safe.StateGet[*omnires.ClusterStatus](
-		ctx,
-		omniState,
-		omnires.NewClusterStatus(clusterName).Metadata(),
-	)
-	if err != nil {
-		if state.IsNotFoundError(err) ||
-			errors.Is(err, context.DeadlineExceeded) ||
-			errors.Is(err, context.Canceled) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
-	}
-
-	return status.TypedSpec().Value.GetPhase() == specs.ClusterStatusSpec_RUNNING, nil
+	return checkClusterStatus(ctx, omniState, clusterName, func(phase specs.ClusterStatusSpec_Phase, _ bool) bool {
+		return phase == specs.ClusterStatusSpec_RUNNING
+	})
 }

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -231,12 +231,16 @@ func (p *Provider) CreateCluster(
 // clusterReadyPollInterval is the interval between cluster readiness polls.
 const clusterReadyPollInterval = 10 * time.Second
 
-// WaitForClusterReady polls the ClusterStatus resource until the cluster is ready
-// (Phase == RUNNING and Ready == true) or the timeout expires.
-func (p *Provider) WaitForClusterReady(
+// clusterCheckFunc checks a cluster condition and returns true when the condition is met.
+type clusterCheckFunc func(ctx context.Context, st state.State, clusterName string) (bool, error)
+
+// waitForCluster polls a cluster condition until it is met or the timeout expires.
+func (p *Provider) waitForCluster(
 	ctx context.Context,
 	clusterName string,
 	timeout time.Duration,
+	check clusterCheckFunc,
+	conditionLabel string,
 ) error {
 	if p.st == nil {
 		return provider.ErrProviderUnavailable
@@ -249,12 +253,12 @@ func (p *Provider) WaitForClusterReady(
 	defer ticker.Stop()
 
 	for {
-		ready, err := isClusterRunningAndReady(ctx, p.st, clusterName)
+		ok, err := check(ctx, p.st, clusterName)
 		if err != nil {
 			return err
 		}
 
-		if ready {
+		if ok {
 			return nil
 		}
 
@@ -263,49 +267,28 @@ func (p *Provider) WaitForClusterReady(
 			ctxErr := ctx.Err()
 			if errors.Is(ctxErr, context.Canceled) {
 				return fmt.Errorf(
-					"cancelled waiting for cluster %q to become ready: %w",
-					clusterName,
-					ctxErr,
+					"cancelled waiting for cluster %q to %s: %w",
+					clusterName, conditionLabel, ctxErr,
 				)
 			}
 
 			return fmt.Errorf(
-				"timed out waiting for cluster %q to become ready: %w",
-				clusterName,
-				ctxErr,
+				"timed out waiting for cluster %q to %s: %w",
+				clusterName, conditionLabel, ctxErr,
 			)
 		case <-ticker.C:
 		}
 	}
 }
 
-// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
-// It returns (false, nil) when the cluster resource is not yet found or when the context
-// is cancelled/expired, allowing the caller to retry or handle the context via ctx.Done().
-func isClusterRunningAndReady(
+// WaitForClusterReady polls the ClusterStatus resource until the cluster is ready
+// (Phase == RUNNING and Ready == true) or the timeout expires.
+func (p *Provider) WaitForClusterReady(
 	ctx context.Context,
-	omniState state.State,
 	clusterName string,
-) (bool, error) {
-	status, err := safe.StateGet[*omnires.ClusterStatus](
-		ctx,
-		omniState,
-		omnires.NewClusterStatus(clusterName).Metadata(),
-	)
-	if err != nil {
-		if state.IsNotFoundError(err) ||
-			errors.Is(err, context.DeadlineExceeded) ||
-			errors.Is(err, context.Canceled) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
-	}
-
-	phase := status.TypedSpec().Value.GetPhase()
-	ready := status.TypedSpec().Value.GetReady()
-
-	return phase == specs.ClusterStatusSpec_RUNNING && ready, nil
+	timeout time.Duration,
+) error {
+	return p.waitForCluster(ctx, clusterName, timeout, isClusterRunningAndReady, "become ready")
 }
 
 // WaitForClusterRunning polls the ClusterStatus resource until the cluster phase
@@ -318,55 +301,17 @@ func (p *Provider) WaitForClusterRunning(
 	clusterName string,
 	timeout time.Duration,
 ) error {
-	if p.st == nil {
-		return provider.ErrProviderUnavailable
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(clusterReadyPollInterval)
-	defer ticker.Stop()
-
-	for {
-		running, err := isClusterRunning(ctx, p.st, clusterName)
-		if err != nil {
-			return err
-		}
-
-		if running {
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			ctxErr := ctx.Err()
-			if errors.Is(ctxErr, context.Canceled) {
-				return fmt.Errorf(
-					"cancelled waiting for cluster %q to reach RUNNING phase: %w",
-					clusterName,
-					ctxErr,
-				)
-			}
-
-			return fmt.Errorf(
-				"timed out waiting for cluster %q to reach RUNNING phase: %w",
-				clusterName,
-				ctxErr,
-			)
-		case <-ticker.C:
-		}
-	}
+	return p.waitForCluster(ctx, clusterName, timeout, isClusterRunning, "reach RUNNING phase")
 }
 
-// isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
-// It returns (false, nil) when the cluster resource is not yet found or when the context
-// is cancelled/expired, allowing the caller to retry or handle the context via ctx.Done().
-func isClusterRunning(
+// getClusterStatus retrieves the ClusterStatus resource for the given cluster.
+// It returns (nil, nil) when the resource is not found or the context is done,
+// allowing the caller to retry or handle the context via ctx.Done().
+func getClusterStatus(
 	ctx context.Context,
 	omniState state.State,
 	clusterName string,
-) (bool, error) {
+) (*omnires.ClusterStatus, error) {
 	status, err := safe.StateGet[*omnires.ClusterStatus](
 		ctx,
 		omniState,
@@ -376,15 +321,44 @@ func isClusterRunning(
 		if state.IsNotFoundError(err) ||
 			errors.Is(err, context.DeadlineExceeded) ||
 			errors.Is(err, context.Canceled) {
-			return false, nil
+			return nil, nil
 		}
 
-		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
+		return nil, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
+	}
+
+	return status, nil
+}
+
+// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
+func isClusterRunningAndReady(
+	ctx context.Context,
+	omniState state.State,
+	clusterName string,
+) (bool, error) {
+	status, err := getClusterStatus(ctx, omniState, clusterName)
+	if err != nil || status == nil {
+		return false, err
 	}
 
 	phase := status.TypedSpec().Value.GetPhase()
+	ready := status.TypedSpec().Value.GetReady()
 
-	return phase == specs.ClusterStatusSpec_RUNNING, nil
+	return phase == specs.ClusterStatusSpec_RUNNING && ready, nil
+}
+
+// isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
+func isClusterRunning(
+	ctx context.Context,
+	omniState state.State,
+	clusterName string,
+) (bool, error) {
+	status, err := getClusterStatus(ctx, omniState, clusterName)
+	if err != nil || status == nil {
+		return false, err
+	}
+
+	return status.TypedSpec().Value.GetPhase() == specs.ClusterStatusSpec_RUNNING, nil
 }
 
 // DefaultKubeconfigTTL is the default time-to-live for Omni service-account

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -600,9 +600,14 @@ func isClusterRunningAndReady(
 	omniState state.State,
 	clusterName string,
 ) (bool, error) {
-	return checkClusterStatus(ctx, omniState, clusterName, func(phase specs.ClusterStatusSpec_Phase, ready bool) bool {
-		return phase == specs.ClusterStatusSpec_RUNNING && ready
-	})
+	return checkClusterStatus(
+		ctx,
+		omniState,
+		clusterName,
+		func(phase specs.ClusterStatusSpec_Phase, ready bool) bool {
+			return phase == specs.ClusterStatusSpec_RUNNING && ready
+		},
+	)
 }
 
 // isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
@@ -611,7 +616,12 @@ func isClusterRunning(
 	omniState state.State,
 	clusterName string,
 ) (bool, error) {
-	return checkClusterStatus(ctx, omniState, clusterName, func(phase specs.ClusterStatusSpec_Phase, _ bool) bool {
-		return phase == specs.ClusterStatusSpec_RUNNING
-	})
+	return checkClusterStatus(
+		ctx,
+		omniState,
+		clusterName,
+		func(phase specs.ClusterStatusSpec_Phase, _ bool) bool {
+			return phase == specs.ClusterStatusSpec_RUNNING
+		},
+	)
 }

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -308,6 +308,85 @@ func isClusterRunningAndReady(
 	return phase == specs.ClusterStatusSpec_RUNNING && ready, nil
 }
 
+// WaitForClusterRunning polls the ClusterStatus resource until the cluster phase
+// is RUNNING or the timeout expires. Unlike WaitForClusterReady, this does NOT
+// require Ready==true, which depends on all nodes being Ready in Kubernetes.
+// Nodes cannot become Ready until a CNI is installed, so this method is used
+// during cluster creation when CNI installation happens as a post-creation step.
+func (p *Provider) WaitForClusterRunning(
+	ctx context.Context,
+	clusterName string,
+	timeout time.Duration,
+) error {
+	if p.st == nil {
+		return provider.ErrProviderUnavailable
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(clusterReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		running, err := isClusterRunning(ctx, p.st, clusterName)
+		if err != nil {
+			return err
+		}
+
+		if running {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			ctxErr := ctx.Err()
+			if errors.Is(ctxErr, context.Canceled) {
+				return fmt.Errorf(
+					"cancelled waiting for cluster %q to reach RUNNING phase: %w",
+					clusterName,
+					ctxErr,
+				)
+			}
+
+			return fmt.Errorf(
+				"timed out waiting for cluster %q to reach RUNNING phase: %w",
+				clusterName,
+				ctxErr,
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+// isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
+// It returns (false, nil) when the cluster resource is not yet found or when the context
+// is cancelled/expired, allowing the caller to retry or handle the context via ctx.Done().
+func isClusterRunning(
+	ctx context.Context,
+	omniState state.State,
+	clusterName string,
+) (bool, error) {
+	status, err := safe.StateGet[*omnires.ClusterStatus](
+		ctx,
+		omniState,
+		omnires.NewClusterStatus(clusterName).Metadata(),
+	)
+	if err != nil {
+		if state.IsNotFoundError(err) ||
+			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, context.Canceled) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
+	}
+
+	phase := status.TypedSpec().Value.GetPhase()
+
+	return phase == specs.ClusterStatusSpec_RUNNING, nil
+}
+
 // DefaultKubeconfigTTL is the default time-to-live for Omni service-account
 // kubeconfig tokens. Tokens are automatically refreshed by the CLI's
 // PersistentPreRunE hook when they expire; the 30-day default keeps

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -561,14 +561,14 @@ func (p *Provider) waitForCluster(
 	}
 }
 
-// getClusterStatus retrieves the ClusterStatus resource for the given cluster.
-// It returns (nil, nil) when the resource is not found or the context is done,
-// allowing the caller to retry or handle the context via ctx.Done().
-func getClusterStatus(
+// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
+// It returns (false, nil) when the cluster resource is not yet found or when the context
+// is cancelled/expired, allowing the caller to retry or handle the context via ctx.Done().
+func isClusterRunningAndReady(
 	ctx context.Context,
 	omniState state.State,
 	clusterName string,
-) (*omnires.ClusterStatus, error) {
+) (bool, error) {
 	status, err := safe.StateGet[*omnires.ClusterStatus](
 		ctx,
 		omniState,
@@ -578,24 +578,10 @@ func getClusterStatus(
 		if state.IsNotFoundError(err) ||
 			errors.Is(err, context.DeadlineExceeded) ||
 			errors.Is(err, context.Canceled) {
-			return nil, nil
+			return false, nil
 		}
 
-		return nil, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
-	}
-
-	return status, nil
-}
-
-// isClusterRunningAndReady checks whether the Omni cluster has Phase==RUNNING and Ready==true.
-func isClusterRunningAndReady(
-	ctx context.Context,
-	omniState state.State,
-	clusterName string,
-) (bool, error) {
-	status, err := getClusterStatus(ctx, omniState, clusterName)
-	if err != nil || status == nil {
-		return false, err
+		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
 	}
 
 	phase := status.TypedSpec().Value.GetPhase()
@@ -605,14 +591,26 @@ func isClusterRunningAndReady(
 }
 
 // isClusterRunning checks whether the Omni cluster has Phase==RUNNING (regardless of Ready).
+// It returns (false, nil) when the cluster resource is not yet found or when the context
+// is cancelled/expired, allowing the caller to retry or handle the context via ctx.Done().
 func isClusterRunning(
 	ctx context.Context,
 	omniState state.State,
 	clusterName string,
 ) (bool, error) {
-	status, err := getClusterStatus(ctx, omniState, clusterName)
-	if err != nil || status == nil {
-		return false, err
+	status, err := safe.StateGet[*omnires.ClusterStatus](
+		ctx,
+		omniState,
+		omnires.NewClusterStatus(clusterName).Metadata(),
+	)
+	if err != nil {
+		if state.IsNotFoundError(err) ||
+			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, context.Canceled) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to get cluster status for %q: %w", clusterName, err)
 	}
 
 	return status.TypedSpec().Value.GetPhase() == specs.ClusterStatusSpec_RUNNING, nil

--- a/pkg/svc/provider/omni/provider_test.go
+++ b/pkg/svc/provider/omni/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provider/omni"
+	"github.com/siderolabs/omni/client/api/omni/specs"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -145,6 +146,117 @@ func TestWaitForClusterReady_NilClient(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}
+
+func TestWaitForClusterRunning_NilClient(t *testing.T) {
+	t.Parallel()
+
+	prov := omni.NewProvider(nil)
+
+	err := prov.WaitForClusterRunning(context.Background(), "test-cluster", time.Second)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}
+
+func TestWaitForClusterRunning_ClusterNotFound_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	prov := omni.NewProviderWithState(newInMemState())
+
+	ctx := context.Background()
+	err := prov.WaitForClusterRunning(ctx, "nonexistent", 500*time.Millisecond)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+}
+
+func TestWaitForClusterRunning_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	prov := omni.NewProviderWithState(newInMemState())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	err := prov.WaitForClusterRunning(ctx, "test-cluster", 5*time.Second)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+}
+
+func TestWaitForClusterRunning_RunningNotReady_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	testState := newInMemState()
+	prov := omni.NewProviderWithState(testState)
+
+	// Create a ClusterStatus with Phase=RUNNING but Ready=false
+	// This simulates a cluster where CNI hasn't been installed yet
+	cs := omnires.NewClusterStatus("test-cluster")
+	cs.TypedSpec().Value.Phase = specs.ClusterStatusSpec_RUNNING
+	cs.TypedSpec().Value.Ready = false
+
+	require.NoError(t, testState.Create(context.Background(), cs))
+
+	err := prov.WaitForClusterRunning(context.Background(), "test-cluster", 5*time.Second)
+
+	// Should succeed because Phase==RUNNING, even though Ready==false
+	require.NoError(t, err)
+}
+
+func TestWaitForClusterRunning_RunningAndReady_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	testState := newInMemState()
+	prov := omni.NewProviderWithState(testState)
+
+	cs := omnires.NewClusterStatus("test-cluster")
+	cs.TypedSpec().Value.Phase = specs.ClusterStatusSpec_RUNNING
+	cs.TypedSpec().Value.Ready = true
+
+	require.NoError(t, testState.Create(context.Background(), cs))
+
+	err := prov.WaitForClusterRunning(context.Background(), "test-cluster", 5*time.Second)
+
+	require.NoError(t, err)
+}
+
+func TestWaitForClusterReady_RunningNotReady_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	testState := newInMemState()
+	prov := omni.NewProviderWithState(testState)
+
+	// Create a ClusterStatus with Phase=RUNNING but Ready=false
+	cs := omnires.NewClusterStatus("test-cluster")
+	cs.TypedSpec().Value.Phase = specs.ClusterStatusSpec_RUNNING
+	cs.TypedSpec().Value.Ready = false
+
+	require.NoError(t, testState.Create(context.Background(), cs))
+
+	err := prov.WaitForClusterReady(context.Background(), "test-cluster", 500*time.Millisecond)
+
+	// Should time out because Ready==false
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+}
+
+func TestWaitForClusterReady_RunningAndReady_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	testState := newInMemState()
+	prov := omni.NewProviderWithState(testState)
+
+	cs := omnires.NewClusterStatus("test-cluster")
+	cs.TypedSpec().Value.Phase = specs.ClusterStatusSpec_RUNNING
+	cs.TypedSpec().Value.Ready = true
+
+	require.NoError(t, testState.Create(context.Background(), cs))
+
+	err := prov.WaitForClusterReady(context.Background(), "test-cluster", 5*time.Second)
+
+	require.NoError(t, err)
 }
 
 func TestGetKubeconfig_NilClient(t *testing.T) {

--- a/pkg/svc/provider/omni/provider_test.go
+++ b/pkg/svc/provider/omni/provider_test.go
@@ -259,6 +259,33 @@ func TestWaitForClusterReady_RunningAndReady_Succeeds(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWaitForClusterReady_NotFoundTimesOut(t *testing.T) {
+	t.Parallel()
+
+	testState := newInMemState()
+	prov := omni.NewProviderWithState(testState)
+
+	err := prov.WaitForClusterReady(context.Background(), "nonexistent", 500*time.Millisecond)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+}
+
+func TestWaitForClusterReady_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	testState := newInMemState()
+	prov := omni.NewProviderWithState(testState)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := prov.WaitForClusterReady(ctx, "test-cluster", 5*time.Second)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+}
+
 func TestGetKubeconfig_NilClient(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -16,9 +16,9 @@ import (
 
 const (
 	// omniAPIServerReadinessTimeout is the timeout for verifying the API server
-	// is reachable through the Omni proxy after WaitForClusterReady returns.
-	// The Omni proxy may report the cluster as ready before it is operational
-	// for kubectl connections, so this absorbs the propagation delay.
+	// is reachable through the Omni proxy after WaitForClusterRunning returns.
+	// The Omni proxy may report the cluster phase as RUNNING before it is
+	// operational for kubectl connections, so this absorbs the propagation delay.
 	omniAPIServerReadinessTimeout = 2 * time.Minute
 )
 
@@ -88,8 +88,8 @@ func (p *Provisioner) createOmniCluster(ctx context.Context, clusterName string)
 }
 
 // verifyOmniAPIServerReachable checks that the API server is reachable through
-// the Omni proxy. WaitForClusterReady polls ClusterStatus until
-// Phase==RUNNING && Ready, but the Omni SaaS proxy may not yet be forwarding
+// the Omni proxy. WaitForClusterRunning polls ClusterStatus until
+// Phase==RUNNING, but the Omni SaaS proxy may not yet be forwarding
 // kubectl connections at that point. This probe absorbs the proxy propagation
 // delay so downstream commands (e.g., ksail cluster info) don't fail with
 // "proxy error".
@@ -178,7 +178,9 @@ func (p *Provisioner) buildOmniPatchInfos() []omniprovider.PatchInfo {
 	return patches
 }
 
-// syncAndWaitOmniCluster builds a cluster template, syncs it to Omni, and waits for readiness.
+// syncAndWaitOmniCluster builds a cluster template, syncs it to Omni, and waits
+// for the cluster to reach the RUNNING phase. It does not wait for full node
+// readiness (Ready==true) because CNI is installed as a post-creation step.
 func (p *Provisioner) syncAndWaitOmniCluster(
 	ctx context.Context,
 	omniProv *omniprovider.Provider,

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -199,16 +199,19 @@ func (p *Provisioner) syncAndWaitOmniCluster(
 	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster template synced\n")
 	_, _ = fmt.Fprintf(
 		p.logWriter,
-		"  Waiting for cluster to become ready (timeout: %s)...\n",
+		"  Waiting for cluster to reach RUNNING phase (timeout: %s)...\n",
 		clusterReadinessTimeout,
 	)
 
-	err = omniProv.WaitForClusterReady(ctx, params.ClusterName, clusterReadinessTimeout)
+	// Wait for Phase==RUNNING without requiring Ready==true.
+	// Nodes cannot become Ready until CNI is installed, which happens
+	// as a post-creation step in handlePostCreationSetup.
+	err = omniProv.WaitForClusterRunning(ctx, params.ClusterName, clusterReadinessTimeout)
 	if err != nil {
-		return fmt.Errorf("cluster created but not ready: %w", err)
+		return fmt.Errorf("cluster created but not running: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster is ready\n")
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster is running\n")
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #3875

During cluster creation via the Omni provider, `WaitForClusterReady` required both `Phase==RUNNING` and `Ready==true`. The `Ready` flag depends on all Kubernetes nodes being Ready, which requires CNI to be installed. Since CNI installation happens in `handlePostCreationSetup()` **after** `provisioner.Create()` returns, this created a chicken-and-egg deadlock causing a 20-minute timeout.

## Changes

### 1. Relaxed readiness check for Omni cluster creation
- Added `WaitForClusterRunning()` to the Omni provider that waits only for `Phase==RUNNING` without requiring `Ready==true`
- Added `isClusterRunning()` helper matching the pattern of existing `isClusterRunningAndReady()`
- Updated `syncAndWaitOmniCluster()` to use `WaitForClusterRunning` instead of `WaitForClusterReady`

### 2. Fixed kubeconfig context name for Omni
- Omni-generated kubeconfigs use service-account context names, not the Talos convention (`admin@<name>`)
- Updated `runClusterCreationWorkflow()` to use empty context (kubeconfig's `current-context`) for Omni provider
- This ensures post-creation setup (CNI install, GitOps reconciliation) can connect to the cluster

### 3. Tests
- Added 8 tests for `WaitForClusterRunning` and `WaitForClusterReady` covering: nil client, cluster not found (timeout), cancelled context, Phase==RUNNING with Ready==false (succeeds for Running, times out for Ready), and Phase==RUNNING with Ready==true