### PR TITLE
fix: install hcloud-ccm before other infra components on Hetzner

### DIFF
--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -299,6 +299,47 @@ func SetCSRApproverWaitForTests(
 	}
 }
 
+var (
+	//nolint:gochecknoglobals // dependency injection for tests
+	loadBalancerInstallMu sync.RWMutex
+	//nolint:gochecknoglobals // dependency injection for tests
+	loadBalancerInstallOverride silentInstallFunc
+)
+
+// getLoadBalancerInstallFn returns the load-balancer install function,
+// using the test override if one is set. This allows tests to mock the
+// hcloud-ccm installation in the cloud-provider init pre-phase without
+// needing a real Helm client.
+func getLoadBalancerInstallFn() silentInstallFunc {
+	loadBalancerInstallMu.RLock()
+	defer loadBalancerInstallMu.RUnlock()
+
+	if loadBalancerInstallOverride != nil {
+		return loadBalancerInstallOverride
+	}
+
+	return InstallLoadBalancerSilent
+}
+
+// SetLoadBalancerInstallForTests overrides the load-balancer install function for testing.
+// Returns a cleanup function that restores the previous function.
+func SetLoadBalancerInstallForTests(fn silentInstallFunc) func() {
+	loadBalancerInstallMu.Lock()
+
+	previous := loadBalancerInstallOverride
+	loadBalancerInstallOverride = fn
+
+	loadBalancerInstallMu.Unlock()
+
+	return func() {
+		loadBalancerInstallMu.Lock()
+
+		loadBalancerInstallOverride = previous
+
+		loadBalancerInstallMu.Unlock()
+	}
+}
+
 // ShouldPushOCIArtifact determines if OCI artifact push should happen for GitOps engines.
 // Returns true if Flux or ArgoCD is enabled and a local registry is configured.
 func ShouldPushOCIArtifact(clusterCfg *v1alpha1.Cluster) bool {
@@ -501,7 +542,7 @@ func needsCloudProviderInitPhase(
 // and waits for nodes to become schedulable. The CCM chart includes a built-in
 // toleration for the uninitialized taint, so it can schedule on tainted nodes.
 // Once running, the CCM initializes nodes by assigning provider IDs and removing
-// the taint. We wait for at least one worker to become schedulable before
+// the taint. We wait for at least one node to become schedulable before
 // returning, so subsequent components (cert-manager, metrics-server, etc.) can
 // schedule without hitting FailedScheduling.
 func runCloudProviderInitPhase(
@@ -513,7 +554,7 @@ func runCloudProviderInitPhase(
 	factories *InstallerFactories,
 	cniInstalled bool,
 ) error {
-	ccmTask := newTask("load-balancer", clusterCfg, factories, InstallLoadBalancerSilent)
+	ccmTask := newTask("load-balancer", clusterCfg, factories, getLoadBalancerInstallFn())
 
 	err := runInfraPhase(
 		ctx, clusterCfg, writer, labels, tmr,

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -301,42 +301,45 @@ func SetCSRApproverWaitForTests(
 
 var (
 	//nolint:gochecknoglobals // dependency injection for tests
-	loadBalancerInstallMu sync.RWMutex
+	cloudProviderInitInstallMu sync.RWMutex
 	//nolint:gochecknoglobals // dependency injection for tests
-	loadBalancerInstallOverride silentInstallFunc
+	cloudProviderInitInstallOverride silentInstallFunc
 )
 
-// getLoadBalancerInstallFn returns the load-balancer install function,
-// using the test override if one is set. This allows tests to mock the
-// hcloud-ccm installation in the cloud-provider init pre-phase without
-// needing a real Helm client.
+// getLoadBalancerInstallFn returns the load-balancer install function used by
+// the cloud-provider init pre-phase, using the test override if one is set.
+// This allows tests to mock the hcloud-ccm installation without needing a real
+// Helm client. Note: the override only affects the pre-phase; the normal
+// parallel infra path uses InstallLoadBalancerSilent directly.
 func getLoadBalancerInstallFn() silentInstallFunc {
-	loadBalancerInstallMu.RLock()
-	defer loadBalancerInstallMu.RUnlock()
+	cloudProviderInitInstallMu.RLock()
+	defer cloudProviderInitInstallMu.RUnlock()
 
-	if loadBalancerInstallOverride != nil {
-		return loadBalancerInstallOverride
+	if cloudProviderInitInstallOverride != nil {
+		return cloudProviderInitInstallOverride
 	}
 
 	return InstallLoadBalancerSilent
 }
 
-// SetLoadBalancerInstallForTests overrides the load-balancer install function for testing.
-// Returns a cleanup function that restores the previous function.
-func SetLoadBalancerInstallForTests(fn silentInstallFunc) func() {
-	loadBalancerInstallMu.Lock()
+// SetCloudProviderInitInstallForTests overrides the load-balancer install
+// function used by the cloud-provider init pre-phase for testing. The override
+// only affects runCloudProviderInitPhase; the normal parallel infra path is not
+// affected. Returns a cleanup function that restores the previous function.
+func SetCloudProviderInitInstallForTests(fn silentInstallFunc) func() {
+	cloudProviderInitInstallMu.Lock()
 
-	previous := loadBalancerInstallOverride
-	loadBalancerInstallOverride = fn
+	previous := cloudProviderInitInstallOverride
+	cloudProviderInitInstallOverride = fn
 
-	loadBalancerInstallMu.Unlock()
+	cloudProviderInitInstallMu.Unlock()
 
 	return func() {
-		loadBalancerInstallMu.Lock()
+		cloudProviderInitInstallMu.Lock()
 
-		loadBalancerInstallOverride = previous
+		cloudProviderInitInstallOverride = previous
 
-		loadBalancerInstallMu.Unlock()
+		cloudProviderInitInstallMu.Unlock()
 	}
 }
 
@@ -653,7 +656,7 @@ func InstallPostCNIComponents(
 	)
 }
 
-//nolint:cyclop // Phase orchestration is inherently branchy; each phase gate is a distinct concern.
+//nolint:cyclop,funlen // Phase orchestration is inherently branchy; each phase gate is a distinct concern.
 func installComponentsInPhases(
 	ctx context.Context,
 	cmd *cobra.Command,

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -196,6 +196,75 @@ var (
 	csrApproverWaitOverride func(context.Context, *v1alpha1.Cluster) error
 )
 
+var (
+	//nolint:gochecknoglobals // dependency injection for tests
+	nodeSchedulabilityWaitMu sync.RWMutex
+	//nolint:gochecknoglobals // dependency injection for tests
+	nodeSchedulabilityWaitOverride func(context.Context, *v1alpha1.Cluster) error
+)
+
+// getNodeSchedulabilityWaitFn returns the node schedulability wait function,
+// using the test override if one is set.
+func getNodeSchedulabilityWaitFn() func(context.Context, *v1alpha1.Cluster) error {
+	nodeSchedulabilityWaitMu.RLock()
+	defer nodeSchedulabilityWaitMu.RUnlock()
+
+	if nodeSchedulabilityWaitOverride != nil {
+		return nodeSchedulabilityWaitOverride
+	}
+
+	return waitForNodeSchedulability
+}
+
+// SetNodeSchedulabilityWaitForTests overrides the node schedulability wait function for testing.
+// Returns a cleanup function that restores the previous function.
+func SetNodeSchedulabilityWaitForTests(
+	fn func(context.Context, *v1alpha1.Cluster) error,
+) func() {
+	nodeSchedulabilityWaitMu.Lock()
+
+	previous := nodeSchedulabilityWaitOverride
+	nodeSchedulabilityWaitOverride = fn
+
+	nodeSchedulabilityWaitMu.Unlock()
+
+	return func() {
+		nodeSchedulabilityWaitMu.Lock()
+
+		nodeSchedulabilityWaitOverride = previous
+
+		nodeSchedulabilityWaitMu.Unlock()
+	}
+}
+
+// waitForNodeSchedulability waits for all nodes to reach Ready state and for at
+// least one node to be schedulable (no blocking taints). Used after hcloud-ccm
+// installation to ensure the uninitialized taint has been removed before
+// subsequent components attempt to schedule pods.
+func waitForNodeSchedulability(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+) error {
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(clusterCfg)
+	if err != nil {
+		return fmt.Errorf("get kubeconfig path for node schedulability check: %w", err)
+	}
+
+	clientset, err := k8s.NewClientset(
+		kubeconfigPath, clusterCfg.Spec.Cluster.Connection.Context,
+	)
+	if err != nil {
+		return fmt.Errorf("create clientset for node schedulability check: %w", err)
+	}
+
+	err = readiness.WaitForAllNodesReadyAndSchedulable(ctx, clientset, nodeReadinessTimeout)
+	if err != nil {
+		return fmt.Errorf("wait for nodes to become schedulable after cloud provider init: %w", err)
+	}
+
+	return nil
+}
+
 // getWaitForCSRApproverFn returns the CSR approver wait function,
 // using the test override if one is set.
 func getWaitForCSRApproverFn() func(context.Context, *v1alpha1.Cluster) error {
@@ -414,6 +483,57 @@ func emitKWOKUnsupportedComponentWarnings(cmd *cobra.Command, clusterCfg *v1alph
 	}
 }
 
+// needsCloudProviderInitPhase returns true when the cluster uses an external
+// cloud controller manager that must initialize nodes (remove the
+// node.cloudprovider.kubernetes.io/uninitialized:NoSchedule taint) before any
+// other infrastructure component can schedule pods. Currently this applies to
+// Talos × Hetzner clusters where hcloud-ccm is the external CCM.
+func needsCloudProviderInitPhase(
+	clusterCfg *v1alpha1.Cluster,
+	reqs ComponentRequirements,
+) bool {
+	return clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionTalos &&
+		clusterCfg.Spec.Cluster.Provider == v1alpha1.ProviderHetzner &&
+		reqs.NeedsLoadBalancer
+}
+
+// runCloudProviderInitPhase installs the cloud controller manager (hcloud-ccm)
+// and waits for nodes to become schedulable. The CCM chart includes a built-in
+// toleration for the uninitialized taint, so it can schedule on tainted nodes.
+// Once running, the CCM initializes nodes by assigning provider IDs and removing
+// the taint. We wait for at least one worker to become schedulable before
+// returning, so subsequent components (cert-manager, metrics-server, etc.) can
+// schedule without hitting FailedScheduling.
+func runCloudProviderInitPhase(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	writer io.Writer,
+	labels notify.ProgressLabels,
+	tmr timer.Timer,
+	factories *InstallerFactories,
+	cniInstalled bool,
+) error {
+	ccmTask := newTask("load-balancer", clusterCfg, factories, InstallLoadBalancerSilent)
+
+	err := runInfraPhase(
+		ctx, clusterCfg, writer, labels, tmr,
+		[]notify.ProgressTask{ccmTask},
+		cniInstalled, false,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = getNodeSchedulabilityWaitFn()(ctx, clusterCfg)
+	if err != nil {
+		return fmt.Errorf(
+			"nodes not schedulable after cloud provider initialization: %w", err,
+		)
+	}
+
+	return nil
+}
+
 // InstallPostCNIComponents installs all post-CNI components in parallel.
 // This includes metrics-server, CSI, cert-manager, and GitOps engines (Flux/ArgoCD).
 // For Flux, the OCI artifact push and readiness wait happens after installation.
@@ -478,6 +598,25 @@ func installComponentsInPhases(
 ) error {
 	writer := cmd.OutOrStdout()
 	labels := notify.InstallingLabels()
+
+	// On Hetzner clusters, all nodes carry the
+	// node.cloudprovider.kubernetes.io/uninitialized:NoSchedule taint until the
+	// external cloud controller manager (hcloud-ccm) initializes them. Install
+	// hcloud-ccm first and wait for nodes to become schedulable before any other
+	// infrastructure component, otherwise all pods fail with FailedScheduling.
+	if needsCloudProviderInitPhase(clusterCfg, reqs) {
+		err := runCloudProviderInitPhase(
+			ctx, clusterCfg, writer, labels, tmr, factories, cniInstalled,
+		)
+		if err != nil {
+			return err
+		}
+
+		// hcloud-ccm is installed; exclude it from the parallel infra phase below.
+		// Clear cniInstalled so subsequent phases run the full stability check.
+		reqs.NeedsLoadBalancer = false
+		cniInstalled = false
+	}
 
 	// When cert-manager and a policy engine are both needed, install cert-manager
 	// first in its own sequential phase before the parallel infrastructure phase.

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -653,6 +653,7 @@ func InstallPostCNIComponents(
 	)
 }
 
+//nolint:cyclop // Phase orchestration is inherently branchy; each phase gate is a distinct concern.
 func installComponentsInPhases(
 	ctx context.Context,
 	cmd *cobra.Command,

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -575,6 +575,31 @@ func runCloudProviderInitPhase(
 	return nil
 }
 
+// runCloudProviderInitAndClearReqs runs the cloud-provider init pre-phase and
+// returns updated requirements with NeedsLoadBalancer cleared and cniInstalled
+// set to false so subsequent phases run the full stability check.
+func runCloudProviderInitAndClearReqs(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	writer io.Writer,
+	labels notify.ProgressLabels,
+	tmr timer.Timer,
+	factories *InstallerFactories,
+	reqs ComponentRequirements,
+	cniInstalled bool,
+) (ComponentRequirements, bool, error) {
+	err := runCloudProviderInitPhase(
+		ctx, clusterCfg, writer, labels, tmr, factories, cniInstalled,
+	)
+	if err != nil {
+		return reqs, cniInstalled, err
+	}
+
+	reqs.NeedsLoadBalancer = false
+
+	return reqs, false, nil
+}
+
 // InstallPostCNIComponents installs all post-CNI components in parallel.
 // This includes metrics-server, CSI, cert-manager, and GitOps engines (Flux/ArgoCD).
 // For Flux, the OCI artifact push and readiness wait happens after installation.
@@ -646,17 +671,14 @@ func installComponentsInPhases(
 	// hcloud-ccm first and wait for nodes to become schedulable before any other
 	// infrastructure component, otherwise all pods fail with FailedScheduling.
 	if needsCloudProviderInitPhase(clusterCfg, reqs) {
-		err := runCloudProviderInitPhase(
-			ctx, clusterCfg, writer, labels, tmr, factories, cniInstalled,
+		var err error
+
+		reqs, cniInstalled, err = runCloudProviderInitAndClearReqs(
+			ctx, clusterCfg, writer, labels, tmr, factories, reqs, cniInstalled,
 		)
 		if err != nil {
 			return err
 		}
-
-		// hcloud-ccm is installed; exclude it from the parallel infra phase below.
-		// Clear cniInstalled so subsequent phases run the full stability check.
-		reqs.NeedsLoadBalancer = false
-		cniInstalled = false
 	}
 
 	// When cert-manager and a policy engine are both needed, install cert-manager

--- a/pkg/cli/setup/post_cni.go
+++ b/pkg/cli/setup/post_cni.go
@@ -580,7 +580,9 @@ func runCloudProviderInitPhase(
 
 // runCloudProviderInitAndClearReqs runs the cloud-provider init pre-phase and
 // returns updated requirements with NeedsLoadBalancer cleared and cniInstalled
-// set to false so subsequent phases run the full stability check.
+// set to false so subsequent phases include the node readiness check in their
+// stability pre-flight (the in-cluster connectivity check is separate and only
+// runs for Cilium CNI).
 func runCloudProviderInitAndClearReqs(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
 	installer "github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/timer"
@@ -673,6 +674,13 @@ func TestInstallComponentsInPhases_HetznerCCMPrePhaseExcludesFromParallelPhase(t
 	factories := &InstallerFactories{
 		CertManager: func(_ *v1alpha1.Cluster) (installer.Installer, error) {
 			return &mockInstaller{}, nil
+		},
+		// HelmClientFactory fails explicitly if the parallel infra path tries
+		// to install the load-balancer again via InstallLoadBalancerSilent.
+		HelmClientFactory: func(_ *v1alpha1.Cluster) (*helm.Client, string, error) {
+			t.Fatal("HelmClientFactory called — load-balancer leaked into parallel phase")
+
+			return nil, "", nil
 		},
 	}
 

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -421,7 +421,7 @@ func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T)
 		func(context.Context, *v1alpha1.Cluster) error { return nil },
 	))
 
-	t.Cleanup(SetLoadBalancerInstallForTests(
+	t.Cleanup(SetCloudProviderInitInstallForTests(
 		func(_ context.Context, _ *v1alpha1.Cluster, _ *InstallerFactories) error {
 			record("load-balancer")
 
@@ -565,7 +565,7 @@ func TestRunCloudProviderInitPhase_WaitsForNodeSchedulability(t *testing.T) {
 		},
 	))
 
-	t.Cleanup(SetLoadBalancerInstallForTests(
+	t.Cleanup(SetCloudProviderInitInstallForTests(
 		func(context.Context, *v1alpha1.Cluster, *InstallerFactories) error {
 			order = append(order, "load-balancer-install")
 
@@ -613,7 +613,7 @@ func TestRunCloudProviderInitPhase_ReturnsErrorWhenNodeSchedulabilityFails(t *te
 		func(context.Context, *v1alpha1.Cluster, bool) error { return nil },
 	))
 
-	t.Cleanup(SetLoadBalancerInstallForTests(
+	t.Cleanup(SetCloudProviderInitInstallForTests(
 		func(context.Context, *v1alpha1.Cluster, *InstallerFactories) error { return nil },
 	))
 
@@ -659,7 +659,7 @@ func TestInstallComponentsInPhases_HetznerCCMPrePhaseExcludesFromParallelPhase(t
 		func(context.Context, *v1alpha1.Cluster) error { return nil },
 	))
 
-	t.Cleanup(SetLoadBalancerInstallForTests(
+	t.Cleanup(SetCloudProviderInitInstallForTests(
 		func(context.Context, *v1alpha1.Cluster, *InstallerFactories) error {
 			lbCallCount++
 

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -684,6 +684,10 @@ func TestInstallComponentsInPhases_HetznerCCMPrePhaseExcludesFromParallelPhase(t
 	)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, lbCallCount,
-		"load-balancer installer must run exactly once (pre-phase only, not again in parallel phase)")
+	assert.Equal(
+		t,
+		1,
+		lbCallCount,
+		"load-balancer installer must run exactly once (pre-phase only, not again in parallel phase)",
+	)
 }

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -387,13 +387,70 @@ func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T)
 		},
 	}
 
-	// Verify needsCloudProviderInitPhase returns true for this config,
-	// ensuring the pre-phase will trigger before cert-manager.
+	var (
+		orderMu sync.Mutex
+		order   []string
+	)
+
+	record := func(name string) {
+		orderMu.Lock()
+		defer orderMu.Unlock()
+
+		order = append(order, name)
+	}
+
+	makeInstaller := func(name string) func(*v1alpha1.Cluster) (installer.Installer, error) {
+		return func(*v1alpha1.Cluster) (installer.Installer, error) {
+			return &mockInstaller{
+				install: func(context.Context) error {
+					record(name)
+
+					return nil
+				},
+			}, nil
+		}
+	}
+
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error { return nil },
+	))
+
+	t.Cleanup(SetNodeSchedulabilityWaitForTests(
+		func(context.Context, *v1alpha1.Cluster) error { return nil },
+	))
+
+	t.Cleanup(SetLoadBalancerInstallForTests(
+		func(_ context.Context, _ *v1alpha1.Cluster, _ *InstallerFactories) error {
+			record("load-balancer")
+
+			return nil
+		},
+	))
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetOut(io.Discard)
+
+	factories := &InstallerFactories{
+		CertManager:  makeInstaller("cert-manager"),
+		PolicyEngine: makeInstaller("policy-engine"),
+	}
+
 	reqs := GetComponentRequirements(clusterCfg)
-	assert.True(t, needsCloudProviderInitPhase(clusterCfg, reqs),
-		"Hetzner × Talos with LoadBalancer should need cloud provider init phase")
-	assert.True(t, reqs.NeedsCertManager, "cert-manager should be needed")
-	assert.True(t, reqs.NeedsPolicyEngine, "policy engine should be needed")
+	tmr := timer.New()
+
+	err := installComponentsInPhases(
+		context.Background(), cmd, clusterCfg, factories, tmr, reqs, true,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, order, 3,
+		"all three components should have been installed")
+	assert.Equal(t, "load-balancer", order[0],
+		"hcloud-ccm must install before cert-manager and policy-engine")
+	assert.Equal(t, "cert-manager", order[1],
+		"cert-manager must install before policy-engine")
+	assert.Equal(t, "policy-engine", order[2],
+		"policy-engine must install last")
 }
 
 func TestNeedsCloudProviderInitPhase(t *testing.T) {
@@ -483,16 +540,64 @@ func TestNeedsCloudProviderInitPhase(t *testing.T) {
 }
 
 func TestRunCloudProviderInitPhase_WaitsForNodeSchedulability(t *testing.T) {
-	// Verify that the node schedulability wait test seam is properly wired.
-	var waitCalled bool
+	// Verify that runCloudProviderInitPhase calls the load-balancer install
+	// and then the node schedulability wait in the correct order.
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionTalos,
+				Provider:     v1alpha1.ProviderHetzner,
+				CNI:          v1alpha1.CNICilium,
+			},
+		},
+	}
 
-	t.Cleanup(SetNodeSchedulabilityWaitForTests(
-		func(context.Context, *v1alpha1.Cluster) error {
-			waitCalled = true
+	var order []string
+
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error {
+			order = append(order, "stability-check")
 
 			return nil
 		},
 	))
+
+	t.Cleanup(SetLoadBalancerInstallForTests(
+		func(context.Context, *v1alpha1.Cluster, *InstallerFactories) error {
+			order = append(order, "load-balancer-install")
+
+			return nil
+		},
+	))
+
+	t.Cleanup(SetNodeSchedulabilityWaitForTests(
+		func(context.Context, *v1alpha1.Cluster) error {
+			order = append(order, "node-schedulability-wait")
+
+			return nil
+		},
+	))
+
+	factories := &InstallerFactories{}
+	tmr := timer.New()
+
+	err := runCloudProviderInitPhase(
+		context.Background(), clusterCfg, io.Discard,
+		notify.InstallingLabels(), tmr, factories, true,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, order, 3)
+	assert.Equal(t, "stability-check", order[0],
+		"stability check should run first")
+	assert.Equal(t, "load-balancer-install", order[1],
+		"load-balancer install should run after stability check")
+	assert.Equal(t, "node-schedulability-wait", order[2],
+		"node schedulability wait should run after load-balancer install")
+}
+
+func TestRunCloudProviderInitPhase_ReturnsErrorWhenNodeSchedulabilityFails(t *testing.T) {
+	errNodesNotReady := errors.New("nodes still tainted")
 
 	clusterCfg := &v1alpha1.Cluster{
 		Spec: v1alpha1.Spec{
@@ -503,14 +608,13 @@ func TestRunCloudProviderInitPhase_WaitsForNodeSchedulability(t *testing.T) {
 		},
 	}
 
-	waitFn := getNodeSchedulabilityWaitFn()
-	err := waitFn(context.Background(), clusterCfg)
-	require.NoError(t, err)
-	assert.True(t, waitCalled, "node schedulability wait must be callable through test seam")
-}
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error { return nil },
+	))
 
-func TestRunCloudProviderInitPhase_ReturnsErrorWhenNodeSchedulabilityFails(t *testing.T) {
-	errNodesNotReady := errors.New("nodes still tainted")
+	t.Cleanup(SetLoadBalancerInstallForTests(
+		func(context.Context, *v1alpha1.Cluster, *InstallerFactories) error { return nil },
+	))
 
 	t.Cleanup(SetNodeSchedulabilityWaitForTests(
 		func(context.Context, *v1alpha1.Cluster) error {
@@ -518,40 +622,67 @@ func TestRunCloudProviderInitPhase_ReturnsErrorWhenNodeSchedulabilityFails(t *te
 		},
 	))
 
-	clusterCfg := &v1alpha1.Cluster{
-		Spec: v1alpha1.Spec{
-			Cluster: v1alpha1.ClusterSpec{
-				Distribution: v1alpha1.DistributionTalos,
-				Provider:     v1alpha1.ProviderHetzner,
-			},
-		},
-	}
+	factories := &InstallerFactories{}
+	tmr := timer.New()
 
-	waitFn := getNodeSchedulabilityWaitFn()
-	err := waitFn(context.Background(), clusterCfg)
+	err := runCloudProviderInitPhase(
+		context.Background(), clusterCfg, io.Discard,
+		notify.InstallingLabels(), tmr, factories, true,
+	)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, errNodesNotReady)
+	assert.ErrorContains(t, err, "nodes not schedulable after cloud provider initialization")
 }
 
 func TestInstallComponentsInPhases_HetznerCCMPrePhaseExcludesFromParallelPhase(t *testing.T) {
-	// After the cloud provider init pre-phase, NeedsLoadBalancer should be
-	// cleared so hcloud-ccm isn't installed again in the parallel phase.
+	// After the cloud provider init pre-phase, the load-balancer installer
+	// must run exactly once — not again in the parallel phase.
 	clusterCfg := &v1alpha1.Cluster{
 		Spec: v1alpha1.Spec{
 			Cluster: v1alpha1.ClusterSpec{
 				Distribution: v1alpha1.DistributionTalos,
 				Provider:     v1alpha1.ProviderHetzner,
 				CertManager:  v1alpha1.CertManagerEnabled,
+				PolicyEngine: v1alpha1.PolicyEngineNone,
 				LoadBalancer: v1alpha1.LoadBalancerDefault,
 			},
 		},
 	}
 
-	reqs := GetComponentRequirements(clusterCfg)
-	assert.True(t, reqs.NeedsLoadBalancer, "initial reqs should need load-balancer")
+	var lbCallCount int
 
-	// After the pre-phase runs, NeedsLoadBalancer would be set to false.
-	// Verify the flag is true initially and that the pre-phase is triggered.
-	assert.True(t, needsCloudProviderInitPhase(clusterCfg, reqs),
-		"should need cloud provider init phase")
+	t.Cleanup(SetClusterStabilityCheckForTests(
+		func(context.Context, *v1alpha1.Cluster, bool) error { return nil },
+	))
+
+	t.Cleanup(SetNodeSchedulabilityWaitForTests(
+		func(context.Context, *v1alpha1.Cluster) error { return nil },
+	))
+
+	t.Cleanup(SetLoadBalancerInstallForTests(
+		func(context.Context, *v1alpha1.Cluster, *InstallerFactories) error {
+			lbCallCount++
+
+			return nil
+		},
+	))
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetOut(io.Discard)
+
+	factories := &InstallerFactories{
+		CertManager: func(_ *v1alpha1.Cluster) (installer.Installer, error) {
+			return &mockInstaller{}, nil
+		},
+	}
+
+	reqs := GetComponentRequirements(clusterCfg)
+	tmr := timer.New()
+
+	err := installComponentsInPhases(
+		context.Background(), cmd, clusterCfg, factories, tmr, reqs, true,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, lbCallCount,
+		"load-balancer installer must run exactly once (pre-phase only, not again in parallel phase)")
 }

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -371,7 +371,8 @@ func TestInstallComponentsInPhases_CertManagerRunsBeforePolicyEngine(t *testing.
 		"policy-engine must be installed after cert-manager")
 }
 
-func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T) { //nolint:funlen // integration test with multiple mocked phases
+//nolint:funlen // integration test with multiple mocked phases
+func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T) {
 	// On Hetzner × Talos clusters, hcloud-ccm must install before cert-manager
 	// because all nodes carry the node.cloudprovider.kubernetes.io/uninitialized
 	// taint until the CCM initializes them. Without this ordering, cert-manager
@@ -454,7 +455,8 @@ func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T)
 		"policy-engine must install last")
 }
 
-func TestNeedsCloudProviderInitPhase(t *testing.T) { //nolint:funlen // table-driven test with comprehensive cases
+//nolint:funlen // table-driven test with comprehensive cases
+func TestNeedsCloudProviderInitPhase(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -19,6 +19,7 @@ import (
 var (
 	errNotStable        = errors.New("not stable")
 	errApproverNotReady = errors.New("approver not ready")
+	errNodesNotReady    = errors.New("nodes still tainted")
 )
 
 func TestRunGitOpsPhase_AlwaysChecksClusterStabilityBeforeInstallingGitOps(t *testing.T) {
@@ -370,7 +371,7 @@ func TestInstallComponentsInPhases_CertManagerRunsBeforePolicyEngine(t *testing.
 		"policy-engine must be installed after cert-manager")
 }
 
-func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T) {
+func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T) { //nolint:funlen // integration test with multiple mocked phases
 	// On Hetzner × Talos clusters, hcloud-ccm must install before cert-manager
 	// because all nodes carry the node.cloudprovider.kubernetes.io/uninitialized
 	// taint until the CCM initializes them. Without this ordering, cert-manager
@@ -453,7 +454,7 @@ func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T)
 		"policy-engine must install last")
 }
 
-func TestNeedsCloudProviderInitPhase(t *testing.T) {
+func TestNeedsCloudProviderInitPhase(t *testing.T) { //nolint:funlen // table-driven test with comprehensive cases
 	t.Parallel()
 
 	tests := []struct {
@@ -597,8 +598,6 @@ func TestRunCloudProviderInitPhase_WaitsForNodeSchedulability(t *testing.T) {
 }
 
 func TestRunCloudProviderInitPhase_ReturnsErrorWhenNodeSchedulabilityFails(t *testing.T) {
-	errNodesNotReady := errors.New("nodes still tainted")
-
 	clusterCfg := &v1alpha1.Cluster{
 		Spec: v1alpha1.Spec{
 			Cluster: v1alpha1.ClusterSpec{

--- a/pkg/cli/setup/post_cni_internal_test.go
+++ b/pkg/cli/setup/post_cni_internal_test.go
@@ -369,3 +369,189 @@ func TestInstallComponentsInPhases_CertManagerRunsBeforePolicyEngine(t *testing.
 	assert.Equal(t, "policy-engine", order[1],
 		"policy-engine must be installed after cert-manager")
 }
+
+func TestInstallComponentsInPhases_HetznerCCMRunsBeforeCertManager(t *testing.T) {
+	// On Hetzner × Talos clusters, hcloud-ccm must install before cert-manager
+	// because all nodes carry the node.cloudprovider.kubernetes.io/uninitialized
+	// taint until the CCM initializes them. Without this ordering, cert-manager
+	// pods fail to schedule on any node.
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionTalos,
+				Provider:     v1alpha1.ProviderHetzner,
+				CertManager:  v1alpha1.CertManagerEnabled,
+				PolicyEngine: v1alpha1.PolicyEngineKyverno,
+				LoadBalancer: v1alpha1.LoadBalancerDefault,
+			},
+		},
+	}
+
+	// Verify needsCloudProviderInitPhase returns true for this config,
+	// ensuring the pre-phase will trigger before cert-manager.
+	reqs := GetComponentRequirements(clusterCfg)
+	assert.True(t, needsCloudProviderInitPhase(clusterCfg, reqs),
+		"Hetzner × Talos with LoadBalancer should need cloud provider init phase")
+	assert.True(t, reqs.NeedsCertManager, "cert-manager should be needed")
+	assert.True(t, reqs.NeedsPolicyEngine, "policy engine should be needed")
+}
+
+func TestNeedsCloudProviderInitPhase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cluster  *v1alpha1.Cluster
+		reqs     ComponentRequirements
+		expected bool
+	}{
+		{
+			name: "Talos x Hetzner with load-balancer needed",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution: v1alpha1.DistributionTalos,
+						Provider:     v1alpha1.ProviderHetzner,
+					},
+				},
+			},
+			reqs:     ComponentRequirements{NeedsLoadBalancer: true},
+			expected: true,
+		},
+		{
+			name: "Talos x Docker does not need pre-phase",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution: v1alpha1.DistributionTalos,
+						Provider:     v1alpha1.ProviderDocker,
+					},
+				},
+			},
+			reqs:     ComponentRequirements{NeedsLoadBalancer: true},
+			expected: false,
+		},
+		{
+			name: "Vanilla x Docker does not need pre-phase",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution: v1alpha1.DistributionVanilla,
+						Provider:     v1alpha1.ProviderDocker,
+					},
+				},
+			},
+			reqs:     ComponentRequirements{NeedsLoadBalancer: true},
+			expected: false,
+		},
+		{
+			name: "Talos x Hetzner without load-balancer does not need pre-phase",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution: v1alpha1.DistributionTalos,
+						Provider:     v1alpha1.ProviderHetzner,
+					},
+				},
+			},
+			reqs:     ComponentRequirements{NeedsLoadBalancer: false},
+			expected: false,
+		},
+		{
+			name: "Talos x Omni does not need pre-phase",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Distribution: v1alpha1.DistributionTalos,
+						Provider:     v1alpha1.ProviderOmni,
+					},
+				},
+			},
+			reqs:     ComponentRequirements{NeedsLoadBalancer: true},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := needsCloudProviderInitPhase(tc.cluster, tc.reqs)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestRunCloudProviderInitPhase_WaitsForNodeSchedulability(t *testing.T) {
+	// Verify that the node schedulability wait test seam is properly wired.
+	var waitCalled bool
+
+	t.Cleanup(SetNodeSchedulabilityWaitForTests(
+		func(context.Context, *v1alpha1.Cluster) error {
+			waitCalled = true
+
+			return nil
+		},
+	))
+
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionTalos,
+				Provider:     v1alpha1.ProviderHetzner,
+			},
+		},
+	}
+
+	waitFn := getNodeSchedulabilityWaitFn()
+	err := waitFn(context.Background(), clusterCfg)
+	require.NoError(t, err)
+	assert.True(t, waitCalled, "node schedulability wait must be callable through test seam")
+}
+
+func TestRunCloudProviderInitPhase_ReturnsErrorWhenNodeSchedulabilityFails(t *testing.T) {
+	errNodesNotReady := errors.New("nodes still tainted")
+
+	t.Cleanup(SetNodeSchedulabilityWaitForTests(
+		func(context.Context, *v1alpha1.Cluster) error {
+			return errNodesNotReady
+		},
+	))
+
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionTalos,
+				Provider:     v1alpha1.ProviderHetzner,
+			},
+		},
+	}
+
+	waitFn := getNodeSchedulabilityWaitFn()
+	err := waitFn(context.Background(), clusterCfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNodesNotReady)
+}
+
+func TestInstallComponentsInPhases_HetznerCCMPrePhaseExcludesFromParallelPhase(t *testing.T) {
+	// After the cloud provider init pre-phase, NeedsLoadBalancer should be
+	// cleared so hcloud-ccm isn't installed again in the parallel phase.
+	clusterCfg := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: v1alpha1.DistributionTalos,
+				Provider:     v1alpha1.ProviderHetzner,
+				CertManager:  v1alpha1.CertManagerEnabled,
+				LoadBalancer: v1alpha1.LoadBalancerDefault,
+			},
+		},
+	}
+
+	reqs := GetComponentRequirements(clusterCfg)
+	assert.True(t, reqs.NeedsLoadBalancer, "initial reqs should need load-balancer")
+
+	// After the pre-phase runs, NeedsLoadBalancer would be set to false.
+	// Verify the flag is true initially and that the pre-phase is triggered.
+	assert.True(t, needsCloudProviderInitPhase(clusterCfg, reqs),
+		"should need cloud provider init phase")
+}


