### PR TITLE
perf: optimize CI system test speed via root cause fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -693,11 +693,53 @@ jobs:
         exclude:
           # init=false primarily validates CLI flag parsing — the provisioner/installer
           # logic is the same as init=true. Keep only default and full-stack variants.
-          - init: false
+          - distribution: Vanilla
+            provider: Docker
+            init: false
             args: "--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"
-          - init: false
+          - distribution: Vanilla
+            provider: Docker
+            init: false
             args: "--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
-          - init: false
+          - distribution: Vanilla
+            provider: Docker
+            init: false
+            args: "--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+          - distribution: K3s
+            provider: Docker
+            init: false
+            args: "--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"
+          - distribution: K3s
+            provider: Docker
+            init: false
+            args: "--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+          - distribution: K3s
+            provider: Docker
+            init: false
+            args: "--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+          - distribution: Talos
+            provider: Docker
+            init: false
+            args: "--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"
+          - distribution: Talos
+            provider: Docker
+            init: false
+            args: "--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+          - distribution: Talos
+            provider: Docker
+            init: false
+            args: "--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+          - distribution: VCluster
+            provider: Docker
+            init: false
+            args: "--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"
+          - distribution: VCluster
+            provider: Docker
+            init: false
+            args: "--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+          - distribution: VCluster
+            provider: Docker
+            init: false
             args: "--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
         include:
           - distribution: Talos

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -679,7 +679,7 @@ jobs:
       packages: write
     strategy:
       fail-fast: true
-      max-parallel: 15
+      max-parallel: 20
       matrix:
         distribution: [Vanilla, K3s, Talos, VCluster]
         provider: [Docker]
@@ -690,6 +690,15 @@ jobs:
           - "--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"
           - "--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
           - "--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+        exclude:
