### PR TITLE
fix: skip NoDiagnostics check for non-Docker providers with kubelet cert rotation

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -11,6 +11,7 @@ import (
 	omniprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/omni"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/docker/docker/api/types/container"
+	check "github.com/siderolabs/talos/pkg/cluster/check"
 )
 
 // NodeWithRoleForTest is the exported alias of nodeWithRole for testing.
@@ -288,6 +289,26 @@ func (p *Provisioner) IsDockerProviderForTest() bool {
 // ClusterReadinessChecksCountForTest returns the number of checks from clusterReadinessChecks for unit testing.
 func (p *Provisioner) ClusterReadinessChecksCountForTest() int {
 	return len(p.clusterReadinessChecks())
+}
+
+// PreBootChecksCountForTest returns just the pre-boot check count for unit testing,
+// isolating the pre-boot sequence selection from the k8s component checks.
+func (p *Provisioner) PreBootChecksCountForTest() int {
+	skipNodeReadiness := (p.talosConfigs != nil && p.talosConfigs.IsCNIDisabled()) ||
+		p.options.SkipCNIChecks
+
+	if !skipNodeReadiness {
+		return len(check.PreBootSequenceChecks())
+	}
+
+	switch {
+	case p.isDockerProvider():
+		return len(dockerPreBootSequenceChecks())
+	case p.talosConfigs != nil && p.talosConfigs.IsKubeletCertRotationEnabled():
+		return len(preBootSequenceChecksSkipDiagnostics())
+	default:
+		return len(check.PreBootSequenceChecks())
+	}
 }
 
 // EnsureAutoscalerSecretIfNeededForTest exposes ensureAutoscalerSecretIfNeeded for unit testing.

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -293,12 +293,15 @@ func (p *Provisioner) ClusterReadinessChecksCountForTest() int {
 
 // PreBootChecksCountForTest returns just the pre-boot check count for unit testing,
 // isolating the pre-boot sequence selection from the k8s component checks.
+// Only valid when skipNodeReadiness is true (CNI disabled or SkipCNIChecks set);
+// when skipNodeReadiness is false, production code uses DefaultClusterChecks()
+// which does not separate pre-boot from k8s component checks.
 func (p *Provisioner) PreBootChecksCountForTest() int {
 	skipNodeReadiness := (p.talosConfigs != nil && p.talosConfigs.IsCNIDisabled()) ||
 		p.options.SkipCNIChecks
 
 	if !skipNodeReadiness {
-		return len(check.PreBootSequenceChecks())
+		panic("PreBootChecksCountForTest is only valid when skipNodeReadiness is true")
 	}
 
 	switch {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -355,8 +355,8 @@ func apidCheck() check.ClusterCheck {
 }
 
 // dockerPreBootSequenceChecks returns a trimmed subset of the upstream
-// check.PreBootSequenceChecks() (github.com/siderolabs/talos v1.13.0-beta.1,
-// pkg/cluster/check/check.go) optimized for Docker environments. It omits
+// check.PreBootSequenceChecks() (github.com/siderolabs/talos v1.13.0,
+// pkg/cluster/check/default.go) optimized for Docker environments. It omits
 // purely diagnostic checks (AllNodesMemorySizes, AllNodesDiskSizes, NoDiagnostics)
 // that add polling overhead without catching real issues in Docker containers.
 //
@@ -374,7 +374,7 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 }
 
 // preBootSequenceChecksSkipDiagnostics returns the upstream PreBootSequenceChecks
-// (github.com/siderolabs/talos, pkg/cluster/check/default.go) with the
+// (github.com/siderolabs/talos v1.13.0, pkg/cluster/check/default.go) with the
 // NoDiagnostics check omitted. Used for non-Docker providers (Hetzner, Omni) when
 // kubelet cert rotation is enabled and CNI is not yet installed (CNI disabled in
 // config or skipped via SkipCNIChecks because it is installed post-creation).

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -344,6 +344,16 @@ func kubeletAndBootChecks() []check.ClusterCheck {
 	}
 }
 
+// apidCheck returns the apid readiness check shared across all provider-specific
+// pre-boot sequences.
+func apidCheck() check.ClusterCheck {
+	return func(cluster check.ClusterInfo) conditions.Condition {
+		return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
+			return check.ApidReadyAssertion(ctx, cluster)
+		}, preBootPollInterval)
+	}
+}
+
 // dockerPreBootSequenceChecks returns a trimmed subset of the upstream
 // check.PreBootSequenceChecks() (github.com/siderolabs/talos v1.13.0-beta.1,
 // pkg/cluster/check/check.go) optimized for Docker environments. It omits
