### PR TITLE
fix(vcluster): retry on 503 egress limit exceeded during image pull

### DIFF
--- a/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
+++ b/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
@@ -49,4 +49,4 @@ Global Flags:
 
 ```
 
-> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/guides/companion-tools/) guide.
+> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/integrations/companion-tools/) guide.

--- a/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
+++ b/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
@@ -49,4 +49,4 @@ Global Flags:
 
 ```
 
-> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/integrations/companion-tools/) guide.
+> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/guides/companion-tools/) guide.

--- a/pkg/svc/provisioner/cluster/vcluster/provisioner.go
+++ b/pkg/svc/provisioner/cluster/vcluster/provisioner.go
@@ -76,12 +76,15 @@ const dbusErrorSubstring = "Failed to connect to bus"
 // daemon or container runtime hits a temporary invalid-argument condition.
 // "fetching blob: denied: denied" has been observed when GHCR transiently
 // rejects blob downloads mid-pull for the VCluster Kubernetes base image.
+// "Egress is over the account limit" is returned by GHCR when the GitHub
+// Actions runner exceeds its egress bandwidth ceiling mid-transfer (503).
 // Network-level errors (i/o timeout, connection reset, TLS failures, DNS
 // failures) cover transient infrastructure conditions on CI runners.
 func transientCreateErrors() []string {
 	return []string{
 		"exit status 22",
 		"fetching blob: denied: denied",
+		"Egress is over the account limit",
 		"i/o timeout",
 		"connection reset by peer",
 		"TLS handshake timeout",

--- a/pkg/svc/provisioner/cluster/vcluster/provisioner.go
+++ b/pkg/svc/provisioner/cluster/vcluster/provisioner.go
@@ -77,7 +77,8 @@ const dbusErrorSubstring = "Failed to connect to bus"
 // "fetching blob: denied: denied" has been observed when GHCR transiently
 // rejects blob downloads mid-pull for the VCluster Kubernetes base image.
 // "Egress is over the account limit" is returned by GHCR when the GitHub
-// Actions runner exceeds its egress bandwidth ceiling mid-transfer (503).
+// Actions runner or account hits an egress quota/account limit mid-transfer
+// (HTTP 503).
 // Network-level errors (i/o timeout, connection reset, TLS failures, DNS
 // failures) cover transient infrastructure conditions on CI runners.
 func transientCreateErrors() []string {

--- a/pkg/svc/provisioner/cluster/vcluster/retry_test.go
+++ b/pkg/svc/provisioner/cluster/vcluster/retry_test.go
@@ -28,6 +28,9 @@ var (
 	errRegistryDenied = errors.New(
 		"reading blob sha256:abc: fetching blob: denied: denied",
 	)
+	errEgressLimit = errors.New(
+		"copying blob sha256:fa365: fetching blob: received unexpected HTTP status: 503 Egress is over the account limit.",
+	)
 	errIOTimeout    = errors.New("dial tcp 1.2.3.4:443: i/o timeout")
 	errConnReset    = errors.New("read tcp 10.0.0.1:54321->1.2.3.4:443: connection reset by peer")
 	errTLSTimeout   = errors.New("net/http: TLS handshake timeout")
@@ -55,6 +58,7 @@ func TestIsTransientCreateError(t *testing.T) {
 		{"exit_status_22_in_wrapped_error", errWrapped22, true},
 		{"exit_status_1_is_not_transient", errExitStatus1, false},
 		{"registry_denied_is_transient", errRegistryDenied, true},
+		{"egress_limit_is_transient", errEgressLimit, true},
 		{"io_timeout_is_transient", errIOTimeout, true},
 		{"connection_reset_is_transient", errConnReset, true},
 		{"tls_handshake_timeout_is_transient", errTLSTimeout, true},

--- a/pkg/svc/provisioner/cluster/vcluster/retry_test.go
+++ b/pkg/svc/provisioner/cluster/vcluster/retry_test.go
@@ -29,7 +29,7 @@ var (
 		"reading blob sha256:abc: fetching blob: denied: denied",
 	)
 	errEgressLimit = errors.New(
-		"copying blob sha256:fa365: fetching blob: received unexpected HTTP status: 503 Egress is over the account limit.",
+		"copying blob sha256:fa365: fetching blob: received unexpected HTTP status: 503 Egress is over the account limit",
 	)
 	errIOTimeout    = errors.New("dial tcp 1.2.3.4:443: i/o timeout")
 	errConnReset    = errors.New("read tcp 10.0.0.1:54321->1.2.3.4:443: connection reset by peer")


### PR DESCRIPTION
## Description

Add `"Egress is over the account limit"` to the VCluster provisioner's transient error patterns so that `createWithRetry` (5 attempts) handles GHCR 503 egress-limit failures automatically during cluster creation.

## Changes

- **`pkg/svc/provisioner/cluster/vcluster/provisioner.go`** — Added the error substring to `transientCreateErrors()` and documented it in the function comment.
- **`pkg/svc/provisioner/cluster/vcluster/retry_test.go`** — Added `errEgressLimit` test variable and `egress_limit_is_transient` test case.

## Context

The warm-mirror-cache action already pre-pulls VCluster images (via the Dockerfile grep), so the gap was purely in retry recognition — the 503 error was treated as non-transient and failed immediately instead of retrying.

Fixes #3842