### PR TITLE
fix: ensure cluster-autoscaler-config secret during cluster update

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -297,3 +297,11 @@ func (p *Provisioner) IsDockerProviderForTest() bool {
 func (p *Provisioner) ClusterReadinessChecksCountForTest() int {
 	return len(p.clusterReadinessChecks())
 }
+
+// EnsureAutoscalerSecretIfNeededForTest exposes ensureAutoscalerSecretIfNeeded for unit testing.
+func (p *Provisioner) EnsureAutoscalerSecretIfNeededForTest(
+	ctx context.Context,
+	clusterName string,
+) error {
+	return p.ensureAutoscalerSecretIfNeeded(ctx, clusterName)
+}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -312,5 +312,6 @@ func (p *Provisioner) WithTalosConfigsForTest(
 	configs *talosconfigmanager.Configs,
 ) *Provisioner {
 	p.talosConfigs = configs
+
 	return p
 }

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	omniprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/omni"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
@@ -304,4 +305,12 @@ func (p *Provisioner) EnsureAutoscalerSecretIfNeededForTest(
 	clusterName string,
 ) error {
 	return p.ensureAutoscalerSecretIfNeeded(ctx, clusterName)
+}
+
+// WithTalosConfigsForTest sets talosConfigs on the provisioner for unit testing.
+func (p *Provisioner) WithTalosConfigsForTest(
+	configs *talosconfigmanager.Configs,
+) *Provisioner {
+	p.talosConfigs = configs
+	return p
 }

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -819,8 +819,10 @@ func (p *Provisioner) syncHetznerFirewallRules(
 
 // ensureAutoscalerSecretIfNeeded creates or updates the cluster-autoscaler-config
 // Secret when the node autoscaler is enabled on Hetzner. It is a no-op when
-// autoscaling is disabled, the provider is not Hetzner, or the snapshot image
-// cannot be resolved. This mirrors the create-time call in bootstrapAndFinalize.
+// autoscaling is disabled, the provider is not Hetzner, or the config bundle
+// is unavailable. Snapshot image lookup errors are propagated because they
+// indicate a misconfigured cluster. This mirrors the create-time call in
+// bootstrapAndFinalize.
 func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
 	ctx context.Context,
 	clusterName string,
@@ -829,12 +831,15 @@ func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
 		return nil
 	}
 
+	configBundle := p.talosConfigs.Bundle()
+	if configBundle == nil {
+		return nil
+	}
+
 	snapshotImageID, err := p.ensureSnapshotImage(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("looking up snapshot image for autoscaler secret: %w", err)
 	}
-
-	configBundle := p.talosConfigs.Bundle()
 
 	return p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID)
 }

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -101,6 +101,17 @@ func (p *Provisioner) Update(
 	// actually running (e.g., booted from a Hetzner ISO at a different version).
 	// See: https://github.com/devantler-tech/ksail/issues/4260
 
+	// Ensure the cluster-autoscaler-config Secret exists when the node autoscaler
+	// is enabled. During cluster create, this secret is created by
+	// bootstrapAndFinalize. During update the component reconciler installs the
+	// Helm chart but did not previously create the prerequisite secret, causing
+	// the autoscaler pod to enter CreateContainerConfigError.
+	// See: https://github.com/devantler-tech/ksail/issues/4606
+	secretErr = p.ensureAutoscalerSecretIfNeeded(ctx, clusterName)
+	if secretErr != nil {
+		return result, fmt.Errorf("failed to ensure autoscaler config secret: %w", secretErr)
+	}
+
 	return result, nil
 }
 
@@ -804,4 +815,26 @@ func (p *Provisioner) syncHetznerFirewallRules(
 	}
 
 	return nil
