### PR TITLE
fix: wait for kubelet-serving-cert-approver before metrics-server on Talos

### DIFF
--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -475,7 +475,17 @@ func installComponentsInPhases(
 	if len(infraTasks) > 0 {
 		needsCSRApproverWait := reqs.NeedsMetricsServer &&
 			clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionTalos
-		err := runInfraPhase(ctx, clusterCfg, writer, labels, tmr, infraTasks, cniInstalled, needsCSRApproverWait)
+
+		err := runInfraPhase(
+			ctx,
+			clusterCfg,
+			writer,
+			labels,
+			tmr,
+			infraTasks,
+			cniInstalled,
+			needsCSRApproverWait,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -95,6 +95,13 @@ const (
 	// (e.g. VCluster) where Cilium eBPF stabilization takes longer because the
 	// virtual cluster runs atop a host cluster's network layer.
 	inClusterConnectivityTimeoutSlow = 3 * time.Minute
+
+	// csrApproverReadinessTimeout is the maximum time to wait for the
+	// kubelet-serving-cert-approver deployment (from Talos extraManifests) to
+	// become ready. After CNI is installed, the approver pod needs to be
+	// scheduled, pull its image, start, and begin approving kubelet serving
+	// CSRs. Two minutes accommodates image pulls on fresh cloud nodes.
+	csrApproverReadinessTimeout = 2 * time.Minute
 )
 
 // apiServerStabilitySuccesses returns the number of consecutive successful
@@ -174,6 +181,47 @@ func SetClusterStabilityCheckForTests(
 		clusterStabilityCheckOverride = previous
 
 		clusterStabilityCheckMu.Unlock()
+	}
+}
+
+var (
+	//nolint:gochecknoglobals // dependency injection for tests
+	csrApproverWaitMu sync.RWMutex
+	//nolint:gochecknoglobals // dependency injection for tests
+	csrApproverWaitOverride func(context.Context, *v1alpha1.Cluster) error
+)
+
+// getWaitForCSRApproverFn returns the CSR approver wait function,
+// using the test override if one is set.
+func getWaitForCSRApproverFn() func(context.Context, *v1alpha1.Cluster) error {
+	csrApproverWaitMu.RLock()
+	defer csrApproverWaitMu.RUnlock()
+
+	if csrApproverWaitOverride != nil {
+		return csrApproverWaitOverride
+	}
+
+	return waitForKubeletCSRApprover
+}
+
+// SetCSRApproverWaitForTests overrides the CSR approver wait function for testing.
+// Returns a cleanup function that restores the previous function.
+func SetCSRApproverWaitForTests(
+	fn func(context.Context, *v1alpha1.Cluster) error,
+) func() {
+	csrApproverWaitMu.Lock()
+
+	previous := csrApproverWaitOverride
+	csrApproverWaitOverride = fn
+
+	csrApproverWaitMu.Unlock()
+
+	return func() {
+		csrApproverWaitMu.Lock()
+
+		csrApproverWaitOverride = previous
+
+		csrApproverWaitMu.Unlock()
 	}
 }
 
@@ -425,7 +473,9 @@ func installComponentsInPhases(
 
 	infraTasks := buildInfrastructureTasks(clusterCfg, factories, reqs)
 	if len(infraTasks) > 0 {
-		err := runInfraPhase(ctx, clusterCfg, writer, labels, tmr, infraTasks, cniInstalled)
+		needsCSRApproverWait := reqs.NeedsMetricsServer &&
+			clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionTalos
+		err := runInfraPhase(ctx, clusterCfg, writer, labels, tmr, infraTasks, cniInstalled, needsCSRApproverWait)
 		if err != nil {
 			return err
 		}
@@ -450,6 +500,10 @@ func installComponentsInPhases(
 // has programmed pod-to-service routing before components are deployed.
 // cniInstalled indicates whether CNI was just installed — when true, the node
 // readiness check in the stability pre-flight is skipped.
+// needsCSRApproverWait indicates whether to wait for the kubelet-serving-cert-approver
+// deployment (from Talos extraManifests) to be ready before starting the parallel
+// infrastructure installations. This prevents the race condition where metrics-server
+// starts before kubelet serving CSRs are approved.
 func runInfraPhase(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
@@ -458,12 +512,22 @@ func runInfraPhase(
 	tmr timer.Timer,
 	infraTasks []notify.ProgressTask,
 	cniInstalled bool,
+	needsCSRApproverWait bool,
 ) error {
 	if needsInClusterConnectivityCheck(clusterCfg) {
 		err := getClusterStabilityCheckFn()(ctx, clusterCfg, cniInstalled)
 		if err != nil {
 			return fmt.Errorf(
 				"cluster not stable before infrastructure installation: %w", err,
+			)
+		}
+	}
+
+	if needsCSRApproverWait {
+		err := getWaitForCSRApproverFn()(ctx, clusterCfg)
+		if err != nil {
+			return fmt.Errorf(
+				"kubelet CSR approver not ready before infrastructure installation: %w", err,
 			)
 		}
 	}
@@ -720,6 +784,48 @@ func needsInClusterConnectivityCheck(clusterCfg *v1alpha1.Cluster) bool {
 	}
 
 	return clusterCfg.Spec.Cluster.CNI == v1alpha1.CNICilium
+}
+
+// waitForKubeletCSRApprover waits for the kubelet-serving-cert-approver deployment
+// (installed via Talos extraManifests) to be ready before starting infrastructure
+// component installations.
+//
+// On Talos clusters with rotate-server-certificates enabled, kubelets submit CSRs
+// for their serving certificates. These CSRs must be approved by a cert approver
+// before metrics-server can TLS-handshake with kubelets. When CNI is managed by
+// KSail (e.g., Cilium), the extraManifests-installed approver pods can't start
+// until after CNI is installed. Without this wait, metrics-server races the
+// approver startup and fails with TLS errors.
+//
+// If the deployment does not exist (user didn't include the extraManifests patch),
+// this function returns nil immediately — it is a no-op in that case.
+func waitForKubeletCSRApprover(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+) error {
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(clusterCfg)
+	if err != nil {
+		return fmt.Errorf("get kubeconfig path for CSR approver check: %w", err)
+	}
+
+	clientset, err := k8s.NewClientset(
+		kubeconfigPath, clusterCfg.Spec.Cluster.Connection.Context,
+	)
+	if err != nil {
+		return fmt.Errorf("create clientset for CSR approver check: %w", err)
+	}
+
+	err = readiness.WaitForDeploymentReadyIfExists(
+		ctx, clientset,
+		"kubelet-serving-cert-approver",
+		"kubelet-serving-cert-approver",
+		csrApproverReadinessTimeout,
+	)
+	if err != nil {
+		return fmt.Errorf("wait for kubelet-serving-cert-approver: %w", err)
+	}
+
+	return nil
 }
 
 type silentInstallFunc func(ctx context.Context, cfg *v1alpha1.Cluster, f *InstallerFactories) error

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var errNotStable = errors.New("not stable")
+var (
+	errNotStable       = errors.New("not stable")
+	errApproverNotReady = errors.New("approver not ready")
+)
 
 func TestRunGitOpsPhase_AlwaysChecksClusterStabilityBeforeInstallingGitOps(t *testing.T) {
 	clusterCfg := &v1alpha1.Cluster{
@@ -113,4 +116,165 @@ func TestRunGitOpsPhase_ReturnsErrorBeforeGitOpsInstallWhenStabilityCheckFails(t
 	require.Error(t, err)
 	require.ErrorContains(t, err, "cluster not stable before GitOps installation")
 	assert.False(t, taskRan, "GitOps installation must not start when stability check fails")
+}
+
+func TestRunInfraPhase_WaitsForCSRApproverBeforeInfraTasks(t *testing.T) {
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution:  v1alpha1.DistributionTalos,
+				MetricsServer: v1alpha1.MetricsServerEnabled,
+			},
+		},
+	}
+
+	var (
+		approverWaitCalled bool
+		taskRan            bool
+		order              []string
+	)
+
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error {
+			return nil
+		},
+	))
+
+	t.Cleanup(SetCSRApproverWaitForTests(
+		func(_ context.Context, _ *v1alpha1.Cluster) error {
+			approverWaitCalled = true
+			order = append(order, "csr-approver-wait")
+
+			return nil
+		},
+	))
+
+	infraTasks := []notify.ProgressTask{
+		{
+			Name: "metrics-server",
+			Fn: func(context.Context) error {
+				taskRan = true
+				order = append(order, "infra-install")
+
+				return nil
+			},
+		},
+	}
+
+	tmr := timer.New()
+	err := runInfraPhase(
+		context.Background(),
+		clusterCfg,
+		io.Discard,
+		notify.InstallingLabels(),
+		tmr,
+		infraTasks,
+		false,
+		true,
+	)
+	require.NoError(t, err)
+	assert.True(t, approverWaitCalled, "CSR approver wait should be called")
+	assert.True(t, taskRan, "infrastructure tasks should run after approver wait")
+	assert.Equal(t, []string{"csr-approver-wait", "infra-install"}, order,
+		"CSR approver wait must happen before infrastructure tasks")
+}
+
+func TestRunInfraPhase_ReturnsErrorWhenCSRApproverWaitFails(t *testing.T) {
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution:  v1alpha1.DistributionTalos,
+				MetricsServer: v1alpha1.MetricsServerEnabled,
+			},
+		},
+	}
+
+	var taskRan bool
+
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error {
+			return nil
+		},
+	))
+
+	t.Cleanup(SetCSRApproverWaitForTests(
+		func(context.Context, *v1alpha1.Cluster) error {
+			return errApproverNotReady
+		},
+	))
+
+	infraTasks := []notify.ProgressTask{
+		{
+			Name: "metrics-server",
+			Fn: func(context.Context) error {
+				taskRan = true
+
+				return nil
+			},
+		},
+	}
+
+	tmr := timer.New()
+	err := runInfraPhase(
+		context.Background(),
+		clusterCfg,
+		io.Discard,
+		notify.InstallingLabels(),
+		tmr,
+		infraTasks,
+		false,
+		true,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "kubelet CSR approver not ready")
+	assert.False(t, taskRan, "infrastructure tasks must not start when CSR approver wait fails")
+}
+
+func TestRunInfraPhase_SkipsCSRApproverWaitWhenNotNeeded(t *testing.T) {
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution:  v1alpha1.DistributionVanilla,
+				MetricsServer: v1alpha1.MetricsServerEnabled,
+			},
+		},
+	}
+
+	var approverWaitCalled bool
+
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error {
+			return nil
+		},
+	))
+
+	t.Cleanup(SetCSRApproverWaitForTests(
+		func(context.Context, *v1alpha1.Cluster) error {
+			approverWaitCalled = true
+
+			return nil
+		},
+	))
+
+	infraTasks := []notify.ProgressTask{
+		{
+			Name: "metrics-server",
+			Fn:   func(context.Context) error { return nil },
+		},
+	}
+
+	tmr := timer.New()
+	err := runInfraPhase(
+		context.Background(),
+		clusterCfg,
+		io.Discard,
+		notify.InstallingLabels(),
+		tmr,
+		infraTasks,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	assert.False(t, approverWaitCalled,
+		"CSR approver wait should NOT be called when needsCSRApproverWait is false")
 }

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	errNotStable       = errors.New("not stable")
+	errNotStable        = errors.New("not stable")
 	errApproverNotReady = errors.New("approver not ready")
 )
 
