### PR TITLE
fix(ci): prevent cloud test cleanup race on turnstyle timeout

### DIFF
--- a/.github/actions/cleanup-hetzner/action.yaml
+++ b/.github/actions/cleanup-hetzner/action.yaml
@@ -1,7 +1,8 @@
 name: Cleanup Hetzner Resources
 description: |
-  Deletes all Hetzner Cloud resources labeled with ksail.owned=true to ensure clean slate
-  for next CI run, even if individual test jobs fail to clean up after themselves.
+  Deletes Hetzner Cloud resources matching the given label selector to ensure
+  clean slate for next CI run, even if individual test jobs fail to clean up
+  after themselves.
 
 inputs:
   label-selector:

--- a/.github/actions/cleanup-hetzner/action.yaml
+++ b/.github/actions/cleanup-hetzner/action.yaml
@@ -6,8 +6,7 @@ description: |
 inputs:
   label-selector:
     description: Label selector for resources to delete
-    required: false
-    default: "ksail.owned=true"
+    required: true
 
 runs:
   using: composite

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -851,10 +851,10 @@ jobs:
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ❌ Fail on turnstyle timeout
+      - name: ❌ Fail on turnstyle failure
         if: steps.turnstyle.outcome != 'success'
         run: |
-          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          echo "::error::Turnstyle failed or timed out waiting for cloud test queue — no resources were created"
           exit 1
 
   system-test-hetzner-noinit:
@@ -955,10 +955,10 @@ jobs:
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ❌ Fail on turnstyle timeout
+      - name: ❌ Fail on turnstyle failure
         if: steps.turnstyle.outcome != 'success'
         run: |
-          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          echo "::error::Turnstyle failed or timed out waiting for cloud test queue — no resources were created"
           exit 1
 
   # Omni cloud tests are serialized across workflow runs via turnstyle to
@@ -1065,10 +1065,10 @@ jobs:
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ❌ Fail on turnstyle timeout
+      - name: ❌ Fail on turnstyle failure
         if: steps.turnstyle.outcome != 'success'
         run: |
-          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          echo "::error::Turnstyle failed or timed out waiting for cloud test queue — no resources were created"
           exit 1
 
   system-test-omni-noinit:
@@ -1166,10 +1166,10 @@ jobs:
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ❌ Fail on turnstyle timeout
+      - name: ❌ Fail on turnstyle failure
         if: steps.turnstyle.outcome != 'success'
         run: |
-          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          echo "::error::Turnstyle failed or timed out waiting for cloud test queue — no resources were created"
           exit 1
 
   benchmark:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -749,8 +749,12 @@ jobs:
   # Unlike concurrency groups (which cancel intermediate pending jobs),
   # turnstyle implements a true FIFO queue by polling the GitHub API.
   # Cluster names include github.run_id for defense-in-depth uniqueness.
-  system-test-hetzner:
-    name: "🧪 System Test (Hetzner/${{ matrix.init && 'init' || 'noinit' }})"
+  #
+  # Split into separate jobs (not matrix) so each job owns its own
+  # outputs.started flag — matrix output aggregation uses last-write-wins,
+  # which would erase a running variation's flag if the other times out.
+  system-test-hetzner-init:
+    name: "🧪 System Test (Hetzner/init)"
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs:
@@ -767,20 +771,8 @@ jobs:
       actions: read
       contents: read
       packages: write
