### PR TITLE
feat(installer): add HA-ready defaults to all component bootstrap installs

### DIFF
--- a/pkg/cli/setup/cni.go
+++ b/pkg/cli/setup/cni.go
@@ -136,6 +136,7 @@ func installCiliumCNI(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster, tmr time
 		clusterCfg.Spec.Cluster.Distribution,
 		clusterCfg.Spec.Cluster.Provider,
 		clusterCfg.Spec.Cluster.LoadBalancer,
+		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 	)
 
 	return runCNIInstallation(
@@ -157,6 +158,7 @@ func installCalicoCNI(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster, tmr time
 		clusterCfg.Spec.Cluster.Connection.Context,
 		setup.timeout,
 		clusterCfg.Spec.Cluster.Distribution,
+		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 	)
 
 	return runCNIInstallation(

--- a/pkg/cli/setup/cni.go
+++ b/pkg/cli/setup/cni.go
@@ -136,7 +136,9 @@ func installCiliumCNI(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster, tmr time
 		clusterCfg.Spec.Cluster.Distribution,
 		clusterCfg.Spec.Cluster.Provider,
 		clusterCfg.Spec.Cluster.LoadBalancer,
-		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+		installer.IsHAEnabled(
+			clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+		),
 	)
 
 	return runCNIInstallation(
@@ -158,7 +160,9 @@ func installCalicoCNI(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster, tmr time
 		clusterCfg.Spec.Cluster.Connection.Context,
 		setup.timeout,
 		clusterCfg.Spec.Cluster.Distribution,
-		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+		installer.IsHAEnabled(
+			clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+		),
 	)
 
 	return runCNIInstallation(

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -195,6 +195,47 @@ func helmInstallerFactory(
 	}
 }
 
+// certManagerInstallerFactory creates a factory for the cert-manager installer
+// that derives haEnabled from the cluster node count.
+func certManagerInstallerFactory(
+	factories *InstallerFactories,
+) func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
+	return func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
+		helmClient, timeout, err := resolveHelmClientAndTimeout(
+			factories, clusterCfg,
+			installer.CertManagerInstallTimeout,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return certmanagerinstaller.NewInstaller(
+			helmClient, timeout,
+			installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+		), nil
+	}
+}
+
+// kubeletCSRApproverInstallerFactory creates a factory for the kubelet-csr-approver
+// installer that derives haEnabled from the cluster node count.
+func kubeletCSRApproverInstallerFactory(
+	factories *InstallerFactories,
+) func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
+	return func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
+		helmClient, timeout, err := resolveHelmClientAndTimeout(
+			factories, clusterCfg, 0,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return kubeletcsrapproverinstaller.NewInstaller(
+			helmClient, timeout,
+			installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+		), nil
+	}
+}
+
 // argoCDInstallerFactory creates a factory for the ArgoCD installer
 // that evaluates SOPS configuration from the cluster spec.
 func argoCDInstallerFactory(
@@ -231,21 +272,9 @@ func DefaultInstallerFactories() *InstallerFactories {
 		return fluxinstaller.NewInstaller(client, timeout)
 	}
 
-	factories.CertManager = helmInstallerFactory(
-		factories,
-		func(c helm.Interface, t time.Duration) installer.Installer {
-			return certmanagerinstaller.NewInstaller(c, t, false)
-		},
-		installer.CertManagerInstallTimeout,
-	)
+	factories.CertManager = certManagerInstallerFactory(factories)
 	factories.ArgoCD = argoCDInstallerFactory(factories)
-	factories.KubeletCSRApprover = helmInstallerFactory(
-		factories,
-		func(c helm.Interface, t time.Duration) installer.Installer {
-			return kubeletcsrapproverinstaller.NewInstaller(c, t, false)
-		},
-		0,
-	)
+	factories.KubeletCSRApprover = kubeletCSRApproverInstallerFactory(factories)
 	factories.CSI = csiFactory(factories)
 	factories.PolicyEngine = policyEngineFactory(factories)
 

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -177,10 +177,12 @@ func resolveHelmClientAndTimeout(
 	return helmClient, timeout, nil
 }
 
-// helmInstallerFactory creates a factory function for helm-based installers.
-func helmInstallerFactory(
+// haHelmInstallerFactory creates a factory for Helm-based installers that
+// derive haEnabled from the cluster node count. The constructor receives
+// (helmClient, timeout, haEnabled).
+func haHelmInstallerFactory(
 	factories *InstallerFactories,
-	newInstaller func(client helm.Interface, timeout time.Duration) installer.Installer,
+	newInstaller func(client helm.Interface, timeout time.Duration, haEnabled bool) installer.Installer,
 	minTimeout time.Duration,
 ) func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
 	return func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
@@ -191,48 +193,11 @@ func helmInstallerFactory(
 			return nil, err
 		}
 
-		return newInstaller(helmClient, timeout), nil
-	}
-}
-
-// certManagerInstallerFactory creates a factory for the cert-manager installer
-// that derives haEnabled from the cluster node count.
-func certManagerInstallerFactory(
-	factories *InstallerFactories,
-) func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
-	return func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
-		helmClient, timeout, err := resolveHelmClientAndTimeout(
-			factories, clusterCfg,
-			installer.CertManagerInstallTimeout,
+		haEnabled := installer.IsHAEnabled(
+			clusterCfg.Spec.Cluster.ControlPlanes + clusterCfg.Spec.Cluster.Workers,
 		)
-		if err != nil {
-			return nil, err
-		}
 
-		return certmanagerinstaller.NewInstaller(
-			helmClient, timeout,
-			installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
-		), nil
-	}
-}
-
-// kubeletCSRApproverInstallerFactory creates a factory for the kubelet-csr-approver
-// installer that derives haEnabled from the cluster node count.
-func kubeletCSRApproverInstallerFactory(
-	factories *InstallerFactories,
-) func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
-	return func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
-		helmClient, timeout, err := resolveHelmClientAndTimeout(
-			factories, clusterCfg, 0,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		return kubeletcsrapproverinstaller.NewInstaller(
-			helmClient, timeout,
-			installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
-		), nil
+		return newInstaller(helmClient, timeout, haEnabled), nil
 	}
 }
 
@@ -272,9 +237,21 @@ func DefaultInstallerFactories() *InstallerFactories {
 		return fluxinstaller.NewInstaller(client, timeout)
 	}
 
-	factories.CertManager = certManagerInstallerFactory(factories)
+	factories.CertManager = haHelmInstallerFactory(
+		factories,
+		func(c helm.Interface, t time.Duration, ha bool) installer.Installer {
+			return certmanagerinstaller.NewInstaller(c, t, ha)
+		},
+		installer.CertManagerInstallTimeout,
+	)
 	factories.ArgoCD = argoCDInstallerFactory(factories)
-	factories.KubeletCSRApprover = kubeletCSRApproverInstallerFactory(factories)
+	factories.KubeletCSRApprover = haHelmInstallerFactory(
+		factories,
+		func(c helm.Interface, t time.Duration, ha bool) installer.Installer {
+			return kubeletcsrapproverinstaller.NewInstaller(c, t, ha)
+		},
+		0,
+	)
 	factories.CSI = csiFactory(factories)
 	factories.PolicyEngine = policyEngineFactory(factories)
 

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -103,12 +103,14 @@ func policyEngineFactory(
 
 			return kyvernoinstaller.NewInstaller(
 				helmClient, timeout, kubeconfig, clusterCfg.Spec.Cluster.Connection.Context,
+				installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 			), nil
 		case v1alpha1.PolicyEngineGatekeeper:
 			timeout = max(timeout, installer.GatekeeperInstallTimeout)
 
 			return gatekeeperinstaller.NewInstaller(
 				helmClient, kubeconfig, clusterCfg.Spec.Cluster.Connection.Context, timeout,
+				installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 			), nil
 		default:
 			return nil, fmt.Errorf("%w: unknown engine %q", ErrPolicyEngineDisabled, engine)
@@ -142,6 +144,7 @@ func csiFactory(
 				clusterCfg.Spec.Cluster.Connection.Context,
 				timeout,
 				networkName,
+				installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 			), nil
 		}
 
@@ -212,6 +215,7 @@ func argoCDInstallerFactory(
 
 		return argocdinstaller.NewInstaller(
 			helmClient, timeout, sopsEnabled,
+			installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 		), nil
 	}
 }
@@ -230,7 +234,7 @@ func DefaultInstallerFactories() *InstallerFactories {
 	factories.CertManager = helmInstallerFactory(
 		factories,
 		func(c helm.Interface, t time.Duration) installer.Installer {
-			return certmanagerinstaller.NewInstaller(c, t)
+			return certmanagerinstaller.NewInstaller(c, t, false)
 		},
 		installer.CertManagerInstallTimeout,
 	)
@@ -238,7 +242,7 @@ func DefaultInstallerFactories() *InstallerFactories {
 	factories.KubeletCSRApprover = helmInstallerFactory(
 		factories,
 		func(c helm.Interface, t time.Duration) installer.Installer {
-			return kubeletcsrapproverinstaller.NewInstaller(c, t)
+			return kubeletcsrapproverinstaller.NewInstaller(c, t, false)
 		},
 		0,
 	)

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -102,15 +102,25 @@ func policyEngineFactory(
 			timeout = max(timeout, installer.KyvernoInstallTimeout)
 
 			return kyvernoinstaller.NewInstaller(
-				helmClient, timeout, kubeconfig, clusterCfg.Spec.Cluster.Connection.Context,
-				installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+				helmClient,
+				timeout,
+				kubeconfig,
+				clusterCfg.Spec.Cluster.Connection.Context,
+				installer.IsHAEnabled(
+					clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+				),
 			), nil
 		case v1alpha1.PolicyEngineGatekeeper:
 			timeout = max(timeout, installer.GatekeeperInstallTimeout)
 
 			return gatekeeperinstaller.NewInstaller(
-				helmClient, kubeconfig, clusterCfg.Spec.Cluster.Connection.Context, timeout,
-				installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+				helmClient,
+				kubeconfig,
+				clusterCfg.Spec.Cluster.Connection.Context,
+				timeout,
+				installer.IsHAEnabled(
+					clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+				),
 			), nil
 		default:
 			return nil, fmt.Errorf("%w: unknown engine %q", ErrPolicyEngineDisabled, engine)
@@ -144,7 +154,9 @@ func csiFactory(
 				clusterCfg.Spec.Cluster.Connection.Context,
 				timeout,
 				networkName,
-				installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+				installer.IsHAEnabled(
+					clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+				),
 			), nil
 		}
 
@@ -220,8 +232,12 @@ func argoCDInstallerFactory(
 		)
 
 		return argocdinstaller.NewInstaller(
-			helmClient, timeout, sopsEnabled,
-			installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+			helmClient,
+			timeout,
+			sopsEnabled,
+			installer.IsHAEnabled(
+				clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+			),
 		), nil
 	}
 }

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -161,6 +161,7 @@ func InstallMetricsServerSilent(
 		helmClient,
 		timeout,
 		clusterCfg.Spec.Cluster.Distribution,
+		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 	)
 
 	installErr := msInstaller.Install(ctx)
@@ -289,6 +290,7 @@ func installHcloudCCM(
 		clusterCfg.Spec.Cluster.Connection.Context,
 		timeout,
 		networkName,
+		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
 	)
 
 	installErr := ccmInstaller.Install(ctx)

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -161,7 +161,9 @@ func InstallMetricsServerSilent(
 		helmClient,
 		timeout,
 		clusterCfg.Spec.Cluster.Distribution,
-		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+		installer.IsHAEnabled(
+			clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+		),
 	)
 
 	installErr := msInstaller.Install(ctx)
@@ -290,7 +292,9 @@ func installHcloudCCM(
 		clusterCfg.Spec.Cluster.Connection.Context,
 		timeout,
 		networkName,
-		installer.IsHAEnabled(clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers),
+		installer.IsHAEnabled(
+			clusterCfg.Spec.Cluster.ControlPlanes+clusterCfg.Spec.Cluster.Workers,
+		),
 	)
 
 	installErr := ccmInstaller.Install(ctx)

