### PR TITLE
fix(update): detect autoscaler and Talos config from live cluster to eliminate false-positive diffs

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -1227,7 +1227,8 @@ func handleCreateRunE(
 
 	// Persist the ClusterSpec so that future updates have an accurate baseline
 	// for fields that cannot be detected from the live cluster (e.g., Talos ISO).
-	if saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster); saveErr != nil {
+	saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
+	if saveErr != nil {
 		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
 	}
 
@@ -7202,7 +7203,8 @@ func applyInPlaceChanges(
 	}
 
 	// Persist the updated ClusterSpec for future update baselines.
-	if saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster); saveErr != nil {
+	saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
+	if saveErr != nil {
 		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
 	}
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -7203,9 +7203,13 @@ func applyInPlaceChanges(
 	}
 
 	// Persist the updated ClusterSpec for future update baselines.
-	saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
-	if saveErr != nil {
-		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
+	// Only save when all changes applied successfully: failed changes mean
+	// the cluster state is partially applied and does not match the desired spec.
+	if len(result.FailedChanges) == 0 && componentErr == nil {
+		saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
+		if saveErr != nil {
+			notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
+		}
 	}
 
 	return nil

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -1225,6 +1225,12 @@ func handleCreateRunE(
 		return err
 	}
 
+	// Persist the ClusterSpec so that future updates have an accurate baseline
+	// for fields that cannot be detected from the live cluster (e.g., Talos ISO).
+	if saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster); saveErr != nil {
+		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
+	}
+
 	return maybeWaitForTTL(cmd, clusterName, ctx.ClusterCfg)
 }
 
@@ -6884,6 +6890,7 @@ func computeSpecOnlyDiff(
 			currentSpec.CertManager = detected.CertManager
 			currentSpec.PolicyEngine = detected.PolicyEngine
 			currentSpec.GitOpsEngine = detected.GitOpsEngine
+			currentSpec.Autoscaler.Node = detected.Autoscaler.Node
 		}
 	}
 
