### PR TITLE
feat(cluster): add nodeAutoscaling guard to skip node-count diffs on update

### DIFF
--- a/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
@@ -12,27 +12,27 @@ Usage:
   ksail cluster create [flags]
 
 Flags:
-      --cdi CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
-      --cert-manager CertManager           Cert-Manager configuration (Enabled: install, Disabled: skip)
-      --cni CNI                            Container Network Interface (CNI) to use
-  -c, --context string                     Kubernetes context of cluster
-      --control-planes int32               Number of control-plane nodes (default 1)
-      --csi CSI                            Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
-  -d, --distribution Distribution          Kubernetes distribution to use
-      --distribution-config string         Configuration file for the distribution
-  -g, --gitops-engine GitOpsEngine         GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --import-images string               Path to tar archive with container images to import after cluster creation but before component installation
-  -k, --kubeconfig string                  Path to kubeconfig file (default "~/.kube/config")
-      --load-balancer LoadBalancer         LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
-      --local-registry string              Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
-      --metrics-server MetricsServer       Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
-      --mirror-registry strings            Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
-  -n, --name string                        Cluster name used for container names, registry names, and kubeconfig context
-      --node-autoscaling NodeAutoscaling   Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
-      --policy-engine PolicyEngine         Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
-      --provider Provider                  Infrastructure provider backend (e.g., Docker)
-      --ttl string                         Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
-      --workers int32                      Number of worker nodes
+      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
+      --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
+      --cni CNI                        Container Network Interface (CNI) to use
+  -c, --context string                 Kubernetes context of cluster
+      --control-planes int32           Number of control-plane nodes (default 1)
+      --csi CSI                        Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
+  -d, --distribution Distribution      Kubernetes distribution to use
+      --distribution-config string     Configuration file for the distribution
+  -g, --gitops-engine GitOpsEngine     GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
+      --import-images string           Path to tar archive with container images to import after cluster creation but before component installation
+  -k, --kubeconfig string              Path to kubeconfig file (default "~/.kube/config")
+      --load-balancer LoadBalancer     LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
+      --local-registry string          Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
+      --metrics-server MetricsServer   Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
+      --mirror-registry strings        Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
+  -n, --name string                    Cluster name used for container names, registry names, and kubeconfig context
+      --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
+      --provider Provider              Infrastructure provider backend (e.g., Docker)
+      --ttl string                     Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
+      --node-autoscaling NodeAutoscaling   Node autoscaling (Talos: Enabled defers worker and control-plane scaling to an external autoscaler, Disabled lets KSail manage node counts; other distributions currently ignore this setting)
+      --workers int32                  Number of worker nodes
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
@@ -12,27 +12,27 @@ Usage:
   ksail cluster create [flags]
 
 Flags:
-      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
-      --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
-      --cni CNI                        Container Network Interface (CNI) to use
-  -c, --context string                 Kubernetes context of cluster
-      --control-planes int32           Number of control-plane nodes (default 1)
-      --csi CSI                        Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
-  -d, --distribution Distribution      Kubernetes distribution to use
-      --distribution-config string     Configuration file for the distribution
-  -g, --gitops-engine GitOpsEngine     GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --import-images string           Path to tar archive with container images to import after cluster creation but before component installation
-  -k, --kubeconfig string              Path to kubeconfig file (default "~/.kube/config")
-      --load-balancer LoadBalancer     LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
-      --local-registry string          Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
-      --metrics-server MetricsServer   Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
-      --mirror-registry strings        Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
-  -n, --name string                    Cluster name used for container names, registry names, and kubeconfig context
-      --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
-      --provider Provider              Infrastructure provider backend (e.g., Docker)
-      --ttl string                     Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
+      --cdi CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
+      --cert-manager CertManager           Cert-Manager configuration (Enabled: install, Disabled: skip)
+      --cni CNI                            Container Network Interface (CNI) to use
+  -c, --context string                     Kubernetes context of cluster
+      --control-planes int32               Number of control-plane nodes (default 1)
+      --csi CSI                            Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
+  -d, --distribution Distribution          Kubernetes distribution to use
+      --distribution-config string         Configuration file for the distribution
+  -g, --gitops-engine GitOpsEngine         GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
+      --import-images string               Path to tar archive with container images to import after cluster creation but before component installation
+  -k, --kubeconfig string                  Path to kubeconfig file (default "~/.kube/config")
+      --load-balancer LoadBalancer         LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
+      --local-registry string              Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
+      --metrics-server MetricsServer       Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
+      --mirror-registry strings            Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
+  -n, --name string                        Cluster name used for container names, registry names, and kubeconfig context
       --node-autoscaling NodeAutoscaling   Node autoscaling (Talos: Enabled defers worker and control-plane scaling to an external autoscaler, Disabled lets KSail manage node counts; other distributions currently ignore this setting)
-      --workers int32                  Number of worker nodes
+      --policy-engine PolicyEngine         Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
+      --provider Provider                  Infrastructure provider backend (e.g., Docker)
+      --ttl string                         Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
+      --workers int32                      Number of worker nodes
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
@@ -12,27 +12,27 @@ Usage:
   ksail cluster create [flags]
 
 Flags:
