### PR TITLE
feat(ci): add scan step to ksail-cluster composite action

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -45,7 +45,7 @@ inputs:
     description: "Whether to validate manifests before cluster creation"
     default: "false"
   scan:
-    description: "Whether to run ksail workload scan after validation"
+    description: "Whether to run ksail workload scan (can be enabled independently of validate)"
     default: "false"
   scan-framework:
     description: "Comma-separated security frameworks to scan against (e.g. 'nsa,mitre'). Supports any framework known to Kubescape."
@@ -327,9 +327,9 @@ runs:
         [[ -n "$CONFIG" ]] && cmd_args+=(--config "$CONFIG")
         cmd_args+=(workload scan)
         [[ -n "$SCAN_PATH" ]] && cmd_args+=("$SCAN_PATH")
-        cmd_args+=(--framework "$SCAN_FRAMEWORK")
-        cmd_args+=(--compliance-threshold "$SCAN_THRESHOLD")
-        cmd_args+=(--format "$SCAN_FORMAT")
+        [[ -n "$SCAN_FRAMEWORK" ]] && cmd_args+=(--framework "$SCAN_FRAMEWORK")
+        [[ -n "$SCAN_THRESHOLD" ]] && cmd_args+=(--compliance-threshold "$SCAN_THRESHOLD")
+        [[ -n "$SCAN_FORMAT" ]] && cmd_args+=(--format "$SCAN_FORMAT")
         [[ -n "$SCAN_OUTPUT" ]] && cmd_args+=(--output "$SCAN_OUTPUT")
         [[ "$SCAN_VERBOSE" == "true" ]] && cmd_args+=(--verbose)
         ksail "${cmd_args[@]}"

--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -44,6 +44,27 @@ inputs:
   validate:
     description: "Whether to validate manifests before cluster creation"
     default: "false"
+  scan:
+    description: "Whether to run ksail workload scan after validation"
+    default: "false"
+  scan-framework:
+    description: "Comma-separated security frameworks to scan against (e.g. 'nsa,mitre'). Supports any framework known to Kubescape."
+    default: "nsa"
+  scan-compliance-threshold:
+    description: "Fail if the compliance score is below this threshold (0–100)"
+    default: "0"
+  scan-format:
+    description: "Scan output format (pretty-printer, json, sarif, junit). Use sarif with scan-output to enable GitHub Code Scanning upload."
+    default: "pretty-printer"
+  scan-output:
+    description: "File path to write scan results to. Defaults to stdout when empty."
+    default: ""
+  scan-path:
+    description: "Path to scan. When empty, ksail resolves the path from spec.workload.sourceDirectory in ksail.yaml (or 'k8s/' by default)."
+    default: ""
+  scan-verbose:
+    description: "Show all scanned resources in output, not just failed ones"
+    default: "false"
   delete:
     description: "Whether to delete the cluster at the end (runs even on failure)"
     default: "false"
@@ -288,6 +309,30 @@ runs:
       env:
         CONFIG: ${{ inputs.config }}
       run: ksail ${CONFIG:+--config "$CONFIG"} workload validate
+
+    - name: 🔍 Scan manifests
+      if: inputs.scan == 'true'
+      shell: bash
+      env:
+        CONFIG: ${{ inputs.config }}
+        SCAN_FRAMEWORK: ${{ inputs.scan-framework }}
+        SCAN_THRESHOLD: ${{ inputs.scan-compliance-threshold }}
+        SCAN_FORMAT: ${{ inputs.scan-format }}
+        SCAN_OUTPUT: ${{ inputs.scan-output }}
+        SCAN_PATH: ${{ inputs.scan-path }}
+        SCAN_VERBOSE: ${{ inputs.scan-verbose }}
+      run: |
+        set -euo pipefail
+        cmd_args=()
+        [[ -n "$CONFIG" ]] && cmd_args+=(--config "$CONFIG")
+        cmd_args+=(workload scan)
+        [[ -n "$SCAN_PATH" ]] && cmd_args+=("$SCAN_PATH")
+        cmd_args+=(--framework "$SCAN_FRAMEWORK")
+        cmd_args+=(--compliance-threshold "$SCAN_THRESHOLD")
+        cmd_args+=(--format "$SCAN_FORMAT")
+        [[ -n "$SCAN_OUTPUT" ]] && cmd_args+=(--output "$SCAN_OUTPUT")
+        [[ "$SCAN_VERBOSE" == "true" ]] && cmd_args+=(--verbose)
+        ksail "${cmd_args[@]}"
 
     - name: 🚀 Create Cluster
       id: create

