### PR TITLE
fix(ci): use `setup-copilot-skills` action in update-skills workflow

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -28,27 +28,11 @@ jobs:
           persist-credentials: true
 
       - name: 🔄 Update Copilot skills
-        run: |
-          if ! gh skill --help >/dev/null 2>&1; then
-            echo "::error::Installed gh does not support 'gh skill'. Ensure the runner has a gh version with skill support."
-            exit 1
-          fi
-
-          if [ ! -f skills-lock.json ]; then
-            echo "::error::skills-lock.json not found"
-            exit 1
-          fi
-          jq_output=$(jq -e -c '.skills | to_entries[] | {"source": .value.source, "skillName": .key}' skills-lock.json)
-          if [ -z "$jq_output" ]; then
-            echo "::error::No skills found in skills-lock.json"
-            exit 1
-          fi
-          while IFS= read -r skill_entry; do
-            skill_source=$(jq -r '.source' <<< "$skill_entry")
-            skill_name=$(jq -r '.skillName' <<< "$skill_entry")
-            echo "Updating ${skill_source}/${skill_name}..."
-            gh skill install "$skill_source" "$skill_name" --agent github-copilot --scope user
-          done < <(printf '%s\n' "$jq_output")
+        uses: devantler-tech/actions/setup-copilot-skills@538d7103ed24531647941b3a460393b5ac7ed756 # v2.2.0
+        with:
+          skills-lock: skills-lock.json
+          agent: github-copilot
+          scope: user
 
       - name: 📦 Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
## Description

Stacked on top of #4105. Fixes the `gh skill` version mismatch that causes manual (and scheduled) runs of the `Update Copilot Skills` workflow to fail on this branch with:

```
::error::Installed gh does not support 'gh skill'. Ensure the runner has a gh version with skill support.
```

### Root cause

`ubuntu-latest` currently ships `gh` 2.89.0; `gh skill` was introduced in 2.90.0. The inline step in this branch's `update-skills.yaml` early-exits with the error above instead of installing a new-enough `gh`.

### Fix

Replace the inline `jq` + `gh skill install` loop with the [`devantler-tech/actions/setup-copilot-skills`](https://github.com/devantler-tech/actions/tree/main/setup-copilot-skills) composite action (pinned to the v2.2.0 commit SHA `538d7103`). That action:

- Detects whether the runner `gh` supports `gh skill`, and if not downloads `gh` 2.90.0 from the cli/cli releases into `$RUNNER_TEMP/setup-copilot-skills/bin` and prepends it to `GITHUB_PATH`.
- Reads `skills-lock.json` (same schema this workflow already uses) and iterates each entry, calling `gh skill install <source> <skill> --agent <agent> --scope <scope>`.

Net diff is −21 / +5 lines, and the behaviour/inputs passed to `gh skill install` are unchanged (`agent: github-copilot`, `scope: user`).

### Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Notes

- Target branch is `copilot/manage-skills-with-github-cli` (head of #4105), so this stacks cleanly.
- #4106 (source-all-skills-from-devantler-tech/skills) is also stacked on #4105 and is unaffected — it only edits `skills-lock.json` + `.agents/skills/`.
