### PR TITLE
fix(kubeconfighook): detect stale Omni kubeconfigs via API health check

### DIFF
--- a/pkg/cli/kubeconfighook/hook.go
+++ b/pkg/cli/kubeconfighook/hook.go
@@ -347,7 +347,10 @@ func IsKubeconfigStale(kubeconfigPath, kubeconfigContext string) bool {
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return false
+		// The REST config is unusable (e.g., missing cert/key files,
+		// invalid host). A refresh is warranted since downstream
+		// operations would fail with the same config.
+		return true
 	}
 
 	_, err = clientset.Discovery().ServerVersion()

--- a/pkg/cli/kubeconfighook/hook.go
+++ b/pkg/cli/kubeconfighook/hook.go
@@ -20,6 +20,8 @@ import (
 	omniprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/omni"
 	clusterprovisioner "github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster"
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -35,16 +37,24 @@ const (
 	// (header.payload.signature). Requiring exactly 3 prevents non-JWT
 	// bearer tokens that happen to contain a dot from being parsed.
 	jwtParts = 3
+
+	// staleCheckTimeout is the timeout for the lightweight API health check
+	// used to detect stale kubeconfigs (e.g., after cluster recreation).
+	staleCheckTimeout = 3 * time.Second
 )
 
 // MaybeRefreshOmniKubeconfig checks whether the current kubeconfig's service-account
-// token is expired for Omni-managed clusters and transparently refreshes it.
+// token is expired or stale for Omni-managed clusters and transparently refreshes it.
 //
 // This function is designed to be called from Cobra PersistentPreRunE hooks.
 // It is a fast no-op (~1ms) when:
 //   - No KSail config is found or the provider is not Omni
 //   - The kubeconfig file does not exist yet (e.g., before cluster create)
-//   - The token is still valid
+//
+// Refresh is triggered when:
+//   - The JWT token in the kubeconfig is expired or about to expire
+//   - The kubeconfig credentials are rejected by the API server (e.g., after
+//     cluster recreation with the same name)
 //
 // On refresh failure, a warning is logged but the error is not propagated —
 // the command proceeds with the existing kubeconfig.
@@ -54,7 +64,18 @@ func MaybeRefreshOmniKubeconfig(cmd *cobra.Command) {
 		return
 	}
 
-	if !IsTokenExpired(canonicalPath) {
+	needsRefresh := IsTokenExpired(canonicalPath)
+
+	// When the token is not expired, check if the credentials are still
+	// accepted by the API server. After cluster recreation the token may
+	// be structurally valid (not expired) but rejected by the new cluster.
+	if !needsRefresh {
+		kubeconfigContext := cfg.Spec.Cluster.Connection.Context
+
+		needsRefresh = isKubeconfigStale(canonicalPath, kubeconfigContext)
+	}
+
+	if !needsRefresh {
 		return
 	}
 
@@ -292,6 +313,35 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	}
 
 	return nil
+}
+
+// isKubeconfigStale performs a lightweight API server health check to detect
+// kubeconfigs with valid (non-expired) tokens that are rejected by the server.
+// This happens when a cluster is recreated with the same name — the old token
+// is structurally valid but the new cluster does not accept it.
+//
+// Returns true only when the API server explicitly rejects the credentials
+// (HTTP 401/403). Connection errors and timeouts return false to avoid
+// unnecessary refresh attempts when the cluster is simply unreachable.
+func isKubeconfigStale(kubeconfigPath, kubeconfigContext string) bool {
+	restConfig, err := k8s.BuildRESTConfig(kubeconfigPath, kubeconfigContext)
+	if err != nil {
+		return false
+	}
+
+	restConfig.Timeout = staleCheckTimeout
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return false
+	}
+
+	_, err = clientset.Discovery().ServerVersion()
+	if err == nil {
+		return false
+	}
+
+	return apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)
 }
 
 // IsTokenExpired checks whether the bearer token in the kubeconfig's current