-    strategy:
-      fail-fast: true
-      matrix:
-        # Cluster names use st-hetzner-{init,noinit}-<run_id> pattern.
-        # Keep in sync with cleanup-hetzner label-selector values below.
-        include:
-          - distribution: Talos
-            provider: Hetzner
-            init: true
-            args: "--name st-hetzner-init-${{ github.run_id }}"
-          - distribution: Talos
-            provider: Hetzner
-            init: false
-            args: "--name st-hetzner-noinit-${{ github.run_id }}"
+    outputs:
+      started: ${{ steps.test-started.outputs.value }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -793,24 +785,34 @@ jobs:
           persist-credentials: false
 
       - name: ⏳ Wait for cloud test queue
+        id: turnstyle
+        continue-on-error: true
         uses: softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586 # v3.2.3
         with:
           same-branch-only: false
-          job-to-wait-for: "🧪 System Test (Hetzner/${{ matrix.init && 'init' || 'noinit' }})"
+          # Keep in sync with cleanup-hetzner label-selector values below.
+          job-to-wait-for: "🧪 System Test (Hetzner/init)"
           poll-interval-seconds: 30
           abort-after-seconds: 3600
 
+      - name: 🏁 Mark test as started (past turnstyle)
+        id: test-started
+        if: steps.turnstyle.outcome == 'success'
+        run: echo "value=true" >> "$GITHUB_OUTPUT"
+
       - name: 🧹 Free disk space
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/free-disk-space
 
       - name: 🔐 Login to Docker Hub
-        if: ${{ vars.DOCKERHUB_USERNAME != '' }}
+        if: steps.turnstyle.outcome == 'success' && vars.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }} # zizmor: ignore[secrets-outside-env] - third-party action input, no environment scoping available
 
       - name: ⚙️ Setup Go
+        if: steps.turnstyle.outcome == 'success'
         id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -818,6 +820,7 @@ jobs:
           cache: false
 
       - name: 📦 Cache KSail Binary
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/cache-ksail-binary
         with:
           go-version: ${{ steps.setup-go.outputs.go-version }}
@@ -826,32 +829,36 @@ jobs:
           save: "false"
 
       - name: 📥 Restore Helm Cache
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/restore-helm-cache
 
       - name: 📥 Restore Mirror Cache
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/restore-mirror-cache
 
       - name: 🧪 Run KSail System Test
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/ksail-system-test
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
         with:
-          distribution: ${{ matrix.distribution }}
-          provider: ${{ matrix.provider }}
-          init: ${{ matrix.init }}
-          args: ${{ matrix.args }}
+          distribution: Talos
+          provider: Hetzner
+          init: true
+          args: "--name st-hetzner-init-${{ github.run_id }}"
           apply-overlay-path: ".github/fixtures/podinfo-overlay"
 
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Omni cloud tests are serialized across workflow runs via turnstyle to
-  # prevent resource conflicts (shared machine pool).
-  # Unlike concurrency groups (which cancel intermediate pending jobs),
-  # turnstyle implements a true FIFO queue by polling the GitHub API.
-  # Cluster names include github.run_id for defense-in-depth uniqueness.
-  system-test-omni:
-    name: "🧪 System Test (Omni/${{ matrix.init && 'init' || 'noinit' }})"
+      - name: ❌ Fail on turnstyle timeout
+        if: steps.turnstyle.outcome != 'success'
+        run: |
+          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          exit 1
+
+  system-test-hetzner-noinit:
+    name: "🧪 System Test (Hetzner/noinit)"
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs:
@@ -868,45 +875,48 @@ jobs:
       actions: read
       contents: read
       packages: write
-    strategy:
-      fail-fast: true
-      matrix:
-        # Cluster names use st-omni-{init,noinit}-<run_id> pattern.
-        # Keep in sync with cleanup-omni cluster-names input below.
-        include:
-          - distribution: Talos
-            provider: Omni
-            init: true
-            args: "--name st-omni-init-${{ github.run_id }}"
-          - distribution: Talos
-            provider: Omni
-            init: false
-            args: "--name st-omni-noinit-${{ github.run_id }}"
+    outputs:
+      started: ${{ steps.test-started.outputs.value }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: ⏳ Wait for cloud test queue
+        id: turnstyle
+        continue-on-error: true
         uses: softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586 # v3.2.3
         with:
           same-branch-only: false
-          job-to-wait-for: "🧪 System Test (Omni/${{ matrix.init && 'init' || 'noinit' }})"
+          # Keep in sync with cleanup-hetzner label-selector values below.
+          job-to-wait-for: "🧪 System Test (Hetzner/noinit)"
           poll-interval-seconds: 30
           abort-after-seconds: 3600
 
+      - name: 🏁 Mark test as started (past turnstyle)
+        id: test-started
+        if: steps.turnstyle.outcome == 'success'
+        run: echo "value=true" >> "$GITHUB_OUTPUT"
+
       - name: 🧹 Free disk space
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/free-disk-space
 
       - name: 🔐 Login to Docker Hub
-        if: ${{ vars.DOCKERHUB_USERNAME != '' }}
+        if: steps.turnstyle.outcome == 'success' && vars.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }} # zizmor: ignore[secrets-outside-env] - third-party action input, no environment scoping available
 
       - name: ⚙️ Setup Go
