### PR TITLE
feat(installer): add VPA installer and HPA metrics-server dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -677,7 +677,7 @@ jobs:
   system-test-docker:
     name: 🧪 System Test (Docker)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     needs: [changes, build-artifact, warm-helm-cache, warm-mirror-cache]
     if: >-
       (github.event_name == 'pull_request'

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -200,6 +200,7 @@ Editor command for interactive workflows (e.g., `code --wait`, `vim`). Falls bac
 | `gitOpsEngine` | enum | – |  |
 | `sops` | SOPS | – |  |
 | `nodeAutoscaling` | enum | – |  |
+| `autoscaler` | AutoscalerConfig | – |  |
 | `importImages` | string | – | Path to tar archive with container images to import after cluster creation but before component installation |
 | `controlPlanes` | int32 | `1` | Number of control-plane nodes to create for the cluster (provider/distribution-agnostic) |
 | `workers` | int32 | – | Number of worker nodes to create for the cluster (provider/distribution-agnostic) |

--- a/pkg/fsutil/validator/ksail/validator.go
+++ b/pkg/fsutil/validator/ksail/validator.go
@@ -104,6 +104,7 @@ func (v *Validator) Validate(config *v1alpha1.Cluster) *validator.ValidationResu
 	v.validateCNIAlignment(config, result)
 	v.validateRegistry(config, result)
 	v.validateFlux(config, result)
+	v.validatePodAutoscaler(config, result)
 
 	return result
 }
@@ -591,4 +592,26 @@ func (v *Validator) validateFlux(
 ) {
 	// Flux-specific configuration is now handled via the FluxInstance CR.
 	// No additional validation required in the KSail config.
+}
+
+// validatePodAutoscaler validates pod autoscaler settings for cross-configuration consistency.
+// HPA requires metrics-server; if the user has explicitly disabled metrics-server while enabling
+// HPA, a warning is emitted because metrics-server will be auto-enabled at install time.
+func (v *Validator) validatePodAutoscaler(
+	config *v1alpha1.Cluster,
+	result *validator.ValidationResult,
+) {
+	if config.Spec.Cluster.Autoscaler.Pod.Horizontal != v1alpha1.PodAutoscalerHorizontalEnabled {
+		return
+	}
+
+	if config.Spec.Cluster.MetricsServer == v1alpha1.MetricsServerDisabled {
+		result.AddWarning(validator.ValidationError{
+			Field:         "spec.cluster.metricsServer",
+			Message:       "metrics-server is disabled but required by Horizontal Pod Autoscaler (HPA); it will be auto-enabled",
+			CurrentValue:  string(config.Spec.Cluster.MetricsServer),
+			ExpectedValue: string(v1alpha1.MetricsServerEnabled),
+			FixSuggestion: "Remove spec.cluster.metricsServer: Disabled or set it to Enabled/Default to suppress this warning",
+		})
+	}
 }

--- a/pkg/fsutil/validator/ksail/validator_test.go
+++ b/pkg/fsutil/validator/ksail/validator_test.go
@@ -2029,3 +2029,66 @@ func TestKSailValidatorK3dDefaultCNIAlignment(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePodAutoscaler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hpa_enabled_and_metrics_server_disabled_emits_warning", func(t *testing.T) {
+		t.Parallel()
+
+		v := ksailvalidator.NewValidator()
+		config := createValidKSailConfig(v1alpha1.DistributionVanilla)
+		config.Spec.Cluster.Autoscaler.Pod.Horizontal = v1alpha1.PodAutoscalerHorizontalEnabled
+		config.Spec.Cluster.MetricsServer = v1alpha1.MetricsServerDisabled
+
+		result := v.Validate(config)
+
+		assert.True(t, result.Valid, "config should still be valid; this is only a warning")
+		require.Len(t, result.Warnings, 1)
+		assert.Equal(t, "spec.cluster.metricsServer", result.Warnings[0].Field)
+		assert.Contains(t, result.Warnings[0].Message, "metrics-server is disabled")
+		assert.Contains(t, result.Warnings[0].Message, "Horizontal Pod Autoscaler")
+	})
+
+	t.Run("hpa_enabled_and_metrics_server_enabled_no_warning", func(t *testing.T) {
+		t.Parallel()
+
+		v := ksailvalidator.NewValidator()
+		config := createValidKSailConfig(v1alpha1.DistributionVanilla)
+		config.Spec.Cluster.Autoscaler.Pod.Horizontal = v1alpha1.PodAutoscalerHorizontalEnabled
+		config.Spec.Cluster.MetricsServer = v1alpha1.MetricsServerEnabled
+
+		result := v.Validate(config)
+
+		assert.True(t, result.Valid)
+		assert.Empty(t, result.Warnings)
+	})
+
+	t.Run("hpa_enabled_and_metrics_server_default_no_warning", func(t *testing.T) {
+		t.Parallel()
+
+		v := ksailvalidator.NewValidator()
+		config := createValidKSailConfig(v1alpha1.DistributionVanilla)
+		config.Spec.Cluster.Autoscaler.Pod.Horizontal = v1alpha1.PodAutoscalerHorizontalEnabled
+		config.Spec.Cluster.MetricsServer = v1alpha1.MetricsServerDefault
+
+		result := v.Validate(config)
+
+		assert.True(t, result.Valid)
+		assert.Empty(t, result.Warnings)
+	})
+
+	t.Run("hpa_disabled_metrics_server_disabled_no_warning", func(t *testing.T) {
+		t.Parallel()
+
+		v := ksailvalidator.NewValidator()
+		config := createValidKSailConfig(v1alpha1.DistributionVanilla)
+		config.Spec.Cluster.Autoscaler.Pod.Horizontal = v1alpha1.PodAutoscalerHorizontalDisabled
+		config.Spec.Cluster.MetricsServer = v1alpha1.MetricsServerDisabled
+
+		result := v.Validate(config)
+
+		assert.True(t, result.Valid)
+		assert.Empty(t, result.Warnings)
+	})
+}

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -21,6 +21,7 @@ import (
 	localpathstorageinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/localpathstorage"
 	metallbinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/metallb"
 	metricsserverinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/metricsserver"
+	vpainstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/vpa"
 	"github.com/docker/docker/client"
 )
 