@@ -143,6 +143,7 @@ func TestRunInfraPhase_WaitsForCSRApproverBeforeInfraTasks(t *testing.T) {
 	t.Cleanup(SetCSRApproverWaitForTests(
 		func(_ context.Context, _ *v1alpha1.Cluster) error {
 			approverWaitCalled = true
+
 			order = append(order, "csr-approver-wait")
 
 			return nil
@@ -154,6 +155,7 @@ func TestRunInfraPhase_WaitsForCSRApproverBeforeInfraTasks(t *testing.T) {
 			Name: "metrics-server",
 			Fn: func(context.Context) error {
 				taskRan = true
+
 				order = append(order, "infra-install")
 
 				return nil

--- a/pkg/k8s/readiness/deployment.go
+++ b/pkg/k8s/readiness/deployment.go
@@ -64,8 +64,8 @@ func WaitForDeploymentReady(
 // If it exists, this function waits for it to be fully ready using the same criteria
 // as WaitForDeploymentReady.
 //
-// The initial existence check is bounded by the same deadline to prevent indefinite
-// blocking if the API server is slow or unresponsive.
+// A single deadline bounds the total wall-clock time for both the initial existence
+// check and the subsequent readiness polling.
 //
 // Returns nil if the deployment does not exist (including when the namespace does not exist).
 // Returns an error if the deployment exists but is not ready within the deadline.
@@ -75,12 +75,12 @@ func WaitForDeploymentReadyIfExists(
 	namespace, name string,
 	deadline time.Duration,
 ) error {
-	checkCtx, cancel := context.WithTimeout(ctx, deadline)
+	deadlineCtx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
 	_, err := clientset.AppsV1().
 		Deployments(namespace).
-		Get(checkCtx, name, metav1.GetOptions{})
+		Get(deadlineCtx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -89,5 +89,30 @@ func WaitForDeploymentReadyIfExists(
 		return fmt.Errorf("failed to check deployment %s/%s: %w", namespace, name, err)
 	}
 
-	return WaitForDeploymentReady(ctx, clientset, namespace, name, deadline)
+	return PollForReadiness(deadlineCtx, deadline, func(ctx context.Context) (bool, error) {
+		deployment, err := clientset.AppsV1().
+			Deployments(namespace).
+			Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
+		}
+
+		if deployment.Status.Replicas == 0 {
+			return false, nil
+		}
+
+		if deployment.Status.UpdatedReplicas < deployment.Status.Replicas {
+			return false, nil
+		}
+
+		if deployment.Status.AvailableReplicas < deployment.Status.Replicas {
+			return false, nil
+		}
+
+		return true, nil
+	})
 }

--- a/pkg/k8s/readiness/deployment.go
+++ b/pkg/k8s/readiness/deployment.go
@@ -10,25 +10,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// WaitForDeploymentReady waits for a Deployment to be ready.
-//
-// This function polls the specified Deployment until it is ready or the deadline is reached.
-// A Deployment is considered ready when:
-//   - It has at least one replica
-//   - All replicas have been updated
-//   - All replicas are available
-//
-// The function tolerates NotFound errors and continues polling. Other API errors
-// are returned immediately.
-//
-// Returns an error if the Deployment is not ready within the deadline or if an API error occurs.
-func WaitForDeploymentReady(
-	ctx context.Context,
+// deploymentReadyCheck returns a poll function that checks whether a Deployment is ready.
+// A Deployment is considered ready when it has at least one replica and all replicas
+// are updated and available. NotFound errors are tolerated (returns false to continue polling).
+func deploymentReadyCheck(
 	clientset kubernetes.Interface,
 	namespace, name string,
-	deadline time.Duration,
-) error {
-	return PollForReadiness(ctx, deadline, func(ctx context.Context) (bool, error) {
+) func(context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
 		deployment, err := clientset.AppsV1().
 			Deployments(namespace).
 			Get(ctx, name, metav1.GetOptions{})
@@ -53,7 +42,28 @@ func WaitForDeploymentReady(
 		}
 
 		return true, nil
-	})
+	}
+}
+
+// WaitForDeploymentReady waits for a Deployment to be ready.
+//
+// This function polls the specified Deployment until it is ready or the deadline is reached.
+// A Deployment is considered ready when:
+//   - It has at least one replica
+//   - All replicas have been updated
+//   - All replicas are available
+//
+// The function tolerates NotFound errors and continues polling. Other API errors
+// are returned immediately.
+//
+// Returns an error if the Deployment is not ready within the deadline or if an API error occurs.
+func WaitForDeploymentReady(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, name string,
+	deadline time.Duration,
+) error {
+	return PollForReadiness(ctx, deadline, deploymentReadyCheck(clientset, namespace, name))
 }
 
 // WaitForDeploymentReadyIfExists waits for a Deployment to be ready, but returns
@@ -89,30 +99,5 @@ func WaitForDeploymentReadyIfExists(
 		return fmt.Errorf("failed to check deployment %s/%s: %w", namespace, name, err)
 	}
 
-	return PollForReadiness(deadlineCtx, deadline, func(ctx context.Context) (bool, error) {
-		deployment, err := clientset.AppsV1().
-			Deployments(namespace).
-			Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
-
-			return false, fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
-		}
-
-		if deployment.Status.Replicas == 0 {
-			return false, nil
-		}
-
-		if deployment.Status.UpdatedReplicas < deployment.Status.Replicas {
-			return false, nil
-		}
-
-		if deployment.Status.AvailableReplicas < deployment.Status.Replicas {
-			return false, nil
-		}
-
-		return true, nil
-	})
+	return PollForReadiness(deadlineCtx, deadline, deploymentReadyCheck(clientset, namespace, name))
 }

--- a/pkg/k8s/readiness/deployment.go
+++ b/pkg/k8s/readiness/deployment.go
@@ -64,6 +64,9 @@ func WaitForDeploymentReady(
 // If it exists, this function waits for it to be fully ready using the same criteria
 // as WaitForDeploymentReady.
 //
+// The initial existence check is bounded by the same deadline to prevent indefinite
+// blocking if the API server is slow or unresponsive.
+//
 // Returns nil if the deployment does not exist (including when the namespace does not exist).
 // Returns an error if the deployment exists but is not ready within the deadline.
 func WaitForDeploymentReadyIfExists(
@@ -72,9 +75,12 @@ func WaitForDeploymentReadyIfExists(
 	namespace, name string,
 	deadline time.Duration,
 ) error {
+	checkCtx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
 	_, err := clientset.AppsV1().
 		Deployments(namespace).
-		Get(ctx, name, metav1.GetOptions{})
+		Get(checkCtx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil

--- a/pkg/k8s/readiness/deployment.go
+++ b/pkg/k8s/readiness/deployment.go
@@ -55,3 +55,33 @@ func WaitForDeploymentReady(
 		return true, nil
 	})
 }
+
+// WaitForDeploymentReadyIfExists waits for a Deployment to be ready, but returns
+// immediately if the deployment does not exist.
+//
+// This is useful when a component may or may not be installed (e.g., kubelet-serving-cert-approver
+// via Talos extraManifests). If the deployment is absent, there is nothing to wait for.
+// If it exists, this function waits for it to be fully ready using the same criteria
+// as WaitForDeploymentReady.
+//
+// Returns nil if the deployment does not exist (including when the namespace does not exist).
+// Returns an error if the deployment exists but is not ready within the deadline.
+func WaitForDeploymentReadyIfExists(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, name string,
+	deadline time.Duration,
+) error {
+	_, err := clientset.AppsV1().
+		Deployments(namespace).
+		Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to check deployment %s/%s: %w", namespace, name, err)
+	}
+
+	return WaitForDeploymentReady(ctx, clientset, namespace, name, deadline)
+}

--- a/pkg/k8s/readiness/readiness_test.go
+++ b/pkg/k8s/readiness/readiness_test.go
@@ -408,3 +408,104 @@ func pollForReadinessWithDefaultTimeout(
 	//nolint:wrapcheck // test utility function
 	return readiness.PollForReadiness(ctx, 200*time.Millisecond, checker)
 }
+
+func TestWaitForDeploymentReadyIfExists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DeploymentDoesNotExist_ReturnsNilImmediately", func(t *testing.T) {
+		t.Parallel()
+
+		client := fake.NewClientset()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		err := readiness.WaitForDeploymentReadyIfExists(
+			ctx, client, "nonexistent-ns", "nonexistent-deploy", 200*time.Millisecond,
+		)
+
+		expectNoError(t, err, "WaitForDeploymentReadyIfExists with absent deployment")
+	})
+
+	t.Run("DeploymentExistsAndReady_ReturnsNil", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			namespace = "kubelet-serving-cert-approver"
+			name      = "kubelet-serving-cert-approver"
+		)
+
+		client := fake.NewClientset(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				UpdatedReplicas:   1,
+				AvailableReplicas: 1,
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		err := readiness.WaitForDeploymentReadyIfExists(
+			ctx, client, namespace, name, 200*time.Millisecond,
+		)
+
+		expectNoError(t, err, "WaitForDeploymentReadyIfExists with ready deployment")
+	})
+
+	t.Run("DeploymentExistsNotReady_TimesOut", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			namespace = "kubelet-serving-cert-approver"
+			name      = "kubelet-serving-cert-approver"
+		)
+
+		client := fake.NewClientset(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				UpdatedReplicas:   0,
+				AvailableReplicas: 0,
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+
+		err := readiness.WaitForDeploymentReadyIfExists(
+			ctx, client, namespace, name, 150*time.Millisecond,
+		)
+
+		expectErrorContains(
+			t, err, "failed to poll for readiness",
+			"WaitForDeploymentReadyIfExists with not-ready deployment",
+		)
+	})
+
+	t.Run("APIError_PropagatesImmediately", func(t *testing.T) {
+		t.Parallel()
+
+		client := fake.NewClientset()
+		client.PrependReactor(
+			"get",
+			"deployments",
+			func(_ k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, errDeploymentFail
+			},
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		err := readiness.WaitForDeploymentReadyIfExists(
+			ctx, client, "test-ns", "test-deploy", 200*time.Millisecond,
+		)
+
+		expectErrorContains(
+			t, err, "failed to check deployment",
+			"WaitForDeploymentReadyIfExists with API error",
+		)
+	})
+}

--- a/pkg/k8s/readiness/readiness_test.go
+++ b/pkg/k8s/readiness/readiness_test.go
@@ -412,100 +412,109 @@ func pollForReadinessWithDefaultTimeout(
 func TestWaitForDeploymentReadyIfExists(t *testing.T) {
 	t.Parallel()
 
-	t.Run("DeploymentDoesNotExist_ReturnsNilImmediately", func(t *testing.T) {
-		t.Parallel()
+	t.Run("DeploymentDoesNotExist_ReturnsNilImmediately", testIfExistsDeploymentAbsent)
+	t.Run("DeploymentExistsAndReady_ReturnsNil", testIfExistsDeploymentReady)
+	t.Run("DeploymentExistsNotReady_TimesOut", testIfExistsDeploymentNotReady)
+	t.Run("APIError_PropagatesImmediately", testIfExistsAPIError)
+}
 
-		client := fake.NewClientset()
+func testIfExistsDeploymentAbsent(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
+	client := fake.NewClientset()
 
-		err := readiness.WaitForDeploymentReadyIfExists(
-			ctx, client, "nonexistent-ns", "nonexistent-deploy", 200*time.Millisecond,
-		)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
 
-		expectNoError(t, err, "WaitForDeploymentReadyIfExists with absent deployment")
+	err := readiness.WaitForDeploymentReadyIfExists(
+		ctx, client, "nonexistent-ns", "nonexistent-deploy", 200*time.Millisecond,
+	)
+
+	expectNoError(t, err, "WaitForDeploymentReadyIfExists with absent deployment")
+}
+
+func testIfExistsDeploymentReady(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	const (
+		namespace = "kubelet-serving-cert-approver"
+		name      = "kubelet-serving-cert-approver"
+	)
+
+	client := fake.NewClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          1,
+			UpdatedReplicas:   1,
+			AvailableReplicas: 1,
+		},
 	})
 
-	t.Run("DeploymentExistsAndReady_ReturnsNil", func(t *testing.T) {
-		t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
 
-		const (
-			namespace = "kubelet-serving-cert-approver"
-			name      = "kubelet-serving-cert-approver"
-		)
+	err := readiness.WaitForDeploymentReadyIfExists(
+		ctx, client, namespace, name, 200*time.Millisecond,
+	)
 
-		client := fake.NewClientset(&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Status: appsv1.DeploymentStatus{
-				Replicas:          1,
-				UpdatedReplicas:   1,
-				AvailableReplicas: 1,
-			},
-		})
+	expectNoError(t, err, "WaitForDeploymentReadyIfExists with ready deployment")
+}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
+func testIfExistsDeploymentNotReady(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-		err := readiness.WaitForDeploymentReadyIfExists(
-			ctx, client, namespace, name, 200*time.Millisecond,
-		)
+	const (
+		namespace = "kubelet-serving-cert-approver"
+		name      = "kubelet-serving-cert-approver"
+	)
 
-		expectNoError(t, err, "WaitForDeploymentReadyIfExists with ready deployment")
+	client := fake.NewClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          1,
+			UpdatedReplicas:   0,
+			AvailableReplicas: 0,
+		},
 	})
 
-	t.Run("DeploymentExistsNotReady_TimesOut", func(t *testing.T) {
-		t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
 
-		const (
-			namespace = "kubelet-serving-cert-approver"
-			name      = "kubelet-serving-cert-approver"
-		)
+	err := readiness.WaitForDeploymentReadyIfExists(
+		ctx, client, namespace, name, 150*time.Millisecond,
+	)
 
-		client := fake.NewClientset(&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Status: appsv1.DeploymentStatus{
-				Replicas:          1,
-				UpdatedReplicas:   0,
-				AvailableReplicas: 0,
-			},
-		})
+	expectErrorContains(
+		t, err, "failed to poll for readiness",
+		"WaitForDeploymentReadyIfExists with not-ready deployment",
+	)
+}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
-		defer cancel()
+func testIfExistsAPIError(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-		err := readiness.WaitForDeploymentReadyIfExists(
-			ctx, client, namespace, name, 150*time.Millisecond,
-		)
+	client := fake.NewClientset()
+	client.PrependReactor(
+		"get",
+		"deployments",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errDeploymentFail
+		},
+	)
 
-		expectErrorContains(
-			t, err, "failed to poll for readiness",
-			"WaitForDeploymentReadyIfExists with not-ready deployment",
-		)
-	})
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
 
