### PR TITLE
ci: add go-licenses dependency license check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -549,13 +549,13 @@ jobs:
           go-version-file: go.mod
 
       - name: 📦 Install go-licenses
-        run: go install github.com/google/go-licenses/v2@latest
+        run: go install github.com/google/go-licenses/v2@v2.0.1
 
       - name: 🔍 Check dependency licenses
         run: |
           go-licenses check ./... \
             --disallowed_types=forbidden \
-            --ignore github.com/devantler-tech/ksail \
+            --ignore github.com/devantler-tech/ksail/v7 \
             --ignore github.com/spdx/tools-golang
 
   audit-docs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -529,6 +529,35 @@ jobs:
             not included in the originating commit.
           delete-branch: true
 
+  license-check:
+    name: 🔍 License Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [changes]
+    if: github.event_name != 'merge_group' && needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: 📦 Install go-licenses
+        run: go install github.com/google/go-licenses/v2@latest
+
+      - name: 🔍 Check dependency licenses
+        run: |
+          go-licenses check ./... \
+            --disallowed_types=forbidden \
+            --ignore github.com/devantler-tech/ksail \
+            --ignore github.com/spdx/tools-golang
+
   audit-docs:
     name: 🔍 Audit Docs Dependencies
     runs-on: ubuntu-latest
@@ -1164,6 +1193,7 @@ jobs:
         warm-helm-cache,
         warm-mirror-cache,
         system-test-docker,
+        license-check,
         audit-docs,
         audit-vsce,
         build-docs,
@@ -1187,6 +1217,7 @@ jobs:
             ${{ needs.warm-helm-cache.result }}
             ${{ needs.warm-mirror-cache.result }}
             ${{ needs.system-test-docker.result }}
+            ${{ needs.license-check.result }}
             ${{ needs.audit-docs.result }}
             ${{ needs.audit-vsce.result }}
             ${{ needs.build-docs.result }}


### PR DESCRIPTION
## Summary

Add a new `license-check` CI job that uses [google/go-licenses](https://github.com/google/go-licenses) to detect dependencies with forbidden license types. The check runs on PRs and pushes when Go code changes and is wired into the required checks gate.

## Changes

- **New `license-check` job** in `ci.yaml` — installs `go-licenses` v2 and runs `go-licenses check ./... --disallowed_types=forbidden`
- **Added to `require-checks-in-pr`** — the license check is a required CI gate

### Ignored packages

| Package | Reason |
|---------|--------|
| `github.com/devantler-tech/ksail` | PolyForm Shield license is not recognized by go-licenses |
| `github.com/spdx/tools-golang` | Dual-licensed Apache-2.0/GPL-2.0-or-later — go-licenses detects the GPL file but Apache-2.0 applies |