### PR TITLE
feat(distribution): scaffold EKS distribution via eksctl declarative config

### DIFF
--- a/docs/gen_docs_prose.go
+++ b/docs/gen_docs_prose.go
@@ -180,7 +180,8 @@ const distributionDetails = `See [Distributions](/concepts/#distributions) for d
 - ` + bt + `K3s` + bt + ` – Lightweight Kubernetes via [K3d](https://k3d.io/)
 - ` + bt + `Talos` + bt + ` – [Talos Linux](https://www.talos.dev/) in Docker containers or Hetzner Cloud servers
 - ` + bt + `VCluster` + bt + ` – Virtual clusters via [vCluster](https://www.vcluster.com/)
-- ` + bt + `KWOK` + bt + ` – Simulated clusters via [KWOK](https://kwok.sigs.k8s.io/) (control-plane only, no real workloads)`
+- ` + bt + `KWOK` + bt + ` – Simulated clusters via [KWOK](https://kwok.sigs.k8s.io/) (control-plane only, no real workloads)
+- ` + bt + `EKS` + bt + ` – Amazon Elastic Kubernetes Service via [eksctl](https://eksctl.io/) (requires AWS credentials and the ` + bt + `eksctl` + bt + ` CLI on ` + bt + `PATH` + bt + `)`
 
 // providerDetails provides prose after the provider enum list.
 const providerDetails = `See [Providers](/concepts/#providers) for more details.
@@ -188,9 +189,10 @@ const providerDetails = `See [Providers](/concepts/#providers) for more details.
 - ` + bt + `Docker` + bt + ` (default) – Run nodes as Docker containers (local development)
 - ` + bt + `Hetzner` + bt + ` – Run nodes on Hetzner Cloud servers (requires ` + bt + `HCLOUD_TOKEN` + bt + `)
 - ` + bt + `Omni` + bt + ` – Manage Talos cluster nodes through [Sidero Omni](https://omni.siderolabs.com/)
+- ` + bt + `AWS` + bt + ` – Manage EKS clusters on Amazon Web Services (requires standard AWS SDK credentials)
 
 > [!NOTE]
-> Hetzner and Omni providers are only supported with the ` + bt + `Talos` + bt + ` distribution.`
+> Hetzner and Omni providers are only supported with the ` + bt + `Talos` + bt + ` distribution. The AWS provider is only supported with the ` + bt + `EKS` + bt + ` distribution.`
 
 // configDistributionProse describes the distributionConfig field.
 const configDistributionProse = `#### distributionConfig
@@ -204,6 +206,7 @@ Path to the distribution-specific configuration file or directory. This tells KS
 - ` + bt + `Talos` + bt + ` → ` + bt + `talos/` + bt + ` (directory)
 - ` + bt + `VCluster` + bt + ` → ` + bt + `vcluster.yaml` + bt + `
 - ` + bt + `KWOK` + bt + ` → ` + bt + `kwok.yaml` + bt + `
+- ` + bt + `EKS` + bt + ` → ` + bt + `eksctl.yaml` + bt + `
 
 See [Distribution Configuration](#distribution-configuration) below for details on each format.`
 

--- a/docs/gen_docs_prose.go
+++ b/docs/gen_docs_prose.go
@@ -206,7 +206,7 @@ Path to the distribution-specific configuration file or directory. This tells KS
 - ` + bt + `Talos` + bt + ` → ` + bt + `talos/` + bt + ` (directory)
 - ` + bt + `VCluster` + bt + ` → ` + bt + `vcluster.yaml` + bt + `
 - ` + bt + `KWOK` + bt + ` → ` + bt + `kwok.yaml` + bt + `
-- ` + bt + `EKS` + bt + ` → ` + bt + `eksctl.yaml` + bt + `
+- ` + bt + `EKS` + bt + ` → ` + bt + `eks.yaml` + bt + `
 
 See [Distribution Configuration](#distribution-configuration) below for details on each format.`
 

--- a/docs/src/content/docs/cli-flags/cluster/cluster-delete.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-delete.mdx
@@ -32,7 +32,7 @@ Flags:
   -f, --force               Skip confirmation prompt and delete immediately
   -k, --kubeconfig string   Path to kubeconfig file for context cleanup
   -n, --name string         Name of the cluster to delete
-  -p, --provider Provider   Provider to use ([Docker Hetzner Omni])
+  -p, --provider Provider   Provider to use ([Docker Hetzner Omni AWS])
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-info.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-info.mdx
@@ -13,7 +13,7 @@ Usage:
 
 Flags:
   -n, --name string         Name of the cluster to target
-  -p, --provider Provider   Provider to use ([Docker Hetzner Omni])
+  -p, --provider Provider   Provider to use ([Docker Hetzner Omni AWS])
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-list.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-list.mdx
@@ -43,7 +43,7 @@ Usage:
   ksail cluster list [flags]
 
 Flags:
-  -p, --provider Provider   Filter by provider (Docker, Hetzner, Omni). If not specified, lists all providers.
+  -p, --provider Provider   Filter by provider (Docker, Hetzner, Omni, AWS). If not specified, lists all providers.
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-start.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-start.mdx
@@ -25,7 +25,7 @@ Usage:
 
 Flags:
   -n, --name string         Name of the cluster to target
-  -p, --provider Provider   Provider to use ([Docker Hetzner Omni])
+  -p, --provider Provider   Provider to use ([Docker Hetzner Omni AWS])
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-stop.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-stop.mdx
@@ -25,7 +25,7 @@ Usage:
 
 Flags:
   -n, --name string         Name of the cluster to target
-  -p, --provider Provider   Provider to use ([Docker Hetzner Omni])
+  -p, --provider Provider   Provider to use ([Docker Hetzner Omni AWS])
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -202,6 +202,7 @@ Editor command for interactive workflows (e.g., `code --wait`, `vim`). Falls bac
 | `importImages` | string | – | Path to tar archive with container images to import after cluster creation but before component installation |
 | `vanilla` | OptionsVanilla | – |  |
 | `talos` | OptionsTalos | – |  |
+| `eks` | OptionsEKS | – |  |
 
 #### distribution
 
@@ -212,6 +213,7 @@ See [Distributions](/concepts/#distributions) for detailed information.
 - `Talos` – [Talos Linux](https://www.talos.dev/) in Docker containers or Hetzner Cloud servers
 - `VCluster` – Virtual clusters via [vCluster](https://www.vcluster.com/)
 - `KWOK` – Simulated clusters via [KWOK](https://kwok.sigs.k8s.io/) (control-plane only, no real workloads)
+- `EKS` – Amazon Elastic Kubernetes Service via [eksctl](https://eksctl.io/) (requires AWS credentials and the `eksctl` CLI on `PATH`)
 
 #### provider
 
@@ -220,9 +222,10 @@ See [Providers](/concepts/#providers) for more details.
 - `Docker` (default) – Run nodes as Docker containers (local development)
 - `Hetzner` – Run nodes on Hetzner Cloud servers (requires `HCLOUD_TOKEN`)
 - `Omni` – Manage Talos cluster nodes through [Sidero Omni](https://omni.siderolabs.com/)
+- `AWS` – Manage EKS clusters on Amazon Web Services (requires standard AWS SDK credentials)
 
 > [!NOTE]
-> Hetzner and Omni providers are only supported with the `Talos` distribution.
+> Hetzner and Omni providers are only supported with the `Talos` distribution. The AWS provider is only supported with the `EKS` distribution.
 
 #### distributionConfig
 
@@ -235,6 +238,7 @@ Path to the distribution-specific configuration file or directory. This tells KS
 - `Talos` → `talos/` (directory)
 - `VCluster` → `vcluster.yaml`
 - `KWOK` → `kwok.yaml`
+- `EKS` → `eksctl.yaml`
 
 See [Distribution Configuration](#distribution-configuration) below for details on each format.
 

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -238,7 +238,7 @@ Path to the distribution-specific configuration file or directory. This tells KS
 - `Talos` → `talos/` (directory)
 - `VCluster` → `vcluster.yaml`
 - `KWOK` → `kwok.yaml`
-- `EKS` → `eksctl.yaml`
+- `EKS` → `eks.yaml`
 
 See [Distribution Configuration](#distribution-configuration) below for details on each format.
 

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -202,7 +202,6 @@ Editor command for interactive workflows (e.g., `code --wait`, `vim`). Falls bac
 | `importImages` | string | – | Path to tar archive with container images to import after cluster creation but before component installation |
 | `vanilla` | OptionsVanilla | – |  |
 | `talos` | OptionsTalos | – |  |
-| `eks` | OptionsEKS | – |  |
 
 #### distribution
 

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -11,6 +11,9 @@ const (
 	DefaultVClusterDistributionConfig = "vcluster.yaml"
 	// DefaultKWOKDistributionConfig is the default KWOK distribution configuration filename.
 	DefaultKWOKDistributionConfig = "kwok.yaml"
+	// DefaultEKSDistributionConfig is the default EKS distribution configuration filename
+	// (declarative eksctl ClusterConfig consumed by the eksctl CLI).
+	DefaultEKSDistributionConfig = "eksctl.yaml"
 	// DefaultSourceDirectory is the default directory for Kubernetes manifests.
 	DefaultSourceDirectory = "k8s"
 	// DefaultKubeconfigPath is the default path to the kubeconfig file.
@@ -63,6 +66,8 @@ func ExpectedDistributionConfigName(distribution Distribution) string {
 		return DefaultVClusterDistributionConfig
 	case DistributionKWOK:
 		return DefaultKWOKDistributionConfig
+	case DistributionEKS:
+		return DefaultEKSDistributionConfig
 	default:
 		return DefaultVanillaDistributionConfig
 	}
@@ -81,6 +86,11 @@ func ExpectedContextName(distribution Distribution) string {
 		return "vcluster-docker_vcluster-default"
 	case DistributionKWOK:
 		return "kwok-kwok-default"
+	case DistributionEKS:
+		// eksctl generates kubeconfig contexts as <iam-identity>@<name>.<region>.eksctl.io;
+		// the identity segment is only known after AWS credentials resolve at create time.
+		// Scaffolding falls back to the region-less suffix so ksail.yaml remains deterministic.
+		return "eks-default.eksctl.io"
 	default:
 		return ""
 	}

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -13,7 +13,7 @@ const (
 	DefaultKWOKDistributionConfig = "kwok.yaml"
 	// DefaultEKSDistributionConfig is the default EKS distribution configuration filename
 	// (declarative eksctl ClusterConfig consumed by the eksctl CLI).
-	DefaultEKSDistributionConfig = "eksctl.yaml"
+	DefaultEKSDistributionConfig = "eks.yaml"
 	// DefaultSourceDirectory is the default directory for Kubernetes manifests.
 	DefaultSourceDirectory = "k8s"
 	// DefaultKubeconfigPath is the default path to the kubeconfig file.

--- a/pkg/apis/cluster/v1alpha1/distribution.go
+++ b/pkg/apis/cluster/v1alpha1/distribution.go
@@ -33,7 +33,11 @@ func (d *Distribution) ProvidesCDIByDefault() bool {
 	switch *d {
 	case DistributionTalos:
 		return true
-	case DistributionVanilla, DistributionK3s, DistributionVCluster, DistributionKWOK, DistributionEKS:
+	case DistributionVanilla,
+		DistributionK3s,
+		DistributionVCluster,
+		DistributionKWOK,
+		DistributionEKS:
 		return false
 	default:
 		return false
@@ -47,7 +51,11 @@ func (d *Distribution) ProvidesMetricsServerByDefault() bool {
 	switch *d {
 	case DistributionK3s:
 		return true
-	case DistributionVanilla, DistributionTalos, DistributionVCluster, DistributionKWOK, DistributionEKS:
+	case DistributionVanilla,
+		DistributionTalos,
+		DistributionVCluster,
+		DistributionKWOK,
+		DistributionEKS:
 		return false
 	default:
 		return false

--- a/pkg/apis/cluster/v1alpha1/distribution.go
+++ b/pkg/apis/cluster/v1alpha1/distribution.go
@@ -20,6 +20,10 @@ const (
 	DistributionVCluster Distribution = "VCluster"
 	// DistributionKWOK is the KWOK distribution (simulated Kubernetes cluster).
 	DistributionKWOK Distribution = "KWOK"
+	// DistributionEKS is the Amazon EKS distribution (managed Kubernetes on AWS).
+	// Cluster creation is delegated to the eksctl CLI; Upgrade, Delete and nodegroup
+	// scaling are handled via the embedded eksctl Go libraries.
+	DistributionEKS Distribution = "EKS"
 )
 
 // ProvidesCDIByDefault returns true if the distribution enables CDI by default.
@@ -29,7 +33,7 @@ func (d *Distribution) ProvidesCDIByDefault() bool {
 	switch *d {
 	case DistributionTalos:
 		return true
-	case DistributionVanilla, DistributionK3s, DistributionVCluster, DistributionKWOK:
+	case DistributionVanilla, DistributionK3s, DistributionVCluster, DistributionKWOK, DistributionEKS:
 		return false
 	default:
 		return false
@@ -38,12 +42,12 @@ func (d *Distribution) ProvidesCDIByDefault() bool {
 
 // ProvidesMetricsServerByDefault returns true if the distribution includes metrics-server by default.
 // K3s includes metrics-server.
-// Vanilla, Talos, and VCluster (Vind with Distro: k8s) do not.
+// Vanilla, Talos, VCluster, KWOK, and EKS do not.
 func (d *Distribution) ProvidesMetricsServerByDefault() bool {
 	switch *d {
 	case DistributionK3s:
 		return true
-	case DistributionVanilla, DistributionTalos, DistributionVCluster, DistributionKWOK:
+	case DistributionVanilla, DistributionTalos, DistributionVCluster, DistributionKWOK, DistributionEKS:
 		return false
 	default:
 		return false
@@ -51,11 +55,12 @@ func (d *Distribution) ProvidesMetricsServerByDefault() bool {
 }
 
 // ProvidesStorageByDefault returns true if the distribution includes a storage provisioner by default.
-// K3s includes local-path-provisioner.
-// Vanilla, Talos, and VCluster (Vind with Distro: k8s) do not have a default storage class.
+// K3s includes local-path-provisioner; EKS includes the Amazon EBS CSI addon by default
+// when scaffolded via eksctl.
+// Vanilla, Talos, VCluster (Vind with Distro: k8s), and KWOK do not have a default storage class.
 func (d *Distribution) ProvidesStorageByDefault() bool {
 	switch *d {
-	case DistributionK3s:
+	case DistributionK3s, DistributionEKS:
 		return true
 	case DistributionVanilla, DistributionTalos, DistributionVCluster, DistributionKWOK:
 		return false
@@ -76,6 +81,9 @@ func (d *Distribution) ProvidesCSIByDefault(provider Provider) bool {
 	case DistributionTalos:
 		// Talos × Hetzner provides Hetzner CSI by default
 		return provider == ProviderHetzner
+	case DistributionEKS:
+		// EKS × AWS: Amazon EBS CSI driver is scaffolded as an eksctl addon
+		return provider == ProviderAWS
 	case DistributionVanilla, DistributionVCluster, DistributionKWOK:
 		// Vanilla (Kind), VCluster (Vind with Distro: k8s), and KWOK do not provide CSI by default
 		return false
@@ -101,6 +109,9 @@ func (d *Distribution) ProvidesLoadBalancerByDefault(provider Provider) bool {
 	case DistributionTalos:
 		// Talos × Hetzner: hcloud-ccm provides LB support (installed by KSail)
 		return provider == ProviderHetzner
+	case DistributionEKS:
+		// EKS × AWS: AWS Load Balancer Controller + native ELB Service integration
+		return provider == ProviderAWS
 	case DistributionVanilla, DistributionKWOK:
 		// Vanilla (Kind) and KWOK do not provide LoadBalancer by default
 		return false
@@ -120,7 +131,7 @@ func (d *Distribution) Set(value string) error {
 	}
 
 	return fmt.Errorf(
-		"%w: %s (valid options: %s, %s, %s, %s, %s)",
+		"%w: %s (valid options: %s, %s, %s, %s, %s, %s)",
 		ErrInvalidDistribution,
 		value,
 		DistributionVanilla,
@@ -128,6 +139,7 @@ func (d *Distribution) Set(value string) error {
 		DistributionTalos,
 		DistributionVCluster,
 		DistributionKWOK,
+		DistributionEKS,
 	)
 }
 
@@ -159,6 +171,7 @@ func (d *Distribution) ValidValues() []string {
 		string(DistributionTalos),
 		string(DistributionVCluster),
 		string(DistributionKWOK),
+		string(DistributionEKS),
 	}
 }
 
@@ -185,6 +198,11 @@ func (d *Distribution) ContextName(clusterName string) string {
 		return "vcluster-docker_" + clusterName
 	case DistributionKWOK:
 		return "kwok-" + clusterName
+	case DistributionEKS:
+		// eksctl writes kubeconfig contexts as <iam-user-or-role>@<cluster>.<region>.eksctl.io
+		// We cannot know the IAM identity at scaffold time, so we return the suffix only.
+		// Callers that need the full context should query the kubeconfig after cluster creation.
+		return clusterName + ".eksctl.io"
 	default:
 		return ""
 	}
@@ -209,6 +227,8 @@ func (d *Distribution) DefaultClusterName() string {
 		return "vcluster-default"
 	case DistributionKWOK:
 		return "kwok-default"
+	case DistributionEKS:
+		return "eks-default"
 	default:
 		return "kind"
 	}

--- a/pkg/apis/cluster/v1alpha1/enums_test.go
+++ b/pkg/apis/cluster/v1alpha1/enums_test.go
@@ -28,7 +28,8 @@ func TestDistribution_ValidValues(t *testing.T) {
 	assert.Contains(t, values, "Talos")
 	assert.Contains(t, values, "VCluster")
 	assert.Contains(t, values, "KWOK")
-	assert.Len(t, values, 5)
+	assert.Contains(t, values, "EKS")
+	assert.Len(t, values, 6)
 }
 
 func TestCNI_Default(t *testing.T) {
@@ -355,7 +356,8 @@ func TestProvider_ValidValues(t *testing.T) {
 	assert.Contains(t, values, "Docker")
 	assert.Contains(t, values, "Hetzner")
 	assert.Contains(t, values, "Omni")
-	assert.Len(t, values, 3)
+	assert.Contains(t, values, "AWS")
+	assert.Len(t, values, 4)
 }
 
 func TestProvider_IsCloud(t *testing.T) {
@@ -369,6 +371,7 @@ func TestProvider_IsCloud(t *testing.T) {
 		{"docker", v1alpha1.ProviderDocker, false},
 		{"hetzner", v1alpha1.ProviderHetzner, true},
 		{"omni", v1alpha1.ProviderOmni, true},
+		{"aws", v1alpha1.ProviderAWS, true},
 		{"empty", v1alpha1.Provider(""), false},
 	}
 

--- a/pkg/apis/cluster/v1alpha1/errors.go
+++ b/pkg/apis/cluster/v1alpha1/errors.go
@@ -62,7 +62,8 @@ var ErrLocalRegistryNotSupported = errors.New(
 
 // ErrAWSCredentialsMissing is returned when AWS credentials cannot be resolved via the SDK credential chain.
 var ErrAWSCredentialsMissing = errors.New(
-	"AWS credentials not found; configure them via 'aws configure', AWS_PROFILE, or static AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY",
+	"AWS credentials not found; configure them via 'aws configure', AWS_PROFILE, " +
+		"or static AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY",
 )
 
 // ErrEksctlBinaryMissing is returned when the eksctl CLI binary is not on PATH.

--- a/pkg/apis/cluster/v1alpha1/errors.go
+++ b/pkg/apis/cluster/v1alpha1/errors.go
@@ -59,3 +59,15 @@ var ErrLocalRegistryNotSupported = errors.New(
 	"cloud provider requires an external registry\n" +
 		"- use --local-registry with an internet-accessible registry (e.g., ghcr.io/myorg)",
 )
+
+// ErrAWSCredentialsMissing is returned when AWS credentials cannot be resolved via the SDK credential chain.
+var ErrAWSCredentialsMissing = errors.New(
+	"AWS credentials not found; configure them via 'aws configure', AWS_PROFILE, or static AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY",
+)
+
+// ErrEksctlBinaryMissing is returned when the eksctl CLI binary is not on PATH.
+// Cluster creation on the EKS distribution is delegated to eksctl; see
+// https://eksctl.io/installation/ for installation instructions.
+var ErrEksctlBinaryMissing = errors.New(
+	"eksctl binary not found on PATH; install from https://eksctl.io/installation/",
+)

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -149,42 +149,12 @@ type OptionsOmni struct {
 	Machines []string `json:"machines,omitzero"`
 }
 
-// --- EKS / AWS Options ---
-
-// OptionsEKS defines options specific to the Amazon EKS distribution.
-// These options seed the default values used when scaffolding eksctl.yaml and
-// provide runtime overrides consumed by the EKS provisioner (nodegroup scale,
-// version upgrade).
+// --- AWS Options ---
 //
-// The authoritative, fully-expressive cluster definition lives in eksctl.yaml
-// (eksctl.io/v1alpha5 ClusterConfig). These fields are the minimum KSail needs
-// to render that file and reason about in-place updates.
-type OptionsEKS struct {
-	// Region is the AWS region for the EKS cluster (e.g., "us-east-1").
-	// Defaults to "us-east-1" via struct tag.
-	Region string `default:"us-east-1" json:"region,omitzero"`
-	// KubernetesVersion is the EKS-supported Kubernetes version (e.g., "1.30").
-	// When empty, eksctl picks the default supported version at create time.
-	KubernetesVersion string `json:"kubernetesVersion,omitzero"`
-	// NodeGroupName is the name of the default managed nodegroup.
-	// Defaults to "ng-default".
-	NodeGroupName string `default:"ng-default" json:"nodeGroupName,omitzero"`
-	// InstanceType is the EC2 instance type for the default managed nodegroup.
-	// Defaults to "t3.medium".
-	InstanceType string `default:"t3.medium" json:"instanceType,omitzero"`
-	// DesiredCapacity is the desired node count for the default managed nodegroup.
-	// Defaults to 2.
-	DesiredCapacity int32 `default:"2" json:"desiredCapacity,omitzero"`
-	// MinSize is the minimum node count for the default managed nodegroup.
-	// Defaults to 1.
-	MinSize int32 `default:"1" json:"minSize,omitzero"`
-	// MaxSize is the maximum node count for the default managed nodegroup.
-	// Defaults to 3.
-	MaxSize int32 `default:"3" json:"maxSize,omitzero"`
-	// AMIFamily selects the EKS-optimised AMI family (e.g., "AmazonLinux2023",
-	// "AmazonLinux2", "Bottlerocket"). Defaults to "AmazonLinux2023".
-	AMIFamily string `default:"AmazonLinux2023" json:"amiFamily,omitzero"`
-}
+// EKS cluster metadata (region, Kubernetes version, nodegroup shape, AMI
+// family, etc.) lives in eks.yaml (eksctl.io/v1alpha5 ClusterConfig), which is
+// the authoritative source of truth. KSail does not duplicate those fields in
+// ksail.yaml; the EKS provisioner loads the eksctl ClusterConfig directly.
 
 // OptionsAWS defines options specific to the AWS cloud provider.
 // Credentials are resolved via the standard AWS SDK v2 credential chain;
@@ -195,7 +165,7 @@ type OptionsAWS struct {
 	// Defaults to "AWS_PROFILE".
 	ProfileEnvVar string `default:"AWS_PROFILE" json:"profileEnvVar,omitzero"`
 	// RegionEnvVar is the environment variable containing the AWS region.
-	// Takes precedence over OptionsEKS.Region when set.
+	// When set, it overrides the region declared in eks.yaml.
 	// Defaults to "AWS_REGION".
 	RegionEnvVar string `default:"AWS_REGION" json:"regionEnvVar,omitzero"`
 	// AccessKeyIDEnvVar is the environment variable containing a static AWS access key ID.

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -148,3 +148,64 @@ type OptionsOmni struct {
 	// available (unallocated) machines in Omni and uses them for node allocation.
 	Machines []string `json:"machines,omitzero"`
 }
+
+// --- EKS / AWS Options ---
+
+// OptionsEKS defines options specific to the Amazon EKS distribution.
+// These options seed the default values used when scaffolding eksctl.yaml and
+// provide runtime overrides consumed by the EKS provisioner (nodegroup scale,
+// version upgrade).
+//
+// The authoritative, fully-expressive cluster definition lives in eksctl.yaml
+// (eksctl.io/v1alpha5 ClusterConfig). These fields are the minimum KSail needs
+// to render that file and reason about in-place updates.
+type OptionsEKS struct {
+	// Region is the AWS region for the EKS cluster (e.g., "us-east-1").
+	// Defaults to "us-east-1" via struct tag.
+	Region string `default:"us-east-1" json:"region,omitzero"`
+	// KubernetesVersion is the EKS-supported Kubernetes version (e.g., "1.30").
+	// When empty, eksctl picks the default supported version at create time.
+	KubernetesVersion string `json:"kubernetesVersion,omitzero"`
+	// NodeGroupName is the name of the default managed nodegroup.
+	// Defaults to "ng-default".
+	NodeGroupName string `default:"ng-default" json:"nodeGroupName,omitzero"`
+	// InstanceType is the EC2 instance type for the default managed nodegroup.
+	// Defaults to "t3.medium".
+	InstanceType string `default:"t3.medium" json:"instanceType,omitzero"`
+	// DesiredCapacity is the desired node count for the default managed nodegroup.
+	// Defaults to 2.
+	DesiredCapacity int32 `default:"2" json:"desiredCapacity,omitzero"`
+	// MinSize is the minimum node count for the default managed nodegroup.
+	// Defaults to 1.
+	MinSize int32 `default:"1" json:"minSize,omitzero"`
+	// MaxSize is the maximum node count for the default managed nodegroup.
+	// Defaults to 3.
+	MaxSize int32 `default:"3" json:"maxSize,omitzero"`
+	// AMIFamily selects the EKS-optimised AMI family (e.g., "AmazonLinux2023",
+	// "AmazonLinux2", "Bottlerocket"). Defaults to "AmazonLinux2023".
+	AMIFamily string `default:"AmazonLinux2023" json:"amiFamily,omitzero"`
+}
+
+// OptionsAWS defines options specific to the AWS cloud provider.
+// Credentials are resolved via the standard AWS SDK v2 credential chain;
+// the *EnvVar fields let users point KSail at non-standard environment
+// variable names (mirrors the Hetzner/Omni pattern).
+type OptionsAWS struct {
+	// ProfileEnvVar is the environment variable containing the AWS shared-config profile name.
+	// Defaults to "AWS_PROFILE".
+	ProfileEnvVar string `default:"AWS_PROFILE" json:"profileEnvVar,omitzero"`
+	// RegionEnvVar is the environment variable containing the AWS region.
+	// Takes precedence over OptionsEKS.Region when set.
+	// Defaults to "AWS_REGION".
+	RegionEnvVar string `default:"AWS_REGION" json:"regionEnvVar,omitzero"`
+	// AccessKeyIDEnvVar is the environment variable containing a static AWS access key ID.
+	// Defaults to "AWS_ACCESS_KEY_ID".
+	AccessKeyIDEnvVar string `default:"AWS_ACCESS_KEY_ID" json:"accessKeyIdEnvVar,omitzero"`
+	// SecretAccessKeyEnvVar is the environment variable containing a static AWS secret access key.
+	// Defaults to "AWS_SECRET_ACCESS_KEY".
+	SecretAccessKeyEnvVar string `default:"AWS_SECRET_ACCESS_KEY" json:"secretAccessKeyEnvVar,omitzero"`
+	// SessionTokenEnvVar is the environment variable containing an AWS session token
+	// (used with temporary credentials from STS).
+	// Defaults to "AWS_SESSION_TOKEN".
+	SessionTokenEnvVar string `default:"AWS_SESSION_TOKEN" json:"sessionTokenEnvVar,omitzero"`
+}

--- a/pkg/apis/cluster/v1alpha1/provider.go
+++ b/pkg/apis/cluster/v1alpha1/provider.go
@@ -17,6 +17,8 @@ const (
 	ProviderHetzner Provider = "Hetzner"
 	// ProviderOmni runs cluster nodes managed by Sidero Omni.
 	ProviderOmni Provider = "Omni"
+	// ProviderAWS runs EKS managed Kubernetes clusters on AWS.
+	ProviderAWS Provider = "AWS"
 )
 
 // Set for Provider (pflag.Value interface).
@@ -30,12 +32,13 @@ func (p *Provider) Set(value string) error {
 	}
 
 	return fmt.Errorf(
-		"%w: %s (valid options: %s, %s, %s)",
+		"%w: %s (valid options: %s, %s, %s, %s)",
 		ErrInvalidProvider,
 		value,
 		ProviderDocker,
 		ProviderHetzner,
 		ProviderOmni,
+		ProviderAWS,
 	)
 }
 
@@ -56,7 +59,12 @@ func (p *Provider) Default() any {
 
 // ValidValues returns all valid Provider values as strings.
 func (p *Provider) ValidValues() []string {
-	return []string{string(ProviderDocker), string(ProviderHetzner), string(ProviderOmni)}
+	return []string{
+		string(ProviderDocker),
+		string(ProviderHetzner),
+		string(ProviderOmni),
+		string(ProviderAWS),
+	}
 }
 
 // supportedProviders returns the valid providers for a given distribution.
@@ -66,15 +74,17 @@ func supportedProviders(distribution Distribution) []Provider {
 		return []Provider{ProviderDocker}
 	case DistributionTalos:
 		return []Provider{ProviderDocker, ProviderHetzner, ProviderOmni}
+	case DistributionEKS:
+		return []Provider{ProviderAWS}
 	default:
 		return nil
 	}
 }
 
-// IsCloud returns true if the provider is a cloud provider (Hetzner or Omni).
+// IsCloud returns true if the provider is a cloud provider (Hetzner, Omni, or AWS).
 // Cloud providers run nodes on remote servers and cannot access local Docker infrastructure.
 func (p *Provider) IsCloud() bool {
-	return *p == ProviderHetzner || *p == ProviderOmni
+	return *p == ProviderHetzner || *p == ProviderOmni || *p == ProviderAWS
 }
 
 // ValidateForDistribution validates that the provider is valid for the given distribution.

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -62,7 +62,6 @@ type ClusterSpec struct {
 	// Distribution-specific options
 	Vanilla OptionsVanilla `json:"vanilla,omitzero"`
 	Talos   OptionsTalos   `json:"talos,omitzero"`
-	EKS     OptionsEKS     `json:"eks,omitzero"`
 }
 
 // WorkloadSpec defines workload-related configuration.

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -38,6 +38,7 @@ type Spec struct {
 type ProviderSpec struct {
 	Hetzner OptionsHetzner `json:"hetzner,omitzero"`
 	Omni    OptionsOmni    `json:"omni,omitzero"`
+	AWS     OptionsAWS     `json:"aws,omitzero"`
 }
 
 // ClusterSpec defines cluster-related configuration.
@@ -61,6 +62,7 @@ type ClusterSpec struct {
 	// Distribution-specific options
 	Vanilla OptionsVanilla `json:"vanilla,omitzero"`
 	Talos   OptionsTalos   `json:"talos,omitzero"`
+	EKS     OptionsEKS     `json:"eks,omitzero"`
 }
 
 // WorkloadSpec defines workload-related configuration.

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -203,7 +203,8 @@ func ValidateLocalRegistryForProvider(provider Provider, registry LocalRegistry)
 	}
 
 	// Cloud providers require external registries with proper host configuration
-	if (provider == ProviderHetzner || provider == ProviderOmni || provider == ProviderAWS) && !registry.IsExternal() {
+	if (provider == ProviderHetzner || provider == ProviderOmni || provider == ProviderAWS) &&
+		!registry.IsExternal() {
 		return ErrLocalRegistryNotSupported
 	}
 

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -51,6 +51,7 @@ func ValidDistributions() []Distribution {
 		DistributionTalos,
 		DistributionVCluster,
 		DistributionKWOK,
+		DistributionEKS,
 	}
 }
 
@@ -123,7 +124,7 @@ func ValidPolicyEngines() []PolicyEngine {
 
 // ValidProviders returns supported provider values.
 func ValidProviders() []Provider {
-	return []Provider{ProviderDocker, ProviderHetzner, ProviderOmni}
+	return []Provider{ProviderDocker, ProviderHetzner, ProviderOmni, ProviderAWS}
 }
 
 // ValidPlacementGroupStrategies returns supported placement group strategy values.
@@ -146,7 +147,7 @@ func ValidateMirrorRegistriesForProvider(provider Provider, mirrorRegistries []s
 	}
 
 	// Cloud providers cannot access local Docker containers as mirrors
-	if provider == ProviderHetzner || provider == ProviderOmni {
+	if provider == ProviderHetzner || provider == ProviderOmni || provider == ProviderAWS {
 		for _, spec := range mirrorRegistries {
 			if isLocalMirrorSpec(spec) {
 				return fmt.Errorf(
@@ -202,7 +203,7 @@ func ValidateLocalRegistryForProvider(provider Provider, registry LocalRegistry)
 	}
 
 	// Cloud providers require external registries with proper host configuration
-	if (provider == ProviderHetzner || provider == ProviderOmni) && !registry.IsExternal() {
+	if (provider == ProviderHetzner || provider == ProviderOmni || provider == ProviderAWS) && !registry.IsExternal() {
 		return ErrLocalRegistryNotSupported
 	}
 

--- a/pkg/apis/cluster/v1alpha1/validation_test.go
+++ b/pkg/apis/cluster/v1alpha1/validation_test.go
@@ -59,7 +59,8 @@ func TestValidDistributions_IncludesTalos(t *testing.T) {
 	assert.Contains(t, distributions, v1alpha1.DistributionTalos)
 	assert.Contains(t, distributions, v1alpha1.DistributionVCluster)
 	assert.Contains(t, distributions, v1alpha1.DistributionKWOK)
-	assert.Len(t, distributions, 5) // Vanilla, K3s, Talos, VCluster, KWOK
+	assert.Contains(t, distributions, v1alpha1.DistributionEKS)
+	assert.Len(t, distributions, 6) // Vanilla, K3s, Talos, VCluster, KWOK, EKS
 }
 
 func TestTalosProvidesMetricsServerByDefault_ReturnsFalse(t *testing.T) {
@@ -233,7 +234,8 @@ func TestValidProviders(t *testing.T) {
 	assert.Contains(t, providers, v1alpha1.ProviderDocker)
 	assert.Contains(t, providers, v1alpha1.ProviderHetzner)
 	assert.Contains(t, providers, v1alpha1.ProviderOmni)
-	assert.Len(t, providers, 3)
+	assert.Contains(t, providers, v1alpha1.ProviderAWS)
+	assert.Len(t, providers, 4)
 }
 
 func TestValidPlacementGroupStrategies(t *testing.T) {

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -1699,7 +1699,7 @@ func resolveClusterNameFromContext(ctx *localregistry.Context) string {
 	case v1alpha1.DistributionKWOK:
 		return resolveKWOKName(ctx)
 	case v1alpha1.DistributionEKS:
-		// EKS config is owned by eksctl (eksctl.yaml) and not cached on the
+		// EKS config is owned by eksctl (eks.yaml) and not cached on the
 		// local registry context; fall back to the cluster-level name.
 		return resolveFallbackName(ctx)
 	default:
@@ -3683,7 +3683,7 @@ func createEmptyDistributionConfig(
 			KWOK: &clusterprovisioner.KWOKConfig{},
 		}
 	case v1alpha1.DistributionEKS:
-		// EKS does not populate the shared DistributionConfig; eksctl.yaml is
+		// EKS does not populate the shared DistributionConfig; eks.yaml is
 		// owned by the EKS provisioner. Return an empty config so list
 		// operations do not NPE for EKS entries.
 		return &clusterprovisioner.DistributionConfig{}

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -1698,6 +1698,10 @@ func resolveClusterNameFromContext(ctx *localregistry.Context) string {
 		return resolveVClusterName(ctx)
 	case v1alpha1.DistributionKWOK:
 		return resolveKWOKName(ctx)
+	case v1alpha1.DistributionEKS:
+		// EKS config is owned by eksctl (eksctl.yaml) and not cached on the
+		// local registry context; fall back to the cluster-level name.
+		return resolveFallbackName(ctx)
 	default:
 		return resolveFallbackName(ctx)
 	}
@@ -2131,6 +2135,11 @@ func buildDeletionPreview(
 		// For Omni, the cluster resource will be destroyed which deallocates all machines
 		machinePlaceholder := "(all machines allocated to cluster: " + resolved.ClusterName + ")"
 		preview.Servers = []string{machinePlaceholder}
+	case v1alpha1.ProviderAWS:
+		// For AWS/EKS, deletion is delegated to eksctl which tears down the
+		// CloudFormation stacks owning the control plane and managed nodegroups.
+		eksPlaceholder := "(EKS cluster and managed nodegroups for: " + resolved.ClusterName + ")"
+		preview.Servers = []string{eksPlaceholder}
 	}
 
 	return preview
@@ -2769,6 +2778,11 @@ func getProviderStatus(
 		return getHetznerProviderStatus(cmd.Context(), clusterName)
 	case v1alpha1.ProviderOmni:
 		return getOmniProviderStatus(cmd.Context(), clusterName, omniOpts)
+	case v1alpha1.ProviderAWS:
+		// AWS/EKS status is derived from the EKS API through the provisioner,
+		// not from local container inspection. Return a minimal stub so callers
+		// that rely on this helper do not fail for EKS.
+		return &provider.ClusterStatus{Phase: "unknown"}, nil
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedProvider, prov)
 	}
@@ -3475,6 +3489,11 @@ func getProviderClusters(
 		return getHetznerClusters(ctx, deps)
 	case v1alpha1.ProviderOmni:
 		return getOmniClusters(ctx, deps)
+	case v1alpha1.ProviderAWS:
+		// EKS cluster listing goes through the EKS API; not yet implemented
+		// in the local list path. Return an empty slice so `cluster list`
+		// does not error when AWS is configured in a profile.
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedProvider, provider)
 	}
@@ -3663,6 +3682,11 @@ func createEmptyDistributionConfig(
 		return &clusterprovisioner.DistributionConfig{
 			KWOK: &clusterprovisioner.KWOKConfig{},
 		}
+	case v1alpha1.DistributionEKS:
+		// EKS does not populate the shared DistributionConfig; eksctl.yaml is
+		// owned by the EKS provisioner. Return an empty config so list
+		// operations do not NPE for EKS entries.
+		return &clusterprovisioner.DistributionConfig{}
 	default:
 		return &clusterprovisioner.DistributionConfig{
 			Kind: &v1alpha4.Cluster{},

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -351,6 +351,10 @@ func runHostDebug(cmd *cobra.Command, nodeName string, args []string) error {
 		}
 
 		return runDockerHostDebug(cmd, info, nodeName, args)
+	case v1alpha1.DistributionEKS:
+		// Host-level debug on EKS nodes is not supported via KSail's host-debug
+		// path; users should use SSM/SSH directly against the EC2 instances.
+		return fmt.Errorf("%w: %s", ErrUnsupportedHostDebug, info.Distribution)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedHostDebug, info.Distribution)
 	}
@@ -406,6 +410,10 @@ func resolveTalosNodeEndpoint(
 			nodeName,
 			info.Provider,
 		)
+	case v1alpha1.ProviderAWS:
+		// EKS host-level debug is not supported: nodes are AWS EC2 instances
+		// reachable only via SSM/SSH, not via Talos or Docker host debug paths.
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedHostDebug, info.Provider)
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnsupportedHostDebug, info.Provider)
 	}
@@ -647,6 +655,10 @@ func distributionToLabelScheme(distribution v1alpha1.Distribution) dockerprovide
 		return dockerprovider.LabelSchemeVCluster
 	case v1alpha1.DistributionKWOK:
 		return dockerprovider.LabelSchemeKWOK
+	case v1alpha1.DistributionEKS:
+		// EKS nodes are EC2 instances without Docker labels; fall back to the
+		// default scheme — this path is not used for EKS in practice.
+		return dockerprovider.LabelSchemeKind
 	default:
 		return dockerprovider.LabelSchemeKind
 	}

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -358,6 +358,15 @@ func CreateMinimalProvisionerForProvider(
 
 		return provisioner, nil
 
+	case v1alpha1.ProviderAWS:
+		// AWS only supports EKS, which is not a docker-based distribution
+		// and therefore cannot be produced by the minimal multi-provisioner
+		// path. EKS lifecycle operations go through the factory-driven path.
+		return nil, fmt.Errorf(
+			"%w: AWS provider is only supported via the EKS distribution",
+			clusterprovisioner.ErrUnsupportedProvider,
+		)
+
 	default:
 		return nil, fmt.Errorf(
 			"%w: %s",

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -192,13 +192,17 @@ func InstallLoadBalancerSilent(
 		case v1alpha1.ProviderOmni:
 			// Omni manages the machine lifecycle; MetalLB is not applicable
 			return nil
+		case v1alpha1.ProviderAWS:
+			// AWS is not a supported provider for Talos.
+			return nil
 		}
 	case v1alpha1.DistributionK3s:
 		// K3s already has ServiceLB (Klipper) by default, no installation needed
 		return nil
-	case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK:
+	case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK, v1alpha1.DistributionEKS:
 		// VCluster (Vind) handles LoadBalancer via its own networking.
-		// KWOK is a simulation cluster with no real network dataplane — LoadBalancer installation is not needed.
+		// KWOK is a simulation cluster with no real network dataplane.
+		// EKS relies on AWS Load Balancer Controller (installed separately).
 		return nil
 	}
 

--- a/pkg/cli/setup/localregistry/resolve.go
+++ b/pkg/cli/setup/localregistry/resolve.go
@@ -60,13 +60,53 @@ func resolveClusterName(
 	talosConfig *talosconfigmanager.Configs,
 	vclusterConfig *clusterprovisioner.VClusterConfig,
 ) string {
-	switch clusterCfg.Spec.Cluster.Distribution {
+	distribution := clusterCfg.Spec.Cluster.Distribution
+	if name, handled := resolveCoreDistributionName(
+		distribution,
+		clusterCfg,
+		kindConfig,
+		k3dConfig,
+		talosConfig,
+	); handled {
+		return name
+	}
+
+	return resolveAuxDistributionName(distribution, clusterCfg, vclusterConfig)
+}
+
+// resolveCoreDistributionName handles the distributions that delegate name
+// resolution to their respective configmanager packages.
+func resolveCoreDistributionName(
+	distribution v1alpha1.Distribution,
+	clusterCfg *v1alpha1.Cluster,
+	kindConfig *kindv1alpha4.Cluster,
+	k3dConfig *k3dv1alpha5.SimpleConfig,
+	talosConfig *talosconfigmanager.Configs,
+) (string, bool) {
+	switch distribution {
 	case v1alpha1.DistributionVanilla:
-		return kindconfigmanager.ResolveClusterName(clusterCfg, kindConfig)
+		return kindconfigmanager.ResolveClusterName(clusterCfg, kindConfig), true
 	case v1alpha1.DistributionK3s:
-		return k3dconfigmanager.ResolveClusterName(clusterCfg, k3dConfig)
+		return k3dconfigmanager.ResolveClusterName(clusterCfg, k3dConfig), true
 	case v1alpha1.DistributionTalos:
-		return talosconfigmanager.ResolveClusterName(clusterCfg, talosConfig)
+		return talosconfigmanager.ResolveClusterName(clusterCfg, talosConfig), true
+	case v1alpha1.DistributionVCluster,
+		v1alpha1.DistributionKWOK,
+		v1alpha1.DistributionEKS:
+		return "", false
+	}
+
+	return "", false
+}
+
+// resolveAuxDistributionName handles distributions without a dedicated
+// configmanager name resolver.
+func resolveAuxDistributionName(
+	distribution v1alpha1.Distribution,
+	clusterCfg *v1alpha1.Cluster,
+	vclusterConfig *clusterprovisioner.VClusterConfig,
+) string {
+	switch distribution {
 	case v1alpha1.DistributionVCluster:
 		if vclusterConfig != nil {
 			if name := strings.TrimSpace(vclusterConfig.GetClusterName()); name != "" {
@@ -84,6 +124,16 @@ func resolveClusterName(
 		}
 
 		return "kwok-default"
+	case v1alpha1.DistributionEKS:
+		if name := strings.TrimSpace(clusterCfg.Spec.Cluster.Connection.Context); name != "" {
+			return name
+		}
+
+		return "eks-default"
+	case v1alpha1.DistributionVanilla,
+		v1alpha1.DistributionK3s,
+		v1alpha1.DistributionTalos:
+		return "ksail"
 	}
 
 	return "ksail"
@@ -104,6 +154,9 @@ func resolveNetworkName(
 		return "vcluster." + trimOrDefault(clusterName, "vcluster-default")
 	case v1alpha1.DistributionKWOK:
 		return "kwok-" + trimOrDefault(clusterName, "kwok-default")
+	case v1alpha1.DistributionEKS:
+		// EKS does not use a local Docker network.
+		return ""
 	default:
 		return ""
 	}

--- a/pkg/cli/setup/localregistry/resolve.go
+++ b/pkg/cli/setup/localregistry/resolve.go
@@ -125,7 +125,7 @@ func resolveAuxDistributionName(
 
 		return "kwok-default"
 	case v1alpha1.DistributionEKS:
-		if name := strings.TrimSpace(clusterCfg.Spec.Cluster.Connection.Context); name != "" {
+		if name := parseEKSContext(clusterCfg.Spec.Cluster.Connection.Context); name != "" {
 			return name
 		}
 
@@ -169,6 +169,33 @@ func trimOrDefault(name, fallback string) string {
 	}
 
 	return trimmed
+}
+
+// parseEKSContext extracts the cluster name from an EKS kubeconfig context.
+// eksctl-produced contexts look like "<iam-identity>@<name>.<region>.eksctl.io";
+// bare "<name>.eksctl.io" contexts are also common. Returns an empty string
+// when the context is not recognisably an EKS context so the caller can fall
+// back to a default.
+func parseEKSContext(ctx string) string {
+	ctx = strings.TrimSpace(ctx)
+	if ctx == "" {
+		return ""
+	}
+
+	if idx := strings.LastIndex(ctx, "@"); idx >= 0 && idx+1 < len(ctx) {
+		ctx = ctx[idx+1:]
+	}
+
+	trimmed, ok := strings.CutSuffix(ctx, ".eksctl.io")
+	if !ok {
+		return ""
+	}
+
+	if idx := strings.Index(trimmed, "."); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+
+	return strings.TrimSpace(trimmed)
 }
 
 func newCreateOptions(

--- a/pkg/cli/setup/mirrorregistry/cleanup.go
+++ b/pkg/cli/setup/mirrorregistry/cleanup.go
@@ -101,6 +101,9 @@ func GetNetworkNameForDistribution(distribution v1alpha1.Distribution, clusterNa
 		return "vcluster." + clusterName
 	case v1alpha1.DistributionKWOK:
 		return "kwok-" + clusterName
+	case v1alpha1.DistributionEKS:
+		// EKS does not use a local Docker network.
+		return ""
 	default:
 		return clusterName
 	}

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -99,6 +99,10 @@ func apiServerStabilitySuccesses(dist v1alpha1.Distribution, prov v1alpha1.Provi
 		return apiServerStabilitySuccessesDefault
 	case v1alpha1.DistributionVCluster:
 		return apiServerStabilitySuccessesDefault
+	case v1alpha1.DistributionEKS:
+		// EKS control plane stability is managed by AWS; use the default
+		// conservative threshold.
+		return apiServerStabilitySuccessesDefault
 	default:
 		return apiServerStabilitySuccessesDefault
 	}

--- a/pkg/cli/ui/confirm/confirm.go
+++ b/pkg/cli/ui/confirm/confirm.go
@@ -145,6 +145,8 @@ func ShowDeletionPreview(writer io.Writer, preview *DeletionPreview) {
 		writeHetznerResources(&previewText, preview)
 	case v1alpha1.ProviderOmni:
 		writeOmniResources(&previewText, preview)
+	case v1alpha1.ProviderAWS:
+		writeAWSResources(&previewText, preview)
 	}
 
 	notify.Warningf(writer, "%s", previewText.String())
@@ -210,6 +212,19 @@ func writeOmniResources(previewText *strings.Builder, preview *DeletionPreview) 
 
 		for _, machine := range preview.Servers {
 			previewText.WriteString("\n    - " + machine)
+		}
+	}
+}
+
+// writeAWSResources writes AWS/EKS-specific resources to the preview.
+// eksctl owns the underlying CloudFormation stacks so we only surface a
+// human-readable placeholder rather than individual AWS resource names.
+func writeAWSResources(previewText *strings.Builder, preview *DeletionPreview) {
+	if len(preview.Servers) > 0 {
+		previewText.WriteString("\n  EKS Resources:")
+
+		for _, resource := range preview.Servers {
+			previewText.WriteString("\n    - " + resource)
 		}
 	}
 }

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -125,7 +125,7 @@ func (m *ConfigManager) loadAndCacheDistributionConfig() error {
 	case v1alpha1.DistributionKWOK:
 		return m.cacheKWOKConfig()
 	case v1alpha1.DistributionEKS:
-		// EKS distribution config (eksctl.yaml) is loaded by the EKS
+		// EKS distribution config (eks.yaml) is loaded by the EKS
 		// provisioner directly and not cached on the ConfigManager.
 		return nil
 	default:

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -124,6 +124,10 @@ func (m *ConfigManager) loadAndCacheDistributionConfig() error {
 		return m.cacheVClusterConfig()
 	case v1alpha1.DistributionKWOK:
 		return m.cacheKWOKConfig()
+	case v1alpha1.DistributionEKS:
+		// EKS distribution config (eksctl.yaml) is loaded by the EKS
+		// provisioner directly and not cached on the ConfigManager.
+		return nil
 	default:
 		return nil
 	}

--- a/pkg/fsutil/configmanager/ksail/validation.go
+++ b/pkg/fsutil/configmanager/ksail/validation.go
@@ -81,6 +81,10 @@ func (m *ConfigManager) createDistributionValidator() (*ksailvalidator.Validator
 		return m.createVClusterValidator()
 	case v1alpha1.DistributionKWOK:
 		return m.createKWOKValidator()
+	case v1alpha1.DistributionEKS:
+		// EKS does not yet participate in declarative config validation; the
+		// eksctl.yaml is validated by the EKS provisioner.
+		return ksailvalidator.NewValidator(), nil
 	default:
 		return ksailvalidator.NewValidator(), nil
 	}
@@ -180,6 +184,8 @@ func expectedDistributionConfigName(distribution v1alpha1.Distribution) string {
 		return "vcluster.yaml"
 	case v1alpha1.DistributionKWOK:
 		return "kwok.yaml"
+	case v1alpha1.DistributionEKS:
+		return "eksctl.yaml"
 	default:
 		return ""
 	}

--- a/pkg/fsutil/configmanager/ksail/validation.go
+++ b/pkg/fsutil/configmanager/ksail/validation.go
@@ -83,7 +83,7 @@ func (m *ConfigManager) createDistributionValidator() (*ksailvalidator.Validator
 		return m.createKWOKValidator()
 	case v1alpha1.DistributionEKS:
 		// EKS does not yet participate in declarative config validation; the
-		// eksctl.yaml is validated by the EKS provisioner.
+		// eks.yaml is validated by the EKS provisioner.
 		return ksailvalidator.NewValidator(), nil
 	default:
 		return ksailvalidator.NewValidator(), nil
@@ -185,7 +185,7 @@ func expectedDistributionConfigName(distribution v1alpha1.Distribution) string {
 	case v1alpha1.DistributionKWOK:
 		return "kwok.yaml"
 	case v1alpha1.DistributionEKS:
-		return "eksctl.yaml"
+		return "eks.yaml"
 	default:
 		return ""
 	}

--- a/pkg/fsutil/scaffolder/errors.go
+++ b/pkg/fsutil/scaffolder/errors.go
@@ -30,6 +30,9 @@ var (
 	// ErrKWOKConfigGeneration wraps failures when creating KWOK configuration.
 	ErrKWOKConfigGeneration = errors.New("failed to generate kwok configuration")
 
+	// ErrEKSConfigGeneration wraps failures when creating EKS (eksctl) configuration.
+	ErrEKSConfigGeneration = errors.New("failed to generate eksctl configuration")
+
 	// ErrKustomizationGeneration wraps failures when creating kustomization.yaml.
 	ErrKustomizationGeneration = errors.New("failed to generate kustomization configuration")
 

--- a/pkg/fsutil/scaffolder/scaffolder.go
+++ b/pkg/fsutil/scaffolder/scaffolder.go
@@ -352,6 +352,8 @@ func (s *Scaffolder) generateDistributionConfig(output string, force bool) error
 		return s.generateVClusterConfig(output, force)
 	case v1alpha1.DistributionKWOK:
 		return s.generateKWOKConfig(output, force)
+	case v1alpha1.DistributionEKS:
+		return s.generateEKSConfig(output, force)
 	default:
 		return ErrUnknownDistribution
 	}

--- a/pkg/fsutil/scaffolder/scaffolder_eks.go
+++ b/pkg/fsutil/scaffolder/scaffolder_eks.go
@@ -4,70 +4,30 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-
-	v1alpha1 "github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
 )
 
 // EKSConfigFile is the default eksctl configuration filename.
-const EKSConfigFile = "eksctl.yaml"
-
-// eksConfigDefaults holds resolved defaults for the scaffolded eksctl.yaml.
-// Zero and empty values from the user's KSail configuration are replaced with
-// sensible starting points so the scaffolded file is ready to apply.
-type eksConfigDefaults struct {
-	clusterName     string
-	region          string
-	version         string
-	nodeGroupName   string
-	instanceType    string
-	amiFamily       string
-	desiredCapacity int32
-	minSize         int32
-	maxSize         int32
-}
-
-func firstNonEmpty(value, fallback string) string {
-	if v := strings.TrimSpace(value); v != "" {
-		return v
-	}
-
-	return fallback
-}
-
-func firstPositiveInt32(value, fallback int32) int32 {
-	if value > 0 {
-		return value
-	}
-
-	return fallback
-}
+const EKSConfigFile = "eks.yaml"
 
 const (
+	defaultEKSClusterName           = "eks-default"
+	defaultEKSRegion                = "us-east-1"
+	defaultEKSVersion               = "1.31"
+	defaultEKSNodeGroupName         = "default"
+	defaultEKSInstanceType          = "t3.medium"
+	defaultEKSAMIFamily             = "AmazonLinux2023"
 	defaultEKSDesiredCapacity int32 = 2
 	defaultEKSMinSize         int32 = 1
 	defaultEKSMaxSize         int32 = 3
 )
 
-func resolveEKSDefaults(opts v1alpha1.OptionsEKS) eksConfigDefaults {
-	return eksConfigDefaults{
-		clusterName:     "eks-default",
-		region:          firstNonEmpty(opts.Region, "us-east-1"),
-		version:         firstNonEmpty(opts.KubernetesVersion, "1.31"),
-		nodeGroupName:   firstNonEmpty(opts.NodeGroupName, "default"),
-		instanceType:    firstNonEmpty(opts.InstanceType, "t3.medium"),
-		amiFamily:       firstNonEmpty(opts.AMIFamily, "AmazonLinux2023"),
-		desiredCapacity: firstPositiveInt32(opts.DesiredCapacity, defaultEKSDesiredCapacity),
-		minSize:         firstPositiveInt32(opts.MinSize, defaultEKSMinSize),
-		maxSize:         firstPositiveInt32(opts.MaxSize, defaultEKSMaxSize),
-	}
-}
-
-// generateEKSConfig generates the eksctl.yaml configuration file.
+// generateEKSConfig generates the eks.yaml (eksctl ClusterConfig) file.
 // It scaffolds a minimal declarative eksctl `ClusterConfig` with a single
 // managed node group, IAM OIDC enabled, and the addons KSail considers
 // "provided by default" for EKS (VPC CNI, kube-proxy, CoreDNS, EBS CSI).
 // Users are expected to edit the file to match their AWS environment.
+// All cluster metadata lives in this file — it is the authoritative source of
+// truth for the EKS cluster definition.
 func (s *Scaffolder) generateEKSConfig(output string, force bool) error {
 	configPath := filepath.Join(output, EKSConfigFile)
 
@@ -80,18 +40,16 @@ func (s *Scaffolder) generateEKSConfig(output string, force bool) error {
 		return nil
 	}
 
-	defaults := resolveEKSDefaults(s.KSailConfig.Spec.Cluster.EKS)
-
 	content := fmt.Appendf(nil, eksDefaultConfigTemplate,
-		defaults.clusterName,
-		defaults.region,
-		defaults.version,
-		defaults.nodeGroupName,
-		defaults.instanceType,
-		defaults.desiredCapacity,
-		defaults.minSize,
-		defaults.maxSize,
-		defaults.amiFamily,
+		defaultEKSClusterName,
+		defaultEKSRegion,
+		defaultEKSVersion,
+		defaultEKSNodeGroupName,
+		defaultEKSInstanceType,
+		defaultEKSDesiredCapacity,
+		defaultEKSMinSize,
+		defaultEKSMaxSize,
+		defaultEKSAMIFamily,
 	)
 
 	err := os.WriteFile(configPath, content, filePerm)
@@ -114,7 +72,7 @@ func (s *Scaffolder) generateEKSConfig(output string, force bool) error {
 // eksDefaultConfigTemplate is the scaffolded eksctl ClusterConfig.
 // See https://eksctl.io/usage/schema/ for the full schema.
 // The placeholders are, in order: cluster name, region, Kubernetes version,
-// nodegroup name, instance type, desiredCapacity, minSize, maxSize.
+// nodegroup name, instance type, desiredCapacity, minSize, maxSize, amiFamily.
 const eksDefaultConfigTemplate = `# eksctl cluster configuration.
 # See https://eksctl.io/usage/schema/ for the full schema.
 apiVersion: eksctl.io/v1alpha5

--- a/pkg/fsutil/scaffolder/scaffolder_eks.go
+++ b/pkg/fsutil/scaffolder/scaffolder_eks.go
@@ -5,10 +5,63 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v6/pkg/apis/cluster/v1alpha1"
 )
 
 // EKSConfigFile is the default eksctl configuration filename.
 const EKSConfigFile = "eksctl.yaml"
+
+// eksConfigDefaults holds resolved defaults for the scaffolded eksctl.yaml.
+// Zero and empty values from the user's KSail configuration are replaced with
+// sensible starting points so the scaffolded file is ready to apply.
+type eksConfigDefaults struct {
+	clusterName     string
+	region          string
+	version         string
+	nodeGroupName   string
+	instanceType    string
+	amiFamily       string
+	desiredCapacity int32
+	minSize         int32
+	maxSize         int32
+}
+
+func firstNonEmpty(value, fallback string) string {
+	if v := strings.TrimSpace(value); v != "" {
+		return v
+	}
+
+	return fallback
+}
+
+func firstPositiveInt32(value, fallback int32) int32 {
+	if value > 0 {
+		return value
+	}
+
+	return fallback
+}
+
+const (
+	defaultEKSDesiredCapacity int32 = 2
+	defaultEKSMinSize         int32 = 1
+	defaultEKSMaxSize         int32 = 3
+)
+
+func resolveEKSDefaults(opts v1alpha1.OptionsEKS) eksConfigDefaults {
+	return eksConfigDefaults{
+		clusterName:     "eks-default",
+		region:          firstNonEmpty(opts.Region, "us-east-1"),
+		version:         firstNonEmpty(opts.KubernetesVersion, "1.31"),
+		nodeGroupName:   firstNonEmpty(opts.NodeGroupName, "default"),
+		instanceType:    firstNonEmpty(opts.InstanceType, "t3.medium"),
+		amiFamily:       firstNonEmpty(opts.AMIFamily, "AmazonLinux2023"),
+		desiredCapacity: firstPositiveInt32(opts.DesiredCapacity, defaultEKSDesiredCapacity),
+		minSize:         firstPositiveInt32(opts.MinSize, defaultEKSMinSize),
+		maxSize:         firstPositiveInt32(opts.MaxSize, defaultEKSMaxSize),
+	}
+}
 
 // generateEKSConfig generates the eksctl.yaml configuration file.
 // It scaffolds a minimal declarative eksctl `ClusterConfig` with a single
@@ -27,59 +80,19 @@ func (s *Scaffolder) generateEKSConfig(output string, force bool) error {
 		return nil
 	}
 
-	clusterName := "eks-default"
+	defaults := resolveEKSDefaults(s.KSailConfig.Spec.Cluster.EKS)
 
-	region := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.Region)
-	if region == "" {
-		region = "us-east-1"
-	}
-
-	version := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.KubernetesVersion)
-	if version == "" {
-		version = "1.31"
-	}
-
-	nodeGroupName := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.NodeGroupName)
-	if nodeGroupName == "" {
-		nodeGroupName = "default"
-	}
-
-	instanceType := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.InstanceType)
-	if instanceType == "" {
-		instanceType = "t3.medium"
-	}
-
-	desiredCapacity := s.KSailConfig.Spec.Cluster.EKS.DesiredCapacity
-	if desiredCapacity <= 0 {
-		desiredCapacity = 2
-	}
-
-	minSize := s.KSailConfig.Spec.Cluster.EKS.MinSize
-	if minSize <= 0 {
-		minSize = 1
-	}
-
-	maxSize := s.KSailConfig.Spec.Cluster.EKS.MaxSize
-	if maxSize <= 0 {
-		maxSize = 3
-	}
-
-	amiFamily := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.AMIFamily)
-	if amiFamily == "" {
-		amiFamily = "AmazonLinux2023"
-	}
-
-	content := []byte(fmt.Sprintf(eksDefaultConfigTemplate,
-		clusterName,
-		region,
-		version,
-		nodeGroupName,
-		instanceType,
-		desiredCapacity,
-		minSize,
-		maxSize,
-		amiFamily,
-	))
+	content := fmt.Appendf(nil, eksDefaultConfigTemplate,
+		defaults.clusterName,
+		defaults.region,
+		defaults.version,
+		defaults.nodeGroupName,
+		defaults.instanceType,
+		defaults.desiredCapacity,
+		defaults.minSize,
+		defaults.maxSize,
+		defaults.amiFamily,
+	)
 
 	err := os.WriteFile(configPath, content, filePerm)
 	if err != nil {

--- a/pkg/fsutil/scaffolder/scaffolder_eks.go
+++ b/pkg/fsutil/scaffolder/scaffolder_eks.go
@@ -1,0 +1,132 @@
+package scaffolder
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EKSConfigFile is the default eksctl configuration filename.
+const EKSConfigFile = "eksctl.yaml"
+
+// generateEKSConfig generates the eksctl.yaml configuration file.
+// It scaffolds a minimal declarative eksctl `ClusterConfig` with a single
+// managed node group, IAM OIDC enabled, and the addons KSail considers
+// "provided by default" for EKS (VPC CNI, kube-proxy, CoreDNS, EBS CSI).
+// Users are expected to edit the file to match their AWS environment.
+func (s *Scaffolder) generateEKSConfig(output string, force bool) error {
+	configPath := filepath.Join(output, EKSConfigFile)
+
+	skip, existed, previousModTime := s.checkFileExistsAndSkip(
+		configPath,
+		EKSConfigFile,
+		force,
+	)
+	if skip {
+		return nil
+	}
+
+	clusterName := "eks-default"
+
+	region := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.Region)
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	version := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.KubernetesVersion)
+	if version == "" {
+		version = "1.31"
+	}
+
+	nodeGroupName := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.NodeGroupName)
+	if nodeGroupName == "" {
+		nodeGroupName = "default"
+	}
+
+	instanceType := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.InstanceType)
+	if instanceType == "" {
+		instanceType = "t3.medium"
+	}
+
+	desiredCapacity := s.KSailConfig.Spec.Cluster.EKS.DesiredCapacity
+	if desiredCapacity <= 0 {
+		desiredCapacity = 2
+	}
+
+	minSize := s.KSailConfig.Spec.Cluster.EKS.MinSize
+	if minSize <= 0 {
+		minSize = 1
+	}
+
+	maxSize := s.KSailConfig.Spec.Cluster.EKS.MaxSize
+	if maxSize <= 0 {
+		maxSize = 3
+	}
+
+	amiFamily := strings.TrimSpace(s.KSailConfig.Spec.Cluster.EKS.AMIFamily)
+	if amiFamily == "" {
+		amiFamily = "AmazonLinux2023"
+	}
+
+	content := []byte(fmt.Sprintf(eksDefaultConfigTemplate,
+		clusterName,
+		region,
+		version,
+		nodeGroupName,
+		instanceType,
+		desiredCapacity,
+		minSize,
+		maxSize,
+		amiFamily,
+	))
+
+	err := os.WriteFile(configPath, content, filePerm)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrEKSConfigGeneration, err)
+	}
+
+	if force && existed {
+		err = ensureOverwriteModTime(configPath, previousModTime)
+		if err != nil {
+			return fmt.Errorf("failed to update mod time for %s: %w", EKSConfigFile, err)
+		}
+	}
+
+	s.notifyFileAction(EKSConfigFile, existed)
+
+	return nil
+}
+
+// eksDefaultConfigTemplate is the scaffolded eksctl ClusterConfig.
+// See https://eksctl.io/usage/schema/ for the full schema.
+// The placeholders are, in order: cluster name, region, Kubernetes version,
+// nodegroup name, instance type, desiredCapacity, minSize, maxSize.
+const eksDefaultConfigTemplate = `# eksctl cluster configuration.
+# See https://eksctl.io/usage/schema/ for the full schema.
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: %s
+  region: %s
+  version: "%s"
+
+iam:
+  withOIDC: true
+
+addons:
+  - name: vpc-cni
+  - name: kube-proxy
+  - name: coredns
+  - name: aws-ebs-csi-driver
+
+managedNodeGroups:
+  - name: %s
+    instanceType: %s
+    desiredCapacity: %d
+    minSize: %d
+    maxSize: %d
+    volumeSize: 20
+    amiFamily: %s
+`

--- a/pkg/fsutil/scaffolder/scaffolder_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_test.go
@@ -930,7 +930,7 @@ func generateDistributionContent(
 	case v1alpha1.DistributionKWOK:
 		// KWOK config is snapshotted via the scaffolder's kwok.yaml generation
 	case v1alpha1.DistributionEKS:
-		// EKS config is snapshotted via the scaffolder's eksctl.yaml generation
+		// EKS config is snapshotted via the scaffolder's eks.yaml generation
 	}
 }
 
@@ -980,7 +980,7 @@ func minimalDistributionConfigFile(distribution v1alpha1.Distribution) string {
 	case v1alpha1.DistributionKWOK:
 		return "kwok.yaml"
 	case v1alpha1.DistributionEKS:
-		return "eksctl.yaml"
+		return "eks.yaml"
 	case v1alpha1.DistributionVanilla:
 		return ""
 	default:

--- a/pkg/fsutil/scaffolder/scaffolder_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_test.go
@@ -929,6 +929,8 @@ func generateDistributionContent(
 		// VCluster doesn't have a separate distribution config file to snapshot
 	case v1alpha1.DistributionKWOK:
 		// KWOK config is snapshotted via the scaffolder's kwok.yaml generation
+	case v1alpha1.DistributionEKS:
+		// EKS config is snapshotted via the scaffolder's eksctl.yaml generation
 	}
 }
 
@@ -945,53 +947,44 @@ func createMinimalClusterForSnapshot(
 		},
 	}
 
-	// Only add spec fields if they differ from defaults to match original hardcoded output
+	// For Kind, the original hardcoded output had no spec.
+	if distribution == v1alpha1.DistributionVanilla {
+		return minimalCluster
+	}
+
+	configFile := minimalDistributionConfigFile(distribution)
+	if configFile == "" {
+		return minimalCluster
+	}
+
+	minimalCluster.Spec = v1alpha1.Spec{
+		Cluster: v1alpha1.ClusterSpec{
+			Distribution:       distribution,
+			DistributionConfig: configFile,
+		},
+	}
+
+	return minimalCluster
+}
+
+// minimalDistributionConfigFile returns the scaffolded distribution config
+// filename for a given distribution, or empty when no config file applies.
+func minimalDistributionConfigFile(distribution v1alpha1.Distribution) string {
 	switch distribution {
-	case v1alpha1.DistributionVanilla:
-		// For Kind, the original hardcoded output had no spec, so return minimal cluster
-		return minimalCluster
 	case v1alpha1.DistributionK3s:
-		// For K3d, the original hardcoded output included distribution and distributionConfig
-		minimalCluster.Spec = v1alpha1.Spec{
-			Cluster: v1alpha1.ClusterSpec{
-				Distribution:       v1alpha1.DistributionK3s,
-				DistributionConfig: "k3d.yaml",
-			},
-		}
-
-		return minimalCluster
+		return "k3d.yaml"
 	case v1alpha1.DistributionTalos:
-		// For Talos, include distribution and distributionConfig
-		minimalCluster.Spec = v1alpha1.Spec{
-			Cluster: v1alpha1.ClusterSpec{
-				Distribution:       v1alpha1.DistributionTalos,
-				DistributionConfig: "talos",
-			},
-		}
-
-		return minimalCluster
+		return "talos"
 	case v1alpha1.DistributionVCluster:
-		// For VCluster, include distribution and distributionConfig
-		minimalCluster.Spec = v1alpha1.Spec{
-			Cluster: v1alpha1.ClusterSpec{
-				Distribution:       v1alpha1.DistributionVCluster,
-				DistributionConfig: "vcluster.yaml",
-			},
-		}
-
-		return minimalCluster
+		return "vcluster.yaml"
 	case v1alpha1.DistributionKWOK:
-		// For KWOK, include distribution and distributionConfig
-		minimalCluster.Spec = v1alpha1.Spec{
-			Cluster: v1alpha1.ClusterSpec{
-				Distribution:       v1alpha1.DistributionKWOK,
-				DistributionConfig: "kwok.yaml",
-			},
-		}
-
-		return minimalCluster
+		return "kwok.yaml"
+	case v1alpha1.DistributionEKS:
+		return "eksctl.yaml"
+	case v1alpha1.DistributionVanilla:
+		return ""
 	default:
-		return minimalCluster
+		return ""
 	}
 }
 

--- a/pkg/fsutil/validator/ksail/validator.go
+++ b/pkg/fsutil/validator/ksail/validator.go
@@ -204,20 +204,31 @@ func (v *Validator) getExpectedContextName(config *v1alpha1.Cluster) string {
 		return ""
 	}
 
-	switch config.Spec.Cluster.Distribution {
-	case v1alpha1.DistributionVanilla:
-		return "kind-" + distributionName
-	case v1alpha1.DistributionK3s:
-		return "k3d-" + distributionName
-	case v1alpha1.DistributionTalos:
-		return "admin@" + distributionName
-	case v1alpha1.DistributionVCluster:
-		return "vcluster-docker_" + distributionName
-	case v1alpha1.DistributionKWOK:
-		return "kwok-" + distributionName
-	default:
-		return ""
+	return formatExpectedContextName(config.Spec.Cluster.Distribution, distributionName)
+}
+
+// formatExpectedContextName returns the canonical kubeconfig context name used
+// by a given distribution's tooling.
+func formatExpectedContextName(
+	distribution v1alpha1.Distribution,
+	distributionName string,
+) string {
+	prefixes := map[v1alpha1.Distribution]string{
+		v1alpha1.DistributionVanilla:  "kind-",
+		v1alpha1.DistributionK3s:      "k3d-",
+		v1alpha1.DistributionTalos:    "admin@",
+		v1alpha1.DistributionVCluster: "vcluster-docker_",
+		v1alpha1.DistributionKWOK:     "kwok-",
 	}
+	if prefix, ok := prefixes[distribution]; ok {
+		return prefix + distributionName
+	}
+
+	if distribution == v1alpha1.DistributionEKS {
+		return distributionName + ".eksctl.io"
+	}
+
+	return ""
 }
 
 // getDistributionConfigName extracts the cluster name from the distribution configuration.
@@ -233,6 +244,10 @@ func (v *Validator) getDistributionConfigName(distribution v1alpha1.Distribution
 		return v.getVClusterConfigName()
 	case v1alpha1.DistributionKWOK:
 		return v.getKWOKConfigName()
+	case v1alpha1.DistributionEKS:
+		// EKS config is not provided to the validator (eksctl manages it);
+		// skip distribution-level name validation.
+		return ""
 	default:
 		return ""
 	}
@@ -324,9 +339,9 @@ func (v *Validator) validateCiliumCNI(
 		v.validateK3dCiliumCNIAlignment(result)
 	case v1alpha1.DistributionTalos:
 		v.validateTalosCiliumCNIAlignment(result)
-	case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK:
-		// VCluster manages its own CNI internally; KWOK simulates all pods.
-		// No alignment check needed.
+	case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK, v1alpha1.DistributionEKS:
+		// VCluster manages its own CNI internally; KWOK simulates all pods;
+		// EKS uses AWS VPC CNI (managed by the cloud). No alignment check needed.
 	}
 }
 
@@ -342,8 +357,8 @@ func (v *Validator) validateDefaultCNI(
 		v.validateK3dDefaultCNIAlignment(result)
 	case v1alpha1.DistributionTalos:
 		v.validateTalosDefaultCNIAlignment(result)
-	case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK:
-		// VCluster and KWOK manage CNI internally; no alignment check needed.
+	case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK, v1alpha1.DistributionEKS:
+		// VCluster, KWOK, and EKS manage CNI internally; no alignment check needed.
 	}
 }
 

--- a/pkg/fsutil/validator/ksail/validator_test.go
+++ b/pkg/fsutil/validator/ksail/validator_test.go
@@ -273,6 +273,9 @@ func createValidKSailConfig(distribution v1alpha1.Distribution) *v1alpha1.Cluste
 	case v1alpha1.DistributionKWOK:
 		distributionConfigFile = "kwok.yaml"
 		contextName = "kwok-kwok-default" // Sample context name
+	case v1alpha1.DistributionEKS:
+		distributionConfigFile = "eksctl.yaml"
+		contextName = "eks-default.eksctl.io" // Sample context name
 	default:
 		distributionConfigFile = "cluster.yaml"
 		contextName = "ksail"

--- a/pkg/fsutil/validator/ksail/validator_test.go
+++ b/pkg/fsutil/validator/ksail/validator_test.go
@@ -274,7 +274,7 @@ func createValidKSailConfig(distribution v1alpha1.Distribution) *v1alpha1.Cluste
 		distributionConfigFile = "kwok.yaml"
 		contextName = "kwok-kwok-default" // Sample context name
 	case v1alpha1.DistributionEKS:
-		distributionConfigFile = "eksctl.yaml"
+		distributionConfigFile = "eks.yaml"
 		contextName = "eks-default.eksctl.io" // Sample context name
 	default:
 		distributionConfigFile = "cluster.yaml"

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -145,7 +145,8 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 				switch e.distribution {
 				case v1alpha1.DistributionK3s,
 					v1alpha1.DistributionVCluster,
-					v1alpha1.DistributionKWOK:
+					v1alpha1.DistributionKWOK,
+					v1alpha1.DistributionEKS:
 					return string(v1alpha1.CDIDisabled)
 				case v1alpha1.DistributionVanilla, v1alpha1.DistributionTalos:
 					return string(spec.CDI.EffectiveValue(e.distribution, e.provider))
@@ -298,13 +299,13 @@ func (e *Engine) checkLocalRegistryChange(
 				Category: clusterupdate.ChangeCategoryInPlace,
 				Reason:   reasons[e.distribution],
 			})
-		case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK:
+		case v1alpha1.DistributionVCluster, v1alpha1.DistributionKWOK, v1alpha1.DistributionEKS:
 			result.InPlaceChanges = append(result.InPlaceChanges, clusterupdate.Change{
 				Field:    "cluster.localRegistry.registry",
 				OldValue: oldSpec.LocalRegistry.Registry,
 				NewValue: newSpec.LocalRegistry.Registry,
 				Category: clusterupdate.ChangeCategoryInPlace,
-				Reason:   "VCluster/KWOK manages registry independently via Docker networking",
+				Reason:   "VCluster/KWOK/EKS manage registry independently of the node OS",
 			})
 		}
 	}

--- a/pkg/svc/installer/cni/calico/installer.go
+++ b/pkg/svc/installer/cni/calico/installer.go
@@ -176,8 +176,9 @@ func (c *Installer) getCalicoValues() map[string]string {
 	case v1alpha1.DistributionVanilla,
 		v1alpha1.DistributionK3s,
 		v1alpha1.DistributionVCluster,
-		v1alpha1.DistributionKWOK:
-		// Vanilla, K3s, VCluster, and KWOK use default values
+		v1alpha1.DistributionKWOK,
+		v1alpha1.DistributionEKS:
+		// Vanilla, K3s, VCluster, KWOK, and EKS use default values.
 	}
 
 	return values

--- a/pkg/svc/installer/cni/cilium/installer.go
+++ b/pkg/svc/installer/cni/cilium/installer.go
@@ -179,8 +179,9 @@ func (c *Installer) getCiliumValues() map[string]string {
 	case v1alpha1.DistributionVanilla,
 		v1alpha1.DistributionK3s,
 		v1alpha1.DistributionVCluster,
-		v1alpha1.DistributionKWOK:
-		// Vanilla, K3s, VCluster, and KWOK use default values
+		v1alpha1.DistributionKWOK,
+		v1alpha1.DistributionEKS:
+		// Vanilla, K3s, VCluster, KWOK, and EKS use default values.
 	}
 
 	// Add provider-specific values.
@@ -194,8 +195,9 @@ func (c *Installer) getCiliumValues() map[string]string {
 		if effective != v1alpha1.LoadBalancerEnabled {
 			maps.Copy(values, dockerCiliumValues())
 		}
-	case v1alpha1.ProviderHetzner, v1alpha1.ProviderOmni:
-		// Hetzner and Omni use default values
+	case v1alpha1.ProviderHetzner, v1alpha1.ProviderOmni, v1alpha1.ProviderAWS:
+		// Hetzner, Omni, and AWS use default values (Cilium is not installed
+		// on EKS by KSail, but if selected it behaves like other cloud providers).
 	}
 
 	return values

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -135,6 +135,12 @@ func (f DefaultFactory) Create(
 		return f.createVClusterProvisioner(cluster)
 	case v1alpha1.DistributionKWOK:
 		return f.createKWOKProvisioner(cluster)
+	case v1alpha1.DistributionEKS:
+		return nil, nil, fmt.Errorf(
+			"%w: %s (EKS provisioner is added in a follow-up change)",
+			ErrUnsupportedDistribution,
+			cluster.Spec.Cluster.Distribution,
+		)
 	default:
 		return nil, "", fmt.Errorf(
 			"%w: %s",

--- a/pkg/svc/provisioner/cluster/kwok/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/provisioner.go
@@ -19,8 +19,7 @@ import (
 	startcluster "sigs.k8s.io/kwok/pkg/kwokctl/cmd/start/cluster"
 	stopcluster "sigs.k8s.io/kwok/pkg/kwokctl/cmd/stop/cluster"
 	kwokruntime "sigs.k8s.io/kwok/pkg/kwokctl/runtime"
-	// Register the Docker compose runtime so kwokctl can find it.
-	_ "sigs.k8s.io/kwok/pkg/kwokctl/runtime/compose"
+	_ "sigs.k8s.io/kwok/pkg/kwokctl/runtime/compose" // Register the Docker compose runtime so kwokctl can find it.
 	kwoklog "sigs.k8s.io/kwok/pkg/log"
 )
 

--- a/pkg/svc/provisioner/cluster/multi.go
+++ b/pkg/svc/provisioner/cluster/multi.go
@@ -194,6 +194,11 @@ func CreateMinimalProvisioner(
 		return createMinimalVClusterProvisioner(clusterName)
 	case v1alpha1.DistributionKWOK:
 		return kwokprovisioner.NewProvisioner(clusterName, "", nil), nil
+	case v1alpha1.DistributionEKS:
+		return nil, fmt.Errorf(
+			"%w: EKS does not support the multi-provisioner path",
+			ErrUnsupportedDistribution,
+		)
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedDistribution, dist)
 	}

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -154,6 +154,10 @@ func configureInfraProvider(
 		// Store Omni options so the provisioner can route to Omni-specific logic
 		provisioner.WithOmniOptions(omniOpts)
 
+	case v1alpha1.ProviderAWS:
+		return fmt.Errorf("%w: %s (AWS is only supported with the EKS distribution)",
+			ErrUnsupportedProvider, providerType)
+
 	default:
 		return fmt.Errorf("%w: %s (supported: %s, %s, %s)",
 			ErrUnsupportedProvider, providerType,

--- a/schemas/gen_schema_test.go
+++ b/schemas/gen_schema_test.go
@@ -103,7 +103,7 @@ func TestGeneratedSchema(t *testing.T) {
 		cluster := mustNestedProp(t, schema, "spec", "cluster")
 		dist := mustMap(t, cluster["properties"], "cluster.properties")
 		distProp := mustMap(t, dist["distribution"], "distribution")
-		assertEnum(t, distProp, []string{"Vanilla", "K3s", "Talos", "VCluster", "KWOK"})
+		assertEnum(t, distProp, []string{"Vanilla", "K3s", "Talos", "VCluster", "KWOK", "EKS"})
 	})
 
 	t.Run("provider enum", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestGeneratedSchema(t *testing.T) {
 		cluster := mustNestedProp(t, schema, "spec", "cluster")
 		props := mustMap(t, cluster["properties"], "cluster.properties")
 		prov := mustMap(t, props["provider"], "provider")
-		assertEnum(t, prov, []string{"Docker", "Hetzner", "Omni"})
+		assertEnum(t, prov, []string{"Docker", "Hetzner", "Omni", "AWS"})
 	})
 
 	testNoRequiredFields(t, schema)

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -204,36 +204,6 @@
               },
               "additionalProperties": false,
               "type": "object"
-            },
-            "eks": {
-              "properties": {
-                "region": {
-                  "type": "string"
-                },
-                "kubernetesVersion": {
-                  "type": "string"
-                },
-                "nodeGroupName": {
-                  "type": "string"
-                },
-                "instanceType": {
-                  "type": "string"
-                },
-                "desiredCapacity": {
-                  "type": "integer"
-                },
-                "minSize": {
-                  "type": "integer"
-                },
-                "maxSize": {
-                  "type": "integer"
-                },
-                "amiFamily": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "type": "object"
             }
           },
           "additionalProperties": false,

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -47,7 +47,8 @@
                 "K3s",
                 "Talos",
                 "VCluster",
-                "KWOK"
+                "KWOK",
+                "EKS"
               ]
             },
             "provider": {
@@ -55,7 +56,8 @@
               "enum": [
                 "Docker",
                 "Hetzner",
-                "Omni"
+                "Omni",
+                "AWS"
               ]
             },
             "cni": {
@@ -202,6 +204,36 @@
               },
               "additionalProperties": false,
               "type": "object"
+            },
+            "eks": {
+              "properties": {
+                "region": {
+                  "type": "string"
+                },
+                "kubernetesVersion": {
+                  "type": "string"
+                },
+                "nodeGroupName": {
+                  "type": "string"
+                },
+                "instanceType": {
+                  "type": "string"
+                },
+                "desiredCapacity": {
+                  "type": "integer"
+                },
+                "minSize": {
+                  "type": "integer"
+                },
+                "maxSize": {
+                  "type": "integer"
+                },
+                "amiFamily": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
             }
           },
           "additionalProperties": false,
@@ -280,6 +312,27 @@
                     "type": "string"
                   },
                   "type": "array"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
+            },
+            "aws": {
+              "properties": {
+                "profileEnvVar": {
+                  "type": "string"
+                },
+                "regionEnvVar": {
+                  "type": "string"
+                },
+                "accessKeyIdEnvVar": {
+                  "type": "string"
+                },
+                "secretAccessKeyEnvVar": {
+                  "type": "string"
+                },
+                "sessionTokenEnvVar": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false,


### PR DESCRIPTION
## Summary

Adds **EKS** as a new distribution and **AWS** as a new provider, with `ksail cluster init --distribution EKS --provider AWS` scaffolding a declarative `eksctl.io/v1alpha5` `ClusterConfig`.

This is the **foundation PR** in a stack. It lands the enum, options, validation, defaults, and scaffolder work needed before the eksctl integration, provisioner, installer gating, detector, and diff classification can follow.

## What this PR does

- Adds `Distribution=EKS` to `pkg/apis/cluster/v1alpha1` with the full `ProvidesXByDefault` matrix (CNI ✅, CSI ✅, LoadBalancer ✅, MetricsServer ❌, Storage ✅, CDI ❌).
- Adds `Provider=AWS` — cloud provider (rejects local mirror/local registries), only valid with `Distribution=EKS`.
- Adds `eks.yaml` (region, kubernetesVersion, nodeGroupName, instanceType, desiredCapacity, min/maxSize, amiFamily — defined by eksctl's `ClusterConfig` type; ksail.yaml does not duplicate these fields) and `OptionsAWS` (credential env var overrides, mirroring the Hetzner/Omni pattern).
- Adds `ErrAWSCredentialsMissing` and `ErrEksctlBinaryMissing` (the latter reserved for the follow-up provisioner PR).
- `ExpectedDistributionConfigName(EKS) → eks.yaml`; `ExpectedContextName(EKS) → <name>.eksctl.io`; `DefaultClusterName(EKS) → eks-default`.
- `pkg/fsutil/scaffolder/scaffolder_eks.go` generates a minimal `eks.yaml` with IAM OIDC, the four "provided by default" addons (`vpc-cni`, `kube-proxy`, `coredns`, `aws-ebs-csi-driver`), and one managed nodegroup with sensible defaults (editable by the user).
- Regenerates `schemas/ksail-config.schema.json` and the declarative-configuration docs.

## What this PR does NOT do (deferred to follow-up stacked PRs)

- AWS provider implementation (`pkg/svc/provider/aws/`).
- EKS provisioner (`pkg/svc/provisioner/cluster/eks/`) — embeds eksctl's `pkg/actions/cluster` (Upgrade/Delete) and `pkg/actions/nodegroup` (scale), and shells out to the `eksctl` CLI binary for Create. See [spike findings](#spike-findings) below.
- Factory wiring in `pkg/svc/provisioner/cluster/factory.go` — **`ksail cluster create --distribution EKS` currently fails with `ErrUnsupportedDistribution` until the provisioner PR lands**.
- Installer matrix gating, detector, diff engine, cluster switch, state persistence, distribution/provider doc pages.
- Fargate profiles, self-managed nodegroups, Karpenter, cross-account/multi-region — explicitly out of scope for v1.

## Spike findings (documented for reviewers)

`eksctl-io/eksctl` @ v0.225.0 (module path still `github.com/weaveworks/eksctl`):

- `pkg/actions/cluster.Cluster` interface is **`Upgrade` + `Delete` only** — no `Create`. Create logic lives in `pkg/ctl/create/cluster.go`, tightly coupled to Cobra/pflag/cmdutils with `sync.Once` globals — not library-safe.
- `pkg/actions/nodegroup` scale ops are library-safe.
- `pkg/eks.ClusterProvider` can be constructed via `pkg/eks.New(...)` without importing `pkg/ctl/...`.

**Decision:** Hybrid integration — embed types + Upgrade + Delete + nodegroup scale; shell out to the `eksctl` binary for Create. `eksctl` joins Docker as an external dep for the EKS distribution.

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ (entire repo green)
- E2E smoke: `ksail cluster init --distribution EKS --provider AWS` produces `ksail.yaml`, `eks.yaml`, `k8s/kustomization.yaml`.
- `ksail cluster init --distribution EKS --provider Docker` correctly rejected with `ErrInvalidDistributionProviderCombination`.
- Schema round-trip: `go generate ./schemas/...` produces stable `ksail-config.schema.json` containing `EKS` and `AWS` enum values.

## Follow-up stack

1. `pkg/svc/provider/aws` — AWS SDK v2 credential chain + provider interface.
2. `pkg/svc/provisioner/cluster/eks` — eksctl SDK wrapper + binary exec for create.
3. Factory wiring, installer gating, detector, diff, state.
4. Distribution/provider docs pages + lifecycle test coverage.