--- a/pkg/cli/kubeconfighook/hook.go
+++ b/pkg/cli/kubeconfighook/hook.go
@@ -47,9 +47,14 @@ const (
 // token is expired or stale for Omni-managed clusters and transparently refreshes it.
 //
 // This function is designed to be called from Cobra PersistentPreRunE hooks.
-// It is a fast no-op (~1ms) when:
+// It is a fast no-op when:
 //   - No KSail config is found or the provider is not Omni
 //   - The kubeconfig file does not exist yet (e.g., before cluster create)
+//
+// For Omni clusters with an existing kubeconfig, this function first checks
+// JWT token expiry (~1ms, local-only). If the token is still valid, a
+// lightweight API server probe (up to staleCheckTimeout) detects credentials
+// that are structurally valid but rejected by a recreated cluster.
 //
 // Refresh is triggered when:
 //   - The JWT token in the kubeconfig is expired or about to expire
@@ -64,15 +69,15 @@ func MaybeRefreshOmniKubeconfig(cmd *cobra.Command) {
 		return
 	}
 
-	needsRefresh := IsTokenExpired(canonicalPath)
+	kubeconfigContext := cfg.Spec.Cluster.Connection.Context
+
+	needsRefresh := IsTokenExpired(canonicalPath, kubeconfigContext)
 
 	// When the token is not expired, check if the credentials are still
 	// accepted by the API server. After cluster recreation the token may
 	// be structurally valid (not expired) but rejected by the new cluster.
 	if !needsRefresh {
-		kubeconfigContext := cfg.Spec.Cluster.Connection.Context
-
-		needsRefresh = isKubeconfigStale(canonicalPath, kubeconfigContext)
+		needsRefresh = IsKubeconfigStale(canonicalPath, kubeconfigContext)
 	}
 
 	if !needsRefresh {
@@ -86,7 +91,7 @@ func MaybeRefreshOmniKubeconfig(cmd *cobra.Command) {
 
 	// Determine the desired kubeconfig context name.
 	// If explicitly configured, use that; otherwise derive from the Talos convention.
-	desiredContext := cfg.Spec.Cluster.Connection.Context
+	desiredContext := kubeconfigContext
 	if desiredContext == "" {
 		desiredContext = cfg.Spec.Cluster.Distribution.ContextName(clusterName)
 	}
@@ -315,18 +320,27 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
-// isKubeconfigStale performs a lightweight API server health check to detect
+// IsKubeconfigStale performs a lightweight API server health check to detect
 // kubeconfigs with valid (non-expired) tokens that are rejected by the server.
 // This happens when a cluster is recreated with the same name — the old token
 // is structurally valid but the new cluster does not accept it.
 //
-// Returns true only when the API server explicitly rejects the credentials
-// (HTTP 401/403). Connection errors and timeouts return false to avoid
-// unnecessary refresh attempts when the cluster is simply unreachable.
-func isKubeconfigStale(kubeconfigPath, kubeconfigContext string) bool {
+// Returns true when:
+//   - The kubeconfig cannot be loaded or the configured context is missing
+//     (subsequent K8s operations would fail anyway, so a refresh is warranted)
+//   - The API server explicitly rejects the credentials (HTTP 401/403)
+//
+// Returns false when:
+//   - The API server responds successfully (credentials are valid)
+//   - A non-auth error occurs (connection refused, timeout, TLS errors) —
+//     the cluster is simply unreachable, not necessarily using stale credentials
+func IsKubeconfigStale(kubeconfigPath, kubeconfigContext string) bool {
 	restConfig, err := k8s.BuildRESTConfig(kubeconfigPath, kubeconfigContext)
 	if err != nil {
-		return false
+		// The kubeconfig cannot be loaded or the configured context is
+		// missing. A refresh is warranted since downstream operations
+		// using this kubeconfig would fail.
+		return true
 	}
 
 	restConfig.Timeout = staleCheckTimeout
@@ -344,19 +358,27 @@ func isKubeconfigStale(kubeconfigPath, kubeconfigContext string) bool {
 	return apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)
 }
 
-// IsTokenExpired checks whether the bearer token in the kubeconfig's current
+// IsTokenExpired checks whether the bearer token in the kubeconfig's specified
 // context has expired (or will expire within the expiryBuffer).
+//
+// When kubeconfigContext is non-empty, the token for that context is checked.
+// When empty, the kubeconfig's CurrentContext is used.
 //
 // Returns false (not expired) when the kubeconfig cannot be parsed, has no
 // token, or the token is not a JWT — erring on the side of not refreshing
 // unnecessarily.
-func IsTokenExpired(kubeconfigPath string) bool {
+func IsTokenExpired(kubeconfigPath, kubeconfigContext string) bool {
 	cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
 		return false
 	}
 
-	currentCtx, contextExists := cfg.Contexts[cfg.CurrentContext]
+	contextName := kubeconfigContext
+	if contextName == "" {
+		contextName = cfg.CurrentContext
+	}
+
+	currentCtx, contextExists := cfg.Contexts[contextName]
 	if !contextExists {
 		return false
 	}

--- a/pkg/cli/kubeconfighook/hook_test.go
+++ b/pkg/cli/kubeconfighook/hook_test.go
@@ -134,7 +134,6 @@ func TestIsTokenExpired_TimeBased(t *testing.T) {
 
 		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
-
 }
 
 func TestIsTokenExpired_ExplicitContext(t *testing.T) {

--- a/pkg/cli/kubeconfighook/hook_test.go
+++ b/pkg/cli/kubeconfighook/hook_test.go
@@ -61,8 +61,10 @@ func writeKubeconfig(t *testing.T, dir, token string) string {
 }
 
 // writeKubeconfigWithServer writes a kubeconfig pointing at the given server URL.
-func writeKubeconfigWithServer(t *testing.T, dir, contextName, serverURL, token string) string {
+func writeKubeconfigWithServer(t *testing.T, dir, serverURL, token string) string {
 	t.Helper()
+
+	const contextName = "test"
 
 	kubeconfigPath := filepath.Join(dir, "kubeconfig")
 
@@ -133,36 +135,37 @@ func TestIsTokenExpired_TimeBased(t *testing.T) {
 		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
-	t.Run("ExplicitContextOverride", func(t *testing.T) {
-		t.Parallel()
+}
 
-		dir := t.TempDir()
-		kubeconfigPath := filepath.Join(dir, "kubeconfig")
+func TestIsTokenExpired_ExplicitContext(t *testing.T) {
+	t.Parallel()
 
-		validToken := makeJWT(t, time.Now().Add(24*time.Hour).Unix())
-		expiredToken := makeJWT(t, time.Now().Add(-1*time.Hour).Unix())
+	dir := t.TempDir()
+	kubeconfigPath := filepath.Join(dir, "kubeconfig")
 
-		cfg := clientcmdapi.NewConfig()
-		cfg.CurrentContext = "valid-ctx"
-		cfg.Clusters["valid-ctx"] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6443"}
-		cfg.AuthInfos["valid-user"] = &clientcmdapi.AuthInfo{Token: validToken}
-		cfg.Contexts["valid-ctx"] = &clientcmdapi.Context{
-			Cluster: "valid-ctx", AuthInfo: "valid-user",
-		}
-		cfg.Clusters["expired-ctx"] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6444"}
-		cfg.AuthInfos["expired-user"] = &clientcmdapi.AuthInfo{Token: expiredToken}
-		cfg.Contexts["expired-ctx"] = &clientcmdapi.Context{
-			Cluster: "expired-ctx", AuthInfo: "expired-user",
-		}
+	validToken := makeJWT(t, time.Now().Add(24*time.Hour).Unix())
+	expiredToken := makeJWT(t, time.Now().Add(-1*time.Hour).Unix())
 
-		err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
-		require.NoError(t, err)
+	cfg := clientcmdapi.NewConfig()
+	cfg.CurrentContext = "valid-ctx"
+	cfg.Clusters["valid-ctx"] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6443"}
+	cfg.AuthInfos["valid-user"] = &clientcmdapi.AuthInfo{Token: validToken}
+	cfg.Contexts["valid-ctx"] = &clientcmdapi.Context{
+		Cluster: "valid-ctx", AuthInfo: "valid-user",
+	}
+	cfg.Clusters["expired-ctx"] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6444"}
+	cfg.AuthInfos["expired-user"] = &clientcmdapi.AuthInfo{Token: expiredToken}
+	cfg.Contexts["expired-ctx"] = &clientcmdapi.Context{
+		Cluster: "expired-ctx", AuthInfo: "expired-user",
+	}
 
-		// CurrentContext has a valid token
-		assert.False(t, kubeconfighook.IsTokenExpired(kubeconfigPath, ""))
-		// Explicit context has an expired token
-		assert.True(t, kubeconfighook.IsTokenExpired(kubeconfigPath, "expired-ctx"))
-	})
+	err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
+	require.NoError(t, err)
+
+	// CurrentContext has a valid token
+	assert.False(t, kubeconfighook.IsTokenExpired(kubeconfigPath, ""))
+	// Explicit context has an expired token
+	assert.True(t, kubeconfighook.IsTokenExpired(kubeconfigPath, "expired-ctx"))
 }
 
 func TestIsTokenExpired_EdgeCases(t *testing.T) {
@@ -226,7 +229,7 @@ func TestIsTokenExpired_EdgeCases(t *testing.T) {
 	})
 }
 
-func TestIsKubeconfigStale(t *testing.T) {
+func TestIsKubeconfigStale_AuthErrors(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Unauthorized401", func(t *testing.T) {
@@ -235,12 +238,12 @@ func TestIsKubeconfigStale(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}`)
+			_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}`)
 		}))
 		defer srv.Close()
 
 		dir := t.TempDir()
-		path := writeKubeconfigWithServer(t, dir, "test", srv.URL, "stale-token")
+		path := writeKubeconfigWithServer(t, dir, srv.URL, "stale-token")
 
 		assert.True(t, kubeconfighook.IsKubeconfigStale(path, ""))
 	})
@@ -251,27 +254,31 @@ func TestIsKubeconfigStale(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Forbidden","reason":"Forbidden","code":403}`)
+			_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Forbidden","reason":"Forbidden","code":403}`)
 		}))
 		defer srv.Close()
 
 		dir := t.TempDir()
-		path := writeKubeconfigWithServer(t, dir, "test", srv.URL, "stale-token")
+		path := writeKubeconfigWithServer(t, dir, srv.URL, "stale-token")
 
 		assert.True(t, kubeconfighook.IsKubeconfigStale(path, ""))
 	})
