### PR TITLE
feat(hetzner): add server availability precheck before infrastructure creation

### DIFF
--- a/pkg/svc/provider/hetzner/availability.go
+++ b/pkg/svc/provider/hetzner/availability.go
@@ -93,13 +93,13 @@ func deduplicateServerTypes(types []string) []string {
 	seen := make(map[string]struct{}, len(types))
 	result := make([]string, 0, len(types))
 
-	for _, t := range types {
-		if _, ok := seen[t]; ok {
+	for _, serverType := range types {
+		if _, ok := seen[serverType]; ok {
 			continue
 		}
 
-		seen[t] = struct{}{}
-		result = append(result, t)
+		seen[serverType] = struct{}{}
+		result = append(result, serverType)
 	}
 
 	return result

--- a/pkg/svc/provider/hetzner/availability.go
+++ b/pkg/svc/provider/hetzner/availability.go
@@ -1,0 +1,116 @@
+package hetzner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// CheckServerAvailability verifies that every requested server type is available
+// in at least one of the configured locations (primary + fallbacks).
+// It returns an error on the first server type that cannot be satisfied.
+// Call this before creating infrastructure resources to fail fast.
+func (p *Provider) CheckServerAvailability(
+	ctx context.Context,
+	serverTypes []string,
+	primaryLocation string,
+	fallbackLocations []string,
+) error {
+	if p.client == nil {
+		return provider.ErrProviderUnavailable
+	}
+
+	uniqueTypes := deduplicateServerTypes(serverTypes)
+	locations := buildLocationList(primaryLocation, fallbackLocations)
+
+	for _, serverTypeName := range uniqueTypes {
+		err := p.checkSingleServerType(ctx, serverTypeName, locations)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkSingleServerType verifies that serverTypeName is available in at least one
+// of the given locations.
+func (p *Provider) checkSingleServerType(
+	ctx context.Context,
+	serverTypeName string,
+	locations []string,
+) error {
+	serverType, _, err := p.client.ServerType.GetByName(ctx, serverTypeName)
+	if err != nil {
+		return fmt.Errorf("looking up server type %q: %w", serverTypeName, err)
+	}
+
+	if serverType == nil {
+		return fmt.Errorf("%w: %q", ErrServerTypeNotFound, serverTypeName)
+	}
+
+	available := availableLocations(serverType, locations)
+	if len(available) == 0 {
+		return fmt.Errorf(
+			"%w: %q is not available in %s",
+			ErrServerTypeUnavailable,
+			serverTypeName,
+			strings.Join(locations, ", "),
+		)
+	}
+
+	return nil
+}
+
+// availableLocations returns the subset of candidateLocations where the
+// server type reports Available == true.
+func availableLocations(
+	serverType *hcloud.ServerType,
+	candidateLocations []string,
+) []string {
+	var result []string
+
+	for _, candidate := range candidateLocations {
+		for _, stLoc := range serverType.Locations {
+			if stLoc.Location != nil &&
+				stLoc.Location.Name == candidate &&
+				stLoc.Available {
+				result = append(result, candidate)
+
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+// deduplicateServerTypes returns a deduplicated slice preserving order.
+func deduplicateServerTypes(types []string) []string {
+	seen := make(map[string]struct{}, len(types))
+	result := make([]string, 0, len(types))
+
+	for _, t := range types {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+
+		seen[t] = struct{}{}
+		result = append(result, t)
+	}
+
+	return result
+}
+
+// buildLocationList constructs the ordered list of locations to check:
+// primary first, then fallbacks.
+func buildLocationList(primary string, fallbacks []string) []string {
+	locations := make([]string, 0, 1+len(fallbacks))
+	locations = append(locations, primary)
+	locations = append(locations, fallbacks...)
+
+	return locations
+}

--- a/pkg/svc/provider/hetzner/availability.go
+++ b/pkg/svc/provider/hetzner/availability.go
@@ -89,28 +89,48 @@ func availableLocations(
 }
 
 // deduplicateServerTypes returns a deduplicated slice preserving order.
+// Empty and whitespace-only entries are skipped.
 func deduplicateServerTypes(types []string) []string {
 	seen := make(map[string]struct{}, len(types))
 	result := make([]string, 0, len(types))
 
 	for _, serverType := range types {
-		if _, ok := seen[serverType]; ok {
+		trimmed := strings.TrimSpace(serverType)
+		if trimmed == "" {
 			continue
 		}
 
-		seen[serverType] = struct{}{}
-		result = append(result, serverType)
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+
+		seen[trimmed] = struct{}{}
+		result = append(result, trimmed)
 	}
 
 	return result
 }
 
 // buildLocationList constructs the ordered list of locations to check:
-// primary first, then fallbacks.
+// primary first, then fallbacks. Empty strings are skipped and
+// duplicates are removed while preserving order.
 func buildLocationList(primary string, fallbacks []string) []string {
+	seen := make(map[string]struct{}, 1+len(fallbacks))
 	locations := make([]string, 0, 1+len(fallbacks))
-	locations = append(locations, primary)
-	locations = append(locations, fallbacks...)
+
+	for _, loc := range append([]string{primary}, fallbacks...) {
+		trimmed := strings.TrimSpace(loc)
+		if trimmed == "" {
+			continue
+		}
+
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+
+		seen[trimmed] = struct{}{}
+		locations = append(locations, trimmed)
+	}
 
 	return locations
 }

--- a/pkg/svc/provider/hetzner/availability_test.go
+++ b/pkg/svc/provider/hetzner/availability_test.go
@@ -273,6 +273,26 @@ func TestDeduplicateServerTypes(t *testing.T) {
 			input: []string{"cx23"},
 			want:  []string{"cx23"},
 		},
+		{
+			name:  "SkipsEmpty",
+			input: []string{"cx23", "", "cpx31"},
+			want:  []string{"cx23", "cpx31"},
+		},
+		{
+			name:  "SkipsWhitespace",
+			input: []string{"cx23", "  ", "\t", "cpx31"},
+			want:  []string{"cx23", "cpx31"},
+		},
+		{
+			name:  "TrimsWhitespace",
+			input: []string{" cx23 ", "cpx31"},
+			want:  []string{"cx23", "cpx31"},
+		},
+		{
+			name:  "AllEmpty",
+			input: []string{"", " ", "\t"},
+			want:  []string{},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -311,6 +331,24 @@ func TestBuildLocationList(t *testing.T) {
 			primary:   "fsn1",
 			fallbacks: []string{},
 			want:      []string{"fsn1"},
+		},
+		{
+			name:      "EmptyPrimary",
+			primary:   "",
+			fallbacks: []string{"nbg1", "hel1"},
+			want:      []string{"nbg1", "hel1"},
+		},
+		{
+			name:      "DuplicateLocations",
+			primary:   "fsn1",
+			fallbacks: []string{"fsn1", "nbg1"},
+			want:      []string{"fsn1", "nbg1"},
+		},
+		{
+			name:      "WhitespaceFiltered",
+			primary:   "  ",
+			fallbacks: []string{"", "nbg1"},
+			want:      []string{"nbg1"},
 		},
 	}
 

--- a/pkg/svc/provider/hetzner/availability_test.go
+++ b/pkg/svc/provider/hetzner/availability_test.go
@@ -30,7 +30,7 @@ type serverTypeSchema struct {
 
 // serverTypeListResp mirrors the Hetzner API list response.
 type serverTypeListResp struct {
-	ServerTypes []serverTypeSchema `json:"server_types"`
+	ServerTypes []serverTypeSchema `json:"server_types"` //nolint:tagliatelle // Hetzner API uses snake_case
 }
 
 // newAvailabilityTestServer creates a test HTTP server that responds to
@@ -39,15 +39,15 @@ func newAvailabilityTestServer(t *testing.T, types map[string]serverTypeSchema) 
 	t.Helper()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /server_types", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /server_types", func(writer http.ResponseWriter, r *http.Request) {
 		name := r.URL.Query().Get("name")
 
 		resp := serverTypeListResp{}
-		if st, ok := types[name]; ok {
-			resp.ServerTypes = []serverTypeSchema{st}
+		if serverType, ok := types[name]; ok {
+			resp.ServerTypes = []serverTypeSchema{serverType}
 		}
 
-		writeJSONResponse(t, w, resp)
+		writeJSONResponse(t, writer, resp)
 	})
 
 	srv := httptest.NewServer(mux)

--- a/pkg/svc/provider/hetzner/availability_test.go
+++ b/pkg/svc/provider/hetzner/availability_test.go
@@ -1,0 +1,151 @@
+package hetzner_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvailableLocations(t *testing.T) {
+	t.Parallel()
+
+	serverType := &hcloud.ServerType{
+		Locations: []hcloud.ServerTypeLocation{
+			{Location: &hcloud.Location{Name: "fsn1"}, Available: true},
+			{Location: &hcloud.Location{Name: "nbg1"}, Available: false},
+			{Location: &hcloud.Location{Name: "hel1"}, Available: true},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		candidates []string
+		want       []string
+	}{
+		{
+			name:       "AllAvailable",
+			candidates: []string{"fsn1", "hel1"},
+			want:       []string{"fsn1", "hel1"},
+		},
+		{
+			name:       "PrimaryAvailable",
+			candidates: []string{"fsn1"},
+			want:       []string{"fsn1"},
+		},
+		{
+			name:       "OnlyFallbackAvailable",
+			candidates: []string{"nbg1", "hel1"},
+			want:       []string{"hel1"},
+		},
+		{
+			name:       "NoneAvailable",
+			candidates: []string{"nbg1"},
+			want:       nil,
+		},
+		{
+			name:       "UnknownLocation",
+			candidates: []string{"ash1"},
+			want:       nil,
+		},
+		{
+			name:       "EmptyCandidates",
+			candidates: []string{},
+			want:       nil,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hetzner.AvailableLocationsForTest(serverType, testCase.candidates)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func TestDeduplicateServerTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "NoDuplicates",
+			input: []string{"cx23", "cpx31"},
+			want:  []string{"cx23", "cpx31"},
+		},
+		{
+			name:  "WithDuplicates",
+			input: []string{"cx23", "cpx31", "cx23"},
+			want:  []string{"cx23", "cpx31"},
+		},
+		{
+			name:  "AllSame",
+			input: []string{"cx23", "cx23", "cx23"},
+			want:  []string{"cx23"},
+		},
+		{
+			name:  "Empty",
+			input: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "Single",
+			input: []string{"cx23"},
+			want:  []string{"cx23"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hetzner.DeduplicateServerTypesForTest(testCase.input)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func TestBuildLocationList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		primary   string
+		fallbacks []string
+		want      []string
+	}{
+		{
+			name:      "PrimaryOnly",
+			primary:   "fsn1",
+			fallbacks: nil,
+			want:      []string{"fsn1"},
+		},
+		{
+			name:      "PrimaryWithFallbacks",
+			primary:   "fsn1",
+			fallbacks: []string{"nbg1", "hel1"},
+			want:      []string{"fsn1", "nbg1", "hel1"},
+		},
+		{
+			name:      "EmptyFallbacks",
+			primary:   "fsn1",
+			fallbacks: []string{},
+			want:      []string{"fsn1"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hetzner.BuildLocationListForTest(testCase.primary, testCase.fallbacks)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/pkg/svc/provider/hetzner/availability_test.go
+++ b/pkg/svc/provider/hetzner/availability_test.go
@@ -2,7 +2,6 @@ package hetzner_test
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -154,7 +153,7 @@ func TestCheckServerAvailability(t *testing.T) {
 
 			if testCase.wantErr != nil {
 				require.Error(t, err)
-				assert.True(t, errors.Is(err, testCase.wantErr),
+				assert.ErrorIs(t, err, testCase.wantErr,
 					"expected %v, got %v", testCase.wantErr, err)
 
 				if testCase.wantErrContains != "" {
@@ -180,7 +179,7 @@ func TestCheckServerAvailability_NilClient(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, provider.ErrProviderUnavailable))
+	assert.ErrorIs(t, err, provider.ErrProviderUnavailable)
 }
 
 func TestAvailableLocations(t *testing.T) {

--- a/pkg/svc/provider/hetzner/availability_test.go
+++ b/pkg/svc/provider/hetzner/availability_test.go
@@ -1,12 +1,187 @@
 package hetzner_test
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// serverTypeLocSchema mirrors the Hetzner API schema for a server type location.
+type serverTypeLocSchema struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	Available bool   `json:"available"`
+}
+
+// serverTypeSchema mirrors the Hetzner API schema for a server type.
+type serverTypeSchema struct {
+	ID        int64                 `json:"id"`
+	Name      string                `json:"name"`
+	Locations []serverTypeLocSchema `json:"locations"`
+}
+
+// serverTypeListResp mirrors the Hetzner API list response.
+type serverTypeListResp struct {
+	ServerTypes []serverTypeSchema `json:"server_types"`
+}
+
+// newAvailabilityTestServer creates a test HTTP server that responds to
+// GET /server_types?name=... with the given server type schemas.
+func newAvailabilityTestServer(t *testing.T, types map[string]serverTypeSchema) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /server_types", func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+
+		resp := serverTypeListResp{}
+		if st, ok := types[name]; ok {
+			resp.ServerTypes = []serverTypeSchema{st}
+		}
+
+		writeJSONResponse(t, w, resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+//nolint:funlen // Table-driven test with many cases
+func TestCheckServerAvailability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		types             map[string]serverTypeSchema
+		serverTypes       []string
+		primaryLocation   string
+		fallbackLocations []string
+		wantErr           error
+		wantErrContains   string
+	}{
+		{
+			name: "AvailableInPrimary",
+			types: map[string]serverTypeSchema{
+				"cx22": {ID: 1, Name: "cx22", Locations: []serverTypeLocSchema{
+					{ID: 1, Name: "fsn1", Available: true},
+				}},
+			},
+			serverTypes:     []string{"cx22"},
+			primaryLocation: "fsn1",
+		},
+		{
+			name: "AvailableInFallback",
+			types: map[string]serverTypeSchema{
+				"cx22": {ID: 1, Name: "cx22", Locations: []serverTypeLocSchema{
+					{ID: 1, Name: "fsn1", Available: false},
+					{ID: 2, Name: "nbg1", Available: true},
+				}},
+			},
+			serverTypes:       []string{"cx22"},
+			primaryLocation:   "fsn1",
+			fallbackLocations: []string{"nbg1"},
+		},
+		{
+			name: "MultipleTypesAllAvailable",
+			types: map[string]serverTypeSchema{
+				"cx22": {ID: 1, Name: "cx22", Locations: []serverTypeLocSchema{
+					{ID: 1, Name: "fsn1", Available: true},
+				}},
+				"cpx31": {ID: 2, Name: "cpx31", Locations: []serverTypeLocSchema{
+					{ID: 1, Name: "fsn1", Available: true},
+				}},
+			},
+			serverTypes:     []string{"cx22", "cpx31"},
+			primaryLocation: "fsn1",
+		},
+		{
+			name:            "ServerTypeNotFound",
+			types:           map[string]serverTypeSchema{},
+			serverTypes:     []string{"nonexistent"},
+			primaryLocation: "fsn1",
+			wantErr:         hetzner.ErrServerTypeNotFound,
+		},
+		{
+			name: "UnavailableInAllLocations",
+			types: map[string]serverTypeSchema{
+				"cx22": {ID: 1, Name: "cx22", Locations: []serverTypeLocSchema{
+					{ID: 1, Name: "fsn1", Available: false},
+					{ID: 2, Name: "nbg1", Available: false},
+				}},
+			},
+			serverTypes:       []string{"cx22"},
+			primaryLocation:   "fsn1",
+			fallbackLocations: []string{"nbg1"},
+			wantErr:           hetzner.ErrServerTypeUnavailable,
+		},
+		{
+			name: "UnavailableLocationNotListed",
+			types: map[string]serverTypeSchema{
+				"cx22": {ID: 1, Name: "cx22", Locations: []serverTypeLocSchema{
+					{ID: 1, Name: "hel1", Available: true},
+				}},
+			},
+			serverTypes:     []string{"cx22"},
+			primaryLocation: "fsn1",
+			wantErr:         hetzner.ErrServerTypeUnavailable,
+			wantErrContains: "fsn1",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newAvailabilityTestServer(t, testCase.types)
+			prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+			err := prov.CheckServerAvailability(
+				context.Background(),
+				testCase.serverTypes,
+				testCase.primaryLocation,
+				testCase.fallbackLocations,
+			)
+
+			if testCase.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, testCase.wantErr),
+					"expected %v, got %v", testCase.wantErr, err)
+
+				if testCase.wantErrContains != "" {
+					assert.Contains(t, err.Error(), testCase.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckServerAvailability_NilClient(t *testing.T) {
+	t.Parallel()
+
+	prov := hetzner.NewProvider(nil)
+
+	err := prov.CheckServerAvailability(
+		context.Background(),
+		[]string{"cx22"},
+		"fsn1",
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, provider.ErrProviderUnavailable))
+}
 
 func TestAvailableLocations(t *testing.T) {
 	t.Parallel()

--- a/pkg/svc/provider/hetzner/availability_test.go
+++ b/pkg/svc/provider/hetzner/availability_test.go
@@ -153,7 +153,7 @@ func TestCheckServerAvailability(t *testing.T) {
 
 			if testCase.wantErr != nil {
 				require.Error(t, err)
-				assert.ErrorIs(t, err, testCase.wantErr,
+				require.ErrorIs(t, err, testCase.wantErr,
 					"expected %v, got %v", testCase.wantErr, err)
 
 				if testCase.wantErrContains != "" {
@@ -267,11 +267,6 @@ func TestDeduplicateServerTypes(t *testing.T) {
 			name:  "Empty",
 			input: []string{},
 			want:  []string{},
-		},
-		{
-			name:  "Single",
-			input: []string{"cx23"},
-			want:  []string{"cx23"},
 		},
 		{
 			name:  "SkipsEmpty",

--- a/pkg/svc/provider/hetzner/errors.go
+++ b/pkg/svc/provider/hetzner/errors.go
@@ -26,6 +26,8 @@ var (
 	ErrServerTypeNotFound = errors.New("server type not found")
 	// ErrServerTypeUnavailable indicates that the server type is not available in any configured location.
 	ErrServerTypeUnavailable = errors.New("server type unavailable in all configured locations")
+	// ErrNoLocationsConfigured indicates that no valid locations were provided for server creation.
+	ErrNoLocationsConfigured = errors.New("no locations configured for server creation")
 )
 
 // retryableErrorCodes are Hetzner API error codes that warrant a retry.

--- a/pkg/svc/provider/hetzner/errors.go
+++ b/pkg/svc/provider/hetzner/errors.go
@@ -22,6 +22,10 @@ var (
 	ErrImageAndISOBothSet = errors.New("ImageID and ISOID are mutually exclusive; set only one")
 	// ErrImageOrISORequired indicates that neither ImageID nor ISOID was provided, but one is required.
 	ErrImageOrISORequired = errors.New("either ImageID or ISOID must be provided")
+	// ErrServerTypeNotFound indicates that the requested server type does not exist.
+	ErrServerTypeNotFound = errors.New("server type not found")
+	// ErrServerTypeUnavailable indicates that the server type is not available in any configured location.
+	ErrServerTypeUnavailable = errors.New("server type unavailable in all configured locations")
 )
 
 // retryableErrorCodes are Hetzner API error codes that warrant a retry.

--- a/pkg/svc/provider/hetzner/errors_test.go
+++ b/pkg/svc/provider/hetzner/errors_test.go
@@ -46,6 +46,12 @@ func TestSentinelErrors(t *testing.T) {
 		require.Error(t, hetzner.ErrServerTypeUnavailable)
 		assert.Contains(t, hetzner.ErrServerTypeUnavailable.Error(), "unavailable")
 	})
+
+	t.Run("ErrNoLocationsConfigured", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, hetzner.ErrNoLocationsConfigured)
+		assert.Contains(t, hetzner.ErrNoLocationsConfigured.Error(), "no locations")
+	})
 }
 
 //nolint:funlen // Table-driven test with many cases

--- a/pkg/svc/provider/hetzner/errors_test.go
+++ b/pkg/svc/provider/hetzner/errors_test.go
@@ -34,6 +34,18 @@ func TestSentinelErrors(t *testing.T) {
 		require.Error(t, hetzner.ErrAllLocationsFailed)
 		assert.Contains(t, hetzner.ErrAllLocationsFailed.Error(), "location")
 	})
+
+	t.Run("ErrServerTypeNotFound", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, hetzner.ErrServerTypeNotFound)
+		assert.Contains(t, hetzner.ErrServerTypeNotFound.Error(), "not found")
+	})
+
+	t.Run("ErrServerTypeUnavailable", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, hetzner.ErrServerTypeUnavailable)
+		assert.Contains(t, hetzner.ErrServerTypeUnavailable.Error(), "unavailable")
+	})
 }
 
 //nolint:funlen // Table-driven test with many cases

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -41,6 +41,15 @@ func CalculateRetryDelayForTest(attempt int) time.Duration {
 // NormalizeNodeRoleForTest exports normalizeNodeRole for testing.
 var NormalizeNodeRoleForTest = normalizeNodeRole
 
+// AvailableLocationsForTest exports availableLocations for testing.
+var AvailableLocationsForTest = availableLocations
+
+// DeduplicateServerTypesForTest exports deduplicateServerTypes for testing.
+var DeduplicateServerTypesForTest = deduplicateServerTypes
+
+// BuildLocationListForTest exports buildLocationList for testing.
+var BuildLocationListForTest = buildLocationList
+
 // NewSnapshotManagerWithUploaderForTest creates a SnapshotManager with a custom uploader,
 // allowing tests to inject a mock without hitting real Hetzner upload infrastructure.
 // A nil logWriter is replaced with io.Discard, matching NewSnapshotManager behavior.

--- a/pkg/svc/provider/hetzner/server_retry.go
+++ b/pkg/svc/provider/hetzner/server_retry.go
@@ -35,6 +35,10 @@ func (p *Provider) CreateServerWithRetry(
 	// Build list of locations to try: primary + fallbacks
 	locations := buildLocationList(opts.Location, retryOpts.FallbackLocations)
 
+	if len(locations) == 0 {
+		return nil, ErrNoLocationsConfigured
+	}
+
 	var lastErr error
 
 	originalPlacementGroupID := opts.PlacementGroupID

--- a/pkg/svc/provider/hetzner/server_retry.go
+++ b/pkg/svc/provider/hetzner/server_retry.go
@@ -33,9 +33,7 @@ func (p *Provider) CreateServerWithRetry(
 	}
 
 	// Build list of locations to try: primary + fallbacks
-	locations := make([]string, 0, 1+len(retryOpts.FallbackLocations))
-	locations = append(locations, opts.Location)
-	locations = append(locations, retryOpts.FallbackLocations...)
+	locations := buildLocationList(opts.Location, retryOpts.FallbackLocations)
 
 	var lastErr error
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -623,17 +623,17 @@ func uniqueServerTypes(types ...string) []string {
 	seen := make(map[string]struct{}, len(types))
 	result := make([]string, 0, len(types))
 
-	for _, t := range types {
-		if t == "" {
+	for _, serverType := range types {
+		if serverType == "" {
 			continue
 		}
 
-		if _, ok := seen[t]; ok {
+		if _, ok := seen[serverType]; ok {
 			continue
 		}
 
-		seen[t] = struct{}{}
-		result = append(result, t)
+		seen[serverType] = struct{}{}
+		result = append(result, serverType)
 	}
 
 	return result

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -500,6 +500,12 @@ func (p *Provisioner) createHetznerCluster(ctx context.Context, clusterName stri
 		return err
 	}
 
+	// Verify server type availability before creating infrastructure resources
+	err = p.checkHetznerAvailability(ctx, hzProvider)
+	if err != nil {
+		return err
+	}
+
 	// Create infrastructure resources
 	infra, err := p.ensureHetznerInfra(ctx, hzProvider, clusterName)
 	if err != nil {
@@ -576,6 +582,61 @@ func (p *Provisioner) ensureSnapshotImage(ctx context.Context, clusterName strin
 	}
 
 	return snapshotImageID, nil
+}
+
+// checkHetznerAvailability verifies that the configured server types are available
+// in the primary location or any fallback locations. This check runs before
+// infrastructure resource creation to avoid creating networks, firewalls, and
+// placement groups that would need cleanup if servers cannot be provisioned.
+func (p *Provisioner) checkHetznerAvailability(
+	ctx context.Context,
+	hzProvider *hetzner.Provider,
+) error {
+	if p.hetznerOpts == nil {
+		return nil
+	}
+
+	serverTypes := uniqueServerTypes(
+		p.hetznerOpts.ControlPlaneServerType,
+		p.hetznerOpts.WorkerServerType,
+	)
+
+	_, _ = fmt.Fprintf(p.logWriter, "Checking server type availability...\n")
+
+	err := hzProvider.CheckServerAvailability(
+		ctx,
+		serverTypes,
+		p.hetznerOpts.Location,
+		p.hetznerOpts.FallbackLocations,
+	)
+	if err != nil {
+		return fmt.Errorf("server availability check failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Server types available\n")
+
+	return nil
+}
+
+// uniqueServerTypes returns a deduplicated list of non-empty server type names.
+func uniqueServerTypes(types ...string) []string {
+	seen := make(map[string]struct{}, len(types))
+	result := make([]string, 0, len(types))
+
+	for _, t := range types {
+		if t == "" {
+			continue
+		}
+
+		if _, ok := seen[t]; ok {
+			continue
+		}
+
+		seen[t] = struct{}{}
+		result = append(result, t)
+	}
+
+	return result
 }
 
 // applyConfigsAndBootstrap updates machine configs with the correct endpoint,

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -44,6 +44,12 @@ func (p *Provisioner) addHetznerNodes(
 
 	nextIndex := nextHetznerNodeIndex(existing, clusterName, role)
 
+	// Verify server type availability before creating infrastructure
+	err = p.checkHetznerAvailabilityForRole(ctx, hzProvider, role)
+	if err != nil {
+		return err
+	}
+
 	infra, err := p.ensureHetznerInfra(ctx, hzProvider, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to ensure Hetzner infrastructure: %w", err)
@@ -333,4 +339,38 @@ func (p *Provisioner) hetznerRetryOpts() hetzner.ServerRetryOpts {
 	}
 
 	return opts
+}
+
+// checkHetznerAvailabilityForRole verifies that the server type for the given
+// role is available in the configured locations. Used during scale-up to fail
+// fast before creating infrastructure resources.
+func (p *Provisioner) checkHetznerAvailabilityForRole(
+	ctx context.Context,
+	hzProvider *hetzner.Provider,
+	role string,
+) error {
+	if p.hetznerOpts == nil {
+		return nil
+	}
+
+	serverType := p.hetznerServerType(role)
+	if serverType == "" {
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "Checking server type availability for %s...\n", role)
+
+	err := hzProvider.CheckServerAvailability(
+		ctx,
+		[]string{serverType},
+		p.hetznerOpts.Location,
+		p.hetznerOpts.FallbackLocations,
+	)
+	if err != nil {
+		return fmt.Errorf("server availability check failed for %s: %w", role, err)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Server type %q available\n", serverType)
+
+	return nil
 }


### PR DESCRIPTION
## Summary

Check server type availability in primary and fallback locations using the hcloud `ServerType` API **before** creating network, firewall, and placement group resources. This prevents unnecessary infrastructure creation when the requested server types are unavailable.

## Problem

Previously, KSail would create infrastructure resources (network, firewall, placement group) before attempting to create servers. If server types were unavailable in the configured locations, the user would only discover this after infrastructure was already created:

```
Creating infrastructure resources...
 ✓ Network prod-network created
 ✓ Firewall prod-firewall created
 ✓ Placement group prod-placement created
Creating 3 worker node(s)...
 ⚠ Placement failed for prod-worker-3 in fsn1, retrying without placement group...
```

## Solution

Added a `CheckServerAvailability` method to the Hetzner provider that queries the hcloud `ServerType.GetByName()` API. Each `ServerType` exposes `Locations []ServerTypeLocation` with per-location `Available bool` flags, enabling a cheap read-only precheck.

The precheck is wired into both:
- **Cluster creation** (`createHetznerCluster`) — between `ensureSnapshotImage` and `ensureHetznerInfra`
- **Scale-up** (`addHetznerNodes`) — before `ensureHetznerInfra`

## Changes

| File | Change |
|------|--------|
| `pkg/svc/provider/hetzner/availability.go` | New: `CheckServerAvailability`, `checkSingleServerType`, `availableLocations`, `deduplicateServerTypes`, `buildLocationList` |
| `pkg/svc/provider/hetzner/errors.go` | Added `ErrServerTypeNotFound` and `ErrServerTypeUnavailable` sentinel errors |
| `pkg/svc/provider/hetzner/export_test.go` | Test seam exports for pure helper functions |
| `pkg/svc/provider/hetzner/availability_test.go` | Table-driven tests for `availableLocations`, `deduplicateServerTypes`, `buildLocationList` |
| `pkg/svc/provider/hetzner/errors_test.go` | Tests for new sentinel errors |
| `pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go` | Wired precheck into `createHetznerCluster` + `checkHetznerAvailability` and `uniqueServerTypes` helpers |
| `pkg/svc/provisioner/cluster/talos/scale_hetzner.go` | Wired precheck into `addHetznerNodes` + `checkHetznerAvailabilityForRole` helper |