-	t.Run("APIError_PropagatesImmediately", func(t *testing.T) {
-		t.Parallel()
+	err := readiness.WaitForDeploymentReadyIfExists(
+		ctx, client, "test-ns", "test-deploy", 200*time.Millisecond,
+	)
 
-		client := fake.NewClientset()
-		client.PrependReactor(
-			"get",
-			"deployments",
-			func(_ k8stesting.Action) (bool, runtime.Object, error) {
-				return true, nil, errDeploymentFail
-			},
-		)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-
-		err := readiness.WaitForDeploymentReadyIfExists(
-			ctx, client, "test-ns", "test-deploy", 200*time.Millisecond,
-		)
-
-		expectErrorContains(
-			t, err, "failed to check deployment",
-			"WaitForDeploymentReadyIfExists with API error",
-		)
-	})
+	expectErrorContains(
+		t, err, "failed to check deployment",
+		"WaitForDeploymentReadyIfExists with API error",
+	)
 }


### PR DESCRIPTION
## Summary

Fixes #4259

On Talos clusters with `rotate-server-certificates: true` (especially on Hetzner), `ksail cluster create` fails at the metrics-server installation step due to a **race condition** with the kubelet-serving-cert-approver.

### Root Cause

The `alex1989hu/kubelet-serving-cert-approver` is correctly installed via Talos `extraManifests` during bootstrap. However, when CNI is managed by KSail (e.g., Cilium), the approver pods can't start until CNI is installed. After CNI installation, KSail immediately starts the infrastructure phase (including metrics-server) without waiting for the approver to become ready and approve kubelet serving CSRs.

