### PR TITLE
fix(chat): capture CLI stderr on headless startup failure

### DIFF
--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -53,6 +54,8 @@ const (
 	sessionIdleTimeoutSeconds = 1800 // 30 minutes
 	// authRetryMaxWait is the maximum wait duration for auth retry backoff.
 	authRetryMaxWait = 4 * time.Second
+	// diagnoseTimeout is the timeout for the post-failure diagnostic subprocess.
+	diagnoseTimeout = 5 * time.Second
 )
 
 // Sentinel errors for the chat command.
@@ -249,14 +252,22 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 
 	err := client.Start(ctx)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to start Copilot client: %w\n\n"+
-				"To fix:\n"+
-				"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication\n"+
-				"  - Install the Copilot CLI: npm install -g @github/copilot\n"+
-				"  - Verify the CLI works: copilot --version",
-			err,
-		)
+		msg := "failed to start Copilot client: %w\n\n"
+
+		if cliPath != "" {
+			diagnostic := diagnoseCLIStartupFailure(ctx, cliPath, opts.Env)
+			if diagnostic != "" {
+				msg += "CLI diagnostic output:\n  " +
+					strings.ReplaceAll(diagnostic, "\n", "\n  ") + "\n\n"
+			}
+		}
+
+		msg += "To fix:\n" +
+			"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication\n" +
+			"  - Install the Copilot CLI: npm install -g @github/copilot\n" +
+			"  - Verify the CLI works: copilot --version"
+
+		return nil, fmt.Errorf(msg, err)
 	}
 
 	return client, nil
@@ -287,6 +298,27 @@ func verifyCopilotCLI(ctx context.Context, cliPath string, env []string) error {
 	}
 
 	return nil
+}
+
+// diagnoseCLIStartupFailure re-runs the copilot CLI in headless mode with
+// stderr captured, returning any diagnostic output. The Copilot SDK discards
+// the subprocess's stderr, so this post-failure re-run is the only way to
+// surface why the CLI crashed during startup.
+func diagnoseCLIStartupFailure(ctx context.Context, cliPath string, env []string) string {
+	diagCtx, cancel := context.WithTimeout(ctx, diagnoseTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(diagCtx, cliPath,
+		"--headless", "--no-auto-update", "--log-level", "debug", "--stdio",
+	)
+	cmd.Env = env
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	_ = cmd.Run()
+
+	return strings.TrimSpace(stderr.String())
 }
 
 // filterEnvVars returns a copy of env with the specified variable names removed.

--- a/pkg/cli/cmd/chat/chat_diagnostic_test.go
+++ b/pkg/cli/cmd/chat/chat_diagnostic_test.go
@@ -1,0 +1,76 @@
+package chat_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/chat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeScript(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+
+	return path
+}
+
+func TestDiagnoseCLIStartupFailure(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test relies on shell scripts")
+	}
+
+	diagnose := chat.GetDiagnoseCLIStartupFailure()
+
+	t.Run("captures stderr from failing process", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot", "#!/bin/sh\necho 'Error: missing config' >&2\nexit 1\n")
+
+		result := diagnose(context.Background(), script, os.Environ())
+		assert.Equal(t, "Error: missing config", result)
+	})
+
+	t.Run("returns empty string when no stderr", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot", "#!/bin/sh\nexit 1\n")
+
+		result := diagnose(context.Background(), script, os.Environ())
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns empty string on cancelled context", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot", "#!/bin/sh\nsleep 60\n")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		result := diagnose(ctx, script, os.Environ())
+		assert.Empty(t, result)
+	})
+
+	t.Run("captures multiline stderr", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot",
+			"#!/bin/sh\necho 'line 1' >&2\necho 'line 2' >&2\nexit 1\n")
+
+		result := diagnose(context.Background(), script, os.Environ())
+		assert.Equal(t, "line 1\nline 2", result)
+	})
+}

--- a/pkg/cli/cmd/chat/export_test.go
+++ b/pkg/cli/cmd/chat/export_test.go
@@ -32,6 +32,14 @@ func GetFilterEnvVars() func([]string, []string) []string {
 	return filterEnvVars
 }
 
+// DiagnoseTimeout exports the diagnoseTimeout constant for testing.
+const DiagnoseTimeout = diagnoseTimeout
+
+// GetDiagnoseCLIStartupFailure returns the diagnoseCLIStartupFailure function for testing.
+func GetDiagnoseCLIStartupFailure() func(context.Context, string, []string) string {
+	return diagnoseCLIStartupFailure
+}
+
 // AuthMaxAttempts exports the authMaxAttempts constant for testing.
 const AuthMaxAttempts = authMaxAttempts
 


### PR DESCRIPTION
## Problem

`ksail chat` fails with an opaque error when the Copilot CLI crashes in headless mode. The Copilot SDK never sets `cmd.Stderr` on the subprocess, so stderr output from the failing CLI is silently discarded.

## Solution

Add `diagnoseCLIStartupFailure()` — a post-failure diagnostic that re-runs the copilot CLI in headless mode with stderr captured. When `client.Start()` fails, the captured stderr is included in the error message, giving users actionable diagnostic information.

## Changes

- **`pkg/cli/cmd/chat/chat.go`**: Add `diagnoseCLIStartupFailure()` function and wire it into the `startCopilotClient()` error path
- **`pkg/cli/cmd/chat/export_test.go`**: Export diagnostic function for testing
- **`pkg/cli/cmd/chat/chat_diagnostic_test.go`**: Tests covering stderr capture, empty output, cancelled context, and multiline output