@@ -64,6 +65,7 @@ func (f *Factory) CreateInstallersForConfig(cfg *v1alpha1.Cluster) map[string]In
 	f.addPolicyEngineInstaller(installers, spec)
 	f.addCertManagerInstaller(installers, spec)
 	f.addMetricsServerInstaller(installers, spec)
+	f.addPodAutoscalerInstaller(installers, spec)
 	f.addCSIInstallers(installers, cfg)
 	f.addLoadBalancerInstaller(installers, cfg)
 
@@ -175,12 +177,19 @@ func (f *Factory) addMetricsServerInstaller(
 	installers map[string]Installer,
 	spec v1alpha1.ClusterSpec,
 ) {
-	if spec.MetricsServer == v1alpha1.MetricsServerEnabled ||
-		(spec.MetricsServer == v1alpha1.MetricsServerDefault &&
-			!spec.Distribution.ProvidesMetricsServerByDefault()) {
+	if f.needsMetricsServer(spec) {
 		installers["metrics-server"] = metricsserverinstaller.NewInstallerWithDistribution(
 			f.helmClient, f.timeout, f.distribution,
 		)
+	}
+}
+
+func (f *Factory) addPodAutoscalerInstaller(
+	installers map[string]Installer,
+	spec v1alpha1.ClusterSpec,
+) {
+	if spec.Autoscaler.Pod.Vertical == v1alpha1.PodAutoscalerVerticalEnabled {
+		installers["vpa"] = vpainstaller.NewInstaller(f.helmClient, f.timeout)
 	}
 }
 
@@ -319,4 +328,17 @@ func (f *Factory) needsHcloudCCM(spec v1alpha1.ClusterSpec) bool {
 	return spec.LoadBalancer == v1alpha1.LoadBalancerDefault ||
 		spec.LoadBalancer == v1alpha1.LoadBalancerEnabled ||
 		spec.CSI != v1alpha1.CSIDisabled
+}
+
+// needsMetricsServer determines if metrics-server is needed.
+// HPA (Horizontal Pod Autoscaler) requires metrics-server to function, so it is
+// auto-enabled when HPA is enabled regardless of the MetricsServer flag value.
+func (f *Factory) needsMetricsServer(spec v1alpha1.ClusterSpec) bool {
+	if spec.Autoscaler.Pod.Horizontal == v1alpha1.PodAutoscalerHorizontalEnabled {
+		return true
+	}
+
+	return spec.MetricsServer == v1alpha1.MetricsServerEnabled ||
+		(spec.MetricsServer == v1alpha1.MetricsServerDefault &&
+			!spec.Distribution.ProvidesMetricsServerByDefault())
 }

--- a/pkg/svc/installer/factory_test.go
+++ b/pkg/svc/installer/factory_test.go
@@ -495,6 +495,69 @@ func TestFactory_CreateInstallersForConfig_MultipleComponents(t *testing.T) {
 	assert.Contains(t, installers, "local-path-storage")
 }
 
+func TestFactory_CreateInstallersForConfig_VPA(t *testing.T) {
+	t.Parallel()
+
+	t.Run("vertical_enabled_creates_vpa_installer", func(t *testing.T) {
+		t.Parallel()
+
+		factory := newTestFactory(t, v1alpha1.DistributionVanilla)
+		cfg := newTestCluster(func(clusterSpec *v1alpha1.ClusterSpec) {
+			clusterSpec.Autoscaler.Pod.Vertical = v1alpha1.PodAutoscalerVerticalEnabled
+		})
+
+		installers := factory.CreateInstallersForConfig(cfg)
+
+		assert.Contains(t, installers, "vpa")
+	})
+
+	t.Run("vertical_disabled_no_vpa_installer", func(t *testing.T) {
+		t.Parallel()
+
+		factory := newTestFactory(t, v1alpha1.DistributionVanilla)
+		cfg := newTestCluster(func(clusterSpec *v1alpha1.ClusterSpec) {
+			clusterSpec.Autoscaler.Pod.Vertical = v1alpha1.PodAutoscalerVerticalDisabled
+		})
+
+		installers := factory.CreateInstallersForConfig(cfg)
+
+		assert.NotContains(t, installers, "vpa")
+	})
+}
+
+func TestFactory_CreateInstallersForConfig_HPA_AutoEnablesMetricsServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hpa_enabled_installs_metrics_server_even_when_disabled", func(t *testing.T) {
+		t.Parallel()
+
+		factory := newTestFactory(t, v1alpha1.DistributionVanilla)
+		cfg := newTestCluster(func(clusterSpec *v1alpha1.ClusterSpec) {
+			clusterSpec.Autoscaler.Pod.Horizontal = v1alpha1.PodAutoscalerHorizontalEnabled
+			clusterSpec.MetricsServer = v1alpha1.MetricsServerDisabled
+		})
+
+		installers := factory.CreateInstallersForConfig(cfg)
+
+		assert.Contains(t, installers, "metrics-server",
+			"HPA requires metrics-server; it must be auto-enabled even when MetricsServer=Disabled")
+	})
+
+	t.Run("hpa_disabled_respects_metrics_server_disabled", func(t *testing.T) {
+		t.Parallel()
+
+		factory := newTestFactory(t, v1alpha1.DistributionVanilla)
+		cfg := newTestCluster(func(clusterSpec *v1alpha1.ClusterSpec) {
+			clusterSpec.Autoscaler.Pod.Horizontal = v1alpha1.PodAutoscalerHorizontalDisabled
+			clusterSpec.MetricsServer = v1alpha1.MetricsServerDisabled
+		})
+
+		installers := factory.CreateInstallersForConfig(cfg)
+
+		assert.NotContains(t, installers, "metrics-server")
+	})
+}
+
 // Tests for GetImagesFromInstallers.
 
 func TestGetImagesFromInstallers_EmptyMap(t *testing.T) {

--- a/pkg/svc/installer/vpa/doc.go
+++ b/pkg/svc/installer/vpa/doc.go
@@ -1,0 +1,5 @@
+// Package vpainstaller provides an installer for the Vertical Pod Autoscaler (VPA).
+//
+// VPA automatically adjusts CPU and memory resource requests for pods based on
+// historical usage, improving resource utilization and cluster efficiency.
+package vpainstaller

--- a/pkg/svc/installer/vpa/installer.go
+++ b/pkg/svc/installer/vpa/installer.go
@@ -1,0 +1,44 @@
+package vpainstaller
+
+import (
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/installer/internal/helmutil"
+)
+
+// Installer installs or upgrades the Vertical Pod Autoscaler (VPA).
+//
+// It embeds helmutil.Base to provide standard Helm chart lifecycle management.
+type Installer struct {
+	*helmutil.Base
+}
+
+// NewInstaller creates a new VPA installer instance.
+func NewInstaller(
+	client helm.Interface,
+	timeout time.Duration,
+) *Installer {
+	return &Installer{
+		Base: helmutil.NewBase(
+			"vpa",
+			client,
+			timeout,
+			&helm.RepositoryEntry{
+				Name: "fairwinds-stable",
+				URL:  "https://charts.fairwinds.com/stable",
+			},
+			&helm.ChartSpec{
+				ReleaseName: "vpa",
+				ChartName:   "fairwinds-stable/vpa",
+				Namespace:   "kube-system",
+				Version:     chartVersion(),
+				RepoURL:     "https://charts.fairwinds.com/stable",
+				Atomic:      true,
+				Wait:        true,
+				WaitForJobs: true,
+				Timeout:     timeout,
+			},
+		),
+	}
+}

--- a/pkg/svc/installer/vpa/installer_test.go
+++ b/pkg/svc/installer/vpa/installer_test.go
@@ -1,0 +1,130 @@
+package vpainstaller_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+	vpainstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/vpa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInstaller(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer := vpainstaller.NewInstaller(client, 5*time.Minute)
+
+	assert.NotNil(t, installer)
+}
+
+func TestVPAInstallerInstallSuccess(t *testing.T) {
+	t.Parallel()
+
+	installer, client := newVPAInstallerWithDefaults(t)
+	expectVPAInstall(t, client, nil)
+
+	err := installer.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestVPAInstallerInstallError(t *testing.T) {
+	t.Parallel()
+
+	installer, client := newVPAInstallerWithDefaults(t)
+	expectVPAInstall(t, client, assert.AnError)
+
+	err := installer.Install(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to install vpa")
+}
+
+func TestVPAInstallerInstallAddRepositoryError(t *testing.T) {
+	t.Parallel()
+
+	installer, client := newVPAInstallerWithDefaults(t)
+	expectVPAAddRepository(t, client, assert.AnError)
+
+	err := installer.Install(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to add fairwinds-stable repository")
+}
+
+func TestVPAInstallerUninstallSuccess(t *testing.T) {
+	t.Parallel()
+
+	installer, client := newVPAInstallerWithDefaults(t)
+	client.EXPECT().
+		UninstallRelease(mock.Anything, "vpa", "kube-system").
+		Return(nil)
+
+	err := installer.Uninstall(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestVPAInstallerUninstallError(t *testing.T) {
+	t.Parallel()
+
+	installer, client := newVPAInstallerWithDefaults(t)
+	client.EXPECT().
+		UninstallRelease(mock.Anything, "vpa", "kube-system").
+		Return(assert.AnError)
+
+	err := installer.Uninstall(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to uninstall vpa")
+}
+
+func newVPAInstallerWithDefaults(t *testing.T) (*vpainstaller.Installer, *helm.MockInterface) {
+	t.Helper()
+
+	client := helm.NewMockInterface(t)
+	installer := vpainstaller.NewInstaller(client, 5*time.Second)
+
+	return installer, client
+}
+
+func expectVPAAddRepository(t *testing.T, client *helm.MockInterface, err error) {
+	t.Helper()
+	client.EXPECT().
+		AddRepository(
+			mock.Anything,
+			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {
+				assert.Equal(t, "fairwinds-stable", entry.Name)
+				assert.Equal(t, "https://charts.fairwinds.com/stable", entry.URL)
+
+				return true
+			}),
+			mock.Anything,
+		).
+		Return(err)
+}
+
+func expectVPAInstall(t *testing.T, client *helm.MockInterface, installErr error) {
+	t.Helper()
+	expectVPAAddRepository(t, client, nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(
+			mock.Anything,
+			mock.MatchedBy(func(spec *helm.ChartSpec) bool {
+				assert.Equal(t, "vpa", spec.ReleaseName)
+				assert.Equal(t, "fairwinds-stable/vpa", spec.ChartName)
+				assert.Equal(t, "kube-system", spec.Namespace)
+				assert.Equal(t, "https://charts.fairwinds.com/stable", spec.RepoURL)
+				assert.True(t, spec.Atomic)
+				assert.True(t, spec.Wait)
+				assert.True(t, spec.WaitForJobs)
+
+				return true
+			}),
+		).
+		Return(nil, installErr)
+}

--- a/pkg/svc/installer/vpa/version.go
+++ b/pkg/svc/installer/vpa/version.go
@@ -1,0 +1,8 @@
+package vpainstaller
+
+// chartVersion returns the pinned VPA chart version.
+// The chart version (4.x) diverges from the app version (1.x), so it cannot be
+// tracked via a Dockerfile image tag. This constant must be updated manually.
+func chartVersion() string {
+	return "4.11.0"
+}


### PR DESCRIPTION
## Summary

Implements Slice 5 of #4384 — pod autoscaler support.

### Changes

#### VPA (Vertical Pod Autoscaler) installer
- New `pkg/svc/installer/vpa` package using the `fairwinds-stable/vpa` Helm chart (v4.11.0, repo: https://charts.fairwinds.com/stable)
- Follows the established `helmutil.Base` pattern used by `metricsserver`, `kyverno`, etc.
- Wired into the installer factory: installed when `spec.cluster.autoscaler.pod.vertical: Enabled`

#### HPA → metrics-server dependency
- Factory: metrics-server is auto-enabled when `spec.cluster.autoscaler.pod.horizontal: Enabled`, regardless of the `MetricsServer` flag value (HPA is built into kube-controller-manager but requires metrics-server for pod resource metrics)
- Validator: emits a warning when HPA is enabled and `MetricsServer` is explicitly `Disabled`, informing the user that metrics-server will be auto-enabled at install time

### Tests
- `pkg/svc/installer/vpa/installer_test.go` — Install/Uninstall success and error paths, mocked helm client
- `pkg/svc/installer/factory_test.go` — VPA enabled/disabled cases, HPA+metrics-server auto-enable
- `pkg/fsutil/validator/ksail/validator_test.go` — pod autoscaler warning conditions

Fixes #4384 (partial — Slice 5)