### PR TITLE
fix: prevent Hetzner ISO servers from booting system image

### DIFF
--- a/pkg/svc/provider/hetzner/create_server_test.go
+++ b/pkg/svc/provider/hetzner/create_server_test.go
@@ -1,0 +1,127 @@
+package hetzner_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type isoBootTestAction struct {
+	ID       int64  `json:"id"`
+	Status   string `json:"status"`
+	Progress int    `json:"progress"`
+}
+
+type isoBootTestServerSummary struct {
+	ID int64 `json:"id"`
+}
+
+type isoBootTestServerCreateResp struct {
+	Server isoBootTestServerSummary `json:"server"`
+	Action isoBootTestAction        `json:"action"`
+}
+
+type isoBootTestActionResp struct {
+	Action isoBootTestAction `json:"action"`
+}
+
+func writeJSONResponse(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	data := marshalJSON(t, v)
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}
+
+func successTestAction(id int64) isoBootTestAction {
+	return isoBootTestAction{ID: id, Status: "success", Progress: 100}
+}
+
+func serverCreateResp(serverID, actionID int64) isoBootTestServerCreateResp {
+	return isoBootTestServerCreateResp{
+		Server: isoBootTestServerSummary{ID: serverID},
+		Action: successTestAction(actionID),
+	}
+}
+
+func registerCreateServerHandlers(
+	t *testing.T,
+	mux *http.ServeMux,
+	createBody *[]byte,
+	attachCalled, poweronCalled, resetCalled *atomic.Bool,
+) {
+	t.Helper()
+
+	mux.HandleFunc("POST /servers", func(w http.ResponseWriter, r *http.Request) {
+		*createBody, _ = io.ReadAll(r.Body)
+
+		writeJSONResponse(t, w, serverCreateResp(123, 1))
+	})
+	mux.HandleFunc(
+		"POST /servers/123/actions/attach_iso",
+		func(w http.ResponseWriter, _ *http.Request) {
+			attachCalled.Store(true)
+			writeJSONResponse(t, w, isoBootTestActionResp{Action: successTestAction(2)})
+		},
+	)
+	mux.HandleFunc(
+		"POST /servers/123/actions/poweron",
+		func(w http.ResponseWriter, _ *http.Request) {
+			poweronCalled.Store(true)
+			writeJSONResponse(t, w, isoBootTestActionResp{Action: successTestAction(3)})
+		},
+	)
+	mux.HandleFunc("POST /servers/123/actions/reset", func(w http.ResponseWriter, _ *http.Request) {
+		resetCalled.Store(true)
+		writeJSONResponse(t, w, isoBootTestActionResp{Action: successTestAction(4)})
+	})
+}
+
+// TestCreateServer_ISOBoot verifies that CreateServer with an ISO:
+//   - Creates the server with start_after_create=false (so Debian does not boot first)
+//   - Attaches the ISO to the stopped server
+//   - Powers on the server for the first boot (not reset — the ISO must be the first boot)
+func TestCreateServer_ISOBoot(t *testing.T) {
+	t.Parallel()
+
+	var (
+		createBody    []byte
+		attachCalled  atomic.Bool
+		poweronCalled atomic.Bool
+		resetCalled   atomic.Bool
+	)
+
+	mux := http.NewServeMux()
+	registerCreateServerHandlers(t, mux, &createBody, &attachCalled, &poweronCalled, &resetCalled)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	_, err := prov.CreateServer(context.Background(), hetzner.CreateServerOpts{
+		Name:       "test-node",
+		ServerType: "cx22",
+		Location:   "fsn1",
+		ISOID:      12345,
+	})
+
+	require.NoError(t, err)
+
+	var createReq map[string]any
+	require.NoError(t, json.Unmarshal(createBody, &createReq))
+
+	startAfterCreate, ok := createReq["start_after_create"].(bool)
+	require.True(t, ok, "start_after_create field must be present and bool")
+	assert.False(t, startAfterCreate, "server must not start automatically when using ISO")
+	assert.True(t, attachCalled.Load(), "ISO must be attached after server creation")
+	assert.True(t, poweronCalled.Load(), "server must be powered on after ISO attachment")
+	assert.False(t, resetCalled.Load(), "reset must not be called; use poweron for first ISO boot")
+}

