### PR TITLE
[docs] docs: sync Go version references to 1.26.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -260,7 +260,7 @@ ksail cluster init --help
 **"Go version mismatch"**:
 
 ```bash
-go version  # Should match the version in go.mod (go 1.26.0)
+go version  # Should match the version in go.mod (go 1.26.1)
 # If not, install/update Go from https://go.dev/dl/
 ```
 
@@ -293,7 +293,7 @@ npm run dev                            # Test locally (if needed)
 
 ### Important Notes
 
-- The project uses **Go 1.26.0+** (see `go.mod`)
+- The project uses **Go 1.26.1+** (see `go.mod`)
 - All Kubernetes tools are embedded as Go libraries - only Docker is required externally
 - Unit tests run quickly and should generally pass
 - System tests in CI cover extensive scenarios with multiple tool combinations
@@ -366,7 +366,7 @@ For a deeper dive into KSail's design and internals, refer to:
 
 ## Active Technologies
 
-- Go 1.26.0+ (see `go.mod`)
+- Go 1.26.1+ (see `go.mod`)
 - Embedded Kubernetes tools (kubectl, helm, kind, k3d, vcluster, flux, argocd) as Go libraries
 - Docker as the only external dependency
 - Astro with Starlight for documentation (Node.js-based)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For detailed package and API documentation, refer to the Go documentation at [pk
 
 Before you begin developing, ensure you have the following installed:
 
-- [Go (v1.26.0+)](https://go.dev/doc/install)
+- [Go (v1.26.1+)](https://go.dev/doc/install)
 - [mockery (v3.5+)](https://vektra.github.io/mockery/v3.5/installation/)
 - [golangci-lint](https://golangci-lint.run/docs/welcome/install/)
 - [mega-linter](https://github.com/oxsecurity/megalinter/tree/main/mega-linter-runner#installation)

--- a/docs/src/content/docs/development.mdx
+++ b/docs/src/content/docs/development.mdx
@@ -5,7 +5,7 @@ description: Guide for setting up KSail development environment and contributing
 
 ## Prerequisites
 
-**Required:** [Go 1.26.0+](https://go.dev/dl/) (`go version` ≥ 1.26.0), [Docker](https://docs.docker.com/get-started/) (`docker ps` without errors), [Git](https://git-scm.com/).
+**Required:** [Go 1.26.1+](https://go.dev/dl/) (`go version` ≥ 1.26.1), [Docker](https://docs.docker.com/get-started/) (`docker ps` without errors), [Git](https://git-scm.com/).
 
 **Optional:** Node.js 24 (docs), golangci-lint, VSCode with Go extension.
 
@@ -205,7 +205,7 @@ VSCode users can set breakpoints and press F5 with a `.vscode/launch.json` confi
 | Error | Fix |
 |-------|-----|
 | "Docker not available" | Verify Docker is running: `docker ps`. Check Docker Desktop is started (macOS/Windows) or socket permissions (Linux). |
-| "Go version mismatch" | Run `go version` — must be 1.26.0+. Update from [go.dev/dl](https://go.dev/dl/). |
+| "Go version mismatch" | Run `go version` — must be 1.26.1+. Update from [go.dev/dl](https://go.dev/dl/). |
 | "Import cycle not allowed" | Move shared types to `pkg/apis/` or a utility package. Avoid circular imports. |
 | "Linter failures" | Run `golangci-lint run --fix` to auto-fix. Check `.golangci.yml` for enabled linters; some issues require manual fixes. |
 


### PR DESCRIPTION
Update all Go version references from 1.26.0 to 1.26.1 to match the version specified in go.mod after the module path update to v6.

Fixes https://github.com/devantler-tech/ksail/issues/3863