### PR TITLE
fix(kyverno): wait for MutatingWebhookConfiguration caBundle before returning from Install

### DIFF
--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -88,7 +88,7 @@ func policyEngineFactory(
 			return nil, ErrPolicyEngineDisabled
 		}
 
-		helmClient, _, err := factories.HelmClientFactory(clusterCfg)
+		helmClient, kubeconfig, err := factories.HelmClientFactory(clusterCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +100,7 @@ func policyEngineFactory(
 		case v1alpha1.PolicyEngineKyverno:
 			timeout = max(timeout, installer.KyvernoInstallTimeout)
 
-			return kyvernoinstaller.NewInstaller(helmClient, timeout), nil
+			return kyvernoinstaller.NewInstaller(helmClient, timeout, kubeconfig, clusterCfg.Spec.Cluster.Connection.Context), nil
 		case v1alpha1.PolicyEngineGatekeeper:
 			timeout = max(timeout, installer.GatekeeperInstallTimeout)
 

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -100,7 +100,9 @@ func policyEngineFactory(
 		case v1alpha1.PolicyEngineKyverno:
 			timeout = max(timeout, installer.KyvernoInstallTimeout)
 
-			return kyvernoinstaller.NewInstaller(helmClient, timeout, kubeconfig, clusterCfg.Spec.Cluster.Connection.Context), nil
+			return kyvernoinstaller.NewInstaller(
+				helmClient, timeout, kubeconfig, clusterCfg.Spec.Cluster.Connection.Context,
+			), nil
 		case v1alpha1.PolicyEngineGatekeeper:
 			timeout = max(timeout, installer.GatekeeperInstallTimeout)
 

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -100,11 +100,13 @@ const (
 	// kubelet-serving-cert-approver deployment (from Talos inlineManifests) to
 	// become ready. The approver pod starts at cluster creation (before CNI),
 	// so it enters CrashLoopBackOff while CNI is unavailable. When a
-	// sequential pre-phase (e.g. cert-manager) precedes the main infra phase,
-	// the pod may be in an 80–160 s backoff cycle by the time the wait starts.
-	// Five minutes covers up to two additional CrashLoopBackOff cycles after
-	// the pre-phase completes and CNI is available.
-	csrApproverReadinessTimeout = 5 * time.Minute
+	// sequential pre-phase (e.g. cert-manager) precedes the main infra phase
+	// and a slower CNI (e.g. Cilium) is used, the pod can be in a 160–300 s
+	// backoff cycle by the time the wait starts. Ten minutes provides enough
+	// headroom for the pod to exit CrashLoopBackOff, restart, and pass its
+	// readiness probe even in the worst-case combination of Cilium CNI and a
+	// cert-manager pre-phase.
+	csrApproverReadinessTimeout = 10 * time.Minute
 )
 
 // apiServerStabilitySuccesses returns the number of consecutive successful

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -98,10 +98,13 @@ const (
 
 	// csrApproverReadinessTimeout is the maximum time to wait for the
 	// kubelet-serving-cert-approver deployment (from Talos inlineManifests) to
-	// become ready. After CNI is installed, the approver pod needs to be
-	// scheduled, pull its image, start, and begin approving kubelet serving
-	// CSRs. Two minutes accommodates image pulls on fresh cloud nodes.
-	csrApproverReadinessTimeout = 2 * time.Minute
+	// become ready. The approver pod starts at cluster creation (before CNI),
+	// so it enters CrashLoopBackOff while CNI is unavailable. When a
+	// sequential pre-phase (e.g. cert-manager) precedes the main infra phase,
+	// the pod may be in an 80–160 s backoff cycle by the time the wait starts.
+	// Five minutes covers up to two additional CrashLoopBackOff cycles after
+	// the pre-phase completes and CNI is available.
+	csrApproverReadinessTimeout = 5 * time.Minute
 )
 
 // apiServerStabilitySuccesses returns the number of consecutive successful

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -471,6 +471,30 @@ func installComponentsInPhases(
 	writer := cmd.OutOrStdout()
 	labels := notify.InstallingLabels()
 
+	// When cert-manager and a policy engine are both needed, install cert-manager
+	// first in its own sequential phase before the parallel infrastructure phase.
+	// This ensures cert-manager is fully ready (webhook + cainjector up) when the
+	// policy engine starts — otherwise cert issuance for Kyverno's webhook TLS can
+	// take 15-20+ minutes because cert-manager is still initialising.
+	if reqs.NeedsCertManager && reqs.NeedsPolicyEngine {
+		certManagerTask := newTask("cert-manager", clusterCfg, factories, InstallCertManagerSilent)
+
+		err := runInfraPhase(
+			ctx, clusterCfg, writer, labels, tmr,
+			[]notify.ProgressTask{certManagerTask},
+			cniInstalled, false,
+		)
+		if err != nil {
+			return err
+		}
+
+		// cert-manager is installed; exclude it from the parallel infra phase below.
+		// Also clear cniInstalled so the main phase runs the full stability check
+		// (node readiness + kube-system DaemonSets) rather than the abbreviated one.
+		reqs.NeedsCertManager = false
+		cniInstalled = false
+	}
+
 	infraTasks := buildInfrastructureTasks(clusterCfg, factories, reqs)
 	if len(infraTasks) > 0 {
 		needsCSRApproverWait := reqs.NeedsMetricsServer &&
@@ -504,10 +528,11 @@ func installComponentsInPhases(
 	return nil
 }
 
-// runInfraPhase installs Phase 1 infrastructure components (metrics-server,
-// load-balancer, kubelet-csr-approver, CSI, cert-manager, policy-engine).
-// For Cilium CNI, a pre-flight stability check ensures the eBPF dataplane
-// has programmed pod-to-service routing before components are deployed.
+// runInfraPhase runs a set of infrastructure tasks in parallel, preceded by a
+// pre-flight stability check for Cilium CNI and an optional CSR approver wait.
+// It is safe to call multiple times (e.g., once for cert-manager, once for the
+// remaining components). The stability check completes quickly when the cluster
+// is already stable after a previous call.
 // cniInstalled indicates whether CNI was just installed — when true, the node
 // readiness check in the stability pre-flight is skipped.
 // needsCSRApproverWait indicates whether to wait for the kubelet-serving-cert-approver

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
+	installer "github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/timer"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -279,4 +282,90 @@ func TestRunInfraPhase_SkipsCSRApproverWaitWhenNotNeeded(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, approverWaitCalled,
 		"CSR approver wait should NOT be called when needsCSRApproverWait is false")
+}
+
+// mockInstaller is a minimal installer.Installer implementation for testing.
+type mockInstallerType struct {
+	install func(ctx context.Context) error
+}
+
+func (m *mockInstallerType) Install(ctx context.Context) error {
+	if m.install != nil {
+		return m.install(ctx)
+	}
+
+	return nil
+}
+
+func (m *mockInstallerType) Uninstall(context.Context) error { return nil }
+
+func (m *mockInstallerType) Images(context.Context) ([]string, error) { return nil, nil }
+
+var _ installer.Installer = (*mockInstallerType)(nil)
+
+func TestInstallComponentsInPhases_CertManagerRunsBeforePolicyEngine(t *testing.T) {
+	// When both cert-manager and a policy engine are needed, cert-manager must be
+	// installed in a dedicated sequential pre-phase before the parallel infra phase
+	// that installs the policy engine. This prevents the cert-issuance race where
+	// Kyverno requests a TLS cert before cert-manager is ready.
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionVanilla,
+				PolicyEngine: v1alpha1.PolicyEngineKyverno,
+				CertManager:  v1alpha1.CertManagerEnabled,
+			},
+		},
+	}
+
+	var (
+		orderMu sync.Mutex
+		order   []string
+	)
+
+	makeInstaller := func(name string) func(*v1alpha1.Cluster) (installer.Installer, error) {
+		return func(*v1alpha1.Cluster) (installer.Installer, error) {
+			return &mockInstallerType{
+				install: func(context.Context) error {
+					orderMu.Lock()
+					defer orderMu.Unlock()
+
+					order = append(order, name)
+
+					return nil
+				},
+			}, nil
+		}
+	}
+
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error {
+			return nil
+		},
+	))
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetOut(io.Discard)
+
+	factories := &InstallerFactories{
+		CertManager:  makeInstaller("cert-manager"),
+		PolicyEngine: makeInstaller("policy-engine"),
+	}
+
+	reqs := ComponentRequirements{
+		NeedsCertManager:  true,
+		NeedsPolicyEngine: true,
+	}
+
+	tmr := timer.New()
+	err := installComponentsInPhases(
+		context.Background(), cmd, clusterCfg, factories, tmr, reqs, false,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, order, 2, "both cert-manager and policy-engine should have been installed")
+	assert.Equal(t, "cert-manager", order[0],
+		"cert-manager must be installed before policy-engine")
+	assert.Equal(t, "policy-engine", order[1],
+		"policy-engine must be installed after cert-manager")
 }

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -285,11 +285,11 @@ func TestRunInfraPhase_SkipsCSRApproverWaitWhenNotNeeded(t *testing.T) {
 }
 
 // mockInstaller is a minimal installer.Installer implementation for testing.