+}
+
+func TestIsKubeconfigStale_NonStale(t *testing.T) {
+	t.Parallel()
 
 	t.Run("SuccessfulResponse", func(t *testing.T) {
 		t.Parallel()
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"major":"1","minor":"30","gitVersion":"v1.30.0"}`)
+			_, _ = fmt.Fprint(w, `{"major":"1","minor":"30","gitVersion":"v1.30.0"}`)
 		}))
 		defer srv.Close()
 
 		dir := t.TempDir()
-		path := writeKubeconfigWithServer(t, dir, "test", srv.URL, "valid-token")
+		path := writeKubeconfigWithServer(t, dir, srv.URL, "valid-token")
 
 		assert.False(t, kubeconfighook.IsKubeconfigStale(path, ""))
 	})
@@ -281,10 +288,14 @@ func TestIsKubeconfigStale(t *testing.T) {
 
 		dir := t.TempDir()
 		// Port 1 is unlikely to be listening
-		path := writeKubeconfigWithServer(t, dir, "test", "https://127.0.0.1:1", "some-token")
+		path := writeKubeconfigWithServer(t, dir, "https://127.0.0.1:1", "some-token")
 
 		assert.False(t, kubeconfighook.IsKubeconfigStale(path, ""))
 	})
+}
+
+func TestIsKubeconfigStale_ConfigEdgeCases(t *testing.T) {
+	t.Parallel()
 
 	t.Run("MissingFile", func(t *testing.T) {
 		t.Parallel()
@@ -296,47 +307,47 @@ func TestIsKubeconfigStale(t *testing.T) {
 		t.Parallel()
 
 		dir := t.TempDir()
-		path := writeKubeconfigWithServer(t, dir, "test", "https://127.0.0.1:6443", "token")
+		path := writeKubeconfigWithServer(t, dir, "https://127.0.0.1:6443", "token")
 
 		// Request a context that doesn't exist in the kubeconfig
 		assert.True(t, kubeconfighook.IsKubeconfigStale(path, "nonexistent-context"))
 	})
+}
 
-	t.Run("ExplicitContextHonored", func(t *testing.T) {
-		t.Parallel()
+func TestIsKubeconfigStale_ExplicitContext(t *testing.T) {
+	t.Parallel()
 
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"major":"1","minor":"30","gitVersion":"v1.30.0"}`)
-		}))
-		defer srv.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"major":"1","minor":"30","gitVersion":"v1.30.0"}`)
+	}))
+	defer srv.Close()
 
-		dir := t.TempDir()
-		kubeconfigPath := filepath.Join(dir, "kubeconfig")
+	dir := t.TempDir()
+	kubeconfigPath := filepath.Join(dir, "kubeconfig")
 
-		cfg := clientcmdapi.NewConfig()
-		cfg.CurrentContext = "default"
-		cfg.Clusters["default"] = &clientcmdapi.Cluster{
-			Server:                "https://127.0.0.1:1", // unreachable
-			InsecureSkipTLSVerify: true,
-		}
-		cfg.AuthInfos["default"] = &clientcmdapi.AuthInfo{Token: "tok"}
-		cfg.Contexts["default"] = &clientcmdapi.Context{
-			Cluster: "default", AuthInfo: "default",
-		}
-		cfg.Clusters["reachable"] = &clientcmdapi.Cluster{
-			Server:                srv.URL,
-			InsecureSkipTLSVerify: true,
-		}
-		cfg.AuthInfos["reachable"] = &clientcmdapi.AuthInfo{Token: "tok"}
-		cfg.Contexts["reachable"] = &clientcmdapi.Context{
-			Cluster: "reachable", AuthInfo: "reachable",
-		}
+	cfg := clientcmdapi.NewConfig()
+	cfg.CurrentContext = "default"
+	cfg.Clusters["default"] = &clientcmdapi.Cluster{
+		Server:                "https://127.0.0.1:1", // unreachable
+		InsecureSkipTLSVerify: true,
+	}
+	cfg.AuthInfos["default"] = &clientcmdapi.AuthInfo{Token: "tok"}
+	cfg.Contexts["default"] = &clientcmdapi.Context{
+		Cluster: "default", AuthInfo: "default",
+	}
+	cfg.Clusters["reachable"] = &clientcmdapi.Cluster{
+		Server:                srv.URL,
+		InsecureSkipTLSVerify: true,
+	}
+	cfg.AuthInfos["reachable"] = &clientcmdapi.AuthInfo{Token: "tok"}
+	cfg.Contexts["reachable"] = &clientcmdapi.Context{
+		Cluster: "reachable", AuthInfo: "reachable",
+	}
 
-		err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
-		require.NoError(t, err)
+	err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
+	require.NoError(t, err)
 
-		// Explicit context points to the reachable server → not stale
-		assert.False(t, kubeconfighook.IsKubeconfigStale(kubeconfigPath, "reachable"))
-	})
+	// Explicit context points to the reachable server → not stale
+	assert.False(t, kubeconfighook.IsKubeconfigStale(kubeconfigPath, "reachable"))
 }

--- a/pkg/cli/kubeconfighook/hook_test.go
+++ b/pkg/cli/kubeconfighook/hook_test.go
@@ -238,7 +238,9 @@ func TestIsKubeconfigStale_AuthErrors(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}`)
+			_, _ = fmt.Fprint(w,
+				`{"kind":"Status","apiVersion":"v1","status":"Failure",`+
+					`"message":"Unauthorized","reason":"Unauthorized","code":401}`)
 		}))
 		defer srv.Close()
 
