### PR TITLE
fix: wire cluster-autoscaler installer and config secret

### DIFF
--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -153,6 +153,12 @@ type OptionsHetzner struct {
 	// deletion so that autoscaler-managed nodes are cleaned up alongside
 	// KSail-managed nodes.
 	AutoscalerNodePoolNames []string `json:"autoscalerNodePoolNames,omitzero"`
+	// NodeAutoscalerEnabled is set by the cluster factory when
+	// spec.cluster.autoscaler.node.enabled (or deprecated nodeAutoscaling)
+	// is true. The Talos provisioner reads this to decide whether to create
+	// the cluster-autoscaler-config Secret during bootstrap.
+	// Not user-facing in ksail.yaml — derived at runtime.
+	NodeAutoscalerEnabled bool `json:"-"`
 }
 
 // OptionsOmni defines options specific to the Sidero Omni provider.

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -30,11 +30,13 @@ var (
 	ErrKubeletCSRApproverInstallerFactoryNil = errors.New(
 		"kubelet-csr-approver installer factory is nil",
 	)
-	ErrCSIInstallerFactoryNil                  = errors.New("CSI installer factory is nil")
-	ErrPolicyEngineInstallerFactoryNil         = errors.New("policy engine installer factory is nil")
-	ErrPolicyEngineDisabled                    = errors.New("policy engine is disabled")
-	ErrClusterConfigNil                        = errors.New("cluster config is nil")
-	ErrClusterAutoscalerInstallerFactoryNil    = errors.New("cluster-autoscaler installer factory is nil")
+	ErrCSIInstallerFactoryNil               = errors.New("CSI installer factory is nil")
+	ErrPolicyEngineInstallerFactoryNil      = errors.New("policy engine installer factory is nil")
+	ErrPolicyEngineDisabled                 = errors.New("policy engine is disabled")
+	ErrClusterConfigNil                     = errors.New("cluster config is nil")
+	ErrClusterAutoscalerInstallerFactoryNil = errors.New(
+		"cluster-autoscaler installer factory is nil",
+	)
 )
 
 // InstallerFactories holds factory functions for creating component installers.

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	argocdinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/argocd"
 	certmanagerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/certmanager"
+	clusterautoscalerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/clusterautoscaler"
 	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
 	gatekeeperinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/gatekeeper"
 	hcloudccminstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/hcloudccm"
@@ -29,10 +30,11 @@ var (
 	ErrKubeletCSRApproverInstallerFactoryNil = errors.New(
 		"kubelet-csr-approver installer factory is nil",
 	)
-	ErrCSIInstallerFactoryNil          = errors.New("CSI installer factory is nil")
-	ErrPolicyEngineInstallerFactoryNil = errors.New("policy engine installer factory is nil")
-	ErrPolicyEngineDisabled            = errors.New("policy engine is disabled")
-	ErrClusterConfigNil                = errors.New("cluster config is nil")
+	ErrCSIInstallerFactoryNil                  = errors.New("CSI installer factory is nil")
+	ErrPolicyEngineInstallerFactoryNil         = errors.New("policy engine installer factory is nil")
+	ErrPolicyEngineDisabled                    = errors.New("policy engine is disabled")
+	ErrClusterConfigNil                        = errors.New("cluster config is nil")
+	ErrClusterAutoscalerInstallerFactoryNil    = errors.New("cluster-autoscaler installer factory is nil")
 )
 
 // InstallerFactories holds factory functions for creating component installers.
