### PR TITLE
refactor: remove stale gh-aw workarounds from agentic workflows

### DIFF
--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -66,15 +66,14 @@ source: githubnext/agentics/workflows/ci-doctor.md@7c7feb61a52b662eb2089aa294558
 
 You are the CI Failure Doctor, an expert investigative agent that analyzes failed GitHub Actions workflows to identify root causes and patterns. Your goal is to conduct a deep investigation when the CI workflow fails.
 
-> **CRITICAL — MANDATORY SAFE OUTPUT**: You **MUST** call exactly one safe output tool before finishing — **no exceptions**:
->
-> - `noop` — when no action is needed (e.g., workflow succeeded, duplicate investigation, or no actionable findings)
-> - `create-issue` — when creating a new investigation issue
-> - `add-comment` — when adding findings to an existing issue
->
-> **If you finish without calling one of these tools, this workflow is considered FAILED.**
-> If you are unsure what to do, call `noop` with a summary of what you checked.
-> If you encounter any error during investigation, call `noop` with a description of the error and **stop immediately**. Do **not** continue investigating or call any other tool afterward.
+Use the appropriate safe output tool based on your findings:
+
+- `noop` — when no action is needed (e.g., workflow succeeded, duplicate investigation, or no actionable findings)
+- `create-issue` — when creating a new investigation issue
+- `add-comment` — when adding findings to an existing issue
+
+If you are unsure what to do, call `noop` with a summary of what you checked.
+If you encounter any error during investigation, call `noop` with a description of the error and **stop immediately**. Do **not** continue investigating or call any other tool afterward.
 
 ## Current Context
 
@@ -295,7 +294,7 @@ When creating an investigation issue, use this structure:
 
 Before finishing, verify:
 
-1. ✅ You called exactly one safe output tool (`noop`, `create-issue`, or `add-comment`)
+1. ✅ You called at least one safe output tool (`noop`, `create-issue`, or `add-comment`)
 2. If you created an issue, it follows the Investigation Issue Template above
 3. If you found a duplicate issue/pattern that matches an existing issue, you used `add-comment` on the existing issue instead of creating a new one
 4. If this workflow run ID was already investigated (Phase 1 deduplication), you used `noop` rather than `add-comment` or `create-issue`

--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -69,8 +69,8 @@ You are the CI Failure Doctor, an expert investigative agent that analyzes faile
 Use the appropriate safe output tool based on your findings:
 
 - `noop` — when no action is needed (e.g., workflow succeeded, duplicate investigation, or no actionable findings)
-- `create-issue` — when creating a new investigation issue
-- `add-comment` — when adding findings to an existing issue
+- `create_issue` — when creating a new investigation issue
+- `add_comment` — when adding findings to an existing issue
 
 If you are unsure what to do, call `noop` with a summary of what you checked.
 If you encounter any error during investigation, call `noop` with a description of the error and **stop immediately**. Do **not** continue investigating or call any other tool afterward.
@@ -262,7 +262,7 @@ When creating an investigation issue, use this structure:
 
 ## Important Guidelines
 
-- **Always Produce Output**: You MUST call `noop`, `create-issue`, or `add-comment` before finishing — never end silently. This is the single most important rule.
+- **Always Produce Output**: You MUST call `noop`, `create_issue`, or `add_comment` before finishing — never end silently. This is the single most important rule.
 - **Be Thorough**: Don't just report the error - investigate the underlying cause
 - **Use Memory**: Always check for similar past failures and learn from them
 - **Be Specific**: Provide exact file paths, line numbers, and error messages
@@ -270,7 +270,7 @@ When creating an investigation issue, use this structure:
 - **Pattern Building**: Contribute to the knowledge base for future investigations
 - **Resource Efficient**: Use caching to avoid re-downloading large logs
 - **Security Conscious**: Never execute untrusted code from logs or external sources
-- **Fail Safe**: If anything goes wrong during investigation (errors, timeouts, missing data), call `noop` with a description of what happened and **stop immediately** rather than ending without output, but only if you have not already called a safe output tool; if you already called `noop`, `create-issue`, or `add-comment`, do not call another and stop immediately
+- **Fail Safe**: If anything goes wrong during investigation (errors, timeouts, missing data), call `noop` with a description of what happened and **stop immediately** rather than ending without output, but only if you have not already called a safe output tool; if you already called `noop`, `create_issue`, or `add_comment`, do not call another and stop immediately
 
 ## Cache Usage Strategy
 
@@ -282,21 +282,21 @@ When creating an investigation issue, use this structure:
 
 ## Final Mandatory Step
 
