### PR TITLE
feat(workload): add native retry to push and reconcile commands

### DIFF
--- a/pkg/cli/cmd/workload/export_test.go
+++ b/pkg/cli/cmd/workload/export_test.go
@@ -253,20 +253,49 @@ func ExportPollUntilKustomizationReady(
 	return pollUntilKustomizationReady(ctx, fluxReconciler, name, dependsOn, failed)
 }
 
-// ExportPushMaxRetryAttempts allows tests to override the push retry attempt count.
-var ExportPushMaxRetryAttempts = &pushMaxRetryAttempts //nolint:gochecknoglobals // test export
+// SetPushRetryParamsForTests overrides push retry parameters for a test and
+// returns a cleanup function that restores the previous values.
+func SetPushRetryParamsForTests(maxAttempts int, baseWait, maxWait time.Duration) func() {
+	prevMaxAttempts := pushMaxRetryAttempts
+	prevBaseWait := pushRetryBaseWait
+	prevMaxWait := pushRetryMaxWait
 
-// ExportPushRetryBaseWait allows tests to override the push retry base wait duration.
-var ExportPushRetryBaseWait = &pushRetryBaseWait //nolint:gochecknoglobals // test export
+	pushMaxRetryAttempts = maxAttempts
+	pushRetryBaseWait = baseWait
+	pushRetryMaxWait = maxWait
 
-// ExportPushRetryMaxWait allows tests to override the push retry max wait duration.
-var ExportPushRetryMaxWait = &pushRetryMaxWait //nolint:gochecknoglobals // test export
+	return func() {
+		pushMaxRetryAttempts = prevMaxAttempts
+		pushRetryBaseWait = prevBaseWait
+		pushRetryMaxWait = prevMaxWait
+	}
+}
 
-// ExportReconcileMaxRetryAttempts allows tests to override the reconcile retry attempt count.
-var ExportReconcileMaxRetryAttempts = &reconcileMaxRetryAttempts //nolint:gochecknoglobals // test export
+// SetReconcileRetryParamsForTests overrides reconcile retry parameters for a
+// test and returns a cleanup function that restores the previous values.
+func SetReconcileRetryParamsForTests(maxAttempts int, baseWait, maxWait time.Duration) func() {
+	prevMaxAttempts := reconcileMaxRetryAttempts
+	prevBaseWait := reconcileRetryBaseWait
+	prevMaxWait := reconcileRetryMaxWait
 
-// ExportReconcileRetryBaseWait allows tests to override the reconcile retry base wait duration.
-var ExportReconcileRetryBaseWait = &reconcileRetryBaseWait //nolint:gochecknoglobals // test export
+	reconcileMaxRetryAttempts = maxAttempts
+	reconcileRetryBaseWait = baseWait
+	reconcileRetryMaxWait = maxWait
 
-// ExportReconcileRetryMaxWait allows tests to override the reconcile retry max wait duration.
-var ExportReconcileRetryMaxWait = &reconcileRetryMaxWait //nolint:gochecknoglobals // test export
+	return func() {
+		reconcileMaxRetryAttempts = prevMaxAttempts
+		reconcileRetryBaseWait = prevBaseWait
+		reconcileRetryMaxWait = prevMaxWait
+	}
+}
+
+// ExportRetryOnTransientError exposes retryOnTransientError for unit testing.
+func ExportRetryOnTransientError(
+	ctx context.Context,
+	cmd *cobra.Command,
+	maxAttempts int,
+	baseWait, maxWait time.Duration,
+	fn func() error,
+) error {
+	return retryOnTransientError(ctx, cmd, maxAttempts, baseWait, maxWait, fn)
+}

--- a/pkg/cli/cmd/workload/export_test.go
+++ b/pkg/cli/cmd/workload/export_test.go
@@ -252,3 +252,21 @@ func ExportPollUntilKustomizationReady(
 ) error {
 	return pollUntilKustomizationReady(ctx, fluxReconciler, name, dependsOn, failed)
 }