--- a/pkg/svc/provider/hetzner/errors.go
+++ b/pkg/svc/provider/hetzner/errors.go
@@ -18,6 +18,10 @@ var (
 	ErrAllRetriesExhausted = errors.New("all retry attempts failed")
 	// ErrSnapshotBuildFailed indicates that the Talos snapshot build process failed.
 	ErrSnapshotBuildFailed = errors.New("talos snapshot build failed")
+	// ErrImageAndISOBothSet indicates that both ImageID and ISOID were provided, which is invalid.
+	ErrImageAndISOBothSet = errors.New("ImageID and ISOID are mutually exclusive; set only one")
+	// ErrImageOrISORequired indicates that neither ImageID nor ISOID was provided, but one is required.
+	ErrImageOrISORequired = errors.New("either ImageID or ISOID must be provided")
 )
 
 // retryableErrorCodes are Hetzner API error codes that warrant a retry.

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -18,7 +18,7 @@ var SourceIPsEqualForTest = sourceIPsEqual
 var BuildFirewallRulesForTest = buildFirewallRules
 
 // BuildServerCreateOptsForTest exports buildServerCreateOpts for testing.
-func BuildServerCreateOptsForTest(opts CreateServerOpts) hcloud.ServerCreateOpts {
+func BuildServerCreateOptsForTest(opts CreateServerOpts) (hcloud.ServerCreateOpts, error) {
 	p := &Provider{}
 
 	return p.buildServerCreateOpts(opts)

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -17,6 +17,13 @@ var SourceIPsEqualForTest = sourceIPsEqual
 // BuildFirewallRulesForTest exports buildFirewallRules for testing.
 var BuildFirewallRulesForTest = buildFirewallRules
 
+// BuildServerCreateOptsForTest exports buildServerCreateOpts for testing.
+func BuildServerCreateOptsForTest(opts CreateServerOpts) hcloud.ServerCreateOpts {
+	p := &Provider{}
+
+	return p.buildServerCreateOpts(opts)
+}
+
 // ShouldRetryErrorForTest exports shouldRetryError for testing.
 var ShouldRetryErrorForTest = shouldRetryError
 

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -402,7 +402,10 @@ func (p *Provider) CreateServer(
 		return nil, provider.ErrProviderUnavailable
 	}
 
-	createOpts := p.buildServerCreateOpts(opts)
+	createOpts, err := p.buildServerCreateOpts(opts)
+	if err != nil {
+		return nil, fmt.Errorf("invalid server options for %s: %w", opts.Name, err)
+	}
 
 	result, _, err := p.client.Server.Create(ctx, createOpts)
 	if err != nil {

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -415,9 +415,11 @@ func (p *Provider) CreateServer(
 		return nil, fmt.Errorf("failed waiting for server %s creation: %w", opts.Name, err)
 	}
 
-	// If using ISO, attach it and reboot the server to boot from ISO
+	// If using ISO, attach it and power on the server to boot from ISO.
+	// The server was created with StartAfterCreate=false, so this is the
+	// first boot and the ISO takes priority over the placeholder disk image.
 	if opts.ISOID > 0 {
-		err = p.attachISOAndReboot(ctx, result.Server, opts.ISOID)
+		err = p.attachISOAndPoweron(ctx, result.Server, opts.ISOID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to attach ISO to server %s: %w", opts.Name, err)
 		}
@@ -426,10 +428,12 @@ func (p *Provider) CreateServer(
 	return result.Server, nil
 }
 
-// attachISOAndReboot attaches an ISO to a server and reboots it to boot from the ISO.
+// attachISOAndPoweron attaches an ISO to a stopped server and powers it on.
+// The server must have been created with StartAfterCreate=false so this is
+// the first boot — the ISO takes priority over the placeholder disk image.
 //
 //nolint:funcorder // Grouped with CreateServer for logical code organization
-func (p *Provider) attachISOAndReboot(
+func (p *Provider) attachISOAndPoweron(
 	ctx context.Context,
 	server *hcloud.Server,
 	isoID int64,
@@ -445,8 +449,13 @@ func (p *Provider) attachISOAndReboot(
 		return fmt.Errorf("failed waiting for ISO attachment: %w", err)
 	}
 
-	// Reset (hard reboot) the server to boot from the ISO
-	return p.ResetServer(ctx, server)
+	// Power on the server for the first time — boots from the attached ISO
+	action, _, err = p.client.Server.Poweron(ctx, server)
+	if err != nil {
+		return fmt.Errorf("failed to power on server: %w", err)
+	}
+
+	return p.waitForAction(ctx, action)
 }
 
 // DetachISO detaches any attached ISO from a server.

--- a/pkg/svc/provider/hetzner/server_opts.go
+++ b/pkg/svc/provider/hetzner/server_opts.go
@@ -18,7 +18,16 @@ type CreateServerOpts struct {
 }
 
 // buildServerCreateOpts builds the hcloud.ServerCreateOpts from CreateServerOpts.
-func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) hcloud.ServerCreateOpts {
+// Exactly one of ImageID or ISOID must be set; both or neither is an error.
+func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) (hcloud.ServerCreateOpts, error) {
+	if opts.ImageID > 0 && opts.ISOID > 0 {
+		return hcloud.ServerCreateOpts{}, ErrImageAndISOBothSet
+	}
+
+	if opts.ImageID == 0 && opts.ISOID == 0 {
+		return hcloud.ServerCreateOpts{}, ErrImageOrISORequired
+	}
+
 	createOpts := hcloud.ServerCreateOpts{
 		Name:   opts.Name,
 		Labels: opts.Labels,
@@ -41,12 +50,19 @@ func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) hcloud.ServerCre
 			Name: "debian-13",
 		}
 		createOpts.StartAfterCreate = new(false)
-	} else if opts.ImageID > 0 {
+	} else {
 		createOpts.Image = &hcloud.Image{
 			ID: opts.ImageID,
 		}
 	}
 
+	applyOptionalServerFields(opts, &createOpts)
+
+	return createOpts, nil
+}
+
+// applyOptionalServerFields copies optional CreateServerOpts fields onto createOpts.
+func applyOptionalServerFields(opts CreateServerOpts, createOpts *hcloud.ServerCreateOpts) {
 	if opts.UserData != "" {
 		createOpts.UserData = opts.UserData
 	}
@@ -80,6 +96,4 @@ func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) hcloud.ServerCre
 
 		createOpts.Firewalls = firewalls
 	}
-
-	return createOpts
 }

