### PR TITLE
chore: enrich MCP Registry metadata and document registry availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/devantler-tech/ksail/v6.svg)](https://pkg.go.dev/github.com/devantler-tech/ksail/v6)
 [![codecov](https://codecov.io/gh/devantler-tech/ksail/graph/badge.svg?token=HSUfhaiXwq)](https://app.codecov.io/gh/devantler-tech/ksail)
 [![CI - KSail](https://github.com/devantler-tech/ksail/actions/workflows/ci.yaml/badge.svg)](https://github.com/devantler-tech/ksail/actions/workflows/ci.yaml)
-[![MCP Registry](https://img.shields.io/badge/MCP_Registry-io.github.devantler--tech/ksail-blue?logo=github)](https://github.com/mcp?q=ksail)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-io.github.devantler--tech/ksail-blue?logo=github)](https://github.com/mcp)
 
 # 🛥️🐳 KSail
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/devantler-tech/ksail/v6.svg)](https://pkg.go.dev/github.com/devantler-tech/ksail/v6)
 [![codecov](https://codecov.io/gh/devantler-tech/ksail/graph/badge.svg?token=HSUfhaiXwq)](https://app.codecov.io/gh/devantler-tech/ksail)
 [![CI - KSail](https://github.com/devantler-tech/ksail/actions/workflows/ci.yaml/badge.svg)](https://github.com/devantler-tech/ksail/actions/workflows/ci.yaml)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-io.github.devantler--tech/ksail-blue?logo=github)](https://github.com/mcp?q=ksail)
 
 # 🛥️🐳 KSail
 

--- a/docs/src/content/docs/guides/ai-mcp.mdx
+++ b/docs/src/content/docs/guides/ai-mcp.mdx
@@ -7,6 +7,9 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 KSail's MCP ([Model Context Protocol](https://modelcontextprotocol.io/)) server exposes all cluster and workload commands as structured tools that AI assistants can invoke. This guide shows how to connect Claude Desktop, Cursor, and Windsurf to KSail so you can manage Kubernetes clusters using natural language.
 
+> [!TIP]
+> KSail is listed in the [GitHub MCP Registry](https://github.com/mcp) as `io.github.devantler-tech/ksail`. MCP clients that support the registry can discover and install KSail automatically — no manual configuration needed.
+
 > [!NOTE]
 > For a full reference of the MCP server's available tools, configuration options, and troubleshooting, see the [MCP Server](/mcp/) reference page.
 

--- a/docs/src/content/docs/guides/ai-mcp.mdx
+++ b/docs/src/content/docs/guides/ai-mcp.mdx
@@ -8,7 +8,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 KSail's MCP ([Model Context Protocol](https://modelcontextprotocol.io/)) server exposes all cluster and workload commands as structured tools that AI assistants can invoke. This guide shows how to connect Claude Desktop, Cursor, and Windsurf to KSail so you can manage Kubernetes clusters using natural language.
 
 > [!TIP]
-> KSail is listed in the [GitHub MCP Registry](https://github.com/mcp) as `io.github.devantler-tech/ksail`. MCP clients that support the registry can discover and install KSail automatically — no manual configuration needed.
+> KSail is listed in the [GitHub MCP Registry](https://github.com/mcp) as `io.github.devantler-tech/ksail`. MCP clients that support the registry can discover and install KSail automatically, without the manual JSON configuration shown below.
 
 > [!NOTE]
 > For a full reference of the MCP server's available tools, configuration options, and troubleshooting, see the [MCP Server](/mcp/) reference page.

--- a/server.json
+++ b/server.json
@@ -3,9 +3,11 @@
   "name": "io.github.devantler-tech/ksail",
   "title": "KSail",
   "description": "SDK for creating, managing, and operating Kubernetes clusters and workloads with ease.",
+  "websiteUrl": "https://ksail.devantler.tech",
   "repository": {
     "url": "https://github.com/devantler-tech/ksail",
-    "source": "github"
+    "source": "github",
+    "id": "737584922"
   },
   "version": "0.0.0",
   "packages": [


### PR DESCRIPTION
## Summary

Enriches the MCP Registry listing metadata and documents registry availability across the project documentation.

KSail is already published to the [GitHub MCP Registry](https://github.com/mcp) — multiple versions are live via the automated CD workflow. This PR improves the listing quality and discoverability.

## Changes

- **`server.json`**: Add `websiteUrl` and `repository.id` fields for richer registry metadata
- **`README.md`**: Add MCP Registry badge to the badge row
- **`docs/src/content/docs/guides/ai-mcp.mdx`**: Add tip about registry availability for auto-discovery

Fixes #3835