### PR TITLE
fix(chat): capture CLI stderr on headless startup failure

### DIFF
--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -56,6 +56,13 @@ const (
 	authRetryMaxWait = 4 * time.Second
 	// diagnoseTimeout is the timeout for the post-failure diagnostic subprocess.
 	diagnoseTimeout = 5 * time.Second
+	// startupErrFmt is the static format string for Copilot client startup errors.
+	// %w is the underlying error; %s is an optional diagnostic block (empty or
+	// "CLI diagnostic output:\n  ...\n\n").
+	startupErrFmt = "failed to start Copilot client: %w\n\n%sTo fix:\n" +
+		"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication\n" +
+		"  - Install the Copilot CLI: npm install -g @github/copilot\n" +
+		"  - Verify the CLI works: copilot --version"
 )
 
 // Sentinel errors for the chat command.
@@ -252,22 +259,7 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 
 	err := client.Start(ctx)
 	if err != nil {
-		msg := "failed to start Copilot client: %w\n\n"
-
-		if cliPath != "" {
-			diagnostic := diagnoseCLIStartupFailure(ctx, cliPath, opts.Env)
-			if diagnostic != "" {
-				msg += "CLI diagnostic output:\n  " +
-					strings.ReplaceAll(diagnostic, "\n", "\n  ") + "\n\n"
-			}
-		}
-
-		msg += "To fix:\n" +
-			"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication\n" +
-			"  - Install the Copilot CLI: npm install -g @github/copilot\n" +
-			"  - Verify the CLI works: copilot --version"
-
-		return nil, fmt.Errorf(msg, err)
+		return nil, fmt.Errorf(startupErrFmt, err, buildDiagnosticBlock(ctx, cliPath, opts.Env))
 	}
 
 	return client, nil
@@ -298,6 +290,22 @@ func verifyCopilotCLI(ctx context.Context, cliPath string, env []string) error {
 	}
 
 	return nil
