### PR TITLE
fix(chat): set CLIPath and add pre-flight validation for Copilot CLI

### DIFF
--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -220,7 +220,7 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 	}
 
 	if pathErr == nil {
-		verifyErr := verifyCopilotCLI(ctx, cliPath)
+		verifyErr := verifyCopilotCLI(ctx, cliPath, opts.Env)
 		if verifyErr != nil {
 			return nil, verifyErr
 		}
@@ -260,14 +260,16 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 
 // verifyCopilotCLI runs a quick version check on the resolved copilot binary
 // to catch common issues (missing binary, corrupt install, wrong binary)
-// before the SDK attempts a full startup.
-func verifyCopilotCLI(ctx context.Context, cliPath string) error {
+// before the SDK attempts a full startup. The provided env is used so the
+// pre-flight check matches the filtered environment the SDK will use.
+func verifyCopilotCLI(ctx context.Context, cliPath string, env []string) error {
 	const verifyTimeout = 5 * time.Second
 
 	verifyCtx, cancel := context.WithTimeout(ctx, verifyTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(verifyCtx, cliPath, "--version")
+	cmd.Env = env
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -213,7 +213,8 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 	// (embedded CLI → PATH fallback) for forward compatibility.
 	cliPath, pathErr := resolveCopilotCLIPath()
 	if pathErr == nil {
-		if verifyErr := verifyCopilotCLI(ctx, cliPath); verifyErr != nil {
+		verifyErr := verifyCopilotCLI(ctx, cliPath)
+		if verifyErr != nil {
 			return nil, verifyErr
 		}
 
@@ -260,8 +261,8 @@ func verifyCopilotCLI(ctx context.Context, cliPath string) error {
 	defer cancel()
 
 	cmd := exec.CommandContext(verifyCtx, cliPath, "--version")
-	output, err := cmd.CombinedOutput()
 
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf(
 			"copilot CLI at %q failed pre-flight check: %w (output: %s)\n\n"+

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -209,9 +209,16 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 	// Resolve CLI path explicitly so we get a clear error if it's missing,
 	// rather than the opaque "CLI process exited: exit status 1" from the SDK.
 	// This checks COPILOT_CLI_PATH, the SDK cache directory, and system PATH.
-	// If resolution fails, omit CLIPath and let the SDK try its own resolution
-	// (embedded CLI → PATH fallback) for forward compatibility.
+	//
+	// When COPILOT_CLI_PATH is explicitly set, errors are fatal: the user
+	// expects that specific binary to be used. Otherwise, resolution failures
+	// are ignored so the SDK can try its own resolution (embedded CLI → PATH
+	// fallback) for forward compatibility.
 	cliPath, pathErr := resolveCopilotCLIPath()
+	if pathErr != nil && os.Getenv("COPILOT_CLI_PATH") != "" {
+		return nil, pathErr
+	}
+
 	if pathErr == nil {
 		verifyErr := verifyCopilotCLI(ctx, cliPath)
 		if verifyErr != nil {

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -206,6 +206,20 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 		Env:      filterEnvVars(os.Environ(), filteredEnvVars),
 	}
 
+	// Resolve CLI path explicitly so we get a clear error if it's missing,
+	// rather than the opaque "CLI process exited: exit status 1" from the SDK.
+	// This checks COPILOT_CLI_PATH, the SDK cache directory, and system PATH.
+	// If resolution fails, omit CLIPath and let the SDK try its own resolution
+	// (embedded CLI → PATH fallback) for forward compatibility.
+	cliPath, pathErr := resolveCopilotCLIPath()
+	if pathErr == nil {
+		if verifyErr := verifyCopilotCLI(ctx, cliPath); verifyErr != nil {
+			return nil, verifyErr
+		}
+
+		opts.CLIPath = cliPath
+	}
+
 	cwd, cwdErr := os.Getwd()
 	if cwdErr == nil {
 		opts.Cwd = cwd
@@ -226,12 +240,39 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 		return nil, fmt.Errorf(
 			"failed to start Copilot client: %w\n\n"+
 				"To fix:\n"+
-				"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication",
+				"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication\n"+
+				"  - Install the Copilot CLI: npm install -g @github/copilot\n"+
+				"  - Verify the CLI works: copilot --version",
 			err,
 		)
 	}
 
 	return client, nil
+}
+
+// verifyCopilotCLI runs a quick version check on the resolved copilot binary
+// to catch common issues (missing binary, corrupt install, wrong binary)
+// before the SDK attempts a full startup.
+func verifyCopilotCLI(ctx context.Context, cliPath string) error {
+	const verifyTimeout = 5 * time.Second
+
+	verifyCtx, cancel := context.WithTimeout(ctx, verifyTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(verifyCtx, cliPath, "--version")
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return fmt.Errorf(
+			"copilot CLI at %q failed pre-flight check: %w (output: %s)\n\n"+
+				"To fix:\n"+
+				"  - Install or reinstall the Copilot CLI: npm install -g @github/copilot\n"+
+				"  - Or set COPILOT_CLI_PATH to a working copilot binary",
+			cliPath, err, strings.TrimSpace(string(output)),
+		)
+	}
+
+	return nil
 }
 
 // filterEnvVars returns a copy of env with the specified variable names removed.


### PR DESCRIPTION
## Summary

Fixes the opaque `ksail chat` startup error:

```
failed to start Copilot client: CLI process exited: exit status 1
  failed to kill CLI process: os: process already finished
```

## Root Cause

KSail didn't set `ClientOptions.CLIPath` when creating the Copilot SDK client. The SDK's internal resolution (`embeddedcli.Path()` → `"copilot"` in PATH) silently failed when the CLI was missing or broken, producing an unhelpful error.

## Changes

- **Set `CLIPath` explicitly**: Uses `resolveCopilotCLIPath()` (checks `COPILOT_CLI_PATH` → SDK cache `~/Library/Caches/copilot-sdk/` → system PATH) and passes the resolved path to the SDK via `ClientOptions.CLIPath`
- **Add pre-flight validation**: New `verifyCopilotCLI()` runs `copilot --version` before full startup to catch corrupt installs or wrong binaries with clear error messages
- **Improve error guidance**: The "To fix" message now includes CLI installation and verification steps alongside the existing token suggestion

## Testing

- `go build` ✅
- `go test ./pkg/cli/cmd/chat/...` ✅
- `go test ./...` ✅ (only pre-existing K3d Docker test fails — unrelated)