### PR TITLE
fix(ci): remove stale registry containers between cluster create retries

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -341,7 +341,15 @@ runs:
               # shellcheck disable=SC2086
               ksail ${CONFIG:+--config "$CONFIG"} cluster delete --distribution "$DISTRIBUTION" --provider "$PROVIDER" $ARGS --force || true
             fi
-            # Prune any unused Docker resources left by the failed attempt (but not volumes)
+            # Remove any lingering mirror registry containers by name pattern.
+            # ksail cluster delete may not remove registry containers, leaving their
+            # Docker network endpoints alive. The next create attempt then fails with
+            # "endpoint with name <cluster>-<registry> already exists in network <cluster>".
+            for _reg_suffix in docker.io ghcr.io quay.io registry.k8s.io; do
+              docker ps -aq --filter "name=-${_reg_suffix}" \
+                | xargs -r docker rm -f 2>/dev/null || true
+            done
+            # Prune unused Docker resources (networks, stopped containers, dangling images)
             docker system prune -f || true
             } 2>&1 | tee "$CLEANUP_LOG"
             echo "⚠️ waiting 30s before retry…"

--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -341,12 +341,16 @@ runs:
               # shellcheck disable=SC2086
               ksail ${CONFIG:+--config "$CONFIG"} cluster delete --distribution "$DISTRIBUTION" --provider "$PROVIDER" $ARGS --force || true
             fi
-            # Remove any lingering mirror registry containers by name pattern.
+            # Remove any lingering KSail-managed mirror registry containers.
             # ksail cluster delete may not remove registry containers, leaving their
             # Docker network endpoints alive. The next create attempt then fails with
             # "endpoint with name <cluster>-<registry> already exists in network <cluster>".
+            # Filter by the KSail ownership label first, and keep the suffix match to
+            # limit cleanup to the known registry container naming scheme.
             for _reg_suffix in docker.io ghcr.io quay.io registry.k8s.io; do
-              docker ps -aq --filter "name=-${_reg_suffix}" \
+              docker ps -aq \
+                --filter "label=io.ksail.registry" \
+                --filter "name=-${_reg_suffix}" \
                 | xargs -r docker rm -f 2>/dev/null || true
             done
             # Prune unused Docker resources (networks, stopped containers, dangling images)

--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -347,6 +347,13 @@ runs:
             # fails with "cluster already exists" or "network '<cluster>' already exists".
             docker ps -aq --filter "label=talos.owned=true" \
               | xargs -r docker rm -f 2>/dev/null || true
+            # Remove any lingering Talos cluster state directories.
+            # ksail cluster delete --force may not clean up ~/.talos/clusters/<name>/.
+            # On the next attempt, the Talos provisioner checks for this directory and
+            # refuses to create with "state directory already exists, is the cluster
+            # already running?". Since this retry loop is only for Talos+Docker on a
+            # single-use CI runner, it is safe to remove all leftover Talos state.
+            rm -rf ~/.talos/clusters/ || true
             # Remove any lingering KSail-managed mirror registry containers.
             # ksail cluster delete may not remove registry containers, leaving their
             # Docker network endpoints alive. The next create attempt then fails with

--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -341,6 +341,12 @@ runs:
               # shellcheck disable=SC2086
               ksail ${CONFIG:+--config "$CONFIG"} cluster delete --distribution "$DISTRIBUTION" --provider "$PROVIDER" $ARGS --force || true
             fi
+            # Remove any lingering Talos cluster node containers.
+            # ksail cluster delete --force may leave Talos Docker containers behind,
+            # keeping the cluster Docker network alive. The next create attempt then
+            # fails with "cluster already exists" or "network '<cluster>' already exists".
+            docker ps -aq --filter "label=talos.owned=true" \
+              | xargs -r docker rm -f 2>/dev/null || true
             # Remove any lingering KSail-managed mirror registry containers.
             # ksail cluster delete may not remove registry containers, leaving their
             # Docker network endpoints alive. The next create attempt then fails with
@@ -353,7 +359,9 @@ runs:
                 --filter "name=-${_reg_suffix}" \
                 | xargs -r docker rm -f 2>/dev/null || true
             done
-            # Prune unused Docker resources (networks, stopped containers, dangling images)
+            # Prune unused Docker resources (networks, stopped containers, dangling images).
+            # This will also remove any cluster Docker networks left behind after the
+            # container cleanup above.
             docker system prune -f || true
             } 2>&1 | tee "$CLEANUP_LOG"
             echo "⚠️ waiting 30s before retry…"


### PR DESCRIPTION
## Problem

When `ksail cluster create` fails and the CI retry logic kicks in, the cleanup between attempts calls:
1. `ksail cluster delete --force` — deletes cluster nodes but does not always remove the mirror registry containers
2. `docker system prune -f` — prunes unused resources, but the registry containers still have active Docker network endpoints, so the cluster network is not pruned

The next retry attempt then calls `cluster create` again, which tries to re-connect the registry containers to the cluster network. Docker rejects this with:
```
endpoint with name <cluster>-docker.io already exists in network <cluster>
```

This caused 9 consecutive merge-queue failures for PR #4382, always on the second or third retry attempt.

## Fix

Explicitly stop and remove any running containers whose names match the KSail mirror registry suffix pattern (`-docker.io`, `-ghcr.io`, `-quay.io`, `-registry.k8s.io`) before calling `docker system prune`. These are the KSail mirror registry containers and are safe to remove unconditionally during a retry-cleanup pass.

## Testing

No production code changed. The fix applies only to the retry-cleanup path in `.github/actions/ksail-cluster/action.yml`. It will be exercised by the next Talos+Docker system test that triggers a retry.

Fixes #4289 (partially — addresses the cleanup gap in the retry logic)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>