### PR TITLE
test(ci): add verification and cleanup for workload install E2E

### DIFF
--- a/.github/actions/ksail-test-workload/action.yaml
+++ b/.github/actions/ksail-test-workload/action.yaml
@@ -129,28 +129,34 @@ runs:
       env:
         TIMEOUT: ${{ inputs.workload-timeout }}
       run: |
-        # Discover the deployment created by the Helm release
-        DEPLOY_NAME=$(ksail workload get deployment -o name 2>/dev/null | grep "ksail-install-test" || true)
-        if [ -z "$DEPLOY_NAME" ]; then
+        # Discover deployments created by the Helm release.
+        # Note: podinfo chart does not set app.kubernetes.io/instance, so we
+        # discover by name pattern instead of label selector.
+        DEPLOYS=$(ksail workload get deployment -o name | grep "ksail-install-test" || true)
+        if [ -z "$DEPLOYS" ]; then
           echo "❌ No deployment found for release ksail-install-test"
           exit 1
         fi
-        echo "Found deployment: $DEPLOY_NAME"
 
-        # Verify the installed chart's deployment is healthy
-        ksail workload wait --for=condition=Available "$DEPLOY_NAME" --timeout="$TIMEOUT"
-        echo "✅ $DEPLOY_NAME is Available"
+        # Wait for each matched deployment individually
+        for DEPLOY in $DEPLOYS; do
+          echo "Waiting for $DEPLOY…"
+          ksail workload wait --for=condition=Available "$DEPLOY" --timeout="$TIMEOUT"
+          echo "✅ $DEPLOY is Available"
+        done
 
         # Verify the Helm release secret exists
         ksail workload get secret -l owner=helm,name=ksail-install-test
         echo "✅ Helm release secret verified"
 
     - name: 🧪 ksail workload install — cleanup
-      if: always() && steps.workload-install.outcome == 'success'
+      if: ${{ !failure() && steps.workload-install.outcome == 'success' }}
       shell: bash
       run: |
-        # Delete chart-managed resources by name pattern
-        for RES in $(ksail workload get deployment,service,pod -o name 2>/dev/null | grep "ksail-install-test" || true); do
+        # Delete chart-managed resources by name pattern.
+        # Note: podinfo chart does not set app.kubernetes.io/instance, so we
+        # discover by name pattern instead of label selector.
+        for RES in $(ksail workload get all -o name | grep "ksail-install-test" || true); do
           ksail workload delete "$RES" --ignore-not-found
         done
         # Delete the Helm release secret

--- a/.github/actions/ksail-test-workload/action.yaml
+++ b/.github/actions/ksail-test-workload/action.yaml
@@ -129,9 +129,9 @@ runs:
       env:
         TIMEOUT: ${{ inputs.workload-timeout }}
       run: |
-        # Verify the installed chart's deployment is healthy
-        ksail workload wait --for=condition=Available deployment/ksail-install-test-podinfo --timeout="$TIMEOUT"
-        echo "✅ deployment/ksail-install-test-podinfo is Available"
+        # Verify the installed chart's deployment is healthy using label selector
+        ksail workload wait --for=condition=Available deployment -l app.kubernetes.io/instance=ksail-install-test --timeout="$TIMEOUT"
+        echo "✅ deployment for release ksail-install-test is Available"
 
         # Verify the Helm release secret exists
         ksail workload get secret -l owner=helm,name=ksail-install-test
@@ -141,8 +141,8 @@ runs:
       if: always() && steps.workload-install.outcome == 'success'
       shell: bash
       run: |
-        ksail workload delete deployment/ksail-install-test-podinfo --ignore-not-found
-        ksail workload delete secret -l owner=helm,name=ksail-install-test --ignore-not-found 2>/dev/null || true
+        ksail workload delete all,configmap,secret,serviceaccount,ingress,networkpolicy,persistentvolumeclaim,role,rolebinding -l app.kubernetes.io/instance=ksail-install-test --ignore-not-found
+        ksail workload delete secret -l owner=helm,name=ksail-install-test --ignore-not-found
         echo "✅ workload install cleanup complete"
 
     - name: 🧪 ksail workload apply

--- a/.github/actions/ksail-test-workload/action.yaml
+++ b/.github/actions/ksail-test-workload/action.yaml
@@ -104,11 +104,13 @@ runs:
     - name: 🧪 ksail workload install
       id: workload-install
       shell: bash
+      env:
+        TIMEOUT: ${{ inputs.workload-timeout }}
       run: |
         # Install a lightweight Helm chart to verify workload install works
         install_succeeded=false
         for attempt in 1 2 3; do
-          if ksail workload install ksail-install-test oci://ghcr.io/stefanprodan/charts/podinfo --version=6.7.1 --wait --timeout=120s; then
+          if ksail workload install ksail-install-test oci://ghcr.io/stefanprodan/charts/podinfo --version=6.7.1 --wait --timeout="$TIMEOUT"; then
             install_succeeded=true
             break
           fi
@@ -120,6 +122,28 @@ runs:
           exit 1
         fi
         echo "✅ workload install succeeded"