@@ -44,6 +46,7 @@ type InstallerFactories struct {
 	PolicyEngine       func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
 	ArgoCD             func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
 	KubeletCSRApprover func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	ClusterAutoscaler  func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
 	// EnsureArgoCDResources configures default Argo CD resources post-install.
 	EnsureArgoCDResources func(
 		ctx context.Context, kubeconfig string, clusterCfg *v1alpha1.Cluster, clusterName string,
@@ -170,6 +173,27 @@ func csiFactory(
 	}
 }
 
+// clusterAutoscalerFactory creates the Cluster Autoscaler factory function.
+func clusterAutoscalerFactory(
+	factories *InstallerFactories,
+) func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
+	return func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error) {
+		helmClient, _, err := factories.HelmClientFactory(clusterCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		timeout := installer.GetInstallTimeout(clusterCfg)
+		haEnabled := installer.IsHAEnabled(
+			clusterCfg.Spec.Cluster.ControlPlanes + clusterCfg.Spec.Cluster.Workers,
+		)
+
+		return clusterautoscalerinstaller.NewInstaller(
+			helmClient, timeout, clusterCfg.Spec.Cluster.Autoscaler.Node, haEnabled,
+		)
+	}
+}
+
 // resolveHelmClientAndTimeout creates a Helm client and computes the
 // effective install timeout for the given cluster configuration.
 func resolveHelmClientAndTimeout(
@@ -270,6 +294,7 @@ func DefaultInstallerFactories() *InstallerFactories {
 	)
 	factories.CSI = csiFactory(factories)
 	factories.PolicyEngine = policyEngineFactory(factories)
+	factories.ClusterAutoscaler = clusterAutoscalerFactory(factories)
 
 	factories.EnsureArgoCDResources = EnsureArgoCDResources
 	factories.EnsureFluxResources = fluxinstaller.EnsureDefaultResources

--- a/pkg/cli/setup/components_factories_test.go
+++ b/pkg/cli/setup/components_factories_test.go
@@ -436,30 +436,7 @@ func TestClusterAutoscalerFactory(t *testing.T) {
 				}
 			}
 
