### PR TITLE
fix: add worker role label to Talos worker node configs

### DIFF
--- a/pkg/fsutil/configmanager/ksail/coverage_test.go
+++ b/pkg/fsutil/configmanager/ksail/coverage_test.go
@@ -326,7 +326,7 @@ func TestResolveVClusterName(t *testing.T) {
 func TestGetDefaultTalosPatches(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no metrics server returns empty", func(t *testing.T) {
+	t.Run("no metrics server returns worker role label only", func(t *testing.T) {
 		t.Parallel()
 
 		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
@@ -339,7 +339,8 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		assert.Empty(t, patches)
+		require.Len(t, patches, 1)
+		assert.Contains(t, string(patches[0].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run("metrics server enabled returns kubelet patches", func(t *testing.T) {
@@ -355,9 +356,10 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 2)
+		require.Len(t, patches, 3)
 		assert.Contains(t, string(patches[0].Content), "rotate-server-certificates")
 		assert.Contains(t, string(patches[1].Content), "kubelet-serving-cert-approver")
+		assert.Contains(t, string(patches[2].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run("hetzner provider returns external cloud provider patch", func(t *testing.T) {
@@ -373,13 +375,14 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 1)
+		require.Len(t, patches, 2)
 		assert.Contains(t, string(patches[0].Content), "externalCloudProvider")
 		assert.Contains(t, string(patches[0].Content), "enabled: true")
 		assert.Contains(t, string(patches[0].Content), "cloud-provider: external")
+		assert.Contains(t, string(patches[1].Content), "node-role.kubernetes.io/worker")
 	})
 
-	t.Run("docker provider does not return external cloud provider patch", func(t *testing.T) {
+	t.Run("docker provider returns worker role label only", func(t *testing.T) {
 		t.Parallel()
 
 		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
@@ -392,7 +395,8 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		assert.Empty(t, patches)
+		require.Len(t, patches, 1)
+		assert.Contains(t, string(patches[0].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run("hetzner with metrics server returns all three patches", func(t *testing.T) {
@@ -409,10 +413,11 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 3)
+		require.Len(t, patches, 4)
 		assert.Contains(t, string(patches[0].Content), "rotate-server-certificates")
 		assert.Contains(t, string(patches[1].Content), "kubelet-serving-cert-approver")
 		assert.Contains(t, string(patches[2].Content), "externalCloudProvider")
+		assert.Contains(t, string(patches[3].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run("cilium CNI returns disable CNI patch", func(t *testing.T) {
@@ -428,9 +433,10 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 1)
+		require.Len(t, patches, 2)
 		assert.Contains(t, string(patches[0].Content), "cni")
 		assert.Contains(t, string(patches[0].Content), "name: none")
+		assert.Contains(t, string(patches[1].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run("calico CNI returns disable CNI patch", func(t *testing.T) {
@@ -446,12 +452,13 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 1)
+		require.Len(t, patches, 2)
 		assert.Contains(t, string(patches[0].Content), "cni")
 		assert.Contains(t, string(patches[0].Content), "name: none")
+		assert.Contains(t, string(patches[1].Content), "node-role.kubernetes.io/worker")
 	})
 
-	t.Run("default CNI does not return disable CNI patch", func(t *testing.T) {
+	t.Run("default CNI returns worker role label only", func(t *testing.T) {
 		t.Parallel()
 
 		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
@@ -464,7 +471,8 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		assert.Empty(t, patches)
+		require.Len(t, patches, 1)
+		assert.Contains(t, string(patches[0].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run(
@@ -483,10 +491,11 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 			}
 
 			patches := mgr.GetDefaultTalosPatchesForTest()
-			require.Len(t, patches, 3)
+			require.Len(t, patches, 4)
 			assert.Contains(t, string(patches[0].Content), "name: none")
 			assert.Contains(t, string(patches[1].Content), "rotate-server-certificates")
 			assert.Contains(t, string(patches[2].Content), "kubelet-serving-cert-approver")
+			assert.Contains(t, string(patches[3].Content), "node-role.kubernetes.io/worker")
 		},
 	)
 }

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -127,6 +127,13 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 	// (e.g., permissions), we inject the patches as a fail-safe.
 	m.addKubeletCertRotationPatches(talosManager, patchesDir)
 
+	// Inject worker role label patch at runtime when the patch file doesn't
+	// already exist on disk. Projects initialized with this version+ have
+	// the patch file; older projects or manually-managed talos/ directories
+	// may not. The runtime injection ensures worker nodes always get the
+	// node-role.kubernetes.io/worker label.
+	m.addWorkerRoleLabelPatch(talosManager, patchesDir)
+
 	// Wire extensions from ksail.yaml so that machine.install.image is patched
 	// to use a Talos Image Factory installer containing the requested extensions.
 	// Skip when an explicit SchematicID is set — it takes precedence over extensions.
@@ -186,6 +193,19 @@ func (m *ConfigManager) addKubeletCertRotationPatches(
 	if m.Config.Spec.Cluster.MetricsServer == v1alpha1.MetricsServerEnabled &&
 		!kubeletPatchFilesExist(patchesDir) {
 		talosManager.WithAdditionalPatches(kubeletCertRotationAndApproverPatches())
+	}
+}
+
+// addWorkerRoleLabelPatch injects the worker role label patch at runtime
+// when the patch file does not exist on disk. This ensures existing
+// scaffolded projects (created before this patch was introduced) still
+// get the node-role.kubernetes.io/worker label on worker nodes.
+func (m *ConfigManager) addWorkerRoleLabelPatch(
+	talosManager *talosconfigmanager.ConfigManager,
+	patchesDir string,
+) {
+	if !workerRoleLabelPatchFileExists(patchesDir) {
+		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
 	}
 }
 
@@ -365,6 +385,16 @@ func kubeletPatchFilesExist(patchesDir string) bool {
 	_, err2 := os.Stat(csrApprover)
 
 	return err1 == nil && err2 == nil
+}
+
+// workerRoleLabelPatchFileExists returns true when the worker role label
+// patch file exists on disk. If the file is missing or stat fails for any
+// reason, returns false so that the runtime patch is injected as a fail-safe.
+func workerRoleLabelPatchFileExists(patchesDir string) bool {
+	patchFile := filepath.Join(patchesDir, "workers", "worker-role-label.yaml")
+	_, err := os.Stat(patchFile)
+
+	return err == nil
 }
 
 // ingressFirewallPatchPaths returns the expected ingress firewall patch file paths

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -311,6 +311,10 @@ func (m *ConfigManager) getDefaultTalosPatches() []talosconfigmanager.Patch {
 		patches = append(patches, externalCloudProviderPatches()...)
 	}
 
+	// Always label worker nodes with node-role.kubernetes.io/worker.
+	// This is worker-scoped so it only affects worker configs.
+	patches = append(patches, workerRoleLabelPatch())
+
 	return patches
 }
 
@@ -575,6 +579,17 @@ func externalCloudProviderPatches() []talosconfigmanager.Patch {
 			Scope:   talosconfigmanager.PatchScopeCluster,
 			Content: []byte(talosgenerator.ExternalCloudProviderPatchYAML),
 		},
+	}
+}
+
+// workerRoleLabelPatch returns a Talos machine config patch that labels worker nodes
+// with node-role.kubernetes.io/worker. Used for runtime injection when no scaffolded
+// project exists (init=false). Worker-scoped so it only affects worker configs.
+func workerRoleLabelPatch() talosconfigmanager.Patch {
+	return talosconfigmanager.Patch{
+		Path:    "worker-role-label",
+		Scope:   talosconfigmanager.PatchScopeWorker,
+		Content: []byte(talosgenerator.WorkerRoleLabelPatchYAML),
 	}
 }
 

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -44,6 +44,8 @@ const (
 	ingressFirewallRulesFileName = "ingress-firewall-rules.yaml"
 	// oidcFileName is the name of the OIDC API server configuration patch file.
 	oidcFileName = "oidc.yaml"
+	// workerRoleLabelFileName is the name of the worker role label patch file.
+	workerRoleLabelFileName = "worker-role-label.yaml"
 )
 
 // KubeletServingCertApproverManifestURL is the URL for the kubelet-serving-cert-approver manifest.
@@ -89,6 +91,20 @@ machine:
   kubelet:
     extraArgs:
       cloud-provider: external
+`
+
+// WorkerRoleLabelPatchYAML is the Talos machine config patch YAML that labels worker nodes
+// with the standard Kubernetes worker role. This is the single source of truth for the patch
+// content, shared between the generator (file-based scaffolding) and the runtime config manager
+// (in-memory patch injection when no scaffolded project exists).
+//
+// Talos does not set node-role.kubernetes.io/worker on worker nodes by default (unlike
+// control-plane nodes which receive node-role.kubernetes.io/control-plane automatically).
+// Without this label, kubectl shows <none> for the worker role column and operators that
+// target workers by role label cannot find them.
+const WorkerRoleLabelPatchYAML = `machine:
+  nodeLabels:
+    node-role.kubernetes.io/worker: ""
 `
 
 // ErrConfigRequired is returned when a nil config is provided.
@@ -234,6 +250,11 @@ func (g *Generator) getDirectoriesWithPatches(
 		dirs["cluster"] = true
 	}
 
+	// Worker role label patch goes to workers/
+	if model.WorkerNodes > 0 {
+		dirs["workers"] = true
+	}
+
 	// Disable CNI patch goes to cluster/
 	if model.DisableDefaultCNI {
 		dirs["cluster"] = true
@@ -301,6 +322,14 @@ func (g *Generator) generateConditionalPatches(
 	// Generate allow-scheduling-on-control-planes patch when no workers are configured
 	if model.WorkerNodes == 0 {
 		err := g.generateAllowSchedulingPatch(rootPath, force)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Generate worker role label patch when workers are configured
+	if model.WorkerNodes > 0 {
+		err := g.generateWorkerRoleLabelPatch(rootPath, force)
 		if err != nil {
 			return err
 		}
@@ -515,6 +544,29 @@ func (g *Generator) generateAllowSchedulingPatch(
 	err := os.WriteFile(patchPath, []byte(patchContent), filePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create allow-scheduling-on-control-planes patch: %w", err)
+	}
+
+	return nil
+}
+
+// generateWorkerRoleLabelPatch creates a Talos patch file that labels worker nodes
+// with node-role.kubernetes.io/worker. This goes into the workers/ directory so it
+// only applies to worker machine configs.
+func (g *Generator) generateWorkerRoleLabelPatch(
+	rootPath string,
+	force bool,
+) error {
+	patchPath := filepath.Join(rootPath, "workers", workerRoleLabelFileName)
+
+	// Check if file already exists
+	_, statErr := os.Stat(patchPath)
+	if statErr == nil && !force {
+		return nil
+	}
+
+	err := os.WriteFile(patchPath, []byte(WorkerRoleLabelPatchYAML), filePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create worker-role-label patch: %w", err)
 	}
 
 	return nil

--- a/pkg/fsutil/generator/talos/generator_skipexisting_test.go
+++ b/pkg/fsutil/generator/talos/generator_skipexisting_test.go
@@ -111,6 +111,20 @@ func TestGenerate_AllowSchedulingSkipExisting(t *testing.T) {
 	})
 }
 
+// TestGenerate_WorkerRoleLabelSkipExisting verifies that the worker-role-label
+// patch is not overwritten when force is false.
+func TestGenerate_WorkerRoleLabelSkipExisting(t *testing.T) {
+	t.Parallel()
+
+	assertGenerateSkipExistingPreservesContent(t, &talosgenerator.Config{
+		PatchesDir:  "talos",
+		WorkerNodes: 1, // triggers worker-role-label patch
+	}, skipExistingFile{
+		relativePath: filepath.Join("talos", "workers", "worker-role-label.yaml"),
+		content:      "original",
+	})
+}
+
 // TestGenerate_DisableCNISkipExisting verifies that the disable-cni patch is
 // not overwritten when force is false.
 func TestGenerate_DisableCNISkipExisting(t *testing.T) {

--- a/pkg/fsutil/generator/talos/generator_test.go
+++ b/pkg/fsutil/generator/talos/generator_test.go
@@ -53,7 +53,11 @@ func TestGenerator_Generate_CreatesDirectoryStructure(t *testing.T) {
 	// workers/ should NOT have .gitkeep since it has the worker-role-label patch
 	gitkeepPath := filepath.Join(tempDir, "talos", "workers", ".gitkeep")
 	_, err = os.Stat(gitkeepPath)
-	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist in workers/ when patches are generated")
+	assert.True(
+		t,
+		os.IsNotExist(err),
+		"expected .gitkeep to not exist in workers/ when patches are generated",
+	)
 }
 
 func TestGenerator_Generate_NilConfig(t *testing.T) {
@@ -248,7 +252,11 @@ func TestGenerator_Generate_DisableDefaultCNI(t *testing.T) {
 
 	// Verify .gitkeep was NOT created in workers/ since worker-role-label patch is generated there
 	_, err = os.Stat(filepath.Join(tempDir, "talos", "workers", ".gitkeep"))
-	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when worker patches are generated")
+	assert.True(
+		t,
+		os.IsNotExist(err),
+		"expected .gitkeep to not exist when worker patches are generated",
+	)
 }
 
 func TestGenerator_Generate_NoDisableCNIPatchWhenFalse(t *testing.T) {
@@ -365,7 +373,11 @@ func TestGenerator_Generate_WorkerRoleLabel_NotGeneratedWithoutWorkers(t *testin
 	// Verify worker-role-label.yaml was NOT created
 	patchPath := filepath.Join(tempDir, "talos", "workers", "worker-role-label.yaml")
 	_, err = os.Stat(patchPath)
-	assert.True(t, os.IsNotExist(err), "expected worker-role-label.yaml to not exist when WorkerNodes == 0")
+	assert.True(
+		t,
+		os.IsNotExist(err),
+		"expected worker-role-label.yaml to not exist when WorkerNodes == 0",
+	)
 }
 
 func TestGenerator_Generate_MirrorRegistries(t *testing.T) {

--- a/pkg/fsutil/generator/talos/generator_test.go
+++ b/pkg/fsutil/generator/talos/generator_test.go
@@ -24,10 +24,11 @@ func TestGenerator_Generate_CreatesDirectoryStructure(t *testing.T) {
 	tempDir := t.TempDir()
 	gen := talosgenerator.NewGenerator()
 
-	// With workers > 0 and no other patches, all dirs should have .gitkeep
+	// With workers > 0, cluster/ and control-planes/ should have .gitkeep,
+	// but workers/ should have the worker-role-label patch instead
 	config := &talosgenerator.Config{
 		PatchesDir:  "talos",
-		WorkerNodes: 1, // Prevents allow-scheduling patch from being generated
+		WorkerNodes: 1,
 	}
 	opts := yamlgenerator.Options{
 		Output: tempDir,
@@ -37,18 +38,22 @@ func TestGenerator_Generate_CreatesDirectoryStructure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tempDir, "talos"), result)
 
-	// Verify directory structure - all should have .gitkeep since no patches generated
-	expectedPaths := []string{
+	// Verify directory structure - cluster/ and control-planes/ should have .gitkeep
+	gitkeepPaths := []string{
 		filepath.Join(tempDir, "talos", "cluster", ".gitkeep"),
 		filepath.Join(tempDir, "talos", "control-planes", ".gitkeep"),
-		filepath.Join(tempDir, "talos", "workers", ".gitkeep"),
 	}
 
-	for _, path := range expectedPaths {
+	for _, path := range gitkeepPaths {
 		info, err := os.Stat(path)
 		require.NoError(t, err, "expected path to exist: %s", path)
 		assert.False(t, info.IsDir(), "expected file, got directory: %s", path)
 	}
+
+	// workers/ should NOT have .gitkeep since it has the worker-role-label patch
+	gitkeepPath := filepath.Join(tempDir, "talos", "workers", ".gitkeep")
+	_, err = os.Stat(gitkeepPath)
+	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist in workers/ when patches are generated")
 }
 
 func TestGenerator_Generate_NilConfig(t *testing.T) {
@@ -237,11 +242,13 @@ func TestGenerator_Generate_DisableDefaultCNI(t *testing.T) {
 	_, err = os.Stat(gitkeepPath)
 	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when patches are generated")
 
-	// Verify .gitkeep WAS created in other directories
+	// Verify .gitkeep WAS created in control-planes/ (no patches there)
 	_, err = os.Stat(filepath.Join(tempDir, "talos", "control-planes", ".gitkeep"))
 	require.NoError(t, err, "expected .gitkeep in control-planes/")
+
+	// Verify .gitkeep was NOT created in workers/ since worker-role-label patch is generated there
 	_, err = os.Stat(filepath.Join(tempDir, "talos", "workers", ".gitkeep"))
-	require.NoError(t, err, "expected .gitkeep in workers/")
+	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when worker patches are generated")
 }
 
 func TestGenerator_Generate_NoDisableCNIPatchWhenFalse(t *testing.T) {
@@ -303,6 +310,62 @@ func TestGenerator_Generate_AllowSchedulingOnControlPlanes(t *testing.T) {
 	gitkeepPath := filepath.Join(clusterDir, ".gitkeep")
 	_, err = os.Stat(gitkeepPath)
 	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when patches are generated")
+}
+
+func TestGenerator_Generate_WorkerRoleLabel(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	gen := talosgenerator.NewGenerator()
+
+	config := &talosgenerator.Config{
+		PatchesDir:  "talos",
+		WorkerNodes: 3,
+	}
+	opts := yamlgenerator.Options{
+		Output: tempDir,
+	}
+
+	result, err := gen.Generate(config, opts)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempDir, "talos"), result)
+
+	// Verify worker-role-label.yaml was created in workers/
+	workersDir := filepath.Join(tempDir, "talos", "workers")
+	patchPath := filepath.Join(workersDir, "worker-role-label.yaml")
+	content, err := os.ReadFile(patchPath) //nolint:gosec // Test file path is safe
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "machine:")
+	assert.Contains(t, string(content), "nodeLabels:")
+	assert.Contains(t, string(content), `node-role.kubernetes.io/worker: ""`)
+
+	// Verify .gitkeep was NOT created in workers/ since we have a patch there
+	gitkeepPath := filepath.Join(workersDir, ".gitkeep")
+	_, err = os.Stat(gitkeepPath)
+	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when patches are generated")
+}
+
+func TestGenerator_Generate_WorkerRoleLabel_NotGeneratedWithoutWorkers(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	gen := talosgenerator.NewGenerator()
+
+	config := &talosgenerator.Config{
+		PatchesDir:  "talos",
+		WorkerNodes: 0,
+	}
+	opts := yamlgenerator.Options{
+		Output: tempDir,
+	}
+
+	_, err := gen.Generate(config, opts)
+	require.NoError(t, err)
+
+	// Verify worker-role-label.yaml was NOT created
+	patchPath := filepath.Join(tempDir, "talos", "workers", "worker-role-label.yaml")
+	_, err = os.Stat(patchPath)
+	assert.True(t, os.IsNotExist(err), "expected worker-role-label.yaml to not exist when WorkerNodes == 0")
 }
 
 func TestGenerator_Generate_MirrorRegistries(t *testing.T) {

--- a/pkg/fsutil/generator/talos/generator_writeerror_test.go
+++ b/pkg/fsutil/generator/talos/generator_writeerror_test.go
@@ -93,6 +93,31 @@ func TestGenerate_AllowSchedulingWriteError(t *testing.T) {
 	}, "allow-scheduling-on-control-planes")
 }
 
+func TestGenerate_WorkerRoleLabelWriteError(t *testing.T) {
+	t.Parallel()
+
+	skipPermissionWriteFailureTest(t)
+
+	config := &talosgenerator.Config{
+		PatchesDir:  "talos",
+		WorkerNodes: 1,
+	}
+
+	tempDir := t.TempDir()
+	gen := talosgenerator.NewGenerator()
+
+	_, err := gen.Generate(config, yamlgenerator.Options{Output: tempDir, Force: true})
+	require.NoError(t, err)
+
+	workersDir := filepath.Join(tempDir, "talos", "workers")
+	prepareClusterDirForWriteFailure(t, workersDir)
+
+	_, err = gen.Generate(config, yamlgenerator.Options{Output: tempDir, Force: true})
+	require.Error(t, err)
+	require.ErrorIs(t, err, fs.ErrPermission, "expected permission-denied write failure")
+	assert.Contains(t, err.Error(), "worker-role-label")
+}
+
 func TestGenerate_DisableCNIWriteError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fsutil/scaffolder/scaffolder_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_test.go
@@ -1543,7 +1543,7 @@ func TestScaffoldTalos_CreatesDirectoryStructure(t *testing.T) {
 	expectedPaths := []string{
 		filepath.Join(tempDir, scaffolder.TalosConfigDir, "cluster", ".gitkeep"),
 		filepath.Join(tempDir, scaffolder.TalosConfigDir, "control-planes", ".gitkeep"),
-		filepath.Join(tempDir, scaffolder.TalosConfigDir, "workers", ".gitkeep"),
+		filepath.Join(tempDir, scaffolder.TalosConfigDir, "workers", "worker-role-label.yaml"),
 		filepath.Join(tempDir, "ksail.yaml"),
 		filepath.Join(tempDir, "k8s", "kustomization.yaml"),
 	}


### PR DESCRIPTION
## Summary

Talos SDK does not set `node-role.kubernetes.io/worker` on worker machine configs by default (unlike `node-role.kubernetes.io/control-plane` on control-plane configs). This causes worker nodes to show `<none>` role in `kubectl get nodes`, preventing proper workload scheduling.

## Changes

Adds a `WorkerRoleLabelPatchYAML` constant as a single source of truth, following the existing `DisableDefaultCNIPatchYAML` / `ExternalCloudProviderPatchYAML` pattern:

**Generator** (`pkg/fsutil/generator/talos/generator.go`):
- Scaffolds `worker-role-label.yaml` patch file in `workers/` directory when `WorkerNodes > 0`

**Runtime config manager** (`pkg/fsutil/configmanager/ksail/distribution.go`):
- Injects the patch at runtime with `PatchScopeWorker` scope (only applies to worker machine configs)
- Added unconditionally — safe because worker-scoped patches only affect worker configs

**Patch content:**
```yaml
machine:
  nodeLabels:
    node-role.kubernetes.io/worker: ""
```

## Scope

Applies to **all Talos providers** (Docker, Hetzner, Omni), not just Hetzner.

## Testing

- Updated all existing `TestGetDefaultTalosPatches` subtests (patch count +1 in every case)
- Added generator tests: content verification, skip-existing, write-error, zero-workers guard
- Build and test pass locally