### PR TITLE
fix: reuse existing cluster secrets when scaling Talos nodes during update

### DIFF
--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -243,6 +243,54 @@ func (c *Configs) WithEndpoint(endpointIP string) (*Configs, error) {
 	)
 }
 
+// WithSecrets creates a new Configs with the provided secrets bundle, preserving the cluster's
+// existing PKI (CA, certificates, tokens, bootstrap secrets) across config regeneration.
+// This is used during cluster update to ensure that newly generated machine configs for
+// scale-up operations use the same CA and tokens as the running cluster.
+//
+// Returns a new Configs instance; the original is not modified.
+// Returns an error if bundle regeneration fails.
+// Returns the original Configs unchanged if existingSecrets is nil.
+func (c *Configs) WithSecrets(existingSecrets *secrets.Bundle) (*Configs, error) {
+	if existingSecrets == nil {
+		return c, nil
+	}
+
+	kubernetesVersion := c.kubernetesVersion
+	if kubernetesVersion == "" {
+		kubernetesVersion = DefaultKubernetesVersion
+	}
+
+	networkCIDR := c.networkCIDR
+	if networkCIDR == "" {
+		networkCIDR = DefaultNetworkCIDR
+	}
+
+	return newConfigsWithEndpointAndSecrets(
+		c.Name,
+		kubernetesVersion,
+		networkCIDR,
+		c.endpoint,
+		c.patches,
+		existingSecrets,
+		c.versionContract,
+		c.extensions,
+	)
+}
+
+// ExtractSecrets extracts the secrets bundle from the current config for reuse.
+// Returns nil if the bundle or control plane config is not set.
+func (c *Configs) ExtractSecrets() *secrets.Bundle {
+	if c.bundle == nil || c.bundle.ControlPlaneCfg == nil {
+		return nil
+	}
+
+	return secrets.NewBundleFromConfig(
+		secrets.NewFixedClock(time.Now()),
+		c.bundle.ControlPlaneCfg,
+	)
+}
+
 // KubernetesVersion returns the Kubernetes version used for this config.
 // Falls back to DefaultKubernetesVersion if not set.
 func (c *Configs) KubernetesVersion() string {

--- a/pkg/fsutil/configmanager/talos/configs_test.go
+++ b/pkg/fsutil/configmanager/talos/configs_test.go
@@ -428,3 +428,85 @@ func TestConfigs_Patches(t *testing.T) {
 		assert.Equal(t, "test.yaml", configs.Patches()[0].Path, "internal state was mutated")
 	})
 }
