### PR TITLE
fix(connect): silence klog so it stops corrupting the k9s TUI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/siderolabs/omni/client v1.6.5
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/kwok v0.7.1-0.20260414082732-bea15031f3ec
 )
 
@@ -775,7 +776,6 @@ require (
 	k8s.io/component-helpers v0.35.3 // indirect
 	k8s.io/cri-api v0.35.3 // indirect
 	k8s.io/cri-client v0.35.0 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-aggregator v0.35.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260330154417-16be699c7b31 // indirect
 	k8s.io/kube-proxy v0.33.0 // indirect

--- a/pkg/client/k9s/client.go
+++ b/pkg/client/k9s/client.go
@@ -11,6 +11,10 @@ import (
 )
 
 // silenceKlogOnce ensures klog is configured at most once per process.
+//
+// klog flag registration across any caller within the process.
+//
+//nolint:gochecknoglobals // sync.Once must be package-scoped to deduplicate
 var silenceKlogOnce sync.Once
 
 // silenceKlog redirects klog output away from stderr so client-go log lines

--- a/pkg/client/k9s/client.go
+++ b/pkg/client/k9s/client.go
@@ -1,11 +1,49 @@
 package k9s
 
 import (
+	"flag"
 	"os"
+	"sync"
 
 	k9scmd "github.com/derailed/k9s/cmd"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 )
+
+// silenceKlogOnce ensures klog is configured at most once per process.
+var silenceKlogOnce sync.Once
+
+// silenceKlog redirects klog output away from stderr so client-go log lines
+// (e.g. reflector "Failed to watch" errors) do not corrupt the k9s TUI.
+//
+// The upstream k9s binary performs the same setup from its own main.go
+// init(). Because ksail embeds only the k9s cmd/ subpackage, that init is
+// never executed and klog writes directly to stderr while the alternate
+// screen is active, producing the garbled output reported in
+// `ksail cluster connect`.
+//
+// See github.com/derailed/k9s/main.go for the reference implementation.
+func silenceKlog() {
+	silenceKlogOnce.Do(func() {
+		// klog.InitFlags panics if its flags are already registered on the
+		// default flag.CommandLine (e.g. by another dependency). Only bind
+		// klog's flags if they aren't already present.
+		if flag.Lookup("logtostderr") == nil {
+			klog.InitFlags(nil)
+		}
+
+		for name, value := range map[string]string{
+			"logtostderr":     "false",
+			"alsologtostderr": "false",
+			"stderrthreshold": "fatal",
+			"v":               "-10",
+		} {
+			// Errors here would only occur if klog's flag names change upstream.
+			// Ignore to keep the TUI launch path side-effect free.
+			_ = flag.Set(name, value)
+		}
+	})
+}
 
 // Client wraps k9s command functionality.
 type Client struct{}
@@ -56,6 +94,9 @@ func (c *Client) runK9s(kubeConfigPath, context string, args []string) error {
 
 	// Set os.Args for k9s to parse
 	os.Args = k9sArgs
+
+	// Prevent client-go klog messages from leaking onto the TUI.
+	silenceKlog()
 
 	// Execute k9s.
 	k9scmd.Execute()

--- a/pkg/client/k9s/client_test.go
+++ b/pkg/client/k9s/client_test.go
@@ -78,6 +78,8 @@ func TestCreateConnectCommandStructure(t *testing.T) {
 // client-go log messages do not leak onto the k9s TUI. This is the fix
 // for the garbled `ksail cluster connect` output caused by klog writing
 // to stderr while the alternate screen is active.
+//
+//nolint:paralleltest // Mutates process-global flag.CommandLine state.
 func TestSilenceKlog(t *testing.T) {
 	// Not parallel: mutates process-global flag state.
 	k9s.SilenceKlogForTest()

--- a/pkg/client/k9s/client_test.go
+++ b/pkg/client/k9s/client_test.go
@@ -1,6 +1,7 @@
 package k9s_test
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v6/pkg/client/k9s"
@@ -70,4 +71,27 @@ func TestCreateConnectCommandStructure(t *testing.T) {
 	require.NotNil(t, cmd.RunE, "expected RunE to be set")
 
 	// NOTE: We cannot execute RunE in unit tests because it launches k9s.
+}
+
+// TestSilenceKlog verifies that invoking the k9s client's klog-silencing
+// helper (exposed via the exported test seam) configures klog flags so
+// client-go log messages do not leak onto the k9s TUI. This is the fix
+// for the garbled `ksail cluster connect` output caused by klog writing
+// to stderr while the alternate screen is active.
+func TestSilenceKlog(t *testing.T) {
+	// Not parallel: mutates process-global flag state.
+	k9s.SilenceKlogForTest()
+
+	cases := map[string]string{
+		"logtostderr":     "false",
+		"alsologtostderr": "false",
+		// klog's stderrthreshold is a severity value; "fatal" stringifies to "3".
+		"stderrthreshold": "3",
+		"v":               "-10",
+	}
+	for name, want := range cases {
+		f := flag.Lookup(name)
+		require.NotNilf(t, f, "expected klog flag %q to be registered", name)
+		require.Equalf(t, want, f.Value.String(), "flag %q value mismatch", name)
+	}
 }

--- a/pkg/client/k9s/export_test.go
+++ b/pkg/client/k9s/export_test.go
@@ -1,0 +1,7 @@
+package k9s
+
+// SilenceKlogForTest exposes the unexported silenceKlog helper to tests in
+// this package's _test variant. Production code should never call this.
+func SilenceKlogForTest() {
+	silenceKlog()
+}


### PR DESCRIPTION
`ksail cluster connect` launches k9s, but client-go's klog reflector errors (e.g. `"Failed to watch" ... reflector.go:204`) were writing directly to stderr while the alternate screen was active, garbling the TUI (see reporter screenshot).

Root cause: the upstream k9s binary silences klog from its own [`main.go` `init()`](https://github.com/derailed/k9s/blob/v0.50.18/main.go) (`logtostderr=false`, `alsologtostderr=false`, `stderrthreshold=fatal`, `v=-10`). ksail embeds only the `cmd/` subpackage via `k9scmd.Execute()`, so that init never ran. Not a TTY/PTY issue.

Fix: replicate the same klog setup inside `pkg/client/k9s` before invoking `k9scmd.Execute()`. The helper is guarded by `sync.Once` and skips `klog.InitFlags` if another dependency already registered klog's flags on `flag.CommandLine`, so it composes safely with the rest of the CLI.

## Type of change

- [x] 🪲 Bug fix