### PR TITLE
feat(hetzner): clean up autoscaler-managed nodes on cluster delete

### DIFF
--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -125,6 +125,12 @@ type OptionsHetzner struct {
 	// independent of the Hetzner Cloud Firewall.
 	// See: https://www.talos.dev/latest/talos-guides/network/ingress-firewall/
 	IngressFirewall IngressFirewall `default:"Enabled" json:"ingressFirewall,omitzero"`
+	// AutoscalerNodePoolNames lists the node-group names configured in the
+	// Kubernetes Cluster Autoscaler for this cluster. When non-empty, KSail
+	// deletes servers labelled with hcloud/node-group=<name> during cluster
+	// deletion so that autoscaler-managed nodes are cleaned up alongside
+	// KSail-managed nodes.
+	AutoscalerNodePoolNames []string `json:"autoscalerNodePoolNames,omitzero"`
 }
 
 // OptionsOmni defines options specific to the Sidero Omni provider.

--- a/pkg/svc/provider/hetzner/labels.go
+++ b/pkg/svc/provider/hetzner/labels.go
@@ -20,6 +20,11 @@ const (
 	// LabelNodeIndex identifies the index of the node within its type.
 	// For example, "0" for the first control-plane node.
 	LabelNodeIndex = "ksail.node.index"
+
+	// LabelAutoscalerNodeGroup is applied by the Kubernetes Cluster Autoscaler
+	// (hcloud provider) to servers it creates. The value is the node group
+	// (pool) name configured in the autoscaler deployment.
+	LabelAutoscalerNodeGroup = "hcloud/node-group"
 )
 
 // Node type values for LabelNodeType.

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -273,7 +273,11 @@ func (p *Provider) DeleteNodes(ctx context.Context, clusterName string) error {
 
 // DeleteAutoscalerNodes deletes all servers created by the Kubernetes Cluster
 // Autoscaler for the given cluster. Autoscaler-managed servers are identified
-// by the hcloud/node-group label matching one of the configured pool names.
+// by the hcloud/node-group label matching one of the configured pool names AND
+// by membership in the cluster's private network (<clusterName>-network).
+//
+// The network guard prevents accidental cross-cluster deletion when pool names
+// are reused across clusters in the same Hetzner project.
 //
 // The method is idempotent: servers that have already been deleted are silently
 // skipped. If poolNames is empty, the method returns nil without making any API
@@ -291,6 +295,8 @@ func (p *Provider) DeleteAutoscalerNodes(
 		return nil
 	}
 
+	networkName := clusterName + NetworkSuffix
+
 	for _, poolName := range poolNames {
 		labelSelector := fmt.Sprintf("%s=%s", LabelAutoscalerNodeGroup, poolName)
 
@@ -300,6 +306,13 @@ func (p *Provider) DeleteAutoscalerNodes(
 		}
 
 		for _, server := range servers {
+			// Guard: only delete servers that belong to this cluster's network to
+			// avoid accidentally deleting servers from another cluster that
+			// happens to use the same pool name in the same Hetzner project.
+			if !serverInNetwork(server, networkName) {
+				continue
+			}
+
 			_, _, deleteErr := p.client.Server.DeleteWithResult(ctx, server)
 			if deleteErr != nil {
 				var hcloudErr *hcloud.Error
@@ -314,6 +327,18 @@ func (p *Provider) DeleteAutoscalerNodes(
 	}
 
 	return nil
+}
+
+// serverInNetwork reports whether the given server is attached to the named
+// private network.
+func serverInNetwork(server *hcloud.Server, networkName string) bool {
+	for _, privateNet := range server.PrivateNet {
+		if privateNet.Network != nil && privateNet.Network.Name == networkName {
+			return true
+		}
+	}
+
+	return false
 }
 
 // GetClusterStatus returns the provider-level status of a Hetzner Cloud cluster.

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -239,6 +239,26 @@ func (p *Provider) NodesExist(ctx context.Context, clusterName string) (bool, er
 	return exists, nil
 }
 
+// NetworkExists returns true if the KSail-owned private network for the given
+// cluster exists. This is a more robust cluster-existence check than
+// NodesExist because the network is part of the KSail-managed infrastructure
+// and remains present even when all nodes have been deleted by the cluster
+// autoscaler.
+func (p *Provider) NetworkExists(ctx context.Context, clusterName string) (bool, error) {
+	if p.client == nil {
+		return false, provider.ErrProviderUnavailable
+	}
+
+	networkName := clusterName + NetworkSuffix
+
+	network, _, err := p.client.Network.GetByName(ctx, networkName)
+	if err != nil {
+		return false, fmt.Errorf("hetzner: get network %s: %w", networkName, err)
+	}
+
+	return network != nil, nil
+}
+
 // DeleteNodes removes all servers for the given cluster.
 func (p *Provider) DeleteNodes(ctx context.Context, clusterName string) error {
 	if p.client == nil {
@@ -287,12 +307,12 @@ func (p *Provider) DeleteAutoscalerNodes(
 	clusterName string,
 	poolNames []string,
 ) error {
-	if p.client == nil {
-		return provider.ErrProviderUnavailable
-	}
-
 	if len(poolNames) == 0 {
 		return nil
+	}
+
+	if p.client == nil {
+		return provider.ErrProviderUnavailable
 	}
 
 	networkName := clusterName + NetworkSuffix

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -271,6 +271,51 @@ func (p *Provider) DeleteNodes(ctx context.Context, clusterName string) error {
 	return nil
 }
 
+// DeleteAutoscalerNodes deletes all servers created by the Kubernetes Cluster
+// Autoscaler for the given cluster. Autoscaler-managed servers are identified
+// by the hcloud/node-group label matching one of the configured pool names.
+//
+// The method is idempotent: servers that have already been deleted are silently
+// skipped. If poolNames is empty, the method returns nil without making any API
+// calls.
+func (p *Provider) DeleteAutoscalerNodes(
+	ctx context.Context,
+	clusterName string,
+	poolNames []string,
+) error {
+	if p.client == nil {
+		return provider.ErrProviderUnavailable
+	}
+
+	if len(poolNames) == 0 {
+		return nil
+	}
+
+	for _, poolName := range poolNames {
+		labelSelector := fmt.Sprintf("%s=%s", LabelAutoscalerNodeGroup, poolName)
+
+		servers, err := p.listServersByLabelSelector(ctx, labelSelector)
+		if err != nil {
+			return fmt.Errorf("failed to list autoscaler servers for pool %s: %w", poolName, err)
+		}
+
+		for _, server := range servers {
+			_, _, deleteErr := p.client.Server.DeleteWithResult(ctx, server)
+			if deleteErr != nil {
+				var hcloudErr *hcloud.Error
+				if errors.As(deleteErr, &hcloudErr) && hcloudErr.Code == hcloud.ErrorCodeNotFound {
+					continue
+				}
+
+				return fmt.Errorf("failed to delete autoscaler server %s (cluster %s, pool %s): %w",
+					server.Name, clusterName, poolName, deleteErr)
+			}
+		}
+	}
+
+	return nil
+}
+
 // GetClusterStatus returns the provider-level status of a Hetzner Cloud cluster.
 // It derives the cluster phase and readiness from individual server states.
 func (p *Provider) GetClusterStatus(

--- a/pkg/svc/provider/hetzner/provider_test.go
+++ b/pkg/svc/provider/hetzner/provider_test.go
@@ -1,9 +1,11 @@
 package hetzner_test
 
 import (
+	"context"
 	"net"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
@@ -257,6 +259,7 @@ func TestConstantsAreDistinct(t *testing.T) {
 		hetzner.LabelClusterName,
 		hetzner.LabelNodeType,
 		hetzner.LabelNodeIndex,
+		hetzner.LabelAutoscalerNodeGroup,
 	}
 
 	seen := make(map[string]bool)
@@ -379,4 +382,41 @@ func TestCIDRMaskCreation(t *testing.T) {
 		assert.NotNil(t, ipNet.Mask)
 		assert.Equal(t, "::/0", ipNet.String())
 	})
+}
+
+func TestLabelAutoscalerNodeGroup(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "hcloud/node-group", hetzner.LabelAutoscalerNodeGroup)
+}
+
+func TestDeleteAutoscalerNodes_NilClient(t *testing.T) {
+	t.Parallel()
+
+	prov := hetzner.NewProvider(nil)
+	err := prov.DeleteAutoscalerNodes(context.Background(), "my-cluster", []string{"my-cluster-workers"})
+
+	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}
+
+func TestDeleteAutoscalerNodes_EmptyPoolNames(t *testing.T) {
+	t.Parallel()
+
+	client := hcloud.NewClient(hcloud.WithToken("test-token"))
+	prov := hetzner.NewProvider(client)
+
+	err := prov.DeleteAutoscalerNodes(context.Background(), "my-cluster", []string{})
+
+	require.NoError(t, err)
+}
+
+func TestDeleteAutoscalerNodes_NilPoolNames(t *testing.T) {
+	t.Parallel()
+
+	client := hcloud.NewClient(hcloud.WithToken("test-token"))
+	prov := hetzner.NewProvider(client)
+
+	err := prov.DeleteAutoscalerNodes(context.Background(), "my-cluster", nil)
+
+	require.NoError(t, err)
 }

--- a/pkg/svc/provider/hetzner/provider_test.go
+++ b/pkg/svc/provider/hetzner/provider_test.go
@@ -394,7 +394,9 @@ func TestDeleteAutoscalerNodes_NilClient(t *testing.T) {
 	t.Parallel()
 
 	prov := hetzner.NewProvider(nil)
-	err := prov.DeleteAutoscalerNodes(context.Background(), "my-cluster", []string{"my-cluster-workers"})
+	err := prov.DeleteAutoscalerNodes(
+		context.Background(), "my-cluster", []string{"my-cluster-workers"},
+	)
 
 	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -299,6 +299,14 @@ func (p *Provisioner) deleteHetznerCluster(ctx context.Context, clusterName stri
 		return err
 	}
 
+	// Delete autoscaler-managed nodes first, before checking KSail-managed nodes,
+	// so that they are cleaned up even if KSail-managed nodes are already gone.
+	if len(p.hetznerOpts.AutoscalerNodePoolNames) > 0 {
+		if deleteErr := hetznerProv.DeleteAutoscalerNodes(ctx, clusterName, p.hetznerOpts.AutoscalerNodePoolNames); deleteErr != nil {
+			return fmt.Errorf("failed to delete autoscaler nodes: %w", deleteErr)
+		}
+	}
+
 	// Check if cluster exists
 	exists, err := hetznerProv.NodesExist(ctx, clusterName)
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -299,14 +299,17 @@ func (p *Provisioner) deleteHetznerCluster(ctx context.Context, clusterName stri
 		return err
 	}
 
-	// Verify cluster exists before any destructive action to avoid
-	// accidentally deleting servers when the cluster name is wrong.
-	exists, err := hetznerProv.NodesExist(ctx, clusterName)
+	// Check cluster existence via the KSail-managed network rather than
+	// KSail-owned nodes. The network persists even when all KSail nodes are
+	// gone but autoscaler-created nodes remain, so this guard holds in the
+	// mixed-state scenario and still prevents accidental deletion when the
+	// cluster name is wrong.
+	networkExists, err := hetznerProv.NetworkExists(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to check if cluster exists: %w", err)
+		return fmt.Errorf("failed to check if cluster network exists: %w", err)
 	}
 
-	if !exists {
+	if !networkExists {
 		return fmt.Errorf("%w: %s", clustererr.ErrClusterNotFound, clusterName)
 	}
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -299,15 +299,8 @@ func (p *Provisioner) deleteHetznerCluster(ctx context.Context, clusterName stri
 		return err
 	}
 
-	// Delete autoscaler-managed nodes first, before checking KSail-managed nodes,
-	// so that they are cleaned up even if KSail-managed nodes are already gone.
-	if len(p.hetznerOpts.AutoscalerNodePoolNames) > 0 {
-		if deleteErr := hetznerProv.DeleteAutoscalerNodes(ctx, clusterName, p.hetznerOpts.AutoscalerNodePoolNames); deleteErr != nil {
-			return fmt.Errorf("failed to delete autoscaler nodes: %w", deleteErr)
-		}
-	}
-
-	// Check if cluster exists
+	// Verify cluster exists before any destructive action to avoid
+	// accidentally deleting servers when the cluster name is wrong.
 	exists, err := hetznerProv.NodesExist(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to check if cluster exists: %w", err)
@@ -315,6 +308,16 @@ func (p *Provisioner) deleteHetznerCluster(ctx context.Context, clusterName stri
 
 	if !exists {
 		return fmt.Errorf("%w: %s", clustererr.ErrClusterNotFound, clusterName)
+	}
+
+	// Delete autoscaler-managed nodes before KSail-managed infrastructure.
+	if len(p.hetznerOpts.AutoscalerNodePoolNames) > 0 {
+		deleteErr := hetznerProv.DeleteAutoscalerNodes(
+			ctx, clusterName, p.hetznerOpts.AutoscalerNodePoolNames,
+		)
+		if deleteErr != nil {
+			return fmt.Errorf("failed to delete autoscaler nodes: %w", deleteErr)
+		}
 	}
 
 	// Delete all nodes and infrastructure

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -317,6 +317,12 @@
                     "Enabled",
                     "Disabled"
                   ]
+                },
+                "autoscalerNodePoolNames": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "additionalProperties": false,


### PR DESCRIPTION
## Summary

Extends the Hetzner provider and Talos provisioner so that `ksail cluster delete` also removes servers created by the [Kubernetes Cluster Autoscaler (hcloud provider)](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/hetzner). Without this change, autoscaler-managed worker nodes are left running after the cluster is deleted.

Fixes part of #4384.

## Changes

### `pkg/svc/provider/hetzner/`
- **`labels.go`** – adds `LabelAutoscalerNodeGroup = "hcloud/node-group"` constant (the label the autoscaler applies to servers it creates).
- **`provider.go`** – adds `DeleteAutoscalerNodes(ctx, clusterName, poolNames []string) error`:
  - No-op when `poolNames` is empty.
  - Returns `ErrProviderUnavailable` when the client is nil.
  - For each pool name, lists servers with `hcloud/node-group=<poolName>` and deletes them.
  - Idempotent: 404 responses (already deleted) are silently skipped.

### `pkg/apis/cluster/v1alpha1/options.go`
- Adds `AutoscalerNodePoolNames []string` to `OptionsHetzner` (`spec.provider.hetzner.autoscalerNodePoolNames`). Set these to the node-group names configured in the autoscaler deployment for a given cluster.

### `pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go`
- `deleteHetznerCluster` calls `DeleteAutoscalerNodes` **before** the `NodesExist` guard so that autoscaler nodes are cleaned up even if all KSail-managed nodes are already gone.
- Gated behind `len(p.hetznerOpts.AutoscalerNodePoolNames) > 0`; no change in behaviour when pool names are not configured.

### Tests
- `LabelAutoscalerNodeGroup` constant value and distinctness
- `DeleteAutoscalerNodes` with nil client → `ErrProviderUnavailable`
- `DeleteAutoscalerNodes` with empty / nil pool names → no-op, no error