@@ -358,17 +368,7 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	// NoDiagnostics — skipped: informational-only, not a readiness gate
 	return slices.Concat(
 		etcdChecks(),
-		[]check.ClusterCheck{
-			func(cluster check.ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition(
-					"apid to be ready",
-					func(ctx context.Context) error {
-						return check.ApidReadyAssertion(ctx, cluster)
-					},
-					preBootPollInterval,
-				)
-			},
-		},
+		[]check.ClusterCheck{apidCheck()},
 		kubeletAndBootChecks(),
 	)
 }
@@ -397,15 +397,7 @@ func preBootSequenceChecksSkipDiagnostics() []check.ClusterCheck {
 	return slices.Concat(
 		etcdChecks(),
 		[]check.ClusterCheck{
-			func(cluster check.ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition(
-					"apid to be ready",
-					func(ctx context.Context) error {
-						return check.ApidReadyAssertion(ctx, cluster)
-					},
-					preBootPollInterval,
-				)
-			},
+			apidCheck(),
 			func(cluster check.ClusterInfo) conditions.Condition {
 				return conditions.PollingCondition(
 					"all nodes memory sizes",

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -358,18 +358,109 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	)
 }
 
-// clusterReadinessChecks returns the appropriate set of cluster readiness checks
-// based on CNI and kubelet certificate configuration.
+// preBootSequenceChecksSkipDiagnostics returns the upstream PreBootSequenceChecks
+// (github.com/siderolabs/talos, pkg/cluster/check/default.go) with the
+// NoDiagnostics check omitted. Used for non-Docker providers (Hetzner, Omni) when
+// kubelet cert rotation is enabled and CNI is disabled.
 //
-// When CNI is disabled (either by Talos config or SkipCNIChecks option), returns
-// lighter checks that skip node Ready status, since nodes will remain NotReady
-// until the CNI is installed post-creation.
+// Without CNI, the kubelet-serving-cert-approver pod cannot schedule (nodes have
+// not-ready:NoSchedule taint), so kubelet serving CSRs remain pending. Talos
+// reports this as a diagnostic ("CSR is not approved"), causing NoDiagnostics to
+// never pass — which would deadlock check.Wait since CNI installation only
+// happens after the provisioner returns.
 //
-// For Docker providers, uses a trimmed pre-boot check set that skips purely
-// diagnostic checks (memory/disk sizes, diagnostics) to reduce sequential
-// polling overhead.
+// Unlike dockerPreBootSequenceChecks, this retains AllNodesMemorySizes and
+// AllNodesDiskSizes checks because cloud servers have meaningful resource
+// constraints worth validating.
 //
-// Additionally, when kubelet serving certificate rotation is enabled with CNI disabled,
+// When upgrading the Talos dependency, verify this list against the upstream
+// check.PreBootSequenceChecks() to pick up any new essential readiness gates.
+func preBootSequenceChecksSkipDiagnostics() []check.ClusterCheck {
+	allNodeTypes := check.WithNodeTypes(
+		machine.TypeInit,
+		machine.TypeControlPlane,
+		machine.TypeWorker,
+	)
+	cpTypes := check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane)
+
+	return []check.ClusterCheck{
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"etcd to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(ctx, cluster, "etcd", cpTypes)
+				},
+				preBootPollInterval,
+			)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"etcd members to be consistent across nodes",
+				func(ctx context.Context) error {
+					return check.EtcdConsistentAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"etcd members to be control plane nodes",
+				func(ctx context.Context) error {
+					return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"apid to be ready",
+				func(ctx context.Context) error {
+					return check.ApidReadyAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"all nodes memory sizes",
+				func(ctx context.Context) error {
+					return check.AllNodesMemorySizes(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"all nodes disk sizes",
+				func(ctx context.Context) error {
+					return check.AllNodesDiskSizes(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
+		},
+		// NoDiagnostics — skipped: creates deadlock when kubelet cert rotation is enabled
+		// without CNI (cert-approver can't schedule, "CSR is not approved" diagnostic never clears)
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"kubelet to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
+				},
+				preBootPollInterval,
+			)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition(
+				"all nodes to finish boot sequence",
+				func(ctx context.Context) error {
+					return check.AllNodesBootedAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
+		},
+	}
+}
+
 // the K8sControlPlaneStaticPods check is skipped because it depends on Talos
 // StaticPodStatus resources which require a kubelet serving certificate. Without CNI,
 // the kubelet-serving-cert-approver pod cannot schedule, leaving CSRs unapproved and
@@ -385,11 +476,6 @@ func (p *Provisioner) clusterReadinessChecks() []check.ClusterCheck {
 		return check.DefaultClusterChecks()
 	}
 
-	preBootChecks := check.PreBootSequenceChecks()
-	if p.isDockerProvider() {
-		preBootChecks = dockerPreBootSequenceChecks()
-	}
-
 	// When kubelet cert rotation is enabled with CNI disabled, the kubelet-serving-cert-approver
 	// pod cannot schedule (node has not-ready taint), so kubelet serving CSRs remain pending.
 	// Without a serving certificate, Talos cannot connect to kubelet, and StaticPodStatus
@@ -397,6 +483,20 @@ func (p *Provisioner) clusterReadinessChecks() []check.ClusterCheck {
 	// K8sFullControlPlaneAssertion which validates the same thing via the K8s API.
 	skipStaticPodStatusCheck := p.talosConfigs != nil &&
 		p.talosConfigs.IsKubeletCertRotationEnabled()
+
+	var preBootChecks []check.ClusterCheck
+
+	switch {
+	case p.isDockerProvider():
+		preBootChecks = dockerPreBootSequenceChecks()
+	case skipStaticPodStatusCheck:
+		// Non-Docker providers with kubelet cert rotation: skip NoDiagnostics to
+		// avoid deadlock (cert-approver can't schedule without CNI, so the "CSR
+		// is not approved" diagnostic never clears).
+		preBootChecks = preBootSequenceChecksSkipDiagnostics()
+	default:
+		preBootChecks = check.PreBootSequenceChecks()
+	}
 
 	if skipStaticPodStatusCheck {
 		return slices.Concat(

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -436,7 +436,8 @@ func (p *Provisioner) clusterReadinessChecks() []check.ClusterCheck {
 		return check.DefaultClusterChecks()
 	}
 
-	// When kubelet cert rotation is enabled with CNI disabled, the kubelet-serving-cert-approver
+	// When kubelet cert rotation is enabled and node readiness checks are skipped
+	// (CNI not yet installed or SkipCNIChecks set), the kubelet-serving-cert-approver
 	// pod cannot schedule (node has not-ready taint), so kubelet serving CSRs remain pending.
 	// Without a serving certificate, Talos cannot connect to kubelet, and StaticPodStatus
 	// resources are never populated. Skip the Talos-based static pod check and rely on

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -324,14 +324,22 @@ func kubeletAndBootChecks() []check.ClusterCheck {
 
 	return []check.ClusterCheck{
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"kubelet to be healthy",
+				func(ctx context.Context) error {
+					return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
+				},
+				preBootPollInterval,
+			)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
-				return check.AllNodesBootedAssertion(ctx, cluster)
-			}, preBootPollInterval)
+			return conditions.PollingCondition(
+				"all nodes to finish boot sequence",
+				func(ctx context.Context) error {
+					return check.AllNodesBootedAssertion(ctx, cluster)
+				},
+				preBootPollInterval,
+			)
 		},
 	}
 }
@@ -352,9 +360,13 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 		etcdChecks(),
 		[]check.ClusterCheck{
 			func(cluster check.ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
-					return check.ApidReadyAssertion(ctx, cluster)
-				}, preBootPollInterval)
+				return conditions.PollingCondition(
+					"apid to be ready",
+					func(ctx context.Context) error {
+						return check.ApidReadyAssertion(ctx, cluster)
+					},
+					preBootPollInterval,
+				)
 			},
 		},
 		kubeletAndBootChecks(),
@@ -386,19 +398,31 @@ func preBootSequenceChecksSkipDiagnostics() []check.ClusterCheck {
 		etcdChecks(),
 		[]check.ClusterCheck{
 			func(cluster check.ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
-					return check.ApidReadyAssertion(ctx, cluster)
-				}, preBootPollInterval)
+				return conditions.PollingCondition(
+					"apid to be ready",
+					func(ctx context.Context) error {
+						return check.ApidReadyAssertion(ctx, cluster)
+					},
+					preBootPollInterval,
+				)
 			},
 			func(cluster check.ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition("all nodes memory sizes", func(ctx context.Context) error {
-					return check.AllNodesMemorySizes(ctx, cluster)
-				}, preBootPollInterval)
+				return conditions.PollingCondition(
+					"all nodes memory sizes",
+					func(ctx context.Context) error {
+						return check.AllNodesMemorySizes(ctx, cluster)
+					},
+					preBootPollInterval,
+				)
 			},
 			func(cluster check.ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition("all nodes disk sizes", func(ctx context.Context) error {
-					return check.AllNodesDiskSizes(ctx, cluster)
-				}, preBootPollInterval)
+				return conditions.PollingCondition(
+					"all nodes disk sizes",
+					func(ctx context.Context) error {
+						return check.AllNodesDiskSizes(ctx, cluster)
+					},
+					preBootPollInterval,
+				)
 			},
 		},
 		kubeletAndBootChecks(),

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -313,6 +313,29 @@ func etcdChecks() []check.ClusterCheck {
 	}
 }
 