-type mockInstallerType struct {
+type mockInstaller struct {
 	install func(ctx context.Context) error
 }
 
-func (m *mockInstallerType) Install(ctx context.Context) error {
+func (m *mockInstaller) Install(ctx context.Context) error {
 	if m.install != nil {
 		return m.install(ctx)
 	}
@@ -297,11 +297,11 @@ func (m *mockInstallerType) Install(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockInstallerType) Uninstall(context.Context) error { return nil }
+func (m *mockInstaller) Uninstall(context.Context) error { return nil }
 
-func (m *mockInstallerType) Images(context.Context) ([]string, error) { return nil, nil }
+func (m *mockInstaller) Images(context.Context) ([]string, error) { return nil, nil }
 
-var _ installer.Installer = (*mockInstallerType)(nil)
+var _ installer.Installer = (*mockInstaller)(nil)
 
 func TestInstallComponentsInPhases_CertManagerRunsBeforePolicyEngine(t *testing.T) {
 	// When both cert-manager and a policy engine are needed, cert-manager must be
@@ -325,7 +325,7 @@ func TestInstallComponentsInPhases_CertManagerRunsBeforePolicyEngine(t *testing.
 
 	makeInstaller := func(name string) func(*v1alpha1.Cluster) (installer.Installer, error) {
 		return func(*v1alpha1.Cluster) (installer.Installer, error) {
-			return &mockInstallerType{
+			return &mockInstaller{
 				install: func(context.Context) error {
 					orderMu.Lock()
 					defer orderMu.Unlock()

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -148,7 +148,7 @@ func (f *Factory) addPolicyEngineInstaller(
 	switch spec.PolicyEngine {
 	case v1alpha1.PolicyEngineKyverno:
 		installers["kyverno"] = kyvernoinstaller.NewInstaller(
-			f.helmClient, max(f.timeout, KyvernoInstallTimeout),
+			f.helmClient, max(f.timeout, KyvernoInstallTimeout), f.kubeconfig, f.kubecontext,
 		)
 	case v1alpha1.PolicyEngineGatekeeper:
 		installers["gatekeeper"] = gatekeeperinstaller.NewInstaller(

--- a/pkg/svc/installer/helpers.go
+++ b/pkg/svc/installer/helpers.go
@@ -24,7 +24,8 @@ const (
 	// extra time for multiple deployments and CRDs to become ready (admission-controller,
 	// background-controller, cleanup-controller, reports-controller, and policy CRDs), and
 	// for cert-manager's cainjector to populate the MutatingWebhookConfiguration caBundle.
-	KyvernoInstallTimeout = 15 * time.Minute
+	// K3s distributions with CNI+CSI enabled take longer due to additional resource pressure.
+	KyvernoInstallTimeout = 20 * time.Minute
 	// CertManagerInstallTimeout is the timeout for cert-manager installs, which need
 	// extra time for multiple deployments and webhook configurations to become ready.
 	CertManagerInstallTimeout = 10 * time.Minute

--- a/pkg/svc/installer/helpers.go
+++ b/pkg/svc/installer/helpers.go
@@ -22,9 +22,10 @@ const (
 	CalicoInstallTimeout = 10 * time.Minute
 	// KyvernoInstallTimeout is the timeout for Kyverno policy engine installs, which need
 	// extra time for multiple deployments and CRDs to become ready (admission-controller,
-	// background-controller, cleanup-controller, reports-controller, and policy CRDs), and
-	// for cert-manager's cainjector to populate the MutatingWebhookConfiguration caBundle.
+	// background-controller, cleanup-controller, reports-controller, and policy CRDs).
 	// K3s distributions with CNI+CSI enabled take longer due to additional resource pressure.
+	// Note: caBundle injection into the MutatingWebhookConfiguration is handled separately
+	// as a best-effort check with its own independent timeout (see webhookReadinessTimeout).
 	KyvernoInstallTimeout = 20 * time.Minute
 	// CertManagerInstallTimeout is the timeout for cert-manager installs, which need
 	// extra time for multiple deployments and webhook configurations to become ready.

--- a/pkg/svc/installer/helpers.go
+++ b/pkg/svc/installer/helpers.go
@@ -22,8 +22,9 @@ const (
 	CalicoInstallTimeout = 10 * time.Minute
 	// KyvernoInstallTimeout is the timeout for Kyverno policy engine installs, which need
 	// extra time for multiple deployments and CRDs to become ready (admission-controller,
-	// background-controller, cleanup-controller, reports-controller, and policy CRDs).
-	KyvernoInstallTimeout = 10 * time.Minute
+	// background-controller, cleanup-controller, reports-controller, and policy CRDs), and
+	// for cert-manager's cainjector to populate the MutatingWebhookConfiguration caBundle.
+	KyvernoInstallTimeout = 15 * time.Minute
 	// CertManagerInstallTimeout is the timeout for cert-manager installs, which need
 	// extra time for multiple deployments and webhook configurations to become ready.
 	CertManagerInstallTimeout = 10 * time.Minute

--- a/pkg/svc/installer/helpers_test.go
+++ b/pkg/svc/installer/helpers_test.go
@@ -160,7 +160,7 @@ func TestTimeoutConstants(t *testing.T) {
 
 	t.Run("kyverno_install_timeout", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, 15*time.Minute, installer.KyvernoInstallTimeout)
+		assert.Equal(t, 20*time.Minute, installer.KyvernoInstallTimeout)
 	})
 
 	t.Run("argocd_install_timeout", func(t *testing.T) {

--- a/pkg/svc/installer/helpers_test.go
+++ b/pkg/svc/installer/helpers_test.go
@@ -160,7 +160,7 @@ func TestTimeoutConstants(t *testing.T) {
 
 	t.Run("kyverno_install_timeout", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, 10*time.Minute, installer.KyvernoInstallTimeout)
+		assert.Equal(t, 15*time.Minute, installer.KyvernoInstallTimeout)
 	})
 
 	t.Run("argocd_install_timeout", func(t *testing.T) {

--- a/pkg/svc/installer/kyverno/export_test.go
+++ b/pkg/svc/installer/kyverno/export_test.go
@@ -4,7 +4,7 @@ import "k8s.io/client-go/kubernetes"
 
 // SetNewClientsetFn overrides the clientset factory for testing.
 // Returns a cleanup function that restores the original factory.
-func SetNewClientsetFn(fn func(kubeconfig, context string) (kubernetes.Interface, error)) func() {
+func SetNewClientsetFn(fn func(kubeconfig, kubecontext string) (kubernetes.Interface, error)) func() {
 	original := newClientsetFn
 	newClientsetFn = fn
 

--- a/pkg/svc/installer/kyverno/export_test.go
+++ b/pkg/svc/installer/kyverno/export_test.go
@@ -4,7 +4,9 @@ import "k8s.io/client-go/kubernetes"
 
 // SetNewClientsetFn overrides the clientset factory for testing.
 // Returns a cleanup function that restores the original factory.
-func SetNewClientsetFn(fn func(kubeconfig, kubecontext string) (kubernetes.Interface, error)) func() {
+func SetNewClientsetFn(
+	fn func(kubeconfig, kubecontext string) (kubernetes.Interface, error),
+) func() {
 	original := newClientsetFn
 	newClientsetFn = fn
 

--- a/pkg/svc/installer/kyverno/export_test.go
+++ b/pkg/svc/installer/kyverno/export_test.go
@@ -1,0 +1,12 @@
+package kyvernoinstaller
+
+import "k8s.io/client-go/kubernetes"
+
+// SetNewClientsetFn overrides the clientset factory for testing.
+// Returns a cleanup function that restores the original factory.
+func SetNewClientsetFn(fn func(kubeconfig, context string) (kubernetes.Interface, error)) func() {
+	original := newClientsetFn
+	newClientsetFn = fn
+
+	return func() { newClientsetFn = original }
+}

--- a/pkg/svc/installer/kyverno/export_test.go
+++ b/pkg/svc/installer/kyverno/export_test.go
@@ -1,6 +1,10 @@
 package kyvernoinstaller
 
-import "k8s.io/client-go/kubernetes"
+import (
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+)
 
 // SetNewClientsetFn overrides the clientset factory for testing.
 // Returns a cleanup function that restores the original factory.
@@ -11,4 +15,13 @@ func SetNewClientsetFn(
 	newClientsetFn = fn
 
 	return func() { newClientsetFn = original }
+}
+
+// SetWebhookReadinessTimeout overrides the webhook readiness timeout for testing.
+// Returns a cleanup function that restores the original timeout.
+func SetWebhookReadinessTimeout(d time.Duration) func() {
+	original := webhookReadinessTimeout
+	webhookReadinessTimeout = d
+
+	return func() { webhookReadinessTimeout = original }
 }

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -1,6 +1,8 @@
 package kyvernoinstaller
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
@@ -9,13 +11,21 @@ import (
 
 // Installer installs or upgrades Kyverno.
 //
-// It embeds helmutil.Base to provide standard Helm chart lifecycle management.
+// It embeds helmutil.Base to provide standard Helm chart lifecycle management
+// and adds a post-install webhook readiness wait to ensure the admission
+// controller is accepting requests before returning.
 type Installer struct {
 	*helmutil.Base
+
+	kubeconfig string
+	context    string
+	timeout    time.Duration
 }
 
 // NewInstaller creates a new Kyverno installer instance.
-func NewInstaller(client helm.Interface, timeout time.Duration) *Installer {
+// kubeconfig and context are used after Helm install to wait for the Kyverno
+// admission webhook to be ready before returning.
+func NewInstaller(client helm.Interface, timeout time.Duration, kubeconfig, context string) *Installer {
 	return &Installer{
 		Base: helmutil.NewBase(
 			"kyverno",
@@ -46,5 +56,25 @@ func NewInstaller(client helm.Interface, timeout time.Duration) *Installer {
 				},
 			},
 		),
+		kubeconfig: kubeconfig,
+		context:    context,
+		timeout:    timeout,
 	}
+}
+
+// Install installs or upgrades Kyverno via its Helm chart, then waits for the
+// admission webhook to be ready before returning. This extra wait prevents the
+// race condition where Helm reports install success but the webhook server has
+// not yet populated its caBundle, causing transient admission failures for the
+// first workload operations after cluster setup.
+func (i *Installer) Install(ctx context.Context) error {
+	if err := i.Base.Install(ctx); err != nil {
+		return err
+	}
+
+	if err := i.waitForWebhookReady(ctx); err != nil {
+		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -75,7 +75,7 @@ func (i *Installer) Install(ctx context.Context) error {
 	defer cancel()
 
 	if err := i.Base.Install(overallCtx); err != nil {
-		return err
+		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
 	if err := i.waitForWebhookReady(overallCtx); err != nil {

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -83,7 +83,7 @@ func (i *Installer) Install(ctx context.Context) error {
 		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
-	err := i.waitForWebhookReady(overallCtx)
+	err = i.waitForWebhookReady(overallCtx)
 	if err != nil {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -85,7 +85,8 @@ func (i *Installer) Install(ctx context.Context) error {
 	webhookCtx, webhookCancel := context.WithTimeout(context.Background(), i.timeout)
 	defer webhookCancel()
 
-	err = i.waitForWebhookReady(webhookCtx) //nolint:contextcheck // intentionally uses context.Background() so the webhook waiter always gets a full independent budget after a long Helm install
+	//nolint:contextcheck // rooted at context.Background() for a fully independent deadline
+	err = i.waitForWebhookReady(webhookCtx)
 	if err != nil {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -72,20 +72,20 @@ func NewInstaller(
 // not yet populated its caBundle, causing transient admission failures for the
 // first workload operations after cluster setup.
 //
-// A single overall deadline governs both the Helm install and the webhook
-// readiness poll. The budget is timeout + 2×buffer: the inner Base.Install call
-// creates its own context with timeout + buffer, so Helm consumes at most that
-// window; the second buffer is reserved for the webhook readiness poll.
+// Base.Install manages its own context deadline (timeout + buffer) internally,
+// so ctx is passed through as-is. The webhook readiness poll gets a separate,
+// independent deadline of timeout to avoid competing for the same budget as
+// the Helm install.
 func (i *Installer) Install(ctx context.Context) error {
-	overallCtx, cancel := context.WithTimeout(ctx, i.timeout+2*helm.ContextTimeoutBuffer)
-	defer cancel()
-
-	err := i.Base.Install(overallCtx)
+	err := i.Base.Install(ctx)
 	if err != nil {
 		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
-	err = i.waitForWebhookReady(overallCtx)
+	webhookCtx, webhookCancel := context.WithTimeout(ctx, i.timeout)
+	defer webhookCancel()
+
+	err = i.waitForWebhookReady(webhookCtx)
 	if err != nil {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -80,20 +80,18 @@ func NewInstaller(
 // CI failures while still confirming readiness when the environment is fast.
 //
 // Base.Install manages its own context deadline (timeout + buffer) internally,
-// so ctx is passed through as-is. The webhook readiness poll is rooted at
-// context.Background() rather than ctx so it always receives a full independent
-// deadline of webhookReadinessTimeout, regardless of how much time the Helm
-// install consumed.
+// so ctx is passed through as-is. The webhook readiness poll derives from ctx
+// so it remains cancellable by the caller while still being capped at
+// webhookReadinessTimeout.
 func (i *Installer) Install(ctx context.Context) error {
 	err := i.Base.Install(ctx)
 	if err != nil {
 		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
-	webhookCtx, webhookCancel := context.WithTimeout(context.Background(), webhookReadinessTimeout)
+	webhookCtx, webhookCancel := context.WithTimeout(ctx, webhookReadinessTimeout)
 	defer webhookCancel()
 
-	//nolint:contextcheck // rooted at context.Background() for a fully independent deadline
 	err = i.waitForWebhookReady(webhookCtx)
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, errNoTimeRemaining) {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -2,6 +2,7 @@ package kyvernoinstaller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -66,28 +67,35 @@ func NewInstaller(
 	}
 }
 
-// Install installs or upgrades Kyverno via its Helm chart, then waits for the
-// admission webhook to be ready before returning. This extra wait prevents the
-// race condition where Helm reports install success but the webhook server has
-// not yet populated its caBundle, causing transient admission failures for the
-// first workload operations after cluster setup.
+// Install installs or upgrades Kyverno via its Helm chart, then performs a
+// best-effort wait for the admission webhook caBundle to be populated.
+//
+// The wait is best-effort: if the caBundle is not populated within
+// webhookReadinessTimeout, Install returns success rather than an error.
+// This is safe because the webhook is configured with failurePolicy: Ignore,
+// which means API operations succeed even when the webhook is not yet fully
+// initialised. In some environments (e.g. Cilium + cert-manager CI) the
+// Kyverno certmanager-controller informer cache sync takes longer than any
+// practical timeout, so treating the timeout as non-fatal avoids permanent
+// CI failures while still confirming readiness when the environment is fast.
 //
 // Base.Install manages its own context deadline (timeout + buffer) internally,
 // so ctx is passed through as-is. The webhook readiness poll is rooted at
 // context.Background() rather than ctx so it always receives a full independent
-// deadline of timeout, regardless of how much time the Helm install consumed.
+// deadline of webhookReadinessTimeout, regardless of how much time the Helm
+// install consumed.
 func (i *Installer) Install(ctx context.Context) error {
 	err := i.Base.Install(ctx)
 	if err != nil {
 		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
-	webhookCtx, webhookCancel := context.WithTimeout(context.Background(), i.timeout)
+	//nolint:contextcheck // rooted at context.Background() for a fully independent deadline
+	webhookCtx, webhookCancel := context.WithTimeout(context.Background(), webhookReadinessTimeout)
 	defer webhookCancel()
 
-	//nolint:contextcheck // rooted at context.Background() for a fully independent deadline
 	err = i.waitForWebhookReady(webhookCtx)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, errNoTimeRemaining) {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}
 

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -25,7 +25,11 @@ type Installer struct {
 // NewInstaller creates a new Kyverno installer instance.
 // kubeconfig and context are used after Helm install to wait for the Kyverno
 // admission webhook to be ready before returning.
-func NewInstaller(client helm.Interface, timeout time.Duration, kubeconfig, context string) *Installer {
+func NewInstaller(
+	client helm.Interface,
+	timeout time.Duration,
+	kubeconfig, context string,
+) *Installer {
 	return &Installer{
 		Base: helmutil.NewBase(
 			"kyverno",
@@ -74,11 +78,13 @@ func (i *Installer) Install(ctx context.Context) error {
 	overallCtx, cancel := context.WithTimeout(ctx, i.timeout+helm.ContextTimeoutBuffer)
 	defer cancel()
 
-	if err := i.Base.Install(overallCtx); err != nil {
+	err := i.Base.Install(overallCtx)
+	if err != nil {
 		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
-	if err := i.waitForWebhookReady(overallCtx); err != nil {
+	err := i.waitForWebhookReady(overallCtx)
+	if err != nil {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}
 

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -73,9 +73,11 @@ func NewInstaller(
 // first workload operations after cluster setup.
 //
 // A single overall deadline governs both the Helm install and the webhook
-// readiness poll so the total wall time stays within timeout + buffer.
+// readiness poll. The budget is timeout + 2×buffer: the inner Base.Install call
+// creates its own context with timeout + buffer, so Helm consumes at most that
+// window; the second buffer is reserved for the webhook readiness poll.
 func (i *Installer) Install(ctx context.Context) error {
-	overallCtx, cancel := context.WithTimeout(ctx, i.timeout+helm.ContextTimeoutBuffer)
+	overallCtx, cancel := context.WithTimeout(ctx, i.timeout+2*helm.ContextTimeoutBuffer)
 	defer cancel()
 
 	err := i.Base.Install(overallCtx)

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -67,12 +67,18 @@ func NewInstaller(client helm.Interface, timeout time.Duration, kubeconfig, cont
 // race condition where Helm reports install success but the webhook server has
 // not yet populated its caBundle, causing transient admission failures for the
 // first workload operations after cluster setup.
+//
+// A single overall deadline governs both the Helm install and the webhook
+// readiness poll so the total wall time stays within timeout + buffer.
 func (i *Installer) Install(ctx context.Context) error {
-	if err := i.Base.Install(ctx); err != nil {
+	overallCtx, cancel := context.WithTimeout(ctx, i.timeout+helm.ContextTimeoutBuffer)
+	defer cancel()
+
+	if err := i.Base.Install(overallCtx); err != nil {
 		return err
 	}
 
-	if err := i.waitForWebhookReady(ctx); err != nil {
+	if err := i.waitForWebhookReady(overallCtx); err != nil {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}
 

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -93,7 +93,8 @@ func (i *Installer) Install(ctx context.Context) error {
 	defer webhookCancel()
 
 	err = i.waitForWebhookReady(webhookCtx)
-	if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, errNoTimeRemaining) {
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) &&
+		!errors.Is(err, errNoTimeRemaining) {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}
 

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -17,18 +17,18 @@ import (
 type Installer struct {
 	*helmutil.Base
 
-	kubeconfig string
-	context    string
-	timeout    time.Duration
+	kubeconfig  string
+	kubecontext string
+	timeout     time.Duration
 }
 
 // NewInstaller creates a new Kyverno installer instance.
-// kubeconfig and context are used after Helm install to wait for the Kyverno
+// kubeconfig and kubecontext are used after Helm install to wait for the Kyverno
 // admission webhook to be ready before returning.
 func NewInstaller(
 	client helm.Interface,
 	timeout time.Duration,
-	kubeconfig, context string,
+	kubeconfig, kubecontext string,
 ) *Installer {
 	return &Installer{
 		Base: helmutil.NewBase(
@@ -60,9 +60,9 @@ func NewInstaller(
 				},
 			},
 		),
-		kubeconfig: kubeconfig,
-		context:    context,
-		timeout:    timeout,
+		kubeconfig:  kubeconfig,
+		kubecontext: kubecontext,
+		timeout:     timeout,
 	}
 }
 

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -73,16 +73,16 @@ func NewInstaller(
 // first workload operations after cluster setup.
 //
 // Base.Install manages its own context deadline (timeout + buffer) internally,
-// so ctx is passed through as-is. The webhook readiness poll gets a separate,
-// independent deadline of timeout to avoid competing for the same budget as
-// the Helm install.
+// so ctx is passed through as-is. The webhook readiness poll is rooted at
+// context.Background() rather than ctx so it always receives a full independent
+// deadline of timeout, regardless of how much time the Helm install consumed.
 func (i *Installer) Install(ctx context.Context) error {
 	err := i.Base.Install(ctx)
 	if err != nil {
 		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
-	webhookCtx, webhookCancel := context.WithTimeout(ctx, i.timeout)
+	webhookCtx, webhookCancel := context.WithTimeout(context.Background(), i.timeout)
 	defer webhookCancel()
 
 	err = i.waitForWebhookReady(webhookCtx)

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -90,10 +90,10 @@ func (i *Installer) Install(ctx context.Context) error {
 		return fmt.Errorf("installing kyverno base chart: %w", err)
 	}
 
-	//nolint:contextcheck // rooted at context.Background() for a fully independent deadline
 	webhookCtx, webhookCancel := context.WithTimeout(context.Background(), webhookReadinessTimeout)
 	defer webhookCancel()
 
+	//nolint:contextcheck // rooted at context.Background() for a fully independent deadline
 	err = i.waitForWebhookReady(webhookCtx)
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, errNoTimeRemaining) {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -85,7 +85,7 @@ func (i *Installer) Install(ctx context.Context) error {
 	webhookCtx, webhookCancel := context.WithTimeout(context.Background(), i.timeout)
 	defer webhookCancel()
 
-	err = i.waitForWebhookReady(webhookCtx)
+	err = i.waitForWebhookReady(webhookCtx) //nolint:contextcheck // intentionally uses context.Background() so the webhook waiter always gets a full independent budget after a long Helm install
 	if err != nil {
 		return fmt.Errorf("kyverno webhook not ready after install: %w", err)
 	}

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -187,6 +187,8 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 	defer restore()
 
 	// Populate caBundle after a short delay to simulate delayed TLS init.
+	// Use a buffered channel so the goroutine never blocks if Install returns first.
+	updateErrCh := make(chan error, 1)
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 
@@ -194,7 +196,7 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 		_, err := fakeClientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Update(context.Background(), cfg, metav1.UpdateOptions{})
-		assert.NoError(t, err)
+		updateErrCh <- err
 	}()
 
 	installer, client := newInstallerWithDefaults(t)
@@ -203,6 +205,7 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 	err := installer.Install(context.Background())
 
 	require.NoError(t, err)
+	require.NoError(t, <-updateErrCh, "webhook Update in goroutine failed")
 }
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -156,3 +156,75 @@ func readyWebhookConfig() *admissionregistrationv1.MutatingWebhookConfiguration 
 		},
 	}
 }
+
+// unreadyWebhookConfig returns a MutatingWebhookConfiguration with an empty
+// caBundle, simulating a Kyverno admission controller that has not yet
+// initialised its TLS certificate.
+func unreadyWebhookConfig() *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno-resource-mutating-webhook-cfg"},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name:         "mutate.kyverno.svc",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+			},
+		},
+	}
+}
+
+func TestInstallWebhookDelayedReadiness(t *testing.T) {
+	// Not parallel: overrides the package-level newClientsetFn var.
+	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
+	restore := kyvernoinstaller.SetNewClientsetFn(
+		func(_, _ string) (kubernetes.Interface, error) { return fakeClientset, nil },
+	)
+	defer restore()
+
+	// Populate caBundle after a short delay to simulate delayed TLS init.
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+
+		cfg := readyWebhookConfig()
+		_, err := fakeClientset.AdmissionregistrationV1().
+			MutatingWebhookConfigurations().
+			Update(context.Background(), cfg, metav1.UpdateOptions{})
+		require.NoError(t, err)
+	}()
+
+	installer, client := newInstallerWithDefaults(t)
+	expectKyvernoInstall(t, client, nil)
+
+	err := installer.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestInstallWebhookNeverReady(t *testing.T) {
+	// Not parallel: overrides the package-level newClientsetFn var.
+	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
+	restore := kyvernoinstaller.SetNewClientsetFn(
+		func(_, _ string) (kubernetes.Interface, error) { return fakeClientset, nil },
+	)
+	defer restore()
+
+	client := helm.NewMockInterface(t)
+	timeout := 3 * time.Second
+	installer := kyvernoinstaller.NewInstaller(client, timeout, "", "")
+
+	client.EXPECT().
+		AddRepository(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(mock.Anything, mock.Anything).
+		Return(nil, nil)
+
+	// Use a parent context with a tight deadline so the overall budget
+	// (timeout + ContextTimeoutBuffer) is bounded by the parent.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := installer.Install(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kyverno webhook not ready after install")
+}

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -229,8 +229,9 @@ func TestInstallWebhookNeverReady(t *testing.T) {
 		InstallOrUpgradeChart(mock.Anything, mock.Anything).
 		Return(nil, nil)
 
-	// Use a parent context with a tight deadline so the overall budget
-	// (timeout + 2*ContextTimeoutBuffer) is bounded by the parent.
+	// Use a parent context with a deadline longer than i.timeout as a safety
+	// net; the webhook wait uses its own independent context of i.timeout (3 s)
+	// derived from ctx, so the test runs for at most 3 s.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -172,7 +172,8 @@ func unreadyWebhookConfig() *admissionregistrationv1.MutatingWebhookConfiguratio
 	}
 }
 
-func TestInstallWebhookDelayedReadiness(t *testing.T) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestInstallWebhookDelayedReadiness(t *testing.T) {
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
 	restore := kyvernoinstaller.SetNewClientsetFn(
@@ -199,7 +200,8 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) { //nolint:paralleltest //
 	require.NoError(t, err)
 }
 
-func TestInstallWebhookNeverReady(t *testing.T) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestInstallWebhookNeverReady(t *testing.T) {
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
 	restore := kyvernoinstaller.SetNewClientsetFn(

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -25,9 +25,10 @@ func TestNewInstaller(t *testing.T) {
 	assert.NotNil(t, installer)
 }
 
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestInstallSuccess(
 	t *testing.T,
-) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+) {
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(readyWebhookConfig())
 

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -189,10 +189,12 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 	// Populate caBundle after a short delay to simulate delayed TLS init.
 	// Use a buffered channel so the goroutine never blocks if Install returns first.
 	updateErrCh := make(chan error, 1)
+
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 
 		cfg := readyWebhookConfig()
+
 		_, err := fakeClientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Update(context.Background(), cfg, metav1.UpdateOptions{})

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -25,9 +25,12 @@ func TestNewInstaller(t *testing.T) {
 	assert.NotNil(t, installer)
 }
 
-func TestInstallSuccess(t *testing.T) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestInstallSuccess(
+	t *testing.T,
+) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(readyWebhookConfig())
+
 	restore := kyvernoinstaller.SetNewClientsetFn(
 		func(_, _ string) (kubernetes.Interface, error) { return fakeClientset, nil },
 	)
@@ -176,6 +179,7 @@ func unreadyWebhookConfig() *admissionregistrationv1.MutatingWebhookConfiguratio
 func TestInstallWebhookDelayedReadiness(t *testing.T) {
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
+
 	restore := kyvernoinstaller.SetNewClientsetFn(
 		func(_, _ string) (kubernetes.Interface, error) { return fakeClientset, nil },
 	)
@@ -204,6 +208,7 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 func TestInstallWebhookNeverReady(t *testing.T) {
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
+
 	restore := kyvernoinstaller.SetNewClientsetFn(
 		func(_, _ string) (kubernetes.Interface, error) { return fakeClientset, nil },
 	)

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -10,19 +10,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := kyvernoinstaller.NewInstaller(client, 5*time.Second)
+	installer := kyvernoinstaller.NewInstaller(client, 5*time.Second, "", "")
 
 	assert.NotNil(t, installer)
 }
 
 func TestInstallSuccess(t *testing.T) {
-	t.Parallel()
+	// Not parallel: overrides the package-level newClientsetFn var.
+	fakeClientset := k8sfake.NewClientset(readyWebhookConfig())
+	restore := kyvernoinstaller.SetNewClientsetFn(
+		func(_, _ string) (kubernetes.Interface, error) { return fakeClientset, nil },
+	)
+	defer restore()
 
 	installer, client := newInstallerWithDefaults(t)
 	expectKyvernoInstall(t, client, nil)
@@ -89,7 +98,7 @@ func newInstallerWithDefaults(
 	t.Helper()
 
 	client := helm.NewMockInterface(t)
-	installer := kyvernoinstaller.NewInstaller(client, 2*time.Minute)
+	installer := kyvernoinstaller.NewInstaller(client, 2*time.Minute, "", "")
 
 	return installer, client
 }
@@ -130,4 +139,20 @@ func expectKyvernoInstall(t *testing.T, client *helm.MockInterface, installErr e
 			}),
 		).
 		Return(nil, installErr)
+}
+
+// readyWebhookConfig returns a MutatingWebhookConfiguration with a populated
+// caBundle, simulating a fully-initialised Kyverno admission controller.
+func readyWebhookConfig() *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno-resource-mutating-webhook-cfg"},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name: "mutate.kyverno.svc",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					CABundle: []byte("fake-ca-bundle"),
+				},
+			},
+		},
+	}
 }

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -25,7 +25,7 @@ func TestNewInstaller(t *testing.T) {
 	assert.NotNil(t, installer)
 }
 
-func TestInstallSuccess(t *testing.T) {
+func TestInstallSuccess(t *testing.T) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(readyWebhookConfig())
 	restore := kyvernoinstaller.SetNewClientsetFn(
@@ -172,7 +172,7 @@ func unreadyWebhookConfig() *admissionregistrationv1.MutatingWebhookConfiguratio
 	}
 }
 
-func TestInstallWebhookDelayedReadiness(t *testing.T) {
+func TestInstallWebhookDelayedReadiness(t *testing.T) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
 	restore := kyvernoinstaller.SetNewClientsetFn(
@@ -188,7 +188,7 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 		_, err := fakeClientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Update(context.Background(), cfg, metav1.UpdateOptions{})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	installer, client := newInstallerWithDefaults(t)
@@ -199,7 +199,7 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestInstallWebhookNeverReady(t *testing.T) {
+func TestInstallWebhookNeverReady(t *testing.T) { //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
 	restore := kyvernoinstaller.SetNewClientsetFn(

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -209,34 +209,27 @@ func TestInstallWebhookDelayedReadiness(t *testing.T) {
 }
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
-func TestInstallWebhookNeverReady(t *testing.T) {
-	// Not parallel: overrides the package-level newClientsetFn var.
+func TestInstallWebhookTimeoutIsNonBlocking(t *testing.T) {
+	// Not parallel: overrides the package-level newClientsetFn and
+	// webhookReadinessTimeout vars.
 	fakeClientset := k8sfake.NewClientset(unreadyWebhookConfig())
 
-	restore := kyvernoinstaller.SetNewClientsetFn(
+	restoreClientset := kyvernoinstaller.SetNewClientsetFn(
 		func(_, _ string) (kubernetes.Interface, error) { return fakeClientset, nil },
 	)
-	defer restore()
+	defer restoreClientset()
 
-	client := helm.NewMockInterface(t)
-	timeout := 3 * time.Second
-	installer := kyvernoinstaller.NewInstaller(client, timeout, "", "")
+	// Use a very short webhook timeout so the test does not wait 5 minutes.
+	restoreTimeout := kyvernoinstaller.SetWebhookReadinessTimeout(500 * time.Millisecond)
+	defer restoreTimeout()
 
-	client.EXPECT().
-		AddRepository(mock.Anything, mock.Anything, mock.Anything).
-		Return(nil)
-	client.EXPECT().
-		InstallOrUpgradeChart(mock.Anything, mock.Anything).
-		Return(nil, nil)
+	installer, client := newInstallerWithDefaults(t)
+	expectKyvernoInstall(t, client, nil)
 
-	// Use a parent context with a deadline longer than i.timeout as a safety
-	// net; the webhook wait uses its own independent context of i.timeout (3 s)
-	// derived from ctx, so the test runs for at most 3 s.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	// The caBundle is never populated, but Install should return nil because the
+	// webhook wait is best-effort — failurePolicy: Ignore ensures API operations
+	// succeed even without a fully initialised webhook.
+	err := installer.Install(context.Background())
 
-	err := installer.Install(ctx)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "kyverno webhook not ready after install")
+	require.NoError(t, err)
 }

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -230,7 +230,7 @@ func TestInstallWebhookNeverReady(t *testing.T) {
 		Return(nil, nil)
 
 	// Use a parent context with a tight deadline so the overall budget
-	// (timeout + ContextTimeoutBuffer) is bounded by the parent.
+	// (timeout + 2*ContextTimeoutBuffer) is bounded by the parent.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -26,9 +26,7 @@ func TestNewInstaller(t *testing.T) {
 }
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
-func TestInstallSuccess(
-	t *testing.T,
-) {
+func TestInstallSuccess(t *testing.T) {
 	// Not parallel: overrides the package-level newClientsetFn var.
 	fakeClientset := k8sfake.NewClientset(readyWebhookConfig())
 

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -28,8 +28,8 @@ var errNoTimeRemaining = errors.New("no time remaining for webhook readiness che
 // newClientsetFn is the factory used to create a Kubernetes clientset.
 //
 //nolint:gochecknoglobals // allows overriding in tests
-var newClientsetFn = func(kubeconfig, context string) (kubernetes.Interface, error) {
-	return k8s.NewClientset(kubeconfig, context)
+var newClientsetFn = func(kubeconfig, kubecontext string) (kubernetes.Interface, error) {
+	return k8s.NewClientset(kubeconfig, kubecontext)
 }
 
 // waitForWebhookReady polls the Kyverno MutatingWebhookConfiguration until every

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -65,7 +65,11 @@ func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 				return false, nil
 			}
 
-			return false, fmt.Errorf("getting MutatingWebhookConfiguration %q: %w", kyvernoResourceWebhookName, err)
+			return false, fmt.Errorf(
+				"getting MutatingWebhookConfiguration %q: %w",
+				kyvernoResourceWebhookName,
+				err,
+			)
 		}
 
 		if len(webhook.Webhooks) == 0 {

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -50,7 +50,7 @@ func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 		}
 	}
 
-	clientset, err := newClientsetFn(i.kubeconfig, i.context)
+	clientset, err := newClientsetFn(i.kubeconfig, i.kubecontext)
 	if err != nil {
 		return fmt.Errorf("creating clientset for Kyverno webhook readiness check: %w", err)
 	}

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -2,6 +2,7 @@ package kyvernoinstaller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -19,6 +20,10 @@ const (
 	// caBundle is therefore a reliable signal that the webhook is ready to serve.
 	kyvernoResourceWebhookName = "kyverno-resource-mutating-webhook-cfg"
 )
+
+// errNoTimeRemaining is returned when the context deadline has already elapsed
+// before the webhook readiness poll can begin.
+var errNoTimeRemaining = errors.New("no time remaining for webhook readiness check")
 
 // newClientsetFn is the factory used to create a Kubernetes clientset.
 //
@@ -41,7 +46,7 @@ func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 	if dl, ok := ctx.Deadline(); ok {
 		remaining = time.Until(dl)
 		if remaining <= 0 {
-			return fmt.Errorf("no time remaining for webhook readiness check")
+			return errNoTimeRemaining
 		}
 	}
 
@@ -50,7 +55,7 @@ func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 		return fmt.Errorf("creating clientset for Kyverno webhook readiness check: %w", err)
 	}
 
-	return readiness.PollForReadiness(ctx, remaining, func(ctx context.Context) (bool, error) {
+	if err := readiness.PollForReadiness(ctx, remaining, func(ctx context.Context) (bool, error) {
 		webhook, err := clientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Get(ctx, kyvernoResourceWebhookName, metav1.GetOptions{})
@@ -74,5 +79,9 @@ func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 		}
 
 		return true, nil
-	})
+	}); err != nil {
+		return fmt.Errorf("polling Kyverno webhook readiness: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -1,0 +1,66 @@
+package kyvernoinstaller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// kyvernoResourceWebhookName is the MutatingWebhookConfiguration that intercepts
+	// all resource operations (create/update/delete). Kyverno populates its caBundle
+	// once the admission controller has initialised its TLS certificate — a non-empty
+	// caBundle is therefore a reliable signal that the webhook is ready to serve.
+	kyvernoResourceWebhookName = "kyverno-resource-mutating-webhook-cfg"
+)
+
+// newClientsetFn is the factory used to create a Kubernetes clientset.
+//
+//nolint:gochecknoglobals // allows overriding in tests
+var newClientsetFn = func(kubeconfig, context string) (kubernetes.Interface, error) {
+	return k8s.NewClientset(kubeconfig, context)
+}
+
+// waitForWebhookReady polls the Kyverno MutatingWebhookConfiguration until every
+// webhook entry has a non-empty caBundle. This guards against the race condition
+// where Helm reports the chart as installed and the admission controller pods are
+// Running/Ready, but the controller has not yet initialised its TLS certificate and
+// injected it into the webhook configuration. Any workload operation that triggers
+// the webhook before the caBundle is set will fail.
+func (i *Installer) waitForWebhookReady(ctx context.Context) error {
+	clientset, err := newClientsetFn(i.kubeconfig, i.context)
+	if err != nil {
+		return fmt.Errorf("creating clientset for Kyverno webhook readiness check: %w", err)
+	}
+
+	return readiness.PollForReadiness(ctx, i.timeout, func(ctx context.Context) (bool, error) {
+		webhook, err := clientset.AdmissionregistrationV1().
+			MutatingWebhookConfigurations().
+			Get(ctx, kyvernoResourceWebhookName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// Not yet created — keep polling
+				return false, nil
+			}
+
+			return false, fmt.Errorf("getting MutatingWebhookConfiguration %q: %w", kyvernoResourceWebhookName, err)
+		}
+
+		if len(webhook.Webhooks) == 0 {
+			return false, nil
+		}
+
+		for _, wh := range webhook.Webhooks {
+			if len(wh.ClientConfig.CABundle) == 0 {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -3,6 +3,7 @@ package kyvernoinstaller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
@@ -32,13 +33,24 @@ var newClientsetFn = func(kubeconfig, context string) (kubernetes.Interface, err
 // Running/Ready, but the controller has not yet initialised its TLS certificate and
 // injected it into the webhook configuration. Any workload operation that triggers
 // the webhook before the caBundle is set will fail.
+//
+// The polling deadline is derived from the context so that the Helm install and
+// webhook wait share a single overall timeout budget.
 func (i *Installer) waitForWebhookReady(ctx context.Context) error {
+	remaining := i.timeout // fallback when ctx has no deadline
+	if dl, ok := ctx.Deadline(); ok {
+		remaining = time.Until(dl)
+		if remaining <= 0 {
+			return fmt.Errorf("no time remaining for webhook readiness check")
+		}
+	}
+
 	clientset, err := newClientsetFn(i.kubeconfig, i.context)
 	if err != nil {
 		return fmt.Errorf("creating clientset for Kyverno webhook readiness check: %w", err)
 	}
 
-	return readiness.PollForReadiness(ctx, i.timeout, func(ctx context.Context) (bool, error) {
+	return readiness.PollForReadiness(ctx, remaining, func(ctx context.Context) (bool, error) {
 		webhook, err := clientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Get(ctx, kyvernoResourceWebhookName, metav1.GetOptions{})

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -55,7 +55,7 @@ func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 		return fmt.Errorf("creating clientset for Kyverno webhook readiness check: %w", err)
 	}
 
-	if err := readiness.PollForReadiness(ctx, remaining, func(ctx context.Context) (bool, error) {
+	err = readiness.PollForReadiness(ctx, remaining, func(ctx context.Context) (bool, error) {
 		webhook, err := clientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Get(ctx, kyvernoResourceWebhookName, metav1.GetOptions{})
@@ -79,7 +79,8 @@ func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 		}
 
 		return true, nil
-	}); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("polling Kyverno webhook readiness: %w", err)
 	}
 

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -39,8 +39,8 @@ var newClientsetFn = func(kubeconfig, context string) (kubernetes.Interface, err
 // injected it into the webhook configuration. Any workload operation that triggers
 // the webhook before the caBundle is set will fail.
 //
-// The polling deadline is derived from the context so that the Helm install and
-// webhook wait share a single overall timeout budget.
+// ctx should carry its own independent deadline (typically timeout) so that the
+// webhook wait does not compete with the Helm install for the same budget.
 func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 	remaining := i.timeout // fallback when ctx has no deadline
 	if dl, ok := ctx.Deadline(); ok {

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -25,6 +25,17 @@ const (
 // before the webhook readiness poll can begin.
 var errNoTimeRemaining = errors.New("no time remaining for webhook readiness check")
 
+// webhookReadinessTimeout is the independent deadline given to the webhook caBundle
+// readiness check after Helm install. The wait is best-effort: if the caBundle is not
+// populated within this window, Install returns success anyway because
+// failurePolicy: Ignore ensures API operations proceed even without a fully initialised
+// webhook. A dedicated constant (shorter than KyvernoInstallTimeout) prevents the
+// best-effort check from consuming an excessive share of the CI job's time budget in
+// environments where informer cache sync takes longer than expected.
+//
+//nolint:gochecknoglobals // allows overriding in tests via export_test.go
+var webhookReadinessTimeout = 5 * time.Minute
+
 // newClientsetFn is the factory used to create a Kubernetes clientset.
 //
 //nolint:gochecknoglobals // allows overriding in tests

--- a/pkg/svc/installer/kyverno/webhook_waiter.go
+++ b/pkg/svc/installer/kyverno/webhook_waiter.go
@@ -47,11 +47,13 @@ var newClientsetFn = func(kubeconfig, kubecontext string) (kubernetes.Interface,
 // webhook entry has a non-empty caBundle. This guards against the race condition
 // where Helm reports the chart as installed and the admission controller pods are
 // Running/Ready, but the controller has not yet initialised its TLS certificate and
-// injected it into the webhook configuration. Any workload operation that triggers
-// the webhook before the caBundle is set will fail.
+// injected it into the webhook configuration. Workload operations that trigger the
+// webhook before the caBundle is populated are still admitted because the Kyverno
+// webhook is configured with failurePolicy: Ignore, but the caBundle check provides
+// an early signal that the controller is fully ready.
 //
-// ctx should carry its own independent deadline (typically timeout) so that the
-// webhook wait does not compete with the Helm install for the same budget.
+// ctx should carry an appropriate deadline so the check does not wait indefinitely.
+// Callers treat context.DeadlineExceeded as non-fatal (see Installer.Install).
 func (i *Installer) waitForWebhookReady(ctx context.Context) error {
 	remaining := i.timeout // fallback when ctx has no deadline
 	if dl, ok := ctx.Deadline(); ok {


### PR DESCRIPTION
## Summary

After Helm install reports success and Kyverno pods are Running/Ready, the admission controller may not have yet initialised its TLS certificate and injected the `caBundle` into `kyverno-resource-mutating-webhook-cfg`. While `failurePolicy: Ignore` ensures API operations proceed even without a populated `caBundle`, waiting for it provides an early signal that the admission controller is fully ready in fast environments.

In some CI environments (Cilium + cert-manager), Kyverno's internal `certmanager-controller` informer cache sync takes longer than any practical fixed timeout, meaning the `caBundle` may never be populated within the wait window. The webhook wait is therefore **best-effort**: if the timeout fires, `Install()` returns success anyway. A dedicated 5-minute `webhookReadinessTimeout` (shorter than `KyvernoInstallTimeout`) avoids consuming excessive CI time on the best-effort check.

## Changes

- **`pkg/svc/installer/kyverno/webhook_waiter.go`** (new): polls `kyverno-resource-mutating-webhook-cfg` MutatingWebhookConfiguration until every webhook entry has a non-empty `caBundle`, using `readiness.PollForReadiness`; injectable `newClientsetFn` and `webhookReadinessTimeout` (5 min) for testing
- **`pkg/svc/installer/kyverno/installer.go`**: adds `kubeconfig`/`kubecontext`/`timeout` fields; overrides `Install()` to call base Helm install then a best-effort `waitForWebhookReady` (timeout treated as success); updated `NewInstaller` signature
- **`pkg/svc/installer/kyverno/export_test.go`** (new): exposes `SetNewClientsetFn` and `SetWebhookReadinessTimeout` for test injection (each returns cleanup func)
- **`pkg/svc/installer/kyverno/installer_test.go`**: updated `NewInstaller` call sites; tests cover success, delayed readiness, and timeout-is-non-blocking paths
- **`pkg/svc/installer/factory.go`**: passes `kubeconfig`/`kubecontext` from the factory struct to `NewInstaller`
- **`pkg/cli/setup/components.go`**: captures `kubeconfig` from `HelmClientFactory` and passes it to `NewInstaller`
- **`pkg/svc/installer/helpers.go`**: increases `KyvernoInstallTimeout` from 10 min to 20 min for the Helm chart install phase
- **`pkg/cli/setup/post_cni.go`**: when both cert-manager and a policy engine are requested, cert-manager now runs in a dedicated sequential pre-phase before the parallel infra phase that installs the policy engine; this eliminates the race condition where cert-manager and Kyverno start simultaneously and cert-manager's cainjector does not inject the `caBundle` in time; the `csrApproverReadinessTimeout` (Talos only) is increased from 2 min to 10 min to account for the additional time the pre-phase and a slower CNI (e.g. Cilium) add before the CSR approver wait starts

Fixes #4357