### PR TITLE
fix(gitops): use workload.tag for Flux and ArgoCD OCI artifact tag

### DIFF
--- a/pkg/cli/setup/export_test.go
+++ b/pkg/cli/setup/export_test.go
@@ -1,6 +1,9 @@
 package setup
 
-import "github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
+import (
+	"github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
+	argocdgitops "github.com/devantler-tech/ksail/v6/pkg/client/argocd"
+)
 
 // NeedsInClusterConnectivityCheck exports needsInClusterConnectivityCheck for testing.
 //
@@ -34,4 +37,13 @@ func ClusterWithCNI(cni v1alpha1.CNI) *v1alpha1.Cluster {
 			},
 		},
 	}
+}
+
+// BuildArgoCDEnsureOptions exports buildArgoCDEnsureOptions for testing.
+func BuildArgoCDEnsureOptions(
+	clusterCfg *v1alpha1.Cluster,
+	clusterName string,
+	registryHost string,
+) argocdgitops.EnsureOptions {
+	return buildArgoCDEnsureOptions(clusterCfg, clusterName, registryHost)
 }

--- a/pkg/cli/setup/install_gitops.go
+++ b/pkg/cli/setup/install_gitops.go
@@ -103,13 +103,27 @@ func buildArgoCDEnsureOptions(
 	clusterName string,
 	registryHost string,
 ) argocdgitops.EnsureOptions {
+	localRegistry := clusterCfg.Spec.Cluster.LocalRegistry
+
+	// Resolve tag: workload tag > registry-embedded tag > default.
+	tag := clusterCfg.Spec.Workload.Tag
+	if tag == "" && localRegistry.IsExternal() {
+		parsed := localRegistry.Parse()
+		if parsed.Tag != "" {
+			tag = parsed.Tag
+		}
+	}
+
+	if tag == "" {
+		tag = registry.DefaultLocalArtifactTag
+	}
+
 	opts := argocdgitops.EnsureOptions{
 		SourcePath:      ".",
 		ApplicationName: "ksail",
-		TargetRevision:  "dev",
+		TargetRevision:  tag,
 	}
 
-	localRegistry := clusterCfg.Spec.Cluster.LocalRegistry
 	if localRegistry.IsExternal() {
 		applyExternalRegistryOptions(&opts, localRegistry)
 	} else {

--- a/pkg/cli/setup/install_gitops_test.go
+++ b/pkg/cli/setup/install_gitops_test.go
@@ -1,0 +1,122 @@
+package setup_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v6/pkg/cli/setup"
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:funlen // Table-driven test with comprehensive test cases.
+func TestBuildArgoCDEnsureOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		clusterCfg         *v1alpha1.Cluster
+		clusterName        string
+		registryHost       string
+		wantTargetRevision string
+	}{
+		{
+			name: "local registry with default tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+					},
+				},
+			},
+			clusterName:        "test-cluster",
+			wantTargetRevision: "dev",
+		},
+		{
+			name: "local registry with custom workload tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+						Tag:             "latest",
+					},
+				},
+			},
+			clusterName:        "test-cluster",
+			wantTargetRevision: "latest",
+		},
+		{
+			name: "external registry with default tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{
+							Registry: "ghcr.io/example/repo",
+						},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+					},
+				},
+			},
+			clusterName:        "test-cluster",
+			wantTargetRevision: "dev",
+		},
+		{
+			name: "external registry with registry-embedded tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{
+							Registry: "ghcr.io/example/repo:custom",
+						},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+					},
+				},
+			},
+			clusterName:        "test-cluster",
+			wantTargetRevision: "custom",
+		},
+		{
+			name: "workload tag takes priority over registry-embedded tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{
+							Registry: "ghcr.io/example/repo:custom",
+						},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+						Tag:             "v1.0",
+					},
+				},
+			},
+			clusterName:        "test-cluster",
+			wantTargetRevision: "v1.0",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := setup.BuildArgoCDEnsureOptions(
+				testCase.clusterCfg,
+				testCase.clusterName,
+				testCase.registryHost,
+			)
+
+			assert.Equal(t, testCase.wantTargetRevision, opts.TargetRevision)
+			assert.Equal(t, "ksail", opts.ApplicationName)
+			assert.Equal(t, ".", opts.SourcePath)
+		})
+	}
+}

--- a/pkg/svc/installer/flux/fluxinstance_manager.go
+++ b/pkg/svc/installer/flux/fluxinstance_manager.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	defaultSourceDirectory   = "k8s"
-	defaultArtifactTag       = "dev"
 	fluxIntervalFallback     = time.Minute
 	fluxDistributionVersion  = "2.x"
 	fluxDistributionRegistry = "ghcr.io/fluxcd"
