### PR TITLE
docs: slim README and harden daily-docs root-file audit

### DIFF
--- a/.github/workflows/daily-docs.md
+++ b/.github/workflows/daily-docs.md
@@ -154,7 +154,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
 
    Checks to perform:
 
-   - **README length**: `wc -l README.md` must be ≤ ~100 lines. If over, move detail into the canonical `docs/` page and replace with a link.
+   - **README length**: `wc -l README.md` must report ≤ 100 lines. If over, move detail into the canonical `docs/` page and replace with a link.
    - **README scope**: `README.md` must NOT contain content that duplicates `docs/src/content/docs/index.mdx`. Specifically flag and remove: Mermaid architecture diagrams, full `ksail cluster init` flag reference, Native Configuration Files walkthroughs, Presentations lists, Blog Posts lists, verbose "Why KSail?" / "Key Features" bullet lists. These belong on `/architecture/`, `/cli-flags/cluster/cluster-init/`, `/configuration/`, and `/resources/`.
    - **Distribution × Provider matrix parity**: The provider/distribution matrix in `README.md` must list the same distributions and providers as `docs/src/content/docs/index.mdx`. When a new distribution or provider is added (for example, when a new provisioner or provider package lands under `pkg/svc/provisioner/` or `pkg/svc/provider/`), both matrices must be updated in lockstep.
    - **Top-level command parity**: If `README.md` names specific top-level commands, they must match the output of `go run . --help` (Available Commands section). New top-level commands (like `tenant`) must be reflected.
@@ -168,7 +168,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
    Each root file serves a different audience and medium. Do NOT duplicate content across them — link instead.
 
    - **README.md** (audience: end-user, medium: GitHub landing page)
-     - Keep under ~100 lines: badges, one-paragraph intro, feature bullet list, prerequisites table, and a prominent link to the docs site
+     - Keep under 100 lines (`wc -l README.md` ≤ 100): badges, one-paragraph intro, feature bullet list, prerequisites table, and a prominent link to the docs site
      - Do NOT include tutorials, detailed configuration, architecture internals, or content that duplicates `docs/src/content/docs/index.mdx`
      - Link to the docs site for anything beyond a quick overview (e.g., "See the [Installation Guide](https://ksail.devantler.tech/installation/)")
 
@@ -231,7 +231,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
      - **Concept/explanation pages**: Explain "why" and "what"; link to reference pages for "how"
      - **Guide pages**: Goal-oriented, complete workflow from start to finish; include troubleshooting tips
      - **Reference pages**: Exhaustive and scannable; prefer tables over prose; document every option
-     - **README.md**: Under ~100 lines, link-heavy, no tutorials or detailed configuration
+     - **README.md**: Under 100 lines (`wc -l README.md` ≤ 100), link-heavy, no tutorials or detailed configuration
    - End-user docs (`docs/`) do not contain contributor-only content (internal APIs, package paths, design decisions)
 
 8. **Quality Assurance**
@@ -314,7 +314,7 @@ ls README.md vsce/README.md CONTRIBUTING.md .github/copilot-instructions.md 2>/d
 
 **Root-file specific checks** (apply when a root file is selected):
 
-- `README.md` — must be ≤ ~100 lines, must not duplicate `docs/src/content/docs/index.mdx` (no Mermaid diagrams, full init flag reference, Native Configuration Files walkthrough, Presentations list, Blog Posts list), and must keep its Distribution × Provider matrix in sync with `docs/index.mdx`.
+- `README.md` — `wc -l README.md` must report ≤ 100 lines, must not duplicate `docs/src/content/docs/index.mdx` (no Mermaid diagrams, full init flag reference, Native Configuration Files walkthrough, Presentations list, Blog Posts list), and must keep its Distribution × Provider matrix in sync with `docs/index.mdx`.
 - `vsce/README.md` — concise marketplace description only; full usage belongs on `/vscode-extension/`.
 - `CONTRIBUTING.md` / `.github/copilot-instructions.md` — contributor content only; no end-user tutorials or marketing.
 

--- a/.github/workflows/daily-docs.md
+++ b/.github/workflows/daily-docs.md
@@ -148,7 +148,22 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
    - Cross-reference the diff against your documentation inventory to find affected pages
    - Identify documentation gaps like failing tests: a "red build" until fixed
 
