### PR TITLE
ci: increase goreleaser job timeout to 45 minutes

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -25,7 +25,7 @@ jobs:
   goreleaser:
     name: Release with GoReleaser
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## What

Increases the `goreleaser` job `timeout-minutes` from 30 to 45 in `.github/workflows/cd.yaml`.

## Why

The job was consistently exceeding the 30-minute limit. The last successful run took ~34 minutes, so 45 minutes gives a safer buffer.