### PR TITLE
ci: migrate Docker system tests from merge queue to pull_request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -599,7 +599,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [changes, build-artifact]
-    if: (github.event_name == 'pull_request' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
+    if: >-
+      (github.event_name == 'pull_request'
+      && needs.changes.outputs.system-test == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     permissions:
       contents: read
     outputs:
@@ -633,7 +637,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [changes, build-artifact]
-    if: (github.event_name == 'pull_request' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
+    if: >-
+      (github.event_name == 'pull_request'
+      && needs.changes.outputs.system-test == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     permissions:
       contents: read
     outputs:
@@ -669,8 +677,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
-    if: (github.event_name == 'pull_request' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
-    environment: ci
+    if: >-
+      (github.event_name == 'pull_request'
+      && needs.changes.outputs.system-test == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
-  merge_group:
+  # merge_group:  # commented out — system tests moved to pull_request (re-enable if needed)
   workflow_dispatch:
     inputs:
       run_system_tests:
-        description: "Run system tests (normally only runs in merge queue)"
+        description: "Run system tests"
         required: false
         type: boolean
         default: true
@@ -31,71 +31,68 @@ concurrency:
 permissions: {}
 
 jobs:
-  # Cancel stale merge queue runs for the same PR.
-  # Merge queue refs include a unique SHA suffix (gh-readonly-queue/<base>/pr-<id>-<sha>),
-  # so the workflow-level concurrency group can't deduplicate them. This job strips the
-  # SHA to find older runs for the same queue entry and cancels them.
-  cancel-stale-merge-queue:
-    name: 🧹 Cancel Stale Merge Queue Runs
-    if: github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      actions: write
-    steps:
-      - name: Cancel previous runs for same merge queue entry
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const ref = context.ref;
-            const match = ref.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
-            if (!match) {
-              console.log('Not a merge queue ref, skipping');
-              return;
-            }
-            const stablePrefix = match[1];
-
-            for (const status of ['in_progress', 'queued']) {
-              let page = 1;
-              while (true) {
-                const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'ci.yaml',
-                  event: 'merge_group',
-                  status,
-                  per_page: 100,
-                  page,
-                });
-
-                if (runs.length === 0) break;
-
-                for (const run of runs) {
-                  if (run.run_number >= context.runNumber) continue;
-                  const runRef = `refs/heads/${run.head_branch}`;
-                  const runMatch = runRef.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
-                  if (runMatch && runMatch[1] === stablePrefix) {
-                    console.log(`Cancelling stale run ${run.id} (${runRef})`);
-                    try {
-                      await github.rest.actions.cancelWorkflowRun({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        run_id: run.id,
-                      });
-                    } catch (error) {
-                      if (error && (error.status === 409 || error.status === 422)) {
-                        console.log(`Skipping run ${run.id}; it is no longer cancellable (${error.status})`);
-                        continue;
-                      }
-                      throw error;
-                    }
-                  }
-                }
-
-                if (runs.length < 100) break;
-                page += 1;
-              }
-            }
+  # cancel-stale-merge-queue — commented out: system tests moved to pull_request (re-enable if needed)
+  # cancel-stale-merge-queue:
+  #   name: 🧹 Cancel Stale Merge Queue Runs
+  #   if: github.event_name == 'merge_group'
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 2
+  #   permissions:
+  #     actions: write
+  #   steps:
+  #     - name: Cancel previous runs for same merge queue entry
+  #       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+  #       with:
+  #         script: |
+  #           const ref = context.ref;
+  #           const match = ref.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
+  #           if (!match) {
+  #             console.log('Not a merge queue ref, skipping');
+  #             return;
+  #           }
+  #           const stablePrefix = match[1];
+  #
+  #           for (const status of ['in_progress', 'queued']) {
+  #             let page = 1;
+  #             while (true) {
+  #               const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
+  #                 owner: context.repo.owner,
+  #                 repo: context.repo.repo,
+  #                 workflow_id: 'ci.yaml',
+  #                 event: 'merge_group',
+  #                 status,
+  #                 per_page: 100,
+  #                 page,
+  #               });
+  #
+  #               if (runs.length === 0) break;
+  #
+  #               for (const run of runs) {
+  #                 if (run.run_number >= context.runNumber) continue;
+  #                 const runRef = `refs/heads/${run.head_branch}`;
+  #                 const runMatch = runRef.match(/^(refs\/heads\/gh-readonly-queue\/.+)-[0-9a-f]+$/);
+  #                 if (runMatch && runMatch[1] === stablePrefix) {
+  #                   console.log(`Cancelling stale run ${run.id} (${runRef})`);
+  #                   try {
+  #                     await github.rest.actions.cancelWorkflowRun({
+  #                       owner: context.repo.owner,
+  #                       repo: context.repo.repo,
+  #                       run_id: run.id,
+  #                     });
+  #                   } catch (error) {
+  #                     if (error && (error.status === 409 || error.status === 422)) {
+  #                       console.log(`Skipping run ${run.id}; it is no longer cancellable (${error.status})`);
+  #                       continue;
+  #                     }
+  #                     throw error;
+  #                   }
+  #                 }
+  #               }
+  #
+  #               if (runs.length < 100) break;
+  #               page += 1;
+  #             }
+  #           }
 
   # Wait for sufficient GitHub API rate limit before proceeding
   rate-limit-gate:
@@ -212,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [changes]
-    if: github.event_name == 'workflow_dispatch' || ((github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.outputs.code == 'true' || needs.changes.outputs.cli == 'true'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (needs.changes.outputs.code == 'true' || needs.changes.outputs.cli == 'true' || needs.changes.outputs.system-test == 'true'))
     permissions:
       contents: read
     steps:
@@ -602,7 +599,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [changes, build-artifact]
-    if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     permissions:
       contents: read
     outputs:
@@ -636,7 +633,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [changes, build-artifact]
-    if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     permissions:
       contents: read
     outputs:
@@ -672,7 +669,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
-    if: (github.event_name == 'merge_group' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.system-test == 'true') || (github.event_name == 'workflow_dispatch' && inputs.run_system_tests == true)
     environment: ci
     permissions:
       contents: read


### PR DESCRIPTION
Docker system tests previously only ran in the merge queue, delaying feedback until after PR review was complete. This makes it harder for both humans and agents to iterate on failures during the PR lifecycle.

This change moves the `warm-helm-cache`, `warm-mirror-cache`, and `system-test-docker` jobs to trigger on `pull_request` instead of `merge_group`, providing earlier CI feedback. The `merge_group` trigger and `cancel-stale-merge-queue` job are commented out (not deleted) so they can be easily re-enabled if this worsens things.

Additionally, the `build-artifact` condition now includes `system-test` changes to cover the edge case where only `.github/fixtures/**` or `.github/workflows/ci.yaml` change (triggers system tests but not the `code` filter).

## Type of change

- [x] 🧹 Refactor