+}
+
+// buildDiagnosticBlock runs the CLI diagnostic and returns a formatted block
+// suitable for inclusion in an error message, or an empty string if there is
+// nothing to report.
+func buildDiagnosticBlock(ctx context.Context, cliPath string, env []string) string {
+	if cliPath == "" {
+		return ""
+	}
+
+	d := diagnoseCLIStartupFailure(ctx, cliPath, env)
+	if d == "" {
+		return ""
+	}
+
+	return "CLI diagnostic output:\n  " + strings.ReplaceAll(d, "\n", "\n  ") + "\n\n"
 }
 
 // diagnoseCLIStartupFailure re-runs the copilot CLI in headless mode with

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -324,6 +324,7 @@ func diagnoseCLIStartupFailure(ctx context.Context, cliPath string, env []string
 	cmd.Env = env
 
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 
 	_ = cmd.Run()

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -55,7 +55,9 @@ const (
 	// authRetryMaxWait is the maximum wait duration for auth retry backoff.
 	authRetryMaxWait = 4 * time.Second
 	// diagnoseTimeout is the timeout for the post-failure diagnostic subprocess.
-	diagnoseTimeout = 5 * time.Second
+	// Kept intentionally short: ksail chat is interactive, so a brief wait on
+	// failure to surface the real root cause is an acceptable trade-off.
+	diagnoseTimeout = 3 * time.Second
 	// startupErrFmt is the static format string for Copilot client startup errors.
 	// %w is the underlying error; %s is an optional diagnostic block (empty or
 	// "CLI diagnostic output:\n  ...\n\n").
@@ -317,7 +319,7 @@ func diagnoseCLIStartupFailure(ctx context.Context, cliPath string, env []string
 	defer cancel()
 
 	cmd := exec.CommandContext(diagCtx, cliPath,
-		"--headless", "--no-auto-update", "--log-level", "debug", "--stdio",
+		"--headless", "--no-auto-update", "--log-level", "error", "--stdio",
 	)
 	cmd.Env = env
 

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -261,7 +261,11 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 
 	err := client.Start(ctx)
 	if err != nil {
-		return nil, fmt.Errorf(startupErrFmt, err, buildDiagnosticBlock(ctx, cliPath, opts.GitHubToken, opts.Env))
+		return nil, fmt.Errorf(
+			startupErrFmt,
+			err,
+			buildDiagnosticBlock(ctx, cliPath, opts.GitHubToken, opts.Env),
+		)
 	}
 
 	return client, nil
@@ -320,7 +324,11 @@ func buildDiagnosticBlock(ctx context.Context, cliPath, githubToken string, env 
 // When githubToken is non-empty, it is passed via the same COPILOT_SDK_AUTH_TOKEN
 // env var and --auth-token-env flag that the SDK uses, so the diagnostic
 // reproduces the same auth path as the real startup.
-func diagnoseCLIStartupFailure(ctx context.Context, cliPath, githubToken string, env []string) string {
+func diagnoseCLIStartupFailure(
+	ctx context.Context,
+	cliPath, githubToken string,
+	env []string,
+) string {
 	diagCtx, cancel := context.WithTimeout(ctx, diagnoseTimeout)
 	defer cancel()
 

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -261,7 +261,7 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 
 	err := client.Start(ctx)
 	if err != nil {
-		return nil, fmt.Errorf(startupErrFmt, err, buildDiagnosticBlock(ctx, cliPath, opts.Env))
+		return nil, fmt.Errorf(startupErrFmt, err, buildDiagnosticBlock(ctx, cliPath, opts.GitHubToken, opts.Env))
 	}
 
 	return client, nil
@@ -296,13 +296,15 @@ func verifyCopilotCLI(ctx context.Context, cliPath string, env []string) error {
 
 // buildDiagnosticBlock runs the CLI diagnostic and returns a formatted block
 // suitable for inclusion in an error message, or an empty string if there is
-// nothing to report.
-func buildDiagnosticBlock(ctx context.Context, cliPath string, env []string) string {
+// nothing to report. When githubToken is non-empty, it is injected into the
+// subprocess environment via COPILOT_SDK_AUTH_TOKEN (mirroring the SDK) so the
+// diagnostic runs under the same auth context as the real startup attempt.
+func buildDiagnosticBlock(ctx context.Context, cliPath, githubToken string, env []string) string {
 	if cliPath == "" {
 		return ""
 	}
 
-	d := diagnoseCLIStartupFailure(ctx, cliPath, env)
+	d := diagnoseCLIStartupFailure(ctx, cliPath, githubToken, env)
 	if d == "" {
 		return ""
 	}
@@ -314,14 +316,24 @@ func buildDiagnosticBlock(ctx context.Context, cliPath string, env []string) str
 // stderr captured, returning any diagnostic output. The Copilot SDK discards
 // the subprocess's stderr, so this post-failure re-run is the only way to
 // surface why the CLI crashed during startup.
-func diagnoseCLIStartupFailure(ctx context.Context, cliPath string, env []string) string {
+//
+// When githubToken is non-empty, it is passed via the same COPILOT_SDK_AUTH_TOKEN
+// env var and --auth-token-env flag that the SDK uses, so the diagnostic
+// reproduces the same auth path as the real startup.
+func diagnoseCLIStartupFailure(ctx context.Context, cliPath, githubToken string, env []string) string {
 	diagCtx, cancel := context.WithTimeout(ctx, diagnoseTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(diagCtx, cliPath,
-		"--headless", "--no-auto-update", "--log-level", "error", "--stdio",
-	)
-	cmd.Env = env
+	args := []string{"--headless", "--no-auto-update", "--log-level", "error", "--stdio"}
+	diagEnv := env
+
+	if githubToken != "" {
+		args = append(args, "--auth-token-env", "COPILOT_SDK_AUTH_TOKEN")
+		diagEnv = append(append([]string{}, diagEnv...), "COPILOT_SDK_AUTH_TOKEN="+githubToken)
+	}
+
+	cmd := exec.CommandContext(diagCtx, cliPath, args...)
+	cmd.Env = diagEnv
 
 	var stderr bytes.Buffer
 

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -53,6 +54,8 @@ const (
 	sessionIdleTimeoutSeconds = 1800 // 30 minutes
 	// authRetryMaxWait is the maximum wait duration for auth retry backoff.
 	authRetryMaxWait = 4 * time.Second
+	// diagnoseTimeout is the timeout for the post-failure diagnostic subprocess.
+	diagnoseTimeout = 5 * time.Second
 )
 
 // Sentinel errors for the chat command.
@@ -249,14 +252,22 @@ func startCopilotClient(ctx context.Context) (*copilot.Client, error) {
 
 	err := client.Start(ctx)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to start Copilot client: %w\n\n"+
-				"To fix:\n"+
-				"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication\n"+
-				"  - Install the Copilot CLI: npm install -g @github/copilot\n"+
-				"  - Verify the CLI works: copilot --version",
-			err,
-		)
+		msg := "failed to start Copilot client: %w\n\n"
+
+		if cliPath != "" {
+			diagnostic := diagnoseCLIStartupFailure(ctx, cliPath, opts.Env)
+			if diagnostic != "" {
+				msg += "CLI diagnostic output:\n  " +
+					strings.ReplaceAll(diagnostic, "\n", "\n  ") + "\n\n"
+			}
+		}
+
+		msg += "To fix:\n" +
+			"  - Set KSAIL_COPILOT_TOKEN or COPILOT_TOKEN for token-based authentication\n" +
+			"  - Install the Copilot CLI: npm install -g @github/copilot\n" +
+			"  - Verify the CLI works: copilot --version"
+
+		return nil, fmt.Errorf(msg, err)
 	}
 
 	return client, nil
@@ -287,6 +298,27 @@ func verifyCopilotCLI(ctx context.Context, cliPath string, env []string) error {
 	}
 
 	return nil
+}
+
+// diagnoseCLIStartupFailure re-runs the copilot CLI in headless mode with
+// stderr captured, returning any diagnostic output. The Copilot SDK discards
+// the subprocess's stderr, so this post-failure re-run is the only way to
+// surface why the CLI crashed during startup.
+func diagnoseCLIStartupFailure(ctx context.Context, cliPath string, env []string) string {
+	diagCtx, cancel := context.WithTimeout(ctx, diagnoseTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(diagCtx, cliPath,
+		"--headless", "--no-auto-update", "--log-level", "debug", "--stdio",
+	)
+	cmd.Env = env
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	_ = cmd.Run()
+
+	return strings.TrimSpace(stderr.String())
 }
 
 // filterEnvVars returns a copy of env with the specified variable names removed.

--- a/pkg/cli/cmd/chat/chat_diagnostic_test.go
+++ b/pkg/cli/cmd/chat/chat_diagnostic_test.go
@@ -2,9 +2,12 @@ package chat_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/chat"
@@ -73,5 +76,110 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 
 		result := diagnose(context.Background(), script, os.Environ())
 		assert.Equal(t, "line 1\nline 2", result)
+	})
+}
+
+func TestBuildDiagnosticBlock(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test relies on shell scripts")
+	}
+
+	build := chat.GetBuildDiagnosticBlock()
+
+	t.Run("returns empty string for empty cliPath", func(t *testing.T) {
+		t.Parallel()
+
+		result := build(context.Background(), "", os.Environ())
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns empty string when no stderr", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "#!/bin/sh\nexit 1\n")
+
+		result := build(context.Background(), script, os.Environ())
+		assert.Empty(t, result)
+	})
+
+	t.Run("formats stderr as indented block", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "#!/bin/sh\necho 'not logged in' >&2\nexit 1\n")
+
+		result := build(context.Background(), script, os.Environ())
+		assert.Equal(t, "CLI diagnostic output:\n  not logged in\n\n", result)
+	})
+
+	t.Run("indents multiline stderr correctly", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "#!/bin/sh\necho 'line 1' >&2\necho 'line 2' >&2\nexit 1\n")
+
+		result := build(context.Background(), script, os.Environ())
+		assert.Equal(t, "CLI diagnostic output:\n  line 1\n  line 2\n\n", result)
+	})
+}
+
+func TestStartupErrFmt(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test relies on shell scripts")
+	}
+
+	t.Run("includes diagnostic block in error when CLI writes stderr", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "#!/bin/sh\necho 'not logged in' >&2\nexit 1\n")
+
+		build := chat.GetBuildDiagnosticBlock()
+		block := build(context.Background(), script, os.Environ())
+
+		cause := errors.New("CLI process exited: exit status 1")
+		err := fmt.Errorf(chat.StartupErrFmt, cause, block)
+
+		assert.ErrorIs(t, err, cause)
+		assert.True(t, strings.Contains(err.Error(), "CLI diagnostic output:"))
+		assert.True(t, strings.Contains(err.Error(), "not logged in"))
+		assert.True(t, strings.Contains(err.Error(), "To fix:"))
+	})
+
+	t.Run("omits diagnostic section when CLI writes no stderr", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "#!/bin/sh\nexit 1\n")
+
+		build := chat.GetBuildDiagnosticBlock()
+		block := build(context.Background(), script, os.Environ())
+
+		cause := errors.New("CLI process exited: exit status 1")
+		err := fmt.Errorf(chat.StartupErrFmt, cause, block)
+
+		assert.ErrorIs(t, err, cause)
+		assert.False(t, strings.Contains(err.Error(), "CLI diagnostic output:"))
+		assert.True(t, strings.Contains(err.Error(), "To fix:"))
+	})
+
+	t.Run("percent signs in CLI stderr are not treated as format verbs", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "#!/bin/sh\nprintf '100%% complete but failed' >&2\nexit 1\n")
+
+		build := chat.GetBuildDiagnosticBlock()
+		block := build(context.Background(), script, os.Environ())
+
+		cause := errors.New("CLI process exited: exit status 1")
+		err := fmt.Errorf(chat.StartupErrFmt, cause, block)
+
+		assert.True(t, strings.Contains(err.Error(), "100% complete but failed"))
 	})
 }