--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -60,7 +60,7 @@ inputs:
     description: "File path to write scan results to. Defaults to stdout when empty."
     default: ""
   scan-path:
-    description: "Path to scan. When empty, ksail resolves the path from spec.workload.sourceDirectory in ksail.yaml (or 'k8s/' by default)."
+    description: "Path to scan. When empty, ksail resolves the path from the active config file (or 'k8s/' by default)."
     default: ""
   scan-verbose:
     description: "Show all scanned resources in output, not just failed ones"

--- a/docs/src/content/docs/guides/pr-preview-clusters.mdx
+++ b/docs/src/content/docs/guides/pr-preview-clusters.mdx
@@ -171,6 +171,13 @@ You can also set it globally for all subsequent steps:
 | `provider` | `Docker` | Infrastructure provider (Docker, Hetzner) |
 | `config` | `""` | Path to alternate `ksail.yaml` (e.g. `ksail.staging.yaml`) |
 | `validate` | `false` | Run `ksail workload validate` before cluster creation (after `init`, when enabled) |
+| `scan` | `false` | Run `ksail workload scan` (can be enabled independently of `validate`) |
+| `scan-framework` | `nsa` | Comma-separated security frameworks to scan against (e.g. `nsa,mitre`) |
+| `scan-compliance-threshold` | `0` | Fail if compliance score is below this threshold (0–100) |
+| `scan-format` | `pretty-printer` | Scan output format (`pretty-printer`, `json`, `sarif`, `junit`) |
+| `scan-output` | `""` | File path to write scan results to (defaults to stdout) |
+| `scan-path` | `""` | Path to scan (defaults to active config's `sourceDirectory` or `k8s/`) |
+| `scan-verbose` | `false` | Show all scanned resources in output, not just failed ones |
 | `push` | `false` | Run `ksail workload push` after creation |
 | `reconcile` | `false` | Run `ksail workload reconcile` after push |
 | `delete` | `false` | Delete cluster at the end (`if: always()`) |


### PR DESCRIPTION
## Summary

Extends `.github/actions/ksail-cluster/action.yml` with a `🔍 Scan manifests` step that runs `ksail workload scan` (Kubescape security scanning) as an opt-in step alongside the existing `validate` step.

## Changes

**New inputs** added to `ksail-cluster`:

| Input | Default | Description |
|-------|---------|-------------|
| `scan` | `false` | Master switch — set to `true` to enable scanning |
| `scan-framework` | `nsa` | Comma-separated Kubescape frameworks (nsa, mitre, cis, pss) |
| `scan-compliance-threshold` | `0` | Fail if score drops below this (0–100) |
| `scan-format` | `pretty-printer` | Output format; use `sarif` for GitHub Code Scanning upload |
| `scan-output` | `""` | Results file path; empty → stdout |
| `scan-path` | `""` | Directory to scan; empty → resolved from `ksail.yaml` (`k8s/` default) |
| `scan-verbose` | `false` | Show all resources, not just failures |

The step is placed **after** `Validate manifests` and **before** `Create Cluster`, so all static checks complete before any Docker work starts.

## Usage Example

```yaml
- uses: devantler-tech/ksail/.github/actions/ksail-cluster@main
  with:
    validate: "true"
    scan: "true"
    scan-framework: "nsa,mitre"
    scan-compliance-threshold: "50"
```

To emit SARIF for GitHub Code Scanning:

```yaml
- uses: devantler-tech/ksail/.github/actions/ksail-cluster@main
  with:
    scan: "true"
    scan-format: "sarif"
    scan-output: "results.sarif"

- uses: github/codeql-action/upload-sarif@v3
  with:
    sarif_file: results.sarif
```

## Notes

- `--framework` is a Cobra `StringSlice` — comma-separated values (e.g. `"nsa,mitre"`) are parsed natively.
- All existing inputs and behaviour are unchanged — fully backwards-compatible.