### PR TITLE
feat(hetzner): add Talos snapshot lifecycle manager

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,6 +77,7 @@ linters:
           list-mode: strict
           allow:
             - $gostd
+            - github.com/apricote
             - github.com/atotto
             - github.com/devantler-tech
             - github.com/charmbracelet

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/apricote/hcloud-upload-image/hcloudimages v1.3.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -172,7 +173,6 @@ require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/apricote/hcloud-upload-image/hcloudimages v1.3.0 // indirect
 	github.com/aquasecurity/go-pep440-version v0.0.1 // indirect
 	github.com/aquasecurity/go-version v0.0.1 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect

--- a/go.mod
+++ b/go.mod
@@ -172,6 +172,7 @@ require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/apricote/hcloud-upload-image/hcloudimages v1.3.0 // indirect
 	github.com/aquasecurity/go-pep440-version v0.0.1 // indirect
 	github.com/aquasecurity/go-version v0.0.1 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/apricote/hcloud-upload-image/hcloudimages v1.3.0 h1:FVIKGSqpxdkO4+t1N8a8xu/xxc+13vHy2QaTAWICuQo=
+github.com/apricote/hcloud-upload-image/hcloudimages v1.3.0/go.mod h1:NiCZ7xGoYNbWeK9L083leB7/g5oa7SAOZq405XkUSeQ=
 github.com/aquasecurity/go-pep440-version v0.0.1 h1:8VKKQtH2aV61+0hovZS3T//rUF+6GDn18paFTVS0h0M=
 github.com/aquasecurity/go-pep440-version v0.0.1/go.mod h1:3naPe+Bp6wi3n4l5iBFCZgS0JG8vY6FT0H4NGhFJ+i4=
 github.com/aquasecurity/go-version v0.0.1 h1:4cNl516agK0TCn5F7mmYN+xVs1E3S45LkgZk3cbaW2E=

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -38,7 +38,14 @@ type OptionsTalos struct {
 	// Only used when targeting cloud providers (e.g., Hetzner Cloud).
 	// For Hetzner: See https://docs.hetzner.cloud/changelog for available Talos ISOs.
 	// Defaults to 122630 (Talos Linux 1.11.2 x86). Use 122629 for ARM.
+	// When SchematicID is set, ISO is ignored in favour of a pre-built snapshot.
 	ISO int64 `default:"122630" json:"iso,omitzero"`
+	// SchematicID is the Talos factory schematic ID used to build a Hetzner snapshot image.
+	// When set, KSail uploads a Talos OS disk snapshot using this schematic ID and Version
+	// instead of booting from the cloud ISO specified in ISO.
+	// Obtain a schematic ID from https://factory.talos.dev.
+	// Only used when targeting cloud providers (e.g., Hetzner Cloud).
+	SchematicID string `json:"schematicId,omitzero"`
 	// ExtraPortMappings defines additional port mappings from Docker containers to the host.
 	// Only used with the Docker provider. Useful on macOS where MetalLB virtual IPs
 	// are not accessible from the host because Docker runs in a Linux VM.

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -1930,7 +1930,7 @@ func runDeleteAction(
 	}
 
 	// Create provisioner for the provider
-	provisioner, err := createDeleteProvisioner(clusterInfo, resolved.OmniOpts)
+	provisioner, err := createDeleteProvisioner(clusterInfo, resolved.OmniOpts, flags.storage)
 	if err != nil {
 		return fmt.Errorf("failed to create provisioner: %w", err)
 	}
@@ -2074,6 +2074,7 @@ func promptForDeletion(
 func createDeleteProvisioner(
 	clusterInfo *clusterdetector.Info,
 	omniOpts v1alpha1.OptionsOmni,
+	deleteStorage bool,
 ) (clusterprovisioner.Provisioner, error) {
 	// Check for test factory override
 	clusterProvisionerFactoryMu.RLock()
@@ -2091,7 +2092,7 @@ func createDeleteProvisioner(
 		return provisioner, nil
 	}
 
-	provisioner, err := lifecycle.CreateMinimalProvisionerForProvider(clusterInfo, omniOpts)
+	provisioner, err := lifecycle.CreateMinimalProvisionerForProvider(clusterInfo, omniOpts, deleteStorage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create provisioner for provider: %w", err)
 	}
@@ -5934,7 +5935,7 @@ func autoDeleteCluster(
 		Provider:     clusterCfg.Spec.Cluster.Provider,
 	}
 
-	provisioner, err := createDeleteProvisioner(info, clusterCfg.Spec.Provider.Omni)
+	provisioner, err := createDeleteProvisioner(info, clusterCfg.Spec.Provider.Omni, false)
 	if err != nil {
 		return fmt.Errorf("TTL auto-delete: failed to create provisioner: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -2092,7 +2092,9 @@ func createDeleteProvisioner(
 		return provisioner, nil
 	}
 
-	provisioner, err := lifecycle.CreateMinimalProvisionerForProvider(clusterInfo, omniOpts, deleteStorage)
+	provisioner, err := lifecycle.CreateMinimalProvisionerForProvider(
+		clusterInfo, omniOpts, deleteStorage,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create provisioner for provider: %w", err)
 	}

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -290,7 +290,7 @@ func runSimpleLifecycleAction(
 		KubeconfigPath: resolved.KubeconfigPath,
 	}
 
-	provisioner, err := CreateMinimalProvisionerForProvider(clusterInfo, resolved.OmniOpts)
+	provisioner, err := CreateMinimalProvisionerForProvider(clusterInfo, resolved.OmniOpts, false)
 	if err != nil {
 		return fmt.Errorf("failed to create provisioner: %w", err)
 	}
@@ -335,6 +335,7 @@ func CreateMinimalProvisioner(
 func CreateMinimalProvisionerForProvider(
 	info *clusterdetector.Info,
 	omniOpts v1alpha1.OptionsOmni,
+	deleteStorage bool,
 ) (clusterprovisioner.Provisioner, error) {
 	switch info.Provider {
 	case v1alpha1.ProviderDocker, "":
@@ -365,6 +366,8 @@ func CreateMinimalProvisionerForProvider(
 		if err != nil {
 			return nil, fmt.Errorf("failed to create talos provisioner: %w", err)
 		}
+
+		provisioner.WithDeleteStorage(deleteStorage)
 
 		return provisioner, nil
 

--- a/pkg/svc/provider/hetzner/errors.go
+++ b/pkg/svc/provider/hetzner/errors.go
@@ -16,6 +16,8 @@ var (
 	ErrAllLocationsFailed = errors.New("server creation failed in all locations")
 	// ErrAllRetriesExhausted indicates that all retry attempts failed for a location.
 	ErrAllRetriesExhausted = errors.New("all retry attempts failed")
+	// ErrSnapshotBuildFailed indicates that the Talos snapshot build process failed.
+	ErrSnapshotBuildFailed = errors.New("talos snapshot build failed")
 )
 
 // retryableErrorCodes are Hetzner API error codes that warrant a retry.

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -33,11 +33,16 @@ func CalculateRetryDelayForTest(attempt int) time.Duration {
 
 // NewSnapshotManagerWithUploaderForTest creates a SnapshotManager with a custom uploader,
 // allowing tests to inject a mock without hitting real Hetzner upload infrastructure.
+// A nil logWriter is replaced with io.Discard, matching NewSnapshotManager behavior.
 func NewSnapshotManagerWithUploaderForTest(
 	hcloudClient *hcloud.Client,
 	uploader snapshotUploader,
 	logWriter io.Writer,
 ) *SnapshotManager {
+	if logWriter == nil {
+		logWriter = io.Discard
+	}
+
 	return &SnapshotManager{
 		hcloudClient: hcloudClient,
 		uploader:     uploader,

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -1,7 +1,12 @@
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
 package hetzner
 
-import "time"
+import (
+"io"
+"time"
+
+"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
 
 // FirewallRulesMatchForTest exports firewallRulesMatch for testing.
 var FirewallRulesMatchForTest = firewallRulesMatch
@@ -21,7 +26,21 @@ var ShouldDisablePlacementForTest = shouldDisablePlacement
 // CalculateRetryDelayForTest exposes calculateRetryDelay for testing via a nil-client provider.
 // Only the attempt number matters; the client field is unused by this method.
 func CalculateRetryDelayForTest(attempt int) time.Duration {
-	p := &Provider{}
+p := &Provider{}
 
-	return p.calculateRetryDelay(attempt)
+return p.calculateRetryDelay(attempt)
+}
+
+// NewSnapshotManagerWithUploaderForTest creates a SnapshotManager with a custom uploader,
+// allowing tests to inject a mock without hitting real Hetzner upload infrastructure.
+func NewSnapshotManagerWithUploaderForTest(
+hcloudClient *hcloud.Client,
+uploader snapshotUploader,
+logWriter io.Writer,
+) *SnapshotManager {
+return &SnapshotManager{
+hcloudClient: hcloudClient,
+uploader:     uploader,
+logWriter:    logWriter,
+}
 }

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -2,10 +2,10 @@
 package hetzner
 
 import (
-"io"
-"time"
+	"io"
+	"time"
 
-"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 // FirewallRulesMatchForTest exports firewallRulesMatch for testing.
@@ -26,21 +26,21 @@ var ShouldDisablePlacementForTest = shouldDisablePlacement
 // CalculateRetryDelayForTest exposes calculateRetryDelay for testing via a nil-client provider.
 // Only the attempt number matters; the client field is unused by this method.
 func CalculateRetryDelayForTest(attempt int) time.Duration {
-p := &Provider{}
+	p := &Provider{}
 
-return p.calculateRetryDelay(attempt)
+	return p.calculateRetryDelay(attempt)
 }
 
 // NewSnapshotManagerWithUploaderForTest creates a SnapshotManager with a custom uploader,
 // allowing tests to inject a mock without hitting real Hetzner upload infrastructure.
 func NewSnapshotManagerWithUploaderForTest(
-hcloudClient *hcloud.Client,
-uploader snapshotUploader,
-logWriter io.Writer,
+	hcloudClient *hcloud.Client,
+	uploader snapshotUploader,
+	logWriter io.Writer,
 ) *SnapshotManager {
-return &SnapshotManager{
-hcloudClient: hcloudClient,
-uploader:     uploader,
-logWriter:    logWriter,
-}
+	return &SnapshotManager{
+		hcloudClient: hcloudClient,
+		uploader:     uploader,
+		logWriter:    logWriter,
+	}
 }

--- a/pkg/svc/provider/hetzner/labels.go
+++ b/pkg/svc/provider/hetzner/labels.go
@@ -27,6 +27,19 @@ const (
 	LabelAutoscalerNodeGroup = "hcloud/node-group"
 )
 
+// Label constants for Talos snapshot images.
+// These use the ksail.io/ prefix to distinguish them from server/infrastructure labels.
+const (
+	// LabelTalosVersion identifies the Talos version of the snapshot image.
+	LabelTalosVersion = "ksail.io/talos-version"
+
+	// LabelTalosSchematic identifies the Talos factory schematic ID of the snapshot image.
+	LabelTalosSchematic = "ksail.io/talos-schematic"
+
+	// LabelTalosCluster identifies which cluster created the snapshot image.
+	LabelTalosCluster = "ksail.io/cluster"
+)
+
 // Node type values for LabelNodeType.
 const (
 	// NodeTypeControlPlane indicates a control-plane node.

--- a/pkg/svc/provider/hetzner/snapshot.go
+++ b/pkg/svc/provider/hetzner/snapshot.go
@@ -30,7 +30,12 @@ type SnapshotManager struct {
 }
 
 // NewSnapshotManager creates a new SnapshotManager backed by the given Hetzner Cloud client.
+// A nil logWriter is silently replaced with io.Discard.
 func NewSnapshotManager(hcloudClient *hcloud.Client, logWriter io.Writer) *SnapshotManager {
+	if logWriter == nil {
+		logWriter = io.Discard
+	}
+
 	return &SnapshotManager{
 		hcloudClient: hcloudClient,
 		uploader:     hcloudimages.NewClient(hcloudClient),

--- a/pkg/svc/provider/hetzner/snapshot.go
+++ b/pkg/svc/provider/hetzner/snapshot.go
@@ -1,0 +1,154 @@
+package hetzner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/apricote/hcloud-upload-image/hcloudimages"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// talosFactoryImageURLFormat is the URL template for Talos factory raw disk images for Hetzner Cloud.
+// Parameters: schematicID, talosVersion.
+const talosFactoryImageURLFormat = "https://factory.talos.dev/image/%s/%s/hcloud-amd64.raw.xz"
+
+// snapshotUploader is the interface used by SnapshotManager to create a snapshot from a raw image URL.
+// It is satisfied by *hcloudimages.Client and can be replaced in tests.
+type snapshotUploader interface {
+	Upload(ctx context.Context, opts hcloudimages.UploadOptions) (*hcloud.Image, error)
+}
+
+// SnapshotManager manages Talos OS disk snapshots on Hetzner Cloud.
+// It looks up existing snapshots by label selectors, and builds new ones using hcloud-upload-image.
+type SnapshotManager struct {
+	hcloudClient *hcloud.Client
+	uploader     snapshotUploader
+	logWriter    io.Writer
+}
+
+// NewSnapshotManager creates a new SnapshotManager backed by the given Hetzner Cloud client.
+func NewSnapshotManager(hcloudClient *hcloud.Client, logWriter io.Writer) *SnapshotManager {
+	return &SnapshotManager{
+		hcloudClient: hcloudClient,
+		uploader:     hcloudimages.NewClient(hcloudClient),
+		logWriter:    logWriter,
+	}
+}
+
+// EnsureTalosSnapshot ensures a Talos snapshot image exists for the given version and schematic.
+// It first looks up existing images by labels (ksail.io/talos-version + ksail.io/talos-schematic),
+// and if not found, builds one using hcloud-upload-image from the Talos factory URL.
+// The resulting snapshot is labeled with LabelTalosVersion, LabelTalosSchematic, and LabelTalosCluster.
+func (sm *SnapshotManager) EnsureTalosSnapshot(
+	ctx context.Context,
+	clusterName string,
+	talosVersion string,
+	schematicID string,
+) (int64, error) {
+	if !strings.HasPrefix(talosVersion, "v") {
+		talosVersion = "v" + talosVersion
+	}
+
+	imageID, err := sm.findExistingSnapshot(ctx, talosVersion, schematicID)
+	if err != nil {
+		return 0, err
+	}
+
+	if imageID > 0 {
+		_, _ = fmt.Fprintf(sm.logWriter, "  ✓ Found existing Talos snapshot (ID: %d)\n", imageID)
+
+		return imageID, nil
+	}
+
+	_, _ = fmt.Fprintf(sm.logWriter,
+		"  Building Talos snapshot (version: %s, schematic: %s)...\n",
+		talosVersion, schematicID,
+	)
+
+	imageURL, err := url.Parse(fmt.Sprintf(talosFactoryImageURLFormat, schematicID, talosVersion))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse Talos image URL: %w", err)
+	}
+
+	image, err := sm.uploader.Upload(ctx, hcloudimages.UploadOptions{
+		ImageURL:         imageURL,
+		ImageCompression: hcloudimages.CompressionXZ,
+		Architecture:     hcloud.ArchitectureX86,
+		Labels: map[string]string{
+			LabelTalosVersion:   talosVersion,
+			LabelTalosSchematic: schematicID,
+			LabelTalosCluster:   clusterName,
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", ErrSnapshotBuildFailed, err)
+	}
+
+	_, _ = fmt.Fprintf(sm.logWriter, "  ✓ Talos snapshot built (ID: %d)\n", image.ID)
+
+	return image.ID, nil
+}
+
+// DeleteTalosSnapshots deletes all ksail-managed Talos snapshot images for the given cluster.
+func (sm *SnapshotManager) DeleteTalosSnapshots(ctx context.Context, clusterName string) error {
+	images, err := sm.hcloudClient.Image.AllWithOpts(ctx, hcloud.ImageListOpts{
+		Type: []hcloud.ImageType{hcloud.ImageTypeSnapshot},
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: fmt.Sprintf("%s=%s", LabelTalosCluster, clusterName),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list Talos snapshots for cluster %q: %w", clusterName, err)
+	}
+
+	if len(images) == 0 {
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(
+		sm.logWriter,
+		"Deleting %d Talos snapshot(s) for cluster %q...\n",
+		len(images), clusterName,
+	)
+
+	for _, image := range images {
+		_, err := sm.hcloudClient.Image.Delete(ctx, image)
+		if err != nil {
+			return fmt.Errorf("failed to delete Talos snapshot %d: %w", image.ID, err)
+		}
+
+		_, _ = fmt.Fprintf(sm.logWriter, "  ✓ Deleted snapshot %d\n", image.ID)
+	}
+
+	return nil
+}
+
+// findExistingSnapshot looks up an existing Talos snapshot by version and schematic labels.
+// Returns the image ID if found, or 0 if not found.
+func (sm *SnapshotManager) findExistingSnapshot(
+	ctx context.Context,
+	talosVersion string,
+	schematicID string,
+) (int64, error) {
+	images, err := sm.hcloudClient.Image.AllWithOpts(ctx, hcloud.ImageListOpts{
+		Type: []hcloud.ImageType{hcloud.ImageTypeSnapshot},
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+				LabelTalosVersion, talosVersion,
+				LabelTalosSchematic, schematicID,
+			),
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to look up Talos snapshot: %w", err)
+	}
+
+	if len(images) == 0 {
+		return 0, nil
+	}
+
+	return images[0].ID, nil
+}

--- a/pkg/svc/provider/hetzner/snapshot.go
+++ b/pkg/svc/provider/hetzner/snapshot.go
@@ -44,8 +44,9 @@ func NewSnapshotManager(hcloudClient *hcloud.Client, logWriter io.Writer) *Snaps
 }
 
 // EnsureTalosSnapshot ensures a Talos snapshot image exists for the given version and schematic.
-// It first looks up existing images by labels (ksail.io/talos-version + ksail.io/talos-schematic),
+// It first looks up existing images by labels (ksail.io/talos-version + ksail.io/talos-schematic + ksail.io/cluster),
 // and if not found, builds one using hcloud-upload-image from the Talos factory URL.
+// Snapshots are scoped per cluster so that deleting one cluster does not remove snapshots used by another.
 // The resulting snapshot is labeled with LabelTalosVersion, LabelTalosSchematic, and LabelTalosCluster.
 func (sm *SnapshotManager) EnsureTalosSnapshot(
 	ctx context.Context,
@@ -57,7 +58,7 @@ func (sm *SnapshotManager) EnsureTalosSnapshot(
 		talosVersion = "v" + talosVersion
 	}
 
-	imageID, err := sm.findExistingSnapshot(ctx, talosVersion, schematicID)
+	imageID, err := sm.findExistingSnapshot(ctx, clusterName, talosVersion, schematicID)
 	if err != nil {
 		return 0, err
 	}
@@ -131,19 +132,22 @@ func (sm *SnapshotManager) DeleteTalosSnapshots(ctx context.Context, clusterName
 	return nil
 }
 
-// findExistingSnapshot looks up an existing Talos snapshot by version and schematic labels.
-// Returns the image ID if found, or 0 if not found.
+// findExistingSnapshot looks up an existing Talos snapshot by cluster, version, and schematic labels.
+// Snapshots are scoped per cluster to prevent cross-cluster deletion side-effects.
+// Returns the first available image ID if found, or 0 if not found.
 func (sm *SnapshotManager) findExistingSnapshot(
 	ctx context.Context,
+	clusterName string,
 	talosVersion string,
 	schematicID string,
 ) (int64, error) {
 	images, err := sm.hcloudClient.Image.AllWithOpts(ctx, hcloud.ImageListOpts{
 		Type: []hcloud.ImageType{hcloud.ImageTypeSnapshot},
 		ListOpts: hcloud.ListOpts{
-			LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s,%s=%s",
 				LabelTalosVersion, talosVersion,
 				LabelTalosSchematic, schematicID,
+				LabelTalosCluster, clusterName,
 			),
 		},
 	})
@@ -151,9 +155,11 @@ func (sm *SnapshotManager) findExistingSnapshot(
 		return 0, fmt.Errorf("failed to look up Talos snapshot: %w", err)
 	}
 
-	if len(images) == 0 {
-		return 0, nil
+	for _, image := range images {
+		if image.Status == hcloud.ImageStatusAvailable {
+			return image.ID, nil
+		}
 	}
 
-	return images[0].ID, nil
+	return 0, nil
 }

--- a/pkg/svc/provider/hetzner/snapshot_test.go
+++ b/pkg/svc/provider/hetzner/snapshot_test.go
@@ -1,0 +1,279 @@
+package hetzner_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/apricote/hcloud-upload-image/hcloudimages"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	hcloudtest "github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockUploader is a test-only snapshotUploader that returns a canned result.
+type mockUploader struct {
+	image *hcloudtest.Image
+	err   error
+}
+
+func (m *mockUploader) Upload(_ context.Context, _ hcloudimages.UploadOptions) (*hcloudtest.Image, error) {
+	return m.image, m.err
+}
+
+// hcloudImageListResponse mirrors the Hetzner API response schema for image listing.
+type hcloudImageListResponse struct {
+	Images []hcloudImageSchema `json:"images"`
+}
+
+type hcloudImageSchema struct {
+	ID     int64             `json:"id"`
+	Name   *string           `json:"name"`
+	Labels map[string]string `json:"labels"`
+	Type   string            `json:"type"`
+	Status string            `json:"status"`
+}
+
+// hcloudDeleteResponse is the empty 200 response for image deletion.
+type hcloudDeleteResponse struct{}
+
+// newTestHcloudClient creates an hcloud.Client pointing at a test HTTP server.
+func newTestHcloudClient(serverURL string) *hcloudtest.Client {
+	return hcloudtest.NewClient(
+		hcloudtest.WithToken("test-token"),
+		hcloudtest.WithEndpoint(serverURL),
+	)
+}
+
+func marshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return data
+}
+
+func TestSnapshotManager_EnsureTalosSnapshot_ExistingFound(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "test-cluster"
+		version     = "v1.9.0"
+		schematic   = "abc123"
+		imageID     = int64(42)
+	)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := hcloudImageListResponse{
+			Images: []hcloudImageSchema{
+				{
+					ID:     imageID,
+					Labels: map[string]string{"ksail.io/talos-version": version, "ksail.io/talos-schematic": schematic},
+					Type:   "snapshot",
+					Status: "available",
+				},
+			},
+		}
+		_, _ = w.Write(marshalJSON(t, resp))
+	})
+
+	client := newTestHcloudClient(srv.URL)
+	uploader := &mockUploader{}
+	var logBuf bytes.Buffer
+
+	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
+
+	gotID, err := sm.EnsureTalosSnapshot(context.Background(), clusterName, version, schematic)
+
+	require.NoError(t, err)
+	assert.Equal(t, imageID, gotID)
+	// The uploader should not have been called.
+	assert.Nil(t, uploader.image)
+	assert.Contains(t, logBuf.String(), "Found existing Talos snapshot")
+}
+
+func TestSnapshotManager_EnsureTalosSnapshot_BuildsNew(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "new-cluster"
+		version     = "1.9.0" // without "v" prefix — must be normalized
+		schematic   = "def456"
+		builtID     = int64(99)
+	)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// No images exist yet.
+	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(marshalJSON(t, hcloudImageListResponse{Images: []hcloudImageSchema{}}))
+	})
+
+	client := newTestHcloudClient(srv.URL)
+	uploader := &mockUploader{
+		image: &hcloudtest.Image{ID: builtID},
+	}
+	var logBuf bytes.Buffer
+
+	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
+
+	gotID, err := sm.EnsureTalosSnapshot(context.Background(), clusterName, version, schematic)
+
+	require.NoError(t, err)
+	assert.Equal(t, builtID, gotID)
+	assert.Contains(t, logBuf.String(), "Building Talos snapshot")
+	assert.Contains(t, logBuf.String(), "snapshot built")
+}
+
+func TestSnapshotManager_EnsureTalosSnapshot_UploaderError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "err-cluster"
+		version     = "v1.9.0"
+		schematic   = "ghi789"
+	)
+
+	uploadErr := errors.New("server quota exceeded")
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(marshalJSON(t, hcloudImageListResponse{Images: []hcloudImageSchema{}}))
+	})
+
+	client := newTestHcloudClient(srv.URL)
+	uploader := &mockUploader{err: uploadErr}
+	var logBuf bytes.Buffer
+
+	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
+
+	_, err := sm.EnsureTalosSnapshot(context.Background(), clusterName, version, schematic)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, hetzner.ErrSnapshotBuildFailed)
+	assert.ErrorIs(t, err, uploadErr)
+}
+
+func TestSnapshotManager_DeleteTalosSnapshots_DeletesImages(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "del-cluster"
+
+	deletedIDs := make(chan int64, 2)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := hcloudImageListResponse{
+			Images: []hcloudImageSchema{
+				{ID: 10, Type: "snapshot", Status: "available", Labels: map[string]string{"ksail.io/cluster": clusterName}},
+				{ID: 11, Type: "snapshot", Status: "available", Labels: map[string]string{"ksail.io/cluster": clusterName}},
+			},
+		}
+		_, _ = w.Write(marshalJSON(t, resp))
+	})
+
+	mux.HandleFunc("/images/10", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletedIDs <- 10
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	mux.HandleFunc("/images/11", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletedIDs <- 11
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	client := newTestHcloudClient(srv.URL)
+	uploader := &mockUploader{}
+	var logBuf bytes.Buffer
+
+	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
+
+	err := sm.DeleteTalosSnapshots(context.Background(), clusterName)
+
+	require.NoError(t, err)
+	close(deletedIDs)
+
+	var got []int64
+	for id := range deletedIDs {
+		got = append(got, id)
+	}
+
+	assert.ElementsMatch(t, []int64{10, 11}, got)
+	assert.Contains(t, logBuf.String(), "Deleting 2 Talos snapshot(s)")
+}
+
+func TestSnapshotManager_DeleteTalosSnapshots_NoOp(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "empty-cluster"
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(marshalJSON(t, hcloudImageListResponse{Images: []hcloudImageSchema{}}))
+	})
+
+	client := newTestHcloudClient(srv.URL)
+	uploader := &mockUploader{}
+	var logBuf bytes.Buffer
+
+	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
+
+	err := sm.DeleteTalosSnapshots(context.Background(), clusterName)
+
+	require.NoError(t, err)
+	assert.Empty(t, logBuf.String())
+}
+
+func TestNewSnapshotManager(t *testing.T) {
+	t.Parallel()
+
+	client := hcloudtest.NewClient(hcloudtest.WithToken("test"))
+	var logBuf bytes.Buffer
+
+	sm := hetzner.NewSnapshotManager(client, &logBuf)
+
+	require.NotNil(t, sm)
+}
+
+// Compile-time check: EnsureTalosSnapshot URL template is valid.
+func TestSnapshotManager_TalosImageURL(t *testing.T) {
+	t.Parallel()
+
+	rawURL := "https://factory.talos.dev/image/abc123/v1.9.0/hcloud-amd64.raw.xz"
+	parsed, err := url.Parse(rawURL)
+
+	require.NoError(t, err)
+	assert.Equal(t, "factory.talos.dev", parsed.Host)
+	assert.Equal(t, ".raw.xz", rawURL[len(rawURL)-7:])
+}

--- a/pkg/svc/provider/hetzner/snapshot_test.go
+++ b/pkg/svc/provider/hetzner/snapshot_test.go
@@ -89,6 +89,7 @@ func TestSnapshotManager_EnsureTalosSnapshot_ExistingFound(t *testing.T) {
 					Labels: map[string]string{
 						"ksail.io/talos-version":   version,
 						"ksail.io/talos-schematic": schematic,
+						"ksail.io/cluster":         clusterName,
 					},
 					Type:   "snapshot",
 					Status: "available",
@@ -325,4 +326,57 @@ func TestSnapshotManager_TalosImageURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "factory.talos.dev", parsed.Host)
 	assert.Equal(t, ".raw.xz", rawURL[len(rawURL)-7:])
+}
+
+func TestSnapshotManager_EnsureTalosSnapshot_SkipsNonAvailableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "test-cluster"
+		version     = "v1.9.0"
+		schematic   = "abc123"
+		builtID     = int64(77)
+	)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Simulate a snapshot in "creating" state — must not be returned as usable.
+	mux.HandleFunc("/images", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+
+		resp := hcloudImageListResponse{
+			Images: []hcloudImageSchema{
+				{
+					ID:     42,
+					Type:   "snapshot",
+					Status: "creating",
+					Labels: map[string]string{
+						"ksail.io/talos-version":   version,
+						"ksail.io/talos-schematic": schematic,
+						"ksail.io/cluster":         clusterName,
+					},
+				},
+			},
+		}
+		_, _ = responseWriter.Write(marshalJSON(t, resp))
+	})
+
+	client := newTestHcloudClient(srv.URL)
+	uploader := &mockUploader{image: &hcloudtest.Image{ID: builtID}}
+
+	var logBuf bytes.Buffer
+
+	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
+
+	gotID, err := sm.EnsureTalosSnapshot(context.Background(), clusterName, version, schematic)
+
+	require.NoError(t, err)
+	assert.Equal(t, builtID, gotID)
+	assert.True(
+		t,
+		uploader.called,
+		"Upload should have been called when existing snapshot is not available",
+	)
 }

--- a/pkg/svc/provider/hetzner/snapshot_test.go
+++ b/pkg/svc/provider/hetzner/snapshot_test.go
@@ -23,7 +23,9 @@ type mockUploader struct {
 	err   error
 }
 
-func (m *mockUploader) Upload(_ context.Context, _ hcloudimages.UploadOptions) (*hcloudtest.Image, error) {
+func (m *mockUploader) Upload(
+	_ context.Context, _ hcloudimages.UploadOptions,
+) (*hcloudtest.Image, error) {
 	return m.image, m.err
 }
 
@@ -40,8 +42,8 @@ type hcloudImageSchema struct {
 	Status string            `json:"status"`
 }
 
-// hcloudDeleteResponse is the empty 200 response for image deletion.
-type hcloudDeleteResponse struct{}
+// errServerQuotaExceeded is a static sentinel used in uploader-error tests.
+var errServerQuotaExceeded = errors.New("server quota exceeded")
 
 // newTestHcloudClient creates an hcloud.Client pointing at a test HTTP server.
 func newTestHcloudClient(serverURL string) *hcloudtest.Client {
@@ -74,23 +76,28 @@ func TestSnapshotManager_EnsureTalosSnapshot_ExistingFound(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	mux.HandleFunc("/images", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+
 		resp := hcloudImageListResponse{
 			Images: []hcloudImageSchema{
 				{
-					ID:     imageID,
-					Labels: map[string]string{"ksail.io/talos-version": version, "ksail.io/talos-schematic": schematic},
+					ID: imageID,
+					Labels: map[string]string{
+						"ksail.io/talos-version":   version,
+						"ksail.io/talos-schematic": schematic,
+					},
 					Type:   "snapshot",
 					Status: "available",
 				},
 			},
 		}
-		_, _ = w.Write(marshalJSON(t, resp))
+		_, _ = responseWriter.Write(marshalJSON(t, resp))
 	})
 
 	client := newTestHcloudClient(srv.URL)
 	uploader := &mockUploader{}
+
 	var logBuf bytes.Buffer
 
 	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
@@ -128,6 +135,7 @@ func TestSnapshotManager_EnsureTalosSnapshot_BuildsNew(t *testing.T) {
 	uploader := &mockUploader{
 		image: &hcloudtest.Image{ID: builtID},
 	}
+
 	var logBuf bytes.Buffer
 
 	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
@@ -149,19 +157,20 @@ func TestSnapshotManager_EnsureTalosSnapshot_UploaderError(t *testing.T) {
 		schematic   = "ghi789"
 	)
 
-	uploadErr := errors.New("server quota exceeded")
-
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(marshalJSON(t, hcloudImageListResponse{Images: []hcloudImageSchema{}}))
+	mux.HandleFunc("/images", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write(
+			marshalJSON(t, hcloudImageListResponse{Images: []hcloudImageSchema{}}),
+		)
 	})
 
 	client := newTestHcloudClient(srv.URL)
-	uploader := &mockUploader{err: uploadErr}
+	uploader := &mockUploader{err: errServerQuotaExceeded}
+
 	var logBuf bytes.Buffer
 
 	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
@@ -169,8 +178,56 @@ func TestSnapshotManager_EnsureTalosSnapshot_UploaderError(t *testing.T) {
 	_, err := sm.EnsureTalosSnapshot(context.Background(), clusterName, version, schematic)
 
 	require.Error(t, err)
-	assert.ErrorIs(t, err, hetzner.ErrSnapshotBuildFailed)
-	assert.ErrorIs(t, err, uploadErr)
+	require.ErrorIs(t, err, hetzner.ErrSnapshotBuildFailed)
+	assert.ErrorIs(t, err, errServerQuotaExceeded)
+}
+
+// registerDeleteTestHandlers wires the Hetzner mock endpoints for snapshot delete tests.
+func registerDeleteTestHandlers(
+	t *testing.T,
+	mux *http.ServeMux,
+	clusterName string,
+	deletedIDs chan<- int64,
+) {
+	t.Helper()
+
+	mux.HandleFunc("/images", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+
+		resp := hcloudImageListResponse{
+			Images: []hcloudImageSchema{
+				{
+					ID:     10,
+					Type:   "snapshot",
+					Status: "available",
+					Labels: map[string]string{"ksail.io/cluster": clusterName},
+				},
+				{
+					ID:     11,
+					Type:   "snapshot",
+					Status: "available",
+					Labels: map[string]string{"ksail.io/cluster": clusterName},
+				},
+			},
+		}
+		_, _ = responseWriter.Write(marshalJSON(t, resp))
+	})
+
+	mux.HandleFunc("/images/10", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletedIDs <- 10
+
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	mux.HandleFunc("/images/11", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletedIDs <- 11
+
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
 }
 
 func TestSnapshotManager_DeleteTalosSnapshots_DeletesImages(t *testing.T) {
@@ -179,38 +236,15 @@ func TestSnapshotManager_DeleteTalosSnapshots_DeletesImages(t *testing.T) {
 	const clusterName = "del-cluster"
 
 	deletedIDs := make(chan int64, 2)
-
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	mux.HandleFunc("/images", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		resp := hcloudImageListResponse{
-			Images: []hcloudImageSchema{
-				{ID: 10, Type: "snapshot", Status: "available", Labels: map[string]string{"ksail.io/cluster": clusterName}},
-				{ID: 11, Type: "snapshot", Status: "available", Labels: map[string]string{"ksail.io/cluster": clusterName}},
-			},
-		}
-		_, _ = w.Write(marshalJSON(t, resp))
-	})
-
-	mux.HandleFunc("/images/10", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
-			deletedIDs <- 10
-			w.WriteHeader(http.StatusNoContent)
-		}
-	})
-
-	mux.HandleFunc("/images/11", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
-			deletedIDs <- 11
-			w.WriteHeader(http.StatusNoContent)
-		}
-	})
+	registerDeleteTestHandlers(t, mux, clusterName, deletedIDs)
 
 	client := newTestHcloudClient(srv.URL)
 	uploader := &mockUploader{}
+
 	var logBuf bytes.Buffer
 
 	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
@@ -245,6 +279,7 @@ func TestSnapshotManager_DeleteTalosSnapshots_NoOp(t *testing.T) {
 
 	client := newTestHcloudClient(srv.URL)
 	uploader := &mockUploader{}
+
 	var logBuf bytes.Buffer
 
 	sm := hetzner.NewSnapshotManagerWithUploaderForTest(client, uploader, &logBuf)
@@ -259,6 +294,7 @@ func TestNewSnapshotManager(t *testing.T) {
 	t.Parallel()
 
 	client := hcloudtest.NewClient(hcloudtest.WithToken("test"))
+
 	var logBuf bytes.Buffer
 
 	sm := hetzner.NewSnapshotManager(client, &logBuf)

--- a/pkg/svc/provider/hetzner/snapshot_test.go
+++ b/pkg/svc/provider/hetzner/snapshot_test.go
@@ -19,13 +19,16 @@ import (
 
 // mockUploader is a test-only snapshotUploader that returns a canned result.
 type mockUploader struct {
-	image *hcloudtest.Image
-	err   error
+	image  *hcloudtest.Image
+	err    error
+	called bool
 }
 
 func (m *mockUploader) Upload(
 	_ context.Context, _ hcloudimages.UploadOptions,
 ) (*hcloudtest.Image, error) {
+	m.called = true
+
 	return m.image, m.err
 }
 
@@ -106,8 +109,8 @@ func TestSnapshotManager_EnsureTalosSnapshot_ExistingFound(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, imageID, gotID)
-	// The uploader should not have been called.
-	assert.Nil(t, uploader.image)
+	// The uploader must not have been invoked when an existing snapshot was found.
+	assert.False(t, uploader.called)
 	assert.Contains(t, logBuf.String(), "Found existing Talos snapshot")
 }
 
@@ -298,6 +301,16 @@ func TestNewSnapshotManager(t *testing.T) {
 	var logBuf bytes.Buffer
 
 	sm := hetzner.NewSnapshotManager(client, &logBuf)
+
+	require.NotNil(t, sm)
+}
+
+func TestNewSnapshotManager_NilLogWriter(t *testing.T) {
+	t.Parallel()
+
+	client := hcloudtest.NewClient(hcloudtest.WithToken("test"))
+
+	sm := hetzner.NewSnapshotManager(client, nil)
 
 	require.NotNil(t, sm)
 }

--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -43,4 +43,13 @@ var (
 	// ErrNoControlPlaneForRefresh is returned when no control-plane node can be found
 	// for kubeconfig refresh.
 	ErrNoControlPlaneForRefresh = errors.New("no control-plane node found for kubeconfig refresh")
+	// ErrSchematicRequiresVersion is returned when a schematicId is set but talos.version is empty.
+	ErrSchematicRequiresVersion = errors.New(
+		"spec.cluster.talos.version must be set when spec.cluster.talos.schematicId is set",
+	)
+	// ErrARM64SnapshotNotSupported is returned when snapshot-based boot is requested with ARM64
+	// Hetzner server types (cax*). ARM64 snapshot support is not yet implemented.
+	ErrARM64SnapshotNotSupported = errors.New(
+		"snapshot-based boot (schematicId) does not support ARM64 server types (cax*) yet",
+	)
 )

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -147,7 +147,7 @@ func configureInfraProvider(
 		infraProvider = docker.NewProvider(dockerClient, docker.LabelSchemeTalos)
 
 	case v1alpha1.ProviderHetzner:
-		hetznerProvider, err := createHetznerProvider(hetznerOpts)
+		hetznerProvider, hcloudClient, err := createHetznerProvider(hetznerOpts)
 		if err != nil {
 			return err
 		}
@@ -157,6 +157,10 @@ func configureInfraProvider(
 		provisioner.WithHetznerOptions(applyHetznerDefaults(hetznerOpts))
 		// Store Talos options with defaults applied (includes ISO)
 		provisioner.WithTalosOptions(applyTalosDefaults(opts))
+
+		// Wire the snapshot manager so EnsureTalosSnapshot / DeleteTalosSnapshots can be called.
+		snapshotManager := hetzner.NewSnapshotManager(hcloudClient, os.Stdout)
+		provisioner.WithSnapshotManager(snapshotManager)
 
 	case v1alpha1.ProviderOmni:
 		omniProvider, err := createOmniProvider(omniOpts)
@@ -183,8 +187,8 @@ func configureInfraProvider(
 	return nil
 }
 
-// createHetznerProvider creates a Hetzner provider from the given options.
-func createHetznerProvider(opts v1alpha1.OptionsHetzner) (*hetzner.Provider, error) {
+// createHetznerProvider creates a Hetzner provider and returns the underlying hcloud client.
+func createHetznerProvider(opts v1alpha1.OptionsHetzner) (*hetzner.Provider, *hcloud.Client, error) {
 	// Determine the token environment variable name
 	tokenEnvVar := opts.TokenEnvVar
 	if tokenEnvVar == "" {
@@ -194,7 +198,7 @@ func createHetznerProvider(opts v1alpha1.OptionsHetzner) (*hetzner.Provider, err
 	// Get the token from the environment
 	token := os.Getenv(tokenEnvVar)
 	if token == "" {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"%w: environment variable %s is not set",
 			ErrMissingHetznerToken,
 			tokenEnvVar,
@@ -204,7 +208,7 @@ func createHetznerProvider(opts v1alpha1.OptionsHetzner) (*hetzner.Provider, err
 	// Create the Hetzner client and provider
 	client := hcloud.NewClient(hcloud.WithToken(token))
 
-	return hetzner.NewProvider(client), nil
+	return hetzner.NewProvider(client), client, nil
 }
 
 // applyTalosDefaults applies default values to Talos options.

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -188,7 +188,9 @@ func configureInfraProvider(
 }
 
 // createHetznerProvider creates a Hetzner provider and returns the underlying hcloud client.
-func createHetznerProvider(opts v1alpha1.OptionsHetzner) (*hetzner.Provider, *hcloud.Client, error) {
+func createHetznerProvider(
+	opts v1alpha1.OptionsHetzner,
+) (*hetzner.Provider, *hcloud.Client, error) {
 	// Determine the token environment variable name
 	tokenEnvVar := opts.TokenEnvVar
 	if tokenEnvVar == "" {

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -159,7 +159,7 @@ func configureInfraProvider(
 		provisioner.WithTalosOptions(applyTalosDefaults(opts))
 
 		// Wire the snapshot manager so EnsureTalosSnapshot / DeleteTalosSnapshots can be called.
-		snapshotManager := hetzner.NewSnapshotManager(hcloudClient, os.Stdout)
+		snapshotManager := hetzner.NewSnapshotManager(hcloudClient, provisioner.logWriter)
 		provisioner.WithSnapshotManager(snapshotManager)
 
 	case v1alpha1.ProviderOmni:

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -110,6 +110,7 @@ func (p *Provisioner) createHetznerNodes(
 				Name:             nodeName,
 				ServerType:       opts.ServerType,
 				ISOID:            opts.ISOID,
+				ImageID:          opts.ImageID,
 				Location:         opts.Location,
 				Labels:           hetzner.NodeLabels(opts.ClusterName, opts.Role, nodeIndex+1),
 				NetworkID:        infra.NetworkID,

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -94,7 +94,8 @@ type HetznerNodeGroupOpts struct {
 	Role        string // "control-plane" or "worker"
 	Count       int
 	ServerType  string
-	ISOID       int64
+	ISOID       int64 // ISO ID (for Talos public ISOs) - mutually exclusive with ImageID
+	ImageID     int64 // snapshot image ID - mutually exclusive with ISOID
 	Location    string
 }
 
@@ -156,6 +157,12 @@ type Provisioner struct {
 	// imagePullRetry controls retry behavior for Docker image pulls.
 	// Tests can override this via WithImagePullRetryConfig to use near-zero delays.
 	imagePullRetry imagePullRetryConfig
+	// snapshotManager manages Talos snapshot images on Hetzner Cloud.
+	// Set when the Hetzner provider is configured and schematic-based snapshots are used.
+	snapshotManager *hetzner.SnapshotManager
+	// deleteStorage controls whether Talos snapshot images are deleted alongside the cluster.
+	// When true, DeleteTalosSnapshots is called during cluster deletion on Hetzner.
+	deleteStorage bool
 }
 
 // NewProvisioner creates a new Provisioner.
@@ -256,6 +263,21 @@ func (p *Provisioner) WithImagePullRetryConfig(
 		baseWait:   baseWait,
 		maxWait:    maxWait,
 	}
+
+	return p
+}
+
+// WithSnapshotManager sets the Hetzner snapshot manager used for Talos OS disk image lifecycle.
+func (p *Provisioner) WithSnapshotManager(sm *hetzner.SnapshotManager) *Provisioner {
+	p.snapshotManager = sm
+
+	return p
+}
+
+// WithDeleteStorage controls whether Talos snapshot images are deleted alongside the cluster.
+// When true, DeleteTalosSnapshots is called during cluster deletion on Hetzner.
+func (p *Provisioner) WithDeleteStorage(deleteStorage bool) *Provisioner {
+	p.deleteStorage = deleteStorage
 
 	return p
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -75,18 +75,27 @@ func (p *Provisioner) ensureHetznerInfra(
 }
 
 // createHetznerNodeGroups creates both control plane and worker node groups.
+// When imageID > 0 (snapshot-based), servers boot directly from the snapshot image.
+// When imageID == 0 (ISO-based, legacy), servers use the public Talos ISO.
 func (p *Provisioner) createHetznerNodeGroups(
 	ctx context.Context,
 	hzProvider *hetzner.Provider,
 	infra HetznerInfra,
 	clusterName string,
+	imageID int64,
 ) ([]*hcloud.Server, []*hcloud.Server, error) {
+	isoID := p.talosOpts.ISO
+	if imageID > 0 {
+		isoID = 0 // snapshot takes precedence; ISO is not used
+	}
+
 	controlPlaneServers, err := p.createHetznerNodes(ctx, hzProvider, infra, HetznerNodeGroupOpts{
 		ClusterName: clusterName,
 		Role:        RoleControlPlane,
 		Count:       p.options.ControlPlaneNodes,
 		ServerType:  p.hetznerOpts.ControlPlaneServerType,
-		ISOID:       p.talosOpts.ISO,
+		ISOID:       isoID,
+		ImageID:     imageID,
 		Location:    p.hetznerOpts.Location,
 	})
 	if err != nil {
@@ -98,7 +107,8 @@ func (p *Provisioner) createHetznerNodeGroups(
 		Role:        RoleWorker,
 		Count:       p.options.WorkerNodes,
 		ServerType:  p.hetznerOpts.WorkerServerType,
-		ISOID:       p.talosOpts.ISO,
+		ISOID:       isoID,
+		ImageID:     imageID,
 		Location:    p.hetznerOpts.Location,
 	})
 	if err != nil {
@@ -245,6 +255,23 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 		return fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
 	}
 
+	// Ensure a Talos snapshot image exists when a schematic ID is configured.
+	// This must happen before node creation so we can pass the image ID to servers.
+	var snapshotImageID int64
+	if p.snapshotManager != nil && p.talosOpts != nil && p.talosOpts.SchematicID != "" {
+		_, _ = fmt.Fprintf(p.logWriter, "Ensuring Talos snapshot image...\n")
+
+		snapshotImageID, err = p.snapshotManager.EnsureTalosSnapshot(
+			ctx,
+			clusterName,
+			p.talosOpts.Version,
+			p.talosOpts.SchematicID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to ensure Talos snapshot: %w", err)
+		}
+	}
+
 	// Create infrastructure resources
 	infra, err := p.ensureHetznerInfra(ctx, hzProvider, clusterName)
 	if err != nil {
@@ -253,7 +280,7 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 
 	// Create node groups
 	controlPlaneServers, workerServers, err := p.createHetznerNodeGroups(
-		ctx, hzProvider, infra, clusterName,
+		ctx, hzProvider, infra, clusterName, snapshotImageID,
 	)
 	if err != nil {
 		return err
@@ -329,6 +356,13 @@ func (p *Provisioner) deleteHetznerCluster(ctx context.Context, clusterName stri
 	err = hetznerProv.DeleteNodes(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to delete Hetzner nodes: %w", err)
+	}
+
+	// Delete Talos snapshot images when --delete-storage is set
+	if p.deleteStorage && p.snapshotManager != nil {
+		if snapshotErr := p.snapshotManager.DeleteTalosSnapshots(ctx, clusterName); snapshotErr != nil {
+			return fmt.Errorf("failed to delete Talos snapshots: %w", snapshotErr)
+		}
 	}
 
 	// Clean up config files (kubeconfig and talosconfig)

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
@@ -181,12 +182,9 @@ func (p *Provisioner) bootstrapAndFinalize(
 	clusterName string,
 	controlPlaneServers, workerServers, allServers []*hcloud.Server,
 ) error {
-	// Detach ISOs and reboot
-	_, _ = fmt.Fprintf(p.logWriter, "Detaching ISOs and rebooting nodes...\n")
-
-	err := p.detachISOsAndReboot(ctx, hzProvider, allServers)
+	err := p.detachOrWaitForReboot(ctx, hzProvider, allServers)
 	if err != nil {
-		return fmt.Errorf("failed to detach ISOs: %w", err)
+		return err
 	}
 
 	// Bootstrap etcd cluster
@@ -234,6 +232,25 @@ func (p *Provisioner) bootstrapAndFinalize(
 	}
 
 	return nil
+}
+
+// detachOrWaitForReboot handles the post-config boot sequence.
+// For ISO-based boot: detaches ISOs from all servers and waits for auto-reboot.
+// For snapshot-based boot: no ISO is attached, so only wait for servers to be reachable.
+func (p *Provisioner) detachOrWaitForReboot(
+	ctx context.Context,
+	hzProvider *hetzner.Provider,
+	allServers []*hcloud.Server,
+) error {
+	if p.talosOpts != nil && p.talosOpts.SchematicID != "" {
+		_, _ = fmt.Fprintf(p.logWriter, "Waiting for nodes to be reachable after reboot...\n")
+
+		return p.waitForServersToBeReachable(ctx, allServers)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "Detaching ISOs and rebooting nodes...\n")
+
+	return p.detachISOsAndReboot(ctx, hzProvider, allServers)
 }
 
 // createHetznerCluster creates a Talos cluster on Hetzner Cloud infrastructure.
@@ -297,6 +314,15 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 func (p *Provisioner) ensureSnapshotImage(ctx context.Context, clusterName string) (int64, error) {
 	if p.snapshotManager == nil || p.talosOpts == nil || p.talosOpts.SchematicID == "" {
 		return 0, nil
+	}
+
+	if p.talosOpts.Version == "" {
+		return 0, ErrSchematicRequiresVersion
+	}
+
+	if strings.HasPrefix(strings.ToLower(p.hetznerOpts.ControlPlaneServerType), "cax") ||
+		strings.HasPrefix(strings.ToLower(p.hetznerOpts.WorkerServerType), "cax") {
+		return 0, ErrARM64SnapshotNotSupported
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter, "Ensuring Talos snapshot image...\n")

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -255,21 +255,9 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 		return fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
 	}
 
-	// Ensure a Talos snapshot image exists when a schematic ID is configured.
-	// This must happen before node creation so we can pass the image ID to servers.
-	var snapshotImageID int64
-	if p.snapshotManager != nil && p.talosOpts != nil && p.talosOpts.SchematicID != "" {
-		_, _ = fmt.Fprintf(p.logWriter, "Ensuring Talos snapshot image...\n")
-
-		snapshotImageID, err = p.snapshotManager.EnsureTalosSnapshot(
-			ctx,
-			clusterName,
-			p.talosOpts.Version,
-			p.talosOpts.SchematicID,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to ensure Talos snapshot: %w", err)
-		}
+	snapshotImageID, err := p.ensureSnapshotImage(ctx, clusterName)
+	if err != nil {
+		return err
 	}
 
 	// Create infrastructure resources
@@ -288,24 +276,8 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 
 	_, _ = fmt.Fprintf(p.logWriter, "\nInfrastructure created. Bootstrapping Talos cluster...\n")
 
-	// Update configs with correct endpoint
-	err = p.updateConfigsWithEndpoint(controlPlaneServers)
-	if err != nil {
-		return err
-	}
-
-	allServers := slices.Concat(controlPlaneServers, workerServers)
-
-	// Prepare and apply configs
-	err = p.prepareAndApplyConfigs(ctx, clusterName, controlPlaneServers, workerServers, allServers)
-	if err != nil {
-		return err
-	}
-
-	// Bootstrap, save configs, and wait for cluster readiness
-	err = p.bootstrapAndFinalize(
-		ctx, hzProvider, clusterName,
-		controlPlaneServers, workerServers, allServers,
+	err = p.applyConfigsAndBootstrap(
+		ctx, hzProvider, clusterName, controlPlaneServers, workerServers,
 	)
 	if err != nil {
 		return err
@@ -318,6 +290,54 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 	)
 
 	return nil
+}
+
+// ensureSnapshotImage ensures a Talos snapshot image exists when a schematic ID is configured.
+// It returns the snapshot image ID (0 when snapshot boot is not configured).
+func (p *Provisioner) ensureSnapshotImage(ctx context.Context, clusterName string) (int64, error) {
+	if p.snapshotManager == nil || p.talosOpts == nil || p.talosOpts.SchematicID == "" {
+		return 0, nil
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "Ensuring Talos snapshot image...\n")
+
+	snapshotImageID, err := p.snapshotManager.EnsureTalosSnapshot(
+		ctx,
+		clusterName,
+		p.talosOpts.Version,
+		p.talosOpts.SchematicID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to ensure Talos snapshot: %w", err)
+	}
+
+	return snapshotImageID, nil
+}
+
+// applyConfigsAndBootstrap updates machine configs with the correct endpoint,
+// applies them to all nodes, and bootstraps the Talos cluster.
+func (p *Provisioner) applyConfigsAndBootstrap(
+	ctx context.Context,
+	hzProvider *hetzner.Provider,
+	clusterName string,
+	controlPlaneServers, workerServers []*hcloud.Server,
+) error {
+	err := p.updateConfigsWithEndpoint(controlPlaneServers)
+	if err != nil {
+		return err
+	}
+
+	allServers := slices.Concat(controlPlaneServers, workerServers)
+
+	err = p.prepareAndApplyConfigs(ctx, clusterName, controlPlaneServers, workerServers, allServers)
+	if err != nil {
+		return err
+	}
+
+	return p.bootstrapAndFinalize(
+		ctx, hzProvider, clusterName,
+		controlPlaneServers, workerServers, allServers,
+	)
 }
 
 func (p *Provisioner) deleteHetznerCluster(ctx context.Context, clusterName string) error {
@@ -360,7 +380,8 @@ func (p *Provisioner) deleteHetznerCluster(ctx context.Context, clusterName stri
 
 	// Delete Talos snapshot images when --delete-storage is set
 	if p.deleteStorage && p.snapshotManager != nil {
-		if snapshotErr := p.snapshotManager.DeleteTalosSnapshots(ctx, clusterName); snapshotErr != nil {
+		snapshotErr := p.snapshotManager.DeleteTalosSnapshots(ctx, clusterName)
+		if snapshotErr != nil {
 			return fmt.Errorf("failed to delete Talos snapshots: %w", snapshotErr)
 		}
 	}

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -312,11 +312,18 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 // ensureSnapshotImage ensures a Talos snapshot image exists when a schematic ID is configured.
 // It returns the snapshot image ID (0 when snapshot boot is not configured).
 func (p *Provisioner) ensureSnapshotImage(ctx context.Context, clusterName string) (int64, error) {
-	if p.snapshotManager == nil || p.talosOpts == nil || p.talosOpts.SchematicID == "" {
+	if p.snapshotManager == nil || p.talosOpts == nil {
 		return 0, nil
 	}
 
-	if p.talosOpts.Version == "" {
+	schematicID := strings.TrimSpace(p.talosOpts.SchematicID)
+	version := strings.TrimSpace(p.talosOpts.Version)
+
+	if schematicID == "" {
+		return 0, nil
+	}
+
+	if version == "" {
 		return 0, ErrSchematicRequiresVersion
 	}
 
@@ -330,8 +337,8 @@ func (p *Provisioner) ensureSnapshotImage(ctx context.Context, clusterName strin
 	snapshotImageID, err := p.snapshotManager.EnsureTalosSnapshot(
 		ctx,
 		clusterName,
-		p.talosOpts.Version,
-		p.talosOpts.SchematicID,
+		version,
+		schematicID,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to ensure Talos snapshot: %w", err)

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -229,6 +229,9 @@
                 "iso": {
                   "type": "integer"
                 },
+                "schematicId": {
+                  "type": "string"
+                },
                 "extraPortMappings": {
                   "items": {
                     "properties": {


### PR DESCRIPTION
## Summary

Implements Slice 2 of issue #4384: a Talos OS disk snapshot lifecycle manager for the Hetzner Cloud provider.

Fixes #4384 (Slice 2)

## Changes

### New: `SnapshotManager` (`pkg/svc/provider/hetzner/snapshot.go`)
- `EnsureTalosSnapshot`: looks up existing snapshots by `ksail.io/talos-version` + `ksail.io/talos-schematic` labels; if not found, builds a new one from `https://factory.talos.dev/image/<schematicID>/<version>/hcloud-amd64.raw.xz` using `hcloud-upload-image` v1.3.0
- `DeleteTalosSnapshots`: deletes all snapshot images labeled `ksail.io/cluster=<name>`
- `snapshotUploader` interface extracted for testability

### API (`pkg/apis/cluster/v1alpha1/options.go`)
- `OptionsTalos.SchematicID string` — when set, enables snapshot-based node boot instead of the legacy public ISO

### Labels (`pkg/svc/provider/hetzner/labels.go`)
- `LabelTalosVersion`, `LabelTalosSchematic`, `LabelTalosCluster` constants

### Provisioner wiring
- `provisioner.go`: `snapshotManager *hetzner.SnapshotManager`, `deleteStorage bool`, `ImageID int64` in `HetznerNodeGroupOpts`; `WithSnapshotManager` and `WithDeleteStorage` builder methods
- `provisioner_hetzner.go`: `createHetznerCluster` calls `EnsureTalosSnapshot` when `SchematicID != ""`; `deleteHetznerCluster` calls `DeleteTalosSnapshots` when `deleteStorage` is true; `createHetznerNodeGroups` accepts `snapshotImageID int64`
- `hetzner_nodes.go`: passes `ImageID` from opts to `CreateServerOpts` alongside `ISOID`
- `factory.go`: `createHetznerProvider` now returns `(*hetzner.Provider, *hcloud.Client, error)` so `configureInfraProvider` can construct and wire `SnapshotManager`

### CLI threading
- `simple.go` / `cluster.go`: `deleteStorage bool` threaded through `CreateMinimalProvisionerForProvider` → `WithDeleteStorage`

### Tests (`pkg/svc/provider/hetzner/snapshot_test.go`)
- `EnsureTalosSnapshot` — found existing image (mock hcloud API)
- `EnsureTalosSnapshot` — builds new via mock uploader
- `EnsureTalosSnapshot` — uploader error wraps `ErrSnapshotBuildFailed`
- `DeleteTalosSnapshots` — deletes listed images
- `DeleteTalosSnapshots` — no-op when none found

### Dependencies
- `go get github.com/apricote/hcloud-upload-image/hcloudimages@v1.3.0`
- Added `github.com/apricote` to depguard allow list