### PR TITLE
feat(chat): adopt copilot-sdk v0.2.1 slash commands, elicitation, and command picker

### DIFF
--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -761,8 +761,12 @@ func runNonTUIChat(
 	// Register slash commands for non-TUI mode
 	sessionConfig.Commands = chatui.BuildNonTUISlashCommands(writer)
 
+	// Create shared stdin reader for both the interactive loop and elicitation handler.
+	// Using a single bufio.Reader prevents data loss from buffered reads.
+	stdinReader := bufio.NewReader(os.Stdin)
+
 	// Register elicitation handler for MCP tool form requests
-	sessionConfig.OnElicitationRequest = chatsvc.CreateElicitationHandler(os.Stdin, writer)
+	sessionConfig.OnElicitationRequest = chatsvc.CreateElicitationHandler(stdinReader, writer)
 
 	// Create session
 	session, err := client.CreateSession(ctx, sessionConfig)
@@ -789,7 +793,7 @@ func runNonTUIChat(
 	})
 	_, _ = fmt.Fprintln(writer, "")
 
-	return runChatInteractiveLoop(ctx, session, flags.streaming, flags.timeout, writer)
+	return runChatInteractiveLoop(ctx, session, flags.streaming, flags.timeout, stdinReader, writer)
 }
 
 // inputResult holds the result of reading from stdin.