-      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
-      --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
-      --cni CNI                        Container Network Interface (CNI) to use
-  -c, --context string                 Kubernetes context of cluster
-      --control-planes int32           Number of control-plane nodes (default 1)
-      --csi CSI                        Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
-  -d, --distribution Distribution      Kubernetes distribution to use
-      --distribution-config string     Configuration file for the distribution
-  -g, --gitops-engine GitOpsEngine     GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --import-images string           Path to tar archive with container images to import after cluster creation but before component installation
-  -k, --kubeconfig string              Path to kubeconfig file (default "~/.kube/config")
-      --load-balancer LoadBalancer     LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
-      --local-registry string          Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
-      --metrics-server MetricsServer   Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
-      --mirror-registry strings        Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
-  -n, --name string                    Cluster name used for container names, registry names, and kubeconfig context
-      --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
-      --provider Provider              Infrastructure provider backend (e.g., Docker)
-      --ttl string                     Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
-      --unknown NodeAutoscaling        Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
-      --workers int32                  Number of worker nodes
+      --cdi CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
+      --cert-manager CertManager           Cert-Manager configuration (Enabled: install, Disabled: skip)
+      --cni CNI                            Container Network Interface (CNI) to use
+  -c, --context string                     Kubernetes context of cluster
+      --control-planes int32               Number of control-plane nodes (default 1)
+      --csi CSI                            Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
+  -d, --distribution Distribution          Kubernetes distribution to use
+      --distribution-config string         Configuration file for the distribution
+  -g, --gitops-engine GitOpsEngine         GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
+      --import-images string               Path to tar archive with container images to import after cluster creation but before component installation
+  -k, --kubeconfig string                  Path to kubeconfig file (default "~/.kube/config")
+      --load-balancer LoadBalancer         LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
+      --local-registry string              Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
+      --metrics-server MetricsServer       Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
+      --mirror-registry strings            Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
+  -n, --name string                        Cluster name used for container names, registry names, and kubeconfig context
+      --node-autoscaling NodeAutoscaling   Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
+      --policy-engine PolicyEngine         Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
+      --provider Provider                  Infrastructure provider backend (e.g., Docker)
+      --ttl string                         Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
+      --workers int32                      Number of worker nodes
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-create.mdx
@@ -31,6 +31,7 @@ Flags:
       --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider              Infrastructure provider backend (e.g., Docker)
       --ttl string                     Auto-destroy cluster after duration (e.g. 1h, 30m, 2h30m). If not set, cluster persists indefinitely.
+      --unknown NodeAutoscaling        Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
       --workers int32                  Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -35,6 +35,7 @@ Flags:
       --policy-engine PolicyEngine             Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider                      Infrastructure provider backend (e.g., Docker)
   -s, --source-directory string                Directory containing workloads to deploy (default "k8s")
+      --unknown NodeAutoscaling                Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
       --workers int32                          Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -35,7 +35,7 @@ Flags:
       --policy-engine PolicyEngine             Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider                      Infrastructure provider backend (e.g., Docker)
   -s, --source-directory string                Directory containing workloads to deploy (default "k8s")
-      --unknown NodeAutoscaling                Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
+      --node-autoscaling NodeAutoscaling       Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
       --workers int32                          Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -31,11 +31,11 @@ Flags:
       --metrics-server MetricsServer           Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
       --mirror-registry strings                Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
   -n, --name string                            Cluster name used for container names, registry names, and kubeconfig context
-      --node-autoscaling NodeAutoscaling       Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
   -o, --output string                          Output directory for the project
       --policy-engine PolicyEngine             Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider                      Infrastructure provider backend (e.g., Docker)
   -s, --source-directory string                Directory containing workloads to deploy (default "k8s")
+      --node-autoscaling NodeAutoscaling       Node autoscaling (Talos: Enabled defers worker and control-plane scaling to an external autoscaler, Disabled lets KSail manage node counts; other distributions currently ignore this setting)
       --workers int32                          Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -31,11 +31,11 @@ Flags:
       --metrics-server MetricsServer           Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
       --mirror-registry strings                Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
   -n, --name string                            Cluster name used for container names, registry names, and kubeconfig context
+      --node-autoscaling NodeAutoscaling       Node autoscaling (Talos: Enabled defers worker and control-plane scaling to an external autoscaler, Disabled lets KSail manage node counts; other distributions currently ignore this setting)
   -o, --output string                          Output directory for the project
       --policy-engine PolicyEngine             Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider                      Infrastructure provider backend (e.g., Docker)
   -s, --source-directory string                Directory containing workloads to deploy (default "k8s")
-      --node-autoscaling NodeAutoscaling       Node autoscaling (Talos: Enabled defers worker and control-plane scaling to an external autoscaler, Disabled lets KSail manage node counts; other distributions currently ignore this setting)
       --workers int32                          Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-init.mdx
@@ -31,11 +31,11 @@ Flags:
       --metrics-server MetricsServer           Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
       --mirror-registry strings                Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
   -n, --name string                            Cluster name used for container names, registry names, and kubeconfig context
+      --node-autoscaling NodeAutoscaling       Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
   -o, --output string                          Output directory for the project
       --policy-engine PolicyEngine             Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider                      Infrastructure provider backend (e.g., Docker)
   -s, --source-directory string                Directory containing workloads to deploy (default "k8s")
-      --node-autoscaling NodeAutoscaling       Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
       --workers int32                          Number of worker nodes
 
 Global Flags:

--- a/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
@@ -49,6 +49,7 @@ Flags:
       --output string                  Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
       --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
       --provider Provider              Infrastructure provider backend (e.g., Docker)
+      --unknown NodeAutoscaling        Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
       --update-distribution            Upgrade the distribution to the latest stable version available in the OCI registry
       --update-kubernetes              Upgrade Kubernetes to the latest stable version available in the OCI registry
       --workers int32                  Number of worker nodes

--- a/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
@@ -28,32 +28,32 @@ Usage:
   ksail cluster update [flags]
 
 Flags:
