### PR TITLE
fix(ci): pin --cli-version in go tool bundler invocations

### DIFF
--- a/.github/actions/cache-ksail-binary/action.yaml
+++ b/.github/actions/cache-ksail-binary/action.yaml
@@ -102,7 +102,7 @@ runs:
           # Build binary (generate embedded docs + bundle Copilot CLI)
           mkdir -p ./.cache
           go generate ./pkg/svc/chat/...
-          go tool bundler
+          go tool bundler --cli-version 0.1.8
           go build -trimpath -ldflags="-s -w" -o ./.cache/ksail .
           # Copy to target location
           if [[ "$output_target" = /* ]]; then

--- a/.github/actions/cache-ksail-binary/action.yaml
+++ b/.github/actions/cache-ksail-binary/action.yaml
@@ -102,7 +102,7 @@ runs:
           # Build binary (generate embedded docs + bundle Copilot CLI)
           mkdir -p ./.cache
           go generate ./pkg/svc/chat/...
-          go tool bundler --cli-version 0.1.8
+          go tool bundler --cli-version 1.0.10
           go build -trimpath -ldflags="-s -w" -o ./.cache/ksail .
           # Copy to target location
           if [[ "$output_target" = /* ]]; then

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - -s -w -X github.com/devantler-tech/ksail/v6/internal/buildmeta.Version={{.Version}} -X github.com/devantler-tech/ksail/v6/internal/buildmeta.Commit={{.Commit}} -X github.com/devantler-tech/ksail/v6/internal/buildmeta.Date={{.Date}}
     hooks:
       pre:
-        - go tool bundler --platform {{ .Os }}/{{ .Arch }}
+        - go tool bundler --platform {{ .Os }}/{{ .Arch }} --cli-version 0.1.8
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - -s -w -X github.com/devantler-tech/ksail/v6/internal/buildmeta.Version={{.Version}} -X github.com/devantler-tech/ksail/v6/internal/buildmeta.Commit={{.Commit}} -X github.com/devantler-tech/ksail/v6/internal/buildmeta.Date={{.Date}}
     hooks:
       pre:
-        - go tool bundler --platform {{ .Os }}/{{ .Arch }} --cli-version 0.1.8
+        - go tool bundler --platform {{ .Os }}/{{ .Arch }} --cli-version 1.0.10
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
## Summary

Pin `--cli-version 0.1.8` in all `go tool bundler` invocations to eliminate network-dependent CLI version auto-detection that caused a transient `connection reset by peer` failure in CI run [#10537](https://github.com/devantler-tech/ksail/actions/runs/24307307209).

## Changes

- `.github/actions/cache-ksail-binary/action.yaml`: `go tool bundler` → `go tool bundler --cli-version 0.1.8`
- `.goreleaser.yaml`: `go tool bundler --platform ...` → `go tool bundler --platform ... --cli-version 0.1.8`

## Notes

- CLI version `0.1.8` corresponds to `copilot-sdk v0.2.0` (current `go.mod` version), verified from [`nodejs/package-lock.json`](https://raw.githubusercontent.com/github/copilot-sdk/v0.2.0/nodejs/package-lock.json)
- When bumping `github.com/github/copilot-sdk/go` in `go.mod`, update `--cli-version` in both files

Fixes #3965