@@ -254,7 +256,9 @@ func TestIsKubeconfigStale_AuthErrors(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
-			_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Forbidden","reason":"Forbidden","code":403}`)
+			_, _ = fmt.Fprint(w,
+				`{"kind":"Status","apiVersion":"v1","status":"Failure",`+
+					`"message":"Forbidden","reason":"Forbidden","code":403}`)
 		}))
 		defer srv.Close()
 

--- a/pkg/cli/kubeconfighook/hook_test.go
+++ b/pkg/cli/kubeconfighook/hook_test.go
@@ -3,6 +3,9 @@ package kubeconfighook_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
@@ -57,6 +60,32 @@ func writeKubeconfig(t *testing.T, dir, token string) string {
 	return kubeconfigPath
 }
 
+// writeKubeconfigWithServer writes a kubeconfig pointing at the given server URL.
+func writeKubeconfigWithServer(t *testing.T, dir, contextName, serverURL, token string) string {
+	t.Helper()
+
+	kubeconfigPath := filepath.Join(dir, "kubeconfig")
+
+	cfg := clientcmdapi.NewConfig()
+	cfg.CurrentContext = contextName
+	cfg.Clusters[contextName] = &clientcmdapi.Cluster{
+		Server:                serverURL,
+		InsecureSkipTLSVerify: true,
+	}
+	cfg.AuthInfos[contextName] = &clientcmdapi.AuthInfo{
+		Token: token,
+	}
+	cfg.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  contextName,
+		AuthInfo: contextName,
+	}
+
+	err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
+	require.NoError(t, err)
+
+	return kubeconfigPath
+}
+
 func TestIsTokenExpired_TimeBased(t *testing.T) {
 	t.Parallel()
 
@@ -68,7 +97,7 @@ func TestIsTokenExpired_TimeBased(t *testing.T) {
 		token := makeJWT(t, expiredAt)
 		path := writeKubeconfig(t, dir, token)
 
-		assert.True(t, kubeconfighook.IsTokenExpired(path))
+		assert.True(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
 	t.Run("ValidToken", func(t *testing.T) {
@@ -79,7 +108,7 @@ func TestIsTokenExpired_TimeBased(t *testing.T) {
 		token := makeJWT(t, expiresAt)
 		path := writeKubeconfig(t, dir, token)
 
-		assert.False(t, kubeconfighook.IsTokenExpired(path))
+		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
 	t.Run("TokenExpiringWithinBuffer", func(t *testing.T) {
@@ -90,7 +119,7 @@ func TestIsTokenExpired_TimeBased(t *testing.T) {
 		token := makeJWT(t, expiresAt)
 		path := writeKubeconfig(t, dir, token)
 
-		assert.True(t, kubeconfighook.IsTokenExpired(path))
+		assert.True(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
 	t.Run("TokenExpiringOutsideBuffer", func(t *testing.T) {
@@ -101,7 +130,38 @@ func TestIsTokenExpired_TimeBased(t *testing.T) {
 		token := makeJWT(t, expiresAt)
 		path := writeKubeconfig(t, dir, token)
 
-		assert.False(t, kubeconfighook.IsTokenExpired(path))
+		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
+	})
+
+	t.Run("ExplicitContextOverride", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		kubeconfigPath := filepath.Join(dir, "kubeconfig")
+
+		validToken := makeJWT(t, time.Now().Add(24*time.Hour).Unix())
+		expiredToken := makeJWT(t, time.Now().Add(-1*time.Hour).Unix())
+
+		cfg := clientcmdapi.NewConfig()
+		cfg.CurrentContext = "valid-ctx"
+		cfg.Clusters["valid-ctx"] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6443"}
+		cfg.AuthInfos["valid-user"] = &clientcmdapi.AuthInfo{Token: validToken}
+		cfg.Contexts["valid-ctx"] = &clientcmdapi.Context{
+			Cluster: "valid-ctx", AuthInfo: "valid-user",
+		}
+		cfg.Clusters["expired-ctx"] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6444"}
+		cfg.AuthInfos["expired-user"] = &clientcmdapi.AuthInfo{Token: expiredToken}
+		cfg.Contexts["expired-ctx"] = &clientcmdapi.Context{
+			Cluster: "expired-ctx", AuthInfo: "expired-user",
+		}
+
+		err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
+		require.NoError(t, err)
+
+		// CurrentContext has a valid token
+		assert.False(t, kubeconfighook.IsTokenExpired(kubeconfigPath, ""))
+		// Explicit context has an expired token
+		assert.True(t, kubeconfighook.IsTokenExpired(kubeconfigPath, "expired-ctx"))
 	})
 }
 
@@ -114,7 +174,7 @@ func TestIsTokenExpired_EdgeCases(t *testing.T) {
 		dir := t.TempDir()
 		path := writeKubeconfig(t, dir, "plain-bearer-token")
 
-		assert.False(t, kubeconfighook.IsTokenExpired(path))
+		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
 	t.Run("TwoSegmentToken", func(t *testing.T) {
@@ -123,7 +183,7 @@ func TestIsTokenExpired_EdgeCases(t *testing.T) {
 		dir := t.TempDir()
 		path := writeKubeconfig(t, dir, "header.payload")
 
-		assert.False(t, kubeconfighook.IsTokenExpired(path))
+		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
 	t.Run("FourSegmentToken", func(t *testing.T) {
@@ -132,7 +192,7 @@ func TestIsTokenExpired_EdgeCases(t *testing.T) {
 		dir := t.TempDir()
 		path := writeKubeconfig(t, dir, "a.b.c.d")
 
-		assert.False(t, kubeconfighook.IsTokenExpired(path))
+		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
 	t.Run("NoToken", func(t *testing.T) {
@@ -141,13 +201,13 @@ func TestIsTokenExpired_EdgeCases(t *testing.T) {
 		dir := t.TempDir()
 		path := writeKubeconfig(t, dir, "")
 
-		assert.False(t, kubeconfighook.IsTokenExpired(path))
+		assert.False(t, kubeconfighook.IsTokenExpired(path, ""))
 	})
 
 	t.Run("MissingFile", func(t *testing.T) {
 		t.Parallel()
 
-		assert.False(t, kubeconfighook.IsTokenExpired("/nonexistent/kubeconfig"))
+		assert.False(t, kubeconfighook.IsTokenExpired("/nonexistent/kubeconfig", ""))
 	})
 
 	t.Run("MissingContext", func(t *testing.T) {
@@ -162,6 +222,121 @@ func TestIsTokenExpired_EdgeCases(t *testing.T) {
 		err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
 		require.NoError(t, err)
 
-		assert.False(t, kubeconfighook.IsTokenExpired(kubeconfigPath))
+		assert.False(t, kubeconfighook.IsTokenExpired(kubeconfigPath, ""))
+	})
+}
+
+func TestIsKubeconfigStale(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Unauthorized401", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}`)
+		}))
+		defer srv.Close()
+
+		dir := t.TempDir()
+		path := writeKubeconfigWithServer(t, dir, "test", srv.URL, "stale-token")
+
+		assert.True(t, kubeconfighook.IsKubeconfigStale(path, ""))
+	})
+
+	t.Run("Forbidden403", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Forbidden","reason":"Forbidden","code":403}`)
+		}))
+		defer srv.Close()
+
+		dir := t.TempDir()
+		path := writeKubeconfigWithServer(t, dir, "test", srv.URL, "stale-token")
+
+		assert.True(t, kubeconfighook.IsKubeconfigStale(path, ""))
+	})
+
+	t.Run("SuccessfulResponse", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"major":"1","minor":"30","gitVersion":"v1.30.0"}`)
+		}))
+		defer srv.Close()
+
+		dir := t.TempDir()
+		path := writeKubeconfigWithServer(t, dir, "test", srv.URL, "valid-token")
+
+		assert.False(t, kubeconfighook.IsKubeconfigStale(path, ""))
+	})
+
+	t.Run("ConnectionRefused", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		// Port 1 is unlikely to be listening
+		path := writeKubeconfigWithServer(t, dir, "test", "https://127.0.0.1:1", "some-token")
+
+		assert.False(t, kubeconfighook.IsKubeconfigStale(path, ""))
+	})
+
+	t.Run("MissingFile", func(t *testing.T) {
+		t.Parallel()
+
+		assert.True(t, kubeconfighook.IsKubeconfigStale("/nonexistent/kubeconfig", ""))
+	})
+
+	t.Run("MissingContext", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		path := writeKubeconfigWithServer(t, dir, "test", "https://127.0.0.1:6443", "token")
+
+		// Request a context that doesn't exist in the kubeconfig
+		assert.True(t, kubeconfighook.IsKubeconfigStale(path, "nonexistent-context"))
+	})
+
+	t.Run("ExplicitContextHonored", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"major":"1","minor":"30","gitVersion":"v1.30.0"}`)
+		}))
+		defer srv.Close()
+
+		dir := t.TempDir()
+		kubeconfigPath := filepath.Join(dir, "kubeconfig")
+
+		cfg := clientcmdapi.NewConfig()
+		cfg.CurrentContext = "default"
+		cfg.Clusters["default"] = &clientcmdapi.Cluster{
+			Server:                "https://127.0.0.1:1", // unreachable
+			InsecureSkipTLSVerify: true,
+		}
+		cfg.AuthInfos["default"] = &clientcmdapi.AuthInfo{Token: "tok"}
+		cfg.Contexts["default"] = &clientcmdapi.Context{
+			Cluster: "default", AuthInfo: "default",
+		}
+		cfg.Clusters["reachable"] = &clientcmdapi.Cluster{
+			Server:                srv.URL,
+			InsecureSkipTLSVerify: true,
+		}
+		cfg.AuthInfos["reachable"] = &clientcmdapi.AuthInfo{Token: "tok"}
+		cfg.Contexts["reachable"] = &clientcmdapi.Context{
+			Cluster: "reachable", AuthInfo: "reachable",
+		}
+
+		err := clientcmd.WriteToFile(*cfg, kubeconfigPath)
+		require.NoError(t, err)
+
+		// Explicit context points to the reachable server → not stale
+		assert.False(t, kubeconfighook.IsKubeconfigStale(kubeconfigPath, "reachable"))
 	})
 }


### PR DESCRIPTION
## Description

Fixes #3922

Enhances `MaybeRefreshOmniKubeconfig` in the `PersistentPreRunE` hook to detect **both** expired tokens and stale kubeconfigs (valid token but wrong cluster instance).

### Problem

`cluster update` for Omni clusters relied on the pre-existing kubeconfig which may be stale after cluster recreation. The existing hook only refreshed **expired** JWT tokens — it did not handle tokens that are structurally valid but rejected by a recreated cluster.

### Solution

When the JWT token is not expired, a lightweight `Discovery().ServerVersion()` check (3s timeout) probes the K8s API server. If the server returns 401/403 (authentication error), the kubeconfig is refreshed from the Omni API. Connection errors and timeouts are ignored to avoid unnecessary refreshes when the cluster is simply unreachable.

This adds ~100ms latency for Omni clusters with valid kubeconfigs (negligible for a CLI tool) and correctly handles the stale-after-recreation scenario.

### Changes

- `pkg/cli/kubeconfighook/hook.go` — add `isKubeconfigStale` function, update `MaybeRefreshOmniKubeconfig` to call it when token is not expired