-      --cdi CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
-      --cert-manager CertManager           Cert-Manager configuration (Enabled: install, Disabled: skip)
-      --cni CNI                            Container Network Interface (CNI) to use
-  -c, --context string                     Kubernetes context of cluster
-      --control-planes int32               Number of control-plane nodes (default 1)
-      --csi CSI                            Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
-  -d, --distribution Distribution          Kubernetes distribution to use
-      --distribution-config string         Configuration file for the distribution
-      --dry-run                            Preview changes without applying them
-      --force                              Skip confirmation prompt and proceed with cluster recreation
-  -g, --gitops-engine GitOpsEngine         GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --import-images string               Path to tar archive with container images to import after cluster creation but before component installation
-  -k, --kubeconfig string                  Path to kubeconfig file (default "~/.kube/config")
-      --load-balancer LoadBalancer         LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
-      --local-registry string              Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
-      --metrics-server MetricsServer       Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
-      --mirror-registry strings            Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
-  -n, --name string                        Cluster name used for container names, registry names, and kubeconfig context
-      --node-autoscaling NodeAutoscaling   Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
-      --output string                      Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
-      --policy-engine PolicyEngine         Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
-      --provider Provider                  Infrastructure provider backend (e.g., Docker)
-      --update-distribution                Upgrade the distribution to the latest stable version available in the OCI registry
-      --update-kubernetes                  Upgrade Kubernetes to the latest stable version available in the OCI registry
-      --workers int32                      Number of worker nodes
-  -y, --yes                                Skip confirmation prompt (alias for --force)
+      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
+      --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
+      --cni CNI                        Container Network Interface (CNI) to use
+  -c, --context string                 Kubernetes context of cluster
+      --control-planes int32           Number of control-plane nodes (default 1)
+      --csi CSI                        Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
+  -d, --distribution Distribution      Kubernetes distribution to use
+      --distribution-config string     Configuration file for the distribution
+      --dry-run                        Preview changes without applying them
+      --force                          Skip confirmation prompt and proceed with cluster recreation
+  -g, --gitops-engine GitOpsEngine     GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
+      --import-images string           Path to tar archive with container images to import after cluster creation but before component installation
+  -k, --kubeconfig string              Path to kubeconfig file (default "~/.kube/config")
+      --load-balancer LoadBalancer     LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
+      --local-registry string          Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
+      --metrics-server MetricsServer   Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
+      --mirror-registry strings        Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
+  -n, --name string                    Cluster name used for container names, registry names, and kubeconfig context
+      --output string                  Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
+      --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
+      --provider Provider              Infrastructure provider backend (e.g., Docker)
+      --node-autoscaling NodeAutoscaling   Node autoscaling (Talos: Enabled defers worker and control-plane scaling to an external autoscaler, Disabled lets KSail manage node counts; other distributions currently ignore this setting)
+      --update-distribution            Upgrade the distribution to the latest stable version available in the OCI registry
+      --update-kubernetes              Upgrade Kubernetes to the latest stable version available in the OCI registry
+      --workers int32                  Number of worker nodes
+  -y, --yes                            Skip confirmation prompt (alias for --force)
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
@@ -28,32 +28,32 @@ Usage:
   ksail cluster update [flags]
 
 Flags:
-      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
-      --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
-      --cni CNI                        Container Network Interface (CNI) to use
-  -c, --context string                 Kubernetes context of cluster
-      --control-planes int32           Number of control-plane nodes (default 1)
-      --csi CSI                        Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
-  -d, --distribution Distribution      Kubernetes distribution to use
-      --distribution-config string     Configuration file for the distribution
-      --dry-run                        Preview changes without applying them
-      --force                          Skip confirmation prompt and proceed with cluster recreation
-  -g, --gitops-engine GitOpsEngine     GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --import-images string           Path to tar archive with container images to import after cluster creation but before component installation
-  -k, --kubeconfig string              Path to kubeconfig file (default "~/.kube/config")
-      --load-balancer LoadBalancer     LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
-      --local-registry string          Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
-      --metrics-server MetricsServer   Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
-      --mirror-registry strings        Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
-  -n, --name string                    Cluster name used for container names, registry names, and kubeconfig context
-      --output string                  Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
-      --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
-      --provider Provider              Infrastructure provider backend (e.g., Docker)
+      --cdi CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
+      --cert-manager CertManager           Cert-Manager configuration (Enabled: install, Disabled: skip)
+      --cni CNI                            Container Network Interface (CNI) to use
+  -c, --context string                     Kubernetes context of cluster
+      --control-planes int32               Number of control-plane nodes (default 1)
+      --csi CSI                            Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
+  -d, --distribution Distribution          Kubernetes distribution to use
+      --distribution-config string         Configuration file for the distribution
+      --dry-run                            Preview changes without applying them
+      --force                              Skip confirmation prompt and proceed with cluster recreation
+  -g, --gitops-engine GitOpsEngine         GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
+      --import-images string               Path to tar archive with container images to import after cluster creation but before component installation
+  -k, --kubeconfig string                  Path to kubeconfig file (default "~/.kube/config")
+      --load-balancer LoadBalancer         LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
+      --local-registry string              Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
+      --metrics-server MetricsServer       Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
+      --mirror-registry strings            Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
+  -n, --name string                        Cluster name used for container names, registry names, and kubeconfig context
       --node-autoscaling NodeAutoscaling   Node autoscaling (Talos: Enabled defers worker and control-plane scaling to an external autoscaler, Disabled lets KSail manage node counts; other distributions currently ignore this setting)
-      --update-distribution            Upgrade the distribution to the latest stable version available in the OCI registry
-      --update-kubernetes              Upgrade Kubernetes to the latest stable version available in the OCI registry
-      --workers int32                  Number of worker nodes
-  -y, --yes                            Skip confirmation prompt (alias for --force)
+      --output string                      Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
+      --policy-engine PolicyEngine         Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
+      --provider Provider                  Infrastructure provider backend (e.g., Docker)
+      --update-distribution                Upgrade the distribution to the latest stable version available in the OCI registry
+      --update-kubernetes                  Upgrade Kubernetes to the latest stable version available in the OCI registry
+      --workers int32                      Number of worker nodes
+  -y, --yes                                Skip confirmation prompt (alias for --force)
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-update.mdx
@@ -28,32 +28,32 @@ Usage:
   ksail cluster update [flags]
 
 Flags:
