### PR TITLE
fix(reconcile): replace Get+Update with Patch to avoid rate limiter timeout

### DIFF
--- a/pkg/client/flux/reconciler.go
+++ b/pkg/client/flux/reconciler.go
@@ -728,7 +728,7 @@ func handleTransientError(
 	select {
 	case <-waitCtx.Done():
 		return fmt.Errorf(
-			"timed out waiting for %s to be available (last error: %v): %w",
+			"timed out waiting for %s to be available (last error: %w): %w",
 			resourceDescription,
 			err,
 			waitCtx.Err(),
@@ -760,11 +760,11 @@ func triggerReconciliationWithRetry(
 	defer ticker.Stop()
 
 	// Build the merge patch once; the timestamp is set at trigger time.
-	patch := []byte(fmt.Sprintf(
+	patch := fmt.Appendf(nil,
 		`{"metadata":{"annotations":{%q:%q}}}`,
 		reconcileAnnotationKey,
 		time.Now().Format(time.RFC3339Nano),
-	))
+	)
 
 	var lastErr error
 
@@ -778,7 +778,7 @@ func triggerReconciliationWithRetry(
 		if err != nil {
 			if lastErr != nil {
 				return fmt.Errorf(
-					"timed out waiting for %s to be available (last error: %v): %w",
+					"timed out waiting for %s to be available (last error: %w): %w",
 					resourceDescription,
 					lastErr,
 					err,
@@ -788,7 +788,13 @@ func triggerReconciliationWithRetry(
 			return fmt.Errorf("trigger %s reconciliation: %w", resourceDescription, err)
 		}
 
-		_, err = client.Patch(waitCtx, resourceName, types.MergePatchType, patch, metav1.PatchOptions{})
+		_, err = client.Patch(
+			waitCtx,
+			resourceName,
+			types.MergePatchType,
+			patch,
+			metav1.PatchOptions{},
+		)
 		if err == nil {
 			return nil
 		}

--- a/pkg/client/flux/reconciler.go
+++ b/pkg/client/flux/reconciler.go
@@ -738,74 +738,69 @@ func handleTransientError(
 }
 
 // triggerReconciliationWithRetry triggers reconciliation on a Flux resource with retry logic
-// for handling optimistic concurrency conflicts and transient API errors.
-// This is necessary because Flux controllers may not be fully ready immediately after
-// cluster creation, especially in slow CI environments.
+// for handling transient API errors (e.g. resource not yet created in slow CI environments).
+//
+// A JSON merge patch is used instead of the traditional Get+Update approach.  Patches
+// are applied atomically server-side, so they never produce 409 Conflict errors even
+// when Flux controllers are concurrently updating the same resource status.  This
+// prevents the retry loop from running for the full apiAvailabilityTimeout when the
+// cluster has many HelmReleases or kustomizations.
 func triggerReconciliationWithRetry(
 	ctx context.Context,
 	client dynamic.ResourceInterface,
 	resourceName string,
 	resourceDescription string,
 ) error {
-	// Create a timeout context for the entire retry operation
+	// Create a timeout context for the entire retry operation.
 	waitCtx, cancel := context.WithTimeout(ctx, apiAvailabilityTimeout)
 	defer cancel()
 
 	ticker := time.NewTicker(apiAvailabilityPollInterval)
 	defer ticker.Stop()
 
+	// Build the merge patch once; the timestamp is set at trigger time.
+	patch := []byte(fmt.Sprintf(
+		`{"metadata":{"annotations":{%q:%q}}}`,
+		reconcileAnnotationKey,
+		time.Now().Format(time.RFC3339Nano),
+	))
+
 	var lastErr error
 
 	for {
-		resource, err := client.Get(waitCtx, resourceName, metav1.GetOptions{})
-		if err != nil {
-			// Check if this is a transient API error that should be retried
-			if isTransientAPIError(err) {
-				lastErr = err
-
-				retryErr := handleTransientError(waitCtx, ticker, resourceDescription, lastErr)
-				if retryErr != nil {
-					return retryErr
-				}
-
-				continue
-			}
-
-			// Non-transient error, fail immediately
-			return fmt.Errorf("get %s: %w", resourceDescription, err)
-		}
-
-		// Resource found, try to update it
-		annotations := resource.GetAnnotations()
-		if annotations == nil {
-			annotations = make(map[string]string)
-		}
-
-		annotations[reconcileAnnotationKey] = time.Now().Format(time.RFC3339Nano)
-		resource.SetAnnotations(annotations)
-
-		_, err = client.Update(waitCtx, resource, metav1.UpdateOptions{})
-		if err == nil {
-			return nil // Success
-		}
-
-		// Check if this is a transient error (conflict or API not ready)
-		if isTransientAPIError(err) {
-			lastErr = err
-
-			select {
-			case <-waitCtx.Done():
+		// Guard against an expired context before making an API call.
+		// Without this check, an expired context causes the k8s rate limiter to
+		// return "rate: Wait(n=1) would exceed context deadline", which is not
+		// recognised as a context error and propagates as a confusing permanent
+		// failure.
+		if err := waitCtx.Err(); err != nil {
+			if lastErr != nil {
 				return fmt.Errorf(
-					"timed out updating %s: %w",
+					"timed out waiting for %s to be available: %w",
 					resourceDescription,
 					lastErr,
 				)
-			case <-ticker.C:
-				continue
 			}
+
+			return fmt.Errorf("trigger %s reconciliation: %w", resourceDescription, err)
 		}
 
-		// Non-transient error on update, fail immediately
+		_, err := client.Patch(waitCtx, resourceName, types.MergePatchType, patch, metav1.PatchOptions{})
+		if err == nil {
+			return nil
+		}
+
+		if isTransientAPIError(err) {
+			lastErr = err
+
+			retryErr := handleTransientError(waitCtx, ticker, resourceDescription, lastErr)
+			if retryErr != nil {
+				return retryErr
+			}
+
+			continue
+		}
+
 		return fmt.Errorf("trigger %s reconciliation: %w", resourceDescription, err)
 	}
 }

--- a/pkg/client/flux/reconciler.go
+++ b/pkg/client/flux/reconciler.go
@@ -774,7 +774,8 @@ func triggerReconciliationWithRetry(
 		// return "rate: Wait(n=1) would exceed context deadline" — a plain
 		// fmt.Errorf that does not wrap context.DeadlineExceeded and produces
 		// confusing user-facing error messages if it bubbles up unhandled.
-		if err := waitCtx.Err(); err != nil {
+		err := waitCtx.Err()
+		if err != nil {
 			if lastErr != nil {
 				return fmt.Errorf(
 					"timed out waiting for %s to be available (last error: %v): %w",
@@ -787,7 +788,7 @@ func triggerReconciliationWithRetry(
 			return fmt.Errorf("trigger %s reconciliation: %w", resourceDescription, err)
 		}
 
-		_, err := client.Patch(waitCtx, resourceName, types.MergePatchType, patch, metav1.PatchOptions{})
+		_, err = client.Patch(waitCtx, resourceName, types.MergePatchType, patch, metav1.PatchOptions{})
 		if err == nil {
 			return nil
 		}

--- a/pkg/client/flux/reconciler.go
+++ b/pkg/client/flux/reconciler.go
@@ -118,8 +118,8 @@ type ReconcileOptions struct {
 }
 
 // TriggerOCIRepositoryReconciliation triggers OCIRepository reconciliation without waiting.
-// It uses retry logic to handle optimistic concurrency conflicts that can occur when the
-// Flux controller updates the resource between our Get and Update calls.
+// It uses a JSON merge patch with retry logic for transient API errors (e.g. resource not
+// yet created, API server temporarily unavailable).
 func (r *Reconciler) TriggerOCIRepositoryReconciliation(ctx context.Context) error {
 	return triggerReconciliationWithRetry(
 		ctx,
@@ -165,8 +165,8 @@ func (r *Reconciler) WaitForOCIRepositoryReady(ctx context.Context, timeout time
 }
 
 // TriggerKustomizationReconciliation triggers Kustomization reconciliation without waiting.
-// It uses retry logic to handle optimistic concurrency conflicts that can occur when the
-// Flux controller updates the resource between our Get and Update calls.
+// It uses a JSON merge patch with retry logic for transient API errors (e.g. resource not
+// yet created, API server temporarily unavailable).
 func (r *Reconciler) TriggerKustomizationReconciliation(ctx context.Context) error {
 	return triggerReconciliationWithRetry(
 		ctx,

--- a/pkg/client/flux/reconciler.go
+++ b/pkg/client/flux/reconciler.go
@@ -728,9 +728,10 @@ func handleTransientError(
 	select {
 	case <-waitCtx.Done():
 		return fmt.Errorf(
-			"timed out waiting for %s to be available: %w",
+			"timed out waiting for %s to be available (last error: %v): %w",
 			resourceDescription,
 			err,
+			waitCtx.Err(),
 		)
 	case <-ticker.C:
 		return nil // Continue retry loop
@@ -770,15 +771,16 @@ func triggerReconciliationWithRetry(
 	for {
 		// Guard against an expired context before making an API call.
 		// Without this check, an expired context causes the k8s rate limiter to
-		// return "rate: Wait(n=1) would exceed context deadline", which is not
-		// recognised as a context error and propagates as a confusing permanent
-		// failure.
+		// return "rate: Wait(n=1) would exceed context deadline" — a plain
+		// fmt.Errorf that does not wrap context.DeadlineExceeded and produces
+		// confusing user-facing error messages if it bubbles up unhandled.
 		if err := waitCtx.Err(); err != nil {
 			if lastErr != nil {
 				return fmt.Errorf(
-					"timed out waiting for %s to be available: %w",
+					"timed out waiting for %s to be available (last error: %v): %w",
 					resourceDescription,
 					lastErr,
+					err,
 				)
 			}
 

--- a/pkg/client/reconciler/errors.go
+++ b/pkg/client/reconciler/errors.go
@@ -3,9 +3,26 @@ package reconciler
 import (
 	"context"
 	"errors"
+	"strings"
 )
 
-// IsContextError checks if the error is caused by a context deadline or cancellation.
+// rateLimiterContextErrSubstr is the substring in the k8s client-go rate limiter
+// error that indicates the context deadline would be exceeded.  The rate limiter
+// in golang.org/x/time/rate returns a plain fmt.Errorf string (not a wrapped
+// context.DeadlineExceeded) when Wait cannot complete within the context deadline.
+const rateLimiterContextErrSubstr = "would exceed context deadline"
+
+// IsContextError checks if the error is caused by a context deadline or
+// cancellation, including the k8s client-go rate limiter error that surfaces
+// when the context is expired or about to expire.
 func IsContextError(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	// The k8s client-go rate limiter (golang.org/x/time/rate) returns a plain
+	// fmt.Errorf when the context deadline would be exceeded.  This does not wrap
+	// context.DeadlineExceeded, so errors.Is cannot detect it.  Treat the
+	// substring match as equivalent to a context deadline error.
+	return err != nil && strings.Contains(err.Error(), rateLimiterContextErrSubstr)
 }

--- a/pkg/client/reconciler/errors_test.go
+++ b/pkg/client/reconciler/errors_test.go
@@ -63,6 +63,20 @@ func TestIsContextError(t *testing.T) {
 			err:      fmt.Errorf("wrap: %w", errReconcilerNotContext),
 			expected: false,
 		},
+		{
+			// The k8s client-go rate limiter returns a plain fmt.Errorf containing
+			// "would exceed context deadline" when the context deadline is imminent.
+			// This is NOT a wrapped context.DeadlineExceeded, so errors.Is cannot
+			// detect it.  IsContextError must treat it as a context error.
+			name:     "k8s rate limiter context deadline error",
+			err:      fmt.Errorf("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline"),
+			expected: true,
+		},
+		{
+			name:     "wrapped k8s rate limiter context deadline error",
+			err:      fmt.Errorf("get flux kustomization: %w", fmt.Errorf("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")),
+			expected: true,
+		},
 	}
 
 	for index := range tests {

--- a/pkg/client/reconciler/errors_test.go
+++ b/pkg/client/reconciler/errors_test.go
@@ -11,28 +11,20 @@ import (
 )
 
 var (
-	errReconcilerSomethingWentWrong = errors.New("something went wrong")
-	errReconcilerNotContext         = errors.New("not a context error")
+	errReconcilerSomethingWentWrong    = errors.New("something went wrong")
+	errReconcilerNotContext            = errors.New("not a context error")
+	errRateLimiterContextDeadline      = errors.New("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")
 )
 
 func TestIsContextError(t *testing.T) {
 	t.Parallel()
-
 	tests := []struct {
 		name     string
 		err      error
 		expected bool
 	}{
-		{
-			name:     "deadline exceeded",
-			err:      context.DeadlineExceeded,
-			expected: true,
-		},
-		{
-			name:     "context canceled",
-			err:      context.Canceled,
-			expected: true,
-		},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, expected: true},
+		{name: "context canceled", err: context.Canceled, expected: true},
 		{
 			name:     "wrapped deadline exceeded",
 			err:      fmt.Errorf("operation failed: %w", context.DeadlineExceeded),
@@ -48,37 +40,20 @@ func TestIsContextError(t *testing.T) {
 			err:      fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", context.DeadlineExceeded)),
 			expected: true,
 		},
-		{
-			name:     "nil error",
-			err:      nil,
-			expected: false,
-		},
-		{
-			name:     "generic error",
-			err:      errReconcilerSomethingWentWrong,
-			expected: false,
-		},
+		{name: "nil error", err: nil, expected: false},
+		{name: "generic error", err: errReconcilerSomethingWentWrong, expected: false},
 		{
 			name:     "wrapped generic error",
 			err:      fmt.Errorf("wrap: %w", errReconcilerNotContext),
 			expected: false,
 		},
-		{
-			// The k8s client-go rate limiter returns a plain fmt.Errorf containing
-			// "would exceed context deadline" when the context deadline is imminent.
-			// This is NOT a wrapped context.DeadlineExceeded, so errors.Is cannot
-			// detect it.  IsContextError must treat it as a context error.
-			name:     "k8s rate limiter context deadline error",
-			err:      fmt.Errorf("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline"),
-			expected: true,
-		},
+		{name: "k8s rate limiter context deadline error", err: errRateLimiterContextDeadline, expected: true},
 		{
 			name:     "wrapped k8s rate limiter context deadline error",
-			err:      fmt.Errorf("get flux kustomization: %w", fmt.Errorf("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")),
+			err:      fmt.Errorf("get flux kustomization: %w", errRateLimiterContextDeadline),
 			expected: true,
 		},
 	}
-
 	for index := range tests {
 		t.Run(tests[index].name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/client/reconciler/errors_test.go
+++ b/pkg/client/reconciler/errors_test.go
@@ -20,6 +20,7 @@ var (
 
 func TestIsContextError(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		name     string
 		err      error
@@ -49,7 +50,11 @@ func TestIsContextError(t *testing.T) {
 			err:      fmt.Errorf("wrap: %w", errReconcilerNotContext),
 			expected: false,
 		},
-		{name: "k8s rate limiter context deadline error", err: errRateLimiterContextDeadline, expected: true},
+		{
+			name:     "k8s rate limiter context deadline error",
+			err:      errRateLimiterContextDeadline,
+			expected: true,
+		},
 		{
 			name:     "wrapped k8s rate limiter context deadline error",
 			err:      fmt.Errorf("get flux kustomization: %w", errRateLimiterContextDeadline),

--- a/pkg/client/reconciler/errors_test.go
+++ b/pkg/client/reconciler/errors_test.go
@@ -11,9 +11,11 @@ import (
 )
 
 var (
-	errReconcilerSomethingWentWrong    = errors.New("something went wrong")
-	errReconcilerNotContext            = errors.New("not a context error")
-	errRateLimiterContextDeadline      = errors.New("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")
+	errReconcilerSomethingWentWrong = errors.New("something went wrong")
+	errReconcilerNotContext         = errors.New("not a context error")
+	errRateLimiterContextDeadline   = errors.New(
+		"client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline",
+	)
 )
 
 func TestIsContextError(t *testing.T) {


### PR DESCRIPTION
## Summary

`ksail workload reconcile` consistently failed on clusters with many kustomizations (~4+) and HelmReleases (~25+) with:

```
✗ trigger kustomization reconciliation: get flux kustomization: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
```

## Root Cause

In `triggerReconciliationWithRetry`, the **Get + Update** pattern used to annotate Flux resources with `reconcile.fluxcd.io/requestedAt` caused repeated **409 Conflicts** on busy clusters. Flux controllers continuously update resource status, so our full `Update` conflicted on every attempt. These conflicts are treated as transient errors and retried for up to `apiAvailabilityTimeout = 2 minutes`.

After 2 minutes of retries, the inner `waitCtx` expired. The next `client.Get(waitCtx, ...)` call then returned the k8s rate limiter error `"rate: Wait(n=1) would exceed context deadline"` — a plain `fmt.Errorf` from `golang.org/x/time/rate` that does **not** wrap `context.DeadlineExceeded`. Neither `IsContextError` nor `isTransientAPIError` recognised it, so it propagated as a permanent error with a confusing message.

## Changes

### Fix 1 — Replace Get+Update with Patch (`pkg/client/flux/reconciler.go`)

Replace the 2-step Get+Update pattern with a single **JSON merge Patch**. Patches are applied atomically server-side and never produce 409 Conflicts, eliminating the entire 2-minute retry loop.

### Fix 2 — Context-expiry guard (`pkg/client/flux/reconciler.go`)

Add a `waitCtx.Err()` check at the start of each loop iteration in `triggerReconciliationWithRetry` so an expired context returns a clean, descriptive error before any API call is attempted.

### Fix 3 — Extend `IsContextError` (`pkg/client/reconciler/errors.go`)

Extend `IsContextError` to detect the `"would exceed context deadline"` substring from the k8s rate limiter, treating it as a context deadline error everywhere in the polling code.

Fixes #4669