+          # init=false primarily validates CLI flag parsing — the provisioner/installer
+          # logic is the same as init=true. Keep only default and full-stack variants.
+          - init: false
+            args: "--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"
+          - init: false
+            args: "--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
+          - init: false
+            args: "--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"
         include:
           - distribution: Talos
             provider: Docker

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -1436,7 +1436,7 @@ func handlePostCreationSetup(
 	clusterCfg *v1alpha1.Cluster,
 	tmr timer.Timer,
 ) error {
-	_, err := setup.InstallCNI(cmd, clusterCfg, tmr)
+	cniInstalled, err := setup.InstallCNI(cmd, clusterCfg, tmr)
 	if err != nil {
 		return fmt.Errorf("failed to install CNI: %w", err)
 	}
@@ -1450,6 +1450,7 @@ func handlePostCreationSetup(
 		clusterCfg,
 		factories,
 		outputTimer,
+		cniInstalled,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to install post-CNI components: %w", err)

--- a/pkg/cli/cmd/cluster/cluster_test.go
+++ b/pkg/cli/cmd/cluster/cluster_test.go
@@ -1481,7 +1481,7 @@ func setupMockRegistryBackend(t *testing.T) {
 	// Tests use a fake kubeconfig without a real cluster, so the real
 	// stability check would time out waiting for API server connectivity.
 	t.Cleanup(setup.SetClusterStabilityCheckForTests(
-		func(_ context.Context, _ *v1alpha1.Cluster) error {
+		func(_ context.Context, _ *v1alpha1.Cluster, _ bool) error {
 			return nil
 		},
 	))

--- a/pkg/cli/setup/cni.go
+++ b/pkg/cli/setup/cni.go
@@ -162,10 +162,11 @@ func runCNIInstallation(
 		return fmt.Errorf("%s installation failed: %w", cniName, err)
 	}
 
-	// Wait for at least one node to become Ready before declaring success.
+	// Wait for all nodes to become Ready before declaring success.
 	// This is critical for CNIs like Calico that use SkipWait (Helm returns
 	// before pods are ready), ensuring the network layer is functional
-	// before post-CNI components begin installing.
+	// before post-CNI components begin installing. Waiting for all nodes
+	// (not just one) means the skip in waitForClusterStability is safe.
 	err = waitForCNIReadiness(cmd.Context(), setup, clusterCfg, cniNamespaces)
 	if err != nil {
 		return fmt.Errorf("node readiness check after %s install failed: %w", cniName, err)

--- a/pkg/cli/setup/cni.go
+++ b/pkg/cli/setup/cni.go
@@ -181,7 +181,7 @@ func runCNIInstallation(
 	return nil
 }
 
-// waitForCNIReadiness waits for at least one node to become Ready after CNI installation.
+// waitForCNIReadiness waits for all nodes to become Ready after CNI installation.
 // On timeout, it diagnoses pod failures in the CNI namespaces to provide actionable errors.
 func waitForCNIReadiness(
 	ctx context.Context,
@@ -197,7 +197,7 @@ func waitForCNIReadiness(
 		return fmt.Errorf("create kubernetes client: %w", err)
 	}
 
-	err = readiness.WaitForNodeReady(ctx, clientset, setup.timeout)
+	err = readiness.WaitForAllNodesReady(ctx, clientset, setup.timeout)
 	if err != nil {
 		diag := k8s.DiagnosePodFailures(ctx, clientset, cniNamespaces)
 		if diag != "" {

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -70,14 +70,22 @@ const (
 )
 
 // apiServerStabilitySuccesses returns the number of consecutive successful
-// API server health checks required based on the distribution. Vanilla and K3s
-// distributions stabilize faster after webhook registrations, so fewer
-// consecutive successes are required.
-func apiServerStabilitySuccesses(dist v1alpha1.Distribution) int {
+// API server health checks required based on the distribution and provider.
+// Vanilla and K3s distributions stabilize faster after webhook registrations,
+// so fewer consecutive successes are required. Talos on the Docker provider
+// also uses the fast threshold because Docker containers do not experience
+// the network flapping seen in cloud environments.
+func apiServerStabilitySuccesses(dist v1alpha1.Distribution, prov v1alpha1.Provider) int {
 	switch dist {
 	case v1alpha1.DistributionVanilla, v1alpha1.DistributionK3s:
 		return apiServerStabilitySuccessesFast
-	case v1alpha1.DistributionTalos, v1alpha1.DistributionVCluster:
+	case v1alpha1.DistributionTalos:
+		if prov == v1alpha1.ProviderDocker || prov == "" {
+			return apiServerStabilitySuccessesFast
+		}
+
+		return apiServerStabilitySuccessesDefault
+	case v1alpha1.DistributionVCluster:
 		return apiServerStabilitySuccessesDefault
 	default:
 		return apiServerStabilitySuccessesDefault
@@ -100,12 +108,12 @@ var (
 	//nolint:gochecknoglobals // dependency injection for tests
 	clusterStabilityCheckMu sync.RWMutex
 	//nolint:gochecknoglobals // dependency injection for tests
-	clusterStabilityCheckOverride func(context.Context, *v1alpha1.Cluster) error
+	clusterStabilityCheckOverride func(context.Context, *v1alpha1.Cluster, bool) error
 )
 
 // getClusterStabilityCheckFn returns the cluster stability check function,
 // using the test override if one is set.
-func getClusterStabilityCheckFn() func(context.Context, *v1alpha1.Cluster) error {
+func getClusterStabilityCheckFn() func(context.Context, *v1alpha1.Cluster, bool) error {
 	clusterStabilityCheckMu.RLock()
 	defer clusterStabilityCheckMu.RUnlock()
 
@@ -119,7 +127,7 @@ func getClusterStabilityCheckFn() func(context.Context, *v1alpha1.Cluster) error
 // SetClusterStabilityCheckForTests overrides the cluster stability check for testing.
 // Returns a cleanup function that restores the previous check.
 func SetClusterStabilityCheckForTests(
-	fn func(context.Context, *v1alpha1.Cluster) error,
+	fn func(context.Context, *v1alpha1.Cluster, bool) error,
 ) func() {
 	clusterStabilityCheckMu.Lock()
 
@@ -263,11 +271,15 @@ func needsCSIInstall(clusterCfg *v1alpha1.Cluster) bool {
 // InstallPostCNIComponents installs all post-CNI components in parallel.
 // This includes metrics-server, CSI, cert-manager, and GitOps engines (Flux/ArgoCD).
 // For Flux, the OCI artifact push and readiness wait happens after installation.
+// cniInstalled indicates whether CNI was just installed — when true, the node
+// readiness check in the stability pre-flight is skipped since waitForCNIReadiness
+// already verified it.
 func InstallPostCNIComponents(
 	cmd *cobra.Command,
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
 	tmr timer.Timer,
+	cniInstalled bool,
 ) error {
 	reqs := GetComponentRequirements(clusterCfg)
 
@@ -292,7 +304,7 @@ func InstallPostCNIComponents(
 		}
 	}
 
-	err := installComponentsInPhases(ctx, cmd, clusterCfg, factories, tmr, reqs)
+	err := installComponentsInPhases(ctx, cmd, clusterCfg, factories, tmr, reqs, cniInstalled)
 	if err != nil {
 		return err
 	}
@@ -314,13 +326,14 @@ func installComponentsInPhases(
 	factories *InstallerFactories,
 	tmr timer.Timer,
 	reqs ComponentRequirements,
+	cniInstalled bool,
 ) error {
 	writer := cmd.OutOrStdout()
 	labels := notify.InstallingLabels()
 
 	infraTasks := buildInfrastructureTasks(clusterCfg, factories, reqs)
 	if len(infraTasks) > 0 {
-		err := runInfraPhase(ctx, clusterCfg, writer, labels, tmr, infraTasks)
+		err := runInfraPhase(ctx, clusterCfg, writer, labels, tmr, infraTasks, cniInstalled)
 		if err != nil {
 			return err
 		}
@@ -328,6 +341,8 @@ func installComponentsInPhases(
 
 	gitopsTasks := buildGitOpsTasks(clusterCfg, factories, reqs)
 	if len(gitopsTasks) > 0 {
+		// After infra phase, CNI node readiness is no longer fresh — always
+		// run the full stability check before GitOps installation.
 		err := runGitOpsPhase(ctx, clusterCfg, writer, labels, tmr, infraTasks, gitopsTasks)
 		if err != nil {
 			return err
@@ -341,6 +356,8 @@ func installComponentsInPhases(
 // load-balancer, kubelet-csr-approver, CSI, cert-manager, policy-engine).
 // For Cilium CNI, a pre-flight stability check ensures the eBPF dataplane
 // has programmed pod-to-service routing before components are deployed.
+// cniInstalled indicates whether CNI was just installed — when true, the node
+// readiness check in the stability pre-flight is skipped.
 func runInfraPhase(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
@@ -348,9 +365,10 @@ func runInfraPhase(
 	labels notify.ProgressLabels,
 	tmr timer.Timer,
 	infraTasks []notify.ProgressTask,
+	cniInstalled bool,
 ) error {
 	if needsInClusterConnectivityCheck(clusterCfg) {
-		err := getClusterStabilityCheckFn()(ctx, clusterCfg)
+		err := getClusterStabilityCheckFn()(ctx, clusterCfg, cniInstalled)
 		if err != nil {
 			return fmt.Errorf(
 				"cluster not stable before infrastructure installation: %w", err,
@@ -392,7 +410,7 @@ func runGitOpsPhase(
 	infraTasks []notify.ProgressTask,
 	gitopsTasks []notify.ProgressTask,
 ) error {
-	err := getClusterStabilityCheckFn()(ctx, clusterCfg)
+	err := getClusterStabilityCheckFn()(ctx, clusterCfg, false)
 	if err != nil {
 		if len(infraTasks) > 0 {
 			return fmt.Errorf(
@@ -498,9 +516,13 @@ func buildGitOpsTasks(
 // dataplane programming) and as a gate between Phase 1 and Phase 2 (to prevent
 // GitOps operators from entering CrashLoopBackOff due to transient API server
 // connectivity issues after infrastructure components register webhooks).
+//
+// When cniInstalled is true, the WaitForAllNodesReady check is skipped because
+// waitForCNIReadiness already verified node readiness moments ago.
 func waitForClusterStability(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
+	cniInstalled bool,
 ) error {
 	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(clusterCfg)
 	if err != nil {
@@ -514,7 +536,10 @@ func waitForClusterStability(
 		return fmt.Errorf("create clientset for API server check: %w", err)
 	}
 
-	successes := apiServerStabilitySuccesses(clusterCfg.Spec.Cluster.Distribution)
+	successes := apiServerStabilitySuccesses(
+		clusterCfg.Spec.Cluster.Distribution,
+		clusterCfg.Spec.Cluster.Provider,
+	)
 
 	err = readiness.WaitForAPIServerStable(
 		ctx, clientset, apiServerStabilityTimeout, successes,
@@ -528,9 +553,14 @@ func waitForClusterStability(
 	// NotReady taint that prevents workload scheduling. Without this check,
 	// pods deployed immediately after stability checks pass can hit
 	// FailedScheduling errors.
-	err = readiness.WaitForAllNodesReady(ctx, clientset, nodeReadinessTimeout)
-	if err != nil {
-		return fmt.Errorf("wait for all nodes to be ready: %w", err)
+	//
+	// Skipped when CNI was just installed: waitForCNIReadiness already verified
+	// node readiness, so re-checking immediately would be redundant.
+	if !cniInstalled {
+		err = readiness.WaitForAllNodesReady(ctx, clientset, nodeReadinessTimeout)
+		if err != nil {
+			return fmt.Errorf("wait for all nodes to be ready: %w", err)
+		}
 	}
 
 	// Wait for all kube-system DaemonSets (including the CNI, e.g. Cilium)

--- a/pkg/cli/setup/post_cni_test.go
+++ b/pkg/cli/setup/post_cni_test.go
@@ -431,26 +431,43 @@ func TestAPIServerStabilitySuccesses(t *testing.T) {
 	tests := []struct {
 		name         string
 		distribution v1alpha1.Distribution
+		provider     v1alpha1.Provider
 		expected     int
 	}{
 		{
 			name:         "Vanilla uses fast (reduced) successes",
 			distribution: v1alpha1.DistributionVanilla,
+			provider:     v1alpha1.ProviderDocker,
 			expected:     setup.APIServerStabilitySuccessesFast,
 		},
 		{
 			name:         "K3s uses fast (reduced) successes",
 			distribution: v1alpha1.DistributionK3s,
+			provider:     v1alpha1.ProviderDocker,
 			expected:     setup.APIServerStabilitySuccessesFast,
 		},
 		{
-			name:         "Talos uses default (full) successes",
+			name:         "Talos Docker uses fast (reduced) successes",
 			distribution: v1alpha1.DistributionTalos,
+			provider:     v1alpha1.ProviderDocker,
+			expected:     setup.APIServerStabilitySuccessesFast,
+		},
+		{
+			name:         "Talos empty provider uses fast (reduced) successes",
+			distribution: v1alpha1.DistributionTalos,
+			provider:     "",
+			expected:     setup.APIServerStabilitySuccessesFast,
+		},
+		{
+			name:         "Talos Hetzner uses default (full) successes",
+			distribution: v1alpha1.DistributionTalos,
+			provider:     v1alpha1.ProviderHetzner,
 			expected:     setup.APIServerStabilitySuccessesDefault,
 		},
 		{
 			name:         "VCluster uses default (full) successes",
 			distribution: v1alpha1.DistributionVCluster,
+			provider:     v1alpha1.ProviderDocker,
 			expected:     setup.APIServerStabilitySuccessesDefault,
 		},
 	}
@@ -460,7 +477,7 @@ func TestAPIServerStabilitySuccesses(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(
-				t, testCase.expected, setup.APIServerStabilitySuccesses(testCase.distribution),
+				t, testCase.expected, setup.APIServerStabilitySuccesses(testCase.distribution, testCase.provider),
 			)
 		})
 	}

--- a/pkg/cli/setup/post_cni_test.go
+++ b/pkg/cli/setup/post_cni_test.go
@@ -477,7 +477,9 @@ func TestAPIServerStabilitySuccesses(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(
-				t, testCase.expected, setup.APIServerStabilitySuccesses(testCase.distribution, testCase.provider),
+				t,
+				testCase.expected,
+				setup.APIServerStabilitySuccesses(testCase.distribution, testCase.provider),
 			)
 		})
 	}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -232,3 +232,13 @@ func RenameKubeconfigContextForTest(kubeconfigData []byte, desiredContext string
 
 	return result, nil
 }
+
+// IsDockerProviderForTest exposes isDockerProvider for unit testing.
+func (p *Provisioner) IsDockerProviderForTest() bool {
+	return p.isDockerProvider()
+}
+
+// ClusterReadinessChecksCountForTest returns the number of checks from clusterReadinessChecks for unit testing.
+func (p *Provisioner) ClusterReadinessChecksCountForTest() int {
+	return len(p.clusterReadinessChecks())
+}

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -58,6 +58,9 @@ const (
 	talosAPIWaitTimeout = 5 * time.Minute
 	// bootstrapTimeout is the timeout for bootstrap operations.
 	bootstrapTimeout = 2 * time.Minute
+	// preBootPollInterval is the polling interval for pre-boot sequence checks.
+	// Matches the Talos SDK's default of 5 seconds per check.
+	preBootPollInterval = 5 * time.Second
 	// retryInterval is the default interval between retry attempts.
 	retryInterval = 5 * time.Second
 	// longRetryInterval is the interval for longer operations.

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -197,21 +197,15 @@ func (p *Provisioner) isDockerProvider() bool {
 	return ok
 }
 
-// dockerPreBootSequenceChecks returns a trimmed set of pre-boot sequence checks
-// optimized for Docker environments. It skips purely diagnostic checks
-// (AllNodesMemorySizes, AllNodesDiskSizes, NoDiagnostics) that add polling
-// overhead without catching real issues in Docker containers, where resources
-// are always consistent.
-func dockerPreBootSequenceChecks() []check.ClusterCheck {
+// dockerEtcdChecks returns the etcd-related pre-boot checks for Docker environments.
+func dockerEtcdChecks() []check.ClusterCheck {
+	cpTypes := check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane)
 	return []check.ClusterCheck{
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition(
 				"etcd to be healthy",
 				func(ctx context.Context) error {
-					return check.ServiceHealthAssertion(
-						ctx, cluster, "etcd",
-						check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
-					)
+					return check.ServiceHealthAssertion(ctx, cluster, "etcd", cpTypes)
 				},
 				preBootPollInterval,
 			)
@@ -234,6 +228,18 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 				preBootPollInterval,
 			)
 		},
+	}
+}
+
+// dockerPreBootSequenceChecks returns a trimmed set of pre-boot sequence checks
+// optimized for Docker environments. It skips purely diagnostic checks
+// (AllNodesMemorySizes, AllNodesDiskSizes, NoDiagnostics) that add polling
+// overhead without catching real issues in Docker containers, where resources
+// are always consistent.
+func dockerPreBootSequenceChecks() []check.ClusterCheck {
+	allNodeTypes := check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker)
+	return append(
+		dockerEtcdChecks(),
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
 				return check.ApidReadyAssertion(ctx, cluster)
@@ -243,33 +249,16 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 		// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
 		// NoDiagnostics — skipped: informational-only, not a readiness gate
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"kubelet to be healthy",
-				func(ctx context.Context) error {
-					return check.ServiceHealthAssertion(
-						ctx,
-						cluster,
-						"kubelet",
-						check.WithNodeTypes(
-							machine.TypeInit,
-							machine.TypeControlPlane,
-							machine.TypeWorker,
-						),
-					)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
+				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"all nodes to finish boot sequence",
-				func(ctx context.Context) error {
-					return check.AllNodesBootedAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
+				return check.AllNodesBootedAssertion(ctx, cluster)
+			}, preBootPollInterval)
 		},
-	}
+	)
 }
 
 // clusterReadinessChecks returns the appropriate set of cluster readiness checks

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -200,6 +200,7 @@ func (p *Provisioner) isDockerProvider() bool {
 // dockerEtcdChecks returns the etcd-related pre-boot checks for Docker environments.
 func dockerEtcdChecks() []check.ClusterCheck {
 	cpTypes := check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane)
+
 	return []check.ClusterCheck{
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition(
@@ -237,7 +238,12 @@ func dockerEtcdChecks() []check.ClusterCheck {
 // overhead without catching real issues in Docker containers, where resources
 // are always consistent.
 func dockerPreBootSequenceChecks() []check.ClusterCheck {
-	allNodeTypes := check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker)
+	allNodeTypes := check.WithNodeTypes(
+		machine.TypeInit,
+		machine.TypeControlPlane,
+		machine.TypeWorker,
+	)
+
 	return append(
 		dockerEtcdChecks(),
 		func(cluster check.ClusterInfo) conditions.Condition {
@@ -249,14 +255,22 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 		// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
 		// NoDiagnostics — skipped: informational-only, not a readiness gate
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"kubelet to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
-				return check.AllNodesBootedAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"all nodes to finish boot sequence",
+				func(ctx context.Context) error {
+					return check.AllNodesBootedAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 	)
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -205,22 +205,34 @@ func (p *Provisioner) isDockerProvider() bool {
 func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	return []check.ClusterCheck{
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(
-					ctx, cluster, "etcd",
-					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
-				)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"etcd to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(
+						ctx, cluster, "etcd",
+						check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
+					)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd members to be consistent across nodes", func(ctx context.Context) error {
-				return check.EtcdConsistentAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"etcd members to be consistent across nodes",
+				func(ctx context.Context) error {
+					return check.EtcdConsistentAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd members to be control plane nodes", func(ctx context.Context) error {
-				return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"etcd members to be control plane nodes",
+				func(ctx context.Context) error {
+					return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
@@ -231,17 +243,25 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 		// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
 		// NoDiagnostics — skipped: informational-only, not a readiness gate
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(
-					ctx, cluster, "kubelet",
-					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
-				)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"kubelet to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(
+						ctx, cluster, "kubelet",
+						check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
+					)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
-				return check.AllNodesBootedAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"all nodes to finish boot sequence",
+				func(ctx context.Context) error {
+					return check.AllNodesBootedAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 	}
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/devantler-tech/ksail/v6/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v6/pkg/k8s"
+	dockerprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/docker"
 	"github.com/siderolabs/talos/pkg/cluster/check"
 	"github.com/siderolabs/talos/pkg/conditions"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/bundle"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -182,12 +184,72 @@ func (p *Provisioner) cleanupTalosconfig(clusterName string) error {
 	return nil
 }
 
+// isDockerProvider returns true if the provisioner is using the Docker provider.
+// This is the case when infraProvider is a *dockerprovider.Provider, or when
+// infraProvider is nil (legacy fallback to dockerClient).
+func (p *Provisioner) isDockerProvider() bool {
+	if p.infraProvider == nil {
+		return true
+	}
+
+	_, ok := p.infraProvider.(*dockerprovider.Provider)
+
+	return ok
+}
+
+// dockerPreBootSequenceChecks returns a trimmed set of pre-boot sequence checks
+// optimized for Docker environments. It skips purely diagnostic checks
+// (AllNodesMemorySizes, AllNodesDiskSizes, NoDiagnostics) that add polling
+// overhead without catching real issues in Docker containers, where resources
+// are always consistent.
+func dockerPreBootSequenceChecks() []check.ClusterCheck {
+	return []check.ClusterCheck{
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
+				return check.ServiceHealthAssertion(ctx, cluster, "etcd", check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
+			}, preBootPollInterval)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("etcd members to be consistent across nodes", func(ctx context.Context) error {
+				return check.EtcdConsistentAssertion(ctx, cluster)
+			}, preBootPollInterval)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("etcd members to be control plane nodes", func(ctx context.Context) error {
+				return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
+			}, preBootPollInterval)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
+				return check.ApidReadyAssertion(ctx, cluster)
+			}, preBootPollInterval)
+		},
+		// AllNodesMemorySizes — skipped: diagnostic-only, Docker containers have consistent resources
+		// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
+		// NoDiagnostics — skipped: informational-only, not a readiness gate
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
+				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
+			}, preBootPollInterval)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
+				return check.AllNodesBootedAssertion(ctx, cluster)
+			}, preBootPollInterval)
+		},
+	}
+}
+
 // clusterReadinessChecks returns the appropriate set of cluster readiness checks
 // based on CNI and kubelet certificate configuration.
 //
 // When CNI is disabled (either by Talos config or SkipCNIChecks option), returns
 // lighter checks that skip node Ready status, since nodes will remain NotReady
 // until the CNI is installed post-creation.
+//
+// For Docker providers, uses a trimmed pre-boot check set that skips purely
+// diagnostic checks (memory/disk sizes, diagnostics) to reduce sequential
+// polling overhead.
 //
 // Additionally, when kubelet serving certificate rotation is enabled with CNI disabled,
 // the K8sControlPlaneStaticPods check is skipped because it depends on Talos
@@ -205,6 +267,11 @@ func (p *Provisioner) clusterReadinessChecks() []check.ClusterCheck {
 		return check.DefaultClusterChecks()
 	}
 
+	preBootChecks := check.PreBootSequenceChecks()
+	if p.isDockerProvider() {
+		preBootChecks = dockerPreBootSequenceChecks()
+	}
+
 	// When kubelet cert rotation is enabled with CNI disabled, the kubelet-serving-cert-approver
 	// pod cannot schedule (node has not-ready taint), so kubelet serving CSRs remain pending.
 	// Without a serving certificate, Talos cannot connect to kubelet, and StaticPodStatus
@@ -215,13 +282,13 @@ func (p *Provisioner) clusterReadinessChecks() []check.ClusterCheck {
 
 	if skipStaticPodStatusCheck {
 		return slices.Concat(
-			check.PreBootSequenceChecks(),
+			preBootChecks,
 			p.k8sComponentsReadinessChecksWithoutStaticPodStatus(),
 		)
 	}
 
 	return slices.Concat(
-		check.PreBootSequenceChecks(),
+		preBootChecks,
 		check.K8sComponentsReadinessChecks(),
 	)
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -205,34 +205,22 @@ func (p *Provisioner) isDockerProvider() bool {
 func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	return []check.ClusterCheck{
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"etcd to be healthy",
-				func(ctx context.Context) error {
-					return check.ServiceHealthAssertion(
-						ctx, cluster, "etcd",
-						check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
-					)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
+				return check.ServiceHealthAssertion(
+					ctx, cluster, "etcd",
+					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
+				)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"etcd members to be consistent across nodes",
-				func(ctx context.Context) error {
-					return check.EtcdConsistentAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("etcd members to be consistent across nodes", func(ctx context.Context) error {
+				return check.EtcdConsistentAssertion(ctx, cluster)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"etcd members to be control plane nodes",
-				func(ctx context.Context) error {
-					return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("etcd members to be control plane nodes", func(ctx context.Context) error {
+				return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
@@ -243,25 +231,17 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 		// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
 		// NoDiagnostics — skipped: informational-only, not a readiness gate
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"kubelet to be healthy",
-				func(ctx context.Context) error {
-					return check.ServiceHealthAssertion(
-						ctx, cluster, "kubelet",
-						check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
-					)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
+				return check.ServiceHealthAssertion(
+					ctx, cluster, "kubelet",
+					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker),
+				)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"all nodes to finish boot sequence",
-				func(ctx context.Context) error {
-					return check.AllNodesBootedAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
+				return check.AllNodesBootedAssertion(ctx, cluster)
+			}, preBootPollInterval)
 		},
 	}
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -205,22 +205,34 @@ func (p *Provisioner) isDockerProvider() bool {
 func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	return []check.ClusterCheck{
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(
-					ctx, cluster, "etcd",
-					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
-				)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"etcd to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(
+						ctx, cluster, "etcd",
+						check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
+					)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd members to be consistent across nodes", func(ctx context.Context) error {
-				return check.EtcdConsistentAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"etcd members to be consistent across nodes",
+				func(ctx context.Context) error {
+					return check.EtcdConsistentAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd members to be control plane nodes", func(ctx context.Context) error {
-				return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"etcd members to be control plane nodes",
+				func(ctx context.Context) error {
+					return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
@@ -231,17 +243,31 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 		// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
 		// NoDiagnostics — skipped: informational-only, not a readiness gate
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(
-					ctx, cluster, "kubelet",
-					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker),
-				)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"kubelet to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(
+						ctx,
+						cluster,
+						"kubelet",
+						check.WithNodeTypes(
+							machine.TypeInit,
+							machine.TypeControlPlane,
+							machine.TypeWorker,
+						),
+					)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
-				return check.AllNodesBootedAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"all nodes to finish boot sequence",
+				func(ctx context.Context) error {
+					return check.AllNodesBootedAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 	}
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -232,11 +232,14 @@ func dockerEtcdChecks() []check.ClusterCheck {
 	}
 }
 
-// dockerPreBootSequenceChecks returns a trimmed set of pre-boot sequence checks
-// optimized for Docker environments. It skips purely diagnostic checks
-// (AllNodesMemorySizes, AllNodesDiskSizes, NoDiagnostics) that add polling
-// overhead without catching real issues in Docker containers, where resources
-// are always consistent.
+// dockerPreBootSequenceChecks returns a trimmed subset of the upstream
+// check.PreBootSequenceChecks() (github.com/siderolabs/talos v1.13.0-beta.1,
+// pkg/cluster/check/check.go) optimized for Docker environments. It omits
+// purely diagnostic checks (AllNodesMemorySizes, AllNodesDiskSizes, NoDiagnostics)
+// that add polling overhead without catching real issues in Docker containers.
+//
+// When upgrading the Talos dependency, verify this list against the upstream
+// check.PreBootSequenceChecks() to pick up any new essential readiness gates.
 func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	allNodeTypes := check.WithNodeTypes(
 		machine.TypeInit,

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -206,7 +206,10 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	return []check.ClusterCheck{
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(ctx, cluster, "etcd", check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
+				return check.ServiceHealthAssertion(
+					ctx, cluster, "etcd",
+					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
+				)
 			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
@@ -229,7 +232,10 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 		// NoDiagnostics — skipped: informational-only, not a readiness gate
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
+				return check.ServiceHealthAssertion(
+					ctx, cluster, "kubelet",
+					check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane),
+				)
 			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
@@ -3,9 +3,9 @@ package talosprovisioner_test
 import (
 	"testing"
 
-	talosprovisioner "github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster/talos"
 	dockerprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/docker"
 	hetzner "github.com/devantler-tech/ksail/v6/pkg/svc/provider/hetzner"
+	talosprovisioner "github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster/talos"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
@@ -1,0 +1,73 @@
+package talosprovisioner_test
+
+import (
+	"testing"
+
+	talosprovisioner "github.com/devantler-tech/ksail/v6/pkg/svc/provisioner/cluster/talos"
+	dockerprovider "github.com/devantler-tech/ksail/v6/pkg/svc/provider/docker"
+	hetzner "github.com/devantler-tech/ksail/v6/pkg/svc/provider/hetzner"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- isDockerProvider ---
+
+func TestIsDockerProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		prov func() *talosprovisioner.Provisioner
+		want bool
+	}{
+		{
+			name: "nil infra provider is Docker (legacy default)",
+			prov: func() *talosprovisioner.Provisioner {
+				return talosprovisioner.NewProvisioner(nil, nil)
+			},
+			want: true,
+		},
+		{
+			name: "explicit Docker provider returns true",
+			prov: func() *talosprovisioner.Provisioner {
+				return talosprovisioner.NewProvisioner(nil, nil).
+					WithInfraProvider(&dockerprovider.Provider{})
+			},
+			want: true,
+		},
+		{
+			name: "Hetzner provider returns false",
+			prov: func() *talosprovisioner.Provisioner {
+				return talosprovisioner.NewProvisioner(nil, nil).
+					WithInfraProvider(&hetzner.Provider{})
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, tc.prov().IsDockerProviderForTest())
+		})
+	}
+}
+
+// --- clusterReadinessChecks provider selection ---
+
+func TestClusterReadinessChecks_DockerUsesFewerChecks(t *testing.T) {
+	t.Parallel()
+
+	opts := talosprovisioner.NewOptions()
+	opts.SkipCNIChecks = true
+
+	dockerProvisioner := talosprovisioner.NewProvisioner(nil, opts)
+	hetznerProvisioner := talosprovisioner.NewProvisioner(nil, opts).
+		WithInfraProvider(&hetzner.Provider{})
+
+	dockerCount := dockerProvisioner.ClusterReadinessChecksCountForTest()
+	hetznerCount := hetznerProvisioner.ClusterReadinessChecksCountForTest()
+
+	assert.Less(t, dockerCount, hetznerCount,
+		"Docker provider should use fewer pre-boot checks than Hetzner provider")
+}


### PR DESCRIPTION
## Summary

Optimizes merge queue CI wall clock time (currently 70–106 min) by addressing root causes of Talos test slowness and reducing unnecessary matrix jobs.

## Changes

### Go code optimizations (Talos provisioner + post-CNI setup)

1. **Skip diagnostic pre-boot checks for Docker provider** (`provisioner_config.go`)
   - Adds `dockerPreBootSequenceChecks()` that skips `AllNodesMemorySizes`, `AllNodesDiskSizes`, `NoDiagnostics` — purely diagnostic checks that add sequential polling overhead without catching real issues in Docker containers
   - Saves ~1–3 min per Talos Docker test

2. **Reduce API server stability successes for Talos+Docker** (`post_cni.go`)
   - `apiServerStabilitySuccesses()` now considers the provider — Talos+Docker uses 3 consecutive successes (same as Vanilla/K3s) instead of 5, since Docker doesn't experience cloud-like API flapping
   - Talos+Hetzner/Omni still uses 5 for cloud resilience

3. **Skip redundant node readiness after CNI install** (`post_cni.go`, `cluster.go`)
   - Threads `cniInstalled` bool from `InstallCNI()` through to `waitForClusterStability()`
   - Skips `WaitForAllNodesReady` when CNI was just installed, since `waitForCNIReadiness` already verified node readiness
   - The GitOps phase stability check (after infra) always runs the full check

### CI workflow optimizations (`ci.yaml`)

4. **Reduce no-init matrix** — Excludes 12 jobs (3 arg variants × 4 distributions) for `init=false` that duplicate `init=true` coverage. Keeps `init=false` for default and full-stack variants. Saves ~96 min compute, ~5–10 min wall clock.

5. **Increase max-parallel** — 15 → 20 (GitHub's limit for public repos). Fewer queueing waves saves ~3–5 min wall clock.

## Expected Impact

| Optimization | Wall Clock | Compute |
|---|---|---|
| Skip diagnostic pre-boot checks | 1–3 min/Talos job | ~11–33 min total |
| Reduce stability successes | ~10–20s/check | Minor |
| Skip redundant node readiness | 5–30s/check | Minor |
| Reduce no-init matrix | 5–10 min | ~96 min |
| Increase max-parallel | 3–5 min | None |

**Combined**: ~70–106 min → ~55–85 min estimated wall clock