### PR TITLE
feat: add Talos version pin to OptionsTalos

### DIFF
--- a/pkg/apis/cluster/v1alpha1/coverage_test.go
+++ b/pkg/apis/cluster/v1alpha1/coverage_test.go
@@ -288,6 +288,7 @@ func TestCluster_MarshalJSON_TalosNonDefaultsKept(t *testing.T) {
 				Talos: v1alpha1.OptionsTalos{
 					ControlPlanes: 3,
 					Workers:       5,
+					Version:       "v1.11.2",
 					Config:        "/custom/talosconfig",
 					ISO:           999999,
 				},
@@ -314,6 +315,7 @@ func TestCluster_MarshalJSON_TalosNonDefaultsKept(t *testing.T) {
 
 	assert.InDelta(t, 3, talos["controlPlanes"], 0)
 	assert.InDelta(t, 5, talos["workers"], 0)
+	assert.Equal(t, "v1.11.2", talos["version"])
 	assert.Equal(t, "/custom/talosconfig", talos["config"])
 	assert.InDelta(t, 999999, talos["iso"], 0)
 }

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -12,6 +12,12 @@ type OptionsVanilla struct {
 
 // OptionsTalos defines options specific to the Talos distribution.
 type OptionsTalos struct {
+	// Version pins the Talos OS version used for cluster creation and upgrades.
+	// When set, KSail uses this version as the Docker container image tag and
+	// caps `--update-distribution` upgrades at this version. Accepts values
+	// with or without the "v" prefix (e.g., "v1.11.2" or "1.11.2").
+	// When empty, KSail uses its built-in default version.
+	Version string `json:"version,omitzero"`
 	// ControlPlanes is the number of control-plane nodes (default: 1).
 	ControlPlanes int32 `default:"1" json:"controlPlanes,omitzero"`
 	// Workers is the number of worker nodes (default: 0).

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6475,6 +6475,8 @@ const (
 // executePinnedDistributionUpgrade handles Talos distribution upgrades when a version pin is set.
 // It normalizes the pinned version, validates it is a parseable semver, guards against downgrades,
 // and either skips (already at pin), applies the upgrade, or reports a dry-run summary.
+//
+//nolint:funlen // Sequential upgrade orchestration with distinct skip/dry-run/apply phases.
 func executePinnedDistributionUpgrade(
 	cmd *cobra.Command,
 	upgrader clusterupdate.Upgrader,

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6491,6 +6491,7 @@ func executePinnedDistributionUpgrade(
 	if skipReason == pinnedVersionAlreadyAtIt {
 		notify.Infof(cmd.OutOrStdout(),
 			"distribution is already at pinned version %s", pinnedVersion)
+
 		return nil
 	}
 
@@ -6498,6 +6499,7 @@ func executePinnedDistributionUpgrade(
 		notify.Infof(cmd.OutOrStdout(),
 			"cluster is at %s which is newer than pinned version %s; skipping downgrade",
 			currentVersion, pinnedVersion)
+
 		return nil
 	}
 
@@ -6512,6 +6514,7 @@ func executePinnedDistributionUpgrade(
 	if dryRun {
 		notify.Infof(cmd.OutOrStdout(),
 			"Dry run complete. Would upgrade distribution to pinned version %s.", pinnedVersion)
+
 		return nil
 	}
 
@@ -6521,15 +6524,17 @@ func executePinnedDistributionUpgrade(
 	if upgradeErr != nil {
 		if errors.Is(upgradeErr, clustererr.ErrUpgradeSkipped) {
 			notify.Infof(cmd.OutOrStdout(), "distribution upgrade skipped: %v", upgradeErr)
+
 			return nil
 		}
+
 		return fmt.Errorf("distribution upgrade to pinned version %s failed: %w",
 			pinnedVersion, upgradeErr)
 	}
 
 	notify.WriteMessage(notify.Message{
 		Type:    notify.SuccessType,
-		Content: fmt.Sprintf("distribution upgraded to pinned version %s", pinnedVersion),
+		Content: "distribution upgraded to pinned version " + pinnedVersion,
 		Writer:  cmd.OutOrStdout(),
 	})
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6207,18 +6207,67 @@ func handleVersionUpgrades(
 
 	// Distribution upgrades first (runtime must support K8s version).
 	if updateDist { //nolint:nestif // sequential phase with version refresh guard
-		stepRecreated, err := executeVersionUpgrade(
-			cmd, cfgManager, ctx, deps, upgrader, resolver, clusterName,
-			"distribution", upgrader.DistributionImageRef(),
-			currentVersions.DistributionVersion, upgrader.VersionSuffix(),
-			upgrader.UpgradeDistribution, force, dryRun,
-		)
-		if err != nil {
-			return false, err
-		}
+		// Respect Talos version pin: when spec.cluster.talos.version is set,
+		// cap the distribution upgrade at the pinned version instead of
+		// discovering the latest from OCI. Skip entirely if already at the pin.
+		if ctx.ClusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionTalos &&
+			ctx.ClusterCfg.Spec.Cluster.Talos.Version != "" {
+			pinnedVersion := ctx.ClusterCfg.Spec.Cluster.Talos.Version
+			if pinnedVersion[0] != 'v' {
+				pinnedVersion = "v" + pinnedVersion
+			}
 
-		if stepRecreated {
-			recreated = true
+			if currentVersions.DistributionVersion == pinnedVersion {
+				notify.Infof(cmd.OutOrStdout(),
+					"distribution is already at pinned version %s", pinnedVersion)
+			} else {
+				notify.WriteMessage(notify.Message{
+					Type:  notify.InfoType,
+					Emoji: "📌",
+					Content: fmt.Sprintf(
+						"distribution upgrade capped at pinned version %s (current: %s)",
+						pinnedVersion, currentVersions.DistributionVersion,
+					),
+					Writer: cmd.OutOrStdout(),
+				})
+
+				if !dryRun {
+					upgradeErr := upgrader.UpgradeDistribution(
+						cmd.Context(), clusterName,
+						currentVersions.DistributionVersion, pinnedVersion,
+					)
+					if upgradeErr != nil {
+						return false, fmt.Errorf(
+							"distribution upgrade to pinned version %s failed: %w",
+							pinnedVersion, upgradeErr,
+						)
+					}
+
+					notify.WriteMessage(notify.Message{
+						Type:    notify.SuccessType,
+						Content: fmt.Sprintf("distribution upgraded to pinned version %s", pinnedVersion),
+						Writer:  cmd.OutOrStdout(),
+					})
+				} else {
+					notify.Infof(cmd.OutOrStdout(),
+						"Dry run complete. Would upgrade distribution to pinned version %s.",
+						pinnedVersion)
+				}
+			}
+		} else {
+			stepRecreated, err := executeVersionUpgrade(
+				cmd, cfgManager, ctx, deps, upgrader, resolver, clusterName,
+				"distribution", upgrader.DistributionImageRef(),
+				currentVersions.DistributionVersion, upgrader.VersionSuffix(),
+				upgrader.UpgradeDistribution, force, dryRun,
+			)
+			if err != nil {
+				return false, err
+			}
+
+			if stepRecreated {
+				recreated = true
+			}
 		}
 
 		// Re-fetch versions after distribution upgrade since recreation may

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -100,6 +100,12 @@ var ErrInvalidCompressionLevel = errors.New(
 	"compression level out of range",
 )
 
+// ErrEmptyPinnedVersion is returned when spec.cluster.talos.version is set to
+// an empty string in a context where a pinned version is expected.
+var ErrEmptyPinnedVersion = errors.New(
+	"pinned distribution version is empty",
+)
+
 // BackupMetadata contains metadata about a backup.
 type BackupMetadata struct {
 	Version       string    `json:"version"`
@@ -6212,47 +6218,13 @@ func handleVersionUpgrades(
 		// discovering the latest from OCI. Skip entirely if already at the pin.
 		if ctx.ClusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionTalos &&
 			ctx.ClusterCfg.Spec.Cluster.Talos.Version != "" {
-			pinnedVersion := ctx.ClusterCfg.Spec.Cluster.Talos.Version
-			if pinnedVersion[0] != 'v' {
-				pinnedVersion = "v" + pinnedVersion
-			}
-
-			if currentVersions.DistributionVersion == pinnedVersion {
-				notify.Infof(cmd.OutOrStdout(),
-					"distribution is already at pinned version %s", pinnedVersion)
-			} else {
-				notify.WriteMessage(notify.Message{
-					Type:  notify.InfoType,
-					Emoji: "📌",
-					Content: fmt.Sprintf(
-						"distribution upgrade capped at pinned version %s (current: %s)",
-						pinnedVersion, currentVersions.DistributionVersion,
-					),
-					Writer: cmd.OutOrStdout(),
-				})
-
-				if !dryRun {
-					upgradeErr := upgrader.UpgradeDistribution(
-						cmd.Context(), clusterName,
-						currentVersions.DistributionVersion, pinnedVersion,
-					)
-					if upgradeErr != nil {
-						return false, fmt.Errorf(
-							"distribution upgrade to pinned version %s failed: %w",
-							pinnedVersion, upgradeErr,
-						)
-					}
-
-					notify.WriteMessage(notify.Message{
-						Type:    notify.SuccessType,
-						Content: fmt.Sprintf("distribution upgraded to pinned version %s", pinnedVersion),
-						Writer:  cmd.OutOrStdout(),
-					})
-				} else {
-					notify.Infof(cmd.OutOrStdout(),
-						"Dry run complete. Would upgrade distribution to pinned version %s.",
-						pinnedVersion)
-				}
+			err := executePinnedDistributionUpgrade(
+				cmd, upgrader, clusterName,
+				ctx.ClusterCfg.Spec.Cluster.Talos.Version,
+				currentVersions.DistributionVersion, dryRun,
+			)
+			if err != nil {
+				return false, err
 			}
 		} else {
 			stepRecreated, err := executeVersionUpgrade(
@@ -6489,6 +6461,116 @@ func handleRecreationUpgrade(
 	})
 
 	return executeRecreateFlow(cmd, cfgManager, ctx, deps, clusterName, force)
+}
+
+// pinnedVersionSkipReason indicates why a pinned version upgrade was skipped.
+type pinnedVersionSkipReason int
+
+const (
+	pinnedVersionProceed     pinnedVersionSkipReason = iota // No skip — proceed with upgrade.
+	pinnedVersionAlreadyAtIt                                // Cluster is already at the pinned version.
+	pinnedVersionNewer                                      // Cluster is newer than the pinned version.
+)
+
+// executePinnedDistributionUpgrade handles Talos distribution upgrades when a version pin is set.
+// It normalizes the pinned version, validates it is a parseable semver, guards against downgrades,
+// and either skips (already at pin), applies the upgrade, or reports a dry-run summary.
+func executePinnedDistributionUpgrade(
+	cmd *cobra.Command,
+	upgrader clusterupdate.Upgrader,
+	clusterName string,
+	rawPinnedVersion string,
+	currentVersion string,
+	dryRun bool,
+) error {
+	pinnedVersion, skipReason, err := normalizePinnedVersion(rawPinnedVersion, currentVersion)
+	if err != nil {
+		return err
+	}
+
+	if skipReason == pinnedVersionAlreadyAtIt {
+		notify.Infof(cmd.OutOrStdout(),
+			"distribution is already at pinned version %s", pinnedVersion)
+		return nil
+	}
+
+	if skipReason == pinnedVersionNewer {
+		notify.Infof(cmd.OutOrStdout(),
+			"cluster is at %s which is newer than pinned version %s; skipping downgrade",
+			currentVersion, pinnedVersion)
+		return nil
+	}
+
+	notify.WriteMessage(notify.Message{
+		Type:  notify.InfoType,
+		Emoji: "📌",
+		Content: fmt.Sprintf("distribution upgrade capped at pinned version %s (current: %s)",
+			pinnedVersion, currentVersion),
+		Writer: cmd.OutOrStdout(),
+	})
+
+	if dryRun {
+		notify.Infof(cmd.OutOrStdout(),
+			"Dry run complete. Would upgrade distribution to pinned version %s.", pinnedVersion)
+		return nil
+	}
+
+	upgradeErr := upgrader.UpgradeDistribution(
+		cmd.Context(), clusterName, currentVersion, pinnedVersion,
+	)
+	if upgradeErr != nil {
+		if errors.Is(upgradeErr, clustererr.ErrUpgradeSkipped) {
+			notify.Infof(cmd.OutOrStdout(), "distribution upgrade skipped: %v", upgradeErr)
+			return nil
+		}
+		return fmt.Errorf("distribution upgrade to pinned version %s failed: %w",
+			pinnedVersion, upgradeErr)
+	}
+
+	notify.WriteMessage(notify.Message{
+		Type:    notify.SuccessType,
+		Content: fmt.Sprintf("distribution upgraded to pinned version %s", pinnedVersion),
+		Writer:  cmd.OutOrStdout(),
+	})
+
+	return nil
+}
+
+// normalizePinnedVersion validates and normalizes a pinned Talos version.
+// Returns the normalized version string and a skip reason. When the skip reason
+// is pinnedVersionProceed, the caller should proceed with the upgrade.
+// Returns an error if the version is empty or not a valid semver tag.
+func normalizePinnedVersion(
+	rawPinnedVersion, currentVersion string,
+) (string, pinnedVersionSkipReason, error) {
+	if rawPinnedVersion == "" {
+		return "", pinnedVersionProceed, ErrEmptyPinnedVersion
+	}
+
+	pinnedVersion := rawPinnedVersion
+	if !strings.HasPrefix(pinnedVersion, "v") {
+		pinnedVersion = "v" + pinnedVersion
+	}
+
+	// Validate the pinned version is a parseable semver tag.
+	pinned, pinErr := versionresolver.ParseVersion(pinnedVersion)
+	if pinErr != nil {
+		return "", pinnedVersionProceed, fmt.Errorf(
+			"invalid pinned Talos version %q: %w", rawPinnedVersion, pinErr,
+		)
+	}
+
+	if currentVersion == pinnedVersion {
+		return pinnedVersion, pinnedVersionAlreadyAtIt, nil
+	}
+
+	// Guard against downgrades: skip if the cluster is already newer than the pin.
+	current, curErr := versionresolver.ParseVersion(currentVersion)
+	if curErr == nil && pinned.Less(current) {
+		return pinnedVersion, pinnedVersionNewer, nil
+	}
+
+	return pinnedVersion, pinnedVersionProceed, nil
 }
 
 // createAndVerifyProvisioner creates a provisioner and verifies the cluster exists.

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6548,6 +6548,7 @@ func executePinnedDistributionUpgrade(
 func normalizePinnedVersion(
 	rawPinnedVersion, currentVersion string,
 ) (string, pinnedVersionSkipReason, error) {
+	rawPinnedVersion = strings.TrimSpace(rawPinnedVersion)
 	if rawPinnedVersion == "" {
 		return "", pinnedVersionProceed, ErrEmptyPinnedVersion
 	}

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -17,6 +17,7 @@ import (
 	talosgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/talos"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	k3dv1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	kindv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/yaml"
 )
@@ -101,6 +102,17 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 		"", // Use default Kubernetes version
 		"", // Use default network CIDR
 	)
+
+	// Align the version contract with the pinned Talos version so that
+	// generated machine configs only use fields the target version supports.
+	if m.Config.Spec.Cluster.Talos.Version != "" {
+		contract, contractErr := talosconfig.ParseContractFromVersion(
+			m.Config.Spec.Cluster.Talos.Version,
+		)
+		if contractErr == nil {
+			talosManager.WithVersionContract(contract)
+		}
+	}
 
 	// Add Hetzner-specific patches (external cloud provider + ingress firewall).
 	err = m.addHetznerPatches(talosManager, patchesDir)

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -105,13 +105,10 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 
 	// Align the version contract with the pinned Talos version so that
 	// generated machine configs only use fields the target version supports.
-	if m.Config.Spec.Cluster.Talos.Version != "" {
-		contract, contractErr := talosconfig.ParseContractFromVersion(
-			m.Config.Spec.Cluster.Talos.Version,
-		)
-		if contractErr == nil {
-			talosManager.WithVersionContract(contract)
-		}
+	if contractErr := applyPinnedVersionContract(
+		m.Config.Spec.Cluster.Talos.Version, talosManager,
+	); contractErr != nil {
+		return nil, contractErr
 	}
 
 	// Add Hetzner-specific patches (external cloud provider + ingress firewall).
@@ -595,4 +592,29 @@ func ingressFirewallPatches(networkCIDR string, cniPort int) ([]talosconfigmanag
 			Content: []byte(talosgenerator.IngressFirewallWorkerRulesYAML(normalizedCIDR, cniPort)),
 		},
 	}, nil
+}
+
+// applyPinnedVersionContract sets the version contract on the Talos config manager
+// when a pinned Talos version is specified. Returns an error if the version cannot
+// be parsed. Does nothing when pinnedVersion is empty.
+func applyPinnedVersionContract(
+	pinnedVersion string,
+	talosManager *talosconfigmanager.ConfigManager,
+) error {
+	if pinnedVersion == "" {
+		return nil
+	}
+
+	if !strings.HasPrefix(pinnedVersion, "v") {
+		pinnedVersion = "v" + pinnedVersion
+	}
+
+	contract, err := talosconfig.ParseContractFromVersion(pinnedVersion)
+	if err != nil {
+		return fmt.Errorf("parse Talos version contract for pinned version %q: %w", pinnedVersion, err)
+	}
+
+	talosManager.WithVersionContract(contract)
+
+	return nil
 }

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -105,9 +105,10 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 
 	// Align the version contract with the pinned Talos version so that
 	// generated machine configs only use fields the target version supports.
-	if contractErr := applyPinnedVersionContract(
+	contractErr := applyPinnedVersionContract(
 		m.Config.Spec.Cluster.Talos.Version, talosManager,
-	); contractErr != nil {
+	)
+	if contractErr != nil {
 		return nil, contractErr
 	}
 
@@ -611,7 +612,11 @@ func applyPinnedVersionContract(
 
 	contract, err := talosconfig.ParseContractFromVersion(pinnedVersion)
 	if err != nil {
-		return fmt.Errorf("parse Talos version contract for pinned version %q: %w", pinnedVersion, err)
+		return fmt.Errorf(
+			"parse Talos version contract for pinned version %q: %w",
+			pinnedVersion,
+			err,
+		)
 	}
 
 	talosManager.WithVersionContract(contract)

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -602,6 +602,7 @@ func applyPinnedVersionContract(
 	pinnedVersion string,
 	talosManager *talosconfigmanager.ConfigManager,
 ) error {
+	pinnedVersion = strings.TrimSpace(pinnedVersion)
 	if pinnedVersion == "" {
 		return nil
 	}

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -355,6 +355,12 @@ func (e *Engine) checkTalosOptionsChange(
 //nolint:gochecknoglobals // Immutable field-rule table; avoids per-call heap allocation.
 var talosFieldRules = []fieldRule{
 	{
+		field:    "cluster.talos.version",
+		category: clusterupdate.ChangeCategoryInPlace,
+		reason:   "version pin change only affects future operations (image selection, upgrade cap)",
+		getVal:   func(s *v1alpha1.ClusterSpec) string { return s.Talos.Version },
+	},
+	{
 		field:    "cluster.talos.controlPlanes",
 		category: clusterupdate.ChangeCategoryInPlace,
 		reason:   "Talos supports adding/removing control-plane nodes via provider",

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -446,6 +446,13 @@ func TestEngine_TalosOptionsChange(t *testing.T) {
 		newValue string
 	}{
 		{
+			name:     "version pin change",
+			mutate:   func(s *v1alpha1.ClusterSpec) { s.Talos.Version = "v1.12.0" },
+			field:    "cluster.talos.version",
+			oldValue: "",
+			newValue: "v1.12.0",
+		},
+		{
 			name:     "control plane count change",
 			mutate:   func(s *v1alpha1.ClusterSpec) { s.Talos.ControlPlanes = 3 },
 			field:    "cluster.talos.controlPlanes",

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -435,6 +435,7 @@ func TestEngine_VanillaOptionsChange_SkippedForNonVanilla(t *testing.T) {
 	}
 }
 
+//nolint:dupl // Structural similarity with HetznerOptionsChange table-driven test is intentional.
 func TestEngine_TalosOptionsChange(t *testing.T) {
 	t.Parallel()
 
@@ -513,6 +514,7 @@ func TestEngine_TalosOptionsChange_SkippedForNonTalos(t *testing.T) {
 	}
 }
 
+//nolint:dupl // Structural similarity with TalosOptionsChange table-driven test is intentional.
 func TestEngine_HetznerOptionsChange_RecreateRequired(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
@@ -94,8 +95,8 @@ func newProvisionerFromOptions(
 
 	// Override the default Talos container image when a version pin is set.
 	if opts.Version != "" {
-		version := opts.Version
-		if version[0] != 'v' {
+		version := strings.TrimSpace(opts.Version)
+		if !strings.HasPrefix(version, "v") {
 			version = "v" + version
 		}
 

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -94,8 +94,7 @@ func newProvisionerFromOptions(
 		WithSkipCNIChecks(skipCNIChecks)
 
 	// Override the default Talos container image when a version pin is set.
-	if opts.Version != "" {
-		version := strings.TrimSpace(opts.Version)
+	if version := strings.TrimSpace(opts.Version); version != "" {
 		if !strings.HasPrefix(version, "v") {
 			version = "v" + version
 		}

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -92,6 +92,16 @@ func newProvisionerFromOptions(
 		WithTalosconfigPath(talosconfigPath).
 		WithSkipCNIChecks(skipCNIChecks)
 
+	// Override the default Talos container image when a version pin is set.
+	if opts.Version != "" {
+		version := opts.Version
+		if version[0] != 'v' {
+			version = "v" + version
+		}
+
+		options.WithTalosImage(talosImageRepository + ":" + version)
+	}
+
 	if opts.ControlPlanes > 0 {
 		options.WithControlPlaneNodes(int(opts.ControlPlanes))
 	}

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -200,6 +200,9 @@
             },
             "talos": {
               "properties": {
+                "version": {
+                  "type": "string"
+                },
                 "controlPlanes": {
                   "type": "integer"
                 },


### PR DESCRIPTION
## Summary

Add `Version` field to `OptionsTalos` so users can pin the Talos OS version in ksail.yaml. When set:

- **Docker provider**: Uses the pinned version as the container image tag instead of KSail's built-in default
- **`--update-distribution`**: Caps upgrades at the pinned version instead of discovering latest from OCI
- **Version contract**: Aligned with the pin for compatible machine config generation (prevents generating fields unknown to the running Talos version)
- **Diff engine**: Detects version pin changes as in-place changes

## Rationale

The Talos OS version is an infrastructure concern not settable via native Talos machine config patches. This follows the existing pattern in `OptionsOmni.TalosVersion`.

When `Version` is empty (default), behavior is unchanged — KSail uses its built-in default version. This preserves full backward compatibility.

## Example

```yaml
spec:
  cluster:
    distribution: Talos
    talos:
      version: v1.11.2
      iso: 122630
```

## Changes

| File | Change |
|------|--------|
| `pkg/apis/cluster/v1alpha1/options.go` | Add `Version` field to `OptionsTalos` |
| `pkg/svc/provisioner/cluster/talos/factory.go` | Override Docker image when version is pinned |
| `pkg/fsutil/configmanager/ksail/distribution.go` | Align version contract with pinned version |
| `pkg/cli/cmd/cluster/cluster.go` | Cap `--update-distribution` at pinned version |
| `pkg/svc/diff/engine.go` | Add diff rule for version field |
| `schemas/ksail-config.schema.json` | Regenerated with new field |
| Tests | Diff engine and coverage tests updated |

Fixes #4380