### PR TITLE
fix: register cluster-autoscaler reconciler for update command

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -4334,7 +4334,9 @@ func (r *componentReconciler) doReconcileClusterAutoscaler(ctx context.Context) 
 	}
 
 	// Autoscaler no longer needed — uninstall only on Talos × Hetzner clusters
-	// where it could have been previously installed.
+	// where it could have been previously installed. Treat "release not found"
+	// as a successful no-op so the update is idempotent when the autoscaler was
+	// never installed (e.g. cluster created before autoscaler support).
 	if r.clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionTalos ||
 		r.clusterCfg.Spec.Cluster.Provider != v1alpha1.ProviderHetzner {
 		return nil
@@ -4344,7 +4346,12 @@ func (r *componentReconciler) doReconcileClusterAutoscaler(ctx context.Context) 
 		return setup.ErrClusterAutoscalerInstallerFactoryNil
 	}
 
-	return r.uninstallWithFactory(ctx, r.factories.ClusterAutoscaler)
+	err := r.uninstallWithFactory(ctx, r.factories.ClusterAutoscaler)
+	if err != nil && errors.Is(err, helm.ErrReleaseNotFound) {
+		return nil
+	}
+
+	return err
 }
 
 // reconcileCertManager installs or uninstalls cert-manager.

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -4131,6 +4131,11 @@ type componentReconciler struct {
 	clusterCfg  *v1alpha1.Cluster
 	clusterName string
 	factories   *setup.InstallerFactories
+	// autoscalerReconciled tracks whether the cluster autoscaler has already been
+	// reconciled during this update pass. Multiple diff fields share the
+	// "cluster.autoscaler.node." prefix and map to a single Helm operation;
+	// this flag deduplicates the install/upgrade/uninstall call.
+	autoscalerReconciled bool
 }
 
 // newComponentReconciler creates a reconciler for applying component changes.
@@ -4206,9 +4211,18 @@ func (r *componentReconciler) handlerForField(
 		"cluster.workload.tag":  r.reconcileWorkloadTag,
 	}
 
-	handler, ok := handlers[field]
+	if handler, ok := handlers[field]; ok {
+		return handler, true
+	}
 
-	return handler, ok
+	// Prefix-based matching for fields with dynamic suffixes.
+	// All cluster.autoscaler.node.* fields (enabled, maxNodesTotal, expander,
+	// scaleDownUnneededTime, pools[...]) map to a single Helm install/upgrade.
+	if strings.HasPrefix(field, "cluster.autoscaler.node.") {
+		return r.reconcileClusterAutoscaler, true
+	}
+
+	return nil, false
 }
 
 // reconcileCNI switches the CNI by installing the new CNI.
@@ -4283,6 +4297,43 @@ func (r *componentReconciler) reconcileLoadBalancer(
 	}
 
 	return nil
+}
+
+// reconcileClusterAutoscaler installs or uninstalls the Cluster Autoscaler.
+// Multiple autoscaler diff fields (enabled, maxNodesTotal, pools, …) map to this
+// single handler. The autoscalerReconciled guard ensures the Helm operation runs
+// at most once per update pass.
+func (r *componentReconciler) reconcileClusterAutoscaler(
+	ctx context.Context,
+	_ clusterupdate.Change,
+) error {
+	if r.autoscalerReconciled {
+		return nil
+	}
+
+	r.autoscalerReconciled = true
+
+	if setup.NeedsClusterAutoscalerInstall(r.clusterCfg) {
+		err := setup.InstallClusterAutoscalerSilent(ctx, r.clusterCfg, r.factories)
+		if err != nil {
+			return fmt.Errorf("failed to install cluster-autoscaler: %w", err)
+		}
+
+		return nil
+	}
+
+	// Autoscaler no longer needed — uninstall only on Talos × Hetzner clusters
+	// where it could have been previously installed.
+	if r.clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionTalos ||
+		r.clusterCfg.Spec.Cluster.Provider != v1alpha1.ProviderHetzner {
+		return nil
+	}
+
+	if r.factories.ClusterAutoscaler == nil {
+		return nil
+	}
+
+	return r.uninstallWithFactory(ctx, r.factories.ClusterAutoscaler)
 }
 
 // reconcileCertManager installs or uninstalls cert-manager.
@@ -5936,6 +5987,15 @@ func SetPolicyEngineInstallerFactoryForTests(
 ) func() {
 	return overrideInstallerFactory(func(f *setup.InstallerFactories) {
 		f.PolicyEngine = factory
+	})
+}
+
+// SetClusterAutoscalerInstallerFactoryForTests overrides the cluster-autoscaler installer factory.
+func SetClusterAutoscalerInstallerFactoryForTests(
+	factory func(*v1alpha1.Cluster) (installer.Installer, error),
+) func() {
+	return overrideInstallerFactory(func(f *setup.InstallerFactories) {
+		f.ClusterAutoscaler = factory
 	})
 }
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -4135,7 +4135,10 @@ type componentReconciler struct {
 	// reconciled during this update pass. Multiple diff fields share the
 	// "cluster.autoscaler.node." prefix and map to a single Helm operation;
 	// this flag deduplicates the install/upgrade/uninstall call.
+	// autoscalerErr preserves the error from the first attempt so that
+	// subsequent calls surface the same failure instead of silently succeeding.
 	autoscalerReconciled bool
+	autoscalerErr        error
 }
 
 // newComponentReconciler creates a reconciler for applying component changes.
