### PR TITLE
ci: expand cloud provider E2E matrix and disable auto-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Release
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/system-test-hetzner.yaml
+++ b/.github/workflows/system-test-hetzner.yaml
@@ -187,10 +187,11 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
-        # On schedule: test both init and noinit with defaults.
-        # On workflow_dispatch: run only the user-selected variant.
-        init: ${{ github.event_name == 'schedule' && fromJSON('[true, false]') || fromJSON(format('[{0}]', inputs.init)) }}
+        # On schedule: run all important configurations sequentially for broad E2E coverage.
+        # On workflow_dispatch: run a single user-selected configuration.
+        include: ${{ github.event_name == 'schedule' && fromJSON('[{"init":true,"suffix":"default-init","args":""},{"init":false,"suffix":"default-noinit","args":""},{"init":true,"suffix":"fullstack","args":"--cni Cilium --csi Enabled --load-balancer Enabled --metrics-server Enabled --policy-engine Kyverno --cert-manager Enabled --gitops-engine Flux"},{"init":true,"suffix":"altstack","args":"--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"},{"init":true,"suffix":"flux-reg","args":"--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"},{"init":true,"suffix":"argocd-reg","args":"--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"}]') || fromJSON(format('[{"init":{0},"suffix":"dispatch","args":""}]', inputs.init)) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -253,20 +254,23 @@ jobs:
         id: args
         shell: bash
         run: |
-          ARGS="--name st-hetzner-${{ matrix.init && 'init' || 'noinit' }}-${{ github.run_id }}"
+          ARGS="--name st-hetzner-${{ matrix.suffix }}-${{ github.run_id }}"
 
-          # Component configurations (only add non-default values)
-          [[ "${{ inputs.cni }}" != "Default" && -n "${{ inputs.cni }}" ]] && ARGS+=" --cni ${{ inputs.cni }}"
-          [[ "${{ inputs.csi }}" != "Default" && -n "${{ inputs.csi }}" ]] && ARGS+=" --csi ${{ inputs.csi }}"
-          [[ "${{ inputs.load_balancer }}" != "Default" && -n "${{ inputs.load_balancer }}" ]] && ARGS+=" --load-balancer ${{ inputs.load_balancer }}"
-          [[ "${{ inputs.metrics_server }}" != "Default" && -n "${{ inputs.metrics_server }}" ]] && ARGS+=" --metrics-server ${{ inputs.metrics_server }}"
-          [[ "${{ inputs.policy_engine }}" != "None" && -n "${{ inputs.policy_engine }}" ]] && ARGS+=" --policy-engine ${{ inputs.policy_engine }}"
-          [[ "${{ inputs.cert_manager }}" != "Disabled" && -n "${{ inputs.cert_manager }}" ]] && ARGS+=" --cert-manager ${{ inputs.cert_manager }}"
-          [[ "${{ inputs.gitops_engine }}" != "None" && -n "${{ inputs.gitops_engine }}" ]] && ARGS+=" --gitops-engine ${{ inputs.gitops_engine }}"
-
-          # Scale
-          [[ "${{ inputs.control_planes }}" != "1" && -n "${{ inputs.control_planes }}" ]] && ARGS+=" --control-planes ${{ inputs.control_planes }}"
-          [[ "${{ inputs.workers }}" != "0" && -n "${{ inputs.workers }}" ]] && ARGS+=" --workers ${{ inputs.workers }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Build from user-selected inputs
+            [[ "${{ inputs.cni }}" != "Default" && -n "${{ inputs.cni }}" ]] && ARGS+=" --cni ${{ inputs.cni }}"
+            [[ "${{ inputs.csi }}" != "Default" && -n "${{ inputs.csi }}" ]] && ARGS+=" --csi ${{ inputs.csi }}"
+            [[ "${{ inputs.load_balancer }}" != "Default" && -n "${{ inputs.load_balancer }}" ]] && ARGS+=" --load-balancer ${{ inputs.load_balancer }}"
+            [[ "${{ inputs.metrics_server }}" != "Default" && -n "${{ inputs.metrics_server }}" ]] && ARGS+=" --metrics-server ${{ inputs.metrics_server }}"
+            [[ "${{ inputs.policy_engine }}" != "None" && -n "${{ inputs.policy_engine }}" ]] && ARGS+=" --policy-engine ${{ inputs.policy_engine }}"
+            [[ "${{ inputs.cert_manager }}" != "Disabled" && -n "${{ inputs.cert_manager }}" ]] && ARGS+=" --cert-manager ${{ inputs.cert_manager }}"
+            [[ "${{ inputs.gitops_engine }}" != "None" && -n "${{ inputs.gitops_engine }}" ]] && ARGS+=" --gitops-engine ${{ inputs.gitops_engine }}"
+            [[ "${{ inputs.control_planes }}" != "1" && -n "${{ inputs.control_planes }}" ]] && ARGS+=" --control-planes ${{ inputs.control_planes }}"
+            [[ "${{ inputs.workers }}" != "0" && -n "${{ inputs.workers }}" ]] && ARGS+=" --workers ${{ inputs.workers }}"
+          else
+            # Use pre-defined matrix args for scheduled runs
+            ARGS+=" ${{ matrix.args }}"
+          fi
 
           echo "value=${ARGS}" >> "$GITHUB_OUTPUT"
           echo "Args: ${ARGS}"
@@ -312,16 +316,51 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🧹 Cleanup Hetzner resources for init cluster
+      - name: 🧹 Cleanup Hetzner resources (default-init)
         uses: ./.github/actions/cleanup-hetzner
         with:
-          label-selector: "ksail.cluster.name=st-hetzner-init-${{ github.run_id }}"
+          label-selector: "ksail.cluster.name=st-hetzner-default-init-${{ github.run_id }}"
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
 
-      - name: 🧹 Cleanup Hetzner resources for noinit cluster
+      - name: 🧹 Cleanup Hetzner resources (default-noinit)
         uses: ./.github/actions/cleanup-hetzner
         with:
-          label-selector: "ksail.cluster.name=st-hetzner-noinit-${{ github.run_id }}"
+          label-selector: "ksail.cluster.name=st-hetzner-default-noinit-${{ github.run_id }}"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+      - name: 🧹 Cleanup Hetzner resources (fullstack)
+        uses: ./.github/actions/cleanup-hetzner
+        with:
+          label-selector: "ksail.cluster.name=st-hetzner-fullstack-${{ github.run_id }}"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+      - name: 🧹 Cleanup Hetzner resources (altstack)
+        uses: ./.github/actions/cleanup-hetzner
+        with:
+          label-selector: "ksail.cluster.name=st-hetzner-altstack-${{ github.run_id }}"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+      - name: 🧹 Cleanup Hetzner resources (flux-reg)
+        uses: ./.github/actions/cleanup-hetzner
+        with:
+          label-selector: "ksail.cluster.name=st-hetzner-flux-reg-${{ github.run_id }}"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+      - name: 🧹 Cleanup Hetzner resources (argocd-reg)
+        uses: ./.github/actions/cleanup-hetzner
+        with:
+          label-selector: "ksail.cluster.name=st-hetzner-argocd-reg-${{ github.run_id }}"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+      - name: 🧹 Cleanup Hetzner resources (dispatch)
+        uses: ./.github/actions/cleanup-hetzner
+        with:
+          label-selector: "ksail.cluster.name=st-hetzner-dispatch-${{ github.run_id }}"
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/system-test-hetzner.yaml
+++ b/.github/workflows/system-test-hetzner.yaml
@@ -191,7 +191,7 @@ jobs:
       matrix:
         # On schedule: run all important configurations sequentially for broad E2E coverage.
         # On workflow_dispatch: run a single user-selected configuration.
-        include: ${{ github.event_name == 'schedule' && fromJSON('[{"init":true,"suffix":"default-init","args":""},{"init":false,"suffix":"default-noinit","args":""},{"init":true,"suffix":"fullstack","args":"--cni Cilium --csi Enabled --load-balancer Enabled --metrics-server Enabled --policy-engine Kyverno --cert-manager Enabled --gitops-engine Flux"},{"init":true,"suffix":"altstack","args":"--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"},{"init":true,"suffix":"flux-reg","args":"--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"},{"init":true,"suffix":"argocd-reg","args":"--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"}]') || fromJSON(format('[{"init":{0},"suffix":"dispatch","args":""}]', inputs.init)) }}
+        include: ${{ github.event_name == 'schedule' && fromJSON('[{"init":true,"suffix":"default-init","args":""},{"init":false,"suffix":"default-noinit","args":""},{"init":true,"suffix":"fullstack","args":"--cni Cilium --csi Enabled --load-balancer Enabled --metrics-server Enabled --policy-engine Kyverno --cert-manager Enabled --gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"},{"init":true,"suffix":"altstack","args":"--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"}]') || fromJSON(format('[{"init":{0},"suffix":"dispatch","args":""}]', inputs.init)) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -341,20 +341,6 @@ jobs:
         uses: ./.github/actions/cleanup-hetzner
         with:
           label-selector: "ksail.cluster.name=st-hetzner-altstack-${{ github.run_id }}"
-        env:
-          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-
-      - name: 🧹 Cleanup Hetzner resources (flux-reg)
-        uses: ./.github/actions/cleanup-hetzner
-        with:
-          label-selector: "ksail.cluster.name=st-hetzner-flux-reg-${{ github.run_id }}"
-        env:
-          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-
-      - name: 🧹 Cleanup Hetzner resources (argocd-reg)
-        uses: ./.github/actions/cleanup-hetzner
-        with:
-          label-selector: "ksail.cluster.name=st-hetzner-argocd-reg-${{ github.run_id }}"
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
 

--- a/.github/workflows/system-test-omni.yaml
+++ b/.github/workflows/system-test-omni.yaml
@@ -187,10 +187,11 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
-        # On schedule: test both init and noinit with defaults.
-        # On workflow_dispatch: run only the user-selected variant.
-        init: ${{ github.event_name == 'schedule' && fromJSON('[true, false]') || fromJSON(format('[{0}]', inputs.init)) }}
+        # On schedule: run all important configurations sequentially for broad E2E coverage.
+        # On workflow_dispatch: run a single user-selected configuration.
+        include: ${{ github.event_name == 'schedule' && fromJSON('[{"init":true,"suffix":"default-init","args":""},{"init":false,"suffix":"default-noinit","args":""},{"init":true,"suffix":"fullstack","args":"--cni Cilium --csi Enabled --load-balancer Enabled --metrics-server Enabled --policy-engine Kyverno --cert-manager Enabled --gitops-engine Flux"},{"init":true,"suffix":"altstack","args":"--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"},{"init":true,"suffix":"flux-reg","args":"--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"},{"init":true,"suffix":"argocd-reg","args":"--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"}]') || fromJSON(format('[{"init":{0},"suffix":"dispatch","args":""}]', inputs.init)) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -253,20 +254,23 @@ jobs:
         id: args
         shell: bash
         run: |
-          ARGS="--name st-omni-${{ matrix.init && 'init' || 'noinit' }}-${{ github.run_id }}"
+          ARGS="--name st-omni-${{ matrix.suffix }}-${{ github.run_id }}"
 
-          # Component configurations (only add non-default values)
-          [[ "${{ inputs.cni }}" != "Default" && -n "${{ inputs.cni }}" ]] && ARGS+=" --cni ${{ inputs.cni }}"
-          [[ "${{ inputs.csi }}" != "Default" && -n "${{ inputs.csi }}" ]] && ARGS+=" --csi ${{ inputs.csi }}"
-          [[ "${{ inputs.load_balancer }}" != "Default" && -n "${{ inputs.load_balancer }}" ]] && ARGS+=" --load-balancer ${{ inputs.load_balancer }}"
-          [[ "${{ inputs.metrics_server }}" != "Default" && -n "${{ inputs.metrics_server }}" ]] && ARGS+=" --metrics-server ${{ inputs.metrics_server }}"
-          [[ "${{ inputs.policy_engine }}" != "None" && -n "${{ inputs.policy_engine }}" ]] && ARGS+=" --policy-engine ${{ inputs.policy_engine }}"
-          [[ "${{ inputs.cert_manager }}" != "Disabled" && -n "${{ inputs.cert_manager }}" ]] && ARGS+=" --cert-manager ${{ inputs.cert_manager }}"
-          [[ "${{ inputs.gitops_engine }}" != "None" && -n "${{ inputs.gitops_engine }}" ]] && ARGS+=" --gitops-engine ${{ inputs.gitops_engine }}"
-
-          # Scale
-          [[ "${{ inputs.control_planes }}" != "1" && -n "${{ inputs.control_planes }}" ]] && ARGS+=" --control-planes ${{ inputs.control_planes }}"
-          [[ "${{ inputs.workers }}" != "0" && -n "${{ inputs.workers }}" ]] && ARGS+=" --workers ${{ inputs.workers }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Build from user-selected inputs
+            [[ "${{ inputs.cni }}" != "Default" && -n "${{ inputs.cni }}" ]] && ARGS+=" --cni ${{ inputs.cni }}"
+            [[ "${{ inputs.csi }}" != "Default" && -n "${{ inputs.csi }}" ]] && ARGS+=" --csi ${{ inputs.csi }}"
+            [[ "${{ inputs.load_balancer }}" != "Default" && -n "${{ inputs.load_balancer }}" ]] && ARGS+=" --load-balancer ${{ inputs.load_balancer }}"
+            [[ "${{ inputs.metrics_server }}" != "Default" && -n "${{ inputs.metrics_server }}" ]] && ARGS+=" --metrics-server ${{ inputs.metrics_server }}"
+            [[ "${{ inputs.policy_engine }}" != "None" && -n "${{ inputs.policy_engine }}" ]] && ARGS+=" --policy-engine ${{ inputs.policy_engine }}"
+            [[ "${{ inputs.cert_manager }}" != "Disabled" && -n "${{ inputs.cert_manager }}" ]] && ARGS+=" --cert-manager ${{ inputs.cert_manager }}"
+            [[ "${{ inputs.gitops_engine }}" != "None" && -n "${{ inputs.gitops_engine }}" ]] && ARGS+=" --gitops-engine ${{ inputs.gitops_engine }}"
+            [[ "${{ inputs.control_planes }}" != "1" && -n "${{ inputs.control_planes }}" ]] && ARGS+=" --control-planes ${{ inputs.control_planes }}"
+            [[ "${{ inputs.workers }}" != "0" && -n "${{ inputs.workers }}" ]] && ARGS+=" --workers ${{ inputs.workers }}"
+          else
+            # Use pre-defined matrix args for scheduled runs
+            ARGS+=" ${{ matrix.args }}"
+          fi
 
           echo "value=${ARGS}" >> "$GITHUB_OUTPUT"
           echo "Args: ${ARGS}"
@@ -332,7 +336,7 @@ jobs:
       - name: 🧹 Cleanup KSail test clusters from Omni
         uses: ./.github/actions/cleanup-omni
         with:
-          cluster-names: "st-omni-init-${{ github.run_id }} st-omni-noinit-${{ github.run_id }}"
+          cluster-names: "st-omni-default-init-${{ github.run_id }} st-omni-default-noinit-${{ github.run_id }} st-omni-fullstack-${{ github.run_id }} st-omni-altstack-${{ github.run_id }} st-omni-flux-reg-${{ github.run_id }} st-omni-argocd-reg-${{ github.run_id }} st-omni-dispatch-${{ github.run_id }}"
         env:
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}

--- a/.github/workflows/system-test-omni.yaml
+++ b/.github/workflows/system-test-omni.yaml
@@ -191,7 +191,7 @@ jobs:
       matrix:
         # On schedule: run all important configurations sequentially for broad E2E coverage.
         # On workflow_dispatch: run a single user-selected configuration.
-        include: ${{ github.event_name == 'schedule' && fromJSON('[{"init":true,"suffix":"default-init","args":""},{"init":false,"suffix":"default-noinit","args":""},{"init":true,"suffix":"fullstack","args":"--cni Cilium --csi Enabled --load-balancer Enabled --metrics-server Enabled --policy-engine Kyverno --cert-manager Enabled --gitops-engine Flux"},{"init":true,"suffix":"altstack","args":"--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD"},{"init":true,"suffix":"flux-reg","args":"--gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"},{"init":true,"suffix":"argocd-reg","args":"--gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"}]') || fromJSON(format('[{"init":{0},"suffix":"dispatch","args":""}]', inputs.init)) }}
+        include: ${{ github.event_name == 'schedule' && fromJSON('[{"init":true,"suffix":"default-init","args":""},{"init":false,"suffix":"default-noinit","args":""},{"init":true,"suffix":"fullstack","args":"--cni Cilium --csi Enabled --load-balancer Enabled --metrics-server Enabled --policy-engine Kyverno --cert-manager Enabled --gitops-engine Flux --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"},{"init":true,"suffix":"altstack","args":"--cni Calico --csi Disabled --load-balancer Disabled --metrics-server Disabled --policy-engine Gatekeeper --gitops-engine ArgoCD --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests"}]') || fromJSON(format('[{"init":{0},"suffix":"dispatch","args":""}]', inputs.init)) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -336,7 +336,7 @@ jobs:
       - name: 🧹 Cleanup KSail test clusters from Omni
         uses: ./.github/actions/cleanup-omni
         with:
-          cluster-names: "st-omni-default-init-${{ github.run_id }} st-omni-default-noinit-${{ github.run_id }} st-omni-fullstack-${{ github.run_id }} st-omni-altstack-${{ github.run_id }} st-omni-flux-reg-${{ github.run_id }} st-omni-argocd-reg-${{ github.run_id }} st-omni-dispatch-${{ github.run_id }}"
+          cluster-names: "st-omni-default-init-${{ github.run_id }} st-omni-default-noinit-${{ github.run_id }} st-omni-fullstack-${{ github.run_id }} st-omni-altstack-${{ github.run_id }} st-omni-dispatch-${{ github.run_id }}"
         env:
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}


### PR DESCRIPTION
## Summary

Expands cloud provider system tests to cover all important configurations on schedule and disables auto-releases.

## Changes

### Disable auto-release (`release.yaml`)
- Removed `push: branches: [main]` trigger — releases are now manual-only via `workflow_dispatch`

### Expand Hetzner & Omni system test matrices
Both `system-test-hetzner.yaml` and `system-test-omni.yaml` are expanded from 2 default-only scheduled configurations to 6 comprehensive configurations:

| # | Suffix | Description |
|---|--------|-------------|
| 1 | `default-init` | Defaults with `init=true` |
| 2 | `default-noinit` | Defaults with `init=false` |
| 3 | `fullstack` | Cilium + CSI + LB + Metrics + Kyverno + CertManager + Flux |
| 4 | `altstack` | Calico + Gatekeeper + ArgoCD (disabled CSI/LB/Metrics) |
| 5 | `flux-reg` | Flux + local GHCR registry |
| 6 | `argocd-reg` | ArgoCD + local GHCR registry |

- `max-parallel: 1` ensures sequential execution to avoid cloud resource conflicts
- `workflow_dispatch` inputs preserved for ad-hoc testing of individual configurations
- Cleanup jobs updated to handle all possible cluster names