### PR TITLE
fix: enable Talos externalCloudProvider for Hetzner provider

### DIFF
--- a/pkg/fsutil/configmanager/ksail/coverage_test.go
+++ b/pkg/fsutil/configmanager/ksail/coverage_test.go
@@ -321,6 +321,8 @@ func TestResolveVClusterName(t *testing.T) {
 }
 
 // TestGetDefaultTalosPatches tests the default Talos patches generation.
+//
+//nolint:funlen // Table-driven test with multiple sub-tests is naturally long.
 func TestGetDefaultTalosPatches(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fsutil/configmanager/ksail/coverage_test.go
+++ b/pkg/fsutil/configmanager/ksail/coverage_test.go
@@ -357,4 +357,59 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		assert.Contains(t, string(patches[0].Content), "rotate-server-certificates")
 		assert.Contains(t, string(patches[1].Content), "kubelet-serving-cert-approver")
 	})
+
+	t.Run("hetzner provider returns external cloud provider patch", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
+		mgr.Config = &v1alpha1.Cluster{
+			Spec: v1alpha1.Spec{
+				Cluster: v1alpha1.ClusterSpec{
+					Provider: v1alpha1.ProviderHetzner,
+				},
+			},
+		}
+
+		patches := mgr.GetDefaultTalosPatchesForTest()
+		require.Len(t, patches, 1)
+		assert.Contains(t, string(patches[0].Content), "externalCloudProvider")
+		assert.Contains(t, string(patches[0].Content), "enabled: true")
+		assert.Contains(t, string(patches[0].Content), "cloud-provider: external")
+	})
+
+	t.Run("docker provider does not return external cloud provider patch", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
+		mgr.Config = &v1alpha1.Cluster{
+			Spec: v1alpha1.Spec{
+				Cluster: v1alpha1.ClusterSpec{
+					Provider: v1alpha1.ProviderDocker,
+				},
+			},
+		}
+
+		patches := mgr.GetDefaultTalosPatchesForTest()
+		assert.Empty(t, patches)
+	})
+
+	t.Run("hetzner with metrics server returns both patches", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
+		mgr.Config = &v1alpha1.Cluster{
+			Spec: v1alpha1.Spec{
+				Cluster: v1alpha1.ClusterSpec{
+					Provider:      v1alpha1.ProviderHetzner,
+					MetricsServer: v1alpha1.MetricsServerEnabled,
+				},
+			},
+		}
+
+		patches := mgr.GetDefaultTalosPatchesForTest()
+		require.Len(t, patches, 3)
+		assert.Contains(t, string(patches[0].Content), "rotate-server-certificates")
+		assert.Contains(t, string(patches[1].Content), "kubelet-serving-cert-approver")
+		assert.Contains(t, string(patches[2].Content), "externalCloudProvider")
+	})
 }

--- a/pkg/fsutil/configmanager/ksail/coverage_test.go
+++ b/pkg/fsutil/configmanager/ksail/coverage_test.go
@@ -395,7 +395,7 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		assert.Empty(t, patches)
 	})
 
