### PR TITLE
fix: set HCLOUD_NETWORK env var in hcloud-ccm Helm values

### DIFF
--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -278,11 +278,14 @@ func installHcloudCCM(
 		return fmt.Errorf("failed to setup helm client for hcloud-ccm: %w", err)
 	}
 
+	networkName := hcloudccminstaller.ResolveHetznerNetworkName(clusterCfg)
+
 	ccmInstaller := hcloudccminstaller.NewInstaller(
 		helmClient,
 		kubeconfigPath,
 		clusterCfg.Spec.Cluster.Connection.Context,
 		timeout,
+		networkName,
 	)
 
 	installErr := ccmInstaller.Install(ctx)

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -65,7 +65,7 @@ func (f *Factory) CreateInstallersForConfig(cfg *v1alpha1.Cluster) map[string]In
 	f.addCertManagerInstaller(installers, spec)
 	f.addMetricsServerInstaller(installers, spec)
 	f.addCSIInstallers(installers, spec)
-	f.addLoadBalancerInstaller(installers, spec)
+	f.addLoadBalancerInstaller(installers, cfg)
 
 	return installers
 }
@@ -204,8 +204,10 @@ func (f *Factory) addCSIInstallers(installers map[string]Installer, spec v1alpha
 
 func (f *Factory) addLoadBalancerInstaller(
 	installers map[string]Installer,
-	spec v1alpha1.ClusterSpec,
+	cfg *v1alpha1.Cluster,
 ) {
+	spec := cfg.Spec.Cluster
+
 	if f.needsCloudProviderKind(spec) && f.dockerClient != nil {
 		installers["cloud-provider-kind"] = cloudproviderkindinstaller.NewInstaller(
 			f.dockerClient,
@@ -223,11 +225,13 @@ func (f *Factory) addLoadBalancerInstaller(
 	}
 
 	if f.needsHcloudCCM(spec) {
+		networkName := hcloudccminstaller.ResolveHetznerNetworkName(cfg)
 		installers["hcloud-ccm"] = hcloudccminstaller.NewInstaller(
 			f.helmClient,
 			f.kubeconfig,
 			f.kubecontext,
 			f.timeout,
+			networkName,
 		)
 	}
 }

--- a/pkg/svc/installer/hcloudccm/export_test.go
+++ b/pkg/svc/installer/hcloudccm/export_test.go
@@ -1,0 +1,4 @@
+package hcloudccminstaller
+
+// BuildValuesYamlForTest exports buildValuesYaml for testing.
+var BuildValuesYamlForTest = buildValuesYaml //nolint:gochecknoglobals // Standard Go export_test.go pattern.

--- a/pkg/svc/installer/hcloudccm/installer.go
+++ b/pkg/svc/installer/hcloudccm/installer.go
@@ -1,6 +1,7 @@
 package hcloudccminstaller
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
@@ -17,22 +18,50 @@ var ErrHetznerTokenNotSet = hetzner.ErrTokenNotSet
 //
 // The cloud controller manager enables LoadBalancer services on Hetzner Cloud
 // by provisioning Hetzner Load Balancers and managing their lifecycle.
+// It also initializes nodes by matching Kubernetes nodes to Hetzner Cloud servers
+// using private network IPs (requires HCLOUD_NETWORK to be set).
 //
 // Prerequisites:
 //   - HCLOUD_TOKEN environment variable must be set with a valid Hetzner Cloud API token
 //   - The token requires read/write access to Load Balancers
 type Installer = hetzner.Installer
 
+// DefaultClusterCIDR is the default pod CIDR for Kubernetes clusters.
+// This matches the Talos/Kubernetes default and is required by Cilium
+// in ipam.mode=kubernetes for node pod CIDR allocation.
+const DefaultClusterCIDR = "10.244.0.0/16"
+
 // NewInstaller creates a new Hetzner Cloud Controller Manager installer instance.
+// The networkName parameter specifies the Hetzner Cloud private network name
+// that CCM uses to look up servers by their private IPs. If empty, networking
+// support is not enabled in the CCM chart values.
 func NewInstaller(
 	client helm.Interface,
 	kubeconfig, context string,
 	timeout time.Duration,
+	networkName string,
 ) *Installer {
 	return hetzner.NewInstaller(client, kubeconfig, context, timeout, hetzner.ChartConfig{
 		Name:        "hcloud-ccm",
 		ReleaseName: "hcloud-cloud-controller-manager",
 		ChartName:   "hcloud/hcloud-cloud-controller-manager",
 		Version:     chartVersion(),
+		ValuesYaml:  buildValuesYaml(networkName),
 	})
+}
+
+// buildValuesYaml generates the Helm values YAML for the hcloud-ccm chart.
+// When networkName is set, it enables the chart's networking section so that
+// HCLOUD_NETWORK is injected into the CCM pod, allowing it to match Kubernetes
+// nodes to Hetzner Cloud servers by their private network IPs.
+func buildValuesYaml(networkName string) string {
+	if networkName == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(`networking:
+  enabled: true
+  clusterCIDR: %s
+  network:
+    value: %q`, DefaultClusterCIDR, networkName)
 }

--- a/pkg/svc/installer/hcloudccm/installer_test.go
+++ b/pkg/svc/installer/hcloudccm/installer_test.go
@@ -13,52 +13,7 @@ import (
 func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		kubeconfig  string
-		context     string
-		timeout     time.Duration
-		networkName string
-		wantNil     bool
-		description string
-	}{
-		{
-			name:        "creates installer with valid parameters",
-			kubeconfig:  "/path/to/kubeconfig",
-			context:     "test-context",
-			timeout:     5 * time.Minute,
-			networkName: "dev-network",
-			wantNil:     false,
-			description: "Should successfully create an installer instance",
-		},
-		{
-			name:        "creates installer with empty kubeconfig",
-			kubeconfig:  "",
-			context:     "test-context",
-			timeout:     5 * time.Minute,
-			networkName: "dev-network",
-			wantNil:     false,
-			description: "Empty kubeconfig should still create installer",
-		},
-		{
-			name:        "creates installer with zero timeout",
-			kubeconfig:  "/path/to/kubeconfig",
-			context:     "test-context",
-			timeout:     0,
-			networkName: "dev-network",
-			wantNil:     false,
-			description: "Zero timeout should still create installer",
-		},
-		{
-			name:        "creates installer with empty network name",
-			kubeconfig:  "/path/to/kubeconfig",
-			context:     "test-context",
-			timeout:     5 * time.Minute,
-			networkName: "",
-			wantNil:     false,
-			description: "Empty network name should still create installer",
-		},
-	}
+	tests := newInstallerTestCases()
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -76,6 +31,37 @@ func TestNewInstaller(t *testing.T) {
 				require.NotNil(t, installer, testCase.description)
 			}
 		})
+	}
+}
+
+type installerTestCase struct {
+	name, kubeconfig, context, networkName, description string
+	timeout                                             time.Duration
+	wantNil                                             bool
+}
+
+func newInstallerTestCases() []installerTestCase {
+	return []installerTestCase{
+		{
+			name: "creates installer with valid parameters", kubeconfig: "/path/to/kubeconfig",
+			context: "test-context", timeout: 5 * time.Minute, networkName: "dev-network",
+			description: "Should successfully create an installer instance",
+		},
+		{
+			name: "creates installer with empty kubeconfig", kubeconfig: "",
+			context: "test-context", timeout: 5 * time.Minute, networkName: "dev-network",
+			description: "Empty kubeconfig should still create installer",
+		},
+		{
+			name: "creates installer with zero timeout", kubeconfig: "/path/to/kubeconfig",
+			context: "test-context", networkName: "dev-network",
+			description: "Zero timeout should still create installer",
+		},
+		{
+			name: "creates installer with empty network name", kubeconfig: "/path/to/kubeconfig",
+			context: "test-context", timeout: 5 * time.Minute,
+			description: "Empty network name should still create installer",
+		},
 	}
 }
 

