### PR TITLE
feat(talos): generate autoscaler worker config Secret

### DIFF
--- a/pkg/k8s/secret.go
+++ b/pkg/k8s/secret.go
@@ -28,8 +28,13 @@ func MergeSecretData(secret *corev1.Secret, desiredData map[string][]byte) bool 
 // SecretDataContains returns true when every key in desiredData exists in
 // existing with an equal value.
 func SecretDataContains(existing, desiredData map[string][]byte) bool {
-	for k, v := range desiredData {
-		if !bytes.Equal(existing[k], v) {
+	for key, desiredValue := range desiredData {
+		existingValue, ok := existing[key]
+		if !ok {
+			return false
+		}
+
+		if !bytes.Equal(existingValue, desiredValue) {
 			return false
 		}
 	}

--- a/pkg/k8s/secret.go
+++ b/pkg/k8s/secret.go
@@ -1,0 +1,38 @@
+package k8s
+
+import (
+	"bytes"
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// MergeSecretData merges desiredData into secret.Data in place, setting
+// StringData to nil to avoid conflicts. It returns false (no update needed)
+// when every key in desiredData already matches the existing value.
+func MergeSecretData(secret *corev1.Secret, desiredData map[string][]byte) bool {
+	if SecretDataContains(secret.Data, desiredData) {
+		return false
+	}
+
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte, len(desiredData))
+	}
+
+	maps.Copy(secret.Data, desiredData)
+	secret.StringData = nil
+
+	return true
+}
+
+// SecretDataContains returns true when every key in desiredData exists in
+// existing with an equal value.
+func SecretDataContains(existing, desiredData map[string][]byte) bool {
+	for k, v := range desiredData {
+		if !bytes.Equal(existing[k], v) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/k8s/secret_test.go
+++ b/pkg/k8s/secret_test.go
@@ -79,6 +79,13 @@ func TestSecretDataContains_NoMatch(t *testing.T) {
 			existing:    nil,
 			desiredData: map[string][]byte{"a": []byte("1")},
 		},
+		{
+			// A nil desired value must not match a missing key (before the fix,
+			// existing[k] also returns nil for missing keys, causing a false positive).
+			name:        "nil desired value does not match missing key",
+			existing:    map[string][]byte{},
+			desiredData: map[string][]byte{"missing": nil},
+		},
 	}
 
 	for _, testCase := range tests {

--- a/pkg/k8s/secret_test.go
+++ b/pkg/k8s/secret_test.go
@@ -1,0 +1,167 @@
+package k8s_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSecretDataContains_Matches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		existing    map[string][]byte
+		desiredData map[string][]byte
+		expected    bool
+	}{
+		{
+			name:        "all desired keys match",
+			existing:    map[string][]byte{"a": []byte("1"), "b": []byte("2")},
+			desiredData: map[string][]byte{"a": []byte("1"), "b": []byte("2")},
+			expected:    true,
+		},
+		{
+			// existing has extra keys — desired keys still match
+			name: "existing has extra keys desired keys still match",
+			existing: map[string][]byte{
+				"a": []byte("1"), "b": []byte("2"), "extra": []byte("x"),
+			},
+			desiredData: map[string][]byte{"a": []byte("1"), "b": []byte("2")},
+			expected:    true,
+		},
+		{
+			name:        "empty desiredData always matches",
+			existing:    map[string][]byte{"a": []byte("1")},
+			desiredData: map[string][]byte{},
+			expected:    true,
+		},
+		{
+			name:        "nil existing with empty desired returns true",
+			existing:    nil,
+			desiredData: map[string][]byte{},
+			expected:    true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := k8s.SecretDataContains(testCase.existing, testCase.desiredData)
+			assert.Equal(t, testCase.expected, got)
+		})
+	}
+}
+
+func TestSecretDataContains_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		existing    map[string][]byte
+		desiredData map[string][]byte
+	}{
+		{
+			name:        "one value differs",
+			existing:    map[string][]byte{"a": []byte("1"), "b": []byte("changed")},
+			desiredData: map[string][]byte{"a": []byte("1"), "b": []byte("2")},
+		},
+		{
+			name:        "desired key missing from existing",
+			existing:    map[string][]byte{"a": []byte("1")},
+			desiredData: map[string][]byte{"a": []byte("1"), "b": []byte("2")},
+		},
+		{
+			name:        "nil existing with non-empty desired returns false",
+			existing:    nil,
+			desiredData: map[string][]byte{"a": []byte("1")},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := k8s.SecretDataContains(testCase.existing, testCase.desiredData)
+			assert.False(t, got)
+		})
+	}
+}
+
+func TestMergeSecretData_UpdatesAndPreserves(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		secretData    map[string][]byte
+		desiredData   map[string][]byte
+		expectChanged bool
+		expectData    map[string][]byte
+	}{
+		{
+			name:          "updates secret when values differ",
+			secretData:    map[string][]byte{"a": []byte("old")},
+			desiredData:   map[string][]byte{"a": []byte("new")},
+			expectChanged: true,
+			expectData:    map[string][]byte{"a": []byte("new")},
+		},
+		{
+			name:          "no-op when values already match",
+			secretData:    map[string][]byte{"a": []byte("same")},
+			desiredData:   map[string][]byte{"a": []byte("same")},
+			expectChanged: false,
+			expectData:    map[string][]byte{"a": []byte("same")},
+		},
+		{
+			name:          "preserves extra keys on update",
+			secretData:    map[string][]byte{"a": []byte("old"), "extra": []byte("keep")},
+			desiredData:   map[string][]byte{"a": []byte("new")},
+			expectChanged: true,
+			expectData:    map[string][]byte{"a": []byte("new"), "extra": []byte("keep")},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			secret := &corev1.Secret{Data: testCase.secretData}
+
+			changed := k8s.MergeSecretData(secret, testCase.desiredData)
+
+			assert.Equal(t, testCase.expectChanged, changed)
+			assert.Equal(t, testCase.expectData, secret.Data)
+		})
+	}
+}
+
+func TestMergeSecretData_NilHandling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("initialises nil Data before writing", func(t *testing.T) {
+		t.Parallel()
+
+		secret := &corev1.Secret{}
+		changed := k8s.MergeSecretData(secret, map[string][]byte{"a": []byte("val")})
+
+		assert.True(t, changed)
+		assert.Equal(t, map[string][]byte{"a": []byte("val")}, secret.Data)
+	})
+
+	t.Run("sets StringData to nil on change", func(t *testing.T) {
+		t.Parallel()
+
+		secret := &corev1.Secret{
+			Data:       map[string][]byte{"a": []byte("old")},
+			StringData: map[string]string{"shouldBeCleared": "yes"},
+		}
+
+		changed := k8s.MergeSecretData(secret, map[string][]byte{"a": []byte("new")})
+
+		assert.True(t, changed)
+		assert.Nil(t, secret.StringData)
+	})
+}