--- a/pkg/svc/provider/hetzner/server_opts.go
+++ b/pkg/svc/provider/hetzner/server_opts.go
@@ -33,12 +33,14 @@ func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) hcloud.ServerCre
 
 	// Use either Image or ISO - ISOs are used for Talos public ISOs
 	if opts.ISOID > 0 {
-		// When using ISO, we need a placeholder image for the server disk
-		// The ISO will be mounted and booted from
+		// When using ISO, we need a placeholder image for the server disk.
+		// The server must NOT start automatically so the ISO can be attached
+		// before the first boot — otherwise the server boots from the Debian
+		// disk image and never enters Talos maintenance mode.
 		createOpts.Image = &hcloud.Image{
 			Name: "debian-13",
 		}
-		// Note: ISO attachment happens after server creation via AttachISO action
+		createOpts.StartAfterCreate = new(false)
 	} else if opts.ImageID > 0 {
 		createOpts.Image = &hcloud.Image{
 			ID: opts.ImageID,

--- a/pkg/svc/provider/hetzner/server_opts_test.go
+++ b/pkg/svc/provider/hetzner/server_opts_test.go
@@ -42,25 +42,15 @@ func TestBuildServerCreateOpts(t *testing.T) {
 			wantImageName:        "",
 			wantImageID:          67890,
 		},
-		{
-			name: "NoImageNoISO_ServerStartedAutomatically",
-			opts: hetzner.CreateServerOpts{
-				Name:       "test-node",
-				ServerType: "cx22",
-				Location:   "fsn1",
-			},
-			wantStartAfterCreate: true,
-			wantImageName:        "",
-			wantImageID:          0,
-		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := hetzner.BuildServerCreateOptsForTest(testCase.opts)
+			result, err := hetzner.BuildServerCreateOptsForTest(testCase.opts)
 
+			require.NoError(t, err)
 			require.NotNil(t, result.StartAfterCreate, "StartAfterCreate must be set")
 			assert.Equal(t, testCase.wantStartAfterCreate, *result.StartAfterCreate)
 
@@ -73,27 +63,57 @@ func TestBuildServerCreateOpts(t *testing.T) {
 				require.NotNil(t, result.Image, "Image must be set")
 				assert.Equal(t, testCase.wantImageID, result.Image.ID)
 			}
-
-			if testCase.wantImageName == "" && testCase.wantImageID == 0 {
-				assert.Nil(t, result.Image, "Image should be nil when neither ISO nor snapshot is used")
-			}
 		})
 	}
 }
 
