### PR TITLE
ci: require docker system tests to pass before cloud tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -670,12 +670,9 @@ jobs:
     name: "🧪 System Test (Hetzner/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
+    needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache, system-test-docker]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
-    # Hetzner cloud tests are allowed to fail without blocking the merge queue
-    # because Hetzner infrastructure can be intermittently unavailable.
-    continue-on-error: true
     permissions:
       actions: read
       contents: read
@@ -767,7 +764,7 @@ jobs:
     name: "🧪 System Test (Omni/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
+    needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache, system-test-docker]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
     permissions:


### PR DESCRIPTION
Cloud system tests (Hetzner, Omni) previously ran in parallel with Docker system tests. This meant cloud tests could consume cloud resources and time even when Docker tests -- which exercise the same code paths locally -- were failing.

This PR adds `system-test-docker` as a dependency for both `system-test-hetzner` and `system-test-omni`, so cloud tests only start after all Docker-based system tests pass. It also removes `continue-on-error: true` from the Hetzner job so its failures are now accurately reported to the final status check.

## Type of change

- [x] 🧹 Refactor