@@ -260,19 +259,24 @@ func buildInstance(
 ) (*FluxInstance, error) {
 	localRegistry := clusterCfg.Spec.Cluster.LocalRegistry
 
-	var repoURL, pullSecret, tag string
+	var repoURL, pullSecret, registryTag string
 
 	if localRegistry.IsExternal() {
-		repoURL, pullSecret, tag = buildExternalRegistryURL(localRegistry)
+		repoURL, pullSecret, registryTag = buildExternalRegistryURL(localRegistry)
 	} else {
 		repoURL = buildLocalRegistryURL(
 			localRegistry, clusterCfg, clusterName, registryHostOverride,
 		)
 	}
 
-	// Use configured tag if provided, otherwise default
+	// Resolve tag: workload tag > registry-embedded tag > default.
+	tag := clusterCfg.Spec.Workload.Tag
+	if tag == "" && registryTag != "" {
+		tag = registryTag
+	}
+
 	if tag == "" {
-		tag = defaultArtifactTag
+		tag = registry.DefaultLocalArtifactTag
 	}
 
 	intervalPtr := &metav1.Duration{Duration: fluxIntervalFallback}

--- a/pkg/svc/installer/flux/resources_test.go
+++ b/pkg/svc/installer/flux/resources_test.go
@@ -226,9 +226,10 @@ func TestBuildInstance(t *testing.T) {
 		clusterCfg  *v1alpha1.Cluster
 		clusterName string
 		wantName    string
+		wantRef     string
 	}{
 		{
-			name: "local registry enabled",
+			name: "local registry with default tag",
 			clusterCfg: &v1alpha1.Cluster{
 				Spec: v1alpha1.Spec{
 					Cluster: v1alpha1.ClusterSpec{
@@ -241,9 +242,27 @@ func TestBuildInstance(t *testing.T) {
 			},
 			clusterName: "test-cluster",
 			wantName:    "flux",
+			wantRef:     "dev",
 		},
 		{
-			name: "external registry",
+			name: "local registry with custom workload tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+						Tag:             "latest",
+					},
+				},
+			},
+			clusterName: "test-cluster",
+			wantName:    "flux",
+			wantRef:     "latest",
+		},
+		{
+			name: "external registry with default tag",
 			clusterCfg: &v1alpha1.Cluster{
 				Spec: v1alpha1.Spec{
 					Cluster: v1alpha1.ClusterSpec{
@@ -258,6 +277,44 @@ func TestBuildInstance(t *testing.T) {
 			},
 			clusterName: "test-cluster",
 			wantName:    "flux",
+			wantRef:     "dev",
+		},
+		{
+			name: "external registry with registry-embedded tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{
+							Registry: "ghcr.io/example/repo:custom",
+						},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+					},
+				},
+			},
+			clusterName: "test-cluster",
+			wantName:    "flux",
+			wantRef:     "custom",
+		},
+		{
+			name: "workload tag takes priority over registry-embedded tag",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						LocalRegistry: v1alpha1.LocalRegistry{
+							Registry: "ghcr.io/example/repo:custom",
+						},
+					},
+					Workload: v1alpha1.WorkloadSpec{
+						SourceDirectory: "k8s",
+						Tag:             "v1.0",
+					},
+				},
+			},
+			clusterName: "test-cluster",
+			wantName:    "flux",
+			wantRef:     "v1.0",
 		},
 	}
 
@@ -282,6 +339,7 @@ func TestBuildInstance(t *testing.T) {
 			assert.NotNil(t, instance.Spec.Sync)
 			assert.Equal(t, "OCIRepository", instance.Spec.Sync.Kind)
 			assert.NotEmpty(t, instance.Spec.Sync.URL)
+			assert.Equal(t, testCase.wantRef, instance.Spec.Sync.Ref)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Both Flux `OCIRepository` (`buildInstance`) and ArgoCD `Application` (`buildArgoCDEnsureOptions`) hardcoded `"dev"` as the artifact tag, ignoring the configured `spec.workload.tag`. This caused Flux/ArgoCD to look for a tag that doesn't exist in the registry when `workload.tag` differs from `"dev"`.

## Changes

Apply the same priority-based tag resolution used by `workload push`:
**workload.tag > registry-embedded tag > default `"dev"`**

### Files changed

- **`pkg/svc/installer/flux/fluxinstance_manager.go`** — `buildInstance()` now checks `Spec.Workload.Tag` before falling back to the registry-embedded tag or default. Removed redundant `defaultArtifactTag` constant.
- **`pkg/cli/setup/install_gitops.go`** — `buildArgoCDEnsureOptions()` now uses priority-based tag resolution instead of hardcoded `"dev"`.
- **`pkg/cli/setup/export_test.go`** — Exported `BuildArgoCDEnsureOptions` for testing.
- **`pkg/svc/installer/flux/resources_test.go`** — Expanded `TestBuildInstance` with tag-specific test cases.
- **`pkg/cli/setup/install_gitops_test.go`** — New test for `buildArgoCDEnsureOptions` tag resolution.

Fixes #3927