### PR TITLE
fix(hcloudccm): store network name in secret instead of inline Helm value

### DIFF
--- a/pkg/svc/installer/hcloudccm/export_test.go
+++ b/pkg/svc/installer/hcloudccm/export_test.go
@@ -2,3 +2,6 @@ package hcloudccminstaller
 
 // BuildValuesYamlForTest exports buildValuesYaml for testing.
 var BuildValuesYamlForTest = buildValuesYaml //nolint:gochecknoglobals // Standard Go export_test.go pattern.
+
+// BuildSecretDataForTest exports buildSecretData for testing.
+var BuildSecretDataForTest = buildSecretData //nolint:gochecknoglobals // Standard Go export_test.go pattern.

--- a/pkg/svc/installer/hcloudccm/installer.go
+++ b/pkg/svc/installer/hcloudccm/installer.go
@@ -35,6 +35,10 @@ const DefaultClusterCIDR = "10.244.0.0/16"
 // The networkName parameter specifies the Hetzner Cloud private network name
 // that CCM uses to look up servers by their private IPs. If empty, networking
 // support is not enabled in the CCM chart values.
+//
+// When networkName is set, the network name is stored in the shared "hcloud"
+// Kubernetes secret (key "network") so the chart's default
+// valueFrom.secretKeyRef can read it as HCLOUD_NETWORK.
 func NewInstaller(
 	client helm.Interface,
 	kubeconfig, context string,
@@ -47,13 +51,28 @@ func NewInstaller(
 		ChartName:   "hcloud/hcloud-cloud-controller-manager",
 		Version:     chartVersion(),
 		ValuesYaml:  buildValuesYaml(networkName),
+		SecretData:  buildSecretData(networkName),
 	})
+}
+
+// buildSecretData returns extra key-value pairs for the shared "hcloud" secret.
+// When networkName is set, it includes the "network" key so the chart's default
+// valueFrom.secretKeyRef reads it as HCLOUD_NETWORK.
+func buildSecretData(networkName string) map[string][]byte {
+	if networkName == "" {
+		return nil
+	}
+
+	return map[string][]byte{
+		"network": []byte(networkName),
+	}
 }
 
 // buildValuesYaml generates the Helm values YAML for the hcloud-ccm chart.
 // When networkName is set, it enables the chart's networking section so that