--- a/pkg/svc/installer/hcloudccm/installer_test.go
+++ b/pkg/svc/installer/hcloudccm/installer_test.go
@@ -18,6 +18,7 @@ func TestNewInstaller(t *testing.T) {
 		kubeconfig  string
 		context     string
 		timeout     time.Duration
+		networkName string
 		wantNil     bool
 		description string
 	}{
@@ -26,6 +27,7 @@ func TestNewInstaller(t *testing.T) {
 			kubeconfig:  "/path/to/kubeconfig",
 			context:     "test-context",
 			timeout:     5 * time.Minute,
+			networkName: "dev-network",
 			wantNil:     false,
 			description: "Should successfully create an installer instance",
 		},
@@ -34,6 +36,7 @@ func TestNewInstaller(t *testing.T) {
 			kubeconfig:  "",
 			context:     "test-context",
 			timeout:     5 * time.Minute,
+			networkName: "dev-network",
 			wantNil:     false,
 			description: "Empty kubeconfig should still create installer",
 		},
@@ -42,8 +45,18 @@ func TestNewInstaller(t *testing.T) {
 			kubeconfig:  "/path/to/kubeconfig",
 			context:     "test-context",
 			timeout:     0,
+			networkName: "dev-network",
 			wantNil:     false,
 			description: "Zero timeout should still create installer",
+		},
+		{
+			name:        "creates installer with empty network name",
+			kubeconfig:  "/path/to/kubeconfig",
+			context:     "test-context",
+			timeout:     5 * time.Minute,
+			networkName: "",
+			wantNil:     false,
+			description: "Empty network name should still create installer",
 		},
 	}
 
