### PR TITLE
test(ci): add E2E coverage for workload export and import

### DIFF
--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -6,7 +6,7 @@ description: |
     Phase 1 — Setup (provider validation, artifact tag, GHCR resolution)
     Phase 2 — Offline tests (gen/smoke, tenant — no cluster needed)
     Phase 3 — Cluster provisioning (init + create, info, list)
-    Phase 4 — Online tests (workload CRUD, online gen, backup/restore, update)
+    Phase 4 — Online tests (workload CRUD, image export/import, online gen, backup/restore, update)
     Phase 5 — Debug (on failure)
     Phase 6 — Lifecycle tests (stop, start, switch)
     Phase 7 — Cleanup (cluster delete, always)
@@ -186,6 +186,15 @@ runs:
         ghcr-token: ${{ inputs.ghcr-token }}
         gitops-path: ${{ inputs.gitops-path }}
 
+    - name: 🧪 Image Export/Import Tests
+      id: image-export-import-tests
+      if: inputs.distribution == 'Vanilla' || inputs.distribution == 'K3s'
+      uses: ./.github/actions/ksail-test-image-export-import
+      with:
+        test-workload-name: ${{ inputs.test-workload-name }}
+        test-workload-image: ${{ inputs.test-workload-image }}
+        workload-timeout: ${{ inputs.workload-timeout }}
+
     - name: 🧪 Workload Watch Tests
       id: workload-watch-tests
       uses: ./.github/actions/ksail-test-workload-watch
@@ -286,7 +295,7 @@ runs:
     # ── Phase 5 — Debug ──────────────────────────────────────────────
 
     - name: 🐞 Debug Kubernetes failure
-      if: failure() && (steps.cluster-create.outcome == 'failure' || steps.workload-watch-tests.outcome == 'failure' || steps.online-gen.outcome == 'failure' || steps.cluster-update-dry-run.outcome == 'failure' || steps.cluster-update.outcome == 'failure')
+      if: failure() && (steps.cluster-create.outcome == 'failure' || steps.image-export-import-tests.outcome == 'failure' || steps.workload-watch-tests.outcome == 'failure' || steps.online-gen.outcome == 'failure' || steps.cluster-update-dry-run.outcome == 'failure' || steps.cluster-update.outcome == 'failure')
       uses: ./.github/actions/debug-kubernetes-failure
       with:
         kubectl-command: "ksail workload"

--- a/.github/actions/ksail-test-image-export-import/action.yaml
+++ b/.github/actions/ksail-test-image-export-import/action.yaml
@@ -77,9 +77,11 @@ runs:
         # Import the previously exported images back
         ksail workload import /tmp/test-images.tar
         echo "✅ Image import succeeded"
-        # Verify the workload still runs (images are available)
+        # Restart pods to force an image lookup from containerd, validating
+        # that the imported images are actually usable on the node.
+        ksail workload rollout restart deployment/"$WORKLOAD_NAME"
         ksail workload wait --for=condition=Available deployment/"$WORKLOAD_NAME" --timeout="$TIMEOUT"
-        echo "✅ Import round-trip validated"
+        echo "✅ Import round-trip validated (pods restarted and healthy)"
 
     - name: 🧪 Cleanup export/import test workload
       if: always()

--- a/.github/actions/ksail-test-image-export-import/action.yaml
+++ b/.github/actions/ksail-test-image-export-import/action.yaml
@@ -62,10 +62,21 @@ runs:
       env:
         WORKLOAD_IMAGE: ${{ inputs.test-workload-image }}
       run: |