--- a/pkg/svc/installer/internal/hetzner/secret.go
+++ b/pkg/svc/installer/internal/hetzner/secret.go
@@ -2,10 +2,8 @@
 package hetzner
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"maps"
 	"os"
 	"time"
 
@@ -141,7 +139,7 @@ func updateSecretIfNeeded(
 	existingSecret *corev1.Secret,
 	desiredData map[string][]byte,
 ) error {
-	if desiredDataMatches(existingSecret.Data, desiredData) {
+	if !k8s.MergeSecretData(existingSecret, desiredData) {
 		return nil
 	}
 
@@ -153,17 +151,9 @@ func updateSecretIfNeeded(
 			return fmt.Errorf("failed to get secret for update: %w", err)
 		}
 
-		if desiredDataMatches(latest.Data, desiredData) {
+		if !k8s.MergeSecretData(latest, desiredData) {
 			return nil
 		}
-
-		if latest.Data == nil {
-			latest.Data = make(map[string][]byte, len(desiredData))
-		}
-
-		maps.Copy(latest.Data, desiredData)
-
-		latest.StringData = nil
 
 		_, err = secretsClient.Update(ctx, latest, metav1.UpdateOptions{})
 		if err != nil {
@@ -177,18 +167,6 @@ func updateSecretIfNeeded(
 	}
 
 	return nil
-}
-
-// desiredDataMatches returns true when every key in desiredData exists in
-// existing with an equal value.
-func desiredDataMatches(existing, desiredData map[string][]byte) bool {
-	for k, v := range desiredData {
-		if !bytes.Equal(existing[k], v) {
-			return false
-		}
-	}
-
-	return true
 }
 
 // InstallWithSecret ensures the Hetzner Cloud API token secret exists and then

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -1,0 +1,120 @@
+package talosprovisioner
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	autoscalerConfigSecretName      = "cluster-autoscaler-config"
+	autoscalerConfigSecretNamespace = "kube-system"
+)
+
+// GenerateAutoscalerWorkerConfig generates a stripped Talos worker config
+// suitable for autoscaler-provisioned compute-only nodes. It sets
+// machine.install.wipe to true, removes machine.disks (autoscaler nodes have
+// no attached Hetzner Volumes), and removes the Longhorn storage node label
+// while preserving machine.kubelet.extraMounts for CSI consumer access.
+func GenerateAutoscalerWorkerConfig(workerConfig talosconfig.Provider) ([]byte, error) {
+	if workerConfig == nil {
+		return nil, ErrNilWorkerConfig
+	}
+
+	patched, err := workerConfig.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		if cfg.MachineConfig.MachineInstall == nil {
+			cfg.MachineConfig.MachineInstall = &v1alpha1.InstallConfig{}
+		}
+
+		wipe := true
+		cfg.MachineConfig.MachineInstall.InstallWipe = &wipe
+
+		cfg.MachineConfig.MachineDisks = nil //nolint:staticcheck // deprecated; v1alpha1.Config has no replacement field
+
+		delete(cfg.MachineConfig.MachineNodeLabels, "node.longhorn.io/create-default-disk")
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("patch autoscaler worker config: %w", err)
+	}
+
+	cfgBytes, err := patched.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("marshal autoscaler worker config: %w", err)
+	}
+
+	return cfgBytes, nil
+}
+
+// ApplyAutoscalerConfigSecret creates or updates the cluster-autoscaler-config
+// Secret in kube-system. The Secret holds the Hetzner snapshot image ID and a
+// base64-encoded Talos worker config that the node-autoscaler uses as
+// cloud-init user-data when provisioning new worker nodes.
+func ApplyAutoscalerConfigSecret(
+	ctx context.Context,
+	kubeclient kubernetes.Interface,
+	snapshotImageID string,
+	workerConfigYAML []byte,
+) error {
+	encodedConfig := base64.StdEncoding.EncodeToString(workerConfigYAML)
+
+	desiredData := map[string][]byte{
+		"hcloud_image":      []byte(snapshotImageID),
+		"hcloud_cloud_init": []byte(encodedConfig),
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      autoscalerConfigSecretName,
+			Namespace: autoscalerConfigSecretNamespace,
+		},
+		Data: desiredData,
+	}
+
+	secretsClient := kubeclient.CoreV1().Secrets(autoscalerConfigSecretNamespace)
+
+	_, err := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("get autoscaler config secret: %w", err)
+		}
+
+		_, createErr := secretsClient.Create(ctx, secret, metav1.CreateOptions{})
+		if createErr != nil {
+			return fmt.Errorf("create autoscaler config secret: %w", createErr)
+		}
+
+		return nil
+	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, getErr := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("get autoscaler config secret for update: %w", getErr)
+		}
+
+		latest.Data = desiredData
+		latest.StringData = nil
+
+		_, updateErr := secretsClient.Update(ctx, latest, metav1.UpdateOptions{})
+		if updateErr != nil {
+			return fmt.Errorf("update autoscaler config secret: %w", updateErr)
+		}
+
+		return nil
+	})
+	if retryErr != nil {
+		return fmt.Errorf("failed to update autoscaler config secret: %w", retryErr)
+	}
+
+	return nil
+}

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -144,20 +144,20 @@ func updateAutoscalerSecretIfNeeded(
 	secretsClient := client.CoreV1().Secrets(autoscalerConfigSecretNamespace)
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest, err := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("get autoscaler config secret for update: %w", err)
+		latest, getErr := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("get autoscaler config secret for update: %w", getErr)
 		}
 
 		if autoscalerSecretDataMatches(latest.Data, desiredData) {
 			return nil
 		}
 