-**After completing your investigation (or deciding no investigation is needed), you MUST call exactly one of these tools:**
+**After completing your investigation (or deciding no investigation is needed), you MUST call at least one of these tools:**
 
 1. `noop` — if no action was needed or no actionable findings
-2. `create-issue` — if you have investigation findings to report
-3. `add-comment` — if adding to an existing issue
+2. `create_issue` — if you have investigation findings to report
+3. `add_comment` — if adding to an existing issue
 
-**Do NOT finish without calling one of these.** If you have already called one, do not call another.
+**Do NOT finish without calling one of these.**
 
 ## Completion Checklist
 
 Before finishing, verify:
 
-1. ✅ You called at least one safe output tool (`noop`, `create-issue`, or `add-comment`)
+1. ✅ You called at least one safe output tool (`noop`, `create_issue`, or `add_comment`)
 2. If you created an issue, it follows the Investigation Issue Template above
-3. If you found a duplicate issue/pattern that matches an existing issue, you used `add-comment` on the existing issue instead of creating a new one
-4. If this workflow run ID was already investigated (Phase 1 deduplication), you used `noop` rather than `add-comment` or `create-issue`
+3. If you found a duplicate issue/pattern that matches an existing issue, you used `add_comment` on the existing issue instead of creating a new one
+4. If this workflow run ID was already investigated (Phase 1 deduplication), you used `noop` rather than `add_comment` or `create_issue`
 5. If you performed an investigation, investigation data was saved to `/tmp/memory/investigations/` for future reference
 6. After completing a new investigation, append the run ID to `/tmp/memory/investigations/analyzed-runs.json` to prevent re-analysis

--- a/.github/workflows/daily-docs.md
+++ b/.github/workflows/daily-docs.md
@@ -57,8 +57,8 @@ You are a documentation maintenance agent for `${{ github.repository }}`. You op
 Use the appropriate safe output tool based on your results:
 
 - `noop` — when no action is needed (e.g., push only changes CI dependencies, no documentation impact, or no code changes require doc updates)
-- `create-pull-request` — when creating a documentation update PR
-- `add-comment` — when adding a comment to an existing PR or issue (only when there is a PR/issue context — never on push events)
+- `create_pull_request` — when creating a documentation update PR
+- `add_comment` — when adding a comment to an existing PR or issue (only when there is a PR/issue context — never on push events)
 
 If you are unsure what to do, call `noop` with a summary of what you checked.
 

--- a/.github/workflows/daily-docs.md
+++ b/.github/workflows/daily-docs.md
@@ -54,13 +54,13 @@ tools:
 
 You are a documentation maintenance agent for `${{ github.repository }}`. You operate in two modes based on the trigger:
 
-> **CRITICAL**: You **MUST** call exactly one safe output tool before finishing:
->
-> - `noop` — when no action is needed (e.g., push only changes CI dependencies, no documentation impact, or no code changes require doc updates)
-> - `create-pull-request` — when creating a documentation update PR
-> - `add-comment` — when adding a comment to an existing PR or issue (only when there is a PR/issue context — never on push events)
->
-> Never finish without calling one of these tools. If you are unsure what to do, call `noop` with a summary of what you checked.
+Use the appropriate safe output tool based on your results:
+
+- `noop` — when no action is needed (e.g., push only changes CI dependencies, no documentation impact, or no code changes require doc updates)
+- `create-pull-request` — when creating a documentation update PR
+- `add-comment` — when adding a comment to an existing PR or issue (only when there is a PR/issue context — never on push events)
+
+If you are unsure what to do, call `noop` with a summary of what you checked.
 
 - **Doc Sync mode** (push to main): Analyze code diffs and update documentation to stay in sync
 - **Bloat Reduction mode** (schedule or `/unbloat` slash command): Scan docs for bloat and simplify

--- a/.github/workflows/daily-workflow-maintenance.md
+++ b/.github/workflows/daily-workflow-maintenance.md
@@ -388,4 +388,4 @@ To decide which deep-mode phase to perform:
 - **Include both `.lock.yml` and `.md` source files in PRs** — both compiled `.lock.yml` files and `.md` workflow source files should be committed when they change (e.g., after action version updates or codemod fixes).
 - The gh-aw CLI extension has already been installed and is available
 - Always check the gh-aw changelog before making manual fixes
-- **You MUST always produce a safe output** — either `noop`, `create_pull_request`, or `create_issue`
+- **Always produce a safe output** — either `noop`, `create_pull_request`, or `create_issue`

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -187,16 +187,14 @@ steps:
 
 # Repo Assist
 
