### PR TITLE
fix(config): remove eager default from NodeAutoscalingFieldSelector

### DIFF
--- a/pkg/fsutil/configmanager/ksail/autoscaler_integration_test.go
+++ b/pkg/fsutil/configmanager/ksail/autoscaler_integration_test.go
@@ -153,7 +153,7 @@ spec:
 	// which is what triggers the eager default injection in the buggy code path.
 	cmd := &cobra.Command{Use: "test"}
 	selectors := []configmanager.FieldSelector[v1alpha1.Cluster]{
-		configmanager.NodeAutoscalingFieldSelector(), //nolint:staticcheck // backward-compat test
+		configmanager.NodeAutoscalingFieldSelector(),
 		configmanager.NodeAutoscalerEnabledFieldSelector(),
 	}
 	mgr := configmanager.NewCommandConfigManager(cmd, selectors)
@@ -163,8 +163,12 @@ spec:
 	require.NoError(t, err, "loading a config with only autoscaler.node.enabled must not error")
 	require.NotNil(t, cluster)
 
-	assert.Equal(t, v1alpha1.NodeAutoscalerEnabledEnabled, cluster.Spec.Cluster.Autoscaler.Node.Enabled,
-		"autoscaler.node.enabled should be Enabled as specified in the config file")
+	assert.Equal(
+		t,
+		v1alpha1.NodeAutoscalerEnabledEnabled,
+		cluster.Spec.Cluster.Autoscaler.Node.Enabled,
+		"autoscaler.node.enabled should be Enabled as specified in the config file",
+	)
 	assert.Empty(t, cluster.Spec.Cluster.NodeAutoscaling,
 		"deprecated nodeAutoscaling field should remain empty when not set in config")
 }

--- a/pkg/fsutil/configmanager/ksail/autoscaler_integration_test.go
+++ b/pkg/fsutil/configmanager/ksail/autoscaler_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	configmanagerinterface "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,4 +118,53 @@ spec:
 		"migration should clear the deprecated nodeAutoscaling field")
 	assert.Contains(t, out.String(), "deprecated",
 		"migration should emit a deprecation warning")