-		if latest.Data == nil {
-			latest.Data = make(map[string][]byte, len(desiredData))
-		}
-
-		maps.Copy(latest.Data, desiredData)
+		// Build the merged data map, preserving any existing keys not in desiredData.
+		merged := make(map[string][]byte, len(latest.Data)+len(desiredData))
+		maps.Copy(merged, latest.Data)
+		maps.Copy(merged, desiredData)
+		latest.Data = merged
 		latest.StringData = nil
 
 		_, updateErr := secretsClient.Update(ctx, latest, metav1.UpdateOptions{})

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -1,9 +1,11 @@
 package talosprovisioner
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
 
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -30,6 +32,10 @@ func GenerateAutoscalerWorkerConfig(workerConfig talosconfig.Provider) ([]byte, 
 	}
 
 	patched, err := workerConfig.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		if cfg.MachineConfig == nil {
+			cfg.MachineConfig = &v1alpha1.MachineConfig{}
+		}
+
 		if cfg.MachineConfig.MachineInstall == nil {
 			cfg.MachineConfig.MachineInstall = &v1alpha1.InstallConfig{}
 		}
@@ -57,8 +63,8 @@ func GenerateAutoscalerWorkerConfig(workerConfig talosconfig.Provider) ([]byte, 
 
 // ApplyAutoscalerConfigSecret creates or updates the cluster-autoscaler-config
 // Secret in kube-system. The Secret holds the Hetzner snapshot image ID and a
-// base64-encoded Talos worker config that the node-autoscaler uses as
-// cloud-init user-data when provisioning new worker nodes.
+// base64-encoded Talos worker config that Kubernetes Cluster Autoscaler uses
+// as cloud-init user-data when provisioning new worker nodes.
 func ApplyAutoscalerConfigSecret(
 	ctx context.Context,
 	kubeclient kubernetes.Interface,
@@ -82,27 +88,76 @@ func ApplyAutoscalerConfigSecret(
 
 	secretsClient := kubeclient.CoreV1().Secrets(autoscalerConfigSecretNamespace)
 
-	_, err := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
+	existing, err := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("get autoscaler config secret: %w", err)
 		}
 
-		_, createErr := secretsClient.Create(ctx, secret, metav1.CreateOptions{})
-		if createErr != nil {
-			return fmt.Errorf("create autoscaler config secret: %w", createErr)
+		return createOrUpdateAutoscalerSecretOnConflict(ctx, kubeclient, secret)
+	}
+
+	return updateAutoscalerSecretIfNeeded(ctx, kubeclient, existing, desiredData)
+}
+
+// createOrUpdateAutoscalerSecretOnConflict creates the Secret. If a concurrent
+// caller already created it between the outer Get and this Create, it falls
+// back to a merge-update to stay idempotent.
+func createOrUpdateAutoscalerSecretOnConflict(
+	ctx context.Context,
+	client kubernetes.Interface,
+	secret *corev1.Secret,
+) error {
+	secretsClient := client.CoreV1().Secrets(autoscalerConfigSecretNamespace)
+
+	_, err := secretsClient.Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create autoscaler config secret: %w", err)
 		}
 
+		existing, getErr := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("get autoscaler config secret after conflict: %w", getErr)
+		}
+
+		return updateAutoscalerSecretIfNeeded(ctx, client, existing, secret.Data)
+	}
+
+	return nil
+}
+
+// updateAutoscalerSecretIfNeeded merges the desired keys into the existing
+// Secret. It skips the update when all desired keys already match to avoid
+// unnecessary API calls. RetryOnConflict handles 409 responses from concurrent
+// updaters.
+func updateAutoscalerSecretIfNeeded(
+	ctx context.Context,
+	client kubernetes.Interface,
+	existing *corev1.Secret,
+	desiredData map[string][]byte,
+) error {
+	if autoscalerSecretDataMatches(existing.Data, desiredData) {
 		return nil
 	}
 
+	secretsClient := client.CoreV1().Secrets(autoscalerConfigSecretNamespace)
+
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest, getErr := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
-		if getErr != nil {
-			return fmt.Errorf("get autoscaler config secret for update: %w", getErr)
+		latest, err := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get autoscaler config secret for update: %w", err)
 		}
 
-		latest.Data = desiredData
+		if autoscalerSecretDataMatches(latest.Data, desiredData) {
+			return nil
+		}
+
+		if latest.Data == nil {
+			latest.Data = make(map[string][]byte, len(desiredData))
+		}
+
+		maps.Copy(latest.Data, desiredData)
 		latest.StringData = nil
 
 		_, updateErr := secretsClient.Update(ctx, latest, metav1.UpdateOptions{})
@@ -117,4 +172,16 @@ func ApplyAutoscalerConfigSecret(
 	}
 
 	return nil
+}
+
+// autoscalerSecretDataMatches returns true when every key in desiredData
+// exists in existing with an equal value.
+func autoscalerSecretDataMatches(existing, desiredData map[string][]byte) bool {
+	for k, v := range desiredData {
+		if !bytes.Equal(existing[k], v) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -1,12 +1,11 @@
 package talosprovisioner
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
-	"maps"
 
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -137,7 +136,7 @@ func updateAutoscalerSecretIfNeeded(
 	existing *corev1.Secret,
 	desiredData map[string][]byte,
 ) error {
-	if autoscalerSecretDataMatches(existing.Data, desiredData) {
+	if !k8s.MergeSecretData(existing, desiredData) {
 		return nil
 	}
 
@@ -149,16 +148,9 @@ func updateAutoscalerSecretIfNeeded(
 			return fmt.Errorf("get autoscaler config secret for update: %w", getErr)
 		}
 
-		if autoscalerSecretDataMatches(latest.Data, desiredData) {
+		if !k8s.MergeSecretData(latest, desiredData) {
 			return nil
 		}
-
-		// Build the merged data map, preserving any existing keys not in desiredData.
-		merged := make(map[string][]byte, len(latest.Data)+len(desiredData))
-		maps.Copy(merged, latest.Data)
-		maps.Copy(merged, desiredData)
-		latest.Data = merged
-		latest.StringData = nil
 
 		_, updateErr := secretsClient.Update(ctx, latest, metav1.UpdateOptions{})
 		if updateErr != nil {
@@ -172,16 +164,4 @@ func updateAutoscalerSecretIfNeeded(
 	}
 
 	return nil
-}
-
-// autoscalerSecretDataMatches returns true when every key in desiredData
-// exists in existing with an equal value.
-func autoscalerSecretDataMatches(existing, desiredData map[string][]byte) bool {
-	for k, v := range desiredData {
-		if !bytes.Equal(existing[k], v) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -12,8 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 // newTestWorkerProvider builds a minimal v1alpha1 Config wrapped in a Provider
@@ -262,4 +266,62 @@ func TestApplyAutoscalerConfigSecret_UpdatesExistingSecret(t *testing.T) {
 
 	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
 	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+}
+
+func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.T) {
+	t.Parallel()
+
+	// Pre-create the secret so subsequent Gets (after AlreadyExists) succeed.
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cluster-autoscaler-config",
+			Namespace:       "kube-system",
+			ResourceVersion: "1",
+		},
+		Data: map[string][]byte{
+			"hcloud_image":      []byte("old-image"),
+			"hcloud_cloud_init": []byte("old-config"),
+		},
+	}
+	clientset := fake.NewClientset(preExisting)
+
+	getCallCount := 0
+
+	clientset.PrependReactor(
+		"get",
+		"secrets",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			getCallCount++
+			if getCallCount == 1 {
+				// First Get: return NotFound to enter the create path.
+				return true, nil, apierrors.NewNotFound(
+					schema.GroupResource{Group: "", Resource: "secrets"},
+					"cluster-autoscaler-config",
+				)
+			}
+
+			// Subsequent Gets: pass through to the fake clientset.
+			return false, nil, nil
+		},
+	)
+
+	// Simulate a concurrent caller that created the Secret first.
+	clientset.PrependReactor(
+		"create",
+		"secrets",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewAlreadyExists(
+				schema.GroupResource{Group: "", Resource: "secrets"},
+				"cluster-autoscaler-config",
+			)
+		},
+	)
+
+	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(),
+		clientset,
+		"new-image",
+		[]byte("new-config"),
+	)
+	require.NoError(t, err)
 }

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -324,4 +324,17 @@ func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.
 		[]byte("new-config"),
 	)
 	require.NoError(t, err)
