### PR TITLE
ci: replace concurrency groups with turnstyle for cloud E2E FIFO queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -669,7 +669,7 @@ jobs:
   system-test-hetzner:
     name: "🧪 System Test (Hetzner/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
@@ -766,7 +766,7 @@ jobs:
   system-test-omni:
     name: "🧪 System Test (Omni/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -661,23 +661,23 @@ jobs:
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Hetzner cloud tests are serialized across workflow runs via a concurrency
-  # group to prevent resource conflicts (shared servers, firewalls, networks).
+  # Hetzner cloud tests are serialized across workflow runs via turnstyle to
+  # prevent resource conflicts (shared servers, firewalls, networks).
+  # Unlike concurrency groups (which cancel intermediate pending jobs),
+  # turnstyle implements a true FIFO queue by polling the GitHub API.
   # Cluster names include github.run_id for defense-in-depth uniqueness.
   system-test-hetzner:
-    name: 🧪 System Test (Hetzner)
+    name: "🧪 System Test (Hetzner/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
     # Hetzner cloud tests are allowed to fail without blocking the merge queue
     # because Hetzner infrastructure can be intermittently unavailable.
     continue-on-error: true
-    concurrency:
-      group: cloud-system-test-hetzner-${{ matrix.init }}
-      cancel-in-progress: false
     permissions:
+      actions: read
       contents: read
       packages: write
     strategy:
@@ -704,6 +704,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: ⏳ Wait for cloud test queue
+        uses: softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586 # v3.2.3
+        with:
+          same-branch-only: false
+          job-to-wait-for: "🧪 System Test (Hetzner/${{ matrix.init && 'init' || 'noinit' }})"
+          poll-interval-seconds: 30
+          abort-after-seconds: 3600
 
       - name: 🧹 Free disk space
         uses: ./.github/actions/free-disk-space
@@ -750,20 +758,20 @@ jobs:
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Omni cloud tests are serialized across workflow runs via a concurrency
-  # group to prevent resource conflicts (shared machine pool).
+  # Omni cloud tests are serialized across workflow runs via turnstyle to
+  # prevent resource conflicts (shared machine pool).
+  # Unlike concurrency groups (which cancel intermediate pending jobs),
+  # turnstyle implements a true FIFO queue by polling the GitHub API.
   # Cluster names include github.run_id for defense-in-depth uniqueness.
   system-test-omni:
-    name: 🧪 System Test (Omni)
+    name: "🧪 System Test (Omni/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
-    concurrency:
-      group: cloud-system-test-omni-${{ matrix.init }}
-      cancel-in-progress: false
     permissions:
+      actions: read
       contents: read
       packages: write
     strategy:
@@ -785,6 +793,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: ⏳ Wait for cloud test queue
+        uses: softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586 # v3.2.3
+        with:
+          same-branch-only: false
+          job-to-wait-for: "🧪 System Test (Omni/${{ matrix.init && 'init' || 'noinit' }})"
+          poll-interval-seconds: 30
+          abort-after-seconds: 3600
 
       - name: 🧹 Free disk space
         uses: ./.github/actions/free-disk-space


### PR DESCRIPTION
## Summary

Fixes the issue where Hetzner and Omni E2E tests are canceled with _"Canceling since a higher priority waiting request for cloud-system-test-hetzner-false exists"_ when multiple merge queue items trigger cloud tests concurrently.

## Problem

GitHub Actions `concurrency` groups only maintain **one running + one pending** slot per group. When a third workflow run enters the same group, the intermediate pending job is canceled — there is no true FIFO queue. This is [by design](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).

## Solution

Replace job-level `concurrency` blocks with [`softprops/turnstyle`](https://github.com/softprops/turnstyle) (364★, MIT, actively maintained), which polls the GitHub API to implement true FIFO serialization across workflow runs.

### Changes

- **Remove** `concurrency` blocks from `system-test-hetzner` and `system-test-omni`
- **Add** `softprops/turnstyle@v3.2.3` step after checkout with `job-to-wait-for` matching the stable job name per matrix combination
- **Rename** jobs to stable names that exclude `matrix.args` (which contains `run_id`):
  - `🧪 System Test (Hetzner/init)` / `🧪 System Test (Hetzner/noinit)`
  - `🧪 System Test (Omni/init)` / `🧪 System Test (Omni/noinit)`
- **Add** `actions: read` permission (needed for turnstyle API polling)
- **Increase** `timeout-minutes` from 45 → 90 to account for potential queue wait time

### How it works

1. Turnstyle fetches all `in_progress` / `queued` / `waiting` workflow runs
2. Finds the most recent earlier run (lower run ID)
3. Checks if the specific `job-to-wait-for` is completed in that run
4. If not completed → polls every 30s (aborts after 1 hour)
5. If completed (including skipped/cancelled) → proceeds
6. For PR runs where cloud tests are skipped: turnstyle sees them as completed → no blocking

### Trade-off

A runner is allocated while polling (vs free pending state with concurrency groups), but the cost is minimal (~$0.008/min for ubuntu-latest) compared to the cloud resources being protected.