### PR TITLE
fix(ci): update mcp-publisher to v1.7.6 and migrate app-id to client-id

### DIFF
--- a/.github/actions/npm-audit-and-fix/action.yaml
+++ b/.github/actions/npm-audit-and-fix/action.yaml
@@ -6,8 +6,8 @@ inputs:
   working-directory:
     description: Directory containing package.json (e.g., 'docs' or 'vsce').
     required: true
-  app-id:
-    description: GitHub App ID for generating commit token.
+  client-id:
+    description: GitHub App Client ID for generating commit token.
     required: false
   app-private-key:
     description: GitHub App private key for generating commit token.
@@ -37,11 +37,11 @@ runs:
   using: composite
   steps:
     - name: 🔑 Generate GitHub App Token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: generate-token
-      if: ${{ inputs.app-id != '' && inputs.app-private-key != '' }}
+      if: ${{ inputs.client-id != '' && inputs.app-private-key != '' }}
       with:
-        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.client-id }}
         private-key: ${{ inputs.app-private-key }}
 
     - name: 📄 Checkout

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -148,7 +148,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 📑 Checkout main
@@ -259,11 +259,11 @@ jobs:
 
       - name: 📥 Install mcp-publisher
         run: |
-          curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/mcp-publisher_linux_amd64.tar.gz"
-          curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/registry_1.5.0_checksums.txt"
-          grep "mcp-publisher_linux_amd64.tar.gz$" registry_1.5.0_checksums.txt | sha256sum --check
+          curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.6/mcp-publisher_linux_amd64.tar.gz"
+          curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.6/registry_1.7.6_checksums.txt"
+          grep "mcp-publisher_linux_amd64.tar.gz$" registry_1.7.6_checksums.txt | sha256sum --check
           tar -xzf mcp-publisher_linux_amd64.tar.gz mcp-publisher
-          rm mcp-publisher_linux_amd64.tar.gz registry_1.5.0_checksums.txt
+          rm mcp-publisher_linux_amd64.tar.gz registry_1.7.6_checksums.txt
 
       - name: 🔐 Authenticate with MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -259,6 +259,7 @@ jobs:
 
       - name: 📥 Install mcp-publisher
         run: |
+          set -euo pipefail
           curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.6/mcp-publisher_linux_amd64.tar.gz"
           curl -sLO "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.6/registry_1.7.6_checksums.txt"
           grep "mcp-publisher_linux_amd64.tar.gz$" registry_1.7.6_checksums.txt | sha256sum --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -357,7 +357,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] - GitHub App token generation, no environment scoping available for app installations
 
       - name: 📄 Checkout
@@ -453,7 +453,7 @@ jobs:
         uses: ./.github/actions/npm-audit-and-fix
         with:
           working-directory: docs
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] - GitHub App token generation, no environment scoping available for app installations
           commit-message: "chore(docs): fix npm audit vulnerabilities"
 
@@ -475,7 +475,7 @@ jobs:
         uses: ./.github/actions/npm-audit-and-fix
         with:
           working-directory: vsce
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] - GitHub App token generation, no environment scoping available for app installations
           commit-message: "chore(vsce): fix npm audit vulnerabilities"
 


### PR DESCRIPTION
The CD workflow has two failures:

1. **MCP Registry publish exits with code 1** -- `mcp-publisher` v1.5.0 requests a GitHub OIDC token with audience `mcp-registry`, but the registry now expects `https://registry.modelcontextprotocol.io`.
2. **`app-id` deprecation warning** -- `actions/create-github-app-token@v3.1.1` deprecated `app-id` in v3.1.0 in favour of `client-id`.

## Changes

- Update `mcp-publisher` from v1.5.0 to v1.7.6 (latest) in the `mcp-publish` job, including the checksum file reference.
- Migrate the deprecated `app-id` input to `client-id` across `cd.yaml`, `ci.yaml`, and the `npm-audit-and-fix` composite action, referencing the existing `vars.APP_CLIENT_ID` variable.
- Bump `npm-audit-and-fix`'s internal `create-github-app-token` from v2.2.1 to v3.1.1 for consistency with the workflow files.

## Notes

- The auto-merge warning in the `copilot-plugin` job is a repo settings concern (auto-merge must be enabled), not a workflow bug. It is already handled gracefully with a `::warning::` annotation.