@@ -54,6 +67,7 @@ func TestNewInstaller(t *testing.T) {
 			mockClient := helm.NewMockInterface(t)
 			installer := hcloudccminstaller.NewInstaller(
 				mockClient, testCase.kubeconfig, testCase.context, testCase.timeout,
+				testCase.networkName,
 			)
 
 			if testCase.wantNil {

--- a/pkg/svc/installer/hcloudccm/network.go
+++ b/pkg/svc/installer/hcloudccm/network.go
@@ -1,0 +1,48 @@
+package hcloudccminstaller
+
+import (
+	"strings"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	hetznerProvider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+)
+
+// ResolveHetznerNetworkName determines the Hetzner Cloud private network name
+// for the CCM from the cluster configuration.
+//
+// Resolution order:
+//  1. If spec.provider.hetzner.networkName is explicitly set, use that.
+//  2. Otherwise, extract the cluster name from the kubeconfig context
+//     (e.g., "admin@dev" → "dev") and append the standard network suffix
+//     ("-network") to match what hetzner.Provider.EnsureNetwork creates.
+//
+// Returns empty string if the network name cannot be determined.
+func ResolveHetznerNetworkName(cfg *v1alpha1.Cluster) string {
+	// Explicit network name override takes precedence.
+	if nn := cfg.Spec.Provider.Hetzner.NetworkName; nn != "" {
+		return nn
+	}
+
+	// Derive from context: for Talos the context is "admin@<clusterName>".
+	clusterName := extractClusterNameFromTalosContext(
+		cfg.Spec.Cluster.Connection.Context,
+	)
+	if clusterName == "" {
+		return ""
+	}
+
+	return clusterName + hetznerProvider.NetworkSuffix
+}
+
+// extractClusterNameFromTalosContext extracts the cluster name from a Talos
+// kubeconfig context string. Talos contexts follow the pattern "admin@<name>".
+func extractClusterNameFromTalosContext(context string) string {
+	const talosPrefix = "admin@"
+
+	name, found := strings.CutPrefix(context, talosPrefix)
+	if !found || name == "" {
+		return ""
+	}
+
+	return name
+}

--- a/pkg/svc/installer/hcloudccm/network.go
+++ b/pkg/svc/installer/hcloudccm/network.go
@@ -11,30 +11,29 @@ import (
 // for the CCM from the cluster configuration.
 //
 // Resolution order:
-//  1. Extract the cluster name from the kubeconfig context
+//  1. If spec.provider.hetzner.networkName is explicitly set, use that.
+//     This matches the API contract: "If empty, a network named
+//     '<cluster-name>-network' will be created."
+//  2. Otherwise, extract the cluster name from the kubeconfig context
 //     (e.g., "admin@dev" → "dev") and append the standard network suffix
 //     ("-network") to match what hetzner.Provider.EnsureNetwork creates.
-//  2. If the effective created network name cannot be derived from the
-//     context, fall back to spec.provider.hetzner.networkName if set.
 //
 // Returns empty string if the network name cannot be determined.
 func ResolveHetznerNetworkName(cfg *v1alpha1.Cluster) string {
-	// Derive the effective network name used by the Hetzner provider.
-	// For Talos the context is "admin@<clusterName>".
-	clusterName := extractClusterNameFromTalosContext(
-		cfg.Spec.Cluster.Connection.Context,
-	)
-	if clusterName != "" {
-		return clusterName + hetznerProvider.NetworkSuffix
-	}
-
-	// Fall back to an explicitly configured name only when the effective
-	// provider-created network name cannot be derived.
+	// Explicit network name takes precedence per the API contract.
 	if nn := cfg.Spec.Provider.Hetzner.NetworkName; nn != "" {
 		return nn
 	}
 
-	return ""
+	// Derive from context: for Talos the context is "admin@<clusterName>".
+	clusterName := extractClusterNameFromTalosContext(
+		cfg.Spec.Cluster.Connection.Context,
+	)
+	if clusterName == "" {
+		return ""
+	}
+
+	return clusterName + hetznerProvider.NetworkSuffix
 }
 
 // extractClusterNameFromTalosContext extracts the cluster name from a Talos

--- a/pkg/svc/installer/hcloudccm/network.go
+++ b/pkg/svc/installer/hcloudccm/network.go
@@ -11,27 +11,30 @@ import (
 // for the CCM from the cluster configuration.
 //
 // Resolution order:
-//  1. If spec.provider.hetzner.networkName is explicitly set, use that.
-//  2. Otherwise, extract the cluster name from the kubeconfig context
+//  1. Extract the cluster name from the kubeconfig context
 //     (e.g., "admin@dev" → "dev") and append the standard network suffix
 //     ("-network") to match what hetzner.Provider.EnsureNetwork creates.
+//  2. If the effective created network name cannot be derived from the
+//     context, fall back to spec.provider.hetzner.networkName if set.
 //
 // Returns empty string if the network name cannot be determined.
 func ResolveHetznerNetworkName(cfg *v1alpha1.Cluster) string {
-	// Explicit network name override takes precedence.
+	// Derive the effective network name used by the Hetzner provider.
+	// For Talos the context is "admin@<clusterName>".
+	clusterName := extractClusterNameFromTalosContext(
+		cfg.Spec.Cluster.Connection.Context,
+	)
+	if clusterName != "" {
+		return clusterName + hetznerProvider.NetworkSuffix
+	}
+
+	// Fall back to an explicitly configured name only when the effective
+	// provider-created network name cannot be derived.
 	if nn := cfg.Spec.Provider.Hetzner.NetworkName; nn != "" {
 		return nn
 	}
 
-	// Derive from context: for Talos the context is "admin@<clusterName>".
-	clusterName := extractClusterNameFromTalosContext(
-		cfg.Spec.Cluster.Connection.Context,
-	)
-	if clusterName == "" {
-		return ""
-	}
-
-	return clusterName + hetznerProvider.NetworkSuffix
+	return ""
 }
 
 // extractClusterNameFromTalosContext extracts the cluster name from a Talos
@@ -39,7 +42,11 @@ func ResolveHetznerNetworkName(cfg *v1alpha1.Cluster) string {
 func extractClusterNameFromTalosContext(context string) string {
 	const talosPrefix = "admin@"
 
+	context = strings.TrimSpace(context)
+
 	name, found := strings.CutPrefix(context, talosPrefix)
+	name = strings.TrimSpace(name)
+
 	if !found || name == "" {
 		return ""
 	}

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -1,0 +1,164 @@
+package hcloudccminstaller_test
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	hcloudccminstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/hcloudccm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildValuesYaml(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		networkName string
+		wantEmpty   bool
+		wantContain []string
+	}{
+		{
+			name:        "empty network name returns empty values",
+			networkName: "",
+			wantEmpty:   true,
+		},
+		{
+			name:        "network name generates networking values",
+			networkName: "dev-network",
+			wantContain: []string{
+				"networking:",
+				"enabled: true",
+				"clusterCIDR: " + hcloudccminstaller.DefaultClusterCIDR,
+				`value: "dev-network"`,
+			},
+		},
+		{
+			name:        "custom network name is properly quoted",
+			networkName: "my-custom-net",
+			wantContain: []string{
+				`value: "my-custom-net"`,
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hcloudccminstaller.BuildValuesYamlForTest(testCase.networkName)
+
+			if testCase.wantEmpty {
+				assert.Empty(t, result)
+			} else {
+				for _, s := range testCase.wantContain {
+					assert.Contains(t, result, s)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveHetznerNetworkName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      *v1alpha1.Cluster
+		expected string
+	}{
+		{
+			name: "explicit network name takes precedence",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "admin@dev",
+						},
+					},
+					Provider: v1alpha1.ProviderSpec{
+						Hetzner: v1alpha1.OptionsHetzner{
+							NetworkName: "custom-network",
+						},
+					},
+				},
+			},
+			expected: "custom-network",
+		},
+		{
+			name: "derives from Talos context when no explicit name",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "admin@dev",
+						},
+					},
+				},
+			},
+			expected: "dev-network",
+		},
+		{
+			name: "derives from Talos context with hyphenated cluster name",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "admin@my-production-cluster",
+						},
+					},
+				},
+			},
+			expected: "my-production-cluster-network",
+		},
+		{
+			name: "empty context returns empty",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "non-Talos context returns empty",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "kind-local",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "admin@ with no cluster name returns empty",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "admin@",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hcloudccminstaller.ResolveHetznerNetworkName(testCase.cfg)
+
+			require.Equal(t, testCase.expected, result)
+		})
+	}
+}

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -62,128 +62,7 @@ func TestBuildValuesYaml(t *testing.T) {
 func TestResolveHetznerNetworkName(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name     string
-		cfg      *v1alpha1.Cluster
-		expected string
-	}{
-		{
-			name: "context-derived name takes precedence over explicit",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "admin@dev",
-						},
-					},
-					Provider: v1alpha1.ProviderSpec{
-						Hetzner: v1alpha1.OptionsHetzner{
-							NetworkName: "custom-network",
-						},
-					},
-				},
-			},
-			expected: "dev-network",
-		},
-		{
-			name: "falls back to explicit name when context cannot be derived",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "kind-local",
-						},
-					},
-					Provider: v1alpha1.ProviderSpec{
-						Hetzner: v1alpha1.OptionsHetzner{
-							NetworkName: "custom-network",
-						},
-					},
-				},
-			},
-			expected: "custom-network",
-		},
-		{
-			name: "derives from Talos context when no explicit name",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "admin@dev",
-						},
-					},
-				},
-			},
-			expected: "dev-network",
-		},
-		{
-			name: "derives from Talos context with hyphenated cluster name",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "admin@my-production-cluster",
-						},
-					},
-				},
-			},
-			expected: "my-production-cluster-network",
-		},
-		{
-			name: "empty context returns empty",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "",
-						},
-					},
-				},
-			},
-			expected: "",
-		},
-		{
-			name: "non-Talos context without explicit name returns empty",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "kind-local",
-						},
-					},
-				},
-			},
-			expected: "",
-		},
-		{
-			name: "trims whitespace from context",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "  admin@dev  ",
-						},
-					},
-				},
-			},
-			expected: "dev-network",
-		},
-		{
-			name: "admin@ with no cluster name returns empty",
-			cfg: &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Connection: v1alpha1.Connection{
-							Context: "admin@",
-						},
-					},
-				},
-			},
-			expected: "",
-		},
-	}
-
-	for _, testCase := range tests {
+	for _, testCase := range resolveNetworkNameTestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -191,5 +70,69 @@ func TestResolveHetznerNetworkName(t *testing.T) {
 
 			require.Equal(t, testCase.expected, result)
 		})
