### PR TITLE
fix: rename Omni kubeconfig context and prevent nil pointer in Helm client

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -4966,12 +4966,10 @@ func runClusterCreationWorkflow(
 	// (which resolve cluster name from distribution configs, not from context) but before
 	// post-CNI setup (which needs the kubectl context name like "kind-kind").
 	//
-	// Omni-generated kubeconfigs use a service-account context name that differs from
-	// the talosctl "admin@<name>" convention. Use empty context (= kubeconfig's
-	// current-context) so helm/kubectl pick the right context automatically.
-	if ctx.ClusterCfg.Spec.Cluster.Provider == v1alpha1.ProviderOmni {
-		ctx.ClusterCfg.Spec.Cluster.Connection.Context = ""
-	} else {
+	// For Omni clusters, the kubeconfig context is now renamed during saveOmniKubeconfig
+	// to match the configured context or the Talos convention (admin@<name>).
+	// If an explicit context is already configured, preserve it.
+	if ctx.ClusterCfg.Spec.Cluster.Connection.Context == "" {
 		clusterName := resolveClusterNameFromContext(ctx)
 		ctx.ClusterCfg.Spec.Cluster.Connection.Context = ctx.ClusterCfg.Spec.Cluster.Distribution.ContextName(
 			clusterName,

--- a/pkg/cli/cmd/cluster/cluster_test.go
+++ b/pkg/cli/cmd/cluster/cluster_test.go
@@ -1507,12 +1507,17 @@ spec:
 		"kind.yaml",
 		"kind: Cluster\napiVersion: kind.x-k8s.io/v1alpha4\nname: test\nnodes: []\n",
 	)
-	// Create a fake kubeconfig file to prevent errors when ArgoCD tries to create Helm client
+	// Create a fake kubeconfig file with the expected context entry to prevent
+	// validation errors when ArgoCD tries to create a Helm client.
+	// Vanilla distribution with kind.yaml name "test" → context "kind-test".
 	writeFile(
 		t,
 		workingDir,
 		"kubeconfig",
-		"apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []\n",
+		"apiVersion: v1\nkind: Config\ncurrent-context: kind-test\nclusters:\n"+
+			"- cluster:\n    server: https://127.0.0.1:6443\n  name: kind-test\n"+
+			"contexts:\n- context:\n    cluster: kind-test\n    user: kind-test\n  name: kind-test\n"+
+			"users:\n- name: kind-test\n  user:\n    token: fake\n",
 	)
 }
 

--- a/pkg/cli/kubeconfighook/hook.go
+++ b/pkg/cli/kubeconfighook/hook.go
@@ -62,10 +62,18 @@ func MaybeRefreshOmniKubeconfig(cmd *cobra.Command) {
 		return
 	}
 
+	// Determine the desired kubeconfig context name.
+	// If explicitly configured, use that; otherwise derive from the Talos convention.
+	desiredContext := cfg.Spec.Cluster.Connection.Context
+	if desiredContext == "" {
+		desiredContext = cfg.Spec.Cluster.Distribution.ContextName(clusterName)
+	}
+
 	refreshErr := refreshKubeconfig(
 		cmd.Context(),
 		cfg.Spec.Provider.Omni,
 		clusterName,
+		desiredContext,
 		canonicalPath,
 	)
 	if refreshErr != nil {
@@ -158,7 +166,8 @@ func clusterNameFromDistConfig(distCfg *clusterprovisioner.DistributionConfig) s
 }
 
 // clusterNameFromKubeconfig extracts the current context name from the kubeconfig file.
-// For Omni, the context name matches the Omni cluster name.
+// Note: After context renaming, this may return the renamed context (e.g., "admin@<name>")
+// rather than the raw Omni cluster name. The distribution config is the preferred source.
 func clusterNameFromKubeconfig(kubeconfigPath string) string {
 	cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
@@ -169,12 +178,14 @@ func clusterNameFromKubeconfig(kubeconfigPath string) string {
 }
 
 // refreshKubeconfig creates an Omni client and fetches a fresh kubeconfig.
-// The write is atomic (temp file + rename) to prevent corruption if the
-// process is interrupted.
+// The Omni-generated context is renamed to desiredContext so the kubeconfig
+// matches spec.cluster.connection.context. The write is atomic (temp file +
+// rename) to prevent corruption if the process is interrupted.
 func refreshKubeconfig(
 	ctx context.Context,
 	omniOpts v1alpha1.OptionsOmni,
 	clusterName string,
+	desiredContext string,
 	kubeconfigPath string,
 ) error {
 	prov, err := omniprovider.NewProviderFromOptions(omniOpts)
@@ -193,12 +204,74 @@ func refreshKubeconfig(
 		return fmt.Errorf("fetch kubeconfig: %w", err)
 	}
 
+	// Rename the Omni-generated context to match the configured context name
+	if desiredContext != "" {
+		data, err = renameKubeconfigContext(data, desiredContext)
+		if err != nil {
+			return fmt.Errorf("rename kubeconfig context: %w", err)
+		}
+	}
+
 	writeErr := atomicWriteFile(kubeconfigPath, data, kubeconfigFileMode)
 	if writeErr != nil {
 		return fmt.Errorf("write kubeconfig: %w", writeErr)
 	}
 
 	return nil
+}
+
+// renameKubeconfigContext renames the current context in a kubeconfig to the desired name.
+// It updates the context, cluster, and user entry names, along with CurrentContext.
+func renameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]byte, error) {
+	config, err := clientcmd.Load(kubeconfigData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	oldContext := config.CurrentContext
+	if oldContext == "" || oldContext == desiredContext {
+		if desiredContext != "" {
+			config.CurrentContext = desiredContext
+		}
+
+		return clientcmd.Write(*config)
+	}
+
+	ctxEntry, exists := config.Contexts[oldContext]
+	if !exists {
+		return nil, fmt.Errorf("current context %q not found in kubeconfig", oldContext)
+	}
+
+	// Rename context entry
+	delete(config.Contexts, oldContext)
+	config.Contexts[desiredContext] = ctxEntry
+
+	// Rename cluster reference
+	if oldCluster := ctxEntry.Cluster; oldCluster != "" {
+		if clusterEntry, ok := config.Clusters[oldCluster]; ok {
+			delete(config.Clusters, oldCluster)
+			config.Clusters[desiredContext] = clusterEntry
+			ctxEntry.Cluster = desiredContext
+		}
+	}
+
+	// Rename user/authinfo reference
+	if oldUser := ctxEntry.AuthInfo; oldUser != "" {
+		if authEntry, ok := config.AuthInfos[oldUser]; ok {
+			delete(config.AuthInfos, oldUser)
+			config.AuthInfos[desiredContext] = authEntry
+			ctxEntry.AuthInfo = desiredContext
+		}
+	}
+
+	config.CurrentContext = desiredContext
+
+	result, err := clientcmd.Write(*config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize kubeconfig: %w", err)
+	}
+
+	return result, nil
 }
 
 // atomicWriteFile writes data to a temp file in the same directory and

--- a/pkg/cli/kubeconfighook/hook.go
+++ b/pkg/cli/kubeconfighook/hook.go
@@ -15,6 +15,7 @@ import (
 	"github.com/devantler-tech/ksail/v6/pkg/cli/kubeconfig"
 	"github.com/devantler-tech/ksail/v6/pkg/fsutil"
 	configmanager "github.com/devantler-tech/ksail/v6/pkg/fsutil/configmanager"
+	"github.com/devantler-tech/ksail/v6/pkg/k8s"
 	"github.com/devantler-tech/ksail/v6/pkg/notify"
 	omniprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/omni"
 	clusterprovisioner "github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster"
@@ -165,16 +166,21 @@ func clusterNameFromDistConfig(distCfg *clusterprovisioner.DistributionConfig) s
 	return ""
 }
 
-// clusterNameFromKubeconfig extracts the current context name from the kubeconfig file.
-// Note: After context renaming, this may return the renamed context (e.g., "admin@<name>")
-// rather than the raw Omni cluster name. The distribution config is the preferred source.
+// clusterNameFromKubeconfig extracts the cluster name from the kubeconfig file.
+// After context renaming, the current context may be "admin@<name>" rather than
+// the raw Omni cluster name. We strip the "admin@" prefix if present.
 func clusterNameFromKubeconfig(kubeconfigPath string) string {
 	cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
 		return ""
 	}
 
-	return cfg.CurrentContext
+	ctx := cfg.CurrentContext
+	if after, ok := strings.CutPrefix(ctx, "admin@"); ok {
+		return after
+	}
+
+	return ctx
 }
 
 // refreshKubeconfig creates an Omni client and fetches a fresh kubeconfig.
@@ -206,7 +212,7 @@ func refreshKubeconfig(
 
 	// Rename the Omni-generated context to match the configured context name
 	if desiredContext != "" {
-		data, err = renameKubeconfigContext(data, desiredContext)
+		data, err = k8s.RenameKubeconfigContext(data, desiredContext)
 		if err != nil {
 			return fmt.Errorf("rename kubeconfig context: %w", err)
 		}
@@ -218,60 +224,6 @@ func refreshKubeconfig(
 	}
 
 	return nil
-}
-
-// renameKubeconfigContext renames the current context in a kubeconfig to the desired name.
-// It updates the context, cluster, and user entry names, along with CurrentContext.
-func renameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]byte, error) {
-	config, err := clientcmd.Load(kubeconfigData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
-	}
-
-	oldContext := config.CurrentContext
-	if oldContext == "" || oldContext == desiredContext {
-		if desiredContext != "" {
-			config.CurrentContext = desiredContext
-		}
-
-		return clientcmd.Write(*config)
-	}
-
-	ctxEntry, exists := config.Contexts[oldContext]
-	if !exists {
-		return nil, fmt.Errorf("current context %q not found in kubeconfig", oldContext)
-	}
-
-	// Rename context entry
-	delete(config.Contexts, oldContext)
-	config.Contexts[desiredContext] = ctxEntry
-
-	// Rename cluster reference
-	if oldCluster := ctxEntry.Cluster; oldCluster != "" {
-		if clusterEntry, ok := config.Clusters[oldCluster]; ok {
-			delete(config.Clusters, oldCluster)
-			config.Clusters[desiredContext] = clusterEntry
-			ctxEntry.Cluster = desiredContext
-		}
-	}
-
-	// Rename user/authinfo reference
-	if oldUser := ctxEntry.AuthInfo; oldUser != "" {
-		if authEntry, ok := config.AuthInfos[oldUser]; ok {
-			delete(config.AuthInfos, oldUser)
-			config.AuthInfos[desiredContext] = authEntry
-			ctxEntry.AuthInfo = desiredContext
-		}
-	}
-
-	config.CurrentContext = desiredContext
-
-	result, err := clientcmd.Write(*config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize kubeconfig: %w", err)
-	}
-
-	return result, nil
 }
 
 // atomicWriteFile writes data to a temp file in the same directory and