+
+	// Verify the Secret was actually updated with the new values (not a no-op).
+	updated, err := clientset.CoreV1().Secrets("kube-system").Get(
+		context.Background(),
+		"cluster-autoscaler-config",
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("new-image"), updated.Data["hcloud_image"])
+
+	wantEncoded := base64.StdEncoding.EncodeToString([]byte("new-config"))
+	assert.Equal(t, []byte(wantEncoded), updated.Data["hcloud_cloud_init"])
 }

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -268,21 +268,11 @@ func TestApplyAutoscalerConfigSecret_UpdatesExistingSecret(t *testing.T) {
 	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
 }
 
-func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.T) {
-	t.Parallel()
-
-	// Pre-create the secret so subsequent Gets (after AlreadyExists) succeed.
-	preExisting := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "cluster-autoscaler-config",
-			Namespace:       "kube-system",
-			ResourceVersion: "1",
-		},
-		Data: map[string][]byte{
-			"hcloud_image":      []byte("old-image"),
-			"hcloud_cloud_init": []byte("old-config"),
-		},
-	}
+// newConflictClientset returns a fake clientset pre-seeded with an existing
+// cluster-autoscaler-config Secret and reactors that simulate concurrent
+// creation: the first Get returns NotFound (entering the create path) and
+// Create returns AlreadyExists (simulating a concurrent writer).
+func newConflictClientset(preExisting *corev1.Secret) *fake.Clientset {
 	clientset := fake.NewClientset(preExisting)
 
 	getCallCount := 0
@@ -293,19 +283,16 @@ func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.
 		func(_ k8stesting.Action) (bool, runtime.Object, error) {
 			getCallCount++
 			if getCallCount == 1 {
-				// First Get: return NotFound to enter the create path.
 				return true, nil, apierrors.NewNotFound(
 					schema.GroupResource{Group: "", Resource: "secrets"},
 					"cluster-autoscaler-config",
 				)
 			}
 
-			// Subsequent Gets: pass through to the fake clientset.
 			return false, nil, nil
 		},
 	)
 