+	}
+}
+
+type resolveNetworkNameTestCase struct {
+	name     string
+	cfg      *v1alpha1.Cluster
+	expected string
+}
+
+func resolveNetworkNameTestCases() []resolveNetworkNameTestCase {
+	return []resolveNetworkNameTestCase{
+		{
+			name:     "context-derived name takes precedence over explicit",
+			cfg:      clusterCfg("admin@dev", "custom-network"),
+			expected: "dev-network",
+		},
+		{
+			name:     "falls back to explicit name when context cannot be derived",
+			cfg:      clusterCfg("kind-local", "custom-network"),
+			expected: "custom-network",
+		},
+		{
+			name:     "derives from Talos context when no explicit name",
+			cfg:      clusterCfg("admin@dev", ""),
+			expected: "dev-network",
+		},
+		{
+			name:     "derives from Talos context with hyphenated cluster name",
+			cfg:      clusterCfg("admin@my-production-cluster", ""),
+			expected: "my-production-cluster-network",
+		},
+		{
+			name:     "empty context returns empty",
+			cfg:      clusterCfg("", ""),
+			expected: "",
+		},
+		{
+			name:     "non-Talos context without explicit name returns empty",
+			cfg:      clusterCfg("kind-local", ""),
+			expected: "",
+		},
+		{
+			name:     "trims whitespace from context",
+			cfg:      clusterCfg("  admin@dev  ", ""),
+			expected: "dev-network",
+		},
+		{
+			name:     "admin@ with no cluster name returns empty",
+			cfg:      clusterCfg("admin@", ""),
+			expected: "",
+		},
+	}
+}
+
+func clusterCfg(context, networkName string) *v1alpha1.Cluster {
+	return &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Connection: v1alpha1.Connection{Context: context},
+			},
+			Provider: v1alpha1.ProviderSpec{
+				Hetzner: v1alpha1.OptionsHetzner{NetworkName: networkName},
+			},
+		},
 	}
 }

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -68,12 +68,30 @@ func TestResolveHetznerNetworkName(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "explicit network name takes precedence",
+			name: "context-derived name takes precedence over explicit",
 			cfg: &v1alpha1.Cluster{
 				Spec: v1alpha1.Spec{
 					Cluster: v1alpha1.ClusterSpec{
 						Connection: v1alpha1.Connection{
 							Context: "admin@dev",
+						},
+					},
+					Provider: v1alpha1.ProviderSpec{
+						Hetzner: v1alpha1.OptionsHetzner{
+							NetworkName: "custom-network",
+						},
+					},
+				},
+			},
+			expected: "dev-network",
+		},
+		{
+			name: "falls back to explicit name when context cannot be derived",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "kind-local",
 						},
 					},
 					Provider: v1alpha1.ProviderSpec{
@@ -125,7 +143,7 @@ func TestResolveHetznerNetworkName(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "non-Talos context returns empty",
+			name: "non-Talos context without explicit name returns empty",
 			cfg: &v1alpha1.Cluster{
 				Spec: v1alpha1.Spec{
 					Cluster: v1alpha1.ClusterSpec{
@@ -136,6 +154,19 @@ func TestResolveHetznerNetworkName(t *testing.T) {
 				},
 			},
 			expected: "",
+		},
+		{
+			name: "trims whitespace from context",
+			cfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Connection: v1alpha1.Connection{
+							Context: "  admin@dev  ",
+						},
+					},
+				},
+			},
+			expected: "dev-network",
 		},
 		{
 			name: "admin@ with no cluster name returns empty",

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -82,9 +82,9 @@ type resolveNetworkNameTestCase struct {
 func resolveNetworkNameTestCases() []resolveNetworkNameTestCase {
 	return []resolveNetworkNameTestCase{
 		{
-			name:     "context-derived name takes precedence over explicit",
+			name:     "explicit name takes precedence over context-derived name",
 			cfg:      clusterCfg("admin@dev", "custom-network"),
-			expected: "dev-network",
+			expected: "custom-network",
 		},
 		{
 			name:     "falls back to explicit name when context cannot be derived",

--- a/pkg/svc/installer/internal/hetzner/secret.go
+++ b/pkg/svc/installer/internal/hetzner/secret.go
@@ -189,6 +189,8 @@ type ChartConfig struct {
 	ChartName string
 	// Version is the pinned chart version.
 	Version string
+	// ValuesYaml is optional Helm values YAML to pass to the chart.
+	ValuesYaml string
 }
 
 // NewInstaller creates a standard Hetzner Cloud installer with the shared
@@ -220,6 +222,7 @@ func NewInstaller(
 				Wait:            true,
 				WaitForJobs:     true,
 				Timeout:         timeout,
+				ValuesYaml:      cfg.ValuesYaml,
 			},
 		),
 		kubeconfig: kubeconfig,


### PR DESCRIPTION
## Summary

Enable the hcloud-cloud-controller-manager chart's `networking` section so CCM can match Kubernetes nodes to Hetzner Cloud servers by their private network IPs.

Without `HCLOUD_NETWORK`, CCM fails to initialize nodes — the `node.cloudprovider.kubernetes.io/uninitialized` taint is never removed, causing all pods that don't tolerate it (CSI, metrics-server, cert-manager, etc.) to stay `Pending`.

## Changes

- **`pkg/svc/installer/internal/hetzner/secret.go`**: Add `ValuesYaml` field to `ChartConfig`, pass through to `helm.ChartSpec`
- **`pkg/svc/installer/hcloudccm/installer.go`**: Accept `networkName` parameter, generate `networking.enabled: true` + `networking.network.value` Helm values
- **`pkg/svc/installer/hcloudccm/network.go`** (new): `ResolveHetznerNetworkName` resolves the Hetzner network name from `spec.provider.hetzner.networkName` or derives it from the Talos kubeconfig context (`admin@<name>` → `<name>-network`)
- **`pkg/cli/setup/install_infrastructure.go`**: Pass resolved network name at install call site
- **`pkg/svc/installer/factory.go`**: Pass resolved network name in factory (for `images` command)

## Testing

- New tests for `buildValuesYaml` (3 cases) and `ResolveHetznerNetworkName` (6 cases)
- Updated `TestNewInstaller` for the new `networkName` parameter
- All affected package tests pass (`hcloudccm`, `installer`, `setup`)

Fixes #4321