### PR TITLE
feat(installer): skip component install when GitOps controller owns the Helm release

### DIFF
--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -298,11 +298,14 @@ func (c *Client) ListReleases(ctx context.Context) ([]ReleaseInfo, error) {
 	return result, nil
 }
 
-// GetReleaseSecretLabels returns the labels from the latest Helm release Secret
-// for the given release name and namespace. Returns ErrNoReleaseSecrets when no
-// matching Secrets exist. Helm v4 stores each release revision as a Kubernetes
-// Secret with labels name=<release> and owner=helm.
-func (c *Client) GetReleaseSecretLabels(
+// GetReleaseStorageLabels returns the Kubernetes object labels from the latest
+// Helm release storage object (Secret or ConfigMap) for the given release name
+// and namespace. The storage backend is determined by the HELM_DRIVER
+// environment variable: "configmap"/"configmaps" queries ConfigMaps, "memory"
+// always returns ErrNoReleaseStorage (no Kubernetes objects), and the default
+// queries Secrets. Returns (nil, ErrNoReleaseStorage) when no matching storage
+// objects exist.
+func (c *Client) GetReleaseStorageLabels(
 	ctx context.Context,
 	releaseName, namespace string,
 ) (map[string]string, error) {
@@ -314,45 +317,84 @@ func (c *Client) GetReleaseSecretLabels(
 		namespace = c.settings.Namespace()
 	}
 
+	driver := os.Getenv("HELM_DRIVER")
+	if driver == "memory" {
+		return nil, ErrNoReleaseStorage
+	}
+
 	restConfig, err := c.settings.RESTClientGetter().ToRESTConfig()
 	if err != nil {
-		return nil, fmt.Errorf("get REST config for release secret labels: %w", err)
+		return nil, fmt.Errorf("get REST config for release storage labels: %w", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("create kubernetes clientset for release secret labels: %w", err)
+		return nil, fmt.Errorf("create kubernetes clientset for release storage labels: %w", err)
 	}
 
-	secretList, err := clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("name=%s,owner=helm", releaseName),
-	})
-	if err != nil {
-		return nil, fmt.Errorf(
-			"list helm release secrets for %q in namespace %q: %w",
-			releaseName,
-			namespace,
-			err,
-		)
+	selector := fmt.Sprintf("name=%s,owner=helm", releaseName)
+
+	return c.fetchStorageLabels(ctx, clientset, driver, namespace, selector)
+}
+
+// fetchStorageLabels queries either ConfigMaps or Secrets (based on driver) and
+// returns labels from the storage object with the highest version.
+func (c *Client) fetchStorageLabels(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	driver, namespace, selector string,
+) (map[string]string, error) {
+	type labeledItem struct {
+		Labels map[string]string
 	}
 
-	if len(secretList.Items) == 0 {
-		return nil, ErrNoReleaseSecrets
+	var items []labeledItem
+
+	switch driver {
+	case "configmap", "configmaps":
+		cmList, err := clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"list helm release configmaps in namespace %q: %w", namespace, err,
+			)
+		}
+
+		for i := range cmList.Items {
+			items = append(items, labeledItem{Labels: cmList.Items[i].Labels})
+		}
+	default:
+		secretList, err := clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"list helm release secrets in namespace %q: %w", namespace, err,
+			)
+		}
+
+		for i := range secretList.Items {
+			items = append(items, labeledItem{Labels: secretList.Items[i].Labels})
+		}
 	}
 
-	// Find the latest revision (highest version label value).
+	if len(items) == 0 {
+		return nil, ErrNoReleaseStorage
+	}
+
 	bestIdx := 0
 	bestVersion := -1
 
-	for i := range secretList.Items {
-		v, _ := strconv.Atoi(secretList.Items[i].Labels["version"])
+	for i, item := range items {
+		v, _ := strconv.Atoi(item.Labels["version"])
 		if v > bestVersion {
 			bestIdx = i
 			bestVersion = v
 		}
 	}
 
-	return secretList.Items[bestIdx].Labels, nil
+	return items[bestIdx].Labels, nil
 }
 
 func (c *Client) installRelease(

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	helmv4action "helm.sh/helm/v4/pkg/action"
@@ -14,6 +15,8 @@ import (
 	helmv4release "helm.sh/helm/v4/pkg/release"
 	v1 "helm.sh/helm/v4/pkg/release/v1"
 	helmv4driver "helm.sh/helm/v4/pkg/storage/driver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -378,4 +381,52 @@ func (c *Client) upgradeRelease(ctx context.Context, spec *ChartSpec) (*v1.Relea
 	}
 
 	return executeAndExtractRelease(runFn)
+}
+
+// GetReleaseSecretLabels returns the labels from the latest Helm release Secret
+// for the given release name and namespace. Returns (nil, nil) when no matching
+// Secrets exist. Helm v4 stores each release revision as a Kubernetes Secret
+// with labels name=<release> and owner=helm.
+func (c *Client) GetReleaseSecretLabels(
+	ctx context.Context,
+	releaseName, namespace string,
+) (map[string]string, error) {
+	if releaseName == "" {
+		return nil, errReleaseNameRequired
+	}
+
+	restConfig, err := c.settings.RESTClientGetter().ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("get REST config for release secret labels: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes clientset for release secret labels: %w", err)
+	}
+
+	secretList, err := clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("name=%s,owner=helm", releaseName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list helm release secrets for %q: %w", releaseName, err)
+	}
+
+	if len(secretList.Items) == 0 {
+		return nil, nil
+	}
+
+	// Find the latest revision (highest version label value).
+	bestIdx := 0
+	bestVersion := -1
+
+	for i := range secretList.Items {
+		v, _ := strconv.Atoi(secretList.Items[i].Labels["version"])
+		if v > bestVersion {
+			bestIdx = i
+			bestVersion = v
+		}
+	}
+
+	return secretList.Items[bestIdx].Labels, nil
 }

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -328,7 +328,12 @@ func (c *Client) GetReleaseSecretLabels(
 		LabelSelector: fmt.Sprintf("name=%s,owner=helm", releaseName),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("list helm release secrets for %q in namespace %q: %w", releaseName, namespace, err)
+		return nil, fmt.Errorf(
+			"list helm release secrets for %q in namespace %q: %w",
+			releaseName,
+			namespace,
+			err,
+		)
 	}
 
 	if len(secretList.Items) == 0 {

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -298,6 +298,58 @@ func (c *Client) ListReleases(ctx context.Context) ([]ReleaseInfo, error) {
 	return result, nil
 }
 
+// GetReleaseSecretLabels returns the labels from the latest Helm release Secret
+// for the given release name and namespace. Returns ErrNoReleaseSecrets when no
+// matching Secrets exist. Helm v4 stores each release revision as a Kubernetes
+// Secret with labels name=<release> and owner=helm.
+func (c *Client) GetReleaseSecretLabels(
+	ctx context.Context,
+	releaseName, namespace string,
+) (map[string]string, error) {
+	if releaseName == "" {
+		return nil, errReleaseNameRequired
+	}
+
+	if namespace == "" {
+		namespace = c.settings.Namespace()
+	}
+
+	restConfig, err := c.settings.RESTClientGetter().ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("get REST config for release secret labels: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes clientset for release secret labels: %w", err)
+	}
+
+	secretList, err := clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("name=%s,owner=helm", releaseName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list helm release secrets for %q in namespace %q: %w", releaseName, namespace, err)
+	}
+
+	if len(secretList.Items) == 0 {
+		return nil, ErrNoReleaseSecrets
+	}
+
+	// Find the latest revision (highest version label value).
+	bestIdx := 0
+	bestVersion := -1
+
+	for i := range secretList.Items {
+		v, _ := strconv.Atoi(secretList.Items[i].Labels["version"])
+		if v > bestVersion {
+			bestIdx = i
+			bestVersion = v
+		}
+	}
+
+	return secretList.Items[bestIdx].Labels, nil
+}
+
 func (c *Client) installRelease(
 	ctx context.Context,
 	spec *ChartSpec,
@@ -381,52 +433,4 @@ func (c *Client) upgradeRelease(ctx context.Context, spec *ChartSpec) (*v1.Relea
 	}
 
 	return executeAndExtractRelease(runFn)
-}
-
-// GetReleaseSecretLabels returns the labels from the latest Helm release Secret
-// for the given release name and namespace. Returns (nil, nil) when no matching
-// Secrets exist. Helm v4 stores each release revision as a Kubernetes Secret
-// with labels name=<release> and owner=helm.
-func (c *Client) GetReleaseSecretLabels(
-	ctx context.Context,
-	releaseName, namespace string,
-) (map[string]string, error) {
-	if releaseName == "" {
-		return nil, errReleaseNameRequired
-	}
-
-	restConfig, err := c.settings.RESTClientGetter().ToRESTConfig()
-	if err != nil {
-		return nil, fmt.Errorf("get REST config for release secret labels: %w", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create kubernetes clientset for release secret labels: %w", err)
-	}
-
-	secretList, err := clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("name=%s,owner=helm", releaseName),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list helm release secrets for %q: %w", releaseName, err)
-	}
-
-	if len(secretList.Items) == 0 {
-		return nil, nil
-	}
-
-	// Find the latest revision (highest version label value).
-	bestIdx := 0
-	bestVersion := -1
-
-	for i := range secretList.Items {
-		v, _ := strconv.Atoi(secretList.Items[i].Labels["version"])
-		if v > bestVersion {
-			bestIdx = i
-			bestVersion = v
-		}
-	}
-
-	return secretList.Items[bestIdx].Labels, nil
 }