+
+// ExportPushMaxRetryAttempts allows tests to override the push retry attempt count.
+var ExportPushMaxRetryAttempts = &pushMaxRetryAttempts //nolint:gochecknoglobals // test export
+
+// ExportPushRetryBaseWait allows tests to override the push retry base wait duration.
+var ExportPushRetryBaseWait = &pushRetryBaseWait //nolint:gochecknoglobals // test export
+
+// ExportPushRetryMaxWait allows tests to override the push retry max wait duration.
+var ExportPushRetryMaxWait = &pushRetryMaxWait //nolint:gochecknoglobals // test export
+
+// ExportReconcileMaxRetryAttempts allows tests to override the reconcile retry attempt count.
+var ExportReconcileMaxRetryAttempts = &reconcileMaxRetryAttempts //nolint:gochecknoglobals // test export
+
+// ExportReconcileRetryBaseWait allows tests to override the reconcile retry base wait duration.
+var ExportReconcileRetryBaseWait = &reconcileRetryBaseWait //nolint:gochecknoglobals // test export
+
+// ExportReconcileRetryMaxWait allows tests to override the reconcile retry max wait duration.
+var ExportReconcileRetryMaxWait = &reconcileRetryMaxWait //nolint:gochecknoglobals // test export

--- a/pkg/cli/cmd/workload/export_test.go
+++ b/pkg/cli/cmd/workload/export_test.go
@@ -253,49 +253,13 @@ func ExportPollUntilKustomizationReady(
 	return pollUntilKustomizationReady(ctx, fluxReconciler, name, dependsOn, failed)
 }
 
-// SetPushRetryParamsForTests overrides push retry parameters for a test and
-// returns a cleanup function that restores the previous values.
-func SetPushRetryParamsForTests(maxAttempts int, baseWait, maxWait time.Duration) func() {
-	prevMaxAttempts := pushMaxRetryAttempts
-	prevBaseWait := pushRetryBaseWait
-	prevMaxWait := pushRetryMaxWait
-
-	pushMaxRetryAttempts = maxAttempts
-	pushRetryBaseWait = baseWait
-	pushRetryMaxWait = maxWait
-
-	return func() {
-		pushMaxRetryAttempts = prevMaxAttempts
-		pushRetryBaseWait = prevBaseWait
-		pushRetryMaxWait = prevMaxWait
-	}
-}
-
-// SetReconcileRetryParamsForTests overrides reconcile retry parameters for a
-// test and returns a cleanup function that restores the previous values.
-func SetReconcileRetryParamsForTests(maxAttempts int, baseWait, maxWait time.Duration) func() {
-	prevMaxAttempts := reconcileMaxRetryAttempts
-	prevBaseWait := reconcileRetryBaseWait
-	prevMaxWait := reconcileRetryMaxWait
-
-	reconcileMaxRetryAttempts = maxAttempts
-	reconcileRetryBaseWait = baseWait
-	reconcileRetryMaxWait = maxWait
-
-	return func() {
-		reconcileMaxRetryAttempts = prevMaxAttempts
-		reconcileRetryBaseWait = prevBaseWait
-		reconcileRetryMaxWait = prevMaxWait
-	}
-}
-
 // ExportRetryOnTransientError exposes retryOnTransientError for unit testing.
 func ExportRetryOnTransientError(
 	ctx context.Context,
 	cmd *cobra.Command,
 	maxAttempts int,
 	baseWait, maxWait time.Duration,
-	fn func() error,
+	operation func() error,
 ) error {
-	return retryOnTransientError(ctx, cmd, maxAttempts, baseWait, maxWait, fn)
+	return retryOnTransientError(ctx, cmd, maxAttempts, baseWait, maxWait, operation)
 }

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -1964,9 +1964,8 @@ const (
 )
 
 // Retry configuration for the push command.
-// Package-level vars allow test overrides via export_test.go.
 //
