### PR TITLE
feat: add CDI (Container Device Interface) flag to cluster init and create

### DIFF
--- a/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
@@ -30,6 +30,7 @@ Flags:
       --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider              Infrastructure provider backend (e.g., Docker)
       --ttl string                     Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
+      --unknown CDI                    Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --workers int32                  Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
@@ -12,6 +12,7 @@ Usage:
   ksail cluster create [flags]
 
 Flags:
+      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
       --cni CNI                        Container Network Interface (CNI) to use
   -c, --context string                 Kubernetes context of cluster
@@ -30,7 +31,6 @@ Flags:
       --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider              Infrastructure provider backend (e.g., Docker)
       --ttl string                     Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
-      --unknown CDI                    Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --workers int32                  Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -34,6 +34,7 @@ Flags:
       --policy-engine PolicyEngine             Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider                      Infrastructure provider backend (e.g., Docker)
   -s, --source-directory string                Directory containing workloads to deploy (default "k8s")
+      --unknown CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --workers int32                          Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -12,6 +12,7 @@ Usage:
   ksail cluster init [flags]
 
 Flags:
+      --cdi CDI                                Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --cert-manager CertManager               Cert-Manager configuration (Enabled: install, Disabled: skip)
       --cni CNI                                Container Network Interface (CNI) to use
   -c, --context string                         Kubernetes context of cluster
@@ -34,7 +35,6 @@ Flags:
       --policy-engine PolicyEngine             Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider                      Infrastructure provider backend (e.g., Docker)
   -s, --source-directory string                Directory containing workloads to deploy (default "k8s")
-      --unknown CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --workers int32                          Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
@@ -28,6 +28,7 @@ Usage:
   ksail cluster update [flags]
 
 Flags:
+      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
       --cni CNI                        Container Network Interface (CNI) to use
   -c, --context string                 Kubernetes context of cluster
@@ -48,7 +49,6 @@ Flags:
       --output string                  Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
       --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider              Infrastructure provider backend (e.g., Docker)
-      --unknown CDI                    Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --workers int32                  Number of worker nodes
   -y, --yes                            Skip confirmation prompt (alias for --force)
 

--- a/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
@@ -48,6 +48,7 @@ Flags:
       --output string                  Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
       --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider              Infrastructure provider backend (e.g., Docker)
+      --unknown CDI                    Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
       --workers int32                  Number of worker nodes
   -y, --yes                            Skip confirmation prompt (alias for --force)
 

--- a/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
+++ b/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
@@ -49,4 +49,4 @@ Global Flags:
 
 ```
 
-> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/guides/companion-tools/) guide.
+> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/integrations/companion-tools/) guide.

--- a/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
+++ b/docs/src/content/docs/cli-flags/workload/workload-watch.mdx
@@ -49,4 +49,4 @@ Global Flags:
 
 ```
 
-> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/integrations/companion-tools/) guide.
+> For image rebuild automation and local↔remote traffic bridging, see the [Companion Tools](/guides/companion-tools/) guide.

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -191,6 +191,7 @@ Editor command for interactive workflows (e.g., `code --wait`, `vim`). Falls bac
 | `provider` | enum | – |  |
 | `cni` | enum | – |  |
 | `csi` | enum | – |  |
+| `cdi` | enum | – |  |
 | `metricsServer` | enum | – |  |
 | `loadBalancer` | enum | – |  |
 | `certManager` | enum | – |  |