-3. **Synchronize Root Documentation Files**
+3. **Root File Audit (always runs, not gated on the diff)**
+
+   Root documentation files drift silently because most pushes don't touch them. Audit them on every Doc Sync run, independently of whether the current diff suggests a root-file change. If any check fails, fix it in the same PR as (or in addition to) diff-driven updates.
+
+   Checks to perform:
+
+   - **README length**: `wc -l README.md` must be ≤ ~100 lines. If over, move detail into the canonical `docs/` page and replace with a link.
+   - **README scope**: `README.md` must NOT contain content that duplicates `docs/src/content/docs/index.mdx`. Specifically flag and remove: Mermaid architecture diagrams, full `ksail cluster init` flag reference, Native Configuration Files walkthroughs, Presentations lists, Blog Posts lists, verbose "Why KSail?" / "Key Features" bullet lists. These belong on `/architecture/`, `/cli-flags/cluster/cluster-init/`, `/configuration/`, and `/resources/`.
+   - **Distribution × Provider matrix parity**: The provider/distribution matrix in `README.md` must list the same distributions and providers as `docs/src/content/docs/index.mdx`. When a new distribution or provider is added (for example, when a new provisioner or provider package lands under `pkg/svc/provisioner/` or `pkg/svc/provider/`), both matrices must be updated in lockstep.
+   - **Top-level command parity**: If `README.md` names specific top-level commands, they must match the output of `go run . --help` (Available Commands section). New top-level commands (like `tenant`) must be reflected.
+   - **`vsce/README.md`**: must remain a concise marketplace description that links to `/vscode-extension/` — never a full docs page copy.
+   - **`CONTRIBUTING.md` and `.github/copilot-instructions.md`**: must not contain end-user tutorials or feature marketing; those belong in `docs/`.
+
+   If every root-file check passes and the diff surfaces no doc impact, call `noop` with a summary of what was checked. Do not claim `noop` without running these checks.
+
+4. **Synchronize Root Documentation Files**
 
    Each root file serves a different audience and medium. Do NOT duplicate content across them — link instead.
 
@@ -175,7 +190,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
      - Architecture overview, build commands, project structure, and package layout for AI assistant guidance
      - **Do NOT add, maintain, or re-create a "Recent Changes" section** — this section has been intentionally removed
 
-4. **Create or Update Documentation**
+5. **Create or Update Documentation**
 
    Before writing or modifying any content, consult your **page ownership map** and documentation inventory.
 
@@ -186,7 +201,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
    - Follow progressive disclosure: high-level concepts first, detailed examples second
    - Create clear, actionable documentation that serves both newcomers and power users
 
-5. **Sidebar & Structure Refinement**
+6. **Sidebar & Structure Refinement**
 
    Continuously evaluate and refine the sidebar navigation (`docs/astro.config.mjs`) and overall docs structure to keep them well-organized, easy to navigate, and holistic.
 
@@ -204,7 +219,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
    - **Collapsed sections**: Use `collapsed: true` only for large reference sections (e.g., CLI flags). Keep primary navigation sections expanded.
    - **Holistic structure**: Step back and evaluate the overall docs structure. If the documentation has grown in a way that no longer makes sense (e.g., a section has too many pages, related topics are scattered across sections), propose reorganization — move pages, rename sections, or create new groupings as needed.
 
-6. **Coherence Review**
+7. **Coherence Review**
 
    After making changes, verify the full documentation set remains coherent:
 
@@ -219,12 +234,12 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
      - **README.md**: Under ~100 lines, link-heavy, no tutorials or detailed configuration
    - End-user docs (`docs/`) do not contain contributor-only content (internal APIs, package paths, design decisions)
 
-7. **Quality Assurance**
+8. **Quality Assurance**
    - Check for broken links, missing images, or formatting issues
    - **Link verification**: Scan documentation files for HTTP(S) links and test them. For broken links, search for replacement URLs (try common variations like www, http vs https, archived pages). Fix broken links in-place. Use `cache-memory` to avoid re-checking links that were previously verified or confirmed unfixable.
    - Ensure code examples are accurate and functional
 
-8. **Output**
+9. **Output**
    - Create focused draft pull requests with clear descriptions
    - When triggered by a `push` event and no documentation changes are needed, call `noop` — do NOT call `add_comment` (there is no PR or issue context on push)
    - Exit if no code changes require documentation updates