+// kubeletAndBootChecks returns the kubelet health and boot sequence completion
+// checks shared across all provider-specific pre-boot sequences.
+func kubeletAndBootChecks() []check.ClusterCheck {
+	allNodeTypes := check.WithNodeTypes(
+		machine.TypeInit,
+		machine.TypeControlPlane,
+		machine.TypeWorker,
+	)
+
+	return []check.ClusterCheck{
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
+				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
+			}, preBootPollInterval)
+		},
+		func(cluster check.ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
+				return check.AllNodesBootedAssertion(ctx, cluster)
+			}, preBootPollInterval)
+		},
+	}
+}
+
 // dockerPreBootSequenceChecks returns a trimmed subset of the upstream
 // check.PreBootSequenceChecks() (github.com/siderolabs/talos v1.13.0-beta.1,
 // pkg/cluster/check/check.go) optimized for Docker environments. It omits
@@ -322,40 +345,19 @@ func etcdChecks() []check.ClusterCheck {
 // When upgrading the Talos dependency, verify this list against the upstream
 // check.PreBootSequenceChecks() to pick up any new essential readiness gates.
 func dockerPreBootSequenceChecks() []check.ClusterCheck {
-	allNodeTypes := check.WithNodeTypes(
-		machine.TypeInit,
-		machine.TypeControlPlane,
-		machine.TypeWorker,
-	)
-
-	return append(
+	// AllNodesMemorySizes — skipped: diagnostic-only, Docker containers have consistent resources
+	// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
+	// NoDiagnostics — skipped: informational-only, not a readiness gate
+	return slices.Concat(
 		etcdChecks(),
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
-				return check.ApidReadyAssertion(ctx, cluster)
-			}, preBootPollInterval)
+		[]check.ClusterCheck{
+			func(cluster check.ClusterInfo) conditions.Condition {
+				return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
+					return check.ApidReadyAssertion(ctx, cluster)
+				}, preBootPollInterval)
+			},
 		},
