### PR TITLE
fix(setup): wait for all nodes to be ready before workload operations

### DIFF
--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -50,6 +50,12 @@ const (
 	// the API server ClusterIP) is functional before GitOps operators start.
 	daemonSetStabilityTimeout = 3 * time.Minute
 
+	// nodeReadinessTimeout is the maximum time to wait for all cluster nodes
+	// to reach condition Ready=True. After Kind/K3d cluster creation, control-
+	// plane nodes may briefly carry a NotReady taint, causing FailedScheduling
+	// for workload pods if they are deployed before the taint clears.
+	nodeReadinessTimeout = 1 * time.Minute
+
 	// inClusterConnectivityTimeout is the maximum time to wait for a test pod
 	// to successfully reach the API server ClusterIP from within the cluster.
 	// This catches eBPF dataplane race conditions where Cilium DaemonSet pods
@@ -466,6 +472,16 @@ func waitForClusterStability(
 	)
 	if err != nil {
 		return fmt.Errorf("wait for API server stability: %w", err)
+	}
+
+	// Wait for all nodes to reach Ready state. After Kind/K3d cluster creation
+	// or infrastructure installations, control-plane nodes may briefly carry a
+	// NotReady taint that prevents workload scheduling. Without this check,
+	// pods deployed immediately after stability checks pass can hit
+	// FailedScheduling errors.
+	err = readiness.WaitForAllNodesReady(ctx, clientset, nodeReadinessTimeout)
+	if err != nil {
+		return fmt.Errorf("wait for all nodes to be ready: %w", err)
 	}
 
 	// Wait for all kube-system DaemonSets (including the CNI, e.g. Cilium)

--- a/pkg/k8s/readiness/node.go
+++ b/pkg/k8s/readiness/node.go
@@ -34,6 +34,35 @@ func WaitForNodeReady(
 	})
 }
 
+// WaitForAllNodesReady polls until every node in the cluster has condition Ready=True.
+// Unlike WaitForNodeReady which succeeds when at least one node is Ready, this function
+// ensures all nodes are schedulable. This prevents FailedScheduling errors from
+// transient NotReady taints on control-plane nodes during early cluster initialization.
+func WaitForAllNodesReady(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	deadline time.Duration,
+) error {
+	return PollForReadiness(ctx, deadline, func(ctx context.Context) (bool, error) {
+		nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, nil //nolint:nilerr // returning nil to continue polling
+		}
+
+		if len(nodes.Items) == 0 {
+			return false, nil
+		}
+
+		for i := range nodes.Items {
+			if !isNodeReady(&nodes.Items[i]) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}
+
 // isNodeReady returns true if the node has condition Ready=True.
 func isNodeReady(node *corev1.Node) bool {
 	for _, cond := range node.Status.Conditions {

--- a/pkg/k8s/readiness/node.go
+++ b/pkg/k8s/readiness/node.go
@@ -17,31 +17,49 @@ func WaitForNodeReady(
 	clientset kubernetes.Interface,
 	deadline time.Duration,
 ) error {
-	return PollForReadiness(ctx, deadline, func(ctx context.Context) (bool, error) {
-		nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-		if err != nil {
-			// Continue polling on transient errors
-			return false, nil //nolint:nilerr // returning nil to continue polling
-		}
-
-		for i := range nodes.Items {
-			if isNodeReady(&nodes.Items[i]) {
-				return true, nil
+	return waitForNodes(ctx, clientset, deadline, func(nodes []corev1.Node) bool {
+		for i := range nodes {
+			if isNodeReady(&nodes[i]) {
+				return true
 			}
 		}
 
-		return false, nil
+		return false
 	})
 }
 
 // WaitForAllNodesReady polls until every node in the cluster has condition Ready=True.
-// Unlike WaitForNodeReady which succeeds when at least one node is Ready, this function
-// ensures all nodes are schedulable. This prevents FailedScheduling errors from
-// transient NotReady taints on control-plane nodes during early cluster initialization.
+// Unlike WaitForNodeReady, which succeeds when at least one node is Ready, this function
+// waits for all listed nodes to report Ready=True before proceeding. This helps avoid
+// moving on while nodes still have transient NotReady state during early cluster
+// initialization, but it does not verify schedulability, taints, cordon state
+// (spec.unschedulable), or other scheduling constraints.
 func WaitForAllNodesReady(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	deadline time.Duration,
+) error {
+	return waitForNodes(ctx, clientset, deadline, func(nodes []corev1.Node) bool {
+		if len(nodes) == 0 {
+			return false
+		}
+
+		for i := range nodes {
+			if !isNodeReady(&nodes[i]) {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
+// waitForNodes polls nodes and passes them to the check function until it returns true.
+func waitForNodes(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	deadline time.Duration,
+	check func([]corev1.Node) bool,
 ) error {
 	return PollForReadiness(ctx, deadline, func(ctx context.Context) (bool, error) {
 		nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
@@ -49,17 +67,7 @@ func WaitForAllNodesReady(
 			return false, nil //nolint:nilerr // returning nil to continue polling
 		}
 
-		if len(nodes.Items) == 0 {
-			return false, nil
-		}
-
-		for i := range nodes.Items {
-			if !isNodeReady(&nodes.Items[i]) {
-				return false, nil
-			}
-		}
-
-		return true, nil
+		return check(nodes.Items), nil
 	})
 }
 

--- a/pkg/k8s/readiness/node_test.go
+++ b/pkg/k8s/readiness/node_test.go
@@ -41,7 +41,7 @@ func TestWaitForNodeReady_NodeNotReady(t *testing.T) {
 		},
 	})
 
-	err := readiness.WaitForNodeReady(context.Background(), clientset, 3*time.Second)
+	err := readiness.WaitForNodeReady(context.Background(), clientset, 100*time.Millisecond)
 	assert.Error(t, err)
 }
 
@@ -50,7 +50,7 @@ func TestWaitForNodeReady_NoNodes(t *testing.T) {
 
 	clientset := fake.NewClientset()
 
-	err := readiness.WaitForNodeReady(context.Background(), clientset, 3*time.Second)
+	err := readiness.WaitForNodeReady(context.Background(), clientset, 100*time.Millisecond)
 	assert.Error(t, err)
 }
 
@@ -114,7 +114,7 @@ func TestWaitForAllNodesReady_OneNotReady(t *testing.T) {
 		},
 	)
 
-	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 3*time.Second)
+	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 100*time.Millisecond)
 	assert.Error(t, err)
 }
 
@@ -123,7 +123,7 @@ func TestWaitForAllNodesReady_NoNodes(t *testing.T) {
 
 	clientset := fake.NewClientset()
 
-	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 3*time.Second)
+	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 100*time.Millisecond)
 	assert.Error(t, err)
 }
 

--- a/pkg/k8s/readiness/node_test.go
+++ b/pkg/k8s/readiness/node_test.go
@@ -65,3 +65,92 @@ func TestWaitForNodeReady_ContextCancelled(t *testing.T) {
 	err := readiness.WaitForNodeReady(ctx, clientset, 5*time.Second)
 	assert.Error(t, err)
 }
+
+func TestWaitForAllNodesReady_AllReady(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "control-plane"},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				},
+			},
+		},
+	)
+
+	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 5*time.Second)
+	require.NoError(t, err)
+}
+
+func TestWaitForAllNodesReady_OneNotReady(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "control-plane"},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+				},
+			},
+		},
+	)
+
+	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 3*time.Second)
+	assert.Error(t, err)
+}
+
+func TestWaitForAllNodesReady_NoNodes(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset()
+
+	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 3*time.Second)
+	assert.Error(t, err)
+}
+
+func TestWaitForAllNodesReady_SingleNode(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "kind-control-plane"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	})
+
+	err := readiness.WaitForAllNodesReady(context.Background(), clientset, 5*time.Second)
+	require.NoError(t, err)
+}
+
+func TestWaitForAllNodesReady_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := readiness.WaitForAllNodesReady(ctx, clientset, 5*time.Second)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Add `WaitForAllNodesReady` to the cluster stability check so that all nodes have `condition=Ready` before proceeding to infrastructure/GitOps installation. This prevents `FailedScheduling` errors from transient `NotReady` taints on Kind/K3d control-plane nodes.