--- a/pkg/cli/kubeconfighook/hook.go
+++ b/pkg/cli/kubeconfighook/hook.go
@@ -167,20 +167,20 @@ func clusterNameFromDistConfig(distCfg *clusterprovisioner.DistributionConfig) s
 }
 
 // clusterNameFromKubeconfig extracts the cluster name from the kubeconfig file.
-// After context renaming, the current context may be "admin@<name>" rather than
-// the raw Omni cluster name. We strip the "admin@" prefix if present.
+// Only returns a cluster name when the current context follows the Talos "admin@<name>"
+// convention. Returns empty for arbitrary/renamed context names since those cannot
+// reliably map to Omni cluster names.
 func clusterNameFromKubeconfig(kubeconfigPath string) string {
 	cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
 		return ""
 	}
 
-	ctx := cfg.CurrentContext
-	if after, ok := strings.CutPrefix(ctx, "admin@"); ok {
+	if after, ok := strings.CutPrefix(cfg.CurrentContext, "admin@"); ok {
 		return after
 	}
 
-	return ctx
+	return ""
 }
 
 // refreshKubeconfig creates an Omni client and fetches a fresh kubeconfig.

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -345,6 +345,7 @@ func CreateMinimalProvisionerForProvider(
 		provisioner, err := talosprovisioner.CreateProvisioner(
 			talosConfig,
 			kubeconfigPath,
+			"",
 			info.Provider,
 			v1alpha1.OptionsTalos{},
 			v1alpha1.OptionsHetzner{},

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -58,15 +58,10 @@ func HelmClientForCluster(clusterCfg *v1alpha1.Cluster) (*helm.Client, string, e
 
 // validateKubeconfigContext checks that the specified context exists in the kubeconfig file.
 // Returns a descriptive error listing available contexts when the target context is missing.
-// Skips validation when the kubeconfig has no context entries (stub/placeholder file).
 func validateKubeconfigContext(kubeconfigPath, contextName string) error {
 	config, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig for context validation: %w", err)
-	}
-
-	if len(config.Contexts) == 0 {
-		return nil
 	}
 
 	if _, exists := config.Contexts[contextName]; exists {

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devantler-tech/ksail/v6/pkg/cli/kubeconfig"
 	dockerclient "github.com/devantler-tech/ksail/v6/pkg/client/docker"
 	"github.com/devantler-tech/ksail/v6/pkg/client/helm"
+	"github.com/devantler-tech/ksail/v6/pkg/k8s"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/installer"
 	cloudproviderkindinstaller "github.com/devantler-tech/ksail/v6/pkg/svc/installer/cloudproviderkind"
 	hcloudccminstaller "github.com/devantler-tech/ksail/v6/pkg/svc/installer/hcloudccm"
@@ -56,10 +57,15 @@ func HelmClientForCluster(clusterCfg *v1alpha1.Cluster) (*helm.Client, string, e
 
 // validateKubeconfigContext checks that the specified context exists in the kubeconfig file.
 // Returns a descriptive error listing available contexts when the target context is missing.
+// Skips validation when the kubeconfig has no context entries (stub/placeholder file).
 func validateKubeconfigContext(kubeconfigPath, contextName string) error {
 	config, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig for context validation: %w", err)
+	}
+
+	if len(config.Contexts) == 0 {
+		return nil
 	}
 
 	if _, exists := config.Contexts[contextName]; exists {
@@ -74,7 +80,8 @@ func validateKubeconfigContext(kubeconfigPath, contextName string) error {
 	sort.Strings(available)
 
 	return fmt.Errorf(
-		"kubeconfig context %q not found in %s (available: %s)",
+		"%w: %q not found in %s (available: %s)",
+		k8s.ErrKubeconfigContextNotFound,
 		contextName, kubeconfigPath, strings.Join(available, ", "),
 	)
 }

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -42,7 +42,8 @@ func HelmClientForCluster(clusterCfg *v1alpha1.Cluster) (*helm.Client, string, e
 	// dereference panics in Helm v4, which defers context validation until
 	// the REST client is actually used (e.g., in IsReachable).
 	if kubeContext != "" {
-		if err := validateKubeconfigContext(kubeconfigPath, kubeContext); err != nil {
+		err := validateKubeconfigContext(kubeconfigPath, kubeContext)
+		if err != nil {
 			return nil, "", err
 		}
 	}

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
@@ -15,9 +17,12 @@ import (
 	hcloudccminstaller "github.com/devantler-tech/ksail/v6/pkg/svc/installer/hcloudccm"
 	metallbinstaller "github.com/devantler-tech/ksail/v6/pkg/svc/installer/metallb"
 	metricsserverinstaller "github.com/devantler-tech/ksail/v6/pkg/svc/installer/metricsserver"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // HelmClientForCluster creates a Helm client configured for the cluster.
+// It validates that the kubeconfig file exists and that the specified context
+// is present in the kubeconfig before creating the Helm client.
 func HelmClientForCluster(clusterCfg *v1alpha1.Cluster) (*helm.Client, string, error) {
 	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(clusterCfg)
 	if err != nil {
@@ -30,12 +35,48 @@ func HelmClientForCluster(clusterCfg *v1alpha1.Cluster) (*helm.Client, string, e
 		return nil, "", fmt.Errorf("failed to access kubeconfig file: %w", err)
 	}
 
-	helmClient, err := helm.NewClient(kubeconfigPath, clusterCfg.Spec.Cluster.Connection.Context)
+	kubeContext := clusterCfg.Spec.Cluster.Connection.Context
+
+	// Validate the context exists in the kubeconfig to prevent nil pointer
+	// dereference panics in Helm v4, which defers context validation until
+	// the REST client is actually used (e.g., in IsReachable).
+	if kubeContext != "" {
+		if err := validateKubeconfigContext(kubeconfigPath, kubeContext); err != nil {
+			return nil, "", err
+		}
+	}
+
+	helmClient, err := helm.NewClient(kubeconfigPath, kubeContext)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create Helm client: %w", err)
 	}
 
 	return helmClient, kubeconfigPath, nil
+}
+
+// validateKubeconfigContext checks that the specified context exists in the kubeconfig file.
+// Returns a descriptive error listing available contexts when the target context is missing.
+func validateKubeconfigContext(kubeconfigPath, contextName string) error {
+	config, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig for context validation: %w", err)
+	}
+
+	if _, exists := config.Contexts[contextName]; exists {
+		return nil
+	}
+
+	available := make([]string, 0, len(config.Contexts))
+	for name := range config.Contexts {
+		available = append(available, name)
+	}
+
+	sort.Strings(available)
+
+	return fmt.Errorf(
+		"kubeconfig context %q not found in %s (available: %s)",
+		contextName, kubeconfigPath, strings.Join(available, ", "),
+	)
 }
 
 // NeedsMetricsServerInstall determines if metrics-server needs to be installed.

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -12,3 +12,7 @@ var ErrKubeconfigNoCurrentContext = errors.New("kubeconfig has no current contex
 // ErrKubeconfigContextNotFound is returned when the specified context name
 // does not exist in the kubeconfig.
 var ErrKubeconfigContextNotFound = errors.New("kubeconfig context not found")
+
+// ErrKubeconfigContextCollision is returned when the desired context name
+// already exists as a different context entry in the kubeconfig.
+var ErrKubeconfigContextCollision = errors.New("kubeconfig context name collision")

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -4,3 +4,11 @@ import "errors"
 
 // ErrKubeconfigPathEmpty is returned when kubeconfig path is empty.
 var ErrKubeconfigPathEmpty = errors.New("kubeconfig path is empty")
+
+// ErrKubeconfigNoCurrentContext is returned when a kubeconfig has no current context
+// and multiple context entries, making it ambiguous which context to rename.
+var ErrKubeconfigNoCurrentContext = errors.New("kubeconfig has no current context")
+
+// ErrKubeconfigContextNotFound is returned when the specified context name
+// does not exist in the kubeconfig.
+var ErrKubeconfigContextNotFound = errors.New("kubeconfig context not found")

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -118,7 +118,17 @@ func RenameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]by
 		return nil, err
 	}
 
-	if oldContext == "" || oldContext == desiredContext {
+	if oldContext == "" {
+		if len(config.Contexts) == 0 {
+			return nil, fmt.Errorf("%w: no contexts in kubeconfig", ErrKubeconfigContextNotFound)
+		}
+
+		config.CurrentContext = desiredContext
+
+		return writeConfig(config)
+	}
+
+	if oldContext == desiredContext {
 		config.CurrentContext = desiredContext
 
 		return writeConfig(config)

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -98,9 +98,14 @@ func removeEntriesFromKubeconfig(
 // user entries) in raw kubeconfig bytes to desiredContext.
 //
 // If desiredContext is empty or already matches the current context, the kubeconfig is
-// returned as-is. Returns an error when CurrentContext is empty and no single context
-// entry can be unambiguously selected.
+// returned as-is. Returns an error when the desired context name collides with an
+// existing different context entry, or when CurrentContext is empty and no single
+// context entry can be unambiguously selected.
 func RenameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]byte, error) {
+	if desiredContext == "" {
+		return kubeconfigData, nil
+	}
+
 	config, err := clientcmd.Load(kubeconfigData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
@@ -112,9 +117,7 @@ func RenameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]by
 	}
 
 	if oldContext == "" || oldContext == desiredContext {
-		if desiredContext != "" {
-			config.CurrentContext = desiredContext
-		}
+		config.CurrentContext = desiredContext
 
 		return writeConfig(config)
 	}
@@ -122,6 +125,12 @@ func RenameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]by
 	ctxEntry, exists := config.Contexts[oldContext]
 	if !exists {
 		return nil, fmt.Errorf("%w: %q", ErrKubeconfigContextNotFound, oldContext)
+	}
+
+	if _, collision := config.Contexts[desiredContext]; collision {
+		return nil, fmt.Errorf(
+			"%w: %q already exists in kubeconfig", ErrKubeconfigContextCollision, desiredContext,
+		)
 	}
 
 	// Rename context entry

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -106,52 +106,62 @@ func RenameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]by
 		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
 	}
 
-	oldContext := config.CurrentContext
-
-	// When CurrentContext is empty, try to pick the sole context entry.
-	if oldContext == "" {
-		switch len(config.Contexts) {
-		case 0:
-			// No contexts at all — just set CurrentContext and return.
-			if desiredContext != "" {
-				config.CurrentContext = desiredContext
-			}
-
-			return clientcmd.Write(*config)
-		case 1:
-			for name := range config.Contexts {
-				oldContext = name
-			}
-		default:
-			return nil, fmt.Errorf(
-				"kubeconfig has no current context and %d context entries; cannot determine which to rename",
-				len(config.Contexts),
-			)
-		}
+	oldContext, err := resolveOldContext(config)
+	if err != nil {
+		return nil, err
 	}
 
-	if oldContext == desiredContext {
-		return clientcmd.Write(*config)
+	if oldContext == "" || oldContext == desiredContext {
+		if desiredContext != "" {
+			config.CurrentContext = desiredContext
+		}
+
+		return writeConfig(config)
 	}
 
 	ctxEntry, exists := config.Contexts[oldContext]
 	if !exists {
-		return nil, fmt.Errorf("current context %q not found in kubeconfig", oldContext)
+		return nil, fmt.Errorf("%w: %q", ErrKubeconfigContextNotFound, oldContext)
 	}
 
 	// Rename context entry
 	delete(config.Contexts, oldContext)
 	config.Contexts[desiredContext] = ctxEntry
 
-	// Rename cluster reference only when its name matches the old context name
-	// and the desired key does not already exist (avoids clobbering shared entries).
+	// Rename cluster and user references when they match the old context name
 	renameKubeconfigClusterRef(config, ctxEntry, oldContext, desiredContext)
-
-	// Rename user/authinfo reference under the same conditions.
 	renameKubeconfigAuthInfoRef(config, ctxEntry, oldContext, desiredContext)
 
 	config.CurrentContext = desiredContext
 
+	return writeConfig(config)
+}
+
+// resolveOldContext determines the context to rename. If CurrentContext is set,
+// it is returned. If empty, the sole context entry is selected; multiple entries
+// produce an error.
+func resolveOldContext(config *api.Config) (string, error) {
+	if config.CurrentContext != "" {
+		return config.CurrentContext, nil
+	}
+
+	switch len(config.Contexts) {
+	case 0:
+		return "", nil
+	case 1:
+		for name := range config.Contexts {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"%w and %d context entries; cannot determine which to rename",
+		ErrKubeconfigNoCurrentContext, len(config.Contexts),
+	)
+}
+
+// writeConfig serializes a kubeconfig, wrapping the error.
+func writeConfig(config *api.Config) ([]byte, error) {
 	result, err := clientcmd.Write(*config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize kubeconfig: %w", err)

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -97,10 +97,12 @@ func removeEntriesFromKubeconfig(
 // RenameKubeconfigContext renames the current context (and its associated cluster and
 // user entries) in raw kubeconfig bytes to desiredContext.
 //
-// If desiredContext is empty or already matches the current context, the kubeconfig is
-// returned as-is. Returns an error when the desired context name collides with an
-// existing different context entry, or when CurrentContext is empty and no single
-// context entry can be unambiguously selected.
+// If desiredContext is empty, the kubeconfig is returned unchanged. If desiredContext
+// already matches the current context, the kubeconfig is returned unchanged. If there
+// is no current context but the kubeconfig can be resolved without ambiguity, the
+// kubeconfig is updated to set CurrentContext to desiredContext. Returns an error when
+// the desired context name collides with an existing different context entry, or when
+// CurrentContext is empty and no single context entry can be unambiguously selected.
 func RenameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]byte, error) {
 	if desiredContext == "" {
 		return kubeconfigData, nil

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -94,6 +94,118 @@ func removeEntriesFromKubeconfig(
 	return nil
 }
 
+// RenameKubeconfigContext renames the current context (and its associated cluster and
+// user entries) in raw kubeconfig bytes to desiredContext.
+//
+// If desiredContext is empty or already matches the current context, the kubeconfig is
+// returned as-is. Returns an error when CurrentContext is empty and no single context
+// entry can be unambiguously selected.
+func RenameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]byte, error) {
+	config, err := clientcmd.Load(kubeconfigData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	oldContext := config.CurrentContext
+
+	// When CurrentContext is empty, try to pick the sole context entry.
+	if oldContext == "" {
+		switch len(config.Contexts) {
+		case 0:
+			// No contexts at all — just set CurrentContext and return.
+			if desiredContext != "" {
+				config.CurrentContext = desiredContext
+			}
+
+			return clientcmd.Write(*config)
+		case 1:
+			for name := range config.Contexts {
+				oldContext = name
+			}
+		default:
+			return nil, fmt.Errorf(
+				"kubeconfig has no current context and %d context entries; cannot determine which to rename",
+				len(config.Contexts),
+			)
+		}
+	}
+
+	if oldContext == desiredContext {
+		return clientcmd.Write(*config)
+	}
+
+	ctxEntry, exists := config.Contexts[oldContext]
+	if !exists {
+		return nil, fmt.Errorf("current context %q not found in kubeconfig", oldContext)
+	}
+
+	// Rename context entry
+	delete(config.Contexts, oldContext)
+	config.Contexts[desiredContext] = ctxEntry
+
+	// Rename cluster reference only when its name matches the old context name
+	// and the desired key does not already exist (avoids clobbering shared entries).
+	renameKubeconfigClusterRef(config, ctxEntry, oldContext, desiredContext)
+
+	// Rename user/authinfo reference under the same conditions.
+	renameKubeconfigAuthInfoRef(config, ctxEntry, oldContext, desiredContext)
+
+	config.CurrentContext = desiredContext
+
+	result, err := clientcmd.Write(*config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize kubeconfig: %w", err)
+	}
+
+	return result, nil
+}
+
+// renameKubeconfigClusterRef renames the cluster entry referenced by the context
+// when its name matches oldContext and desiredContext is not already taken.
+func renameKubeconfigClusterRef(
+	config *api.Config,
+	ctxEntry *api.Context,
+	oldContext, desiredContext string,
+) {
+	oldCluster := ctxEntry.Cluster
+	if oldCluster == "" || oldCluster != oldContext {
+		return
+	}
+
+	if _, collision := config.Clusters[desiredContext]; collision {
+		return
+	}
+
+	if clusterEntry, ok := config.Clusters[oldCluster]; ok {
+		delete(config.Clusters, oldCluster)
+		config.Clusters[desiredContext] = clusterEntry
+		ctxEntry.Cluster = desiredContext
+	}
+}
+
+// renameKubeconfigAuthInfoRef renames the authinfo/user entry referenced by the
+// context when its name matches oldContext and desiredContext is not already taken.
+func renameKubeconfigAuthInfoRef(
+	config *api.Config,
+	ctxEntry *api.Context,
+	oldContext, desiredContext string,
+) {
+	oldUser := ctxEntry.AuthInfo
+	if oldUser == "" || oldUser != oldContext {
+		return
+	}
+
+	if _, collision := config.AuthInfos[desiredContext]; collision {
+		return
+	}
+
+	if authEntry, ok := config.AuthInfos[oldUser]; ok {
+		delete(config.AuthInfos, oldUser)
+		config.AuthInfos[desiredContext] = authEntry
+		ctxEntry.AuthInfo = desiredContext
+	}
+}
+
 // hasKubeconfigEntriesToCleanup checks if any kubeconfig entries exist for cleanup.
 // Returns true if at least one of: context, cluster, user, or current-context needs removal.
 func hasKubeconfigEntriesToCleanup(

--- a/pkg/k8s/kubeconfig_test.go
+++ b/pkg/k8s/kubeconfig_test.go
@@ -459,8 +459,8 @@ users:
     token: new-token
 `,
 			desiredContext: "new-ctx",
-			wantErr:       true,
-			errContains:   "context name collision",
+			wantErr:        true,
+			errContains:    "context name collision",
 		},
 	}
 

--- a/pkg/k8s/kubeconfig_test.go
+++ b/pkg/k8s/kubeconfig_test.go
@@ -313,6 +313,7 @@ users:
 	assert.True(t, hasDifferentUser, "different user should remain")
 }
 
+//nolint:funlen // table-driven test with multiple test cases
 // TestRenameKubeconfigContext tests context renaming in kubeconfig bytes.
 func TestRenameKubeconfigContext(t *testing.T) {
 	t.Parallel()

--- a/pkg/k8s/kubeconfig_test.go
+++ b/pkg/k8s/kubeconfig_test.go
@@ -358,9 +358,10 @@ users:
 			wantContext:    "devantler-devantler-dev-ksail",
 		},
 		{
-			name:       "error on invalid kubeconfig",
-			kubeconfig: "not-valid-yaml: {{{",
-			wantErr:    true,
+			name:           "error on invalid kubeconfig",
+			kubeconfig:     "not-valid-yaml: {{{",
+			desiredContext: "some-context",
+			wantErr:        true,
 		},
 		{
 			name: "error when no current context and multiple entries",
@@ -429,7 +430,7 @@ users: []
 			wantContext:    "admin@test",
 		},
 		{
-			name: "does not clobber existing cluster entry",
+			name: "returns error on context name collision",
 			kubeconfig: `apiVersion: v1
 kind: Config
 current-context: old-ctx
@@ -458,7 +459,8 @@ users:
     token: new-token
 `,
 			desiredContext: "new-ctx",
-			wantContext:    "new-ctx",
+			wantErr:       true,
+			errContains:   "context name collision",
 		},
 	}
 

--- a/pkg/k8s/kubeconfig_test.go
+++ b/pkg/k8s/kubeconfig_test.go
@@ -313,8 +313,9 @@ users:
 	assert.True(t, hasDifferentUser, "different user should remain")
 }
 
-//nolint:funlen // table-driven test with multiple test cases
 // TestRenameKubeconfigContext tests context renaming in kubeconfig bytes.
+//
+//nolint:funlen // table-driven test with multiple test cases
 func TestRenameKubeconfigContext(t *testing.T) {
 	t.Parallel()
 
@@ -391,8 +392,8 @@ users:
     token: b
 `,
 			desiredContext: "admin@test",
-			wantErr:       true,
-			errContains:   "no current context",
+			wantErr:        true,
+			errContains:    "no current context",
 		},
 		{
 			name: "picks sole context when current context is empty",
@@ -471,9 +472,11 @@ users:
 
 			if testCase.wantErr {
 				require.Error(t, err)
+
 				if testCase.errContains != "" {
 					assert.Contains(t, err.Error(), testCase.errContains)
 				}
+
 				return
 			}
 

--- a/pkg/k8s/kubeconfig_test.go
+++ b/pkg/k8s/kubeconfig_test.go
@@ -312,3 +312,175 @@ users:
 	assert.False(t, hasTargetContext, "target context should be removed")
 	assert.True(t, hasDifferentUser, "different user should remain")
 }
+
+// TestRenameKubeconfigContext tests context renaming in kubeconfig bytes.
+func TestRenameKubeconfigContext(t *testing.T) {
+	t.Parallel()
+
+	omniKubeconfig := `apiVersion: v1
+kind: Config
+current-context: devantler-devantler-dev-ksail
+clusters:
+- cluster:
+    server: https://10.0.0.1:6443
+  name: devantler-devantler-dev-ksail
+contexts:
+- context:
+    cluster: devantler-devantler-dev-ksail
+    user: devantler-devantler-dev-ksail
+  name: devantler-devantler-dev-ksail
+users:
+- name: devantler-devantler-dev-ksail
+  user:
+    token: test-token
+`
+
+	tests := []struct {
+		name           string
+		kubeconfig     string
+		desiredContext string
+		wantContext    string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "renames Omni SA context",
+			kubeconfig:     omniKubeconfig,
+			desiredContext: "admin@devantler-dev",
+			wantContext:    "admin@devantler-dev",
+		},
+		{
+			name:           "no-op when already correct",
+			kubeconfig:     omniKubeconfig,
+			desiredContext: "devantler-devantler-dev-ksail",
+			wantContext:    "devantler-devantler-dev-ksail",
+		},
+		{
+			name:       "error on invalid kubeconfig",
+			kubeconfig: "not-valid-yaml: {{{",
+			wantErr:    true,
+		},
+		{
+			name: "error when no current context and multiple entries",
+			kubeconfig: `apiVersion: v1
+kind: Config
+current-context: ""
+clusters:
+- cluster:
+    server: https://a:6443
+  name: ctx-a
+- cluster:
+    server: https://b:6443
+  name: ctx-b
+contexts:
+- context:
+    cluster: ctx-a
+    user: user-a
+  name: ctx-a
+- context:
+    cluster: ctx-b
+    user: user-b
+  name: ctx-b
+users:
+- name: user-a
+  user:
+    token: a
+- name: user-b
+  user:
+    token: b
+`,
+			desiredContext: "admin@test",
+			wantErr:       true,
+			errContains:   "no current context",
+		},
+		{
+			name: "picks sole context when current context is empty",
+			kubeconfig: `apiVersion: v1
+kind: Config
+current-context: ""
+clusters:
+- cluster:
+    server: https://10.0.0.1:6443
+  name: only-ctx
+contexts:
+- context:
+    cluster: only-ctx
+    user: only-ctx
+  name: only-ctx
+users:
+- name: only-ctx
+  user:
+    token: t
+`,
+			desiredContext: "admin@my-cluster",
+			wantContext:    "admin@my-cluster",
+		},
+		{
+			name: "handles empty kubeconfig with no contexts",
+			kubeconfig: `apiVersion: v1
+kind: Config
+contexts: []
+clusters: []
+users: []
+`,
+			desiredContext: "admin@test",
+			wantContext:    "admin@test",
+		},
+		{
+			name: "does not clobber existing cluster entry",
+			kubeconfig: `apiVersion: v1
+kind: Config
+current-context: old-ctx
+clusters:
+- cluster:
+    server: https://old:6443
+  name: old-ctx
+- cluster:
+    server: https://new:6443
+  name: new-ctx
+contexts:
+- context:
+    cluster: old-ctx
+    user: old-ctx
+  name: old-ctx
+- context:
+    cluster: new-ctx
+    user: new-user
+  name: new-ctx
+users:
+- name: old-ctx
+  user:
+    token: old-token
+- name: new-user
+  user:
+    token: new-token
+`,
+			desiredContext: "new-ctx",
+			wantContext:    "new-ctx",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := k8s.RenameKubeconfigContext(
+				[]byte(testCase.kubeconfig), testCase.desiredContext,
+			)
+
+			if testCase.wantErr {
+				require.Error(t, err)
+				if testCase.errContains != "" {
+					assert.Contains(t, err.Error(), testCase.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			config, parseErr := clientcmd.Load(result)
+			require.NoError(t, parseErr)
+			assert.Equal(t, testCase.wantContext, config.CurrentContext)
+		})
+	}
+}

--- a/pkg/k8s/kubeconfig_test.go
+++ b/pkg/k8s/kubeconfig_test.go
@@ -419,7 +419,7 @@ users:
 			wantContext:    "admin@my-cluster",
 		},
 		{
-			name: "handles empty kubeconfig with no contexts",
+			name: "error on empty kubeconfig with no contexts",
 			kubeconfig: `apiVersion: v1
 kind: Config
 contexts: []
@@ -427,7 +427,8 @@ clusters: []
 users: []
 `,
 			desiredContext: "admin@test",
-			wantContext:    "admin@test",
+			wantErr:        true,
+			errContains:    "no contexts in kubeconfig",
 		},
 		{
 			name: "returns error on context name collision",

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -330,6 +330,7 @@ func (f DefaultFactory) createTalosProvisioner(
 	provisioner, err := talosprovisioner.CreateProvisioner(
 		f.DistributionConfig.Talos,
 		cluster.Spec.Cluster.Connection.Kubeconfig,
+		cluster.Spec.Cluster.Connection.Context,
 		cluster.Spec.Cluster.Provider,
 		cluster.Spec.Cluster.Talos,
 		cluster.Spec.Provider.Hetzner,

--- a/pkg/svc/provisioner/cluster/multi.go
+++ b/pkg/svc/provisioner/cluster/multi.go
@@ -205,6 +205,7 @@ func CreateMinimalProvisioner(
 		provisioner, err := talosprovisioner.CreateProvisioner(
 			talosConfig,
 			kubeconfigPath,
+			"",
 			providerType,
 			v1alpha1.OptionsTalos{},
 			v1alpha1.OptionsHetzner{},

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v6/pkg/k8s"
 	omniprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/omni"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster/clusterupdate"
 )
@@ -138,7 +139,7 @@ func InstallerImageFromTagForTest(tag string) string {
 	return installerImageFromTag(tag)
 }
 
-// RenameKubeconfigContextForTest exposes renameKubeconfigContext for unit testing.
+// RenameKubeconfigContextForTest exposes k8s.RenameKubeconfigContext for unit testing.
 func RenameKubeconfigContextForTest(kubeconfigData []byte, desiredContext string) ([]byte, error) {
-	return renameKubeconfigContext(kubeconfigData, desiredContext)
+	return k8s.RenameKubeconfigContext(kubeconfigData, desiredContext)
 }

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -137,3 +137,8 @@ func ExtractTagFromImageForTest(image string) string {
 func InstallerImageFromTagForTest(tag string) string {
 	return installerImageFromTag(tag)
 }
+
+// RenameKubeconfigContextForTest exposes renameKubeconfigContext for unit testing.
+func RenameKubeconfigContextForTest(kubeconfigData []byte, desiredContext string) ([]byte, error) {
+	return renameKubeconfigContext(kubeconfigData, desiredContext)
+}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -2,6 +2,7 @@ package talosprovisioner
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v6/pkg/k8s"
@@ -141,5 +142,10 @@ func InstallerImageFromTagForTest(tag string) string {
 
 // RenameKubeconfigContextForTest exposes k8s.RenameKubeconfigContext for unit testing.
 func RenameKubeconfigContextForTest(kubeconfigData []byte, desiredContext string) ([]byte, error) {
-	return k8s.RenameKubeconfigContext(kubeconfigData, desiredContext)
+	result, err := k8s.RenameKubeconfigContext(kubeconfigData, desiredContext)
+	if err != nil {
+		return nil, fmt.Errorf("rename kubeconfig context: %w", err)
+	}
+
+	return result, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -29,6 +29,7 @@ var ErrMissingHetznerToken = errors.New("hetzner API token not set")
 // Parameters:
 //   - talosConfigs: Pre-loaded Talos machine configurations with all patches applied
 //   - kubeconfigPath: Path where the kubeconfig should be written
+//   - kubeconfigContext: Desired kubeconfig context name (empty = derive from distribution)
 //   - provider: Infrastructure provider (e.g., Docker, Hetzner, Omni)
 //   - opts: Talos-specific options (node counts, etc.)
 //   - hetznerOpts: Hetzner-specific options (required when provider is Hetzner)
@@ -38,6 +39,7 @@ var ErrMissingHetznerToken = errors.New("hetzner API token not set")
 func CreateProvisioner(
 	talosConfigs *talosconfigmanager.Configs,
 	kubeconfigPath string,
+	kubeconfigContext string,
 	providerType v1alpha1.Provider,
 	opts v1alpha1.OptionsTalos,
 	hetznerOpts v1alpha1.OptionsHetzner,
@@ -52,6 +54,7 @@ func CreateProvisioner(
 	provisioner, provErr := newProvisionerFromOptions(
 		talosConfigs,
 		kubeconfigPath,
+		kubeconfigContext,
 		opts,
 		skipCNIChecks,
 	)
@@ -74,6 +77,7 @@ func CreateProvisioner(
 func newProvisionerFromOptions(
 	talosConfigs *talosconfigmanager.Configs,
 	kubeconfigPath string,
+	kubeconfigContext string,
 	opts v1alpha1.OptionsTalos,
 	skipCNIChecks bool,
 ) (*Provisioner, error) {
@@ -84,6 +88,7 @@ func newProvisionerFromOptions(
 
 	options := NewOptions().
 		WithKubeconfigPath(kubeconfigPath).
+		WithKubeconfigContext(kubeconfigContext).
 		WithTalosconfigPath(talosconfigPath).
 		WithSkipCNIChecks(skipCNIChecks)
 

--- a/pkg/svc/provisioner/cluster/talos/options.go
+++ b/pkg/svc/provisioner/cluster/talos/options.go
@@ -43,6 +43,11 @@ type Options struct {
 	// TalosconfigPath is the path to write the talosconfig.
 	TalosconfigPath string
 
+	// KubeconfigContext is the desired kubeconfig context name.
+	// When set, the Omni-generated kubeconfig context is renamed to this value.
+	// When empty, the context is derived from Distribution.ContextName(clusterName).
+	KubeconfigContext string
+
 	// SkipCNIChecks indicates whether to skip CNI-dependent cluster checks
 	// (CoreDNS, kube-proxy) during bootstrap. This should be set to true when
 	// KSail will install a custom CNI (Cilium, Calico) after cluster creation,
@@ -115,6 +120,14 @@ func (o *Options) WithTalosconfigPath(path string) *Options {
 	if path != "" {
 		o.TalosconfigPath = path
 	}
+
+	return o
+}
+
+// WithKubeconfigContext sets the desired kubeconfig context name.
+// When set, the Omni-generated kubeconfig context will be renamed to this value.
+func (o *Options) WithKubeconfigContext(context string) *Options {
+	o.KubeconfigContext = context
 
 	return o
 }

--- a/pkg/svc/provisioner/cluster/talos/options_test.go
+++ b/pkg/svc/provisioner/cluster/talos/options_test.go
@@ -22,6 +22,7 @@ func TestNewOptions_DefaultValues(t *testing.T) {
 	assert.Equal(t, talos.DefaultNetworkCIDR, opts.NetworkCIDR)
 	assert.Empty(t, opts.KubeconfigPath)
 	assert.Empty(t, opts.TalosconfigPath)
+	assert.Empty(t, opts.KubeconfigContext)
 	assert.False(t, opts.SkipCNIChecks)
 }
 
@@ -156,6 +157,29 @@ func TestOptions_WithTalosconfigPath(t *testing.T) {
 			opts := talosprovisioner.NewOptions().WithTalosconfigPath(testCase.path)
 
 			assert.Equal(t, testCase.expected, opts.TalosconfigPath)
+		})
+	}
+}
+
+func TestOptions_WithKubeconfigContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		context  string
+		expected string
+	}{
+		{"sets context", "admin@my-cluster", "admin@my-cluster"},
+		{"sets custom context", "devantler-dev", "devantler-dev"},
+		{"allows empty string", "", ""},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := talosprovisioner.NewOptions().WithKubeconfigContext(testCase.context)
+
+			assert.Equal(t, testCase.expected, opts.KubeconfigContext)
 		})
 	}
 }
@@ -321,6 +345,7 @@ func TestOptions_Chaining(t *testing.T) {
 		WithWorkerNodes(2).
 		WithNetworkCIDR("10.0.0.0/8").
 		WithKubeconfigPath("/tmp/kc").
+		WithKubeconfigContext("admin@test").
 		WithTalosconfigPath("/tmp/tc").
 		WithSkipCNIChecks(true).
 		WithExtraPortMappings([]string{"8080:80/tcp"})
@@ -329,6 +354,7 @@ func TestOptions_Chaining(t *testing.T) {
 	assert.Equal(t, 2, opts.WorkerNodes)
 	assert.Equal(t, "10.0.0.0/8", opts.NetworkCIDR)
 	assert.Equal(t, "/tmp/kc", opts.KubeconfigPath)
+	assert.Equal(t, "admin@test", opts.KubeconfigContext)
 	assert.Equal(t, "/tmp/tc", opts.TalosconfigPath)
 	assert.True(t, opts.SkipCNIChecks)
 	assert.Equal(t, []string{"8080:80/tcp"}, opts.ExtraPortMappings)

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -12,6 +12,8 @@ import (
 	"github.com/devantler-tech/ksail/v6/pkg/k8s/readiness"
 	omniprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/omni"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster/clustererr"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (
@@ -350,6 +352,9 @@ func (p *Provisioner) saveOmniConfig(
 }
 
 // saveOmniKubeconfig retrieves and saves the kubeconfig from Omni.
+// If a desired context name is configured (via Options.KubeconfigContext) or can be
+// derived from the cluster name, the Omni-generated context is renamed to match.
+// This ensures the kubeconfig context name matches spec.cluster.connection.context.
 func (p *Provisioner) saveOmniKubeconfig(
 	ctx context.Context,
 	omniProv *omniprovider.Provider,
@@ -364,7 +369,92 @@ func (p *Provisioner) saveOmniKubeconfig(
 		return fmt.Errorf("failed to get kubeconfig from Omni: %w", err)
 	}
 
+	// Determine the desired context name
+	desiredContext := p.options.KubeconfigContext
+	if desiredContext == "" {
+		// Default to the Talos convention: admin@<clusterName>
+		desiredContext = "admin@" + clusterName
+	}
+
+	// Rename the Omni-generated context to the desired name
+	kubeconfigData, err = renameKubeconfigContext(kubeconfigData, desiredContext)
+	if err != nil {
+		return fmt.Errorf("failed to rename kubeconfig context: %w", err)
+	}
+
 	return p.saveOmniConfig(kubeconfigData, p.options.KubeconfigPath, "Kubeconfig")
+}
+
+// renameKubeconfigContext renames the current context in a kubeconfig to the desired name.
+// It updates the context, cluster, and user entry names, along with CurrentContext.
+func renameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]byte, error) {
+	config, err := clientcmd.Load(kubeconfigData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	oldContext := config.CurrentContext
+	if oldContext == "" || oldContext == desiredContext {
+		// Nothing to rename — either no current context or already correct
+		if desiredContext != "" {
+			config.CurrentContext = desiredContext
+		}
+
+		return clientcmd.Write(*config)
+	}
+
+	ctxEntry, exists := config.Contexts[oldContext]
+	if !exists {
+		return nil, fmt.Errorf("current context %q not found in kubeconfig", oldContext)
+	}
+
+	// Rename context entry
+	delete(config.Contexts, oldContext)
+	config.Contexts[desiredContext] = ctxEntry
+
+	// Rename cluster reference if it matches the old context
+	renameClusterRef(config, ctxEntry, desiredContext)
+
+	// Rename user/authinfo reference if it matches the old context
+	renameAuthInfoRef(config, ctxEntry, desiredContext)
+
+	config.CurrentContext = desiredContext
+
+	result, err := clientcmd.Write(*config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize kubeconfig: %w", err)
+	}
+
+	return result, nil
+}
+
+// renameClusterRef renames the cluster entry referenced by the context if the old
+// cluster name matches the old context name.
+func renameClusterRef(config *clientcmdapi.Config, ctxEntry *clientcmdapi.Context, desiredContext string) {
+	oldCluster := ctxEntry.Cluster
+	if oldCluster == "" {
+		return
+	}
+
+	if clusterEntry, ok := config.Clusters[oldCluster]; ok {
+		delete(config.Clusters, oldCluster)
+		config.Clusters[desiredContext] = clusterEntry
+		ctxEntry.Cluster = desiredContext
+	}
+}
+
+// renameAuthInfoRef renames the authinfo/user entry referenced by the context.
+func renameAuthInfoRef(config *clientcmdapi.Config, ctxEntry *clientcmdapi.Context, desiredContext string) {
+	oldUser := ctxEntry.AuthInfo
+	if oldUser == "" {
+		return
+	}
+
+	if authEntry, ok := config.AuthInfos[oldUser]; ok {
+		delete(config.AuthInfos, oldUser)
+		config.AuthInfos[desiredContext] = authEntry
+		ctxEntry.AuthInfo = desiredContext
+	}
 }
 
 // saveOmniTalosconfig retrieves and saves the talosconfig from Omni.
@@ -397,10 +487,10 @@ func (p *Provisioner) waitForOmniAPIServerReady(ctx context.Context) error {
 		return fmt.Errorf("canonicalize kubeconfig path for readiness check: %w", err)
 	}
 
-	// Use empty context to pick the kubeconfig's current-context, because
-	// Omni-generated kubeconfigs use a service-account context name that
-	// differs from the talosctl "admin@<name>" convention.
-	clientset, err := k8s.NewClientset(kubeconfigPath, "")
+	// Use the configured context name. If KubeconfigContext is set, it was used
+	// to rename the Omni-generated context during saveOmniKubeconfig. If empty,
+	// use the kubeconfig's current-context by passing "".
+	clientset, err := k8s.NewClientset(kubeconfigPath, p.options.KubeconfigContext)
 	if err != nil {
 		return fmt.Errorf("create clientset for Omni API readiness check: %w", err)
 	}

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -12,8 +12,6 @@ import (
 	"github.com/devantler-tech/ksail/v6/pkg/k8s/readiness"
 	omniprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/omni"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster/clustererr"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (
@@ -377,84 +375,12 @@ func (p *Provisioner) saveOmniKubeconfig(
 	}
 
 	// Rename the Omni-generated context to the desired name
-	kubeconfigData, err = renameKubeconfigContext(kubeconfigData, desiredContext)
+	kubeconfigData, err = k8s.RenameKubeconfigContext(kubeconfigData, desiredContext)
 	if err != nil {
 		return fmt.Errorf("failed to rename kubeconfig context: %w", err)
 	}
 
 	return p.saveOmniConfig(kubeconfigData, p.options.KubeconfigPath, "Kubeconfig")
-}
-
-// renameKubeconfigContext renames the current context in a kubeconfig to the desired name.
-// It updates the context, cluster, and user entry names, along with CurrentContext.
-func renameKubeconfigContext(kubeconfigData []byte, desiredContext string) ([]byte, error) {
-	config, err := clientcmd.Load(kubeconfigData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
-	}
-
-	oldContext := config.CurrentContext
-	if oldContext == "" || oldContext == desiredContext {
-		// Nothing to rename — either no current context or already correct
-		if desiredContext != "" {
-			config.CurrentContext = desiredContext
-		}
-
-		return clientcmd.Write(*config)
-	}
-
-	ctxEntry, exists := config.Contexts[oldContext]
-	if !exists {
-		return nil, fmt.Errorf("current context %q not found in kubeconfig", oldContext)
-	}
-
-	// Rename context entry
-	delete(config.Contexts, oldContext)
-	config.Contexts[desiredContext] = ctxEntry
-
-	// Rename cluster reference if it matches the old context
-	renameClusterRef(config, ctxEntry, desiredContext)
-
-	// Rename user/authinfo reference if it matches the old context
-	renameAuthInfoRef(config, ctxEntry, desiredContext)
-
-	config.CurrentContext = desiredContext
-
-	result, err := clientcmd.Write(*config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize kubeconfig: %w", err)
-	}
-
-	return result, nil
-}
-
-// renameClusterRef renames the cluster entry referenced by the context if the old
-// cluster name matches the old context name.
-func renameClusterRef(config *clientcmdapi.Config, ctxEntry *clientcmdapi.Context, desiredContext string) {
-	oldCluster := ctxEntry.Cluster
-	if oldCluster == "" {
-		return
-	}
-
-	if clusterEntry, ok := config.Clusters[oldCluster]; ok {
-		delete(config.Clusters, oldCluster)
-		config.Clusters[desiredContext] = clusterEntry
-		ctxEntry.Cluster = desiredContext
-	}
-}
-
-// renameAuthInfoRef renames the authinfo/user entry referenced by the context.
-func renameAuthInfoRef(config *clientcmdapi.Config, ctxEntry *clientcmdapi.Context, desiredContext string) {
-	oldUser := ctxEntry.AuthInfo
-	if oldUser == "" {
-		return
-	}
-
-	if authEntry, ok := config.AuthInfos[oldUser]; ok {
-		delete(config.AuthInfos, oldUser)
-		config.AuthInfos[desiredContext] = authEntry
-		ctxEntry.AuthInfo = desiredContext
-	}
 }
 
 // saveOmniTalosconfig retrieves and saves the talosconfig from Omni.

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni_test.go
@@ -416,6 +416,8 @@ func TestSaveOmniConfig_WritesFile(t *testing.T) {
 func TestRenameKubeconfigContext(t *testing.T) {
 	t.Parallel()
 
+	// Core renaming logic is tested in pkg/k8s/kubeconfig_test.go.
+	// This test verifies the test seam delegates correctly.
 	validKubeconfig := `apiVersion: v1
 kind: Config
 current-context: devantler-devantler-dev-ksail
@@ -434,69 +436,12 @@ users:
     token: test-token
 `
 
-	tests := []struct {
-		name           string
-		kubeconfig     string
-		desiredContext string
-		wantContext    string
-		hasEntries     bool
-		wantErr        bool
-	}{
-		{
-			name:           "renames Omni SA context to desired name",
-			kubeconfig:     validKubeconfig,
-			desiredContext: "admin@devantler-dev",
-			wantContext:    "admin@devantler-dev",
-			hasEntries:     true,
-		},
-		{
-			name:           "renames to simple context name",
-			kubeconfig:     validKubeconfig,
-			desiredContext: "devantler-dev",
-			wantContext:    "devantler-dev",
-			hasEntries:     true,
-		},
-		{
-			name:       "returns error for invalid kubeconfig",
-			kubeconfig: "not-valid-yaml: {{{",
-			wantErr:    true,
-		},
-		{
-			name: "handles kubeconfig with no contexts",
-			kubeconfig: `apiVersion: v1
-kind: Config
-contexts: []
-clusters: []
-users: []
-`,
-			desiredContext: "admin@test",
-			wantContext:    "admin@test",
-		},
-	}
+	result, err := talosprovisioner.RenameKubeconfigContextForTest(
+		[]byte(validKubeconfig), "admin@devantler-dev",
+	)
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			result, err := talosprovisioner.RenameKubeconfigContextForTest(
-				[]byte(testCase.kubeconfig), testCase.desiredContext,
-			)
-
-			if testCase.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-
-			// Verify current-context is set correctly
-			assert.Contains(t, string(result), "current-context: "+testCase.wantContext)
-			if testCase.hasEntries {
-				// Verify context/cluster/user entries are renamed
-				assert.Contains(t, string(result), "name: "+testCase.wantContext)
-				// Verify the original Omni context name is removed
-				assert.NotContains(t, string(result), "devantler-devantler-dev-ksail")
-			}
-		})
-	}
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "current-context: admin@devantler-dev")
+	assert.Contains(t, string(result), "name: admin@devantler-dev")
+	assert.NotContains(t, string(result), "devantler-devantler-dev-ksail")
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni_test.go
@@ -412,3 +412,91 @@ func TestSaveOmniConfig_WritesFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, dummyData, written)
 }
+
+func TestRenameKubeconfigContext(t *testing.T) {
+	t.Parallel()
+
+	validKubeconfig := `apiVersion: v1
+kind: Config
+current-context: devantler-devantler-dev-ksail
+clusters:
+- cluster:
+    server: https://10.0.0.1:6443
+  name: devantler-devantler-dev-ksail
+contexts:
+- context:
+    cluster: devantler-devantler-dev-ksail
+    user: devantler-devantler-dev-ksail
+  name: devantler-devantler-dev-ksail
+users:
+- name: devantler-devantler-dev-ksail
+  user:
+    token: test-token
+`
+
+	tests := []struct {
+		name           string
+		kubeconfig     string
+		desiredContext string
+		wantContext    string
+		hasEntries     bool
+		wantErr        bool
+	}{
+		{
+			name:           "renames Omni SA context to desired name",
+			kubeconfig:     validKubeconfig,
+			desiredContext: "admin@devantler-dev",
+			wantContext:    "admin@devantler-dev",
+			hasEntries:     true,
+		},
+		{
+			name:           "renames to simple context name",
+			kubeconfig:     validKubeconfig,
+			desiredContext: "devantler-dev",
+			wantContext:    "devantler-dev",
+			hasEntries:     true,
+		},
+		{
+			name:       "returns error for invalid kubeconfig",
+			kubeconfig: "not-valid-yaml: {{{",
+			wantErr:    true,
+		},
+		{
+			name: "handles kubeconfig with no contexts",
+			kubeconfig: `apiVersion: v1
+kind: Config
+contexts: []
+clusters: []
+users: []
+`,
+			desiredContext: "admin@test",
+			wantContext:    "admin@test",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := talosprovisioner.RenameKubeconfigContextForTest(
+				[]byte(testCase.kubeconfig), testCase.desiredContext,
+			)
+
+			if testCase.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Verify current-context is set correctly
+			assert.Contains(t, string(result), "current-context: "+testCase.wantContext)
+			if testCase.hasEntries {
+				// Verify context/cluster/user entries are renamed
+				assert.Contains(t, string(result), "name: "+testCase.wantContext)
+				// Verify the original Omni context name is removed
+				assert.NotContains(t, string(result), "devantler-devantler-dev-ksail")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two related bugs when using the Omni provider (#3904):

1. **Kubeconfig context name mismatch**: `cluster create` with Omni generates a kubeconfig with the Omni service-account context name (e.g., `devantler-devantler-dev-ksail`) instead of the configured `spec.cluster.connection.context` (e.g., `admin@devantler-dev`). This causes all subsequent commands that look up the configured context to fail.

2. **Nil pointer panic in `cluster update`**: When the kubeconfig context specified in config doesn't exist, the Helm v4 client defers context validation until runtime, producing a nil REST config that panics in `kube.(*Client).IsReachable`.

## Changes

### Bug 1: Rename Omni kubeconfig context

- **`provisioner_omni.go`**: After fetching kubeconfig from Omni, `saveOmniKubeconfig()` now renames the context/cluster/user entries to match the configured context name (or derives `admin@<clusterName>` for Talos)
- **`kubeconfighook/hook.go`**: `refreshKubeconfig()` also renames the context after Omni token refresh
- **`cluster.go`**: Removed the Omni-specific `Connection.Context = ""` workaround — the standard context derivation now works for all providers
- **`talos/options.go`**: Added `KubeconfigContext` field with `WithKubeconfigContext()` builder
- **`talos/factory.go`**: Passes `Connection.Context` through the factory chain
- **`cluster/factory.go`**, **`multi.go`**, **`simple.go`**: Updated callers for the new parameter

### Bug 2: Graceful error for missing kubeconfig context

- **`install_infrastructure.go`**: `HelmClientForCluster()` now validates that the specified context exists in the kubeconfig before creating the Helm client, returning a descriptive error listing available contexts instead of panicking

### Tests

- Added `TestOptions_WithKubeconfigContext` and updated `TestOptions_Chaining`
- Added `TestRenameKubeconfigContext` with cases for renaming, invalid kubeconfig, and empty contexts
- Added `RenameKubeconfigContextForTest` test seam

Fixes #3904