-//nolint:gochecknoglobals // package-level vars allow test overrides via export_test.go
+//nolint:gochecknoglobals // package-level vars for retry configuration
 var (
 	pushMaxRetryAttempts = 3
 	pushRetryBaseWait    = 5 * time.Second
@@ -1974,9 +1973,8 @@ var (
 )
 
 // Retry configuration for the reconcile command.
-// Package-level vars allow test overrides via export_test.go.
 //
-//nolint:gochecknoglobals // package-level vars allow test overrides via export_test.go
+//nolint:gochecknoglobals // package-level vars for retry configuration
 var (
 	reconcileMaxRetryAttempts = 3
 	reconcileRetryBaseWait    = 5 * time.Second
@@ -2118,6 +2116,10 @@ func runReconcile(cmd *cobra.Command) error {
 
 	tmr.NewStage()
 
+	// --timeout is a per-attempt bound: each retry attempt creates a fresh
+	// context.WithTimeout(timeout) inside executeReconciliation, so total
+	// runtime can be up to reconcileMaxRetryAttempts*timeout + cumulative
+	// backoff. This is intentional: each attempt deserves the full window.
 	err = retryOnTransientError(
 		cmd.Context(), cmd,
 		reconcileMaxRetryAttempts, reconcileRetryBaseWait, reconcileRetryMaxWait,

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -2017,16 +2017,16 @@ func retryOnTransientError(
 			attempt, maxAttempts, delay, lastErr,
 		)
 
-		t := time.NewTimer(delay)
+		retryTimer := time.NewTimer(delay)
 
 		select {
 		case <-ctx.Done():
-			if !t.Stop() {
-				<-t.C
+			if !retryTimer.Stop() {
+				<-retryTimer.C
 			}
 
 			return fmt.Errorf("retry cancelled: %w", ctx.Err())
-		case <-t.C:
+		case <-retryTimer.C:
 		}
 	}
 

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -1993,7 +1993,7 @@ func retryOnTransientError(
 	cmd *cobra.Command,
 	maxAttempts int,
 	baseWait, maxWait time.Duration,
-	fn func() error,
+	operation func() error,
 ) error {
 	if maxAttempts < 1 {
 		maxAttempts = 1
@@ -2002,7 +2002,7 @@ func retryOnTransientError(
 	var lastErr error
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err := fn()
+		err := operation()
 		if err == nil {
 			return nil
 		}

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -1995,6 +1995,10 @@ func retryOnTransientError(
 	baseWait, maxWait time.Duration,
 	fn func() error,
 ) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
 	var lastErr error
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -32,6 +32,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/client/kubeconform"
 	"github.com/devantler-tech/ksail/v7/pkg/client/kubectl"
 	"github.com/devantler-tech/ksail/v7/pkg/client/kustomize"
+	"github.com/devantler-tech/ksail/v7/pkg/client/netretry"
 	"github.com/devantler-tech/ksail/v7/pkg/client/oci"
 	reconcilerclient "github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
 	"github.com/devantler-tech/ksail/v7/pkg/di"
@@ -1628,7 +1629,13 @@ func runPushCommand(
 		}
 	}
 
-	return buildAndPushArtifact(cmd, params, outputTimer)
+	return retryOnTransientError(
+		cmd.Context(), cmd,
+		pushMaxRetryAttempts, pushRetryBaseWait, pushRetryMaxWait,
+		func() error {
+			return buildAndPushArtifact(cmd, params, outputTimer)
+		},
+	)
 }
 
 // validateManifests runs manifest validation and reports progress.
@@ -1956,6 +1963,80 @@ const (
 	kwokReconcileSkipMsg = "KWOK distribution: GitOps controllers are simulated and cannot sync — reconciliation skipped"
 )
 
+// Retry configuration for the push command.
+// Package-level vars allow test overrides via export_test.go.
+//
+//nolint:gochecknoglobals // package-level vars allow test overrides via export_test.go
+var (
+	pushMaxRetryAttempts = 3
+	pushRetryBaseWait    = 5 * time.Second
+	pushRetryMaxWait     = 30 * time.Second
+)
+
+// Retry configuration for the reconcile command.
+// Package-level vars allow test overrides via export_test.go.
+//
+//nolint:gochecknoglobals // package-level vars allow test overrides via export_test.go
+var (
+	reconcileMaxRetryAttempts = 3
+	reconcileRetryBaseWait    = 5 * time.Second
+	reconcileRetryMaxWait     = 30 * time.Second
+)
+
+// retryOnTransientError retries fn up to maxAttempts times when the returned
+// error is transient according to netretry.IsRetryable. It uses exponential
+// backoff between attempts and emits a warning notification on each retry so
+// the user can see what is happening. Returns nil on the first successful
+// attempt, or the last error once all attempts are exhausted.
+func retryOnTransientError(
+	ctx context.Context,
+	cmd *cobra.Command,
+	maxAttempts int,
+	baseWait, maxWait time.Duration,
+	fn func() error,
+) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		if !netretry.IsRetryable(lastErr) || attempt == maxAttempts {
+			break
+		}
+
+		delay := netretry.ExponentialDelay(attempt, baseWait, maxWait)
+
+		notify.Warningf(
+			cmd.OutOrStdout(),
+			"attempt %d/%d failed (retrying in %s): %v",
+			attempt, maxAttempts, delay, lastErr,
+		)
+
+		t := time.NewTimer(delay)
+
+		select {
+		case <-ctx.Done():
+			if !t.Stop() {
+				<-t.C
+			}
+
+			return fmt.Errorf("retry cancelled: %w", ctx.Err())
+		case <-t.C:
+		}
+	}
+
+	if !netretry.IsRetryable(lastErr) {
+		return lastErr
+	}
+
+	return fmt.Errorf("failed after %d attempts: %w", maxAttempts, lastErr)
+}
+
 // getKubeconfigPath returns the kubeconfig path from config or default.
 func getKubeconfigPath(clusterCfg *v1alpha1.Cluster) (string, error) {
 	kubeconfigPath := strings.TrimSpace(clusterCfg.Spec.Cluster.Connection.Kubeconfig)
@@ -2033,7 +2114,13 @@ func runReconcile(cmd *cobra.Command) error {
 
 	tmr.NewStage()
 
-	err = executeReconciliation(cmd, clusterCfg, gitOpsEngine, timeout, outputTimer)
+	err = retryOnTransientError(
+		cmd.Context(), cmd,
+		reconcileMaxRetryAttempts, reconcileRetryBaseWait, reconcileRetryMaxWait,
+		func() error {
+			return executeReconciliation(cmd, clusterCfg, gitOpsEngine, timeout, outputTimer)
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/workload/workload_pure_test.go
+++ b/pkg/cli/cmd/workload/workload_pure_test.go
@@ -865,6 +865,16 @@ func TestFindKustomizationDir_FileInRoot(t *testing.T) {
 // retryOnTransientError — retry helper behavior
 // ===========================================================================
 
+// Test sentinel errors for retryOnTransientError tests.
+//
+//nolint:gochecknoglobals // test sentinel errors follow the same pattern as pkg/svc/registryresolver/oci_test.go
+var (
+	errRetryNotTransient     = errors.New("not a transient error")
+	errRetryConnectionReset  = errors.New("connection reset by peer")
+	errRetryServiceUnavail   = errors.New("Service Unavailable")
+	errRetryDeadlineExceeded = errors.New("context deadline exceeded")
+)
+
 func TestRetryOnTransientError_SuccessFirstAttempt(t *testing.T) {
 	t.Parallel()
 
@@ -879,7 +889,7 @@ func TestRetryOnTransientError_SuccessFirstAttempt(t *testing.T) {
 		},
 	)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
 }
 
@@ -888,17 +898,16 @@ func TestRetryOnTransientError_NonRetryableError(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	calls := 0
-	sentinel := errors.New("not a transient error")
 
 	err := workload.ExportRetryOnTransientError(
 		t.Context(), cmd, 3, 0, 0,
 		func() error {
 			calls++
-			return sentinel
+			return errRetryNotTransient
 		},
 	)
 
-	assert.ErrorIs(t, err, sentinel)
+	require.ErrorIs(t, err, errRetryNotTransient)
 	assert.Equal(t, 1, calls, "non-retryable error should not be retried")
 }
 
@@ -907,13 +916,12 @@ func TestRetryOnTransientError_RetryableExhausted(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	calls := 0
-	transient := errors.New("connection reset by peer")
 
 	err := workload.ExportRetryOnTransientError(
 		t.Context(), cmd, 3, 0, 0,
 		func() error {
 			calls++
-			return transient
+			return errRetryConnectionReset
 		},
 	)
 
@@ -933,13 +941,13 @@ func TestRetryOnTransientError_SucceedsAfterRetry(t *testing.T) {
 		func() error {
 			calls++
 			if calls < 3 {
-				return errors.New("Service Unavailable")
+				return errRetryServiceUnavail
 			}
 			return nil
 		},
 	)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 3, calls)
 }
 
@@ -955,7 +963,7 @@ func TestRetryOnTransientError_ContextCancelled(t *testing.T) {
 		func() error {
 			calls++
 			cancel()
-			return errors.New("context deadline exceeded")
+			return errRetryDeadlineExceeded
 		},
 	)
 
@@ -977,6 +985,6 @@ func TestRetryOnTransientError_ZeroMaxAttemptsClampedToOne(t *testing.T) {
 		},
 	)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 1, calls, "maxAttempts=0 should be clamped to 1 so fn is always called")
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "maxAttempts=0 should be clamped to 1 so operation is always called")
 }

--- a/pkg/cli/cmd/workload/workload_pure_test.go
+++ b/pkg/cli/cmd/workload/workload_pure_test.go
@@ -867,7 +867,7 @@ func TestFindKustomizationDir_FileInRoot(t *testing.T) {
 
 // Test sentinel errors for retryOnTransientError tests.
 //
-//nolint:gochecknoglobals // test sentinel errors follow the same pattern as pkg/svc/registryresolver/oci_test.go
+
 var (
 	errRetryNotTransient     = errors.New("not a transient error")
 	errRetryConnectionReset  = errors.New("connection reset by peer")
@@ -885,6 +885,7 @@ func TestRetryOnTransientError_SuccessFirstAttempt(t *testing.T) {
 		t.Context(), cmd, 3, 0, 0,
 		func() error {
 			calls++
+
 			return nil
 		},
 	)
@@ -903,6 +904,7 @@ func TestRetryOnTransientError_NonRetryableError(t *testing.T) {
 		t.Context(), cmd, 3, 0, 0,
 		func() error {
 			calls++
+
 			return errRetryNotTransient
 		},
 	)
@@ -921,6 +923,7 @@ func TestRetryOnTransientError_RetryableExhausted(t *testing.T) {
 		t.Context(), cmd, 3, 0, 0,
 		func() error {
 			calls++
+
 			return errRetryConnectionReset
 		},
 	)
@@ -943,6 +946,7 @@ func TestRetryOnTransientError_SucceedsAfterRetry(t *testing.T) {
 			if calls < 3 {
 				return errRetryServiceUnavail
 			}
+
 			return nil
 		},
 	)
@@ -962,7 +966,9 @@ func TestRetryOnTransientError_ContextCancelled(t *testing.T) {
 		ctx, cmd, 5, time.Millisecond, time.Millisecond,
 		func() error {
 			calls++
+
 			cancel()
+
 			return errRetryDeadlineExceeded
 		},
 	)
@@ -981,6 +987,7 @@ func TestRetryOnTransientError_ZeroMaxAttemptsClampedToOne(t *testing.T) {
 		t.Context(), cmd, 0, 0, 0,
 		func() error {
 			calls++
+
 			return nil
 		},
 	)

--- a/pkg/cli/cmd/workload/workload_pure_test.go
+++ b/pkg/cli/cmd/workload/workload_pure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -879,6 +880,7 @@ func TestRetryOnTransientError_SuccessFirstAttempt(t *testing.T) {
 	t.Parallel()
 
 	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -898,6 +900,7 @@ func TestRetryOnTransientError_NonRetryableError(t *testing.T) {
 	t.Parallel()
 
 	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -917,6 +920,7 @@ func TestRetryOnTransientError_RetryableExhausted(t *testing.T) {
 	t.Parallel()
 
 	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -937,6 +941,7 @@ func TestRetryOnTransientError_SucceedsAfterRetry(t *testing.T) {
 	t.Parallel()
 
 	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -960,6 +965,7 @@ func TestRetryOnTransientError_ContextCancelled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -981,6 +987,7 @@ func TestRetryOnTransientError_ZeroMaxAttemptsClampedToOne(t *testing.T) {
 	t.Parallel()
 
 	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(

--- a/pkg/cli/cmd/workload/workload_pure_test.go
+++ b/pkg/cli/cmd/workload/workload_pure_test.go
@@ -881,6 +881,7 @@ func TestRetryOnTransientError_SuccessFirstAttempt(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
+
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -901,6 +902,7 @@ func TestRetryOnTransientError_NonRetryableError(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
+
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -921,6 +923,7 @@ func TestRetryOnTransientError_RetryableExhausted(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
+
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -942,6 +945,7 @@ func TestRetryOnTransientError_SucceedsAfterRetry(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
+
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -966,6 +970,7 @@ func TestRetryOnTransientError_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
+
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(
@@ -988,6 +993,7 @@ func TestRetryOnTransientError_ZeroMaxAttemptsClampedToOne(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
+
 	calls := 0
 
 	err := workload.ExportRetryOnTransientError(

--- a/pkg/cli/cmd/workload/workload_pure_test.go
+++ b/pkg/cli/cmd/workload/workload_pure_test.go
@@ -1,7 +1,9 @@
 package workload_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +13,7 @@ import (
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/workload"
 	dockerprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/docker"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -856,4 +859,124 @@ func TestFindKustomizationDir_FileInRoot(t *testing.T) {
 
 	result := workload.ExportFindKustomizationDir(testFile, dir)
 	assert.Equal(t, dir, result)
+}
+
+// ===========================================================================
+// retryOnTransientError — retry helper behavior
+// ===========================================================================
+
+func TestRetryOnTransientError_SuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	calls := 0
+
+	err := workload.ExportRetryOnTransientError(
+		t.Context(), cmd, 3, 0, 0,
+		func() error {
+			calls++
+			return nil
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnTransientError_NonRetryableError(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	calls := 0
+	sentinel := errors.New("not a transient error")
+
+	err := workload.ExportRetryOnTransientError(
+		t.Context(), cmd, 3, 0, 0,
+		func() error {
+			calls++
+			return sentinel
+		},
+	)
+
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, calls, "non-retryable error should not be retried")
+}
+
+func TestRetryOnTransientError_RetryableExhausted(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	calls := 0
+	transient := errors.New("connection reset by peer")
+
+	err := workload.ExportRetryOnTransientError(
+		t.Context(), cmd, 3, 0, 0,
+		func() error {
+			calls++
+			return transient
+		},
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, 3, calls, "should retry until maxAttempts exhausted")
+	assert.ErrorContains(t, err, "failed after 3 attempts")
+}
+
+func TestRetryOnTransientError_SucceedsAfterRetry(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	calls := 0
+
+	err := workload.ExportRetryOnTransientError(
+		t.Context(), cmd, 3, 0, 0,
+		func() error {
+			calls++
+			if calls < 3 {
+				return errors.New("Service Unavailable")
+			}
+			return nil
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestRetryOnTransientError_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cmd := &cobra.Command{}
+	calls := 0
+
+	err := workload.ExportRetryOnTransientError(
+		ctx, cmd, 5, time.Millisecond, time.Millisecond,
+		func() error {
+			calls++
+			cancel()
+			return errors.New("context deadline exceeded")
+		},
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "context cancel should stop retries")
+}
+
+func TestRetryOnTransientError_ZeroMaxAttemptsClampedToOne(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	calls := 0
+
+	err := workload.ExportRetryOnTransientError(
+		t.Context(), cmd, 0, 0, 0,
+		func() error {
+			calls++
+			return nil
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls, "maxAttempts=0 should be clamped to 1 so fn is always called")
 }

--- a/pkg/cli/cmd/workload/workload_pure_test.go
+++ b/pkg/cli/cmd/workload/workload_pure_test.go
@@ -871,7 +871,7 @@ func TestFindKustomizationDir_FileInRoot(t *testing.T) {
 var (
 	errRetryNotTransient     = errors.New("not a transient error")
 	errRetryConnectionReset  = errors.New("connection reset by peer")
-	errRetryServiceUnavail   = errors.New("Service Unavailable")
+	errRetryServiceUnavail   = errors.New("503 Service Unavailable")
 	errRetryDeadlineExceeded = errors.New("context deadline exceeded")
 )
 


### PR DESCRIPTION
## Summary

Adds command-level retry to `ksail workload push` and `ksail workload reconcile` so ksail handles transient failures natively, eliminating the need for caller-side retry shell scripts (supersedes #4350).

## Failure modes addressed

- **push**: GHCR rate-limiting (429) or 5xx during OCI artifact upload
- **reconcile**: Flux/ArgoCD timeout (`context deadline exceeded`) under CI load

## What changed

### `pkg/cli/cmd/workload/workload.go`

- Imports `pkg/client/netretry`
- Adds retry configuration vars for push (3 attempts, 5–30s exponential) and reconcile (3 attempts, 5–30s exponential) as package-level vars
- Adds `retryOnTransientError` helper — mirrors the pattern in `pkg/svc/registryresolver/oci.go`; uses `netretry.IsRetryable` as the predicate; emits `notify.Warningf` on each retry
- Wraps `buildAndPushArtifact` in `runPushCommand` with the retry helper
- Wraps `executeReconciliation` in `runReconcile` with the retry helper

### `pkg/cli/cmd/workload/export_test.go`

- Exports `ExportRetryOnTransientError` so unit tests can call the helper directly with custom `maxAttempts`, `baseWait`, and `maxWait` — no per-var pointer exports needed

### `pkg/cli/cmd/workload/workload_pure_test.go`

- Adds six `TestRetryOnTransientError_*` tests covering: success first attempt, non-retryable error, retryable exhausted, success after retry, context cancellation, and zero maxAttempts clamped to 1

## Why command-level retry (not low-level)

`workload push` previously only had low-level per-`remote.Write` retries (3 attempts, 2–10s) inside `pkg/client/oci`. The higher-level build+push-cycle retry in `pkg/svc/registryresolver` (`retryExternalPush`) is only used by lifecycle commands. The new wrapper covers the full push cycle.

`workload reconcile` had no retry at all.

## No new flags

Retries are an internal reliability concern — not user-configurable behavior.

Fixes #4335
Supersedes #4350