### PR TITLE
feat: unify kubeconfig refresh for all Talos providers

### DIFF
--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -16,6 +16,7 @@ CI uses Node.js 24. Documentation builds in ~2-3 seconds.
 ## Content Structure
 
 Documentation follows the [Diátaxis framework](https://diataxis.fr/):
+
 - **Tutorials** — Learning-oriented walkthroughs
 - **How-to guides** — Task-oriented procedures
 - **Reference** — CLI flags, API types, configuration schemas

--- a/.github/instructions/go-code.instructions.md
+++ b/.github/instructions/go-code.instructions.md
@@ -19,6 +19,7 @@ applyTo: "**/*.go"
 ## Dependency Guard
 
 `.golangci.yml` enforces a strict import allowlist via `depguard`. Adding a new dependency requires:
+
 1. Adding it to the `allow` list in `.golangci.yml`
 2. Running `golangci-lint run` to verify
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6512,7 +6512,11 @@ func refreshAndVerifyKubeconfig(
 		return fmt.Errorf("failed to refresh kubeconfig: %w", err)
 	}
 
-	if clusterCfg.Spec.Cluster.Provider != v1alpha1.ProviderOmni {
+	// Verify kubeconfig exists on disk for all cloud providers.
+	// Cloud providers (Omni, Hetzner) fetch kubeconfig from remote APIs;
+	// if the fetch silently no-ops, downstream Helm/GitOps calls would fail
+	// with a cryptic "stat <path>: no such file or directory" error.
+	if !clusterCfg.Spec.Cluster.Provider.IsCloud() {
 		return nil
 	}
 
@@ -6524,8 +6528,8 @@ func refreshAndVerifyKubeconfig(
 	_, statErr := os.Stat(kubeconfigPath)
 	if statErr != nil {
 		return fmt.Errorf(
-			"kubeconfig not available after Omni refresh at %q: %w",
-			kubeconfigPath, statErr,
+			"kubeconfig not available after refresh for %s provider at %q: %w",
+			clusterCfg.Spec.Cluster.Provider, kubeconfigPath, statErr,
 		)
 	}
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6495,12 +6495,12 @@ func createAndVerifyProvisioner(
 	return provisioner, nil
 }
 
-// refreshAndVerifyKubeconfig invokes the provisioner's KubeconfigRefresher and,
-// for Omni providers, ensures the kubeconfig file actually exists on disk after
-// the refresh. This is a defense-in-depth guard (regression #4112): if any
-// upstream step silently no-ops the fetch, downstream Helm/GitOps calls would
-// otherwise only surface a cryptic "stat <path>: no such file or directory"
-// warning. Failing here produces a clear, actionable error.
+// refreshAndVerifyKubeconfig invokes the provisioner's KubeconfigRefresher and
+// ensures the kubeconfig file actually exists on disk after the refresh.
+// This is a defense-in-depth guard (regression #4112): if any upstream step
+// silently no-ops the fetch, downstream Helm/GitOps calls would otherwise only
+// surface a cryptic "stat <path>: no such file or directory" warning.
+// Failing here produces a clear, actionable error.
 func refreshAndVerifyKubeconfig(
 	ctx context.Context,
 	refresher clusterprovisioner.KubeconfigRefresher,
@@ -6510,14 +6510,6 @@ func refreshAndVerifyKubeconfig(
 	err := refresher.RefreshKubeconfig(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to refresh kubeconfig: %w", err)
-	}
-
-	// Verify kubeconfig exists on disk for all cloud providers.
-	// Cloud providers (Omni, Hetzner) fetch kubeconfig from remote APIs;
-	// if the fetch silently no-ops, downstream Helm/GitOps calls would fail
-	// with a cryptic "stat <path>: no such file or directory" error.
-	if !clusterCfg.Spec.Cluster.Provider.IsCloud() {
-		return nil
 	}
 
 	kubeconfigPath, pathErr := kubeconfig.GetKubeconfigPathFromConfig(clusterCfg)

--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -41,6 +41,6 @@ var (
 	// ErrEmptyVersionResponse is returned when a Talos node returns an empty version response.
 	ErrEmptyVersionResponse = errors.New("empty version response from node")
 	// ErrNoControlPlaneForRefresh is returned when no control-plane node can be found
-	// for kubeconfig refresh on cloud providers (Hetzner).
+	// for kubeconfig refresh.
 	ErrNoControlPlaneForRefresh = errors.New("no control-plane node found for kubeconfig refresh")
 )

--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -42,5 +42,5 @@ var (
 	ErrEmptyVersionResponse = errors.New("empty version response from node")
 	// ErrNoControlPlaneForRefresh is returned when no control-plane node can be found
 	// for kubeconfig refresh on cloud providers (Hetzner).
-	ErrNoControlPlaneForRefresh = errors.New("kubeconfig refresh failed")
+	ErrNoControlPlaneForRefresh = errors.New("no control-plane node found for kubeconfig refresh")
 )

--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -40,4 +40,7 @@ var (
 	ErrNodeNotReady = errors.New("node did not become ready within timeout")
 	// ErrEmptyVersionResponse is returned when a Talos node returns an empty version response.
 	ErrEmptyVersionResponse = errors.New("empty version response from node")
+	// ErrNoControlPlaneForRefresh is returned when no control-plane node can be found
+	// for kubeconfig refresh on cloud providers (Hetzner).
+	ErrNoControlPlaneForRefresh = errors.New("kubeconfig refresh failed")
 )

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -208,6 +208,24 @@ func ContainerNameForTest(ctr container.Summary) string {
 	return containerName(ctr)
 }
 
+// KubeconfigFetcherForTest is the exported alias of kubeconfigFetcher for testing.
+type KubeconfigFetcherForTest = kubeconfigFetcher
+
+// WithTalosClientFactoryForTest sets the talosClientFactory for testing,
+// allowing injection of a mock that returns known kubeconfig bytes.
+func (p *Provisioner) WithTalosClientFactoryForTest(
+	f func(ctx context.Context, ip string) (KubeconfigFetcherForTest, error),
+) *Provisioner {
+	p.talosClientFactory = f
+
+	return p
+}
+
+// FetchAndWriteKubeconfigForCPForTest exposes fetchAndWriteKubeconfigForCP for testing.
+func (p *Provisioner) FetchAndWriteKubeconfigForCPForTest(ctx context.Context, cpIP string) error {
+	return p.fetchAndWriteKubeconfigForCP(ctx, cpIP)
+}
+
 // NthIPInNetworkForTest exposes nthIPInNetwork for unit testing.
 func NthIPInNetworkForTest(prefix netip.Prefix, offset int) (netip.Addr, error) {
 	return nthIPInNetwork(prefix, offset)

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -222,8 +222,13 @@ func (p *Provisioner) WithTalosClientFactoryForTest(
 }
 
 // FetchAndWriteKubeconfigForCPForTest exposes fetchAndWriteKubeconfigForCP for testing.
-func (p *Provisioner) FetchAndWriteKubeconfigForCPForTest(ctx context.Context, cpIP string) error {
-	return p.fetchAndWriteKubeconfigForCP(ctx, cpIP)
+func (p *Provisioner) FetchAndWriteKubeconfigForCPForTest(ctx context.Context, talosEndpoint, k8sEndpoint string) error {
+	return p.fetchAndWriteKubeconfigForCP(ctx, talosEndpoint, k8sEndpoint)
+}
+
+// GetMappedK8sAPIEndpointForTest exposes getMappedK8sAPIEndpoint for testing.
+func (p *Provisioner) GetMappedK8sAPIEndpointForTest(ctx context.Context, clusterName string) (string, error) {
+	return p.getMappedK8sAPIEndpoint(ctx, clusterName)
 }
 
 // NthIPInNetworkForTest exposes nthIPInNetwork for unit testing.

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -222,7 +222,10 @@ func (p *Provisioner) WithTalosClientFactoryForTest(
 }
 
 // FetchAndWriteKubeconfigForCPForTest exposes fetchAndWriteKubeconfigForCP for testing.
-func (p *Provisioner) FetchAndWriteKubeconfigForCPForTest(ctx context.Context, talosEndpoint, k8sEndpoint string) error {
+func (p *Provisioner) FetchAndWriteKubeconfigForCPForTest(
+	ctx context.Context,
+	talosEndpoint, k8sEndpoint string,
+) error {
 	return p.fetchAndWriteKubeconfigForCP(ctx, talosEndpoint, k8sEndpoint)
 }
 

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -230,7 +230,10 @@ func (p *Provisioner) FetchAndWriteKubeconfigForCPForTest(
 }
 
 // GetMappedK8sAPIEndpointForTest exposes getMappedK8sAPIEndpoint for testing.
-func (p *Provisioner) GetMappedK8sAPIEndpointForTest(ctx context.Context, clusterName string) (string, error) {
+func (p *Provisioner) GetMappedK8sAPIEndpointForTest(
+	ctx context.Context,
+	clusterName string,
+) (string, error) {
 	return p.getMappedK8sAPIEndpoint(ctx, clusterName)
 }
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -122,6 +122,13 @@ func defaultImagePullRetryConfig() imagePullRetryConfig {
 	}
 }
 
+// kubeconfigFetcher abstracts the Talos client methods needed for kubeconfig refresh.
+// Using an interface allows test doubles without requiring real Talos API connectivity.
+type kubeconfigFetcher interface {
+	Kubeconfig(ctx context.Context) ([]byte, error)
+	Close() error
+}
+
 // Provisioner implements ClusterProvisioner for Talos-in-Docker clusters.
 type Provisioner struct {
 	// talosConfigs holds the loaded Talos machine configurations with all patches applied.
@@ -140,6 +147,9 @@ type Provisioner struct {
 	// omniOpts holds Omni-specific options when using the Omni provider.
 	omniOpts           *v1alpha1.OptionsOmni
 	provisionerFactory func(ctx context.Context) (provision.Provisioner, error)
+	// talosClientFactory creates a Talos client for the given node IP.
+	// Tests can override this via export_test.go to inject a mock.
+	talosClientFactory func(ctx context.Context, ip string) (kubeconfigFetcher, error)
 	logWriter          io.Writer
 	logMu              sync.Mutex
 	componentDetector  *detector.ComponentDetector
@@ -160,7 +170,7 @@ func NewProvisioner(
 		options = NewOptions()
 	}
 
-	return &Provisioner{
+	p := &Provisioner{
 		talosConfigs: talosConfigs,
 		options:      options,
 		provisionerFactory: func(ctx context.Context) (provision.Provisioner, error) {
@@ -169,6 +179,12 @@ func NewProvisioner(
 		logWriter:      os.Stdout,
 		imagePullRetry: defaultImagePullRetryConfig(),
 	}
+
+	p.talosClientFactory = func(ctx context.Context, ip string) (kubeconfigFetcher, error) {
+		return p.createTalosClient(ctx, ip)
+	}
+
+	return p
 }
 
 // WithDockerClient sets the Docker client for container operations.
@@ -281,57 +297,6 @@ func (p *Provisioner) RefreshKubeconfig(ctx context.Context, name string) error 
 	default:
 		return nil
 	}
-}
-
-// refreshHetznerKubeconfig fetches the kubeconfig from a Hetzner control-plane
-// node's Talos API and writes it to the configured kubeconfig path.
-// This enables `cluster update` on ephemeral CI runners where the kubeconfig
-// generated during `cluster create` does not persist (Fixes #4369).
-func (p *Provisioner) refreshHetznerKubeconfig(ctx context.Context, clusterName string) error {
-	nodes, err := p.getHetznerNodesByRole(ctx, clusterName)
-	if err != nil {
-		return fmt.Errorf("failed to list Hetzner nodes for kubeconfig refresh: %w", err)
-	}
-
-	// Find the first control-plane node
-	var cpIP string
-
-	for _, node := range nodes {
-		if node.Role == RoleControlPlane {
-			cpIP = node.IP
-
-			break
-		}
-	}
-
-	if cpIP == "" {
-		return fmt.Errorf(
-			"%w: no control-plane nodes found for cluster %q",
-			ErrNoControlPlaneForRefresh, clusterName,
-		)
-	}
-
-	talosClient, err := p.createTalosClient(ctx, cpIP)
-	if err != nil {
-		return fmt.Errorf("failed to create Talos client for kubeconfig refresh: %w", err)
-	}
-
-	defer talosClient.Close() //nolint:errcheck
-
-	kubeconfig, err := talosClient.Kubeconfig(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to fetch kubeconfig from Talos API: %w", err)
-	}
-
-	kubeconfig, err = rewriteKubeconfigEndpoint(
-		kubeconfig,
-		"https://"+net.JoinHostPort(cpIP, "6443"),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to rewrite kubeconfig endpoint: %w", err)
-	}
-
-	return p.writeKubeconfig(kubeconfig)
 }
 
 // Options returns the current runtime options.
@@ -560,6 +525,63 @@ func (p *Provisioner) Stop(ctx context.Context, name string) error {
 	_, _ = fmt.Fprintf(p.logWriter, "Successfully stopped Talos cluster %q\n", clusterName)
 
 	return nil
+}
+
+// refreshHetznerKubeconfig fetches the kubeconfig from a Hetzner control-plane
+// node's Talos API and writes it to the configured kubeconfig path.
+// This enables `cluster update` on ephemeral CI runners where the kubeconfig
+// generated during `cluster create` does not persist (Fixes #4369).
+func (p *Provisioner) refreshHetznerKubeconfig(ctx context.Context, clusterName string) error {
+	nodes, err := p.getHetznerNodesByRole(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to list Hetzner nodes for kubeconfig refresh for cluster %q: %w", clusterName, err)
+	}
+
+	// Find the first control-plane node
+	var cpIP string
+
+	for _, node := range nodes {
+		if node.Role == RoleControlPlane {
+			cpIP = node.IP
+
+			break
+		}
+	}
+
+	if cpIP == "" {
+		return fmt.Errorf(
+			"%w: no control-plane nodes found for cluster %q",
+			ErrNoControlPlaneForRefresh, clusterName,
+		)
+	}
+
+	return p.fetchAndWriteKubeconfigForCP(ctx, cpIP)
+}
+
+// fetchAndWriteKubeconfigForCP fetches the kubeconfig from the Talos API at cpIP,
+// rewrites the server endpoint to https://cpIP:6443, and writes the result to disk.
+func (p *Provisioner) fetchAndWriteKubeconfigForCP(ctx context.Context, cpIP string) error {
+	talosClient, err := p.talosClientFactory(ctx, cpIP)
+	if err != nil {
+		return fmt.Errorf("failed to create Talos client for kubeconfig refresh: %w", err)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	kubeconfig, err := talosClient.Kubeconfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch kubeconfig from Talos API: %w", err)
+	}
+
+	kubeconfig, err = rewriteKubeconfigEndpoint(
+		kubeconfig,
+		"https://"+net.JoinHostPort(cpIP, "6443"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to rewrite kubeconfig endpoint: %w", err)
+	}
+
+	return p.writeKubeconfig(kubeconfig)
 }
 
 // resolveClusterName returns the provided name if non-empty, otherwise the cluster name from configs.

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -530,7 +530,11 @@ func (p *Provisioner) Stop(ctx context.Context, name string) error {
 func (p *Provisioner) refreshKubeconfigFromTalosAPI(ctx context.Context, clusterName string) error {
 	nodes, err := p.getNodesByRole(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to list nodes for kubeconfig refresh for cluster %q: %w", clusterName, err)
+		return fmt.Errorf(
+			"failed to list nodes for kubeconfig refresh for cluster %q: %w",
+			clusterName,
+			err,
+		)
 	}
 
 	var cpIP string
@@ -574,7 +578,10 @@ func (p *Provisioner) refreshKubeconfigFromTalosAPI(ctx context.Context, cluster
 // rewrites the server endpoint to k8sEndpoint, and writes the result to disk.
 // Docker clusters pass mapped host ports for both endpoints; other providers pass the
 // raw control-plane IP (with k8sEndpoint as https://cpIP:6443).
-func (p *Provisioner) fetchAndWriteKubeconfigForCP(ctx context.Context, talosEndpoint, k8sEndpoint string) error {
+func (p *Provisioner) fetchAndWriteKubeconfigForCP(
+	ctx context.Context,
+	talosEndpoint, k8sEndpoint string,
+) error {
 	talosClient, err := p.talosClientFactory(ctx, talosEndpoint)
 	if err != nil {
 		return fmt.Errorf("failed to create Talos client for kubeconfig refresh: %w", err)

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"sync"
 	"time"
@@ -257,21 +258,80 @@ func (p *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
 
 // RefreshKubeconfig fetches and saves the kubeconfig for a running cluster.
 // For Omni clusters, the kubeconfig is retrieved from the Omni API.
-// For Docker and Hetzner clusters, kubeconfig is expected to persist from creation.
+// For Hetzner clusters, the kubeconfig is fetched from the Talos control-plane
+// API via a control-plane node's public IP. This is needed on ephemeral CI runners
+// where the kubeconfig from cluster create does not persist between runs.
+// For Docker clusters, kubeconfig is expected to persist from creation (local).
 // This implements the KubeconfigRefresher interface.
 func (p *Provisioner) RefreshKubeconfig(ctx context.Context, name string) error {
-	if p.omniOpts == nil {
-		return nil
-	}
-
 	clusterName := p.resolveClusterName(name)
 
-	omniProv, err := p.omniProvider()
+	switch {
+	case p.omniOpts != nil:
+		omniProv, err := p.omniProvider()
+		if err != nil {
+			return err
+		}
+
+		return p.saveOmniKubeconfig(ctx, omniProv, clusterName)
+
+	case p.hetznerOpts != nil:
+		return p.refreshHetznerKubeconfig(ctx, clusterName)
+
+	default:
+		return nil
+	}
+}
+
+// refreshHetznerKubeconfig fetches the kubeconfig from a Hetzner control-plane
+// node's Talos API and writes it to the configured kubeconfig path.
+// This enables `cluster update` on ephemeral CI runners where the kubeconfig
+// generated during `cluster create` does not persist (Fixes #4369).
+func (p *Provisioner) refreshHetznerKubeconfig(ctx context.Context, clusterName string) error {
+	nodes, err := p.getHetznerNodesByRole(ctx, clusterName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list Hetzner nodes for kubeconfig refresh: %w", err)
 	}
 
-	return p.saveOmniKubeconfig(ctx, omniProv, clusterName)
+	// Find the first control-plane node
+	var cpIP string
+
+	for _, node := range nodes {
+		if node.Role == RoleControlPlane {
+			cpIP = node.IP
+
+			break
+		}
+	}
+
+	if cpIP == "" {
+		return fmt.Errorf(
+			"%w: no control-plane nodes found for cluster %q",
+			ErrNoControlPlaneForRefresh, clusterName,
+		)
+	}
+
+	talosClient, err := p.createTalosClient(ctx, cpIP)
+	if err != nil {
+		return fmt.Errorf("failed to create Talos client for kubeconfig refresh: %w", err)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	kubeconfig, err := talosClient.Kubeconfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch kubeconfig from Talos API: %w", err)
+	}
+
+	kubeconfig, err = rewriteKubeconfigEndpoint(
+		kubeconfig,
+		"https://"+net.JoinHostPort(cpIP, "6443"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to rewrite kubeconfig endpoint: %w", err)
+	}
+
+	return p.writeKubeconfig(kubeconfig)
 }
 
 // Options returns the current runtime options.

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -273,30 +273,27 @@ func (p *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
 }
 
 // RefreshKubeconfig fetches and saves the kubeconfig for a running cluster.
-// For Omni clusters, the kubeconfig is retrieved from the Omni API.
-// For Hetzner clusters, the kubeconfig is fetched from the Talos control-plane
-// API via a control-plane node's public IP. This is needed on ephemeral CI runners
-// where the kubeconfig from cluster create does not persist between runs.
-// For Docker clusters, kubeconfig is expected to persist from creation (local).
+// For Omni clusters, the kubeconfig is first retrieved from the Omni API;
+// if that fails, it falls back to the Talos API via a control-plane node.
+// For all other providers (Docker, Hetzner), the kubeconfig is fetched
+// from the Talos control-plane API. Docker uses mapped host ports; Hetzner
+// uses the node's public IP directly.
 // This implements the KubeconfigRefresher interface.
 func (p *Provisioner) RefreshKubeconfig(ctx context.Context, name string) error {
 	clusterName := p.resolveClusterName(name)
 
-	switch {
-	case p.omniOpts != nil:
+	// Omni: prefer the Omni SaaS API; fall back to Talos API on failure.
+	if p.omniOpts != nil {
 		omniProv, err := p.omniProvider()
-		if err != nil {
-			return err
+		if err == nil {
+			if saveErr := p.saveOmniKubeconfig(ctx, omniProv, clusterName); saveErr == nil {
+				return nil
+			}
 		}
-
-		return p.saveOmniKubeconfig(ctx, omniProv, clusterName)
-
-	case p.hetznerOpts != nil:
-		return p.refreshHetznerKubeconfig(ctx, clusterName)
-
-	default:
-		return nil
+		// Fall through to the Talos API path.
 	}
+
+	return p.refreshKubeconfigFromTalosAPI(ctx, clusterName)
 }
 
 // Options returns the current runtime options.
@@ -527,21 +524,15 @@ func (p *Provisioner) Stop(ctx context.Context, name string) error {
 	return nil
 }
 
-// refreshHetznerKubeconfig fetches the kubeconfig from a Hetzner control-plane
-// node's Talos API and writes it to the configured kubeconfig path.
-// This enables `cluster update` on ephemeral CI runners where the kubeconfig
-// generated during `cluster create` does not persist (Fixes #4369).
-func (p *Provisioner) refreshHetznerKubeconfig(ctx context.Context, clusterName string) error {
-	nodes, err := p.getHetznerNodesByRole(ctx, clusterName)
+// refreshKubeconfigFromTalosAPI discovers a control-plane node, connects to its
+// Talos API, fetches the kubeconfig, and writes it to disk. For Docker clusters
+// it resolves mapped host ports; for Hetzner/Omni it uses the node IP directly.
+func (p *Provisioner) refreshKubeconfigFromTalosAPI(ctx context.Context, clusterName string) error {
+	nodes, err := p.getNodesByRole(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf(
-			"failed to list Hetzner nodes for kubeconfig refresh for cluster %q: %w",
-			clusterName,
-			err,
-		)
+		return fmt.Errorf("failed to list nodes for kubeconfig refresh for cluster %q: %w", clusterName, err)
 	}
 
-	// Find the first control-plane node
 	var cpIP string
 
 	for _, node := range nodes {
@@ -559,13 +550,32 @@ func (p *Provisioner) refreshHetznerKubeconfig(ctx context.Context, clusterName 
 		)
 	}
 
-	return p.fetchAndWriteKubeconfigForCP(ctx, cpIP)
+	talosEndpoint := cpIP
+	k8sEndpoint := "https://" + net.JoinHostPort(cpIP, "6443")
+
+	if p.isDockerProvider() {
+		talosEndpoint, err = p.getMappedTalosAPIEndpoint(ctx, clusterName)
+		if err != nil {
+			return fmt.Errorf("failed to resolve mapped Talos API endpoint: %w", err)
+		}
+
+		mappedK8sHost, mappedErr := p.getMappedK8sAPIEndpoint(ctx, clusterName)
+		if mappedErr != nil {
+			return fmt.Errorf("failed to resolve mapped K8s API endpoint: %w", mappedErr)
+		}
+
+		k8sEndpoint = "https://" + mappedK8sHost
+	}
+
+	return p.fetchAndWriteKubeconfigForCP(ctx, talosEndpoint, k8sEndpoint)
 }
 
-// fetchAndWriteKubeconfigForCP fetches the kubeconfig from the Talos API at cpIP,
-// rewrites the server endpoint to https://cpIP:6443, and writes the result to disk.
-func (p *Provisioner) fetchAndWriteKubeconfigForCP(ctx context.Context, cpIP string) error {
-	talosClient, err := p.talosClientFactory(ctx, cpIP)
+// fetchAndWriteKubeconfigForCP fetches the kubeconfig from the Talos API at talosEndpoint,
+// rewrites the server endpoint to k8sEndpoint, and writes the result to disk.
+// Docker clusters pass mapped host ports for both endpoints; other providers pass the
+// raw control-plane IP (with k8sEndpoint as https://cpIP:6443).
+func (p *Provisioner) fetchAndWriteKubeconfigForCP(ctx context.Context, talosEndpoint, k8sEndpoint string) error {
+	talosClient, err := p.talosClientFactory(ctx, talosEndpoint)
 	if err != nil {
 		return fmt.Errorf("failed to create Talos client for kubeconfig refresh: %w", err)
 	}
@@ -579,7 +589,7 @@ func (p *Provisioner) fetchAndWriteKubeconfigForCP(ctx context.Context, cpIP str
 
 	kubeconfig, err = rewriteKubeconfigEndpoint(
 		kubeconfig,
-		"https://"+net.JoinHostPort(cpIP, "6443"),
+		k8sEndpoint,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to rewrite kubeconfig endpoint: %w", err)

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -170,7 +170,7 @@ func NewProvisioner(
 		options = NewOptions()
 	}
 
-	p := &Provisioner{ //nolint:varnamelen
+	prov := &Provisioner{
 		talosConfigs: talosConfigs,
 		options:      options,
 		provisionerFactory: func(ctx context.Context) (provision.Provisioner, error) {
@@ -180,11 +180,11 @@ func NewProvisioner(
 		imagePullRetry: defaultImagePullRetryConfig(),
 	}
 
-	p.talosClientFactory = func(ctx context.Context, ip string) (kubeconfigFetcher, error) {
-		return p.createTalosClient(ctx, ip)
+	prov.talosClientFactory = func(ctx context.Context, ip string) (kubeconfigFetcher, error) {
+		return prov.createTalosClient(ctx, ip)
 	}
 
-	return p
+	return prov
 }
 
 // WithDockerClient sets the Docker client for container operations.
@@ -282,15 +282,15 @@ func (p *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
 func (p *Provisioner) RefreshKubeconfig(ctx context.Context, name string) error {
 	clusterName := p.resolveClusterName(name)
 
-	// Omni: prefer the Omni SaaS API; fall back to Talos API on failure.
+	// Omni: use the Omni SaaS API (Talos API fallback is not viable because
+	// getOmniNodesByRole returns machine IDs, not reachable IPs).
 	if p.omniOpts != nil {
 		omniProv, err := p.omniProvider()
-		if err == nil {
-			if saveErr := p.saveOmniKubeconfig(ctx, omniProv, clusterName); saveErr == nil {
-				return nil
-			}
+		if err != nil {
+			return fmt.Errorf("omni provider for kubeconfig refresh: %w", err)
 		}
-		// Fall through to the Talos API path.
+
+		return p.saveOmniKubeconfig(ctx, omniProv, clusterName)
 	}
 
 	return p.refreshKubeconfigFromTalosAPI(ctx, clusterName)

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -534,7 +534,11 @@ func (p *Provisioner) Stop(ctx context.Context, name string) error {
 func (p *Provisioner) refreshHetznerKubeconfig(ctx context.Context, clusterName string) error {
 	nodes, err := p.getHetznerNodesByRole(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to list Hetzner nodes for kubeconfig refresh for cluster %q: %w", clusterName, err)
+		return fmt.Errorf(
+			"failed to list Hetzner nodes for kubeconfig refresh for cluster %q: %w",
+			clusterName,
+			err,
+		)
 	}
 
 	// Find the first control-plane node

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -170,7 +170,7 @@ func NewProvisioner(
 		options = NewOptions()
 	}
 
-	p := &Provisioner{
+	p := &Provisioner{ //nolint:varnamelen
 		talosConfigs: talosConfigs,
 		options:      options,
 		provisionerFactory: func(ctx context.Context) (provision.Provisioner, error) {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -36,6 +36,12 @@ func (p *Provisioner) writeKubeconfig(kubeconfig []byte) error {
 		}
 	}
 
+	// Canonicalize the path (resolve symlinks) before writing
+	kubeconfigPath, err = fsutil.EvalCanonicalPath(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to canonicalize kubeconfig path: %w", err)
+	}
+
 	// Write kubeconfig to file
 	err = os.WriteFile(kubeconfigPath, kubeconfig, kubeconfigFileMode)
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_docker.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_docker.go
@@ -690,18 +690,22 @@ func (p *Provisioner) buildNodeRequests(
 // talosAPIPort is the Talos apid service port.
 const talosAPIPort = 50000
 
-// getMappedTalosAPIEndpoint finds the control plane container and returns the mapped
-// Talos API endpoint. On macOS and other non-Linux systems, Docker runs in a VM,
-// so we need to use the mapped port via 127.0.0.1 instead of the container's internal IP.
-func (p *Provisioner) getMappedTalosAPIEndpoint(
+// k8sAPIPort is the Kubernetes API server port.
+const k8sAPIPort = 6443
+
+// getMappedPortEndpoint inspects the first control-plane container for the given
+// cluster and returns a 127.0.0.1:<hostPort> endpoint for the specified container port.
+// On macOS and other non-Linux systems Docker runs in a VM, so we need to use the
+// mapped port via 127.0.0.1 instead of the container's internal IP.
+func (p *Provisioner) getMappedPortEndpoint(
 	ctx context.Context,
 	clusterName string,
+	containerPort int,
 ) (string, error) {
 	if p.dockerClient == nil {
 		return "", ErrDockerNotAvailable
 	}
 
-	// Find the control plane container for this cluster
 	containers, err := p.listDockerNodesByRole(ctx, clusterName, RoleControlPlane)
 	if err != nil {
 		return "", fmt.Errorf("failed to list control-plane containers: %w", err)
@@ -711,25 +715,33 @@ func (p *Provisioner) getMappedTalosAPIEndpoint(
 		return "", fmt.Errorf("%w for cluster %s", ErrNoControlPlane, clusterName)
 	}
 
-	// Get the first control plane container (they all have the same port mapping)
-	containerID := containers[0].ID
-
-	// Inspect the container to get port mappings
-	inspect, err := p.dockerClient.ContainerInspect(ctx, containerID)
+	inspect, err := p.dockerClient.ContainerInspect(ctx, containers[0].ID)
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect container: %w", err)
 	}
 
-	// Find the mapped port for Talos API (50000/tcp)
-	portKey := nat.Port(fmt.Sprintf("%d/tcp", talosAPIPort))
+	portKey := nat.Port(fmt.Sprintf("%d/tcp", containerPort))
 
 	bindings, ok := inspect.NetworkSettings.Ports[portKey]
 	if !ok || len(bindings) == 0 {
-		return "", fmt.Errorf("%w for Talos API port %d", ErrNoPortMapping, talosAPIPort)
+		return "", fmt.Errorf("%w for port %d", ErrNoPortMapping, containerPort)
 	}
 
-	// Use the first binding's host port
-	hostPort := bindings[0].HostPort
+	return net.JoinHostPort("127.0.0.1", bindings[0].HostPort), nil
+}
 
-	return net.JoinHostPort("127.0.0.1", hostPort), nil
+// getMappedTalosAPIEndpoint returns the host-mapped endpoint for the Talos API (port 50000).
+func (p *Provisioner) getMappedTalosAPIEndpoint(
+	ctx context.Context,
+	clusterName string,
+) (string, error) {
+	return p.getMappedPortEndpoint(ctx, clusterName, talosAPIPort)
+}
+
+// getMappedK8sAPIEndpoint returns the host-mapped endpoint for the Kubernetes API (port 6443).
+func (p *Provisioner) getMappedK8sAPIEndpoint(
+	ctx context.Context,
+	clusterName string,
+) (string, error) {
+	return p.getMappedPortEndpoint(ctx, clusterName, k8sAPIPort)
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_test.go
@@ -908,7 +908,7 @@ users:
 
 	require.NoError(t, err)
 
-	data, readErr := os.ReadFile(kubeconfigPath)
+	data, readErr := os.ReadFile(kubeconfigPath) //nolint:gosec
 	require.NoError(t, readErr)
 	assert.Contains(t, string(data), "https://1.2.3.4:6443")
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_test.go
@@ -810,13 +810,13 @@ func TestProvisioner_Delete_OmniProvider(t *testing.T) {
 
 // RefreshKubeconfig tests — verify routing for Docker, Hetzner, and Omni.
 
-func TestProvisioner_RefreshKubeconfig_DockerNoOp(t *testing.T) {
+func TestProvisioner_RefreshKubeconfig_DefaultNoOp(t *testing.T) {
 	t.Parallel()
 
 	configs := createTestTalosConfigs(t, "docker-cluster")
 	provisioner := talosprovisioner.NewProvisioner(configs, nil).
 		WithDockerClient(docker.NewMockAPIClient(t))
-	// Docker provisioner: no hetznerOpts, no omniOpts → no-op
+	// No hetznerOpts, no omniOpts → default no-op path
 
 	ctx := context.Background()
 	err := provisioner.RefreshKubeconfig(ctx, "")
@@ -824,12 +824,12 @@ func TestProvisioner_RefreshKubeconfig_DockerNoOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestProvisioner_RefreshKubeconfig_DockerNoClient(t *testing.T) {
+func TestProvisioner_RefreshKubeconfig_NoClientNoOp(t *testing.T) {
 	t.Parallel()
 
 	configs := createTestTalosConfigs(t, "docker-cluster")
 	provisioner := talosprovisioner.NewProvisioner(configs, nil)
-	// No Docker client, no Hetzner/Omni opts → still a no-op (Docker default path)
+	// No Docker client, no Hetzner/Omni opts → still a no-op (default path)
 
 	ctx := context.Background()
 	err := provisioner.RefreshKubeconfig(ctx, "")
@@ -852,6 +852,65 @@ func TestProvisioner_RefreshKubeconfig_HetznerNilInfraProvider(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, talosprovisioner.ErrNoControlPlaneForRefresh)
+}
+
+// mockKubeconfigFetcher satisfies KubeconfigFetcherForTest for unit testing
+// fetchAndWriteKubeconfigForCP without a real Talos control-plane.
+type mockKubeconfigFetcher struct {
+	kubeconfig []byte
+	fetchErr   error
+}
+
+func (m *mockKubeconfigFetcher) Kubeconfig(_ context.Context) ([]byte, error) {
+	return m.kubeconfig, m.fetchErr
+}
+
+func (m *mockKubeconfigFetcher) Close() error {
+	return nil
+}
+
+func TestProvisioner_RefreshKubeconfig_HetznerFetchAndWrite(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	kubeconfigPath := tmpDir + "/kube.yaml"
+
+	// A minimal but valid kubeconfig: rewriteKubeconfigEndpoint uses clientcmd.Load,
+	// which requires at least one cluster entry to rewrite.
+	minimalKubeconfig := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://0.0.0.0:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: admin@test
+  name: admin@test
+current-context: admin@test
+users:
+- name: admin@test
+  user: {}
+`)
+
+	configs := createTestTalosConfigs(t, "hetzner-cluster")
+	opts := talosprovisioner.NewOptions().WithKubeconfigPath(kubeconfigPath)
+	provisioner := talosprovisioner.NewProvisioner(configs, opts).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{}).
+		WithLogWriter(io.Discard).
+		WithTalosClientFactoryForTest(func(_ context.Context, _ string) (talosprovisioner.KubeconfigFetcherForTest, error) {
+			return &mockKubeconfigFetcher{kubeconfig: minimalKubeconfig}, nil
+		})
+
+	ctx := context.Background()
+	err := provisioner.FetchAndWriteKubeconfigForCPForTest(ctx, "1.2.3.4")
+
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(kubeconfigPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "https://1.2.3.4:6443")
 }
 
 func TestProvisioner_RefreshKubeconfig_OmniRoutes(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_test.go
@@ -882,34 +882,18 @@ func TestProvisioner_RefreshKubeconfig_HetznerFetchAndWrite(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	kubeconfigPath := tmpDir + "/kube.yaml"
-
-	// A minimal but valid kubeconfig: rewriteKubeconfigEndpoint uses clientcmd.Load,
-	// which requires at least one cluster entry to rewrite.
-	minimalKubeconfig := []byte(`apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: https://0.0.0.0:6443
-  name: test
-contexts:
-- context:
-    cluster: test
-    user: admin@test
-  name: admin@test
-current-context: admin@test
-users:
-- name: admin@test
-  user: {}
-`)
+	minimalKubeconfig := minimalKubeconfigBytes()
 
 	configs := createTestTalosConfigs(t, "hetzner-cluster")
 	opts := talosprovisioner.NewOptions().WithKubeconfigPath(kubeconfigPath)
 	provisioner := talosprovisioner.NewProvisioner(configs, opts).
 		WithHetznerOptions(v1alpha1.OptionsHetzner{}).
 		WithLogWriter(io.Discard).
-		WithTalosClientFactoryForTest(func(_ context.Context, _ string) (talosprovisioner.KubeconfigFetcherForTest, error) {
-			return &mockKubeconfigFetcher{kubeconfig: minimalKubeconfig}, nil
-		})
+		WithTalosClientFactoryForTest(
+			func(_ context.Context, _ string) (talosprovisioner.KubeconfigFetcherForTest, error) {
+				return &mockKubeconfigFetcher{kubeconfig: minimalKubeconfig}, nil
+			},
+		)
 
 	ctx := context.Background()
 	err := provisioner.FetchAndWriteKubeconfigForCPForTest(ctx, "1.2.3.4", "https://1.2.3.4:6443")
@@ -935,11 +919,11 @@ func TestProvisioner_RefreshKubeconfig_OmniRoutes(t *testing.T) {
 	ctx := context.Background()
 	err := provisioner.RefreshKubeconfig(ctx, "")
 
-	// Omni API fails (nil client → ErrProviderUnavailable), then falls back to
-	// Talos API path via getNodesByRole. getOmniNodesByRole also fails because
-	// the Omni provider has no real client. The important thing is that it
-	// does NOT return nil (which would mean no refresh was attempted).
+	// Omni uses the Omni SaaS API exclusively (no Talos API fallback because
+	// getOmniNodesByRole returns machine IDs, not reachable IPs). With a nil
+	// client the Omni API call fails with ErrProviderUnavailable.
 	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrProviderUnavailable)
 }
 
 func TestProvisioner_RefreshKubeconfig_DockerFetchAndWrite(t *testing.T) {
@@ -947,8 +931,38 @@ func TestProvisioner_RefreshKubeconfig_DockerFetchAndWrite(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	kubeconfigPath := tmpDir + "/kube.yaml"
+	clusterName := "docker-cluster"
+	containerID := "docker-cp-container-1"
 
-	minimalKubeconfig := []byte(`apiVersion: v1
+	cpContainer, inspectResp := dockerCPFixtures(clusterName, containerID)
+	mockClient := dockerRefreshMock(t, cpContainer, inspectResp, containerID)
+
+	minimalKubeconfig := minimalKubeconfigBytes()
+	configs := createTestTalosConfigs(t, clusterName)
+	opts := talosprovisioner.NewOptions().WithKubeconfigPath(kubeconfigPath)
+	provisioner := talosprovisioner.NewProvisioner(configs, opts).
+		WithDockerClient(mockClient).
+		WithLogWriter(io.Discard).
+		WithTalosClientFactoryForTest(
+			func(_ context.Context, endpoint string) (talosprovisioner.KubeconfigFetcherForTest, error) {
+				assert.Equal(t, "127.0.0.1:33333", endpoint)
+
+				return &mockKubeconfigFetcher{kubeconfig: minimalKubeconfig}, nil
+			},
+		)
+
+	ctx := context.Background()
+	err := provisioner.RefreshKubeconfig(ctx, "")
+
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(kubeconfigPath) //nolint:gosec
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "https://127.0.0.1:44444")
+}
+
+func minimalKubeconfigBytes() []byte {
+	return []byte(`apiVersion: v1
 kind: Config
 clusters:
 - cluster:
@@ -964,9 +978,11 @@ users:
 - name: admin@test
   user: {}
 `)
-	containerID := "docker-cp-container-1"
-	clusterName := "docker-cluster"
+}
 
+func dockerCPFixtures(
+	clusterName, containerID string,
+) (container.Summary, container.InspectResponse) {
 	cpContainer := container.Summary{
 		ID:    containerID,
 		Names: []string{"/" + clusterName + "-controlplane-1"},
@@ -981,19 +997,34 @@ users:
 		},
 	}
 
-	// ContainerInspect response with port mappings for both Talos API and K8s API.
 	inspectResp := container.InspectResponse{
 		NetworkSettings: &container.NetworkSettings{
-			NetworkSettingsBase: container.NetworkSettingsBase{
+			NetworkSettingsBase: container.NetworkSettingsBase{ //nolint:staticcheck
 				Ports: nat.PortMap{
-					"50000/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "33333"}},
-					"6443/tcp":  []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "44444"}},
+					"50000/tcp": []nat.PortBinding{
+						{HostIP: "0.0.0.0", HostPort: "33333"},
+					},
+					"6443/tcp": []nat.PortBinding{
+						{HostIP: "0.0.0.0", HostPort: "44444"},
+					},
 				},
 			},
 		},
 	}
 
+	return cpContainer, inspectResp
+}
+
+func dockerRefreshMock(
+	t *testing.T,
+	cpContainer container.Summary,
+	inspectResp container.InspectResponse,
+	containerID string,
+) *docker.MockAPIClient {
+	t.Helper()
+
 	mockClient := docker.NewMockAPIClient(t)
+
 	// getDockerNodesByRole calls ContainerList
 	mockClient.EXPECT().
 		ContainerList(mock.Anything, mock.Anything).
@@ -1013,25 +1044,5 @@ users:
 		ContainerInspect(mock.Anything, containerID).
 		Return(inspectResp, nil)
 
-	configs := createTestTalosConfigs(t, clusterName)
-	opts := talosprovisioner.NewOptions().WithKubeconfigPath(kubeconfigPath)
-	provisioner := talosprovisioner.NewProvisioner(configs, opts).
-		WithDockerClient(mockClient).
-		WithLogWriter(io.Discard).
-		WithTalosClientFactoryForTest(func(_ context.Context, endpoint string) (talosprovisioner.KubeconfigFetcherForTest, error) {
-			// Verify the Talos client receives the mapped endpoint, not the container IP
-			assert.Equal(t, "127.0.0.1:33333", endpoint)
-
-			return &mockKubeconfigFetcher{kubeconfig: minimalKubeconfig}, nil
-		})
-
-	ctx := context.Background()
-	err := provisioner.RefreshKubeconfig(ctx, "")
-
-	require.NoError(t, err)
-
-	data, readErr := os.ReadFile(kubeconfigPath) //nolint:gosec
-	require.NoError(t, readErr)
-	// kubeconfig endpoint should be rewritten to the mapped K8s API port
-	assert.Contains(t, string(data), "https://127.0.0.1:44444")
+	return mockClient
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_test.go
@@ -807,3 +807,69 @@ func TestProvisioner_Delete_OmniProvider(t *testing.T) {
 	require.NotErrorIs(t, err, talosprovisioner.ErrDockerNotAvailable)
 	assert.ErrorIs(t, err, provider.ErrProviderUnavailable)
 }
+
+// RefreshKubeconfig tests — verify routing for Docker, Hetzner, and Omni.
+
+func TestProvisioner_RefreshKubeconfig_DockerNoOp(t *testing.T) {
+	t.Parallel()
+
+	configs := createTestTalosConfigs(t, "docker-cluster")
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).
+		WithDockerClient(docker.NewMockAPIClient(t))
+	// Docker provisioner: no hetznerOpts, no omniOpts → no-op
+
+	ctx := context.Background()
+	err := provisioner.RefreshKubeconfig(ctx, "")
+
+	require.NoError(t, err)
+}
+
+func TestProvisioner_RefreshKubeconfig_DockerNoClient(t *testing.T) {
+	t.Parallel()
+
+	configs := createTestTalosConfigs(t, "docker-cluster")
+	provisioner := talosprovisioner.NewProvisioner(configs, nil)
+	// No Docker client, no Hetzner/Omni opts → still a no-op (Docker default path)
+
+	ctx := context.Background()
+	err := provisioner.RefreshKubeconfig(ctx, "")
+
+	require.NoError(t, err)
+}
+
+func TestProvisioner_RefreshKubeconfig_HetznerNilInfraProvider(t *testing.T) {
+	t.Parallel()
+
+	configs := createTestTalosConfigs(t, "hetzner-cluster")
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{}).
+		WithLogWriter(io.Discard)
+	// Hetzner opts set but no infra provider → getHetznerNodesByRole returns nil nodes
+	// → ErrNoControlPlaneForRefresh
+
+	ctx := context.Background()
+	err := provisioner.RefreshKubeconfig(ctx, "")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, talosprovisioner.ErrNoControlPlaneForRefresh)
+}
+
+func TestProvisioner_RefreshKubeconfig_OmniRoutes(t *testing.T) {
+	t.Parallel()
+
+	omniProv := omni.NewProvider(nil)
+
+	configs := createTestTalosConfigs(t, "omni-cluster")
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).
+		WithInfraProvider(omniProv).
+		WithOmniOptions(v1alpha1.OptionsOmni{Endpoint: "https://test.omni.example.com"}).
+		WithLogWriter(io.Discard)
+
+	ctx := context.Background()
+	err := provisioner.RefreshKubeconfig(ctx, "")
+
+	// Should attempt Omni path and fail with provider error (nil client),
+	// NOT return nil (which would mean the Docker no-op path was taken).
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}

--- a/pkg/svc/provisioner/cluster/talos/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -810,31 +812,37 @@ func TestProvisioner_Delete_OmniProvider(t *testing.T) {
 
 // RefreshKubeconfig tests — verify routing for Docker, Hetzner, and Omni.
 
-func TestProvisioner_RefreshKubeconfig_DefaultNoOp(t *testing.T) {
+func TestProvisioner_RefreshKubeconfig_DockerNoContainers(t *testing.T) {
 	t.Parallel()
+
+	mockClient := docker.NewMockAPIClient(t)
+	mockClient.EXPECT().
+		ContainerList(mock.Anything, mock.Anything).
+		Return([]container.Summary{}, nil)
 
 	configs := createTestTalosConfigs(t, "docker-cluster")
 	provisioner := talosprovisioner.NewProvisioner(configs, nil).
-		WithDockerClient(docker.NewMockAPIClient(t))
-	// No hetznerOpts, no omniOpts → default no-op path
+		WithDockerClient(mockClient)
 
 	ctx := context.Background()
 	err := provisioner.RefreshKubeconfig(ctx, "")
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, talosprovisioner.ErrNoControlPlaneForRefresh)
 }
 
-func TestProvisioner_RefreshKubeconfig_NoClientNoOp(t *testing.T) {
+func TestProvisioner_RefreshKubeconfig_NoProviderError(t *testing.T) {
 	t.Parallel()
 
 	configs := createTestTalosConfigs(t, "docker-cluster")
 	provisioner := talosprovisioner.NewProvisioner(configs, nil)
-	// No Docker client, no Hetzner/Omni opts → still a no-op (default path)
+	// No Docker client, no Hetzner/Omni opts → getNodesByRole returns error
 
 	ctx := context.Background()
 	err := provisioner.RefreshKubeconfig(ctx, "")
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, talosprovisioner.ErrDockerNotAvailable)
 }
 
 func TestProvisioner_RefreshKubeconfig_HetznerNilInfraProvider(t *testing.T) {
@@ -904,7 +912,7 @@ users:
 		})
 
 	ctx := context.Background()
-	err := provisioner.FetchAndWriteKubeconfigForCPForTest(ctx, "1.2.3.4")
+	err := provisioner.FetchAndWriteKubeconfigForCPForTest(ctx, "1.2.3.4", "https://1.2.3.4:6443")
 
 	require.NoError(t, err)
 
@@ -927,8 +935,103 @@ func TestProvisioner_RefreshKubeconfig_OmniRoutes(t *testing.T) {
 	ctx := context.Background()
 	err := provisioner.RefreshKubeconfig(ctx, "")
 
-	// Should attempt Omni path and fail with provider error (nil client),
-	// NOT return nil (which would mean the Docker no-op path was taken).
+	// Omni API fails (nil client → ErrProviderUnavailable), then falls back to
+	// Talos API path via getNodesByRole. getOmniNodesByRole also fails because
+	// the Omni provider has no real client. The important thing is that it
+	// does NOT return nil (which would mean no refresh was attempted).
 	require.Error(t, err)
-	assert.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}
+
+func TestProvisioner_RefreshKubeconfig_DockerFetchAndWrite(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	kubeconfigPath := tmpDir + "/kube.yaml"
+
+	minimalKubeconfig := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://0.0.0.0:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: admin@test
+  name: admin@test
+current-context: admin@test
+users:
+- name: admin@test
+  user: {}
+`)
+	containerID := "docker-cp-container-1"
+	clusterName := "docker-cluster"
+
+	cpContainer := container.Summary{
+		ID:    containerID,
+		Names: []string{"/" + clusterName + "-controlplane-1"},
+		Labels: map[string]string{
+			talosprovisioner.LabelTalosOwned:       "true",
+			talosprovisioner.LabelTalosClusterName: clusterName,
+		},
+		NetworkSettings: &container.NetworkSettingsSummary{
+			Networks: map[string]*network.EndpointSettings{
+				"talos-net": {IPAddress: "10.5.0.2"},
+			},
+		},
+	}
+
+	// ContainerInspect response with port mappings for both Talos API and K8s API.
+	inspectResp := container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			NetworkSettingsBase: container.NetworkSettingsBase{
+				Ports: nat.PortMap{
+					"50000/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "33333"}},
+					"6443/tcp":  []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "44444"}},
+				},
+			},
+		},
+	}
+
+	mockClient := docker.NewMockAPIClient(t)
+	// getDockerNodesByRole calls ContainerList
+	mockClient.EXPECT().
+		ContainerList(mock.Anything, mock.Anything).
+		Return([]container.Summary{cpContainer}, nil)
+	// getMappedTalosAPIEndpoint calls listDockerNodesByRole + ContainerInspect
+	mockClient.EXPECT().
+		ContainerList(mock.Anything, mock.Anything).
+		Return([]container.Summary{cpContainer}, nil)
+	mockClient.EXPECT().
+		ContainerInspect(mock.Anything, containerID).
+		Return(inspectResp, nil)
+	// getMappedK8sAPIEndpoint calls listDockerNodesByRole + ContainerInspect
+	mockClient.EXPECT().
+		ContainerList(mock.Anything, mock.Anything).
+		Return([]container.Summary{cpContainer}, nil)
+	mockClient.EXPECT().
+		ContainerInspect(mock.Anything, containerID).
+		Return(inspectResp, nil)
+
+	configs := createTestTalosConfigs(t, clusterName)
+	opts := talosprovisioner.NewOptions().WithKubeconfigPath(kubeconfigPath)
+	provisioner := talosprovisioner.NewProvisioner(configs, opts).
+		WithDockerClient(mockClient).
+		WithLogWriter(io.Discard).
+		WithTalosClientFactoryForTest(func(_ context.Context, endpoint string) (talosprovisioner.KubeconfigFetcherForTest, error) {
+			// Verify the Talos client receives the mapped endpoint, not the container IP
+			assert.Equal(t, "127.0.0.1:33333", endpoint)
+
+			return &mockKubeconfigFetcher{kubeconfig: minimalKubeconfig}, nil
+		})
+
+	ctx := context.Background()
+	err := provisioner.RefreshKubeconfig(ctx, "")
+
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(kubeconfigPath) //nolint:gosec
+	require.NoError(t, readErr)
+	// kubeconfig endpoint should be rewritten to the mapped K8s API port
+	assert.Contains(t, string(data), "https://127.0.0.1:44444")
 }


### PR DESCRIPTION
## Summary

Fixes #4369

`cluster update` fails on Talos clusters when the kubeconfig is missing (e.g., ephemeral CI runners). Previously, `RefreshKubeconfig` was a no-op for non-Omni providers, so Docker and Hetzner clusters silently proceeded with a stale or missing kubeconfig and failed later.

This PR implements unified kubeconfig refresh from the Talos API for **all** Talos × provider combinations:

### Provider-specific behavior

| Provider | Talos API endpoint | K8s API endpoint |
|----------|-------------------|-----------------|
| **Docker** | `127.0.0.1:<mapped-50000-port>` (host-mapped) | `https://127.0.0.1:<mapped-6443-port>` (host-mapped) |
| **Hetzner** | `<public-CP-IP>:50000` | `https://<public-CP-IP>:6443` |
| **Omni** | Uses Omni SaaS API exclusively (no Talos API fallback) | N/A |

### Changes

- **Unified `RefreshKubeconfig`**: Replaced the three-way switch (Omni-only/Hetzner/no-op) with a single flow that works for all providers
- **Docker port mapping**: Added `getMappedK8sAPIEndpoint` (analogous to `getMappedTalosAPIEndpoint`) and extracted shared `getMappedPortEndpoint` helper
- **Refactored `fetchAndWriteKubeconfigForCP`**: Now accepts separate `talosEndpoint` and `k8sEndpoint` parameters so Docker can pass mapped host ports
- **Removed `IsCloud()` guard**: Post-refresh kubeconfig verification now applies to all providers (not just cloud)
- **Omni returns error on failure**: Since `getOmniNodesByRole` returns machine IDs (not reachable IPs), Omni does not fall back to the Talos API
- **Path safety**: Added `fsutil.EvalCanonicalPath` in `writeKubeconfig` for safe path canonicalization
- **New tests**: Docker success-path test with mock port mappings, Omni routing test, existing Hetzner test updated

### Sentinel errors

- `ErrNoControlPlaneForRefresh` — returned when no control-plane node is found (applies to all providers)