+
+func TestConfigs_WithSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves PKI secrets across regeneration", func(t *testing.T) {
+		t.Parallel()
+
+		// Create two independent config bundles — they'll have different secrets
+		manager1 := talos.NewConfigManager("", "cluster-a", "1.32.0", "10.5.0.0/24")
+		configs1, err := manager1.Load(configmanager.LoadOptions{})
+		require.NoError(t, err)
+
+		manager2 := talos.NewConfigManager("", "cluster-b", "1.32.0", "10.5.0.0/24")
+		configs2, err := manager2.Load(configmanager.LoadOptions{})
+		require.NoError(t, err)
+
+		// Extract secrets from config1
+		secrets1 := configs1.ExtractSecrets()
+		require.NotNil(t, secrets1)
+
+		// Rebuild config2 with config1's secrets
+		rebuilt, err := configs2.WithSecrets(secrets1)
+		require.NoError(t, err)
+
+		// The rebuilt config should have the same OS CA as config1
+		originalOSCA := configs1.ControlPlane().Machine().Security().IssuingCA().Crt
+		rebuiltOSCA := rebuilt.ControlPlane().Machine().Security().IssuingCA().Crt
+		assert.Equal(t, originalOSCA, rebuiltOSCA, "OS CA should match after WithSecrets")
+
+		// The rebuilt config should have the same cluster CA as config1
+		originalClusterCA := configs1.ControlPlane().Cluster().IssuingCA().Crt
+		rebuiltClusterCA := rebuilt.ControlPlane().Cluster().IssuingCA().Crt
+		assert.Equal(t, originalClusterCA, rebuiltClusterCA, "cluster CA should match after WithSecrets")
+
+		// The rebuilt config should have the same machine token as config1
+		originalToken := configs1.ControlPlane().Machine().Security().Token()
+		rebuiltToken := rebuilt.ControlPlane().Machine().Security().Token()
+		assert.Equal(t, originalToken, rebuiltToken, "machine token should match after WithSecrets")
+
+		// The rebuilt config should still have config2's cluster name
+		assert.Equal(t, "cluster-b", rebuilt.GetClusterName())
+	})
+
+	t.Run("returns same config when secrets is nil", func(t *testing.T) {
+		t.Parallel()
+
+		manager := talos.NewConfigManager("", "my-cluster", "1.32.0", "10.5.0.0/24")
+		configs, err := manager.Load(configmanager.LoadOptions{})
+		require.NoError(t, err)
+
+		same, err := configs.WithSecrets(nil)
+		require.NoError(t, err)
+		assert.Same(t, configs, same, "should return same config when secrets is nil")
+	})
+}
+
+func TestConfigs_ExtractSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts secrets from loaded config", func(t *testing.T) {
+		t.Parallel()
+
+		manager := talos.NewConfigManager("", "extract-test", "1.32.0", "10.5.0.0/24")
+		configs, err := manager.Load(configmanager.LoadOptions{})
+		require.NoError(t, err)
+
+		secretsBundle := configs.ExtractSecrets()
+		require.NotNil(t, secretsBundle)
+		assert.NotNil(t, secretsBundle.Certs)
+		assert.NotNil(t, secretsBundle.Certs.K8s)
+		assert.NotNil(t, secretsBundle.Certs.Etcd)
+		assert.NotNil(t, secretsBundle.Certs.OS)
+		assert.NotEmpty(t, secretsBundle.TrustdInfo.Token)
+	})
+
+	t.Run("returns nil when bundle is nil", func(t *testing.T) {
+		t.Parallel()
+
+		configs := &talos.Configs{}
+		assert.Nil(t, configs.ExtractSecrets())
+	})
+}

