### PR TITLE
fix(ci): add warm-mirror-cache to required checks gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1548,6 +1548,7 @@ jobs:
         generate-docs,
         auto-commit,
         warm-helm-cache,
+        warm-mirror-cache,
         system-test-docker,
         system-test-hetzner-init,
         system-test-hetzner-noinit,
@@ -1580,6 +1581,7 @@ jobs:
             ${{ needs.generate-docs.result }}
             ${{ needs.auto-commit.result }}
             ${{ needs.warm-helm-cache.result }}
+            ${{ needs.warm-mirror-cache.result }}
             ${{ needs.system-test-docker.result }}
             ${{ needs.system-test-hetzner-init.result }}
             ${{ needs.system-test-hetzner-noinit.result }}


### PR DESCRIPTION
## Summary

The `status` job ("CI - Required Checks") was missing `warm-mirror-cache` from its `needs` list and `job-results` input. Every other non-utility job was already covered — `warm-helm-cache` (identical pattern) was present but `warm-mirror-cache` was accidentally omitted.

## Analysis

Full audit of all 24 jobs vs the `status.needs` list:

- **22 of 23 non-self jobs** were already gated ✅
- **`warm-mirror-cache`** was the only missing job ❌ → now added ✅
- **`cancel-stale-merge-queue`** is intentionally excluded (utility-only, merge_group housekeeping, no downstream dependents)

### PR vs merge_group overlap check

The event split is clean with no wasteful overlap:

| Scope | Jobs |
|---|---|
| **PR-only** (lightweight) | `generate-schema`, `generate-docs`, `auto-commit`, `audit-docs`, `audit-vsce`, `build-docs`, `vscode-extension`, `benchmark` |
| **merge_group-only** (heavy) | `warm-*-cache`, `system-test-*`, `cleanup-*` |
| **Both** (intentional infra) | `rate-limit-gate`, `changes` (necessary gates), `build-artifact` (binary cache pre-warming for merge_group) |