### PR TITLE
fix: normalize Hetzner/Omni node roles and introspect server types

### DIFF
--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -38,6 +38,9 @@ func CalculateRetryDelayForTest(attempt int) time.Duration {
 	return p.calculateRetryDelay(attempt)
 }
 
+// NormalizeNodeRoleForTest exports normalizeNodeRole for testing.
+var NormalizeNodeRoleForTest = normalizeNodeRole
+
 // NewSnapshotManagerWithUploaderForTest creates a SnapshotManager with a custom uploader,
 // allowing tests to inject a mock without hitting real Hetzner upload infrastructure.
 // A nil logWriter is replaced with io.Discard, matching NewSnapshotManager behavior.

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -195,15 +195,31 @@ func (p *Provider) ListNodes(ctx context.Context, clusterName string) ([]provide
 	for _, server := range servers {
 		nodeType := server.Labels[LabelNodeType]
 
+		var serverType string
+		if server.ServerType != nil {
+			serverType = server.ServerType.Name
+		}
+
 		nodes = append(nodes, provider.NodeInfo{
 			Name:        server.Name,
 			ClusterName: clusterName,
-			Role:        nodeType,
+			Role:        normalizeNodeRole(nodeType),
 			State:       string(server.Status),
+			ServerType:  serverType,
 		})
 	}
 
 	return nodes, nil
+}
+
+// normalizeNodeRole maps Hetzner-specific node type label values to the
+// canonical role strings defined by provider.NodeInfo (control-plane, worker).
+func normalizeNodeRole(hetznerNodeType string) string {
+	if hetznerNodeType == NodeTypeControlPlane {
+		return "control-plane"
+	}
+
+	return hetznerNodeType
 }
 
 // ListAllClusters returns the names of all clusters managed by this provider.