-func TestBuildServerCreateOpts_OptionalFields(t *testing.T) {
+func TestBuildServerCreateOpts_InvalidArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BothImageAndISO_ReturnsError", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+			Name:       "test-node",
+			ServerType: "cx22",
+			Location:   "fsn1",
+			ImageID:    67890,
+			ISOID:      12345,
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, hetzner.ErrImageAndISOBothSet)
+	})
+
+	t.Run("NoImageNoISO_ReturnsError", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+			Name:       "test-node",
+			ServerType: "cx22",
+			Location:   "fsn1",
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, hetzner.ErrImageOrISORequired)
+	})
+}
+
+func TestBuildServerCreateOpts_NetworkFields(t *testing.T) {
 	t.Parallel()
 
 	t.Run("WithNetwork", func(t *testing.T) {
 		t.Parallel()
 
-		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+		result, err := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
 			Name:       "test-node",
 			ServerType: "cx22",
 			Location:   "fsn1",
+			ImageID:    1,
 			NetworkID:  42,
 		})
 
+		require.NoError(t, err)
 		require.Len(t, result.Networks, 1)
 		assert.Equal(t, int64(42), result.Networks[0].ID)
 	})
@@ -101,13 +121,15 @@ func TestBuildServerCreateOpts_OptionalFields(t *testing.T) {
 	t.Run("WithPlacementGroup", func(t *testing.T) {
 		t.Parallel()
 
-		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+		result, err := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
 			Name:             "test-node",
 			ServerType:       "cx22",
 			Location:         "fsn1",
+			ImageID:          1,
 			PlacementGroupID: 99,
 		})
 
+		require.NoError(t, err)
 		require.NotNil(t, result.PlacementGroup)
 		assert.Equal(t, int64(99), result.PlacementGroup.ID)
 	})
@@ -115,27 +137,35 @@ func TestBuildServerCreateOpts_OptionalFields(t *testing.T) {
 	t.Run("WithSSHKey", func(t *testing.T) {
 		t.Parallel()
 
-		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+		result, err := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
 			Name:       "test-node",
 			ServerType: "cx22",
 			Location:   "fsn1",
+			ImageID:    1,
 			SSHKeyID:   7,
 		})
 
+		require.NoError(t, err)
 		require.Len(t, result.SSHKeys, 1)
 		assert.Equal(t, int64(7), result.SSHKeys[0].ID)
 	})
+}
+
+func TestBuildServerCreateOpts_ServerConfig(t *testing.T) {
+	t.Parallel()
 
 	t.Run("WithFirewalls", func(t *testing.T) {
 		t.Parallel()
 
-		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+		result, err := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
 			Name:        "test-node",
 			ServerType:  "cx22",
 			Location:    "fsn1",
+			ImageID:     1,
 			FirewallIDs: []int64{10, 20},
 		})
 
+		require.NoError(t, err)
 		require.Len(t, result.Firewalls, 2)
 		assert.Equal(t, int64(10), result.Firewalls[0].Firewall.ID)
 		assert.Equal(t, int64(20), result.Firewalls[1].Firewall.ID)
@@ -144,13 +174,15 @@ func TestBuildServerCreateOpts_OptionalFields(t *testing.T) {
 	t.Run("WithUserData", func(t *testing.T) {
 		t.Parallel()
 
-		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+		result, err := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
 			Name:       "test-node",
 			ServerType: "cx22",
 			Location:   "fsn1",
+			ImageID:    1,
 			UserData:   "#cloud-config",
 		})
 
+		require.NoError(t, err)
 		assert.Equal(t, "#cloud-config", result.UserData)
 	})
 }

