### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See the [feature overview](https://ksail.devantler.tech/features/) and [architec
 
 | Provider | Vanilla  | K3s     | Talos | VCluster | KWOK        | EKS |
 |----------|----------|---------|-------|----------|-------------|-----|
-| Docker   | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | ❌   |
+| Docker   | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | —   |
 | Hetzner  | —        | —       | ✅     | —        | —           | —   |
 | Omni     | —        | —       | ✅     | —        | —           | —   |
 | AWS      | —        | —       | —     | —        | —           | 🚧  |


### PR DESCRIPTION
Replace the ❌ marker for EKS on Docker with — to match the table's existing convention for "not supported / not applicable" entries (Hetzner, Omni, and AWS rows all use —).