### PR TITLE
fix: merge kubeconfig and talosconfig instead of overwriting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -553,10 +553,21 @@ jobs:
 
       - name: 🔍 Check dependency licenses
         run: |
+          # --ignore flags below exclude transitive dependencies whose licenses
+          # exist at the repository root but are not discoverable by go-licenses
+          # at the sub-package level (false-positive "license not found" errors).
           go-licenses check ./... \
             --disallowed_types=forbidden \
             --ignore github.com/devantler-tech/ksail/v7 \
-            --ignore github.com/spdx/tools-golang
+            --ignore github.com/spdx/tools-golang \
+            --ignore github.com/in-toto/in-toto-golang \
+            --ignore github.com/in-toto/attestation \
+            --ignore github.com/inconshreveable/go-update \
+            --ignore github.com/loft-sh/admin-apis \
+            --ignore github.com/segmentio/asm \
+            --ignore github.com/alibabacloud-go/cr-20160607 \
+            --ignore github.com/cyberphone/json-canonicalization \
+            --ignore github.com/deitch/magic
 
   audit-docs:
     name: 🔍 Audit Docs Dependencies

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/image-factory v1.2.0
 	github.com/siderolabs/omni/client v1.7.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.36.0
 	google.golang.org/grpc v1.80.0
@@ -914,7 +915,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.50.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/image-factory v1.2.0
 	github.com/siderolabs/omni/client v1.7.1
-	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.36.0
 	google.golang.org/grpc v1.80.0
@@ -915,6 +914,7 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.50.0 // indirect