### PR DESCRIPTION
## Problem

On `ksail cluster create` for Hetzner × Talos clusters with both `certManager: Enabled` and `policyEngine: Kyverno`, cert-manager installation fails with "Progress deadline exceeded" on all three deployments.

**Root cause:** All nodes carry the `node.cloudprovider.kubernetes.io/uninitialized:NoSchedule` taint (set by kubelet when Talos configures `--cloud-provider=external` for Hetzner). Only the hcloud-ccm can remove this taint after initializing nodes. The current installation order installs cert-manager **before** hcloud-ccm when both cert-manager and a policy engine are enabled, so all cert-manager pods are permanently Pending (0/6 nodes schedulable).

Confirmed via live debugging on the `devantler-tech/platform` production cluster:
```
$ kubectl --context admin@prod get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.taints}{"\n"}{end}'
prod-worker-1	[{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true"}]
prod-worker-2	[{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true"}]
...
```

## Solution

Add a cloud-provider initialization pre-phase in `installComponentsInPhases` that:

1. Installs hcloud-ccm first (it has a built-in toleration for the uninitialized taint)
2. Waits for nodes to become schedulable (taint removed)
3. Clears `NeedsLoadBalancer` to avoid double-installing hcloud-ccm

This eliminates both the guaranteed failure (cert-manager pre-phase) and the race condition (parallel phase on clusters without a policy engine).

## Changes

- **`pkg/cli/setup/post_cni.go`**: Added `needsCloudProviderInitPhase`, `runCloudProviderInitPhase`, `waitForNodeSchedulability`, and the test-seam override (`SetNodeSchedulabilityWaitForTests`)
- **`pkg/cli/setup/post_cni_internal_test.go`**: Added 7 test cases covering the pre-phase trigger, table-driven `needsCloudProviderInitPhase` scenarios, node schedulability wait seam, and load-balancer exclusion after pre-phase