### PR TITLE
fix: add clusterName fallback to ResolveHetznerNetworkName

### DIFF
--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -129,9 +129,7 @@ func csiFactory(
 			clusterCfg.Spec.Cluster.Provider == v1alpha1.ProviderHetzner {
 			networkName := hcloudccminstaller.ResolveHetznerNetworkName(
 				clusterCfg,
-				hcloudccminstaller.ExtractClusterNameFromTalosContext(
-					clusterCfg.Spec.Cluster.Connection.Context,
-				),
+				resolveClusterNameFromContext(clusterCfg),
 			)
 
 			return hetznercsiinstaller.NewInstaller(

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -127,7 +127,12 @@ func csiFactory(
 		// For Talos × Hetzner, use the Hetzner CSI driver
 		if clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionTalos &&
 			clusterCfg.Spec.Cluster.Provider == v1alpha1.ProviderHetzner {
-			networkName := hcloudccminstaller.ResolveHetznerNetworkName(clusterCfg)
+			networkName := hcloudccminstaller.ResolveHetznerNetworkName(
+				clusterCfg,
+				hcloudccminstaller.ExtractClusterNameFromTalosContext(
+					clusterCfg.Spec.Cluster.Connection.Context,
+				),
+			)
 
 			return hetznercsiinstaller.NewInstaller(
 				helmClient,

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -278,7 +278,12 @@ func installHcloudCCM(
 		return fmt.Errorf("failed to setup helm client for hcloud-ccm: %w", err)
 	}
 
-	networkName := hcloudccminstaller.ResolveHetznerNetworkName(clusterCfg)
+	networkName := hcloudccminstaller.ResolveHetznerNetworkName(
+		clusterCfg,
+		hcloudccminstaller.ExtractClusterNameFromTalosContext(
+			clusterCfg.Spec.Cluster.Connection.Context,
+		),
+	)
 
 	ccmInstaller := hcloudccminstaller.NewInstaller(
 		helmClient,

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -280,9 +280,7 @@ func installHcloudCCM(
 
 	networkName := hcloudccminstaller.ResolveHetznerNetworkName(
 		clusterCfg,
-		hcloudccminstaller.ExtractClusterNameFromTalosContext(
-			clusterCfg.Spec.Cluster.Connection.Context,
-		),
+		resolveClusterNameFromContext(clusterCfg),
 	)
 
 	ccmInstaller := hcloudccminstaller.NewInstaller(

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -194,7 +194,10 @@ func (f *Factory) addCSIInstallers(installers map[string]Installer, cfg *v1alpha
 	}
 
 	if f.needsHetznerCSI(spec) {
-		networkName := hcloudccminstaller.ResolveHetznerNetworkName(cfg)
+		networkName := hcloudccminstaller.ResolveHetznerNetworkName(
+			cfg,
+			hcloudccminstaller.ExtractClusterNameFromTalosContext(f.kubecontext),
+		)
 		installers["hetzner-csi"] = hetznercsiinstaller.NewInstaller(
 			f.helmClient, f.kubeconfig, f.kubecontext, f.timeout, networkName,
 		)
@@ -228,7 +231,10 @@ func (f *Factory) addLoadBalancerInstaller(
 	}
 
 	if f.needsHcloudCCM(spec) {
-		networkName := hcloudccminstaller.ResolveHetznerNetworkName(cfg)
+		networkName := hcloudccminstaller.ResolveHetznerNetworkName(
+			cfg,
+			hcloudccminstaller.ExtractClusterNameFromTalosContext(f.kubecontext),
+		)
 		installers["hcloud-ccm"] = hcloudccminstaller.NewInstaller(
 			f.helmClient,
 			f.kubeconfig,

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -194,10 +194,12 @@ func (f *Factory) addCSIInstallers(installers map[string]Installer, cfg *v1alpha
 	}
 
 	if f.needsHetznerCSI(spec) {
-		networkName := hcloudccminstaller.ResolveHetznerNetworkName(
-			cfg,
-			hcloudccminstaller.ExtractClusterNameFromTalosContext(f.kubecontext),
-		)
+		clusterName := hcloudccminstaller.ExtractClusterNameFromTalosContext(f.kubecontext)
+		if clusterName == "" {
+			clusterName = f.distribution.DefaultClusterName()
+		}
+
+		networkName := hcloudccminstaller.ResolveHetznerNetworkName(cfg, clusterName)
 		installers["hetzner-csi"] = hetznercsiinstaller.NewInstaller(
 			f.helmClient, f.kubeconfig, f.kubecontext, f.timeout, networkName,
 		)
@@ -231,10 +233,12 @@ func (f *Factory) addLoadBalancerInstaller(
 	}
 
 	if f.needsHcloudCCM(spec) {
-		networkName := hcloudccminstaller.ResolveHetznerNetworkName(
-			cfg,
-			hcloudccminstaller.ExtractClusterNameFromTalosContext(f.kubecontext),
-		)
+		clusterName := hcloudccminstaller.ExtractClusterNameFromTalosContext(f.kubecontext)
+		if clusterName == "" {
+			clusterName = f.distribution.DefaultClusterName()
+		}
+
+		networkName := hcloudccminstaller.ResolveHetznerNetworkName(cfg, clusterName)
 		installers["hcloud-ccm"] = hcloudccminstaller.NewInstaller(
 			f.helmClient,
 			f.kubeconfig,

--- a/pkg/svc/installer/hcloudccm/network.go
+++ b/pkg/svc/installer/hcloudccm/network.go
@@ -14,31 +14,43 @@ import (
 //  1. If spec.provider.hetzner.networkName is explicitly set, use that.
 //     This matches the API contract: "If empty, a network named
 //     '<cluster-name>-network' will be created."
-//  2. Otherwise, extract the cluster name from the kubeconfig context
+//  2. Extract the cluster name from the kubeconfig context
 //     (e.g., "admin@dev" → "dev") and append the standard network suffix
 //     ("-network") to match what hetzner.Provider.EnsureNetwork creates.
+//  3. Use the provided clusterName fallback (from the CLI / provisioner) and
+//     append the network suffix. This ensures the installer always matches
+//     the network that hetzner.Provider.EnsureNetwork creates, even when
+//     Connection.Context is empty or doesn't follow the "admin@<name>" pattern.
 //
 // Returns empty string if the network name cannot be determined.
-func ResolveHetznerNetworkName(cfg *v1alpha1.Cluster) string {
+func ResolveHetznerNetworkName(cfg *v1alpha1.Cluster, clusterName string) string {
 	// Explicit network name takes precedence per the API contract.
 	if nn := cfg.Spec.Provider.Hetzner.NetworkName; nn != "" {
 		return nn
 	}
 
 	// Derive from context: for Talos the context is "admin@<clusterName>".
-	clusterName := extractClusterNameFromTalosContext(
+	contextName := ExtractClusterNameFromTalosContext(
 		cfg.Spec.Cluster.Connection.Context,
 	)
-	if clusterName == "" {
-		return ""
+	if contextName != "" {
+		return contextName + hetznerProvider.NetworkSuffix
 	}
 
-	return clusterName + hetznerProvider.NetworkSuffix
+	// Fallback: use the directly-provided cluster name. This matches the
+	// value passed to hetzner.Provider.EnsureNetwork, guaranteeing the
+	// installer and provider agree on the network name.
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName != "" {
+		return clusterName + hetznerProvider.NetworkSuffix
+	}
+
+	return ""
 }
 
-// extractClusterNameFromTalosContext extracts the cluster name from a Talos
+// ExtractClusterNameFromTalosContext extracts the cluster name from a Talos
 // kubeconfig context string. Talos contexts follow the pattern "admin@<name>".
-func extractClusterNameFromTalosContext(context string) string {
+func ExtractClusterNameFromTalosContext(context string) string {
 	const talosPrefix = "admin@"
 
 	context = strings.TrimSpace(context)

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -112,7 +112,9 @@ func TestResolveHetznerNetworkName(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := hcloudccminstaller.ResolveHetznerNetworkName(testCase.cfg, testCase.clusterName)
+			result := hcloudccminstaller.ResolveHetznerNetworkName(
+				testCase.cfg, testCase.clusterName,
+			)
 
 			require.Equal(t, testCase.expected, result)
 		})
@@ -127,6 +129,10 @@ type resolveNetworkNameTestCase struct {
 }
 
 func resolveNetworkNameTestCases() []resolveNetworkNameTestCase {
+	return append(resolveNetworkNameCoreCases(), resolveNetworkNameEdgeCases()...)
+}
+
+func resolveNetworkNameCoreCases() []resolveNetworkNameTestCase {
 	return []resolveNetworkNameTestCase{
 		{
 			name:        "explicit name takes precedence over context-derived name",
@@ -176,6 +182,11 @@ func resolveNetworkNameTestCases() []resolveNetworkNameTestCase {
 			clusterName: "dev",
 			expected:    "dev-network",
 		},
+	}
+}
+
+func resolveNetworkNameEdgeCases() []resolveNetworkNameTestCase {
+	return []resolveNetworkNameTestCase{
 		{
 			name:        "empty context and empty cluster name returns empty",
 			cfg:         clusterCfg("", ""),

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -112,7 +112,7 @@ func TestResolveHetznerNetworkName(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := hcloudccminstaller.ResolveHetznerNetworkName(testCase.cfg)
+			result := hcloudccminstaller.ResolveHetznerNetworkName(testCase.cfg, testCase.clusterName)
 
 			require.Equal(t, testCase.expected, result)
 		})
@@ -120,52 +120,103 @@ func TestResolveHetznerNetworkName(t *testing.T) {
 }
 
 type resolveNetworkNameTestCase struct {
-	name     string
-	cfg      *v1alpha1.Cluster
-	expected string
+	name        string
+	cfg         *v1alpha1.Cluster
+	clusterName string
+	expected    string
 }
 
 func resolveNetworkNameTestCases() []resolveNetworkNameTestCase {
 	return []resolveNetworkNameTestCase{
 		{
-			name:     "explicit name takes precedence over context-derived name",
-			cfg:      clusterCfg("admin@dev", "custom-network"),
-			expected: "custom-network",
+			name:        "explicit name takes precedence over context-derived name",
+			cfg:         clusterCfg("admin@dev", "custom-network"),
+			clusterName: "dev",
+			expected:    "custom-network",
 		},
 		{
-			name:     "falls back to explicit name when context cannot be derived",
-			cfg:      clusterCfg("kind-local", "custom-network"),
-			expected: "custom-network",
+			name:        "falls back to explicit name when context cannot be derived",
+			cfg:         clusterCfg("kind-local", "custom-network"),
+			clusterName: "",
+			expected:    "custom-network",
 		},
 		{
-			name:     "derives from Talos context when no explicit name",
-			cfg:      clusterCfg("admin@dev", ""),
-			expected: "dev-network",
+			name:        "derives from Talos context when no explicit name",
+			cfg:         clusterCfg("admin@dev", ""),
+			clusterName: "",
+			expected:    "dev-network",
 		},
 		{
-			name:     "derives from Talos context with hyphenated cluster name",
-			cfg:      clusterCfg("admin@my-production-cluster", ""),
-			expected: "my-production-cluster-network",
+			name:        "derives from Talos context with hyphenated cluster name",
+			cfg:         clusterCfg("admin@my-production-cluster", ""),
+			clusterName: "",
+			expected:    "my-production-cluster-network",
 		},
 		{
-			name:     "empty context returns empty",
-			cfg:      clusterCfg("", ""),
-			expected: "",
+			name:        "context parsing takes precedence over cluster name fallback",
+			cfg:         clusterCfg("admin@dev", ""),
+			clusterName: "other",
+			expected:    "dev-network",
 		},
 		{
-			name:     "non-Talos context without explicit name returns empty",
-			cfg:      clusterCfg("kind-local", ""),
-			expected: "",
+			name:        "falls back to cluster name when context is empty",
+			cfg:         clusterCfg("", ""),
+			clusterName: "dev",
+			expected:    "dev-network",
 		},
 		{
-			name:     "trims whitespace from context",
-			cfg:      clusterCfg("  admin@dev  ", ""),
-			expected: "dev-network",
+			name:        "falls back to cluster name when context is non-Talos",
+			cfg:         clusterCfg("kind-local", ""),
+			clusterName: "dev",
+			expected:    "dev-network",
 		},
 		{
-			name:     "admin@ with no cluster name returns empty",
-			cfg:      clusterCfg("admin@", ""),
-			expected: "",
+			name:        "falls back to cluster name when context is raw name without admin prefix",
+			cfg:         clusterCfg("default", ""),
+			clusterName: "dev",
+			expected:    "dev-network",
+		},
+		{
+			name:        "empty context and empty cluster name returns empty",
+			cfg:         clusterCfg("", ""),
+			clusterName: "",
+			expected:    "",
+		},
+		{
+			name:        "non-Talos context without explicit name or cluster name returns empty",
+			cfg:         clusterCfg("kind-local", ""),
+			clusterName: "",
+			expected:    "",
+		},
+		{
+			name:        "trims whitespace from context",
+			cfg:         clusterCfg("  admin@dev  ", ""),
+			clusterName: "",
+			expected:    "dev-network",
+		},
+		{
+			name:        "admin@ with no cluster name falls back to cluster name param",
+			cfg:         clusterCfg("admin@", ""),
+			clusterName: "dev",
+			expected:    "dev-network",
+		},
+		{
+			name:        "admin@ with no cluster name and no fallback returns empty",
+			cfg:         clusterCfg("admin@", ""),
+			clusterName: "",
+			expected:    "",
+		},
+		{
+			name:        "trims whitespace from cluster name fallback",
+			cfg:         clusterCfg("", ""),
+			clusterName: "  dev  ",
+			expected:    "dev-network",
+		},
+		{
+			name:        "explicit name takes precedence over cluster name fallback",
+			cfg:         clusterCfg("", "custom-network"),
+			clusterName: "dev",
+			expected:    "custom-network",
 		},
 	}
 }


### PR DESCRIPTION
## Summary

`ResolveHetznerNetworkName` could return an empty network name when `Connection.Context` didn't match the `"admin@<name>"` Talos pattern, causing the `hcloud` Secret to store an incorrect `network` value.

## Changes

- Add a `clusterName` parameter to `ResolveHetznerNetworkName` as a third fallback, matching the name the Hetzner provider uses in `EnsureNetwork`
- Export `ExtractClusterNameFromTalosContext` so callers can derive the cluster name consistently
- Update all call sites in `install_infrastructure.go`, `components.go`, and `factory.go`
- Add 7 new test cases covering the fallback behavior

### Resolution order (updated)

1. Explicit `NetworkName` from config → return verbatim
2. Cluster name extracted from Talos context (`"admin@<name>"`) → return `name + NetworkSuffix`
3. **NEW**: Provided `clusterName` parameter → return `clusterName + NetworkSuffix`
4. Return `""`

Fixes #4343