### PR TITLE
fix(autoscaler): reject Price expander for Hetzner provider

### DIFF
--- a/pkg/apis/cluster/v1alpha1/autoscaler_test.go
+++ b/pkg/apis/cluster/v1alpha1/autoscaler_test.go
@@ -615,6 +615,68 @@ func TestValidateAutoscalerConfig(t *testing.T) {
 			},
 			wantErr: v1alpha1.ErrInvalidServerLimit,
 		},
+		{
+			name: "price expander rejected for hetzner provider",
+			cluster: &v1alpha1.ClusterSpec{
+				Provider:      v1alpha1.ProviderHetzner,
+				ControlPlanes: 1,
+				Workers:       1,
+				Autoscaler: v1alpha1.AutoscalerConfig{
+					Node: v1alpha1.NodeAutoscalerConfig{
+						Enabled:  true,
+						Expander: v1alpha1.AutoscalerExpanderPrice,
+						Pools: []v1alpha1.NodePool{
+							{Name: "workers", ServerType: "cx23", Location: "fsn1", Min: 1, Max: 5},
+						},
+					},
+				},
+			},
+			provider: &v1alpha1.ProviderSpec{
+				Hetzner: v1alpha1.OptionsHetzner{ServerLimit: 10},
+			},
+			wantErr:     v1alpha1.ErrExpanderNotSupportedForProvider,
+			errContains: "pricing API",
+		},
+		{
+			name: "price expander accepted for docker provider",
+			cluster: &v1alpha1.ClusterSpec{
+				Provider:      v1alpha1.ProviderDocker,
+				ControlPlanes: 1,
+				Workers:       1,
+				Autoscaler: v1alpha1.AutoscalerConfig{
+					Node: v1alpha1.NodeAutoscalerConfig{
+						Enabled:  true,
+						Expander: v1alpha1.AutoscalerExpanderPrice,
+						Pools: []v1alpha1.NodePool{
+							{Name: "workers", ServerType: "cx23", Location: "fsn1", Min: 1, Max: 5},
+						},
+					},
+				},
+			},
+			provider: &v1alpha1.ProviderSpec{},
+			wantErr:  nil,
+		},
+		{
+			name: "least-waste expander accepted for hetzner provider",
+			cluster: &v1alpha1.ClusterSpec{
+				Provider:      v1alpha1.ProviderHetzner,
+				ControlPlanes: 1,
+				Workers:       1,
+				Autoscaler: v1alpha1.AutoscalerConfig{
+					Node: v1alpha1.NodeAutoscalerConfig{
+						Enabled:  true,
+						Expander: v1alpha1.AutoscalerExpanderLeastWaste,
+						Pools: []v1alpha1.NodePool{
+							{Name: "workers", ServerType: "cx23", Location: "fsn1", Min: 1, Max: 5},
+						},
+					},
+				},
+			},
+			provider: &v1alpha1.ProviderSpec{
+				Hetzner: v1alpha1.OptionsHetzner{ServerLimit: 10},
+			},
+			wantErr: nil,
+		},
 	}
 
 	for _, testCase := range tests {

--- a/pkg/apis/cluster/v1alpha1/errors.go
+++ b/pkg/apis/cluster/v1alpha1/errors.go
@@ -124,6 +124,14 @@ var ErrAutoscalerExceedsServerLimit = errors.New(
 	"autoscaler configuration exceeds Hetzner server limit",
 )
 
+// ErrExpanderNotSupportedForProvider is returned when the selected autoscaler
+// expander strategy is not supported by the infrastructure provider's cloud
+// provider implementation (e.g., Hetzner does not implement the pricing API
+// required by the Price expander).
+var ErrExpanderNotSupportedForProvider = errors.New(
+	"autoscaler expander not supported for provider",
+)
+
 // ErrAutoscalerEnabledNoPools is returned when node autoscaler is enabled but no pools are configured.
 var ErrAutoscalerEnabledNoPools = errors.New(
 	"node autoscaler is enabled but no pools are configured",

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -270,6 +270,33 @@ func validateAutoscalerEnumFields(
 	return nil
 }
 
+// validateExpanderForProvider checks that the chosen autoscaler expander
+// strategy is supported by the cluster's infrastructure provider. The Hetzner
+// cloud provider in the upstream cluster-autoscaler does not implement the
+// pricing API, so the Price expander causes a fatal crash on startup.
+func validateExpanderForProvider(
+	provider Provider,
+	autoscaler *NodeAutoscalerConfig,
+) error {
+	if !autoscaler.Enabled || autoscaler.Expander == "" {
+		return nil
+	}
+
+	if provider == ProviderHetzner && autoscaler.Expander == AutoscalerExpanderPrice {
+		return fmt.Errorf(
+			"%w: %q is not supported on %s (Hetzner does not implement the pricing API); "+
+				"use %s or %s instead",
+			ErrExpanderNotSupportedForProvider,
+			autoscaler.Expander,
+			ProviderHetzner,
+			AutoscalerExpanderLeastWaste,
+			AutoscalerExpanderRandom,
+		)
+	}
+
+	return nil
+}
+
 // validateNodePools checks each NodePool for name validity, min ≤ max, and uniqueness.
 func validateNodePools(pools []NodePool) error {
 	seen := make(map[string]struct{}, len(pools))
@@ -346,6 +373,10 @@ func ValidateAutoscalerConfig(
 	enumErr := validateAutoscalerEnumFields(autoscaler, &cluster.Autoscaler.Pod)
 	if enumErr != nil {
 		return enumErr
+	}
+
+	if err := validateExpanderForProvider(cluster.Provider, autoscaler); err != nil {
+		return err
 	}
 
 	if autoscaler.Enabled && len(autoscaler.Pools) == 0 {

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -375,8 +375,9 @@ func ValidateAutoscalerConfig(
 		return enumErr
 	}
 
-	if err := validateExpanderForProvider(cluster.Provider, autoscaler); err != nil {
-		return err
+	expanderErr := validateExpanderForProvider(cluster.Provider, autoscaler)
+	if expanderErr != nil {
+		return expanderErr
 	}
 
 	if autoscaler.Enabled && len(autoscaler.Pools) == 0 {


### PR DESCRIPTION
## Summary

The Hetzner cloud provider in the upstream cluster-autoscaler does not implement the pricing API, causing a fatal crash (`CrashLoopBackOff`) when `--expander=price` is passed:

```
F0509 08:08:19.491791  1 expander_factory.go:89] Couldn't access cloud provider pricing for price expander: Not implemented
```

This PR adds provider-aware validation in `ValidateAutoscalerConfig` to reject `AutoscalerExpanderPrice` when the provider is Hetzner, with a clear error message suggesting `LeastWaste` or `Random` as alternatives.

## Changes

- **`pkg/apis/cluster/v1alpha1/errors.go`** — New `ErrExpanderNotSupportedForProvider` sentinel error
- **`pkg/apis/cluster/v1alpha1/validation.go`** — New `validateExpanderForProvider` function called from `ValidateAutoscalerConfig`; rejects `Price` for Hetzner with helpful alternative suggestions
- **`pkg/apis/cluster/v1alpha1/autoscaler_test.go`** — 3 new test cases: Price+Hetzner (error), Price+Docker (ok), LeastWaste+Hetzner (ok)

## Validation

- `go build ./...` ✅
- `go test ./pkg/apis/cluster/v1alpha1/...` ✅ (26/26 pass)

Fixes #4660