-	t.Run("hetzner with metrics server returns both patches", func(t *testing.T) {
+	t.Run("hetzner with metrics server returns all three patches", func(t *testing.T) {
 		t.Parallel()
 
 		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -436,16 +436,9 @@ func (m *ConfigManager) resolveEKSNameFromContext() string {
 func externalCloudProviderPatches() []talosconfigmanager.Patch {
 	return []talosconfigmanager.Patch{
 		{
-			Path:  "external-cloud-provider",
-			Scope: talosconfigmanager.PatchScopeCluster,
-			Content: []byte(`cluster:
-  externalCloudProvider:
-    enabled: true
-machine:
-  kubelet:
-    extraArgs:
-      cloud-provider: external
-`),
+			Path:    "external-cloud-provider",
+			Scope:   talosconfigmanager.PatchScopeCluster,
+			Content: []byte(talosgenerator.ExternalCloudProviderPatchYAML),
 		},
 	}
 }

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -101,6 +101,13 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 		"", // Use default network CIDR
 	)
 
+	// Add external cloud provider patch when using Hetzner provider.
+	// This enables CCM to initialize nodes with a providerID and write node labels
+	// required by the CSI DaemonSet.
+	if m.Config.Spec.Cluster.Provider == v1alpha1.ProviderHetzner {
+		talosManager.WithAdditionalPatches(externalCloudProviderPatches())
+	}
+
 	config, err := talosManager.Load(configmanagerinterface.LoadOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load Talos config: %w", err)
@@ -232,6 +239,13 @@ func (m *ConfigManager) getDefaultTalosPatches() []talosconfigmanager.Patch {
 `),
 		}
 		patches = append(patches, kubeletCSRApproverPatch)
+	}
+
+	// When using Hetzner provider, enable external cloud provider so that the
+	// Cloud Controller Manager can initialize nodes with a providerID and write
+	// node labels required by the CSI DaemonSet.
+	if m.Config.Spec.Cluster.Provider == v1alpha1.ProviderHetzner {
+		patches = append(patches, externalCloudProviderPatches()...)
 	}
 
 	return patches
@@ -410,4 +424,28 @@ func (m *ConfigManager) resolveEKSNameFromContext() string {
 	}
 
 	return "eks-default"
+}
+
+// externalCloudProviderPatches returns Talos patches that enable the external cloud provider.
+// This configures both the cluster-level externalCloudProvider and the kubelet cloud-provider
+// flag, which are required for cloud controller managers (e.g., Hetzner CCM) to:
+//  1. Initialize nodes with a providerID (spec.providerID)
+//  2. Write node labels that CSI DaemonSets require for scheduling
+//
+// See: https://www.talos.dev/latest/kubernetes-guides/configuration/cloud-provider/
+func externalCloudProviderPatches() []talosconfigmanager.Patch {
+	return []talosconfigmanager.Patch{
+		{
+			Path:  "external-cloud-provider",
+			Scope: talosconfigmanager.PatchScopeCluster,
+			Content: []byte(`cluster:
+  externalCloudProvider:
+    enabled: true
+machine:
+  kubelet:
+    extraArgs:
+      cloud-provider: external
+`),
+		},
+	}
 }

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -192,7 +192,7 @@ func (g *Generator) getDirectoriesWithPatches(
 
 // generateConditionalPatches generates optional patches based on the configuration.
 //
-//nolint:cyclop // Sequential conditional patch generation - each condition is independent and simple.
+//nolint:cyclop,funlen // Sequential conditional patch generation - each condition is independent and simple.
 func (g *Generator) generateConditionalPatches(
 	rootPath string,
 	model *Config,

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -46,6 +46,25 @@ const (
 //nolint:lll // URL cannot be shortened
 const KubeletServingCertApproverManifestURL = "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml"
 
+// ExternalCloudProviderPatchYAML is the Talos machine config patch YAML that enables
+// the external cloud provider. This is the single source of truth for the patch content,
+// shared between the generator (file-based scaffolding) and the runtime config manager
+// (in-memory patch injection for existing projects).
+//
+// It enables both the cluster-level externalCloudProvider and the kubelet cloud-provider
+// flag, which are required for cloud controller managers (e.g., Hetzner CCM) to initialize
+// nodes with a providerID and write node labels.
+//
+// See: https://www.talos.dev/latest/kubernetes-guides/configuration/cloud-provider/
+const ExternalCloudProviderPatchYAML = `cluster:
+  externalCloudProvider:
+    enabled: true
+machine:
+  kubelet:
+    extraArgs:
+      cloud-provider: external
+`
+
 // ErrConfigRequired is returned when a nil config is provided.
 var ErrConfigRequired = errors.New("talos config is required")
 
@@ -642,16 +661,7 @@ func (g *Generator) generateExternalCloudProviderPatch(
 		return nil
 	}
 
-	patchContent := `cluster:
-  externalCloudProvider:
-    enabled: true
-machine:
-  kubelet:
-    extraArgs:
-      cloud-provider: external
-`
-
-	err := os.WriteFile(patchPath, []byte(patchContent), filePerm)
+	err := os.WriteFile(patchPath, []byte(ExternalCloudProviderPatchYAML), filePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create external-cloud-provider patch: %w", err)
 	}

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -32,6 +32,8 @@ const (
 	imageVerificationFileName = "image-verification.yaml"
 	// disableCDIFileName is the name of the CDI disable patch file.
 	disableCDIFileName = "disable-cdi.yaml"
+	// externalCloudProviderFileName is the name of the external cloud provider patch file.
+	externalCloudProviderFileName = "external-cloud-provider.yaml"
 )
 
 // KubeletServingCertApproverManifestURL is the URL for the kubelet-serving-cert-approver manifest.
@@ -78,6 +80,13 @@ type Config struct {
 	// When true, generates a disable-cdi.yaml patch to set machine.features.enableCDI to false.
 	// Talos 1.13+ enables CDI by default, so this patch is only needed when CDI should be turned off.
 	DisableCDI bool
+	// EnableExternalCloudProvider indicates whether to enable the external cloud provider.
+	// When true, generates an external-cloud-provider.yaml patch that sets
+	// cluster.externalCloudProvider.enabled to true and machine.kubelet.extraArgs.cloud-provider
+	// to "external". This is required for Hetzner Cloud so that the Cloud Controller Manager
+	// can initialize nodes with a providerID and the CSI driver can schedule.
+	// See: https://www.talos.dev/latest/kubernetes-guides/configuration/cloud-provider/
+	EnableExternalCloudProvider bool
 }
 
 // Generator generates the Talos directory structure.
@@ -173,6 +182,11 @@ func (g *Generator) getDirectoriesWithPatches(
 		dirs["cluster"] = true
 	}
 
+	// External cloud provider patch goes to cluster/
+	if model.EnableExternalCloudProvider {
+		dirs["cluster"] = true
+	}
+
 	return dirs
 }
 
@@ -242,6 +256,14 @@ func (g *Generator) generateConditionalPatches(
 	// Generate disable-cdi patch when CDI should be turned off
 	if model.DisableCDI {
 		err := g.generateDisableCDIPatch(rootPath, force)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Generate external cloud provider patch when cloud provider integration is needed
+	if model.EnableExternalCloudProvider {
+		err := g.generateExternalCloudProviderPatch(rootPath, force)
 		if err != nil {
 			return err
 		}
@@ -593,6 +615,45 @@ func (g *Generator) generateDisableCDIPatch(
 	err := os.WriteFile(patchPath, []byte(patchContent), filePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create disable-cdi patch: %w", err)
+	}
+
+	return nil
+}
+
+// generateExternalCloudProviderPatch creates a Talos patch file to enable the external
+// cloud provider. This is required for cloud providers like Hetzner Cloud so that the
+// Cloud Controller Manager (CCM) can:
+//  1. Initialize nodes with a providerID (spec.providerID)
+//  2. Write node labels that the CSI DaemonSet requires for scheduling
+//
+// Without this patch, nodes come up Ready but without providerID, and CSI pods never
+// schedule because their node affinity depends on labels written by CCM.
+//
+// See: https://www.talos.dev/latest/kubernetes-guides/configuration/cloud-provider/
+func (g *Generator) generateExternalCloudProviderPatch(
+	rootPath string,
+	force bool,
+) error {
+	patchPath := filepath.Join(rootPath, "cluster", externalCloudProviderFileName)
+
+	// Check if file already exists
+	_, statErr := os.Stat(patchPath)
+	if statErr == nil && !force {
+		return nil
+	}
+
+	patchContent := `cluster:
+  externalCloudProvider:
+    enabled: true
+machine:
+  kubelet:
+    extraArgs:
+      cloud-provider: external
+`
+
+	err := os.WriteFile(patchPath, []byte(patchContent), filePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create external-cloud-provider patch: %w", err)
 	}
 
 	return nil

--- a/pkg/fsutil/generator/talos/generator_test.go
+++ b/pkg/fsutil/generator/talos/generator_test.go
@@ -687,3 +687,64 @@ func TestGenerator_Generate_NoImageVerificationPatchWhenFalse(t *testing.T) {
 	_, err = os.Stat(patchPath)
 	assert.True(t, os.IsNotExist(err), "expected image-verification.yaml to not exist")
 }
+
+// TestGenerator_Generate_ExternalCloudProvider tests that external-cloud-provider.yaml
+// is generated when EnableExternalCloudProvider is true.
+func TestGenerator_Generate_ExternalCloudProvider(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	gen := talosgenerator.NewGenerator()
+
+	config := &talosgenerator.Config{
+		PatchesDir:                  "talos",
+		EnableExternalCloudProvider: true,
+		WorkerNodes:                 1, // Prevents allow-scheduling patch
+	}
+	opts := yamlgenerator.Options{
+		Output: tempDir,
+	}
+
+	result, err := gen.Generate(config, opts)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempDir, "talos"), result)
+
+	// Verify external-cloud-provider.yaml was created
+	patchPath := filepath.Join(tempDir, "talos", "cluster", "external-cloud-provider.yaml")
+	content, err := os.ReadFile(patchPath) //nolint:gosec // Test file path is safe
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "externalCloudProvider:")
+	assert.Contains(t, string(content), "enabled: true")
+	assert.Contains(t, string(content), "cloud-provider: external")
+
+	// Verify .gitkeep was NOT created in cluster/ since we have a patch there
+	gitkeepPath := filepath.Join(tempDir, "talos", "cluster", ".gitkeep")
+	_, err = os.Stat(gitkeepPath)
+	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when patches are generated")
+}
+
+// TestGenerator_Generate_ExternalCloudProviderDisabled tests that external-cloud-provider.yaml
+// is NOT generated when EnableExternalCloudProvider is false.
+func TestGenerator_Generate_ExternalCloudProviderDisabled(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	gen := talosgenerator.NewGenerator()
+
+	config := &talosgenerator.Config{
+		PatchesDir:                  "talos",
+		WorkerNodes:                 1,
+		EnableExternalCloudProvider: false,
+	}
+	opts := yamlgenerator.Options{
+		Output: tempDir,
+	}
+
+	_, err := gen.Generate(config, opts)
+	require.NoError(t, err)
+
+	// Verify external-cloud-provider.yaml was NOT created
+	patchPath := filepath.Join(tempDir, "talos", "cluster", "external-cloud-provider.yaml")
+	_, err = os.Stat(patchPath)
+	assert.True(t, os.IsNotExist(err), "expected external-cloud-provider.yaml to not exist")
+}

--- a/pkg/fsutil/scaffolder/scaffolder_coverage_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_coverage_test.go
@@ -521,7 +521,12 @@ func TestScaffoldTalos_HetznerExternalCloudProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify external-cloud-provider.yaml was created
-	patchPath := filepath.Join(tempDir, scaffolder.TalosConfigDir, "cluster", "external-cloud-provider.yaml")
+	patchPath := filepath.Join(
+		tempDir,
+		scaffolder.TalosConfigDir,
+		"cluster",
+		"external-cloud-provider.yaml",
+	)
 	content, readErr := os.ReadFile(patchPath) //nolint:gosec // test file
 	require.NoError(t, readErr)
 	assert.Contains(t, string(content), "externalCloudProvider:")
@@ -554,7 +559,16 @@ func TestScaffoldTalos_DockerNoExternalCloudProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify external-cloud-provider.yaml was NOT created
-	patchPath := filepath.Join(tempDir, scaffolder.TalosConfigDir, "cluster", "external-cloud-provider.yaml")
+	patchPath := filepath.Join(
+		tempDir,
+		scaffolder.TalosConfigDir,
+		"cluster",
+		"external-cloud-provider.yaml",
+	)
 	_, err = os.Stat(patchPath)
-	assert.True(t, os.IsNotExist(err), "expected external-cloud-provider.yaml to not exist for Docker provider")
+	assert.True(
+		t,
+		os.IsNotExist(err),
+		"expected external-cloud-provider.yaml to not exist for Docker provider",
+	)
 }

--- a/pkg/fsutil/scaffolder/scaffolder_coverage_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_coverage_test.go
@@ -495,3 +495,66 @@ func TestScaffold_GetKindMirrorsDir(t *testing.T) {
 
 	assert.NotEmpty(t, result, "GetKindMirrorsDir should return non-empty path")
 }
+
+// TestScaffoldTalos_HetznerExternalCloudProvider tests that the external cloud provider
+// patch is generated when scaffolding for the Hetzner provider.
+func TestScaffoldTalos_HetznerExternalCloudProvider(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cluster := v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution:       v1alpha1.DistributionTalos,
+				DistributionConfig: scaffolder.TalosConfigDir,
+				Provider:           v1alpha1.ProviderHetzner,
+			},
+			Workload: v1alpha1.WorkloadSpec{
+				SourceDirectory: "k8s",
+			},
+		},
+	}
+
+	scaffolderInstance := scaffolder.NewScaffolder(cluster, io.Discard, nil)
+
+	err := scaffolderInstance.Scaffold(tempDir, true)
+	require.NoError(t, err)
+
+	// Verify external-cloud-provider.yaml was created
+	patchPath := filepath.Join(tempDir, scaffolder.TalosConfigDir, "cluster", "external-cloud-provider.yaml")
+	content, readErr := os.ReadFile(patchPath) //nolint:gosec // test file
+	require.NoError(t, readErr)
+	assert.Contains(t, string(content), "externalCloudProvider:")
+	assert.Contains(t, string(content), "enabled: true")
+	assert.Contains(t, string(content), "cloud-provider: external")
+}
+
+// TestScaffoldTalos_DockerNoExternalCloudProvider tests that the external cloud provider
+// patch is NOT generated when scaffolding for the Docker provider.
+func TestScaffoldTalos_DockerNoExternalCloudProvider(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cluster := v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution:       v1alpha1.DistributionTalos,
+				DistributionConfig: scaffolder.TalosConfigDir,
+				Provider:           v1alpha1.ProviderDocker,
+			},
+			Workload: v1alpha1.WorkloadSpec{
+				SourceDirectory: "k8s",
+			},
+		},
+	}
+
+	scaffolderInstance := scaffolder.NewScaffolder(cluster, io.Discard, nil)
+
+	err := scaffolderInstance.Scaffold(tempDir, true)
+	require.NoError(t, err)
+
+	// Verify external-cloud-provider.yaml was NOT created
+	patchPath := filepath.Join(tempDir, scaffolder.TalosConfigDir, "cluster", "external-cloud-provider.yaml")
+	_, err = os.Stat(patchPath)
+	assert.True(t, os.IsNotExist(err), "expected external-cloud-provider.yaml to not exist for Docker provider")
+}

--- a/pkg/fsutil/scaffolder/scaffolder_talos.go
+++ b/pkg/fsutil/scaffolder/scaffolder_talos.go
@@ -31,20 +31,26 @@ func (s *Scaffolder) generateTalosConfig(output string, force bool) error {
 	// so we only need a patch when CDI should be turned off.
 	disableCDI := s.KSailConfig.Spec.Cluster.CDI == v1alpha1.CDIDisabled
 
+	// Enable external cloud provider when using a cloud provider (e.g., Hetzner) that
+	// requires the CCM to initialize nodes with a providerID and write node labels.
+	enableExternalCloudProvider := s.KSailConfig.Spec.Cluster.Provider == v1alpha1.ProviderHetzner
+
 	// Mirror the conditions in generator.getDirectoriesWithPatches() exactly so
 	// .gitkeep notifications match the files the generator actually writes.
 	clusterHasPatches := workers == 0 || len(s.MirrorRegistries) > 0 || disableDefaultCNI ||
-		enableKubeletCertRotation || s.ClusterName != "" || enableImageVerification || disableCDI
+		enableKubeletCertRotation || s.ClusterName != "" || enableImageVerification || disableCDI ||
+		enableExternalCloudProvider
 
 	config := &talosgenerator.Config{
-		PatchesDir:                TalosConfigDir,
-		MirrorRegistries:          s.MirrorRegistries,
-		WorkerNodes:               workers,
-		DisableDefaultCNI:         disableDefaultCNI,
-		EnableKubeletCertRotation: enableKubeletCertRotation,
-		ClusterName:               s.ClusterName,
-		EnableImageVerification:   enableImageVerification,
-		DisableCDI:                disableCDI,
+		PatchesDir:                  TalosConfigDir,
+		MirrorRegistries:            s.MirrorRegistries,
+		WorkerNodes:                 workers,
+		DisableDefaultCNI:           disableDefaultCNI,
+		EnableKubeletCertRotation:   enableKubeletCertRotation,
+		ClusterName:                 s.ClusterName,
+		EnableImageVerification:     enableImageVerification,
+		DisableCDI:                  disableCDI,
+		EnableExternalCloudProvider: enableExternalCloudProvider,
 	}
 
 	opts := yamlgenerator.Options{
@@ -63,6 +69,7 @@ func (s *Scaffolder) generateTalosConfig(output string, force bool) error {
 		enableKubeletCertRotation,
 		enableImageVerification,
 		disableCDI,
+		enableExternalCloudProvider,
 		clusterHasPatches,
 	)
 
@@ -72,7 +79,8 @@ func (s *Scaffolder) generateTalosConfig(output string, force bool) error {
 // notifyTalosGenerated sends notifications about generated Talos files.
 func (s *Scaffolder) notifyTalosGenerated(
 	workers int,
-	disableDefaultCNI, enableKubeletCertRotation, enableImageVerification, disableCDI bool,
+	disableDefaultCNI, enableKubeletCertRotation, enableImageVerification, disableCDI,
+	enableExternalCloudProvider bool,
 	clusterHasPatches bool,
 ) {
 	// Notify about .gitkeep files only for directories without patches
@@ -100,6 +108,7 @@ func (s *Scaffolder) notifyTalosGenerated(
 		{s.ClusterName != "", "cluster", "cluster-name.yaml"},
 		{enableImageVerification, "cluster", "image-verification.yaml"},
 		{disableCDI, "cluster", "disable-cdi.yaml"},
+		{enableExternalCloudProvider, "cluster", "external-cloud-provider.yaml"},
 	}
 
 	for _, patch := range patches {


### PR DESCRIPTION
## Summary

When using the Hetzner provider with the Talos distribution, the generated machine config was missing the `externalCloudProvider` configuration. Without it, the Hetzner Cloud Controller Manager cannot initialize nodes with a `providerID`, and the CSI DaemonSet never schedules because it requires node labels that CCM writes after providerID initialization.

## Changes

Add the external cloud provider Talos patch at three levels:

1. **Generator** (`pkg/fsutil/generator/talos/generator.go`): New `EnableExternalCloudProvider` field and `generateExternalCloudProviderPatch()` method that writes `external-cloud-provider.yaml` to the cluster patches directory

2. **Scaffolder** (`pkg/fsutil/scaffolder/scaffolder_talos.go`): Set `EnableExternalCloudProvider=true` when provider is Hetzner during `ksail cluster init`

3. **Runtime** (`pkg/fsutil/configmanager/ksail/distribution.go`): Inject the patch via `WithAdditionalPatches()` and `getDefaultTalosPatches()` when the Hetzner provider is configured, ensuring it is applied during `cluster create` and `cluster update`

The patch sets:
```yaml
cluster:
  externalCloudProvider:
    enabled: true
machine:
  kubelet:
    extraArgs:
      cloud-provider: external
```

## References

- https://www.talos.dev/latest/kubernetes-guides/configuration/cloud-provider/

Fixes #4258