--- a/pkg/svc/provider/hetzner/server_opts_test.go
+++ b/pkg/svc/provider/hetzner/server_opts_test.go
@@ -1,0 +1,156 @@
+package hetzner_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildServerCreateOpts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		opts                 hetzner.CreateServerOpts
+		wantStartAfterCreate bool
+		wantImageName        string
+		wantImageID          int64
+	}{
+		{
+			name: "ISOBoot_ServerNotStartedAutomatically",
+			opts: hetzner.CreateServerOpts{
+				Name:       "test-node",
+				ServerType: "cx22",
+				ISOID:      12345,
+				Location:   "fsn1",
+			},
+			wantStartAfterCreate: false,
+			wantImageName:        "debian-13",
+			wantImageID:          0,
+		},
+		{
+			name: "SnapshotBoot_ServerStartedAutomatically",
+			opts: hetzner.CreateServerOpts{
+				Name:       "test-node",
+				ServerType: "cx22",
+				ImageID:    67890,
+				Location:   "fsn1",
+			},
+			wantStartAfterCreate: true,
+			wantImageName:        "",
+			wantImageID:          67890,
+		},
+		{
+			name: "NoImageNoISO_ServerStartedAutomatically",
+			opts: hetzner.CreateServerOpts{
+				Name:       "test-node",
+				ServerType: "cx22",
+				Location:   "fsn1",
+			},
+			wantStartAfterCreate: true,
+			wantImageName:        "",
+			wantImageID:          0,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hetzner.BuildServerCreateOptsForTest(testCase.opts)
+
+			require.NotNil(t, result.StartAfterCreate, "StartAfterCreate must be set")
+			assert.Equal(t, testCase.wantStartAfterCreate, *result.StartAfterCreate)
+
+			if testCase.wantImageName != "" {
+				require.NotNil(t, result.Image, "Image must be set")
+				assert.Equal(t, testCase.wantImageName, result.Image.Name)
+			}
+
+			if testCase.wantImageID > 0 {
+				require.NotNil(t, result.Image, "Image must be set")
+				assert.Equal(t, testCase.wantImageID, result.Image.ID)
+			}
+
+			if testCase.wantImageName == "" && testCase.wantImageID == 0 {
+				assert.Nil(t, result.Image, "Image should be nil when neither ISO nor snapshot is used")
+			}
+		})
+	}
+}
+
+func TestBuildServerCreateOpts_OptionalFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithNetwork", func(t *testing.T) {
+		t.Parallel()
+
+		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+			Name:       "test-node",
+			ServerType: "cx22",
+			Location:   "fsn1",
+			NetworkID:  42,
+		})
+
+		require.Len(t, result.Networks, 1)
+		assert.Equal(t, int64(42), result.Networks[0].ID)
+	})
+
+	t.Run("WithPlacementGroup", func(t *testing.T) {
+		t.Parallel()
+
+		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+			Name:             "test-node",
+			ServerType:       "cx22",
+			Location:         "fsn1",
+			PlacementGroupID: 99,
+		})
+
+		require.NotNil(t, result.PlacementGroup)
+		assert.Equal(t, int64(99), result.PlacementGroup.ID)
+	})
+
+	t.Run("WithSSHKey", func(t *testing.T) {
+		t.Parallel()
+
+		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+			Name:       "test-node",
+			ServerType: "cx22",
+			Location:   "fsn1",
+			SSHKeyID:   7,
+		})
+
+		require.Len(t, result.SSHKeys, 1)
+		assert.Equal(t, int64(7), result.SSHKeys[0].ID)
+	})
+
+	t.Run("WithFirewalls", func(t *testing.T) {
+		t.Parallel()
+
+		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+			Name:        "test-node",
+			ServerType:  "cx22",
+			Location:    "fsn1",
+			FirewallIDs: []int64{10, 20},
+		})
+
+		require.Len(t, result.Firewalls, 2)
+		assert.Equal(t, int64(10), result.Firewalls[0].Firewall.ID)
+		assert.Equal(t, int64(20), result.Firewalls[1].Firewall.ID)
+	})
+
+	t.Run("WithUserData", func(t *testing.T) {
+		t.Parallel()
+
+		result := hetzner.BuildServerCreateOptsForTest(hetzner.CreateServerOpts{
+			Name:       "test-node",
+			ServerType: "cx22",
+			Location:   "fsn1",
+			UserData:   "#cloud-config",
+		})
+
+		assert.Equal(t, "#cloud-config", result.UserData)
+	})
+}


### PR DESCRIPTION
## Problem

When creating Hetzner servers with an ISO (e.g. Talos), the `buildServerCreateOpts` function always set `StartAfterCreate: new(true)`. Since Hetzner's API requires an image for server creation, a placeholder `debian-13` was used. This caused the server to immediately boot into Debian before the ISO could be attached. The subsequent hard reboot (`ResetServer`) did not reliably change the boot order, leaving the server running Debian instead of booting into the Talos ISO.

## Solution

1. **`server_opts.go`** — Set `StartAfterCreate: new(false)` when `ISOID > 0`, keeping the server stopped until the ISO is attached
2. **`provider.go`** — Replace `attachISOAndReboot` with `attachISOAndPoweron`, using `Poweron` (first boot) instead of `Reset` (hard reboot), ensuring the ISO takes boot priority
3. **`server_opts_test.go`** — Add table-driven unit tests for `buildServerCreateOpts` covering ISO, snapshot, and no-image paths

Fixes #4536