--- a/pkg/cli/ui/chat/permission_test.go
+++ b/pkg/cli/ui/chat/permission_test.go
@@ -324,7 +324,11 @@ func TestPermissionHandler_NilChatModeRef(t *testing.T) {
 	select {
 	case result := <-resultChan:
 		if result.Kind != copilot.PermissionRequestResultKindRejected {
-			t.Errorf("expected %q, got %q", copilot.PermissionRequestResultKindRejected, result.Kind)
+			t.Errorf(
+				"expected %q, got %q",
+				copilot.PermissionRequestResultKindRejected,
+				result.Kind,
+			)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for permission handler result")

--- a/pkg/cli/ui/chat/streamhandlers_test.go
+++ b/pkg/cli/ui/chat/streamhandlers_test.go
@@ -1030,7 +1030,9 @@ func TestHandleAutoModeSwitchRequested_IncludesErrorCode(t *testing.T) {
 
 	var updated tea.Model = model
 
-	updated, _ = updated.Update(chat.ExportNewAutoModeSwitchRequestedMsg("req-2", "rate_limit_exceeded"))
+	updated, _ = updated.Update(
+		chat.ExportNewAutoModeSwitchRequestedMsg("req-2", "rate_limit_exceeded"),
+	)
 	m := requireModel(t, updated)
 
 	content := chat.ExportGetMessageContent(m, 0)

--- a/pkg/svc/installer/argocd/argocd_coverage_test.go
+++ b/pkg/svc/installer/argocd/argocd_coverage_test.go
@@ -45,7 +45,7 @@ func TestArgoCDInstallerImages_Error(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false)
+	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false, false)
 
 	client.EXPECT().
 		TemplateChart(mock.Anything, mock.Anything).
@@ -62,7 +62,7 @@ func TestArgoCDInstallerImages_Success(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false)
+	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false, false)
 
 	manifest := `apiVersion: apps/v1
 kind: Deployment
@@ -91,7 +91,7 @@ func TestNewInstaller_SOPSEnabled(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, true)
+	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, true, false)
 
 	require.NotNil(t, installer)
 
@@ -103,7 +103,7 @@ func TestChartSpec_SOPSDisabled_NoValuesYaml(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false)
+	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false, false)
 
 	spec := installer.ChartSpec()
 
@@ -120,7 +120,7 @@ func TestChartSpec_VersionNonEmpty(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false)
+	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false, false)
 
 	spec := installer.ChartSpec()
 
@@ -131,7 +131,7 @@ func TestInstaller_Install_ContextCanceled(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := argocdinstaller.NewInstaller(client, 5*time.Second, false)
+	installer := argocdinstaller.NewInstaller(client, 5*time.Second, false, false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/pkg/svc/installer/argocd/installer.go
+++ b/pkg/svc/installer/argocd/installer.go
@@ -31,8 +31,18 @@ type Installer struct {
 // transparently decrypts SOPS-encrypted manifests using an Age key.
 // When haEnabled is true the chart is configured with HA defaults
 // (replicas, PDB) for server and repo-server.
-func NewInstaller(client helm.Interface, timeout time.Duration, sopsEnabled bool, haEnabled bool) *Installer {
-	return &Installer{client: client, timeout: timeout, sopsEnabled: sopsEnabled, haEnabled: haEnabled}
+func NewInstaller(
+	client helm.Interface,
+	timeout time.Duration,
+	sopsEnabled bool,
+	haEnabled bool,
+) *Installer {
+	return &Installer{
+		client:      client,
+		timeout:     timeout,
+		sopsEnabled: sopsEnabled,
+		haEnabled:   haEnabled,
+	}
 }
 
 // Install installs or upgrades Argo CD via its Helm chart.
@@ -87,6 +97,7 @@ func (a *Installer) chartSpec() *helm.ChartSpec {
 		if spec.SetValues == nil {
 			spec.SetValues = make(map[string]string)
 		}
+
 		spec.SetValues["server.replicas"] = "2"
 		spec.SetValues["repoServer.replicas"] = "2"
 		spec.SetValues["server.pdb.enabled"] = "true"

--- a/pkg/svc/installer/argocd/installer.go
+++ b/pkg/svc/installer/argocd/installer.go
@@ -23,13 +23,16 @@ type Installer struct {
 	timeout     time.Duration
 	client      helm.Interface
 	sopsEnabled bool
+	haEnabled   bool
 }
 
 // NewInstaller creates a new Argo CD installer instance.
 // When sopsEnabled is true the chart is deployed with a CMP sidecar that
 // transparently decrypts SOPS-encrypted manifests using an Age key.
-func NewInstaller(client helm.Interface, timeout time.Duration, sopsEnabled bool) *Installer {
-	return &Installer{client: client, timeout: timeout, sopsEnabled: sopsEnabled}
+// When haEnabled is true the chart is configured with HA defaults
+// (replicas, PDB) for server and repo-server.
+func NewInstaller(client helm.Interface, timeout time.Duration, sopsEnabled bool, haEnabled bool) *Installer {
+	return &Installer{client: client, timeout: timeout, sopsEnabled: sopsEnabled, haEnabled: haEnabled}
 }
 
 // Install installs or upgrades Argo CD via its Helm chart.
@@ -78,6 +81,18 @@ func (a *Installer) chartSpec() *helm.ChartSpec {
 
 	if a.sopsEnabled {
 		spec.ValuesYaml = buildSOPSValuesYaml()
+	}
+
+	if a.haEnabled {
+		if spec.SetValues == nil {
+			spec.SetValues = make(map[string]string)
+		}
+		spec.SetValues["server.replicas"] = "2"
+		spec.SetValues["repoServer.replicas"] = "2"
+		spec.SetValues["server.pdb.enabled"] = "true"
+		spec.SetValues["server.pdb.minAvailable"] = "1"
+		spec.SetValues["repoServer.pdb.enabled"] = "true"
+		spec.SetValues["repoServer.pdb.minAvailable"] = "1"
 	}
 
 	return spec

--- a/pkg/svc/installer/argocd/installer_test.go
+++ b/pkg/svc/installer/argocd/installer_test.go
@@ -22,6 +22,41 @@ func TestNewInstaller(t *testing.T) {
 	require.NotNil(t, installer)
 }
 
+func TestNewInstaller_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer := argocdinstaller.NewInstaller(client, 5*time.Minute, false, true)
+
+	require.NotNil(t, installer)
+}
+
+func TestChartSpec_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	inst := argocdinstaller.NewInstaller(client, 5*time.Minute, false, true)
+	spec := inst.ChartSpec()
+
+	require.NotNil(t, spec.SetValues)
+	assert.Equal(t, "2", spec.SetValues["server.replicas"])
+	assert.Equal(t, "2", spec.SetValues["repoServer.replicas"])
+	assert.Equal(t, "true", spec.SetValues["server.pdb.enabled"])
+	assert.Equal(t, "1", spec.SetValues["server.pdb.minAvailable"])
+	assert.Equal(t, "true", spec.SetValues["repoServer.pdb.enabled"])
+	assert.Equal(t, "1", spec.SetValues["repoServer.pdb.minAvailable"])
+}
+
+func TestChartSpec_HADisabled(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	inst := argocdinstaller.NewInstaller(client, 5*time.Minute, false, false)
+	spec := inst.ChartSpec()
+
+	assert.Empty(t, spec.SetValues, "SetValues should be empty when HA is disabled")
+}
+
 func TestChartSpecValuesYaml(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/argocd/installer_test.go
+++ b/pkg/svc/installer/argocd/installer_test.go
@@ -17,7 +17,7 @@ func TestNewInstaller(t *testing.T) {
 
 	timeout := 5 * time.Minute
 	client := helm.NewMockInterface(t)
-	installer := argocdinstaller.NewInstaller(client, timeout, false)
+	installer := argocdinstaller.NewInstaller(client, timeout, false, false)
 
 	require.NotNil(t, installer)
 }
@@ -48,7 +48,7 @@ func TestChartSpecValuesYaml(t *testing.T) {
 
 			client := helm.NewMockInterface(t)
 			inst := argocdinstaller.NewInstaller(
-				client, 5*time.Minute, testCase.sopsEnabled,
+				client, 5*time.Minute, testCase.sopsEnabled, false,
 			)
 			spec := inst.ChartSpec()
 
@@ -118,6 +118,7 @@ func newArgoCDInstallerWithDefaults(
 	installer := argocdinstaller.NewInstaller(
 		client,
 		5*time.Second,
+		false,
 		false,
 	)
 

--- a/pkg/svc/installer/certmanager/installer.go
+++ b/pkg/svc/installer/certmanager/installer.go
@@ -15,7 +15,41 @@ type Installer struct {
 }
 
 // NewInstaller creates a new cert-manager installer instance.
-func NewInstaller(client helm.Interface, timeout time.Duration) *Installer {
+// When haEnabled is true the chart is configured with HA defaults
+// (replicas, PDB, topology spread) for the controller and webhook deployments.
+func NewInstaller(client helm.Interface, timeout time.Duration, haEnabled bool) *Installer {
+	setValues := map[string]string{
+		"installCRDs":             "true",
+		"startupapicheck.timeout": startupAPICheckTimeout(timeout),
+	}
+
+	var valuesYaml string
+
+	if haEnabled {
+		setValues["replicaCount"] = "2"
+		setValues["webhook.replicaCount"] = "2"
+		setValues["podDisruptionBudget.enabled"] = "true"
+		setValues["podDisruptionBudget.minAvailable"] = "1"
+		setValues["webhook.podDisruptionBudget.enabled"] = "true"
+		setValues["webhook.podDisruptionBudget.minAvailable"] = "1"
+
+		valuesYaml = `topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/component: controller
+webhook:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: webhook`
+	}
+
 	return &Installer{
 		Base: helmutil.NewBase(
 			"cert-manager",
@@ -36,10 +70,8 @@ func NewInstaller(client helm.Interface, timeout time.Duration) *Installer {
 				Wait:            true,
 				WaitForJobs:     true,
 				Timeout:         timeout,
-				SetValues: map[string]string{
-					"installCRDs":             "true",
-					"startupapicheck.timeout": startupAPICheckTimeout(timeout),
-				},
+				SetValues:       setValues,
+				ValuesYaml:      valuesYaml,
 			},
 		),
 	}

--- a/pkg/svc/installer/certmanager/installer_test.go
+++ b/pkg/svc/installer/certmanager/installer_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	repoName = "jetstack"
+	repoURL  = "https://charts.jetstack.io"
+)
+
 func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 
@@ -44,8 +49,8 @@ func TestInstallSuccessWithScaledTimeout(t *testing.T) {
 		AddRepository(
 			mock.Anything,
 			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {
-				return entry != nil && entry.Name == "jetstack" &&
-					entry.URL == "https://charts.jetstack.io"
+				return entry != nil && entry.Name == repoName &&
+					entry.URL == repoURL
 			}),
 			mock.Anything,
 		).
@@ -93,8 +98,8 @@ func TestInstallSuccess_HAEnabled(t *testing.T) {
 		AddRepository(
 			mock.Anything,
 			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {
-				return entry != nil && entry.Name == "jetstack" &&
-					entry.URL == "https://charts.jetstack.io"
+				return entry != nil && entry.Name == repoName &&
+					entry.URL == repoURL
 			}),
 			mock.Anything,
 		).
@@ -203,8 +208,8 @@ func expectCertManagerInstall(t *testing.T, client *helm.MockInterface, installE
 		AddRepository(
 			mock.Anything,
 			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {
-				return entry != nil && entry.Name == "jetstack" &&
-					entry.URL == "https://charts.jetstack.io"
+				return entry != nil && entry.Name == repoName &&
+					entry.URL == repoURL
 			}),
 			mock.Anything,
 		).
@@ -221,7 +226,7 @@ func expectCertManagerInstall(t *testing.T, client *helm.MockInterface, installE
 				assert.Equal(t, "cert-manager", spec.ReleaseName)
 				assert.Equal(t, "jetstack/cert-manager", spec.ChartName)
 				assert.Equal(t, "cert-manager", spec.Namespace)
-				assert.Equal(t, "https://charts.jetstack.io", spec.RepoURL)
+				assert.Equal(t, repoURL, spec.RepoURL)
 				assert.True(t, spec.CreateNamespace)
 				assert.True(t, spec.Atomic)
 				assert.True(t, spec.Wait)

--- a/pkg/svc/installer/certmanager/installer_test.go
+++ b/pkg/svc/installer/certmanager/installer_test.go
@@ -74,6 +74,60 @@ func TestInstallSuccessWithScaledTimeout(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNewInstaller_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer := certmanagerinstaller.NewInstaller(client, 5*time.Second, true)
+
+	require.NotNil(t, installer)
+}
+
+func TestInstallSuccess_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer := certmanagerinstaller.NewInstaller(client, 2*time.Minute, true)
+
+	client.EXPECT().
+		AddRepository(
+			mock.Anything,
+			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {
+				return entry != nil && entry.Name == "jetstack" &&
+					entry.URL == "https://charts.jetstack.io"
+			}),
+			mock.Anything,
+		).
+		Return(nil)
+
+	client.EXPECT().
+		InstallOrUpgradeChart(
+			mock.Anything,
+			mock.MatchedBy(func(spec *helm.ChartSpec) bool {
+				if spec == nil {
+					return false
+				}
+
+				assert.Equal(t, "cert-manager", spec.ReleaseName)
+				assert.Equal(t, "2", spec.SetValues["replicaCount"])
+				assert.Equal(t, "2", spec.SetValues["webhook.replicaCount"])
+				assert.Equal(t, "true", spec.SetValues["podDisruptionBudget.enabled"])
+				assert.Equal(t, "1", spec.SetValues["podDisruptionBudget.minAvailable"])
+				assert.Equal(t, "true", spec.SetValues["webhook.podDisruptionBudget.enabled"])
+				assert.Equal(t, "1", spec.SetValues["webhook.podDisruptionBudget.minAvailable"])
+				assert.Contains(t, spec.ValuesYaml, "topologySpreadConstraints")
+				assert.Contains(t, spec.ValuesYaml, "kubernetes.io/hostname")
+
+				return true
+			}),
+		).
+		Return(nil, nil)
+
+	err := installer.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
 func TestInstallRepoError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/certmanager/installer_test.go
+++ b/pkg/svc/installer/certmanager/installer_test.go
@@ -16,7 +16,7 @@ func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := certmanagerinstaller.NewInstaller(client, 5*time.Second)
+	installer := certmanagerinstaller.NewInstaller(client, 5*time.Second, false)
 
 	assert.NotNil(t, installer)
 }
@@ -36,7 +36,7 @@ func TestInstallSuccessWithScaledTimeout(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := certmanagerinstaller.NewInstaller(client, 10*time.Minute)
+	installer := certmanagerinstaller.NewInstaller(client, 10*time.Minute, false)
 	client.EXPECT().
 		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
@@ -134,7 +134,7 @@ func newInstallerWithDefaults(
 	t.Helper()
 
 	client := helm.NewMockInterface(t)
-	installer := certmanagerinstaller.NewInstaller(client, 2*time.Minute)
+	installer := certmanagerinstaller.NewInstaller(client, 2*time.Minute, false)
 
 	return installer, client
 }

--- a/pkg/svc/installer/certmanager/installer_test.go
+++ b/pkg/svc/installer/certmanager/installer_test.go
@@ -95,6 +95,9 @@ func TestInstallSuccess_HAEnabled(t *testing.T) {
 	installer := certmanagerinstaller.NewInstaller(client, 2*time.Minute, true)
 
 	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	client.EXPECT().
 		AddRepository(
 			mock.Anything,
 			mock.MatchedBy(func(entry *helm.RepositoryEntry) bool {

--- a/pkg/svc/installer/clusterautoscaler/installer.go
+++ b/pkg/svc/installer/clusterautoscaler/installer.go
@@ -47,12 +47,15 @@ type Installer struct {
 // NewInstaller creates a new Cluster Autoscaler installer instance.
 // The nodeAutoscaler parameter drives the Helm values rendered for the chart:
 // node pools, expander strategy, scale-down timing, and node count limits.
+// When haEnabled is true the chart is configured with replicas=2
+// for fast failover via leader election.
 func NewInstaller(
 	client helm.Interface,
 	timeout time.Duration,
 	nodeAutoscaler v1alpha1.NodeAutoscalerConfig,
+	haEnabled bool,
 ) (*Installer, error) {
-	valuesYaml, err := buildValuesYaml(nodeAutoscaler)
+	valuesYaml, err := buildValuesYaml(nodeAutoscaler, haEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("clusterautoscaler: failed to build chart values: %w", err)
 	}
@@ -86,6 +89,7 @@ func NewInstaller(
 // All user-supplied strings are embedded in struct fields so that
 // sigs.k8s.io/yaml handles escaping, preventing YAML injection.
 type chartValues struct {
+	Replicas          int32                `json:"replicas,omitempty"`
 	CloudProvider     string               `json:"cloudProvider"`
 	AutoscalingGroups []autoscalingGroup   `json:"autoscalingGroups,omitempty"`
 	ExtraArgs         chartExtraArgs       `json:"extraArgs"`
@@ -161,7 +165,8 @@ type chartResources struct {
 // buildValuesYaml generates the Helm values YAML for the cluster-autoscaler chart
 // from the given NodeAutoscalerConfig. It uses a typed struct marshaled via
 // sigs.k8s.io/yaml to prevent YAML injection from user-supplied strings.
-func buildValuesYaml(cfg v1alpha1.NodeAutoscalerConfig) (string, error) {
+// When haEnabled is true an extra standby replica is configured.
+func buildValuesYaml(cfg v1alpha1.NodeAutoscalerConfig, haEnabled bool) (string, error) {
 	scaleDownTime := cfg.ScaleDownUnneededTime
 	if scaleDownTime == "" {
 		scaleDownTime = defaultScaleDownUnneededTime
@@ -169,7 +174,13 @@ func buildValuesYaml(cfg v1alpha1.NodeAutoscalerConfig) (string, error) {
 
 	groups := buildAutoscalingGroups(cfg.Pools)
 
+	var replicas int32
+	if haEnabled {
+		replicas = 2
+	}
+
 	vals := chartValues{
+		Replicas:          replicas,
 		CloudProvider:     "hetzner",
 		AutoscalingGroups: groups,
 		ExtraArgs: chartExtraArgs{

--- a/pkg/svc/installer/clusterautoscaler/installer.go
+++ b/pkg/svc/installer/clusterautoscaler/installer.go
@@ -167,6 +167,18 @@ type chartResources struct {
 // sigs.k8s.io/yaml to prevent YAML injection from user-supplied strings.
 // When haEnabled is true an extra standby replica is configured.
 func buildValuesYaml(cfg v1alpha1.NodeAutoscalerConfig, haEnabled bool) (string, error) {
+	vals := buildChartValues(cfg, haEnabled)
+
+	out, err := yaml.Marshal(vals)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Helm chart values: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// buildChartValues constructs the typed Helm values struct from the given config.
+func buildChartValues(cfg v1alpha1.NodeAutoscalerConfig, haEnabled bool) chartValues {
 	scaleDownTime := cfg.ScaleDownUnneededTime
 	if scaleDownTime == "" {
 		scaleDownTime = defaultScaleDownUnneededTime
@@ -179,7 +191,7 @@ func buildValuesYaml(cfg v1alpha1.NodeAutoscalerConfig, haEnabled bool) (string,
 		replicas = 2
 	}
 
-	vals := chartValues{
+	return chartValues{
 		Replicas:          replicas,
 		CloudProvider:     "hetzner",
 		AutoscalingGroups: groups,
@@ -224,13 +236,6 @@ func buildValuesYaml(cfg v1alpha1.NodeAutoscalerConfig, haEnabled bool) (string,
 			Limits:   chartResourceLimits{Memory: "256Mi"},
 		},
 	}
-
-	out, err := yaml.Marshal(vals)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal Helm chart values: %w", err)
-	}
-
-	return string(out), nil
 }
 
 // buildAutoscalingGroups converts NodePool specs to autoscalingGroup chart values.

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -36,42 +36,48 @@ func TestNewInstaller_HAEnabled(t *testing.T) {
 	require.NotNil(t, installer)
 }
 
-func TestClusterAutoscalerInstaller_ValuesYaml_HAEnabled(t *testing.T) {
+func TestClusterAutoscalerInstaller_ValuesYaml_HA(t *testing.T) {
 	t.Parallel()
 
-	cfg := v1alpha1.NodeAutoscalerConfig{
-		Pools: []v1alpha1.NodePool{
-			{Name: "workers", ServerType: "cx23", Location: "fsn1", Min: 1, Max: 5},
+	tests := []struct {
+		name      string
+		haEnabled bool
+		assertFn  func(t *testing.T, valuesYaml string)
+	}{
+		{
+			name:      "HAEnabled",
+			haEnabled: true,
+			assertFn: func(t *testing.T, valuesYaml string) {
+				t.Helper()
+				assert.Contains(t, valuesYaml, "replicas: 2",
+					"ValuesYaml should contain replicas: 2 when HA is enabled")
+			},
 		},
-		Expander: v1alpha1.AutoscalerExpanderLeastWaste,
+		{
+			name:      "HADisabled",
+			haEnabled: false,
+			assertFn: func(t *testing.T, valuesYaml string) {
+				t.Helper()
+				assert.NotContains(t, valuesYaml, "replicas: 2",
+					"ValuesYaml should not contain replicas: 2 when HA is disabled")
+			},
+		},
 	}
 
-	client := helm.NewMockInterface(t)
-	client.EXPECT().
-		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, nil)
-	expectAddRepository(t, client, nil)
-	client.EXPECT().
-		InstallOrUpgradeChart(
-			mock.Anything,
-			mock.MatchedBy(func(spec *helm.ChartSpec) bool {
-				assert.Contains(t, spec.ValuesYaml, "replicas: 2",
-					"ValuesYaml should contain replicas: 2 when HA is enabled")
-
-				return true
-			}),
-		).
-		Return(nil, nil)
-
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, true)
-	require.NoError(t, err)
-
-	err = installer.Install(context.Background())
-	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assertHAValuesYaml(t, test.haEnabled, test.assertFn)
+		})
+	}
 }
 
-func TestClusterAutoscalerInstaller_ValuesYaml_HADisabled(t *testing.T) {
-	t.Parallel()
+func assertHAValuesYaml(
+	t *testing.T,
+	haEnabled bool,
+	assertFn func(t *testing.T, valuesYaml string),
+) {
+	t.Helper()
 
 	cfg := v1alpha1.NodeAutoscalerConfig{
 		Pools: []v1alpha1.NodePool{
@@ -89,15 +95,16 @@ func TestClusterAutoscalerInstaller_ValuesYaml_HADisabled(t *testing.T) {
 		InstallOrUpgradeChart(
 			mock.Anything,
 			mock.MatchedBy(func(spec *helm.ChartSpec) bool {
-				assert.NotContains(t, spec.ValuesYaml, "replicas: 2",
-					"ValuesYaml should not contain replicas: 2 when HA is disabled")
+				assertFn(t, spec.ValuesYaml)
 
 				return true
 			}),
 		).
 		Return(nil, nil)
 
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
+	installer, err := clusterautoscalerinstaller.NewInstaller(
+		client, 5*time.Second, cfg, haEnabled,
+	)
 	require.NoError(t, err)
 
 	err = installer.Install(context.Background())

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -25,6 +25,79 @@ func TestNewInstaller(t *testing.T) {
 	assert.NotNil(t, installer)
 }
 
+func TestNewInstaller_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer, err := clusterautoscalerinstaller.NewInstaller(
+		client, 5*time.Minute, v1alpha1.NodeAutoscalerConfig{}, true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, installer)
+}
+
+func TestClusterAutoscalerInstaller_ValuesYaml_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := v1alpha1.NodeAutoscalerConfig{
+		Pools: []v1alpha1.NodePool{
+			{Name: "workers", ServerType: "cx23", Location: "fsn1", Min: 1, Max: 5},
+		},
+		Expander: v1alpha1.AutoscalerExpanderLeastWaste,
+	}
+
+	client := helm.NewMockInterface(t)
+	expectAddRepository(t, client, nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(
+			mock.Anything,
+			mock.MatchedBy(func(spec *helm.ChartSpec) bool {
+				assert.Contains(t, spec.ValuesYaml, "replicas: 2",
+					"ValuesYaml should contain replicas: 2 when HA is enabled")
+
+				return true
+			}),
+		).
+		Return(nil, nil)
+
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, true)
+	require.NoError(t, err)
+
+	err = installer.Install(context.Background())
+	require.NoError(t, err)
+}
+
+func TestClusterAutoscalerInstaller_ValuesYaml_HADisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := v1alpha1.NodeAutoscalerConfig{
+		Pools: []v1alpha1.NodePool{
+			{Name: "workers", ServerType: "cx23", Location: "fsn1", Min: 1, Max: 5},
+		},
+		Expander: v1alpha1.AutoscalerExpanderLeastWaste,
+	}
+
+	client := helm.NewMockInterface(t)
+	expectAddRepository(t, client, nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(
+			mock.Anything,
+			mock.MatchedBy(func(spec *helm.ChartSpec) bool {
+				assert.NotContains(t, spec.ValuesYaml, "replicas: 2",
+					"ValuesYaml should not contain replicas: 2 when HA is disabled")
+
+				return true
+			}),
+		).
+		Return(nil, nil)
+
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
+	require.NoError(t, err)
+
+	err = installer.Install(context.Background())
+	require.NoError(t, err)
+}
+
 func TestClusterAutoscalerInstaller_InstallSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -47,6 +47,9 @@ func TestClusterAutoscalerInstaller_ValuesYaml_HAEnabled(t *testing.T) {
 	}
 
 	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(
@@ -78,6 +81,9 @@ func TestClusterAutoscalerInstaller_ValuesYaml_HADisabled(t *testing.T) {
 	}
 
 	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -18,7 +18,7 @@ func TestNewInstaller(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	installer, err := clusterautoscalerinstaller.NewInstaller(
-		client, 5*time.Minute, v1alpha1.NodeAutoscalerConfig{},
+		client, 5*time.Minute, v1alpha1.NodeAutoscalerConfig{}, false,
 	)
 	require.NoError(t, err)
 
@@ -128,7 +128,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_NodePools(t *testing.T) {
 		).
 		Return(nil, nil)
 
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg)
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
 	require.NoError(t, err)
 
 	err = installer.Install(context.Background())
@@ -211,7 +211,7 @@ func runExpanderTest(
 		).
 		Return(nil, nil)
 
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg)
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
 	require.NoError(t, err)
 	require.NotNil(t, installer)
 
@@ -280,7 +280,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_Contents(t *testing.T) {
 		).
 		Return(nil, nil)
 
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg)
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
 	require.NoError(t, err)
 	err = installer.Install(context.Background())
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_DefaultScaleDownTime(t *testing.T
 		).
 		Return(nil, nil)
 
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg)
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
 	require.NoError(t, err)
 	err = installer.Install(context.Background())
 	require.NoError(t, err)
@@ -352,7 +352,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_MaxNodesTotalOmittedWhenZero(t *t
 		).
 		Return(nil, nil)
 
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg)
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
 	require.NoError(t, err)
 	err = installer.Install(context.Background())
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func newInstallerWithDefaults(t *testing.T) (
 		Expander:              v1alpha1.AutoscalerExpanderLeastWaste,
 		ScaleDownUnneededTime: "10m",
 	}
-	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg)
+	installer, err := clusterautoscalerinstaller.NewInstaller(client, 5*time.Second, cfg, false)
 	require.NoError(t, err)
 
 	return installer, client

--- a/pkg/svc/installer/cni/calico/calico_coverage_test.go
+++ b/pkg/svc/installer/cni/calico/calico_coverage_test.go
@@ -23,6 +23,7 @@ func TestInstaller_Install_TalosDistribution(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionTalos,
+		false,
 	)
 
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
@@ -67,6 +68,7 @@ func TestInstaller_Install_APIServerCheckerError(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionK3s,
+		false,
 	)
 
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error {
@@ -89,6 +91,7 @@ func TestInstaller_Images_Success(t *testing.T) {
 		"test-context",
 		5*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	manifest := `apiVersion: apps/v1
@@ -123,6 +126,7 @@ func TestInstaller_Images_NilClient(t *testing.T) {
 		"test-context",
 		5*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	images, err := installer.Images(context.Background())
@@ -142,6 +146,7 @@ func TestInstaller_Uninstall_ContextCanceled(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -171,6 +176,7 @@ func newCovInstallerWithDistribution(
 		"test-context",
 		2*time.Minute,
 		distribution,
+		false,
 	)
 
 	return installer, client

--- a/pkg/svc/installer/cni/calico/calico_export_test.go
+++ b/pkg/svc/installer/cni/calico/calico_export_test.go
@@ -4,8 +4,11 @@ package calicoinstaller
 // TalosCalicoValuesForTest exposes talosCalicoValues for testing.
 var TalosCalicoValuesForTest = talosCalicoValues
 
-// DefaultCalicoValuesForTest exposes defaultCalicoValues for testing.
-var DefaultCalicoValuesForTest = defaultCalicoValues
+// DefaultCalicoValuesForTest exposes defaultCalicoValues for testing (haEnabled=false).
+var DefaultCalicoValuesForTest = func() map[string]string {
+	inst := &Installer{}
+	return inst.defaultCalicoValues()
+}
 
 // CalicoCRDNamesForTest exposes calicoCRDNames for testing.
 var CalicoCRDNamesForTest = calicoCRDNames

--- a/pkg/svc/installer/cni/calico/calico_export_test.go
+++ b/pkg/svc/installer/cni/calico/calico_export_test.go
@@ -7,12 +7,14 @@ var TalosCalicoValuesForTest = talosCalicoValues
 // DefaultCalicoValuesForTest exposes defaultCalicoValues for testing (haEnabled=false).
 var DefaultCalicoValuesForTest = func() map[string]string {
 	inst := &Installer{}
+
 	return inst.defaultCalicoValues()
 }
 
 // DefaultCalicoValuesHAForTest exposes defaultCalicoValues for testing (haEnabled=true).
 var DefaultCalicoValuesHAForTest = func() map[string]string {
 	inst := &Installer{haEnabled: true}
+
 	return inst.defaultCalicoValues()
 }
 

--- a/pkg/svc/installer/cni/calico/calico_export_test.go
+++ b/pkg/svc/installer/cni/calico/calico_export_test.go
@@ -10,6 +10,12 @@ var DefaultCalicoValuesForTest = func() map[string]string {
 	return inst.defaultCalicoValues()
 }
 
+// DefaultCalicoValuesHAForTest exposes defaultCalicoValues for testing (haEnabled=true).
+var DefaultCalicoValuesHAForTest = func() map[string]string {
+	inst := &Installer{haEnabled: true}
+	return inst.defaultCalicoValues()
+}
+
 // CalicoCRDNamesForTest exposes calicoCRDNames for testing.
 var CalicoCRDNamesForTest = calicoCRDNames
 

--- a/pkg/svc/installer/cni/calico/calico_internal_test.go
+++ b/pkg/svc/installer/cni/calico/calico_internal_test.go
@@ -37,6 +37,15 @@ func TestDefaultCalicoValues(t *testing.T) {
 	assert.Empty(t, values, "default values should be empty map")
 }
 
+func TestDefaultCalicoValues_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	values := calicoinstaller.DefaultCalicoValuesHAForTest()
+
+	require.NotEmpty(t, values, "HA calico values should not be empty")
+	assert.Equal(t, "2", values["installation.controlPlaneReplicas"])
+}
+
 func TestCalicoCRDNames(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/cni/calico/calico_retry_test.go
+++ b/pkg/svc/installer/cni/calico/calico_retry_test.go
@@ -35,6 +35,7 @@ func TestInstaller_Install_TalosDistribution_Values(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionTalos,
+		false,
 	)
 	// Override API server checker to avoid needing a real cluster
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
@@ -59,6 +60,7 @@ func TestInstaller_Install_APIDiscoveryErrorRetry(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	client.EXPECT().
@@ -95,6 +97,7 @@ func TestInstaller_Install_ContextCanceled_Vanilla(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	client.EXPECT().
@@ -126,6 +129,7 @@ func TestInstaller_Install_K3s_APIServerUnavailableRetrySucceeds(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionK3s,
+		false,
 	)
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
 	installer.SetRetryBackoffForTest(func(_ context.Context) error { return nil })
@@ -161,6 +165,7 @@ func TestInstaller_Install_K3s_APIServerUnavailableRetryExhausted(t *testing.T) 
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionK3s,
+		false,
 	)
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
 	installer.SetRetryBackoffForTest(func(_ context.Context) error { return nil })
@@ -196,6 +201,7 @@ func TestInstaller_Install_Vanilla_NoRetryOnAPIServerUnavailable(t *testing.T) {
 		"test-context",
 		2*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	client.EXPECT().

--- a/pkg/svc/installer/cni/calico/installer.go
+++ b/pkg/svc/installer/cni/calico/installer.go
@@ -282,6 +282,7 @@ func (c *Installer) defaultCalicoValues() map[string]string {
 	if c.haEnabled {
 		vals["installation.controlPlaneReplicas"] = "2"
 	}
+
 	return vals
 }
 

--- a/pkg/svc/installer/cni/calico/installer.go
+++ b/pkg/svc/installer/cni/calico/installer.go
@@ -24,6 +24,7 @@ type Installer struct {
 	*cni.InstallerBase
 
 	distribution v1alpha1.Distribution
+	haEnabled    bool
 	// apiServerChecker is called before Helm operations to ensure the API server
 	// is stable. It defaults to WaitForAPIServerStability and can be overridden
 	// in tests to avoid needing a real cluster.
@@ -51,18 +52,22 @@ func NewInstaller(
 	kubeconfig, kubeContext string,
 	timeout time.Duration,
 ) *Installer {
-	return NewInstallerWithDistribution(client, kubeconfig, kubeContext, timeout, "")
+	return NewInstallerWithDistribution(client, kubeconfig, kubeContext, timeout, "", false)
 }
 
 // NewInstallerWithDistribution creates a new Calico installer with distribution-specific configuration.
+// When haEnabled is true the chart is configured with HA defaults
+// for the Typha control plane (controlPlaneReplicas).
 func NewInstallerWithDistribution(
 	client helm.Interface,
 	kubeconfig, kubeContext string,
 	timeout time.Duration,
 	distribution v1alpha1.Distribution,
+	haEnabled bool,
 ) *Installer {
 	calicoInstaller := &Installer{
 		distribution: distribution,
+		haEnabled:    haEnabled,
 	}
 	calicoInstaller.InstallerBase = cni.NewInstallerBase(
 		client,
@@ -254,7 +259,7 @@ func (c *Installer) attemptCalicoInstall(
 
 // getCalicoValues returns the Helm values for Calico based on the distribution.
 func (c *Installer) getCalicoValues() map[string]string {
-	values := defaultCalicoValues()
+	values := c.defaultCalicoValues()
 
 	// Add distribution-specific values
 	switch c.distribution {
@@ -272,8 +277,12 @@ func (c *Installer) getCalicoValues() map[string]string {
 	return values
 }
 
-func defaultCalicoValues() map[string]string {
-	return map[string]string{}
+func (c *Installer) defaultCalicoValues() map[string]string {
+	vals := map[string]string{}
+	if c.haEnabled {
+		vals["installation.controlPlaneReplicas"] = "2"
+	}
+	return vals
 }
 
 // talosCalicoValues returns Talos-specific Calico configuration.

--- a/pkg/svc/installer/cni/calico/installer_test.go
+++ b/pkg/svc/installer/cni/calico/installer_test.go
@@ -69,6 +69,7 @@ func TestNewInstallerWithDistribution(t *testing.T) {
 				"test-context",
 				5*time.Minute,
 				testCase.distribution,
+				false,
 			)
 
 			require.NotNil(t, installer, "expected installer to be created")
@@ -199,6 +200,7 @@ func TestInstaller_Install_NilClient(t *testing.T) {
 		"test-context",
 		5*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	err := installer.Install(context.Background())
@@ -243,6 +245,7 @@ func TestInstaller_Uninstall_NilClient(t *testing.T) {
 		"test-context",
 		5*time.Minute,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	err := installer.Uninstall(context.Background())
@@ -266,6 +269,7 @@ func newInstallerWithDistribution(
 		"test-context",
 		2*time.Minute,
 		distribution,
+		false,
 	)
 
 	return installer, client

--- a/pkg/svc/installer/cni/cilium/cilium_coverage_test.go
+++ b/pkg/svc/installer/cni/cilium/cilium_coverage_test.go
@@ -25,6 +25,7 @@ func TestInstaller_Install_TalosDistribution(t *testing.T) {
 		v1alpha1.DistributionTalos,
 		v1alpha1.ProviderDocker,
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
@@ -74,6 +75,7 @@ func TestInstaller_Install_HetznerProvider(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		v1alpha1.ProviderHetzner,
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error { return nil })
@@ -123,6 +125,7 @@ func TestInstaller_Install_TalosDockerWithLoadBalancer(t *testing.T) {
 		v1alpha1.DistributionTalos,
 		v1alpha1.ProviderDocker,
 		v1alpha1.LoadBalancerEnabled,
+		false,
 	)
 
 	installer.SetAPIServerCheckerForTest(func(_ context.Context) error { return nil })
@@ -172,6 +175,7 @@ func TestInstaller_Images_Success(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	manifest := `apiVersion: apps/v1
@@ -208,6 +212,7 @@ func TestInstaller_Images_NilClient(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	images, err := installer.Images(context.Background())
@@ -229,6 +234,7 @@ func TestInstaller_Uninstall_ContextCanceled(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/svc/installer/cni/cilium/cilium_export_test.go
+++ b/pkg/svc/installer/cni/cilium/cilium_export_test.go
@@ -7,8 +7,11 @@ var GatewayAPICRDsURLForTest = gatewayAPICRDsURL
 // GatewayAPICRDsVersionForTest exposes gatewayAPICRDsVersion for testing.
 var GatewayAPICRDsVersionForTest = gatewayAPICRDsVersion
 
-// DefaultCiliumValuesForTest exposes defaultCiliumValues for testing.
-var DefaultCiliumValuesForTest = defaultCiliumValues
+// DefaultCiliumValuesForTest exposes defaultCiliumValues for testing (haEnabled=false).
+var DefaultCiliumValuesForTest = func() map[string]string {
+	inst := &Installer{}
+	return inst.defaultCiliumValues()
+}
 
 // TalosCiliumValuesForTest exposes talosCiliumValues for testing.
 var TalosCiliumValuesForTest = talosCiliumValues

--- a/pkg/svc/installer/cni/cilium/cilium_export_test.go
+++ b/pkg/svc/installer/cni/cilium/cilium_export_test.go
@@ -13,6 +13,12 @@ var DefaultCiliumValuesForTest = func() map[string]string {
 	return inst.defaultCiliumValues()
 }
 
+// DefaultCiliumValuesHAForTest exposes defaultCiliumValues for testing (haEnabled=true).
+var DefaultCiliumValuesHAForTest = func() map[string]string {
+	inst := &Installer{haEnabled: true}
+	return inst.defaultCiliumValues()
+}
+
 // TalosCiliumValuesForTest exposes talosCiliumValues for testing.
 var TalosCiliumValuesForTest = talosCiliumValues
 

--- a/pkg/svc/installer/cni/cilium/cilium_export_test.go
+++ b/pkg/svc/installer/cni/cilium/cilium_export_test.go
@@ -10,12 +10,14 @@ var GatewayAPICRDsVersionForTest = gatewayAPICRDsVersion
 // DefaultCiliumValuesForTest exposes defaultCiliumValues for testing (haEnabled=false).
 var DefaultCiliumValuesForTest = func() map[string]string {
 	inst := &Installer{}
+
 	return inst.defaultCiliumValues()
 }
 
 // DefaultCiliumValuesHAForTest exposes defaultCiliumValues for testing (haEnabled=true).
 var DefaultCiliumValuesHAForTest = func() map[string]string {
 	inst := &Installer{haEnabled: true}
+
 	return inst.defaultCiliumValues()
 }
 

--- a/pkg/svc/installer/cni/cilium/cilium_values_test.go
+++ b/pkg/svc/installer/cni/cilium/cilium_values_test.go
@@ -60,6 +60,16 @@ func TestTalosCiliumValues(t *testing.T) {
 	assert.NotContains(t, values["securityContext.capabilities.ciliumAgent"], "SYS_MODULE")
 }
 
+func TestDefaultCiliumValues_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	values := ciliuminstaller.DefaultCiliumValuesHAForTest()
+
+	require.NotEmpty(t, values, "HA cilium values should not be empty")
+	assert.Equal(t, "2", values["operator.replicas"])
+	assert.Equal(t, "true", values["gatewayAPI.enabled"])
+}
+
 func TestDockerCiliumValues(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/cni/cilium/installer.go
+++ b/pkg/svc/installer/cni/cilium/installer.go
@@ -25,6 +25,7 @@ type Installer struct {
 	distribution           v1alpha1.Distribution
 	provider               v1alpha1.Provider
 	loadBalancer           v1alpha1.LoadBalancer
+	haEnabled              bool
 	gatewayAPICRDInstaller GatewayAPICRDInstallerFunc
 	// apiServerChecker is called for distributions that may have an API server
 	// timing gap. It defaults to WaitForAPIServerStability and can be overridden
@@ -40,12 +41,13 @@ func NewInstaller(
 ) *Installer {
 	return NewInstallerWithDistribution(
 		client, kubeconfig, context, timeout,
-		"", "", v1alpha1.LoadBalancerDefault,
+		"", "", v1alpha1.LoadBalancerDefault, false,
 	)
 }
 
 // NewInstallerWithDistribution creates a new Cilium installer instance
 // with distribution and provider-specific configuration.
+// When haEnabled is true the operator replica count is set to 2.
 func NewInstallerWithDistribution(
 	client helm.Interface,
 	kubeconfig, context string,
@@ -53,11 +55,13 @@ func NewInstallerWithDistribution(
 	distribution v1alpha1.Distribution,
 	provider v1alpha1.Provider,
 	loadBalancer v1alpha1.LoadBalancer,
+	haEnabled bool,
 ) *Installer {
 	ciliumInstaller := &Installer{
 		distribution: distribution,
 		provider:     provider,
 		loadBalancer: loadBalancer,
+		haEnabled:    haEnabled,
 	}
 	ciliumInstaller.InstallerBase = cni.NewInstallerBase(
 		client,
@@ -178,7 +182,7 @@ func (c *Installer) helmInstallOrUpgradeCilium(ctx context.Context) error {
 
 // getCiliumValues returns the Helm values for Cilium based on the distribution and provider.
 func (c *Installer) getCiliumValues() map[string]string {
-	values := defaultCiliumValues()
+	values := c.defaultCiliumValues()
 
 	// Add distribution-specific values
 	switch c.distribution {
@@ -212,9 +216,14 @@ func (c *Installer) getCiliumValues() map[string]string {
 	return values
 }
 
-func defaultCiliumValues() map[string]string {
+func (c *Installer) defaultCiliumValues() map[string]string {
+	operatorReplicas := "1"
+	if c.haEnabled {
+		operatorReplicas = "2"
+	}
+
 	return map[string]string{
-		"operator.replicas":  "1", // numeric values don't need quotes
+		"operator.replicas":  operatorReplicas,
 		"gatewayAPI.enabled": "true",
 	}
 }

--- a/pkg/svc/installer/cni/cilium/installer_test.go
+++ b/pkg/svc/installer/cni/cilium/installer_test.go
@@ -71,6 +71,7 @@ func TestNewInstallerWithDistribution(t *testing.T) {
 				testCase.distribution,
 				"",
 				v1alpha1.LoadBalancerDefault,
+				false,
 			)
 
 			require.NotNil(t, installer, "expected installer to be created")
@@ -163,6 +164,7 @@ func TestInstaller_Install_DockerProvider(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		v1alpha1.ProviderDocker,
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error {
@@ -217,6 +219,7 @@ func TestInstaller_Install_DockerProviderWithLoadBalancer(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		v1alpha1.ProviderDocker,
 		v1alpha1.LoadBalancerEnabled,
+		false,
 	)
 
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error {
@@ -311,6 +314,7 @@ func TestInstaller_Install_NilClient(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	err := installer.Install(context.Background())
@@ -331,6 +335,7 @@ func TestInstaller_Install_NilGatewayAPICRDInstaller(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	installer.SetGatewayAPICRDInstaller(nil)
@@ -353,6 +358,7 @@ func TestInstaller_Install_GatewayAPICRDError(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	installer.SetGatewayAPICRDInstaller(func(_ context.Context) error {
@@ -406,6 +412,7 @@ func TestInstaller_Uninstall_NilClient(t *testing.T) {
 		v1alpha1.DistributionVanilla,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	err := installer.Uninstall(context.Background())
@@ -431,6 +438,7 @@ func newInstallerWithDistribution(
 		distribution,
 		"",
 		v1alpha1.LoadBalancerDefault,
+		false,
 	)
 
 	// Use no-op Gateway API CRD installer to avoid requiring a real cluster.

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -59,16 +59,17 @@ func NewFactory(
 func (f *Factory) CreateInstallersForConfig(cfg *v1alpha1.Cluster) (map[string]Installer, error) {
 	installers := make(map[string]Installer)
 	spec := cfg.Spec.Cluster
+	haEnabled := IsHAEnabled(spec.ControlPlanes + spec.Workers)
 
-	f.addGitOpsInstaller(installers, spec)
-	f.addCNIInstaller(installers, spec)
-	f.addPolicyEngineInstaller(installers, spec)
-	f.addCertManagerInstaller(installers, spec)
-	f.addMetricsServerInstaller(installers, spec)
-	f.addCSIInstallers(installers, cfg)
-	f.addLoadBalancerInstaller(installers, cfg)
+	f.addGitOpsInstaller(installers, spec, haEnabled)
+	f.addCNIInstaller(installers, spec, haEnabled)
+	f.addPolicyEngineInstaller(installers, spec, haEnabled)
+	f.addCertManagerInstaller(installers, spec, haEnabled)
+	f.addMetricsServerInstaller(installers, spec, haEnabled)
+	f.addCSIInstallers(installers, cfg, haEnabled)
+	f.addLoadBalancerInstaller(installers, cfg, haEnabled)
 
-	err := f.addClusterAutoscalerInstaller(installers, spec)
+	err := f.addClusterAutoscalerInstaller(installers, spec, haEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +118,7 @@ func (f *Factory) GetImagesForCluster(
 	return GetImagesFromInstallers(ctx, installers)
 }
 
-func (f *Factory) addGitOpsInstaller(installers map[string]Installer, spec v1alpha1.ClusterSpec) {
+func (f *Factory) addGitOpsInstaller(installers map[string]Installer, spec v1alpha1.ClusterSpec, haEnabled bool) {
 	switch spec.GitOpsEngine {
 	case v1alpha1.GitOpsEngineFlux:
 		installers["flux"] = fluxinstaller.NewInstaller(
@@ -126,24 +127,24 @@ func (f *Factory) addGitOpsInstaller(installers map[string]Installer, spec v1alp
 		)
 	case v1alpha1.GitOpsEngineArgoCD:
 		installers["argocd"] = argocdinstaller.NewInstaller(
-			f.helmClient, f.timeout, argocdinstaller.ShouldEnableSOPS(spec.SOPS),
+			f.helmClient, f.timeout, argocdinstaller.ShouldEnableSOPS(spec.SOPS), haEnabled,
 		)
 	case v1alpha1.GitOpsEngineNone:
 		// No GitOps engine configured
 	}
 }
 
-func (f *Factory) addCNIInstaller(installers map[string]Installer, spec v1alpha1.ClusterSpec) {
+func (f *Factory) addCNIInstaller(installers map[string]Installer, spec v1alpha1.ClusterSpec, haEnabled bool) {
 	switch spec.CNI {
 	case v1alpha1.CNICilium:
 		installers["cilium"] = ciliuminstaller.NewInstallerWithDistribution(
 			f.helmClient, f.kubeconfig, f.kubecontext, f.timeout,
-			f.distribution, spec.Provider, spec.LoadBalancer,
+			f.distribution, spec.Provider, spec.LoadBalancer, haEnabled,
 		)
 	case v1alpha1.CNICalico:
 		installers["calico"] = calicoinstaller.NewInstallerWithDistribution(
 			f.helmClient, f.kubeconfig, f.kubecontext,
-			max(f.timeout, CalicoInstallTimeout), f.distribution,
+			max(f.timeout, CalicoInstallTimeout), f.distribution, haEnabled,
 		)
 	case v1alpha1.CNIDefault:
 		// Default CNI - no explicit installer needed
@@ -153,11 +154,12 @@ func (f *Factory) addCNIInstaller(installers map[string]Installer, spec v1alpha1
 func (f *Factory) addPolicyEngineInstaller(
 	installers map[string]Installer,
 	spec v1alpha1.ClusterSpec,
+	haEnabled bool,
 ) {
 	switch spec.PolicyEngine {
 	case v1alpha1.PolicyEngineKyverno:
 		installers["kyverno"] = kyvernoinstaller.NewInstaller(
-			f.helmClient, max(f.timeout, KyvernoInstallTimeout), f.kubeconfig, f.kubecontext,
+			f.helmClient, max(f.timeout, KyvernoInstallTimeout), f.kubeconfig, f.kubecontext, haEnabled,
 		)
 	case v1alpha1.PolicyEngineGatekeeper:
 		installers["gatekeeper"] = gatekeeperinstaller.NewInstaller(
@@ -165,6 +167,7 @@ func (f *Factory) addPolicyEngineInstaller(
 			f.kubeconfig,
 			f.kubecontext,
 			max(f.timeout, GatekeeperInstallTimeout),
+			haEnabled,
 		)
 	case v1alpha1.PolicyEngineNone:
 		// No policy engine configured
@@ -174,10 +177,11 @@ func (f *Factory) addPolicyEngineInstaller(
 func (f *Factory) addCertManagerInstaller(
 	installers map[string]Installer,
 	spec v1alpha1.ClusterSpec,
+	haEnabled bool,
 ) {
 	if spec.CertManager == v1alpha1.CertManagerEnabled {
 		installers["cert-manager"] = certmanagerinstaller.NewInstaller(
-			f.helmClient, max(f.timeout, CertManagerInstallTimeout),
+			f.helmClient, max(f.timeout, CertManagerInstallTimeout), haEnabled,
 		)
 	}
 }
@@ -185,17 +189,18 @@ func (f *Factory) addCertManagerInstaller(
 func (f *Factory) addMetricsServerInstaller(
 	installers map[string]Installer,
 	spec v1alpha1.ClusterSpec,
+	haEnabled bool,
 ) {
 	if spec.MetricsServer == v1alpha1.MetricsServerEnabled ||
 		(spec.MetricsServer == v1alpha1.MetricsServerDefault &&
 			!spec.Distribution.ProvidesMetricsServerByDefault()) {
 		installers["metrics-server"] = metricsserverinstaller.NewInstallerWithDistribution(
-			f.helmClient, f.timeout, f.distribution,
+			f.helmClient, f.timeout, f.distribution, haEnabled,
 		)
 	}
 }
 
-func (f *Factory) addCSIInstallers(installers map[string]Installer, cfg *v1alpha1.Cluster) {
+func (f *Factory) addCSIInstallers(installers map[string]Installer, cfg *v1alpha1.Cluster, haEnabled bool) {
 	spec := cfg.Spec.Cluster
 
 	if f.needsLocalPathStorage(spec) {
@@ -212,11 +217,12 @@ func (f *Factory) addCSIInstallers(installers map[string]Installer, cfg *v1alpha
 
 		networkName := hcloudccminstaller.ResolveHetznerNetworkName(cfg, clusterName)
 		installers["hetzner-csi"] = hetznercsiinstaller.NewInstaller(
-			f.helmClient, f.kubeconfig, f.kubecontext, f.timeout, networkName,
+			f.helmClient, f.kubeconfig, f.kubecontext, f.timeout, networkName, haEnabled,
 		)
 		installers["kubelet-csr-approver"] = kubeletcsrapproverinstaller.NewInstaller(
 			f.helmClient,
 			f.timeout,
+			haEnabled,
 		)
 	}
 }
@@ -224,6 +230,7 @@ func (f *Factory) addCSIInstallers(installers map[string]Installer, cfg *v1alpha
 func (f *Factory) addLoadBalancerInstaller(
 	installers map[string]Installer,
 	cfg *v1alpha1.Cluster,
+	haEnabled bool,
 ) {
 	spec := cfg.Spec.Cluster
 
@@ -256,6 +263,7 @@ func (f *Factory) addLoadBalancerInstaller(
 			f.kubecontext,
 			f.timeout,
 			networkName,
+			haEnabled,
 		)
 	}
 }
@@ -335,13 +343,14 @@ func (f *Factory) needsHcloudCCM(spec v1alpha1.ClusterSpec) bool {
 func (f *Factory) addClusterAutoscalerInstaller(
 	installers map[string]Installer,
 	spec v1alpha1.ClusterSpec,
+	haEnabled bool,
 ) error {
 	if !f.needsClusterAutoscaler(spec) {
 		return nil
 	}
 
 	inst, err := clusterautoscalerinstaller.NewInstaller(
-		f.helmClient, f.timeout, spec.Autoscaler.Node,
+		f.helmClient, f.timeout, spec.Autoscaler.Node, haEnabled,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create cluster-autoscaler installer: %w", err)

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -118,7 +118,11 @@ func (f *Factory) GetImagesForCluster(
 	return GetImagesFromInstallers(ctx, installers)
 }
 
-func (f *Factory) addGitOpsInstaller(installers map[string]Installer, spec v1alpha1.ClusterSpec, haEnabled bool) {
+func (f *Factory) addGitOpsInstaller(
+	installers map[string]Installer,
+	spec v1alpha1.ClusterSpec,
+	haEnabled bool,
+) {
 	switch spec.GitOpsEngine {
 	case v1alpha1.GitOpsEngineFlux:
 		installers["flux"] = fluxinstaller.NewInstaller(
@@ -134,7 +138,11 @@ func (f *Factory) addGitOpsInstaller(installers map[string]Installer, spec v1alp
 	}
 }
 
-func (f *Factory) addCNIInstaller(installers map[string]Installer, spec v1alpha1.ClusterSpec, haEnabled bool) {
+func (f *Factory) addCNIInstaller(
+	installers map[string]Installer,
+	spec v1alpha1.ClusterSpec,
+	haEnabled bool,
+) {
 	switch spec.CNI {
 	case v1alpha1.CNICilium:
 		installers["cilium"] = ciliuminstaller.NewInstallerWithDistribution(
@@ -159,7 +167,11 @@ func (f *Factory) addPolicyEngineInstaller(
 	switch spec.PolicyEngine {
 	case v1alpha1.PolicyEngineKyverno:
 		installers["kyverno"] = kyvernoinstaller.NewInstaller(
-			f.helmClient, max(f.timeout, KyvernoInstallTimeout), f.kubeconfig, f.kubecontext, haEnabled,
+			f.helmClient,
+			max(f.timeout, KyvernoInstallTimeout),
+			f.kubeconfig,
+			f.kubecontext,
+			haEnabled,
 		)
 	case v1alpha1.PolicyEngineGatekeeper:
 		installers["gatekeeper"] = gatekeeperinstaller.NewInstaller(
@@ -200,7 +212,11 @@ func (f *Factory) addMetricsServerInstaller(
 	}
 }
 
-func (f *Factory) addCSIInstallers(installers map[string]Installer, cfg *v1alpha1.Cluster, haEnabled bool) {
+func (f *Factory) addCSIInstallers(
+	installers map[string]Installer,
+	cfg *v1alpha1.Cluster,
+	haEnabled bool,
+) {
 	spec := cfg.Spec.Cluster
 
 	if f.needsLocalPathStorage(spec) {

--- a/pkg/svc/installer/gatekeeper/installer.go
+++ b/pkg/svc/installer/gatekeeper/installer.go
@@ -35,11 +35,48 @@ type Installer struct {
 // wait. kubeContext is optional; if empty, the current context is used. Pass
 // an empty kubeconfig to disable webhook waiting (tests or environments
 // without cluster access).
+//
+// When haEnabled is true the chart is configured with HA defaults
+// (replicas, PDB, topology spread) for the controller-manager.
 func NewInstaller(
 	client helm.Interface,
 	kubeconfig, kubeContext string,
 	timeout time.Duration,
+	haEnabled bool,
 ) *Installer {
+	setValues := map[string]string{
+		// Disable the chart's CRD upgrade hooks. The hooks create
+		// a ServiceAccount that Helm v4's kstatus watcher cannot
+		// assess (ServiceAccounts have no .status field), causing
+		// the install to fail with "status: Unknown". CRDs are
+		// still managed natively by Helm via UpgradeCRDs above.
+		"upgradeCRDs.enabled": "false",
+		// Use Ignore so webhooks do not block API requests when
+		// webhook pods are temporarily unreachable (e.g. during
+		// CNI churn on freshly bootstrapped clusters). Both
+		// validating and mutating policies must be set explicitly
+		// to avoid intermittent kstatus watch timeouts in
+		// components installed in parallel (e.g. ArgoCD).
+		"webhook.failurePolicy":         "Ignore",
+		"mutatingWebhook.failurePolicy": "Ignore",
+	}
+
+	var valuesYaml string
+
+	if haEnabled {
+		setValues["replicas"] = "2"
+		setValues["pdb.controllerManager.minAvailable"] = "1"
+
+		valuesYaml = `controllerManager:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: gatekeeper`
+	}
+
 	return &Installer{
 		kubeconfig:  kubeconfig,
 		kubeContext: kubeContext,
@@ -64,22 +101,8 @@ func NewInstaller(
 				WaitForJobs:     true,
 				UpgradeCRDs:     true,
 				Timeout:         timeout,
-				SetValues: map[string]string{
-					// Disable the chart's CRD upgrade hooks. The hooks create
-					// a ServiceAccount that Helm v4's kstatus watcher cannot
-					// assess (ServiceAccounts have no .status field), causing
-					// the install to fail with "status: Unknown". CRDs are
-					// still managed natively by Helm via UpgradeCRDs above.
-					"upgradeCRDs.enabled": "false",
-					// Use Ignore so webhooks do not block API requests when
-					// webhook pods are temporarily unreachable (e.g. during
-					// CNI churn on freshly bootstrapped clusters). Both
-					// validating and mutating policies must be set explicitly
-					// to avoid intermittent kstatus watch timeouts in
-					// components installed in parallel (e.g. ArgoCD).
-					"webhook.failurePolicy":         "Ignore",
-					"mutatingWebhook.failurePolicy": "Ignore",
-				},
+				SetValues:       setValues,
+				ValuesYaml:      valuesYaml,
 			},
 		),
 	}

--- a/pkg/svc/installer/gatekeeper/installer_test.go
+++ b/pkg/svc/installer/gatekeeper/installer_test.go
@@ -36,7 +36,13 @@ func TestInstallSuccess(t *testing.T) {
 func TestInstallSuccessWithWebhookWait(t *testing.T) {
 	client := helm.NewMockInterface(t)
 	// Use a non-empty kubeconfig to trigger the webhook wait path.
-	installer := gatekeeperinstaller.NewInstaller(client, "/fake/kubeconfig", "", 2*time.Minute, false)
+	installer := gatekeeperinstaller.NewInstaller(
+		client,
+		"/fake/kubeconfig",
+		"",
+		2*time.Minute,
+		false,
+	)
 
 	webhookWaitCalled := false
 
@@ -62,7 +68,13 @@ func TestInstallSuccessWithWebhookWait(t *testing.T) {
 //nolint:paralleltest // Cannot run in parallel — modifies the package-level waitForWebhookReadyFn variable.
 func TestInstallWebhookWaitError(t *testing.T) {
 	client := helm.NewMockInterface(t)
-	installer := gatekeeperinstaller.NewInstaller(client, "/fake/kubeconfig", "", 2*time.Minute, false)
+	installer := gatekeeperinstaller.NewInstaller(
+		client,
+		"/fake/kubeconfig",
+		"",
+		2*time.Minute,
+		false,
+	)
 
 	restore := gatekeeperinstaller.SetWaitForWebhookReadyFn(
 		func(_ context.Context, _, _ string, _ time.Duration) error {

--- a/pkg/svc/installer/gatekeeper/installer_test.go
+++ b/pkg/svc/installer/gatekeeper/installer_test.go
@@ -16,7 +16,7 @@ func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := gatekeeperinstaller.NewInstaller(client, "", "", 5*time.Second)
+	installer := gatekeeperinstaller.NewInstaller(client, "", "", 5*time.Second, false)
 
 	assert.NotNil(t, installer)
 }
@@ -36,7 +36,7 @@ func TestInstallSuccess(t *testing.T) {
 func TestInstallSuccessWithWebhookWait(t *testing.T) {
 	client := helm.NewMockInterface(t)
 	// Use a non-empty kubeconfig to trigger the webhook wait path.
-	installer := gatekeeperinstaller.NewInstaller(client, "/fake/kubeconfig", "", 2*time.Minute)
+	installer := gatekeeperinstaller.NewInstaller(client, "/fake/kubeconfig", "", 2*time.Minute, false)
 
 	webhookWaitCalled := false
 
@@ -62,7 +62,7 @@ func TestInstallSuccessWithWebhookWait(t *testing.T) {
 //nolint:paralleltest // Cannot run in parallel — modifies the package-level waitForWebhookReadyFn variable.
 func TestInstallWebhookWaitError(t *testing.T) {
 	client := helm.NewMockInterface(t)
-	installer := gatekeeperinstaller.NewInstaller(client, "/fake/kubeconfig", "", 2*time.Minute)
+	installer := gatekeeperinstaller.NewInstaller(client, "/fake/kubeconfig", "", 2*time.Minute, false)
 
 	restore := gatekeeperinstaller.SetWaitForWebhookReadyFn(
 		func(_ context.Context, _, _ string, _ time.Duration) error {
@@ -140,7 +140,7 @@ func newInstallerWithDefaults(
 
 	client := helm.NewMockInterface(t)
 	// Pass empty kubeconfig so the webhook wait is skipped in unit tests.
-	installer := gatekeeperinstaller.NewInstaller(client, "", "", 2*time.Minute)
+	installer := gatekeeperinstaller.NewInstaller(client, "", "", 2*time.Minute, false)
 
 	return installer, client
 }

--- a/pkg/svc/installer/hcloudccm/export_test.go
+++ b/pkg/svc/installer/hcloudccm/export_test.go
@@ -1,7 +1,18 @@
 package hcloudccminstaller
 
-// BuildValuesYamlForTest exports buildValuesYaml for testing.
-var BuildValuesYamlForTest = func(networkName string) string { return buildValuesYaml(networkName, false) } //nolint:gochecknoglobals // Standard Go export_test.go pattern.
+// BuildValuesYamlForTest exports buildValuesYaml for testing (haEnabled=false).
+//
+//nolint:gochecknoglobals // Standard Go export_test.go pattern.
+var BuildValuesYamlForTest = func(networkName string) string {
+	return buildValuesYaml(networkName, false)
+}
+
+// BuildValuesYamlHAForTest exports buildValuesYaml for testing (haEnabled=true).
+//
+//nolint:gochecknoglobals // Standard Go export_test.go pattern.
+var BuildValuesYamlHAForTest = func(networkName string) string {
+	return buildValuesYaml(networkName, true)
+}
 
 // BuildSecretDataForTest exports buildSecretData for testing.
 var BuildSecretDataForTest = buildSecretData //nolint:gochecknoglobals // Standard Go export_test.go pattern.

--- a/pkg/svc/installer/hcloudccm/export_test.go
+++ b/pkg/svc/installer/hcloudccm/export_test.go
@@ -1,7 +1,7 @@
 package hcloudccminstaller
 
 // BuildValuesYamlForTest exports buildValuesYaml for testing.
-var BuildValuesYamlForTest = buildValuesYaml //nolint:gochecknoglobals // Standard Go export_test.go pattern.
+var BuildValuesYamlForTest = func(networkName string) string { return buildValuesYaml(networkName, false) } //nolint:gochecknoglobals // Standard Go export_test.go pattern.
 
 // BuildSecretDataForTest exports buildSecretData for testing.
 var BuildSecretDataForTest = buildSecretData //nolint:gochecknoglobals // Standard Go export_test.go pattern.

--- a/pkg/svc/installer/hcloudccm/installer.go
+++ b/pkg/svc/installer/hcloudccm/installer.go
@@ -1,6 +1,7 @@
 package hcloudccminstaller
 
 import (
+	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
@@ -92,10 +93,5 @@ func buildValuesYaml(networkName string, haEnabled bool) string {
 		return ""
 	}
 
-	result := parts[0]
-	for _, p := range parts[1:] {
-		result += "\n" + p
-	}
-
-	return result
+	return strings.Join(parts, "\n")
 }

--- a/pkg/svc/installer/hcloudccm/installer.go
+++ b/pkg/svc/installer/hcloudccm/installer.go
@@ -38,18 +38,22 @@ const DefaultClusterCIDR = "10.244.0.0/16"
 // When networkName is set, the network name is stored in the shared "hcloud"
 // Kubernetes secret (key "network") so the chart's default
 // valueFrom.secretKeyRef can read it as HCLOUD_NETWORK.
+//
+// When haEnabled is true the chart is configured with replicaCount=2
+// for fast failover via leader election.
 func NewInstaller(
 	client helm.Interface,
 	kubeconfig, context string,
 	timeout time.Duration,
 	networkName string,
+	haEnabled bool,
 ) *Installer {
 	return hetzner.NewInstaller(client, kubeconfig, context, timeout, hetzner.ChartConfig{
 		Name:        "hcloud-ccm",
 		ReleaseName: "hcloud-cloud-controller-manager",
 		ChartName:   "hcloud/hcloud-cloud-controller-manager",
 		Version:     chartVersion(),
-		ValuesYaml:  buildValuesYaml(networkName),
+		ValuesYaml:  buildValuesYaml(networkName, haEnabled),
 		SecretData:  buildSecretData(networkName),
 	})
 }
@@ -72,10 +76,26 @@ func buildSecretData(networkName string) map[string][]byte {
 // HCLOUD_NETWORK is injected into the CCM pod. The network name itself is
 // stored in the "hcloud" Kubernetes secret (key "network") and read by the
 // chart's default valueFrom.secretKeyRef — no inline value override is needed.
-func buildValuesYaml(networkName string) string {
-	if networkName == "" {
+// When haEnabled is true an extra standby replica is configured.
+func buildValuesYaml(networkName string, haEnabled bool) string {
+	var parts []string
+
+	if networkName != "" {
+		parts = append(parts, "networking:\n  enabled: true\n  clusterCIDR: "+DefaultClusterCIDR)
+	}
+
+	if haEnabled {
+		parts = append(parts, "replicaCount: 2")
+	}
+
+	if len(parts) == 0 {
 		return ""
 	}
 
-	return "networking:\n  enabled: true\n  clusterCIDR: " + DefaultClusterCIDR
+	result := parts[0]
+	for _, p := range parts[1:] {
+		result += "\n" + p
+	}
+
+	return result
 }

--- a/pkg/svc/installer/hcloudccm/installer_test.go
+++ b/pkg/svc/installer/hcloudccm/installer_test.go
@@ -22,7 +22,7 @@ func TestNewInstaller(t *testing.T) {
 			mockClient := helm.NewMockInterface(t)
 			installer := hcloudccminstaller.NewInstaller(
 				mockClient, testCase.kubeconfig, testCase.context, testCase.timeout,
-				testCase.networkName,
+				testCase.networkName, false,
 			)
 
 			if testCase.wantNil {

--- a/pkg/svc/installer/hcloudccm/installer_test.go
+++ b/pkg/svc/installer/hcloudccm/installer_test.go
@@ -65,6 +65,18 @@ func newInstallerTestCases() []installerTestCase {
 	}
 }
 
+func TestNewInstaller_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	mockClient := helm.NewMockInterface(t)
+	installer := hcloudccminstaller.NewInstaller(
+		mockClient, "/path/to/kubeconfig", "test-context",
+		5*time.Minute, "dev-network", true,
+	)
+
+	require.NotNil(t, installer)
+}
+
 func TestErrHetznerTokenNotSet(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/hcloudccm/network_test.go
+++ b/pkg/svc/installer/hcloudccm/network_test.go
@@ -60,6 +60,48 @@ func TestBuildValuesYaml(t *testing.T) {
 	}
 }
 
+func TestBuildValuesYaml_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		networkName string
+		wantContain []string
+	}{
+		{
+			name:        "HA enabled without network name",
+			networkName: "",
+			wantContain: []string{
+				"replicaCount: 2",
+			},
+		},
+		{
+			name:        "HA enabled with network name",
+			networkName: "dev-network",
+			wantContain: []string{
+				"replicaCount: 2",
+				"networking:",
+				"enabled: true",
+				"clusterCIDR: " + hcloudccminstaller.DefaultClusterCIDR,
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hcloudccminstaller.BuildValuesYamlHAForTest(testCase.networkName)
+
+			require.NotEmpty(t, result)
+
+			for _, s := range testCase.wantContain {
+				assert.Contains(t, result, s)
+			}
+		})
+	}
+}
+
 func TestBuildSecretData(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/helpers.go
+++ b/pkg/svc/installer/helpers.go
@@ -7,6 +7,12 @@ import (
 )
 
 const (
+	// HANodeThreshold is the minimum number of nodes (control-planes + workers) required
+	// to enable HA defaults (replicas ≥ 2, PDB, topology spread) on bootstrap components.
+	// Below this threshold no HA values are injected, keeping single-/dual-node dev
+	// clusters safe from unschedulable pods.
+	HANodeThreshold int32 = 3
+
 	// DefaultInstallTimeout is the default timeout (5 minutes) for component installation.
 	DefaultInstallTimeout = 5 * time.Minute
 	// TalosInstallTimeout is the timeout (8 minutes) for Talos component installation.
@@ -91,4 +97,10 @@ func GetInstallTimeout(clusterCfg *v1alpha1.Cluster) time.Duration {
 	}
 
 	return DefaultInstallTimeout
+}
+
+// IsHAEnabled reports whether the cluster has enough nodes to benefit from
+// HA defaults on bootstrap components.
+func IsHAEnabled(nodeCount int32) bool {
+	return nodeCount >= HANodeThreshold
 }

--- a/pkg/svc/installer/hetznercsi/installer.go
+++ b/pkg/svc/installer/hetznercsi/installer.go
@@ -46,6 +46,10 @@ type Installer struct {
 // which is required by GitOps-managed CCM HelmReleases that read HCLOUD_NETWORK
 // from this secret via the chart's default valueFrom.secretKeyRef.
 //
+// When haEnabled is true the CSI controller Deployment is configured
+// with controller.replicaCount=2 for fast failover via leader election.
+// The node plugin DaemonSet is inherently HA and not affected.
+//
 // An empty networkName leaves the "network" key untouched so concurrent
 // installers (e.g. CCM) don't overwrite each other's values.
 func NewInstaller(
@@ -53,12 +57,19 @@ func NewInstaller(
 	kubeconfig, kubeContext string,
 	timeout time.Duration,
 	networkName string,
+	haEnabled bool,
 ) *Installer {
+	var valuesYaml string
+	if haEnabled {
+		valuesYaml = "controller:\n  replicaCount: 2"
+	}
+
 	base := hetzner.NewInstaller(client, kubeconfig, kubeContext, timeout, hetzner.ChartConfig{
 		Name:        "hetzner-csi",
 		ReleaseName: "hcloud-csi",
 		ChartName:   "hcloud/hcloud-csi",
 		Version:     chartVersion(),
+		ValuesYaml:  valuesYaml,
 		SecretData:  buildSecretData(networkName),
 	})
 

--- a/pkg/svc/installer/hetznercsi/installer_test.go
+++ b/pkg/svc/installer/hetznercsi/installer_test.go
@@ -39,6 +39,7 @@ func TestNewInstaller(t *testing.T) {
 				"test-context",
 				timeout,
 				testCase.networkName,
+				false,
 			)
 
 			assert.NotNil(t, installer)
@@ -102,6 +103,7 @@ func TestHetznerCSIInstaller_Uninstall(t *testing.T) {
 		"test-context",
 		timeout,
 		"",
+		false,
 	)
 	err := installer.Uninstall(context.Background())
 
@@ -145,6 +147,7 @@ func TestHetznerCSIInstaller_Install_WaitsForCCMLabels(t *testing.T) {
 		"test-context",
 		timeout,
 		"",
+		false,
 	)
 
 	err := installer.Install(context.Background())

--- a/pkg/svc/installer/kubeletcsrapprover/installer.go
+++ b/pkg/svc/installer/kubeletcsrapprover/installer.go
@@ -15,10 +15,20 @@ type Installer struct {
 }
 
 // NewInstaller creates a new kubelet-csr-approver installer instance.
+// When haEnabled is true the chart is configured with replicas=2
+// for fast failover via leader election.
 func NewInstaller(
 	client helm.Interface,
 	timeout time.Duration,
+	haEnabled bool,
 ) *Installer {
+	valuesYaml := `providerRegex: ".*"
+bypassDnsResolution: true`
+
+	if haEnabled {
+		valuesYaml += "\nreplicas: 2"
+	}
+
 	return &Installer{
 		Base: helmutil.NewBase(
 			"kubelet-csr-approver",
@@ -40,8 +50,7 @@ func NewInstaller(
 				Timeout:     timeout,
 				// Use providerRegex to allow CSRs from any provider (DNS/IP SANs)
 				// This is safe in local development clusters where kubelet identities are trusted
-				ValuesYaml: `providerRegex: ".*"
-bypassDnsResolution: true`,
+				ValuesYaml: valuesYaml,
 			},
 		),
 	}

--- a/pkg/svc/installer/kubeletcsrapprover/installer_test.go
+++ b/pkg/svc/installer/kubeletcsrapprover/installer_test.go
@@ -17,7 +17,7 @@ func TestNewInstaller(t *testing.T) {
 
 	timeout := 5 * time.Minute
 	client := helm.NewMockInterface(t)
-	installer := kubeletcsrapproverinstaller.NewInstaller(client, timeout)
+	installer := kubeletcsrapproverinstaller.NewInstaller(client, timeout, false)
 
 	assert.NotNil(t, installer)
 }
@@ -94,7 +94,7 @@ func newKubeletCSRApproverInstallerWithDefaults(
 
 	timeout := 5 * time.Second
 	client := helm.NewMockInterface(t)
-	installer := kubeletcsrapproverinstaller.NewInstaller(client, timeout)
+	installer := kubeletcsrapproverinstaller.NewInstaller(client, timeout, false)
 
 	return installer, client
 }

--- a/pkg/svc/installer/kubeletcsrapprover/installer_test.go
+++ b/pkg/svc/installer/kubeletcsrapprover/installer_test.go
@@ -22,6 +22,40 @@ func TestNewInstaller(t *testing.T) {
 	assert.NotNil(t, installer)
 }
 
+func TestNewInstaller_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer := kubeletcsrapproverinstaller.NewInstaller(client, 5*time.Minute, true)
+
+	require.NotNil(t, installer)
+}
+
+func TestKubeletCSRApproverInstaller_HAEnabled_InstallSuccess(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer := kubeletcsrapproverinstaller.NewInstaller(client, 5*time.Second, true)
+	expectKubeletCSRApproverAddRepository(t, client, nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(
+			mock.Anything,
+			mock.MatchedBy(func(spec *helm.ChartSpec) bool {
+				assert.Equal(t, "kubelet-csr-approver", spec.ReleaseName)
+				assert.Contains(t, spec.ValuesYaml, "providerRegex")
+				assert.Contains(t, spec.ValuesYaml, "bypassDnsResolution")
+				assert.Contains(t, spec.ValuesYaml, "replicas: 2")
+
+				return true
+			}),
+		).
+		Return(nil, nil)
+
+	err := installer.Install(context.Background())
+
+	require.NoError(t, err)
+}
+
 func TestKubeletCSRApproverInstallerInstallSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/kubeletcsrapprover/installer_test.go
+++ b/pkg/svc/installer/kubeletcsrapprover/installer_test.go
@@ -36,6 +36,9 @@ func TestKubeletCSRApproverInstaller_HAEnabled_InstallSuccess(t *testing.T) {
 
 	client := helm.NewMockInterface(t)
 	installer := kubeletcsrapproverinstaller.NewInstaller(client, 5*time.Second, true)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	expectKubeletCSRApproverAddRepository(t, client, nil)
 	client.EXPECT().
 		InstallOrUpgradeChart(

--- a/pkg/svc/installer/kyverno/installer.go
+++ b/pkg/svc/installer/kyverno/installer.go
@@ -26,11 +26,40 @@ type Installer struct {
 // NewInstaller creates a new Kyverno installer instance.
 // kubeconfig and kubecontext are used after Helm install to wait for the Kyverno
 // admission webhook to be ready before returning.
+// When haEnabled is true the chart is configured with HA defaults
+// (replicas, PDB, topology spread) for the admission controller.
 func NewInstaller(
 	client helm.Interface,
 	timeout time.Duration,
 	kubeconfig, kubecontext string,
+	haEnabled bool,
 ) *Installer {
+	setValues := map[string]string{
+		// Use Ignore so the admission webhook does not block
+		// API requests when webhook pods are temporarily
+		// unreachable (e.g. during bootstrap or CNI churn).
+		// The chart default is Fail, which can cause cascading
+		// failures for components installed in parallel.
+		"admissionController.webhookServer.failurePolicy": "Ignore",
+	}
+
+	var valuesYaml string
+
+	if haEnabled {
+		setValues["admissionController.replicas"] = "2"
+		setValues["admissionController.podDisruptionBudget.enabled"] = "true"
+		setValues["admissionController.podDisruptionBudget.minAvailable"] = "1"
+
+		valuesYaml = `admissionController:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: admission-controller`
+	}
+
 	return &Installer{
 		Base: helmutil.NewBase(
 			"kyverno",
@@ -51,14 +80,8 @@ func NewInstaller(
 				Wait:            true,
 				WaitForJobs:     true,
 				Timeout:         timeout,
-				SetValues: map[string]string{
-					// Use Ignore so the admission webhook does not block
-					// API requests when webhook pods are temporarily
-					// unreachable (e.g. during bootstrap or CNI churn).
-					// The chart default is Fail, which can cause cascading
-					// failures for components installed in parallel.
-					"admissionController.webhookServer.failurePolicy": "Ignore",
-				},
+				SetValues:       setValues,
+				ValuesYaml:      valuesYaml,
 			},
 		),
 		kubeconfig:  kubeconfig,

--- a/pkg/svc/installer/kyverno/installer_test.go
+++ b/pkg/svc/installer/kyverno/installer_test.go
@@ -20,7 +20,7 @@ func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 
 	client := helm.NewMockInterface(t)
-	installer := kyvernoinstaller.NewInstaller(client, 5*time.Second, "", "")
+	installer := kyvernoinstaller.NewInstaller(client, 5*time.Second, "", "", false)
 
 	assert.NotNil(t, installer)
 }
@@ -103,7 +103,7 @@ func newInstallerWithDefaults(
 	t.Helper()
 
 	client := helm.NewMockInterface(t)
-	installer := kyvernoinstaller.NewInstaller(client, 2*time.Minute, "", "")
+	installer := kyvernoinstaller.NewInstaller(client, 2*time.Minute, "", "", false)
 
 	return installer, client
 }

--- a/pkg/svc/installer/metricsserver/installer.go
+++ b/pkg/svc/installer/metricsserver/installer.go
@@ -46,8 +46,8 @@ func NewInstallerWithDistribution(
 	var setValues map[string]string
 	if haEnabled {
 		setValues = map[string]string{
-			"replicas":                       "2",
-			"podDisruptionBudget.enabled":    "true",
+			"replicas":                         "2",
+			"podDisruptionBudget.enabled":      "true",
 			"podDisruptionBudget.minAvailable": "1",
 		}
 	}

--- a/pkg/svc/installer/metricsserver/installer.go
+++ b/pkg/svc/installer/metricsserver/installer.go
@@ -20,7 +20,7 @@ func NewInstaller(
 	client helm.Interface,
 	timeout time.Duration,
 ) *Installer {
-	return NewInstallerWithDistribution(client, timeout, "")
+	return NewInstallerWithDistribution(client, timeout, "", false)
 }
 
 // NewInstallerWithDistribution creates a new metrics-server installer instance
@@ -32,12 +32,25 @@ func NewInstaller(
 // --authentication-tolerate-lookup-failure is always set to prevent metrics-server
 // from panicking when the API server is transiently unreachable at startup (e.g. Cilium
 // eBPF service map not yet fully programmed for the pod's network namespace).
+//
+// When haEnabled is true the chart is configured with HA defaults
+// (replicas, PDB, topology spread).
 func NewInstallerWithDistribution(
 	client helm.Interface,
 	timeout time.Duration,
 	distribution v1alpha1.Distribution,
+	haEnabled bool,
 ) *Installer {
-	valuesYaml := buildValuesYaml(distribution)
+	valuesYaml := buildValuesYaml(distribution, haEnabled)
+
+	var setValues map[string]string
+	if haEnabled {
+		setValues = map[string]string{
+			"replicas":                       "2",
+			"podDisruptionBudget.enabled":    "true",
+			"podDisruptionBudget.minAvailable": "1",
+		}
+	}
 
 	return &Installer{
 		Base: helmutil.NewBase(
@@ -58,6 +71,7 @@ func NewInstallerWithDistribution(
 				Wait:        true,
 				WaitForJobs: true,
 				Timeout:     timeout,
+				SetValues:   setValues,
 				ValuesYaml:  valuesYaml,
 			},
 		),
@@ -65,8 +79,8 @@ func NewInstallerWithDistribution(
 }
 
 // buildValuesYaml returns the Helm values YAML for metrics-server,
-// adjusted for the target distribution.
-func buildValuesYaml(distribution v1alpha1.Distribution) string {
+// adjusted for the target distribution and HA configuration.
+func buildValuesYaml(distribution v1alpha1.Distribution, haEnabled bool) string {
 	// Use InternalIP for node communication in local development clusters.
 	// Secure TLS is enabled by default - kubelet-csr-approver handles certificate approval.
 	// Tolerate transient auth lookup failures so metrics-server retries rather than
@@ -79,6 +93,17 @@ func buildValuesYaml(distribution v1alpha1.Distribution) string {
 	// self-signed TLS certificates that metrics-server cannot verify.
 	if distribution == v1alpha1.DistributionVCluster {
 		base += "\n  - --kubelet-insecure-tls"
+	}
+
+	if haEnabled {
+		base += `
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: metrics-server`
 	}
 
 	return base

--- a/pkg/svc/installer/metricsserver/installer_test.go
+++ b/pkg/svc/installer/metricsserver/installer_test.go
@@ -37,6 +37,7 @@ func TestNewInstallerWithDistribution(t *testing.T) {
 		client,
 		timeout,
 		v1alpha1.DistributionVCluster,
+		false,
 	)
 
 	assert.NotNil(t, installer)
@@ -52,6 +53,7 @@ func TestNewInstallerWithDistributionNonVCluster(t *testing.T) {
 		client,
 		timeout,
 		v1alpha1.DistributionVanilla,
+		false,
 	)
 
 	assert.NotNil(t, installer)
@@ -98,7 +100,7 @@ func TestMetricsServerInstallerInstallAddRepositoryError(t *testing.T) {
 func TestBuildValuesYaml_VCluster(t *testing.T) {
 	t.Parallel()
 
-	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionVCluster)
+	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionVCluster, false)
 
 	assert.Contains(t, yaml, "--kubelet-preferred-address-types=InternalIP")
 	assert.Contains(t, yaml, "--kubelet-insecure-tls")
@@ -107,7 +109,7 @@ func TestBuildValuesYaml_VCluster(t *testing.T) {
 func TestBuildValuesYaml_Vanilla(t *testing.T) {
 	t.Parallel()
 
-	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionVanilla)
+	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionVanilla, false)
 
 	assert.Contains(t, yaml, "--kubelet-preferred-address-types=InternalIP")
 	assert.NotContains(t, yaml, "--kubelet-insecure-tls")
@@ -116,7 +118,7 @@ func TestBuildValuesYaml_Vanilla(t *testing.T) {
 func TestBuildValuesYaml_K3s(t *testing.T) {
 	t.Parallel()
 
-	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionK3s)
+	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionK3s, false)
 
 	assert.Contains(t, yaml, "--kubelet-preferred-address-types=InternalIP")
 	assert.NotContains(t, yaml, "--kubelet-insecure-tls")
@@ -162,6 +164,7 @@ func newMetricsServerInstallerWithDistribution(
 		client,
 		timeout,
 		distribution,
+		false,
 	)
 
 	return installer, client

--- a/pkg/svc/installer/metricsserver/installer_test.go
+++ b/pkg/svc/installer/metricsserver/installer_test.go
@@ -124,6 +124,41 @@ func TestBuildValuesYaml_K3s(t *testing.T) {
 	assert.NotContains(t, yaml, "--kubelet-insecure-tls")
 }
 
+func TestBuildValuesYaml_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionVanilla, true)
+
+	assert.Contains(t, yaml, "--kubelet-preferred-address-types=InternalIP")
+	assert.Contains(t, yaml, "topologySpreadConstraints")
+	assert.Contains(t, yaml, "kubernetes.io/hostname")
+	assert.Contains(t, yaml, "ScheduleAnyway")
+}
+
+func TestBuildValuesYaml_HADisabled(t *testing.T) {
+	t.Parallel()
+
+	yaml := metricsserverinstaller.BuildValuesYaml(v1alpha1.DistributionVanilla, false)
+
+	assert.NotContains(t, yaml, "topologySpreadConstraints")
+}
+
+func TestNewInstallerWithDistribution_HAEnabled(t *testing.T) {
+	t.Parallel()
+
+	timeout := 5 * time.Minute
+
+	client := helm.NewMockInterface(t)
+	inst := metricsserverinstaller.NewInstallerWithDistribution(
+		client,
+		timeout,
+		v1alpha1.DistributionVanilla,
+		true,
+	)
+
+	assert.NotNil(t, inst)
+}
+
 func TestMetricsServerInstallerInstallVClusterSuccess(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

When the cluster has 3+ nodes (`ControlPlanes + Workers >= 3`), all Helm-based component installers now set HA defaults:

- **Replicas ≥ 2** for fast failover
- **PodDisruptionBudgets** with `minAvailable: 1`
- **Topology spread constraints** (`whenUnsatisfiable: ScheduleAnyway` by `kubernetes.io/hostname`)

Below the threshold, no HA values are added — safe for local dev clusters.

## Components Updated

| Component | HA Values |
|---|---|
| cert-manager | controller + webhook replicas=2, PDB, topology spread |
| metrics-server | replicas=2, PDB, topology spread |
| Kyverno | admissionController replicas=2, PDB, topology spread |
| Gatekeeper | replicas=2, PDB, topology spread |
| ArgoCD | server + repoServer replicas=2, PDB |
| Cilium | operator replicas=2 |
| Calico | Typha controlPlaneReplicas=2 |
| kubelet-csr-approver | replicas=2 |
| cluster-autoscaler | replicas=2 |
| hcloud-ccm | replicaCount=2 |
| hetzner-csi | controller replicaCount=2 |

**Skipped (by design):**
- Flux Operator — single-replica with leader election, no chart support
- MetalLB — controller is single-replica only, speaker is DaemonSet
- DaemonSet components — inherently HA

## Design Decisions

- **HA threshold**: `ControlPlanes + Workers >= 3` (constant `HANodeThreshold`)
- **Topology spread**: `ScheduleAnyway` (soft) — avoids scheduling failures while preferring spread
- **Architecture**: Factory computes `haEnabled` once and passes the boolean to all constructors, avoiding circular dependencies

Fixes #4525