### PR TITLE
fix(ci): write copilot skills to repo scope so PR opens

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -68,7 +68,11 @@ jobs:
         with:
           skills-lock: skills-lock.json
           agent: github-copilot
-          scope: user
+          # `user` scope writes to ~/.copilot/skills on the runner (outside
+          # GITHUB_WORKSPACE), so the working tree never changes and no PR
+          # is opened. Use `repo` scope so installs land inside the repo and
+          # peter-evans/create-pull-request can detect and commit the diff.
+          scope: repo
 
       - name: 📦 Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
@@ -78,9 +82,8 @@ jobs:
           body: |
             Automated update of skills for GitHub Copilot to their latest versions.
 
-            Updated files:
-            - `skills-lock.json`
-            - `.agents/skills/`
+            Picks up any drift in installed skill content (resolved by
+            `gh skill install --scope repo` from `skills-lock.json`).
           branch: deps/copilot-skills-update
           labels: dependencies,automation
           delete-branch: true


### PR DESCRIPTION
The `update-copilot-skills` workflow runs to completion but never opens a PR (e.g. [run 24609491046](https://github.com/devantler-tech/ksail/actions/runs/24609491046)).

**Root cause.** `setup-copilot-skills@v2.2.0` was invoked with `scope: user`, which makes `gh skill install` write to `~/.copilot/skills` on the runner — outside `GITHUB_WORKSPACE`. The repo working tree therefore never changes, and `peter-evans/create-pull-request` reports:

```
No local changes to save
Branch 'deps/copilot-skills-update' is not ahead of base 'main' and will not be created
```

**Fix.** Switch to `scope: repo` so `gh skill install` writes inside the checkout, and `peter-evans/create-pull-request` can detect and commit the diff. PR body wording is updated accordingly (the previous `.agents/skills/` reference was speculative and didn't match what the action actually wrote).

Follow-up PRs (stacked) will fix the same broken default upstream:

- `devantler-tech/actions` — change `setup-copilot-skills` default scope to `repo`.
- `devantler-tech/reusable-workflows` — change `update-copilot-skills.yaml` default scope to `repo` and bump the action pin.

After those land, this workflow can be replaced with a thin caller of the reusable workflow.

## Type of change

- [x] 🪲 Bug fix