### PR TITLE
fix(ci): treat cancelled jobs as failures in merge queue status check

### DIFF
--- a/.github/actions/summarize-workflow/README.md
+++ b/.github/actions/summarize-workflow/README.md
@@ -1,6 +1,6 @@
 # Summarize Workflow Result Action
 
-A GitHub composite action that summarizes the results of multiple jobs and fails if any job failed. Useful for creating status check jobs that aggregate results from matrix builds or parallel jobs.
+A GitHub composite action that summarizes the results of multiple jobs and fails if any job failed or was cancelled. Useful for creating status check jobs that aggregate results from matrix builds or parallel jobs.
 
 ## Why?
 
@@ -42,8 +42,8 @@ jobs:
 | Input             | Description                                  | Required | Default                                 |
 |-------------------|----------------------------------------------|----------|-----------------------------------------|
 | `job-results`     | Space-separated list of job results to check | Yes      | -                                       |
-| `success-message` | Message when all jobs passed                 | No       | `✅ All jobs succeeded or were skipped.` |
-| `failure-message` | Message when a job failed                    | No       | `❌ At least one job failed.`            |
+| `success-message` | Message when all jobs passed                 | No       | `✅ No jobs failed or were cancelled.`   |
+| `failure-message` | Message when a job failed or was cancelled   | No       | `❌ At least one job failed or was cancelled.` |
 
 ## Job Result Values
 
@@ -93,11 +93,11 @@ status:
 On success:
 
 ```text
-✅ All jobs succeeded or were skipped.
+✅ No jobs failed or were cancelled.
 ```
 
 On failure:
 
 ```text
-❌ At least one job failed.
+❌ At least one job failed or was cancelled.
 ```

--- a/.github/actions/summarize-workflow/README.md
+++ b/.github/actions/summarize-workflow/README.md
@@ -39,10 +39,10 @@ jobs:
 
 ## Inputs
 
-| Input             | Description                                  | Required | Default                                 |
-|-------------------|----------------------------------------------|----------|-----------------------------------------|
-| `job-results`     | Space-separated list of job results to check | Yes      | -                                       |
-| `success-message` | Message when all jobs passed                 | No       | `✅ No jobs failed or were cancelled.`   |
+| Input             | Description                                  | Required | Default                                       |
+|-------------------|----------------------------------------------|----------|-----------------------------------------------|
+| `job-results`     | Space-separated list of job results to check | Yes      | -                                             |
+| `success-message` | Message when all jobs passed                 | No       | `✅ No jobs failed or were cancelled.`         |
 | `failure-message` | Message when a job failed or was cancelled   | No       | `❌ At least one job failed or was cancelled.` |
 
 ## Job Result Values

--- a/.github/actions/summarize-workflow/action.yaml
+++ b/.github/actions/summarize-workflow/action.yaml
@@ -14,7 +14,7 @@ inputs:
   success-message:
     description: Message to display when no job failed or was cancelled (success and skipped are acceptable)
     required: false
-    default: "✅ No jobs failed or were cancelled."
+    default: "✅ All jobs succeeded or were skipped."
   failure-message:
     description: Message to display when at least one job failed or was cancelled
     required: false

--- a/.github/actions/summarize-workflow/action.yaml
+++ b/.github/actions/summarize-workflow/action.yaml
@@ -1,7 +1,7 @@
 name: Summarize Workflow Result
 description: |
-  Summarizes the results of multiple jobs and fails if any job failed.
-  Cancelled and skipped jobs are treated as acceptable (non-failure).
+  Summarizes the results of multiple jobs and fails if any job failed or was cancelled.
+  Only skipped jobs are treated as acceptable (non-failure).
   Useful for status check jobs that aggregate results from matrix or parallel jobs.
 
 inputs:
@@ -12,13 +12,13 @@ inputs:
       Example: "success success skipped failure"
     required: true
   success-message:
-    description: Message to display when no job failed (success, skipped, and cancelled are all acceptable)
+    description: Message to display when no job failed or was cancelled (success and skipped are acceptable)
     required: false
-    default: "✅ No jobs failed."
+    default: "✅ No jobs failed or were cancelled."
   failure-message:
-    description: Message to display when at least one job failed
+    description: Message to display when at least one job failed or was cancelled
     required: false
-    default: "❌ At least one job failed."
+    default: "❌ At least one job failed or was cancelled."
 
 runs:
   using: composite
@@ -35,7 +35,7 @@ runs:
 
         for result in $JOB_RESULTS; do
           case "$result" in
-            success|skipped|cancelled)
+            success|skipped)
               ;;
             *)
               failed=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -670,7 +670,14 @@ jobs:
     name: "🧪 System Test (Hetzner/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache, system-test-docker]
+    needs:
+      [
+        changes,
+        build-artifact,
+        warm-helm-cache,
+        warm-mirror-cache,
+        system-test-docker,
+      ]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
     permissions:
@@ -764,7 +771,14 @@ jobs:
     name: "🧪 System Test (Omni/${{ matrix.init && 'init' || 'noinit' }})"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache, system-test-docker]
+    needs:
+      [
+        changes,
+        build-artifact,
+        warm-helm-cache,
+        warm-mirror-cache,
+        system-test-docker,
+      ]
     if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
     permissions:


### PR DESCRIPTION
## Summary

The `summarize-workflow` action treated `cancelled` as an acceptable result alongside `success` and `skipped`. This allowed the CI status check to pass when upstream jobs (e.g. `rate-limit-gate`) were cancelled, causing all downstream jobs to be skipped — letting PRs through the merge queue without any checks actually running.

## Vulnerability chain

1. `rate-limit-gate` gets cancelled (API issues, runner failure, etc.)
2. `changes` is skipped (GitHub skips jobs whose dependencies were cancelled)
3. All downstream jobs are skipped (dependency chain)
4. `status` job runs (`if: always()`) and feeds all results to `summarize-workflow`
5. `summarize-workflow` treats `cancelled` + `skipped` as passing → **status check passes**
6. **Merge queue merges the PR without any checks actually running**

## Fix

Remove `cancelled` from the acceptable-result case in `summarize-workflow/action.yaml`, aligning the code with the [README documentation](https://github.com/devantler-tech/ksail/blob/main/.github/actions/summarize-workflow/README.md#job-result-values) which already documents `cancelled → ❌ Fail`.

## Changes

- `.github/actions/summarize-workflow/action.yaml` — `success|skipped|cancelled` → `success|skipped`
- Updated descriptions and default messages to reflect the corrected behavior