+        if: steps.turnstyle.outcome == 'success'
         id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -914,6 +924,7 @@ jobs:
           cache: false
 
       - name: 📦 Cache KSail Binary
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/cache-ksail-binary
         with:
           go-version: ${{ steps.setup-go.outputs.go-version }}
@@ -922,26 +933,244 @@ jobs:
           save: "false"
 
       - name: 📥 Restore Helm Cache
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/restore-helm-cache
 
       - name: 📥 Restore Mirror Cache
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/restore-mirror-cache
 
       - name: 🧪 Run KSail System Test
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/ksail-system-test
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        with:
+          distribution: Talos
+          provider: Hetzner
+          init: false
+          args: "--name st-hetzner-noinit-${{ github.run_id }}"
+          apply-overlay-path: ".github/fixtures/podinfo-overlay"
+
+          ghcr-user: ${{ github.actor }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ❌ Fail on turnstyle timeout
+        if: steps.turnstyle.outcome != 'success'
+        run: |
+          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          exit 1
+
+  # Omni cloud tests are serialized across workflow runs via turnstyle to
+  # prevent resource conflicts (shared machine pool).
+  # Unlike concurrency groups (which cancel intermediate pending jobs),
+  # turnstyle implements a true FIFO queue by polling the GitHub API.
+  # Cluster names include github.run_id for defense-in-depth uniqueness.
+  #
+  # Split into separate jobs (not matrix) so each job owns its own
+  # outputs.started flag — matrix output aggregation uses last-write-wins,
+  # which would erase a running variation's flag if the other times out.
+  system-test-omni-init:
+    name: "🧪 System Test (Omni/init)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs:
+      [
+        changes,
+        build-artifact,
+        warm-helm-cache,
+        warm-mirror-cache,
+        system-test-docker,
+      ]
+    if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
+    environment: ci
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    outputs:
+      started: ${{ steps.test-started.outputs.value }}
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⏳ Wait for cloud test queue
+        id: turnstyle
+        continue-on-error: true
+        uses: softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586 # v3.2.3
+        with:
+          same-branch-only: false
+          # Keep in sync with cleanup-omni cluster-names input below.
+          job-to-wait-for: "🧪 System Test (Omni/init)"
+          poll-interval-seconds: 30
+          abort-after-seconds: 3600
+
+      - name: 🏁 Mark test as started (past turnstyle)
+        id: test-started
+        if: steps.turnstyle.outcome == 'success'
+        run: echo "value=true" >> "$GITHUB_OUTPUT"
+
+      - name: 🧹 Free disk space
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/free-disk-space
+
+      - name: 🔐 Login to Docker Hub
+        if: steps.turnstyle.outcome == 'success' && vars.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }} # zizmor: ignore[secrets-outside-env] - third-party action input, no environment scoping available
+
+      - name: ⚙️ Setup Go
+        if: steps.turnstyle.outcome == 'success'
+        id: setup-go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: 📦 Cache KSail Binary
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/cache-ksail-binary
+        with:
+          go-version: ${{ steps.setup-go.outputs.go-version }}
+          source-hash: ${{ hashFiles('go.mod', 'go.sum', '**/*.go') }}
+          output-path: /usr/local/bin/ksail
+          save: "false"
+
+      - name: 📥 Restore Helm Cache
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/restore-helm-cache
+
+      - name: 📥 Restore Mirror Cache
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/restore-mirror-cache
+
+      - name: 🧪 Run KSail System Test
+        if: steps.turnstyle.outcome == 'success'
         uses: ./.github/actions/ksail-system-test
         env:
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           KSAIL_SPEC_CLUSTER_OMNI_MACHINECLASS: ksail
         with:
