### PR TITLE
fix: update GetClusterStatus contract and fix Docker scheme loop

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -2741,7 +2741,13 @@ func getDockerProviderStatus(
 
 			status, err := prov.GetClusterStatus(cmd.Context(), clusterName)
 			if err != nil {
-				return fmt.Errorf("docker label scheme %s: %w", scheme, err)
+				if errors.Is(err, provider.ErrClusterNotFound) {
+					continue
+				}
+
+				return fmt.Errorf(
+					"docker label scheme %s: %w", scheme, err,
+				)
 			}
 
 			if status != nil && status.NodesTotal > 0 {

--- a/pkg/svc/provider/provider.go
+++ b/pkg/svc/provider/provider.go
@@ -70,7 +70,7 @@ type Provider interface {
 	DeleteNodes(ctx context.Context, clusterName string) error
 
 	// GetClusterStatus returns the provider-level status of a cluster.
-	// Returns nil and no error if the cluster does not exist in the provider.
+	// Returns ErrClusterNotFound if the cluster does not exist in the provider.
 	GetClusterStatus(ctx context.Context, clusterName string) (*ClusterStatus, error)
 }
 


### PR DESCRIPTION
## Summary

Fix two issues from the cluster info provider-first implementation (#3881):

1. **Interface doc**: Update `GetClusterStatus` contract doc to say it returns `ErrClusterNotFound` (not `nil` and no error) when the cluster does not exist, matching actual behavior after the nilnil linter fix.

2. **Docker label-scheme loop bug**: When iterating Docker label schemes (kind/k3d/talos/vcluster) in `getDockerProviderStatus`, the loop incorrectly returned an error on the first scheme's `ErrClusterNotFound` instead of continuing to try the next scheme. Now uses `continue` to skip `ErrClusterNotFound` per-scheme and only returns the error after all schemes are exhausted.

## Changes
- `pkg/svc/provider/provider.go`: Update interface doc comment
- `pkg/cli/cmd/cluster/cluster.go`: Fix Docker label-scheme loop to `continue` on `ErrClusterNotFound`

Fixes a regression from #3881.