### PR TITLE
fix(ci): cancel stale merge queue runs for the same PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,25 +61,44 @@ jobs:
             const stablePrefix = match[1];
 
             for (const status of ['in_progress', 'queued']) {
-              const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ci.yaml',
-                status,
-                per_page: 50,
-              });
-              for (const run of runs) {
-                if (run.run_number >= context.runNumber) continue;
-                const runRef = `refs/heads/${run.head_branch}`;
-                const runMatch = runRef.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
-                if (runMatch && runMatch[1] === stablePrefix) {
-                  console.log(`Cancelling stale run ${run.id} (${runRef})`);
-                  await github.rest.actions.cancelWorkflowRun({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: run.id,
-                  });
+              let page = 1;
+              while (true) {
+                const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'ci.yaml',
+                  event: 'merge_group',
+                  status,
+                  per_page: 100,
+                  page,
+                });
+
+                if (runs.length === 0) break;
+
+                for (const run of runs) {
+                  if (run.run_number >= context.runNumber) continue;
+                  const runRef = `refs/heads/${run.head_branch}`;
+                  const runMatch = runRef.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
+                  if (runMatch && runMatch[1] === stablePrefix) {
+                    console.log(`Cancelling stale run ${run.id} (${runRef})`);
+                    try {
+                      await github.rest.actions.cancelWorkflowRun({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        run_id: run.id,
+                      });
+                    } catch (error) {
+                      if (error && (error.status === 409 || error.status === 422)) {
+                        console.log(`Skipping run ${run.id}; it is no longer cancellable (${error.status})`);
+                        continue;
+                      }
+                      throw error;
+                    }
+                  }
                 }
+
+                if (runs.length < 100) break;
+                page += 1;
               }
             }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,58 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Cancel stale merge queue runs for the same PR.
+  # Merge queue refs include a unique SHA suffix (gh-readonly-queue/<base>/pr-<id>-<sha>),
+  # so the workflow-level concurrency group can't deduplicate them. This job strips the
+  # SHA to find older runs for the same queue entry and cancels them.
+  cancel-stale-merge-queue:
+    name: 🧹 Cancel Stale Merge Queue Runs
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      actions: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Cancel previous runs for same merge queue entry
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const ref = context.ref;
+            const match = ref.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
+            if (!match) {
+              console.log('Not a merge queue ref, skipping');
+              return;
+            }
+            const stablePrefix = match[1];
+
+            for (const status of ['in_progress', 'queued']) {
+              const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci.yaml',
+                status,
+                per_page: 50,
+              });
+              for (const run of runs) {
+                if (run.run_number >= context.runNumber) continue;
+                const runRef = `refs/heads/${run.head_branch}`;
+                const runMatch = runRef.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
+                if (runMatch && runMatch[1] === stablePrefix) {
+                  console.log(`Cancelling stale run ${run.id} (${runRef})`);
+                  await github.rest.actions.cancelWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                  });
+                }
+              }
+            }
+
   # Wait for sufficient GitHub API rate limit before proceeding
   rate-limit-gate:
     name: ⏳ Rate Limit Gate


### PR DESCRIPTION
## Problem

The CI workflow's concurrency group uses `github.ref`, which for `merge_group` events resolves to `refs/heads/gh-readonly-queue/main/pr-<id>-<SHA>`. Because the SHA suffix changes every time a PR re-enters the queue (or when main advances), each merge queue run gets a **unique** concurrency group — old runs are never cancelled.

## Fix

Add a `cancel-stale-merge-queue` job that runs only for `merge_group` events. It:

1. Extracts the stable per-PR prefix from the merge queue ref by stripping the trailing SHA
2. Lists in-progress and queued workflow runs for `ci.yaml`
3. Cancels any **older** runs that share the same stable prefix (same PR, different SHA)

### How it works

| Merge queue ref | Stable prefix |
|---|---|
| `refs/heads/gh-readonly-queue/main/pr-123-abc123...` | `refs/heads/gh-readonly-queue/main/pr-123` |
| `refs/heads/gh-readonly-queue/main/pr-123-def456...` | `refs/heads/gh-readonly-queue/main/pr-123` |
| `refs/heads/gh-readonly-queue/main/pr-456-abc123...` | `refs/heads/gh-readonly-queue/main/pr-456` |

Runs for the same PR cancel each other's stale runs; different PRs are unaffected.

### Design decisions

- **Per-PR granularity**: Supports parallel merge queue processing — different PRs run independently
- **Race-safe**: Only cancels runs with a lower `run_number` than the current run
- **Independent**: Runs in parallel with other jobs (no `needs` dependency)
- **Scoped permissions**: Only requires `actions: write` on this job