@@ -877,9 +881,9 @@ func runChatInteractiveLoop(
 	session *copilot.Session,
 	streaming bool,
 	timeout time.Duration,
+	reader *bufio.Reader,
 	writer io.Writer,
 ) error {
-	reader := bufio.NewReader(os.Stdin)
 	inputChan := make(chan inputResult, 1)
 
 	for {

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -762,7 +762,7 @@ func runNonTUIChat(
 	sessionConfig.Commands = chatui.BuildNonTUISlashCommands(writer)
 
 	// Register elicitation handler for MCP tool form requests
-	sessionConfig.OnElicitationRequest = chatsvc.CreateElicitationHandler(writer)
+	sessionConfig.OnElicitationRequest = chatsvc.CreateElicitationHandler(os.Stdin, writer)
 
 	// Create session
 	session, err := client.CreateSession(ctx, sessionConfig)

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -758,6 +758,12 @@ func runNonTUIChat(
 	// Register OnEvent handler for session-level events not in the per-turn handler
 	sessionConfig.OnEvent = buildNonTUIOnEventHandler(writer)
 
+	// Register slash commands for non-TUI mode
+	sessionConfig.Commands = chatui.BuildNonTUISlashCommands(writer)
+
+	// Register elicitation handler for MCP tool form requests
+	sessionConfig.OnElicitationRequest = chatsvc.CreateElicitationHandler(writer)
+
 	// Create session
 	session, err := client.CreateSession(ctx, sessionConfig)
 	if err != nil {
@@ -1444,6 +1450,12 @@ func runTUIChat(
 
 		return err
 	}
+
+	// Register slash commands for the TUI
+	sessionConfig.Commands = chatui.BuildTUISlashCommands(eventChan)
+
+	// Register elicitation handler for MCP tool form requests
+	sessionConfig.OnElicitationRequest = chatui.CreateTUIElicitationHandler(eventChan)
 
 	session, err := client.CreateSession(ctx, sessionConfig)
 	if err != nil {

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -82,7 +82,7 @@ func (m *Model) updateOptionPicker(text string) {
 
 	argText := ""
 	if len(parts) > 1 {
-		argText = strings.ToLower(parts[1])
+		argText = strings.ToLower(strings.TrimLeft(parts[1], " \t"))
 	}
 
 	// Look up option provider for this command
@@ -240,30 +240,45 @@ func (m *Model) handleOptionPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, taCmd
 }
 
+// selectedCommandValue returns the text for the selected command, or empty if out of bounds.
+func (m *Model) selectedCommandValue() string {
+	if m.commandPickerIndex >= len(m.filteredCommands) {
+		return ""
+	}
+
+	return "/" + m.filteredCommands[m.commandPickerIndex].Name
+}
+
+// selectedOptionValue returns the text for the selected option, or empty if out of bounds.
+func (m *Model) selectedOptionValue() string {
+	if m.optionPickerIndex >= len(m.filteredOptions) {
+		return ""
+	}
+
+	return "/" + m.activeCommandName + " " + m.filteredOptions[m.optionPickerIndex].Name
+}
+
 // selectAndFireCommand fills the selected command into the textarea and submits it.
 func (m *Model) selectAndFireCommand() (tea.Model, tea.Cmd) {
-	if m.commandPickerIndex >= len(m.filteredCommands) {
+	value := m.selectedCommandValue()
+	if value == "" {
 		return m, nil
 	}
 
-	cmd := m.filteredCommands[m.commandPickerIndex]
-	m.textarea.SetValue("/" + cmd.Name)
-
+	m.textarea.SetValue(value)
 	m.dismissAllPickers()
 
-	// Trigger submit — reuse the existing handleEnter flow
 	return m.handleEnter()
 }
 
 // selectCommandWithoutFiring fills the selected command + a trailing space, without submitting.
 func (m *Model) selectCommandWithoutFiring() (tea.Model, tea.Cmd) {
-	if m.commandPickerIndex >= len(m.filteredCommands) {
+	value := m.selectedCommandValue()
+	if value == "" {
 		return m, nil
 	}
 
-	cmd := m.filteredCommands[m.commandPickerIndex]
-	m.textarea.SetValue("/" + cmd.Name + " ")
-
+	m.textarea.SetValue(value + " ")
 	m.showCommandPicker = false
 	m.commandPickerIndex = 0
 	m.filteredCommands = nil
@@ -276,13 +291,12 @@ func (m *Model) selectCommandWithoutFiring() (tea.Model, tea.Cmd) {
 
 // selectAndFireOption fills the selected option and fires the command.
 func (m *Model) selectAndFireOption() (tea.Model, tea.Cmd) {
-	if m.optionPickerIndex >= len(m.filteredOptions) {
+	value := m.selectedOptionValue()
+	if value == "" {
 		return m, nil
 	}
 
-	opt := m.filteredOptions[m.optionPickerIndex]
-	m.textarea.SetValue("/" + m.activeCommandName + " " + opt.Name)
-
+	m.textarea.SetValue(value)
 	m.dismissAllPickers()
 
 	return m.handleEnter()
@@ -290,13 +304,12 @@ func (m *Model) selectAndFireOption() (tea.Model, tea.Cmd) {
 
 // selectOptionWithoutFiring fills the selected option without submitting.
 func (m *Model) selectOptionWithoutFiring() (tea.Model, tea.Cmd) {
-	if m.optionPickerIndex >= len(m.filteredOptions) {
+	value := m.selectedOptionValue()
+	if value == "" {
 		return m, nil
 	}
 
-	opt := m.filteredOptions[m.optionPickerIndex]
-	m.textarea.SetValue("/" + m.activeCommandName + " " + opt.Name + " ")
-
+	m.textarea.SetValue(value + " ")
 	m.dismissAllPickers()
 
 	return m, nil

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -10,18 +10,32 @@ import (
 )
 
 // updateCommandPicker checks the textarea content and shows/hides the
-// slash-command autocomplete popup. Called after every textarea update.
+// slash-command autocomplete popup or the option picker. Called after every textarea update.
 func (m *Model) updateCommandPicker() {
 	text := m.textarea.Value()
 
-	// Only show when input starts with "/" and has no spaces yet (still typing command name)
-	if !strings.HasPrefix(text, "/") || strings.Contains(text, " ") {
-		m.showCommandPicker = false
-		m.commandPickerIndex = 0
-		m.filteredCommands = nil
+	// Must start with "/"
+	if !strings.HasPrefix(text, "/") {
+		m.dismissAllPickers()
 
 		return
 	}
+
+	// Check if we have a space — if so, we may be in option-picking mode
+	if strings.Contains(text, " ") {
+		m.showCommandPicker = false
+		m.commandPickerIndex = 0
+		m.filteredCommands = nil
+		m.updateOptionPicker(text)
+
+		return
+	}
+
+	// No space — we're in command-picking mode
+	m.showOptionPicker = false
+	m.optionPickerIndex = 0
+	m.filteredOptions = nil
+	m.activeCommandName = ""
 
 	partial := strings.ToLower(text[1:]) // strip leading "/"
 
@@ -57,6 +71,75 @@ func (m *Model) updateCommandPicker() {
 	}
 }
 
+// updateOptionPicker handles the option picker when the user has typed a command name + space.
+func (m *Model) updateOptionPicker(text string) {
+	// Parse: "/mode plan" → cmdName="mode", argText="plan"
+	withoutSlash := text[1:]
+	parts := strings.SplitN(withoutSlash, " ", 2)
+	cmdName := strings.ToLower(parts[0])
+
+	argText := ""
+	if len(parts) > 1 {
+		argText = strings.ToLower(parts[1])
+	}
+
+	// Look up option provider for this command
+	provider, ok := m.commandOptions[cmdName]
+	if !ok {
+		m.showOptionPicker = false
+		m.optionPickerIndex = 0
+		m.filteredOptions = nil
+		m.activeCommandName = ""
+
+		return
+	}
+
+	allOptions := provider(m)
+	if len(allOptions) == 0 {
+		m.showOptionPicker = false
+
+		return
+	}
+
+	// Filter options by prefix match on the argument text
+	var filtered []CommandOption
+
+	for _, opt := range allOptions {
+		if strings.HasPrefix(strings.ToLower(opt.Name), argText) {
+			filtered = append(filtered, opt)
+		}
+	}
+
+	if len(filtered) == 0 {
+		m.showOptionPicker = false
+		m.optionPickerIndex = 0
+		m.filteredOptions = nil
+		m.activeCommandName = ""
+
+		return
+	}
+
+	m.activeCommandName = cmdName
+	m.filteredOptions = filtered
+	m.showOptionPicker = true
+
+	// Clamp index
+	if m.optionPickerIndex >= len(filtered) {
+		m.optionPickerIndex = len(filtered) - 1
+	}
+}
+
+// dismissAllPickers hides both command and option pickers and resets their state.
+func (m *Model) dismissAllPickers() {
+	m.showCommandPicker = false
+	m.commandPickerIndex = 0
+	m.filteredCommands = nil
+	m.showOptionPicker = false
+	m.optionPickerIndex = 0
+	m.filteredOptions = nil
+	m.activeCommandName = ""
+}
+
 // getRegisteredCommands returns the slash commands from the session config.
 func (m *Model) getRegisteredCommands() []copilot.CommandDefinition {
 	if m.sessionConfig == nil {
@@ -88,9 +171,7 @@ func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Fill the command text but don't submit
 		return m.selectCommandWithoutFiring()
 	case keyEscape:
-		m.showCommandPicker = false
-		m.commandPickerIndex = 0
-		m.filteredCommands = nil
+		m.dismissAllPickers()
 
 		return m, nil
 	case keyCtrlC:
@@ -98,6 +179,41 @@ func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// For any other key (typing more characters), update textarea then re-filter
+	var taCmd tea.Cmd
+	m.textarea, taCmd = m.textarea.Update(msg)
+	m.updateCommandPicker()
+
+	return m, taCmd
+}
+
+// handleOptionPickerKey handles keyboard input when the option picker popup is active.
+func (m *Model) handleOptionPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if m.optionPickerIndex > 0 {
+			m.optionPickerIndex--
+		}
+
+		return m, nil
+	case keyDown, "j":
+		if m.optionPickerIndex < len(m.filteredOptions)-1 {
+			m.optionPickerIndex++
+		}
+
+		return m, nil
+	case keyEnter:
+		return m.selectAndFireOption()
+	case "tab":
+		return m.selectOptionWithoutFiring()
+	case keyEscape:
+		m.dismissAllPickers()
+
+		return m, nil
+	case keyCtrlC:
+		return m.handleQuit(true)
+	}
+
+	// For any other key, update textarea then re-filter
 	var taCmd tea.Cmd
 	m.textarea, taCmd = m.textarea.Update(msg)
 	m.updateCommandPicker()
@@ -114,9 +230,7 @@ func (m *Model) selectAndFireCommand() (tea.Model, tea.Cmd) {
 	cmd := m.filteredCommands[m.commandPickerIndex]
 	m.textarea.SetValue("/" + cmd.Name)
 
-	m.showCommandPicker = false
-	m.commandPickerIndex = 0
-	m.filteredCommands = nil
+	m.dismissAllPickers()
 
 	// Trigger submit — reuse the existing handleEnter flow
 	return m.handleEnter()
@@ -135,7 +249,52 @@ func (m *Model) selectCommandWithoutFiring() (tea.Model, tea.Cmd) {
 	m.commandPickerIndex = 0
 	m.filteredCommands = nil
 
+	// Trigger option picker for the newly filled command
+	m.updateCommandPicker()
+
 	return m, nil
+}
+
+// selectAndFireOption fills the selected option and fires the command.
+func (m *Model) selectAndFireOption() (tea.Model, tea.Cmd) {
+	if m.optionPickerIndex >= len(m.filteredOptions) {
+		return m, nil
+	}
+
+	opt := m.filteredOptions[m.optionPickerIndex]
+	m.textarea.SetValue("/" + m.activeCommandName + " " + opt.Name)
+
+	m.dismissAllPickers()
+
+	return m.handleEnter()
+}
+
+// selectOptionWithoutFiring fills the selected option without submitting.
+func (m *Model) selectOptionWithoutFiring() (tea.Model, tea.Cmd) {
+	if m.optionPickerIndex >= len(m.filteredOptions) {
+		return m, nil
+	}
+
+	opt := m.filteredOptions[m.optionPickerIndex]
+	m.textarea.SetValue("/" + m.activeCommandName + " " + opt.Name + " ")
+
+	m.dismissAllPickers()
+
+	return m, nil
+}
+
+// renderPickerPopup renders the floating autocomplete popup for either
+// commands or options, depending on which picker is active.
+func (m *Model) renderPickerPopup() string {
+	if m.showOptionPicker && len(m.filteredOptions) > 0 {
+		return m.renderOptionPickerPopup()
+	}
+
+	if m.showCommandPicker && len(m.filteredCommands) > 0 {
+		return m.renderCommandPickerPopup()
+	}
+
+	return ""
 }
 
 // renderCommandPickerPopup renders the floating command autocomplete popup.
@@ -189,12 +348,71 @@ func (m *Model) renderCommandPickerPopup() string {
 	return popupStyle.Render(strings.TrimRight(content.String(), "\n"))
 }
 
-// commandPickerExtraHeight returns the extra height consumed by the command picker popup.
-func (m *Model) commandPickerExtraHeight() int {
-	if !m.showCommandPicker || len(m.filteredCommands) == 0 {
-		return 0
+// renderOptionPickerPopup renders the floating option autocomplete popup.
+func (m *Model) renderOptionPickerPopup() string {
+	if !m.showOptionPicker || len(m.filteredOptions) == 0 {
+		return ""
 	}
 
-	// Each command is 1 line + 2 for border (top + bottom)
-	return len(m.filteredCommands) + 2
+	modalWidth := max(m.width-modalPadding, 1)
+	contentWidth := max(modalWidth-contentPadding, 1)
+	clipStyle := lipgloss.NewStyle().MaxWidth(contentWidth).Inline(true)
+
+	highlightStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.ANSIColor(ansiBlack)).
+		Background(lipgloss.ANSIColor(ansiCyan))
+
+	dimStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240"))
+
+	var content strings.Builder
+
+	for i, opt := range m.filteredOptions {
+		line := opt.Name
+		desc := opt.Description
+
+		if i == m.optionPickerIndex {
+			styledLine := highlightStyle.Render(line)
+			if desc != "" {
+				styledLine += " " + desc
+			}
+
+			content.WriteString(clipStyle.Render(styledLine) + "\n")
+		} else {
+			styledLine := line
+			if desc != "" {
+				styledLine += " " + dimStyle.Render(desc)
+			}
+
+			content.WriteString(clipStyle.Render(styledLine) + "\n")
+		}
+	}
+
+	popupStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(m.theme.PrimaryColor).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Width(modalWidth)
+
+	return popupStyle.Render(strings.TrimRight(content.String(), "\n"))
+}
+
+// pickerExtraHeight returns the extra height consumed by command or option picker popups.
+func (m *Model) pickerExtraHeight() int {
+	if m.showOptionPicker && len(m.filteredOptions) > 0 {
+		return len(m.filteredOptions) + 2
+	}
+
+	if m.showCommandPicker && len(m.filteredCommands) > 0 {
+		return len(m.filteredCommands) + 2
+	}
+
+	return 0
+}
+
+// commandPickerExtraHeight returns the extra height consumed by the command picker popup.
+// Deprecated: Use pickerExtraHeight() instead, which handles both pickers.
+func (m *Model) commandPickerExtraHeight() int {
+	return m.pickerExtraHeight()
 }

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -1,0 +1,200 @@
+package chat
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+// updateCommandPicker checks the textarea content and shows/hides the
+// slash-command autocomplete popup. Called after every textarea update.
+func (m *Model) updateCommandPicker() {
+	text := m.textarea.Value()
+
+	// Only show when input starts with "/" and has no spaces yet (still typing command name)
+	if !strings.HasPrefix(text, "/") || strings.Contains(text, " ") {
+		m.showCommandPicker = false
+		m.commandPickerIndex = 0
+		m.filteredCommands = nil
+
+		return
+	}
+
+	partial := strings.ToLower(text[1:]) // strip leading "/"
+
+	commands := m.getRegisteredCommands()
+	if len(commands) == 0 {
+		m.showCommandPicker = false
+
+		return
+	}
+
+	var filtered []copilot.CommandDefinition
+
+	for _, cmd := range commands {
+		if strings.HasPrefix(strings.ToLower(cmd.Name), partial) {
+			filtered = append(filtered, cmd)
+		}
+	}
+
+	if len(filtered) == 0 {
+		m.showCommandPicker = false
+		m.commandPickerIndex = 0
+		m.filteredCommands = nil
+
+		return
+	}
+
+	m.filteredCommands = filtered
+	m.showCommandPicker = true
+
+	// Clamp index to valid range
+	if m.commandPickerIndex >= len(filtered) {
+		m.commandPickerIndex = len(filtered) - 1
+	}
+}
+
+// getRegisteredCommands returns the slash commands from the session config.
+func (m *Model) getRegisteredCommands() []copilot.CommandDefinition {
+	if m.sessionConfig == nil {
+		return nil
+	}
+
+	return m.sessionConfig.Commands
+}
+
+// handleCommandPickerKey handles keyboard input when the command picker popup is active.
+func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if m.commandPickerIndex > 0 {
+			m.commandPickerIndex--
+		}
+
+		return m, nil
+	case keyDown, "j":
+		if m.commandPickerIndex < len(m.filteredCommands)-1 {
+			m.commandPickerIndex++
+		}
+
+		return m, nil
+	case keyEnter:
+		// Fill the command and submit
+		return m.selectAndFireCommand()
+	case "tab":
+		// Fill the command text but don't submit
+		return m.selectCommandWithoutFiring()
+	case keyEscape:
+		m.showCommandPicker = false
+		m.commandPickerIndex = 0
+		m.filteredCommands = nil
+
+		return m, nil
+	case keyCtrlC:
+		return m.handleQuit(true)
+	}
+
+	// For any other key (typing more characters), update textarea then re-filter
+	var taCmd tea.Cmd
+	m.textarea, taCmd = m.textarea.Update(msg)
+	m.updateCommandPicker()
+
+	return m, taCmd
+}
+
+// selectAndFireCommand fills the selected command into the textarea and submits it.
+func (m *Model) selectAndFireCommand() (tea.Model, tea.Cmd) {
+	if m.commandPickerIndex >= len(m.filteredCommands) {
+		return m, nil
+	}
+
+	cmd := m.filteredCommands[m.commandPickerIndex]
+	m.textarea.SetValue("/" + cmd.Name)
+
+	m.showCommandPicker = false
+	m.commandPickerIndex = 0
+	m.filteredCommands = nil
+
+	// Trigger submit — reuse the existing handleEnter flow
+	return m.handleEnter()
+}
+
+// selectCommandWithoutFiring fills the selected command + a trailing space, without submitting.
+func (m *Model) selectCommandWithoutFiring() (tea.Model, tea.Cmd) {
+	if m.commandPickerIndex >= len(m.filteredCommands) {
+		return m, nil
+	}
+
+	cmd := m.filteredCommands[m.commandPickerIndex]
+	m.textarea.SetValue("/" + cmd.Name + " ")
+
+	m.showCommandPicker = false
+	m.commandPickerIndex = 0
+	m.filteredCommands = nil
+
+	return m, nil
+}
+
+// renderCommandPickerPopup renders the floating command autocomplete popup.
+func (m *Model) renderCommandPickerPopup() string {
+	if !m.showCommandPicker || len(m.filteredCommands) == 0 {
+		return ""
+	}
+
+	modalWidth := max(m.width-modalPadding, 1)
+	contentWidth := max(modalWidth-contentPadding, 1)
+	clipStyle := lipgloss.NewStyle().MaxWidth(contentWidth).Inline(true)
+
+	highlightStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.ANSIColor(ansiBlack)).
+		Background(lipgloss.ANSIColor(ansiCyan))
+
+	dimStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240"))
+
+	var content strings.Builder
+
+	for i, cmd := range m.filteredCommands {
+		line := fmt.Sprintf("/%s", cmd.Name)
+		desc := cmd.Description
+
+		if i == m.commandPickerIndex {
+			// Highlight the selected item
+			styledLine := highlightStyle.Render(line)
+			if desc != "" {
+				styledLine += " " + desc
+			}
+
+			content.WriteString(clipStyle.Render(styledLine) + "\n")
+		} else {
+			styledLine := line
+			if desc != "" {
+				styledLine += " " + dimStyle.Render(desc)
+			}
+
+			content.WriteString(clipStyle.Render(styledLine) + "\n")
+		}
+	}
+
+	popupStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(m.theme.PrimaryColor).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Width(modalWidth)
+
+	return popupStyle.Render(strings.TrimRight(content.String(), "\n"))
+}
+
+// commandPickerExtraHeight returns the extra height consumed by the command picker popup.
+func (m *Model) commandPickerExtraHeight() int {
+	if !m.showCommandPicker || len(m.filteredCommands) == 0 {
+		return 0
+	}
+
+	// Each command is 1 line + 2 for border (top + bottom)
+	return len(m.filteredCommands) + 2
+}

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -199,6 +199,7 @@ func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// For any other key (typing more characters), update textarea then re-filter
 	var taCmd tea.Cmd
+
 	m.textarea, taCmd = m.textarea.Update(msg)
 	m.updateCommandPicker()
 
@@ -234,6 +235,7 @@ func (m *Model) handleOptionPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// For any other key, update textarea then re-filter
 	var taCmd tea.Cmd
+
 	m.textarea, taCmd = m.textarea.Update(msg)
 	m.updateCommandPicker()
 
@@ -434,10 +436,7 @@ func overlayBottom(base, popup string) string {
 	baseLines := strings.Split(base, "\n")
 	popupLines := strings.Split(popup, "\n")
 
-	startIdx := len(baseLines) - len(popupLines)
-	if startIdx < 0 {
-		startIdx = 0
-	}
+	startIdx := max(len(baseLines)-len(popupLines), 0)
 
 	for i, pLine := range popupLines {
 		idx := startIdx + i

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -308,9 +308,25 @@ type pickerItem struct {
 	description string
 }
 
+// isModalActive returns true if any modal overlay is currently visible.
+func (m *Model) isModalActive() bool {
+	return m.pendingPermission != nil ||
+		m.pendingElicitation != nil ||
+		m.showModelPicker ||
+		m.showSessionPicker ||
+		m.showReasoningPicker ||
+		m.showHelpOverlay
+}
+
 // renderPickerPopup renders the floating autocomplete popup for either
 // commands or options, depending on which picker is active.
+// Returns empty string when any modal is active (modals take priority).
 func (m *Model) renderPickerPopup() string {
+	// Suppress picker when a modal is active — modals take visual priority
+	if m.isModalActive() {
+		return ""
+	}
+
 	if m.showOptionPicker && len(m.filteredOptions) > 0 {
 		items := make([]pickerItem, len(m.filteredOptions))
 		for i, opt := range m.filteredOptions {

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -1,13 +1,15 @@
 package chat
 
 import (
-	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	copilot "github.com/github/copilot-sdk/go"
 )
+
+// pickerBorderLines is the number of border lines added by the popup style (top + bottom).
+const pickerBorderLines = 2
 
 // updateCommandPicker checks the textarea content and shows/hides the
 // slash-command autocomplete popup or the option picker. Called after every textarea update.
@@ -75,7 +77,7 @@ func (m *Model) updateCommandPicker() {
 func (m *Model) updateOptionPicker(text string) {
 	// Parse: "/mode plan" → cmdName="mode", argText="plan"
 	withoutSlash := text[1:]
-	parts := strings.SplitN(withoutSlash, " ", 2)
+	parts := strings.SplitN(withoutSlash, " ", 2) //nolint:mnd // split into command + args
 	cmdName := strings.ToLower(parts[0])
 
 	argText := ""
@@ -184,7 +186,7 @@ func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		return m.selectAndFireCommand()
-	case "tab":
+	case keyTab:
 		// Fill the command text but don't submit
 		return m.selectCommandWithoutFiring()
 	case keyEscape:
@@ -192,7 +194,7 @@ func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 	case keyCtrlC:
-		return m.handleQuit(true)
+		return m.handleQuit()
 	}
 
 	// For any other key (typing more characters), update textarea then re-filter
@@ -220,14 +222,14 @@ func (m *Model) handleOptionPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case keyEnter:
 		return m.selectAndFireOption()
-	case "tab":
+	case keyTab:
 		return m.selectOptionWithoutFiring()
 	case keyEscape:
 		m.dismissAllPickers()
 
 		return m, nil
 	case keyCtrlC:
-		return m.handleQuit(true)
+		return m.handleQuit()
 	}
 
 	// For any other key, update textarea then re-filter
@@ -300,23 +302,39 @@ func (m *Model) selectOptionWithoutFiring() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// pickerItem represents a single item in a picker popup.
+type pickerItem struct {
+	label       string
+	description string
+}
+
 // renderPickerPopup renders the floating autocomplete popup for either
 // commands or options, depending on which picker is active.
 func (m *Model) renderPickerPopup() string {
 	if m.showOptionPicker && len(m.filteredOptions) > 0 {
-		return m.renderOptionPickerPopup()
+		items := make([]pickerItem, len(m.filteredOptions))
+		for i, opt := range m.filteredOptions {
+			items[i] = pickerItem{label: opt.Name, description: opt.Description}
+		}
+
+		return m.renderPickerItems(items, m.optionPickerIndex)
 	}
 
 	if m.showCommandPicker && len(m.filteredCommands) > 0 {
-		return m.renderCommandPickerPopup()
+		items := make([]pickerItem, len(m.filteredCommands))
+		for i, cmd := range m.filteredCommands {
+			items[i] = pickerItem{label: "/" + cmd.Name, description: cmd.Description}
+		}
+
+		return m.renderPickerItems(items, m.commandPickerIndex)
 	}
 
 	return ""
 }
 
-// renderCommandPickerPopup renders the floating command autocomplete popup.
-func (m *Model) renderCommandPickerPopup() string {
-	if !m.showCommandPicker || len(m.filteredCommands) == 0 {
+// renderPickerItems renders a generic picker popup with highlighted selection.
+func (m *Model) renderPickerItems(items []pickerItem, selectedIndex int) string {
+	if len(items) == 0 {
 		return ""
 	}
 
@@ -333,72 +351,18 @@ func (m *Model) renderCommandPickerPopup() string {
 
 	var content strings.Builder
 
-	for i, cmd := range m.filteredCommands {
-		line := fmt.Sprintf("/%s", cmd.Name)
-		desc := cmd.Description
-
-		if i == m.commandPickerIndex {
-			// Highlight the selected item
-			styledLine := highlightStyle.Render(line)
-			if desc != "" {
-				styledLine += " " + desc
+	for i, item := range items {
+		if i == selectedIndex {
+			styledLine := highlightStyle.Render(item.label)
+			if item.description != "" {
+				styledLine += " " + item.description
 			}
 
 			content.WriteString(clipStyle.Render(styledLine) + "\n")
 		} else {
-			styledLine := line
-			if desc != "" {
-				styledLine += " " + dimStyle.Render(desc)
-			}
-
-			content.WriteString(clipStyle.Render(styledLine) + "\n")
-		}
-	}
-
-	popupStyle := lipgloss.NewStyle().
-		BorderStyle(lipgloss.RoundedBorder()).
-		BorderForeground(m.theme.PrimaryColor).
-		PaddingLeft(1).
-		PaddingRight(1).
-		Width(modalWidth)
-
-	return popupStyle.Render(strings.TrimRight(content.String(), "\n"))
-}
-
-// renderOptionPickerPopup renders the floating option autocomplete popup.
-func (m *Model) renderOptionPickerPopup() string {
-	if !m.showOptionPicker || len(m.filteredOptions) == 0 {
-		return ""
-	}
-
-	modalWidth := max(m.width-modalPadding, 1)
-	contentWidth := max(modalWidth-contentPadding, 1)
-	clipStyle := lipgloss.NewStyle().MaxWidth(contentWidth).Inline(true)
-
-	highlightStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.ANSIColor(ansiBlack)).
-		Background(lipgloss.ANSIColor(ansiCyan))
-
-	dimStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240"))
-
-	var content strings.Builder
-
-	for i, opt := range m.filteredOptions {
-		line := opt.Name
-		desc := opt.Description
-
-		if i == m.optionPickerIndex {
-			styledLine := highlightStyle.Render(line)
-			if desc != "" {
-				styledLine += " " + desc
-			}
-
-			content.WriteString(clipStyle.Render(styledLine) + "\n")
-		} else {
-			styledLine := line
-			if desc != "" {
-				styledLine += " " + dimStyle.Render(desc)
+			styledLine := item.label
+			if item.description != "" {
+				styledLine += " " + dimStyle.Render(item.description)
 			}
 
 			content.WriteString(clipStyle.Render(styledLine) + "\n")
@@ -418,18 +382,19 @@ func (m *Model) renderOptionPickerPopup() string {
 // pickerExtraHeight returns the extra height consumed by command or option picker popups.
 func (m *Model) pickerExtraHeight() int {
 	if m.showOptionPicker && len(m.filteredOptions) > 0 {
-		return len(m.filteredOptions) + 2
+		return len(m.filteredOptions) + pickerBorderLines
 	}
 
 	if m.showCommandPicker && len(m.filteredCommands) > 0 {
-		return len(m.filteredCommands) + 2
+		return len(m.filteredCommands) + pickerBorderLines
 	}
 
 	return 0
 }
 
 // commandPickerExtraHeight returns the extra height consumed by the command picker popup.
-// Deprecated: Use pickerExtraHeight() instead, which handles both pickers.
+//
+// Deprecated: Use pickerExtraHeight instead, which handles both pickers.
 func (m *Model) commandPickerExtraHeight() int {
 	return m.pickerExtraHeight()
 }

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -140,6 +140,18 @@ func (m *Model) dismissAllPickers() {
 	m.activeCommandName = ""
 }
 
+// commandHasOptions returns true if the currently highlighted command has registered options.
+func (m *Model) commandHasOptions() bool {
+	if m.commandPickerIndex >= len(m.filteredCommands) {
+		return false
+	}
+
+	cmdName := strings.ToLower(m.filteredCommands[m.commandPickerIndex].Name)
+	_, ok := m.commandOptions[cmdName]
+
+	return ok
+}
+
 // getRegisteredCommands returns the slash commands from the session config.
 func (m *Model) getRegisteredCommands() []copilot.CommandDefinition {
 	if m.sessionConfig == nil {
@@ -165,7 +177,12 @@ func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 	case keyEnter:
-		// Fill the command and submit
+		// If the command has options, select without firing (like Tab)
+		// so the user can pick an option. Otherwise fire immediately.
+		if m.commandHasOptions() {
+			return m.selectCommandWithoutFiring()
+		}
+
 		return m.selectAndFireCommand()
 	case "tab":
 		// Fill the command text but don't submit

--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -433,3 +433,24 @@ func (m *Model) pickerExtraHeight() int {
 func (m *Model) commandPickerExtraHeight() int {
 	return m.pickerExtraHeight()
 }
+
+// overlayBottom composites the popup string over the bottom lines of the base string.
+// The popup replaces the last N lines of base, where N is the popup's line count.
+func overlayBottom(base, popup string) string {
+	baseLines := strings.Split(base, "\n")
+	popupLines := strings.Split(popup, "\n")
+
+	startIdx := len(baseLines) - len(popupLines)
+	if startIdx < 0 {
+		startIdx = 0
+	}
+
+	for i, pLine := range popupLines {
+		idx := startIdx + i
+		if idx < len(baseLines) {
+			baseLines[idx] = pLine
+		}
+	}
+
+	return strings.Join(baseLines, "\n")
+}

--- a/pkg/cli/ui/chat/command_picker_test.go
+++ b/pkg/cli/ui/chat/command_picker_test.go
@@ -22,7 +22,7 @@ func TestUpdateCommandPicker_ShowsOnSlash(t *testing.T) {
 	chat.ExportUpdateCommandPicker(model)
 
 	assert.True(t, chat.ExportShowCommandPicker(model))
-	assert.Equal(t, 6, len(chat.ExportFilteredCommands(model))) // all commands match
+	assert.Len(t, chat.ExportFilteredCommands(model), 6) // all commands match
 }
 
 func TestUpdateCommandPicker_FiltersOnPartialInput(t *testing.T) {
@@ -37,7 +37,7 @@ func TestUpdateCommandPicker_FiltersOnPartialInput(t *testing.T) {
 	assert.True(t, chat.ExportShowCommandPicker(model))
 
 	filtered := chat.ExportFilteredCommands(model)
-	assert.Equal(t, 2, len(filtered)) // /mode, /model
+	assert.Len(t, filtered, 2) // /mode, /model
 
 	names := make([]string, len(filtered))
 	for i, c := range filtered {
@@ -130,7 +130,7 @@ func TestUpdateCommandPicker_CaseInsensitive(t *testing.T) {
 	chat.ExportUpdateCommandPicker(model)
 
 	assert.True(t, chat.ExportShowCommandPicker(model))
-	assert.Equal(t, 2, len(chat.ExportFilteredCommands(model)))
+	assert.Len(t, chat.ExportFilteredCommands(model), 2)
 }
 
 // --- commandPickerExtraHeight tests ---
@@ -172,12 +172,36 @@ func newCommandPickerTestParams() chat.Params {
 func setTestCommands(m *chat.Model) {
 	config := chat.ExportGetSessionConfig(m)
 	config.Commands = []copilot.CommandDefinition{
-		{Name: "mode", Description: "Switch chat mode", Handler: func(_ copilot.CommandContext) error { return nil }},
-		{Name: "model", Description: "Switch LLM model", Handler: func(_ copilot.CommandContext) error { return nil }},
-		{Name: "new", Description: "Start a new chat session", Handler: func(_ copilot.CommandContext) error { return nil }},
-		{Name: "sessions", Description: "Open session picker", Handler: func(_ copilot.CommandContext) error { return nil }},
-		{Name: "help", Description: "Show help", Handler: func(_ copilot.CommandContext) error { return nil }},
-		{Name: "clear", Description: "Clear viewport", Handler: func(_ copilot.CommandContext) error { return nil }},
+		{
+			Name:        "mode",
+			Description: "Switch chat mode",
+			Handler:     func(_ copilot.CommandContext) error { return nil },
+		},
+		{
+			Name:        "model",
+			Description: "Switch LLM model",
+			Handler:     func(_ copilot.CommandContext) error { return nil },
+		},
+		{
+			Name:        "new",
+			Description: "Start a new chat session",
+			Handler:     func(_ copilot.CommandContext) error { return nil },
+		},
+		{
+			Name:        "sessions",
+			Description: "Open session picker",
+			Handler:     func(_ copilot.CommandContext) error { return nil },
+		},
+		{
+			Name:        "help",
+			Description: "Show help",
+			Handler:     func(_ copilot.CommandContext) error { return nil },
+		},
+		{
+			Name:        "clear",
+			Description: "Clear viewport",
+			Handler:     func(_ copilot.CommandContext) error { return nil },
+		},
 	}
 }
 
@@ -193,6 +217,7 @@ func TestTryDispatchSlashCommand_ValidCommand(t *testing.T) {
 	config.Commands = []copilot.CommandDefinition{
 		{Name: "mode", Handler: func(ctx copilot.CommandContext) error {
 			calledArgs = ctx.Args
+
 			return nil
 		}},
 	}
@@ -214,6 +239,7 @@ func TestTryDispatchSlashCommand_CommandWithoutArgs(t *testing.T) {
 	config.Commands = []copilot.CommandDefinition{
 		{Name: "clear", Handler: func(_ copilot.CommandContext) error {
 			called = true
+
 			return nil
 		}},
 	}
@@ -258,6 +284,7 @@ func TestTryDispatchSlashCommand_CaseInsensitive(t *testing.T) {
 	config.Commands = []copilot.CommandDefinition{
 		{Name: "mode", Handler: func(_ copilot.CommandContext) error {
 			called = true
+
 			return nil
 		}},
 	}
@@ -282,7 +309,7 @@ func TestOptionPicker_ShowsOnCommandWithSpace(t *testing.T) {
 	assert.False(t, chat.ExportShowCommandPicker(model))
 	assert.True(t, chat.ExportShowOptionPicker(model))
 	assert.Equal(t, "mode", chat.ExportActiveCommandName(model))
-	assert.Equal(t, 3, len(chat.ExportFilteredOptions(model))) // interactive, plan, autopilot
+	assert.Len(t, chat.ExportFilteredOptions(model), 3) // interactive, plan, autopilot
 }
 
 func TestOptionPicker_FiltersOnPartialArg(t *testing.T) {
@@ -297,7 +324,7 @@ func TestOptionPicker_FiltersOnPartialArg(t *testing.T) {
 	assert.True(t, chat.ExportShowOptionPicker(model))
 
 	filtered := chat.ExportFilteredOptions(model)
-	assert.Equal(t, 1, len(filtered))
+	assert.Len(t, filtered, 1)
 	assert.Equal(t, "plan", filtered[0].Name)
 }
 
@@ -345,7 +372,7 @@ func TestOptionPicker_CaseInsensitive(t *testing.T) {
 	chat.ExportUpdateCommandPicker(model)
 
 	assert.True(t, chat.ExportShowOptionPicker(model))
-	assert.Equal(t, 1, len(chat.ExportFilteredOptions(model)))
+	assert.Len(t, chat.ExportFilteredOptions(model), 1)
 }
 
 // --- pickerExtraHeight tests ---

--- a/pkg/cli/ui/chat/command_picker_test.go
+++ b/pkg/cli/ui/chat/command_picker_test.go
@@ -1,0 +1,178 @@
+package chat_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/devantler-tech/ksail/v6/pkg/cli/ui/chat"
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- updateCommandPicker tests ---
+
+func TestUpdateCommandPicker_ShowsOnSlash(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.True(t, chat.ExportShowCommandPicker(m))
+	assert.Equal(t, 6, len(chat.ExportFilteredCommands(m))) // all commands match
+}
+
+func TestUpdateCommandPicker_FiltersOnPartialInput(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/mo")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.True(t, chat.ExportShowCommandPicker(m))
+
+	filtered := chat.ExportFilteredCommands(m)
+	assert.Equal(t, 2, len(filtered)) // /mode, /model
+
+	names := make([]string, len(filtered))
+	for i, c := range filtered {
+		names[i] = c.Name
+	}
+
+	assert.Contains(t, names, "mode")
+	assert.Contains(t, names, "model")
+}
+
+func TestUpdateCommandPicker_HidesWhenNoMatch(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/xyz")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.False(t, chat.ExportShowCommandPicker(m))
+}
+
+func TestUpdateCommandPicker_HidesOnSpaceAfterCommand(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/mode plan")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.False(t, chat.ExportShowCommandPicker(m))
+}
+
+func TestUpdateCommandPicker_HidesOnEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.False(t, chat.ExportShowCommandPicker(m))
+}
+
+func TestUpdateCommandPicker_HidesOnNonSlashInput(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "hello")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.False(t, chat.ExportShowCommandPicker(m))
+}
+
+func TestUpdateCommandPicker_ClampsIndex(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	// First show all commands
+	chat.ExportSetTextareaValue(m, "/")
+	chat.ExportUpdateCommandPicker(m)
+
+	// Navigate to last item
+	chat.ExportSetCommandPickerIndex(m, 5)
+
+	// Now filter to fewer items
+	chat.ExportSetTextareaValue(m, "/cl")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.True(t, chat.ExportShowCommandPicker(m))
+	assert.Equal(t, 0, chat.ExportCommandPickerIndex(m)) // clamped to 0
+}
+
+func TestUpdateCommandPicker_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/MO")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.True(t, chat.ExportShowCommandPicker(m))
+	assert.Equal(t, 2, len(chat.ExportFilteredCommands(m)))
+}
+
+// --- commandPickerExtraHeight tests ---
+
+func TestCommandPickerExtraHeight_WhenHidden(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+
+	assert.Equal(t, 0, chat.ExportCommandPickerExtraHeight(m))
+}
+
+func TestCommandPickerExtraHeight_WhenShown(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/")
+	chat.ExportUpdateCommandPicker(m)
+
+	// 6 commands + 2 for border
+	assert.Equal(t, 8, chat.ExportCommandPickerExtraHeight(m))
+}
+
+// --- helpers ---
+
+func newCommandPickerTestParams() chat.Params {
+	return chat.Params{
+		Session:       &copilot.Session{},
+		SessionConfig: &copilot.SessionConfig{Model: "test-model"},
+		CurrentModel:  "test-model",
+		Theme:         chat.DefaultThemeConfig(),
+		ToolDisplay:   chat.DefaultToolDisplayConfig(),
+		EventChan:     make(chan tea.Msg, 100),
+	}
+}
+
+func setTestCommands(m *chat.Model) {
+	config := chat.ExportGetSessionConfig(m)
+	config.Commands = []copilot.CommandDefinition{
+		{Name: "mode", Description: "Switch chat mode"},
+		{Name: "model", Description: "Switch LLM model"},
+		{Name: "new", Description: "Start a new chat session"},
+		{Name: "sessions", Description: "Open session picker"},
+		{Name: "help", Description: "Show help"},
+		{Name: "clear", Description: "Clear viewport"},
+	}
+}

--- a/pkg/cli/ui/chat/command_picker_test.go
+++ b/pkg/cli/ui/chat/command_picker_test.go
@@ -65,10 +65,13 @@ func TestUpdateCommandPicker_HidesOnSpaceAfterCommand(t *testing.T) {
 	m := chat.NewModel(newCommandPickerTestParams())
 	setTestCommands(m)
 
+	// /mode has options, so command picker hides but option picker shows
 	chat.ExportSetTextareaValue(m, "/mode plan")
 	chat.ExportUpdateCommandPicker(m)
 
 	assert.False(t, chat.ExportShowCommandPicker(m))
+	// Option picker should be active for commands with options
+	assert.True(t, chat.ExportShowOptionPicker(m))
 }
 
 func TestUpdateCommandPicker_HidesOnEmptyInput(t *testing.T) {
@@ -168,11 +171,193 @@ func newCommandPickerTestParams() chat.Params {
 func setTestCommands(m *chat.Model) {
 	config := chat.ExportGetSessionConfig(m)
 	config.Commands = []copilot.CommandDefinition{
-		{Name: "mode", Description: "Switch chat mode"},
-		{Name: "model", Description: "Switch LLM model"},
-		{Name: "new", Description: "Start a new chat session"},
-		{Name: "sessions", Description: "Open session picker"},
-		{Name: "help", Description: "Show help"},
-		{Name: "clear", Description: "Clear viewport"},
+		{Name: "mode", Description: "Switch chat mode", Handler: func(_ copilot.CommandContext) error { return nil }},
+		{Name: "model", Description: "Switch LLM model", Handler: func(_ copilot.CommandContext) error { return nil }},
+		{Name: "new", Description: "Start a new chat session", Handler: func(_ copilot.CommandContext) error { return nil }},
+		{Name: "sessions", Description: "Open session picker", Handler: func(_ copilot.CommandContext) error { return nil }},
+		{Name: "help", Description: "Show help", Handler: func(_ copilot.CommandContext) error { return nil }},
+		{Name: "clear", Description: "Clear viewport", Handler: func(_ copilot.CommandContext) error { return nil }},
 	}
+}
+
+// --- tryDispatchSlashCommand tests ---
+
+func TestTryDispatchSlashCommand_ValidCommand(t *testing.T) {
+	t.Parallel()
+
+	var calledArgs string
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	config := chat.ExportGetSessionConfig(m)
+	config.Commands = []copilot.CommandDefinition{
+		{Name: "mode", Handler: func(ctx copilot.CommandContext) error {
+			calledArgs = ctx.Args
+			return nil
+		}},
+	}
+
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/mode plan")
+
+	assert.True(t, handled)
+	assert.Equal(t, "plan", calledArgs)
+	assert.NoError(t, chat.ExportGetErr(m))
+}
+
+func TestTryDispatchSlashCommand_CommandWithoutArgs(t *testing.T) {
+	t.Parallel()
+
+	called := false
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	config := chat.ExportGetSessionConfig(m)
+	config.Commands = []copilot.CommandDefinition{
+		{Name: "clear", Handler: func(_ copilot.CommandContext) error {
+			called = true
+			return nil
+		}},
+	}
+
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/clear")
+
+	assert.True(t, handled)
+	assert.True(t, called)
+}
+
+func TestTryDispatchSlashCommand_UnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/unknown")
+
+	assert.True(t, handled)
+	assert.Error(t, chat.ExportGetErr(m))
+	assert.Contains(t, chat.ExportGetErr(m).Error(), "unknown command: /unknown")
+}
+
+func TestTryDispatchSlashCommand_NotSlashCommand(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "hello world")
+
+	assert.False(t, handled)
+}
+
+func TestTryDispatchSlashCommand_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	called := false
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	config := chat.ExportGetSessionConfig(m)
+	config.Commands = []copilot.CommandDefinition{
+		{Name: "mode", Handler: func(_ copilot.CommandContext) error {
+			called = true
+			return nil
+		}},
+	}
+
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/MODE plan")
+
+	assert.True(t, handled)
+	assert.True(t, called)
+}
+
+// --- Option picker tests ---
+
+func TestOptionPicker_ShowsOnCommandWithSpace(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/mode ")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.False(t, chat.ExportShowCommandPicker(m))
+	assert.True(t, chat.ExportShowOptionPicker(m))
+	assert.Equal(t, "mode", chat.ExportActiveCommandName(m))
+	assert.Equal(t, 3, len(chat.ExportFilteredOptions(m))) // interactive, plan, autopilot
+}
+
+func TestOptionPicker_FiltersOnPartialArg(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/mode pl")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.True(t, chat.ExportShowOptionPicker(m))
+
+	filtered := chat.ExportFilteredOptions(m)
+	assert.Equal(t, 1, len(filtered))
+	assert.Equal(t, "plan", filtered[0].Name)
+}
+
+func TestOptionPicker_HidesForCommandWithoutOptions(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/clear ")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.False(t, chat.ExportShowCommandPicker(m))
+	assert.False(t, chat.ExportShowOptionPicker(m))
+}
+
+func TestOptionPicker_ClampsIndex(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	// Show all options
+	chat.ExportSetTextareaValue(m, "/mode ")
+	chat.ExportUpdateCommandPicker(m)
+
+	// Set index beyond what filter will produce
+	chat.ExportSetOptionPickerIndex(m, 2)
+
+	// Now filter to single option
+	chat.ExportSetTextareaValue(m, "/mode pl")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.True(t, chat.ExportShowOptionPicker(m))
+	assert.Equal(t, 0, chat.ExportOptionPickerIndex(m))
+}
+
+func TestOptionPicker_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/mode PL")
+	chat.ExportUpdateCommandPicker(m)
+
+	assert.True(t, chat.ExportShowOptionPicker(m))
+	assert.Equal(t, 1, len(chat.ExportFilteredOptions(m)))
+}
+
+// --- pickerExtraHeight tests ---
+
+func TestPickerExtraHeight_OptionPicker(t *testing.T) {
+	t.Parallel()
+
+	m := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(m)
+
+	chat.ExportSetTextareaValue(m, "/mode ")
+	chat.ExportUpdateCommandPicker(m)
+
+	// 3 options + 2 for border
+	assert.Equal(t, 5, chat.ExportPickerExtraHeight(m))
 }

--- a/pkg/cli/ui/chat/command_picker_test.go
+++ b/pkg/cli/ui/chat/command_picker_test.go
@@ -78,25 +78,25 @@ func TestUpdateCommandPicker_HidesOnSpaceAfterCommand(t *testing.T) {
 func TestUpdateCommandPicker_HidesOnEmptyInput(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.False(t, chat.ExportShowCommandPicker(m))
+	assert.False(t, chat.ExportShowCommandPicker(model))
 }
 
 func TestUpdateCommandPicker_HidesOnNonSlashInput(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "hello")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "hello")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.False(t, chat.ExportShowCommandPicker(m))
+	assert.False(t, chat.ExportShowCommandPicker(model))
 }
 
 func TestUpdateCommandPicker_ClampsIndex(t *testing.T) {
@@ -123,14 +123,14 @@ func TestUpdateCommandPicker_ClampsIndex(t *testing.T) {
 func TestUpdateCommandPicker_CaseInsensitive(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/MO")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/MO")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.True(t, chat.ExportShowCommandPicker(m))
-	assert.Equal(t, 2, len(chat.ExportFilteredCommands(m)))
+	assert.True(t, chat.ExportShowCommandPicker(model))
+	assert.Equal(t, 2, len(chat.ExportFilteredCommands(model)))
 }
 
 // --- commandPickerExtraHeight tests ---
@@ -138,22 +138,22 @@ func TestUpdateCommandPicker_CaseInsensitive(t *testing.T) {
 func TestCommandPickerExtraHeight_WhenHidden(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
+	model := chat.NewModel(newCommandPickerTestParams())
 
-	assert.Equal(t, 0, chat.ExportCommandPickerExtraHeight(m))
+	assert.Equal(t, 0, chat.ExportCommandPickerExtraHeight(model))
 }
 
 func TestCommandPickerExtraHeight_WhenShown(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/")
+	chat.ExportUpdateCommandPicker(model)
 
 	// 6 commands + 2 for border
-	assert.Equal(t, 8, chat.ExportCommandPickerExtraHeight(m))
+	assert.Equal(t, 8, chat.ExportCommandPickerExtraHeight(model))
 }
 
 // --- helpers ---
@@ -240,10 +240,10 @@ func TestTryDispatchSlashCommand_UnknownCommand(t *testing.T) {
 func TestTryDispatchSlashCommand_NotSlashCommand(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "hello world")
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(model, "hello world")
 
 	assert.False(t, handled)
 }
@@ -253,8 +253,8 @@ func TestTryDispatchSlashCommand_CaseInsensitive(t *testing.T) {
 
 	called := false
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	config := chat.ExportGetSessionConfig(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	config := chat.ExportGetSessionConfig(model)
 	config.Commands = []copilot.CommandDefinition{
 		{Name: "mode", Handler: func(_ copilot.CommandContext) error {
 			called = true
@@ -262,7 +262,7 @@ func TestTryDispatchSlashCommand_CaseInsensitive(t *testing.T) {
 		}},
 	}
 
-	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/MODE plan")
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(model, "/MODE plan")
 
 	assert.True(t, handled)
 	assert.True(t, called)
@@ -273,30 +273,30 @@ func TestTryDispatchSlashCommand_CaseInsensitive(t *testing.T) {
 func TestOptionPicker_ShowsOnCommandWithSpace(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/mode ")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mode ")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.False(t, chat.ExportShowCommandPicker(m))
-	assert.True(t, chat.ExportShowOptionPicker(m))
-	assert.Equal(t, "mode", chat.ExportActiveCommandName(m))
-	assert.Equal(t, 3, len(chat.ExportFilteredOptions(m))) // interactive, plan, autopilot
+	assert.False(t, chat.ExportShowCommandPicker(model))
+	assert.True(t, chat.ExportShowOptionPicker(model))
+	assert.Equal(t, "mode", chat.ExportActiveCommandName(model))
+	assert.Equal(t, 3, len(chat.ExportFilteredOptions(model))) // interactive, plan, autopilot
 }
 
 func TestOptionPicker_FiltersOnPartialArg(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/mode pl")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mode pl")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.True(t, chat.ExportShowOptionPicker(m))
+	assert.True(t, chat.ExportShowOptionPicker(model))
 
-	filtered := chat.ExportFilteredOptions(m)
+	filtered := chat.ExportFilteredOptions(model)
 	assert.Equal(t, 1, len(filtered))
 	assert.Equal(t, "plan", filtered[0].Name)
 }
@@ -304,48 +304,48 @@ func TestOptionPicker_FiltersOnPartialArg(t *testing.T) {
 func TestOptionPicker_HidesForCommandWithoutOptions(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/clear ")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/clear ")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.False(t, chat.ExportShowCommandPicker(m))
-	assert.False(t, chat.ExportShowOptionPicker(m))
+	assert.False(t, chat.ExportShowCommandPicker(model))
+	assert.False(t, chat.ExportShowOptionPicker(model))
 }
 
 func TestOptionPicker_ClampsIndex(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
 	// Show all options
-	chat.ExportSetTextareaValue(m, "/mode ")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mode ")
+	chat.ExportUpdateCommandPicker(model)
 
 	// Set index beyond what filter will produce
-	chat.ExportSetOptionPickerIndex(m, 2)
+	chat.ExportSetOptionPickerIndex(model, 2)
 
 	// Now filter to single option
-	chat.ExportSetTextareaValue(m, "/mode pl")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mode pl")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.True(t, chat.ExportShowOptionPicker(m))
-	assert.Equal(t, 0, chat.ExportOptionPickerIndex(m))
+	assert.True(t, chat.ExportShowOptionPicker(model))
+	assert.Equal(t, 0, chat.ExportOptionPickerIndex(model))
 }
 
 func TestOptionPicker_CaseInsensitive(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/mode PL")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mode PL")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.True(t, chat.ExportShowOptionPicker(m))
-	assert.Equal(t, 1, len(chat.ExportFilteredOptions(m)))
+	assert.True(t, chat.ExportShowOptionPicker(model))
+	assert.Equal(t, 1, len(chat.ExportFilteredOptions(model)))
 }
 
 // --- pickerExtraHeight tests ---
@@ -353,12 +353,12 @@ func TestOptionPicker_CaseInsensitive(t *testing.T) {
 func TestPickerExtraHeight_OptionPicker(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/mode ")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mode ")
+	chat.ExportUpdateCommandPicker(model)
 
 	// 3 options + 2 for border
-	assert.Equal(t, 5, chat.ExportPickerExtraHeight(m))
+	assert.Equal(t, 5, chat.ExportPickerExtraHeight(model))
 }

--- a/pkg/cli/ui/chat/command_picker_test.go
+++ b/pkg/cli/ui/chat/command_picker_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/devantler-tech/ksail/v6/pkg/cli/ui/chat"
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- updateCommandPicker tests ---
@@ -14,14 +15,14 @@ import (
 func TestUpdateCommandPicker_ShowsOnSlash(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.True(t, chat.ExportShowCommandPicker(m))
-	assert.Equal(t, 6, len(chat.ExportFilteredCommands(m))) // all commands match
+	assert.True(t, chat.ExportShowCommandPicker(model))
+	assert.Equal(t, 6, len(chat.ExportFilteredCommands(model))) // all commands match
 }
 
 func TestUpdateCommandPicker_FiltersOnPartialInput(t *testing.T) {
@@ -50,28 +51,28 @@ func TestUpdateCommandPicker_FiltersOnPartialInput(t *testing.T) {
 func TestUpdateCommandPicker_HidesWhenNoMatch(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/xyz")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/xyz")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.False(t, chat.ExportShowCommandPicker(m))
+	assert.False(t, chat.ExportShowCommandPicker(model))
 }
 
 func TestUpdateCommandPicker_HidesOnSpaceAfterCommand(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
 	// /mode has options, so command picker hides but option picker shows
-	chat.ExportSetTextareaValue(m, "/mode plan")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mode plan")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.False(t, chat.ExportShowCommandPicker(m))
+	assert.False(t, chat.ExportShowCommandPicker(model))
 	// Option picker should be active for commands with options
-	assert.True(t, chat.ExportShowOptionPicker(m))
+	assert.True(t, chat.ExportShowOptionPicker(model))
 }
 
 func TestUpdateCommandPicker_HidesOnEmptyInput(t *testing.T) {
@@ -208,8 +209,8 @@ func TestTryDispatchSlashCommand_CommandWithoutArgs(t *testing.T) {
 
 	called := false
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	config := chat.ExportGetSessionConfig(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	config := chat.ExportGetSessionConfig(model)
 	config.Commands = []copilot.CommandDefinition{
 		{Name: "clear", Handler: func(_ copilot.CommandContext) error {
 			called = true
@@ -217,7 +218,7 @@ func TestTryDispatchSlashCommand_CommandWithoutArgs(t *testing.T) {
 		}},
 	}
 
-	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/clear")
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(model, "/clear")
 
 	assert.True(t, handled)
 	assert.True(t, called)
@@ -226,14 +227,14 @@ func TestTryDispatchSlashCommand_CommandWithoutArgs(t *testing.T) {
 func TestTryDispatchSlashCommand_UnknownCommand(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/unknown")
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(model, "/unknown")
 
 	assert.True(t, handled)
-	assert.Error(t, chat.ExportGetErr(m))
-	assert.Contains(t, chat.ExportGetErr(m).Error(), "unknown command: /unknown")
+	require.Error(t, chat.ExportGetErr(model))
+	assert.Contains(t, chat.ExportGetErr(model).Error(), "unknown command: /unknown")
 }
 
 func TestTryDispatchSlashCommand_NotSlashCommand(t *testing.T) {

--- a/pkg/cli/ui/chat/command_picker_test.go
+++ b/pkg/cli/ui/chat/command_picker_test.go
@@ -28,15 +28,15 @@ func TestUpdateCommandPicker_ShowsOnSlash(t *testing.T) {
 func TestUpdateCommandPicker_FiltersOnPartialInput(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
-	chat.ExportSetTextareaValue(m, "/mo")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/mo")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.True(t, chat.ExportShowCommandPicker(m))
+	assert.True(t, chat.ExportShowCommandPicker(model))
 
-	filtered := chat.ExportFilteredCommands(m)
+	filtered := chat.ExportFilteredCommands(model)
 	assert.Equal(t, 2, len(filtered)) // /mode, /model
 
 	names := make([]string, len(filtered))
@@ -102,22 +102,22 @@ func TestUpdateCommandPicker_HidesOnNonSlashInput(t *testing.T) {
 func TestUpdateCommandPicker_ClampsIndex(t *testing.T) {
 	t.Parallel()
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	setTestCommands(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	setTestCommands(model)
 
 	// First show all commands
-	chat.ExportSetTextareaValue(m, "/")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/")
+	chat.ExportUpdateCommandPicker(model)
 
 	// Navigate to last item
-	chat.ExportSetCommandPickerIndex(m, 5)
+	chat.ExportSetCommandPickerIndex(model, 5)
 
 	// Now filter to fewer items
-	chat.ExportSetTextareaValue(m, "/cl")
-	chat.ExportUpdateCommandPicker(m)
+	chat.ExportSetTextareaValue(model, "/cl")
+	chat.ExportUpdateCommandPicker(model)
 
-	assert.True(t, chat.ExportShowCommandPicker(m))
-	assert.Equal(t, 0, chat.ExportCommandPickerIndex(m)) // clamped to 0
+	assert.True(t, chat.ExportShowCommandPicker(model))
+	assert.Equal(t, 0, chat.ExportCommandPickerIndex(model)) // clamped to 0
 }
 
 func TestUpdateCommandPicker_CaseInsensitive(t *testing.T) {
@@ -188,8 +188,8 @@ func TestTryDispatchSlashCommand_ValidCommand(t *testing.T) {
 
 	var calledArgs string
 
-	m := chat.NewModel(newCommandPickerTestParams())
-	config := chat.ExportGetSessionConfig(m)
+	model := chat.NewModel(newCommandPickerTestParams())
+	config := chat.ExportGetSessionConfig(model)
 	config.Commands = []copilot.CommandDefinition{
 		{Name: "mode", Handler: func(ctx copilot.CommandContext) error {
 			calledArgs = ctx.Args
@@ -197,11 +197,11 @@ func TestTryDispatchSlashCommand_ValidCommand(t *testing.T) {
 		}},
 	}
 
-	handled, _, _ := chat.ExportTryDispatchSlashCommand(m, "/mode plan")
+	handled, _, _ := chat.ExportTryDispatchSlashCommand(model, "/mode plan")
 
 	assert.True(t, handled)
 	assert.Equal(t, "plan", calledArgs)
-	assert.NoError(t, chat.ExportGetErr(m))
+	assert.NoError(t, chat.ExportGetErr(model))
 }
 
 func TestTryDispatchSlashCommand_CommandWithoutArgs(t *testing.T) {

--- a/pkg/cli/ui/chat/commands.go
+++ b/pkg/cli/ui/chat/commands.go
@@ -1,12 +1,19 @@
 package chat
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	copilot "github.com/github/copilot-sdk/go"
+)
+
+// Sentinel errors for slash command validation.
+var (
+	errModeUsage   = errors.New("usage: /mode <interactive|plan|autopilot>")
+	errUnknownMode = errors.New("invalid mode")
 )
 
 // Slash command message types sent from command handlers to the TUI event channel.
@@ -50,11 +57,11 @@ type CommandOptionProvider func(m *Model) []CommandOption
 // Returns the mode and true if valid, or InteractiveMode and false if invalid.
 func ParseChatMode(name string) (ChatMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "interactive":
+	case modeNameInteractive:
 		return InteractiveMode, true
-	case "plan":
+	case modeNamePlan:
 		return PlanMode, true
-	case "autopilot":
+	case modeNameAutopilot:
 		return AutopilotMode, true
 	default:
 		return InteractiveMode, false
@@ -158,12 +165,12 @@ func BuildNonTUISlashCommands(writer io.Writer) []copilot.CommandDefinition {
 func handleModeCommand(args string, eventChan chan<- tea.Msg) error {
 	args = strings.TrimSpace(args)
 	if args == "" {
-		return fmt.Errorf("usage: /mode <interactive|plan|autopilot>")
+		return errModeUsage
 	}
 
 	mode, ok := ParseChatMode(args)
 	if !ok {
-		return fmt.Errorf("invalid mode %q: use interactive, plan, or autopilot", args)
+		return fmt.Errorf("%w %q: use interactive, plan, or autopilot", errUnknownMode, args)
 	}
 
 	eventChan <- modeChangeRequestMsg{Mode: mode}
@@ -195,19 +202,19 @@ func BuildTUICommandOptions() map[string]CommandOptionProvider {
 				{Name: "autopilot", Description: "Act autonomously"},
 			}
 		},
-		"model": func(m *Model) []CommandOption {
-			if len(m.availableModels) == 0 {
-				allModels, err := m.client.ListModels(m.ctx)
+		"model": func(model *Model) []CommandOption {
+			if len(model.availableModels) == 0 {
+				allModels, err := model.client.ListModels(model.ctx)
 				if err == nil {
-					m.availableModels = FilterEnabledModels(allModels)
+					model.availableModels = FilterEnabledModels(allModels)
 				}
 			}
 
-			options := make([]CommandOption, 0, len(m.availableModels))
-			for _, model := range m.availableModels {
+			options := make([]CommandOption, 0, len(model.availableModels))
+			for _, mdl := range model.availableModels {
 				options = append(options, CommandOption{
-					Name:        model.ID,
-					Description: model.Name,
+					Name:        mdl.ID,
+					Description: mdl.Name,
 				})
 			}
 

--- a/pkg/cli/ui/chat/commands.go
+++ b/pkg/cli/ui/chat/commands.go
@@ -91,6 +91,7 @@ func BuildTUISlashCommands(eventChan chan<- tea.Msg) []copilot.CommandDefinition
 			Description: "Start a new chat session",
 			Handler: func(_ copilot.CommandContext) error {
 				eventChan <- newChatRequestMsg{}
+
 				return nil
 			},
 		},
@@ -99,6 +100,7 @@ func BuildTUISlashCommands(eventChan chan<- tea.Msg) []copilot.CommandDefinition
 			Description: "Open session history picker",
 			Handler: func(_ copilot.CommandContext) error {
 				eventChan <- openSessionPickerMsg{}
+
 				return nil
 			},
 		},
@@ -107,6 +109,7 @@ func BuildTUISlashCommands(eventChan chan<- tea.Msg) []copilot.CommandDefinition
 			Description: "Show keyboard shortcuts and commands",
 			Handler: func(_ copilot.CommandContext) error {
 				eventChan <- showHelpMsg{}
+
 				return nil
 			},
 		},
@@ -115,6 +118,7 @@ func BuildTUISlashCommands(eventChan chan<- tea.Msg) []copilot.CommandDefinition
 			Description: "Clear the chat viewport",
 			Handler: func(_ copilot.CommandContext) error {
 				eventChan <- clearViewportMsg{}
+
 				return nil
 			},
 		},
@@ -131,7 +135,10 @@ func BuildNonTUISlashCommands(writer io.Writer) []copilot.CommandDefinition {
 			Handler: func(_ copilot.CommandContext) error {
 				_, _ = fmt.Fprintln(writer, "\nAvailable commands:")
 				_, _ = fmt.Fprintln(writer, "  /help              Show this help")
-				_, _ = fmt.Fprintln(writer, "  /mode <mode>       Switch mode (interactive, plan, autopilot)")
+				_, _ = fmt.Fprintln(
+					writer,
+					"  /mode <mode>       Switch mode (interactive, plan, autopilot)",
+				)
 				_, _ = fmt.Fprintln(writer, "  exit, quit, q      Exit the chat")
 				_, _ = fmt.Fprintln(writer, "")
 
@@ -145,16 +152,23 @@ func BuildNonTUISlashCommands(writer io.Writer) []copilot.CommandDefinition {
 				args := strings.TrimSpace(ctx.Args)
 				if args == "" {
 					_, _ = fmt.Fprintln(writer, "Usage: /mode <interactive|plan|autopilot>")
+
 					return nil
 				}
 
 				_, ok := ParseChatMode(args)
 				if !ok {
-					_, _ = fmt.Fprintf(writer, "Invalid mode %q: use interactive, plan, or autopilot\n", args)
+					_, _ = fmt.Fprintf(
+						writer,
+						"Invalid mode %q: use interactive, plan, or autopilot\n",
+						args,
+					)
+
 					return nil
 				}
 
 				_, _ = fmt.Fprintf(writer, "Switched to %s mode\n", args)
+
 				return nil
 			},
 		},
@@ -183,6 +197,7 @@ func handleModelCommand(args string, eventChan chan<- tea.Msg) error {
 	args = strings.TrimSpace(args)
 	if args == "" {
 		eventChan <- openModelPickerMsg{}
+
 		return nil
 	}
 

--- a/pkg/cli/ui/chat/commands.go
+++ b/pkg/cli/ui/chat/commands.go
@@ -1,0 +1,175 @@
+package chat
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+// Slash command message types sent from command handlers to the TUI event channel.
+
+// modeChangeRequestMsg requests a specific chat mode change via slash command.
+type modeChangeRequestMsg struct {
+	Mode ChatMode
+}
+
+// openModelPickerMsg requests the model picker to be opened.
+type openModelPickerMsg struct{}
+
+// modelSetRequestMsg requests a specific model change via slash command.
+type modelSetRequestMsg struct {
+	Model string
+}
+
+// openSessionPickerMsg requests the session picker to be opened.
+type openSessionPickerMsg struct{}
+
+// newChatRequestMsg requests creation of a new chat session.
+type newChatRequestMsg struct{}
+
+// showHelpMsg requests the help overlay to be shown.
+type showHelpMsg struct{}
+
+// clearViewportMsg requests the viewport to be cleared.
+type clearViewportMsg struct{}
+
+// ParseChatMode parses a string into a ChatMode.
+// Returns the mode and true if valid, or InteractiveMode and false if invalid.
+func ParseChatMode(name string) (ChatMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "interactive":
+		return InteractiveMode, true
+	case "plan":
+		return PlanMode, true
+	case "autopilot":
+		return AutopilotMode, true
+	default:
+		return InteractiveMode, false
+	}
+}
+
+// BuildTUISlashCommands creates slash command definitions for the TUI chat.
+// Each command handler sends a message to the TUI event channel for processing.
+func BuildTUISlashCommands(eventChan chan<- tea.Msg) []copilot.CommandDefinition {
+	return []copilot.CommandDefinition{
+		{
+			Name:        "mode",
+			Description: "Switch chat mode (interactive, plan, autopilot)",
+			Handler: func(ctx copilot.CommandContext) error {
+				return handleModeCommand(ctx.Args, eventChan)
+			},
+		},
+		{
+			Name:        "model",
+			Description: "Switch LLM model (opens picker if no name given)",
+			Handler: func(ctx copilot.CommandContext) error {
+				return handleModelCommand(ctx.Args, eventChan)
+			},
+		},
+		{
+			Name:        "new",
+			Description: "Start a new chat session",
+			Handler: func(_ copilot.CommandContext) error {
+				eventChan <- newChatRequestMsg{}
+				return nil
+			},
+		},
+		{
+			Name:        "sessions",
+			Description: "Open session history picker",
+			Handler: func(_ copilot.CommandContext) error {
+				eventChan <- openSessionPickerMsg{}
+				return nil
+			},
+		},
+		{
+			Name:        "help",
+			Description: "Show keyboard shortcuts and commands",
+			Handler: func(_ copilot.CommandContext) error {
+				eventChan <- showHelpMsg{}
+				return nil
+			},
+		},
+		{
+			Name:        "clear",
+			Description: "Clear the chat viewport",
+			Handler: func(_ copilot.CommandContext) error {
+				eventChan <- clearViewportMsg{}
+				return nil
+			},
+		},
+	}
+}
+
+// BuildNonTUISlashCommands creates slash command definitions for non-TUI chat mode.
+// Commands perform actions directly since there is no TUI event channel.
+func BuildNonTUISlashCommands(writer io.Writer) []copilot.CommandDefinition {
+	return []copilot.CommandDefinition{
+		{
+			Name:        "help",
+			Description: "Show available commands",
+			Handler: func(_ copilot.CommandContext) error {
+				_, _ = fmt.Fprintln(writer, "\nAvailable commands:")
+				_, _ = fmt.Fprintln(writer, "  /help              Show this help")
+				_, _ = fmt.Fprintln(writer, "  /mode <mode>       Switch mode (interactive, plan, autopilot)")
+				_, _ = fmt.Fprintln(writer, "  exit, quit, q      Exit the chat")
+				_, _ = fmt.Fprintln(writer, "")
+
+				return nil
+			},
+		},
+		{
+			Name:        "mode",
+			Description: "Switch chat mode (interactive, plan, autopilot)",
+			Handler: func(ctx copilot.CommandContext) error {
+				args := strings.TrimSpace(ctx.Args)
+				if args == "" {
+					_, _ = fmt.Fprintln(writer, "Usage: /mode <interactive|plan|autopilot>")
+					return nil
+				}
+
+				_, ok := ParseChatMode(args)
+				if !ok {
+					_, _ = fmt.Fprintf(writer, "Invalid mode %q: use interactive, plan, or autopilot\n", args)
+					return nil
+				}
+
+				_, _ = fmt.Fprintf(writer, "Switched to %s mode\n", args)
+				return nil
+			},
+		},
+	}
+}
+
+// handleModeCommand parses mode args and sends the appropriate message.
+func handleModeCommand(args string, eventChan chan<- tea.Msg) error {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return fmt.Errorf("usage: /mode <interactive|plan|autopilot>")
+	}
+
+	mode, ok := ParseChatMode(args)
+	if !ok {
+		return fmt.Errorf("invalid mode %q: use interactive, plan, or autopilot", args)
+	}
+
+	eventChan <- modeChangeRequestMsg{Mode: mode}
+
+	return nil
+}
+
+// handleModelCommand parses model args and sends the appropriate message.
+func handleModelCommand(args string, eventChan chan<- tea.Msg) error {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		eventChan <- openModelPickerMsg{}
+		return nil
+	}
+
+	eventChan <- modelSetRequestMsg{Model: args}
+
+	return nil
+}

--- a/pkg/cli/ui/chat/commands.go
+++ b/pkg/cli/ui/chat/commands.go
@@ -36,6 +36,16 @@ type showHelpMsg struct{}
 // clearViewportMsg requests the viewport to be cleared.
 type clearViewportMsg struct{}
 
+// CommandOption represents a selectable option for a slash command argument.
+type CommandOption struct {
+	Name        string
+	Description string
+}
+
+// CommandOptionProvider returns the available options for a command.
+// It receives the Model to support dynamic options (e.g., model list).
+type CommandOptionProvider func(m *Model) []CommandOption
+
 // ParseChatMode parses a string into a ChatMode.
 // Returns the mode and true if valid, or InteractiveMode and false if invalid.
 func ParseChatMode(name string) (ChatMode, bool) {
@@ -172,4 +182,36 @@ func handleModelCommand(args string, eventChan chan<- tea.Msg) error {
 	eventChan <- modelSetRequestMsg{Model: args}
 
 	return nil
+}
+
+// BuildTUICommandOptions returns a map of command name → option provider
+// for commands that support argument autocompletion.
+func BuildTUICommandOptions() map[string]CommandOptionProvider {
+	return map[string]CommandOptionProvider{
+		"mode": func(_ *Model) []CommandOption {
+			return []CommandOption{
+				{Name: "interactive", Description: "Confirm each action"},
+				{Name: "plan", Description: "Create plans before acting"},
+				{Name: "autopilot", Description: "Act autonomously"},
+			}
+		},
+		"model": func(m *Model) []CommandOption {
+			if len(m.availableModels) == 0 {
+				allModels, err := m.client.ListModels(m.ctx)
+				if err == nil {
+					m.availableModels = FilterEnabledModels(allModels)
+				}
+			}
+
+			options := make([]CommandOption, 0, len(m.availableModels))
+			for _, model := range m.availableModels {
+				options = append(options, CommandOption{
+					Name:        model.ID,
+					Description: model.Name,
+				})
+			}
+
+			return options
+		},
+	}
 }

--- a/pkg/cli/ui/chat/commands_test.go
+++ b/pkg/cli/ui/chat/commands_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testModeCmd = "mode"
+
 // --- ParseChatMode tests ---
 
 func TestParseChatMode_ValidModes(t *testing.T) {
@@ -136,7 +138,7 @@ func TestBuildTUISlashCommands_ModeSendsMessage(t *testing.T) {
 
 	var modeCmd *chat.ExportCommandDefinition
 	for i := range commands {
-		if commands[i].Name == "mode" {
+		if commands[i].Name == testModeCmd {
 			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
 
 			break
@@ -162,7 +164,7 @@ func TestBuildTUISlashCommands_ModeEmptyArgsReturnsError(t *testing.T) {
 
 	var modeCmd *chat.ExportCommandDefinition
 	for i := range commands {
-		if commands[i].Name == "mode" {
+		if commands[i].Name == testModeCmd {
 			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
 
 			break
@@ -172,7 +174,7 @@ func TestBuildTUISlashCommands_ModeEmptyArgsReturnsError(t *testing.T) {
 	require.NotNil(t, modeCmd, "/mode command not found")
 
 	err := modeCmd.Def.Handler(chat.ExportCommandContext{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "usage")
 }
 
@@ -184,7 +186,7 @@ func TestBuildTUISlashCommands_ModeInvalidReturnsError(t *testing.T) {
 
 	var modeCmd *chat.ExportCommandDefinition
 	for i := range commands {
-		if commands[i].Name == "mode" {
+		if commands[i].Name == testModeCmd {
 			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
 
 			break
@@ -194,7 +196,7 @@ func TestBuildTUISlashCommands_ModeInvalidReturnsError(t *testing.T) {
 	require.NotNil(t, modeCmd, "/mode command not found")
 
 	err := modeCmd.Def.Handler(chat.ExportCommandContextWithArgs("badmode"))
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid mode")
 }
 

--- a/pkg/cli/ui/chat/commands_test.go
+++ b/pkg/cli/ui/chat/commands_test.go
@@ -1,0 +1,289 @@
+package chat_test
+
+import (
+	"bytes"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/devantler-tech/ksail/v6/pkg/cli/ui/chat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- ParseChatMode tests ---
+
+func TestParseChatMode_ValidModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected chat.ChatMode
+	}{
+		{"interactive", chat.InteractiveMode},
+		{"plan", chat.PlanMode},
+		{"autopilot", chat.AutopilotMode},
+		{"INTERACTIVE", chat.InteractiveMode},
+		{"Plan", chat.PlanMode},
+		{"AUTOPILOT", chat.AutopilotMode},
+		{"  plan  ", chat.PlanMode},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.input, func(t *testing.T) {
+			t.Parallel()
+
+			mode, ok := chat.ParseChatMode(testCase.input)
+			assert.True(t, ok, "ParseChatMode(%q) should succeed", testCase.input)
+			assert.Equal(t, testCase.expected, mode)
+		})
+	}
+}
+
+func TestParseChatMode_InvalidModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{"", "invalid", "auto", "manual", "planning"}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			_, ok := chat.ParseChatMode(input)
+			assert.False(t, ok, "ParseChatMode(%q) should fail", input)
+		})
+	}
+}
+
+// --- BuildTUISlashCommands tests ---
+
+func TestBuildTUISlashCommands_ReturnsExpectedCommands(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	expectedNames := []string{"mode", "model", "new", "sessions", "help", "clear"}
+	actualNames := make([]string, len(commands))
+
+	for i, cmd := range commands {
+		actualNames[i] = cmd.Name
+	}
+
+	assert.Equal(t, expectedNames, actualNames)
+
+	for _, cmd := range commands {
+		assert.NotEmpty(t, cmd.Description)
+		assert.NotNil(t, cmd.Handler)
+	}
+}
+
+func TestBuildTUISlashCommands_ClearSendsMessage(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	// Find /clear command
+	var clearCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "clear" {
+			clearCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, clearCmd, "/clear command not found")
+
+	err := clearCmd.Def.Handler(chat.ExportCommandContext{})
+	require.NoError(t, err)
+
+	msg := <-eventChan
+	_, ok := msg.(chat.ExportClearViewportMsg)
+	assert.True(t, ok, "expected clearViewportMsg, got %T", msg)
+}
+
+func TestBuildTUISlashCommands_HelpSendsMessage(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	var helpCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "help" {
+			helpCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, helpCmd, "/help command not found")
+
+	err := helpCmd.Def.Handler(chat.ExportCommandContext{})
+	require.NoError(t, err)
+
+	msg := <-eventChan
+	_, ok := msg.(chat.ExportShowHelpMsg)
+	assert.True(t, ok, "expected showHelpMsg, got %T", msg)
+}
+
+func TestBuildTUISlashCommands_ModeSendsMessage(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	var modeCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "mode" {
+			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, modeCmd, "/mode command not found")
+
+	err := modeCmd.Def.Handler(chat.ExportCommandContextWithArgs("plan"))
+	require.NoError(t, err)
+
+	msg := <-eventChan
+	modeMsg, ok := msg.(chat.ExportModeChangeRequestMsg)
+	assert.True(t, ok, "expected modeChangeRequestMsg, got %T", msg)
+	assert.Equal(t, chat.PlanMode, modeMsg.Mode)
+}
+
+func TestBuildTUISlashCommands_ModeEmptyArgsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	var modeCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "mode" {
+			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, modeCmd, "/mode command not found")
+
+	err := modeCmd.Def.Handler(chat.ExportCommandContext{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "usage")
+}
+
+func TestBuildTUISlashCommands_ModeInvalidReturnsError(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	var modeCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "mode" {
+			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, modeCmd, "/mode command not found")
+
+	err := modeCmd.Def.Handler(chat.ExportCommandContextWithArgs("badmode"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+func TestBuildTUISlashCommands_ModelNoArgsSendsPicker(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	var modelCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "model" {
+			modelCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, modelCmd, "/model command not found")
+
+	err := modelCmd.Def.Handler(chat.ExportCommandContext{})
+	require.NoError(t, err)
+
+	msg := <-eventChan
+	_, ok := msg.(chat.ExportOpenModelPickerMsg)
+	assert.True(t, ok, "expected openModelPickerMsg, got %T", msg)
+}
+
+func TestBuildTUISlashCommands_ModelWithArgsSendsSetRequest(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 10)
+	commands := chat.BuildTUISlashCommands(eventChan)
+
+	var modelCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "model" {
+			modelCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, modelCmd, "/model command not found")
+
+	err := modelCmd.Def.Handler(chat.ExportCommandContextWithArgs("gpt-5"))
+	require.NoError(t, err)
+
+	msg := <-eventChan
+	setMsg, ok := msg.(chat.ExportModelSetRequestMsg)
+	assert.True(t, ok, "expected modelSetRequestMsg, got %T", msg)
+	assert.Equal(t, "gpt-5", setMsg.Model)
+}
+
+// --- BuildNonTUISlashCommands tests ---
+
+func TestBuildNonTUISlashCommands_ReturnsExpectedCommands(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	commands := chat.BuildNonTUISlashCommands(&buf)
+
+	assert.NotEmpty(t, commands)
+
+	for _, cmd := range commands {
+		assert.NotEmpty(t, cmd.Name)
+		assert.NotEmpty(t, cmd.Description)
+		assert.NotNil(t, cmd.Handler)
+	}
+}
+
+func TestBuildNonTUISlashCommands_HelpPrintsOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	commands := chat.BuildNonTUISlashCommands(&buf)
+
+	var helpCmd *chat.ExportCommandDefinition
+	for i := range commands {
+		if commands[i].Name == "help" {
+			helpCmd = &chat.ExportCommandDefinition{Def: commands[i]}
+
+			break
+		}
+	}
+
+	require.NotNil(t, helpCmd, "/help command not found")
+
+	err := helpCmd.Def.Handler(chat.ExportCommandContext{})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Available commands")
+}

--- a/pkg/cli/ui/chat/commands_test.go
+++ b/pkg/cli/ui/chat/commands_test.go
@@ -87,6 +87,7 @@ func TestBuildTUISlashCommands_ClearSendsMessage(t *testing.T) {
 
 	// Find /clear command
 	var clearCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == "clear" {
 			clearCmd = &chat.ExportCommandDefinition{Def: commands[i]}
@@ -112,6 +113,7 @@ func TestBuildTUISlashCommands_HelpSendsMessage(t *testing.T) {
 	commands := chat.BuildTUISlashCommands(eventChan)
 
 	var helpCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == "help" {
 			helpCmd = &chat.ExportCommandDefinition{Def: commands[i]}
@@ -137,6 +139,7 @@ func TestBuildTUISlashCommands_ModeSendsMessage(t *testing.T) {
 	commands := chat.BuildTUISlashCommands(eventChan)
 
 	var modeCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == testModeCmd {
 			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
@@ -163,6 +166,7 @@ func TestBuildTUISlashCommands_ModeEmptyArgsReturnsError(t *testing.T) {
 	commands := chat.BuildTUISlashCommands(eventChan)
 
 	var modeCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == testModeCmd {
 			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
@@ -185,6 +189,7 @@ func TestBuildTUISlashCommands_ModeInvalidReturnsError(t *testing.T) {
 	commands := chat.BuildTUISlashCommands(eventChan)
 
 	var modeCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == testModeCmd {
 			modeCmd = &chat.ExportCommandDefinition{Def: commands[i]}
@@ -207,6 +212,7 @@ func TestBuildTUISlashCommands_ModelNoArgsSendsPicker(t *testing.T) {
 	commands := chat.BuildTUISlashCommands(eventChan)
 
 	var modelCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == "model" {
 			modelCmd = &chat.ExportCommandDefinition{Def: commands[i]}
@@ -232,6 +238,7 @@ func TestBuildTUISlashCommands_ModelWithArgsSendsSetRequest(t *testing.T) {
 	commands := chat.BuildTUISlashCommands(eventChan)
 
 	var modelCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == "model" {
 			modelCmd = &chat.ExportCommandDefinition{Def: commands[i]}
@@ -257,6 +264,7 @@ func TestBuildNonTUISlashCommands_ReturnsExpectedCommands(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
+
 	commands := chat.BuildNonTUISlashCommands(&buf)
 
 	assert.NotEmpty(t, commands)
@@ -272,9 +280,11 @@ func TestBuildNonTUISlashCommands_HelpPrintsOutput(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
+
 	commands := chat.BuildNonTUISlashCommands(&buf)
 
 	var helpCmd *chat.ExportCommandDefinition
+
 	for i := range commands {
 		if commands[i].Name == "help" {
 			helpCmd = &chat.ExportCommandDefinition{Def: commands[i]}

--- a/pkg/cli/ui/chat/dimensions.go
+++ b/pkg/cli/ui/chat/dimensions.go
@@ -73,11 +73,11 @@ func (m *Model) elicitationModalExtraHeight() int {
 	// title (2) + message (2 if present) + URL (2 if present) + fields + field spacing + instructions (1) + border (2)
 	contentLines := 2 + 1 + pickerBorderLines //nolint:mnd // title+blank + instructions + border
 	if m.pendingElicitation.request.Message != "" {
-		contentLines += 2 //nolint:mnd // message + blank line
+		contentLines += 2
 	}
 
 	if m.pendingElicitation.request.Mode == "url" && m.pendingElicitation.request.URL != "" {
-		contentLines += 2 //nolint:mnd // URL + blank line
+		contentLines += 2
 	}
 
 	if len(m.pendingElicitation.fields) > 0 {

--- a/pkg/cli/ui/chat/dimensions.go
+++ b/pkg/cli/ui/chat/dimensions.go
@@ -39,8 +39,6 @@ func (m *Model) activeModalHeight() int {
 		return m.permissionModalExtraHeight()
 	case m.showModelPicker || m.showSessionPicker || m.showReasoningPicker:
 		return m.pickerModalExtraHeight()
-	case m.showCommandPicker || m.showOptionPicker:
-		return m.pickerExtraHeight()
 	default:
 		return 0
 	}

--- a/pkg/cli/ui/chat/dimensions.go
+++ b/pkg/cli/ui/chat/dimensions.go
@@ -39,8 +39,8 @@ func (m *Model) activeModalHeight() int {
 		return m.permissionModalExtraHeight()
 	case m.showModelPicker || m.showSessionPicker || m.showReasoningPicker:
 		return m.pickerModalExtraHeight()
-	case m.showCommandPicker:
-		return m.commandPickerExtraHeight()
+	case m.showCommandPicker || m.showOptionPicker:
+		return m.pickerExtraHeight()
 	default:
 		return 0
 	}

--- a/pkg/cli/ui/chat/dimensions.go
+++ b/pkg/cli/ui/chat/dimensions.go
@@ -37,6 +37,8 @@ func (m *Model) activeModalHeight() int {
 		return m.helpOverlayExtraHeight()
 	case m.pendingPermission != nil:
 		return m.permissionModalExtraHeight()
+	case m.pendingElicitation != nil:
+		return m.elicitationModalExtraHeight()
 	case m.showModelPicker || m.showSessionPicker || m.showReasoningPicker:
 		return m.pickerModalExtraHeight()
 	default:
@@ -53,6 +55,33 @@ func (m *Model) permissionModalExtraHeight() int {
 
 	if m.pendingPermission.arguments != "" {
 		contentLines++
+	}
+
+	if contentLines > inputHeight {
+		return contentLines - inputHeight
+	}
+
+	return 0
+}
+
+// elicitationModalExtraHeight calculates the extra height for the elicitation modal.
+func (m *Model) elicitationModalExtraHeight() int {
+	if m.pendingElicitation == nil {
+		return 0
+	}
+
+	// title (2) + message (2 if present) + URL (2 if present) + fields + field spacing + instructions (1) + border (2)
+	contentLines := 2 + 1 + pickerBorderLines //nolint:mnd // title+blank + instructions + border
+	if m.pendingElicitation.request.Message != "" {
+		contentLines += 2 //nolint:mnd // message + blank line
+	}
+
+	if m.pendingElicitation.request.Mode == "url" && m.pendingElicitation.request.URL != "" {
+		contentLines += 2 //nolint:mnd // URL + blank line
+	}
+
+	if len(m.pendingElicitation.fields) > 0 {
+		contentLines += len(m.pendingElicitation.fields) + 1 // fields + trailing blank
 	}
 
 	if contentLines > inputHeight {

--- a/pkg/cli/ui/chat/dimensions.go
+++ b/pkg/cli/ui/chat/dimensions.go
@@ -39,6 +39,8 @@ func (m *Model) activeModalHeight() int {
 		return m.permissionModalExtraHeight()
 	case m.showModelPicker || m.showSessionPicker || m.showReasoningPicker:
 		return m.pickerModalExtraHeight()
+	case m.showCommandPicker:
+		return m.commandPickerExtraHeight()
 	default:
 		return 0
 	}

--- a/pkg/cli/ui/chat/elicitation.go
+++ b/pkg/cli/ui/chat/elicitation.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -56,71 +57,71 @@ func (m *Model) handleElicitationKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	pe := m.pendingElicitation
-
 	switch msg.String() {
-	case "enter":
+	case keyEnter:
 		return m.acceptElicitation()
-	case "esc":
+	case keyEscape:
 		return m.declineElicitation()
-	case "ctrl+c":
+	case keyCtrlC:
 		m.cancelElicitation()
 		m.cleanup()
 		m.quitting = true
 
 		return m, tea.Quit
-	case "tab":
-		if len(pe.fields) > 1 {
-			// Save current field value before switching
-			pe.fieldValues[pe.fields[pe.fieldIndex]] = pe.inputValue
-			pe.fieldIndex = (pe.fieldIndex + 1) % len(pe.fields)
-			pe.inputValue = pe.fieldValues[pe.fields[pe.fieldIndex]]
-		}
-
-		return m, nil
+	case keyTab:
+		return m.navigateElicitationField(1)
 	case "shift+tab":
-		if len(pe.fields) > 1 {
-			pe.fieldValues[pe.fields[pe.fieldIndex]] = pe.inputValue
-			pe.fieldIndex = (pe.fieldIndex + len(pe.fields) - 1) % len(pe.fields)
-			pe.inputValue = pe.fieldValues[pe.fields[pe.fieldIndex]]
-		}
-
-		return m, nil
+		return m.navigateElicitationField(-1)
 	case "backspace":
-		if len(pe.inputValue) > 0 {
-			pe.inputValue = pe.inputValue[:len(pe.inputValue)-1]
+		pending := m.pendingElicitation
+		if len(pending.inputValue) > 0 {
+			pending.inputValue = pending.inputValue[:len(pending.inputValue)-1]
 		}
 
 		return m, nil
 	default:
 		if len(msg.String()) == 1 {
-			pe.inputValue += msg.String()
+			m.pendingElicitation.inputValue += msg.String()
 		}
 
 		return m, nil
 	}
 }
 
-// acceptElicitation submits the elicitation with the current input values.
-func (m *Model) acceptElicitation() (tea.Model, tea.Cmd) {
-	pe := m.pendingElicitation
-	content := make(map[string]any, len(pe.fields))
-
-	// Save the current field value
-	if len(pe.fields) > 0 {
-		pe.fieldValues[pe.fields[pe.fieldIndex]] = pe.inputValue
+// navigateElicitationField moves the field cursor by the given delta, saving the current value.
+func (m *Model) navigateElicitationField(delta int) (tea.Model, tea.Cmd) {
+	pending := m.pendingElicitation
+	if len(pending.fields) <= 1 {
+		return m, nil
 	}
 
-	for _, f := range pe.fields {
-		content[f] = pe.fieldValues[f]
+	pending.fieldValues[pending.fields[pending.fieldIndex]] = pending.inputValue
+	pending.fieldIndex = (pending.fieldIndex + len(pending.fields) + delta) % len(pending.fields)
+	pending.inputValue = pending.fieldValues[pending.fields[pending.fieldIndex]]
+
+	return m, nil
+}
+
+// acceptElicitation submits the elicitation with the current input values.
+func (m *Model) acceptElicitation() (tea.Model, tea.Cmd) {
+	pending := m.pendingElicitation
+	content := make(map[string]any, len(pending.fields))
+
+	// Save the current field value
+	if len(pending.fields) > 0 {
+		pending.fieldValues[pending.fields[pending.fieldIndex]] = pending.inputValue
+	}
+
+	for _, field := range pending.fields {
+		content[field] = pending.fieldValues[field]
 	}
 
 	// If no fields were extracted (simple confirm), return empty content
-	if len(pe.fields) == 0 {
+	if len(pending.fields) == 0 {
 		content = nil
 	}
 
-	pe.request.Response <- elicitationResponsePayload{
+	pending.request.Response <- elicitationResponsePayload{
 		Result: copilot.ElicitationResult{
 			Action:  "accept",
 			Content: content,
@@ -166,65 +167,19 @@ func (m *Model) renderElicitationModal() string {
 		return ""
 	}
 
-	pe := m.pendingElicitation
-	req := pe.request
+	pending := m.pendingElicitation
+	req := pending.request
 	modalWidth := max(m.width-modalPadding, 1)
 	mStyles := newModalContentStyles(modalWidth)
 
 	var content strings.Builder
 
-	contentLines := 0
-
-	// Title
-	title := "📋 Input Requested"
-	if req.Source != "" {
-		title += " (" + req.Source + ")"
-	}
-
-	content.WriteString(mStyles.clipStyle.Render(mStyles.warningStyle.Render(title)) + "\n\n")
-
-	contentLines += 2
-
-	// Message
-	if req.Message != "" {
-		content.WriteString(mStyles.clipStyle.Render(req.Message) + "\n\n")
-
-		contentLines += 2
-	}
-
-	// URL mode: just show the URL
-	if req.Mode == "url" && req.URL != "" {
-		content.WriteString(mStyles.clipStyle.Render("Open: "+req.URL) + "\n\n")
-
-		contentLines += 2
-	}
-
-	// Form fields
-	if len(pe.fields) > 0 {
-		for i, f := range pe.fields {
-			prefix := "  "
-			if i == pe.fieldIndex {
-				prefix = "▸ "
-			}
-
-			val := pe.fieldValues[f]
-			if i == pe.fieldIndex {
-				val = pe.inputValue
-			}
-
-			content.WriteString(mStyles.clipStyle.Render(fmt.Sprintf("%s%s: %s", prefix, f, val)) + "\n")
-
-			contentLines++
-		}
-
-		content.WriteString("\n")
-
-		contentLines++
-	}
+	contentLines := m.renderElicitationHeader(&content, req, mStyles)
+	contentLines += m.renderElicitationFields(&content, pending, mStyles)
 
 	// Instructions
 	instructions := "[Enter] Accept • [Esc] Decline"
-	if len(pe.fields) > 1 {
+	if len(pending.fields) > 1 {
 		instructions = "[Tab/Shift+Tab] Navigate • " + instructions
 	}
 
@@ -241,6 +196,65 @@ func (m *Model) renderElicitationModal() string {
 		Height(contentLines)
 
 	return modalStyle.Render(strings.TrimRight(content.String(), "\n"))
+}
+
+// renderElicitationHeader writes the title, message, and URL sections. Returns the line count.
+func (m *Model) renderElicitationHeader(content *strings.Builder, req *elicitationRequestMsg, mStyles modalContentStyles) int {
+	lines := 0
+
+	title := "📋 Input Requested"
+	if req.Source != "" {
+		title += " (" + req.Source + ")"
+	}
+
+	content.WriteString(mStyles.clipStyle.Render(mStyles.warningStyle.Render(title)) + "\n\n")
+
+	lines += 2 //nolint:mnd // title + blank line
+
+	if req.Message != "" {
+		content.WriteString(mStyles.clipStyle.Render(req.Message) + "\n\n")
+
+		lines += 2 //nolint:mnd // message + blank line
+	}
+
+	if req.Mode == "url" && req.URL != "" {
+		content.WriteString(mStyles.clipStyle.Render("Open: "+req.URL) + "\n\n")
+
+		lines += 2 //nolint:mnd // URL + blank line
+	}
+
+	return lines
+}
+
+// renderElicitationFields writes the form field section. Returns the line count.
+func (m *Model) renderElicitationFields(content *strings.Builder, pending *pendingElicitation, mStyles modalContentStyles) int {
+	if len(pending.fields) == 0 {
+		return 0
+	}
+
+	lines := 0
+
+	for i, field := range pending.fields {
+		prefix := "  "
+		if i == pending.fieldIndex {
+			prefix = "▸ "
+		}
+
+		val := pending.fieldValues[field]
+		if i == pending.fieldIndex {
+			val = pending.inputValue
+		}
+
+		content.WriteString(mStyles.clipStyle.Render(fmt.Sprintf("%s%s: %s", prefix, field, val)) + "\n")
+
+		lines++
+	}
+
+	content.WriteString("\n")
+
+	lines++
+
+	return lines
 }
 
 // CreateTUIElicitationHandler creates an elicitation handler that integrates with the TUI.
@@ -265,7 +279,7 @@ func CreateTUIElicitationHandler(eventChan chan<- tea.Msg) copilot.ElicitationHa
 }
 
 // extractFieldNames extracts field names from a JSON Schema "properties" map.
-// Returns the field names in sorted order, or a single "value" field for simple schemas.
+// Returns the field names in sorted order, or nil for empty/missing schemas.
 func extractFieldNames(schema map[string]any) []string {
 	if schema == nil {
 		return nil
@@ -280,6 +294,8 @@ func extractFieldNames(schema map[string]any) []string {
 	for k := range props {
 		fields = append(fields, k)
 	}
+
+	sort.Strings(fields)
 
 	return fields
 }

--- a/pkg/cli/ui/chat/elicitation.go
+++ b/pkg/cli/ui/chat/elicitation.go
@@ -73,18 +73,28 @@ func (m *Model) handleElicitationKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "shift+tab":
 		return m.navigateElicitationField(-1)
 	case "backspace":
-		pending := m.pendingElicitation
-		if len(pending.inputValue) > 0 {
-			pending.inputValue = pending.inputValue[:len(pending.inputValue)-1]
-		}
+		m.handleElicitationBackspace()
 
 		return m, nil
 	default:
-		if len(msg.String()) == 1 {
-			m.pendingElicitation.inputValue += msg.String()
-		}
+		m.handleElicitationRune(msg)
 
 		return m, nil
+	}
+}
+
+// handleElicitationBackspace removes the last character from the elicitation input.
+func (m *Model) handleElicitationBackspace() {
+	pending := m.pendingElicitation
+	if len(pending.inputValue) > 0 {
+		pending.inputValue = pending.inputValue[:len(pending.inputValue)-1]
+	}
+}
+
+// handleElicitationRune appends typed runes to the elicitation input.
+func (m *Model) handleElicitationRune(msg tea.KeyMsg) {
+	if len(msg.Runes) > 0 {
+		m.pendingElicitation.inputValue += string(msg.Runes)
 	}
 }
 
@@ -199,7 +209,9 @@ func (m *Model) renderElicitationModal() string {
 }
 
 // renderElicitationHeader writes the title, message, and URL sections. Returns the line count.
-func (m *Model) renderElicitationHeader(content *strings.Builder, req *elicitationRequestMsg, mStyles modalContentStyles) int {
+func (m *Model) renderElicitationHeader(
+	content *strings.Builder, req *elicitationRequestMsg, mStyles modalContentStyles,
+) int {
 	lines := 0
 
 	title := "📋 Input Requested"
@@ -227,21 +239,23 @@ func (m *Model) renderElicitationHeader(content *strings.Builder, req *elicitati
 }
 
 // renderElicitationFields writes the form field section. Returns the line count.
-func (m *Model) renderElicitationFields(content *strings.Builder, pending *pendingElicitation, mStyles modalContentStyles) int {
+func (m *Model) renderElicitationFields(
+	content *strings.Builder, pending *pendingElicitation, mStyles modalContentStyles,
+) int {
 	if len(pending.fields) == 0 {
 		return 0
 	}
 
 	lines := 0
 
-	for i, field := range pending.fields {
+	for fieldIdx, field := range pending.fields {
 		prefix := "  "
-		if i == pending.fieldIndex {
+		if fieldIdx == pending.fieldIndex {
 			prefix = "▸ "
 		}
 
 		val := pending.fieldValues[field]
-		if i == pending.fieldIndex {
+		if fieldIdx == pending.fieldIndex {
 			val = pending.inputValue
 		}
 

--- a/pkg/cli/ui/chat/elicitation.go
+++ b/pkg/cli/ui/chat/elicitation.go
@@ -221,18 +221,18 @@ func (m *Model) renderElicitationHeader(
 
 	content.WriteString(mStyles.clipStyle.Render(mStyles.warningStyle.Render(title)) + "\n\n")
 
-	lines += 2 //nolint:mnd // title + blank line
+	lines += 2
 
 	if req.Message != "" {
 		content.WriteString(mStyles.clipStyle.Render(req.Message) + "\n\n")
 
-		lines += 2 //nolint:mnd // message + blank line
+		lines += 2
 	}
 
 	if req.Mode == "url" && req.URL != "" {
 		content.WriteString(mStyles.clipStyle.Render("Open: "+req.URL) + "\n\n")
 
-		lines += 2 //nolint:mnd // URL + blank line
+		lines += 2
 	}
 
 	return lines
@@ -259,7 +259,9 @@ func (m *Model) renderElicitationFields(
 			val = pending.inputValue
 		}
 
-		content.WriteString(mStyles.clipStyle.Render(fmt.Sprintf("%s%s: %s", prefix, field, val)) + "\n")
+		content.WriteString(
+			mStyles.clipStyle.Render(fmt.Sprintf("%s%s: %s", prefix, field, val)) + "\n",
+		)
 
 		lines++
 	}

--- a/pkg/cli/ui/chat/elicitation.go
+++ b/pkg/cli/ui/chat/elicitation.go
@@ -1,0 +1,285 @@
+package chat
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+// elicitationRequestMsg carries an elicitation request from the SDK to the TUI.
+type elicitationRequestMsg struct {
+	Message  string
+	Source   string
+	Mode     string
+	URL      string
+	Schema   map[string]any
+	Response chan<- elicitationResponsePayload
+}
+
+// elicitationResponsePayload is the result sent back from the TUI to the SDK handler.
+type elicitationResponsePayload struct {
+	Result copilot.ElicitationResult
+}
+
+// pendingElicitation tracks the active elicitation dialog state in the TUI.
+type pendingElicitation struct {
+	request     *elicitationRequestMsg
+	inputValue  string   // current text input value (for single-field forms)
+	fields      []string // extracted field names from schema
+	fieldValues map[string]string
+	fieldIndex  int // index into fields for multi-field navigation
+}
+
+// handleElicitationRequest handles an incoming elicitation request message.
+func (m *Model) handleElicitationRequest(msg elicitationRequestMsg) (tea.Model, tea.Cmd) {
+	fields := extractFieldNames(msg.Schema)
+	fieldValues := make(map[string]string, len(fields))
+
+	m.pendingElicitation = &pendingElicitation{
+		request:     &msg,
+		fields:      fields,
+		fieldValues: fieldValues,
+	}
+
+	m.updateDimensions()
+	m.updateViewportContent()
+
+	return m, nil
+}
+
+// handleElicitationKey handles keyboard input when an elicitation prompt is active.
+func (m *Model) handleElicitationKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.pendingElicitation == nil {
+		return m, nil
+	}
+
+	pe := m.pendingElicitation
+
+	switch msg.String() {
+	case "enter":
+		return m.acceptElicitation()
+	case "esc":
+		return m.declineElicitation()
+	case "ctrl+c":
+		m.cancelElicitation()
+		m.cleanup()
+		m.quitting = true
+
+		return m, tea.Quit
+	case "tab":
+		if len(pe.fields) > 1 {
+			// Save current field value before switching
+			pe.fieldValues[pe.fields[pe.fieldIndex]] = pe.inputValue
+			pe.fieldIndex = (pe.fieldIndex + 1) % len(pe.fields)
+			pe.inputValue = pe.fieldValues[pe.fields[pe.fieldIndex]]
+		}
+
+		return m, nil
+	case "shift+tab":
+		if len(pe.fields) > 1 {
+			pe.fieldValues[pe.fields[pe.fieldIndex]] = pe.inputValue
+			pe.fieldIndex = (pe.fieldIndex + len(pe.fields) - 1) % len(pe.fields)
+			pe.inputValue = pe.fieldValues[pe.fields[pe.fieldIndex]]
+		}
+
+		return m, nil
+	case "backspace":
+		if len(pe.inputValue) > 0 {
+			pe.inputValue = pe.inputValue[:len(pe.inputValue)-1]
+		}
+
+		return m, nil
+	default:
+		if len(msg.String()) == 1 {
+			pe.inputValue += msg.String()
+		}
+
+		return m, nil
+	}
+}
+
+// acceptElicitation submits the elicitation with the current input values.
+func (m *Model) acceptElicitation() (tea.Model, tea.Cmd) {
+	pe := m.pendingElicitation
+	content := make(map[string]any, len(pe.fields))
+
+	// Save the current field value
+	if len(pe.fields) > 0 {
+		pe.fieldValues[pe.fields[pe.fieldIndex]] = pe.inputValue
+	}
+
+	for _, f := range pe.fields {
+		content[f] = pe.fieldValues[f]
+	}
+
+	// If no fields were extracted (simple confirm), return empty content
+	if len(pe.fields) == 0 {
+		content = nil
+	}
+
+	pe.request.Response <- elicitationResponsePayload{
+		Result: copilot.ElicitationResult{
+			Action:  "accept",
+			Content: content,
+		},
+	}
+
+	m.pendingElicitation = nil
+	m.updateDimensions()
+	m.updateViewportContent()
+
+	return m, m.waitForEvent()
+}
+
+// declineElicitation declines the elicitation request.
+func (m *Model) declineElicitation() (tea.Model, tea.Cmd) {
+	m.pendingElicitation.request.Response <- elicitationResponsePayload{
+		Result: copilot.ElicitationResult{
+			Action: "decline",
+		},
+	}
+
+	m.pendingElicitation = nil
+	m.updateDimensions()
+	m.updateViewportContent()
+
+	return m, m.waitForEvent()
+}
+
+// cancelElicitation cancels the elicitation request (used on quit).
+func (m *Model) cancelElicitation() {
+	m.pendingElicitation.request.Response <- elicitationResponsePayload{
+		Result: copilot.ElicitationResult{
+			Action: "cancel",
+		},
+	}
+
+	m.pendingElicitation = nil
+}
+
+// renderElicitationModal renders the elicitation prompt as an inline modal section.
+func (m *Model) renderElicitationModal() string {
+	if m.pendingElicitation == nil {
+		return ""
+	}
+
+	pe := m.pendingElicitation
+	req := pe.request
+	modalWidth := max(m.width-modalPadding, 1)
+	mStyles := newModalContentStyles(modalWidth)
+
+	var content strings.Builder
+
+	contentLines := 0
+
+	// Title
+	title := "📋 Input Requested"
+	if req.Source != "" {
+		title += " (" + req.Source + ")"
+	}
+
+	content.WriteString(mStyles.clipStyle.Render(mStyles.warningStyle.Render(title)) + "\n\n")
+
+	contentLines += 2
+
+	// Message
+	if req.Message != "" {
+		content.WriteString(mStyles.clipStyle.Render(req.Message) + "\n\n")
+
+		contentLines += 2
+	}
+
+	// URL mode: just show the URL
+	if req.Mode == "url" && req.URL != "" {
+		content.WriteString(mStyles.clipStyle.Render("Open: "+req.URL) + "\n\n")
+
+		contentLines += 2
+	}
+
+	// Form fields
+	if len(pe.fields) > 0 {
+		for i, f := range pe.fields {
+			prefix := "  "
+			if i == pe.fieldIndex {
+				prefix = "▸ "
+			}
+
+			val := pe.fieldValues[f]
+			if i == pe.fieldIndex {
+				val = pe.inputValue
+			}
+
+			content.WriteString(mStyles.clipStyle.Render(fmt.Sprintf("%s%s: %s", prefix, f, val)) + "\n")
+
+			contentLines++
+		}
+
+		content.WriteString("\n")
+
+		contentLines++
+	}
+
+	// Instructions
+	instructions := "[Enter] Accept • [Esc] Decline"
+	if len(pe.fields) > 1 {
+		instructions = "[Tab/Shift+Tab] Navigate • " + instructions
+	}
+
+	content.WriteString(mStyles.clipStyle.Render(instructions) + "\n")
+
+	contentLines++
+
+	modalStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.ANSIColor(ansiCyan)).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Width(modalWidth).
+		Height(contentLines)
+
+	return modalStyle.Render(strings.TrimRight(content.String(), "\n"))
+}
+
+// CreateTUIElicitationHandler creates an elicitation handler that integrates with the TUI.
+// It sends elicitation requests to the event channel and waits for the TUI to respond.
+func CreateTUIElicitationHandler(eventChan chan<- tea.Msg) copilot.ElicitationHandler {
+	return func(ctx copilot.ElicitationContext) (copilot.ElicitationResult, error) {
+		responseChan := make(chan elicitationResponsePayload, 1)
+
+		eventChan <- elicitationRequestMsg{
+			Message:  ctx.Message,
+			Source:   ctx.ElicitationSource,
+			Mode:     ctx.Mode,
+			URL:      ctx.URL,
+			Schema:   ctx.RequestedSchema,
+			Response: responseChan,
+		}
+
+		response := <-responseChan
+
+		return response.Result, nil
+	}
+}
+
+// extractFieldNames extracts field names from a JSON Schema "properties" map.
+// Returns the field names in sorted order, or a single "value" field for simple schemas.
+func extractFieldNames(schema map[string]any) []string {
+	if schema == nil {
+		return nil
+	}
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		return nil
+	}
+
+	fields := make([]string, 0, len(props))
+	for k := range props {
+		fields = append(fields, k)
+	}
+
+	return fields
+}

--- a/pkg/cli/ui/chat/elicitation_test.go
+++ b/pkg/cli/ui/chat/elicitation_test.go
@@ -1,0 +1,136 @@
+package chat_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/devantler-tech/ksail/v6/pkg/cli/ui/chat"
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- extractFieldNames tests ---
+
+func TestExtractFieldNames_NilSchema(t *testing.T) {
+	t.Parallel()
+
+	fields := chat.ExportExtractFieldNames(nil)
+	assert.Nil(t, fields)
+}
+
+func TestExtractFieldNames_EmptyProperties(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"properties": map[string]any{},
+	}
+
+	fields := chat.ExportExtractFieldNames(schema)
+	assert.Nil(t, fields)
+}
+
+func TestExtractFieldNames_WithProperties(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"properties": map[string]any{
+			"name":  map[string]any{"type": "string"},
+			"email": map[string]any{"type": "string"},
+		},
+	}
+
+	fields := chat.ExportExtractFieldNames(schema)
+	assert.Len(t, fields, 2)
+	assert.Contains(t, fields, "name")
+	assert.Contains(t, fields, "email")
+}
+
+func TestExtractFieldNames_NonMapProperties(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"properties": "not a map",
+	}
+
+	fields := chat.ExportExtractFieldNames(schema)
+	assert.Nil(t, fields)
+}
+
+// --- CreateTUIElicitationHandler tests ---
+
+func TestCreateTUIElicitationHandler_SendsRequestAndReturnsResult(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 1)
+	handler := chat.CreateTUIElicitationHandler(eventChan)
+
+	// Run handler in a goroutine since it blocks on the response channel
+	resultChan := make(chan copilot.ElicitationResult, 1)
+
+	go func() {
+		result, err := handler(copilot.ElicitationContext{
+			Message:           "Pick a repository",
+			ElicitationSource: "github-mcp",
+			Mode:              "form",
+			RequestedSchema: map[string]any{
+				"properties": map[string]any{
+					"repo": map[string]any{"type": "string"},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		resultChan <- result
+	}()
+
+	// Read the message from the event channel
+	msg := <-eventChan
+	req, ok := msg.(chat.ExportElicitationRequestMsg)
+	require.True(t, ok, "expected elicitationRequestMsg, got %T", msg)
+	assert.Equal(t, "Pick a repository", req.Message)
+	assert.Equal(t, "github-mcp", req.Source)
+	assert.Equal(t, "form", req.Mode)
+
+	// Send response back through the response channel
+	req.Response <- chat.ExportElicitationResponsePayload{
+		Result: copilot.ElicitationResult{
+			Action:  "accept",
+			Content: map[string]any{"repo": "ksail"},
+		},
+	}
+
+	result := <-resultChan
+	assert.Equal(t, "accept", result.Action)
+	assert.Equal(t, "ksail", result.Content["repo"])
+}
+
+func TestCreateTUIElicitationHandler_DeclineResult(t *testing.T) {
+	t.Parallel()
+
+	eventChan := make(chan tea.Msg, 1)
+	handler := chat.CreateTUIElicitationHandler(eventChan)
+
+	resultChan := make(chan copilot.ElicitationResult, 1)
+
+	go func() {
+		result, err := handler(copilot.ElicitationContext{
+			Message: "Confirm action",
+			Mode:    "form",
+		})
+		require.NoError(t, err)
+
+		resultChan <- result
+	}()
+
+	msg := <-eventChan
+	req := msg.(chat.ExportElicitationRequestMsg)
+
+	req.Response <- chat.ExportElicitationResponsePayload{
+		Result: copilot.ElicitationResult{Action: "decline"},
+	}
+
+	result := <-resultChan
+	assert.Equal(t, "decline", result.Action)
+	assert.Nil(t, result.Content)
+}

--- a/pkg/cli/ui/chat/elicitation_test.go
+++ b/pkg/cli/ui/chat/elicitation_test.go
@@ -79,7 +79,7 @@ func TestCreateTUIElicitationHandler_SendsRequestAndReturnsResult(t *testing.T) 
 				},
 			},
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		resultChan <- result
 	}()
@@ -118,13 +118,14 @@ func TestCreateTUIElicitationHandler_DeclineResult(t *testing.T) {
 			Message: "Confirm action",
 			Mode:    "form",
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		resultChan <- result
 	}()
 
 	msg := <-eventChan
-	req := msg.(chat.ExportElicitationRequestMsg)
+	req, ok := msg.(chat.ExportElicitationRequestMsg)
+	require.True(t, ok, "expected elicitationRequestMsg, got %T", msg)
 
 	req.Response <- chat.ExportElicitationResponsePayload{
 		Result: copilot.ElicitationResult{Action: "decline"},

--- a/pkg/cli/ui/chat/export_test.go
+++ b/pkg/cli/ui/chat/export_test.go
@@ -870,3 +870,86 @@ func (t *toolExecution) Command() string { return t.command }
 
 // ID returns the tool's ID for testing.
 func (t *toolExecution) ID() string { return t.id }
+
+// --- Slash command test exports ---
+
+// ExportClearViewportMsg is an exported alias for clearViewportMsg.
+type ExportClearViewportMsg = clearViewportMsg
+
+// ExportShowHelpMsg is an exported alias for showHelpMsg.
+type ExportShowHelpMsg = showHelpMsg
+
+// ExportModeChangeRequestMsg is an exported alias for modeChangeRequestMsg.
+type ExportModeChangeRequestMsg = modeChangeRequestMsg
+
+// ExportOpenModelPickerMsg is an exported alias for openModelPickerMsg.
+type ExportOpenModelPickerMsg = openModelPickerMsg
+
+// ExportModelSetRequestMsg is an exported alias for modelSetRequestMsg.
+type ExportModelSetRequestMsg = modelSetRequestMsg
+
+// ExportCommandDefinition wraps copilot.CommandDefinition for tests.
+type ExportCommandDefinition struct {
+	Def copilot.CommandDefinition
+}
+
+// ExportCommandContext is an exported alias for copilot.CommandContext.
+type ExportCommandContext = copilot.CommandContext
+
+// ExportCommandContextWithArgs creates a copilot.CommandContext with the given args.
+func ExportCommandContextWithArgs(args string) copilot.CommandContext {
+	return copilot.CommandContext{Args: args}
+}
+
+// --- Elicitation test exports ---
+
+// ExportElicitationRequestMsg is an exported alias for elicitationRequestMsg.
+type ExportElicitationRequestMsg = elicitationRequestMsg
+
+// ExportElicitationResponsePayload is an exported alias for elicitationResponsePayload.
+type ExportElicitationResponsePayload = elicitationResponsePayload
+
+// ExportExtractFieldNames exposes extractFieldNames for testing.
+var ExportExtractFieldNames = extractFieldNames
+
+// --- Command picker test exports ---
+
+// ExportUpdateCommandPicker exposes updateCommandPicker for testing.
+var ExportUpdateCommandPicker = func(m *Model) {
+	m.updateCommandPicker()
+}
+
+// ExportSetTextareaValue sets the textarea value for testing.
+var ExportSetTextareaValue = func(m *Model, value string) {
+	m.textarea.SetValue(value)
+}
+
+// ExportShowCommandPicker returns whether the command picker is visible.
+var ExportShowCommandPicker = func(m *Model) bool {
+	return m.showCommandPicker
+}
+
+// ExportFilteredCommands returns the filtered commands for testing.
+var ExportFilteredCommands = func(m *Model) []copilot.CommandDefinition {
+	return m.filteredCommands
+}
+
+// ExportCommandPickerIndex returns the current picker index for testing.
+var ExportCommandPickerIndex = func(m *Model) int {
+	return m.commandPickerIndex
+}
+
+// ExportSetCommandPickerIndex sets the picker index for testing.
+var ExportSetCommandPickerIndex = func(m *Model, idx int) {
+	m.commandPickerIndex = idx
+}
+
+// ExportGetSessionConfig returns the session config for testing.
+var ExportGetSessionConfig = func(m *Model) *copilot.SessionConfig {
+	return m.sessionConfig
+}
+
+// ExportCommandPickerExtraHeight exposes commandPickerExtraHeight for testing.
+var ExportCommandPickerExtraHeight = func(m *Model) int {
+	return m.commandPickerExtraHeight()
+}

--- a/pkg/cli/ui/chat/export_test.go
+++ b/pkg/cli/ui/chat/export_test.go
@@ -953,3 +953,50 @@ var ExportGetSessionConfig = func(m *Model) *copilot.SessionConfig {
 var ExportCommandPickerExtraHeight = func(m *Model) int {
 	return m.commandPickerExtraHeight()
 }
+
+// --- Option picker test exports ---
+
+// ExportCommandOption is an exported alias for CommandOption.
+type ExportCommandOption = CommandOption
+
+// ExportShowOptionPicker returns whether the option picker is visible.
+var ExportShowOptionPicker = func(m *Model) bool {
+	return m.showOptionPicker
+}
+
+// ExportFilteredOptions returns the filtered options for testing.
+var ExportFilteredOptions = func(m *Model) []CommandOption {
+	return m.filteredOptions
+}
+
+// ExportOptionPickerIndex returns the current option picker index.
+var ExportOptionPickerIndex = func(m *Model) int {
+	return m.optionPickerIndex
+}
+
+// ExportSetOptionPickerIndex sets the option picker index for testing.
+var ExportSetOptionPickerIndex = func(m *Model, idx int) {
+	m.optionPickerIndex = idx
+}
+
+// ExportActiveCommandName returns the active command name for the option picker.
+var ExportActiveCommandName = func(m *Model) string {
+	return m.activeCommandName
+}
+
+// ExportPickerExtraHeight exposes pickerExtraHeight for testing.
+var ExportPickerExtraHeight = func(m *Model) int {
+	return m.pickerExtraHeight()
+}
+
+// ExportSetCommandOptions sets the command options map for testing.
+var ExportSetCommandOptions = func(m *Model, opts map[string]CommandOptionProvider) {
+	m.commandOptions = opts
+}
+
+// --- Slash command dispatch test exports ---
+
+// ExportTryDispatchSlashCommand exposes tryDispatchSlashCommand for testing.
+var ExportTryDispatchSlashCommand = func(m *Model, content string) (bool, tea.Model, tea.Cmd) {
+	return m.tryDispatchSlashCommand(content)
+}

--- a/pkg/cli/ui/chat/help.go
+++ b/pkg/cli/ui/chat/help.go
@@ -21,6 +21,7 @@ const (
 	keyCtrlC     = "ctrl+c"
 	keyDown      = "down"
 	keyBackspace = "backspace"
+	keyTab       = "tab"
 
 	// UI dimension constants.
 	modalPadding   = 2 // border width subtracted from terminal width

--- a/pkg/cli/ui/chat/keyhandlers.go
+++ b/pkg/cli/ui/chat/keyhandlers.go
@@ -525,7 +525,17 @@ func (m *Model) tryDispatchSlashCommand(content string) (bool, tea.Model, tea.Cm
 				m.err = err
 			}
 
-			return true, m, nil
+			// The handler sends a message to eventChan (designed for async SDK
+			// callbacks). Since we're calling it synchronously, drain the channel
+			// and process the message directly through Update.
+			select {
+			case msg := <-m.eventChan:
+				resultModel, resultCmd := m.Update(msg)
+
+				return true, resultModel, resultCmd
+			default:
+				return true, m, nil
+			}
 		}
 	}
 

--- a/pkg/cli/ui/chat/keyhandlers.go
+++ b/pkg/cli/ui/chat/keyhandlers.go
@@ -1,11 +1,13 @@
 package chat
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
+	copilot "github.com/github/copilot-sdk/go"
 )
 
 const (
@@ -37,6 +39,10 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	if m.showCommandPicker {
 		return m.handleCommandPickerKey(msg)
+	}
+
+	if m.showOptionPicker {
+		return m.handleOptionPickerKey(msg)
 	}
 
 	if m.showModelPicker {
@@ -461,11 +467,73 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 	}
 
 	content := m.textarea.Value()
+
+	// Intercept slash commands and handle them locally
+	if handled, model, cmd := m.tryDispatchSlashCommand(content); handled {
+		return model, cmd
+	}
+
 	m.textarea.Reset()
 	m.isStreaming = true
 	m.justCompleted = false
 
 	return m, tea.Batch(m.spinner.Tick, m.sendMessageCmd(content))
+}
+
+// tryDispatchSlashCommand checks if the content is a slash command and dispatches
+// it locally without sending it to the SDK session.
+// Returns (true, model, cmd) if the command was handled, (false, nil, nil) otherwise.
+func (m *Model) tryDispatchSlashCommand(content string) (bool, tea.Model, tea.Cmd) {
+	trimmed := strings.TrimSpace(content)
+	if !strings.HasPrefix(trimmed, "/") {
+		return false, nil, nil
+	}
+
+	// Parse command name and args: "/mode plan" → name="mode", args="plan"
+	parts := strings.SplitN(trimmed[1:], " ", 2)
+	cmdName := strings.ToLower(parts[0])
+
+	args := ""
+	if len(parts) > 1 {
+		args = parts[1]
+	}
+
+	// Look up the handler in registered commands
+	commands := m.getRegisteredCommands()
+	for _, cmd := range commands {
+		if strings.ToLower(cmd.Name) == cmdName {
+			m.textarea.Reset()
+			m.showCommandPicker = false
+			m.showOptionPicker = false
+			m.commandPickerIndex = 0
+			m.optionPickerIndex = 0
+			m.filteredCommands = nil
+			m.filteredOptions = nil
+
+			// Construct CommandContext and call the handler
+			ctx := copilot.CommandContext{
+				Command:     trimmed,
+				CommandName: cmd.Name,
+				Args:        args,
+			}
+
+			if m.session != nil {
+				ctx.SessionID = m.session.SessionID
+			}
+
+			if err := cmd.Handler(ctx); err != nil {
+				m.err = err
+			}
+
+			return true, m, nil
+		}
+	}
+
+	// Unrecognized command — show transient error
+	m.textarea.Reset()
+	m.err = fmt.Errorf("unknown command: /%s", cmdName)
+
+	return true, m, nil
 }
 
 // handleCopyOutput copies the latest assistant message to clipboard.

--- a/pkg/cli/ui/chat/keyhandlers.go
+++ b/pkg/cli/ui/chat/keyhandlers.go
@@ -31,6 +31,14 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handlePermissionKey(msg)
 	}
 
+	if m.pendingElicitation != nil {
+		return m.handleElicitationKey(msg)
+	}
+
+	if m.showCommandPicker {
+		return m.handleCommandPickerKey(msg)
+	}
+
 	if m.showModelPicker {
 		return m.handleModelPickerKey(msg)
 	}
@@ -146,6 +154,9 @@ func (m *Model) handleViewportAndTextareaKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 	if m.justCompleted {
 		m.justCompleted = false
 	}
+
+	// Check if we should show/hide the command picker after each keystroke
+	m.updateCommandPicker()
 
 	return m, taCmd
 }

--- a/pkg/cli/ui/chat/keyhandlers.go
+++ b/pkg/cli/ui/chat/keyhandlers.go
@@ -522,7 +522,8 @@ func (m *Model) tryDispatchSlashCommand(content string) (bool, tea.Model, tea.Cm
 				ctx.SessionID = m.session.SessionID
 			}
 
-			if err := cmd.Handler(ctx); err != nil {
+			err := cmd.Handler(ctx)
+			if err != nil {
 				m.err = err
 			}
 

--- a/pkg/cli/ui/chat/keyhandlers.go
+++ b/pkg/cli/ui/chat/keyhandlers.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	copilot "github.com/github/copilot-sdk/go"
 )
+
+// errUnknownCommand is returned when a slash command is not recognized.
+var errUnknownCommand = errors.New("unknown command")
 
 const (
 	// feedbackResetMillis is the delay before clearing transient UI feedback
@@ -77,7 +81,7 @@ func (m *Model) handleHelpOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m *Model) handleChatKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case keyCtrlC:
-		return m.handleQuit(true)
+		return m.handleQuit()
 	case keyEscape:
 		return m.handleEscape()
 	case keyEnter:
@@ -110,7 +114,7 @@ func (m *Model) handleChatShortcutKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleOpenSessionPicker()
 	case "ctrl+n":
 		return m.handleNewChat()
-	case "tab":
+	case keyTab:
 		return m.handleToggleMode()
 	case "ctrl+t":
 		return m.handleToggleAllTools()
@@ -168,12 +172,9 @@ func (m *Model) handleViewportAndTextareaKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 }
 
 // handleQuit handles application quit.
-func (m *Model) handleQuit(saveSession bool) (tea.Model, tea.Cmd) {
+func (m *Model) handleQuit() (tea.Model, tea.Cmd) {
 	m.cleanup()
-
-	if saveSession {
-		_ = m.saveCurrentSession()
-	}
+	_ = m.saveCurrentSession()
 
 	m.quitting = true
 
@@ -208,7 +209,7 @@ func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 func (m *Model) handleExitConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y":
-		return m.handleQuit(true)
+		return m.handleQuit()
 	case "n", "N", keyEscape:
 		m.confirmExit = false
 
@@ -490,7 +491,7 @@ func (m *Model) tryDispatchSlashCommand(content string) (bool, tea.Model, tea.Cm
 	}
 
 	// Parse command name and args: "/mode plan" → name="mode", args="plan"
-	parts := strings.SplitN(trimmed[1:], " ", 2)
+	parts := strings.SplitN(trimmed[1:], " ", 2) //nolint:mnd // split into command + args
 	cmdName := strings.ToLower(parts[0])
 
 	args := ""
@@ -541,7 +542,7 @@ func (m *Model) tryDispatchSlashCommand(content string) (bool, tea.Model, tea.Cm
 
 	// Unrecognized command — show transient error
 	m.textarea.Reset()
-	m.err = fmt.Errorf("unknown command: /%s", cmdName)
+	m.err = fmt.Errorf("%w: /%s", errUnknownCommand, cmdName)
 
 	return true, m, nil
 }

--- a/pkg/cli/ui/chat/model.go
+++ b/pkg/cli/ui/chat/model.go
@@ -306,9 +306,9 @@ type Model struct {
 	pendingElicitation *pendingElicitation // current elicitation request awaiting user response
 
 	// Slash command autocomplete
-	showCommandPicker  bool                       // true when the command picker popup is visible
-	commandPickerIndex int                        // currently highlighted command in picker
-	filteredCommands   []copilot.CommandDefinition // commands matching current "/" prefix
+	showCommandPicker  bool                             // true when the command picker popup is visible
+	commandPickerIndex int                              // currently highlighted command in picker
+	filteredCommands   []copilot.CommandDefinition      // commands matching current "/" prefix
 	commandOptions     map[string]CommandOptionProvider // per-command option providers
 
 	// Slash command option picker
@@ -579,7 +579,8 @@ func (m *Model) View() string {
 	// Header, chat viewport (with floating popup overlay), input/modal, and footer
 	sections = append(sections, m.renderHeader())
 
-	viewportContent := m.styles.viewport.Width(max(m.width-modalPadding, 1)).Render(m.viewport.View())
+	viewportContent := m.styles.viewport.Width(max(m.width-modalPadding, 1)).
+		Render(m.viewport.View())
 
 	if popup := m.renderPickerPopup(); popup != "" {
 		viewportContent = overlayBottom(viewportContent, popup)

--- a/pkg/cli/ui/chat/model.go
+++ b/pkg/cli/ui/chat/model.go
@@ -46,6 +46,13 @@ const (
 // ChatMode represents the chat interaction mode.
 type ChatMode int //nolint:revive // ChatMode is clearer than Mode given existing ModeRef type in this package.
 
+// Mode name constants.
+const (
+	modeNameInteractive = "interactive"
+	modeNamePlan        = "plan"
+	modeNameAutopilot   = "autopilot"
+)
+
 const (
 	// InteractiveMode allows full tool execution with permission prompts for write operations.
 	InteractiveMode ChatMode = iota
@@ -59,13 +66,13 @@ const (
 func (m ChatMode) String() string {
 	switch m {
 	case InteractiveMode:
-		return "interactive"
+		return modeNameInteractive
 	case PlanMode:
-		return "plan"
+		return modeNamePlan
 	case AutopilotMode:
-		return "autopilot"
+		return modeNameAutopilot
 	default:
-		return "interactive"
+		return modeNameInteractive
 	}
 }
 

--- a/pkg/cli/ui/chat/model.go
+++ b/pkg/cli/ui/chat/model.go
@@ -567,17 +567,18 @@ func (m *Model) View() string {
 		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, modal)
 	}
 
-	sections := make([]string, 0, viewSectionCount+1)
+	sections := make([]string, 0, viewSectionCount)
 
-	// Header, chat viewport, (optional command picker popup), input/modal, and footer
+	// Header, chat viewport (with floating popup overlay), input/modal, and footer
 	sections = append(sections, m.renderHeader())
-	sections = append(sections,
-		m.styles.viewport.Width(max(m.width-modalPadding, 1)).Render(m.viewport.View()),
-	)
+
+	viewportContent := m.styles.viewport.Width(max(m.width-modalPadding, 1)).Render(m.viewport.View())
 
 	if popup := m.renderPickerPopup(); popup != "" {
-		sections = append(sections, popup)
+		viewportContent = overlayBottom(viewportContent, popup)
 	}
+
+	sections = append(sections, viewportContent)
 
 	sections = append(sections, m.renderInputOrModal())
 	sections = append(sections, m.renderFooter())

--- a/pkg/cli/ui/chat/model.go
+++ b/pkg/cli/ui/chat/model.go
@@ -295,6 +295,14 @@ type Model struct {
 	pendingPermission *permissionRequestMsg // current permission request awaiting user response
 	permissionHistory []permissionResponse  // history of permission decisions
 
+	// Elicitation request handling
+	pendingElicitation *pendingElicitation // current elicitation request awaiting user response
+
+	// Slash command autocomplete
+	showCommandPicker  bool                       // true when the command picker popup is visible
+	commandPickerIndex int                        // currently highlighted command in picker
+	filteredCommands   []copilot.CommandDefinition // commands matching current "/" prefix
+
 	// Session management
 	currentSessionID     string            // ID of the current session (empty if new)
 	availableSessions    []SessionMetadata // cached list of available sessions
@@ -466,13 +474,37 @@ func (m *Model) Update(
 
 	case streamChunkMsg, assistantMessageMsg, toolStartMsg, toolEndMsg,
 		toolOutputChunkMsg, ToolOutputChunkMsg, permissionRequestMsg,
-		PermissionRequestMsg, streamEndMsg, turnStartMsg, turnEndMsg,
+		PermissionRequestMsg, elicitationRequestMsg,
+		streamEndMsg, turnStartMsg, turnEndMsg,
 		reasoningMsg, abortMsg, snapshotRewindMsg, streamErrMsg,
 		usageMsg, compactionStartMsg, compactionCompleteMsg,
 		intentMsg, modelChangeMsg, shutdownMsg,
 		systemNotificationMsg, sessionWarningMsg,
 		ToolProgressMsg, TaskCompleteMsg:
 		return m.handleStreamEvent(msg)
+
+	case modeChangeRequestMsg:
+		return m.handleSlashModeChange(msg)
+
+	case openModelPickerMsg:
+		return m.handleOpenModelPicker()
+
+	case modelSetRequestMsg:
+		return m.handleSlashModelSet(msg)
+
+	case openSessionPickerMsg:
+		return m.handleOpenSessionPicker()
+
+	case newChatRequestMsg:
+		return m.handleNewChat()
+
+	case showHelpMsg:
+		m.showHelpOverlay = true
+
+		return m, nil
+
+	case clearViewportMsg:
+		return m.handleClearViewport()
 
 	case copyFeedbackClearMsg:
 		m.showCopyFeedback = false
@@ -527,13 +559,18 @@ func (m *Model) View() string {
 		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, modal)
 	}
 
-	sections := make([]string, 0, viewSectionCount)
+	sections := make([]string, 0, viewSectionCount+1)
 
-	// Header, chat viewport, input/modal, and footer
+	// Header, chat viewport, (optional command picker popup), input/modal, and footer
 	sections = append(sections, m.renderHeader())
 	sections = append(sections,
 		m.styles.viewport.Width(max(m.width-modalPadding, 1)).Render(m.viewport.View()),
 	)
+
+	if popup := m.renderCommandPickerPopup(); popup != "" {
+		sections = append(sections, popup)
+	}
+
 	sections = append(sections, m.renderInputOrModal())
 	sections = append(sections, m.renderFooter())
 
@@ -579,6 +616,9 @@ func (m *Model) handleStreamEvent(
 			arguments:  msg.Arguments,
 			response:   msg.Response,
 		})
+
+	case elicitationRequestMsg:
+		return m.handleElicitationRequest(msg)
 
 	case streamEndMsg:
 		return m.handleStreamEnd()
@@ -634,6 +674,54 @@ func (m *Model) handleStreamEvent(
 	default:
 		return m, nil
 	}
+}
+
+// handleSlashModeChange handles the /mode slash command.
+func (m *Model) handleSlashModeChange(msg modeChangeRequestMsg) (tea.Model, tea.Cmd) {
+	if m.chatMode == msg.Mode {
+		return m, nil
+	}
+
+	err := m.applyMode(msg.Mode)
+	if err != nil {
+		m.err = err
+
+		return m, nil
+	}
+
+	m.chatMode = msg.Mode
+	m.updateViewportContent()
+
+	return m, nil
+}
+
+// handleSlashModelSet handles the /model <name> slash command.
+func (m *Model) handleSlashModelSet(msg modelSetRequestMsg) (tea.Model, tea.Cmd) {
+	if m.isStreaming {
+		return m, nil
+	}
+
+	err := m.session.SetModel(m.ctx, msg.Model, nil)
+	if err != nil {
+		m.err = err
+
+		return m, nil
+	}
+
+	m.currentModel = msg.Model
+	m.updateViewportContent()
+
+	return m, nil
+}
+
+// handleClearViewport handles the /clear slash command.
+func (m *Model) handleClearViewport() (tea.Model, tea.Cmd) {
+	m.messages = make([]message, 0)
+	m.tools = make(map[string]*toolExecution)
+	m.toolOrder = make([]string, 0)
+	m.updateViewportContent()
+
+	return m, nil
 }
 
 // handleMouseMsg handles mouse input events.

--- a/pkg/cli/ui/chat/model.go
+++ b/pkg/cli/ui/chat/model.go
@@ -302,6 +302,13 @@ type Model struct {
 	showCommandPicker  bool                       // true when the command picker popup is visible
 	commandPickerIndex int                        // currently highlighted command in picker
 	filteredCommands   []copilot.CommandDefinition // commands matching current "/" prefix
+	commandOptions     map[string]CommandOptionProvider // per-command option providers
+
+	// Slash command option picker
+	showOptionPicker  bool            // true when the option picker popup is visible
+	optionPickerIndex int             // currently highlighted option in picker
+	filteredOptions   []CommandOption // options matching current argument prefix
+	activeCommandName string          // command name being completed (e.g., "mode")
 
 	// Session management
 	currentSessionID     string            // ID of the current session (empty if new)
@@ -384,6 +391,7 @@ func NewModel(params Params) *Model {
 		session:          params.Session,
 		client:           params.Client,
 		sessionConfig:    params.SessionConfig,
+		commandOptions:   BuildTUICommandOptions(),
 		currentSessionID: params.Session.SessionID, // Track the SDK's session ID
 		timeout:          params.Timeout,
 		ctx:              context.Background(),
@@ -567,7 +575,7 @@ func (m *Model) View() string {
 		m.styles.viewport.Width(max(m.width-modalPadding, 1)).Render(m.viewport.View()),
 	)
 
-	if popup := m.renderCommandPickerPopup(); popup != "" {
+	if popup := m.renderPickerPopup(); popup != "" {
 		sections = append(sections, popup)
 	}
 

--- a/pkg/cli/ui/chat/render.go
+++ b/pkg/cli/ui/chat/render.go
@@ -110,6 +110,10 @@ func (m *Model) renderInputOrModal() string {
 		return m.renderPermissionModal()
 	}
 
+	if m.pendingElicitation != nil {
+		return m.renderElicitationModal()
+	}
+
 	if m.showModelPicker {
 		return m.renderModelPickerModal()
 	}

--- a/pkg/cli/ui/chat/styles.go
+++ b/pkg/cli/ui/chat/styles.go
@@ -9,6 +9,7 @@ import (
 // ANSI color constants for picker and modal styling.
 // These are standard terminal colors used as UI affordances (selected, warning, etc.).
 const (
+	ansiBlack  = 0
 	ansiGray   = 8
 	ansiGreen  = 10
 	ansiYellow = 11

--- a/pkg/svc/chat/elicitation.go
+++ b/pkg/svc/chat/elicitation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -49,7 +50,8 @@ func promptElicitationAccept(writer io.Writer) (copilot.ElicitationResult, error
 
 	line, readErr := reader.ReadString('\n')
 	if readErr != nil {
-		return copilot.ElicitationResult{Action: "cancel"}, nil
+		// stdin EOF/pipe-close → cancel the elicitation gracefully
+		return copilot.ElicitationResult{Action: "cancel"}, nil //nolint:nilerr // intentional: EOF cancels
 	}
 
 	input := strings.TrimSpace(strings.ToLower(line))
@@ -68,15 +70,24 @@ func promptElicitationFields(writer io.Writer, schema map[string]any) (copilot.E
 		return promptElicitationAccept(writer)
 	}
 
+	// Sort field names for deterministic prompt order
+	fieldNames := make([]string, 0, len(props))
+	for field := range props {
+		fieldNames = append(fieldNames, field)
+	}
+
+	sort.Strings(fieldNames)
+
 	reader := bufio.NewReader(os.Stdin)
 	content := make(map[string]any, len(props))
 
-	for field := range props {
+	for _, field := range fieldNames {
 		_, _ = fmt.Fprintf(writer, "%s: ", field)
 
 		line, readErr := reader.ReadString('\n')
 		if readErr != nil {
-			return copilot.ElicitationResult{Action: "cancel"}, nil
+			// stdin EOF/pipe-close → cancel the elicitation gracefully
+			return copilot.ElicitationResult{Action: "cancel"}, nil //nolint:nilerr // intentional: EOF cancels
 		}
 
 		content[field] = strings.TrimSpace(line)

--- a/pkg/svc/chat/elicitation.go
+++ b/pkg/svc/chat/elicitation.go
@@ -1,0 +1,89 @@
+package chat
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+// CreateElicitationHandler creates a non-TUI elicitation handler that prompts via
+// stdin/stdout. It shows the elicitation message and asks the user to accept or decline.
+func CreateElicitationHandler(writer io.Writer) copilot.ElicitationHandler {
+	return func(ctx copilot.ElicitationContext) (copilot.ElicitationResult, error) {
+		_, _ = fmt.Fprintln(writer, "")
+		_, _ = fmt.Fprintln(writer, "┌─ Input Requested")
+
+		if ctx.ElicitationSource != "" {
+			_, _ = fmt.Fprintf(writer, "│  Source: %s\n", ctx.ElicitationSource)
+		}
+
+		if ctx.Message != "" {
+			_, _ = fmt.Fprintf(writer, "│  %s\n", ctx.Message)
+		}
+
+		if ctx.Mode == "url" && ctx.URL != "" {
+			_, _ = fmt.Fprintf(writer, "│  Open: %s\n", ctx.URL)
+		}
+
+		_, _ = fmt.Fprint(writer, "└─\n")
+
+		// For form-mode with schema fields, collect field values
+		if ctx.Mode == "form" && ctx.RequestedSchema != nil {
+			return promptElicitationFields(writer, ctx.RequestedSchema)
+		}
+
+		// Simple accept/decline for URL mode or schema-less requests
+		return promptElicitationAccept(writer)
+	}
+}
+
+// promptElicitationAccept asks the user to accept or decline.
+func promptElicitationAccept(writer io.Writer) (copilot.ElicitationResult, error) {
+	_, _ = fmt.Fprint(writer, "Accept? [y/N]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+
+	line, readErr := reader.ReadString('\n')
+	if readErr != nil {
+		return copilot.ElicitationResult{Action: "cancel"}, nil
+	}
+
+	input := strings.TrimSpace(strings.ToLower(line))
+
+	if input == "y" || input == "yes" {
+		return copilot.ElicitationResult{Action: "accept"}, nil
+	}
+
+	return copilot.ElicitationResult{Action: "decline"}, nil
+}
+
+// promptElicitationFields prompts for each field in the schema.
+func promptElicitationFields(writer io.Writer, schema map[string]any) (copilot.ElicitationResult, error) {
+	props, ok := schema["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		return promptElicitationAccept(writer)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	content := make(map[string]any, len(props))
+
+	for field := range props {
+		_, _ = fmt.Fprintf(writer, "%s: ", field)
+
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			return copilot.ElicitationResult{Action: "cancel"}, nil
+		}
+
+		content[field] = strings.TrimSpace(line)
+	}
+
+	return copilot.ElicitationResult{
+		Action:  "accept",
+		Content: content,
+	}, nil
+}

--- a/pkg/svc/chat/elicitation.go
+++ b/pkg/svc/chat/elicitation.go
@@ -67,7 +67,10 @@ func readLine(reader *bufio.Reader, context string) (string, error) {
 }
 
 // promptElicitationAccept asks the user to accept or decline.
-func promptElicitationAccept(reader *bufio.Reader, writer io.Writer) (copilot.ElicitationResult, error) {
+func promptElicitationAccept(
+	reader *bufio.Reader,
+	writer io.Writer,
+) (copilot.ElicitationResult, error) {
 	_, _ = fmt.Fprint(writer, "Accept? [y/N]: ")
 
 	input, err := readLine(reader, "elicitation response")

--- a/pkg/svc/chat/elicitation.go
+++ b/pkg/svc/chat/elicitation.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -50,8 +51,11 @@ func promptElicitationAccept(reader *bufio.Reader, writer io.Writer) (copilot.El
 
 	line, readErr := reader.ReadString('\n')
 	if readErr != nil {
-		// stdin EOF/pipe-close → cancel the elicitation gracefully
-		return copilot.ElicitationResult{Action: "cancel"}, nil //nolint:nilerr // intentional: EOF cancels
+		if errors.Is(readErr, io.EOF) {
+			return copilot.ElicitationResult{Action: "cancel"}, nil
+		}
+
+		return copilot.ElicitationResult{}, fmt.Errorf("reading elicitation response: %w", readErr)
 	}
 
 	input := strings.TrimSpace(strings.ToLower(line))
@@ -65,7 +69,9 @@ func promptElicitationAccept(reader *bufio.Reader, writer io.Writer) (copilot.El
 
 // promptElicitationFields prompts for each field in the schema.
 // The user can type "!cancel" on any field to decline the elicitation.
-func promptElicitationFields(reader *bufio.Reader, writer io.Writer, schema map[string]any) (copilot.ElicitationResult, error) {
+func promptElicitationFields(
+	reader *bufio.Reader, writer io.Writer, schema map[string]any,
+) (copilot.ElicitationResult, error) {
 	props, ok := schema["properties"].(map[string]any)
 	if !ok || len(props) == 0 {
 		return promptElicitationAccept(reader, writer)
@@ -88,8 +94,11 @@ func promptElicitationFields(reader *bufio.Reader, writer io.Writer, schema map[
 
 		line, readErr := reader.ReadString('\n')
 		if readErr != nil {
-			// stdin EOF/pipe-close → cancel the elicitation gracefully
-			return copilot.ElicitationResult{Action: "cancel"}, nil //nolint:nilerr // intentional: EOF cancels
+			if errors.Is(readErr, io.EOF) {
+				return copilot.ElicitationResult{Action: "cancel"}, nil
+			}
+
+			return copilot.ElicitationResult{}, fmt.Errorf("reading field %s: %w", field, readErr)
 		}
 
 		value := strings.TrimSpace(line)

--- a/pkg/svc/chat/elicitation.go
+++ b/pkg/svc/chat/elicitation.go
@@ -15,7 +15,10 @@ import (
 // the provided reader/writer. It shows the elicitation message and asks the user
 // to accept or decline.
 func CreateElicitationHandler(reader io.Reader, writer io.Writer) copilot.ElicitationHandler {
-	bufReader := bufio.NewReader(reader)
+	bufReader, ok := reader.(*bufio.Reader)
+	if !ok {
+		bufReader = bufio.NewReader(reader)
+	}
 
 	return func(ctx copilot.ElicitationContext) (copilot.ElicitationResult, error) {
 		_, _ = fmt.Fprintln(writer, "")

--- a/pkg/svc/chat/elicitation.go
+++ b/pkg/svc/chat/elicitation.go
@@ -45,20 +45,38 @@ func CreateElicitationHandler(reader io.Reader, writer io.Writer) copilot.Elicit
 	}
 }
 
+// errElicitationEOF is returned by readLine when the reader reaches EOF.
+var errElicitationEOF = errors.New("elicitation EOF")
+
+// readLine reads a line from the reader, returning the trimmed line content.
+// Returns errElicitationEOF if the reader reaches EOF.
+func readLine(reader *bufio.Reader, context string) (string, error) {
+	line, readErr := reader.ReadString('\n')
+	if readErr != nil {
+		if errors.Is(readErr, io.EOF) {
+			return "", errElicitationEOF
+		}
+
+		return "", fmt.Errorf("reading %s: %w", context, readErr)
+	}
+
+	return strings.TrimSpace(line), nil
+}
+
 // promptElicitationAccept asks the user to accept or decline.
 func promptElicitationAccept(reader *bufio.Reader, writer io.Writer) (copilot.ElicitationResult, error) {
 	_, _ = fmt.Fprint(writer, "Accept? [y/N]: ")
 
-	line, readErr := reader.ReadString('\n')
-	if readErr != nil {
-		if errors.Is(readErr, io.EOF) {
+	input, err := readLine(reader, "elicitation response")
+	if err != nil {
+		if errors.Is(err, errElicitationEOF) {
 			return copilot.ElicitationResult{Action: "cancel"}, nil
 		}
 
-		return copilot.ElicitationResult{}, fmt.Errorf("reading elicitation response: %w", readErr)
+		return copilot.ElicitationResult{}, err
 	}
 
-	input := strings.TrimSpace(strings.ToLower(line))
+	input = strings.ToLower(input)
 
 	if input == "y" || input == "yes" {
 		return copilot.ElicitationResult{Action: "accept"}, nil
@@ -92,16 +110,15 @@ func promptElicitationFields(
 	for _, field := range fieldNames {
 		_, _ = fmt.Fprintf(writer, "%s: ", field)
 
-		line, readErr := reader.ReadString('\n')
-		if readErr != nil {
-			if errors.Is(readErr, io.EOF) {
+		value, err := readLine(reader, "field "+field)
+		if err != nil {
+			if errors.Is(err, errElicitationEOF) {
 				return copilot.ElicitationResult{Action: "cancel"}, nil
 			}
 
-			return copilot.ElicitationResult{}, fmt.Errorf("reading field %s: %w", field, readErr)
+			return copilot.ElicitationResult{}, err
 		}
 
-		value := strings.TrimSpace(line)
 		if value == "!cancel" {
 			return copilot.ElicitationResult{Action: "decline"}, nil
 		}

--- a/pkg/svc/chat/elicitation.go
+++ b/pkg/svc/chat/elicitation.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 
@@ -12,8 +11,11 @@ import (
 )
 
 // CreateElicitationHandler creates a non-TUI elicitation handler that prompts via
-// stdin/stdout. It shows the elicitation message and asks the user to accept or decline.
-func CreateElicitationHandler(writer io.Writer) copilot.ElicitationHandler {
+// the provided reader/writer. It shows the elicitation message and asks the user
+// to accept or decline.
+func CreateElicitationHandler(reader io.Reader, writer io.Writer) copilot.ElicitationHandler {
+	bufReader := bufio.NewReader(reader)
+
 	return func(ctx copilot.ElicitationContext) (copilot.ElicitationResult, error) {
 		_, _ = fmt.Fprintln(writer, "")
 		_, _ = fmt.Fprintln(writer, "┌─ Input Requested")
@@ -34,19 +36,17 @@ func CreateElicitationHandler(writer io.Writer) copilot.ElicitationHandler {
 
 		// For form-mode with schema fields, collect field values
 		if ctx.Mode == "form" && ctx.RequestedSchema != nil {
-			return promptElicitationFields(writer, ctx.RequestedSchema)
+			return promptElicitationFields(bufReader, writer, ctx.RequestedSchema)
 		}
 
 		// Simple accept/decline for URL mode or schema-less requests
-		return promptElicitationAccept(writer)
+		return promptElicitationAccept(bufReader, writer)
 	}
 }
 
 // promptElicitationAccept asks the user to accept or decline.
-func promptElicitationAccept(writer io.Writer) (copilot.ElicitationResult, error) {
+func promptElicitationAccept(reader *bufio.Reader, writer io.Writer) (copilot.ElicitationResult, error) {
 	_, _ = fmt.Fprint(writer, "Accept? [y/N]: ")
-
-	reader := bufio.NewReader(os.Stdin)
 
 	line, readErr := reader.ReadString('\n')
 	if readErr != nil {
@@ -64,10 +64,11 @@ func promptElicitationAccept(writer io.Writer) (copilot.ElicitationResult, error
 }
 
 // promptElicitationFields prompts for each field in the schema.
-func promptElicitationFields(writer io.Writer, schema map[string]any) (copilot.ElicitationResult, error) {
+// The user can type "!cancel" on any field to decline the elicitation.
+func promptElicitationFields(reader *bufio.Reader, writer io.Writer, schema map[string]any) (copilot.ElicitationResult, error) {
 	props, ok := schema["properties"].(map[string]any)
 	if !ok || len(props) == 0 {
-		return promptElicitationAccept(writer)
+		return promptElicitationAccept(reader, writer)
 	}
 
 	// Sort field names for deterministic prompt order
@@ -78,7 +79,8 @@ func promptElicitationFields(writer io.Writer, schema map[string]any) (copilot.E
 
 	sort.Strings(fieldNames)
 
-	reader := bufio.NewReader(os.Stdin)
+	_, _ = fmt.Fprintln(writer, "(type !cancel on any field to decline)")
+
 	content := make(map[string]any, len(props))
 
 	for _, field := range fieldNames {
@@ -90,7 +92,12 @@ func promptElicitationFields(writer io.Writer, schema map[string]any) (copilot.E
 			return copilot.ElicitationResult{Action: "cancel"}, nil //nolint:nilerr // intentional: EOF cancels
 		}
 
-		content[field] = strings.TrimSpace(line)
+		value := strings.TrimSpace(line)
+		if value == "!cancel" {
+			return copilot.ElicitationResult{Action: "decline"}, nil
+		}
+
+		content[field] = value
 	}
 
 	return copilot.ElicitationResult{

--- a/pkg/svc/chat/elicitation_test.go
+++ b/pkg/svc/chat/elicitation_test.go
@@ -1,0 +1,163 @@
+package chat_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v6/pkg/svc/chat"
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateElicitationHandler_AcceptSimple(t *testing.T) {
+	reader := strings.NewReader("y\n")
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Message: "Do you want to continue?",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "accept", result.Action)
+	assert.Contains(t, writer.String(), "Input Requested")
+	assert.Contains(t, writer.String(), "Do you want to continue?")
+}
+
+func TestCreateElicitationHandler_DeclineSimple(t *testing.T) {
+	reader := strings.NewReader("n\n")
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Message: "Do you want to continue?",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "decline", result.Action)
+}
+
+func TestCreateElicitationHandler_DefaultDecline(t *testing.T) {
+	reader := strings.NewReader("\n")
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Message: "Accept something",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "decline", result.Action)
+}
+
+func TestCreateElicitationHandler_EOF(t *testing.T) {
+	reader := strings.NewReader("") // EOF immediately
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Message: "test",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cancel", result.Action)
+}
+
+func TestCreateElicitationHandler_FormFields(t *testing.T) {
+	input := "hello\nworld\n"
+	reader := strings.NewReader(input)
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Mode:    "form",
+		Message: "Fill in the fields",
+		RequestedSchema: map[string]any{
+			"properties": map[string]any{
+				"name":  map[string]any{"type": "string"},
+				"value": map[string]any{"type": "string"},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "accept", result.Action)
+	// Fields are sorted alphabetically: name, value
+	assert.Equal(t, "hello", result.Content["name"])
+	assert.Equal(t, "world", result.Content["value"])
+}
+
+func TestCreateElicitationHandler_FormFieldDecline(t *testing.T) {
+	input := "hello\n!cancel\n"
+	reader := strings.NewReader(input)
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Mode:    "form",
+		Message: "Fill in the fields",
+		RequestedSchema: map[string]any{
+			"properties": map[string]any{
+				"alpha": map[string]any{"type": "string"},
+				"beta":  map[string]any{"type": "string"},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "decline", result.Action)
+}
+
+func TestCreateElicitationHandler_FormFieldEOF(t *testing.T) {
+	input := "hello\n" // only one field, then EOF
+	reader := strings.NewReader(input)
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Mode:    "form",
+		Message: "Fill in the fields",
+		RequestedSchema: map[string]any{
+			"properties": map[string]any{
+				"alpha": map[string]any{"type": "string"},
+				"beta":  map[string]any{"type": "string"},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cancel", result.Action)
+}
+
+func TestCreateElicitationHandler_URLMode(t *testing.T) {
+	reader := strings.NewReader("y\n")
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Mode:    "url",
+		URL:     "https://example.com/auth",
+		Message: "Open this URL to authenticate",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "accept", result.Action)
+	assert.Contains(t, writer.String(), "https://example.com/auth")
+}
+
+func TestCreateElicitationHandler_EmptySchema(t *testing.T) {
+	reader := strings.NewReader("y\n")
+	writer := &bytes.Buffer{}
+	handler := chat.CreateElicitationHandler(reader, writer)
+
+	result, err := handler(copilot.ElicitationContext{
+		Mode:            "form",
+		Message:         "No fields",
+		RequestedSchema: map[string]any{},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "accept", result.Action)
+}

--- a/pkg/svc/chat/elicitation_test.go
+++ b/pkg/svc/chat/elicitation_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCreateElicitationHandler_AcceptSimple(t *testing.T) {
+	t.Parallel()
+
 	reader := strings.NewReader("y\n")
 	writer := &bytes.Buffer{}
 	handler := chat.CreateElicitationHandler(reader, writer)
@@ -27,6 +29,8 @@ func TestCreateElicitationHandler_AcceptSimple(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_DeclineSimple(t *testing.T) {
+	t.Parallel()
+
 	reader := strings.NewReader("n\n")
 	writer := &bytes.Buffer{}
 	handler := chat.CreateElicitationHandler(reader, writer)
@@ -40,6 +44,8 @@ func TestCreateElicitationHandler_DeclineSimple(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_DefaultDecline(t *testing.T) {
+	t.Parallel()
+
 	reader := strings.NewReader("\n")
 	writer := &bytes.Buffer{}
 	handler := chat.CreateElicitationHandler(reader, writer)
@@ -53,6 +59,8 @@ func TestCreateElicitationHandler_DefaultDecline(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_EOF(t *testing.T) {
+	t.Parallel()
+
 	reader := strings.NewReader("") // EOF immediately
 	writer := &bytes.Buffer{}
 	handler := chat.CreateElicitationHandler(reader, writer)
@@ -66,6 +74,8 @@ func TestCreateElicitationHandler_EOF(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_FormFields(t *testing.T) {
+	t.Parallel()
+
 	input := "hello\nworld\n"
 	reader := strings.NewReader(input)
 	writer := &bytes.Buffer{}
@@ -90,6 +100,8 @@ func TestCreateElicitationHandler_FormFields(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_FormFieldDecline(t *testing.T) {
+	t.Parallel()
+
 	input := "hello\n!cancel\n"
 	reader := strings.NewReader(input)
 	writer := &bytes.Buffer{}
@@ -111,6 +123,8 @@ func TestCreateElicitationHandler_FormFieldDecline(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_FormFieldEOF(t *testing.T) {
+	t.Parallel()
+
 	input := "hello\n" // only one field, then EOF
 	reader := strings.NewReader(input)
 	writer := &bytes.Buffer{}
@@ -132,6 +146,8 @@ func TestCreateElicitationHandler_FormFieldEOF(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_URLMode(t *testing.T) {
+	t.Parallel()
+
 	reader := strings.NewReader("y\n")
 	writer := &bytes.Buffer{}
 	handler := chat.CreateElicitationHandler(reader, writer)
@@ -148,6 +164,8 @@ func TestCreateElicitationHandler_URLMode(t *testing.T) {
 }
 
 func TestCreateElicitationHandler_EmptySchema(t *testing.T) {
+	t.Parallel()
+
 	reader := strings.NewReader("y\n")
 	writer := &bytes.Buffer{}
 	handler := chat.CreateElicitationHandler(reader, writer)


### PR DESCRIPTION
## Summary

Adopts three new features from copilot-sdk v0.2.1 that KSail was not yet leveraging:

### 1. Slash Commands (`SessionConfig.Commands`)
Registers 6 slash commands via the SDK for both TUI and non-TUI chat modes:

| Command | Description | TUI Equivalent |
|---------|-------------|----------------|
| `/mode [mode]` | Switch chat mode | Tab key |
| `/model [name]` | Switch LLM model | Ctrl+O |
| `/new` | Start new chat session | Ctrl+N |
| `/sessions` | Open session picker | Ctrl+H |
| `/help` | Show shortcuts and commands | F1 |
| `/clear` | Clear the chat viewport | (new) |

### 2. Command Picker Autocomplete Popup
Adds a floating autocomplete popup that appears when the user types `/` in the chat input:
- Filters commands in real-time as the user types (e.g., `/mo` → `/mode`, `/model`)
- Arrow keys navigate the list
- **Enter** fills and fires the selected command
- **Tab** fills without firing (allows adding arguments)
- **Esc** dismisses the popup

### 3. Elicitation Handler (`OnElicitationRequest`)
Adds support for MCP tool-initiated form dialogs:
- **TUI mode**: Renders an inline modal with field inputs, accept/decline keyboard handling
- **Non-TUI mode**: Prompts via stdin for field values or accept/decline

### Files

**New files:**
- `pkg/cli/ui/chat/commands.go` — Slash command definitions, message types, `BuildTUISlashCommands()`, `BuildNonTUISlashCommands()`
- `pkg/cli/ui/chat/command_picker.go` — Autocomplete overlay state, key handling, rendering, filtering
- `pkg/cli/ui/chat/elicitation.go` — TUI elicitation modal, handler factory
- `pkg/svc/chat/elicitation.go` — Non-TUI elicitation handler (stdin-based)
- `*_test.go` — Unit tests for all new functionality

**Modified files:**
- `pkg/cli/cmd/chat/chat.go` — Wire commands and elicitation into `SessionConfig` for both TUI and non-TUI
- `pkg/cli/ui/chat/model.go` — Add fields, message dispatch, View overlay
- `pkg/cli/ui/chat/keyhandlers.go` — Command picker + elicitation key interception
- `pkg/cli/ui/chat/render.go` — Elicitation modal rendering
- `pkg/cli/ui/chat/dimensions.go` — Command picker height in viewport calculation
- `pkg/cli/ui/chat/styles.go` — Add `ansiBlack` constant