--- a/pkg/fsutil/configmanager/talos/configs_test.go
+++ b/pkg/fsutil/configmanager/talos/configs_test.go
@@ -460,7 +460,12 @@ func TestConfigs_WithSecrets(t *testing.T) {
 		// The rebuilt config should have the same cluster CA as config1
 		originalClusterCA := configs1.ControlPlane().Cluster().IssuingCA().Crt
 		rebuiltClusterCA := rebuilt.ControlPlane().Cluster().IssuingCA().Crt
-		assert.Equal(t, originalClusterCA, rebuiltClusterCA, "cluster CA should match after WithSecrets")
+		assert.Equal(
+			t,
+			originalClusterCA,
+			rebuiltClusterCA,
+			"cluster CA should match after WithSecrets",
+		)
 
 		// The rebuilt config should have the same machine token as config1
 		originalToken := configs1.ControlPlane().Machine().Security().Token()

--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -55,4 +55,10 @@ var (
 	// ErrNilWorkerConfig is returned when a nil worker config is passed to
 	// GenerateAutoscalerWorkerConfig.
 	ErrNilWorkerConfig = errors.New("worker config must not be nil")
+	// ErrNoControlPlaneForSecretSync is returned when no running control-plane node can be
+	// found to extract PKI secrets from during cluster update.
+	ErrNoControlPlaneForSecretSync = errors.New(
+		"no running control-plane node found for secret sync: " +
+			"cannot reuse cluster PKI — new or updated nodes would receive mismatched certificates",
+	)
 )

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -132,6 +132,14 @@ func (p *Provisioner) ApplyNodeScalingChangesForTest(
 	return p.applyNodeScalingChanges(ctx, clusterName, oldSpec, newSpec, result)
 }
 
+// SyncSecretsFromClusterForTest exposes syncSecretsFromCluster for unit testing.
+func (p *Provisioner) SyncSecretsFromClusterForTest(
+	ctx context.Context,
+	clusterName string,
+) error {
+	return p.syncSecretsFromCluster(ctx, clusterName)
+}
+
 // DockerNodeNameForTest exposes dockerNodeName for unit testing.
 func DockerNodeNameForTest(clusterName, role string, index int) string {
 	return dockerNodeName(clusterName, role, index)

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -140,6 +140,14 @@ func (p *Provisioner) SyncSecretsFromClusterForTest(
 	return p.syncSecretsFromCluster(ctx, clusterName)
 }
 
+// NeedsSecretSyncForTest exposes needsSecretSync for unit testing.
+func (p *Provisioner) NeedsSecretSyncForTest(
+	oldSpec, newSpec *v1alpha1.ClusterSpec,
+	diff *clusterupdate.UpdateResult,
+) bool {
+	return p.needsSecretSync(oldSpec, newSpec, diff)
+}
+
 // DockerNodeNameForTest exposes dockerNodeName for unit testing.
 func DockerNodeNameForTest(clusterName, role string, index int) string {
 	return dockerNodeName(clusterName, role, index)

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -136,8 +136,10 @@ func (p *Provisioner) ApplyNodeScalingChangesForTest(
 func (p *Provisioner) SyncSecretsFromClusterForTest(
 	ctx context.Context,
 	clusterName string,
+	oldSpec, newSpec *v1alpha1.ClusterSpec,
+	diff *clusterupdate.UpdateResult,
 ) error {
-	return p.syncSecretsFromCluster(ctx, clusterName)
+	return p.syncSecretsFromCluster(ctx, clusterName, oldSpec, newSpec, diff)
 }
 
 // NeedsSecretSyncForTest exposes needsSecretSync for unit testing.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -88,11 +88,9 @@ func (p *Provisioner) Update(
 	}
 
 	// Handle reboot-required changes (STAGED mode with rolling reboot)
-	if diff.HasRebootRequired() && opts.RollingReboot {
-		err := p.applyRebootRequiredChanges(ctx, clusterName, result, opts)
-		if err != nil {
-			return result, fmt.Errorf("failed to apply reboot-required changes: %w", err)
-		}
+	rebootErr := p.applyRebootChangesIfNeeded(ctx, clusterName, result, diff, opts)
+	if rebootErr != nil {
+		return result, fmt.Errorf("failed to apply reboot-required changes: %w", rebootErr)
 	}
 
 	// Talos OS version upgrades are NOT performed here. They are only triggered
@@ -413,6 +411,23 @@ func (p *Provisioner) createTalosClient(
 	}
 
 	return nil, clustererr.ErrTalosConfigRequired
+}
+
+// applyRebootChangesIfNeeded applies reboot-required config changes with a
+// rolling reboot when both conditions are met. Returns nil when no reboot
+// changes are needed or rolling reboot is disabled.
+func (p *Provisioner) applyRebootChangesIfNeeded(
+	ctx context.Context,
+	clusterName string,
+	result *clusterupdate.UpdateResult,
+	diff *clusterupdate.UpdateResult,
+	opts clusterupdate.UpdateOptions,
+) error {
+	if !diff.HasRebootRequired() || !opts.RollingReboot {
+		return nil
+	}
+
+	return p.applyRebootRequiredChanges(ctx, clusterName, result, opts)
 }
 
 // needsSecretSync returns true when the update will push machine configs to

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -63,9 +63,12 @@ func (p *Provisioner) Update(
 	// ConfigManager.Load() generates fresh CA/tokens on every call, but scale-up
 	// and in-place config changes must use the same secrets as the running cluster
 	// to avoid "certificate signed by unknown authority" errors on new nodes.
-	secretErr := p.syncSecretsFromCluster(ctx, clusterName)
-	if secretErr != nil {
-		return result, fmt.Errorf("failed to sync cluster secrets: %w", secretErr)
+	// Only sync when machine configs will actually be pushed to nodes.
+	if p.needsSecretSync(oldSpec, newSpec, result) {
+		secretErr := p.syncSecretsFromCluster(ctx, clusterName)
+		if secretErr != nil {
+			return result, fmt.Errorf("failed to sync cluster secrets: %w", secretErr)
+		}
 	}
 
 	// Handle node scaling changes
@@ -415,6 +418,28 @@ func (p *Provisioner) createTalosClient(
 	return nil, clustererr.ErrTalosConfigRequired
 }
 
+// needsSecretSync returns true when the update will push machine configs to
+// nodes and therefore needs the in-memory configs to match the running
+// cluster's PKI. This avoids unnecessary Talos API calls for no-op updates
+// or operations that don't touch machine configs (e.g., pure scale-down).
+func (p *Provisioner) needsSecretSync(
+	oldSpec, newSpec *v1alpha1.ClusterSpec,
+	diff *clusterupdate.UpdateResult,
+) bool {
+	if p.talosConfigs == nil || p.omniOpts != nil {
+		return false
+	}
+
+	// Scale-up: new nodes need the existing cluster's PKI.
+	if oldSpec != nil && newSpec != nil &&
+		(newSpec.ControlPlanes > oldSpec.ControlPlanes || newSpec.Workers > oldSpec.Workers) {
+		return true
+	}
+
+	// In-place or reboot-required config changes push configs to existing nodes.
+	return p.shouldApplyInPlaceChanges(diff) || diff.HasRebootRequired()
+}
+
 // syncSecretsFromCluster connects to a running control-plane node, fetches its
 // machine configuration, extracts the PKI secrets, and rebuilds the in-memory
 // talosConfigs with those secrets. This ensures that configs applied to new nodes
@@ -422,16 +447,12 @@ func (p *Provisioner) createTalosClient(
 // cluster. Without this, ConfigManager.Load() generates fresh PKI on every call,
 // causing certificate mismatch errors when new nodes try to join.
 //
-// This method is a no-op when talosConfigs is nil (used in tests and Omni clusters),
-// or when running on an Omni-managed cluster (Omni handles its own config).
+// Callers must gate this behind needsSecretSync — this method assumes that
+// machine configs will be pushed and fails closed when secrets cannot be obtained.
 func (p *Provisioner) syncSecretsFromCluster(
 	ctx context.Context,
 	clusterName string,
 ) error {
-	if p.talosConfigs == nil || p.omniOpts != nil {
-		return nil
-	}
-
 	nodes, err := p.getNodesByRole(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to discover nodes for secret sync: %w", err)
@@ -449,10 +470,11 @@ func (p *Provisioner) syncSecretsFromCluster(
 	}
 
 	if cpIP == "" {
-		// No running control-plane node found — this can happen when the
-		// cluster is freshly created or all CPs are down. Fall through to
-		// use the in-memory secrets (best effort).
-		return nil
+		return fmt.Errorf(
+			"no running control-plane node found for cluster %q: "+
+				"cannot sync PKI secrets — new or updated nodes would receive "+
+				"mismatched certificates", clusterName,
+		)
 	}
 
 	talosClient, err := p.createTalosClient(ctx, cpIP)

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -63,12 +63,9 @@ func (p *Provisioner) Update(
 	// ConfigManager.Load() generates fresh CA/tokens on every call, but scale-up
 	// and in-place config changes must use the same secrets as the running cluster
 	// to avoid "certificate signed by unknown authority" errors on new nodes.
-	// Only sync when machine configs will actually be pushed to nodes.
-	if p.needsSecretSync(oldSpec, newSpec, result) {
-		secretErr := p.syncSecretsFromCluster(ctx, clusterName)
-		if secretErr != nil {
-			return result, fmt.Errorf("failed to sync cluster secrets: %w", secretErr)
-		}
+	secretErr := p.syncSecretsFromCluster(ctx, clusterName, oldSpec, newSpec, result)
+	if secretErr != nil {
+		return result, fmt.Errorf("failed to sync cluster secrets: %w", secretErr)
 	}
 
 	// Handle node scaling changes
@@ -447,12 +444,19 @@ func (p *Provisioner) needsSecretSync(
 // cluster. Without this, ConfigManager.Load() generates fresh PKI on every call,
 // causing certificate mismatch errors when new nodes try to join.
 //
-// Callers must gate this behind needsSecretSync — this method assumes that
-// machine configs will be pushed and fails closed when secrets cannot be obtained.
+// This is a no-op when no machine configs will be pushed (no scale-up, no in-place
+// changes, no reboot-required changes). When secrets ARE needed but no control-plane
+// node is available, it fails closed to prevent PKI mismatch.
 func (p *Provisioner) syncSecretsFromCluster(
 	ctx context.Context,
 	clusterName string,
+	oldSpec, newSpec *v1alpha1.ClusterSpec,
+	diff *clusterupdate.UpdateResult,
 ) error {
+	if !p.needsSecretSync(oldSpec, newSpec, diff) {
+		return nil
+	}
+
 	nodes, err := p.getNodesByRole(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to discover nodes for secret sync: %w", err)
@@ -470,11 +474,7 @@ func (p *Provisioner) syncSecretsFromCluster(
 	}
 
 	if cpIP == "" {
-		return fmt.Errorf(
-			"no running control-plane node found for cluster %q: "+
-				"cannot sync PKI secrets — new or updated nodes would receive "+
-				"mismatched certificates", clusterName,
-		)
+		return fmt.Errorf("%w: cluster %q", ErrNoControlPlaneForSecretSync, clusterName)
 	}
 
 	talosClient, err := p.createTalosClient(ctx, cpIP)
@@ -485,7 +485,7 @@ func (p *Provisioner) syncSecretsFromCluster(
 	defer talosClient.Close() //nolint:errcheck
 
 	// Fetch the active MachineConfig resource from the running control-plane node.
-	mc, err := safe.StateGet[*talosresconfig.MachineConfig](
+	machineConfig, err := safe.StateGet[*talosresconfig.MachineConfig](
 		ctx,
 		talosClient.COSI,
 		talosresconfig.NewMachineConfig(nil).Metadata(),
@@ -494,7 +494,7 @@ func (p *Provisioner) syncSecretsFromCluster(
 		return fmt.Errorf("failed to fetch machine config from %s: %w", cpIP, err)
 	}
 
-	runningConfig := mc.Config()
+	runningConfig := machineConfig.Config()
 
 	existingSecrets := secrets.NewBundleFromConfig(
 		secrets.NewFixedClock(time.Now()),

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
@@ -16,6 +18,8 @@ import (
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	talosresconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
 // Update applies configuration changes to all nodes in a running Talos cluster.
@@ -53,6 +57,15 @@ func (p *Provisioner) Update(
 	configErr := p.refreshOmniConfigsIfNeeded(ctx, clusterName)
 	if configErr != nil {
 		return result, fmt.Errorf("failed to refresh Omni configs before update: %w", configErr)
+	}
+
+	// Sync in-memory machine configs with the running cluster's PKI secrets.
+	// ConfigManager.Load() generates fresh CA/tokens on every call, but scale-up
+	// and in-place config changes must use the same secrets as the running cluster
+	// to avoid "certificate signed by unknown authority" errors on new nodes.
+	secretErr := p.syncSecretsFromCluster(ctx, clusterName)
+	if secretErr != nil {
+		return result, fmt.Errorf("failed to sync cluster secrets: %w", secretErr)
 	}
 
 	// Handle node scaling changes
@@ -400,6 +413,82 @@ func (p *Provisioner) createTalosClient(
 	}
 
 	return nil, clustererr.ErrTalosConfigRequired
+}
+
+// syncSecretsFromCluster connects to a running control-plane node, fetches its
+// machine configuration, extracts the PKI secrets, and rebuilds the in-memory
+// talosConfigs with those secrets. This ensures that configs applied to new nodes
+// during scale-up use the same CA, tokens, and bootstrap secrets as the running
+// cluster. Without this, ConfigManager.Load() generates fresh PKI on every call,
+// causing certificate mismatch errors when new nodes try to join.
+//
+// This method is a no-op when talosConfigs is nil (used in tests and Omni clusters),
+// or when running on an Omni-managed cluster (Omni handles its own config).
+func (p *Provisioner) syncSecretsFromCluster(
+	ctx context.Context,
+	clusterName string,
+) error {
+	if p.talosConfigs == nil || p.omniOpts != nil {
+		return nil
+	}
+
+	nodes, err := p.getNodesByRole(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to discover nodes for secret sync: %w", err)
+	}
+
+	// Find a control-plane node to extract secrets from
+	var cpIP string
+
+	for _, node := range nodes {
+		if node.Role == RoleControlPlane {
+			cpIP = node.IP
+
+			break
+		}
+	}
+
+	if cpIP == "" {
+		// No running control-plane node found — this can happen when the
+		// cluster is freshly created or all CPs are down. Fall through to
+		// use the in-memory secrets (best effort).
+		return nil
+	}
+
+	talosClient, err := p.createTalosClient(ctx, cpIP)
+	if err != nil {
+		return fmt.Errorf("failed to create Talos client for secret sync: %w", err)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	// Fetch the active MachineConfig resource from the running control-plane node.
+	mc, err := safe.StateGet[*talosresconfig.MachineConfig](
+		ctx,
+		talosClient.COSI,
+		talosresconfig.NewMachineConfig(nil).Metadata(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to fetch machine config from %s: %w", cpIP, err)
+	}
+
+	runningConfig := mc.Config()
+
+	existingSecrets := secrets.NewBundleFromConfig(
+		secrets.NewFixedClock(time.Now()),
+		runningConfig,
+	)
+
+	rebuilt, err := p.talosConfigs.WithSecrets(existingSecrets)
+	if err != nil {
+		return fmt.Errorf("failed to rebuild configs with cluster secrets: %w", err)
+	}
+
+	p.talosConfigs = rebuilt
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Synced cluster secrets from %s\n", cpIP)
+
+	return nil
 }
 
 // nodeWithRole holds an IP address and its role for role-aware config application.

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -380,19 +380,25 @@ func TestDiffConfig_StillValidatesMinimumControlPlanesWhenAutoscalingEnabled(t *
 	assert.ErrorIs(t, err, talosprovisioner.ErrMinimumControlPlanes)
 }
 
-// TestSyncSecretsFromCluster_NilTalosConfigs verifies that syncSecretsFromCluster
-// is a no-op when talosConfigs is nil (e.g., tests that don't load configs).
+// TestSyncSecretsFromCluster_NilTalosConfigs verifies that needsSecretSync
+// returns false when talosConfigs is nil (e.g., tests that don't load configs),
+// preventing syncSecretsFromCluster from being called.
 func TestSyncSecretsFromCluster_NilTalosConfigs(t *testing.T) {
 	t.Parallel()
 
 	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
+		Field: "workers", Category: clusterupdate.ChangeCategoryInPlace,
+	})
 
-	err := provisioner.SyncSecretsFromClusterForTest(context.Background(), "test")
-	require.NoError(t, err)
+	assert.False(t, provisioner.NeedsSecretSyncForTest(
+		&v1alpha1.ClusterSpec{Workers: 0}, &v1alpha1.ClusterSpec{Workers: 1}, diff,
+	))
 }
 
-// TestSyncSecretsFromCluster_OmniSkipped verifies that syncSecretsFromCluster
-// is a no-op for Omni-managed clusters (Omni handles config independently).
+// TestSyncSecretsFromCluster_OmniSkipped verifies that needsSecretSync
+// returns false for Omni-managed clusters (Omni handles config independently).
 func TestSyncSecretsFromCluster_OmniSkipped(t *testing.T) {
 	t.Parallel()
 
@@ -403,6 +409,75 @@ func TestSyncSecretsFromCluster_OmniSkipped(t *testing.T) {
 		WithOmniOptions(v1alpha1.OptionsOmni{}).
 		WithLogWriter(io.Discard)
 
-	err = provisioner.SyncSecretsFromClusterForTest(context.Background(), "test")
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
+		Field: "workers", Category: clusterupdate.ChangeCategoryInPlace,
+	})
+
+	assert.False(t, provisioner.NeedsSecretSyncForTest(
+		&v1alpha1.ClusterSpec{Workers: 0}, &v1alpha1.ClusterSpec{Workers: 1}, diff,
+	))
+}
+
+// TestNeedsSecretSync_ScaleUp verifies that needsSecretSync returns true
+// when the update involves scaling up nodes.
+func TestNeedsSecretSync_ScaleUp(t *testing.T) {
+	t.Parallel()
+
+	configs, err := talosconfigmanager.NewDefaultConfigs()
 	require.NoError(t, err)
+
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).WithLogWriter(io.Discard)
+	diff := clusterupdate.NewEmptyUpdateResult()
+
+	// Workers scale-up
+	assert.True(t, provisioner.NeedsSecretSyncForTest(
+		&v1alpha1.ClusterSpec{ControlPlanes: 1, Workers: 0},
+		&v1alpha1.ClusterSpec{ControlPlanes: 1, Workers: 1},
+		diff,
+	))
+
+	// Control-plane scale-up
+	assert.True(t, provisioner.NeedsSecretSyncForTest(
+		&v1alpha1.ClusterSpec{ControlPlanes: 1, Workers: 0},
+		&v1alpha1.ClusterSpec{ControlPlanes: 3, Workers: 0},
+		diff,
+	))
+}
+
+// TestNeedsSecretSync_NoChanges verifies that needsSecretSync returns false
+// when there are no scaling or config changes.
+func TestNeedsSecretSync_NoChanges(t *testing.T) {
+	t.Parallel()
+
+	configs, err := talosconfigmanager.NewDefaultConfigs()
+	require.NoError(t, err)
+
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).WithLogWriter(io.Discard)
+	diff := clusterupdate.NewEmptyUpdateResult()
+
+	assert.False(t, provisioner.NeedsSecretSyncForTest(
+		&v1alpha1.ClusterSpec{ControlPlanes: 1, Workers: 0},
+		&v1alpha1.ClusterSpec{ControlPlanes: 1, Workers: 0},
+		diff,
+	))
+}
+
+// TestNeedsSecretSync_ScaleDown verifies that needsSecretSync returns false
+// for a pure scale-down with no other config changes (removing nodes doesn't
+// need PKI sync).
+func TestNeedsSecretSync_ScaleDown(t *testing.T) {
+	t.Parallel()
+
+	configs, err := talosconfigmanager.NewDefaultConfigs()
+	require.NoError(t, err)
+
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).WithLogWriter(io.Discard)
+	diff := clusterupdate.NewEmptyUpdateResult()
+
+	assert.False(t, provisioner.NeedsSecretSyncForTest(
+		&v1alpha1.ClusterSpec{ControlPlanes: 1, Workers: 2},
+		&v1alpha1.ClusterSpec{ControlPlanes: 1, Workers: 1},
+		diff,
+	))
 }

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -379,3 +379,30 @@ func TestDiffConfig_StillValidatesMinimumControlPlanesWhenAutoscalingEnabled(t *
 	require.Error(t, err)
 	assert.ErrorIs(t, err, talosprovisioner.ErrMinimumControlPlanes)
 }
+
+// TestSyncSecretsFromCluster_NilTalosConfigs verifies that syncSecretsFromCluster
+// is a no-op when talosConfigs is nil (e.g., tests that don't load configs).
+func TestSyncSecretsFromCluster_NilTalosConfigs(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	err := provisioner.SyncSecretsFromClusterForTest(context.Background(), "test")
+	require.NoError(t, err)
+}
+
+// TestSyncSecretsFromCluster_OmniSkipped verifies that syncSecretsFromCluster
+// is a no-op for Omni-managed clusters (Omni handles config independently).
+func TestSyncSecretsFromCluster_OmniSkipped(t *testing.T) {
+	t.Parallel()
+
+	configs, err := talosconfigmanager.NewDefaultConfigs()
+	require.NoError(t, err)
+
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).
+		WithOmniOptions(v1alpha1.OptionsOmni{}).
+		WithLogWriter(io.Discard)
+
+	err = provisioner.SyncSecretsFromClusterForTest(context.Background(), "test")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

When `cluster update` adds new nodes to an existing Talos cluster, `ConfigManager.Load()` generates fresh CA certificates, tokens, and bootstrap secrets. New nodes receive configs with mismatched PKI and cannot join the cluster ("certificate signed by unknown authority").

## Changes

### `pkg/fsutil/configmanager/talos/configs.go`
- **`WithSecrets(*secrets.Bundle)`** — regenerates the config bundle using a provided secrets bundle, preserving the cluster's existing PKI. Follows the existing `WithEndpoint` pattern.
- **`ExtractSecrets()`** — extracts the `*secrets.Bundle` from a loaded config for reuse.

### `pkg/svc/provisioner/cluster/talos/update.go`
- **`syncSecretsFromCluster()`** — connects to a running control-plane node via the saved talosconfig, fetches its machine config via COSI state API, extracts the secrets bundle, and rebuilds the in-memory `talosConfigs` with those secrets.
- Wired into `Update()` **before** `applyNodeScalingChanges()` and `applyInPlaceConfigChanges()`, ensuring all applied configs use the same CA and tokens as the running cluster.
- No-op for nil `talosConfigs` (tests) and Omni-managed clusters.

### Tests
- `TestConfigs_WithSecrets` — verifies PKI preservation across regeneration and nil no-op.
- `TestConfigs_ExtractSecrets` — verifies secret extraction from loaded configs.
- `TestSyncSecretsFromCluster_NilTalosConfigs` — verifies no-op for nil configs.
- `TestSyncSecretsFromCluster_OmniSkipped` — verifies no-op for Omni clusters.

Fixes #4584