### PR TITLE
docs: document autoscaler configuration and node autoscaling architecture

### DIFF
--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -199,7 +199,8 @@ Editor command for interactive workflows (e.g., `code --wait`, `vim`). Falls bac
 | `localRegistry` | LocalRegistry | – |  |
 | `gitOpsEngine` | enum | – |  |
 | `sops` | SOPS | – |  |
-| `nodeAutoscaling` | enum | – |  |
+| `nodeAutoscaling` | enum | – | **Deprecated** — migrated to `spec.cluster.autoscaler.node.enabled` on load |
+| `autoscaler` | AutoscalerConfig | – | Pod and node autoscaling configuration (see below) |
 | `importImages` | string | – | Path to tar archive with container images to import after cluster creation but before component installation |
 | `controlPlanes` | int32 | `1` | Number of control-plane nodes to create for the cluster (provider/distribution-agnostic) |
 | `workers` | int32 | – | Number of worker nodes to create for the cluster (provider/distribution-agnostic) |
@@ -336,26 +337,62 @@ GitOps engine for continuous deployment. See [GitOps](/concepts/#gitops). When s
 - `Flux` – Install [Flux CD](https://fluxcd.io/) and scaffold FluxInstance CR
 - `ArgoCD` – Install [Argo CD](https://argo-cd.readthedocs.io/) and scaffold Application CR
 
+#### autoscaler (AutoscalerConfig)
+
+Configuration for pod and node autoscaling. Supersedes the deprecated `spec.cluster.nodeAutoscaling` field.
+
+##### autoscaler.pod (PodAutoscalerConfig)
+
+| Field | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `horizontal` | enum | `Disabled` | Enable [Horizontal Pod Autoscaling (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/). Requires `spec.cluster.metricsServer: Enabled` (or distribution-bundled metrics-server) |
+| `vertical` | enum | `Disabled` | Enable [Vertical Pod Autoscaling (VPA)](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler). Installs the Fairwinds VPA Helm chart |
+
+##### autoscaler.node (NodeAutoscalerConfig)
+
+| Field | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `enabled` | enum | `Disabled` | When `Enabled`, `ksail cluster update` skips `controlPlanes`/`workers` diffs; for Talos × Hetzner, also deploys Cluster Autoscaler |
+| `pools` | []NodePool | – | Node pools for Cluster Autoscaler (Talos × Hetzner only) |
+| `maxNodesTotal` | int32 | – | Maximum total nodes allowed across all pools |
+| `expander` | enum | `LeastWaste` | Expander strategy: `Price`, `LeastWaste`, `LeastNodes`, `Random` |
+| `scaleDownUnneededTime` | string | – | How long a node must be unneeded before becoming eligible for removal (e.g. `10m`) |
+
+Each `NodePool` entry:
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `name` | string | Yes | Unique pool identifier (DNS-1123 label) |
+| `serverType` | string | Yes | Hetzner server type (e.g. `cx23`, `cax11`, `cpx51`) |
+| `location` | string | Yes | Hetzner datacenter location (e.g. `fsn1`, `nbg1`, `hel1`) |
+| `min` | int32 | Yes | Minimum nodes in this pool |
+| `max` | int32 | Yes | Maximum nodes in this pool |
+
+> [!NOTE]
+> KSail validates that `controlPlanes + workers + sum(pool.max) ≤ spec.provider.hetzner.serverLimit` (default `10`). Increase `serverLimit` when configuring larger pool capacities.
+
 #### Distribution and Tool Options
 
 Advanced configuration options are direct fields under `spec.cluster`. See [Schema Support](#schema-support) for the complete structure.
 
 **Talos options (`spec.cluster.talos`):**
 
-- `controlPlanes` – Number of control-plane nodes (default: `1`)
-- `workers` – Number of worker nodes (default: `0`)
-- `config` – Path to talosconfig file (default: `~/.talos/config`)
-- `iso` – Cloud provider ISO/image ID for Talos Linux (default: `122630` for x86; use `122629` for ARM)
+- `controlPlanes` — **Deprecated**: use `spec.cluster.controlPlanes`. Kept as migration alias; emits a warning on load.
+- `workers` — **Deprecated**: use `spec.cluster.workers`. Kept as migration alias; emits a warning on load.
+- `version` — Pins the Talos OS version (e.g. `v1.11.2`). Caps `--update-distribution` upgrades at this version.
+- `config` — Path to talosconfig file (default: `~/.talos/config`)
+- `iso` — Cloud provider ISO/image ID for Talos Linux (default: `122630` for x86; use `122629` for ARM)
 
 **Hetzner options (`spec.provider.hetzner`):**
 
-- `controlPlaneServerType` – Server type for control-plane nodes (default: `cx23`)
-- `workerServerType` – Server type for worker nodes (default: `cx23`)
-- `location` – Datacenter location: `fsn1`, `nbg1`, `hel1` (default: `fsn1`)
-- `networkName` – Private network name (default: `<cluster>-network`)
-- `networkCidr` – Network CIDR block (default: `10.0.0.0/16`)
-- `sshKeyName` – SSH key name for server access (optional)
-- `tokenEnvVar` – Environment variable for API token (default: `HCLOUD_TOKEN`)
+- `controlPlaneServerType` — Server type for control-plane nodes (default: `cx23`)
+- `workerServerType` — Server type for worker nodes (default: `cx23`)
+- `location` — Datacenter location: `fsn1`, `nbg1`, `hel1` (default: `fsn1`)
+- `networkName` — Private network name (default: `<cluster>-network`)
+- `networkCidr` — Network CIDR block (default: `10.0.0.0/16`)
+- `sshKeyName` — SSH key name for server access (optional)
+- `tokenEnvVar` — Environment variable for API token (default: `HCLOUD_TOKEN`)
+- `serverLimit` — Maximum total Hetzner servers (control-planes + workers + autoscaler pool capacity) for this cluster (default: `10`). Used to guard against exceeding account/project server quotas.
 
 **Vanilla options (`spec.cluster.vanilla`):**
 
@@ -436,16 +473,15 @@ machine:
       max-pods: "250"
 ```
 
-See [Talos Configuration Reference](https://www.talos.dev/latest/reference/configuration/) for patch syntax. Use `spec.cluster.talos` to configure node counts:
+See [Talos Configuration Reference](https://www.talos.dev/latest/reference/configuration/) for patch syntax. Use `spec.cluster.controlPlanes` and `spec.cluster.workers` to configure node counts:
 
 ```yaml
 spec:
   cluster:
     distribution: Talos
     distributionConfig: talos
-    talos:
-      controlPlanes: 3
-      workers: 2
+    controlPlanes: 3
+    workers: 2
 ```
 
 #### Port Mappings (Docker Provider)

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -199,8 +199,7 @@ Editor command for interactive workflows (e.g., `code --wait`, `vim`). Falls bac
 | `localRegistry` | LocalRegistry | – |  |
 | `gitOpsEngine` | enum | – |  |
 | `sops` | SOPS | – |  |
-| `nodeAutoscaling` | enum | – | **Deprecated** — migrated to `spec.cluster.autoscaler.node.enabled` on load |
-| `autoscaler` | AutoscalerConfig | – | Pod and node autoscaling configuration (see below) |
+| `nodeAutoscaling` | enum | – | Node autoscaling guard: when `Enabled`, `ksail cluster update` skips `controlPlanes`/`workers` diffs (Talos only) |
 | `importImages` | string | – | Path to tar archive with container images to import after cluster creation but before component installation |
 | `controlPlanes` | int32 | `1` | Number of control-plane nodes to create for the cluster (provider/distribution-agnostic) |
 | `workers` | int32 | – | Number of worker nodes to create for the cluster (provider/distribution-agnostic) |
@@ -337,40 +336,6 @@ GitOps engine for continuous deployment. See [GitOps](/concepts/#gitops). When s
 - `Flux` – Install [Flux CD](https://fluxcd.io/) and scaffold FluxInstance CR
 - `ArgoCD` – Install [Argo CD](https://argo-cd.readthedocs.io/) and scaffold Application CR
 
-#### autoscaler (AutoscalerConfig)
-
-Configuration for pod and node autoscaling. Supersedes the deprecated `spec.cluster.nodeAutoscaling` field.
-
-##### autoscaler.pod (PodAutoscalerConfig)
-
-| Field | Type | Default | Description |
-| ----- | ---- | ------- | ----------- |
-| `horizontal` | enum | `Disabled` | Enable [Horizontal Pod Autoscaling (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/). Requires `spec.cluster.metricsServer: Enabled` (or distribution-bundled metrics-server) |
-| `vertical` | enum | `Disabled` | Enable [Vertical Pod Autoscaling (VPA)](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler). Installs the Fairwinds VPA Helm chart |
-
-##### autoscaler.node (NodeAutoscalerConfig)
-
-| Field | Type | Default | Description |
-| ----- | ---- | ------- | ----------- |
-| `enabled` | enum | `Disabled` | When `Enabled`, `ksail cluster update` skips `controlPlanes`/`workers` diffs; for Talos × Hetzner, also deploys Cluster Autoscaler |
-| `pools` | []NodePool | – | Node pools for Cluster Autoscaler (Talos × Hetzner only) |
-| `maxNodesTotal` | int32 | – | Maximum total nodes allowed across all pools |
-| `expander` | enum | `LeastWaste` | Expander strategy: `Price`, `LeastWaste`, `LeastNodes`, `Random` |
-| `scaleDownUnneededTime` | string | – | How long a node must be unneeded before becoming eligible for removal (e.g. `10m`) |
-
-Each `NodePool` entry:
-
-| Field | Type | Required | Description |
-| ----- | ---- | -------- | ----------- |
-| `name` | string | Yes | Unique pool identifier (DNS-1123 label) |
-| `serverType` | string | Yes | Hetzner server type (e.g. `cx23`, `cax11`, `cpx51`) |
-| `location` | string | Yes | Hetzner datacenter location (e.g. `fsn1`, `nbg1`, `hel1`) |
-| `min` | int32 | Yes | Minimum nodes in this pool |
-| `max` | int32 | Yes | Maximum nodes in this pool |
-
-> [!NOTE]
-> KSail validates that `controlPlanes + workers + sum(pool.max) ≤ spec.provider.hetzner.serverLimit` (default `10`). Increase `serverLimit` when configuring larger pool capacities.
-
 #### Distribution and Tool Options
 
 Advanced configuration options are direct fields under `spec.cluster`. See [Schema Support](#schema-support) for the complete structure.
@@ -392,7 +357,6 @@ Advanced configuration options are direct fields under `spec.cluster`. See [Sche
 - `networkCidr` — Network CIDR block (default: `10.0.0.0/16`)
 - `sshKeyName` — SSH key name for server access (optional)
 - `tokenEnvVar` — Environment variable for API token (default: `HCLOUD_TOKEN`)
-- `serverLimit` — Maximum total Hetzner servers (control-planes + workers + autoscaler pool capacity) for this cluster (default: `10`). Used to guard against exceeding account/project server quotas.
 
 **Vanilla options (`spec.cluster.vanilla`):**
 

--- a/docs/src/content/docs/features/cluster-provisioning.mdx
+++ b/docs/src/content/docs/features/cluster-provisioning.mdx
@@ -34,112 +34,18 @@ ksail cluster update --dry-run --output json | jq .recreateRequired
 
 ## Node Autoscaling
 
-KSail supports two complementary levels of autoscaling — pod autoscaling (HPA/VPA) and node autoscaling — configured under `spec.cluster.autoscaler`. For Talos × Hetzner, KSail also natively deploys [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) with heterogeneous node pools.
+When an external node autoscaler (such as [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler), [Karpenter](https://karpenter.sh/), or [Omni dynamic allocation](https://omni.siderolabs.com/)) manages your node counts, set `spec.cluster.nodeAutoscaling: Enabled` in `ksail.yaml` to prevent `ksail cluster update` from interfering.
 
-### Pod Autoscaling
-
-- **Horizontal Pod Autoscaler (HPA)** — set `spec.cluster.autoscaler.pod.horizontal: Enabled`. Requires `spec.cluster.metricsServer: Enabled` (or distribution-bundled metrics-server).
-- **Vertical Pod Autoscaler (VPA)** — set `spec.cluster.autoscaler.pod.vertical: Enabled`. Installs the [Fairwinds VPA Helm chart](https://github.com/FairwindsOps/charts/tree/master/stable/vpa).
+By default (`Disabled`), KSail reconciles `spec.cluster.controlPlanes` and `spec.cluster.workers` on every `ksail cluster update`. With autoscaling enabled, those diffs are skipped — the external autoscaler is the single source of truth for node counts. `ksail cluster create` is unaffected; initial node counts are still applied on first provision.
 
 ```yaml
-spec:
-  cluster:
-    metricsServer: Enabled
-    autoscaler:
-      pod:
-        horizontal: Enabled
-        vertical: Enabled
-```
-
-### Node Autoscaling Architecture (Talos × Hetzner)
-
-KSail models cluster nodes in two tiers:
-
-| Tier | Managed by | Diffable | Purpose |
-|------|------------|----------|---------|
-| **Baseline nodes** | KSail (`spec.cluster.controlPlanes` / `workers`) | Yes — always diffed on `cluster update` | Control-planes and initial workers; sized for steady-state workloads |
-| **Autoscaler pools** | Cluster Autoscaler (`spec.cluster.autoscaler.node.pools`) | No — additive, compute-only | Burst capacity; provisioned and removed by the autoscaler |
-
-Baseline node counts continue to be diffed and reconciled by `ksail cluster update` even when node autoscaling is enabled. Only autoscaler-managed pool nodes are excluded from KSail's diff engine.
-
-### How It Works (Talos × Hetzner)
-
-When `spec.cluster.autoscaler.node.enabled: Enabled` and `spec.cluster.provider: Hetzner`:
-
-1. **Snapshot lifecycle** — KSail builds a Talos node snapshot in the Hetzner Cloud project that matches the cluster's boot ISO schematic. The snapshot is used by the Cluster Autoscaler to provision new nodes with the correct Talos image.
-2. **Worker config Secret** — KSail generates a stripped Talos machine configuration as a Kubernetes `Secret`. The Cluster Autoscaler presents this config to new nodes during bootstrap.
-3. **Cluster Autoscaler installation** — KSail deploys the [Cluster Autoscaler Helm chart](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler) with the Hetzner cloud provider, wired to the configured node pools.
-
-### Node Pools
-
-Each pool targets a specific Hetzner server type and datacenter location, allowing heterogeneous scaling:
-
-```yaml
-spec:
-  cluster:
-    controlPlanes: 3
-    workers: 2
-    autoscaler:
-      node:
-        enabled: Enabled
-        pools:
-          - name: small-fsn1
-            serverType: cx23
-            location: fsn1
-            min: 0
-            max: 3
-          - name: large-nbg1
-            serverType: cpx51
-            location: nbg1
-            min: 0
-            max: 2
-        maxNodesTotal: 10
-        expander: Price
-        scaleDownUnneededTime: 10m
-  provider:
-    hetzner:
-      serverLimit: 15
-```
-
-KSail validates that `controlPlanes + workers + sum(pool.max) ≤ spec.provider.hetzner.serverLimit` (default `10`) before creating or updating the cluster.
-
-#### Expander strategies
-
-| Value | Behaviour |
-|-------|-----------|
-| `Price` | Selects the cheapest node group |
-| `LeastWaste` (default) | Selects the group with the least idle CPU/memory after scale-up |
-| `LeastNodes` | Selects the group that results in the fewest total nodes |
-| `Random` | Selects a group at random |
-
-### Lifecycle
-
-| Operation | Behaviour |
-|-----------|-----------|
-| `cluster create` | Creates baseline nodes and (when enabled) configures the Talos snapshot, worker Secret, and deploys Cluster Autoscaler |
-| `cluster update` | Diffs and applies baseline node counts; skips autoscaler pool nodes; updates Cluster Autoscaler config when pool definitions change |
-| `cluster delete` | Drains and removes autoscaler-managed nodes before tearing down the cluster; also removes the Talos snapshot from Hetzner Cloud |
-
-> [!NOTE]
-> Node autoscaling for Talos × Hetzner is the only natively supported configuration. For other distributions or providers, set `spec.cluster.autoscaler.node.enabled: Enabled` as the guard (so `cluster update` skips node-count diffs) and install an external autoscaler yourself.
-
-### Migrating from `nodeAutoscaling`
-
-`spec.cluster.nodeAutoscaling` is deprecated. On load, KSail automatically migrates it to `spec.cluster.autoscaler.node.enabled`. Update your `ksail.yaml`:
-
-```yaml
-# Before (deprecated)
 spec:
   cluster:
     nodeAutoscaling: Enabled
-
-# After
-spec:
-  cluster:
-    autoscaler:
-      node:
-        enabled: Enabled
 ```
+
+> [!NOTE]
+> Other distributions currently ignore this setting; it is only active for Talos.
 
 ## Version Upgrades
 

--- a/docs/src/content/docs/features/cluster-provisioning.mdx
+++ b/docs/src/content/docs/features/cluster-provisioning.mdx
@@ -34,18 +34,112 @@ ksail cluster update --dry-run --output json | jq .recreateRequired
 
 ## Node Autoscaling
 
-When an external node autoscaler (such as [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler), [Karpenter](https://karpenter.sh/), or [Omni dynamic allocation](https://omni.siderolabs.com/)) manages your node counts, set `spec.cluster.nodeAutoscaling: Enabled` in `ksail.yaml` to prevent `ksail cluster update` from interfering.
+KSail supports two complementary levels of autoscaling — pod autoscaling (HPA/VPA) and node autoscaling — configured under `spec.cluster.autoscaler`. For Talos × Hetzner, KSail also natively deploys [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) with heterogeneous node pools.
 
-By default, `spec.cluster.nodeAutoscaling` is `Disabled`. If you omit the field, or set it to `Disabled`, KSail continues managing node counts normally during `ksail cluster update`, including diffing the configured Talos node-count fields and applying scaling operations as needed.
-With autoscaling enabled, `ksail cluster update` skips diffs for the Talos node-count fields `spec.cluster.talos.controlPlanes` and `spec.cluster.talos.workers` (the same values configured by `ksail cluster init --control-planes` and `--workers`) and does not issue any scaling operations — the external autoscaler remains the single source of truth for node counts. `ksail cluster create` is unaffected; initial node counts are still applied on first provision.
+### Pod Autoscaling
+
+- **Horizontal Pod Autoscaler (HPA)** — set `spec.cluster.autoscaler.pod.horizontal: Enabled`. Requires `spec.cluster.metricsServer: Enabled` (or distribution-bundled metrics-server).
+- **Vertical Pod Autoscaler (VPA)** — set `spec.cluster.autoscaler.pod.vertical: Enabled`. Installs the [Fairwinds VPA Helm chart](https://github.com/FairwindsOps/charts/tree/master/stable/vpa).
 
 ```yaml
 spec:
   cluster:
-    nodeAutoscaling: Enabled
+    metricsServer: Enabled
+    autoscaler:
+      pod:
+        horizontal: Enabled
+        vertical: Enabled
 ```
 
-> **Talos only**: Other distributions currently ignore this setting.
+### Node Autoscaling Architecture (Talos × Hetzner)
+
+KSail models cluster nodes in two tiers:
+
+| Tier | Managed by | Diffable | Purpose |
+|------|------------|----------|---------|
+| **Baseline nodes** | KSail (`spec.cluster.controlPlanes` / `workers`) | Yes — always diffed on `cluster update` | Control-planes and initial workers; sized for steady-state workloads |
+| **Autoscaler pools** | Cluster Autoscaler (`spec.cluster.autoscaler.node.pools`) | No — additive, compute-only | Burst capacity; provisioned and removed by the autoscaler |
+
+Baseline node counts continue to be diffed and reconciled by `ksail cluster update` even when node autoscaling is enabled. Only autoscaler-managed pool nodes are excluded from KSail's diff engine.
+
+### How It Works (Talos × Hetzner)
+
+When `spec.cluster.autoscaler.node.enabled: Enabled` and `spec.cluster.provider: Hetzner`:
+
+1. **Snapshot lifecycle** — KSail builds a Talos node snapshot in the Hetzner Cloud project that matches the cluster's boot ISO schematic. The snapshot is used by the Cluster Autoscaler to provision new nodes with the correct Talos image.
+2. **Worker config Secret** — KSail generates a stripped Talos machine configuration as a Kubernetes `Secret`. The Cluster Autoscaler presents this config to new nodes during bootstrap.
+3. **Cluster Autoscaler installation** — KSail deploys the [Cluster Autoscaler Helm chart](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler) with the Hetzner cloud provider, wired to the configured node pools.
+
+### Node Pools
+
+Each pool targets a specific Hetzner server type and datacenter location, allowing heterogeneous scaling:
+
+```yaml
+spec:
+  cluster:
+    controlPlanes: 3
+    workers: 2
+    autoscaler:
+      node:
+        enabled: Enabled
+        pools:
+          - name: small-fsn1
+            serverType: cx23
+            location: fsn1
+            min: 0
+            max: 3
+          - name: large-nbg1
+            serverType: cpx51
+            location: nbg1
+            min: 0
+            max: 2
+        maxNodesTotal: 10
+        expander: Price
+        scaleDownUnneededTime: 10m
+  provider:
+    hetzner:
+      serverLimit: 15
+```
+
+KSail validates that `controlPlanes + workers + sum(pool.max) ≤ spec.provider.hetzner.serverLimit` (default `10`) before creating or updating the cluster.
+
+#### Expander strategies
+
+| Value | Behaviour |
+|-------|-----------|
+| `Price` | Selects the cheapest node group |
+| `LeastWaste` (default) | Selects the group with the least idle CPU/memory after scale-up |
+| `LeastNodes` | Selects the group that results in the fewest total nodes |
+| `Random` | Selects a group at random |
+
+### Lifecycle
+
+| Operation | Behaviour |
+|-----------|-----------|
+| `cluster create` | Creates baseline nodes and (when enabled) configures the Talos snapshot, worker Secret, and deploys Cluster Autoscaler |
+| `cluster update` | Diffs and applies baseline node counts; skips autoscaler pool nodes; updates Cluster Autoscaler config when pool definitions change |
+| `cluster delete` | Drains and removes autoscaler-managed nodes before tearing down the cluster; also removes the Talos snapshot from Hetzner Cloud |
+
+> [!NOTE]
+> Node autoscaling for Talos × Hetzner is the only natively supported configuration. For other distributions or providers, set `spec.cluster.autoscaler.node.enabled: Enabled` as the guard (so `cluster update` skips node-count diffs) and install an external autoscaler yourself.
+
+### Migrating from `nodeAutoscaling`
+
+`spec.cluster.nodeAutoscaling` is deprecated. On load, KSail automatically migrates it to `spec.cluster.autoscaler.node.enabled`. Update your `ksail.yaml`:
+
+```yaml
+# Before (deprecated)
+spec:
+  cluster:
+    nodeAutoscaling: Enabled
+
+# After
+spec:
+  cluster:
+    autoscaler:
+      node:
+        enabled: Enabled
+```
 
 ## Version Upgrades
 


### PR DESCRIPTION
Adds documentation for the native node autoscaling feature introduced in issue #4384.

## Changes

### `docs/src/content/docs/features/cluster-provisioning.mdx`

Rewrites the Node Autoscaling section with:

- **Pod autoscaling** — HPA (requires metrics-server) and VPA (Fairwinds chart)
- **Two-tier node architecture** — baseline nodes (KSail-managed, always diffable) vs autoscaler pools (additive, Cluster Autoscaler-managed)
- **Talos × Hetzner how-it-works** — Talos snapshot lifecycle, stripped worker config Secret, Cluster Autoscaler Helm deployment
- **Heterogeneous node pools** — multiple server types / datacenter locations with per-pool min/max
- **Expander strategies** — Price, LeastWaste (default), LeastNodes, Random
- **Lifecycle table** — behaviour on `cluster create`, `cluster update`, `cluster delete`
- **Migration guide** — from deprecated `spec.cluster.nodeAutoscaling` to `spec.cluster.autoscaler.node.enabled`

### `docs/src/content/docs/configuration/declarative-configuration.mdx`

- Adds `spec.cluster.autoscaler` to the ClusterSpec table (with `nodeAutoscaling` marked deprecated)
- Adds full `autoscaler.pod` and `autoscaler.node` reference tables, including `NodePool` schema
- Adds `spec.provider.hetzner.serverLimit` to the Hetzner options list
- Deprecates `spec.cluster.talos.controlPlanes` / `.workers` in favour of `spec.cluster.controlPlanes` / `.workers`
- Updates the Talos configuration example to use the promoted top-level fields

## Notes

CLI flag reference pages (`cluster-init.mdx`, `cluster-update.mdx`) are auto-generated from Cobra flags (`go generate ./docs/...`). The `--node-autoscaling` flag is being replaced by the new autoscaler config fields as part of the implementation PRs; the generated pages will update automatically once those PRs merge and `go generate` is re-run.

Fixes #4384