-		// AllNodesMemorySizes — skipped: diagnostic-only, Docker containers have consistent resources
-		// AllNodesDiskSizes — skipped: diagnostic-only, Docker containers have consistent resources
-		// NoDiagnostics — skipped: informational-only, not a readiness gate
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"kubelet to be healthy",
-				func(ctx context.Context) error {
-					return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
-				},
-				preBootPollInterval,
-			)
-		},
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"all nodes to finish boot sequence",
-				func(ctx context.Context) error {
-					return check.AllNodesBootedAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
-		},
+		kubeletAndBootChecks(),
 	)
 }
 
@@ -378,41 +380,28 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 // When upgrading the Talos dependency, verify this list against the upstream
 // check.PreBootSequenceChecks() to pick up any new essential readiness gates.
 func preBootSequenceChecksSkipDiagnostics() []check.ClusterCheck {
-	allNodeTypes := check.WithNodeTypes(
-		machine.TypeInit,
-		machine.TypeControlPlane,
-		machine.TypeWorker,
-	)
-
-	return append(
+	// NoDiagnostics — skipped: creates deadlock when kubelet cert rotation is enabled
+	// without CNI (cert-approver can't schedule, "CSR is not approved" diagnostic never clears)
+	return slices.Concat(
 		etcdChecks(),
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
-				return check.ApidReadyAssertion(ctx, cluster)
-			}, preBootPollInterval)
+		[]check.ClusterCheck{
+			func(cluster check.ClusterInfo) conditions.Condition {
+				return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
+					return check.ApidReadyAssertion(ctx, cluster)
+				}, preBootPollInterval)
+			},
+			func(cluster check.ClusterInfo) conditions.Condition {
+				return conditions.PollingCondition("all nodes memory sizes", func(ctx context.Context) error {
+					return check.AllNodesMemorySizes(ctx, cluster)
+				}, preBootPollInterval)
+			},
+			func(cluster check.ClusterInfo) conditions.Condition {
+				return conditions.PollingCondition("all nodes disk sizes", func(ctx context.Context) error {
+					return check.AllNodesDiskSizes(ctx, cluster)
+				}, preBootPollInterval)
+			},
 		},
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("all nodes memory sizes", func(ctx context.Context) error {
-				return check.AllNodesMemorySizes(ctx, cluster)
-			}, preBootPollInterval)
-		},
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("all nodes disk sizes", func(ctx context.Context) error {
-				return check.AllNodesDiskSizes(ctx, cluster)
-			}, preBootPollInterval)
-		},
-		// NoDiagnostics — skipped: creates deadlock when kubelet cert rotation is enabled
-		// without CNI (cert-approver can't schedule, "CSR is not approved" diagnostic never clears)
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
-				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
-			}, preBootPollInterval)
-		},
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
-				return check.AllNodesBootedAssertion(ctx, cluster)
-			}, preBootPollInterval)
-		},
+		kubeletAndBootChecks(),
 	)
 }
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config.go
@@ -277,8 +277,9 @@ func (p *Provisioner) isDockerProvider() bool {
 	return ok
 }
 
