### PR TITLE
fix(update): detect and fix stale GitOps sync ref during cluster update

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6441,6 +6441,7 @@ func checkWorkloadTagDrift(
 	}
 
 	desiredTag := fluxinstaller.ResolveDesiredTag(ctx.ClusterCfg)
+
 	var currentTag string
 
 	switch gitOpsEngine { //nolint:exhaustive // None/empty already filtered above

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -4099,14 +4099,24 @@ func (r *componentReconciler) reconcileWorkloadTag(
 			return fmt.Errorf("resolve registry host for flux: %w", resolveErr)
 		}
 
-		return fluxinstaller.SetupInstance(
+		err = fluxinstaller.SetupInstance(
 			ctx, kubeconfigPath, r.clusterCfg, r.clusterName, registryHost,
 		)
+		if err != nil {
+			return fmt.Errorf("setup flux instance: %w", err)
+		}
+
+		return nil
 
 	case v1alpha1.GitOpsEngineArgoCD:
-		return setup.EnsureArgoCDResources(
+		err = setup.EnsureArgoCDResources(
 			ctx, kubeconfigPath, r.clusterCfg, r.clusterName,
 		)
+		if err != nil {
+			return fmt.Errorf("ensure argocd resources: %w", err)
+		}
+
+		return nil
 
 	default:
 		return nil
@@ -6433,7 +6443,7 @@ func checkWorkloadTagDrift(
 	desiredTag := fluxinstaller.ResolveDesiredTag(ctx.ClusterCfg)
 	var currentTag string
 
-	switch gitOpsEngine {
+	switch gitOpsEngine { //nolint:exhaustive // None/empty already filtered above
 	case v1alpha1.GitOpsEngineFlux:
 		currentTag, err = fluxinstaller.GetCurrentSyncRef(cmd.Context(), kubeconfigPath)
 	case v1alpha1.GitOpsEngineArgoCD:
@@ -6468,7 +6478,12 @@ func getCurrentArgoCDTargetRevision(
 		return "", fmt.Errorf("create argocd manager: %w", err)
 	}
 
-	return mgr.GetCurrentTargetRevision(goCtx, "")
+	rev, err := mgr.GetCurrentTargetRevision(goCtx, "")
+	if err != nil {
+		return "", fmt.Errorf("get argocd target revision: %w", err)
+	}
+
+	return rev, nil
 }
 
 // applyOrReportChanges handles dry-run, recreate-required, no-changes, and

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6424,6 +6424,9 @@ func checkWorkloadTagDrift(
 
 	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(ctx.ClusterCfg)
 	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot resolve kubeconfig path for workload tag drift detection: %v", err)
+
 		return
 	}
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -31,6 +31,7 @@ import (
 	"github.com/devantler-tech/ksail/v6/pkg/cli/setup/mirrorregistry"
 	"github.com/devantler-tech/ksail/v6/pkg/cli/ui/confirm"
 	"github.com/devantler-tech/ksail/v6/pkg/cli/ui/picker"
+	argocdclient "github.com/devantler-tech/ksail/v6/pkg/client/argocd"
 	docker "github.com/devantler-tech/ksail/v6/pkg/client/docker"
 	"github.com/devantler-tech/ksail/v6/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v6/pkg/client/k9s"
@@ -50,6 +51,7 @@ import (
 	specdiff "github.com/devantler-tech/ksail/v6/pkg/svc/diff"
 	imagesvc "github.com/devantler-tech/ksail/v6/pkg/svc/image"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/installer"
+	fluxinstaller "github.com/devantler-tech/ksail/v6/pkg/svc/installer/flux"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provider"
 	dockerprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/docker"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provider/hetzner"
@@ -3775,20 +3777,23 @@ var errMetricsServerDisableUnsupported = errors.New(
 // componentReconciler applies component-level changes detected by the DiffEngine.
 // It maps field names from the diff to installer Install/Uninstall operations.
 type componentReconciler struct {
-	cmd        *cobra.Command
-	clusterCfg *v1alpha1.Cluster
-	factories  *setup.InstallerFactories
+	cmd         *cobra.Command
+	clusterCfg  *v1alpha1.Cluster
+	clusterName string
+	factories   *setup.InstallerFactories
 }
 
 // newComponentReconciler creates a reconciler for applying component changes.
 func newComponentReconciler(
 	cmd *cobra.Command,
 	clusterCfg *v1alpha1.Cluster,
+	clusterName string,
 ) *componentReconciler {
 	return &componentReconciler{
-		cmd:        cmd,
-		clusterCfg: clusterCfg,
-		factories:  getInstallerFactories(),
+		cmd:         cmd,
+		clusterCfg:  clusterCfg,
+		clusterName: clusterName,
+		factories:   getInstallerFactories(),
 	}
 }
 
@@ -3848,6 +3853,7 @@ func (r *componentReconciler) handlerForField(
 		"cluster.certManager":   r.reconcileCertManager,
 		"cluster.policyEngine":  r.reconcilePolicyEngine,
 		"cluster.gitOpsEngine":  r.reconcileGitOpsEngine,
+		"cluster.workload.tag":  r.reconcileWorkloadTag,
 	}
 
 	handler, ok := handlers[field]
@@ -4062,6 +4068,45 @@ func (r *componentReconciler) uninstallGitOpsEngine(
 		}
 
 		return r.uninstallWithFactory(ctx, r.factories.ArgoCD)
+
+	default:
+		return nil
+	}
+}
+
+// reconcileWorkloadTag updates the GitOps sync resource (FluxInstance or ArgoCD
+// Application) to match the desired workload tag from configuration.
+//
+//nolint:exhaustive // Only Flux and ArgoCD have sync resources to update
+func (r *componentReconciler) reconcileWorkloadTag(
+	ctx context.Context,
+	_ clusterupdate.Change,
+) error {
+	gitOpsEngine := r.clusterCfg.Spec.Cluster.GitOpsEngine
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(r.clusterCfg)
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig path: %w", err)
+	}
+
+	switch gitOpsEngine {
+	case v1alpha1.GitOpsEngineFlux:
+		// Resolve registry host for VCluster (others return empty string)
+		registryHost, resolveErr := setup.ResolveRegistryHostForCluster(
+			ctx, r.clusterCfg, r.clusterName,
+		)
+		if resolveErr != nil {
+			return fmt.Errorf("resolve registry host for flux: %w", resolveErr)
+		}
+
+		return fluxinstaller.SetupInstance(
+			ctx, kubeconfigPath, r.clusterCfg, r.clusterName, registryHost,
+		)
+
+	case v1alpha1.GitOpsEngineArgoCD:
+		return setup.EnsureArgoCDResources(
+			ctx, kubeconfigPath, r.clusterCfg, r.clusterName,
+		)
 
 	default:
 		return nil
@@ -6303,6 +6348,9 @@ func computeUpdateDiff(
 		specdiff.MergeProvisionerDiff(diff, provisionerDiff)
 	}
 
+	// Check for workload tag drift (stale GitOps sync ref)
+	checkWorkloadTagDrift(cmd, ctx, diffEngine, diff)
+
 	return currentSpec, diff, nil
 }
 
@@ -6343,12 +6391,81 @@ func computeSpecOnlyDiff(
 		ctx.ClusterCfg.Spec.Cluster.Provider,
 	)
 
-	return diffEngine.ComputeDiff(
+	diff := diffEngine.ComputeDiff(
 		currentSpec,
 		&ctx.ClusterCfg.Spec.Cluster,
 		nil,
 		&ctx.ClusterCfg.Spec.Provider,
 	)
+
+	// Check for workload tag drift (stale GitOps sync ref)
+	checkWorkloadTagDrift(cmd, ctx, diffEngine, diff)
+
+	return diff
+}
+
+// checkWorkloadTagDrift queries the running GitOps sync resource for its current
+// tag (FluxInstance.sync.ref or ArgoCD Application.targetRevision) and compares
+// it against the desired tag from configuration. If they differ, an in-place
+// change is appended to the diff result. This detects stale sync refs left by
+// pre-v6.7.1 cluster creation.
+// Errors during cluster queries are logged as warnings and skipped — they should
+// not block the rest of the update.
+func checkWorkloadTagDrift(
+	cmd *cobra.Command,
+	ctx *localregistry.Context,
+	diffEngine *specdiff.Engine,
+	diff *clusterupdate.UpdateResult,
+) {
+	gitOpsEngine := ctx.ClusterCfg.Spec.Cluster.GitOpsEngine
+	if gitOpsEngine == v1alpha1.GitOpsEngineNone || gitOpsEngine == "" {
+		return
+	}
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(ctx.ClusterCfg)
+	if err != nil {
+		return
+	}
+
+	desiredTag := fluxinstaller.ResolveDesiredTag(ctx.ClusterCfg)
+	var currentTag string
+
+	switch gitOpsEngine {
+	case v1alpha1.GitOpsEngineFlux:
+		currentTag, err = fluxinstaller.GetCurrentSyncRef(cmd.Context(), kubeconfigPath)
+	case v1alpha1.GitOpsEngineArgoCD:
+		currentTag, err = getCurrentArgoCDTargetRevision(cmd.Context(), kubeconfigPath)
+	default:
+		return
+	}
+
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot query current GitOps sync ref for drift detection: %v", err)
+
+		return
+	}
+
+	// Empty current tag means the resource does not exist yet — no drift to fix.
+	if currentTag == "" {
+		return
+	}
+
+	diffEngine.CheckWorkloadTag(currentTag, desiredTag, gitOpsEngine, diff)
+}
+
+// getCurrentArgoCDTargetRevision queries the ArgoCD Application for its current
+// targetRevision. Returns empty string if the Application does not exist.
+func getCurrentArgoCDTargetRevision(
+	goCtx context.Context,
+	kubeconfigPath string,
+) (string, error) {
+	mgr, err := argocdclient.NewManagerFromKubeconfig(kubeconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("create argocd manager: %w", err)
+	}
+
+	return mgr.GetCurrentTargetRevision(goCtx, "")
 }
 
 // applyOrReportChanges handles dry-run, recreate-required, no-changes, and
@@ -6406,7 +6523,7 @@ func applyOrReportChanges(
 		}
 	}
 
-	reconciler := newComponentReconciler(cmd, ctx.ClusterCfg)
+	reconciler := newComponentReconciler(cmd, ctx.ClusterCfg, clusterName)
 
 	return applyInPlaceChanges(
 		cmd, updater, reconciler, clusterName,

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -183,7 +183,7 @@ var ErrMetricsServerDisableUnsupported = errMetricsServerDisableUnsupported
 
 // ExportHandlerForField reports whether a registered handler exists for the given field name.
 func ExportHandlerForField(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster, field string) bool {
-	r := newComponentReconciler(cmd, clusterCfg)
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 	_, ok := r.handlerForField(field)
 
 	return ok
@@ -195,7 +195,7 @@ func ExportReconcileMetricsServer(
 	clusterCfg *v1alpha1.Cluster,
 	change clusterupdate.Change,
 ) error {
-	r := newComponentReconciler(cmd, clusterCfg)
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 
 	return r.reconcileMetricsServer(context.Background(), change)
 }
@@ -206,7 +206,7 @@ func ExportReconcileCSI(
 	clusterCfg *v1alpha1.Cluster,
 	change clusterupdate.Change,
 ) error {
-	r := newComponentReconciler(cmd, clusterCfg)
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 
 	return r.reconcileCSI(context.Background(), change)
 }
@@ -217,7 +217,7 @@ func ExportReconcileCertManager(
 	clusterCfg *v1alpha1.Cluster,
 	change clusterupdate.Change,
 ) error {
-	r := newComponentReconciler(cmd, clusterCfg)
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 
 	return r.reconcileCertManager(context.Background(), change)
 }
@@ -228,7 +228,7 @@ func ExportReconcilePolicyEngine(
 	clusterCfg *v1alpha1.Cluster,
 	change clusterupdate.Change,
 ) error {
-	r := newComponentReconciler(cmd, clusterCfg)
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 
 	return r.reconcilePolicyEngine(context.Background(), change)
 }
@@ -239,7 +239,7 @@ func ExportReconcileGitOpsEngine(
 	clusterCfg *v1alpha1.Cluster,
 	change clusterupdate.Change,
 ) error {
-	r := newComponentReconciler(cmd, clusterCfg)
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 
 	return r.reconcileGitOpsEngine(context.Background(), change)
 }
@@ -251,7 +251,7 @@ func ExportReconcileComponents(
 	diff *clusterupdate.UpdateResult,
 	result *clusterupdate.UpdateResult,
 ) error {
-	r := newComponentReconciler(cmd, clusterCfg)
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 
 	return r.reconcileComponents(context.Background(), diff, result)
 }

--- a/pkg/cli/setup/registry_host.go
+++ b/pkg/cli/setup/registry_host.go
@@ -65,3 +65,14 @@ func needsRegistryIPResolution(clusterCfg *v1alpha1.Cluster) bool {
 
 	return clusterCfg.Spec.Cluster.LocalRegistry.Enabled()
 }
+
+// ResolveRegistryHostForCluster is the exported variant of resolveRegistryHost.
+// It determines the registry host override needed for the given cluster config,
+// returning an empty string when no override is needed.
+func ResolveRegistryHostForCluster(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	clusterName string,
+) (string, error) {
+	return resolveRegistryHost(ctx, clusterCfg, clusterName)
+}

--- a/pkg/client/argocd/manager.go
+++ b/pkg/client/argocd/manager.go
@@ -137,6 +137,45 @@ func (m *ManagerImpl) UpdateTargetRevision(
 	return nil
 }
 
+// GetCurrentTargetRevision returns the Application's current targetRevision.
+// Returns empty string if the Application does not exist.
+func (m *ManagerImpl) GetCurrentTargetRevision(
+	ctx context.Context,
+	applicationName string,
+) (string, error) {
+	if ctx == nil {
+		return "", errNilContext
+	}
+
+	name := applicationName
+	if name == "" {
+		name = defaultApplicationName
+	}
+
+	obj, err := m.dynamic.Resource(applicationGVR()).
+		Namespace(argoCDNamespace).
+		Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("get Argo CD Application %s: %w", name, err)
+	}
+
+	rev, found, err := unstructured.NestedString(
+		obj.Object,
+		"spec",
+		"source",
+		"targetRevision",
+	)
+	if err != nil || !found {
+		return "", nil //nolint:nilerr // Missing field is not an error
+	}
+
+	return rev, nil
+}
+
 func (m *ManagerImpl) ensureNamespace(ctx context.Context, name string) error {
 	_, err := m.clientset.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 	if err == nil {

--- a/pkg/client/argocd/manager.go
+++ b/pkg/client/argocd/manager.go
@@ -169,8 +169,12 @@ func (m *ManagerImpl) GetCurrentTargetRevision(
 		"source",
 		"targetRevision",
 	)
-	if err != nil || !found {
-		return "", nil //nolint:nilerr // Missing field is not an error
+	if err != nil {
+		return "", fmt.Errorf("read targetRevision from Argo CD Application %s: %w", name, err)
+	}
+
+	if !found {
+		return "", nil
 	}
 
 	return rev, nil

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -430,3 +430,23 @@ func (e *Engine) applyProviderFieldRules(
 			rule.defaultVal, rule.reason, rule.category)
 	}
 }
+
+// CheckWorkloadTag compares the current GitOps sync ref against the desired
+// workload tag and appends an in-place change when they differ. This detects
+// stale sync refs left by pre-v6.7.1 cluster creation.
+// The caller is responsible for querying the cluster for oldTag and resolving
+// newTag from the configuration.
+func (e *Engine) CheckWorkloadTag(
+	oldTag, newTag string,
+	gitOpsEngine v1alpha1.GitOpsEngine,
+	result *clusterupdate.UpdateResult,
+) {
+	if gitOpsEngine == v1alpha1.GitOpsEngineNone || gitOpsEngine == "" {
+		return
+	}
+
+	appendChange(result, "cluster.workload.tag",
+		oldTag, newTag, "",
+		"workload tag can be updated in-place on the GitOps sync resource",
+		clusterupdate.ChangeCategoryInPlace)
+}

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -44,6 +44,26 @@ func (e *Engine) ComputeDiff(
 	return result
 }
 
+// CheckWorkloadTag compares the currently deployed GitOps sync ref against the desired
+// workload tag and appends an in-place change when they differ. This detects
+// stale sync refs left by pre-v6.7.1 cluster creation.
+// The caller is responsible for querying the cluster for oldTag and resolving
+// newTag from the configuration.
+func (e *Engine) CheckWorkloadTag(
+	oldTag, newTag string,
+	gitOpsEngine v1alpha1.GitOpsEngine,
+	result *clusterupdate.UpdateResult,
+) {
+	if gitOpsEngine == v1alpha1.GitOpsEngineNone || gitOpsEngine == "" {
+		return
+	}
+
+	appendChange(result, "cluster.workload.tag",
+		oldTag, newTag, "",
+		"workload tag can be updated in-place on the GitOps sync resource",
+		clusterupdate.ChangeCategoryInPlace)
+}
+
 // fieldRule describes how to diff a single scalar field.
 type fieldRule struct {
 	field    string
@@ -429,24 +449,4 @@ func (e *Engine) applyProviderFieldRules(
 			rule.getVal(oldProvider), rule.getVal(newProvider),
 			rule.defaultVal, rule.reason, rule.category)
 	}
-}
-
-// CheckWorkloadTag compares the current GitOps sync ref against the desired
-// workload tag and appends an in-place change when they differ. This detects
-// stale sync refs left by pre-v6.7.1 cluster creation.
-// The caller is responsible for querying the cluster for oldTag and resolving
-// newTag from the configuration.
-func (e *Engine) CheckWorkloadTag(
-	oldTag, newTag string,
-	gitOpsEngine v1alpha1.GitOpsEngine,
-	result *clusterupdate.UpdateResult,
-) {
-	if gitOpsEngine == v1alpha1.GitOpsEngineNone || gitOpsEngine == "" {
-		return
-	}
-
-	appendChange(result, "cluster.workload.tag",
-		oldTag, newTag, "",
-		"workload tag can be updated in-place on the GitOps sync resource",
-		clusterupdate.ChangeCategoryInPlace)
 }

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -931,7 +931,11 @@ func TestEngine_CheckWorkloadTag(t *testing.T) {
 	}
 }
 
-func assertWorkloadTagChange(t *testing.T, result *clusterupdate.UpdateResult, oldTag, newTag string) {
+func assertWorkloadTagChange(
+	t *testing.T,
+	result *clusterupdate.UpdateResult,
+	oldTag, newTag string,
+) {
 	t.Helper()
 
 	changes := result.InPlaceChanges

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -893,3 +893,86 @@ func assertSingleChange(
 		)
 	}
 }
+
+func TestEngine_CheckWorkloadTag(t *testing.T) {
+	t.Parallel()
+
+	engine := diff.NewEngine(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+
+	tests := []struct {
+		name         string
+		oldTag       string
+		newTag       string
+		gitOpsEngine v1alpha1.GitOpsEngine
+		wantChanges  int
+	}{
+		{
+			name:         "no gitops engine",
+			oldTag:       "dev",
+			newTag:       "latest",
+			gitOpsEngine: v1alpha1.GitOpsEngineNone,
+			wantChanges:  0,
+		},
+		{
+			name:         "empty gitops engine string",
+			oldTag:       "dev",
+			newTag:       "latest",
+			gitOpsEngine: "",
+			wantChanges:  0,
+		},
+		{
+			name:         "same tag no change",
+			oldTag:       "latest",
+			newTag:       "latest",
+			gitOpsEngine: v1alpha1.GitOpsEngineFlux,
+			wantChanges:  0,
+		},
+		{
+			name:         "flux tag drift",
+			oldTag:       "dev",
+			newTag:       "latest",
+			gitOpsEngine: v1alpha1.GitOpsEngineFlux,
+			wantChanges:  1,
+		},
+		{
+			name:         "argocd tag drift",
+			oldTag:       "dev",
+			newTag:       "v1.0.0",
+			gitOpsEngine: v1alpha1.GitOpsEngineArgoCD,
+			wantChanges:  1,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := &clusterupdate.UpdateResult{}
+			engine.CheckWorkloadTag(testCase.oldTag, testCase.newTag, testCase.gitOpsEngine, result)
+
+			if got := result.TotalChanges(); got != testCase.wantChanges {
+				t.Errorf("want %d changes, got %d", testCase.wantChanges, got)
+			}
+
+			if testCase.wantChanges > 0 {
+				changes := result.InPlaceChanges
+				if len(changes) != 1 {
+					t.Fatalf("expected 1 in-place change, got %d", len(changes))
+				}
+
+				change := changes[0]
+				if change.Field != "cluster.workload.tag" {
+					t.Errorf("expected field cluster.workload.tag, got %s", change.Field)
+				}
+
+				if change.OldValue != testCase.oldTag {
+					t.Errorf("expected old value %q, got %q", testCase.oldTag, change.OldValue)
+				}
+
+				if change.NewValue != testCase.newTag {
+					t.Errorf("expected new value %q, got %q", testCase.newTag, change.NewValue)
+				}
+			}
+		})
+	}
+}

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -906,41 +906,11 @@ func TestEngine_CheckWorkloadTag(t *testing.T) {
 		gitOpsEngine v1alpha1.GitOpsEngine
 		wantChanges  int
 	}{
-		{
-			name:         "no gitops engine",
-			oldTag:       "dev",
-			newTag:       "latest",
-			gitOpsEngine: v1alpha1.GitOpsEngineNone,
-			wantChanges:  0,
-		},
-		{
-			name:         "empty gitops engine string",
-			oldTag:       "dev",
-			newTag:       "latest",
-			gitOpsEngine: "",
-			wantChanges:  0,
-		},
-		{
-			name:         "same tag no change",
-			oldTag:       "latest",
-			newTag:       "latest",
-			gitOpsEngine: v1alpha1.GitOpsEngineFlux,
-			wantChanges:  0,
-		},
-		{
-			name:         "flux tag drift",
-			oldTag:       "dev",
-			newTag:       "latest",
-			gitOpsEngine: v1alpha1.GitOpsEngineFlux,
-			wantChanges:  1,
-		},
-		{
-			name:         "argocd tag drift",
-			oldTag:       "dev",
-			newTag:       "v1.0.0",
-			gitOpsEngine: v1alpha1.GitOpsEngineArgoCD,
-			wantChanges:  1,
-		},
+		{"no gitops engine", "dev", "latest", v1alpha1.GitOpsEngineNone, 0},
+		{"empty gitops engine string", "dev", "latest", "", 0},
+		{"same tag no change", "latest", "latest", v1alpha1.GitOpsEngineFlux, 0},
+		{"flux tag drift", "dev", "latest", v1alpha1.GitOpsEngineFlux, 1},
+		{"argocd tag drift", "dev", "v1.0.0", v1alpha1.GitOpsEngineArgoCD, 1},
 	}
 
 	for _, testCase := range tests {
@@ -955,24 +925,30 @@ func TestEngine_CheckWorkloadTag(t *testing.T) {
 			}
 
 			if testCase.wantChanges > 0 {
-				changes := result.InPlaceChanges
-				if len(changes) != 1 {
-					t.Fatalf("expected 1 in-place change, got %d", len(changes))
-				}
-
-				change := changes[0]
-				if change.Field != "cluster.workload.tag" {
-					t.Errorf("expected field cluster.workload.tag, got %s", change.Field)
-				}
-
-				if change.OldValue != testCase.oldTag {
-					t.Errorf("expected old value %q, got %q", testCase.oldTag, change.OldValue)
-				}
-
-				if change.NewValue != testCase.newTag {
-					t.Errorf("expected new value %q, got %q", testCase.newTag, change.NewValue)
-				}
+				assertWorkloadTagChange(t, result, testCase.oldTag, testCase.newTag)
 			}
 		})
+	}
+}
+
+func assertWorkloadTagChange(t *testing.T, result *clusterupdate.UpdateResult, oldTag, newTag string) {
+	t.Helper()
+
+	changes := result.InPlaceChanges
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 in-place change, got %d", len(changes))
+	}
+
+	change := changes[0]
+	if change.Field != "cluster.workload.tag" {
+		t.Errorf("expected field cluster.workload.tag, got %s", change.Field)
+	}
+
+	if change.OldValue != oldTag {
+		t.Errorf("expected old value %q, got %q", oldTag, change.OldValue)
+	}
+
+	if change.NewValue != newTag {
+		t.Errorf("expected new value %q, got %q", newTag, change.NewValue)
 	}
 }