-			clusterCfg := &v1alpha1.Cluster{
-				Spec: v1alpha1.Spec{
-					Cluster: v1alpha1.ClusterSpec{
-						Distribution: v1alpha1.DistributionTalos,
-						Provider:     v1alpha1.ProviderHetzner,
-						Autoscaler: v1alpha1.AutoscalerConfig{
-							Node: v1alpha1.NodeAutoscalerConfig{
-								Enabled: true,
-								Pools: []v1alpha1.NodePool{
-									{
-										Name:       "worker",
-										ServerType: "cx22",
-										Location:   "fsn1",
-										Min:        1,
-										Max:        5,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-
-			inst, err := factories.ClusterAutoscaler(clusterCfg)
+			inst, err := factories.ClusterAutoscaler(newAutoscalerClusterConfig())
 
 			if testCase.expectErr {
 				require.Error(t, err)
@@ -469,6 +446,31 @@ func TestClusterAutoscalerFactory(t *testing.T) {
 				assert.NotNil(t, inst)
 			}
 		})
+	}
+}
+
+func newAutoscalerClusterConfig() *v1alpha1.Cluster {
+	return &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionTalos,
+				Provider:     v1alpha1.ProviderHetzner,
+				Autoscaler: v1alpha1.AutoscalerConfig{
+					Node: v1alpha1.NodeAutoscalerConfig{
+						Enabled: true,
+						Pools: []v1alpha1.NodePool{
+							{
+								Name:       "worker",
+								ServerType: "cx22",
+								Location:   "fsn1",
+								Min:        1,
+								Max:        5,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/cli/setup/components_factories_test.go
+++ b/pkg/cli/setup/components_factories_test.go
@@ -398,3 +398,92 @@ func TestInstallPolicyEngineSilent_InstallError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "install failed")
 }
+
+// TestClusterAutoscalerFactory exercises the cluster autoscaler factory returned by
+// DefaultInstallerFactories. It tests Talos×Hetzner with autoscaler config and
+// helm client errors.
+func TestClusterAutoscalerFactory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		helmErr   error
+		expectErr bool
+	}{
+		{
+			name:      "creates installer with valid config",
+			expectErr: false,
+		},
+		{
+			name:      "helm client error propagates",
+			helmErr:   errTestHelmFactory,
+			expectErr: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			factories := setup.DefaultInstallerFactories()
+			if testCase.helmErr != nil {
+				factories.HelmClientFactory = func(_ *v1alpha1.Cluster) (*helm.Client, string, error) {
+					return nil, "", testCase.helmErr
+				}
+			} else {
+				factories.HelmClientFactory = func(_ *v1alpha1.Cluster) (*helm.Client, string, error) {
+					return nil, testKubeconfig, nil
+				}
+			}
+
+			clusterCfg := &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution: v1alpha1.DistributionTalos,
+						Provider:     v1alpha1.ProviderHetzner,
+						Autoscaler: v1alpha1.AutoscalerConfig{
+							Node: v1alpha1.NodeAutoscalerConfig{
+								Enabled: true,
+								Pools: []v1alpha1.NodePool{
+									{
+										Name:       "worker",
+										ServerType: "cx22",
+										Location:   "fsn1",
+										Min:        1,
+										Max:        5,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			inst, err := factories.ClusterAutoscaler(clusterCfg)
+
+			if testCase.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, inst)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, inst)
+			}
+		})
+	}
+}
+
+// TestInstallClusterAutoscalerSilent_NilFactory verifies error when factory is nil.
+func TestInstallClusterAutoscalerSilent_NilFactory(t *testing.T) {
+	t.Parallel()
+
+	factories := &setup.InstallerFactories{}
+
+	err := setup.InstallClusterAutoscalerSilent(
+		t.Context(),
+		&v1alpha1.Cluster{},
+		factories,
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, setup.ErrClusterAutoscalerInstallerFactoryNil)
+}

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -131,6 +131,22 @@ func NeedsLoadBalancerInstall(clusterCfg *v1alpha1.Cluster) bool {
 	return !dist.ProvidesLoadBalancerByDefault(provider)
 }
 
+// NeedsClusterAutoscalerInstall determines if the Cluster Autoscaler needs to be installed.
+// The Cluster Autoscaler is only supported for Talos clusters on Hetzner Cloud
+// with node autoscaling explicitly enabled.
+func NeedsClusterAutoscalerInstall(clusterCfg *v1alpha1.Cluster) bool {
+	if clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionTalos {
+		return false
+	}
+
+	if clusterCfg.Spec.Cluster.Provider != v1alpha1.ProviderHetzner {
+		return false
+	}
+
+	return clusterCfg.Spec.Cluster.Autoscaler.Node.Enabled ||
+		clusterCfg.Spec.Cluster.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled
+}
+
 // helmClientSetup creates a Helm client and retrieves the install timeout.
 func helmClientSetup(
 	clusterCfg *v1alpha1.Cluster,
@@ -352,6 +368,18 @@ func InstallPolicyEngineSilent(
 	return installFromFactory(
 		ctx, clusterCfg, factories.PolicyEngine,
 		ErrPolicyEngineInstallerFactoryNil, "policy-engine",
+	)
+}
+
+// InstallClusterAutoscalerSilent installs the Cluster Autoscaler silently for parallel execution.
+func InstallClusterAutoscalerSilent(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+) error {
+	return installFromFactory(
+		ctx, clusterCfg, factories.ClusterAutoscaler,
+		ErrClusterAutoscalerInstallerFactoryNil, "cluster-autoscaler",
 	)
 }
 

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -655,7 +655,11 @@ func buildInfrastructureTasks(
 		{needed: reqs.NeedsCSI, name: "csi", fn: InstallCSISilent},
 		{needed: reqs.NeedsCertManager, name: "cert-manager", fn: InstallCertManagerSilent},
 		{needed: reqs.NeedsPolicyEngine, name: "policy-engine", fn: InstallPolicyEngineSilent},
-		{needed: reqs.NeedsClusterAutoscaler, name: "cluster-autoscaler", fn: InstallClusterAutoscalerSilent},
+		{
+			needed: reqs.NeedsClusterAutoscaler,
+			name:   "cluster-autoscaler",
+			fn:     InstallClusterAutoscalerSilent,
+		},
 	})
 }
 

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -275,6 +275,7 @@ type ComponentRequirements struct {
 	NeedsCSI                bool
 	NeedsCertManager        bool
 	NeedsPolicyEngine       bool
+	NeedsClusterAutoscaler  bool
 	NeedsArgoCD             bool
 	NeedsFlux               bool
 }
@@ -288,6 +289,7 @@ func (r ComponentRequirements) Count() int {
 		r.NeedsCSI,
 		r.NeedsCertManager,
 		r.NeedsPolicyEngine,
+		r.NeedsClusterAutoscaler,
 		r.NeedsArgoCD,
 		r.NeedsFlux,
 	}
@@ -349,6 +351,7 @@ func GetComponentRequirements(clusterCfg *v1alpha1.Cluster) ComponentRequirement
 		NeedsCSI:                needsCSI,
 		NeedsCertManager:        needsCertManager,
 		NeedsPolicyEngine:       needsPolicyEngine,
+		NeedsClusterAutoscaler:  NeedsClusterAutoscalerInstall(clusterCfg),
 		NeedsArgoCD:             clusterCfg.Spec.Cluster.GitOpsEngine == v1alpha1.GitOpsEngineArgoCD,
 		NeedsFlux:               needsFlux,
 	}
@@ -652,6 +655,7 @@ func buildInfrastructureTasks(
 		{needed: reqs.NeedsCSI, name: "csi", fn: InstallCSISilent},
 		{needed: reqs.NeedsCertManager, name: "cert-manager", fn: InstallCertManagerSilent},
 		{needed: reqs.NeedsPolicyEngine, name: "policy-engine", fn: InstallPolicyEngineSilent},
+		{needed: reqs.NeedsClusterAutoscaler, name: "cluster-autoscaler", fn: InstallClusterAutoscalerSilent},
 	})
 }
 

--- a/pkg/cli/setup/post_cni_test.go
+++ b/pkg/cli/setup/post_cni_test.go
@@ -26,6 +26,9 @@ func assertComponentRequirements(
 	assert.Equal(t, expected.NeedsCSI, result.NeedsCSI, "CSI")
 	assert.Equal(t, expected.NeedsCertManager, result.NeedsCertManager, "CertManager")
 	assert.Equal(t, expected.NeedsPolicyEngine, result.NeedsPolicyEngine, "PolicyEngine")
+	assert.Equal(
+		t, expected.NeedsClusterAutoscaler, result.NeedsClusterAutoscaler, "ClusterAutoscaler",
+	)
 	assert.Equal(t, expected.NeedsArgoCD, result.NeedsArgoCD, "ArgoCD")
 	assert.Equal(t, expected.NeedsFlux, result.NeedsFlux, "Flux")
 }
@@ -258,6 +261,103 @@ func TestGetComponentRequirements(t *testing.T) {
 			},
 		},
 		{
+			name: "Talos × Hetzner with autoscaler enabled",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution:  v1alpha1.DistributionTalos,
+						Provider:      v1alpha1.ProviderHetzner,
+						LoadBalancer:  v1alpha1.LoadBalancerDefault,
+						MetricsServer: v1alpha1.MetricsServerDefault,
+						CSI:           v1alpha1.CSIDefault,
+						CertManager:   v1alpha1.CertManagerDisabled,
+						PolicyEngine:  v1alpha1.PolicyEngineNone,
+						GitOpsEngine:  v1alpha1.GitOpsEngineNone,
+						Autoscaler: v1alpha1.AutoscalerConfig{
+							Node: v1alpha1.NodeAutoscalerConfig{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 3, // LoadBalancer + CSI + ClusterAutoscaler
+			expected: setup.ComponentRequirements{
+				NeedsLoadBalancer:      true,
+				NeedsCSI:               true,
+				NeedsClusterAutoscaler: true,
+			},
+		},
+		{
+			name: "Talos × Docker with autoscaler enabled does not enable ClusterAutoscaler",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution:  v1alpha1.DistributionTalos,
+						Provider:      v1alpha1.ProviderDocker,
+						MetricsServer: v1alpha1.MetricsServerDefault,
+						CSI:           v1alpha1.CSIDefault,
+						CertManager:   v1alpha1.CertManagerDisabled,
+						PolicyEngine:  v1alpha1.PolicyEngineNone,
+						GitOpsEngine:  v1alpha1.GitOpsEngineNone,
+						Autoscaler: v1alpha1.AutoscalerConfig{
+							Node: v1alpha1.NodeAutoscalerConfig{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 0,
+			expected:      setup.ComponentRequirements{},
+		},
+		{
+			name: "Vanilla with autoscaler enabled does not enable ClusterAutoscaler",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution:  v1alpha1.DistributionVanilla,
+						MetricsServer: v1alpha1.MetricsServerDefault,
+						CSI:           v1alpha1.CSIDefault,
+						CertManager:   v1alpha1.CertManagerDisabled,
+						PolicyEngine:  v1alpha1.PolicyEngineNone,
+						GitOpsEngine:  v1alpha1.GitOpsEngineNone,
+						Autoscaler: v1alpha1.AutoscalerConfig{
+							Node: v1alpha1.NodeAutoscalerConfig{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 0,
+			expected:      setup.ComponentRequirements{},
+		},
+		{
+			name: "Talos × Hetzner with deprecated NodeAutoscaling enabled",
+			clusterCfg: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution:    v1alpha1.DistributionTalos,
+						Provider:        v1alpha1.ProviderHetzner,
+						LoadBalancer:    v1alpha1.LoadBalancerDefault,
+						MetricsServer:   v1alpha1.MetricsServerDefault,
+						CSI:             v1alpha1.CSIDefault,
+						CertManager:     v1alpha1.CertManagerDisabled,
+						PolicyEngine:    v1alpha1.PolicyEngineNone,
+						GitOpsEngine:    v1alpha1.GitOpsEngineNone,
+						NodeAutoscaling: v1alpha1.NodeAutoscalingEnabled,
+					},
+				},
+			},
+			expectedCount: 3, // LoadBalancer + CSI + ClusterAutoscaler
+			expected: setup.ComponentRequirements{
+				NeedsLoadBalancer:      true,
+				NeedsCSI:               true,
+				NeedsClusterAutoscaler: true,
+			},
+		},
+		{
 			name: "KWOK with Flux sets NeedsFlux to false",
 			clusterCfg: &v1alpha1.Cluster{
 				Spec: v1alpha1.Spec{
@@ -341,14 +441,16 @@ func TestComponentRequirementsCount(t *testing.T) {
 			name: "all components enabled",
 			reqs: setup.ComponentRequirements{
 				NeedsMetricsServer:      true,
+				NeedsLoadBalancer:       true,
 				NeedsKubeletCSRApprover: true,
 				NeedsCSI:                true,
 				NeedsCertManager:        true,
 				NeedsPolicyEngine:       true,
+				NeedsClusterAutoscaler:  true,
 				NeedsArgoCD:             true,
 				NeedsFlux:               true,
 			},
-			expected: 7,
+			expected: 9,
 		},
 	}
 

--- a/pkg/cli/setup/post_cni_test.go
+++ b/pkg/cli/setup/post_cni_test.go
@@ -33,7 +33,7 @@ func assertComponentRequirements(
 	assert.Equal(t, expected.NeedsFlux, result.NeedsFlux, "Flux")
 }
 
-//nolint:funlen // Table-driven test with comprehensive test cases
+//nolint:funlen,maintidx // Table-driven test with comprehensive test cases
 func TestGetComponentRequirements(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -379,6 +379,19 @@ func (f DefaultFactory) createTalosProvisioner(
 	hetznerOpts.NodeAutoscalerEnabled = cluster.Spec.Cluster.Autoscaler.Node.Enabled ||
 		cluster.Spec.Cluster.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled
 
+	// Derive pool names from the new autoscaler pools config so that the
+	// delete path can clean up autoscaler-managed Hetzner servers.
+	if len(hetznerOpts.AutoscalerNodePoolNames) == 0 {
+		pools := cluster.Spec.Cluster.Autoscaler.Node.Pools
+		if len(pools) > 0 {
+			names := make([]string, len(pools))
+			for i, pool := range pools {
+				names[i] = pool.Name
+			}
+			hetznerOpts.AutoscalerNodePoolNames = names
+		}
+	}
+
 	provisioner, err := talosprovisioner.CreateProvisioner(
 		f.DistributionConfig.Talos,
 		cluster.Spec.Cluster.Connection.Kubeconfig,

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -375,8 +375,9 @@ func (f DefaultFactory) createTalosProvisioner(
 	// Propagate autoscaler-enabled flag to Hetzner options so the provisioner
 	// can create the cluster-autoscaler-config Secret during bootstrap.
 	hetznerOpts := cluster.Spec.Provider.Hetzner
+	//nolint:staticcheck // bridging deprecated field
 	hetznerOpts.NodeAutoscalerEnabled = cluster.Spec.Cluster.Autoscaler.Node.Enabled ||
-		cluster.Spec.Cluster.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled //nolint:staticcheck // bridging deprecated field
+		cluster.Spec.Cluster.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled
 
 	provisioner, err := talosprovisioner.CreateProvisioner(
 		f.DistributionConfig.Talos,

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -372,13 +372,19 @@ func (f DefaultFactory) createTalosProvisioner(
 	//nolint:staticcheck // intentional: bridging deprecated field
 	talosOpts.Workers = cluster.Spec.Cluster.Workers
 
+	// Propagate autoscaler-enabled flag to Hetzner options so the provisioner
+	// can create the cluster-autoscaler-config Secret during bootstrap.
+	hetznerOpts := cluster.Spec.Provider.Hetzner
+	hetznerOpts.NodeAutoscalerEnabled = cluster.Spec.Cluster.Autoscaler.Node.Enabled ||
+		cluster.Spec.Cluster.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled //nolint:staticcheck // bridging deprecated field
+
 	provisioner, err := talosprovisioner.CreateProvisioner(
 		f.DistributionConfig.Talos,
 		cluster.Spec.Cluster.Connection.Kubeconfig,
 		cluster.Spec.Cluster.Connection.Context,
 		cluster.Spec.Cluster.Provider,
 		talosOpts,
-		cluster.Spec.Provider.Hetzner,
+		hetznerOpts,
 		cluster.Spec.Provider.Omni,
 		skipCNIChecks,
 	)

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -375,7 +375,7 @@ func (f DefaultFactory) createTalosProvisioner(
 	// Propagate autoscaler-enabled flag to Hetzner options so the provisioner
 	// can create the cluster-autoscaler-config Secret during bootstrap.
 	hetznerOpts := cluster.Spec.Provider.Hetzner
-	//nolint:staticcheck // bridging deprecated field
+
 	hetznerOpts.NodeAutoscalerEnabled = cluster.Spec.Cluster.Autoscaler.Node.Enabled ||
 		cluster.Spec.Cluster.NodeAutoscaling == v1alpha1.NodeAutoscalingEnabled
 
@@ -388,6 +388,7 @@ func (f DefaultFactory) createTalosProvisioner(
 			for i, pool := range pools {
 				names[i] = pool.Name
 			}
+
 			hetznerOpts.AutoscalerNodePoolNames = names
 		}
 	}

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
@@ -259,7 +260,12 @@ func (p *Provisioner) ensureAutoscalerSecret(
 
 	_, _ = fmt.Fprintf(p.logWriter, "Applying cluster-autoscaler config secret...\n")
 
-	kubeclient, err := k8s.NewClientset(p.options.KubeconfigPath, "")
+	kubeconfigPath, err := fsutil.ExpandHomePath(p.options.KubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("expanding kubeconfig path for autoscaler secret: %w", err)
+	}
+
+	kubeclient, err := k8s.NewClientset(kubeconfigPath, "")
 	if err != nil {
 		return fmt.Errorf("creating kubeclient for autoscaler secret: %w", err)
 	}

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -176,11 +178,15 @@ func (p *Provisioner) prepareAndApplyConfigs(
 }
 
 // bootstrapAndFinalize bootstraps etcd, saves configs, and waits for cluster readiness.
+// When the node autoscaler is enabled and a snapshot image was used, it also creates
+// the cluster-autoscaler-config Secret in kube-system so the Cluster Autoscaler chart
+// can provision new worker nodes via the Hetzner Cloud API.
 func (p *Provisioner) bootstrapAndFinalize(
 	ctx context.Context,
 	hzProvider *hetzner.Provider,
 	clusterName string,
 	controlPlaneServers, workerServers, allServers []*hcloud.Server,
+	snapshotImageID int64,
 ) error {
 	err := p.detachOrWaitForReboot(ctx, hzProvider, allServers)
 	if err != nil {
@@ -229,6 +235,34 @@ func (p *Provisioner) bootstrapAndFinalize(
 		}
 
 		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster is ready\n")
+	}
+
+	// Create the cluster-autoscaler-config Secret when the node autoscaler is
+	// enabled and bootstrap used a snapshot image (snapshotImageID > 0).
+	if p.hetznerOpts != nil && p.hetznerOpts.NodeAutoscalerEnabled && snapshotImageID > 0 {
+		_, _ = fmt.Fprintf(p.logWriter, "Applying cluster-autoscaler config secret...\n")
+
+		kubeclient, err := k8s.NewClientset(p.options.KubeconfigPath, "")
+		if err != nil {
+			return fmt.Errorf("creating kubeclient for autoscaler secret: %w", err)
+		}
+
+		workerConfigYAML, err := GenerateAutoscalerWorkerConfig(configBundle.Worker())
+		if err != nil {
+			return fmt.Errorf("generating autoscaler worker config: %w", err)
+		}
+
+		err = ApplyAutoscalerConfigSecret(
+			ctx,
+			kubeclient,
+			strconv.FormatInt(snapshotImageID, 10),
+			workerConfigYAML,
+		)
+		if err != nil {
+			return fmt.Errorf("applying autoscaler config secret: %w", err)
+		}
+
+		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret created\n")
 	}
 
 	return nil
@@ -304,7 +338,7 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 	_, _ = fmt.Fprintf(p.logWriter, "\nInfrastructure created. Bootstrapping Talos cluster...\n")
 
 	err = p.applyConfigsAndBootstrap(
-		ctx, hzProvider, clusterName, controlPlaneServers, workerServers,
+		ctx, hzProvider, clusterName, controlPlaneServers, workerServers, snapshotImageID,
 	)
 	if err != nil {
 		return err
@@ -372,6 +406,7 @@ func (p *Provisioner) applyConfigsAndBootstrap(
 	hzProvider *hetzner.Provider,
 	clusterName string,
 	controlPlaneServers, workerServers []*hcloud.Server,
+	snapshotImageID int64,
 ) error {
 	err := p.updateConfigsWithEndpoint(controlPlaneServers)
 	if err != nil {
@@ -388,6 +423,7 @@ func (p *Provisioner) applyConfigsAndBootstrap(
 	return p.bootstrapAndFinalize(
 		ctx, hzProvider, clusterName,
 		controlPlaneServers, workerServers, allServers,
+		snapshotImageID,
 	)
 }
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/siderolabs/talos/pkg/machinery/config/bundle"
 )
 
 // ensureHetznerInfra creates the network, firewall, placement group, and retrieves
@@ -237,33 +238,48 @@ func (p *Provisioner) bootstrapAndFinalize(
 		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster is ready\n")
 	}
 
-	// Create the cluster-autoscaler-config Secret when the node autoscaler is
-	// enabled and bootstrap used a snapshot image (snapshotImageID > 0).
-	if p.hetznerOpts != nil && p.hetznerOpts.NodeAutoscalerEnabled && snapshotImageID > 0 {
-		_, _ = fmt.Fprintf(p.logWriter, "Applying cluster-autoscaler config secret...\n")
-
-		kubeclient, err := k8s.NewClientset(p.options.KubeconfigPath, "")
-		if err != nil {
-			return fmt.Errorf("creating kubeclient for autoscaler secret: %w", err)
-		}
-
-		workerConfigYAML, err := GenerateAutoscalerWorkerConfig(configBundle.Worker())
-		if err != nil {
-			return fmt.Errorf("generating autoscaler worker config: %w", err)
-		}
-
-		err = ApplyAutoscalerConfigSecret(
-			ctx,
-			kubeclient,
-			strconv.FormatInt(snapshotImageID, 10),
-			workerConfigYAML,
-		)
-		if err != nil {
-			return fmt.Errorf("applying autoscaler config secret: %w", err)
-		}
-
-		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret created\n")
+	// Create the cluster-autoscaler-config Secret when applicable.
+	if err := p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID); err != nil {
+		return err
 	}
+
+	return nil
+}
+
+// ensureAutoscalerSecret creates the cluster-autoscaler-config Secret when the
+// node autoscaler is enabled and bootstrap used a snapshot image.
+func (p *Provisioner) ensureAutoscalerSecret(
+	ctx context.Context,
+	configBundle *bundle.Bundle,
+	snapshotImageID int64,
+) error {
+	if p.hetznerOpts == nil || !p.hetznerOpts.NodeAutoscalerEnabled || snapshotImageID <= 0 {
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "Applying cluster-autoscaler config secret...\n")
+
+	kubeclient, err := k8s.NewClientset(p.options.KubeconfigPath, "")
+	if err != nil {
+		return fmt.Errorf("creating kubeclient for autoscaler secret: %w", err)
+	}
+
+	workerConfigYAML, err := GenerateAutoscalerWorkerConfig(configBundle.Worker())
+	if err != nil {
+		return fmt.Errorf("generating autoscaler worker config: %w", err)
+	}
+
+	err = ApplyAutoscalerConfigSecret(
+		ctx,
+		kubeclient,
+		strconv.FormatInt(snapshotImageID, 10),
+		workerConfigYAML,
+	)
+	if err != nil {
+		return fmt.Errorf("applying autoscaler config secret: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret created\n")
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -240,7 +240,8 @@ func (p *Provisioner) bootstrapAndFinalize(
 	}
 
 	// Create the cluster-autoscaler-config Secret when applicable.
-	if err := p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID); err != nil {
+	err = p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

The cluster-autoscaler Helm chart was never deployed despite `autoscaler.node.enabled: Enabled` being set in the cluster spec. Two gaps existed:

1. **Post-CNI setup pipeline** — the autoscaler installer was never invoked
2. **Bootstrap config secret** — `ApplyAutoscalerConfigSecret` was never called, so the `cluster-autoscaler-config` Secret (containing `hcloud_image` and `hcloud_cloud_init`) that the chart depends on was never created

## Changes

### Part 1: Wire installer into post-CNI setup
- Add `NeedsClusterAutoscaler` to `PostCNIRequirements` with count, requirements, and task-building logic
- Add `ClusterAutoscaler` factory, error, and factory function to `ComponentFactories`
- Add `NeedsClusterAutoscalerInstall()` and `InstallClusterAutoscalerSilent()` to infrastructure installer
- Full test coverage for all new logic

### Part 2: Wire config secret into Talos provisioner
- Add `NodeAutoscalerEnabled bool` to `OptionsHetzner` (runtime-derived, not serialized)
- Propagate autoscaler-enabled flag from cluster spec in factory (incl. deprecated `NodeAutoscaling` compat)
- Thread `snapshotImageID` through `applyConfigsAndBootstrap` → `bootstrapAndFinalize`
- Call `GenerateAutoscalerWorkerConfig` + `ApplyAutoscalerConfigSecret` at end of bootstrap when autoscaler is enabled and snapshot image was used

Fixes #4534