### PR TITLE
fix(diff): restore baseline node-count diffability under autoscaling

### DIFF
--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -341,12 +341,7 @@ func (e *Engine) checkTalosOptionsChange(
 		return
 	}
 
-	rules := talosFieldRules
-	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
-		rules = talosFieldRulesNoScaling
-	}
-
-	e.applyFieldRules(oldSpec, newSpec, result, rules)
+	e.applyFieldRules(oldSpec, newSpec, result, talosFieldRules)
 }
 
 // talosFieldRules is the table of Talos-specific scalar field diff rules.
@@ -375,15 +370,7 @@ var talosFieldRules = []fieldRule{
 	talosISORule,
 }
 
-// talosFieldRulesNoScaling is used when node autoscaling is enabled.
-// It excludes controlPlanes and workers rules to avoid conflicts with the external autoscaler.
-//
-//nolint:gochecknoglobals // Immutable field-rule table; avoids per-call heap allocation.
-var talosFieldRulesNoScaling = []fieldRule{
-	talosISORule,
-}
-
-// talosISORule is the shared ISO field rule used by both talosFieldRules and talosFieldRulesNoScaling.
+// talosISORule is the shared ISO field rule used by both Talos rule sets.
 //
 //nolint:gochecknoglobals // Immutable field-rule; avoids per-call heap allocation.
 var talosISORule = fieldRule{

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -370,7 +370,7 @@ var talosFieldRules = []fieldRule{
 	talosISORule,
 }
 
-// talosISORule is the shared ISO field rule used by both Talos rule sets.
+// talosISORule is the ISO field rule used by the Talos field rules.
 //
 //nolint:gochecknoglobals // Immutable field-rule; avoids per-call heap allocation.
 var talosISORule = fieldRule{

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -964,7 +964,7 @@ func assertWorkloadTagChange(
 	}
 }
 
-func TestEngine_TalosNodeCountSuppressed_WhenAutoscalingEnabled(t *testing.T) {
+func TestEngine_TalosBaselineNodeCountDetected_WhenAutoscalingEnabled(t *testing.T) {
 	t.Parallel()
 
 	old := newBaseSpec()
@@ -976,14 +976,28 @@ func TestEngine_TalosNodeCountSuppressed_WhenAutoscalingEnabled(t *testing.T) {
 	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
 	result := engine.ComputeDiff(old, newer, nil, nil)
 
+	foundCP, foundWorkers := false, false
+
 	for _, change := range result.AllChanges() {
-		if change.Field == "cluster.controlPlanes" ||
-			change.Field == "cluster.workers" {
-			t.Errorf(
-				"node count field %q should be suppressed when autoscaling is enabled",
-				change.Field,
-			)
+		if change.Field == "cluster.controlPlanes" {
+			foundCP = true
 		}
+
+		if change.Field == "cluster.workers" {
+			foundWorkers = true
+		}
+	}
+
+	if !foundCP {
+		t.Error(
+			"baseline cluster.controlPlanes diff should be detected when autoscaling is enabled",
+		)
+	}
+
+	if !foundWorkers {
+		t.Error(
+			"baseline cluster.workers diff should be detected when autoscaling is enabled",
+		)
 	}
 }
 

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -110,12 +110,6 @@ func (p *Provisioner) DiffConfig(
 		return nil, ErrMinimumControlPlanes
 	}
 
-	// When node autoscaling is enabled, skip node-count diff entries to avoid
-	// conflicts with the external autoscaler, but still validate the spec above.
-	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
-		return result, nil
-	}
-
 	// Compare control plane count
 	if oldSpec.ControlPlanes != newSpec.ControlPlanes {
 		result.InPlaceChanges = append(result.InPlaceChanges, clusterupdate.Change{
@@ -151,15 +145,6 @@ func (p *Provisioner) applyNodeScalingChanges(
 	result *clusterupdate.UpdateResult,
 ) error {
 	if oldSpec == nil || newSpec == nil {
-		return nil
-	}
-
-	// When node autoscaling is enabled, defer scaling to the external autoscaler.
-	if newSpec.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled {
-		_, _ = fmt.Fprintf(p.logWriter,
-			"  ℹ Node autoscaling is enabled; skipping node scaling for cluster %q\n",
-			clusterName)
-
 		return nil
 	}
 

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -337,7 +337,7 @@ func TestApplyNodeScalingChanges_BelowMinimumControlPlanes(t *testing.T) {
 
 // TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled verifies that DiffConfig
 // returns no in-place changes for controlPlanes and workers when autoscaling is enabled.
-func TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled(t *testing.T) {
+func TestDiffConfig_DetectsBaselineNodeCountsWhenAutoscalingEnabled(t *testing.T) {
 	t.Parallel()
 
 	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
@@ -353,11 +353,12 @@ func TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled(t *testing.T) {
 
 	result, err := provisioner.DiffConfig(context.Background(), "test", oldSpec, newSpec)
 	require.NoError(t, err)
-	assert.Empty(
+	assert.NotEmpty(
 		t,
 		result.InPlaceChanges,
-		"node count diffs should be suppressed when autoscaling is enabled",
+		"baseline node count diffs should be detected when autoscaling is enabled",
 	)
+	assert.Len(t, result.InPlaceChanges, 2, "expected controlPlanes + workers changes")
 }
 
 // TestDiffConfig_StillValidatesMinimumControlPlanesWhenAutoscalingEnabled verifies that
@@ -377,37 +378,4 @@ func TestDiffConfig_StillValidatesMinimumControlPlanesWhenAutoscalingEnabled(t *
 	_, err := provisioner.DiffConfig(context.Background(), "test", oldSpec, newSpec)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, talosprovisioner.ErrMinimumControlPlanes)
-}
-
-// TestApplyNodeScalingChanges_SkipsWhenAutoscalingEnabled verifies that
-// applyNodeScalingChanges is a no-op when autoscaling is enabled.
-func TestApplyNodeScalingChanges_SkipsWhenAutoscalingEnabled(t *testing.T) {
-	t.Parallel()
-
-	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
-	result := clusterupdate.NewEmptyUpdateResult()
-
-	oldSpec := &v1alpha1.ClusterSpec{}
-	oldSpec.ControlPlanes = 1
-	oldSpec.Workers = 0
-
-	newSpec := &v1alpha1.ClusterSpec{}
-	newSpec.ControlPlanes = 5
-	newSpec.Workers = 3
-	newSpec.NodeAutoscaling = v1alpha1.NodeAutoscalingEnabled
-
-	err := provisioner.ApplyNodeScalingChangesForTest(
-		context.Background(),
-		"test",
-		oldSpec,
-		newSpec,
-		result,
-	)
-	require.NoError(t, err)
-	assert.Equal(
-		t,
-		0,
-		result.TotalChanges(),
-		"no scaling changes expected when autoscaling is enabled",
-	)
 }

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -335,8 +335,8 @@ func TestApplyNodeScalingChanges_BelowMinimumControlPlanes(t *testing.T) {
 	assert.ErrorIs(t, err, talosprovisioner.ErrMinimumControlPlanes)
 }
 
-// TestDiffConfig_SkipsNodeCountsWhenAutoscalingEnabled verifies that DiffConfig
-// returns no in-place changes for controlPlanes and workers when autoscaling is enabled.
+// TestDiffConfig_DetectsBaselineNodeCountsWhenAutoscalingEnabled verifies that DiffConfig
+// detects in-place changes for controlPlanes and workers even when autoscaling is enabled.
 func TestDiffConfig_DetectsBaselineNodeCountsWhenAutoscalingEnabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When `nodeAutoscaling: Enabled` was introduced in #4365, the diff engine and Talos provisioner suppressed *all* `controlPlanes`/`workers` diffs to avoid fighting an external autoscaler. This was too aggressive -- baseline (static) workers managed by KSail must remain diffable so that `ksail cluster update` can still scale the guaranteed-minimum node pool. Only future autoscaler-managed pools (added in later slices of #4384) should be exempt from KSail-driven scaling.

This PR removes the `talosFieldRulesNoScaling` rule-swap in the diff engine and the two early-return guards in the Talos provisioner, so that `cluster.controlPlanes` and `cluster.workers` are always diffable regardless of the `nodeAutoscaling` setting.

Fixes #4384 (Slice 0b)

## Type of change

- [x] 🪲 Bug fix