### PR TITLE
fix(ci): use deployment name instead of label selectors for install verify

### DIFF
--- a/.github/actions/ksail-test-workload/action.yaml
+++ b/.github/actions/ksail-test-workload/action.yaml
@@ -104,11 +104,13 @@ runs:
     - name: 🧪 ksail workload install
       id: workload-install
       shell: bash
+      env:
+        TIMEOUT: ${{ inputs.workload-timeout }}
       run: |
         # Install a lightweight Helm chart to verify workload install works
         install_succeeded=false
         for attempt in 1 2 3; do
-          if ksail workload install ksail-install-test oci://ghcr.io/stefanprodan/charts/podinfo --version=6.7.1 --wait --timeout=120s; then
+          if ksail workload install ksail-install-test oci://ghcr.io/stefanprodan/charts/podinfo --version=6.7.1 --wait --timeout="$TIMEOUT"; then
             install_succeeded=true
             break
           fi
@@ -120,6 +122,30 @@ runs:
           exit 1
         fi
         echo "✅ workload install succeeded"
+
+    - name: 🧪 ksail workload install — verify
+      id: workload-install-verify
+      shell: bash
+      env:
+        TIMEOUT: ${{ inputs.workload-timeout }}
+      run: |
+        # Verify the installed chart's deployment is healthy by name
+        # (podinfo chart does not use standard app.kubernetes.io/instance labels)
+        ksail workload wait --for=condition=Available deployment/ksail-install-test-podinfo --timeout="$TIMEOUT"
+        echo "✅ deployment ksail-install-test-podinfo is Available"
+
+        # Verify the Helm release secret exists
+        ksail workload get secret -l owner=helm,name=ksail-install-test
+        echo "✅ Helm release secret verified"
+
+    - name: 🧪 ksail workload install — cleanup
+      if: always() && steps.workload-install.outcome == 'success'
+      shell: bash
+      run: |
+        ksail workload delete deployment/ksail-install-test-podinfo --ignore-not-found
+        ksail workload delete secret -l owner=helm,name=ksail-install-test --ignore-not-found
+        ksail workload delete service/ksail-install-test-podinfo --ignore-not-found
+        echo "✅ workload install cleanup complete"
 
     - name: 🧪 ksail workload apply
       id: workload-apply
@@ -169,7 +195,7 @@ runs:
         ksail workload delete deployment/"$WORKLOAD_NAME" --ignore-not-found
 
     - name: 🐞 Debug Kubernetes failure
-      if: failure() && (steps.workload-create.outcome == 'failure' || steps.workload-install.outcome == 'failure' || steps.workload-apply.outcome == 'failure' || steps.workload-scale.outcome == 'failure' || steps.workload-push-reconcile.outcome == 'failure')
+      if: failure() && (steps.workload-create.outcome == 'failure' || steps.workload-install.outcome == 'failure' || steps.workload-install-verify.outcome == 'failure' || steps.workload-apply.outcome == 'failure' || steps.workload-scale.outcome == 'failure' || steps.workload-push-reconcile.outcome == 'failure')
       uses: ./.github/actions/debug-kubernetes-failure
       with:
         kubectl-command: "ksail workload"


### PR DESCRIPTION
## Summary

The verify and cleanup steps added in PR #3952 used the label selector `app.kubernetes.io/instance=ksail-install-test`, but the podinfo chart (v6.7.1) does **not** include this standard Helm label in its Deployment's `metadata.labels`. This caused `error: no matching resources found` across all 4 tested jobs.

## Changes

- **Verify step**: Uses `deployment/ksail-install-test-podinfo` (the actual deployment name) instead of a label selector
- **Cleanup step**: Deletes by deployment name + Helm's own secret labels (`owner=helm,name=...`)
- **Install step**: Uses `$TIMEOUT` env var from `workload-timeout` input instead of hardcoded `120s`
- **Debug condition**: Includes `workload-install-verify` step

## Root Cause

The `stefanprodan/podinfo` chart uses non-standard Helm labels — it does not include `app.kubernetes.io/instance` in its Deployment metadata. Using the deployment name directly is more robust than label selectors since it doesn't depend on chart labeling conventions.

Fixes #3959