### PR TITLE
fix: refresh kubeconfig from Omni during cluster update

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6291,7 +6291,8 @@ func createAndVerifyProvisioner(
 	// This ensures the kubeconfig is available for component detection
 	// and subsequent Helm operations (CNI, GitOps installation).
 	if refresher, ok := provisioner.(clusterprovisioner.KubeconfigRefresher); ok {
-		if err := refresher.RefreshKubeconfig(cmd.Context(), clusterName); err != nil {
+		err := refresher.RefreshKubeconfig(cmd.Context(), clusterName)
+		if err != nil {
 			return nil, fmt.Errorf("failed to refresh kubeconfig: %w", err)
 		}
 	}

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6260,9 +6260,10 @@ func createAndVerifyProvisioner(
 	ctx *localregistry.Context,
 	clusterName string,
 ) (clusterprovisioner.Provisioner, error) {
-	// Build a ComponentDetector scoped to the running cluster.
-	componentDetector := buildComponentDetector(cmd, ctx)
-
+	// Create provisioner without component detector first.
+	// The detector requires a kubeconfig, which may not exist yet for
+	// remote providers (Omni). We build the detector after refreshing
+	// the kubeconfig below.
 	factory := clusterprovisioner.DefaultFactory{
 		DistributionConfig: &clusterprovisioner.DistributionConfig{
 			Kind:     ctx.KindConfig,
@@ -6270,7 +6271,6 @@ func createAndVerifyProvisioner(
 			Talos:    ctx.TalosConfig,
 			VCluster: ctx.VClusterConfig,
 		},
-		ComponentDetector: componentDetector,
 	}
 
 	provisioner, _, err := factory.Create(cmd.Context(), ctx.ClusterCfg)
@@ -6285,6 +6285,23 @@ func createAndVerifyProvisioner(
 
 	if !exists {
 		return nil, fmt.Errorf("%w: %q", clustererr.ErrClusterDoesNotExist, clusterName)
+	}
+
+	// Refresh kubeconfig from the remote provider if supported.
+	// This ensures the kubeconfig is available for component detection
+	// and subsequent Helm operations (CNI, GitOps installation).
+	if refresher, ok := provisioner.(clusterprovisioner.KubeconfigRefresher); ok {
+		if err := refresher.RefreshKubeconfig(cmd.Context(), clusterName); err != nil {
+			return nil, fmt.Errorf("failed to refresh kubeconfig: %w", err)
+		}
+	}
+
+	// Build a ComponentDetector scoped to the running cluster.
+	// Now that kubeconfig is ensured, the detector can connect.
+	componentDetector := buildComponentDetector(cmd, ctx)
+
+	if aware, ok := provisioner.(clusterprovisioner.ComponentDetectorAware); ok {
+		aware.SetComponentDetector(componentDetector)
 	}
 
 	return provisioner, nil

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -219,7 +219,11 @@ func (k *Provisioner) WithComponentDetector(d *detector.ComponentDetector) {
 	k.componentDetector = d
 }
 
-// runListCommand executes the k3d cluster list command and returns the output.
+// SetComponentDetector sets the component detector for querying cluster state.
+// This implements the ComponentDetectorAware interface.
+func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
+	k.componentDetector = d
+}
 func (k *Provisioner) runListCommand(ctx context.Context) (string, error) {
 	cmd := clustercommand.NewCmdClusterList()
 	args := []string{"--output", "json"}

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -222,8 +222,10 @@ func (k *Provisioner) WithComponentDetector(d *detector.ComponentDetector) {
 // SetComponentDetector sets the component detector for querying cluster state.
 // This implements the ComponentDetectorAware interface.
 func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
-	k.componentDetector = d
+	k.WithComponentDetector(d)
 }
+
+// runListCommand executes the k3d cluster list command and returns the output.
 func (k *Provisioner) runListCommand(ctx context.Context) (string, error) {
 	cmd := clustercommand.NewCmdClusterList()
 	args := []string{"--output", "json"}

--- a/pkg/svc/provisioner/cluster/kind/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kind/provisioner.go
@@ -160,7 +160,11 @@ func (k *Provisioner) WithComponentDetector(d *detector.ComponentDetector) {
 	k.componentDetector = d
 }
 
-// Create creates a kind cluster using kind's Cobra command.
+// SetComponentDetector sets the component detector for querying cluster state.
+// This implements the ComponentDetectorAware interface.
+func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
+	k.componentDetector = d
+}
 func (k *Provisioner) Create(ctx context.Context, name string) error {
 	target := setName(name, k.kindConfig.Name)
 

--- a/pkg/svc/provisioner/cluster/kind/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kind/provisioner.go
@@ -163,8 +163,10 @@ func (k *Provisioner) WithComponentDetector(d *detector.ComponentDetector) {
 // SetComponentDetector sets the component detector for querying cluster state.
 // This implements the ComponentDetectorAware interface.
 func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
-	k.componentDetector = d
+	k.WithComponentDetector(d)
 }
+
+// Create creates a kind cluster using kind's Cobra command.
 func (k *Provisioner) Create(ctx context.Context, name string) error {
 	target := setName(name, k.kindConfig.Name)
 

--- a/pkg/svc/provisioner/cluster/provisioner.go
+++ b/pkg/svc/provisioner/cluster/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v6/pkg/svc/detector"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster/clusterupdate"
 )
@@ -64,4 +65,21 @@ type Updater interface {
 type ProviderAware interface {
 	// SetProvider sets the infrastructure provider for node operations.
 	SetProvider(p provider.Provider)
+}
+
+// KubeconfigRefresher is an optional interface for provisioners that can
+// refresh the kubeconfig for a running cluster from a remote source.
+// This is needed for remote providers (e.g., Omni) where the kubeconfig
+// is not persisted locally and must be fetched from the provider API.
+type KubeconfigRefresher interface {
+	// RefreshKubeconfig fetches and saves the kubeconfig for the named cluster.
+	RefreshKubeconfig(ctx context.Context, name string) error
+}
+
+// ComponentDetectorAware is an optional interface for provisioners that
+// accept a component detector for probing installed cluster components.
+type ComponentDetectorAware interface {
+	// SetComponentDetector sets the component detector used by GetCurrentConfig
+	// to return accurate live state instead of static defaults.
+	SetComponentDetector(d *detector.ComponentDetector)
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -249,7 +249,7 @@ func (p *Provisioner) SetProvider(prov provider.Provider) {
 // SetComponentDetector sets the component detector for querying cluster state.
 // This implements the ComponentDetectorAware interface.
 func (p *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
-	p.componentDetector = d
+	p.WithComponentDetector(d)
 }
 
 // RefreshKubeconfig fetches and saves the kubeconfig for a running cluster.

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -246,6 +246,31 @@ func (p *Provisioner) SetProvider(prov provider.Provider) {
 	p.infraProvider = prov
 }
 
+// SetComponentDetector sets the component detector for querying cluster state.
+// This implements the ComponentDetectorAware interface.
+func (p *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
+	p.componentDetector = d
+}
+
+// RefreshKubeconfig fetches and saves the kubeconfig for a running cluster.
+// For Omni clusters, the kubeconfig is retrieved from the Omni API.
+// For Docker and Hetzner clusters, kubeconfig is expected to persist from creation.
+// This implements the KubeconfigRefresher interface.
+func (p *Provisioner) RefreshKubeconfig(ctx context.Context, name string) error {
+	if p.omniOpts == nil {
+		return nil
+	}
+
+	clusterName := p.resolveClusterName(name)
+
+	omniProv, err := p.omniProvider()
+	if err != nil {
+		return err
+	}
+
+	return p.saveOmniKubeconfig(ctx, omniProv, clusterName)
+}
+
 // Options returns the current runtime options.
 func (p *Provisioner) Options() *Options {
 	return p.options


### PR DESCRIPTION
## Summary

`ksail cluster update` fails for Omni-managed Talos clusters in CI because the kubeconfig file doesn't exist on the runner. The Omni provider can fetch kubeconfig via its API, but this only happens during `cluster create` — never during `cluster update`.

Fixes #3922

## Problem

When running in CI (GitHub Actions), each runner starts fresh without a kubeconfig. The update command's flow was:

1. `buildComponentDetector()` → tries to create Helm client → `os.Stat(kubeconfig)` fails
2. Falls back to nil detector (warning logged)
3. Component reconciliation (CNI Cilium, GitOps Flux) → tries Helm client again → **hard failure**

## Solution

- Add `KubeconfigRefresher` interface — provisioners that can fetch kubeconfig from a remote source
- Add `ComponentDetectorAware` interface — provisioners that accept a component detector (follows existing `ProviderAware` pattern)
- Talos provisioner implements `RefreshKubeconfig` by calling the existing `saveOmniKubeconfig` flow
- Restructure `createAndVerifyProvisioner()`:
  1. Create provisioner **without** component detector
  2. Verify cluster exists (Omni API)
  3. **Refresh kubeconfig** from remote provider (new step)
  4. Build component detector (kubeconfig now exists)
  5. Inject detector into provisioner

## Changed files

| File | Change |
|------|--------|
| `pkg/svc/provisioner/cluster/provisioner.go` | Add `KubeconfigRefresher` and `ComponentDetectorAware` interfaces |
| `pkg/svc/provisioner/cluster/talos/provisioner.go` | Implement `RefreshKubeconfig` (Omni) and `SetComponentDetector` |
| `pkg/svc/provisioner/cluster/kind/provisioner.go` | Add `SetComponentDetector` |
| `pkg/svc/provisioner/cluster/k3d/provisioner.go` | Add `SetComponentDetector` |
| `pkg/cli/cmd/cluster/cluster.go` | Restructure `createAndVerifyProvisioner()` |