@@ -279,8 +294,14 @@ find docs/src/content/docs -type f \( -name '*.md' -o -name '*.mdx' \) ! \( -pat
 
 #### 3. Find Candidate Files
 
+Candidates include **both** user-facing docs under `docs/` **and** root documentation files. Root files (`README.md`, `vsce/README.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`) are scanned here because Doc Sync mode only runs on code pushes — the daily schedule is what catches root-file bloat.
+
 ```bash
+# User-facing docs (excluding auto-generated + blog)
 find docs/src/content/docs -path 'docs/src/content/docs/blog' -prune -o \( -name '*.md' -o -name '*.mdx' \) -type f ! -name 'frontmatter-full.md' -print
+
+# Root documentation files
+ls README.md vsce/README.md CONTRIBUTING.md .github/copilot-instructions.md 2>/dev/null
 ```
 
 **Exclude**:
@@ -290,6 +311,12 @@ find docs/src/content/docs -path 'docs/src/content/docs/blog' -prune -o \( -name
 - Files with `disable-agentic-editing: true` in frontmatter
 - All files under `docs/src/content/docs/cli-flags/*/` — auto-generated by `go generate`
 - `docs/src/content/docs/configuration/declarative-configuration.mdx` — auto-generated by `go generate`
+
+**Root-file specific checks** (apply when a root file is selected):
+
+- `README.md` — must be ≤ ~100 lines, must not duplicate `docs/src/content/docs/index.mdx` (no Mermaid diagrams, full init flag reference, Native Configuration Files walkthrough, Presentations list, Blog Posts list), and must keep its Distribution × Provider matrix in sync with `docs/index.mdx`.
+- `vsce/README.md` — concise marketplace description only; full usage belongs on `/vscode-extension/`.
+- `CONTRIBUTING.md` / `.github/copilot-instructions.md` — contributor content only; no end-user tutorials or marketing.
 
 {{#if ${{ github.event.pull_request.number }}}}
 **Pull Request Context**: Prioritize documentation files modified in PR #${{ github.event.pull_request.number }}.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ ksail cluster create               # spin up the cluster (Docker only)
 ksail cluster connect              # open K9s
 ```
 
-That's it — zero to a running cluster in under a minute. Continue with the [Getting Started guide](https://ksail.devantler.tech/) for GitOps, workload deployment, and multi-tenancy.
+Continue with the [Getting Started guide](https://ksail.devantler.tech/) for GitOps, workloads, and multi-tenancy.
 
 ## What KSail Bundles
-
-Replace `kind + k3d + kubectl + helm + kustomize + flux + argocd + sops + k9s + kubeconform + …` with one binary:
 
 | Category                 | Built-in Capabilities                                       |
 |--------------------------|-------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -42,26 +42,26 @@ That's it — zero to a running cluster in under a minute. Continue with the [Ge
 
 Replace `kind + k3d + kubectl + helm + kustomize + flux + argocd + sops + k9s + kubeconform + …` with one binary:
 
-| Category                 | Built-in Capabilities                                             |
-|--------------------------|-------------------------------------------------------------------|
-| Cluster Provisioning     | Kind, K3d, Talos, VCluster (Vind), KWOK (kwokctl)                 |
-| Container Orchestration  | kubectl, Helm, Kustomize                                          |
-| GitOps Engines           | Flux, ArgoCD                                                      |
-| Secrets Management       | SOPS with Age encryption                                          |
-| Manifest Validation      | Kubeconform                                                       |
-| Cluster Operations       | K9s, backup & restore, multi-tenancy (`ksail tenant`)             |
-| AI Integration           | Chat assistant (Copilot SDK), MCP server, VS Code extension       |
-| Infrastructure Providers | Docker (local), Hetzner Cloud, Sidero Omni                        |
+| Category                 | Built-in Capabilities                                       |
+|--------------------------|-------------------------------------------------------------|
+| Cluster Provisioning     | Kind, K3d, Talos, VCluster (Vind), KWOK (kwokctl)           |
+| Container Orchestration  | kubectl, Helm, Kustomize                                    |
+| GitOps Engines           | Flux, ArgoCD                                                |
+| Secrets Management       | SOPS with Age encryption                                    |
+| Manifest Validation      | Kubeconform                                                 |
+| Cluster Operations       | K9s, backup & restore, multi-tenancy (`ksail tenant`)       |
+| AI Integration           | Chat assistant (Copilot SDK), MCP server, VS Code extension |
+| Infrastructure Providers | Docker (local), Hetzner Cloud, Sidero Omni                  |
 
 See the [feature overview](https://ksail.devantler.tech/features/) and [architecture guide](https://ksail.devantler.tech/architecture/) for details.
 
 ## Supported Platforms
 
-| OS                                              | Architecture |
-|-------------------------------------------------|--------------|
-| 🐧 Linux                                        | amd64, arm64 |
-| 🍎 macOS                                        | arm64        |
-| ⊞ Windows (native untested; WSL2 recommended)   | amd64, arm64 |
+| OS                                            | Architecture |
+|-----------------------------------------------|--------------|
+| 🐧 Linux                                      | amd64, arm64 |
+| 🍎 macOS                                      | arm64        |
+| ⊞ Windows (native untested; WSL2 recommended) | amd64, arm64 |
 
 | Provider | Vanilla  | K3s     | Talos | VCluster | KWOK        |
 |----------|----------|---------|-------|----------|-------------|

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 ![ksail](./docs/src/assets/ksail-cli-dark.png)
 
-KSail is a tool that bundles common Kubernetes tooling into a single binary. It provides a VSCode Extension, CLI, AI-Enabled Chat TUI or MCP interface to create clusters, deploy workloads, and operate cloud-native stacks across different distributions and providers.
+KSail bundles common Kubernetes tooling into a single binary. Spin up local clusters, deploy workloads, and operate cloud-native stacks across distributions and providers through a CLI, VS Code extension, AI chat TUI, or MCP server — with **only Docker required**.
+
+📖 **Full documentation:** <https://ksail.devantler.tech>
 
 ## Quick Install
 
@@ -24,214 +26,68 @@ brew install --cask devantler-tech/tap/ksail
 go install github.com/devantler-tech/ksail/v6@latest
 ```
 
-> See the [Installation Guide](https://ksail.devantler.tech/installation/) for binary downloads and more options.
+See the [Installation Guide](https://ksail.devantler.tech/installation/) for binary downloads and more options.
 
 ## Quick Start
 
 ```bash
-# 1. Create a project and spin up a cluster (only requires Docker)
-ksail cluster init --name my-app
-ksail cluster create
-
-# 2. Connect to your cluster with K9s
-ksail cluster connect
+ksail cluster init --name my-app   # scaffold project + native configs
+ksail cluster create               # spin up the cluster (Docker only)
+ksail cluster connect              # open K9s
 ```
 
-That's it — zero to a running cluster in under a minute.
+That's it — zero to a running cluster in under a minute. Continue with the [Getting Started guide](https://ksail.devantler.tech/) for GitOps, workload deployment, and multi-tenancy.
 
-## What KSail Replaces
+## What KSail Bundles
 
-Most Kubernetes workflows require juggling multiple tools:
+Replace `kind + k3d + kubectl + helm + kustomize + flux + argocd + sops + k9s + kubeconform + …` with one binary:
 
-```text
-kind + k3d + kubectl + helm + kustomize + flux + argocd + sops + k9s + kubeconform + ...
-```
+| Category                 | Built-in Capabilities                                             |
+|--------------------------|-------------------------------------------------------------------|
+| Cluster Provisioning     | Kind, K3d, Talos, VCluster (Vind), KWOK (kwokctl)                 |
+| Container Orchestration  | kubectl, Helm, Kustomize                                          |
+| GitOps Engines           | Flux, ArgoCD                                                      |
+| Secrets Management       | SOPS with Age encryption                                          |
+| Manifest Validation      | Kubeconform                                                       |
+| Cluster Operations       | K9s, backup & restore, multi-tenancy (`ksail tenant`)             |
+| AI Integration           | Chat assistant (Copilot SDK), MCP server, VS Code extension       |
+| Infrastructure Providers | Docker (local), Hetzner Cloud, Sidero Omni                        |
 
-KSail bundles these into **one binary**:
+See the [feature overview](https://ksail.devantler.tech/features/) and [architecture guide](https://ksail.devantler.tech/architecture/) for details.
 
-| Category                 | Built-in Capabilities                                      |
-|--------------------------|------------------------------------------------------------|
-| Cluster Provisioning     | Kind, K3d, Talos, VCluster (Vind)                          |
-| Container Orchestration  | kubectl, Helm, Kustomize                                   |
-| GitOps Engines           | Flux, ArgoCD                                               |
-| Secrets Management       | SOPS with Age encryption                                   |
-| Manifest Validation      | Kubeconform                                                |
-| Cluster Operations       | K9s, backup & restore                                      |
-| AI Integration           | Chat assistant (Copilot SDK), MCP server, VSCode extension |
-| Infrastructure Providers | Docker (local), Hetzner Cloud, Sidero Omni                 |
+## Supported Platforms
 
-**Only Docker is required** — no other tools to install, configure, or keep in sync.
+| OS                                              | Architecture |
+|-------------------------------------------------|--------------|
+| 🐧 Linux                                        | amd64, arm64 |
+| 🍎 macOS                                        | arm64        |
+| ⊞ Windows (native untested; WSL2 recommended)   | amd64, arm64 |
 
-## Why KSail?
-
-Setting up and operating Kubernetes clusters often requires juggling multiple CLI tools, writing bespoke scripts, and dealing with inconsistent workflows. KSail removes the tooling overhead so you can focus on your workloads.
-
-## Key Features
-
-- 📦 **One Binary** — Embeds cluster provisioning, GitOps engines, and deployment tooling. No tool sprawl.
-- ☸️ **Simple Clusters** — Spin up Vanilla, K3s, Talos, or VCluster clusters with one command. Same workflow across distributions.
-- 🔓 **No Lock-In** — Uses native configs (`kind.yaml`, `k3d.yaml`, Talos patches, `vcluster.yaml`). Run clusters with or without KSail.
-- 📥 **Mirror Registries** — Avoid rate limits, and store images once. Same mirrors used by different clusters.
-- 📄 **Everything as Code** — Cluster settings, distribution configs, and workloads in version-controlled files.
-- 🔄 **GitOps Native** — Built-in Flux or ArgoCD support with bootstrap, push, and reconcile commands.
-- 🏢 **Multi-Tenancy** — Generate RBAC isolation, GitOps sync resources, and scaffold tenant repositories with `ksail tenant create` and `ksail tenant delete`.
-- ⚙️ **Customizable Stack** — Select your CNI, CSI, policy engine, cert-manager, and mirror registries.
-- 🔐 **SOPS Built In** — Encrypt, decrypt, and edit secrets with integrated cipher commands.
-- 💾 **Backup & Restore** — Export cluster resources to a compressed archive and restore to any cluster with provenance labels.
-- 🤖 **AI Assistant** — Interactive chat powered by GitHub Copilot for configuration and troubleshooting.
-- 💻 **VSCode Extension** — Manage clusters from VSCode via VS Code Kubernetes extension integration (Cloud Explorer, Cluster Explorer), wizards, and command palette.
-
-## Getting Started
-
-### Prerequisites
-
-KSail works on all major operating systems and CPU architectures:
-
-| OS                                            | Architecture |
-|-----------------------------------------------|--------------|
-| 🐧 Linux                                      | amd64, arm64 |
-|  macOS                                       | arm64        |
-| ⊞ Windows (native untested; WSL2 recommended) | amd64, arm64 |
-
-Supported distributions run on different infrastructure providers:
-
-| Provider | Vanilla  | K3s     | Talos | VCluster |
-|----------|----------|---------|-------|----------|
-| Docker   | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) |
-| Hetzner  | —        | —       | ✅     | —        |
-| Omni     | —        | —       | ✅     | —        |
-
-### Installation
-
-See the [Installation Guide](https://ksail.devantler.tech/installation/) for detailed installation instructions including binary downloads and platform-specific options.
-
-## Usage
-
-```mermaid
-flowchart TD
-    Dev["🧑‍💻 Developer"]
-
-    Dev -->|"edits"| Project
-    Dev -->|"runs"| KSail
-
-    subgraph Project ["📁 Project Repository"]
-        Config["ksail.yaml"] ~~~ DistConfig["kind.yaml · k3d.yaml<br/>vcluster.yaml"] ~~~ Manifests["k8s/ manifests"]
-    end
-
-    KSail -->|"scaffolds & reads"| Project
-    KSail -->|"provisions & operates"| Cluster
-
-    subgraph KSail ["🛥️ KSail — One Binary"]
-        CLI["CLI Commands"] ~~~ Tools["Kind · K3d · Talos · vCluster<br/>Flux · ArgoCD · SOPS<br/>Helm · Kustomize"]
-    end
-
-    subgraph Cluster ["☸️ Kubernetes Cluster"]
-        Infra["CNI · CSI · Metrics<br/>Cert-Manager · Policy Engine"] ~~~ Workloads["Your Workloads ✅"]
-    end
-
-    Manifests -.->|"GitOps sync"| Workloads
-
-    style Dev fill:#f59e0b,stroke:#d97706,color:#000
-    style Project fill:#7c3aed22,stroke:#7c3aed
-    style KSail fill:#10b98122,stroke:#10b981
-    style Cluster fill:#3b82f622,stroke:#3b82f6
-    style CLI fill:#10b981,stroke:#059669,color:#000
-    style Tools fill:#065f46,stroke:#10b981,color:#fff
-    style Infra fill:#1e40af,stroke:#3b82f6,color:#fff
-    style Workloads fill:#166534,stroke:#22c55e,color:#fff
-    style Config fill:#5b21b6,stroke:#7c3aed,color:#fff
-    style DistConfig fill:#5b21b6,stroke:#7c3aed,color:#fff
-    style Manifests fill:#5b21b6,stroke:#7c3aed,color:#fff
-```
-
-```bash
-# 1. Initialize a new project with your preferred stack
-ksail cluster init \
-  --name <cluster-name> \
-  --distribution <Vanilla|K3s|Talos|VCluster> \
-  --cni <Default|Cilium|Calico> \
-  --csi <Default|Enabled|Disabled> \
-  --metrics-server <Default|Enabled|Disabled> \
-  --cert-manager <Enabled|Disabled> \
-  --policy-engine <None|Kyverno|Gatekeeper> \
-  --gitops-engine <None|Flux|ArgoCD> \
-  --mirror-registry <host>=<upstream>
-
-# 2. Create and start the cluster
-ksail cluster create
-
-# 3. Add your manifests to the k8s/ directory
-
-# 4. Deploy your workloads
-ksail workload apply -k ./k8s   # kubectl workflow
-ksail workload reconcile        # gitops workflow
-
-# 5. Update cluster configuration (modify ksail.yaml, then run)
-ksail cluster update            # Apply configuration changes
-
-# 6. Connect to the cluster with K9s
-ksail cluster connect
-```
-
-### Native Configuration Files
-
-KSail generates standard distribution configuration files that you can use directly with the underlying tools:
-
-```bash
-# After ksail cluster init, you'll find native configs:
-# - kind.yaml       (for Vanilla/Kind clusters)
-# - k3d.yaml        (for K3s clusters)
-# - talos/          (for Talos clusters)
-# - vcluster.yaml   (for VCluster clusters)
-
-# You can use these configs directly without KSail:
-kind create cluster --config kind.yaml
-k3d cluster create --config k3d.yaml
-talosctl cluster create --config-patch @talos/cluster/patches.yaml
-vcluster create my-cluster --values vcluster.yaml
-
-# Or let KSail manage the lifecycle:
-ksail cluster create
-```
-
-## Documentation
-
-Browse the documentation at <https://ksail.devantler.tech> (GitHub Pages)
+| Provider | Vanilla  | K3s     | Talos | VCluster | KWOK        |
+|----------|----------|---------|-------|----------|-------------|
+| Docker   | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) |
+| Hetzner  | —        | —       | ✅     | —        | —           |
+| Omni     | —        | —       | ✅     | —        | —           |
 
 ## Community & Support
 
-- 💬 **[GitHub Discussions](https://github.com/devantler-tech/ksail/discussions)** — Ask questions, share ideas, and connect with other users
-- 🐛 **[Issue Tracker](https://github.com/devantler-tech/ksail/issues)** — Report bugs or request features
-- 📖 **[Documentation](https://ksail.devantler.tech)** — Guides, CLI reference, and architecture docs
-- ⭐ **[Star the repo](https://github.com/devantler-tech/ksail)** — Help others discover KSail
+- 💬 **[GitHub Discussions](https://github.com/devantler-tech/ksail/discussions)** — questions, ideas, and community
+- 🐛 **[Issue Tracker](https://github.com/devantler-tech/ksail/issues)** — bugs and feature requests
+- 📖 **[Documentation](https://ksail.devantler.tech)** — guides, CLI reference, architecture
+- 🎓 **[Resources](https://ksail.devantler.tech/resources/)** — presentations, blog posts, tutorials
+- ⭐ **[Star the repo](https://github.com/devantler-tech/ksail)** — help others discover KSail
 
 ## Contributing
 
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our development process, coding standards, and how to submit pull requests.
-
-Looking for a place to start? Check out issues labeled [`good first issue`](https://github.com/devantler-tech/ksail/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the development process, coding standards, and PR guidelines. Start with issues labeled [`good first issue`](https://github.com/devantler-tech/ksail/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 ## Related Projects
-
-KSail is a powerful tool that can be used in many different ways. Here are some projects that use KSail in their setup:
 
 | Project                                                               | Description         | Type     |
 |-----------------------------------------------------------------------|---------------------|----------|
 | [devantler-tech/platform](https://github.com/devantler-tech/platform) | My personal homelab | Platform |
 
-If you use KSail in your project, feel free to open a PR to add it to the list, so others can see how you use KSail.
-
-## Presentations
-
-- **[KSail - a Kubernetes SDK for local GitOps development and CI](https://youtu.be/Q-Hfn_-B7p8?si=2Uec_kld--fNw3gm)** - A presentation on KSail at KCD2024 (Early version of KSail that was built in .NET).
-
-## Blog Posts
-
-- [Local Kubernetes Development with KSail and Kind](https://devantler.tech/blog/local-kubernetes-development-with-ksail-and-kind/)
-- [Local Kubernetes Development with KSail and K3d](https://devantler.tech/blog/local-kubernetes-development-with-ksail-and-k3d/)
-- [Local Kubernetes Development with KSail and Talos](https://devantler.tech/blog/local-kubernetes-development-with-ksail-and-talos/)
-- [Creating Kubernetes Clusters on Hetzner with KSail and Talos](https://devantler.tech/blog/creating-development-kubernetes-clusters-on-hetzner-with-ksail-and-talos/)
-- [AI-first TUI for KSail with Copilot SDK and Bubbletea](https://devantler.tech/blog/building-an-ai-assistant-for-kubernetes-with-github-copilot-sdk/)
+Using KSail in your project? Open a PR to add it here.
 
 ## Star History
 


### PR DESCRIPTION
`README.md` had drifted from the spec defined in `.github/workflows/daily-docs.md`: it was 244 lines (spec: ~100), duplicated big chunks of `docs/src/content/docs/index.mdx` (Mermaid architecture diagram, full `ksail cluster init` flag reference, Native Configuration Files walkthrough, Presentations, Blog Posts), and was missing the **KWOK** distribution and the `tenant` top-level command.

The root cause was in the workflow itself: Doc Sync mode only runs on code pushes and Bloat Reduction mode only scanned `docs/`, so nothing ever audited root files on a schedule. This PR fixes both the symptom and the cause.

## What changed

**`README.md` (244 -> 100 lines)**

- Kept: badges, hero, intro, Quick Install, Quick Start, capability table, OS table, Distribution x Provider matrix, Community, Contributing, Related Projects, Star History.
- Added KWOK row to the provider matrix, listed KWOK in the capability table, and surfaced `ksail tenant` alongside backup/restore under Cluster Operations.
- Removed duplicated sections and replaced them with links to the canonical pages: `/architecture/`, `/cli-flags/cluster/cluster-init/`, `/configuration/`, `/resources/`.
- Fixed the broken/missing macOS emoji cell in the OS table.

**`.github/workflows/daily-docs.md`**

- Doc Sync mode: new **step 3 "Root File Audit"** that runs on every invocation (not gated on the diff). Checks `README.md` length (<= ~100), scope (no `docs/index.mdx` duplicates), Distribution x Provider matrix parity, top-level command parity with `go run . --help`, and scope rules for `vsce/README.md`, `CONTRIBUTING.md`, and `.github/copilot-instructions.md`. `noop` is blocked until the audit passes. Subsequent steps renumbered to 4-9.
- Bloat Reduction mode: candidate file list now includes `README.md`, `vsce/README.md`, `CONTRIBUTING.md`, and `.github/copilot-instructions.md`, with explicit per-file checks so root-file drift gets picked up on the daily schedule.

`daily-docs.lock.yml` is intentionally untouched (managed by GitHub Agentics per `.github/instructions/agentic-workflows.instructions.md`).

## Type of change

- [x] 📚 Documentation update