Fixes #3976
Fixes #3977
Fixes #3982
Fixes #3985

## Root Cause

After Kind/K3d cluster creation, the control-plane node may briefly carry a `node-role.kubernetes.io/control-plane:NoSchedule` taint while transitioning from `NotReady` to `Ready`. The existing `waitForClusterStability` checks:
1. API server stability (`WaitForAPIServerStable`) ✅
2. DaemonSet readiness in kube-system ✅
3. In-cluster connectivity (Cilium only) ✅

But it did **not** check that nodes are actually schedulable. For clusters without a custom CNI (where `WaitForNodeReady` runs post-CNI-install), there was no node readiness gate — workload pods deployed immediately after stability checks could hit `FailedScheduling`.

## Changes

- **`pkg/k8s/readiness/node.go`** — Add `WaitForAllNodesReady()` that polls until every node has `condition=Ready=True` (unlike existing `WaitForNodeReady` which succeeds when *at least one* node is ready)
- **`pkg/cli/setup/post_cni.go`** — Call `WaitForAllNodesReady` in `waitForClusterStability()` after API server stability check, with a 1-minute timeout
- **`pkg/k8s/readiness/node_test.go`** — 5 new tests covering multi-node, single-node, partial-ready, no-nodes, and context-cancelled scenarios

## Type of change

- [x] 🪲 Bug fix

## Test Status

- `go build -o /dev/null ./...` ✅
- `go test ./pkg/k8s/readiness/...` ✅ (all 9 node readiness tests pass)
- `go test ./pkg/cli/setup/...` ✅

## Related Issues/PRs

This is the only remaining actionable fix from a 13-issue CI stability analysis. The other issues are either already fixed on main (#3964, #3994), covered by open PRs (#3986/#3987/#3989/#3999 → PR #4008, #3973 → PR #3991), or infrastructure-level concerns (#3966, #3993).