--- a/pkg/cli/cmd/chat/chat_diagnostic_test.go
+++ b/pkg/cli/cmd/chat/chat_diagnostic_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func writeScript(t *testing.T, dir, name, content string) string {
+func writeScript(t *testing.T, dir, content string) string {
 	t.Helper()
 
-	path := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	path := filepath.Join(dir, "copilot")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	require.NoError(t, os.Chmod(path, 0o700))
 
 	return path
 }
@@ -34,7 +35,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		t.Parallel()
 
 		dir := t.TempDir()
-		script := writeScript(t, dir, "copilot", "#!/bin/sh\necho 'Error: missing config' >&2\nexit 1\n")
+		script := writeScript(t, dir, "#!/bin/sh\necho 'Error: missing config' >&2\nexit 1\n")
 
 		result := diagnose(context.Background(), script, os.Environ())
 		assert.Equal(t, "Error: missing config", result)
@@ -44,7 +45,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		t.Parallel()
 
 		dir := t.TempDir()
-		script := writeScript(t, dir, "copilot", "#!/bin/sh\nexit 1\n")
+		script := writeScript(t, dir, "#!/bin/sh\nexit 1\n")
 
 		result := diagnose(context.Background(), script, os.Environ())
 		assert.Empty(t, result)
@@ -54,7 +55,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		t.Parallel()
 
 		dir := t.TempDir()
-		script := writeScript(t, dir, "copilot", "#!/bin/sh\nsleep 60\n")
+		script := writeScript(t, dir, "#!/bin/sh\nsleep 60\n")
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -67,7 +68,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		t.Parallel()
 
 		dir := t.TempDir()
-		script := writeScript(t, dir, "copilot",
+		script := writeScript(t, dir,
 			"#!/bin/sh\necho 'line 1' >&2\necho 'line 2' >&2\nexit 1\n")
 
 		result := diagnose(context.Background(), script, os.Environ())

--- a/pkg/cli/cmd/chat/chat_diagnostic_test.go
+++ b/pkg/cli/cmd/chat/chat_diagnostic_test.go
@@ -17,7 +17,7 @@ func writeScript(t *testing.T, dir, content string) string {
 
 	path := filepath.Join(dir, "copilot")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
-	require.NoError(t, os.Chmod(path, 0o700))
+	require.NoError(t, os.Chmod(path, 0o500))
 
 	return path
 }

--- a/pkg/cli/cmd/chat/chat_diagnostic_test.go
+++ b/pkg/cli/cmd/chat/chat_diagnostic_test.go
@@ -1,0 +1,76 @@
+package chat_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/chat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeScript(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+
+	return path
+}
+
+func TestDiagnoseCLIStartupFailure(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test relies on shell scripts")
+	}
+
+	diagnose := chat.GetDiagnoseCLIStartupFailure()
+
+	t.Run("captures stderr from failing process", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot", "#!/bin/sh\necho 'Error: missing config' >&2\nexit 1\n")
+
+		result := diagnose(context.Background(), script, os.Environ())
+		assert.Equal(t, "Error: missing config", result)
+	})
+
+	t.Run("returns empty string when no stderr", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot", "#!/bin/sh\nexit 1\n")
+
+		result := diagnose(context.Background(), script, os.Environ())
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns empty string on cancelled context", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot", "#!/bin/sh\nsleep 60\n")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		result := diagnose(ctx, script, os.Environ())
+		assert.Empty(t, result)
+	})
+
+	t.Run("captures multiline stderr", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		script := writeScript(t, dir, "copilot",
+			"#!/bin/sh\necho 'line 1' >&2\necho 'line 2' >&2\nexit 1\n")
+
+		result := diagnose(context.Background(), script, os.Environ())
+		assert.Equal(t, "line 1\nline 2", result)
+	})
+}