Timeline of the race:
1. Talos bootstrap → extraManifests applied → approver Deployment created (pods **Pending** — no CNI)
2. KSail installs CNI (Cilium) → nodes become Ready
3. Stability check passes (API server + DaemonSets + connectivity)
4. Infrastructure phase starts **in parallel** → metrics-server Helm install begins
5. Meanwhile, the approver pod is just now: getting scheduled → pulling image → starting → approving CSRs
6. Metrics-server connects to kubelet → CSRs still pending → TLS error → Helm timeout

### Fix

Add a targeted readiness check before the infrastructure phase: when `metricsServer: Enabled` on a Talos cluster, wait for the `kubelet-serving-cert-approver` deployment (namespace `kubelet-serving-cert-approver`) to have at least one Ready replica before starting parallel component installations.

If the deployment doesn't exist (user didn't include the extraManifests patch), the check returns immediately — no-op.

### Changes

| File | Change |
|------|--------|
| `pkg/k8s/readiness/deployment.go` | Add `WaitForDeploymentReadyIfExists` — returns nil when deployment is absent, waits for readiness otherwise |
| `pkg/cli/setup/post_cni.go` | Add `waitForKubeletCSRApprover` pre-flight + DI override (`SetCSRApproverWaitForTests`) + `csrApproverReadinessTimeout` constant |
| `pkg/k8s/readiness/readiness_test.go` | Tests for `WaitForDeploymentReadyIfExists` (absent, ready, not-ready, API error) |

### Testing

- All existing tests pass (only pre-existing Docker-unavailable failures in `cloudproviderkind`/`k3d`)
- New tests cover all branches of `WaitForDeploymentReadyIfExists`