-      --cdi CDI                        Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
-      --cert-manager CertManager       Cert-Manager configuration (Enabled: install, Disabled: skip)
-      --cni CNI                        Container Network Interface (CNI) to use
-  -c, --context string                 Kubernetes context of cluster
-      --control-planes int32           Number of control-plane nodes (default 1)
-      --csi CSI                        Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
-  -d, --distribution Distribution      Kubernetes distribution to use
-      --distribution-config string     Configuration file for the distribution
-      --dry-run                        Preview changes without applying them
-      --force                          Skip confirmation prompt and proceed with cluster recreation
-  -g, --gitops-engine GitOpsEngine     GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
-      --import-images string           Path to tar archive with container images to import after cluster creation but before component installation
-  -k, --kubeconfig string              Path to kubeconfig file (default "~/.kube/config")
-      --load-balancer LoadBalancer     LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
-      --local-registry string          Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
-      --metrics-server MetricsServer   Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
-      --mirror-registry strings        Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
-  -n, --name string                    Cluster name used for container names, registry names, and kubeconfig context
-      --output string                  Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
-      --policy-engine PolicyEngine     Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
-      --provider Provider              Infrastructure provider backend (e.g., Docker)
-      --unknown NodeAutoscaling        Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
-      --update-distribution            Upgrade the distribution to the latest stable version available in the OCI registry
-      --update-kubernetes              Upgrade Kubernetes to the latest stable version available in the OCI registry
-      --workers int32                  Number of worker nodes
-  -y, --yes                            Skip confirmation prompt (alias for --force)
+      --cdi CDI                            Container Device Interface (Default: use distribution, Enabled: enable CDI, Disabled: disable CDI)
+      --cert-manager CertManager           Cert-Manager configuration (Enabled: install, Disabled: skip)
+      --cni CNI                            Container Network Interface (CNI) to use
+  -c, --context string                     Kubernetes context of cluster
+      --control-planes int32               Number of control-plane nodes (default 1)
+      --csi CSI                            Container Storage Interface (Default: use distribution, Enabled: install CSI, Disabled: skip CSI)
+  -d, --distribution Distribution          Kubernetes distribution to use
+      --distribution-config string         Configuration file for the distribution
+      --dry-run                            Preview changes without applying them
+      --force                              Skip confirmation prompt and proceed with cluster recreation
+  -g, --gitops-engine GitOpsEngine         GitOps engine to use (None disables GitOps, Flux installs Flux controllers, ArgoCD installs Argo CD) (default None)
+      --import-images string               Path to tar archive with container images to import after cluster creation but before component installation
+  -k, --kubeconfig string                  Path to kubeconfig file (default "~/.kube/config")
+      --load-balancer LoadBalancer         LoadBalancer support (Default: use distribution × provider, Enabled: install, Disabled: uninstall)
+      --local-registry string              Local registry specification: [user:pass@]host[:port][/path] (e.g., localhost:5050, ghcr.io/myorg, ${USER}:${PASS}@ghcr.io:443/org)
+      --metrics-server MetricsServer       Metrics Server (Default: use distribution, Enabled: install, Disabled: uninstall)
+      --mirror-registry strings            Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'
+  -n, --name string                        Cluster name used for container names, registry names, and kubeconfig context
+      --node-autoscaling NodeAutoscaling   Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)
+      --output string                      Output format: text (default) or json (machine-readable, for CI/MCP) (default "text")
+      --policy-engine PolicyEngine         Policy engine (None: skip, Kyverno: install Kyverno, Gatekeeper: install Gatekeeper)
+      --provider Provider                  Infrastructure provider backend (e.g., Docker)
+      --update-distribution                Upgrade the distribution to the latest stable version available in the OCI registry
+      --update-kubernetes                  Upgrade Kubernetes to the latest stable version available in the OCI registry
+      --workers int32                      Number of worker nodes
+  -y, --yes                                Skip confirmation prompt (alias for --force)
 
 Global Flags:
       --benchmark       Show per-activity benchmark output

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -199,6 +199,7 @@ Editor command for interactive workflows (e.g., `code --wait`, `vim`). Falls bac
 | `localRegistry` | LocalRegistry | – |  |
 | `gitOpsEngine` | enum | – |  |
 | `sops` | SOPS | – |  |
+| `nodeAutoscaling` | enum | – |  |
 | `importImages` | string | – | Path to tar archive with container images to import after cluster creation but before component installation |
 | `vanilla` | OptionsVanilla | – |  |
 | `talos` | OptionsTalos | – |  |

--- a/pkg/apis/cluster/v1alpha1/coverage_test.go
+++ b/pkg/apis/cluster/v1alpha1/coverage_test.go
@@ -1065,3 +1065,66 @@ func TestValidateMirrorRegistriesForProvider_Omni(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// NodeAutoscaling.Set() — parsing coverage
+// ---------------------------------------------------------------------------
+
+//nolint:funlen // Table-driven enum parsing cases are easier to read inline.
+func TestNodeAutoscaling_Set(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantValue v1alpha1.NodeAutoscaling
+		wantError bool
+	}{
+		{
+			name:      "sets_enabled",
+			input:     "Enabled",
+			wantValue: v1alpha1.NodeAutoscalingEnabled,
+		},
+		{
+			name:      "sets_disabled",
+			input:     "Disabled",
+			wantValue: v1alpha1.NodeAutoscalingDisabled,
+		},
+		{
+			name:      "case_insensitive_enabled",
+			input:     "enabled",
+			wantValue: v1alpha1.NodeAutoscalingEnabled,
+		},
+		{
+			name:      "case_insensitive_disabled",
+			input:     "DISABLED",
+			wantValue: v1alpha1.NodeAutoscalingDisabled,
+		},
+		{
+			name:      "invalid_value_returns_error",
+			input:     "Invalid",
+			wantError: true,
+		},
+		{
+			name:      "empty_string_returns_error",
+			input:     "",
+			wantError: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got v1alpha1.NodeAutoscaling
+
+			err := got.Set(testCase.input)
+			if testCase.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.wantValue, got)
+			}
+		})
+	}
+}