+
+    - name: 🧪 ksail workload install — verify
+      id: workload-install-verify
+      shell: bash
+      env:
+        TIMEOUT: ${{ inputs.workload-timeout }}
+      run: |
+        # Verify the installed chart's deployment is healthy
+        ksail workload wait --for=condition=Available deployment/ksail-install-test-podinfo --timeout="$TIMEOUT"
+        echo "✅ deployment/ksail-install-test-podinfo is Available"
+
+        # Verify the Helm release secret exists
+        ksail workload get secret -l owner=helm,name=ksail-install-test
+        echo "✅ Helm release secret verified"
+
+    - name: 🧪 ksail workload install — cleanup
+      if: always() && steps.workload-install.outcome == 'success'
+      shell: bash
+      run: |
+        ksail workload delete deployment/ksail-install-test-podinfo --ignore-not-found
+        ksail workload delete secret -l owner=helm,name=ksail-install-test --ignore-not-found 2>/dev/null || true
+        echo "✅ workload install cleanup complete"
 
     - name: 🧪 ksail workload apply
       id: workload-apply
@@ -169,7 +193,7 @@ runs:
         ksail workload delete deployment/"$WORKLOAD_NAME" --ignore-not-found
 
     - name: 🐞 Debug Kubernetes failure
-      if: failure() && (steps.workload-create.outcome == 'failure' || steps.workload-install.outcome == 'failure' || steps.workload-apply.outcome == 'failure' || steps.workload-scale.outcome == 'failure' || steps.workload-push-reconcile.outcome == 'failure')
+      if: failure() && (steps.workload-create.outcome == 'failure' || steps.workload-install.outcome == 'failure' || steps.workload-install-verify.outcome == 'failure' || steps.workload-apply.outcome == 'failure' || steps.workload-scale.outcome == 'failure' || steps.workload-push-reconcile.outcome == 'failure')
       uses: ./.github/actions/debug-kubernetes-failure
       with:
         kubectl-command: "ksail workload"

--- a/.github/actions/ksail-test-workload/action.yaml
+++ b/.github/actions/ksail-test-workload/action.yaml
@@ -129,9 +129,17 @@ runs:
       env:
         TIMEOUT: ${{ inputs.workload-timeout }}
       run: |
-        # Verify the installed chart's deployment is healthy using label selector
-        ksail workload wait --for=condition=Available deployment -l app.kubernetes.io/instance=ksail-install-test --timeout="$TIMEOUT"
-        echo "✅ deployment for release ksail-install-test is Available"
+        # Discover the deployment created by the Helm release
+        DEPLOY_NAME=$(ksail workload get deployment -o name 2>/dev/null | grep "ksail-install-test" || true)
+        if [ -z "$DEPLOY_NAME" ]; then
+          echo "❌ No deployment found for release ksail-install-test"
+          exit 1
+        fi
+        echo "Found deployment: $DEPLOY_NAME"
+
+        # Verify the installed chart's deployment is healthy
+        ksail workload wait --for=condition=Available "$DEPLOY_NAME" --timeout="$TIMEOUT"
+        echo "✅ $DEPLOY_NAME is Available"
 
         # Verify the Helm release secret exists
         ksail workload get secret -l owner=helm,name=ksail-install-test
@@ -141,7 +149,11 @@ runs:
       if: always() && steps.workload-install.outcome == 'success'
       shell: bash
       run: |
-        ksail workload delete all,configmap,secret,serviceaccount,ingress,networkpolicy,persistentvolumeclaim,role,rolebinding -l app.kubernetes.io/instance=ksail-install-test --ignore-not-found
+        # Delete chart-managed resources by name pattern
+        for RES in $(ksail workload get deployment,service,pod -o name 2>/dev/null | grep "ksail-install-test" || true); do
+          ksail workload delete "$RES" --ignore-not-found
+        done
+        # Delete the Helm release secret
         ksail workload delete secret -l owner=helm,name=ksail-install-test --ignore-not-found
         echo "✅ workload install cleanup complete"
 


### PR DESCRIPTION
## Summary

Enhances the existing `workload install` E2E step in `.github/actions/ksail-test-workload/action.yaml` with post-install verification and cleanup.

## Changes

- **Timeout**: Uses `workload-timeout` input instead of hardcoded `120s` for consistency with other steps
- **Verify step**: Adds explicit deployment health check (`ksail workload wait --for=condition=Available`) and Helm release secret verification after install
- **Cleanup step**: Removes installed chart resources after verification to keep the cluster tidy
- **Debug condition**: Includes the new verify step in the failure trigger for the debug action

## Acceptance Criteria

Per [#3950](https://github.com/devantler-tech/ksail/issues/3950):

- [x] `ksail workload install` successfully installs a Helm chart (existing step, now with configurable timeout)
- [x] Installed chart's workload reaches healthy/available state (new verify step)
- [x] Test runs for at least one distribution in the CI matrix (action is called from `ksail-system-test`)
- [x] Failure triggers `debug-kubernetes-failure` action (updated condition)

Fixes #3950