+}
+
+// TestConfigManager_NewFieldOnlyDoesNotConflictWithDeprecatedDefault is a regression test for
+// https://github.com/devantler-tech/ksail/issues/4507.
+//
+// When a config file sets only spec.cluster.autoscaler.node.enabled (the canonical new field)
+// and does NOT set spec.cluster.nodeAutoscaling, loading the config through
+// NewCommandConfigManager must succeed without a "deprecated field conflicts" error.
+//
+// The bug: NodeAutoscalingFieldSelector previously declared DefaultValue: NodeAutoscalingDisabled.
+// AddFlagsFromFields called setPflagValueDefault which eagerly wrote "Disabled" into the Config
+// struct before any config file was read. When the config file then populated
+// autoscaler.node.enabled=Enabled, the migration saw old="Disabled" vs new="Enabled" → conflict.
+func TestConfigManager_NewFieldOnlyDoesNotConflictWithDeprecatedDefault(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+
+	const yaml = `apiVersion: ksail.io/v1alpha1
+kind: Cluster
+spec:
+  cluster:
+    distribution: Vanilla
+    autoscaler:
+      node:
+        enabled: Enabled
+`
+
+	configPath := filepath.Join(tempDir, "ksail.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(yaml), 0o600))
+
+	// Use NewCommandConfigManager (via a Cobra command) so that AddFlagsFromFields runs,
+	// which is what triggers the eager default injection in the buggy code path.
+	cmd := &cobra.Command{Use: "test"}
+	selectors := []configmanager.FieldSelector[v1alpha1.Cluster]{
+		configmanager.NodeAutoscalingFieldSelector(), //nolint:staticcheck // backward-compat test
+		configmanager.NodeAutoscalerEnabledFieldSelector(),
+	}
+	mgr := configmanager.NewCommandConfigManager(cmd, selectors)
+	mgr.Viper.SetConfigFile(configPath)
+
+	cluster, err := mgr.Load(configmanagerinterface.LoadOptions{SkipValidation: true})
+	require.NoError(t, err, "loading a config with only autoscaler.node.enabled must not error")
+	require.NotNil(t, cluster)
+
+	assert.Equal(t, v1alpha1.NodeAutoscalerEnabledEnabled, cluster.Spec.Cluster.Autoscaler.Node.Enabled,
+		"autoscaler.node.enabled should be Enabled as specified in the config file")
+	assert.Empty(t, cluster.Spec.Cluster.NodeAutoscaling,
+		"deprecated nodeAutoscaling field should remain empty when not set in config")
 }

--- a/pkg/fsutil/configmanager/ksail/field_selector.go
+++ b/pkg/fsutil/configmanager/ksail/field_selector.go
@@ -231,6 +231,13 @@ func ImageVerificationFieldSelector() FieldSelector[v1alpha1.Cluster] {
 // NodeAutoscalingFieldSelector creates a field selector for node autoscaling.
 //
 // Deprecated: use [NodeAutoscalerEnabledFieldSelector] instead.
+//
+// DefaultValue is intentionally omitted: setting a default here would eagerly write
+// "Disabled" into the Config struct during AddFlagsFromFields (before any config file
+// is read). That causes migrateDeprecatedNodeAutoscaling to see old="Disabled" even
+// when the user only set the new autoscaler.node.enabled field, resulting in a false
+// conflict error. The migration's `if *old == ""` guard correctly skips the field when
+// it is left at its zero value.
 func NodeAutoscalingFieldSelector() FieldSelector[v1alpha1.Cluster] {
 	return FieldSelector[v1alpha1.Cluster]{
 		Selector: func(c *v1alpha1.Cluster) any {
@@ -239,7 +246,6 @@ func NodeAutoscalingFieldSelector() FieldSelector[v1alpha1.Cluster] {
 		Description: "[Deprecated: use autoscaler.node.enabled instead] Node autoscaling " +
 			"(Talos: Enabled defers worker and control-plane scaling to an external autoscaler, " +
 			"Disabled lets KSail manage node counts; other distributions currently ignore this setting)",
-		DefaultValue: v1alpha1.NodeAutoscalingDisabled,
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #4507

`NodeAutoscalingFieldSelector()` declared `DefaultValue: v1alpha1.NodeAutoscalingDisabled`. During `NewCommandConfigManager` → `AddFlagsFromFields` → `setPflagValueDefault`, this eagerly called `pflagValue.Set("Disabled")` on the Config struct **before any config file was read**.

When a config file sets only `spec.cluster.autoscaler.node.enabled: Enabled` (no `nodeAutoscaling`), `Viper.Unmarshal` left `NodeAutoscaling="Disabled"` (the injected default). The migration guard `if *old == ""` never fired, so `migrateDeprecatedNodeAutoscaling` saw `old=Disabled` vs `new=Enabled` → conflict error.

## Fix

Remove `DefaultValue` from `NodeAutoscalingFieldSelector()`. The field stays at `""` during flag registration; the guard correctly skips it.

Explicit `--node-autoscaling Enabled/Disabled` CLI use is unaffected: cobra's `pflag.Set()` at parse time still writes the value, `captureChangedFlagValues()` captures it via `pflag.Visit()`, and the second `migrateDeprecatedNodeAutoscaling` call in `unmarshalWithFlagOverrides` propagates it to the canonical field.

## Changes

- `pkg/fsutil/configmanager/ksail/field_selector.go` — remove `DefaultValue` from `NodeAutoscalingFieldSelector()`; replace with an explanatory comment
- `pkg/fsutil/configmanager/ksail/autoscaler_integration_test.go` — regression test using `NewCommandConfigManager` (the path that triggers `AddFlagsFromFields`) to guard against re-introduction