--- a/pkg/apis/cluster/v1alpha1/coverage_test.go
+++ b/pkg/apis/cluster/v1alpha1/coverage_test.go
@@ -1070,7 +1070,6 @@ func TestValidateMirrorRegistriesForProvider_Omni(t *testing.T) {
 // NodeAutoscaling.Set() — parsing coverage
 // ---------------------------------------------------------------------------
 
-//nolint:funlen // Table-driven enum parsing cases are easier to read inline.
 func TestNodeAutoscaling_Set(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apis/cluster/v1alpha1/errors.go
+++ b/pkg/apis/cluster/v1alpha1/errors.go
@@ -32,6 +32,9 @@ var ErrInvalidPolicyEngine = errors.New("invalid policy engine")
 // ErrInvalidImageVerification is returned when an invalid image verification option is specified.
 var ErrInvalidImageVerification = errors.New("invalid image verification")
 
+// ErrInvalidNodeAutoscaling is returned when an invalid node autoscaling option is specified.
+var ErrInvalidNodeAutoscaling = errors.New("invalid node autoscaling")
+
 // ErrInvalidProvider is returned when an invalid provider is specified.
 var ErrInvalidProvider = errors.New("invalid provider")
 

--- a/pkg/apis/cluster/v1alpha1/nodeautoscaling.go
+++ b/pkg/apis/cluster/v1alpha1/nodeautoscaling.go
@@ -1,0 +1,58 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NodeAutoscaling defines whether an external node autoscaler manages cluster node counts.
+// When Enabled, ksail cluster update skips controlPlanes and workers diffs and scaling
+// operations to avoid conflicts with the autoscaler.
+type NodeAutoscaling string
+
+const (
+	// NodeAutoscalingEnabled indicates an external autoscaler manages node counts.
+	// Update operations will not modify controlPlanes or workers.
+	NodeAutoscalingEnabled NodeAutoscaling = "Enabled"
+	// NodeAutoscalingDisabled indicates KSail manages node counts directly.
+	NodeAutoscalingDisabled NodeAutoscaling = "Disabled"
+)
+
+// Set for NodeAutoscaling (pflag.Value interface).
+func (n *NodeAutoscaling) Set(value string) error {
+	for _, v := range ValidNodeAutoscalings() {
+		if strings.EqualFold(value, string(v)) {
+			*n = v
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"%w: %s (valid options: %s, %s)",
+		ErrInvalidNodeAutoscaling,
+		value,
+		NodeAutoscalingEnabled,
+		NodeAutoscalingDisabled,
+	)
+}
+
+// String returns the string representation of the NodeAutoscaling.
+func (n *NodeAutoscaling) String() string {
+	return string(*n)
+}
+
+// Type returns the type of the NodeAutoscaling.
+func (n *NodeAutoscaling) Type() string {
+	return "NodeAutoscaling"
+}
+
+// Default returns the default value for NodeAutoscaling (Disabled).
+func (n *NodeAutoscaling) Default() any {
+	return NodeAutoscalingDisabled
+}
+
+// ValidValues returns all valid NodeAutoscaling values as strings.
+func (n *NodeAutoscaling) ValidValues() []string {
+	return []string{string(NodeAutoscalingEnabled), string(NodeAutoscalingDisabled)}
+}

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -43,22 +43,22 @@ type ProviderSpec struct {
 
 // ClusterSpec defines cluster-related configuration.
 type ClusterSpec struct {
-	DistributionConfig string        `json:"distributionConfig,omitzero"`
-	Connection         Connection    `json:"connection,omitzero"`
-	Distribution       Distribution  `json:"distribution,omitzero"`
-	Provider           Provider      `json:"provider,omitzero"`
-	CNI                CNI           `json:"cni,omitzero"`
-	CSI                CSI           `json:"csi,omitzero"`
-	CDI                CDI           `json:"cdi,omitzero"`
-	MetricsServer      MetricsServer `json:"metricsServer,omitzero"`
-	LoadBalancer       LoadBalancer  `json:"loadBalancer,omitzero"`
-	CertManager        CertManager   `json:"certManager,omitzero"`
-	PolicyEngine       PolicyEngine  `json:"policyEngine,omitzero"`
-	LocalRegistry      LocalRegistry `json:"localRegistry,omitzero"`
-	GitOpsEngine       GitOpsEngine  `json:"gitOpsEngine,omitzero"`
-	SOPS               SOPS          `json:"sops,omitzero"`
+	DistributionConfig string          `json:"distributionConfig,omitzero"`
+	Connection         Connection      `json:"connection,omitzero"`
+	Distribution       Distribution    `json:"distribution,omitzero"`
+	Provider           Provider        `json:"provider,omitzero"`
+	CNI                CNI             `json:"cni,omitzero"`
+	CSI                CSI             `json:"csi,omitzero"`
+	CDI                CDI             `json:"cdi,omitzero"`
+	MetricsServer      MetricsServer   `json:"metricsServer,omitzero"`
+	LoadBalancer       LoadBalancer    `json:"loadBalancer,omitzero"`
+	CertManager        CertManager     `json:"certManager,omitzero"`
+	PolicyEngine       PolicyEngine    `json:"policyEngine,omitzero"`
+	LocalRegistry      LocalRegistry   `json:"localRegistry,omitzero"`
+	GitOpsEngine       GitOpsEngine    `json:"gitOpsEngine,omitzero"`
+	SOPS               SOPS            `json:"sops,omitzero"`
 	NodeAutoscaling    NodeAutoscaling `json:"nodeAutoscaling,omitzero"`
-	ImportImages       string        `json:"importImages,omitzero"       jsonschema:"description=Path to tar archive with container images to import after cluster creation but before component installation"` //nolint:lll // Long description required for JSON schema
+	ImportImages       string          `json:"importImages,omitzero"       jsonschema:"description=Path to tar archive with container images to import after cluster creation but before component installation"` //nolint:lll // Long description required for JSON schema
 
 	// Distribution-specific options
 	Vanilla OptionsVanilla `json:"vanilla,omitzero"`

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -57,6 +57,7 @@ type ClusterSpec struct {
 	LocalRegistry      LocalRegistry `json:"localRegistry,omitzero"`
 	GitOpsEngine       GitOpsEngine  `json:"gitOpsEngine,omitzero"`
 	SOPS               SOPS          `json:"sops,omitzero"`
+	NodeAutoscaling    NodeAutoscaling `json:"nodeAutoscaling,omitzero"`
 	ImportImages       string        `json:"importImages,omitzero"       jsonschema:"description=Path to tar archive with container images to import after cluster creation but before component installation"` //nolint:lll // Long description required for JSON schema
 
 	// Distribution-specific options

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -132,6 +132,11 @@ func ValidPlacementGroupStrategies() []PlacementGroupStrategy {
 	return []PlacementGroupStrategy{PlacementGroupStrategyNone, PlacementGroupStrategySpread}
 }
 
+// ValidNodeAutoscalings returns supported node autoscaling values.
+func ValidNodeAutoscalings() []NodeAutoscaling {
+	return []NodeAutoscaling{NodeAutoscalingEnabled, NodeAutoscalingDisabled}
+}
+
 // ValidateMirrorRegistriesForProvider validates that mirror registries are compatible with the provider.
 // Cloud providers (like Hetzner) cannot access local Docker containers running as mirror registries.
 // For cloud providers, mirror registries must point to external, internet-accessible registries.

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -3221,6 +3221,7 @@ func InitFieldSelectors() []ksailconfigmanager.FieldSelector[v1alpha1.Cluster] {
 	// Unified node count selectors for all distributions
 	selectors = append(selectors, ksailconfigmanager.ControlPlanesFieldSelector())
 	selectors = append(selectors, ksailconfigmanager.WorkersFieldSelector())
+	selectors = append(selectors, ksailconfigmanager.NodeAutoscalingFieldSelector())
 	// Talos-specific selectors
 	selectors = append(selectors, ksailconfigmanager.ImageVerificationFieldSelector())
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -5056,6 +5056,7 @@ func defaultClusterMutationFieldSelectors() []ksailconfigmanager.FieldSelector[v
 		ksailconfigmanager.DefaultImportImagesFieldSelector(),
 		ksailconfigmanager.ControlPlanesFieldSelector(),
 		ksailconfigmanager.WorkersFieldSelector(),
+		ksailconfigmanager.NodeAutoscalingFieldSelector(),
 	)
 }
 

--- a/pkg/fsutil/configmanager/ksail/binding.go
+++ b/pkg/fsutil/configmanager/ksail/binding.go
@@ -196,6 +196,9 @@ func (m *ConfigManager) getFieldMappings() map[any]string {
 		&m.Config.Spec.Cluster.Talos.ControlPlanes:     "control-planes",
 		&m.Config.Spec.Cluster.Talos.Workers:           "workers",
 		&m.Config.Spec.Cluster.Talos.ImageVerification: "image-verification",
+
+		// Cross-distribution options
+		&m.Config.Spec.Cluster.NodeAutoscaling: "node-autoscaling",
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/binding_test.go
+++ b/pkg/fsutil/configmanager/ksail/binding_test.go
@@ -334,6 +334,11 @@ func TestGenerateFlagName(t *testing.T) {
 			&manager.Config.Spec.Cluster.LocalRegistry.Registry,
 			"local-registry",
 		},
+		{
+			"NodeAutoscaling field",
+			&manager.Config.Spec.Cluster.NodeAutoscaling,
+			"node-autoscaling",
+		},
 	}
 
 	runFlagNameGenerationTests(t, manager, tests)

--- a/pkg/fsutil/configmanager/ksail/field_selector.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector.go
@@ -234,7 +234,8 @@ func NodeAutoscalingFieldSelector() FieldSelector[v1alpha1.Cluster] {
 		Selector: func(c *v1alpha1.Cluster) any {
 			return &c.Spec.Cluster.NodeAutoscaling
 		},
-		Description:  "Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)",
+		Description: "Node autoscaling " +
+			"(Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)",
 		DefaultValue: v1alpha1.NodeAutoscalingDisabled,
 	}
 }

--- a/pkg/fsutil/configmanager/ksail/field_selector.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector.go
@@ -227,3 +227,14 @@ func ImageVerificationFieldSelector() FieldSelector[v1alpha1.Cluster] {
 		DefaultValue: v1alpha1.ImageVerificationDisabled,
 	}
 }
+
+// NodeAutoscalingFieldSelector creates a field selector for node autoscaling.
+func NodeAutoscalingFieldSelector() FieldSelector[v1alpha1.Cluster] {
+	return FieldSelector[v1alpha1.Cluster]{
+		Selector: func(c *v1alpha1.Cluster) any {
+			return &c.Spec.Cluster.NodeAutoscaling
+		},
+		Description:  "Node autoscaling (Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)",
+		DefaultValue: v1alpha1.NodeAutoscalingDisabled,
+	}
+}

--- a/pkg/fsutil/configmanager/ksail/field_selector.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector.go
@@ -235,7 +235,8 @@ func NodeAutoscalingFieldSelector() FieldSelector[v1alpha1.Cluster] {
 			return &c.Spec.Cluster.NodeAutoscaling
 		},
 		Description: "Node autoscaling " +
-			"(Enabled: defer node scaling to an external autoscaler, Disabled: KSail manages node counts)",
+			"(Talos: Enabled defers worker and control-plane scaling to an external autoscaler, " +
+			"Disabled lets KSail manage node counts; other distributions currently ignore this setting)",
 		DefaultValue: v1alpha1.NodeAutoscalingDisabled,
 	}
 }

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -341,7 +341,12 @@ func (e *Engine) checkTalosOptionsChange(
 		return
 	}
 
-	e.applyFieldRules(oldSpec, newSpec, result, talosFieldRules)
+	rules := talosFieldRules
+	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
+		rules = talosFieldRulesNoScaling
+	}
+
+	e.applyFieldRules(oldSpec, newSpec, result, rules)
 }
 
 // talosFieldRules is the table of Talos-specific scalar field diff rules.