--- a/pkg/cli/cmd/chat/chat_diagnostic_test.go
+++ b/pkg/cli/cmd/chat/chat_diagnostic_test.go
@@ -48,7 +48,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		dir := t.TempDir()
 		script := writeScript(t, dir, "#!/bin/sh\necho 'Error: missing config' >&2\nexit 1\n")
 
-		result := diagnose(context.Background(), script, os.Environ())
+		result := diagnose(context.Background(), script, "", os.Environ())
 		assert.Equal(t, "Error: missing config", result)
 	})
 
@@ -58,7 +58,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		dir := t.TempDir()
 		script := writeScript(t, dir, "#!/bin/sh\nexit 1\n")
 
-		result := diagnose(context.Background(), script, os.Environ())
+		result := diagnose(context.Background(), script, "", os.Environ())
 		assert.Empty(t, result)
 	})
 
@@ -71,7 +71,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		result := diagnose(ctx, script, os.Environ())
+		result := diagnose(ctx, script, "", os.Environ())
 		assert.Empty(t, result)
 	})
 
@@ -82,7 +82,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 		script := writeScript(t, dir,
 			"#!/bin/sh\necho 'line 1' >&2\necho 'line 2' >&2\nexit 1\n")
 
-		result := diagnose(context.Background(), script, os.Environ())
+		result := diagnose(context.Background(), script, "", os.Environ())
 		assert.Equal(t, "line 1\nline 2", result)
 	})
 }