--- a/pkg/cli/kubeconfighook/hook.go
+++ b/pkg/cli/kubeconfighook/hook.go
@@ -31,9 +31,6 @@ const (
 	// happens a short while before the token actually expires.
 	expiryBuffer = 5 * time.Minute
 
-	// kubeconfigFileMode is the file mode for kubeconfig files.
-	kubeconfigFileMode = 0o600
-
 	// kubeconfigDirMode is the directory mode used when creating the parent
 	// directory for the kubeconfig on initial fetch (e.g. fresh CI runners).
 	kubeconfigDirMode = 0o700
@@ -290,8 +287,8 @@ func clusterNameFromKubeconfig(kubeconfigPath string) string {
 
 // refreshKubeconfig creates an Omni client and fetches a fresh kubeconfig.
 // The Omni-generated context is renamed to desiredContext so the kubeconfig
-// matches spec.cluster.connection.context. The write is atomic (temp file +
-// rename) to prevent corruption if the process is interrupted.
+// matches spec.cluster.connection.context. The new entries are merged into
+// the existing kubeconfig to preserve other cluster configurations.
 func refreshKubeconfig(
 	ctx context.Context,
 	omniOpts v1alpha1.OptionsOmni,
@@ -323,9 +320,9 @@ func refreshKubeconfig(
 		}
 	}
 
-	writeErr := fsutil.AtomicWriteFile(kubeconfigPath, data, kubeconfigFileMode)
-	if writeErr != nil {
-		return fmt.Errorf("write kubeconfig: %w", writeErr)
+	mergeErr := k8s.MergeKubeconfig(kubeconfigPath, data)
+	if mergeErr != nil {
+		return fmt.Errorf("merge kubeconfig: %w", mergeErr)
 	}
 
 	return nil

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -28,7 +29,6 @@ const kubeconfigDirMode = 0o700
 // attacks.
 //
 // This prevents data loss when multiple clusters share the same kubeconfig file.
-//
 func MergeKubeconfig(kubeconfigPath string, newKubeconfigData []byte) error {
 	newConfig, err := clientcmd.Load(newKubeconfigData)
 	if err != nil {
@@ -39,7 +39,8 @@ func MergeKubeconfig(kubeconfigPath string, newKubeconfigData []byte) error {
 	// requires the parent to exist).
 	kubeconfigDir := filepath.Dir(kubeconfigPath)
 	if kubeconfigDir != "" && kubeconfigDir != "." {
-		if mkdirErr := os.MkdirAll(kubeconfigDir, kubeconfigDirMode); mkdirErr != nil {
+		mkdirErr := os.MkdirAll(kubeconfigDir, kubeconfigDirMode)
+		if mkdirErr != nil {
 			return fmt.Errorf("failed to create kubeconfig directory: %w", mkdirErr)
 		}
 	}
@@ -77,25 +78,19 @@ func mergeKubeconfigEntries(dst, src *api.Config) {
 		dst.Clusters = make(map[string]*api.Cluster)
 	}
 
-	for name, cluster := range src.Clusters {
-		dst.Clusters[name] = cluster
-	}
+	maps.Copy(dst.Clusters, src.Clusters)
 
 	if dst.Contexts == nil {
 		dst.Contexts = make(map[string]*api.Context)
 	}
 
-	for name, ctx := range src.Contexts {
-		dst.Contexts[name] = ctx
-	}
+	maps.Copy(dst.Contexts, src.Contexts)
 
 	if dst.AuthInfos == nil {
 		dst.AuthInfos = make(map[string]*api.AuthInfo)
 	}
 
-	for name, authInfo := range src.AuthInfos {
-		dst.AuthInfos[name] = authInfo
-	}
+	maps.Copy(dst.AuthInfos, src.AuthInfos)
 
 	if src.CurrentContext != "" {
 		dst.CurrentContext = src.CurrentContext

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -13,6 +13,96 @@ import (
 // kubeconfigFileMode is the file mode for kubeconfig files.
 const kubeconfigFileMode = 0o600
 
+// kubeconfigDirMode is the directory mode for kubeconfig parent directories.
+const kubeconfigDirMode = 0o700
+
+// MergeKubeconfig merges the cluster, context, and user entries from newKubeconfigData
+// into the existing kubeconfig file at kubeconfigPath. If the file does not exist, it
+// creates it with the new entries. Existing entries with the same keys are overwritten
+// by the new data. The current context is set to the new config's current context if
+// it is non-empty.
+//
+// This prevents data loss when multiple clusters share the same kubeconfig file.
+//
+//nolint:cyclop // merging is inherently multi-step
+func MergeKubeconfig(kubeconfigPath string, newKubeconfigData []byte) error {
+	newConfig, err := clientcmd.Load(newKubeconfigData)
+	if err != nil {
+		return fmt.Errorf("failed to parse new kubeconfig: %w", err)
+	}
+
+	existing, err := loadOrCreateKubeconfig(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load existing kubeconfig: %w", err)
+	}
+
+	// Merge clusters
+	if existing.Clusters == nil {
+		existing.Clusters = make(map[string]*api.Cluster)
+	}
+
+	for name, cluster := range newConfig.Clusters {
+		existing.Clusters[name] = cluster
+	}
+
+	// Merge contexts
+	if existing.Contexts == nil {
+		existing.Contexts = make(map[string]*api.Context)
+	}
+
+	for name, ctx := range newConfig.Contexts {
+		existing.Contexts[name] = ctx
+	}
+
+	// Merge auth infos (users)
+	if existing.AuthInfos == nil {
+		existing.AuthInfos = make(map[string]*api.AuthInfo)
+	}
+
+	for name, authInfo := range newConfig.AuthInfos {
+		existing.AuthInfos[name] = authInfo
+	}
+
+	// Update current context if the new config specifies one
+	if newConfig.CurrentContext != "" {
+		existing.CurrentContext = newConfig.CurrentContext
+	}
+
+	result, err := clientcmd.Write(*existing)
+	if err != nil {
+		return fmt.Errorf("failed to serialize merged kubeconfig: %w", err)
+	}
+
+	err = fsutil.AtomicWriteFile(kubeconfigPath, result, kubeconfigFileMode)
+	if err != nil {
+		return fmt.Errorf("failed to write merged kubeconfig: %w", err)
+	}
+
+	return nil
+}
+
+// loadOrCreateKubeconfig loads the kubeconfig from disk, or returns an empty
+// config if the file does not exist.
+//
+//nolint:gosec // G304: kubeconfigPath is validated by caller
+func loadOrCreateKubeconfig(kubeconfigPath string) (*api.Config, error) {
+	data, err := os.ReadFile(kubeconfigPath)
+	if os.IsNotExist(err) {
+		return api.NewConfig(), nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to read kubeconfig: %w", err)
+	}
+
+	config, err := clientcmd.Load(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	return config, nil
+}
+
 // CleanupKubeconfig removes the cluster, context, and user entries for a cluster
 // from the kubeconfig file. This only removes entries matching the provided names,
 // leaving other cluster configurations intact.

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"k8s.io/client-go/tools/clientcmd"
@@ -22,6 +23,10 @@ const kubeconfigDirMode = 0o700
 // by the new data. The current context is set to the new config's current context if
 // it is non-empty.
 //
+// MergeKubeconfig creates the parent directory if it does not exist and canonicalizes
+// the path (resolving symlinks) before reading or writing to prevent symlink-escape
+// attacks.
+//
 // This prevents data loss when multiple clusters share the same kubeconfig file.
 //
 //nolint:cyclop // merging is inherently multi-step
@@ -29,6 +34,21 @@ func MergeKubeconfig(kubeconfigPath string, newKubeconfigData []byte) error {
 	newConfig, err := clientcmd.Load(newKubeconfigData)
 	if err != nil {
 		return fmt.Errorf("failed to parse new kubeconfig: %w", err)
+	}
+
+	// Ensure parent directory exists before canonicalization (EvalCanonicalPath
+	// requires the parent to exist).
+	kubeconfigDir := filepath.Dir(kubeconfigPath)
+	if kubeconfigDir != "" && kubeconfigDir != "." {
+		if mkdirErr := os.MkdirAll(kubeconfigDir, kubeconfigDirMode); mkdirErr != nil {
+			return fmt.Errorf("failed to create kubeconfig directory: %w", mkdirErr)
+		}
+	}
+
+	// Canonicalize the path to prevent writes through symlinks.
+	kubeconfigPath, err = fsutil.EvalCanonicalPath(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to canonicalize kubeconfig path: %w", err)
 	}
 
 	existing, err := loadOrCreateKubeconfig(kubeconfigPath)

--- a/pkg/k8s/kubeconfig.go
+++ b/pkg/k8s/kubeconfig.go
@@ -29,7 +29,6 @@ const kubeconfigDirMode = 0o700
 //
 // This prevents data loss when multiple clusters share the same kubeconfig file.
 //
-//nolint:cyclop // merging is inherently multi-step
 func MergeKubeconfig(kubeconfigPath string, newKubeconfigData []byte) error {
 	newConfig, err := clientcmd.Load(newKubeconfigData)
 	if err != nil {
@@ -56,37 +55,7 @@ func MergeKubeconfig(kubeconfigPath string, newKubeconfigData []byte) error {
 		return fmt.Errorf("failed to load existing kubeconfig: %w", err)
 	}
 
-	// Merge clusters
-	if existing.Clusters == nil {
-		existing.Clusters = make(map[string]*api.Cluster)
-	}
-
-	for name, cluster := range newConfig.Clusters {
-		existing.Clusters[name] = cluster
-	}
-
-	// Merge contexts
-	if existing.Contexts == nil {
-		existing.Contexts = make(map[string]*api.Context)
-	}
-
-	for name, ctx := range newConfig.Contexts {
-		existing.Contexts[name] = ctx
-	}
-
-	// Merge auth infos (users)
-	if existing.AuthInfos == nil {
-		existing.AuthInfos = make(map[string]*api.AuthInfo)
-	}
-
-	for name, authInfo := range newConfig.AuthInfos {
-		existing.AuthInfos[name] = authInfo
-	}
-
-	// Update current context if the new config specifies one
-	if newConfig.CurrentContext != "" {
-		existing.CurrentContext = newConfig.CurrentContext
-	}
+	mergeKubeconfigEntries(existing, newConfig)
 
 	result, err := clientcmd.Write(*existing)
 	if err != nil {
@@ -99,6 +68,38 @@ func MergeKubeconfig(kubeconfigPath string, newKubeconfigData []byte) error {
 	}
 
 	return nil
+}
+
+// mergeKubeconfigEntries copies clusters, contexts, and users from src into dst,
+// overwriting entries with the same keys. It also updates the current context.
+func mergeKubeconfigEntries(dst, src *api.Config) {
+	if dst.Clusters == nil {
+		dst.Clusters = make(map[string]*api.Cluster)
+	}
+
+	for name, cluster := range src.Clusters {
+		dst.Clusters[name] = cluster
+	}
+
+	if dst.Contexts == nil {
+		dst.Contexts = make(map[string]*api.Context)
+	}
+
+	for name, ctx := range src.Contexts {
+		dst.Contexts[name] = ctx
+	}
+
+	if dst.AuthInfos == nil {
+		dst.AuthInfos = make(map[string]*api.AuthInfo)
+	}
+
+	for name, authInfo := range src.AuthInfos {
+		dst.AuthInfos[name] = authInfo
+	}
+
+	if src.CurrentContext != "" {
+		dst.CurrentContext = src.CurrentContext
+	}
 }
 
 // loadOrCreateKubeconfig loads the kubeconfig from disk, or returns an empty

--- a/pkg/k8s/kubeconfig_merge_test.go
+++ b/pkg/k8s/kubeconfig_merge_test.go
@@ -56,6 +56,7 @@ func TestMergeKubeconfig(t *testing.T) {
 		name              string
 		existingContent   string
 		newContent        string
+		useNestedDir      bool
 		wantClusters      []string
 		wantContexts      []string
 		wantUsers         []string
@@ -66,6 +67,16 @@ func TestMergeKubeconfig(t *testing.T) {
 			name:            "no existing file creates new",
 			existingContent: "",
 			newContent:      newKubeconfigCluster,
+			wantClusters:    []string{"new-cluster"},
+			wantContexts:    []string{"new-context"},
+			wantUsers:       []string{"new-user"},
+			wantCurrentCtx:  "new-context",
+		},
+		{
+			name:            "creates parent directory if missing",
+			existingContent: "",
+			newContent:      newKubeconfigCluster,
+			useNestedDir:    true,
 			wantClusters:    []string{"new-cluster"},
 			wantContexts:    []string{"new-context"},
 			wantUsers:       []string{"new-user"},
@@ -139,7 +150,13 @@ users:
 			t.Parallel()
 
 			tmpDir := t.TempDir()
-			kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+
+			var kubeconfigPath string
+			if tt.useNestedDir {
+				kubeconfigPath = filepath.Join(tmpDir, "nested", "deep", "kubeconfig")
+			} else {
+				kubeconfigPath = filepath.Join(tmpDir, "kubeconfig")
+			}
 
 			if tt.existingContent != "" {
 				require.NoError(t, os.WriteFile(kubeconfigPath, []byte(tt.existingContent), 0o600))

--- a/pkg/k8s/kubeconfig_merge_test.go
+++ b/pkg/k8s/kubeconfig_merge_test.go
@@ -101,12 +101,12 @@ type mergeKubeconfigTestCase struct {
 func mergeKubeconfigTests() []mergeKubeconfigTestCase {
 	return []mergeKubeconfigTestCase{
 		{
-			name:            "no existing file creates new",
-			newContent:      newKubeconfigCluster,
-			wantClusters:    []string{"new-cluster"},
-			wantContexts:    []string{"new-context"},
-			wantUsers:       []string{"new-user"},
-			wantCurrentCtx:  "new-context",
+			name:           "no existing file creates new",
+			newContent:     newKubeconfigCluster,
+			wantClusters:   []string{"new-cluster"},
+			wantContexts:   []string{"new-context"},
+			wantUsers:      []string{"new-user"},
+			wantCurrentCtx: "new-context",
 		},
 		{
 			name:           "creates parent directory if missing",
@@ -192,6 +192,7 @@ func runMergeKubeconfigTest(t *testing.T, testCase mergeKubeconfigTestCase) {
 	for name := range config.Clusters {
 		clusterNames = append(clusterNames, name)
 	}
+
 	assert.ElementsMatch(t, testCase.wantClusters, clusterNames, "clusters")
 
 	// Check contexts
@@ -199,6 +200,7 @@ func runMergeKubeconfigTest(t *testing.T, testCase mergeKubeconfigTestCase) {
 	for name := range config.Contexts {
 		contextNames = append(contextNames, name)
 	}
+
 	assert.ElementsMatch(t, testCase.wantContexts, contextNames, "contexts")
 
 	// Check users
@@ -206,6 +208,7 @@ func runMergeKubeconfigTest(t *testing.T, testCase mergeKubeconfigTestCase) {
 	for name := range config.AuthInfos {
 		userNames = append(userNames, name)
 	}
+
 	assert.ElementsMatch(t, testCase.wantUsers, userNames, "users")
 
 	// Check current context

--- a/pkg/k8s/kubeconfig_merge_test.go
+++ b/pkg/k8s/kubeconfig_merge_test.go
@@ -49,52 +49,8 @@ users:
     token: existing-token
 `
 
-func TestMergeKubeconfig(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name              string
-		existingContent   string
-		newContent        string
-		useNestedDir      bool
-		wantClusters      []string
-		wantContexts      []string
-		wantUsers         []string
-		wantCurrentCtx    string
-		wantClusterServer map[string]string
-	}{
-		{
-			name:            "no existing file creates new",
-			existingContent: "",
-			newContent:      newKubeconfigCluster,
-			wantClusters:    []string{"new-cluster"},
-			wantContexts:    []string{"new-context"},
-			wantUsers:       []string{"new-user"},
-			wantCurrentCtx:  "new-context",
-		},
-		{
-			name:            "creates parent directory if missing",
-			existingContent: "",
-			newContent:      newKubeconfigCluster,
-			useNestedDir:    true,
-			wantClusters:    []string{"new-cluster"},
-			wantContexts:    []string{"new-context"},
-			wantUsers:       []string{"new-user"},
-			wantCurrentCtx:  "new-context",
-		},
-		{
-			name:            "merges into existing file preserving other clusters",
-			existingContent: existingKubeconfigCluster,
-			newContent:      newKubeconfigCluster,
-			wantClusters:    []string{"existing-cluster", "new-cluster"},
-			wantContexts:    []string{"existing-context", "new-context"},
-			wantUsers:       []string{"existing-user", "new-user"},
-			wantCurrentCtx:  "new-context",
-		},
-		{
-			name:            "overwrites same-named entries",
-			existingContent: existingKubeconfigCluster,
-			newContent: `apiVersion: v1
+// overwriteKubeconfigCluster updates an existing cluster entry with a new server.
+const overwriteKubeconfigCluster = `apiVersion: v1
 kind: Config
 clusters:
 - cluster:
@@ -110,19 +66,10 @@ users:
 - name: existing-user
   user:
     token: updated-token
-`,
-			wantClusters:   []string{"existing-cluster"},
-			wantContexts:   []string{"existing-context"},
-			wantUsers:      []string{"existing-user"},
-			wantCurrentCtx: "existing-context",
-			wantClusterServer: map[string]string{
-				"existing-cluster": "https://updated-server:6443",
-			},
-		},
-		{
-			name:            "preserves current context when new config has none",
-			existingContent: existingKubeconfigCluster,
-			newContent: `apiVersion: v1
+`
+
+// noCurrentContextKubeconfigCluster is a kubeconfig without current-context set.
+const noCurrentContextKubeconfigCluster = `apiVersion: v1
 kind: Config
 clusters:
 - cluster:
@@ -137,72 +84,138 @@ users:
 - name: new-user
   user:
     token: new-token
-`,
-			wantClusters:   []string{"existing-cluster", "new-cluster"},
-			wantContexts:   []string{"existing-context", "new-context"},
-			wantUsers:      []string{"existing-user", "new-user"},
-			wantCurrentCtx: "existing-context",
+`
+
+type mergeKubeconfigTestCase struct {
+	name              string
+	existingContent   string
+	newContent        string
+	useNestedDir      bool
+	wantClusters      []string
+	wantContexts      []string
+	wantUsers         []string
+	wantCurrentCtx    string
+	wantClusterServer map[string]string
+}
+
+func mergeKubeconfigTests() []mergeKubeconfigTestCase {
+	return []mergeKubeconfigTestCase{
+		{
+			name:            "no existing file creates new",
+			newContent:      newKubeconfigCluster,
+			wantClusters:    []string{"new-cluster"},
+			wantContexts:    []string{"new-context"},
+			wantUsers:       []string{"new-user"},
+			wantCurrentCtx:  "new-context",
+		},
+		{
+			name:           "creates parent directory if missing",
+			newContent:     newKubeconfigCluster,
+			useNestedDir:   true,
+			wantClusters:   []string{"new-cluster"},
+			wantContexts:   []string{"new-context"},
+			wantUsers:      []string{"new-user"},
+			wantCurrentCtx: "new-context",
+		},
+		{
+			name:            "merges into existing file preserving other clusters",
+			existingContent: existingKubeconfigCluster,
+			newContent:      newKubeconfigCluster,
+			wantClusters:    []string{"existing-cluster", "new-cluster"},
+			wantContexts:    []string{"existing-context", "new-context"},
+			wantUsers:       []string{"existing-user", "new-user"},
+			wantCurrentCtx:  "new-context",
+		},
+		{
+			name:            "overwrites same-named entries",
+			existingContent: existingKubeconfigCluster,
+			newContent:      overwriteKubeconfigCluster,
+			wantClusters:    []string{"existing-cluster"},
+			wantContexts:    []string{"existing-context"},
+			wantUsers:       []string{"existing-user"},
+			wantCurrentCtx:  "existing-context",
+			wantClusterServer: map[string]string{
+				"existing-cluster": "https://updated-server:6443",
+			},
+		},
+		{
+			name:            "preserves current context when new config has none",
+			existingContent: existingKubeconfigCluster,
+			newContent:      noCurrentContextKubeconfigCluster,
+			wantClusters:    []string{"existing-cluster", "new-cluster"},
+			wantContexts:    []string{"existing-context", "new-context"},
+			wantUsers:       []string{"existing-user", "new-user"},
+			wantCurrentCtx:  "existing-context",
 		},
 	}
+}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+func TestMergeKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range mergeKubeconfigTests() {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-
-			tmpDir := t.TempDir()
-
-			var kubeconfigPath string
-			if tc.useNestedDir {
-				kubeconfigPath = filepath.Join(tmpDir, "nested", "deep", "kubeconfig")
-			} else {
-				kubeconfigPath = filepath.Join(tmpDir, "kubeconfig")
-			}
-
-			if tc.existingContent != "" {
-				require.NoError(t, os.WriteFile(kubeconfigPath, []byte(tc.existingContent), 0o600))
-			}
-
-			err := k8s.MergeKubeconfig(kubeconfigPath, []byte(tc.newContent))
-			require.NoError(t, err)
-
-			// Read back and verify
-			result, err := os.ReadFile(kubeconfigPath) //nolint:gosec // test-controlled temp path
-			require.NoError(t, err)
-
-			config, err := clientcmd.Load(result)
-			require.NoError(t, err)
-
-			// Check clusters
-			clusterNames := make([]string, 0, len(config.Clusters))
-			for name := range config.Clusters {
-				clusterNames = append(clusterNames, name)
-			}
-			assert.ElementsMatch(t, tc.wantClusters, clusterNames, "clusters")
-
-			// Check contexts
-			contextNames := make([]string, 0, len(config.Contexts))
-			for name := range config.Contexts {
-				contextNames = append(contextNames, name)
-			}
-			assert.ElementsMatch(t, tc.wantContexts, contextNames, "contexts")
-
-			// Check users
-			userNames := make([]string, 0, len(config.AuthInfos))
-			for name := range config.AuthInfos {
-				userNames = append(userNames, name)
-			}
-			assert.ElementsMatch(t, tc.wantUsers, userNames, "users")
-
-			// Check current context
-			assert.Equal(t, tc.wantCurrentCtx, config.CurrentContext, "current-context")
-
-			// Check specific server values when requested
-			for name, wantServer := range tc.wantClusterServer {
-				cluster, ok := config.Clusters[name]
-				require.True(t, ok, "cluster %q should exist", name)
-				assert.Equal(t, wantServer, cluster.Server, "cluster %q server", name)
-			}
+			runMergeKubeconfigTest(t, testCase)
 		})
+	}
+}
+
+func runMergeKubeconfigTest(t *testing.T, testCase mergeKubeconfigTestCase) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	var kubeconfigPath string
+	if testCase.useNestedDir {
+		kubeconfigPath = filepath.Join(tmpDir, "nested", "deep", "kubeconfig")
+	} else {
+		kubeconfigPath = filepath.Join(tmpDir, "kubeconfig")
+	}
+
+	if testCase.existingContent != "" {
+		require.NoError(t, os.WriteFile(kubeconfigPath, []byte(testCase.existingContent), 0o600))
+	}
+
+	err := k8s.MergeKubeconfig(kubeconfigPath, []byte(testCase.newContent))
+	require.NoError(t, err)
+
+	// Read back and verify
+	result, err := os.ReadFile(kubeconfigPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(result)
+	require.NoError(t, err)
+
+	// Check clusters
+	clusterNames := make([]string, 0, len(config.Clusters))
+	for name := range config.Clusters {
+		clusterNames = append(clusterNames, name)
+	}
+	assert.ElementsMatch(t, testCase.wantClusters, clusterNames, "clusters")
+
+	// Check contexts
+	contextNames := make([]string, 0, len(config.Contexts))
+	for name := range config.Contexts {
+		contextNames = append(contextNames, name)
+	}
+	assert.ElementsMatch(t, testCase.wantContexts, contextNames, "contexts")
+
+	// Check users
+	userNames := make([]string, 0, len(config.AuthInfos))
+	for name := range config.AuthInfos {
+		userNames = append(userNames, name)
+	}
+	assert.ElementsMatch(t, testCase.wantUsers, userNames, "users")
+
+	// Check current context
+	assert.Equal(t, testCase.wantCurrentCtx, config.CurrentContext, "current-context")
+
+	// Check specific server values when requested
+	for name, wantServer := range testCase.wantClusterServer {
+		cluster, ok := config.Clusters[name]
+		require.True(t, ok, "cluster %q should exist", name)
+		assert.Equal(t, wantServer, cluster.Server, "cluster %q server", name)
 	}
 }
 

--- a/pkg/k8s/kubeconfig_merge_test.go
+++ b/pkg/k8s/kubeconfig_merge_test.go
@@ -1,0 +1,214 @@
+package k8s_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// newKubeconfigCluster is a single-cluster kubeconfig used in merge tests.
+const newKubeconfigCluster = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://new-cluster:6443
+  name: new-cluster
+contexts:
+- context:
+    cluster: new-cluster
+    user: new-user
+  name: new-context
+current-context: new-context
+users:
+- name: new-user
+  user:
+    token: new-token
+`
+
+// existingKubeconfigCluster is an existing kubeconfig with one cluster.
+const existingKubeconfigCluster = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://existing-cluster:6443
+  name: existing-cluster
+contexts:
+- context:
+    cluster: existing-cluster
+    user: existing-user
+  name: existing-context
+current-context: existing-context
+users:
+- name: existing-user
+  user:
+    token: existing-token
+`
+
+func TestMergeKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		existingContent   string
+		newContent        string
+		wantClusters      []string
+		wantContexts      []string
+		wantUsers         []string
+		wantCurrentCtx    string
+		wantClusterServer map[string]string
+	}{
+		{
+			name:            "no existing file creates new",
+			existingContent: "",
+			newContent:      newKubeconfigCluster,
+			wantClusters:    []string{"new-cluster"},
+			wantContexts:    []string{"new-context"},
+			wantUsers:       []string{"new-user"},
+			wantCurrentCtx:  "new-context",
+		},
+		{
+			name:            "merges into existing file preserving other clusters",
+			existingContent: existingKubeconfigCluster,
+			newContent:      newKubeconfigCluster,
+			wantClusters:    []string{"existing-cluster", "new-cluster"},
+			wantContexts:    []string{"existing-context", "new-context"},
+			wantUsers:       []string{"existing-user", "new-user"},
+			wantCurrentCtx:  "new-context",
+		},
+		{
+			name:            "overwrites same-named entries",
+			existingContent: existingKubeconfigCluster,
+			newContent: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://updated-server:6443
+  name: existing-cluster
+contexts:
+- context:
+    cluster: existing-cluster
+    user: existing-user
+  name: existing-context
+current-context: existing-context
+users:
+- name: existing-user
+  user:
+    token: updated-token
+`,
+			wantClusters:   []string{"existing-cluster"},
+			wantContexts:   []string{"existing-context"},
+			wantUsers:      []string{"existing-user"},
+			wantCurrentCtx: "existing-context",
+			wantClusterServer: map[string]string{
+				"existing-cluster": "https://updated-server:6443",
+			},
+		},
+		{
+			name:            "preserves current context when new config has none",
+			existingContent: existingKubeconfigCluster,
+			newContent: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://new-cluster:6443
+  name: new-cluster
+contexts:
+- context:
+    cluster: new-cluster
+    user: new-user
+  name: new-context
+users:
+- name: new-user
+  user:
+    token: new-token
+`,
+			wantClusters:   []string{"existing-cluster", "new-cluster"},
+			wantContexts:   []string{"existing-context", "new-context"},
+			wantUsers:      []string{"existing-user", "new-user"},
+			wantCurrentCtx: "existing-context",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+
+			if tt.existingContent != "" {
+				require.NoError(t, os.WriteFile(kubeconfigPath, []byte(tt.existingContent), 0o600))
+			}
+
+			err := k8s.MergeKubeconfig(kubeconfigPath, []byte(tt.newContent))
+			require.NoError(t, err)
+
+			// Read back and verify
+			result, err := os.ReadFile(kubeconfigPath)
+			require.NoError(t, err)
+
+			config, err := clientcmd.Load(result)
+			require.NoError(t, err)
+
+			// Check clusters
+			var clusterNames []string
+			for name := range config.Clusters {
+				clusterNames = append(clusterNames, name)
+			}
+			assert.ElementsMatch(t, tt.wantClusters, clusterNames, "clusters")
+
+			// Check contexts
+			var contextNames []string
+			for name := range config.Contexts {
+				contextNames = append(contextNames, name)
+			}
+			assert.ElementsMatch(t, tt.wantContexts, contextNames, "contexts")
+
+			// Check users
+			var userNames []string
+			for name := range config.AuthInfos {
+				userNames = append(userNames, name)
+			}
+			assert.ElementsMatch(t, tt.wantUsers, userNames, "users")
+
+			// Check current context
+			assert.Equal(t, tt.wantCurrentCtx, config.CurrentContext, "current-context")
+
+			// Check specific server values when requested
+			for name, wantServer := range tt.wantClusterServer {
+				cluster, ok := config.Clusters[name]
+				require.True(t, ok, "cluster %q should exist", name)
+				assert.Equal(t, wantServer, cluster.Server, "cluster %q server", name)
+			}
+		})
+	}
+}
+
+func TestMergeKubeconfig_InvalidNewData(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+
+	err := k8s.MergeKubeconfig(kubeconfigPath, []byte("not valid yaml {{{"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse new kubeconfig")
+}
+
+func TestMergeKubeconfig_InvalidExistingFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte("not valid yaml {{{"), 0o600))
+
+	err := k8s.MergeKubeconfig(kubeconfigPath, []byte(newKubeconfigCluster))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load existing kubeconfig")
+}

--- a/pkg/k8s/kubeconfig_merge_test.go
+++ b/pkg/k8s/kubeconfig_merge_test.go
@@ -145,59 +145,59 @@ users:
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			tmpDir := t.TempDir()
 
 			var kubeconfigPath string
-			if tt.useNestedDir {
+			if tc.useNestedDir {
 				kubeconfigPath = filepath.Join(tmpDir, "nested", "deep", "kubeconfig")
 			} else {
 				kubeconfigPath = filepath.Join(tmpDir, "kubeconfig")
 			}
 
-			if tt.existingContent != "" {
-				require.NoError(t, os.WriteFile(kubeconfigPath, []byte(tt.existingContent), 0o600))
+			if tc.existingContent != "" {
+				require.NoError(t, os.WriteFile(kubeconfigPath, []byte(tc.existingContent), 0o600))
 			}
 
-			err := k8s.MergeKubeconfig(kubeconfigPath, []byte(tt.newContent))
+			err := k8s.MergeKubeconfig(kubeconfigPath, []byte(tc.newContent))
 			require.NoError(t, err)
 
 			// Read back and verify
-			result, err := os.ReadFile(kubeconfigPath)
+			result, err := os.ReadFile(kubeconfigPath) //nolint:gosec // test-controlled temp path
 			require.NoError(t, err)
 
 			config, err := clientcmd.Load(result)
 			require.NoError(t, err)
 
 			// Check clusters
-			var clusterNames []string
+			clusterNames := make([]string, 0, len(config.Clusters))
 			for name := range config.Clusters {
 				clusterNames = append(clusterNames, name)
 			}
-			assert.ElementsMatch(t, tt.wantClusters, clusterNames, "clusters")
+			assert.ElementsMatch(t, tc.wantClusters, clusterNames, "clusters")
 
 			// Check contexts
-			var contextNames []string
+			contextNames := make([]string, 0, len(config.Contexts))
 			for name := range config.Contexts {
 				contextNames = append(contextNames, name)
 			}
-			assert.ElementsMatch(t, tt.wantContexts, contextNames, "contexts")
+			assert.ElementsMatch(t, tc.wantContexts, contextNames, "contexts")
 
 			// Check users
-			var userNames []string
+			userNames := make([]string, 0, len(config.AuthInfos))
 			for name := range config.AuthInfos {
 				userNames = append(userNames, name)
 			}
-			assert.ElementsMatch(t, tt.wantUsers, userNames, "users")
+			assert.ElementsMatch(t, tc.wantUsers, userNames, "users")
 
 			// Check current context
-			assert.Equal(t, tt.wantCurrentCtx, config.CurrentContext, "current-context")
+			assert.Equal(t, tc.wantCurrentCtx, config.CurrentContext, "current-context")
 
 			// Check specific server values when requested
-			for name, wantServer := range tt.wantClusterServer {
+			for name, wantServer := range tc.wantClusterServer {
 				cluster, ok := config.Clusters[name]
 				require.True(t, ok, "cluster %q should exist", name)
 				assert.Equal(t, wantServer, cluster.Server, "cluster %q server", name)

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -315,3 +315,8 @@ func (p *Provisioner) WithTalosConfigsForTest(
 
 	return p
 }
+
+// MergeTalosconfigBytesForTest exposes mergeTalosconfigBytes for unit testing.
+func MergeTalosconfigBytesForTest(talosconfigPath string, newData []byte) error {
+	return mergeTalosconfigBytes(talosconfigPath, newData)
+}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -80,15 +80,6 @@ func (p *Provisioner) SyncAndWaitOmniClusterForTest(
 	return p.syncAndWaitOmniCluster(ctx, omniProv, params)
 }
 
-// SaveOmniConfigForTest exposes saveOmniConfig for unit testing.
-func (p *Provisioner) SaveOmniConfigForTest(
-	configData []byte,
-	rawPath string,
-	configLabel string,
-) error {
-	return p.saveOmniConfig(configData, rawPath, configLabel)
-}
-
 // SaveOmniKubeconfigForTest exposes saveOmniKubeconfig for unit testing.
 func (p *Provisioner) SaveOmniKubeconfigForTest(
 	ctx context.Context,

--- a/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
+++ b/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
@@ -1,0 +1,161 @@
+package talosprovisioner_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// talosconfigFixture is a minimal valid talosconfig with one context.
+func talosconfigFixture(contextName string, endpoint string) []byte {
+	return []byte(`context: ` + contextName + `
+contexts:
+  ` + contextName + `:
+    endpoints:
+      - ` + endpoint + `
+    ca: dGVzdC1jYQ==
+    crt: dGVzdC1jcnQ=
+    key: dGVzdC1rZXk=
+`)
+}
+
+// talosconfigParsed is a helper struct for asserting talosconfig contents.
+type talosconfigParsed struct {
+	Context  string                    `yaml:"context"`
+	Contexts map[string]talosconfigCtx `yaml:"contexts"`
+}
+
+type talosconfigCtx struct {
+	Endpoints []string `yaml:"endpoints"`
+	CA        string   `yaml:"ca,omitempty"`
+	Crt       string   `yaml:"crt,omitempty"`
+	Key       string   `yaml:"key,omitempty"`
+}
+
+func loadTalosconfigForTest(t *testing.T, path string) talosconfigParsed {
+	t.Helper()
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+
+	var parsed talosconfigParsed
+	require.NoError(t, yaml.Unmarshal(data, &parsed))
+
+	return parsed
+}
+
+func TestMergeTalosconfigBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		existingContent  []byte
+		newContent       []byte
+		wantContexts     []string
+		wantCurrentCtx   string
+		wantEndpoint     map[string]string
+		useNestedDir     bool
+	}{
+		{
+			name:            "no existing file creates new talosconfig",
+			existingContent: nil,
+			newContent:      talosconfigFixture("cluster-a", "10.0.0.1"),
+			wantContexts:    []string{"cluster-a"},
+			wantCurrentCtx:  "cluster-a",
+			wantEndpoint:    map[string]string{"cluster-a": "10.0.0.1"},
+		},
+		{
+			name:            "existing contexts from other clusters are preserved",
+			existingContent: talosconfigFixture("cluster-a", "10.0.0.1"),
+			newContent:      talosconfigFixture("cluster-b", "10.0.0.2"),
+			wantContexts:    []string{"cluster-a", "cluster-b"},
+			wantCurrentCtx:  "cluster-b",
+			wantEndpoint: map[string]string{
+				"cluster-a": "10.0.0.1",
+				"cluster-b": "10.0.0.2",
+			},
+		},
+		{
+			name:            "same-named context gets suffix to avoid collision",
+			existingContent: talosconfigFixture("cluster-a", "10.0.0.1"),
+			newContent:      talosconfigFixture("cluster-a", "10.0.0.99"),
+			// Talos SDK Merge renames colliding contexts with a -N suffix
+			wantContexts:   []string{"cluster-a", "cluster-a-1"},
+			wantCurrentCtx: "cluster-a-1",
+			wantEndpoint: map[string]string{
+				"cluster-a":   "10.0.0.1",
+				"cluster-a-1": "10.0.0.99",
+			},
+		},
+		{
+			name:            "creates parent directory if missing",
+			existingContent: nil,
+			newContent:      talosconfigFixture("cluster-a", "10.0.0.1"),
+			useNestedDir:    true,
+			wantContexts:    []string{"cluster-a"},
+			wantCurrentCtx:  "cluster-a",
+			wantEndpoint:    map[string]string{"cluster-a": "10.0.0.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+
+			var talosconfigPath string
+			if tt.useNestedDir {
+				talosconfigPath = filepath.Join(tmpDir, "nested", "deep", "talosconfig")
+			} else {
+				talosconfigPath = filepath.Join(tmpDir, "talosconfig")
+			}
+
+			if tt.existingContent != nil {
+				if tt.useNestedDir {
+					require.NoError(t, os.MkdirAll(filepath.Dir(talosconfigPath), 0o700))
+				}
+				require.NoError(t, os.WriteFile(talosconfigPath, tt.existingContent, 0o600))
+			}
+
+			err := talosprovisioner.MergeTalosconfigBytesForTest(talosconfigPath, tt.newContent)
+			require.NoError(t, err)
+
+			parsed := loadTalosconfigForTest(t, talosconfigPath)
+
+			// Check contexts present
+			var contextNames []string
+			for name := range parsed.Contexts {
+				contextNames = append(contextNames, name)
+			}
+			assert.ElementsMatch(t, tt.wantContexts, contextNames, "contexts")
+
+			// Check current context
+			assert.Equal(t, tt.wantCurrentCtx, parsed.Context, "current context")
+
+			// Check specific endpoint values
+			for ctxName, wantEP := range tt.wantEndpoint {
+				ctx, ok := parsed.Contexts[ctxName]
+				require.True(t, ok, "context %q should exist", ctxName)
+				require.NotEmpty(t, ctx.Endpoints, "context %q endpoints", ctxName)
+				assert.Equal(t, wantEP, ctx.Endpoints[0], "context %q first endpoint", ctxName)
+			}
+		})
+	}
+}
+
+func TestMergeTalosconfigBytes_InvalidNewData(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "talosconfig")
+
+	err := talosprovisioner.MergeTalosconfigBytesForTest(path, []byte("not valid yaml {{{"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse new talosconfig")
+}

--- a/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
+++ b/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
@@ -8,7 +8,7 @@ import (
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v4"
+	"gopkg.in/yaml.v3"
 )
 
 // talosconfigFixture is a minimal valid talosconfig with one context.

--- a/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
+++ b/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
@@ -53,13 +53,13 @@ func TestMergeTalosconfigBytes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		existingContent  []byte
-		newContent       []byte
-		wantContexts     []string
-		wantCurrentCtx   string
-		wantEndpoint     map[string]string
-		useNestedDir     bool
+		name            string
+		existingContent []byte
+		newContent      []byte
+		wantContexts    []string
+		wantCurrentCtx  string
+		wantEndpoint    map[string]string
+		useNestedDir    bool
 	}{
 		{
 			name:            "no existing file creates new talosconfig",
@@ -135,6 +135,7 @@ func runMergeTalosconfigTest(
 		if useNestedDir {
 			require.NoError(t, os.MkdirAll(filepath.Dir(talosconfigPath), 0o700))
 		}
+
 		require.NoError(t, os.WriteFile(talosconfigPath, existingContent, 0o600))
 	}
 
@@ -147,6 +148,7 @@ func runMergeTalosconfigTest(
 	for name := range parsed.Contexts {
 		contextNames = append(contextNames, name)
 	}
+
 	assert.ElementsMatch(t, wantContexts, contextNames, "contexts")
 
 	assert.Equal(t, wantCurrentCtx, parsed.Context, "current context")

--- a/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
+++ b/pkg/svc/provisioner/cluster/talos/merge_talosconfig_test.go
@@ -103,49 +103,59 @@ func TestMergeTalosconfigBytes(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			tmpDir := t.TempDir()
-
-			var talosconfigPath string
-			if tt.useNestedDir {
-				talosconfigPath = filepath.Join(tmpDir, "nested", "deep", "talosconfig")
-			} else {
-				talosconfigPath = filepath.Join(tmpDir, "talosconfig")
-			}
-
-			if tt.existingContent != nil {
-				if tt.useNestedDir {
-					require.NoError(t, os.MkdirAll(filepath.Dir(talosconfigPath), 0o700))
-				}
-				require.NoError(t, os.WriteFile(talosconfigPath, tt.existingContent, 0o600))
-			}
-
-			err := talosprovisioner.MergeTalosconfigBytesForTest(talosconfigPath, tt.newContent)
-			require.NoError(t, err)
-
-			parsed := loadTalosconfigForTest(t, talosconfigPath)
-
-			// Check contexts present
-			var contextNames []string
-			for name := range parsed.Contexts {
-				contextNames = append(contextNames, name)
-			}
-			assert.ElementsMatch(t, tt.wantContexts, contextNames, "contexts")
-
-			// Check current context
-			assert.Equal(t, tt.wantCurrentCtx, parsed.Context, "current context")
-
-			// Check specific endpoint values
-			for ctxName, wantEP := range tt.wantEndpoint {
-				ctx, ok := parsed.Contexts[ctxName]
-				require.True(t, ok, "context %q should exist", ctxName)
-				require.NotEmpty(t, ctx.Endpoints, "context %q endpoints", ctxName)
-				assert.Equal(t, wantEP, ctx.Endpoints[0], "context %q first endpoint", ctxName)
-			}
+			runMergeTalosconfigTest(t, tc.existingContent, tc.newContent, tc.useNestedDir,
+				tc.wantContexts, tc.wantCurrentCtx, tc.wantEndpoint)
 		})
+	}
+}
+
+func runMergeTalosconfigTest(
+	t *testing.T,
+	existingContent, newContent []byte,
+	useNestedDir bool,
+	wantContexts []string,
+	wantCurrentCtx string,
+	wantEndpoint map[string]string,
+) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	var talosconfigPath string
+	if useNestedDir {
+		talosconfigPath = filepath.Join(tmpDir, "nested", "deep", "talosconfig")
+	} else {
+		talosconfigPath = filepath.Join(tmpDir, "talosconfig")
+	}
+
+	if existingContent != nil {
+		if useNestedDir {
+			require.NoError(t, os.MkdirAll(filepath.Dir(talosconfigPath), 0o700))
+		}
+		require.NoError(t, os.WriteFile(talosconfigPath, existingContent, 0o600))
+	}
+
+	err := talosprovisioner.MergeTalosconfigBytesForTest(talosconfigPath, newContent)
+	require.NoError(t, err)
+
+	parsed := loadTalosconfigForTest(t, talosconfigPath)
+
+	contextNames := make([]string, 0, len(parsed.Contexts))
+	for name := range parsed.Contexts {
+		contextNames = append(contextNames, name)
+	}
+	assert.ElementsMatch(t, wantContexts, contextNames, "contexts")
+
+	assert.Equal(t, wantCurrentCtx, parsed.Context, "current context")
+
+	for ctxName, wantEP := range wantEndpoint {
+		ctx, ok := parsed.Contexts[ctxName]
+		require.True(t, ok, "context %q should exist", ctxName)
+		require.NotEmpty(t, ctx.Endpoints, "context %q endpoints", ctxName)
+		assert.Equal(t, wantEP, ctx.Endpoints[0], "context %q first endpoint", ctxName)
 	}
 }
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -49,8 +49,6 @@ const (
 	ipv4Offset = 2
 	// stateDirectoryPermissions is the permissions for the state directory.
 	stateDirectoryPermissions = 0o750
-	// kubeconfigFileMode is the file mode for kubeconfig files.
-	kubeconfigFileMode = 0o600
 	// clusterReadinessTimeout is the timeout for waiting for the cluster to become ready.
 	// This is shared across all Talos providers (Docker, Hetzner, Omni) and matches
 	// the upstream talosctl default of 20 minutes to accommodate slower cloud bring-up.

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -127,7 +127,11 @@ func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 	if openErr != nil {
 		if os.IsNotExist(openErr) {
 			// No existing file; save the new config directly
-			return newConfig.Save(talosconfigPath)
+			if saveErr := newConfig.Save(talosconfigPath); saveErr != nil {
+				return fmt.Errorf("failed to save new talosconfig: %w", saveErr)
+			}
+
+			return nil
 		}
 
 		return fmt.Errorf("failed to open existing talosconfig: %w", openErr)
@@ -136,7 +140,11 @@ func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 	// Merge new contexts into existing config
 	existing.Merge(newConfig)
 
-	return existing.Save(talosconfigPath)
+	if saveErr := existing.Save(talosconfigPath); saveErr != nil {
+		return fmt.Errorf("failed to save merged talosconfig: %w", saveErr)
+	}
+
+	return nil
 }
 
 // rewriteKubeconfigEndpoint rewrites all cluster server endpoints in the kubeconfig

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -19,8 +19,8 @@ import (
 )
 
 // writeKubeconfig merges the raw kubeconfig bytes into the existing kubeconfig file
-// at the configured path. It expands tilde in the path, ensures the directory exists,
-// and merges new entries into the existing file to preserve other cluster configurations.
+// at the configured path. It expands tilde in the path and delegates to MergeKubeconfig
+// which handles directory creation, path canonicalization, and merging.
 func (p *Provisioner) writeKubeconfig(kubeconfig []byte) error {
 	// Expand tilde in kubeconfig path (e.g., ~/.kube/config -> /home/user/.kube/config)
 	kubeconfigPath, err := fsutil.ExpandHomePath(p.options.KubeconfigPath)
@@ -28,22 +28,8 @@ func (p *Provisioner) writeKubeconfig(kubeconfig []byte) error {
 		return fmt.Errorf("failed to expand kubeconfig path: %w", err)
 	}
 
-	// Ensure kubeconfig directory exists
-	kubeconfigDir := filepath.Dir(kubeconfigPath)
-	if kubeconfigDir != "" && kubeconfigDir != "." {
-		mkdirErr := os.MkdirAll(kubeconfigDir, stateDirectoryPermissions)
-		if mkdirErr != nil {
-			return fmt.Errorf("failed to create kubeconfig directory: %w", mkdirErr)
-		}
-	}
-
-	// Canonicalize the path (resolve symlinks) before writing
-	kubeconfigPath, err = fsutil.EvalCanonicalPath(kubeconfigPath)
-	if err != nil {
-		return fmt.Errorf("failed to canonicalize kubeconfig path: %w", err)
-	}
-
-	// Merge into existing kubeconfig to preserve other cluster entries
+	// Merge into existing kubeconfig to preserve other cluster entries.
+	// MergeKubeconfig handles directory creation and path canonicalization.
 	err = k8s.MergeKubeconfig(kubeconfigPath, kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to merge kubeconfig: %w", err)
@@ -70,6 +56,12 @@ func (p *Provisioner) saveTalosconfig(configBundle *bundle.Bundle) error {
 		if mkdirErr != nil {
 			return fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
 		}
+	}
+
+	// Canonicalize the path to prevent writes through symlinks
+	talosconfigPath, err = fsutil.EvalCanonicalPath(talosconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to canonicalize talosconfig path: %w", err)
 	}
 
 	newConfig := configBundle.TalosConfig()
@@ -106,12 +98,28 @@ func (p *Provisioner) saveTalosconfig(configBundle *bundle.Bundle) error {
 
 // mergeTalosconfigBytes merges raw talosconfig bytes into an existing talosconfig file.
 // If the file does not exist, it creates it with the new content.
+// It creates the parent directory and canonicalizes the path before reading or writing
+// to prevent symlink-escape attacks.
 // This is used by Omni paths that receive talosconfig as raw bytes.
 func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 	// Parse the new talosconfig data
 	newConfig, err := clientconfig.FromBytes(newData)
 	if err != nil {
 		return fmt.Errorf("failed to parse new talosconfig: %w", err)
+	}
+
+	// Ensure parent directory exists
+	talosconfigDir := filepath.Dir(talosconfigPath)
+	if talosconfigDir != "" && talosconfigDir != "." {
+		if mkdirErr := os.MkdirAll(talosconfigDir, stateDirectoryPermissions); mkdirErr != nil {
+			return fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
+		}
+	}
+
+	// Canonicalize the path to prevent writes through symlinks
+	talosconfigPath, err = fsutil.EvalCanonicalPath(talosconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to canonicalize talosconfig path: %w", err)
 	}
 
 	// Try to load existing talosconfig

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -111,7 +111,8 @@ func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 	// Ensure parent directory exists
 	talosconfigDir := filepath.Dir(talosconfigPath)
 	if talosconfigDir != "" && talosconfigDir != "." {
-		if mkdirErr := os.MkdirAll(talosconfigDir, stateDirectoryPermissions); mkdirErr != nil {
+		mkdirErr := os.MkdirAll(talosconfigDir, stateDirectoryPermissions)
+		if mkdirErr != nil {
 			return fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
 		}
 	}
@@ -127,7 +128,8 @@ func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 	if openErr != nil {
 		if os.IsNotExist(openErr) {
 			// No existing file; save the new config directly
-			if saveErr := newConfig.Save(talosconfigPath); saveErr != nil {
+			saveErr := newConfig.Save(talosconfigPath)
+			if saveErr != nil {
 				return fmt.Errorf("failed to save new talosconfig: %w", saveErr)
 			}
 
@@ -140,7 +142,8 @@ func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 	// Merge new contexts into existing config
 	existing.Merge(newConfig)
 
-	if saveErr := existing.Save(talosconfigPath); saveErr != nil {
+	saveErr := existing.Save(talosconfigPath)
+	if saveErr != nil {
 		return fmt.Errorf("failed to save merged talosconfig: %w", saveErr)
 	}
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -83,7 +83,7 @@ func (p *Provisioner) saveTalosconfig(configBundle *bundle.Bundle) error {
 		return fmt.Errorf("failed to open existing talosconfig: %w", openErr)
 	}
 
-	// Merge new contexts into existing config (overwrites same-named contexts)
+	// Merge new contexts into existing config (renames colliding contexts with -N suffix)
 	existing.Merge(newConfig)
 
 	saveErr := existing.Save(talosconfigPath)

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -35,7 +35,13 @@ func (p *Provisioner) writeKubeconfig(kubeconfig []byte) error {
 		return fmt.Errorf("failed to merge kubeconfig: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "Kubeconfig saved to %s\n", kubeconfigPath)
+	// Log the canonical path for accuracy (MergeKubeconfig resolves symlinks internally).
+	canonicalPath, _ := fsutil.EvalCanonicalPath(kubeconfigPath)
+	if canonicalPath == "" {
+		canonicalPath = kubeconfigPath
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "Kubeconfig saved to %s\n", canonicalPath)
 
 	return nil
 }
@@ -49,19 +55,9 @@ func (p *Provisioner) saveTalosconfig(configBundle *bundle.Bundle) error {
 		return fmt.Errorf("failed to expand talosconfig path: %w", err)
 	}
 
-	// Ensure talosconfig directory exists
-	talosconfigDir := filepath.Dir(talosconfigPath)
-	if talosconfigDir != "" && talosconfigDir != "." {
-		mkdirErr := os.MkdirAll(talosconfigDir, stateDirectoryPermissions)
-		if mkdirErr != nil {
-			return fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
-		}
-	}
-
-	// Canonicalize the path to prevent writes through symlinks
-	talosconfigPath, err = fsutil.EvalCanonicalPath(talosconfigPath)
+	talosconfigPath, err = prepareTalosconfigPath(talosconfigPath)
 	if err != nil {
-		return fmt.Errorf("failed to canonicalize talosconfig path: %w", err)
+		return err
 	}
 
 	newConfig := configBundle.TalosConfig()
@@ -108,19 +104,9 @@ func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 		return fmt.Errorf("failed to parse new talosconfig: %w", err)
 	}
 
-	// Ensure parent directory exists
-	talosconfigDir := filepath.Dir(talosconfigPath)
-	if talosconfigDir != "" && talosconfigDir != "." {
-		mkdirErr := os.MkdirAll(talosconfigDir, stateDirectoryPermissions)
-		if mkdirErr != nil {
-			return fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
-		}
-	}
-
-	// Canonicalize the path to prevent writes through symlinks
-	talosconfigPath, err = fsutil.EvalCanonicalPath(talosconfigPath)
+	talosconfigPath, err = prepareTalosconfigPath(talosconfigPath)
 	if err != nil {
-		return fmt.Errorf("failed to canonicalize talosconfig path: %w", err)
+		return err
 	}
 
 	// Try to load existing talosconfig
@@ -148,6 +134,25 @@ func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
 	}
 
 	return nil
+}
+
+// prepareTalosconfigPath ensures the parent directory exists and canonicalizes the path.
+// Shared by saveTalosconfig and mergeTalosconfigBytes to avoid duplication.
+func prepareTalosconfigPath(talosconfigPath string) (string, error) {
+	talosconfigDir := filepath.Dir(talosconfigPath)
+	if talosconfigDir != "" && talosconfigDir != "." {
+		mkdirErr := os.MkdirAll(talosconfigDir, stateDirectoryPermissions)
+		if mkdirErr != nil {
+			return "", fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
+		}
+	}
+
+	canonicalPath, err := fsutil.EvalCanonicalPath(talosconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to canonicalize talosconfig path: %w", err)
+	}
+
+	return canonicalPath, nil
 }
 
 // rewriteKubeconfigEndpoint rewrites all cluster server endpoints in the kubeconfig

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -18,8 +18,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// writeKubeconfig writes the raw kubeconfig bytes to the configured kubeconfig path.
-// It expands tilde in the path, ensures the directory exists, and writes the file.
+// writeKubeconfig merges the raw kubeconfig bytes into the existing kubeconfig file
+// at the configured path. It expands tilde in the path, ensures the directory exists,
+// and merges new entries into the existing file to preserve other cluster configurations.
 func (p *Provisioner) writeKubeconfig(kubeconfig []byte) error {
 	// Expand tilde in kubeconfig path (e.g., ~/.kube/config -> /home/user/.kube/config)
 	kubeconfigPath, err := fsutil.ExpandHomePath(p.options.KubeconfigPath)
@@ -42,10 +43,10 @@ func (p *Provisioner) writeKubeconfig(kubeconfig []byte) error {
 		return fmt.Errorf("failed to canonicalize kubeconfig path: %w", err)
 	}
 
-	// Write kubeconfig to file
-	err = os.WriteFile(kubeconfigPath, kubeconfig, kubeconfigFileMode)
+	// Merge into existing kubeconfig to preserve other cluster entries
+	err = k8s.MergeKubeconfig(kubeconfigPath, kubeconfig)
 	if err != nil {
-		return fmt.Errorf("failed to write kubeconfig: %w", err)
+		return fmt.Errorf("failed to merge kubeconfig: %w", err)
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter, "Kubeconfig saved to %s\n", kubeconfigPath)
@@ -53,7 +54,8 @@ func (p *Provisioner) writeKubeconfig(kubeconfig []byte) error {
 	return nil
 }
 
-// saveTalosconfig saves the talosconfig for any cluster type.
+// saveTalosconfig merges the new talosconfig context into the existing talosconfig file.
+// If the file does not exist, it creates it with the new context.
 func (p *Provisioner) saveTalosconfig(configBundle *bundle.Bundle) error {
 	// Expand tilde in talosconfig path
 	talosconfigPath, err := fsutil.ExpandHomePath(p.options.TalosconfigPath)
@@ -70,15 +72,63 @@ func (p *Provisioner) saveTalosconfig(configBundle *bundle.Bundle) error {
 		}
 	}
 
-	// Save the talosconfig
-	saveErr := configBundle.TalosConfig().Save(talosconfigPath)
+	newConfig := configBundle.TalosConfig()
+
+	// Try to load existing talosconfig; if it doesn't exist, save directly
+	existing, openErr := clientconfig.Open(talosconfigPath)
+	if openErr != nil {
+		if os.IsNotExist(openErr) {
+			saveErr := newConfig.Save(talosconfigPath)
+			if saveErr != nil {
+				return fmt.Errorf("failed to save talosconfig: %w", saveErr)
+			}
+
+			_, _ = fmt.Fprintf(p.logWriter, "Talosconfig saved to %s\n", talosconfigPath)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to open existing talosconfig: %w", openErr)
+	}
+
+	// Merge new contexts into existing config (overwrites same-named contexts)
+	existing.Merge(newConfig)
+
+	saveErr := existing.Save(talosconfigPath)
 	if saveErr != nil {
-		return fmt.Errorf("failed to save talosconfig: %w", saveErr)
+		return fmt.Errorf("failed to save merged talosconfig: %w", saveErr)
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter, "Talosconfig saved to %s\n", talosconfigPath)
 
 	return nil
+}
+
+// mergeTalosconfigBytes merges raw talosconfig bytes into an existing talosconfig file.
+// If the file does not exist, it creates it with the new content.
+// This is used by Omni paths that receive talosconfig as raw bytes.
+func mergeTalosconfigBytes(talosconfigPath string, newData []byte) error {
+	// Parse the new talosconfig data
+	newConfig, err := clientconfig.FromBytes(newData)
+	if err != nil {
+		return fmt.Errorf("failed to parse new talosconfig: %w", err)
+	}
+
+	// Try to load existing talosconfig
+	existing, openErr := clientconfig.Open(talosconfigPath)
+	if openErr != nil {
+		if os.IsNotExist(openErr) {
+			// No existing file; save the new config directly
+			return newConfig.Save(talosconfigPath)
+		}
+
+		return fmt.Errorf("failed to open existing talosconfig: %w", openErr)
+	}
+
+	// Merge new contexts into existing config
+	existing.Merge(newConfig)
+
+	return existing.Save(talosconfigPath)
 }
 
 // rewriteKubeconfigEndpoint rewrites all cluster server endpoints in the kubeconfig

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -439,27 +439,20 @@ func (p *Provisioner) saveOmniKubeconfig(
 		return fmt.Errorf("failed to rename kubeconfig context: %w", err)
 	}
 
-	expandedPath, expandErr := fsutil.ExpandHomePath(p.options.KubeconfigPath)
+	// Expand tilde in kubeconfig path
+	kubeconfigPath, expandErr := fsutil.ExpandHomePath(p.options.KubeconfigPath)
 	if expandErr != nil {
 		return fmt.Errorf("failed to expand kubeconfig path: %w", expandErr)
 	}
 
-	mkdirErr := os.MkdirAll(filepath.Dir(expandedPath), stateDirectoryPermissions)
-	if mkdirErr != nil {
-		return fmt.Errorf("failed to create kubeconfig directory: %w", mkdirErr)
-	}
-
-	canonicalPath, canonErr := fsutil.EvalCanonicalPath(expandedPath)
-	if canonErr != nil {
-		return fmt.Errorf("failed to canonicalize kubeconfig path: %w", canonErr)
-	}
-
-	mergeErr := k8s.MergeKubeconfig(canonicalPath, kubeconfigData)
+	// Merge into existing kubeconfig to preserve other cluster entries.
+	// MergeKubeconfig handles directory creation and path canonicalization.
+	mergeErr := k8s.MergeKubeconfig(kubeconfigPath, kubeconfigData)
 	if mergeErr != nil {
 		return fmt.Errorf("failed to merge kubeconfig: %w", mergeErr)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Kubeconfig saved to %s\n", canonicalPath)
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Kubeconfig saved to %s\n", kubeconfigPath)
 
 	return nil
 }
@@ -476,27 +469,20 @@ func (p *Provisioner) saveOmniTalosconfig(
 		return fmt.Errorf("failed to get talosconfig from Omni: %w", err)
 	}
 
-	expandedPath, expandErr := fsutil.ExpandHomePath(p.options.TalosconfigPath)
+	// Expand tilde in talosconfig path
+	talosconfigPath, expandErr := fsutil.ExpandHomePath(p.options.TalosconfigPath)
 	if expandErr != nil {
 		return fmt.Errorf("failed to expand talosconfig path: %w", expandErr)
 	}
 
-	mkdirErr := os.MkdirAll(filepath.Dir(expandedPath), stateDirectoryPermissions)
-	if mkdirErr != nil {
-		return fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
-	}
-
-	canonicalPath, canonErr := fsutil.EvalCanonicalPath(expandedPath)
-	if canonErr != nil {
-		return fmt.Errorf("failed to canonicalize talosconfig path: %w", canonErr)
-	}
-
-	mergeErr := mergeTalosconfigBytes(canonicalPath, talosconfigData)
+	// Merge into existing talosconfig to preserve other cluster contexts.
+	// mergeTalosconfigBytes handles directory creation and path canonicalization.
+	mergeErr := mergeTalosconfigBytes(talosconfigPath, talosconfigData)
 	if mergeErr != nil {
 		return fmt.Errorf("failed to merge talosconfig: %w", mergeErr)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Talosconfig saved to %s\n", canonicalPath)
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Talosconfig saved to %s\n", talosconfigPath)
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -3,7 +3,6 @@ package talosprovisioner
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -375,38 +374,6 @@ func (p *Provisioner) resolveOmniMachines(
 	return resolved, nil
 }
 
-// saveOmniConfig writes already-fetched config data to disk. It expands/canonicalizes
-// the output path, creates parent dirs, and writes the file using configLabel for logs.
-func (p *Provisioner) saveOmniConfig(
-	configData []byte,
-	rawPath string,
-	configLabel string,
-) error {
-	expandedPath, err := fsutil.ExpandHomePath(rawPath)
-	if err != nil {
-		return fmt.Errorf("failed to expand %s path: %w", configLabel, err)
-	}
-
-	err = os.MkdirAll(filepath.Dir(expandedPath), stateDirectoryPermissions)
-	if err != nil {
-		return fmt.Errorf("failed to create %s directory: %w", configLabel, err)
-	}
-
-	canonicalPath, err := fsutil.EvalCanonicalPath(expandedPath)
-	if err != nil {
-		return fmt.Errorf("failed to canonicalize %s path: %w", configLabel, err)
-	}
-
-	err = os.WriteFile(canonicalPath, configData, kubeconfigFileMode)
-	if err != nil {
-		return fmt.Errorf("failed to write %s: %w", configLabel, err)
-	}
-
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ %s saved to %s\n", configLabel, canonicalPath)
-
-	return nil
-}
-
 // saveOmniKubeconfig retrieves and saves the kubeconfig from Omni.
 // If a desired context name is configured (via Options.KubeconfigContext) or can be
 // derived from the cluster name, the Omni-generated context is renamed to match.
@@ -452,7 +419,13 @@ func (p *Provisioner) saveOmniKubeconfig(
 		return fmt.Errorf("failed to merge kubeconfig: %w", mergeErr)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Kubeconfig saved to %s\n", kubeconfigPath)
+	// Log the canonical path for accuracy (MergeKubeconfig resolves symlinks internally).
+	canonicalPath, _ := fsutil.EvalCanonicalPath(kubeconfigPath)
+	if canonicalPath == "" {
+		canonicalPath = kubeconfigPath
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Kubeconfig saved to %s\n", canonicalPath)
 
 	return nil
 }
@@ -482,7 +455,13 @@ func (p *Provisioner) saveOmniTalosconfig(
 		return fmt.Errorf("failed to merge talosconfig: %w", mergeErr)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Talosconfig saved to %s\n", talosconfigPath)
+	// Log the canonical path for accuracy (mergeTalosconfigBytes resolves symlinks internally).
+	canonicalPath, _ := fsutil.EvalCanonicalPath(talosconfigPath)
+	if canonicalPath == "" {
+		canonicalPath = talosconfigPath
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Talosconfig saved to %s\n", canonicalPath)
 
 	return nil
 }
@@ -492,7 +471,7 @@ func (p *Provisioner) saveOmniTalosconfig(
 // report RUNNING/Ready before the proxy is operational for kubectl connections.
 func (p *Provisioner) waitForOmniAPIServerReady(ctx context.Context) error {
 	// Expand ~ and canonicalize the kubeconfig path to match what
-	// saveOmniConfig wrote (which also calls ExpandHomePath + EvalCanonicalPath).
+	// saveOmniKubeconfig wrote (which also calls ExpandHomePath + EvalCanonicalPath).
 	expandedPath, err := fsutil.ExpandHomePath(p.options.KubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("expand kubeconfig path for readiness check: %w", err)

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -411,6 +411,7 @@ func (p *Provisioner) saveOmniConfig(
 // If a desired context name is configured (via Options.KubeconfigContext) or can be
 // derived from the cluster name, the Omni-generated context is renamed to match.
 // This ensures the kubeconfig context name matches spec.cluster.connection.context.
+// The kubeconfig is merged into the existing file to preserve other cluster entries.
 func (p *Provisioner) saveOmniKubeconfig(
 	ctx context.Context,
 	omniProv *omniprovider.Provider,
@@ -438,10 +439,33 @@ func (p *Provisioner) saveOmniKubeconfig(
 		return fmt.Errorf("failed to rename kubeconfig context: %w", err)
 	}
 
-	return p.saveOmniConfig(kubeconfigData, p.options.KubeconfigPath, "Kubeconfig")
+	expandedPath, expandErr := fsutil.ExpandHomePath(p.options.KubeconfigPath)
+	if expandErr != nil {
+		return fmt.Errorf("failed to expand kubeconfig path: %w", expandErr)
+	}
+
+	mkdirErr := os.MkdirAll(filepath.Dir(expandedPath), stateDirectoryPermissions)
+	if mkdirErr != nil {
+		return fmt.Errorf("failed to create kubeconfig directory: %w", mkdirErr)
+	}
+
+	canonicalPath, canonErr := fsutil.EvalCanonicalPath(expandedPath)
+	if canonErr != nil {
+		return fmt.Errorf("failed to canonicalize kubeconfig path: %w", canonErr)
+	}
+
+	mergeErr := k8s.MergeKubeconfig(canonicalPath, kubeconfigData)
+	if mergeErr != nil {
+		return fmt.Errorf("failed to merge kubeconfig: %w", mergeErr)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Kubeconfig saved to %s\n", canonicalPath)
+
+	return nil
 }
 
 // saveOmniTalosconfig retrieves and saves the talosconfig from Omni.
+// The talosconfig is merged into the existing file to preserve other cluster contexts.
 func (p *Provisioner) saveOmniTalosconfig(
 	ctx context.Context,
 	omniProv *omniprovider.Provider,
@@ -452,7 +476,29 @@ func (p *Provisioner) saveOmniTalosconfig(
 		return fmt.Errorf("failed to get talosconfig from Omni: %w", err)
 	}
 
-	return p.saveOmniConfig(talosconfigData, p.options.TalosconfigPath, "Talosconfig")
+	expandedPath, expandErr := fsutil.ExpandHomePath(p.options.TalosconfigPath)
+	if expandErr != nil {
+		return fmt.Errorf("failed to expand talosconfig path: %w", expandErr)
+	}
+
+	mkdirErr := os.MkdirAll(filepath.Dir(expandedPath), stateDirectoryPermissions)
+	if mkdirErr != nil {
+		return fmt.Errorf("failed to create talosconfig directory: %w", mkdirErr)
+	}
+
+	canonicalPath, canonErr := fsutil.EvalCanonicalPath(expandedPath)
+	if canonErr != nil {
+		return fmt.Errorf("failed to canonicalize talosconfig path: %w", canonErr)
+	}
+
+	mergeErr := mergeTalosconfigBytes(canonicalPath, talosconfigData)
+	if mergeErr != nil {
+		return fmt.Errorf("failed to merge talosconfig: %w", mergeErr)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Talosconfig saved to %s\n", canonicalPath)
+
+	return nil
 }
 
 // waitForOmniAPIServerReady verifies that the Kubernetes API server is reachable

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni_test.go
@@ -2,7 +2,6 @@ package talosprovisioner_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -389,28 +388,6 @@ func TestResolveOmniMachines_BothSet_ReturnsConflict(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, omniprovider.ErrMachineAllocationConflict)
 	assert.Nil(t, machines)
-}
-
-func TestSaveOmniConfig_WritesFile(t *testing.T) {
-	t.Parallel()
-
-	// Use a temp dir so tilde expansion is not needed, but verify saveOmniConfig
-	// actually writes the file and handles path expansion/canonicalization.
-	tmpDir := t.TempDir()
-	outPath := filepath.Join(tmpDir, "subdir", "test-kube.yaml")
-
-	configs := createTestTalosConfigs(t, "test-cluster")
-	provisioner := talosprovisioner.NewProvisioner(configs,
-		talosprovisioner.NewOptions().WithKubeconfigPath(outPath),
-	)
-
-	dummyData := []byte("apiVersion: v1\nkind: Config\n")
-	err := provisioner.SaveOmniConfigForTest(dummyData, outPath, "Kubeconfig")
-	require.NoError(t, err)
-
-	written, err := os.ReadFile(outPath) //nolint:gosec // test-controlled temp path
-	require.NoError(t, err)
-	assert.Equal(t, dummyData, written)
 }
 
 func TestRenameKubeconfigContext(t *testing.T) {


### PR DESCRIPTION
## Summary

Replace `os.WriteFile` and `AtomicWriteFile` calls that clobber the entire kubeconfig/talosconfig file with merge-based writes that preserve entries from other clusters.

**Problem:** When creating a Talos cluster (Docker, Hetzner, or Omni provider) or refreshing an Omni kubeconfig token, the entire `~/.kube/config` or `~/.talos/config` file was overwritten. If a user had other clusters configured in the same file, they would lose access to those clusters.

## Affected code paths

| Path | Before | After |
|------|--------|-------|
| Talos Docker `writeKubeconfig` | `os.WriteFile` (overwrite) | `MergeKubeconfig` (upsert) |
| Talos Docker `saveTalosconfig` | `TalosConfig().Save()` (overwrite) | `Config.Merge()` + `Save()` |
| Talos Omni `saveOmniKubeconfig` | `os.WriteFile` via `saveOmniConfig` | `MergeKubeconfig` |
| Talos Omni `saveOmniTalosconfig` | `os.WriteFile` via `saveOmniConfig` | `mergeTalosconfigBytes` |
| Omni kubeconfighook `refreshKubeconfig` | `fsutil.AtomicWriteFile` | `MergeKubeconfig` |

## Already-safe paths (unchanged)

- **Kind** — merges via `WriteMerged()`
- **K3d** — merges via `KubeconfigMerge()`
- **VCluster** — merges via `UpdateKubeConfig()` / `ModifyConfig`
- **Delete** — all distributions use selective cleanup (`CleanupKubeconfig`, `cleanupTalosconfig`)
- **Init** — does not touch kubeconfig/talosconfig

## Changes

- **`pkg/k8s/kubeconfig.go`** — Add `MergeKubeconfig()` that loads existing file (or creates empty), upserts clusters/contexts/authinfos, sets current context, writes atomically
- **`pkg/svc/provisioner/cluster/talos/provisioner_config.go`** — Replace overwrite with merge in `writeKubeconfig` and `saveTalosconfig`; add `mergeTalosconfigBytes` helper using Talos SDK `Config.Merge()`
- **`pkg/svc/provisioner/cluster/talos/provisioner_omni.go`** — Replace `saveOmniConfig` calls in `saveOmniKubeconfig`/`saveOmniTalosconfig` with merge-based writes
- **`pkg/cli/kubeconfighook/hook.go`** — Replace `AtomicWriteFile` with `MergeKubeconfig` in Omni token refresh
- **`pkg/k8s/kubeconfig_merge_test.go`** — Unit tests: no existing file, merge with other clusters, same-key update, preserve current context