-          distribution: ${{ matrix.distribution }}
-          provider: ${{ matrix.provider }}
-          init: ${{ matrix.init }}
-          args: ${{ matrix.args }}
+          distribution: Talos
+          provider: Omni
+          init: true
+          args: "--name st-omni-init-${{ github.run_id }}"
           apply-overlay-path: ".github/fixtures/podinfo-overlay"
 
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ❌ Fail on turnstyle timeout
+        if: steps.turnstyle.outcome != 'success'
+        run: |
+          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          exit 1
+
+  system-test-omni-noinit:
+    name: "🧪 System Test (Omni/noinit)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs:
+      [
+        changes,
+        build-artifact,
+        warm-helm-cache,
+        warm-mirror-cache,
+        system-test-docker,
+      ]
+    if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
+    environment: ci
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    outputs:
+      started: ${{ steps.test-started.outputs.value }}
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⏳ Wait for cloud test queue
+        id: turnstyle
+        continue-on-error: true
+        uses: softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586 # v3.2.3
+        with:
+          same-branch-only: false
+          # Keep in sync with cleanup-omni cluster-names input below.
+          job-to-wait-for: "🧪 System Test (Omni/noinit)"
+          poll-interval-seconds: 30
+          abort-after-seconds: 3600
+
+      - name: 🏁 Mark test as started (past turnstyle)
+        id: test-started
+        if: steps.turnstyle.outcome == 'success'
+        run: echo "value=true" >> "$GITHUB_OUTPUT"
+
+      - name: 🧹 Free disk space
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/free-disk-space
+
+      - name: 🔐 Login to Docker Hub
+        if: steps.turnstyle.outcome == 'success' && vars.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }} # zizmor: ignore[secrets-outside-env] - third-party action input, no environment scoping available
+
+      - name: ⚙️ Setup Go
+        if: steps.turnstyle.outcome == 'success'
+        id: setup-go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: 📦 Cache KSail Binary
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/cache-ksail-binary
+        with:
+          go-version: ${{ steps.setup-go.outputs.go-version }}
+          source-hash: ${{ hashFiles('go.mod', 'go.sum', '**/*.go') }}
+          output-path: /usr/local/bin/ksail
+          save: "false"
+
+      - name: 📥 Restore Helm Cache
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/restore-helm-cache
+
+      - name: 📥 Restore Mirror Cache
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/restore-mirror-cache
+
+      - name: 🧪 Run KSail System Test
+        if: steps.turnstyle.outcome == 'success'
+        uses: ./.github/actions/ksail-system-test
+        env:
+          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
+          OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
+          KSAIL_SPEC_CLUSTER_OMNI_MACHINECLASS: ksail
+        with:
+          distribution: Talos
+          provider: Omni
+          init: false
+          args: "--name st-omni-noinit-${{ github.run_id }}"
+          apply-overlay-path: ".github/fixtures/podinfo-overlay"
+
+          ghcr-user: ${{ github.actor }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ❌ Fail on turnstyle timeout
+        if: steps.turnstyle.outcome != 'success'
+        run: |
+          echo "::error::Turnstyle timed out waiting for cloud test queue — no resources were created"
+          exit 1
 
   benchmark:
     name: 📊 Benchmark
@@ -1086,8 +1315,12 @@ jobs:
     name: 🧹 Cleanup Hetzner Resources
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [system-test-docker, system-test-hetzner]
-    if: ${{ always() && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.system-test-docker.result == 'success' }}
+    needs: [system-test-docker, system-test-hetzner-init, system-test-hetzner-noinit]
+    if: >-
+      always()
+      && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+      && needs.system-test-docker.result == 'success'
+      && (needs.system-test-hetzner-init.outputs.started == 'true' || needs.system-test-hetzner-noinit.outputs.started == 'true')
     environment: ci
     permissions:
       contents: read
@@ -1120,8 +1353,12 @@ jobs:
     name: 🧹 Cleanup Omni Resources
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [system-test-docker, system-test-omni]
-    if: ${{ always() && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.system-test-docker.result == 'success' }}
+    needs: [system-test-docker, system-test-omni-init, system-test-omni-noinit]
+    if: >-
+      always()
+      && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+      && needs.system-test-docker.result == 'success'
+      && (needs.system-test-omni-init.outputs.started == 'true' || needs.system-test-omni-noinit.outputs.started == 'true')
     environment: ci
     permissions:
       contents: read
@@ -1174,8 +1411,10 @@ jobs:
         auto-commit,
         warm-helm-cache,
         system-test-docker,
-        system-test-hetzner,
-        system-test-omni,
+        system-test-hetzner-init,
+        system-test-hetzner-noinit,
+        system-test-omni-init,
+        system-test-omni-noinit,
         cleanup-hetzner,
         cleanup-omni,
         audit-docs,
@@ -1207,8 +1446,10 @@ jobs:
             ${{ needs.auto-commit.result }}
             ${{ needs.warm-helm-cache.result }}
             ${{ needs.system-test-docker.result }}
-            ${{ needs.system-test-hetzner.result }}
-            ${{ needs.system-test-omni.result }}
+            ${{ needs.system-test-hetzner-init.result }}
+            ${{ needs.system-test-hetzner-noinit.result }}
+            ${{ needs.system-test-omni-init.result }}
+            ${{ needs.system-test-omni-noinit.result }}
             ${{ needs.cleanup-hetzner.result }}
             ${{ needs.cleanup-omni.result }}
             ${{ needs.audit-docs.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1315,7 +1315,8 @@ jobs:
     name: 🧹 Cleanup Hetzner Resources
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [system-test-docker, system-test-hetzner-init, system-test-hetzner-noinit]
+    needs:
+      [system-test-docker, system-test-hetzner-init, system-test-hetzner-noinit]
     if: >-
       always()
       && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
Cloud test cleanup jobs (`cleanup-hetzner`, `cleanup-omni`) could run even when turnstyle timed out and no cloud resources were actually created. This happened because turnstyle timeout produces the same `failure` result as a real test failure, and cleanup only gated on `needs.system-test-docker.result == 'success'` -- not on whether cloud tests actually started.

Additionally, the matrix jobs (`system-test-hetzner`, `system-test-omni`) used `fail-fast: true` with two variations each. Matrix output aggregation uses last-write-wins, so if one variation ran successfully but the other timed out (completing last), the timed-out variation's empty output would overwrite the successful variation's `started=true` flag -- potentially preventing cleanup for real resources.

**Approach:** Split the two matrix jobs into four separate jobs (`system-test-hetzner-init`, `system-test-hetzner-noinit`, `system-test-omni-init`, `system-test-omni-noinit`). Each job owns its own `outputs.started` flag, set only after turnstyle succeeds. Cleanup jobs now require at least one variation's `started == 'true'` to run.

- Turnstyle step uses `continue-on-error: true` + `id: turnstyle`; all downstream test steps are gated on `steps.turnstyle.outcome == 'success'`
- A final "Fail on turnstyle timeout" step preserves the `failure` job result with a clear error message
- `cleanup-hetzner/action.yaml` label-selector input changed from `required: false` with `default: "ksail.owned=true"` to `required: true` to prevent accidental broad deletion

## Type of change

- [x] 🪲 Bug fix