-        ksail workload export /tmp/test-images.tar --image="$WORKLOAD_IMAGE"
+        export_image="$WORKLOAD_IMAGE"
+        first_component="${WORKLOAD_IMAGE%%/*}"
+
+        # Normalize shorthand image references to the fully-qualified names
+        # containerd typically stores internally.
+        if [[ "$WORKLOAD_IMAGE" != */* ]]; then
+          export_image="docker.io/library/$WORKLOAD_IMAGE"
+        elif [[ "$first_component" != *.* && "$first_component" != *:* && "$first_component" != "localhost" ]]; then
+          export_image="docker.io/$WORKLOAD_IMAGE"
+        fi
+
+        ksail workload export /tmp/test-images.tar --image="$export_image"
         # Verify the archive was created and is non-empty
         test -s /tmp/test-images.tar
-        echo "✅ Image export succeeded ($(du -h /tmp/test-images.tar | cut -f1))"
+        echo "✅ Image export succeeded ($(du -h /tmp/test-images.tar | cut -f1)) from $export_image"
 
     - name: 🧪 ksail workload import
       id: import
@@ -83,6 +94,12 @@ runs:
         ksail workload wait --for=condition=Available deployment/"$WORKLOAD_NAME" --timeout="$TIMEOUT"
         echo "✅ Import round-trip validated (pods restarted and healthy)"
 
+    - name: 🐞 Debug failure
+      if: failure() && (steps.deploy.outcome == 'failure' || steps.export.outcome == 'failure' || steps.import.outcome == 'failure')
+      uses: ./.github/actions/debug-kubernetes-failure
+      with:
+        kubectl-command: "ksail workload"
+
     - name: 🧪 Cleanup export/import test workload
       if: always()
       shell: bash
@@ -90,12 +107,6 @@ runs:
         WORKLOAD_NAME: ${{ inputs.test-workload-name }}
       run: |
         ksail workload delete deployment/"$WORKLOAD_NAME" --ignore-not-found 2>/dev/null || true
-
-    - name: 🐞 Debug failure
-      if: failure() && (steps.deploy.outcome == 'failure' || steps.export.outcome == 'failure' || steps.import.outcome == 'failure')
-      uses: ./.github/actions/debug-kubernetes-failure
-      with:
-        kubectl-command: "ksail workload"
 
     - name: 🧹 Cleanup temp files
       if: always()

--- a/.github/actions/ksail-test-image-export-import/action.yaml
+++ b/.github/actions/ksail-test-image-export-import/action.yaml
@@ -1,0 +1,102 @@
+name: KSail Image Export/Import Test
+description: |
+  Tests the container image export/import round-trip on a running cluster:
+    1. Deploy a test workload with a known image
+    2. Export specific image to a tar archive
+    3. Verify the archive was created and is non-empty
+    4. Import the archive back into the cluster
+    5. Verify the workload still runs (round-trip integrity)
+
+  Only supported for Vanilla (Kind) and K3s (K3d) distributions.
+  Talos and VCluster are unsupported (immutable OS / nested containerd).
+
+  Does NOT create or delete the cluster — the orchestrator handles that.
+
+inputs:
+  test-workload-name:
+    description: Name for the test workload deployment
+    required: false
+    default: "export-import-test"
+  test-workload-image:
+    description: Image to use for the test workload
+    required: false
+    default: "traefik/whoami:v1.10"
+  workload-timeout:
+    description: |
+      Timeout for workload wait operations. Set to 10 minutes to handle
+      intermittent delays in CI environments (image pulls, resource contention).
+    required: false
+    default: "600s"
+
+runs:
+  using: composite
+  steps:
+    - name: 🧪 Deploy export/import test workload
+      id: deploy
+      shell: bash
+      env:
+        WORKLOAD_NAME: ${{ inputs.test-workload-name }}
+        WORKLOAD_IMAGE: ${{ inputs.test-workload-image }}
+        TIMEOUT: ${{ inputs.workload-timeout }}
+      run: |
+        create_succeeded=false
+        for attempt in 1 2 3; do
+          if ksail workload create deployment "$WORKLOAD_NAME" --image="$WORKLOAD_IMAGE"; then
+            create_succeeded=true
+            break
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "⚠️ workload create attempt $attempt failed, retrying in 10s…"
+            sleep 10
+          fi
+        done
+        if [ "$create_succeeded" != "true" ]; then
+          echo "❌ ksail workload create failed after 3 attempts for deployment/$WORKLOAD_NAME"
+          exit 1
+        fi
+        ksail workload wait --for=condition=Available deployment/"$WORKLOAD_NAME" --timeout="$TIMEOUT"
+
+    - name: 🧪 ksail workload export
+      id: export
+      shell: bash
+      env:
+        WORKLOAD_IMAGE: ${{ inputs.test-workload-image }}
+      run: |
+        ksail workload export /tmp/test-images.tar --image="$WORKLOAD_IMAGE"
+        # Verify the archive was created and is non-empty
+        test -s /tmp/test-images.tar
+        echo "✅ Image export succeeded ($(du -h /tmp/test-images.tar | cut -f1))"
+
+    - name: 🧪 ksail workload import
+      id: import
+      shell: bash
+      env:
+        WORKLOAD_NAME: ${{ inputs.test-workload-name }}
+        TIMEOUT: ${{ inputs.workload-timeout }}
+      run: |
+        # Import the previously exported images back
+        ksail workload import /tmp/test-images.tar
+        echo "✅ Image import succeeded"
+        # Verify the workload still runs (images are available)
+        ksail workload wait --for=condition=Available deployment/"$WORKLOAD_NAME" --timeout="$TIMEOUT"
+        echo "✅ Import round-trip validated"
+
+    - name: 🧪 Cleanup export/import test workload
+      if: always()
+      shell: bash
+      env:
+        WORKLOAD_NAME: ${{ inputs.test-workload-name }}
+      run: |
+        ksail workload delete deployment/"$WORKLOAD_NAME" --ignore-not-found 2>/dev/null || true
+
+    - name: 🐞 Debug failure
+      if: failure() && (steps.deploy.outcome == 'failure' || steps.export.outcome == 'failure' || steps.import.outcome == 'failure')
+      uses: ./.github/actions/debug-kubernetes-failure
+      with:
+        kubectl-command: "ksail workload"
+
+    - name: 🧹 Cleanup temp files
+      if: always()
+      shell: bash
+      run: |
+        rm -f /tmp/test-images.tar


### PR DESCRIPTION
## Summary

Fixes #3955

`ksail workload export` and `ksail workload import` had zero E2E invocations in CI. These commands interact with Docker containers and containerd internals (exporting/importing images via `ctr` inside cluster nodes), making them complex and error-prone.

## Changes

- **New**: `.github/actions/ksail-test-image-export-import/action.yaml` — composite action testing the full export/import round-trip:
  1. Deploy a test workload with a known image
  2. Export the image to a tar archive with `--image` flag
  3. Verify the archive exists and is non-empty
  4. Import the archive back into the cluster
  5. Verify the workload still runs (round-trip integrity)
- **Updated**: `.github/actions/ksail-system-test/action.yaml` — wire the new action into Phase 4 (Online tests), guarded with a distribution condition (`Vanilla`/`K3s` only — Talos and VCluster do not support containerd exec-based image operations)

## Testing

The new action runs as part of the existing system test matrix for Vanilla and K3s distributions on Docker provider.