--- a/pkg/svc/provider/hetzner/provider_test.go
+++ b/pkg/svc/provider/hetzner/provider_test.go
@@ -422,3 +422,44 @@ func TestDeleteAutoscalerNodes_NilPoolNames(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestNormalizeNodeRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "controlplane maps to control-plane",
+			input:    hetzner.NodeTypeControlPlane,
+			expected: "control-plane",
+		},
+		{
+			name:     "worker passes through unchanged",
+			input:    hetzner.NodeTypeWorker,
+			expected: "worker",
+		},
+		{
+			name:     "empty string passes through",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "unknown value passes through",
+			input:    "custom-role",
+			expected: "custom-role",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hetzner.NormalizeNodeRoleForTest(testCase.input)
+
+			assert.Equal(t, testCase.expected, result)
+		})
+	}
+}

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -99,7 +99,7 @@ func (p *Provider) ListNodes(ctx context.Context, clusterName string) ([]provide
 	for machine := range machines.All() {
 		role := "worker"
 		if _, ok := machine.Metadata().Labels().Get(omnires.LabelControlPlaneRole); ok {
-			role = "controlplane"
+			role = "control-plane"
 		}
 
 		stage := "unknown"

--- a/pkg/svc/provider/provider.go
+++ b/pkg/svc/provider/provider.go
@@ -18,6 +18,10 @@ type NodeInfo struct {
 
 	// State is the current state of the node (running, stopped, etc.)
 	State string
+
+	// ServerType is the infrastructure server type (e.g., "cx22", "cx33").
+	// Only populated by cloud providers (Hetzner); empty for Docker/Omni.
+	ServerType string
 }
 
 // ClusterStatus contains the status of a cluster as reported by its infrastructure provider.

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -322,4 +322,6 @@ func MergeTalosconfigBytesForTest(talosconfigPath string, newData []byte) error 
 }
 
 // DetectHetznerServerTypesForTest exports detectHetznerServerTypes for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
 var DetectHetznerServerTypesForTest = detectHetznerServerTypes

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -320,3 +320,6 @@ func (p *Provisioner) WithTalosConfigsForTest(
 func MergeTalosconfigBytesForTest(talosconfigPath string, newData []byte) error {
 	return mergeTalosconfigBytes(talosconfigPath, newData)
 }
+
+// DetectHetznerServerTypesForTest exports detectHetznerServerTypes for unit testing.
+var DetectHetznerServerTypesForTest = detectHetznerServerTypes

--- a/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_omni.go
@@ -20,11 +20,6 @@ const (
 	// The Omni proxy may report the cluster phase as RUNNING before it is
 	// operational for kubectl connections, so this absorbs the propagation delay.
 	omniAPIServerReadinessTimeout = 2 * time.Minute
-
-	// omniRoleControlPlane is the role string returned by Omni's ClusterMachineStatus
-	// for control-plane nodes. This differs from RoleControlPlane ("control-plane")
-	// which is the KSail-internal role identifier.
-	omniRoleControlPlane = "controlplane"
 )
 
 // omniProvider extracts the Omni provider from the infra provider.
@@ -551,12 +546,7 @@ func (p *Provisioner) getOmniNodesByRole(
 	nodes := make([]nodeWithRole, 0, len(listed))
 
 	for _, node := range listed {
-		role := RoleWorker
-		if node.Role == omniRoleControlPlane {
-			role = RoleControlPlane
-		}
-
-		nodes = append(nodes, nodeWithRole{IP: node.Name, Role: role})
+		nodes = append(nodes, nodeWithRole{IP: node.Name, Role: node.Role})
 	}
 
 	return nodes, nil

--- a/pkg/svc/provisioner/cluster/talos/scale_omni.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_omni.go
@@ -184,7 +184,7 @@ func (p *Provisioner) discoverMachinesForScaling(
 	var cpIDs, workerIDs []string
 
 	for _, n := range existingNodes {
-		if n.Role == omniRoleControlPlane {
+		if n.Role == RoleControlPlane {
 			cpIDs = append(cpIDs, n.Name)
 		} else {
 			workerIDs = append(workerIDs, n.Name)

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
-	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	svcprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/docker/docker/api/types/container"
@@ -866,7 +866,7 @@ func countNodeRoles(nodes []nodeWithRole) (int32, int32) {
 // detectHetznerServerTypes determines the actual control-plane and worker
 // server types from a node listing. Returns empty strings when no nodes of
 // a given role are found.
-func detectHetznerServerTypes(nodes []provider.NodeInfo) (cpServerType, workerServerType string) {
+func detectHetznerServerTypes(nodes []svcprovider.NodeInfo) (cpServerType, workerServerType string) {
 	for _, n := range nodes {
 		switch n.Role {
 		case RoleControlPlane:

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -755,23 +755,7 @@ func (p *Provisioner) GetCurrentConfig(
 	var providerSpec *v1alpha1.ProviderSpec
 	if p.hetznerOpts != nil {
 		hetznerSpec := *p.hetznerOpts
-
-		// Introspect actual server types from running servers.
-		if p.infraProvider != nil {
-			clusterName := p.resolveClusterName("")
-
-			nodes, listErr := p.infraProvider.ListNodes(ctx, clusterName)
-			if listErr == nil {
-				cpType, workerType := detectHetznerServerTypes(nodes)
-				if cpType != "" {
-					hetznerSpec.ControlPlaneServerType = cpType
-				}
-
-				if workerType != "" {
-					hetznerSpec.WorkerServerType = workerType
-				}
-			}
-		}
+		p.introspectHetznerServerTypes(ctx, &hetznerSpec)
 
 		providerSpec = &v1alpha1.ProviderSpec{
 			Hetzner: hetznerSpec,
@@ -863,19 +847,45 @@ func countNodeRoles(nodes []nodeWithRole) (int32, int32) {
 	return controlPlanes, workers
 }
 
+// introspectHetznerServerTypes populates the ControlPlaneServerType and
+// WorkerServerType fields on hetznerSpec from the running Hetzner servers.
+func (p *Provisioner) introspectHetznerServerTypes(ctx context.Context, hetznerSpec *v1alpha1.OptionsHetzner) {
+	if p.infraProvider == nil {
+		return
+	}
+
+	clusterName := p.resolveClusterName("")
+
+	nodes, listErr := p.infraProvider.ListNodes(ctx, clusterName)
+	if listErr != nil {
+		return
+	}
+
+	cpType, workerType := detectHetznerServerTypes(nodes)
+	if cpType != "" {
+		hetznerSpec.ControlPlaneServerType = cpType
+	}
+
+	if workerType != "" {
+		hetznerSpec.WorkerServerType = workerType
+	}
+}
+
 // detectHetznerServerTypes determines the actual control-plane and worker
 // server types from a node listing. Returns empty strings when no nodes of
 // a given role are found.
-func detectHetznerServerTypes(nodes []svcprovider.NodeInfo) (cpServerType, workerServerType string) {
-	for _, n := range nodes {
-		switch n.Role {
+func detectHetznerServerTypes(nodes []svcprovider.NodeInfo) (string, string) {
+	var cpServerType, workerServerType string
+
+	for _, node := range nodes {
+		switch node.Role {
 		case RoleControlPlane:
-			if cpServerType == "" && n.ServerType != "" {
-				cpServerType = n.ServerType
+			if cpServerType == "" && node.ServerType != "" {
+				cpServerType = node.ServerType
 			}
 		case RoleWorker:
-			if workerServerType == "" && n.ServerType != "" {
-				workerServerType = n.ServerType
+			if workerServerType == "" && node.ServerType != "" {
+				workerServerType = node.ServerType
 			}
 		}
 

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -753,6 +753,7 @@ func (p *Provisioner) GetCurrentConfig(
 	// fields (location, network, SSH key) cannot be introspected, so we
 	// echo the desired config as the baseline for those.
 	var providerSpec *v1alpha1.ProviderSpec
+
 	if p.hetznerOpts != nil {
 		hetznerSpec := *p.hetznerOpts
 		p.introspectHetznerServerTypes(ctx, &hetznerSpec)
@@ -849,7 +850,10 @@ func countNodeRoles(nodes []nodeWithRole) (int32, int32) {
 
 // introspectHetznerServerTypes populates the ControlPlaneServerType and
 // WorkerServerType fields on hetznerSpec from the running Hetzner servers.
-func (p *Provisioner) introspectHetznerServerTypes(ctx context.Context, hetznerSpec *v1alpha1.OptionsHetzner) {
+func (p *Provisioner) introspectHetznerServerTypes(
+	ctx context.Context,
+	hetznerSpec *v1alpha1.OptionsHetzner,
+) {
 	if p.infraProvider == nil {
 		return
 	}

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/docker/docker/api/types/container"
@@ -747,13 +748,33 @@ func (p *Provisioner) GetCurrentConfig(
 	spec.Talos.Version = p.introspectTalosVersion(ctx)
 
 	// Build provider spec if we have Hetzner options configured.
-	// Hetzner fields (server types, location, network, SSH key) cannot be
-	// introspected from the running cluster, so we echo the desired config
-	// as the baseline — identical to the approach used for NetworkCIDR.
+	// Server types are introspected from the running Hetzner servers so
+	// that changes (e.g., cx22 -> cx33) appear in the diff. Other Hetzner
+	// fields (location, network, SSH key) cannot be introspected, so we
+	// echo the desired config as the baseline for those.
 	var providerSpec *v1alpha1.ProviderSpec
 	if p.hetznerOpts != nil {
+		hetznerSpec := *p.hetznerOpts
+
+		// Introspect actual server types from running servers.
+		if p.infraProvider != nil {
+			clusterName := p.resolveClusterName("")
+
+			nodes, listErr := p.infraProvider.ListNodes(ctx, clusterName)
+			if listErr == nil {
+				cpType, workerType := detectHetznerServerTypes(nodes)
+				if cpType != "" {
+					hetznerSpec.ControlPlaneServerType = cpType
+				}
+
+				if workerType != "" {
+					hetznerSpec.WorkerServerType = workerType
+				}
+			}
+		}
+
 		providerSpec = &v1alpha1.ProviderSpec{
-			Hetzner: *p.hetznerOpts,
+			Hetzner: hetznerSpec,
 		}
 	}
 
@@ -840,6 +861,30 @@ func countNodeRoles(nodes []nodeWithRole) (int32, int32) {
 	}
 
 	return controlPlanes, workers
+}
+
+// detectHetznerServerTypes determines the actual control-plane and worker
+// server types from a node listing. Returns empty strings when no nodes of
+// a given role are found.
+func detectHetznerServerTypes(nodes []provider.NodeInfo) (cpServerType, workerServerType string) {
+	for _, n := range nodes {
+		switch n.Role {
+		case RoleControlPlane:
+			if cpServerType == "" && n.ServerType != "" {
+				cpServerType = n.ServerType
+			}
+		case RoleWorker:
+			if workerServerType == "" && n.ServerType != "" {
+				workerServerType = n.ServerType
+			}
+		}
+
+		if cpServerType != "" && workerServerType != "" {
+			break
+		}
+	}
+
+	return cpServerType, workerServerType
 }
 
 // syncHetznerFirewallRules synchronizes the Hetzner Cloud Firewall rules to the

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	omniprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/omni"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
@@ -656,4 +657,80 @@ func TestEnsureAutoscalerSecretIfNeeded_ErrorWhenNoSchematic(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, talosprovisioner.ErrAutoscalerRequiresSchematic)
+}
+
+//nolint:funlen // Table-driven test with multiple node topology scenarios is clearer as single function
+func TestDetectHetznerServerTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		nodes          []provider.NodeInfo
+		wantCPType     string
+		wantWorkerType string
+	}{
+		{
+			name:           "empty node list returns empty strings",
+			nodes:          nil,
+			wantCPType:     "",
+			wantWorkerType: "",
+		},
+		{
+			name: "single control-plane node",
+			nodes: []provider.NodeInfo{
+				{Name: "cp-0", Role: talosprovisioner.RoleControlPlane, ServerType: "cx22"},
+			},
+			wantCPType:     "cx22",
+			wantWorkerType: "",
+		},
+		{
+			name: "single worker node",
+			nodes: []provider.NodeInfo{
+				{Name: "worker-0", Role: talosprovisioner.RoleWorker, ServerType: "cx33"},
+			},
+			wantCPType:     "",
+			wantWorkerType: "cx33",
+		},
+		{
+			name: "mixed nodes returns first of each role",
+			nodes: []provider.NodeInfo{
+				{Name: "cp-0", Role: talosprovisioner.RoleControlPlane, ServerType: "cx22"},
+				{Name: "cp-1", Role: talosprovisioner.RoleControlPlane, ServerType: "cx44"},
+				{Name: "worker-0", Role: talosprovisioner.RoleWorker, ServerType: "cx33"},
+				{Name: "worker-1", Role: talosprovisioner.RoleWorker, ServerType: "cx55"},
+			},
+			wantCPType:     "cx22",
+			wantWorkerType: "cx33",
+		},
+		{
+			name: "skips nodes with empty ServerType",
+			nodes: []provider.NodeInfo{
+				{Name: "cp-0", Role: talosprovisioner.RoleControlPlane, ServerType: ""},
+				{Name: "cp-1", Role: talosprovisioner.RoleControlPlane, ServerType: "cx22"},
+				{Name: "worker-0", Role: talosprovisioner.RoleWorker, ServerType: ""},
+			},
+			wantCPType:     "cx22",
+			wantWorkerType: "",
+		},
+		{
+			name: "unknown roles are ignored",
+			nodes: []provider.NodeInfo{
+				{Name: "unknown-0", Role: "unknown", ServerType: "cx11"},
+				{Name: "cp-0", Role: talosprovisioner.RoleControlPlane, ServerType: "cx22"},
+			},
+			wantCPType:     "cx22",
+			wantWorkerType: "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cpType, workerType := talosprovisioner.DetectHetznerServerTypesForTest(testCase.nodes)
+
+			assert.Equal(t, testCase.wantCPType, cpType)
+			assert.Equal(t, testCase.wantWorkerType, workerType)
+		})
+	}
 }


### PR DESCRIPTION
The Hetzner provider's `ListNodes()` returned `"controlplane"` (no hyphen) as the node role, while the Talos provisioner expects `"control-plane"` (with hyphen). This mismatch caused `countNodeRoles` to miss control-plane nodes entirely (reporting wrong counts), `syncSecretsFromCluster` to fail finding a control-plane IP, and `GetCurrentConfig` to echo desired state instead of detecting actual server types.

This fix normalizes role strings at the provider boundary in `ListNodes()` for both Hetzner and Omni providers, adds a `ServerType` field to `provider.NodeInfo` populated from the Hetzner API, and uses live node data in `GetCurrentConfig()` to detect actual server types -- making workerServerType/controlPlaneServerType changes visible to the diff engine.

Fixes: #4621

## Type of change

Select the appropriate options and delete the rest:

- [x] 🪲 Bug fix