--- a/pkg/apis/cluster/v1alpha1/cdi.go
+++ b/pkg/apis/cluster/v1alpha1/cdi.go
@@ -1,0 +1,68 @@
+package v1alpha1 //nolint:dupl // enum types follow a consistent pattern by design
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CDI defines the CDI (Container Device Interface) options for a KSail cluster.
+type CDI string
+
+const (
+	// CDIDefault relies on the distribution's default behavior for CDI.
+	CDIDefault CDI = "Default"
+	// CDIEnabled ensures CDI is enabled in the container runtime.
+	CDIEnabled CDI = "Enabled"
+	// CDIDisabled ensures CDI is disabled in the container runtime.
+	CDIDisabled CDI = "Disabled"
+)
+
+// Set for CDI (pflag.Value interface).
+func (c *CDI) Set(value string) error {
+	for _, cdi := range ValidCDIs() {
+		if strings.EqualFold(value, string(cdi)) {
+			*c = cdi
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: %s (valid options: %s, %s, %s)",
+		ErrInvalidCDI, value, CDIDefault, CDIEnabled, CDIDisabled)
+}
+
+// String returns the string representation of the CDI.
+func (c *CDI) String() string {
+	return string(*c)
+}
+
+// Type returns the type of the CDI.
+func (c *CDI) Type() string {
+	return "CDI"
+}
+
+// Default returns the default value for CDI (Default).
+func (c *CDI) Default() any {
+	return CDIDefault
+}
+
+// ValidValues returns all valid CDI values as strings.
+func (c *CDI) ValidValues() []string {
+	return []string{string(CDIDefault), string(CDIEnabled), string(CDIDisabled)}
+}
+
+// EffectiveValue resolves Default to its concrete meaning for the given
+// distribution × provider combination. Enabled and Disabled pass through
+// unchanged. For distributions that enable CDI by default (e.g. Talos 1.13+),
+// Default resolves to Enabled; otherwise it resolves to Disabled.
+func (c *CDI) EffectiveValue(distribution Distribution, _ Provider) CDI {
+	if *c != CDIDefault && *c != "" {
+		return *c
+	}
+
+	if distribution.ProvidesCDIByDefault() {
+		return CDIEnabled
+	}
+
+	return CDIDisabled
+}

--- a/pkg/apis/cluster/v1alpha1/cdi.go
+++ b/pkg/apis/cluster/v1alpha1/cdi.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package v1alpha1 //nolint:dupl
 
 import (
 	"fmt"

--- a/pkg/apis/cluster/v1alpha1/cdi.go
+++ b/pkg/apis/cluster/v1alpha1/cdi.go
@@ -1,4 +1,4 @@
-package v1alpha1 //nolint:dupl
+package v1alpha1
 
 import (
 	"fmt"

--- a/pkg/apis/cluster/v1alpha1/cdi.go
+++ b/pkg/apis/cluster/v1alpha1/cdi.go
@@ -1,4 +1,4 @@
-package v1alpha1 //nolint:dupl // enum types follow a consistent pattern by design
+package v1alpha1
 
 import (
 	"fmt"

--- a/pkg/apis/cluster/v1alpha1/distribution.go
+++ b/pkg/apis/cluster/v1alpha1/distribution.go
@@ -20,6 +20,20 @@ const (
 	DistributionVCluster Distribution = "VCluster"
 )
 
+// ProvidesCDIByDefault returns true if the distribution enables CDI by default.
+// Talos 1.13+ enables CDI (Container Device Interface) by default via machine.features.enableCDI.
+// Vanilla, K3s, and VCluster do not enable CDI by default.
+func (d *Distribution) ProvidesCDIByDefault() bool {
+	switch *d {
+	case DistributionTalos:
+		return true
+	case DistributionVanilla, DistributionK3s, DistributionVCluster:
+		return false
+	default:
+		return false
+	}
+}
+
 // ProvidesMetricsServerByDefault returns true if the distribution includes metrics-server by default.
 // K3s includes metrics-server.
 // Vanilla, Talos, and VCluster (Vind with Distro: k8s) do not.

--- a/pkg/apis/cluster/v1alpha1/enums_test.go
+++ b/pkg/apis/cluster/v1alpha1/enums_test.go
@@ -759,7 +759,6 @@ func TestExpectedContextName(t *testing.T) {
 
 // EffectiveValue tests.
 
-//nolint:funlen // Table-driven test with comprehensive distribution × value combinations.
 func TestCSI_EffectiveValue(t *testing.T) { //nolint:dupl,funlen // enum pattern
 	t.Parallel()
 

--- a/pkg/apis/cluster/v1alpha1/enums_test.go
+++ b/pkg/apis/cluster/v1alpha1/enums_test.go
@@ -760,7 +760,7 @@ func TestExpectedContextName(t *testing.T) {
 // EffectiveValue tests.
 
 //nolint:funlen // Table-driven test with comprehensive distribution × value combinations.
-func TestCSI_EffectiveValue(t *testing.T) {
+func TestCSI_EffectiveValue(t *testing.T) { //nolint:dupl // enum EffectiveValue tests follow a consistent pattern by design
 	t.Parallel()
 
 	tests := []struct {
@@ -1115,7 +1115,7 @@ func TestDistribution_ProvidesCDIByDefault(t *testing.T) {
 	}
 }
 
-func TestCDI_EffectiveValue(t *testing.T) {
+func TestCDI_EffectiveValue(t *testing.T) { //nolint:dupl // enum EffectiveValue tests follow a consistent pattern by design
 	t.Parallel()
 
 	tests := []struct {

--- a/pkg/apis/cluster/v1alpha1/enums_test.go
+++ b/pkg/apis/cluster/v1alpha1/enums_test.go
@@ -1047,3 +1047,141 @@ func TestImageVerification_StringAndType(t *testing.T) {
 	assert.Equal(t, "Enabled", imageVerification.String())
 	assert.Equal(t, "ImageVerification", imageVerification.Type())
 }
+
+func TestCDI_Default(t *testing.T) {
+	t.Parallel()
+
+	var cdi v1alpha1.CDI
+	assert.Equal(t, v1alpha1.CDIDefault, cdi.Default())
+}
+
+func TestCDI_ValidValues(t *testing.T) {
+	t.Parallel()
+
+	var cdi v1alpha1.CDI
+
+	values := cdi.ValidValues()
+	assert.Contains(t, values, "Default")
+	assert.Contains(t, values, "Enabled")
+	assert.Contains(t, values, "Disabled")
+	assert.Len(t, values, 3)
+}
+
+func TestCDI_StringAndType(t *testing.T) {
+	t.Parallel()
+
+	cdi := v1alpha1.CDIEnabled
+	assert.Equal(t, "Enabled", cdi.String())
+	assert.Equal(t, "CDI", cdi.Type())
+}
+
+func TestDistribution_ProvidesCDIByDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		distribution v1alpha1.Distribution
+		expected     bool
+	}{
+		{
+			name:         "talos_provides_cdi",
+			distribution: v1alpha1.DistributionTalos,
+			expected:     true,
+		},
+		{
+			name:         "vanilla_no_cdi",
+			distribution: v1alpha1.DistributionVanilla,
+			expected:     false,
+		},
+		{
+			name:         "k3s_no_cdi",
+			distribution: v1alpha1.DistributionK3s,
+			expected:     false,
+		},
+		{
+			name:         "vcluster_no_cdi",
+			distribution: v1alpha1.DistributionVCluster,
+			expected:     false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := testCase.distribution.ProvidesCDIByDefault()
+			assert.Equal(t, testCase.expected, result)
+		})
+	}
+}
+
+func TestCDI_EffectiveValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		cdi          v1alpha1.CDI
+		distribution v1alpha1.Distribution
+		provider     v1alpha1.Provider
+		expected     v1alpha1.CDI
+	}{
+		{
+			name:         "talos_docker_default_resolves_to_enabled",
+			cdi:          v1alpha1.CDIDefault,
+			distribution: v1alpha1.DistributionTalos,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     v1alpha1.CDIEnabled,
+		},
+		{
+			name:         "vanilla_docker_default_resolves_to_disabled",
+			cdi:          v1alpha1.CDIDefault,
+			distribution: v1alpha1.DistributionVanilla,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     v1alpha1.CDIDisabled,
+		},
+		{
+			name:         "k3s_docker_default_resolves_to_disabled",
+			cdi:          v1alpha1.CDIDefault,
+			distribution: v1alpha1.DistributionK3s,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     v1alpha1.CDIDisabled,
+		},
+		{
+			name:         "vcluster_docker_default_resolves_to_disabled",
+			cdi:          v1alpha1.CDIDefault,
+			distribution: v1alpha1.DistributionVCluster,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     v1alpha1.CDIDisabled,
+		},
+		{
+			name:         "enabled_passes_through",
+			cdi:          v1alpha1.CDIEnabled,
+			distribution: v1alpha1.DistributionVanilla,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     v1alpha1.CDIEnabled,
+		},
+		{
+			name:         "disabled_passes_through",
+			cdi:          v1alpha1.CDIDisabled,
+			distribution: v1alpha1.DistributionTalos,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     v1alpha1.CDIDisabled,
+		},
+		{
+			name:         "empty_string_treated_as_default",
+			cdi:          v1alpha1.CDI(""),
+			distribution: v1alpha1.DistributionTalos,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     v1alpha1.CDIEnabled,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := testCase.cdi.EffectiveValue(testCase.distribution, testCase.provider)
+			assert.Equal(t, testCase.expected, result)
+		})
+	}
+}

--- a/pkg/apis/cluster/v1alpha1/enums_test.go
+++ b/pkg/apis/cluster/v1alpha1/enums_test.go
@@ -760,7 +760,7 @@ func TestExpectedContextName(t *testing.T) {
 // EffectiveValue tests.
 
 //nolint:funlen // Table-driven test with comprehensive distribution × value combinations.
-func TestCSI_EffectiveValue(t *testing.T) { //nolint:dupl // enum EffectiveValue tests follow a consistent pattern by design
+func TestCSI_EffectiveValue(t *testing.T) { //nolint:dupl,funlen // enum pattern
 	t.Parallel()
 
 	tests := []struct {
@@ -1115,7 +1115,7 @@ func TestDistribution_ProvidesCDIByDefault(t *testing.T) {
 	}
 }
 
-func TestCDI_EffectiveValue(t *testing.T) { //nolint:dupl // enum EffectiveValue tests follow a consistent pattern by design
+func TestCDI_EffectiveValue(t *testing.T) { //nolint:dupl,funlen // enum pattern
 	t.Parallel()
 
 	tests := []struct {

--- a/pkg/apis/cluster/v1alpha1/errors.go
+++ b/pkg/apis/cluster/v1alpha1/errors.go
@@ -14,6 +14,9 @@ var ErrInvalidCNI = errors.New("invalid CNI")
 // ErrInvalidCSI is returned when an invalid CSI is specified.
 var ErrInvalidCSI = errors.New("invalid CSI")
 
+// ErrInvalidCDI is returned when an invalid CDI is specified.
+var ErrInvalidCDI = errors.New("invalid CDI")
+
 // ErrInvalidMetricsServer is returned when an invalid metrics server is specified.
 var ErrInvalidMetricsServer = errors.New("invalid metrics server")
 

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -48,6 +48,7 @@ type ClusterSpec struct {
 	Provider           Provider      `json:"provider,omitzero"`
 	CNI                CNI           `json:"cni,omitzero"`
 	CSI                CSI           `json:"csi,omitzero"`
+	CDI                CDI           `json:"cdi,omitzero"`
 	MetricsServer      MetricsServer `json:"metricsServer,omitzero"`
 	LoadBalancer       LoadBalancer  `json:"loadBalancer,omitzero"`
 	CertManager        CertManager   `json:"certManager,omitzero"`

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -72,6 +72,11 @@ func ValidCSIs() []CSI {
 	return []CSI{CSIDefault, CSIEnabled, CSIDisabled}
 }
 
+// ValidCDIs returns supported CDI values.
+func ValidCDIs() []CDI {
+	return []CDI{CDIDefault, CDIEnabled, CDIDisabled}
+}
+
 // ValidMetricsServers returns supported metrics server values.
 func ValidMetricsServers() []MetricsServer {
 	return []MetricsServer{

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -2753,6 +2753,7 @@ func InitFieldSelectors() []ksailconfigmanager.FieldSelector[v1alpha1.Cluster] {
 	selectors = append(selectors, ksailconfigmanager.StandardKustomizationFileFieldSelector())
 	selectors = append(selectors, ksailconfigmanager.DefaultCNIFieldSelector())
 	selectors = append(selectors, ksailconfigmanager.DefaultCSIFieldSelector())
+	selectors = append(selectors, ksailconfigmanager.DefaultCDIFieldSelector())
 	selectors = append(selectors, ksailconfigmanager.DefaultMetricsServerFieldSelector())
 	selectors = append(selectors, ksailconfigmanager.DefaultLoadBalancerFieldSelector())
 	selectors = append(selectors, ksailconfigmanager.DefaultCertManagerFieldSelector())
@@ -4524,6 +4525,7 @@ func defaultClusterMutationFieldSelectors() []ksailconfigmanager.FieldSelector[v
 		ksailconfigmanager.DefaultCertManagerFieldSelector(),
 		ksailconfigmanager.DefaultPolicyEngineFieldSelector(),
 		ksailconfigmanager.DefaultCSIFieldSelector(),
+		ksailconfigmanager.DefaultCDIFieldSelector(),
 		ksailconfigmanager.DefaultImportImagesFieldSelector(),
 		ksailconfigmanager.ControlPlanesFieldSelector(),
 		ksailconfigmanager.WorkersFieldSelector(),

--- a/pkg/fsutil/configmanager/kind/helpers.go
+++ b/pkg/fsutil/configmanager/kind/helpers.go
@@ -109,6 +109,28 @@ per_verifier_timeout = "10s"
 # Configure trust policies and certificates in the notation config directory.
 # See: https://notaryproject.dev/docs/`
 
+// CDIPatch is a containerd config TOML merge patch that enables CDI (Container Device Interface).
+// CDI provides a standardized mechanism for container runtimes to create containers which are able
+// to interact with third party devices (e.g., GPUs, network devices, FPGAs).
+const CDIPatch = `[plugins."io.containerd.grpc.v1.cri"]
+  enable_cdi = true`
+
+// ApplyCDIPatches adds a containerd config patch to enable CDI.
+// The patch is applied at the cluster level and affects every node's containerd configuration.
+// This function is idempotent — it skips appending if the patch is already present.
+func ApplyCDIPatches(kindConfig *kindv1alpha4.Cluster) {
+	for _, patch := range kindConfig.ContainerdConfigPatches {
+		if strings.Contains(patch, `enable_cdi`) {
+			return
+		}
+	}
+
+	kindConfig.ContainerdConfigPatches = append(
+		kindConfig.ContainerdConfigPatches,
+		CDIPatch,
+	)
+}
+
 // ApplyImageVerificationPatches adds a containerd config patch to enable the image verifier plugin.
 // The patch is applied at the cluster level and affects every node's containerd configuration.
 // This function is idempotent — it skips appending if the patch is already present.

--- a/pkg/fsutil/configmanager/ksail/binding.go
+++ b/pkg/fsutil/configmanager/ksail/binding.go
@@ -184,6 +184,7 @@ func (m *ConfigManager) getFieldMappings() map[any]string {
 		&m.Config.Spec.Cluster.GitOpsEngine:           "gitops-engine",
 		&m.Config.Spec.Cluster.CNI:                    "cni",
 		&m.Config.Spec.Cluster.CSI:                    "csi",
+		&m.Config.Spec.Cluster.CDI:                    "cdi",
 		&m.Config.Spec.Cluster.MetricsServer:          "metrics-server",
 		&m.Config.Spec.Cluster.LoadBalancer:           "load-balancer",
 		&m.Config.Spec.Cluster.CertManager:            "cert-manager",

--- a/pkg/fsutil/configmanager/ksail/binding_test.go
+++ b/pkg/fsutil/configmanager/ksail/binding_test.go
@@ -318,6 +318,7 @@ func TestGenerateFlagName(t *testing.T) {
 		{"Timeout field", &manager.Config.Spec.Cluster.Connection.Timeout, "timeout"},
 		{"CNI field", &manager.Config.Spec.Cluster.CNI, "cni"},
 		{"CSI field", &manager.Config.Spec.Cluster.CSI, "csi"},
+		{"CDI field", &manager.Config.Spec.Cluster.CDI, "cdi"},
 		{
 			"MetricsServer field",
 			&manager.Config.Spec.Cluster.MetricsServer,

--- a/pkg/fsutil/configmanager/ksail/field_selector.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector.go
@@ -146,6 +146,15 @@ func DefaultCSIFieldSelector() FieldSelector[v1alpha1.Cluster] {
 	}
 }
 
+// DefaultCDIFieldSelector creates a standard field selector for CDI.
+func DefaultCDIFieldSelector() FieldSelector[v1alpha1.Cluster] {
+	return FieldSelector[v1alpha1.Cluster]{
+		Selector:     func(c *v1alpha1.Cluster) any { return &c.Spec.Cluster.CDI },
+		Description:  "Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)",
+		DefaultValue: v1alpha1.CDIDefault,
+	}
+}
+
 // DefaultKubeconfigFieldSelector creates a standard field selector for kubeconfig.
 func DefaultKubeconfigFieldSelector() FieldSelector[v1alpha1.Cluster] {
 	return FieldSelector[v1alpha1.Cluster]{

--- a/pkg/fsutil/configmanager/ksail/field_selector_test.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector_test.go
@@ -136,7 +136,8 @@ func TestStandardFieldSelectors(t *testing.T) {
 		{
 			name:            "cdi",
 			factory:         configmanager.DefaultCDIFieldSelector,
-			expectedDesc:    "Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)",
+			expectedDesc: "Container Device Interface " +
+				"(Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)",
 			expectedDefault: v1alpha1.CDIDefault,
 			assertPointer: func(t *testing.T, cluster *v1alpha1.Cluster, ptr any) {
 				t.Helper()

--- a/pkg/fsutil/configmanager/ksail/field_selector_test.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector_test.go
@@ -134,8 +134,8 @@ func TestStandardFieldSelectors(t *testing.T) {
 			},
 		},
 		{
-			name:            "cdi",
-			factory:         configmanager.DefaultCDIFieldSelector,
+			name:    "cdi",
+			factory: configmanager.DefaultCDIFieldSelector,
 			expectedDesc: "Container Device Interface " +
 				"(Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)",
 			expectedDefault: v1alpha1.CDIDefault,

--- a/pkg/fsutil/configmanager/ksail/field_selector_test.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector_test.go
@@ -134,6 +134,16 @@ func TestStandardFieldSelectors(t *testing.T) {
 			},
 		},
 		{
+			name:            "cdi",
+			factory:         configmanager.DefaultCDIFieldSelector,
+			expectedDesc:    "Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)",
+			expectedDefault: v1alpha1.CDIDefault,
+			assertPointer: func(t *testing.T, cluster *v1alpha1.Cluster, ptr any) {
+				t.Helper()
+				assertPointerSame(t, ptr, &cluster.Spec.Cluster.CDI)
+			},
+		},
+		{
 			name:            "provider",
 			factory:         configmanager.DefaultProviderFieldSelector,
 			expectedDesc:    "Infrastructure provider backend (e.g., Docker)",

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -30,6 +30,8 @@ const (
 	clusterNameFileName = "cluster-name.yaml"
 	// imageVerificationFileName is the name of the image verification config document file.
 	imageVerificationFileName = "image-verification.yaml"
+	// disableCDIFileName is the name of the CDI disable patch file.
+	disableCDIFileName = "disable-cdi.yaml"
 )
 
 // KubeletServingCertApproverManifestURL is the URL for the kubelet-serving-cert-approver manifest.
@@ -72,6 +74,10 @@ type Config struct {
 	// and commented examples for keyless (Cosign/OIDC) and public key verification.
 	// This requires Talos 1.13+.
 	EnableImageVerification bool
+	// DisableCDI indicates whether to generate a patch that disables CDI.
+	// When true, generates a disable-cdi.yaml patch to set machine.features.enableCDI to false.
+	// Talos 1.13+ enables CDI by default, so this patch is only needed when CDI should be turned off.
+	DisableCDI bool
 }
 
 // Generator generates the Talos directory structure.
@@ -162,6 +168,11 @@ func (g *Generator) getDirectoriesWithPatches(
 		dirs["cluster"] = true
 	}
 
+	// Disable CDI patch goes to cluster/
+	if model.DisableCDI {
+		dirs["cluster"] = true
+	}
+
 	return dirs
 }
 
@@ -223,6 +234,14 @@ func (g *Generator) generateConditionalPatches(
 	// Generate image verification config document when enabled
 	if model.EnableImageVerification {
 		err := g.generateImageVerificationPatch(rootPath, force)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Generate disable-cdi patch when CDI should be turned off
+	if model.DisableCDI {
+		err := g.generateDisableCDIPatch(rootPath, force)
 		if err != nil {
 			return err
 		}
@@ -546,6 +565,34 @@ rules:
 	err := os.WriteFile(patchPath, []byte(patchContent), filePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create image-verification config: %w", err)
+	}
+
+	return nil
+}
+
+// generateDisableCDIPatch creates a Talos patch file to disable CDI.
+// Talos 1.13+ enables CDI (Container Device Interface) by default via machine.features.
+// This patch explicitly disables CDI when the user sets CDI to Disabled.
+func (g *Generator) generateDisableCDIPatch(
+	rootPath string,
+	force bool,
+) error {
+	patchPath := filepath.Join(rootPath, "cluster", disableCDIFileName)
+
+	// Check if file already exists
+	_, statErr := os.Stat(patchPath)
+	if statErr == nil && !force {
+		return nil
+	}
+
+	patchContent := `machine:
+  features:
+    enableCDI: false
+`
+
+	err := os.WriteFile(patchPath, []byte(patchContent), filePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create disable-cdi patch: %w", err)
 	}
 
 	return nil

--- a/pkg/fsutil/scaffolder/scaffolder_kind.go
+++ b/pkg/fsutil/scaffolder/scaffolder_kind.go
@@ -71,6 +71,12 @@ func (s *Scaffolder) buildKindConfig(output string) *v1alpha4.Cluster {
 		kindconfigmanager.ApplyKubeletCertRotationPatches(kindConfig)
 	}
 
+	// Enable CDI when explicitly enabled. Kind does not enable CDI by default,
+	// so we apply a containerd config patch to turn it on.
+	if s.KSailConfig.Spec.Cluster.CDI == v1alpha1.CDIEnabled {
+		kindconfigmanager.ApplyCDIPatches(kindConfig)
+	}
+
 	// Enable containerd image verifier plugin when image verification is enabled.
 	if s.KSailConfig.Spec.Cluster.Talos.ImageVerification == v1alpha1.ImageVerificationEnabled {
 		kindconfigmanager.ApplyImageVerificationPatches(kindConfig)

--- a/pkg/fsutil/scaffolder/scaffolder_talos.go
+++ b/pkg/fsutil/scaffolder/scaffolder_talos.go
@@ -27,10 +27,14 @@ func (s *Scaffolder) generateTalosConfig(output string, force bool) error {
 	// Enable image verification scaffolding when explicitly enabled for Talos.
 	enableImageVerification := s.KSailConfig.Spec.Cluster.Talos.ImageVerification == v1alpha1.ImageVerificationEnabled
 
+	// Disable CDI when explicitly disabled. Talos 1.13+ enables CDI by default,
+	// so we only need a patch when CDI should be turned off.
+	disableCDI := s.KSailConfig.Spec.Cluster.CDI == v1alpha1.CDIDisabled
+
 	// Mirror the conditions in generator.getDirectoriesWithPatches() exactly so
 	// .gitkeep notifications match the files the generator actually writes.
 	clusterHasPatches := workers == 0 || len(s.MirrorRegistries) > 0 || disableDefaultCNI ||
-		enableKubeletCertRotation || s.ClusterName != "" || enableImageVerification
+		enableKubeletCertRotation || s.ClusterName != "" || enableImageVerification || disableCDI
 
 	config := &talosgenerator.Config{
 		PatchesDir:                TalosConfigDir,
@@ -40,6 +44,7 @@ func (s *Scaffolder) generateTalosConfig(output string, force bool) error {
 		EnableKubeletCertRotation: enableKubeletCertRotation,
 		ClusterName:               s.ClusterName,
 		EnableImageVerification:   enableImageVerification,
+		DisableCDI:                disableCDI,
 	}
 
 	opts := yamlgenerator.Options{
@@ -57,6 +62,7 @@ func (s *Scaffolder) generateTalosConfig(output string, force bool) error {
 		disableDefaultCNI,
 		enableKubeletCertRotation,
 		enableImageVerification,
+		disableCDI,
 		clusterHasPatches,
 	)
 
@@ -66,7 +72,7 @@ func (s *Scaffolder) generateTalosConfig(output string, force bool) error {
 // notifyTalosGenerated sends notifications about generated Talos files.
 func (s *Scaffolder) notifyTalosGenerated(
 	workers int,
-	disableDefaultCNI, enableKubeletCertRotation, enableImageVerification bool,
+	disableDefaultCNI, enableKubeletCertRotation, enableImageVerification, disableCDI bool,
 	clusterHasPatches bool,
 ) {
 	// Notify about .gitkeep files only for directories without patches
@@ -93,6 +99,7 @@ func (s *Scaffolder) notifyTalosGenerated(
 		{enableKubeletCertRotation, "cluster", "kubelet-csr-approver.yaml"},
 		{s.ClusterName != "", "cluster", "cluster-name.yaml"},
 		{enableImageVerification, "cluster", "image-verification.yaml"},
+		{disableCDI, "cluster", "disable-cdi.yaml"},
 	}
 
 	for _, patch := range patches {

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -117,6 +117,7 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 				if e.distribution == v1alpha1.DistributionVanilla {
 					return clusterupdate.ChangeCategoryRecreateRequired
 				}
+
 				return clusterupdate.ChangeCategoryRebootRequired
 			},
 			getVal: func(spec *v1alpha1.ClusterSpec) string {
@@ -226,6 +227,7 @@ func (e *Engine) applyFieldRules(
 		if rule.categoryFn != nil {
 			cat = rule.categoryFn()
 		}
+
 		appendChange(result, rule.field,
 			rule.getVal(oldSpec), rule.getVal(newSpec),
 			rule.defaultVal, rule.reason, cat)

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -55,6 +55,10 @@ type fieldRule struct {
 	// by getVal. This prevents false-positive diffs when a config field is unset
 	// (zero value) but the cluster state contains the applied default.
 	defaultVal string
+	// categoryFn, when non-nil, overrides the static category field. Use this for
+	// rules whose change impact varies by distribution/provider (e.g. CDI is
+	// recreate-required on Kind but reboot-required on Talos).
+	categoryFn func() clusterupdate.ChangeCategory
 }
 
 // scalarFieldRules returns the table of simple scalar field diff rules.
@@ -104,20 +108,21 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 			},
 		},
 		{
-			field:    "cluster.cdi",
-			category: clusterupdate.ChangeCategoryRebootRequired,
-			reason:   "CDI requires node-level containerd reconfiguration",
+			field:  "cluster.cdi",
+			reason: "CDI requires node-level containerd reconfiguration",
+			categoryFn: func() clusterupdate.ChangeCategory {
+				// Kind bakes containerd config at creation time — CDI changes
+				// require cluster recreation. Talos can apply machine config
+				// patches via reboot.
+				if e.distribution == v1alpha1.DistributionVanilla {
+					return clusterupdate.ChangeCategoryRecreateRequired
+				}
+				return clusterupdate.ChangeCategoryRebootRequired
+			},
 			getVal: func(spec *v1alpha1.ClusterSpec) string {
-				// Kind bakes containerd config at creation time; CDI changes
-				// require cluster recreation. K3s and VCluster have no CDI
-				// runtime wiring, so treat them as no-op by returning a constant.
+				// K3s and VCluster have no CDI runtime wiring — suppress diffs.
 				switch e.distribution {
-				case v1alpha1.DistributionVanilla:
-					// Kind cannot mutate containerd config after cluster creation.
-					// Force constant so no diff is reported (handled by recreate logic).
-					return string(v1alpha1.CDIDisabled)
 				case v1alpha1.DistributionK3s, v1alpha1.DistributionVCluster:
-					// No runtime CDI wiring — suppress diff.
 					return string(v1alpha1.CDIDisabled)
 				default:
 					return string(spec.CDI.EffectiveValue(e.distribution, e.provider))
@@ -215,9 +220,13 @@ func (e *Engine) applyFieldRules(
 	rules []fieldRule,
 ) {
 	for _, rule := range rules {
+		cat := rule.category
+		if rule.categoryFn != nil {
+			cat = rule.categoryFn()
+		}
 		appendChange(result, rule.field,
 			rule.getVal(oldSpec), rule.getVal(newSpec),
-			rule.defaultVal, rule.reason, rule.category)
+			rule.defaultVal, rule.reason, cat)
 	}
 }
 

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -59,7 +59,7 @@ type fieldRule struct {
 
 // scalarFieldRules returns the table of simple scalar field diff rules.
 // These fields follow a uniform pattern: compare old vs new, emit a Change if different.
-// For CSI, MetricsServer, and LoadBalancer the effective value is used so that
+// For CSI, CDI, MetricsServer, and LoadBalancer the effective value is used so that
 // semantically equivalent states (e.g. Default and Disabled on Vanilla) compare as equal.
 //
 //nolint:funlen // Table-driven rule definitions are clearer as a single cohesive list.
@@ -101,6 +101,14 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 				}
 
 				return string(spec.CSI.EffectiveValue(e.distribution, e.provider))
+			},
+		},
+		{
+			field:    "cluster.cdi",
+			category: clusterupdate.ChangeCategoryRebootRequired,
+			reason:   "CDI requires node-level containerd reconfiguration",
+			getVal: func(spec *v1alpha1.ClusterSpec) string {
+				return string(spec.CDI.EffectiveValue(e.distribution, e.provider))
 			},
 		},
 		{

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -108,7 +108,20 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 			category: clusterupdate.ChangeCategoryRebootRequired,
 			reason:   "CDI requires node-level containerd reconfiguration",
 			getVal: func(spec *v1alpha1.ClusterSpec) string {
-				return string(spec.CDI.EffectiveValue(e.distribution, e.provider))
+				// Kind bakes containerd config at creation time; CDI changes
+				// require cluster recreation. K3s and VCluster have no CDI
+				// runtime wiring, so treat them as no-op by returning a constant.
+				switch e.distribution {
+				case v1alpha1.DistributionVanilla:
+					// Kind cannot mutate containerd config after cluster creation.
+					// Force constant so no diff is reported (handled by recreate logic).
+					return string(v1alpha1.CDIDisabled)
+				case v1alpha1.DistributionK3s, v1alpha1.DistributionVCluster:
+					// No runtime CDI wiring — suppress diff.
+					return string(v1alpha1.CDIDisabled)
+				default:
+					return string(spec.CDI.EffectiveValue(e.distribution, e.provider))
+				}
 			},
 		},
 		{

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -124,6 +124,8 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 				switch e.distribution {
 				case v1alpha1.DistributionK3s, v1alpha1.DistributionVCluster:
 					return string(v1alpha1.CDIDisabled)
+				case v1alpha1.DistributionVanilla, v1alpha1.DistributionTalos:
+					return string(spec.CDI.EffectiveValue(e.distribution, e.provider))
 				default:
 					return string(spec.CDI.EffectiveValue(e.distribution, e.provider))
 				}

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -19,6 +19,7 @@ func newBaseSpec() *v1alpha1.ClusterSpec {
 		Provider:      v1alpha1.ProviderDocker,
 		CNI:           v1alpha1.CNIDefault,
 		CSI:           v1alpha1.CSIDefault,
+		CDI:           v1alpha1.CDIDefault,
 		MetricsServer: "Default",
 		LoadBalancer:  "Default",
 		CertManager:   "Disabled",
@@ -256,6 +257,62 @@ func TestEngine_CSIChange_DetectedForTalos(t *testing.T) {
 
 	assertSingleChange(t, result.InPlaceChanges, "cluster.csi",
 		"Disabled", testValueEnabled, clusterupdate.ChangeCategoryInPlace)
+}
+
+func TestEngine_CDIChange_RecreateRequiredForVanilla(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	newer := clone(old)
+	newer.CDI = v1alpha1.CDIEnabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	if !result.HasRecreateRequired() {
+		t.Fatal("CDI change should require recreate for Vanilla (Kind)")
+	}
+
+	assertSingleChange(t, result.RecreateRequired, "cluster.cdi",
+		"Disabled", testValueEnabled, clusterupdate.ChangeCategoryRecreateRequired)
+}
+
+func TestEngine_CDIChange_RebootRequiredForTalos(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.CDI = v1alpha1.CDIDefault
+	newer := clone(old)
+	newer.CDI = v1alpha1.CDIDisabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	if !result.HasRebootRequired() {
+		t.Fatal("CDI change should require reboot for Talos")
+	}
+
+	assertSingleChange(t, result.RebootRequired, "cluster.cdi",
+		testValueEnabled, "Disabled", clusterupdate.ChangeCategoryRebootRequired)
+}
+
+func TestEngine_CDIChange_SuppressedForK3s(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionK3s
+	newer := clone(old)
+	newer.CDI = v1alpha1.CDIEnabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionK3s, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	for _, change := range result.AllChanges() {
+		if change.Field == "cluster.cdi" {
+			t.Fatal("CDI changes should be suppressed for K3s (no runtime wiring)")
+		}
+	}
 }
 
 func TestEngine_LocalRegistryChange_Vanilla(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -143,6 +143,11 @@ func (f DefaultFactory) createKindProvisioner(
 		kindconfigmanager.ApplyImageVerificationPatches(kindConfig)
 	}
 
+	// Apply containerd CDI patch when CDI is enabled.
+	if cluster.Spec.Cluster.CDI.EffectiveValue(cluster.Spec.Cluster.Distribution, cluster.Spec.Cluster.Provider) == v1alpha1.CDIEnabled {
+		kindconfigmanager.ApplyCDIPatches(kindConfig)
+	}
+
 	provisioner, err := kindprovisioner.CreateProvisioner(
 		kindConfig,
 		cluster.Spec.Cluster.Connection.Kubeconfig,

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -144,7 +144,10 @@ func (f DefaultFactory) createKindProvisioner(
 	}
 
 	// Apply containerd CDI patch when CDI is enabled.
-	if cluster.Spec.Cluster.CDI.EffectiveValue(cluster.Spec.Cluster.Distribution, cluster.Spec.Cluster.Provider) == v1alpha1.CDIEnabled {
+	cdiVal := cluster.Spec.Cluster.CDI.EffectiveValue(
+		cluster.Spec.Cluster.Distribution, cluster.Spec.Cluster.Provider,
+	)
+	if cdiVal == v1alpha1.CDIEnabled {
 		kindconfigmanager.ApplyCDIPatches(kindConfig)
 	}
 

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -73,6 +73,14 @@
                 "Disabled"
               ]
             },
+            "cdi": {
+              "type": "string",
+              "enum": [
+                "Default",
+                "Enabled",
+                "Disabled"
+              ]
+            },
             "metricsServer": {
               "type": "string",
               "enum": [


### PR DESCRIPTION
## Description

Adds a `--cdi Default|Enabled|Disabled` flag to `ksail cluster init` and `ksail cluster create` commands, with a corresponding `spec.cluster.cdi` field in the KSail configuration.

CDI (Container Device Interface) provides a standardized mechanism for container runtimes to create containers that can interact with third-party devices (e.g., GPUs, network devices, FPGAs).

### CDI behavior per distribution

| Distribution | Default behavior | Enabled action | Disabled action |
|---|---|---|---|
| **Talos** | Enabled (1.13+) | No-op (already on) | Generate `disable-cdi.yaml` patch |
| **Vanilla (Kind)** | Disabled | Apply `ContainerdConfigPatches` | No-op (already off) |
| **K3s (K3d)** | Disabled | Stored in config (manual containerd setup needed) | No-op (already off) |
| **VCluster** | Disabled | No-op (host-cluster dependent) | No-op |

### Changes

- **New CDI enum type** (`pkg/apis/cluster/v1alpha1/cdi.go`) with `Default`, `Enabled`, `Disabled` values following the existing CSI pattern
- **API integration**: `ErrInvalidCDI`, `CDI` field on `ClusterSpec`, `ValidCDIs()`, `ProvidesCDIByDefault()`
- **Field selector and CLI flag** registration for `init` and `create` commands
- **Talos scaffolding**: `disable-cdi.yaml` patch generation when CDI is explicitly disabled
- **Kind scaffolding and runtime**: `ContainerdConfigPatches` with `enable_cdi = true` when CDI is enabled (applied both during scaffolding and at cluster create time via the provisioner factory)
- **Diff engine**: Distribution-aware CDI  `ChangeCategoryRecreateRequired` for Kind (containerd config baked at creation), `ChangeCategoryRebootRequired` for Talos (machine config patch), suppressed for K3s/VCluster (no runtime CDI wiring)classification 
- **JSON schema**: Auto-regenerated with CDI enum
- **Tests**: Comprehensive coverage for CDI enum, EffectiveValue resolution, distribution defaults, and diff engine behavior

Fixes #3844