@@ -7192,6 +7199,11 @@ func applyInPlaceChanges(
 
 	if componentErr != nil {
 		return fmt.Errorf("some component changes failed to apply: %w", componentErr)
+	}
+
+	// Persist the updated ClusterSpec for future update baselines.
+	if saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster); saveErr != nil {
+		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
 	}
 
 	return nil

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -7205,7 +7205,7 @@ func applyInPlaceChanges(
 	// Persist the updated ClusterSpec for future update baselines.
 	// Only save when all changes applied successfully: failed changes mean
 	// the cluster state is partially applied and does not match the desired spec.
-	if len(result.FailedChanges) == 0 && componentErr == nil {
+	if len(result.FailedChanges) == 0 {
 		saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
 		if saveErr != nil {
 			notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -348,6 +348,10 @@ func (c *Client) GetReleaseValues(
 		return nil, errReleaseNameRequired
 	}
 
+	if c.actionConfig == nil || c.actionConfig.Releases == nil {
+		return nil, errGetReleaseValuesUnsupported
+	}
+
 	err := ctx.Err()
 	if err != nil {
 		return nil, fmt.Errorf("get release values context cancelled: %w", err)

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -343,7 +343,7 @@ func (c *Client) GetReleaseStorageLabels(
 func (c *Client) GetReleaseValues(
 	ctx context.Context,
 	releaseName, namespace string,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	if releaseName == "" {
 		return nil, errReleaseNameRequired
 	}

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -337,6 +337,39 @@ func (c *Client) GetReleaseStorageLabels(
 	return c.fetchStorageLabels(ctx, clientset, driver, namespace, selector)
 }
 
+// GetReleaseValues returns the user-supplied values for the latest revision of
+// the named release. It reinitialises the action configuration to the target
+// namespace (same pattern as ListReleases) and restores it afterwards.
+func (c *Client) GetReleaseValues(
+	ctx context.Context,
+	releaseName, namespace string,
+) (map[string]interface{}, error) {
+	if releaseName == "" {
+		return nil, errReleaseNameRequired
+	}
+
+	err := ctx.Err()
+	if err != nil {
+		return nil, fmt.Errorf("get release values context cancelled: %w", err)
+	}
+
+	cleanup, err := c.switchNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	defer cleanup()
+
+	getValues := helmv4action.NewGetValues(c.actionConfig)
+
+	values, err := getValues.Run(releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("get release values for %s/%s: %w", namespace, releaseName, err)
+	}
+
+	return values, nil
+}
+
 // fetchStorageLabels queries either ConfigMaps or Secrets (based on driver) and
 // returns labels from the storage object with the highest version.
 func (c *Client) fetchStorageLabels(
@@ -395,38 +428,6 @@ func (c *Client) fetchStorageLabels(
 	}
 
 	return items[bestIdx].Labels, nil
-}
-
-// GetReleaseValues returns the user-supplied values for the latest revision of
-// the named release. It reinitialises the action configuration to the target
-// namespace (same pattern as ListReleases) and restores it afterwards.
-func (c *Client) GetReleaseValues(
-	ctx context.Context,
-	releaseName, namespace string,
-) (map[string]interface{}, error) {
-	if releaseName == "" {
-		return nil, errReleaseNameRequired
-	}
-
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("get release values context cancelled: %w", err)
-	}
-
-	cleanup, err := c.switchNamespace(namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	defer cleanup()
-
-	getValues := helmv4action.NewGetValues(c.actionConfig)
-
-	values, err := getValues.Run(releaseName)
-	if err != nil {
-		return nil, fmt.Errorf("get release values for %s/%s: %w", namespace, releaseName, err)
-	}
-
-	return values, nil
 }
 
 func (c *Client) installRelease(

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -397,6 +397,38 @@ func (c *Client) fetchStorageLabels(
 	return items[bestIdx].Labels, nil
 }
 
+// GetReleaseValues returns the user-supplied values for the latest revision of
+// the named release. It reinitialises the action configuration to the target
+// namespace (same pattern as ListReleases) and restores it afterwards.
+func (c *Client) GetReleaseValues(
+	ctx context.Context,
+	releaseName, namespace string,
+) (map[string]interface{}, error) {
+	if releaseName == "" {
+		return nil, errReleaseNameRequired
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("get release values context cancelled: %w", err)
+	}
+
+	cleanup, err := c.switchNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	defer cleanup()
+
+	getValues := helmv4action.NewGetValues(c.actionConfig)
+
+	values, err := getValues.Run(releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("get release values for %s/%s: %w", namespace, releaseName, err)
+	}
+
+	return values, nil
+}
+
 func (c *Client) installRelease(
 	ctx context.Context,
 	spec *ChartSpec,

--- a/pkg/client/helm/export_test.go
+++ b/pkg/client/helm/export_test.go
@@ -36,7 +36,8 @@ var (
 	ErrRepositoryNameRequired  = errRepositoryNameRequired
 	ErrRepositoryCacheUnset    = errRepositoryCacheUnset
 	ErrRepositoryConfigUnset   = errRepositoryConfigUnset
-	ErrListReleasesUnsupported = errListReleasesUnsupported
+	ErrListReleasesUnsupported      = errListReleasesUnsupported
+	ErrGetReleaseValuesUnsupported  = errGetReleaseValuesUnsupported
 	//nolint:gochecknoglobals // export_test.go exposes package internals as globals for tests.
 	ConvertRepositoryEntry = convertRepositoryEntry
 	//nolint:gochecknoglobals // export_test.go exposes package internals as globals for tests.

--- a/pkg/client/helm/export_test.go
+++ b/pkg/client/helm/export_test.go
@@ -29,15 +29,15 @@ var (
 
 // Expose unexported error sentinels and repository helpers for test assertions.
 var (
-	ErrUnexpectedReleaseType   = errUnexpectedReleaseType
-	ErrReleaseNameRequired     = errReleaseNameRequired
-	ErrChartSpecRequired       = errChartSpecRequired
-	ErrRepositoryEntryRequired = errRepositoryEntryRequired
-	ErrRepositoryNameRequired  = errRepositoryNameRequired
-	ErrRepositoryCacheUnset    = errRepositoryCacheUnset
-	ErrRepositoryConfigUnset   = errRepositoryConfigUnset
-	ErrListReleasesUnsupported      = errListReleasesUnsupported
-	ErrGetReleaseValuesUnsupported  = errGetReleaseValuesUnsupported
+	ErrUnexpectedReleaseType       = errUnexpectedReleaseType
+	ErrReleaseNameRequired         = errReleaseNameRequired
+	ErrChartSpecRequired           = errChartSpecRequired
+	ErrRepositoryEntryRequired     = errRepositoryEntryRequired
+	ErrRepositoryNameRequired      = errRepositoryNameRequired
+	ErrRepositoryCacheUnset        = errRepositoryCacheUnset
+	ErrRepositoryConfigUnset       = errRepositoryConfigUnset
+	ErrListReleasesUnsupported     = errListReleasesUnsupported
+	ErrGetReleaseValuesUnsupported = errGetReleaseValuesUnsupported
 	//nolint:gochecknoglobals // export_test.go exposes package internals as globals for tests.
 	ConvertRepositoryEntry = convertRepositoryEntry
 	//nolint:gochecknoglobals // export_test.go exposes package internals as globals for tests.

--- a/pkg/client/helm/mocks.go
+++ b/pkg/client/helm/mocks.go
@@ -571,3 +571,77 @@ func (_c *MockInterface_GetReleaseStorageLabels_Call) RunAndReturn(run func(ctx 
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetReleaseValues provides a mock function for the type MockInterface
+func (_mock *MockInterface) GetReleaseValues(ctx context.Context, releaseName string, namespace string) (map[string]interface{}, error) {
+	ret := _mock.Called(ctx, releaseName, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReleaseValues")
+	}
+
+	var r0 map[string]interface{}
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]interface{}, error)); ok {
+		return returnFunc(ctx, releaseName, namespace)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, releaseName, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, releaseName, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockInterface_GetReleaseValues_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReleaseValues'
+type MockInterface_GetReleaseValues_Call struct {
+	*mock.Call
+}
+
+// GetReleaseValues is a helper method to define mock.On call
+//   - ctx context.Context
+//   - releaseName string
+//   - namespace string
+func (_e *MockInterface_Expecter) GetReleaseValues(ctx interface{}, releaseName interface{}, namespace interface{}) *MockInterface_GetReleaseValues_Call {
+	return &MockInterface_GetReleaseValues_Call{Call: _e.mock.On("GetReleaseValues", ctx, releaseName, namespace)}
+}
+
+func (_c *MockInterface_GetReleaseValues_Call) Run(run func(ctx context.Context, releaseName string, namespace string)) *MockInterface_GetReleaseValues_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetReleaseValues_Call) Return(values map[string]interface{}, err error) *MockInterface_GetReleaseValues_Call {
+	_c.Call.Return(values, err)
+	return _c
+}
+
+func (_c *MockInterface_GetReleaseValues_Call) RunAndReturn(run func(ctx context.Context, releaseName string, namespace string) (map[string]interface{}, error)) *MockInterface_GetReleaseValues_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -108,4 +108,12 @@ type Interface interface {
 		ctx context.Context,
 		releaseName, namespace string,
 	) (map[string]string, error)
+	// GetReleaseValues returns the user-supplied values for the latest revision
+	// of the named release. Returns (nil, error) when the release does not exist
+	// or cannot be queried. Use this to introspect installed chart configuration
+	// (e.g., detecting autoscaler settings from the live cluster).
+	GetReleaseValues(
+		ctx context.Context,
+		releaseName, namespace string,
+	) (map[string]interface{}, error)
 }

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -115,5 +115,5 @@ type Interface interface {
 	GetReleaseValues(
 		ctx context.Context,
 		releaseName, namespace string,
-	) (map[string]interface{}, error)
+	) (map[string]any, error)
 }

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -15,6 +15,9 @@ var (
 	errListReleasesUnsupported = errors.New(
 		"helm: ListReleases not supported on template-only client",
 	)
+	errGetReleaseValuesUnsupported = errors.New(
+		"helm: GetReleaseValues not supported on template-only client",
+	)
 
 	// ErrNoReleaseStorage is returned by GetReleaseStorageLabels when no
 	// Helm release storage objects (Secrets or ConfigMaps) exist for the

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -631,14 +631,14 @@ func parseAutoscalingGroups(groups []any) []v1alpha1.NodePool {
 	pools := make([]v1alpha1.NodePool, 0, len(groups))
 
 	for _, g := range groups {
-		group, ok := g.(map[string]any)
-		if !ok {
+		group, isMap := g.(map[string]any)
+		if !isMap {
 			continue
 		}
 
 		pool := v1alpha1.NodePool{}
-		name, ok := group["name"].(string)
-		if !ok || name == "" {
+		name, hasName := group["name"].(string)
+		if !hasName || name == "" {
 			continue
 		}
 

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -572,7 +572,7 @@ func (d *ComponentDetector) detectNodeAutoscaler(
 	if err != nil {
 		// Propagate context cancellation/timeout — the caller has given up.
 		if ctx.Err() != nil {
-			return cfg, ctx.Err()
+			return cfg, fmt.Errorf("detect node autoscaler: %w", ctx.Err())
 		}
 		// Release exists but values unreadable — return enabled with defaults.
 		return cfg, nil //nolint:nilerr // graceful fallback; enabled is the critical signal

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -580,18 +580,18 @@ func (d *ComponentDetector) detectNodeAutoscaler(
 }
 
 // parseAutoscalerValues extracts autoscaler config from Helm release values.
-func parseAutoscalerValues(cfg *v1alpha1.NodeAutoscalerConfig, values map[string]interface{}) {
-	if extraArgs, exists := values["extraArgs"].(map[string]interface{}); exists {
+func parseAutoscalerValues(cfg *v1alpha1.NodeAutoscalerConfig, values map[string]any) {
+	if extraArgs, exists := values["extraArgs"].(map[string]any); exists {
 		parseAutoscalerExtraArgs(cfg, extraArgs)
 	}
 
-	if groups, exists := values["autoscalingGroups"].([]interface{}); exists {
+	if groups, exists := values["autoscalingGroups"].([]any); exists {
 		cfg.Pools = parseAutoscalingGroups(groups)
 	}
 }
 
 // parseAutoscalerExtraArgs extracts scalar config from the chart's extraArgs.
-func parseAutoscalerExtraArgs(cfg *v1alpha1.NodeAutoscalerConfig, args map[string]interface{}) {
+func parseAutoscalerExtraArgs(cfg *v1alpha1.NodeAutoscalerConfig, args map[string]any) {
 	if expander, ok := args["expander"].(string); ok {
 		cfg.Expander = helmExpanderToEnum(expander)
 	}
@@ -623,11 +623,11 @@ func helmExpanderToEnum(value string) v1alpha1.AutoscalerExpander {
 }
 
 // parseAutoscalingGroups converts the chart's autoscalingGroups list to NodePool slices.
-func parseAutoscalingGroups(groups []interface{}) []v1alpha1.NodePool {
+func parseAutoscalingGroups(groups []any) []v1alpha1.NodePool {
 	pools := make([]v1alpha1.NodePool, 0, len(groups))
 
 	for _, g := range groups {
-		group, ok := g.(map[string]interface{})
+		group, ok := g.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -671,13 +671,13 @@ func float64ToInt32(f float64) (int32, bool) {
 		return 0, false
 	}
 
-	return int32(f), true //nolint:gosec // bounds checked above
+	return int32(f), true
 }
 
 // toInt32 converts a Helm values entry (which may be float64, json.Number, int, int32,
 // or int64) to int32. Returns (0, false) when the value is not a numeric type, is
 // non-integral, or falls outside the int32 range.
-func toInt32(v interface{}) (int32, bool) {
+func toInt32(v any) (int32, bool) {
 	switch num := v.(type) {
 	case float64:
 		return float64ToInt32(num)

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -659,43 +659,41 @@ func parseAutoscalingGroups(groups []interface{}) []v1alpha1.NodePool {
 	return pools
 }
 
+const (
+	minInt32Float float64 = -1 << 31
+	maxInt32Float float64 = 1<<31 - 1
+)
+
+// float64ToInt32 converts a float64 to int32, validating that it is a whole
+// number within the int32 range. Returns (0, false) when invalid.
+func float64ToInt32(f float64) (int32, bool) {
+	if f != math.Trunc(f) || f < minInt32Float || f > maxInt32Float {
+		return 0, false
+	}
+
+	return int32(f), true //nolint:gosec // bounds checked above
+}
+
 // toInt32 converts a Helm values entry (which may be float64, json.Number, int, int32,
 // or int64) to int32. Returns (0, false) when the value is not a numeric type, is
 // non-integral, or falls outside the int32 range.
 func toInt32(v interface{}) (int32, bool) {
-	const (
-		minInt32 = -1 << 31
-		maxInt32 = 1<<31 - 1
-	)
-
 	switch num := v.(type) {
 	case float64:
-		if num != math.Trunc(num) || num < minInt32 || num > maxInt32 {
-			return 0, false
-		}
-
-		return int32(num), true //nolint:gosec // bounds checked above
+		return float64ToInt32(num)
 	case json.Number:
 		f, err := num.Float64()
-		if err != nil || f != math.Trunc(f) || f < minInt32 || f > maxInt32 {
+		if err != nil {
 			return 0, false
 		}
 
-		return int32(f), true //nolint:gosec // bounds checked above
+		return float64ToInt32(f)
 	case int:
-		if num < minInt32 || num > maxInt32 {
-			return 0, false
-		}
-
-		return int32(num), true //nolint:gosec // bounds checked above
+		return float64ToInt32(float64(num))
 	case int32:
 		return num, true
 	case int64:
-		if num < minInt32 || num > maxInt32 {
-			return 0, false
-		}
-
-		return int32(num), true //nolint:gosec // bounds checked above
+		return float64ToInt32(float64(num))
 	default:
 		return 0, false
 	}

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -637,9 +637,12 @@ func parseAutoscalingGroups(groups []any) []v1alpha1.NodePool {
 		}
 
 		pool := v1alpha1.NodePool{}
-		if name, ok := group["name"].(string); ok {
-			pool.Name = name
+		name, ok := group["name"].(string)
+		if !ok || name == "" {
+			continue
 		}
+
+		pool.Name = name
 
 		if st, ok := group["instanceType"].(string); ok {
 			pool.ServerType = st

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -2,7 +2,9 @@ package detector
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -579,13 +581,11 @@ func (d *ComponentDetector) detectNodeAutoscaler(
 
 // parseAutoscalerValues extracts autoscaler config from Helm release values.
 func parseAutoscalerValues(cfg *v1alpha1.NodeAutoscalerConfig, values map[string]interface{}) {
-	extraArgs, ok := values["extraArgs"].(map[string]interface{})
-	if ok {
+	if extraArgs, exists := values["extraArgs"].(map[string]interface{}); exists {
 		parseAutoscalerExtraArgs(cfg, extraArgs)
 	}
 
-	groups, ok := values["autoscalingGroups"].([]interface{})
-	if ok {
+	if groups, exists := values["autoscalingGroups"].([]interface{}); exists {
 		cfg.Pools = parseAutoscalingGroups(groups)
 	}
 }
@@ -627,29 +627,29 @@ func parseAutoscalingGroups(groups []interface{}) []v1alpha1.NodePool {
 	pools := make([]v1alpha1.NodePool, 0, len(groups))
 
 	for _, g := range groups {
-		gm, ok := g.(map[string]interface{})
+		group, ok := g.(map[string]interface{})
 		if !ok {
 			continue
 		}
 
 		pool := v1alpha1.NodePool{}
-		if name, ok := gm["name"].(string); ok {
+		if name, ok := group["name"].(string); ok {
 			pool.Name = name
 		}
 
-		if st, ok := gm["instanceType"].(string); ok {
+		if st, ok := group["instanceType"].(string); ok {
 			pool.ServerType = st
 		}
 
-		if loc, ok := gm["region"].(string); ok {
+		if loc, ok := group["region"].(string); ok {
 			pool.Location = loc
 		}
 
-		if minSize, ok := toInt32(gm["minSize"]); ok {
+		if minSize, ok := toInt32(group["minSize"]); ok {
 			pool.Min = minSize
 		}
 
-		if maxSize, ok := toInt32(gm["maxSize"]); ok {
+		if maxSize, ok := toInt32(group["maxSize"]); ok {
 			pool.Max = maxSize
 		}
 
@@ -659,18 +659,43 @@ func parseAutoscalingGroups(groups []interface{}) []v1alpha1.NodePool {
 	return pools
 }
 
-// toInt32 converts a Helm values entry (which may be float64 or json.Number)
-// to int32. Returns (0, false) when the value is not a numeric type.
+// toInt32 converts a Helm values entry (which may be float64, json.Number, int, int32,
+// or int64) to int32. Returns (0, false) when the value is not a numeric type, is
+// non-integral, or falls outside the int32 range.
 func toInt32(v interface{}) (int32, bool) {
-	switch n := v.(type) {
+	const (
+		minInt32 = -1 << 31
+		maxInt32 = 1<<31 - 1
+	)
+
+	switch num := v.(type) {
 	case float64:
-		return int32(n), true
+		if num != math.Trunc(num) || num < minInt32 || num > maxInt32 {
+			return 0, false
+		}
+
+		return int32(num), true //nolint:gosec // bounds checked above
+	case json.Number:
+		f, err := num.Float64()
+		if err != nil || f != math.Trunc(f) || f < minInt32 || f > maxInt32 {
+			return 0, false
+		}
+
+		return int32(f), true //nolint:gosec // bounds checked above
 	case int:
-		return int32(n), true
+		if num < minInt32 || num > maxInt32 {
+			return 0, false
+		}
+
+		return int32(num), true //nolint:gosec // bounds checked above
 	case int32:
-		return n, true
+		return num, true
 	case int64:
-		return int32(n), true
+		if num < minInt32 || num > maxInt32 {
+			return 0, false
+		}
+
+		return int32(num), true //nolint:gosec // bounds checked above
 	default:
 		return 0, false
 	}

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -180,6 +180,11 @@ func (d *ComponentDetector) detectAllComponents(
 		return nil, fmt.Errorf("detect GitOpsEngine: %w", err)
 	}
 
+	spec.Autoscaler.Node, err = d.detectNodeAutoscaler(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("detect NodeAutoscaler: %w", err)
+	}
+
 	return spec, nil
 }
 
@@ -537,4 +542,136 @@ func (d *ComponentDetector) containerExists(
 	}
 
 	return len(containers) > 0, nil
+}
+
+// detectNodeAutoscaler detects the Cluster Autoscaler configuration from the
+// live cluster by checking for the Helm release and reading its values.
+func (d *ComponentDetector) detectNodeAutoscaler(
+	ctx context.Context,
+) (v1alpha1.NodeAutoscalerConfig, error) {
+	var cfg v1alpha1.NodeAutoscalerConfig
+
+	exists, err := d.helmClient.ReleaseExists(
+		ctx, ReleaseClusterAutoscaler, NamespaceClusterAutoscaler,
+	)
+	if err != nil {
+		return cfg, fmt.Errorf("check cluster-autoscaler release: %w", err)
+	}
+
+	if !exists {
+		return cfg, nil
+	}
+
+	cfg.Enabled = true
+
+	values, err := d.helmClient.GetReleaseValues(
+		ctx, ReleaseClusterAutoscaler, NamespaceClusterAutoscaler,
+	)
+	if err != nil {
+		// Release exists but values unreadable — return enabled with defaults.
+		return cfg, nil //nolint:nilerr // graceful fallback; enabled is the critical signal
+	}
+
+	parseAutoscalerValues(&cfg, values)
+
+	return cfg, nil
+}
+
+// parseAutoscalerValues extracts autoscaler config from Helm release values.
+func parseAutoscalerValues(cfg *v1alpha1.NodeAutoscalerConfig, values map[string]interface{}) {
+	extraArgs, ok := values["extraArgs"].(map[string]interface{})
+	if ok {
+		parseAutoscalerExtraArgs(cfg, extraArgs)
+	}
+
+	groups, ok := values["autoscalingGroups"].([]interface{})
+	if ok {
+		cfg.Pools = parseAutoscalingGroups(groups)
+	}
+}
+
+// parseAutoscalerExtraArgs extracts scalar config from the chart's extraArgs.
+func parseAutoscalerExtraArgs(cfg *v1alpha1.NodeAutoscalerConfig, args map[string]interface{}) {
+	if expander, ok := args["expander"].(string); ok {
+		cfg.Expander = helmExpanderToEnum(expander)
+	}
+
+	if maxNodes, ok := toInt32(args["max-nodes-total"]); ok {
+		cfg.MaxNodesTotal = maxNodes
+	}
+
+	if scaleDown, ok := args["scale-down-unneeded-time"].(string); ok {
+		cfg.ScaleDownUnneededTime = scaleDown
+	}
+}
+
+// helmExpanderToEnum reverses the Helm chart's lowercase expander value to the
+// KSail enum. Must stay in sync with expanderToHelmValue in the installer.
+func helmExpanderToEnum(value string) v1alpha1.AutoscalerExpander {
+	switch value {
+	case "price":
+		return v1alpha1.AutoscalerExpanderPrice
+	case "least-nodes":
+		return v1alpha1.AutoscalerExpanderLeastNodes
+	case "random":
+		return v1alpha1.AutoscalerExpanderRandom
+	case "least-waste":
+		return v1alpha1.AutoscalerExpanderLeastWaste
+	default:
+		return v1alpha1.AutoscalerExpanderLeastWaste
+	}
+}
+
+// parseAutoscalingGroups converts the chart's autoscalingGroups list to NodePool slices.
+func parseAutoscalingGroups(groups []interface{}) []v1alpha1.NodePool {
+	pools := make([]v1alpha1.NodePool, 0, len(groups))
+
+	for _, g := range groups {
+		gm, ok := g.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		pool := v1alpha1.NodePool{}
+		if name, ok := gm["name"].(string); ok {
+			pool.Name = name
+		}
+
+		if st, ok := gm["instanceType"].(string); ok {
+			pool.ServerType = st
+		}
+
+		if loc, ok := gm["region"].(string); ok {
+			pool.Location = loc
+		}
+
+		if minSize, ok := toInt32(gm["minSize"]); ok {
+			pool.Min = minSize
+		}
+
+		if maxSize, ok := toInt32(gm["maxSize"]); ok {
+			pool.Max = maxSize
+		}
+
+		pools = append(pools, pool)
+	}
+
+	return pools
+}
+
+// toInt32 converts a Helm values entry (which may be float64 or json.Number)
+// to int32. Returns (0, false) when the value is not a numeric type.
+func toInt32(v interface{}) (int32, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int32(n), true
+	case int:
+		return int32(n), true
+	case int32:
+		return n, true
+	case int64:
+		return int32(n), true
+	default:
+		return 0, false
+	}
 }

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -575,7 +575,7 @@ func (d *ComponentDetector) detectNodeAutoscaler(
 			return cfg, fmt.Errorf("detect node autoscaler: %w", ctx.Err())
 		}
 		// Release exists but values unreadable — return enabled with defaults.
-		return cfg, nil //nolint:nilerr // graceful fallback; enabled is the critical signal
+		return cfg, nil
 	}
 
 	parseAutoscalerValues(&cfg, values)

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -637,6 +637,7 @@ func parseAutoscalingGroups(groups []any) []v1alpha1.NodePool {
 		}
 
 		pool := v1alpha1.NodePool{}
+
 		name, hasName := group["name"].(string)
 		if !hasName || name == "" {
 			continue

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -570,6 +570,10 @@ func (d *ComponentDetector) detectNodeAutoscaler(
 		ctx, ReleaseClusterAutoscaler, NamespaceClusterAutoscaler,
 	)
 	if err != nil {
+		// Propagate context cancellation/timeout — the caller has given up.
+		if ctx.Err() != nil {
+			return cfg, ctx.Err()
+		}
 		// Release exists but values unreadable — return enabled with defaults.
 		return cfg, nil //nolint:nilerr // graceful fallback; enabled is the critical signal
 	}

--- a/pkg/svc/detector/component_test.go
+++ b/pkg/svc/detector/component_test.go
@@ -1122,6 +1122,52 @@ func TestDetectNodeAutoscaler_ValuesUnreadable(t *testing.T) {
 	assert.Empty(t, cfg.Pools)
 }
 
+func TestDetectNodeAutoscaler_SkipsPoolWithEmptyName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ReleaseExists", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(true, nil)
+
+	helmClient.On("GetReleaseValues", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(map[string]any{
+		"autoscalingGroups": []any{
+			map[string]any{
+				"name":         "",
+				"instanceType": "cx23",
+				"region":       "fsn1",
+				"minSize":      float64(0),
+				"maxSize":      float64(1),
+			},
+			map[string]any{
+				"instanceType": "cx33",
+				"region":       "fsn1",
+				"minSize":      float64(0),
+				"maxSize":      float64(3),
+			},
+			map[string]any{
+				"name":         "valid-pool",
+				"instanceType": "cx43",
+				"region":       "fsn1",
+				"minSize":      float64(0),
+				"maxSize":      float64(5),
+			},
+		},
+	}, nil)
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	cfg, err := d.ExportDetectNodeAutoscaler(ctx)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Pools, 1)
+	assert.Equal(t, "valid-pool", cfg.Pools[0].Name)
+}
+
 func TestHelmExpanderToEnum(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/detector/component_test.go
+++ b/pkg/svc/detector/component_test.go
@@ -1047,14 +1047,14 @@ func TestDetectNodeAutoscaler_Enabled(t *testing.T) {
 
 	helmClient.On("GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
-	).Return(map[string]interface{}{
-		"extraArgs": map[string]interface{}{
+	).Return(map[string]any{
+		"extraArgs": map[string]any{
 			"expander":                 "price",
 			"max-nodes-total":          float64(10),
 			"scale-down-unneeded-time": "10m",
 		},
-		"autoscalingGroups": []interface{}{
-			map[string]interface{}{
+		"autoscalingGroups": []any{
+			map[string]any{
 				"name":         "autoscale-small",
 				"instanceType": "cx23",
 				"region":       "fsn1",

--- a/pkg/svc/detector/component_test.go
+++ b/pkg/svc/detector/component_test.go
@@ -21,6 +21,7 @@ import (
 var (
 	errHelm   = errors.New("helm error")
 	errDocker = errors.New("docker error")
+	errValues = errors.New("values error")
 )
 
 func TestNewComponentDetector(t *testing.T) {
@@ -1111,7 +1112,7 @@ func TestDetectNodeAutoscaler_ValuesUnreadable(t *testing.T) {
 
 	helmClient.On("GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
-	).Return(nil, errors.New("values error"))
+	).Return(nil, errValues)
 
 	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
 	cfg, err := d.ExportDetectNodeAutoscaler(ctx)

--- a/pkg/svc/detector/component_test.go
+++ b/pkg/svc/detector/component_test.go
@@ -1030,3 +1030,115 @@ func TestDetectFirstRelease_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "helm error")
 }
+
+// --- Node Autoscaler Detection ---
+
+func TestDetectNodeAutoscaler_Enabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ReleaseExists", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(true, nil)
+
+	helmClient.On("GetReleaseValues", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(map[string]interface{}{
+		"extraArgs": map[string]interface{}{
+			"expander":                 "price",
+			"max-nodes-total":          float64(10),
+			"scale-down-unneeded-time": "10m",
+		},
+		"autoscalingGroups": []interface{}{
+			map[string]interface{}{
+				"name":         "autoscale-small",
+				"instanceType": "cx23",
+				"region":       "fsn1",
+				"minSize":      float64(0),
+				"maxSize":      float64(1),
+			},
+		},
+	}, nil)
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	cfg, err := d.ExportDetectNodeAutoscaler(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, v1alpha1.AutoscalerExpanderPrice, cfg.Expander)
+	assert.Equal(t, int32(10), cfg.MaxNodesTotal)
+	assert.Equal(t, "10m", cfg.ScaleDownUnneededTime)
+	require.Len(t, cfg.Pools, 1)
+	assert.Equal(t, "autoscale-small", cfg.Pools[0].Name)
+	assert.Equal(t, "cx23", cfg.Pools[0].ServerType)
+	assert.Equal(t, "fsn1", cfg.Pools[0].Location)
+	assert.Equal(t, int32(0), cfg.Pools[0].Min)
+	assert.Equal(t, int32(1), cfg.Pools[0].Max)
+}
+
+func TestDetectNodeAutoscaler_NotInstalled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ReleaseExists", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(false, nil)
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	cfg, err := d.ExportDetectNodeAutoscaler(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, cfg.Enabled)
+	assert.Empty(t, cfg.Pools)
+}
+
+func TestDetectNodeAutoscaler_ValuesUnreadable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ReleaseExists", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(true, nil)
+
+	helmClient.On("GetReleaseValues", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(nil, errors.New("values error"))
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	cfg, err := d.ExportDetectNodeAutoscaler(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled)
+	assert.Empty(t, cfg.Pools)
+}
+
+func TestHelmExpanderToEnum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected v1alpha1.AutoscalerExpander
+	}{
+		{"price", v1alpha1.AutoscalerExpanderPrice},
+		{"least-waste", v1alpha1.AutoscalerExpanderLeastWaste},
+		{"least-nodes", v1alpha1.AutoscalerExpanderLeastNodes},
+		{"random", v1alpha1.AutoscalerExpanderRandom},
+		{"unknown", v1alpha1.AutoscalerExpanderLeastWaste},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, detector.ExportHelmExpanderToEnum(tc.input))
+		})
+	}
+}

--- a/pkg/svc/detector/export_test.go
+++ b/pkg/svc/detector/export_test.go
@@ -112,3 +112,20 @@ func ExportDetectFirstRelease[T ~string](
 ) (T, error) {
 	return detectFirstRelease(ctx, helmClient, mappings, defaultVal)
 }
+
+// ExportDetectNodeAutoscaler exposes detectNodeAutoscaler for testing.
+func (d *ComponentDetector) ExportDetectNodeAutoscaler(
+	ctx context.Context,
+) (v1alpha1.NodeAutoscalerConfig, error) {
+	return d.detectNodeAutoscaler(ctx)
+}
+
+// ExportParseAutoscalerValues exposes parseAutoscalerValues for testing.
+func ExportParseAutoscalerValues(cfg *v1alpha1.NodeAutoscalerConfig, values map[string]interface{}) {
+	parseAutoscalerValues(cfg, values)
+}
+
+// ExportHelmExpanderToEnum exposes helmExpanderToEnum for testing.
+func ExportHelmExpanderToEnum(value string) v1alpha1.AutoscalerExpander {
+	return helmExpanderToEnum(value)
+}

--- a/pkg/svc/detector/export_test.go
+++ b/pkg/svc/detector/export_test.go
@@ -120,11 +120,6 @@ func (d *ComponentDetector) ExportDetectNodeAutoscaler(
 	return d.detectNodeAutoscaler(ctx)
 }
 
-// ExportParseAutoscalerValues exposes parseAutoscalerValues for testing.
-func ExportParseAutoscalerValues(cfg *v1alpha1.NodeAutoscalerConfig, values map[string]interface{}) {
-	parseAutoscalerValues(cfg, values)
-}
-
 // ExportHelmExpanderToEnum exposes helmExpanderToEnum for testing.
 func ExportHelmExpanderToEnum(value string) v1alpha1.AutoscalerExpander {
 	return helmExpanderToEnum(value)

--- a/pkg/svc/detector/releases.go
+++ b/pkg/svc/detector/releases.go
@@ -69,4 +69,9 @@ const (
 	DeploymentLocalPathProvisionerK3s = "local-path-provisioner"
 	// LabelServiceLBK3s is the label applied to DaemonSets created by K3s ServiceLB.
 	LabelServiceLBK3s = "svccontroller.k3s.cattle.io/svcname"
+
+	// ReleaseClusterAutoscaler is the Helm release name for the Cluster Autoscaler.
+	ReleaseClusterAutoscaler = "cluster-autoscaler"
+	// NamespaceClusterAutoscaler is the namespace where the Cluster Autoscaler is installed.
+	NamespaceClusterAutoscaler = "kube-system"
 )

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -400,7 +400,7 @@ var talosISORule = fieldRule{
 	field:      "cluster.talos.iso",
 	category:   clusterupdate.ChangeCategoryInPlace,
 	reason:     "ISO change only affects newly provisioned nodes",
-	defaultVal: "122630",
+	defaultVal: strconv.FormatInt(v1alpha1.DefaultTalosISO, 10),
 	getVal: func(s *v1alpha1.ClusterSpec) string {
 		if s.Talos.ISO == 0 {
 			return ""

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -96,6 +96,10 @@ type fieldRule struct {
 	// rules whose change impact varies by distribution/provider (e.g. CDI is
 	// recreate-required on Kind but reboot-required on Talos).
 	categoryFn func() clusterupdate.ChangeCategory
+	// skipWhenNewEmpty, when true, skips the diff when the desired (new) value is
+	// empty. Use this for fields that are optional in the user config — when the user
+	// hasn't set the field, any detected current value should not produce a diff.
+	skipWhenNewEmpty bool
 }
 
 // scalarFieldRules returns the table of simple scalar field diff rules.
@@ -263,13 +267,18 @@ func (e *Engine) applyFieldRules(
 	rules []fieldRule,
 ) {
 	for _, rule := range rules {
+		newVal := rule.getVal(newSpec)
+		if rule.skipWhenNewEmpty && newVal == "" {
+			continue
+		}
+
 		cat := rule.category
 		if rule.categoryFn != nil {
 			cat = rule.categoryFn()
 		}
 
 		appendChange(result, rule.field,
-			rule.getVal(oldSpec), rule.getVal(newSpec),
+			rule.getVal(oldSpec), newVal,
 			rule.defaultVal, rule.reason, cat)
 	}
 }
@@ -373,6 +382,10 @@ var talosFieldRules = []fieldRule{
 		category: clusterupdate.ChangeCategoryInPlace,
 		reason:   "version pin change only affects future operations (image selection, upgrade cap)",
 		getVal:   func(s *v1alpha1.ClusterSpec) string { return s.Talos.Version },
+		// skipWhenNewEmpty suppresses false-positive diffs when the user has not
+		// pinned a version in ksail.yaml. The detected running version is
+		// informational; absence of a desired version means "no constraint".
+		skipWhenNewEmpty: true,
 	},
 	{
 		field:    "cluster.controlPlanes",

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -390,13 +390,24 @@ var talosFieldRules = []fieldRule{
 }
 
 // talosISORule is the ISO field rule used by the Talos field rules.
+// ISO is a boot-time setting (Hetzner Cloud ISO ID) that cannot be detected from
+// the running cluster. When the old spec has 0 (unknown/unset), getVal returns ""
+// so that the defaultVal substitution normalises both sides to the config default,
+// suppressing false-positive diffs.
 //
 //nolint:gochecknoglobals // Immutable field-rule; avoids per-call heap allocation.
 var talosISORule = fieldRule{
-	field:    "cluster.talos.iso",
-	category: clusterupdate.ChangeCategoryInPlace,
-	reason:   "ISO change only affects newly provisioned nodes",
-	getVal:   func(s *v1alpha1.ClusterSpec) string { return strconv.FormatInt(s.Talos.ISO, 10) },
+	field:      "cluster.talos.iso",
+	category:   clusterupdate.ChangeCategoryInPlace,
+	reason:     "ISO change only affects newly provisioned nodes",
+	defaultVal: "122630",
+	getVal: func(s *v1alpha1.ClusterSpec) string {
+		if s.Talos.ISO == 0 {
+			return ""
+		}
+
+		return strconv.FormatInt(s.Talos.ISO, 10)
+	},
 }
 
 // checkHetznerOptionsChange checks Hetzner-specific option changes.

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -1361,3 +1361,64 @@ func TestEngine_AutoscalerToggle_NodeCountAlwaysDetected(t *testing.T) {
 	assertSingleChange(t, result.InPlaceChanges, testFieldWorkers,
 		"1", "5", clusterupdate.ChangeCategoryInPlace)
 }
+
+func TestEngine_TalosISO_SuppressedWhenOldUnknown(t *testing.T) {
+	t.Parallel()
+
+	// Simulate GetCurrentConfig returning 0 (unset) for ISO — the live cluster
+	// can't report what ISO it booted from.
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.Talos.ISO = 0
+
+	newer := clone(old)
+	newer.Talos.ISO = 122630
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	// ISO should NOT appear as a change because both sides normalise to the
+	// default "122630" via the defaultVal mechanism.
+	for _, c := range result.AllChanges() {
+		if c.Field == "cluster.talos.iso" {
+			t.Fatalf("expected no ISO diff when old value is 0 (unknown), got %+v", c)
+		}
+	}
+}
+
+func TestEngine_TalosISO_DetectedWhenBothNonZero(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.Talos.ISO = 122630
+
+	newer := clone(old)
+	newer.Talos.ISO = 999999
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.iso",
+		"122630", "999999", clusterupdate.ChangeCategoryInPlace)
+}
+
+func TestEngine_TalosVersion_NoChangeWhenBothSet(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.Talos.Version = "v1.11.2"
+
+	newer := clone(old)
+	newer.Talos.Version = "v1.11.2"
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	for _, c := range result.AllChanges() {
+		if c.Field == "cluster.talos.version" {
+			t.Fatalf("expected no talos.version diff when values match, got %+v", c)
+		}
+	}
+}

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -1427,3 +1427,61 @@ func TestEngine_TalosVersion_NoChangeWhenBothSet(t *testing.T) {
 		}
 	}
 }
+
+func TestEngine_TalosVersion_NoChangeWhenNewEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Old spec has detected version (live cluster); new spec has no version pinned.
+	// This is the regression case: introspectTalosVersion detects a version but
+	// the user hasn't pinned one in ksail.yaml — no diff should be emitted.
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.Talos.Version = "v1.13.0"
+
+	newer := clone(old)
+	newer.Talos.Version = ""
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	for _, c := range result.AllChanges() {
+		if c.Field == "cluster.talos.version" {
+			t.Fatalf("expected no talos.version diff when new version is empty, got %+v", c)
+		}
+	}
+}
+
+func TestEngine_TalosVersion_ChangeWhenNewDiffers(t *testing.T) {
+	t.Parallel()
+
+	// Both specs pin a version but they differ — a diff should be emitted.
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.Talos.Version = "v1.11.2"
+
+	newer := clone(old)
+	newer.Talos.Version = "v1.13.0"
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.version", "v1.11.2", "v1.13.0", clusterupdate.ChangeCategoryInPlace)
+}
+
+func TestEngine_TalosVersion_ChangeWhenOldEmptyNewSet(t *testing.T) {
+	t.Parallel()
+
+	// Old spec has no detected version; new spec pins one.
+	// Detection failed (e.g., no API access) but user wants a specific version.
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.Talos.Version = ""
+
+	newer := clone(old)
+	newer.Talos.Version = "v1.11.2"
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.version", "", "v1.11.2", clusterupdate.ChangeCategoryInPlace)
+}

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -1,6 +1,7 @@
 package diff_test
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -34,7 +35,7 @@ func newBaseSpec() *v1alpha1.ClusterSpec {
 		ControlPlanes: 1,
 		Workers:       0,
 		Talos: v1alpha1.OptionsTalos{
-			ISO: 122630,
+			ISO: v1alpha1.DefaultTalosISO,
 		},
 	}
 }
@@ -477,10 +478,10 @@ func TestEngine_TalosOptionsChange(t *testing.T) {
 		},
 		{
 			name:     "ISO change",
-			mutate:   func(s *v1alpha1.ClusterSpec) { s.Talos.ISO = 122629 },
+			mutate:   func(s *v1alpha1.ClusterSpec) { s.Talos.ISO = v1alpha1.DefaultTalosISO - 1 },
 			field:    "cluster.talos.iso",
-			oldValue: "122630",
-			newValue: "122629",
+			oldValue: strconv.FormatInt(v1alpha1.DefaultTalosISO, 10),
+			newValue: strconv.FormatInt(v1alpha1.DefaultTalosISO-1, 10),
 		},
 	}
 
@@ -1015,7 +1016,7 @@ func TestEngine_TalosISOStillDetected_WhenAutoscalingEnabled(t *testing.T) {
 
 	old := newBaseSpec()
 	newer := clone(old)
-	newer.Talos.ISO = 999999
+	newer.Talos.ISO = v1alpha1.DefaultTalosISO + 1
 	newer.NodeAutoscaling = v1alpha1.NodeAutoscalingEnabled
 
 	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
@@ -1026,7 +1027,7 @@ func TestEngine_TalosISOStillDetected_WhenAutoscalingEnabled(t *testing.T) {
 	}
 
 	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.iso",
-		"122630", "999999", clusterupdate.ChangeCategoryInPlace)
+		strconv.FormatInt(v1alpha1.DefaultTalosISO, 10), strconv.FormatInt(v1alpha1.DefaultTalosISO+1, 10), clusterupdate.ChangeCategoryInPlace)
 }
 
 func TestEngine_AutoscalerNodeEnabledChange(t *testing.T) {
@@ -1372,13 +1373,13 @@ func TestEngine_TalosISO_SuppressedWhenOldUnknown(t *testing.T) {
 	old.Talos.ISO = 0
 
 	newer := clone(old)
-	newer.Talos.ISO = 122630
+	newer.Talos.ISO = v1alpha1.DefaultTalosISO
 
 	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
 	result := engine.ComputeDiff(old, newer, nil, nil)
 
 	// ISO should NOT appear as a change because both sides normalise to the
-	// default "122630" via the defaultVal mechanism.
+	// default ISO via the defaultVal mechanism.
 	for _, c := range result.AllChanges() {
 		if c.Field == "cluster.talos.iso" {
 			t.Fatalf("expected no ISO diff when old value is 0 (unknown), got %+v", c)
@@ -1391,16 +1392,16 @@ func TestEngine_TalosISO_DetectedWhenBothNonZero(t *testing.T) {
 
 	old := newBaseSpec()
 	old.Distribution = v1alpha1.DistributionTalos
-	old.Talos.ISO = 122630
+	old.Talos.ISO = v1alpha1.DefaultTalosISO
 
 	newer := clone(old)
-	newer.Talos.ISO = 999999
+	newer.Talos.ISO = v1alpha1.DefaultTalosISO + 1
 
 	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
 	result := engine.ComputeDiff(old, newer, nil, nil)
 
 	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.iso",
-		"122630", "999999", clusterupdate.ChangeCategoryInPlace)
+		strconv.FormatInt(v1alpha1.DefaultTalosISO, 10), strconv.FormatInt(v1alpha1.DefaultTalosISO+1, 10), clusterupdate.ChangeCategoryInPlace)
 }
 
 func TestEngine_TalosVersion_NoChangeWhenBothSet(t *testing.T) {

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -16,6 +16,7 @@ const (
 	testRegistryAlt        = "localhost:6060"
 	testFieldControlPlanes = "cluster.controlPlanes"
 	testFieldWorkers       = "cluster.workers"
+	testTalosVersionOld    = "v1.11.2"
 )
 
 func newBaseSpec() *v1alpha1.ClusterSpec {
@@ -1413,10 +1414,10 @@ func TestEngine_TalosVersion_NoChangeWhenBothSet(t *testing.T) {
 
 	old := newBaseSpec()
 	old.Distribution = v1alpha1.DistributionTalos
-	old.Talos.Version = "v1.11.2"
+	old.Talos.Version = testTalosVersionOld
 
 	newer := clone(old)
-	newer.Talos.Version = "v1.11.2"
+	newer.Talos.Version = testTalosVersionOld
 
 	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
 	result := engine.ComputeDiff(old, newer, nil, nil)
@@ -1457,7 +1458,7 @@ func TestEngine_TalosVersion_ChangeWhenNewDiffers(t *testing.T) {
 	// Both specs pin a version but they differ — a diff should be emitted.
 	old := newBaseSpec()
 	old.Distribution = v1alpha1.DistributionTalos
-	old.Talos.Version = "v1.11.2"
+	old.Talos.Version = testTalosVersionOld
 
 	newer := clone(old)
 	newer.Talos.Version = "v1.13.0"
@@ -1465,7 +1466,11 @@ func TestEngine_TalosVersion_ChangeWhenNewDiffers(t *testing.T) {
 	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
 	result := engine.ComputeDiff(old, newer, nil, nil)
 
-	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.version", "v1.11.2", "v1.13.0", clusterupdate.ChangeCategoryInPlace)
+	assertSingleChange(
+		t, result.InPlaceChanges,
+		"cluster.talos.version", testTalosVersionOld, "v1.13.0",
+		clusterupdate.ChangeCategoryInPlace,
+	)
 }
 
 func TestEngine_TalosVersion_ChangeWhenOldEmptyNewSet(t *testing.T) {
@@ -1478,10 +1483,14 @@ func TestEngine_TalosVersion_ChangeWhenOldEmptyNewSet(t *testing.T) {
 	old.Talos.Version = ""
 
 	newer := clone(old)
-	newer.Talos.Version = "v1.11.2"
+	newer.Talos.Version = testTalosVersionOld
 
 	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
 	result := engine.ComputeDiff(old, newer, nil, nil)
 
-	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.version", "", "v1.11.2", clusterupdate.ChangeCategoryInPlace)
+	assertSingleChange(
+		t, result.InPlaceChanges,
+		"cluster.talos.version", "", testTalosVersionOld,
+		clusterupdate.ChangeCategoryInPlace,
+	)
 }

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -1027,7 +1027,9 @@ func TestEngine_TalosISOStillDetected_WhenAutoscalingEnabled(t *testing.T) {
 	}
 
 	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.iso",
-		strconv.FormatInt(v1alpha1.DefaultTalosISO, 10), strconv.FormatInt(v1alpha1.DefaultTalosISO+1, 10), clusterupdate.ChangeCategoryInPlace)
+		strconv.FormatInt(v1alpha1.DefaultTalosISO, 10),
+		strconv.FormatInt(v1alpha1.DefaultTalosISO+1, 10),
+		clusterupdate.ChangeCategoryInPlace)
 }
 
 func TestEngine_AutoscalerNodeEnabledChange(t *testing.T) {
@@ -1401,7 +1403,9 @@ func TestEngine_TalosISO_DetectedWhenBothNonZero(t *testing.T) {
 	result := engine.ComputeDiff(old, newer, nil, nil)
 
 	assertSingleChange(t, result.InPlaceChanges, "cluster.talos.iso",
-		strconv.FormatInt(v1alpha1.DefaultTalosISO, 10), strconv.FormatInt(v1alpha1.DefaultTalosISO+1, 10), clusterupdate.ChangeCategoryInPlace)
+		strconv.FormatInt(v1alpha1.DefaultTalosISO, 10),
+		strconv.FormatInt(v1alpha1.DefaultTalosISO+1, 10),
+		clusterupdate.ChangeCategoryInPlace)
 }
 
 func TestEngine_TalosVersion_NoChangeWhenBothSet(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -606,8 +606,8 @@ func (p *Provisioner) introspectNodeCounts(ctx context.Context) (int32, int32) {
 
 // introspectTalosVersion queries a control-plane node for the running Talos
 // version. Returns an empty string when the version cannot be determined
-// (e.g., no Talos API access), which causes the diff engine to fall back to
-// its default-value handling.
+// (e.g., no Talos API access); in that case the diff engine will report a
+// version change if the desired spec specifies a version.
 func (p *Provisioner) introspectTalosVersion(ctx context.Context) string {
 	clusterName := p.resolveClusterName("")
 

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -546,6 +546,7 @@ func (p *Provisioner) GetCurrentConfig(
 			spec.CertManager = detected.CertManager
 			spec.PolicyEngine = detected.PolicyEngine
 			spec.GitOpsEngine = detected.GitOpsEngine
+			spec.Autoscaler.Node = detected.Autoscaler.Node
 		}
 	}
 
@@ -554,6 +555,10 @@ func (p *Provisioner) GetCurrentConfig(
 	controlPlanes, workers := p.introspectNodeCounts(ctx)
 	spec.ControlPlanes = controlPlanes
 	spec.Workers = workers
+
+	// Detect the running Talos version from the cluster to avoid
+	// false-positive diffs when the user pins a version in config.
+	spec.Talos.Version = p.introspectTalosVersion(ctx)
 
 	// Build provider spec if we have Hetzner options configured.
 	// Hetzner fields (server types, location, network, SSH key) cannot be
@@ -597,6 +602,26 @@ func (p *Provisioner) introspectNodeCounts(ctx context.Context) (int32, int32) {
 	}
 
 	return 1, 0
+}
+
+// introspectTalosVersion queries a control-plane node for the running Talos
+// version. Returns an empty string when the version cannot be determined
+// (e.g., no Talos API access), which causes the diff engine to fall back to
+// its default-value handling.
+func (p *Provisioner) introspectTalosVersion(ctx context.Context) string {
+	clusterName := p.resolveClusterName("")
+
+	nodes, err := p.getNodesByRole(ctx, clusterName)
+	if err != nil || len(nodes) == 0 {
+		return ""
+	}
+
+	version, err := p.getRunningTalosVersion(ctx, nodes[0].IP)
+	if err != nil {
+		return ""
+	}
+
+	return version
 }
 
 // countNodeRoles counts control-plane and worker nodes from a list of nodeWithRole.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -616,7 +616,19 @@ func (p *Provisioner) introspectTalosVersion(ctx context.Context) string {
 		return ""
 	}
 
-	version, err := p.getRunningTalosVersion(ctx, nodes[0].IP)
+	// Prefer a control-plane node for the version query; fall back to the
+	// first available node if no control-plane node is found.
+	target := nodes[0]
+
+	for _, node := range nodes {
+		if node.Role == RoleControlPlane {
+			target = node
+
+			break
+		}
+	}
+
+	version, err := p.getRunningTalosVersion(ctx, target.IP)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Problem

`ksail cluster update` in `devantler-tech/platform` (Talos + Hetzner) reports 8 configuration changes on **every** run, even when nothing has changed:

| Field | Before (detected) | After (desired) |
|---|---|---|
| `cluster.talos.version` | *(empty)* | v1.11.2 |
| `cluster.talos.iso` | 0 | 122630 |
| `cluster.autoscaler.node.enabled` | false | true |
| `cluster.autoscaler.node.maxNodesTotal` | 0 | 10 |
| `cluster.autoscaler.node.expander` | LeastWaste | Price |
| `cluster.autoscaler.node.scaleDownUnneededTime` | *(empty)* | 10m |
| `cluster.autoscaler.node.pools[autoscale-medium]` | *(empty)* | Added |
| `cluster.autoscaler.node.pools[autoscale-small]` | *(empty)* | Added |

## Root Cause

`GetCurrentConfig()` started from `DefaultCurrentSpec()` with zero values for Talos-specific and autoscaler fields. The `ComponentDetector` didn't detect these, so they always diffed as false positives — including on ephemeral CI runners.

## Fix

Live cluster detection for all 8 fields:

1. **`GetReleaseValues` on Helm client** — reads installed release config via `helmv4action.NewGetValues`
2. **Autoscaler detection in `ComponentDetector`** — checks `cluster-autoscaler` Helm release + reads values (expander, maxNodesTotal, scaleDownUnneededTime, pools)
3. **Talos version from live cluster** — calls `getRunningTalosVersion()` in `GetCurrentConfig()`
4. **ISO diff suppression** — boot-time setting undetectable from the live cluster; treats `0` (unknown) as the default
5. **State persistence (secondary)** — wires `SaveClusterSpec` into create/update for best-effort local dev support

## Testing

- 12 new tests for autoscaler detection, expander mapping, ISO suppression, and Talos version
- All existing tests pass