-// dockerEtcdChecks returns the etcd-related pre-boot checks for Docker environments.
-func dockerEtcdChecks() []check.ClusterCheck {
+// etcdChecks returns the etcd-related pre-boot readiness checks shared across
+// all provider-specific pre-boot sequences.
+func etcdChecks() []check.ClusterCheck {
 	cpTypes := check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane)
 
 	return []check.ClusterCheck{
@@ -328,7 +329,7 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 	)
 
 	return append(
-		dockerEtcdChecks(),
+		etcdChecks(),
 		func(cluster check.ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
 				return check.ApidReadyAssertion(ctx, cluster)
@@ -361,7 +362,8 @@ func dockerPreBootSequenceChecks() []check.ClusterCheck {
 // preBootSequenceChecksSkipDiagnostics returns the upstream PreBootSequenceChecks
 // (github.com/siderolabs/talos, pkg/cluster/check/default.go) with the
 // NoDiagnostics check omitted. Used for non-Docker providers (Hetzner, Omni) when
-// kubelet cert rotation is enabled and CNI is disabled.
+// kubelet cert rotation is enabled and CNI is not yet installed (CNI disabled in
+// config or skipped via SkipCNIChecks because it is installed post-creation).
 //
 // Without CNI, the kubelet-serving-cert-approver pod cannot schedule (nodes have
 // not-ready:NoSchedule taint), so kubelet serving CSRs remain pending. Talos
@@ -381,84 +383,37 @@ func preBootSequenceChecksSkipDiagnostics() []check.ClusterCheck {
 		machine.TypeControlPlane,
 		machine.TypeWorker,
 	)
-	cpTypes := check.WithNodeTypes(machine.TypeInit, machine.TypeControlPlane)
 
-	return []check.ClusterCheck{
+	return append(
+		etcdChecks(),
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"etcd to be healthy",
-				func(ctx context.Context) error {
-					return check.ServiceHealthAssertion(ctx, cluster, "etcd", cpTypes)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
+				return check.ApidReadyAssertion(ctx, cluster)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"etcd members to be consistent across nodes",
-				func(ctx context.Context) error {
-					return check.EtcdConsistentAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("all nodes memory sizes", func(ctx context.Context) error {
+				return check.AllNodesMemorySizes(ctx, cluster)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"etcd members to be control plane nodes",
-				func(ctx context.Context) error {
-					return check.EtcdControlPlaneNodesAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
-		},
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"apid to be ready",
-				func(ctx context.Context) error {
-					return check.ApidReadyAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
-		},
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"all nodes memory sizes",
-				func(ctx context.Context) error {
-					return check.AllNodesMemorySizes(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
-		},
-		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"all nodes disk sizes",
-				func(ctx context.Context) error {
-					return check.AllNodesDiskSizes(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("all nodes disk sizes", func(ctx context.Context) error {
+				return check.AllNodesDiskSizes(ctx, cluster)
+			}, preBootPollInterval)
 		},
 		// NoDiagnostics — skipped: creates deadlock when kubelet cert rotation is enabled
 		// without CNI (cert-approver can't schedule, "CSR is not approved" diagnostic never clears)
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"kubelet to be healthy",
-				func(ctx context.Context) error {
-					return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
+				return check.ServiceHealthAssertion(ctx, cluster, "kubelet", allNodeTypes)
+			}, preBootPollInterval)
 		},
 		func(cluster check.ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition(
-				"all nodes to finish boot sequence",
-				func(ctx context.Context) error {
-					return check.AllNodesBootedAssertion(ctx, cluster)
-				},
-				preBootPollInterval,
-			)
+			return conditions.PollingCondition("all nodes to finish boot sequence", func(ctx context.Context) error {
+				return check.AllNodesBootedAssertion(ctx, cluster)
+			}, preBootPollInterval)
 		},
-	}
+	)
 }
 
 // the K8sControlPlaneStaticPods check is skipped because it depends on Talos

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
@@ -1,12 +1,16 @@
 package talosprovisioner_test
 
 import (
+	"fmt"
 	"testing"
 
+	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
+	talos "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	dockerprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/docker"
 	hetzner "github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- isDockerProvider ---
@@ -70,4 +74,50 @@ func TestClusterReadinessChecks_DockerUsesFewerChecks(t *testing.T) {
 
 	assert.Less(t, dockerCount, hetznerCount,
 		"Docker provider should use fewer pre-boot checks than Hetzner provider")
+}
+
+func TestClusterReadinessChecks_HetznerCertRotationSkipsDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	certRotationConfigs := loadCertRotationConfigs(t, "hetzner-cert-rotation", "true")
+
+	opts := talosprovisioner.NewOptions()
+	opts.SkipCNIChecks = true
+
+	hetznerWithCertRotation := talosprovisioner.NewProvisioner(nil, opts).
+		WithInfraProvider(&hetzner.Provider{}).
+		WithTalosConfigsForTest(certRotationConfigs)
+	hetznerWithoutCertRotation := talosprovisioner.NewProvisioner(nil, opts).
+		WithInfraProvider(&hetzner.Provider{})
+
+	withRotation := hetznerWithCertRotation.ClusterReadinessChecksCountForTest()
+	withoutRotation := hetznerWithoutCertRotation.ClusterReadinessChecksCountForTest()
+
+	assert.Less(t, withRotation, withoutRotation,
+		"Hetzner with cert rotation should skip NoDiagnostics check (fewer total checks)")
+}
+
+func loadCertRotationConfigs(t *testing.T, clusterName, rotateValue string) *talos.Configs {
+	t.Helper()
+
+	patchContent := fmt.Appendf(nil, `machine:
+  kubelet:
+    extraArgs:
+      rotate-server-certificates: "%s"
+`, rotateValue)
+
+	manager := talos.NewConfigManager("", clusterName, "1.32.0", "10.5.0.0/24")
+	manager = manager.WithAdditionalPatches([]talos.Patch{
+		{
+			Path:    "test-cert-rotation.yaml",
+			Scope:   talos.PatchScopeControlPlane,
+			Content: patchContent,
+		},
+	})
+
+	configs, err := manager.Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, configs)
+
+	return configs
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
@@ -95,8 +95,12 @@ func TestClusterReadinessChecks_HetznerCertRotationSkipsDiagnostics(t *testing.T
 	withRotation := hetznerWithCertRotation.PreBootChecksCountForTest()
 	withoutRotation := hetznerWithoutCertRotation.PreBootChecksCountForTest()
 
-	assert.Less(t, withRotation, withoutRotation,
-		"Hetzner with cert rotation should skip NoDiagnostics pre-boot check (fewer pre-boot checks)")
+	assert.Less(
+		t,
+		withRotation,
+		withoutRotation,
+		"Hetzner with cert rotation should skip NoDiagnostics pre-boot check (fewer pre-boot checks)",
+	)
 }
 
 func loadCertRotationConfigs(t *testing.T, clusterName, rotateValue string) *talos.Configs {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_config_test.go
@@ -90,11 +90,13 @@ func TestClusterReadinessChecks_HetznerCertRotationSkipsDiagnostics(t *testing.T
 	hetznerWithoutCertRotation := talosprovisioner.NewProvisioner(nil, opts).
 		WithInfraProvider(&hetzner.Provider{})
 
-	withRotation := hetznerWithCertRotation.ClusterReadinessChecksCountForTest()
-	withoutRotation := hetznerWithoutCertRotation.ClusterReadinessChecksCountForTest()
+	// Use the pre-boot check count seam to isolate the NoDiagnostics skip from
+	// the separate k8s component check difference (static pod status vs full CP).
+	withRotation := hetznerWithCertRotation.PreBootChecksCountForTest()
+	withoutRotation := hetznerWithoutCertRotation.PreBootChecksCountForTest()
 
 	assert.Less(t, withRotation, withoutRotation,
-		"Hetzner with cert rotation should skip NoDiagnostics check (fewer total checks)")
+		"Hetzner with cert rotation should skip NoDiagnostics pre-boot check (fewer pre-boot checks)")
 }
 
 func loadCertRotationConfigs(t *testing.T, clusterName, rotateValue string) *talos.Configs {
@@ -106,7 +108,7 @@ func loadCertRotationConfigs(t *testing.T, clusterName, rotateValue string) *tal
       rotate-server-certificates: "%s"
 `, rotateValue)
 
-	manager := talos.NewConfigManager("", clusterName, "1.32.0", "10.5.0.0/24")
+	manager := talos.NewConfigManager(t.TempDir(), clusterName, "1.32.0", "10.5.0.0/24")
 	manager = manager.WithAdditionalPatches([]talos.Patch{
 		{
 			Path:    "test-cert-rotation.yaml",


### PR DESCRIPTION
## Problem

When creating a Talos cluster on Hetzner with kubelet serving certificate rotation enabled and CNI disabled (the default flow — CNI is installed post-creation), cluster creation deadlocks at the `NoDiagnostics` readiness check for up to 20 minutes before timing out.

### Root Cause

A circular dependency in the cluster readiness check flow:

1. `check.PreBootSequenceChecks()` includes `NoDiagnostics` which blocks on "kubelet server certificate rotation is enabled, but CSR is not approved"
2. `kubelet-serving-cert-approver` (inline manifest) can't schedule — all nodes have `node.kubernetes.io/not-ready:NoSchedule` taint
3. Nodes are NotReady because CNI isn't installed yet
4. CNI installation happens AFTER the provisioner returns — but the provisioner is blocked waiting for diagnostics

Docker was unaffected because `dockerPreBootSequenceChecks()` already skips `NoDiagnostics`.

## Fix

- Add `preBootSequenceChecksSkipDiagnostics()` that includes all upstream pre-boot checks except `NoDiagnostics` (retains memory/disk size checks meaningful for cloud servers)
- Wire it into `clusterReadinessChecks()` for non-Docker providers when kubelet cert rotation is enabled
- Add test verifying Hetzner with cert rotation uses fewer checks than without

## Evidence

Queried the prod cluster (`admin@prod`) and observed:
- All 6 nodes `NotReady` (CNI not initialized)
- 6 `kubelet-serving` CSRs `Pending`
- `kubelet-serving-cert-approver` pod `Pending` with `FailedScheduling: 6 node(s) had untolerated taint {node.kubernetes.io/not-ready: }`