@@ -361,12 +366,25 @@ var talosFieldRules = []fieldRule{
 		reason:   "Talos supports adding/removing worker nodes via provider",
 		getVal:   func(s *v1alpha1.ClusterSpec) string { return strconv.Itoa(int(s.Talos.Workers)) },
 	},
-	{
-		field:    "cluster.talos.iso",
-		category: clusterupdate.ChangeCategoryInPlace,
-		reason:   "ISO change only affects newly provisioned nodes",
-		getVal:   func(s *v1alpha1.ClusterSpec) string { return strconv.FormatInt(s.Talos.ISO, 10) },
-	},
+	talosISORule,
+}
+
+// talosFieldRulesNoScaling is used when node autoscaling is enabled.
+// It excludes controlPlanes and workers rules to avoid conflicts with the external autoscaler.
+//
+//nolint:gochecknoglobals // Immutable field-rule table; avoids per-call heap allocation.
+var talosFieldRulesNoScaling = []fieldRule{
+	talosISORule,
+}
+
+// talosISORule is the shared ISO field rule used by both talosFieldRules and talosFieldRulesNoScaling.
+//
+//nolint:gochecknoglobals // Immutable field-rule; avoids per-call heap allocation.
+var talosISORule = fieldRule{
+	field:    "cluster.talos.iso",
+	category: clusterupdate.ChangeCategoryInPlace,
+	reason:   "ISO change only affects newly provisioned nodes",
+	getVal:   func(s *v1alpha1.ClusterSpec) string { return strconv.FormatInt(s.Talos.ISO, 10) },
 }
 
 // checkHetznerOptionsChange checks Hetzner-specific option changes.

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -956,3 +956,41 @@ func assertWorkloadTagChange(
 		t.Errorf("expected new value %q, got %q", newTag, change.NewValue)
 	}
 }
