### PR TITLE
test(e2e): add output validation for `ksail cluster info`

### DIFF
--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -159,7 +159,40 @@ runs:
     - name: 🧪 ksail cluster info
       shell: bash
       run: |
-        ksail cluster info
+        output=$(ksail cluster info 2>&1)
+        echo "$output"
+
+        FAILED=0
+        assert_contains() {
+          if echo "$output" | grep -q "$1"; then
+            echo "  ✅ Found: $1"
+          else
+            echo "  ❌ Missing: $1"
+            FAILED=$((FAILED + 1))
+          fi
+        }
+
+        echo "=== Validating cluster info output ==="
+
+        # Provider status
+        assert_contains "Provider:"
+        assert_contains "Cluster:"
+        assert_contains "Status:"
+        assert_contains "Ready:"
+
+        # kubectl cluster-info
+        assert_contains "Kubernetes control plane is running at"
+
+        # KSail cluster details
+        assert_contains "KSail Cluster Details:"
+        assert_contains "Distribution:"
+        assert_contains "Kubeconfig:"
+
+        if [ "$FAILED" -gt 0 ]; then
+          echo "❌ $FAILED cluster info assertions failed"
+          exit 1
+        fi
+        echo "✅ All cluster info assertions passed"
 
     - name: 🧪 ksail cluster connect --help
       shell: bash

--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -159,12 +159,21 @@ runs:
     - name: 🧪 ksail cluster info
       shell: bash
       run: |
-        output=$(ksail cluster info 2>&1)
+        if output=$(ksail cluster info 2>&1); then
+          status=0
+        else
+          status=$?
+        fi
         echo "$output"
+
+        if [ "$status" -ne 0 ]; then
+          echo "❌ ksail cluster info failed with exit code $status"
+          exit "$status"
+        fi
 
         FAILED=0
         assert_contains() {
-          if echo "$output" | grep -q "$1"; then
+          if printf '%s\n' "$output" | grep -Fq -- "$1"; then
             echo "  ✅ Found: $1"
           else
             echo "  ❌ Missing: $1"


### PR DESCRIPTION
## Summary

Enhances the existing `ksail cluster info` E2E step in the system test composite action to validate command output, not just exit code.

## Changes

Replaces the minimal smoke test (exit-code-only) with output capture and assertion of all three output phases:

1. **Provider status** — `Provider:`, `Cluster:`, `Status:`, `Ready:`
2. **kubectl cluster-info** — `Kubernetes control plane is running at`
3. **KSail Cluster Details** — `KSail Cluster Details:`, `Distribution:`, `Kubeconfig:`

## Why

`ksail cluster info` was the only cluster subcommand with zero meaningful test coverage. The existing step ran the command but never validated the output. Regressions in provider status display, kubeconfig resolution, or cluster identity detection would go undetected.

Fixes #3954