@@ -4302,17 +4305,25 @@ func (r *componentReconciler) reconcileLoadBalancer(
 // reconcileClusterAutoscaler installs or uninstalls the Cluster Autoscaler.
 // Multiple autoscaler diff fields (enabled, maxNodesTotal, pools, …) map to this
 // single handler. The autoscalerReconciled guard ensures the Helm operation runs
-// at most once per update pass.
+// at most once per update pass; if it fails, subsequent calls replay the same error
+// so the failure is not masked by silent success.
 func (r *componentReconciler) reconcileClusterAutoscaler(
 	ctx context.Context,
 	_ clusterupdate.Change,
 ) error {
 	if r.autoscalerReconciled {
-		return nil
+		return r.autoscalerErr
 	}
 
 	r.autoscalerReconciled = true
 
+	r.autoscalerErr = r.doReconcileClusterAutoscaler(ctx)
+
+	return r.autoscalerErr
+}
+
+// doReconcileClusterAutoscaler performs the actual install/uninstall logic.
+func (r *componentReconciler) doReconcileClusterAutoscaler(ctx context.Context) error {
 	if setup.NeedsClusterAutoscalerInstall(r.clusterCfg) {
 		err := setup.InstallClusterAutoscalerSilent(ctx, r.clusterCfg, r.factories)
 		if err != nil {
@@ -4330,7 +4341,7 @@ func (r *componentReconciler) reconcileClusterAutoscaler(
 	}
 
 	if r.factories.ClusterAutoscaler == nil {
-		return nil
+		return setup.ErrClusterAutoscalerInstallerFactoryNil
 	}
 
 	return r.uninstallWithFactory(ctx, r.factories.ClusterAutoscaler)

--- a/pkg/cli/cmd/cluster/cluster_test.go
+++ b/pkg/cli/cmd/cluster/cluster_test.go
@@ -3910,6 +3910,11 @@ func TestHandlerForField_KnownFields(t *testing.T) {
 		"cluster.certManager",
 		"cluster.policyEngine",
 		"cluster.gitOpsEngine",
+		"cluster.autoscaler.node.enabled",
+		"cluster.autoscaler.node.maxNodesTotal",
+		"cluster.autoscaler.node.expander",
+		"cluster.autoscaler.node.scaleDownUnneededTime",
+		"cluster.autoscaler.node.pools[my-pool]",
 	}
 
 	for _, field := range knownFields {
@@ -4139,6 +4144,55 @@ func TestReconcileGitOpsEngine_EmptyToEmpty_Noop(t *testing.T) {
 	err := cluster.ExportReconcileGitOpsEngine(cmd, clusterCfg, change)
 
 	require.NoError(t, err, "empty→empty should be a no-op")
+}
+
+// TestReconcileClusterAutoscaler_NilFactory verifies that reconcileClusterAutoscaler returns
+// the factory-nil error when the autoscaler is needed but the factory is nil.
+//
+//nolint:paralleltest // mutates global installerFactoriesOverride; cannot run in parallel
+func TestReconcileClusterAutoscaler_NilFactory(t *testing.T) {
+	restore := cluster.SetClusterAutoscalerInstallerFactoryForTests(nil)
+	t.Cleanup(restore)
+
+	cmd := newReconcileTestCmd()
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionTalos
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderHetzner
+	clusterCfg.Spec.Cluster.Autoscaler.Node.Enabled = true
+
+	change := clusterupdate.Change{
+		Field:    "cluster.autoscaler.node.enabled",
+		OldValue: "false",
+		NewValue: "true",
+	}
+
+	err := cluster.ExportReconcileClusterAutoscaler(cmd, clusterCfg, change)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, setup.ErrClusterAutoscalerInstallerFactoryNil)
+}
+
+// TestReconcileClusterAutoscaler_NotNeeded_Noop verifies that reconcileClusterAutoscaler
+// is a no-op when the cluster does not require the autoscaler (e.g. non-Hetzner provider)
+// and the factory is nil (no uninstall needed for a component that was never installed).
+func TestReconcileClusterAutoscaler_NotNeeded_Noop(t *testing.T) {
+	t.Parallel()
+
+	cmd := newReconcileTestCmd()
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionVanilla
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderDocker
+	clusterCfg.Spec.Cluster.Autoscaler.Node.Enabled = false
+
+	change := clusterupdate.Change{
+		Field:    "cluster.autoscaler.node.enabled",
+		OldValue: "false",
+		NewValue: "false",
+	}
+
+	err := cluster.ExportReconcileClusterAutoscaler(cmd, clusterCfg, change)
+
+	require.NoError(t, err, "non-Hetzner clusters should not attempt autoscaler install")
 }
 
 // TestReconcileComponents_EmptyDiff verifies that an empty diff results in no changes and no error.

--- a/pkg/cli/cmd/cluster/cluster_test.go
+++ b/pkg/cli/cmd/cluster/cluster_test.go
@@ -4195,6 +4195,33 @@ func TestReconcileClusterAutoscaler_NotNeeded_Noop(t *testing.T) {
 	require.NoError(t, err, "non-Hetzner clusters should not attempt autoscaler install")
 }
 
+// TestReconcileClusterAutoscaler_Uninstall_NilFactory verifies that reconcileClusterAutoscaler
+// returns the factory-nil error when the autoscaler is no longer needed on a Talos×Hetzner
+// cluster and the factory is nil.
+//
+//nolint:paralleltest // mutates global installerFactoriesOverride; cannot run in parallel
+func TestReconcileClusterAutoscaler_Uninstall_NilFactory(t *testing.T) {
+	restore := cluster.SetClusterAutoscalerInstallerFactoryForTests(nil)
+	t.Cleanup(restore)
+
+	cmd := newReconcileTestCmd()
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionTalos
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderHetzner
+	clusterCfg.Spec.Cluster.Autoscaler.Node.Enabled = false
+
+	change := clusterupdate.Change{
+		Field:    "cluster.autoscaler.node.enabled",
+		OldValue: "true",
+		NewValue: "false",
+	}
+
+	err := cluster.ExportReconcileClusterAutoscaler(cmd, clusterCfg, change)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, setup.ErrClusterAutoscalerInstallerFactoryNil)
+}
+
 // TestReconcileComponents_EmptyDiff verifies that an empty diff results in no changes and no error.
 func TestReconcileComponents_EmptyDiff(t *testing.T) {
 	t.Parallel()

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -264,6 +264,17 @@ func ExportReconcileComponents(
 	return r.reconcileComponents(context.Background(), diff, result)
 }
 
+// ExportReconcileClusterAutoscaler exposes reconcileClusterAutoscaler for unit testing.
+func ExportReconcileClusterAutoscaler(
+	cmd *cobra.Command,
+	clusterCfg *v1alpha1.Cluster,
+	change clusterupdate.Change,
+) error {
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
+
+	return r.reconcileClusterAutoscaler(context.Background(), change)
+}
+
 // ExportMatchesKindPattern exposes matchesKindPattern for unit testing.
 func ExportMatchesKindPattern(containerName, clusterName string) bool {
 	return matchesKindPattern(containerName, clusterName)

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	helmv4driver "helm.sh/helm/v4/pkg/storage/driver"
 )
 
 var (
@@ -23,6 +25,11 @@ var (
 	// Helm release storage objects (Secrets or ConfigMaps) exist for the
 	// given release name and namespace.
 	ErrNoReleaseStorage = errors.New("helm: no release storage objects found")
+
+	// ErrReleaseNotFound re-exports the Helm SDK sentinel so callers can
+	// check whether an uninstall failed because the release never existed
+	// without importing the Helm driver package directly.
+	ErrReleaseNotFound = helmv4driver.ErrReleaseNotFound
 )
 
 // ChartSpec mirrors the mittwald chart specification while keeping KSail


### PR DESCRIPTION
## Summary

`ksail cluster update` silently skipped autoscaler configuration changes because `componentReconciler.handlerForField` had no entries for `cluster.autoscaler.node.*` diff fields. The diff engine correctly emitted in-place changes, but the reconciler loop skipped them with `continue` (not a component field).

## Changes

- **Add `reconcileClusterAutoscaler` handler** — installs/upgrades the autoscaler via `InstallClusterAutoscalerSilent` when `NeedsClusterAutoscalerInstall` returns true, or uninstalls when no longer needed on Talos × Hetzner clusters
- **Add prefix-based matching in `handlerForField`** — all `cluster.autoscaler.node.*` fields (enabled, maxNodesTotal, expander, scaleDownUnneededTime, pools[…]) route to the single handler
- **Deduplication guard** — `autoscalerReconciled` bool ensures the Helm operation runs at most once per update pass even when multiple autoscaler fields change simultaneously
- **Add `SetClusterAutoscalerInstallerFactoryForTests`** helper for test DI
- **Guard uninstall** to Talos × Hetzner only (the only combination that supports the autoscaler)

## Test coverage

- `TestHandlerForField_KnownFields` — expanded with 5 autoscaler field variants
- `TestReconcileClusterAutoscaler_NilFactory` — verifies error when factory is nil but autoscaler is needed
- `TestReconcileClusterAutoscaler_NotNeeded_Noop` — verifies no-op on non-Hetzner clusters

Fixes #4574