--- a/pkg/svc/installer/flux/resources.go
+++ b/pkg/svc/installer/flux/resources.go
@@ -238,7 +238,9 @@ func WaitForFluxReady(
 // GetCurrentSyncRef queries the running FluxInstance in the cluster and returns
 // its spec.sync.ref value. Returns empty string if the FluxInstance does not exist
 // or has no sync configuration.
-func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) { //nolint:contextcheck // nil-guard consistent with SetupInstance/WaitForFluxReady
+//
+//nolint:contextcheck // nil-guard consistent with SetupInstance/WaitForFluxReady
+func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/pkg/svc/installer/flux/resources.go
+++ b/pkg/svc/installer/flux/resources.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
+	fluxclient "github.com/devantler-tech/ksail/v6/pkg/client/flux"
 	"github.com/devantler-tech/ksail/v6/pkg/k8s"
+	registry "github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/registry"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -231,6 +233,65 @@ func WaitForFluxReady(
 	}
 
 	return nil
+}
+
+// GetCurrentSyncRef queries the running FluxInstance in the cluster and returns
+// its spec.sync.ref value. Returns empty string if the FluxInstance does not exist
+// or has no sync configuration.
+func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) {
+	restConfig, err := loadRESTConfig(kubeconfig)
+	if err != nil {
+		return "", fmt.Errorf("build REST config: %w", err)
+	}
+
+	fluxClient, err := newFluxResourcesClient(restConfig)
+	if err != nil {
+		return "", fmt.Errorf("create flux client: %w", err)
+	}
+
+	instance := &FluxInstance{}
+	key := client.ObjectKey{
+		Name:      fluxInstanceDefaultName,
+		Namespace: fluxclient.DefaultNamespace,
+	}
+
+	err = fluxClient.Get(ctx, key, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("get FluxInstance %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	if instance.Spec.Sync != nil {
+		return instance.Spec.Sync.Ref, nil
+	}
+
+	return "", nil
+}
+
+// ResolveDesiredTag computes the desired OCI artifact tag using the standard
+// resolution priority: workload.tag > registry-embedded tag > default "dev".
+// This is the same logic used by buildInstance and buildArgoCDEnsureOptions.
+func ResolveDesiredTag(clusterCfg *v1alpha1.Cluster) string {
+	tag := clusterCfg.Spec.Workload.Tag
+
+	if tag == "" {
+		localRegistry := clusterCfg.Spec.Cluster.LocalRegistry
+		if localRegistry.IsExternal() {
+			parsed := localRegistry.Parse()
+			if parsed.Tag != "" {
+				tag = parsed.Tag
+			}
+		}
+	}
+
+	if tag == "" {
+		tag = registry.DefaultLocalArtifactTag
+	}
+
+	return tag
 }
 
 // ensureLocalRegistryInsecureIfNeeded patches OCIRepository with insecure: true only for

--- a/pkg/svc/installer/flux/resources.go
+++ b/pkg/svc/installer/flux/resources.go
@@ -239,6 +239,10 @@ func WaitForFluxReady(
 // its spec.sync.ref value. Returns empty string if the FluxInstance does not exist
 // or has no sync configuration.
 func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	restConfig, err := loadRESTConfig(kubeconfig)
 	if err != nil {
 		return "", fmt.Errorf("build REST config: %w", err)
@@ -274,7 +278,12 @@ func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) {
 // ResolveDesiredTag computes the desired OCI artifact tag using the standard
 // resolution priority: workload.tag > registry-embedded tag > default "dev".
 // This is the same logic used by buildInstance and buildArgoCDEnsureOptions.
+// A nil clusterCfg falls back to the default local artifact tag.
 func ResolveDesiredTag(clusterCfg *v1alpha1.Cluster) string {
+	if clusterCfg == nil {
+		return registry.DefaultLocalArtifactTag
+	}
+
 	tag := clusterCfg.Spec.Workload.Tag
 
 	if tag == "" {

--- a/pkg/svc/installer/flux/resources.go
+++ b/pkg/svc/installer/flux/resources.go
@@ -238,7 +238,11 @@ func WaitForFluxReady(
 // GetCurrentSyncRef queries the running FluxInstance in the cluster and returns
 // its spec.sync.ref value. Returns empty string if the FluxInstance does not exist
 // or has no sync configuration.
-func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) {
+func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) { //nolint:contextcheck // nil-guard consistent with SetupInstance/WaitForFluxReady
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	restConfig, err := loadRESTConfig(kubeconfig)
 	if err != nil {
 		return "", fmt.Errorf("build REST config: %w", err)

--- a/pkg/svc/installer/flux/resources.go
+++ b/pkg/svc/installer/flux/resources.go
@@ -239,10 +239,6 @@ func WaitForFluxReady(
 // its spec.sync.ref value. Returns empty string if the FluxInstance does not exist
 // or has no sync configuration.
 func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	restConfig, err := loadRESTConfig(kubeconfig)
 	if err != nil {
 		return "", fmt.Errorf("build REST config: %w", err)


### PR DESCRIPTION
## Summary

`ksail cluster update` now detects stale OCIRepository tags (FluxInstance `sync.ref` or ArgoCD `targetRevision`) left over from pre-v6.7.1 clusters and reconciles them to match the desired configuration.

Fixes #3933

## Problem

PR #3930 (v6.7.1) fixed the tag resolution for FluxInstance `sync.ref` and ArgoCD `targetRevision` during `cluster create`, but `cluster update` never re-checked or fixed the GitOps sync ref. Existing clusters created before v6.7.1 retained a stale `sync.ref` (e.g., `"dev"`) even when the config specifies `workload.tag: latest`.

The root cause was twofold:
1. The diff engine (`pkg/svc/diff/engine.go`) only compared `ClusterSpec` fields — it had no visibility into `WorkloadSpec.Tag` or the running GitOps sync ref.
2. The component reconciler only handled GitOps engine *type* changes (e.g., Flux → ArgoCD), not tag changes *within* the same engine.

## Changes

- **`pkg/svc/installer/flux/resources.go`**: Add `GetCurrentSyncRef()` to query the running FluxInstance for its current sync ref, and `ResolveDesiredTag()` to compute the desired tag using the standard resolution priority (`workload.tag` > registry-embedded tag > default `"dev"`)
- **`pkg/client/argocd/manager.go`**: Add `GetCurrentTargetRevision()` to query the ArgoCD Application for its current `targetRevision`
- **`pkg/svc/diff/engine.go`**: Add `CheckWorkloadTag()` to compare current vs desired tags and emit an in-place change when they differ
- **`pkg/cli/cmd/cluster/cluster.go`**: Integrate `checkWorkloadTagDrift` into both `computeUpdateDiff` and `computeSpecOnlyDiff` paths; add `reconcileWorkloadTag` handler to the component reconciler to update the GitOps resource with the correct tag
- **`pkg/cli/setup/registry_host.go`**: Export `ResolveRegistryHostForCluster()` for use by the reconciler
- **`pkg/svc/diff/engine_test.go`**: Add unit tests for `CheckWorkloadTag` covering no-op cases (no GitOps engine, same tag) and drift detection (Flux and ArgoCD)