--- a/pkg/client/helm/mocks.go
+++ b/pkg/client/helm/mocks.go
@@ -498,12 +498,12 @@ func (_c *MockInterface_UninstallRelease_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
-// GetReleaseSecretLabels provides a mock function for the type MockInterface
-func (_mock *MockInterface) GetReleaseSecretLabels(ctx context.Context, releaseName string, namespace string) (map[string]string, error) {
+// GetReleaseStorageLabels provides a mock function for the type MockInterface
+func (_mock *MockInterface) GetReleaseStorageLabels(ctx context.Context, releaseName string, namespace string) (map[string]string, error) {
 	ret := _mock.Called(ctx, releaseName, namespace)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetReleaseSecretLabels")
+		panic("no return value specified for GetReleaseStorageLabels")
 	}
 
 	var r0 map[string]string
@@ -526,20 +526,20 @@ func (_mock *MockInterface) GetReleaseSecretLabels(ctx context.Context, releaseN
 	return r0, r1
 }
 
-// MockInterface_GetReleaseSecretLabels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReleaseSecretLabels'
-type MockInterface_GetReleaseSecretLabels_Call struct {
+// MockInterface_GetReleaseStorageLabels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReleaseStorageLabels'
+type MockInterface_GetReleaseStorageLabels_Call struct {
 	*mock.Call
 }
 
-// GetReleaseSecretLabels is a helper method to define mock.On call
+// GetReleaseStorageLabels is a helper method to define mock.On call
 //   - ctx context.Context
 //   - releaseName string
 //   - namespace string
-func (_e *MockInterface_Expecter) GetReleaseSecretLabels(ctx interface{}, releaseName interface{}, namespace interface{}) *MockInterface_GetReleaseSecretLabels_Call {
-	return &MockInterface_GetReleaseSecretLabels_Call{Call: _e.mock.On("GetReleaseSecretLabels", ctx, releaseName, namespace)}
+func (_e *MockInterface_Expecter) GetReleaseStorageLabels(ctx interface{}, releaseName interface{}, namespace interface{}) *MockInterface_GetReleaseStorageLabels_Call {
+	return &MockInterface_GetReleaseStorageLabels_Call{Call: _e.mock.On("GetReleaseStorageLabels", ctx, releaseName, namespace)}
 }
 
-func (_c *MockInterface_GetReleaseSecretLabels_Call) Run(run func(ctx context.Context, releaseName string, namespace string)) *MockInterface_GetReleaseSecretLabels_Call {
+func (_c *MockInterface_GetReleaseStorageLabels_Call) Run(run func(ctx context.Context, releaseName string, namespace string)) *MockInterface_GetReleaseStorageLabels_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -562,12 +562,12 @@ func (_c *MockInterface_GetReleaseSecretLabels_Call) Run(run func(ctx context.Co
 	return _c
 }
 
-func (_c *MockInterface_GetReleaseSecretLabels_Call) Return(labels map[string]string, err error) *MockInterface_GetReleaseSecretLabels_Call {
+func (_c *MockInterface_GetReleaseStorageLabels_Call) Return(labels map[string]string, err error) *MockInterface_GetReleaseStorageLabels_Call {
 	_c.Call.Return(labels, err)
 	return _c
 }
 
-func (_c *MockInterface_GetReleaseSecretLabels_Call) RunAndReturn(run func(ctx context.Context, releaseName string, namespace string) (map[string]string, error)) *MockInterface_GetReleaseSecretLabels_Call {
+func (_c *MockInterface_GetReleaseStorageLabels_Call) RunAndReturn(run func(ctx context.Context, releaseName string, namespace string) (map[string]string, error)) *MockInterface_GetReleaseStorageLabels_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/client/helm/mocks.go
+++ b/pkg/client/helm/mocks.go
@@ -497,3 +497,77 @@ func (_c *MockInterface_UninstallRelease_Call) RunAndReturn(run func(ctx context
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetReleaseSecretLabels provides a mock function for the type MockInterface
+func (_mock *MockInterface) GetReleaseSecretLabels(ctx context.Context, releaseName string, namespace string) (map[string]string, error) {
+	ret := _mock.Called(ctx, releaseName, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReleaseSecretLabels")
+	}
+
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]string, error)); ok {
+		return returnFunc(ctx, releaseName, namespace)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]string); ok {
+		r0 = returnFunc(ctx, releaseName, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, releaseName, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockInterface_GetReleaseSecretLabels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReleaseSecretLabels'
+type MockInterface_GetReleaseSecretLabels_Call struct {
+	*mock.Call
+}
+
+// GetReleaseSecretLabels is a helper method to define mock.On call
+//   - ctx context.Context
+//   - releaseName string
+//   - namespace string
+func (_e *MockInterface_Expecter) GetReleaseSecretLabels(ctx interface{}, releaseName interface{}, namespace interface{}) *MockInterface_GetReleaseSecretLabels_Call {
+	return &MockInterface_GetReleaseSecretLabels_Call{Call: _e.mock.On("GetReleaseSecretLabels", ctx, releaseName, namespace)}
+}
+
+func (_c *MockInterface_GetReleaseSecretLabels_Call) Run(run func(ctx context.Context, releaseName string, namespace string)) *MockInterface_GetReleaseSecretLabels_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetReleaseSecretLabels_Call) Return(labels map[string]string, err error) *MockInterface_GetReleaseSecretLabels_Call {
+	_c.Call.Return(labels, err)
+	return _c
+}
+
+func (_c *MockInterface_GetReleaseSecretLabels_Call) RunAndReturn(run func(ctx context.Context, releaseName string, namespace string) (map[string]string, error)) *MockInterface_GetReleaseSecretLabels_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -101,5 +101,8 @@ type Interface interface {
 	// Secret for the given release name and namespace. Returns (nil, nil) when
 	// no release Secrets exist. This is used to inspect labels added by external
 	// controllers (e.g. Flux helm-controller) to determine ownership.
-	GetReleaseSecretLabels(ctx context.Context, releaseName, namespace string) (map[string]string, error)
+	GetReleaseSecretLabels(
+		ctx context.Context,
+		releaseName, namespace string,
+	) (map[string]string, error)
 }

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -15,6 +15,10 @@ var (
 	errListReleasesUnsupported = errors.New(
 		"helm: ListReleases not supported on template-only client",
 	)
+
+	// ErrNoReleaseSecrets is returned by GetReleaseSecretLabels when no
+	// Helm release Secrets exist for the given release name and namespace.
+	ErrNoReleaseSecrets = errors.New("helm: no release secrets found")
 )
 
 // ChartSpec mirrors the mittwald chart specification while keeping KSail

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -93,4 +93,9 @@ type Interface interface {
 	// populated; all other fields (Status, Revision, etc.) are left at their zero
 	// values. Use this for bulk release detection to avoid N separate ReleaseExists roundtrips.
 	ListReleases(ctx context.Context) ([]ReleaseInfo, error)
+	// GetReleaseSecretLabels returns the labels from the latest Helm release
+	// Secret for the given release name and namespace. Returns (nil, nil) when
+	// no release Secrets exist. This is used to inspect labels added by external
+	// controllers (e.g. Flux helm-controller) to determine ownership.
+	GetReleaseSecretLabels(ctx context.Context, releaseName, namespace string) (map[string]string, error)
 }

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -16,9 +16,10 @@ var (
 		"helm: ListReleases not supported on template-only client",
 	)
 
-	// ErrNoReleaseSecrets is returned by GetReleaseSecretLabels when no
-	// Helm release Secrets exist for the given release name and namespace.
-	ErrNoReleaseSecrets = errors.New("helm: no release secrets found")
+	// ErrNoReleaseStorage is returned by GetReleaseStorageLabels when no
+	// Helm release storage objects (Secrets or ConfigMaps) exist for the
+	// given release name and namespace.
+	ErrNoReleaseStorage = errors.New("helm: no release storage objects found")
 )
 
 // ChartSpec mirrors the mittwald chart specification while keeping KSail
@@ -97,12 +98,13 @@ type Interface interface {
 	// populated; all other fields (Status, Revision, etc.) are left at their zero
 	// values. Use this for bulk release detection to avoid N separate ReleaseExists roundtrips.
 	ListReleases(ctx context.Context) ([]ReleaseInfo, error)
-	// GetReleaseSecretLabels returns the labels from the latest Helm release
-	// Secret for the given release name and namespace. Returns
-	// (nil, ErrNoReleaseSecrets) when no release Secrets exist. This is used
-	// to inspect labels added by external controllers (e.g. Flux
+	// GetReleaseStorageLabels returns the Kubernetes object labels from the
+	// latest Helm release storage object (Secret or ConfigMap, depending on
+	// HELM_DRIVER) for the given release name and namespace. Returns
+	// (nil, ErrNoReleaseStorage) when no matching objects exist. This is
+	// used to inspect labels added by external controllers (e.g. Flux
 	// helm-controller) to determine ownership.
-	GetReleaseSecretLabels(
+	GetReleaseStorageLabels(
 		ctx context.Context,
 		releaseName, namespace string,
 	) (map[string]string, error)

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -98,9 +98,10 @@ type Interface interface {
 	// values. Use this for bulk release detection to avoid N separate ReleaseExists roundtrips.
 	ListReleases(ctx context.Context) ([]ReleaseInfo, error)
 	// GetReleaseSecretLabels returns the labels from the latest Helm release
-	// Secret for the given release name and namespace. Returns (nil, nil) when
-	// no release Secrets exist. This is used to inspect labels added by external
-	// controllers (e.g. Flux helm-controller) to determine ownership.
+	// Secret for the given release name and namespace. Returns
+	// (nil, ErrNoReleaseSecrets) when no release Secrets exist. This is used
+	// to inspect labels added by external controllers (e.g. Flux
+	// helm-controller) to determine ownership.
 	GetReleaseSecretLabels(
 		ctx context.Context,
 		releaseName, namespace string,

--- a/pkg/svc/installer/certmanager/installer_test.go
+++ b/pkg/svc/installer/certmanager/installer_test.go
@@ -38,6 +38,9 @@ func TestInstallSuccessWithScaledTimeout(t *testing.T) {
 	client := helm.NewMockInterface(t)
 	installer := certmanagerinstaller.NewInstaller(client, 10*time.Minute)
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	client.EXPECT().
 		AddRepository(
 			mock.Anything,
 			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {
@@ -75,6 +78,9 @@ func TestInstallRepoError(t *testing.T) {
 	t.Parallel()
 
 	installer, client := newInstallerWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(assert.AnError)
@@ -136,6 +142,9 @@ func newInstallerWithDefaults(
 func expectCertManagerInstall(t *testing.T, client *helm.MockInterface, installErr error) {
 	t.Helper()
 
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(
 			mock.Anything,

--- a/pkg/svc/installer/certmanager/installer_test.go
+++ b/pkg/svc/installer/certmanager/installer_test.go
@@ -38,7 +38,7 @@ func TestInstallSuccessWithScaledTimeout(t *testing.T) {
 	client := helm.NewMockInterface(t)
 	installer := certmanagerinstaller.NewInstaller(client, 10*time.Minute)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(
@@ -79,7 +79,7 @@ func TestInstallRepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -143,7 +143,7 @@ func expectCertManagerInstall(t *testing.T, client *helm.MockInterface, installE
 	t.Helper()
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -53,7 +53,7 @@ func TestClusterAutoscalerInstaller_InstallAddRepositoryError(t *testing.T) {
 
 	installer, client := newInstallerWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectAddRepository(t, client, assert.AnError)
 
@@ -106,7 +106,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_NodePools(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
@@ -192,7 +192,7 @@ func runExpanderTest(
 	cfg := v1alpha1.NodeAutoscalerConfig{Expander: expander}
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
@@ -237,7 +237,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_Contents(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
@@ -297,7 +297,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_DefaultScaleDownTime(t *testing.T
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
@@ -333,7 +333,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_MaxNodesTotalOmittedWhenZero(t *t
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
@@ -397,7 +397,7 @@ func expectAddRepository(t *testing.T, client *helm.MockInterface, err error) {
 func expectInstall(t *testing.T, client *helm.MockInterface, installErr error) {
 	t.Helper()
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -52,6 +52,9 @@ func TestClusterAutoscalerInstaller_InstallAddRepositoryError(t *testing.T) {
 	t.Parallel()
 
 	installer, client := newInstallerWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, assert.AnError)
 
 	err := installer.Install(context.Background())
@@ -102,6 +105,9 @@ func TestClusterAutoscalerInstaller_ValuesYaml_NodePools(t *testing.T) {
 	}
 
 	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(
@@ -185,6 +191,9 @@ func runExpanderTest(
 
 	cfg := v1alpha1.NodeAutoscalerConfig{Expander: expander}
 	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(
@@ -227,6 +236,9 @@ func TestClusterAutoscalerInstaller_ValuesYaml_Contents(t *testing.T) {
 	}
 
 	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(
@@ -284,6 +296,9 @@ func TestClusterAutoscalerInstaller_ValuesYaml_DefaultScaleDownTime(t *testing.T
 	}
 
 	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(
@@ -317,6 +332,9 @@ func TestClusterAutoscalerInstaller_ValuesYaml_MaxNodesTotalOmittedWhenZero(t *t
 	}
 
 	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(
@@ -378,6 +396,9 @@ func expectAddRepository(t *testing.T, client *helm.MockInterface, err error) {
 
 func expectInstall(t *testing.T, client *helm.MockInterface, installErr error) {
 	t.Helper()
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(

--- a/pkg/svc/installer/cni/base.go
+++ b/pkg/svc/installer/cni/base.go
@@ -147,7 +147,13 @@ func (b *InstallerBase) CheckGitOpsOwnership(
 	}
 
 	if controller, managed := helmutil.IsGitOpsManaged(labels); managed {
-		fmt.Fprintf(os.Stderr, "%s: skipping install — release %q is managed by %s\n", componentName, releaseName, controller)
+		fmt.Fprintf(
+			os.Stderr,
+			"%s: skipping install — release %q is managed by %s\n",
+			componentName,
+			releaseName,
+			controller,
+		)
 
 		return true, nil
 	}

--- a/pkg/svc/installer/cni/base.go
+++ b/pkg/svc/installer/cni/base.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"os"
 	"time"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -142,12 +142,12 @@ func (b *InstallerBase) CheckGitOpsOwnership(
 	}
 
 	labels, err := client.GetReleaseSecretLabels(ctx, releaseName, namespace)
-	if err != nil {
+	if err != nil && !errors.Is(err, helm.ErrNoReleaseSecrets) {
 		return false, fmt.Errorf("check release ownership for %s: %w", componentName, err)
 	}
 
 	if controller, managed := helmutil.IsGitOpsManaged(labels); managed {
-		log.Printf("%s: skipping install — release %q is managed by %s", componentName, releaseName, controller)
+		fmt.Fprintf(os.Stderr, "%s: skipping install — release %q is managed by %s\n", componentName, releaseName, controller)
 
 		return true, nil
 	}

--- a/pkg/svc/installer/cni/base.go
+++ b/pkg/svc/installer/cni/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -126,6 +127,32 @@ func (b *InstallerBase) RunAPIServerCheck(
 	}
 
 	return nil
+}
+
+// CheckGitOpsOwnership queries the Helm release Secret for the given release
+// and checks whether a GitOps controller (Flux or ArgoCD) manages it. Returns
+// true when the install should be skipped.
+func (b *InstallerBase) CheckGitOpsOwnership(
+	ctx context.Context,
+	componentName, releaseName, namespace string,
+) (bool, error) {
+	client, err := b.GetClient()
+	if err != nil {
+		return false, fmt.Errorf("get helm client: %w", err)
+	}
+
+	labels, err := client.GetReleaseSecretLabels(ctx, releaseName, namespace)
+	if err != nil {
+		return false, fmt.Errorf("check release ownership for %s: %w", componentName, err)
+	}
+
+	if controller, managed := helmutil.IsGitOpsManaged(labels); managed {
+		log.Printf("%s: skipping install — release %q is managed by %s", componentName, releaseName, controller)
+
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // WaitForAPIServerStability waits for the Kubernetes API server to be stable.

--- a/pkg/svc/installer/cni/base.go
+++ b/pkg/svc/installer/cni/base.go
@@ -141,8 +141,8 @@ func (b *InstallerBase) CheckGitOpsOwnership(
 		return false, fmt.Errorf("get helm client: %w", err)
 	}
 
-	labels, err := client.GetReleaseSecretLabels(ctx, releaseName, namespace)
-	if err != nil && !errors.Is(err, helm.ErrNoReleaseSecrets) {
+	labels, err := client.GetReleaseStorageLabels(ctx, releaseName, namespace)
+	if err != nil && !errors.Is(err, helm.ErrNoReleaseStorage) {
 		return false, fmt.Errorf("check release ownership for %s: %w", componentName, err)
 	}
 

--- a/pkg/svc/installer/cni/base_test.go
+++ b/pkg/svc/installer/cni/base_test.go
@@ -173,7 +173,7 @@ func testCheckGitOpsOwnershipSkipsWhenFluxManaged(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(map[string]string{
 			"helm.toolkit.fluxcd.io/name": "cilium",
 		}, nil)
@@ -192,7 +192,7 @@ func testCheckGitOpsOwnershipProceedsWhenNotManaged(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(map[string]string{
 			"name":  "cilium",
 			"owner": "helm",
@@ -212,8 +212,8 @@ func testCheckGitOpsOwnershipProceedsWhenNoRelease(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
-		Return(nil, helm.ErrNoReleaseSecrets)
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, helm.ErrNoReleaseStorage)
 
 	base := cni.NewInstallerBase(client, "", "", time.Second)
 
@@ -229,7 +229,7 @@ func testCheckGitOpsOwnershipReturnsErrorOnFailure(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, assert.AnError)
 
 	base := cni.NewInstallerBase(client, "", "", time.Second)

--- a/pkg/svc/installer/cni/base_test.go
+++ b/pkg/svc/installer/cni/base_test.go
@@ -1,6 +1,7 @@
 package cni_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,7 +10,11 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer/cni"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+var ctx = context.Background()
 
 func expectNoError(t *testing.T, err error, description string) {
 	t.Helper()
@@ -154,4 +159,76 @@ func testBuildRESTConfigMissingContext(t *testing.T) {
 		"context \"missing\" does not exist",
 		"buildRESTConfig missing context",
 	)
+}
+
+func TestCheckGitOpsOwnership(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SkipsWhenFluxManaged", func(t *testing.T) {
+		t.Parallel()
+
+		client := helm.NewMockInterface(t)
+		client.EXPECT().
+			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+			Return(map[string]string{
+				"helm.toolkit.fluxcd.io/name": "cilium",
+			}, nil)
+
+		base := cni.NewInstallerBase(client, "", "", time.Second)
+
+		skipped, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+
+		expectNoError(t, err, "check ownership flux")
+		expectEqual(t, skipped, true, "should skip")
+	})
+
+	t.Run("ProceedsWhenNotManaged", func(t *testing.T) {
+		t.Parallel()
+
+		client := helm.NewMockInterface(t)
+		client.EXPECT().
+			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+			Return(map[string]string{
+				"name":  "cilium",
+				"owner": "helm",
+			}, nil)
+
+		base := cni.NewInstallerBase(client, "", "", time.Second)
+
+		skipped, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+
+		expectNoError(t, err, "check ownership not managed")
+		expectEqual(t, skipped, false, "should not skip")
+	})
+
+	t.Run("ProceedsWhenNoRelease", func(t *testing.T) {
+		t.Parallel()
+
+		client := helm.NewMockInterface(t)
+		client.EXPECT().
+			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+			Return(nil, nil)
+
+		base := cni.NewInstallerBase(client, "", "", time.Second)
+
+		skipped, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+
+		expectNoError(t, err, "check ownership no release")
+		expectEqual(t, skipped, false, "should not skip")
+	})
+
+	t.Run("ReturnsErrorOnFailure", func(t *testing.T) {
+		t.Parallel()
+
+		client := helm.NewMockInterface(t)
+		client.EXPECT().
+			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+			Return(nil, assert.AnError)
+
+		base := cni.NewInstallerBase(client, "", "", time.Second)
+
+		_, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+
+		expectErrorContains(t, err, "check release ownership for cilium", "check ownership error")
+	})
 }

--- a/pkg/svc/installer/cni/base_test.go
+++ b/pkg/svc/installer/cni/base_test.go
@@ -1,7 +1,6 @@
 package cni_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
-
-var ctx = context.Background()
 
 func expectNoError(t *testing.T, err error, description string) {
 	t.Helper()
@@ -164,71 +161,80 @@ func testBuildRESTConfigMissingContext(t *testing.T) {
 func TestCheckGitOpsOwnership(t *testing.T) {
 	t.Parallel()
 
-	t.Run("SkipsWhenFluxManaged", func(t *testing.T) {
-		t.Parallel()
+	t.Run("SkipsWhenFluxManaged", testCheckGitOpsOwnershipSkipsWhenFluxManaged)
+	t.Run("ProceedsWhenNotManaged", testCheckGitOpsOwnershipProceedsWhenNotManaged)
+	t.Run("ProceedsWhenNoRelease", testCheckGitOpsOwnershipProceedsWhenNoRelease)
+	t.Run("ReturnsErrorOnFailure", testCheckGitOpsOwnershipReturnsErrorOnFailure)
+}
 
-		client := helm.NewMockInterface(t)
-		client.EXPECT().
-			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
-			Return(map[string]string{
-				"helm.toolkit.fluxcd.io/name": "cilium",
-			}, nil)
+func testCheckGitOpsOwnershipSkipsWhenFluxManaged(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-		base := cni.NewInstallerBase(client, "", "", time.Second)
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(map[string]string{
+			"helm.toolkit.fluxcd.io/name": "cilium",
+		}, nil)
 
-		skipped, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+	base := cni.NewInstallerBase(client, "", "", time.Second)
 
-		expectNoError(t, err, "check ownership flux")
-		expectEqual(t, skipped, true, "should skip")
-	})
+	skipped, err := base.CheckGitOpsOwnership(t.Context(), "cilium", "cilium", "kube-system")
 
-	t.Run("ProceedsWhenNotManaged", func(t *testing.T) {
-		t.Parallel()
+	expectNoError(t, err, "check ownership flux")
+	expectEqual(t, skipped, true, "should skip")
+}
 
-		client := helm.NewMockInterface(t)
-		client.EXPECT().
-			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
-			Return(map[string]string{
-				"name":  "cilium",
-				"owner": "helm",
-			}, nil)
+func testCheckGitOpsOwnershipProceedsWhenNotManaged(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-		base := cni.NewInstallerBase(client, "", "", time.Second)
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(map[string]string{
+			"name":  "cilium",
+			"owner": "helm",
+		}, nil)
 
-		skipped, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+	base := cni.NewInstallerBase(client, "", "", time.Second)
 
-		expectNoError(t, err, "check ownership not managed")
-		expectEqual(t, skipped, false, "should not skip")
-	})
+	skipped, err := base.CheckGitOpsOwnership(t.Context(), "cilium", "cilium", "kube-system")
 
-	t.Run("ProceedsWhenNoRelease", func(t *testing.T) {
-		t.Parallel()
+	expectNoError(t, err, "check ownership not managed")
+	expectEqual(t, skipped, false, "should not skip")
+}
 
-		client := helm.NewMockInterface(t)
-		client.EXPECT().
-			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
-			Return(nil, nil)
+func testCheckGitOpsOwnershipProceedsWhenNoRelease(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-		base := cni.NewInstallerBase(client, "", "", time.Second)
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, helm.ErrNoReleaseSecrets)
 
-		skipped, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+	base := cni.NewInstallerBase(client, "", "", time.Second)
 
-		expectNoError(t, err, "check ownership no release")
-		expectEqual(t, skipped, false, "should not skip")
-	})
+	skipped, err := base.CheckGitOpsOwnership(t.Context(), "cilium", "cilium", "kube-system")
 
-	t.Run("ReturnsErrorOnFailure", func(t *testing.T) {
-		t.Parallel()
+	expectNoError(t, err, "check ownership no release")
+	expectEqual(t, skipped, false, "should not skip")
+}
 
-		client := helm.NewMockInterface(t)
-		client.EXPECT().
-			GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
-			Return(nil, assert.AnError)
+func testCheckGitOpsOwnershipReturnsErrorOnFailure(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-		base := cni.NewInstallerBase(client, "", "", time.Second)
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, assert.AnError)
 
-		_, err := base.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+	base := cni.NewInstallerBase(client, "", "", time.Second)
 
-		expectErrorContains(t, err, "check release ownership for cilium", "check ownership error")
-	})
+	_, err := base.CheckGitOpsOwnership(t.Context(), "cilium", "cilium", "kube-system")
+
+	expectErrorContains(t, err, "check release ownership for cilium", "check ownership error")
 }

--- a/pkg/svc/installer/cni/calico/calico_coverage_test.go
+++ b/pkg/svc/installer/cni/calico/calico_coverage_test.go
@@ -180,6 +180,10 @@ func expectCovCalicoInstall(t *testing.T, client *helm.MockInterface, installErr
 	t.Helper()
 
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
+
+	client.EXPECT().
 		AddRepository(
 			mock.Anything,
 			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {

--- a/pkg/svc/installer/cni/calico/calico_coverage_test.go
+++ b/pkg/svc/installer/cni/calico/calico_coverage_test.go
@@ -180,7 +180,7 @@ func expectCovCalicoInstall(t *testing.T, client *helm.MockInterface, installErr
 	t.Helper()
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 
 	client.EXPECT().

--- a/pkg/svc/installer/cni/calico/calico_retry_test.go
+++ b/pkg/svc/installer/cni/calico/calico_retry_test.go
@@ -61,6 +61,10 @@ func TestInstaller_Install_APIDiscoveryErrorRetry(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 	)
 
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
+
 	// First call: repo add succeeds
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -94,6 +98,10 @@ func TestInstaller_Install_ContextCanceled_Vanilla(t *testing.T) {
 	)
 
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
+
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
@@ -121,6 +129,10 @@ func TestInstaller_Install_K3s_APIServerUnavailableRetrySucceeds(t *testing.T) {
 	)
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
 	installer.SetRetryBackoffForTest(func(_ context.Context) error { return nil })
+
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
 
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -154,6 +166,10 @@ func TestInstaller_Install_K3s_APIServerUnavailableRetryExhausted(t *testing.T) 
 	installer.SetRetryBackoffForTest(func(_ context.Context) error { return nil })
 
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
+
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
@@ -181,6 +197,10 @@ func TestInstaller_Install_Vanilla_NoRetryOnAPIServerUnavailable(t *testing.T) {
 		2*time.Minute,
 		v1alpha1.DistributionVanilla,
 	)
+
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
 
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).

--- a/pkg/svc/installer/cni/calico/calico_retry_test.go
+++ b/pkg/svc/installer/cni/calico/calico_retry_test.go
@@ -62,7 +62,7 @@ func TestInstaller_Install_APIDiscoveryErrorRetry(t *testing.T) {
 	)
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 
 	// First call: repo add succeeds
@@ -98,7 +98,7 @@ func TestInstaller_Install_ContextCanceled_Vanilla(t *testing.T) {
 	)
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 
 	client.EXPECT().
@@ -131,7 +131,7 @@ func TestInstaller_Install_K3s_APIServerUnavailableRetrySucceeds(t *testing.T) {
 	installer.SetRetryBackoffForTest(func(_ context.Context) error { return nil })
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 
 	client.EXPECT().
@@ -166,7 +166,7 @@ func TestInstaller_Install_K3s_APIServerUnavailableRetryExhausted(t *testing.T) 
 	installer.SetRetryBackoffForTest(func(_ context.Context) error { return nil })
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 
 	client.EXPECT().
@@ -199,7 +199,7 @@ func TestInstaller_Install_Vanilla_NoRetryOnAPIServerUnavailable(t *testing.T) {
 	)
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 
 	client.EXPECT().

--- a/pkg/svc/installer/cni/calico/installer.go
+++ b/pkg/svc/installer/cni/calico/installer.go
@@ -151,12 +151,9 @@ func (c *Installer) chartSpec() *helm.ChartSpec {
 // --- internals ---
 
 func (c *Installer) helmInstallOrUpgradeCalico(ctx context.Context) error {
-	skipped, err := c.CheckGitOpsOwnership(ctx, "calico", "calico", "tigera-operator")
-	if err != nil {
+	if skipped, err := c.CheckGitOpsOwnership(ctx, "calico", "calico", "tigera-operator"); err != nil {
 		return fmt.Errorf("check calico ownership: %w", err)
-	}
-
-	if skipped {
+	} else if skipped {
 		return nil
 	}
 

--- a/pkg/svc/installer/cni/calico/installer.go
+++ b/pkg/svc/installer/cni/calico/installer.go
@@ -151,6 +151,15 @@ func (c *Installer) chartSpec() *helm.ChartSpec {
 // --- internals ---
 
 func (c *Installer) helmInstallOrUpgradeCalico(ctx context.Context) error {
+	skipped, err := c.CheckGitOpsOwnership(ctx, "calico", "calico", "tigera-operator")
+	if err != nil {
+		return fmt.Errorf("check calico ownership: %w", err)
+	}
+
+	if skipped {
+		return nil
+	}
+
 	client, err := c.GetClient()
 	if err != nil {
 		return fmt.Errorf("get helm client: %w", err)

--- a/pkg/svc/installer/cni/calico/installer.go
+++ b/pkg/svc/installer/cni/calico/installer.go
@@ -151,12 +151,19 @@ func (c *Installer) chartSpec() *helm.ChartSpec {
 // --- internals ---
 
 func (c *Installer) helmInstallOrUpgradeCalico(ctx context.Context) error {
-	if skipped, err := c.CheckGitOpsOwnership(ctx, "calico", "calico", "tigera-operator"); err != nil {
-		return fmt.Errorf("check calico ownership: %w", err)
-	} else if skipped {
+	skipped, ownershipErr := c.CheckGitOpsOwnership(ctx, "calico", "calico", "tigera-operator")
+	if ownershipErr != nil {
+		return fmt.Errorf("check calico ownership: %w", ownershipErr)
+	}
+
+	if skipped {
 		return nil
 	}
 
+	return c.installCalico(ctx)
+}
+
+func (c *Installer) installCalico(ctx context.Context) error {
 	client, err := c.GetClient()
 	if err != nil {
 		return fmt.Errorf("get helm client: %w", err)

--- a/pkg/svc/installer/cni/calico/installer_test.go
+++ b/pkg/svc/installer/cni/calico/installer_test.go
@@ -166,6 +166,9 @@ func TestInstaller_Install_RepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDistribution(t, v1alpha1.DistributionVanilla)
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(assert.AnError)
 
@@ -270,6 +273,10 @@ func newInstallerWithDistribution(
 
 func expectCalicoInstall(t *testing.T, client *helm.MockInterface, installErr error) {
 	t.Helper()
+
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		Return(nil, nil)
 
 	client.EXPECT().
 		AddRepository(

--- a/pkg/svc/installer/cni/calico/installer_test.go
+++ b/pkg/svc/installer/cni/calico/installer_test.go
@@ -166,7 +166,7 @@ func TestInstaller_Install_RepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDistribution(t, v1alpha1.DistributionVanilla)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -275,7 +275,7 @@ func expectCalicoInstall(t *testing.T, client *helm.MockInterface, installErr er
 	t.Helper()
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "calico", "tigera-operator").
+		GetReleaseStorageLabels(mock.Anything, "calico", "tigera-operator").
 		Return(nil, nil)
 
 	client.EXPECT().

--- a/pkg/svc/installer/cni/cilium/cilium_coverage_test.go
+++ b/pkg/svc/installer/cni/cilium/cilium_coverage_test.go
@@ -31,6 +31,10 @@ func TestInstaller_Install_TalosDistribution(t *testing.T) {
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error { return nil })
 
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, nil)
+
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
@@ -73,6 +77,10 @@ func TestInstaller_Install_HetznerProvider(t *testing.T) {
 	)
 
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error { return nil })
+
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, nil)
 
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -119,6 +127,10 @@ func TestInstaller_Install_TalosDockerWithLoadBalancer(t *testing.T) {
 
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error { return nil })
+
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, nil)
 
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).

--- a/pkg/svc/installer/cni/cilium/cilium_coverage_test.go
+++ b/pkg/svc/installer/cni/cilium/cilium_coverage_test.go
@@ -31,7 +31,7 @@ func TestInstaller_Install_TalosDistribution(t *testing.T) {
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error { return nil })
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, nil)
 
 	client.EXPECT().
@@ -79,7 +79,7 @@ func TestInstaller_Install_HetznerProvider(t *testing.T) {
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error { return nil })
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, nil)
 
 	client.EXPECT().
@@ -129,7 +129,7 @@ func TestInstaller_Install_TalosDockerWithLoadBalancer(t *testing.T) {
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error { return nil })
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, nil)
 
 	client.EXPECT().

--- a/pkg/svc/installer/cni/cilium/installer.go
+++ b/pkg/svc/installer/cni/cilium/installer.go
@@ -138,6 +138,15 @@ func (c *Installer) chartSpec() *helm.ChartSpec {
 // --- internals ---
 
 func (c *Installer) helmInstallOrUpgradeCilium(ctx context.Context) error {
+	skipped, err := c.CheckGitOpsOwnership(ctx, "cilium", "cilium", "kube-system")
+	if err != nil {
+		return fmt.Errorf("check cilium ownership: %w", err)
+	}
+
+	if skipped {
+		return nil
+	}
+
 	client, err := c.GetClient()
 	if err != nil {
 		return fmt.Errorf("get helm client: %w", err)

--- a/pkg/svc/installer/cni/cilium/installer_test.go
+++ b/pkg/svc/installer/cni/cilium/installer_test.go
@@ -170,7 +170,7 @@ func TestInstaller_Install_DockerProvider(t *testing.T) {
 	})
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, nil)
 
 	client.EXPECT().
@@ -224,7 +224,7 @@ func TestInstaller_Install_DockerProviderWithLoadBalancer(t *testing.T) {
 	})
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, nil)
 
 	client.EXPECT().
@@ -276,7 +276,7 @@ func TestInstaller_Install_RepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDistribution(t, v1alpha1.DistributionVanilla)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -445,7 +445,7 @@ func expectCiliumInstall(t *testing.T, client *helm.MockInterface, installErr er
 	t.Helper()
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		GetReleaseStorageLabels(mock.Anything, "cilium", "kube-system").
 		Return(nil, nil)
 
 	client.EXPECT().

--- a/pkg/svc/installer/cni/cilium/installer_test.go
+++ b/pkg/svc/installer/cni/cilium/installer_test.go
@@ -170,6 +170,10 @@ func TestInstaller_Install_DockerProvider(t *testing.T) {
 	})
 
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, nil)
+
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
@@ -220,6 +224,10 @@ func TestInstaller_Install_DockerProviderWithLoadBalancer(t *testing.T) {
 	})
 
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, nil)
+
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
@@ -267,6 +275,9 @@ func TestInstaller_Install_RepoError(t *testing.T) {
 	t.Parallel()
 
 	installer, client := newInstallerWithDistribution(t, v1alpha1.DistributionVanilla)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(assert.AnError)
@@ -432,6 +443,10 @@ func newInstallerWithDistribution(
 
 func expectCiliumInstall(t *testing.T, client *helm.MockInterface, installErr error) {
 	t.Helper()
+
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "cilium", "kube-system").
+		Return(nil, nil)
 
 	client.EXPECT().
 		AddRepository(

--- a/pkg/svc/installer/gatekeeper/installer_test.go
+++ b/pkg/svc/installer/gatekeeper/installer_test.go
@@ -84,6 +84,9 @@ func TestInstallRepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDefaults(t)
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(assert.AnError)
 
@@ -145,6 +148,9 @@ func newInstallerWithDefaults(
 func expectGatekeeperInstall(t *testing.T, client *helm.MockInterface, installErr error) {
 	t.Helper()
 
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(
 			mock.Anything,

--- a/pkg/svc/installer/gatekeeper/installer_test.go
+++ b/pkg/svc/installer/gatekeeper/installer_test.go
@@ -84,7 +84,7 @@ func TestInstallRepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -149,7 +149,7 @@ func expectGatekeeperInstall(t *testing.T, client *helm.MockInterface, installEr
 	t.Helper()
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(

--- a/pkg/svc/installer/internal/helmutil/base.go
+++ b/pkg/svc/installer/internal/helmutil/base.go
@@ -59,7 +59,13 @@ func (b *Base) Install(ctx context.Context) error {
 	}
 
 	if controller, managed := IsGitOpsManaged(labels); managed {
-		fmt.Fprintf(os.Stderr, "%s: skipping install — release %q is managed by %s\n", b.name, b.spec.ReleaseName, controller)
+		fmt.Fprintf(
+			os.Stderr,
+			"%s: skipping install — release %q is managed by %s\n",
+			b.name,
+			b.spec.ReleaseName,
+			controller,
+		)
 
 		return nil
 	}

--- a/pkg/svc/installer/internal/helmutil/base.go
+++ b/pkg/svc/installer/internal/helmutil/base.go
@@ -2,8 +2,9 @@ package helmutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log"
+	"os"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
@@ -53,12 +54,12 @@ func NewBase(
 // managed values.
 func (b *Base) Install(ctx context.Context) error {
 	labels, err := b.client.GetReleaseSecretLabels(ctx, b.spec.ReleaseName, b.spec.Namespace)
-	if err != nil {
+	if err != nil && !errors.Is(err, helm.ErrNoReleaseSecrets) {
 		return fmt.Errorf("check release ownership for %s: %w", b.name, err)
 	}
 
 	if controller, managed := IsGitOpsManaged(labels); managed {
-		log.Printf("%s: skipping install — release %q is managed by %s", b.name, b.spec.ReleaseName, controller)
+		fmt.Fprintf(os.Stderr, "%s: skipping install — release %q is managed by %s\n", b.name, b.spec.ReleaseName, controller)
 
 		return nil
 	}

--- a/pkg/svc/installer/internal/helmutil/base.go
+++ b/pkg/svc/installer/internal/helmutil/base.go
@@ -3,6 +3,7 @@ package helmutil
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
@@ -46,8 +47,23 @@ func NewBase(
 // It wraps the context with a deadline that includes [helm.ContextTimeoutBuffer]
 // beyond the chart timeout so that Helm's internal kstatus watchers can
 // observe resource readiness and report errors before the Go context expires.
+//
+// If the release Secret already exists and carries GitOps controller labels
+// (Flux or ArgoCD), the install is skipped to avoid overwriting externally
+// managed values.
 func (b *Base) Install(ctx context.Context) error {
-	err := b.client.AddRepository(ctx, b.repo, b.timeout)
+	labels, err := b.client.GetReleaseSecretLabels(ctx, b.spec.ReleaseName, b.spec.Namespace)
+	if err != nil {
+		return fmt.Errorf("check release ownership for %s: %w", b.name, err)
+	}
+
+	if controller, managed := IsGitOpsManaged(labels); managed {
+		log.Printf("%s: skipping install — release %q is managed by %s", b.name, b.spec.ReleaseName, controller)
+
+		return nil
+	}
+
+	err = b.client.AddRepository(ctx, b.repo, b.timeout)
 	if err != nil {
 		return fmt.Errorf("failed to add %s repository: %w", b.repo.Name, err)
 	}

--- a/pkg/svc/installer/internal/helmutil/base.go
+++ b/pkg/svc/installer/internal/helmutil/base.go
@@ -53,8 +53,8 @@ func NewBase(
 // (Flux or ArgoCD), the install is skipped to avoid overwriting externally
 // managed values.
 func (b *Base) Install(ctx context.Context) error {
-	labels, err := b.client.GetReleaseSecretLabels(ctx, b.spec.ReleaseName, b.spec.Namespace)
-	if err != nil && !errors.Is(err, helm.ErrNoReleaseSecrets) {
+	labels, err := b.client.GetReleaseStorageLabels(ctx, b.spec.ReleaseName, b.spec.Namespace)
+	if err != nil && !errors.Is(err, helm.ErrNoReleaseStorage) {
 		return fmt.Errorf("check release ownership for %s: %w", b.name, err)
 	}
 

--- a/pkg/svc/installer/internal/helmutil/helmutil_test.go
+++ b/pkg/svc/installer/internal/helmutil/helmutil_test.go
@@ -43,6 +43,25 @@ func TestBaseInstallSuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBaseInstallProceedsWhenNoReleaseSecrets(t *testing.T) {
+	t.Parallel()
+
+	base, client := newBaseWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(nil, helm.ErrNoReleaseSecrets)
+	client.EXPECT().
+		AddRepository(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(mock.Anything, mock.Anything).
+		Return(nil, nil)
+
+	err := base.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
 func TestBaseInstallSkipsWhenFluxManaged(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/internal/helmutil/helmutil_test.go
+++ b/pkg/svc/installer/internal/helmutil/helmutil_test.go
@@ -29,7 +29,7 @@ func TestBaseInstallSuccess(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -48,8 +48,8 @@ func TestBaseInstallProceedsWhenNoReleaseSecrets(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
-		Return(nil, helm.ErrNoReleaseSecrets)
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
+		Return(nil, helm.ErrNoReleaseStorage)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
@@ -67,7 +67,7 @@ func TestBaseInstallSkipsWhenFluxManaged(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
 		Return(map[string]string{
 			"name":                             "test-release",
 			"owner":                            "helm",
@@ -86,7 +86,7 @@ func TestBaseInstallSkipsWhenArgoCDManaged(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
 		Return(map[string]string{
 			"name":                          "test-release",
 			"owner":                         "helm",
@@ -103,7 +103,7 @@ func TestBaseInstallProceedsWhenNotManaged(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
 		Return(map[string]string{
 			"name":    "test-release",
 			"owner":   "helm",
@@ -126,7 +126,7 @@ func TestBaseInstallOwnershipCheckError(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
 		Return(nil, assert.AnError)
 
 	err := base.Install(context.Background())
@@ -140,7 +140,7 @@ func TestBaseInstallRepoError(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -157,7 +157,7 @@ func TestBaseInstallChartError(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		GetReleaseStorageLabels(mock.Anything, "test-release", "test-namespace").
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).

--- a/pkg/svc/installer/internal/helmutil/helmutil_test.go
+++ b/pkg/svc/installer/internal/helmutil/helmutil_test.go
@@ -50,8 +50,8 @@ func TestBaseInstallSkipsWhenFluxManaged(t *testing.T) {
 	client.EXPECT().
 		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
 		Return(map[string]string{
-			"name":                            "test-release",
-			"owner":                           "helm",
+			"name":                             "test-release",
+			"owner":                            "helm",
 			"helm.toolkit.fluxcd.io/name":      "my-helmrelease",
 			"helm.toolkit.fluxcd.io/namespace": "flux-system",
 		}, nil)

--- a/pkg/svc/installer/internal/helmutil/helmutil_test.go
+++ b/pkg/svc/installer/internal/helmutil/helmutil_test.go
@@ -29,6 +29,9 @@ func TestBaseInstallSuccess(t *testing.T) {
 
 	base, client := newBaseWithDefaults(t)
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(nil, nil)
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 	client.EXPECT().
@@ -40,10 +43,86 @@ func TestBaseInstallSuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBaseInstallSkipsWhenFluxManaged(t *testing.T) {
+	t.Parallel()
+
+	base, client := newBaseWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(map[string]string{
+			"name":                            "test-release",
+			"owner":                           "helm",
+			"helm.toolkit.fluxcd.io/name":      "my-helmrelease",
+			"helm.toolkit.fluxcd.io/namespace": "flux-system",
+		}, nil)
+
+	// AddRepository and InstallOrUpgradeChart should NOT be called.
+	err := base.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestBaseInstallSkipsWhenArgoCDManaged(t *testing.T) {
+	t.Parallel()
+
+	base, client := newBaseWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(map[string]string{
+			"name":                          "test-release",
+			"owner":                         "helm",
+			"argocd.argoproj.io/managed-by": "argocd",
+		}, nil)
+
+	err := base.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestBaseInstallProceedsWhenNotManaged(t *testing.T) {
+	t.Parallel()
+
+	base, client := newBaseWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(map[string]string{
+			"name":    "test-release",
+			"owner":   "helm",
+			"version": "1",
+		}, nil)
+	client.EXPECT().
+		AddRepository(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(mock.Anything, mock.Anything).
+		Return(nil, nil)
+
+	err := base.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestBaseInstallOwnershipCheckError(t *testing.T) {
+	t.Parallel()
+
+	base, client := newBaseWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(nil, assert.AnError)
+
+	err := base.Install(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check release ownership for test")
+}
+
 func TestBaseInstallRepoError(t *testing.T) {
 	t.Parallel()
 
 	base, client := newBaseWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(assert.AnError)
@@ -58,6 +137,9 @@ func TestBaseInstallChartError(t *testing.T) {
 	t.Parallel()
 
 	base, client := newBaseWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, "test-release", "test-namespace").
+		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)

--- a/pkg/svc/installer/internal/helmutil/ownership.go
+++ b/pkg/svc/installer/internal/helmutil/ownership.go
@@ -5,8 +5,6 @@ const (
 	// FluxNameLabel is the label key set by the Flux helm-controller on
 	// Helm release Secrets it manages.
 	FluxNameLabel = "helm.toolkit.fluxcd.io/name"
-	// FluxNamespaceLabel is the companion namespace label set by Flux.
-	FluxNamespaceLabel = "helm.toolkit.fluxcd.io/namespace"
 	// ArgoCDManagedByLabel is the label key set by ArgoCD on resources it
 	// manages. Present on Helm release Secrets when ArgoCD manages charts
 	// through its Helm integration.

--- a/pkg/svc/installer/internal/helmutil/ownership.go
+++ b/pkg/svc/installer/internal/helmutil/ownership.go
@@ -16,7 +16,7 @@ const (
 // IsGitOpsManaged inspects Helm release Secret labels for known GitOps
 // controller ownership markers. It returns the controller name and true when
 // the release is managed externally; ("", false) otherwise.
-func IsGitOpsManaged(labels map[string]string) (controller string, managed bool) {
+func IsGitOpsManaged(labels map[string]string) (string, bool) {
 	if len(labels) == 0 {
 		return "", false
 	}

--- a/pkg/svc/installer/internal/helmutil/ownership.go
+++ b/pkg/svc/installer/internal/helmutil/ownership.go
@@ -1,0 +1,33 @@
+package helmutil
+
+// GitOps controller label keys used to detect ownership of Helm release Secrets.
+const (
+	// FluxNameLabel is the label key set by the Flux helm-controller on
+	// Helm release Secrets it manages.
+	FluxNameLabel = "helm.toolkit.fluxcd.io/name"
+	// FluxNamespaceLabel is the companion namespace label set by Flux.
+	FluxNamespaceLabel = "helm.toolkit.fluxcd.io/namespace"
+	// ArgoCDManagedByLabel is the label key set by ArgoCD on resources it
+	// manages. Present on Helm release Secrets when ArgoCD manages charts
+	// through its Helm integration.
+	ArgoCDManagedByLabel = "argocd.argoproj.io/managed-by"
+)
+
+// IsGitOpsManaged inspects Helm release Secret labels for known GitOps
+// controller ownership markers. It returns the controller name and true when
+// the release is managed externally; ("", false) otherwise.
+func IsGitOpsManaged(labels map[string]string) (controller string, managed bool) {
+	if len(labels) == 0 {
+		return "", false
+	}
+
+	if _, ok := labels[FluxNameLabel]; ok {
+		return "Flux", true
+	}
+
+	if _, ok := labels[ArgoCDManagedByLabel]; ok {
+		return "ArgoCD", true
+	}
+
+	return "", false
+}

--- a/pkg/svc/installer/internal/helmutil/ownership_test.go
+++ b/pkg/svc/installer/internal/helmutil/ownership_test.go
@@ -25,7 +25,7 @@ func testIsGitOpsManagedNilLabels(t *testing.T) {
 
 	controller, managed := helmutil.IsGitOpsManaged(nil)
 
-	assert.Equal(t, "", controller)
+	assert.Empty(t, controller)
 	assert.False(t, managed)
 }
 
@@ -35,7 +35,7 @@ func testIsGitOpsManagedEmptyLabels(t *testing.T) {
 
 	controller, managed := helmutil.IsGitOpsManaged(map[string]string{})
 
-	assert.Equal(t, "", controller)
+	assert.Empty(t, controller)
 	assert.False(t, managed)
 }
 
@@ -50,7 +50,7 @@ func testIsGitOpsManagedStandardHelmLabels(t *testing.T) {
 		"status":  "deployed",
 	})
 
-	assert.Equal(t, "", controller)
+	assert.Empty(t, controller)
 	assert.False(t, managed)
 }
 
@@ -59,8 +59,8 @@ func testIsGitOpsManagedFlux(t *testing.T) {
 	t.Parallel()
 
 	controller, managed := helmutil.IsGitOpsManaged(map[string]string{
-		"name":                            "cert-manager",
-		"owner":                           "helm",
+		"name":                             "cert-manager",
+		"owner":                            "helm",
 		"helm.toolkit.fluxcd.io/name":      "cert-manager",
 		"helm.toolkit.fluxcd.io/namespace": "flux-system",
 	})

--- a/pkg/svc/installer/internal/helmutil/ownership_test.go
+++ b/pkg/svc/installer/internal/helmutil/ownership_test.go
@@ -1,0 +1,92 @@
+package helmutil_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/installer/internal/helmutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGitOpsManaged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		wantController string
+		wantManaged    bool
+	}{
+		{
+			name:           "nil labels",
+			labels:         nil,
+			wantController: "",
+			wantManaged:    false,
+		},
+		{
+			name:           "empty labels",
+			labels:         map[string]string{},
+			wantController: "",
+			wantManaged:    false,
+		},
+		{
+			name: "standard helm labels only",
+			labels: map[string]string{
+				"name":    "cert-manager",
+				"owner":   "helm",
+				"version": "1",
+				"status":  "deployed",
+			},
+			wantController: "",
+			wantManaged:    false,
+		},
+		{
+			name: "flux managed",
+			labels: map[string]string{
+				"name":                            "cert-manager",
+				"owner":                           "helm",
+				"helm.toolkit.fluxcd.io/name":      "cert-manager",
+				"helm.toolkit.fluxcd.io/namespace": "flux-system",
+			},
+			wantController: "Flux",
+			wantManaged:    true,
+		},
+		{
+			name: "flux name label only",
+			labels: map[string]string{
+				"helm.toolkit.fluxcd.io/name": "my-release",
+			},
+			wantController: "Flux",
+			wantManaged:    true,
+		},
+		{
+			name: "argocd managed",
+			labels: map[string]string{
+				"name":                          "cert-manager",
+				"owner":                         "helm",
+				"argocd.argoproj.io/managed-by": "argocd",
+			},
+			wantController: "ArgoCD",
+			wantManaged:    true,
+		},
+		{
+			name: "flux takes precedence over argocd",
+			labels: map[string]string{
+				"helm.toolkit.fluxcd.io/name":   "cert-manager",
+				"argocd.argoproj.io/managed-by": "argocd",
+			},
+			wantController: "Flux",
+			wantManaged:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			controller, managed := helmutil.IsGitOpsManaged(tt.labels)
+
+			assert.Equal(t, tt.wantController, controller)
+			assert.Equal(t, tt.wantManaged, managed)
+		})
+	}
+}

--- a/pkg/svc/installer/internal/helmutil/ownership_test.go
+++ b/pkg/svc/installer/internal/helmutil/ownership_test.go
@@ -10,83 +10,100 @@ import (
 func TestIsGitOpsManaged(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name           string
-		labels         map[string]string
-		wantController string
-		wantManaged    bool
-	}{
-		{
-			name:           "nil labels",
-			labels:         nil,
-			wantController: "",
-			wantManaged:    false,
-		},
-		{
-			name:           "empty labels",
-			labels:         map[string]string{},
-			wantController: "",
-			wantManaged:    false,
-		},
-		{
-			name: "standard helm labels only",
-			labels: map[string]string{
-				"name":    "cert-manager",
-				"owner":   "helm",
-				"version": "1",
-				"status":  "deployed",
-			},
-			wantController: "",
-			wantManaged:    false,
-		},
-		{
-			name: "flux managed",
-			labels: map[string]string{
-				"name":                            "cert-manager",
-				"owner":                           "helm",
-				"helm.toolkit.fluxcd.io/name":      "cert-manager",
-				"helm.toolkit.fluxcd.io/namespace": "flux-system",
-			},
-			wantController: "Flux",
-			wantManaged:    true,
-		},
-		{
-			name: "flux name label only",
-			labels: map[string]string{
-				"helm.toolkit.fluxcd.io/name": "my-release",
-			},
-			wantController: "Flux",
-			wantManaged:    true,
-		},
-		{
-			name: "argocd managed",
-			labels: map[string]string{
-				"name":                          "cert-manager",
-				"owner":                         "helm",
-				"argocd.argoproj.io/managed-by": "argocd",
-			},
-			wantController: "ArgoCD",
-			wantManaged:    true,
-		},
-		{
-			name: "flux takes precedence over argocd",
-			labels: map[string]string{
-				"helm.toolkit.fluxcd.io/name":   "cert-manager",
-				"argocd.argoproj.io/managed-by": "argocd",
-			},
-			wantController: "Flux",
-			wantManaged:    true,
-		},
-	}
+	t.Run("nil labels", testIsGitOpsManagedNilLabels)
+	t.Run("empty labels", testIsGitOpsManagedEmptyLabels)
+	t.Run("standard helm labels only", testIsGitOpsManagedStandardHelmLabels)
+	t.Run("flux managed", testIsGitOpsManagedFlux)
+	t.Run("flux name label only", testIsGitOpsManagedFluxNameOnly)
+	t.Run("argocd managed", testIsGitOpsManagedArgoCD)
+	t.Run("flux takes precedence over argocd", testIsGitOpsManagedFluxPrecedence)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+func testIsGitOpsManagedNilLabels(t *testing.T) {
+	t.Helper()
+	t.Parallel()
 
-			controller, managed := helmutil.IsGitOpsManaged(tt.labels)
+	controller, managed := helmutil.IsGitOpsManaged(nil)
 
-			assert.Equal(t, tt.wantController, controller)
-			assert.Equal(t, tt.wantManaged, managed)
-		})
-	}
+	assert.Equal(t, "", controller)
+	assert.False(t, managed)
+}
+
+func testIsGitOpsManagedEmptyLabels(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	controller, managed := helmutil.IsGitOpsManaged(map[string]string{})
+
+	assert.Equal(t, "", controller)
+	assert.False(t, managed)
+}
+
+func testIsGitOpsManagedStandardHelmLabels(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	controller, managed := helmutil.IsGitOpsManaged(map[string]string{
+		"name":    "cert-manager",
+		"owner":   "helm",
+		"version": "1",
+		"status":  "deployed",
+	})
+
+	assert.Equal(t, "", controller)
+	assert.False(t, managed)
+}
+
+func testIsGitOpsManagedFlux(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	controller, managed := helmutil.IsGitOpsManaged(map[string]string{
+		"name":                            "cert-manager",
+		"owner":                           "helm",
+		"helm.toolkit.fluxcd.io/name":      "cert-manager",
+		"helm.toolkit.fluxcd.io/namespace": "flux-system",
+	})
+
+	assert.Equal(t, "Flux", controller)
+	assert.True(t, managed)
+}
+
+func testIsGitOpsManagedFluxNameOnly(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	controller, managed := helmutil.IsGitOpsManaged(map[string]string{
+		"helm.toolkit.fluxcd.io/name": "my-release",
+	})
+
+	assert.Equal(t, "Flux", controller)
+	assert.True(t, managed)
+}
+
+func testIsGitOpsManagedArgoCD(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	controller, managed := helmutil.IsGitOpsManaged(map[string]string{
+		"name":                          "cert-manager",
+		"owner":                         "helm",
+		"argocd.argoproj.io/managed-by": "argocd",
+	})
+
+	assert.Equal(t, "ArgoCD", controller)
+	assert.True(t, managed)
+}
+
+func testIsGitOpsManagedFluxPrecedence(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	controller, managed := helmutil.IsGitOpsManaged(map[string]string{
+		"helm.toolkit.fluxcd.io/name":   "cert-manager",
+		"argocd.argoproj.io/managed-by": "argocd",
+	})
+
+	assert.Equal(t, "Flux", controller)
+	assert.True(t, managed)
 }

--- a/pkg/svc/installer/kubeletcsrapprover/installer_test.go
+++ b/pkg/svc/installer/kubeletcsrapprover/installer_test.go
@@ -50,7 +50,7 @@ func TestKubeletCSRApproverInstallerInstallAddRepositoryError(t *testing.T) {
 
 	installer, client := newKubeletCSRApproverInstallerWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectKubeletCSRApproverAddRepository(t, client, assert.AnError)
 
@@ -126,7 +126,7 @@ func expectKubeletCSRApproverInstall(
 ) {
 	t.Helper()
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectKubeletCSRApproverAddRepository(t, client, nil)
 	client.EXPECT().

--- a/pkg/svc/installer/kubeletcsrapprover/installer_test.go
+++ b/pkg/svc/installer/kubeletcsrapprover/installer_test.go
@@ -49,6 +49,9 @@ func TestKubeletCSRApproverInstallerInstallAddRepositoryError(t *testing.T) {
 	t.Parallel()
 
 	installer, client := newKubeletCSRApproverInstallerWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectKubeletCSRApproverAddRepository(t, client, assert.AnError)
 
 	err := installer.Install(context.Background())
@@ -122,6 +125,9 @@ func expectKubeletCSRApproverInstall(
 	installErr error,
 ) {
 	t.Helper()
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectKubeletCSRApproverAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -48,6 +48,9 @@ func TestInstallRepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDefaults(t)
 	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
 		Return(assert.AnError)
 
@@ -108,6 +111,9 @@ func newInstallerWithDefaults(
 func expectKyvernoInstall(t *testing.T, client *helm.MockInterface, installErr error) {
 	t.Helper()
 
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(
 			mock.Anything,

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -48,7 +48,7 @@ func TestInstallRepoError(t *testing.T) {
 
 	installer, client := newInstallerWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(mock.Anything, mock.Anything, mock.Anything).
@@ -112,7 +112,7 @@ func expectKyvernoInstall(t *testing.T, client *helm.MockInterface, installErr e
 	t.Helper()
 
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	client.EXPECT().
 		AddRepository(

--- a/pkg/svc/installer/metricsserver/installer_test.go
+++ b/pkg/svc/installer/metricsserver/installer_test.go
@@ -84,6 +84,9 @@ func TestMetricsServerInstallerInstallAddRepositoryError(t *testing.T) {
 	t.Parallel()
 
 	installer, client := newMetricsServerInstallerWithDefaults(t)
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectMetricsServerAddRepository(t, client, assert.AnError)
 
 	err := installer.Install(context.Background())
@@ -190,6 +193,9 @@ func expectMetricsServerInstall(
 	installErr error,
 ) {
 	t.Helper()
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectMetricsServerAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(
@@ -217,6 +223,9 @@ func expectMetricsServerInstallVCluster(
 	installErr error,
 ) {
 	t.Helper()
+	client.EXPECT().
+		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectMetricsServerAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(

--- a/pkg/svc/installer/metricsserver/installer_test.go
+++ b/pkg/svc/installer/metricsserver/installer_test.go
@@ -85,7 +85,7 @@ func TestMetricsServerInstallerInstallAddRepositoryError(t *testing.T) {
 
 	installer, client := newMetricsServerInstallerWithDefaults(t)
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectMetricsServerAddRepository(t, client, assert.AnError)
 
@@ -194,7 +194,7 @@ func expectMetricsServerInstall(
 ) {
 	t.Helper()
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectMetricsServerAddRepository(t, client, nil)
 	client.EXPECT().
@@ -224,7 +224,7 @@ func expectMetricsServerInstallVCluster(
 ) {
 	t.Helper()
 	client.EXPECT().
-		GetReleaseSecretLabels(mock.Anything, mock.Anything, mock.Anything).
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	expectMetricsServerAddRepository(t, client, nil)
 	client.EXPECT().


### PR DESCRIPTION
## Summary

When a GitOps controller (Flux or ArgoCD) already manages a Helm release, KSail's component installers now detect this and skip the install to avoid overwriting custom GitOps values.

## Changes

### Helm Client
- Added `GetReleaseSecretLabels` to `helm.Interface` — queries Kubernetes Secrets API with label selector `name=<release>,owner=helm` to retrieve the labels on the latest Helm release Secret

### Ownership Detection
- Created `helmutil.IsGitOpsManaged()` — checks Helm release Secret labels for Flux (`helm.toolkit.fluxcd.io/name`) or ArgoCD (`argocd.argoproj.io/managed-by`) ownership markers

### Installer Integration
- **`helmutil.Base.Install()`**: Added ownership check at the start — components using the standard install path (cert-manager, metrics-server, kubelet-csr-approver, Kyverno, Gatekeeper, MetalLB, Hetzner CCM/CSI) automatically skip when GitOps-managed
- **`cni.InstallerBase.CheckGitOpsOwnership()`**: Added for Cilium and Calico which bypass `helmutil.Base` and call `InstallOrUpgradeChart` directly
- Flux and ArgoCD installers are excluded (they ARE the GitOps controllers)

### Tests
- 7 table-driven tests for `IsGitOpsManaged` (Flux, ArgoCD, both, neither, empty, nil, unrelated labels)
- 4 tests for `helmutil.Base.Install()` skip behavior
- 4 tests for `cni.InstallerBase.CheckGitOpsOwnership()`
- Updated all existing installer tests with mock expectations

Fixes #4524