-	// Simulate a concurrent caller that created the Secret first.
 	clientset.PrependReactor(
 		"create",
 		"secrets",
@@ -317,19 +304,33 @@ func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.
 		},
 	)
 
+	return clientset
+}
+
+func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.T) {
+	t.Parallel()
+
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cluster-autoscaler-config",
+			Namespace:       "kube-system",
+			ResourceVersion: "1",
+		},
+		Data: map[string][]byte{
+			"hcloud_image":      []byte("old-image"),
+			"hcloud_cloud_init": []byte("old-config"),
+		},
+	}
+	clientset := newConflictClientset(preExisting)
+
 	err := talosprovisioner.ApplyAutoscalerConfigSecret(
-		context.Background(),
-		clientset,
-		"new-image",
-		[]byte("new-config"),
+		context.Background(), clientset, "new-image", []byte("new-config"),
 	)
 	require.NoError(t, err)
 
 	// Verify the Secret was actually updated with the new values (not a no-op).
 	updated, err := clientset.CoreV1().Secrets("kube-system").Get(
-		context.Background(),
-		"cluster-autoscaler-config",
-		metav1.GetOptions{},
+		context.Background(), "cluster-autoscaler-config", metav1.GetOptions{},
 	)
 	require.NoError(t, err)
 

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -131,7 +131,27 @@ func TestGenerateAutoscalerWorkerConfig_InstallNilBeforePatch(t *testing.T) {
 	assert.True(t, *rawCfg.MachineConfig.MachineInstall.InstallWipe)
 }
 