+}
+
+// ensureAutoscalerSecretIfNeeded creates or updates the cluster-autoscaler-config
+// Secret when the node autoscaler is enabled on Hetzner. It is a no-op when
+// autoscaling is disabled, the provider is not Hetzner, or the snapshot image
+// cannot be resolved. This mirrors the create-time call in bootstrapAndFinalize.
+func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
+	ctx context.Context,
+	clusterName string,
+) error {
+	if p.hetznerOpts == nil || !p.hetznerOpts.NodeAutoscalerEnabled || p.talosConfigs == nil {
+		return nil
+	}
+
+	snapshotImageID, err := p.ensureSnapshotImage(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("looking up snapshot image for autoscaler secret: %w", err)
+	}
+
+	configBundle := p.talosConfigs.Bundle()
+
+	return p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID)
 }

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -533,3 +533,24 @@ func TestEnsureAutoscalerSecretIfNeeded_NoopWhenNilTalosConfigs(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
+
+// TestEnsureAutoscalerSecretIfNeeded_NoopWhenNilBundle verifies that
+// ensureAutoscalerSecretIfNeeded is a no-op when talosConfigs is non-nil but
+// Bundle() returns nil, preventing a nil-dereference panic.
+func TestEnsureAutoscalerSecretIfNeeded_NoopWhenNilBundle(t *testing.T) {
+	t.Parallel()
+
+	configs := &talosconfigmanager.Configs{}
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{
+			NodeAutoscalerEnabled: true,
+		}).
+		WithTalosConfigsForTest(configs).
+		WithLogWriter(io.Discard)
+
+	err := provisioner.EnsureAutoscalerSecretIfNeededForTest(
+		context.Background(),
+		"test-cluster",
+	)
+	require.NoError(t, err)
+}

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -481,3 +481,55 @@ func TestNeedsSecretSync_ScaleDown(t *testing.T) {
 		diff,
 	))
 }
+
+// TestEnsureAutoscalerSecretIfNeeded_NoopWhenNotHetzner verifies that
+// ensureAutoscalerSecretIfNeeded is a no-op when hetznerOpts is nil
+// (non-Hetzner provider).
+func TestEnsureAutoscalerSecretIfNeeded_NoopWhenNotHetzner(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	err := provisioner.EnsureAutoscalerSecretIfNeededForTest(
+		context.Background(),
+		"test-cluster",
+	)
+	require.NoError(t, err)
+}
+
+// TestEnsureAutoscalerSecretIfNeeded_NoopWhenAutoscalerDisabled verifies that
+// ensureAutoscalerSecretIfNeeded is a no-op when NodeAutoscalerEnabled is false.
+func TestEnsureAutoscalerSecretIfNeeded_NoopWhenAutoscalerDisabled(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{
+			NodeAutoscalerEnabled: false,
+		}).
+		WithLogWriter(io.Discard)
+
+	err := provisioner.EnsureAutoscalerSecretIfNeededForTest(
+		context.Background(),
+		"test-cluster",
+	)
+	require.NoError(t, err)
+}
+
+// TestEnsureAutoscalerSecretIfNeeded_NoopWhenNilTalosConfigs verifies that
+// ensureAutoscalerSecretIfNeeded is a no-op when talosConfigs is nil, even
+// when autoscaler is enabled on Hetzner.
+func TestEnsureAutoscalerSecretIfNeeded_NoopWhenNilTalosConfigs(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{
+			NodeAutoscalerEnabled: true,
+		}).
+		WithLogWriter(io.Discard)
+
+	err := provisioner.EnsureAutoscalerSecretIfNeededForTest(
+		context.Background(),
+		"test-cluster",
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Description

When `ksail cluster update` installs the cluster-autoscaler Helm chart (via `doReconcileClusterAutoscaler`), the autoscaler pod requires the `cluster-autoscaler-config` Secret in `kube-system`. This secret was only created during `cluster create` by the Talos provisioner's `bootstrapAndFinalize` → `ensureAutoscalerSecret`, but never during update — causing the pod to enter `CreateContainerConfigError`.

## Changes

Add `ensureAutoscalerSecretIfNeeded` to the Talos provisioner's `Update()` method. It reuses the existing `ensureSnapshotImage` and `ensureAutoscalerSecret` methods to create or update the secret **before** the component reconciler installs the Helm chart.

The method is a no-op when:
- The provider is not Hetzner (`hetznerOpts` is nil)
- Node autoscaling is disabled
- Talos configs are not available

## Files Changed

- `pkg/svc/provisioner/cluster/talos/update.go` — add `ensureAutoscalerSecretIfNeeded` and call it from `Update()`
- `pkg/svc/provisioner/cluster/talos/export_test.go` — expose new method for testing
- `pkg/svc/provisioner/cluster/talos/update_test.go` — 3 no-op guard tests

Fixes #4606