-// HCLOUD_NETWORK is injected into the CCM pod, allowing it to match Kubernetes
-// nodes to Hetzner Cloud servers by their private network IPs.
+// HCLOUD_NETWORK is injected into the CCM pod. The network name itself is
+// stored in the "hcloud" Kubernetes secret (key "network") and read by the
+// chart's default valueFrom.secretKeyRef — no inline value override is needed.
 func buildValuesYaml(networkName string) string {
 	if networkName == "" {
 		return ""
@@ -61,7 +80,5 @@ func buildValuesYaml(networkName string) string {
 
 	return fmt.Sprintf(`networking:
   enabled: true
-  clusterCIDR: %s
-  network:
-    value: %q`, DefaultClusterCIDR, networkName)
+  clusterCIDR: %s`, DefaultClusterCIDR)
 }

--- a/pkg/svc/installer/hcloudccm/installer.go
+++ b/pkg/svc/installer/hcloudccm/installer.go
@@ -1,7 +1,6 @@
 package hcloudccminstaller
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
@@ -78,7 +77,5 @@ func buildValuesYaml(networkName string) string {
 		return ""
 	}
 
-	return fmt.Sprintf(`networking:
-  enabled: true
-  clusterCIDR: %s`, DefaultClusterCIDR)
+	return "networking:\n  enabled: true\n  clusterCIDR: " + DefaultClusterCIDR
 }

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -13,10 +13,11 @@ func TestBuildValuesYaml(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		networkName string
-		wantEmpty   bool
-		wantContain []string
+		name           string
+		networkName    string
+		wantEmpty      bool
+		wantContain    []string
+		wantNotContain []string
 	}{
 		{
 			name:        "empty network name returns empty values",
@@ -24,20 +25,16 @@ func TestBuildValuesYaml(t *testing.T) {
 			wantEmpty:   true,
 		},
 		{
-			name:        "network name generates networking values",
+			name:        "network name enables networking without inline value",
 			networkName: "dev-network",
 			wantContain: []string{
 				"networking:",
 				"enabled: true",
 				"clusterCIDR: " + hcloudccminstaller.DefaultClusterCIDR,
-				`value: "dev-network"`,
 			},
-		},
-		{
-			name:        "custom network name is properly quoted",
-			networkName: "my-custom-net",
-			wantContain: []string{
-				`value: "my-custom-net"`,
+			wantNotContain: []string{
+				"value:",
+				"network:",
 			},
 		},
 	}
@@ -54,6 +51,55 @@ func TestBuildValuesYaml(t *testing.T) {
 				for _, s := range testCase.wantContain {
 					assert.Contains(t, result, s)
 				}
+
+				for _, s := range testCase.wantNotContain {
+					assert.NotContains(t, result, s)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSecretData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		networkName string
+		wantNil     bool
+		wantKey     string
+		wantValue   string
+	}{
+		{
+			name:        "empty network name returns nil",
+			networkName: "",
+			wantNil:     true,
+		},
+		{
+			name:        "network name stored in secret data",
+			networkName: "dev-network",
+			wantKey:     "network",
+			wantValue:   "dev-network",
+		},
+		{
+			name:        "custom network name stored in secret data",
+			networkName: "my-custom-net",
+			wantKey:     "network",
+			wantValue:   "my-custom-net",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hcloudccminstaller.BuildSecretDataForTest(testCase.networkName)
+
+			if testCase.wantNil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, testCase.wantValue, string(result[testCase.wantKey]))
 			}
 		})
 	}

--- a/pkg/svc/installer/internal/hetzner/hetzner_concurrent_test.go
+++ b/pkg/svc/installer/internal/hetzner/hetzner_concurrent_test.go
@@ -23,7 +23,7 @@ func TestEnsureSecret_CreateOnNotFound(t *testing.T) {
 
 	clientset := fake.NewClientset()
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "new-token")
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "new-token", nil)
 	require.NoError(t, err)
 
 	got, err := clientset.CoreV1().Secrets(hetzner.Namespace).Get(
@@ -51,7 +51,7 @@ func TestEnsureSecret_UpdateWithDifferentToken(t *testing.T) {
 
 	clientset := fake.NewClientset(existing)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "new-token")
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "new-token", nil)
 	require.NoError(t, err)
 
 	got, err := clientset.CoreV1().Secrets(hetzner.Namespace).Get(
@@ -110,6 +110,6 @@ func TestEnsureSecret_CreateConflictThenUpdate(t *testing.T) {
 		},
 	)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "updated-token")
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "updated-token", nil)
 	require.NoError(t, err)
 }

--- a/pkg/svc/installer/internal/hetzner/hetzner_deep_test.go
+++ b/pkg/svc/installer/internal/hetzner/hetzner_deep_test.go
@@ -52,7 +52,7 @@ func TestEnsureSecret_ValidKubeconfig_NoCluster(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	err := hetzner.EnsureSecret(ctx, kubeconfig, "test")
+	err := hetzner.EnsureSecret(ctx, kubeconfig, "test", nil)
 	// Should create k8s client OK but fail when trying to interact with cluster.
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "failed to create kubernetes client")

--- a/pkg/svc/installer/internal/hetzner/hetzner_edge_test.go
+++ b/pkg/svc/installer/internal/hetzner/hetzner_edge_test.go
@@ -30,7 +30,7 @@ func TestEnsureSecret_CreateError(t *testing.T) {
 		},
 	)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "some-token")
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "some-token", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create secret")
@@ -61,7 +61,7 @@ func TestEnsureSecret_UpdateError(t *testing.T) {
 		},
 	)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "new-token")
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "new-token", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to update secret")
@@ -84,7 +84,7 @@ func TestEnsureSecret_DifferentToken_SuccessfulUpdate(t *testing.T) {
 	clientset := fake.NewClientset(existing)
 
 	newToken := "brand-new-token"
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, newToken)
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, newToken, nil)
 
 	require.NoError(t, err)
 
@@ -128,7 +128,7 @@ func TestEnsureSecret_AlreadyExists_GetFails(t *testing.T) {
 		},
 	)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "some-token")
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "some-token", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get existing secret")

--- a/pkg/svc/installer/internal/hetzner/hetzner_install_test.go
+++ b/pkg/svc/installer/internal/hetzner/hetzner_install_test.go
@@ -59,7 +59,7 @@ func TestInstaller_Install_TokenNotSet(t *testing.T) {
 func TestEnsureSecret_InvalidKubeconfig(t *testing.T) {
 	t.Setenv(hetzner.TokenEnvVar, "test-token-value")
 
-	err := hetzner.EnsureSecret(t.Context(), "/nonexistent/kubeconfig", "test-context")
+	err := hetzner.EnsureSecret(t.Context(), "/nonexistent/kubeconfig", "test-context", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create kubernetes client")
 }

--- a/pkg/svc/installer/internal/hetzner/secret.go
+++ b/pkg/svc/installer/internal/hetzner/secret.go
@@ -37,7 +37,11 @@ var ErrTokenNotSet = fmt.Errorf("environment variable %s is not set", TokenEnvVa
 // EnsureSecret creates or updates the Hetzner Cloud API token secret in
 // kube-system. Both the hcloud-ccm and hetzner-csi installers share this
 // secret, so the logic lives here to avoid duplication.
-func EnsureSecret(ctx context.Context, kubeconfig, kubeContext string) error {
+//
+// extraData contains additional key-value pairs to store alongside the token
+// (e.g. "network" for CCM). These are merged into the existing secret data
+// so that concurrent installers don't overwrite each other's keys.
+func EnsureSecret(ctx context.Context, kubeconfig, kubeContext string, extraData map[string][]byte) error {
 	token := os.Getenv(TokenEnvVar)
 	if token == "" {
 		return ErrTokenNotSet
@@ -48,20 +52,26 @@ func EnsureSecret(ctx context.Context, kubeconfig, kubeContext string) error {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	return ensureSecret(ctx, clientset, token)
+	return ensureSecret(ctx, clientset, token, extraData)
 }
 
 // ensureSecret is the testable core of EnsureSecret. It accepts an injected
 // kubernetes.Interface so that unit tests can substitute a fake clientset.
-func ensureSecret(ctx context.Context, client kubernetes.Interface, token string) error {
+func ensureSecret(ctx context.Context, client kubernetes.Interface, token string, extraData map[string][]byte) error {
+	desiredData := map[string][]byte{
+		"token": []byte(token),
+	}
+
+	for k, v := range extraData {
+		desiredData[k] = v
+	}
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      SecretName,
 			Namespace: Namespace,
 		},
-		Data: map[string][]byte{
-			"token": []byte(token),
-		},
+		Data: desiredData,
 	}
 
 	secretsClient := client.CoreV1().Secrets(Namespace)
@@ -106,16 +116,18 @@ func createOrUpdateOnConflict(
 	return nil
 }
 
-// updateSecretIfNeeded skips the update when the existing token already matches
-// the desired value. Otherwise it uses retry.RetryOnConflict to handle 409
-// Conflict errors that arise under concurrent updaters.
+// updateSecretIfNeeded merges the desired keys into the existing secret data.
+// It skips the update when all desired keys already match. Otherwise it uses
+// retry.RetryOnConflict to handle 409 Conflict errors from concurrent updaters.
+// Merging (rather than replacing) ensures that concurrent installers (e.g. CCM
+// writing "network" and CSI writing only "token") don't overwrite each other's keys.
 func updateSecretIfNeeded(
 	ctx context.Context,
 	client kubernetes.Interface,
 	existingSecret *corev1.Secret,
 	desiredData map[string][]byte,
 ) error {
-	if bytes.Equal(existingSecret.Data["token"], desiredData["token"]) {
+	if desiredDataMatches(existingSecret.Data, desiredData) {
 		return nil
 	}
 
@@ -127,11 +139,18 @@ func updateSecretIfNeeded(
 			return fmt.Errorf("failed to get secret for update: %w", err)
 		}
 
-		if bytes.Equal(latest.Data["token"], desiredData["token"]) {
+		if desiredDataMatches(latest.Data, desiredData) {
 			return nil
 		}
 
-		latest.Data = desiredData
+		if latest.Data == nil {
+			latest.Data = make(map[string][]byte, len(desiredData))
+		}
+
+		for k, v := range desiredData {
+			latest.Data[k] = v
+		}
+
 		latest.StringData = nil
 
 		_, err = secretsClient.Update(ctx, latest, metav1.UpdateOptions{})
@@ -148,14 +167,29 @@ func updateSecretIfNeeded(
 	return nil
 }
 
+// desiredDataMatches returns true when every key in desiredData exists in
+// existing with an equal value.
+func desiredDataMatches(existing, desiredData map[string][]byte) bool {
+	for k, v := range desiredData {
+		if !bytes.Equal(existing[k], v) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // InstallWithSecret ensures the Hetzner Cloud API token secret exists and then
 // installs or upgrades a Helm chart via the given helmutil.Base.
+// extraData contains additional key-value pairs to store in the secret
+// alongside the token (e.g. "network" for CCM).
 func InstallWithSecret(
 	ctx context.Context,
 	base *helmutil.Base,
 	kubeconfig, kubeContext string,
+	extraData map[string][]byte,
 ) error {
-	err := EnsureSecret(ctx, kubeconfig, kubeContext)
+	err := EnsureSecret(ctx, kubeconfig, kubeContext, extraData)
 	if err != nil {
 		return fmt.Errorf("failed to create hetzner secret: %w", err)
 	}
@@ -177,6 +211,7 @@ type Installer struct {
 	kubeconfig string
 	context    string
 	name       string
+	secretData map[string][]byte
 }
 
 // ChartConfig holds the chart-specific parameters that differ between Hetzner installers.
@@ -191,6 +226,11 @@ type ChartConfig struct {
 	Version string
 	// ValuesYaml is optional Helm values YAML to pass to the chart.
 	ValuesYaml string
+	// SecretData contains additional key-value pairs to store in the shared
+	// "hcloud" Kubernetes secret alongside the API token. For example, CCM
+	// stores {"network": "<name>"} so the chart's default valueFrom.secretKeyRef
+	// can read it.
+	SecretData map[string][]byte
 }
 
 // NewInstaller creates a standard Hetzner Cloud installer with the shared
@@ -228,13 +268,14 @@ func NewInstaller(
 		kubeconfig: kubeconfig,
 		context:    kubeContext,
 		name:       cfg.Name,
+		secretData: cfg.SecretData,
 	}
 }
 
 // Install creates the required Hetzner Cloud API token secret and then
 // installs or upgrades the component via its Helm chart.
 func (h *Installer) Install(ctx context.Context) error {
-	err := InstallWithSecret(ctx, h.Base, h.kubeconfig, h.context)
+	err := InstallWithSecret(ctx, h.Base, h.kubeconfig, h.context, h.secretData)
 	if err != nil {
 		return fmt.Errorf("install %s: %w", h.name, err)
 	}

--- a/pkg/svc/installer/internal/hetzner/secret.go
+++ b/pkg/svc/installer/internal/hetzner/secret.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"time"
 
@@ -41,7 +42,11 @@ var ErrTokenNotSet = fmt.Errorf("environment variable %s is not set", TokenEnvVa
 // extraData contains additional key-value pairs to store alongside the token
 // (e.g. "network" for CCM). These are merged into the existing secret data
 // so that concurrent installers don't overwrite each other's keys.
-func EnsureSecret(ctx context.Context, kubeconfig, kubeContext string, extraData map[string][]byte) error {
+func EnsureSecret(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+	extraData map[string][]byte,
+) error {
 	token := os.Getenv(TokenEnvVar)
 	if token == "" {
 		return ErrTokenNotSet
@@ -57,14 +62,17 @@ func EnsureSecret(ctx context.Context, kubeconfig, kubeContext string, extraData
 
 // ensureSecret is the testable core of EnsureSecret. It accepts an injected
 // kubernetes.Interface so that unit tests can substitute a fake clientset.
-func ensureSecret(ctx context.Context, client kubernetes.Interface, token string, extraData map[string][]byte) error {
+func ensureSecret(
+	ctx context.Context,
+	client kubernetes.Interface,
+	token string,
+	extraData map[string][]byte,
+) error {
 	desiredData := map[string][]byte{
 		"token": []byte(token),
 	}
 
-	for k, v := range extraData {
-		desiredData[k] = v
-	}
+	maps.Copy(desiredData, extraData)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -147,9 +155,7 @@ func updateSecretIfNeeded(
 			latest.Data = make(map[string][]byte, len(desiredData))
 		}
 
-		for k, v := range desiredData {
-			latest.Data[k] = v
-		}
+		maps.Copy(latest.Data, desiredData)
 
 		latest.StringData = nil
 

--- a/pkg/svc/installer/internal/hetzner/secret.go
+++ b/pkg/svc/installer/internal/hetzner/secret.go
@@ -72,7 +72,13 @@ func ensureSecret(
 		"token": []byte(token),
 	}
 
-	maps.Copy(desiredData, extraData)
+	for k, v := range extraData {
+		if k == "token" {
+			continue
+		}
+
+		desiredData[k] = v
+	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/svc/installer/internal/hetzner/secret_coverage_test.go
+++ b/pkg/svc/installer/internal/hetzner/secret_coverage_test.go
@@ -72,7 +72,7 @@ func TestEnsureSecret_UpdateWithSameToken(t *testing.T) {
 
 	clientset := fake.NewClientset(existing)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, token)
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, token, nil)
 	require.NoError(t, err)
 
 	got, err := clientset.CoreV1().Secrets(hetzner.Namespace).Get(
@@ -87,7 +87,7 @@ func TestEnsureSecret_UpdateWithSameToken(t *testing.T) {
 func TestEnsureSecret_EmptyToken(t *testing.T) {
 	t.Setenv(hetzner.TokenEnvVar, "")
 
-	err := hetzner.EnsureSecret(context.Background(), "", "")
+	err := hetzner.EnsureSecret(context.Background(), "", "", nil)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, hetzner.ErrTokenNotSet)
@@ -105,7 +105,7 @@ func TestEnsureSecret_GetError(t *testing.T) {
 		},
 	)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "some-token")
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "some-token", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get secret")

--- a/pkg/svc/installer/internal/hetzner/secret_test.go
+++ b/pkg/svc/installer/internal/hetzner/secret_test.go
@@ -129,3 +129,109 @@ func TestEnsureSecret_ConcurrentCreation(t *testing.T) {
 		t.Errorf("expected token %q, got %q", token, string(got.Data["token"]))
 	}
 }
+
+func TestEnsureSecret_MergesExtraDataIntoSecret(t *testing.T) {
+	t.Parallel()
+
+	token := "test-token"
+	extraData := map[string][]byte{
+		"network": []byte("dev-network"),
+	}
+
+	clientset := fake.NewClientset()
+
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, token, extraData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := clientset.CoreV1().Secrets(hetzner.Namespace).Get(
+		context.Background(), hetzner.SecretName, metav1.GetOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to get secret: %v", err)
+	}
+
+	if string(got.Data["token"]) != token {
+		t.Errorf("expected token %q, got %q", token, string(got.Data["token"]))
+	}
+
+	if string(got.Data["network"]) != "dev-network" {
+		t.Errorf("expected network %q, got %q", "dev-network", string(got.Data["network"]))
+	}
+}
+
+func TestEnsureSecret_PreservesExistingKeysOnMerge(t *testing.T) {
+	t.Parallel()
+
+	// Simulate CCM having already written "network" into the secret.
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            hetzner.SecretName,
+			Namespace:       hetzner.Namespace,
+			ResourceVersion: "1",
+		},
+		Data: map[string][]byte{
+			"token":   []byte("old-token"),
+			"network": []byte("dev-network"),
+		},
+	}
+
+	clientset := fake.NewClientset(existing)
+
+	// CSI installer writes only "token" (no extraData). The "network" key must survive.
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, "new-token", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := clientset.CoreV1().Secrets(hetzner.Namespace).Get(
+		context.Background(), hetzner.SecretName, metav1.GetOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to get secret: %v", err)
+	}
+
+	if string(got.Data["token"]) != "new-token" {
+		t.Errorf("expected token %q, got %q", "new-token", string(got.Data["token"]))
+	}
+
+	if string(got.Data["network"]) != "dev-network" {
+		t.Errorf("expected network key to be preserved as %q, got %q", "dev-network", string(got.Data["network"]))
+	}
+}
+
+func TestEnsureSecret_ExtraDataCannotOverrideToken(t *testing.T) {
+	t.Parallel()
+
+	realToken := "real-hcloud-token"
+
+	// Attempt to sneak a different token value via extraData.
+	extraData := map[string][]byte{
+		"token":   []byte("malicious-override"),
+		"network": []byte("dev-network"),
+	}
+
+	clientset := fake.NewClientset()
+
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, realToken, extraData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := clientset.CoreV1().Secrets(hetzner.Namespace).Get(
+		context.Background(), hetzner.SecretName, metav1.GetOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to get secret: %v", err)
+	}
+
+	// The "token" key must always come from the HCLOUD_TOKEN env var, not extraData.
+	if string(got.Data["token"]) != realToken {
+		t.Errorf("expected token from env var %q, got %q (extraData should not override token)", realToken, string(got.Data["token"]))
+	}
+
+	if string(got.Data["network"]) != "dev-network" {
+		t.Errorf("expected network %q, got %q", "dev-network", string(got.Data["network"]))
+	}
+}

--- a/pkg/svc/installer/internal/hetzner/secret_test.go
+++ b/pkg/svc/installer/internal/hetzner/secret_test.go
@@ -15,7 +15,7 @@ import (
 func TestEnsureSecret_TokenNotSet(t *testing.T) {
 	t.Setenv(hetzner.TokenEnvVar, "")
 
-	err := hetzner.EnsureSecret(context.Background(), "", "")
+	err := hetzner.EnsureSecret(context.Background(), "", "", nil)
 	if !errors.Is(err, hetzner.ErrTokenNotSet) {
 		t.Errorf("expected ErrTokenNotSet, got %v", err)
 	}
@@ -28,7 +28,7 @@ func TestEnsureSecret_CreateWhenNotFound(t *testing.T) {
 
 	clientset := fake.NewClientset()
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, token)
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, token, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestEnsureSecret_UpdatePreservesResourceVersion(t *testing.T) {
 
 	clientset := fake.NewClientset(existing)
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, updatedToken)
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, updatedToken, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestEnsureSecret_ConcurrentCreation(t *testing.T) {
 		waitGroup.Go(func() {
 			<-startCh
 
-			errs[goroutineIdx] = hetzner.EnsureSecretForTest(context.Background(), clientset, token)
+			errs[goroutineIdx] = hetzner.EnsureSecretForTest(context.Background(), clientset, token, nil)
 		})
 	}
 

--- a/pkg/svc/installer/internal/hetzner/secret_test.go
+++ b/pkg/svc/installer/internal/hetzner/secret_test.go
@@ -99,7 +99,12 @@ func TestEnsureSecret_ConcurrentCreation(t *testing.T) {
 		waitGroup.Go(func() {
 			<-startCh
 
-			errs[goroutineIdx] = hetzner.EnsureSecretForTest(context.Background(), clientset, token, nil)
+			errs[goroutineIdx] = hetzner.EnsureSecretForTest(
+				context.Background(),
+				clientset,
+				token,
+				nil,
+			)
 		})
 	}
 

--- a/pkg/svc/installer/internal/hetzner/secret_test.go
+++ b/pkg/svc/installer/internal/hetzner/secret_test.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+const testNetworkName = "dev-network"
+
 func TestEnsureSecret_TokenNotSet(t *testing.T) {
 	t.Setenv(hetzner.TokenEnvVar, "")
 
@@ -135,7 +137,7 @@ func TestEnsureSecret_MergesExtraDataIntoSecret(t *testing.T) {
 
 	token := "test-token"
 	extraData := map[string][]byte{
-		"network": []byte("dev-network"),
+		"network": []byte(testNetworkName),
 	}
 
 	clientset := fake.NewClientset()
@@ -156,8 +158,9 @@ func TestEnsureSecret_MergesExtraDataIntoSecret(t *testing.T) {
 		t.Errorf("expected token %q, got %q", token, string(got.Data["token"]))
 	}
 
-	if string(got.Data["network"]) != "dev-network" {
-		t.Errorf("expected network %q, got %q", "dev-network", string(got.Data["network"]))
+	if string(got.Data["network"]) != testNetworkName {
+		t.Errorf("expected network %q, got %q",
+			testNetworkName, string(got.Data["network"]))
 	}
 }
 
@@ -173,7 +176,7 @@ func TestEnsureSecret_PreservesExistingKeysOnMerge(t *testing.T) {
 		},
 		Data: map[string][]byte{
 			"token":   []byte("old-token"),
-			"network": []byte("dev-network"),
+			"network": []byte(testNetworkName),
 		},
 	}
 
@@ -196,25 +199,26 @@ func TestEnsureSecret_PreservesExistingKeysOnMerge(t *testing.T) {
 		t.Errorf("expected token %q, got %q", "new-token", string(got.Data["token"]))
 	}
 
-	if string(got.Data["network"]) != "dev-network" {
-		t.Errorf("expected network key to be preserved as %q, got %q", "dev-network", string(got.Data["network"]))
+	if string(got.Data["network"]) != testNetworkName {
+		t.Errorf("expected network key to be preserved as %q, got %q",
+			testNetworkName, string(got.Data["network"]))
 	}
 }
 
 func TestEnsureSecret_ExtraDataCannotOverrideToken(t *testing.T) {
 	t.Parallel()
 
-	realToken := "real-hcloud-token"
+	envToken := "real-hcloud-token" //nolint:gosec // Test value, not a real credential.
 
 	// Attempt to sneak a different token value via extraData.
 	extraData := map[string][]byte{
 		"token":   []byte("malicious-override"),
-		"network": []byte("dev-network"),
+		"network": []byte(testNetworkName),
 	}
 
 	clientset := fake.NewClientset()
 
-	err := hetzner.EnsureSecretForTest(context.Background(), clientset, realToken, extraData)
+	err := hetzner.EnsureSecretForTest(context.Background(), clientset, envToken, extraData)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -227,11 +231,13 @@ func TestEnsureSecret_ExtraDataCannotOverrideToken(t *testing.T) {
 	}
 
 	// The "token" key must always come from the HCLOUD_TOKEN env var, not extraData.
-	if string(got.Data["token"]) != realToken {
-		t.Errorf("expected token from env var %q, got %q (extraData should not override token)", realToken, string(got.Data["token"]))
+	if string(got.Data["token"]) != envToken {
+		t.Errorf("expected token from env var %q, got %q",
+			envToken, string(got.Data["token"]))
 	}
 
-	if string(got.Data["network"]) != "dev-network" {
-		t.Errorf("expected network %q, got %q", "dev-network", string(got.Data["network"]))
+	if string(got.Data["network"]) != testNetworkName {
+		t.Errorf("expected network %q, got %q",
+			testNetworkName, string(got.Data["network"]))
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #4333

The upstream hcloud-ccm chart defaults `networking.network` to a `valueFrom.secretKeyRef` reading from the `hcloud` secret (key `network`). KSail's `buildValuesYaml()` was setting `networking.network.value` inline. Helm deep-merges these, producing an env var with both `value` and `valueFrom` — which Kubernetes rejects:

```
spec.template.spec.containers[0].env[3].valueFrom: Invalid value: "":
may not be specified when `value` is not empty
```

## Approach

Converge with the chart's built-in defaults: write the network name into the shared `hcloud` Kubernetes secret (key `network`) and let the chart's default `valueFrom.secretKeyRef` read it. No inline value override needed.

## Changes

- **`pkg/svc/installer/internal/hetzner/secret.go`** — Add `SecretData` field to `ChartConfig` and `Installer`. Thread `extraData` through `EnsureSecret`/`ensureSecret`/`InstallWithSecret`. Change `updateSecretIfNeeded` to merge desired keys into existing secret data (rather than replacing) so concurrent installers don't overwrite each other's keys.
- **`pkg/svc/installer/hcloudccm/installer.go`** — Pass `{"network": networkName}` as `SecretData`. Simplify `buildValuesYaml` to only set `networking.enabled` + `clusterCIDR` (no `network.value`).
- **Test files** — Update all `EnsureSecretForTest`/`EnsureSecret` calls with new signature, add `TestBuildSecretData`, update values assertions.

## Verification

- `go build ./...` ✅
- `go test ./pkg/svc/installer/...` — all hcloudccm, hetznercsi, and internal/hetzner tests pass ✅
- `helm template` confirms the chart renders `HCLOUD_NETWORK` with only `valueFrom` when using default networking config ✅