@@ -99,7 +99,7 @@ func TestBuildDiagnosticBlock(t *testing.T) {
 	t.Run("returns empty string for empty cliPath", func(t *testing.T) {
 		t.Parallel()
 
-		result := build(context.Background(), "", os.Environ())
+		result := build(context.Background(), "", "", os.Environ())
 		assert.Empty(t, result)
 	})
 
@@ -109,7 +109,7 @@ func TestBuildDiagnosticBlock(t *testing.T) {
 		dir := t.TempDir()
 		script := writeScript(t, dir, "#!/bin/sh\nexit 1\n")
 
-		result := build(context.Background(), script, os.Environ())
+		result := build(context.Background(), script, "", os.Environ())
 		assert.Empty(t, result)
 	})
 
@@ -119,7 +119,7 @@ func TestBuildDiagnosticBlock(t *testing.T) {
 		dir := t.TempDir()
 		script := writeScript(t, dir, "#!/bin/sh\necho 'not logged in' >&2\nexit 1\n")
 
-		result := build(context.Background(), script, os.Environ())
+		result := build(context.Background(), script, "", os.Environ())
 		assert.Equal(t, "CLI diagnostic output:\n  not logged in\n\n", result)
 	})
 
@@ -129,7 +129,7 @@ func TestBuildDiagnosticBlock(t *testing.T) {
 		dir := t.TempDir()
 		script := writeScript(t, dir, "#!/bin/sh\necho 'line 1' >&2\necho 'line 2' >&2\nexit 1\n")
 
-		result := build(context.Background(), script, os.Environ())
+		result := build(context.Background(), script, "", os.Environ())
 		assert.Equal(t, "CLI diagnostic output:\n  line 1\n  line 2\n\n", result)
 	})
 }