+
+func TestEngine_TalosNodeCountSuppressed_WhenAutoscalingEnabled(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	newer := clone(old)
+	newer.Talos.ControlPlanes = 5
+	newer.Talos.Workers = 3
+	newer.NodeAutoscaling = v1alpha1.NodeAutoscalingEnabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	for _, change := range result.AllChanges() {
+		if change.Field == "cluster.talos.controlPlanes" || change.Field == "cluster.talos.workers" {
+			t.Errorf("node count field %q should be suppressed when autoscaling is enabled", change.Field)
+		}
+	}
+}
+
+func TestEngine_TalosISOStillDetected_WhenAutoscalingEnabled(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	newer := clone(old)
+	newer.Talos.ISO = 999999
+	newer.NodeAutoscaling = v1alpha1.NodeAutoscalingEnabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	if !result.HasInPlaceChanges() {
+		t.Fatal("ISO change should still be detected when autoscaling is enabled")
+	}
+
+	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.iso",
+		"122630", "999999", clusterupdate.ChangeCategoryInPlace)
+}

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -970,8 +970,12 @@ func TestEngine_TalosNodeCountSuppressed_WhenAutoscalingEnabled(t *testing.T) {
 	result := engine.ComputeDiff(old, newer, nil, nil)
 
 	for _, change := range result.AllChanges() {
-		if change.Field == "cluster.talos.controlPlanes" || change.Field == "cluster.talos.workers" {
-			t.Errorf("node count field %q should be suppressed when autoscaling is enabled", change.Field)
+		if change.Field == "cluster.talos.controlPlanes" ||
+			change.Field == "cluster.talos.workers" {
+			t.Errorf(
+				"node count field %q should be suppressed when autoscaling is enabled",
+				change.Field,
+			)
 		}
 	}
 }

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -97,6 +97,12 @@ func (p *Provisioner) DiffConfig(
 		return result, nil
 	}
 
+	// When node autoscaling is enabled, skip node-count diffs to avoid
+	// conflicts with the external autoscaler.
+	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
+		return result, nil
+	}
+
 	// Guard: control-plane count must remain >= 1
 	if newSpec.Talos.ControlPlanes < 1 {
 		return nil, ErrMinimumControlPlanes
@@ -137,6 +143,15 @@ func (p *Provisioner) applyNodeScalingChanges(
 	result *clusterupdate.UpdateResult,
 ) error {
 	if oldSpec == nil || newSpec == nil {
+		return nil
+	}
+
+	// When node autoscaling is enabled, defer scaling to the external autoscaler.
+	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
+		_, _ = fmt.Fprintf(p.logWriter,
+			"  ℹ Node autoscaling is enabled; skipping node scaling for cluster %q\n",
+			clusterName)
+
 		return nil
 	}
 

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -97,15 +97,15 @@ func (p *Provisioner) DiffConfig(
 		return result, nil
 	}
 
-	// When node autoscaling is enabled, skip node-count diffs to avoid
-	// conflicts with the external autoscaler.
-	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
-		return result, nil
-	}
-
-	// Guard: control-plane count must remain >= 1
+	// Guard: control-plane count must remain >= 1 regardless of autoscaling.
 	if newSpec.Talos.ControlPlanes < 1 {
 		return nil, ErrMinimumControlPlanes
+	}
+
+	// When node autoscaling is enabled, skip node-count diff entries to avoid
+	// conflicts with the external autoscaler, but still validate the spec above.
+	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
+		return result, nil
 	}
 
 	// Compare control plane count

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -353,7 +353,11 @@ func TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled(t *testing.T) {
 
 	result, err := provisioner.DiffConfig(context.Background(), "test", oldSpec, newSpec)
 	require.NoError(t, err)
-	assert.Empty(t, result.InPlaceChanges, "node count diffs should be suppressed when autoscaling is enabled")
+	assert.Empty(
+		t,
+		result.InPlaceChanges,
+		"node count diffs should be suppressed when autoscaling is enabled",
+	)
 }
 
 // TestDiffConfig_StillValidatesMinimumControlPlanesWhenAutoscalingEnabled verifies that
@@ -400,5 +404,10 @@ func TestApplyNodeScalingChanges_SkipsWhenAutoscalingEnabled(t *testing.T) {
 		result,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, 0, result.TotalChanges(), "no scaling changes expected when autoscaling is enabled")
+	assert.Equal(
+		t,
+		0,
+		result.TotalChanges(),
+		"no scaling changes expected when autoscaling is enabled",
+	)
 }

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -334,3 +334,52 @@ func TestApplyNodeScalingChanges_BelowMinimumControlPlanes(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, talosprovisioner.ErrMinimumControlPlanes)
 }
