### PR TITLE
ci(system-test-omni): remove scheduled trigger

### DIFF
--- a/.github/workflows/system-test-omni.yaml
+++ b/.github/workflows/system-test-omni.yaml
@@ -60,9 +60,6 @@ on:
         required: false
         type: number
         default: 0
-  schedule:
-    # Weekly: Sunday 04:00 UTC
-    - cron: "0 4 * * 0"
 
 env:
   GOPROXY: "https://proxy.golang.org|direct"
@@ -188,9 +185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # On schedule: test both init and noinit with defaults.
-        # On workflow_dispatch: run only the user-selected variant.
-        init: ${{ github.event_name == 'schedule' && fromJSON('[true, false]') || fromJSON(format('[{0}]', inputs.init)) }}
+        init: ${{ fromJSON(format('[{0}]', inputs.init)) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0


### PR DESCRIPTION
Removes the weekly cron schedule from the Omni system test workflow. The Omni provider is already tested daily via [devantler-tech/platform](https://github.com/devantler-tech/platform), making this schedule redundant. The workflow remains available via `workflow_dispatch` for on-demand testing.

The schedule-dependent matrix logic (`github.event_name == 'schedule'`) is also simplified since only `workflow_dispatch` triggers remain.

## Type of change

- [x] 🧹 Refactor