@@ -148,7 +148,7 @@ func TestStartupErrFmt(t *testing.T) {
 		script := writeScript(t, dir, "#!/bin/sh\necho 'not logged in' >&2\nexit 1\n")
 
 		build := chat.GetBuildDiagnosticBlock()
-		block := build(context.Background(), script, os.Environ())
+		block := build(context.Background(), script, "", os.Environ())
 
 		err := fmt.Errorf(chat.StartupErrFmt, errFakeCLIExit, block)
 
@@ -165,7 +165,7 @@ func TestStartupErrFmt(t *testing.T) {
 		script := writeScript(t, dir, "#!/bin/sh\nexit 1\n")
 
 		build := chat.GetBuildDiagnosticBlock()
-		block := build(context.Background(), script, os.Environ())
+		block := build(context.Background(), script, "", os.Environ())
 
 		err := fmt.Errorf(chat.StartupErrFmt, errFakeCLIExit, block)
 
@@ -181,7 +181,7 @@ func TestStartupErrFmt(t *testing.T) {
 		script := writeScript(t, dir, "#!/bin/sh\nprintf '100%% complete but failed' >&2\nexit 1\n")
 
 		build := chat.GetBuildDiagnosticBlock()
-		block := build(context.Background(), script, os.Environ())
+		block := build(context.Background(), script, "", os.Environ())
 
 		err := fmt.Errorf(chat.StartupErrFmt, errFakeCLIExit, block)
 

--- a/pkg/cli/cmd/chat/chat_diagnostic_test.go
+++ b/pkg/cli/cmd/chat/chat_diagnostic_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/chat"
@@ -15,12 +14,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const osWindows = "windows"
+
+// errFakeCLIExit is a static sentinel used in TestStartupErrFmt to simulate
+// the error produced by the Copilot SDK when its CLI subprocess exits early.
+var errFakeCLIExit = errors.New("CLI process exited: exit status 1")
+
 func writeScript(t *testing.T, dir, content string) string {
 	t.Helper()
 
 	path := filepath.Join(dir, "copilot")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
-	require.NoError(t, os.Chmod(path, 0o500))
+	require.NoError(
+		t,
+		os.Chmod(path, 0o500), //nolint:gosec // scripts need execute bit; file lives in a temp dir
+	)
 
 	return path
 }
@@ -28,7 +36,7 @@ func writeScript(t *testing.T, dir, content string) string {
 func TestDiagnoseCLIStartupFailure(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("test relies on shell scripts")
 	}
 
@@ -82,7 +90,7 @@ func TestDiagnoseCLIStartupFailure(t *testing.T) {
 func TestBuildDiagnosticBlock(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("test relies on shell scripts")
 	}
 
@@ -129,7 +137,7 @@ func TestBuildDiagnosticBlock(t *testing.T) {
 func TestStartupErrFmt(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("test relies on shell scripts")
 	}
 
@@ -142,13 +150,12 @@ func TestStartupErrFmt(t *testing.T) {
 		build := chat.GetBuildDiagnosticBlock()
 		block := build(context.Background(), script, os.Environ())
 
-		cause := errors.New("CLI process exited: exit status 1")
-		err := fmt.Errorf(chat.StartupErrFmt, cause, block)
+		err := fmt.Errorf(chat.StartupErrFmt, errFakeCLIExit, block)
 
-		assert.ErrorIs(t, err, cause)
-		assert.True(t, strings.Contains(err.Error(), "CLI diagnostic output:"))
-		assert.True(t, strings.Contains(err.Error(), "not logged in"))
-		assert.True(t, strings.Contains(err.Error(), "To fix:"))
+		require.ErrorIs(t, err, errFakeCLIExit)
+		assert.Contains(t, err.Error(), "CLI diagnostic output:")
+		assert.Contains(t, err.Error(), "not logged in")
+		assert.Contains(t, err.Error(), "To fix:")
 	})
 
 	t.Run("omits diagnostic section when CLI writes no stderr", func(t *testing.T) {
@@ -160,12 +167,11 @@ func TestStartupErrFmt(t *testing.T) {
 		build := chat.GetBuildDiagnosticBlock()
 		block := build(context.Background(), script, os.Environ())
 
-		cause := errors.New("CLI process exited: exit status 1")
-		err := fmt.Errorf(chat.StartupErrFmt, cause, block)
+		err := fmt.Errorf(chat.StartupErrFmt, errFakeCLIExit, block)
 
-		assert.ErrorIs(t, err, cause)
-		assert.False(t, strings.Contains(err.Error(), "CLI diagnostic output:"))
-		assert.True(t, strings.Contains(err.Error(), "To fix:"))
+		require.ErrorIs(t, err, errFakeCLIExit)
+		assert.NotContains(t, err.Error(), "CLI diagnostic output:")
+		assert.Contains(t, err.Error(), "To fix:")
 	})
 
 	t.Run("percent signs in CLI stderr are not treated as format verbs", func(t *testing.T) {
@@ -177,9 +183,8 @@ func TestStartupErrFmt(t *testing.T) {
 		build := chat.GetBuildDiagnosticBlock()
 		block := build(context.Background(), script, os.Environ())
 
-		cause := errors.New("CLI process exited: exit status 1")
-		err := fmt.Errorf(chat.StartupErrFmt, cause, block)
+		err := fmt.Errorf(chat.StartupErrFmt, errFakeCLIExit, block)
 
-		assert.True(t, strings.Contains(err.Error(), "100% complete but failed"))
+		assert.Contains(t, err.Error(), "100% complete but failed")
 	})
 }

--- a/pkg/cli/cmd/chat/export_test.go
+++ b/pkg/cli/cmd/chat/export_test.go
@@ -39,12 +39,12 @@ const DiagnoseTimeout = diagnoseTimeout
 const StartupErrFmt = startupErrFmt
 
 // GetDiagnoseCLIStartupFailure returns the diagnoseCLIStartupFailure function for testing.
-func GetDiagnoseCLIStartupFailure() func(context.Context, string, []string) string {
+func GetDiagnoseCLIStartupFailure() func(context.Context, string, string, []string) string {
 	return diagnoseCLIStartupFailure
 }
 
 // GetBuildDiagnosticBlock returns the buildDiagnosticBlock function for testing.
-func GetBuildDiagnosticBlock() func(context.Context, string, []string) string {
+func GetBuildDiagnosticBlock() func(context.Context, string, string, []string) string {
 	return buildDiagnosticBlock
 }
 

--- a/pkg/cli/cmd/chat/export_test.go
+++ b/pkg/cli/cmd/chat/export_test.go
@@ -35,9 +35,17 @@ func GetFilterEnvVars() func([]string, []string) []string {
 // DiagnoseTimeout exports the diagnoseTimeout constant for testing.
 const DiagnoseTimeout = diagnoseTimeout
 
+// StartupErrFmt exports the startupErrFmt constant for testing.
+const StartupErrFmt = startupErrFmt
+
 // GetDiagnoseCLIStartupFailure returns the diagnoseCLIStartupFailure function for testing.
 func GetDiagnoseCLIStartupFailure() func(context.Context, string, []string) string {
 	return diagnoseCLIStartupFailure
+}
+
+// GetBuildDiagnosticBlock returns the buildDiagnosticBlock function for testing.
+func GetBuildDiagnosticBlock() func(context.Context, string, []string) string {
+	return buildDiagnosticBlock
 }
 
 // AuthMaxAttempts exports the authMaxAttempts constant for testing.

--- a/pkg/cli/cmd/chat/export_test.go
+++ b/pkg/cli/cmd/chat/export_test.go
@@ -32,6 +32,14 @@ func GetFilterEnvVars() func([]string, []string) []string {
 	return filterEnvVars
 }
 
+// DiagnoseTimeout exports the diagnoseTimeout constant for testing.
+const DiagnoseTimeout = diagnoseTimeout
+
+// GetDiagnoseCLIStartupFailure returns the diagnoseCLIStartupFailure function for testing.
+func GetDiagnoseCLIStartupFailure() func(context.Context, string, []string) string {
+	return diagnoseCLIStartupFailure
+}
+
 // AuthMaxAttempts exports the authMaxAttempts constant for testing.
 const AuthMaxAttempts = authMaxAttempts
 


### PR DESCRIPTION
## Problem

`ksail chat` fails with an opaque error when the Copilot CLI exits immediately in headless mode.

The Copilot SDK spawns `copilot --headless --stdio` but never sets `cmd.Stderr`, so all diagnostic output from the CLI subprocess is silently discarded. The pre-flight `copilot --version` check passes fine, leaving users with no actionable information about why headless startup fails.

## Solution

Add a `diagnoseCLIStartupFailure()` function that re-runs the CLI in headless mode with stderr captured after `client.Start()` fails. The captured output is included in the error message, surfacing the real root cause (e.g. auth errors, missing config, version mismatches).

The diagnostic runs with `--log-level error` (matching the SDK) and a 3-second timeout to avoid blocking indefinitely on a hanging process. When a GitHub token is set via `KSAIL_COPILOT_TOKEN`/`COPILOT_TOKEN`, the diagnostic subprocess inherits the same auth context (`COPILOT_SDK_AUTH_TOKEN` env var + `--auth-token-env` flag) that the SDK uses, so the captured output reflects the real failure.

## Changes

- `pkg/cli/cmd/chat/chat.go` - adds `diagnoseTimeout` (3s) constant and `diagnoseCLIStartupFailure()`, wired into the `startCopilotClient()` error path; auth token is propagated through `buildDiagnosticBlock`
- `pkg/cli/cmd/chat/export_test.go` - exports the diagnostic function and timeout constant for black-box testing
- `pkg/cli/cmd/chat/chat_diagnostic_test.go` - test cases covering stderr capture, no stderr, cancelled context, multiline output, and the formatted error block