+
+// TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled verifies that DiffConfig
+// returns no in-place changes for controlPlanes and workers when autoscaling is enabled.
+func TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	oldSpec := &v1alpha1.ClusterSpec{}
+	oldSpec.Talos.ControlPlanes = 1
+	oldSpec.Talos.Workers = 0
+
+	newSpec := &v1alpha1.ClusterSpec{}
+	newSpec.Talos.ControlPlanes = 5
+	newSpec.Talos.Workers = 3
+	newSpec.NodeAutoscaling = v1alpha1.NodeAutoscalingEnabled
+
+	result, err := provisioner.DiffConfig(context.Background(), "test", oldSpec, newSpec)
+	require.NoError(t, err)
+	assert.Empty(t, result.InPlaceChanges, "node count diffs should be suppressed when autoscaling is enabled")
+}
+
+// TestApplyNodeScalingChanges_SkipsWhenAutoscalingEnabled verifies that
+// applyNodeScalingChanges is a no-op when autoscaling is enabled.
+func TestApplyNodeScalingChanges_SkipsWhenAutoscalingEnabled(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+	result := clusterupdate.NewEmptyUpdateResult()
+
+	oldSpec := &v1alpha1.ClusterSpec{}
+	oldSpec.Talos.ControlPlanes = 1
+	oldSpec.Talos.Workers = 0
+
+	newSpec := &v1alpha1.ClusterSpec{}
+	newSpec.Talos.ControlPlanes = 5
+	newSpec.Talos.Workers = 3
+	newSpec.NodeAutoscaling = v1alpha1.NodeAutoscalingEnabled
+
+	err := provisioner.ApplyNodeScalingChangesForTest(
+		context.Background(),
+		"test",
+		oldSpec,
+		newSpec,
+		result,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.TotalChanges(), "no scaling changes expected when autoscaling is enabled")
+}

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -356,6 +356,25 @@ func TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled(t *testing.T) {
 	assert.Empty(t, result.InPlaceChanges, "node count diffs should be suppressed when autoscaling is enabled")
 }
 
+// TestDiffConfig_StillValidatesMinimumControlPlanesWhenAutoscalingEnabled verifies that
+// the controlPlanes >= 1 guard is enforced even when autoscaling is enabled.
+func TestDiffConfig_StillValidatesMinimumControlPlanesWhenAutoscalingEnabled(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	oldSpec := &v1alpha1.ClusterSpec{}
+	oldSpec.Talos.ControlPlanes = 1
+
+	newSpec := &v1alpha1.ClusterSpec{}
+	newSpec.Talos.ControlPlanes = 0 // invalid
+	newSpec.NodeAutoscaling = v1alpha1.NodeAutoscalingEnabled
+
+	_, err := provisioner.DiffConfig(context.Background(), "test", oldSpec, newSpec)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, talosprovisioner.ErrMinimumControlPlanes)
+}
+
 // TestApplyNodeScalingChanges_SkipsWhenAutoscalingEnabled verifies that
 // applyNodeScalingChanges is a no-op when autoscaling is enabled.
 func TestApplyNodeScalingChanges_SkipsWhenAutoscalingEnabled(t *testing.T) {

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -168,6 +168,13 @@
               "additionalProperties": false,
               "type": "object"
             },
+            "nodeAutoscaling": {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
             "importImages": {
               "type": "string",
               "description": "Path to tar archive with container images to import after cluster creation but before component installation"


### PR DESCRIPTION
## Summary

Adds a `NodeAutoscaling` enum (`Enabled`/`Disabled`) at `spec.cluster.nodeAutoscaling` on `ClusterSpec`. When set to `Enabled`, `ksail cluster update` skips both `controlPlanes` and `workers` diffs and scaling operations to avoid conflicts with external node autoscalers (e.g., cluster-autoscaler, Karpenter, Omni dynamic allocation).

## Problem

When an external node autoscaler manages node counts, `ksail cluster update` computes a diff between the introspected running node counts and the static values in `ksail.yaml`. This causes KSail to forcibly scale the cluster back to `ksail.yaml` values, potentially causing:

- **Resource starvation**: scaling down nodes the autoscaler intentionally added
- **Control conflict**: KSail and the autoscaler fighting over node counts
- **Momentary overscaling**: KSail scaling up while the autoscaler is also scaling

## Approach

Guards are applied at three layers:

1. **Spec-level diff engine** (`pkg/svc/diff/engine.go`) — suppresses `controlPlanes` and `workers` field rules while keeping the ISO rule
2. **Provisioner DiffConfig** (`pkg/svc/provisioner/cluster/talos/update.go`) — skips node-count comparisons
3. **`applyNodeScalingChanges`** — returns early with informational log message

The field is placed at the cluster level (not Talos-specific) for cross-distribution extensibility. It has no effect on `ksail cluster create` — initial node counts are still applied.

## Changes

| File | Change |
|------|--------|
| `pkg/apis/cluster/v1alpha1/nodeautoscaling.go` | New `NodeAutoscaling` enum type |
| `pkg/apis/cluster/v1alpha1/errors.go` | `ErrInvalidNodeAutoscaling` sentinel |
| `pkg/apis/cluster/v1alpha1/validation.go` | `ValidNodeAutoscalings()` |
| `pkg/apis/cluster/v1alpha1/types.go` | `NodeAutoscaling` field on `ClusterSpec` |
| `pkg/fsutil/configmanager/ksail/field_selector.go` | `NodeAutoscalingFieldSelector()` |
| `pkg/cli/cmd/cluster/cluster.go` | Wire field selector into init/create/update |
| `pkg/svc/diff/engine.go` | Guard diff engine with `talosFieldRulesNoScaling` |
| `pkg/svc/provisioner/cluster/talos/update.go` | Guard DiffConfig + applyNodeScalingChanges |
| `schemas/ksail-config.schema.json` | Regenerated with new enum |
| `*_test.go` | 10 new test cases across 3 files |

## Testing

- All new tests pass (diff engine suppression, provisioner DiffConfig skip, scaling skip, enum parsing)
- Full test suite passes (only pre-existing k3d failure due to Docker not running in CI-less env)