-// --- ApplyAutoscalerConfigSecret ---
+func TestGenerateAutoscalerWorkerConfig_NilMachineConfig(t *testing.T) {
+	t.Parallel()
+
+	// Config with nil MachineConfig — the function should initialise it and not panic.
+	provider := taloscontainer.NewV1Alpha1(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+	})
+
+	result, err := talosprovisioner.GenerateAutoscalerWorkerConfig(provider)
+	require.NoError(t, err)
+
+	parsed, err := configloader.NewFromBytes(result)
+	require.NoError(t, err)
+
+	rawCfg := parsed.RawV1Alpha1()
+	require.NotNil(t, rawCfg)
+	require.NotNil(t, rawCfg.MachineConfig)
+	require.NotNil(t, rawCfg.MachineConfig.MachineInstall)
+	require.NotNil(t, rawCfg.MachineConfig.MachineInstall.InstallWipe)
+	assert.True(t, *rawCfg.MachineConfig.MachineInstall.InstallWipe)
+}
 
 func TestApplyAutoscalerConfigSecret_CreatesNewSecret(t *testing.T) {
 	t.Parallel()
@@ -159,6 +179,50 @@ func TestApplyAutoscalerConfigSecret_CreatesNewSecret(t *testing.T) {
 
 	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
 	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+}
+
+func TestApplyAutoscalerConfigSecret_PreservesExtraKeysOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-autoscaler-config",
+			Namespace: "kube-system",
+		},
+		Data: map[string][]byte{
+			"hcloud_image":      []byte("old-image-id"),
+			"hcloud_cloud_init": []byte("old-config"),
+			"extra_key":         []byte("extra-value"),
+		},
+	}
+	clientset := fake.NewClientset(existing)
+
+	snapshotID := "111111111"
+	workerConfig := []byte("machine:\n  type: worker\n")
+
+	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(),
+		clientset,
+		snapshotID,
+		workerConfig,
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().Secrets("kube-system").Get(
+		context.Background(),
+		"cluster-autoscaler-config",
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	// Desired keys must be updated.
+	assert.Equal(t, []byte(snapshotID), secret.Data["hcloud_image"])
+
+	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
+	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+
+	// Extra key must be preserved (merge, not replace).
+	assert.Equal(t, []byte("extra-value"), secret.Data["extra_key"])
 }
 
 func TestApplyAutoscalerConfigSecret_UpdatesExistingSecret(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -1,0 +1,201 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	taloscontainer "github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// newTestWorkerProvider builds a minimal v1alpha1 Config wrapped in a Provider
+// for use across autoscaler worker config tests.
+func newTestWorkerProvider() *taloscontainer.Container {
+	falseVal := false
+
+	return taloscontainer.NewV1Alpha1(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineInstall: &v1alpha1.InstallConfig{
+				InstallWipe: &falseVal,
+			},
+			MachineDisks: []*v1alpha1.MachineDisk{
+				{DeviceName: "/dev/sdb"},
+			},
+			MachineNodeLabels: map[string]string{
+				"node.longhorn.io/create-default-disk": "config",
+				"keep-this-label":                      "value",
+			},
+			MachineKubelet: &v1alpha1.KubeletConfig{
+				KubeletExtraMounts: []v1alpha1.ExtraMount{
+					{Destination: "/var/lib/longhorn"},
+				},
+			},
+		},
+	})
+}
+
+// --- GenerateAutoscalerWorkerConfig ---
+
+func TestGenerateAutoscalerWorkerConfig_StrippingLogic(t *testing.T) {
+	t.Parallel()
+
+	result, err := talosprovisioner.GenerateAutoscalerWorkerConfig(newTestWorkerProvider())
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	parsed, err := configloader.NewFromBytes(result)
+	require.NoError(t, err)
+
+	rawCfg := parsed.RawV1Alpha1()
+	require.NotNil(t, rawCfg)
+	require.NotNil(t, rawCfg.MachineConfig)
+
+	t.Run("sets install.wipe to true", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotNil(t, rawCfg.MachineConfig.MachineInstall)
+		require.NotNil(t, rawCfg.MachineConfig.MachineInstall.InstallWipe)
+		assert.True(t, *rawCfg.MachineConfig.MachineInstall.InstallWipe)
+	})
+
+	t.Run("removes machine.disks", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Empty(t, rawCfg.MachineConfig.MachineDisks) //nolint:staticcheck // deprecated field
+	})
+
+	t.Run("removes longhorn node label", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NotContains(
+			t,
+			rawCfg.MachineConfig.MachineNodeLabels,
+			"node.longhorn.io/create-default-disk",
+		)
+	})
+
+	t.Run("preserves other node labels", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Contains(t, rawCfg.MachineConfig.MachineNodeLabels, "keep-this-label")
+	})
+
+	t.Run("preserves kubelet extra mounts", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotNil(t, rawCfg.MachineConfig.MachineKubelet)
+		assert.NotEmpty(t, rawCfg.MachineConfig.MachineKubelet.KubeletExtraMounts)
+		assert.Equal(
+			t,
+			"/var/lib/longhorn",
+			rawCfg.MachineConfig.MachineKubelet.KubeletExtraMounts[0].Destination,
+		)
+	})
+}
+
+func TestGenerateAutoscalerWorkerConfig_NilInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := talosprovisioner.GenerateAutoscalerWorkerConfig(nil)
+	require.ErrorIs(t, err, talosprovisioner.ErrNilWorkerConfig)
+}
+
+func TestGenerateAutoscalerWorkerConfig_InstallNilBeforePatch(t *testing.T) {
+	t.Parallel()
+
+	// Config with no MachineInstall set — the function should initialise it.
+	provider := taloscontainer.NewV1Alpha1(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+	})
+
+	result, err := talosprovisioner.GenerateAutoscalerWorkerConfig(provider)
+	require.NoError(t, err)
+
+	parsed, err := configloader.NewFromBytes(result)
+	require.NoError(t, err)
+
+	rawCfg := parsed.RawV1Alpha1()
+	require.NotNil(t, rawCfg)
+	require.NotNil(t, rawCfg.MachineConfig.MachineInstall)
+	require.NotNil(t, rawCfg.MachineConfig.MachineInstall.InstallWipe)
+	assert.True(t, *rawCfg.MachineConfig.MachineInstall.InstallWipe)
+}
+
+// --- ApplyAutoscalerConfigSecret ---
+
+func TestApplyAutoscalerConfigSecret_CreatesNewSecret(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset()
+	snapshotID := "123456789"
+	workerConfig := []byte("machine:\n  type: worker\n")
+
+	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(),
+		clientset,
+		snapshotID,
+		workerConfig,
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().Secrets("kube-system").Get(
+		context.Background(),
+		"cluster-autoscaler-config",
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte(snapshotID), secret.Data["hcloud_image"])
+
+	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
+	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+}
+
+func TestApplyAutoscalerConfigSecret_UpdatesExistingSecret(t *testing.T) {
+	t.Parallel()
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-autoscaler-config",
+			Namespace: "kube-system",
+		},
+		Data: map[string][]byte{
+			"hcloud_image":      []byte("old-image-id"),
+			"hcloud_cloud_init": []byte("old-config"),
+		},
+	}
+	clientset := fake.NewClientset(existing)
+
+	snapshotID := "987654321"
+	workerConfig := []byte("machine:\n  type: worker\n  install:\n    wipe: true\n")
+
+	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(),
+		clientset,
+		snapshotID,
+		workerConfig,
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().Secrets("kube-system").Get(
+		context.Background(),
+		"cluster-autoscaler-config",
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte(snapshotID), secret.Data["hcloud_image"])
+
+	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
+	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+}

