### PR TITLE
fix: sync endpoint IP alongside secrets during cluster update

### DIFF
--- a/pkg/fsutil/configmanager/talos/coverage_test.go
+++ b/pkg/fsutil/configmanager/talos/coverage_test.go
@@ -133,8 +133,9 @@ func TestConfigs_WithEndpoint(t *testing.T) {
 
 // TestConfigs_WithSecretsAndEndpoint_PreservesBoth verifies that calling
 // WithSecrets followed by WithEndpoint produces configs that have both the
-// correct secrets and the correct endpoint. This is the pattern used by
-// syncSecretsFromCluster to fix Hetzner cluster updates (issue #4605).
+// correct secrets and the correct endpoint. This mirrors the production
+// pattern in syncSecretsFromCluster / fetchClusterSecretsAndEndpoint where
+// the endpoint is read from the running config (issue #4605).
 func TestConfigs_WithSecretsAndEndpoint_PreservesBoth(t *testing.T) {
 	t.Parallel()
 
@@ -142,9 +143,16 @@ func TestConfigs_WithSecretsAndEndpoint_PreservesBoth(t *testing.T) {
 	runningConfigs, err := talosconfig.NewDefaultConfigs()
 	require.NoError(t, err)
 
-	// Extract secrets from the running config (as syncSecretsFromCluster does)
+	// Extract secrets from the running config (as fetchClusterSecretsAndEndpoint does)
 	existingSecrets := runningConfigs.ExtractSecrets()
 	require.NotNil(t, existingSecrets)
+
+	// Extract endpoint from running config (as fetchClusterSecretsAndEndpoint does).
+	// In production this reads runningConfig.Cluster().Endpoint().Hostname(),
+	// which returns the endpoint the cluster is actually using (deterministic
+	// even in HA clusters with multiple CP nodes).
+	runningEndpoint := runningConfigs.ControlPlane().Cluster().Endpoint().Hostname()
+	require.NotEmpty(t, runningEndpoint, "running config should have a cluster endpoint")
 
 	// Simulate freshly loaded configs (different CA, empty endpoint)
 	freshConfigs, err := talosconfig.NewDefaultConfigs()
@@ -163,10 +171,8 @@ func TestConfigs_WithSecretsAndEndpoint_PreservesBoth(t *testing.T) {
 	syncedCA := afterSecrets.ControlPlane().Machine().Security().IssuingCA().Crt
 	assert.Equal(t, clusterCA, syncedCA, "CA should match running cluster after WithSecrets")
 
-	// Step 2: Sync endpoint (as the fix now does)
-	endpointIP := "78.47.10.20"
-
-	afterEndpoint, err := afterSecrets.WithEndpoint(endpointIP)
+	// Step 2: Sync endpoint extracted from running config
+	afterEndpoint, err := afterSecrets.WithEndpoint(runningEndpoint)
 	require.NoError(t, err)
 
 	// Verify CA is STILL correct after WithEndpoint
@@ -176,7 +182,7 @@ func TestConfigs_WithSecretsAndEndpoint_PreservesBoth(t *testing.T) {
 
 	// Verify endpoint is in the cluster endpoint URL
 	clusterEndpoint := afterEndpoint.ControlPlane().Cluster().Endpoint().String()
-	assert.Contains(t, clusterEndpoint, endpointIP,
+	assert.Contains(t, clusterEndpoint, runningEndpoint,
 		"cluster endpoint should contain the synced IP")
 
 	// Verify worker config also has the correct CA cert

--- a/pkg/fsutil/configmanager/talos/coverage_test.go
+++ b/pkg/fsutil/configmanager/talos/coverage_test.go
@@ -131,6 +131,60 @@ func TestConfigs_WithEndpoint(t *testing.T) {
 	assert.Equal(t, original.GetClusterName(), updated.GetClusterName())
 }
 
+// TestConfigs_WithSecretsAndEndpoint_PreservesBoth verifies that calling
+// WithSecrets followed by WithEndpoint produces configs that have both the
+// correct secrets and the correct endpoint. This is the pattern used by
+// syncSecretsFromCluster to fix Hetzner cluster updates (issue #4605).
+func TestConfigs_WithSecretsAndEndpoint_PreservesBoth(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the running cluster's config (the "source of truth")
+	runningConfigs, err := talosconfig.NewDefaultConfigs()
+	require.NoError(t, err)
+
+	// Extract secrets from the running config (as syncSecretsFromCluster does)
+	existingSecrets := runningConfigs.ExtractSecrets()
+	require.NotNil(t, existingSecrets)
+
+	// Simulate freshly loaded configs (different CA, empty endpoint)
+	freshConfigs, err := talosconfig.NewDefaultConfigs()
+	require.NoError(t, err)
+
+	// Verify fresh configs have a different CA (they are independently generated)
+	originalCA := freshConfigs.ControlPlane().Machine().Security().IssuingCA().Crt
+	clusterCA := runningConfigs.ControlPlane().Machine().Security().IssuingCA().Crt
+	assert.NotEqual(t, originalCA, clusterCA, "fresh configs should have a different CA")
+
+	// Step 1: Sync secrets (as WithSecrets does)
+	afterSecrets, err := freshConfigs.WithSecrets(existingSecrets)
+	require.NoError(t, err)
+
+	// Verify CA was synced
+	syncedCA := afterSecrets.ControlPlane().Machine().Security().IssuingCA().Crt
+	assert.Equal(t, clusterCA, syncedCA, "CA should match running cluster after WithSecrets")
+
+	// Step 2: Sync endpoint (as the fix now does)
+	endpointIP := "78.47.10.20"
+
+	afterEndpoint, err := afterSecrets.WithEndpoint(endpointIP)
+	require.NoError(t, err)
+
+	// Verify CA is STILL correct after WithEndpoint
+	finalCA := afterEndpoint.ControlPlane().Machine().Security().IssuingCA().Crt
+	assert.Equal(t, clusterCA, finalCA,
+		"CA should still match running cluster after WithEndpoint")
+
+	// Verify endpoint is in the cluster endpoint URL
+	clusterEndpoint := afterEndpoint.ControlPlane().Cluster().Endpoint().String()
+	assert.Contains(t, clusterEndpoint, endpointIP,
+		"cluster endpoint should contain the synced IP")
+
+	// Verify worker config also has the correct CA cert
+	workerCA := afterEndpoint.Worker().Machine().Security().IssuingCA().Crt
+	assert.Equal(t, clusterCA, workerCA,
+		"worker CA cert should match running cluster")
+}
+
 // TestConfigs_ExtractMirrorHosts_WithMirrors verifies mirror host extraction from a real config.
 func TestConfigs_ExtractMirrorHosts_WithMirrors(t *testing.T) {
 	t.Parallel()

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -454,10 +454,15 @@ func (p *Provisioner) needsSecretSync(
 
 // syncSecretsFromCluster connects to a running control-plane node, fetches its
 // machine configuration, extracts the PKI secrets, and rebuilds the in-memory
-// talosConfigs with those secrets. This ensures that configs applied to new nodes
-// during scale-up use the same CA, tokens, and bootstrap secrets as the running
-// cluster. Without this, ConfigManager.Load() generates fresh PKI on every call,
+// talosConfigs with those secrets and the correct endpoint IP. This ensures that
+// configs applied to new nodes during scale-up use the same CA, tokens, bootstrap
+// secrets, and cluster endpoint as the running cluster.
+//
+// Without secrets sync, ConfigManager.Load() generates fresh PKI on every call,
 // causing certificate mismatch errors when new nodes try to join.
+// Without endpoint sync, the configs default to a CIDR-derived private IP which
+// is unreachable on cloud providers like Hetzner (where the endpoint must be the
+// control-plane's public IP).
 //
 // This is a no-op when no machine configs will be pushed (no scale-up, no in-place
 // changes, no reboot-required changes). When secrets ARE needed but no control-plane
@@ -519,6 +524,16 @@ func (p *Provisioner) syncSecretsFromCluster(
 	rebuilt, err := p.talosConfigs.WithSecrets(existingSecrets)
 	if err != nil {
 		return fmt.Errorf("failed to rebuild configs with cluster secrets: %w", err)
+	}
+
+	// Also sync the endpoint IP from the running cluster. ConfigManager.Load()
+	// generates configs with an empty endpoint (defaulting to a CIDR-derived
+	// private IP). For Hetzner clusters, the endpoint must be the CP's public IP
+	// so that new workers can reach the control plane. WithEndpoint preserves
+	// the secrets already embedded by WithSecrets. (Fixes #4605)
+	rebuilt, err = rebuilt.WithEndpoint(cpIP)
+	if err != nil {
+		return fmt.Errorf("failed to update configs with cluster endpoint: %w", err)
 	}
 
 	p.talosConfigs = rebuilt

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -453,10 +453,10 @@ func (p *Provisioner) needsSecretSync(
 }
 
 // syncSecretsFromCluster connects to a running control-plane node, fetches its
-// machine configuration, extracts the PKI secrets, and rebuilds the in-memory
-// talosConfigs with those secrets and the correct endpoint IP. This ensures that
-// configs applied to new nodes during scale-up use the same CA, tokens, bootstrap
-// secrets, and cluster endpoint as the running cluster.
+// machine configuration, extracts the PKI secrets and cluster endpoint, and
+// rebuilds the in-memory talosConfigs. This ensures that configs applied to new
+// nodes during scale-up use the same CA, tokens, bootstrap secrets, and cluster
+// endpoint as the running cluster.
 //
 // Without secrets sync, ConfigManager.Load() generates fresh PKI on every call,
 // causing certificate mismatch errors when new nodes try to join.
@@ -482,7 +482,6 @@ func (p *Provisioner) syncSecretsFromCluster(
 		return fmt.Errorf("failed to discover nodes for secret sync: %w", err)
 	}
 
-	// Find a control-plane node to extract secrets from
 	var cpIP string
 
 	for _, node := range nodes {
@@ -497,21 +496,51 @@ func (p *Provisioner) syncSecretsFromCluster(
 		return fmt.Errorf("%w: cluster %q", ErrNoControlPlaneForSecretSync, clusterName)
 	}
 
+	existingSecrets, endpointIP, err := p.fetchClusterSecretsAndEndpoint(ctx, cpIP)
+	if err != nil {
+		return err
+	}
+
+	rebuilt, err := p.talosConfigs.WithSecrets(existingSecrets)
+	if err != nil {
+		return fmt.Errorf("failed to rebuild configs with cluster secrets: %w", err)
+	}
+
+	rebuilt, err = rebuilt.WithEndpoint(endpointIP)
+	if err != nil {
+		return fmt.Errorf("failed to update configs with cluster endpoint: %w", err)
+	}
+
+	p.talosConfigs = rebuilt
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Synced cluster secrets and endpoint (%s) from %s\n", endpointIP, cpIP)
+
+	return nil
+}
+
+// fetchClusterSecretsAndEndpoint connects to a control-plane node via the Talos
+// API, fetches its running MachineConfig, and extracts the PKI secrets bundle
+// and cluster endpoint. The endpoint is read from the running config (not
+// derived from node IPs) so that HA clusters with multiple control-plane nodes
+// always produce a deterministic endpoint.
+func (p *Provisioner) fetchClusterSecretsAndEndpoint(
+	ctx context.Context,
+	cpIP string,
+) (*secrets.Bundle, string, error) {
 	talosClient, err := p.createTalosClient(ctx, cpIP)
 	if err != nil {
-		return fmt.Errorf("failed to create Talos client for secret sync: %w", err)
+		return nil, "", fmt.Errorf("failed to create Talos client for secret sync: %w", err)
 	}
 
 	defer talosClient.Close() //nolint:errcheck
 
-	// Fetch the active MachineConfig resource from the running control-plane node.
 	machineConfig, err := safe.StateGet[*talosresconfig.MachineConfig](
 		ctx,
 		talosClient.COSI,
 		talosresconfig.NewMachineConfig(nil).Metadata(),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to fetch machine config from %s: %w", cpIP, err)
+		return nil, "", fmt.Errorf("failed to fetch machine config from %s: %w", cpIP, err)
 	}
 
 	runningConfig := machineConfig.Config()
@@ -521,26 +550,16 @@ func (p *Provisioner) syncSecretsFromCluster(
 		runningConfig,
 	)
 
-	rebuilt, err := p.talosConfigs.WithSecrets(existingSecrets)
-	if err != nil {
-		return fmt.Errorf("failed to rebuild configs with cluster secrets: %w", err)
+	// Read the endpoint from the running cluster's config rather than deriving
+	// it from node IPs. This avoids non-deterministic ordering in HA clusters
+	// where getNodesByRole may return a different first CP node between updates.
+	// Falls back to cpIP if the running config has no endpoint set.
+	endpointIP := runningConfig.Cluster().Endpoint().Hostname()
+	if endpointIP == "" {
+		endpointIP = cpIP
 	}
 
-	// Also sync the endpoint IP from the running cluster. ConfigManager.Load()
-	// generates configs with an empty endpoint (defaulting to a CIDR-derived
-	// private IP). For Hetzner clusters, the endpoint must be the CP's public IP
-	// so that new workers can reach the control plane. WithEndpoint preserves
-	// the secrets already embedded by WithSecrets. (Fixes #4605)
-	rebuilt, err = rebuilt.WithEndpoint(cpIP)
-	if err != nil {
-		return fmt.Errorf("failed to update configs with cluster endpoint: %w", err)
-	}
-
-	p.talosConfigs = rebuilt
-
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Synced cluster secrets from %s\n", cpIP)
-
-	return nil
+	return existingSecrets, endpointIP, nil
 }
 
 // nodeWithRole holds an IP address and its role for role-aware config application.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -513,7 +513,12 @@ func (p *Provisioner) syncSecretsFromCluster(
 
 	p.talosConfigs = rebuilt
 
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Synced cluster secrets and endpoint (%s) from %s\n", endpointIP, cpIP)
+	_, _ = fmt.Fprintf(
+		p.logWriter,
+		"  ✓ Synced cluster secrets and endpoint (%s) from %s\n",
+		endpointIP,
+		cpIP,
+	)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #4605

`syncSecretsFromCluster` correctly synced PKI secrets (CA, tokens) via `WithSecrets`, but did **not** update the endpoint IP. Freshly loaded configs have an empty endpoint that defaults to a CIDR-derived private IP (e.g., `10.5.0.2`). For Hetzner clusters, the endpoint must be the CP's **public** IP so new workers can reach the control plane.

## Root Cause

During `Create`, `updateConfigsWithEndpoint` sets the endpoint to the CP's public IP. During `Update`, this step was missing — `WithSecrets` preserves the empty endpoint from freshly loaded configs, causing regenerated worker configs to embed a private-network endpoint.

New workers could not reach the control plane to get their Talos API certificates signed → `talosctl version --nodes <IP>` → "certificate signed by unknown authority".

## Fix

In `syncSecretsFromCluster`, call `WithEndpoint(cpIP)` after `WithSecrets`. `cpIP` already holds the correct IP (public IP for Hetzner, container IP for Docker). `WithEndpoint` preserves the secrets already embedded by `WithSecrets`.

## Changes

- `pkg/svc/provisioner/cluster/talos/update.go` — Add `WithEndpoint(cpIP)` call after `WithSecrets` in `syncSecretsFromCluster`
- `pkg/fsutil/configmanager/talos/coverage_test.go` — Add test verifying `WithSecrets` + `WithEndpoint` preserves both secrets and endpoint