-> **CRITICAL**: You **MUST** call at least one configured safe output tool before finishing. Examples include:
->
-> - `noop` — when no tasks produced actionable work (include a summary of what was checked and why no action was needed)
-> - `create_pull_request` — when creating a PR with code changes
-> - `create_issue` — when creating a new issue
-> - `add_comment` — when commenting on an existing issue or PR
-> - `update_issue` — when updating an existing issue
-> - another configured safe output for this workflow — for example `add_labels`, `remove_labels`, `link_sub_issue`, or `push_to_pull_request_branch`, when the selected task requires it
->
-> Never finish without calling one configured safe output tool. If you complete all selected tasks and none produced output, call `noop`.
+Use the appropriate safe output tool based on your results:
+
+- `noop` — when no tasks produced actionable work (include a summary of what was checked and why no action was needed)
+- `create_pull_request` — when creating a PR with code changes
+- `create_issue` — when creating a new issue
+- `add_comment` — when commenting on an existing issue or PR
+- `update_issue` — when updating an existing issue
+- another configured safe output for this workflow — for example `add_labels`, `remove_labels`, `link_sub_issue`, or `push_to_pull_request_branch`, when the selected task requires it
 
 ## Command Mode
 
@@ -516,7 +514,7 @@ Maintain a single open issue titled `[Repo Assist] Monthly Activity {YYYY}-{MM}`
 
 ## Guidelines
 
-- **Always produce a safe output**: You MUST always produce at least one safe output — `noop`, `create_pull_request`, `create_issue`, `add_comment`, or another configured safe output. If none of the selected tasks produce actionable work, call `noop` with a descriptive message summarizing what was checked and why no action was needed.
+- **Always produce a safe output**: call `noop`, `create_pull_request`, `create_issue`, `add_comment`, or another configured safe output. If none of the selected tasks produce actionable work, call `noop` with a descriptive message summarizing what was checked and why no action was needed.
 - **No breaking changes** without maintainer approval via a tracked issue.
 - **No new dependencies** without discussion in an issue first.
 - **Small, focused PRs** — one concern per PR.
@@ -528,4 +526,4 @@ Maintain a single open issue titled `[Repo Assist] Monthly Activity {YYYY}-{MM}`
 - **AI transparency**: every comment, PR, and issue must include a Repo Assist disclosure with 🤖.
 - **Anti-spam**: no repeated or follow-up comments to yourself in a single run; re-engage only when new human comments have appeared.
 - **Quality over quantity**: noise erodes trust. Do nothing rather than add low-value output.
-- **`update_issue` requires a real `issue_number`**: The `update_issue` safe output does NOT resolve temporary IDs (`aw_xxx`). Always use the actual GitHub issue number (integer) when calling `update_issue`. If you have only a `temporary_id` from `create_issue`, include all intended content in the original `create_issue` body instead of planning a same-run follow-up via `update_issue` or `add_comment`. Temporary IDs are only usable for cross-references in text, labels, and sub-issue linking. Only use `update_issue` when the real issue number is already known (for example, for an existing issue found via search).
+

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -526,4 +526,3 @@ Maintain a single open issue titled `[Repo Assist] Monthly Activity {YYYY}-{MM}`
 - **AI transparency**: every comment, PR, and issue must include a Repo Assist disclosure with 🤖.
 - **Anti-spam**: no repeated or follow-up comments to yourself in a single run; re-engage only when new human comments have appeared.
 - **Quality over quantity**: noise erodes trust. Do nothing rather than add low-value output.
-


### PR DESCRIPTION
## Summary

Removes workarounds from agentic workflow prompts that are now addressed upstream in gh-aw.

### Changes

**1. Remove `update_issue` temporary ID warning** (`repo-assist.md`)
- The 4-line workaround instructing agents to front-load all content into `create_issue` because `update_issue` doesn't resolve temporary IDs
- gh-aw has improved temporary ID resolution since v0.43.20 (current: v0.68.1)
- Filed [github/gh-aw#25768](https://github.com/github/gh-aw/issues/25768) for the remaining gap

**2. Remove redundant safe-output enforcement boilerplate** (`ci-doctor.md`, `daily-docs.md`, `daily-workflow-maintenance.md`, `repo-assist.md`)
- gh-aw now generates its own built-in safe-output prompt ([github/gh-aw#22364](https://github.com/github/gh-aw/issues/22364) fixed)
- Removed generic `CRITICAL`/`MUST`/`FAILED` enforcement language
- **Preserved** workflow-specific guidance about which tool to use when

### Not changed

- The `sed -i` injection of `permission-workflows: write` in `daily-workflow-maintenance.md` — this is a confirmed upstream gap. Filed [github/gh-aw#25767](https://github.com/github/gh-aw/issues/25767)
- Python weighted task selection in `repo-assist.md` — legitimate use of `on.steps:` extension point
- `disable-agentic-editing` convention in `daily-docs.md` — content convention, not a workaround