--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -52,4 +52,7 @@ var (
 	ErrARM64SnapshotNotSupported = errors.New(
 		"snapshot-based boot (schematicId) does not support ARM64 server types (cax*) yet",
 	)
+	// ErrNilWorkerConfig is returned when a nil worker config is passed to
+	// GenerateAutoscalerWorkerConfig.
+	ErrNilWorkerConfig = errors.New("worker config must not be nil")
 )


### PR DESCRIPTION
## Summary

Implements Slice 3 of native node autoscaling support for Talos × Hetzner.

Adds two exported helpers to `pkg/svc/provisioner/cluster/talos/`:

- **`GenerateAutoscalerWorkerConfig(talosconfig.Provider) ([]byte, error)`** — strips a Talos worker config for autoscaler-provisioned compute-only nodes:
  - Sets `machine.install.wipe: true` (snapshot needs a fresh install)
  - Removes `machine.disks` (autoscaler servers have no Hetzner Volume at `/dev/sdb`)
  - Removes Longhorn storage labels (`node.longhorn.io/create-default-disk`)
  - Preserves `machine.kubelet.extraMounts` for `/var/lib/longhorn` (CSI consumer access)
  - Cluster CA + bootstrap token are kept (regenerated per `cluster create`)

- **`ApplyAutoscalerConfigSecret(ctx, kubernetes.Interface, string, []byte) error`** — creates or updates the `cluster-autoscaler-config` Secret in `kube-system` with:
  - `hcloud_image`: snapshot ID stored as a plain string (avoids Helm scientific notation)
  - `hcloud_cloud_init`: base64-encoded worker config YAML

Also adds `ErrNilWorkerConfig` sentinel to `errors.go`.

Table-driven unit tests cover all stripping behaviours and both Secret create/update paths.

Wiring into the provisioner lifecycle (on `cluster create` and `--update-distribution`) will be done in Slice 4 alongside the autoscaler installer.

Fixes part of #4384 (Slice 3)