### PR TITLE
fix: delete Hetzner load balancers on cluster delete

### DIFF
--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -41,6 +41,9 @@ func CalculateRetryDelayForTest(attempt int) time.Duration {
 // NormalizeNodeRoleForTest exports normalizeNodeRole for testing.
 var NormalizeNodeRoleForTest = normalizeNodeRole
 
+// LbInNetworkForTest exports lbInNetwork for testing.
+var LbInNetworkForTest = lbInNetwork
+
 // AvailableLocationsForTest exports availableLocations for testing.
 var AvailableLocationsForTest = availableLocations
 

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -41,8 +41,8 @@ func CalculateRetryDelayForTest(attempt int) time.Duration {
 // NormalizeNodeRoleForTest exports normalizeNodeRole for testing.
 var NormalizeNodeRoleForTest = normalizeNodeRole
 
-// LbInNetworkForTest exports lbInNetwork for testing.
-var LbInNetworkForTest = lbInNetwork
+// LBInNetworkForTest exports lbInNetwork for testing.
+var LBInNetworkForTest = lbInNetwork
 
 // AvailableLocationsForTest exports availableLocations for testing.
 var AvailableLocationsForTest = availableLocations

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -405,6 +405,13 @@ func (p *Provider) deleteInfrastructure(ctx context.Context, clusterName string)
 		return err
 	}
 
+	// Delete load balancers before the network — LBs attached to the network
+	// must be removed first, otherwise network deletion will fail.
+	err = p.deleteLoadBalancers(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
 	return p.deleteNetwork(ctx, clusterName)
 }
 
@@ -526,4 +533,75 @@ func (p *Provider) deleteNetwork(ctx context.Context, clusterName string) error 
 	}
 
 	return nil
+}
+
+// deleteLoadBalancers deletes all Hetzner Cloud Load Balancers attached to the
+// cluster's private network. These are typically provisioned by hcloud-ccm for
+// Kubernetes Service objects of type LoadBalancer.
+//
+// Load balancers must be deleted before the network, otherwise network deletion
+// will fail because the network still has attached resources.
+func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) error {
+	networkName := clusterName + NetworkSuffix
+
+	// Look up the network to confirm it exists. If not, there are no LBs to clean up.
+	network, _, err := p.client.Network.GetByName(ctx, networkName)
+	if err != nil || network == nil {
+		return nil //nolint:nilerr // No network means no LBs to clean up
+	}
+
+	loadBalancers, err := p.client.LoadBalancer.AllWithOpts(ctx, hcloud.LoadBalancerListOpts{})
+	if err != nil {
+		return fmt.Errorf("failed to list load balancers: %w", err)
+	}
+
+	for _, lb := range loadBalancers {
+		if !lbInNetwork(lb, networkName) {
+			continue
+		}
+
+		deleteErr := p.deleteLoadBalancerWithRetry(ctx, lb)
+		if deleteErr != nil {
+			return deleteErr
+		}
+	}
+
+	return nil
+}
+
+// deleteLoadBalancerWithRetry deletes a single load balancer with retry logic.
+// Retries handle the case where the LB is still processing actions from the
+// recently deleted cluster.
+//
+//nolint:funcorder // Grouped with deleteLoadBalancers for logical code organization
+func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, lb *hcloud.LoadBalancer) error {
+	for attempt := range MaxDeleteRetries {
+		_, err := p.client.LoadBalancer.Delete(ctx, lb)
+		if err == nil {
+			return nil
+		}
+
+		if attempt == MaxDeleteRetries-1 {
+			return fmt.Errorf(
+				"failed to delete load balancer %s (ID %d) after %d attempts: %w",
+				lb.Name, lb.ID, MaxDeleteRetries, err,
+			)
+		}
+
+		time.Sleep(DefaultDeleteRetryDelay)
+	}
+
+	return nil
+}
+
+// lbInNetwork reports whether the given load balancer is attached to the named
+// private network.
+func lbInNetwork(lb *hcloud.LoadBalancer, networkName string) bool {
+	for _, privateNet := range lb.PrivateNet {
+		if privateNet.Network != nil && privateNet.Network.Name == networkName {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -587,9 +587,9 @@ func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) 
 // recently deleted cluster.
 //
 //nolint:funcorder // Grouped with deleteLoadBalancers for logical code organization
-func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, lb *hcloud.LoadBalancer) error {
+func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, loadBalancer *hcloud.LoadBalancer) error {
 	for attempt := range MaxDeleteRetries {
-		_, err := p.client.LoadBalancer.Delete(ctx, lb)
+		_, err := p.client.LoadBalancer.Delete(ctx, loadBalancer)
 		if err == nil {
 			return nil
 		}
@@ -603,13 +603,13 @@ func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, lb *hcloud.L
 		if attempt == MaxDeleteRetries-1 {
 			return fmt.Errorf(
 				"failed to delete load balancer %s (ID %d) after %d attempts: %w",
-				lb.Name, lb.ID, MaxDeleteRetries, err,
+				loadBalancer.Name, loadBalancer.ID, MaxDeleteRetries, err,
 			)
 		}
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("context cancelled while retrying load balancer deletion: %w", ctx.Err())
 		case <-time.After(DefaultDeleteRetryDelay):
 		}
 	}

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -528,7 +528,7 @@ func (p *Provider) deleteNetwork(ctx context.Context, clusterName string) error 
 
 	network, err := p.getNetworkByClusterName(ctx, clusterName)
 	if err != nil {
-		return nil //nolint:nilerr // Ignoring lookup error - resource may not exist
+		return fmt.Errorf("failed to look up network for deletion: %w", err)
 	}
 
 	if network == nil {

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -544,10 +544,27 @@ func (p *Provider) deleteNetwork(ctx context.Context, clusterName string) error 
 func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) error {
 	networkName := clusterName + NetworkSuffix
 
-	// Look up the network to confirm it exists. If not, there are no LBs to clean up.
-	network, _, err := p.client.Network.GetByName(ctx, networkName)
-	if err != nil || network == nil {
-		return nil //nolint:nilerr // No network means no LBs to clean up
+	// Look up the network with transient-retry to avoid silently skipping LB
+	// cleanup on a transient API error (which could leave billed resources).
+	network, err := retryTransientHetznerOperation(
+		ctx,
+		DefaultTransientRetryCount,
+		p.calculateRetryDelay,
+		func() (*hcloud.Network, error) {
+			network, _, err := p.client.Network.GetByName(ctx, networkName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get network %s: %w", networkName, err)
+			}
+
+			return network, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to look up network for LB cleanup: %w", err)
+	}
+
+	if network == nil {
+		return nil
 	}
 
 	loadBalancers, err := p.client.LoadBalancer.AllWithOpts(ctx, hcloud.LoadBalancerListOpts{})
@@ -581,6 +598,12 @@ func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, lb *hcloud.L
 			return nil
 		}
 
+		// The LB may have been deleted between list and delete (or is already
+		// being removed). Treat not-found as success for idempotency.
+		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+			return nil
+		}
+
 		if attempt == MaxDeleteRetries-1 {
 			return fmt.Errorf(
 				"failed to delete load balancer %s (ID %d) after %d attempts: %w",
@@ -588,7 +611,11 @@ func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, lb *hcloud.L
 			)
 		}
 
-		time.Sleep(DefaultDeleteRetryDelay)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(DefaultDeleteRetryDelay):
+		}
 	}
 
 	return nil

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -502,11 +502,12 @@ func (p *Provider) deleteFirewallWithRetry(ctx context.Context, clusterName stri
 	return nil
 }
 
-// deleteNetwork deletes the network for a cluster if it exists.
-func (p *Provider) deleteNetwork(ctx context.Context, clusterName string) error {
+// getNetworkByClusterName looks up the cluster's private network with
+// transient-retry. Returns (nil, nil) when the network does not exist.
+func (p *Provider) getNetworkByClusterName(ctx context.Context, clusterName string) (*hcloud.Network, error) {
 	networkName := clusterName + NetworkSuffix
 
-	network, err := retryTransientHetznerOperation(
+	return retryTransientHetznerOperation(
 		ctx,
 		DefaultTransientRetryCount,
 		p.calculateRetryDelay,
@@ -519,6 +520,13 @@ func (p *Provider) deleteNetwork(ctx context.Context, clusterName string) error 
 			return network, nil
 		},
 	)
+}
+
+// deleteNetwork deletes the network for a cluster if it exists.
+func (p *Provider) deleteNetwork(ctx context.Context, clusterName string) error {
+	networkName := clusterName + NetworkSuffix
+
+	network, err := p.getNetworkByClusterName(ctx, clusterName)
 	if err != nil {
 		return nil //nolint:nilerr // Ignoring lookup error - resource may not exist
 	}
@@ -546,19 +554,7 @@ func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) 
 
 	// Look up the network with transient-retry to avoid silently skipping LB
 	// cleanup on a transient API error (which could leave billed resources).
-	network, err := retryTransientHetznerOperation(
-		ctx,
-		DefaultTransientRetryCount,
-		p.calculateRetryDelay,
-		func() (*hcloud.Network, error) {
-			network, _, err := p.client.Network.GetByName(ctx, networkName)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get network %s: %w", networkName, err)
-			}
-
-			return network, nil
-		},
-	)
+	network, err := p.getNetworkByClusterName(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to look up network for LB cleanup: %w", err)
 	}

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -588,8 +588,6 @@ func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) 
 // deleteLoadBalancerWithRetry deletes a single load balancer with retry logic.
 // Retries handle the case where the LB is still processing actions from the
 // recently deleted cluster.
-//
-
 func (p *Provider) deleteLoadBalancerWithRetry(
 	ctx context.Context,
 	loadBalancer *hcloud.LoadBalancer,

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -553,8 +553,6 @@ func (p *Provider) deleteNetwork(ctx context.Context, clusterName string) error 
 // Load balancers must be deleted before the network, otherwise network deletion
 // will fail because the network still has attached resources.
 func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) error {
-	networkName := clusterName + NetworkSuffix
-
 	// Look up the network with transient-retry to avoid silently skipping LB
 	// cleanup on a transient API error (which could leave billed resources).
 	network, err := p.getNetworkByClusterName(ctx, clusterName)
@@ -566,13 +564,20 @@ func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) 
 		return nil
 	}
 
-	loadBalancers, err := p.client.LoadBalancer.AllWithOpts(ctx, hcloud.LoadBalancerListOpts{})
+	loadBalancers, err := retryTransientHetznerOperation(
+		ctx,
+		DefaultTransientRetryCount,
+		p.calculateRetryDelay,
+		func() ([]*hcloud.LoadBalancer, error) {
+			return p.client.LoadBalancer.AllWithOpts(ctx, hcloud.LoadBalancerListOpts{})
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to list load balancers: %w", err)
 	}
 
 	for _, lb := range loadBalancers {
-		if !lbInNetwork(lb, networkName) {
+		if !lbInNetwork(lb, network.Name) {
 			continue
 		}
 

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -504,7 +504,10 @@ func (p *Provider) deleteFirewallWithRetry(ctx context.Context, clusterName stri
 
 // getNetworkByClusterName looks up the cluster's private network with
 // transient-retry. Returns (nil, nil) when the network does not exist.
-func (p *Provider) getNetworkByClusterName(ctx context.Context, clusterName string) (*hcloud.Network, error) {
+func (p *Provider) getNetworkByClusterName(
+	ctx context.Context,
+	clusterName string,
+) (*hcloud.Network, error) {
 	networkName := clusterName + NetworkSuffix
 
 	return retryTransientHetznerOperation(
@@ -586,8 +589,11 @@ func (p *Provider) deleteLoadBalancers(ctx context.Context, clusterName string) 
 // Retries handle the case where the LB is still processing actions from the
 // recently deleted cluster.
 //
-//nolint:funcorder // Grouped with deleteLoadBalancers for logical code organization
-func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, loadBalancer *hcloud.LoadBalancer) error {
+
+func (p *Provider) deleteLoadBalancerWithRetry(
+	ctx context.Context,
+	loadBalancer *hcloud.LoadBalancer,
+) error {
 	for attempt := range MaxDeleteRetries {
 		_, err := p.client.LoadBalancer.Delete(ctx, loadBalancer)
 		if err == nil {
@@ -609,7 +615,10 @@ func (p *Provider) deleteLoadBalancerWithRetry(ctx context.Context, loadBalancer
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("context cancelled while retrying load balancer deletion: %w", ctx.Err())
+			return fmt.Errorf(
+				"context cancelled while retrying load balancer deletion: %w",
+				ctx.Err(),
+			)
 		case <-time.After(DefaultDeleteRetryDelay):
 		}
 	}

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -521,3 +521,81 @@ func TestBuildFirewallRulesWithAllowedCIDRs(t *testing.T) {
 		}
 	}
 }
+
+func TestLbInNetwork(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		lb          *hcloud.LoadBalancer
+		networkName string
+		expected    bool
+	}{
+		{
+			name: "MatchingNetwork",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: &hcloud.Network{Name: "my-cluster-network"}},
+				},
+			},
+			networkName: "my-cluster-network",
+			expected:    true,
+		},
+		{
+			name: "DifferentNetwork",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: &hcloud.Network{Name: "other-cluster-network"}},
+				},
+			},
+			networkName: "my-cluster-network",
+			expected:    false,
+		},
+		{
+			name: "NoPrivateNetworks",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: nil,
+			},
+			networkName: "my-cluster-network",
+			expected:    false,
+		},
+		{
+			name: "EmptyPrivateNetworks",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{},
+			},
+			networkName: "my-cluster-network",
+			expected:    false,
+		},
+		{
+			name: "MultipleNetworks_OneMatching",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: &hcloud.Network{Name: "other-network"}},
+					{Network: &hcloud.Network{Name: "my-cluster-network"}},
+				},
+			},
+			networkName: "my-cluster-network",
+			expected:    true,
+		},
+		{
+			name: "NilNetworkField",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: nil},
+				},
+			},
+			networkName: "my-cluster-network",
+			expected:    false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := hetzner.LbInNetworkForTest(testCase.lb, testCase.networkName)
+			assert.Equal(t, testCase.expected, result)
+		})
+	}
+}

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -522,7 +522,7 @@ func TestBuildFirewallRulesWithAllowedCIDRs(t *testing.T) {
 	}
 }
 
-func TestLbInNetwork(t *testing.T) { //nolint:funlen // Table-driven test with comprehensive coverage
+func TestLBInNetwork(t *testing.T) { //nolint:funlen // Table-driven test with comprehensive coverage
 	t.Parallel()
 
 	tests := []struct {
@@ -594,7 +594,7 @@ func TestLbInNetwork(t *testing.T) { //nolint:funlen // Table-driven test with c
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := hetzner.LbInNetworkForTest(testCase.lb, testCase.networkName)
+			result := hetzner.LBInNetworkForTest(testCase.lb, testCase.networkName)
 			assert.Equal(t, testCase.expected, result)
 		})
 	}

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -522,75 +522,31 @@ func TestBuildFirewallRulesWithAllowedCIDRs(t *testing.T) {
 	}
 }
 
-func lbInNetworkTestCases() []struct {
+type lbInNetworkTestCase struct {
 	name        string
 	lb          *hcloud.LoadBalancer
 	networkName string
 	expected    bool
-} {
-	return []struct {
-		name        string
-		lb          *hcloud.LoadBalancer
-		networkName string
-		expected    bool
-	}{
-		{
-			name: "MatchingNetwork",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: &hcloud.Network{Name: "my-cluster-network"}},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    true,
-		},
-		{
-			name: "DifferentNetwork",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: &hcloud.Network{Name: "other-cluster-network"}},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
-		{
-			name: "NoPrivateNetworks",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: nil,
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
-		{
-			name: "EmptyPrivateNetworks",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{},
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
-		{
-			name: "MultipleNetworks_OneMatching",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: &hcloud.Network{Name: "other-network"}},
-					{Network: &hcloud.Network{Name: "my-cluster-network"}},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    true,
-		},
-		{
-			name: "NilNetworkField",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: nil},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
+}
+
+func lbInNetworkTestCases() []lbInNetworkTestCase {
+	net := func(name string) *hcloud.Network { return &hcloud.Network{Name: name} }
+	pn := func(nets ...*hcloud.Network) []hcloud.LoadBalancerPrivateNet {
+		out := make([]hcloud.LoadBalancerPrivateNet, len(nets))
+		for i, n := range nets {
+			out[i] = hcloud.LoadBalancerPrivateNet{Network: n}
+		}
+
+		return out
+	}
+
+	return []lbInNetworkTestCase{
+		{"MatchingNetwork", &hcloud.LoadBalancer{PrivateNet: pn(net("my-cluster-network"))}, "my-cluster-network", true},
+		{"DifferentNetwork", &hcloud.LoadBalancer{PrivateNet: pn(net("other-cluster-network"))}, "my-cluster-network", false},
+		{"NoPrivateNetworks", &hcloud.LoadBalancer{PrivateNet: nil}, "my-cluster-network", false},
+		{"EmptyPrivateNetworks", &hcloud.LoadBalancer{PrivateNet: pn()}, "my-cluster-network", false},
+		{"MultipleNetworks_OneMatching", &hcloud.LoadBalancer{PrivateNet: pn(net("other-network"), net("my-cluster-network"))}, "my-cluster-network", true},
+		{"NilNetworkField", &hcloud.LoadBalancer{PrivateNet: pn(nil)}, "my-cluster-network", false},
 	}
 }
 

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -530,8 +530,10 @@ type lbInNetworkTestCase struct {
 }
 
 func lbInNetworkTestCases() []lbInNetworkTestCase {
-	net := func(name string) *hcloud.Network { return &hcloud.Network{Name: name} }
-	pn := func(nets ...*hcloud.Network) []hcloud.LoadBalancerPrivateNet {
+	mkNet := func(name string) *hcloud.Network {
+		return &hcloud.Network{Name: name}
+	}
+	mkPrivNets := func(nets ...*hcloud.Network) []hcloud.LoadBalancerPrivateNet {
 		out := make([]hcloud.LoadBalancerPrivateNet, len(nets))
 		for i, n := range nets {
 			out[i] = hcloud.LoadBalancerPrivateNet{Network: n}
@@ -539,14 +541,19 @@ func lbInNetworkTestCases() []lbInNetworkTestCase {
 
 		return out
 	}
+	mkLB := func(nets []hcloud.LoadBalancerPrivateNet) *hcloud.LoadBalancer {
+		return &hcloud.LoadBalancer{PrivateNet: nets}
+	}
+	cluster := "my-cluster-network"
 
 	return []lbInNetworkTestCase{
-		{"MatchingNetwork", &hcloud.LoadBalancer{PrivateNet: pn(net("my-cluster-network"))}, "my-cluster-network", true},
-		{"DifferentNetwork", &hcloud.LoadBalancer{PrivateNet: pn(net("other-cluster-network"))}, "my-cluster-network", false},
-		{"NoPrivateNetworks", &hcloud.LoadBalancer{PrivateNet: nil}, "my-cluster-network", false},
-		{"EmptyPrivateNetworks", &hcloud.LoadBalancer{PrivateNet: pn()}, "my-cluster-network", false},
-		{"MultipleNetworks_OneMatching", &hcloud.LoadBalancer{PrivateNet: pn(net("other-network"), net("my-cluster-network"))}, "my-cluster-network", true},
-		{"NilNetworkField", &hcloud.LoadBalancer{PrivateNet: pn(nil)}, "my-cluster-network", false},
+		{"MatchingNetwork", mkLB(mkPrivNets(mkNet(cluster))), cluster, true},
+		{"DifferentNetwork", mkLB(mkPrivNets(mkNet("other"))), cluster, false},
+		{"NoPrivateNetworks", mkLB(nil), cluster, false},
+		{"EmptyPrivateNetworks", mkLB(mkPrivNets()), cluster, false},
+		{"MultipleNetworks_OneMatching",
+			mkLB(mkPrivNets(mkNet("other"), mkNet(cluster))), cluster, true},
+		{"NilNetworkField", mkLB(mkPrivNets(nil)), cluster, false},
 	}
 }
 

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -522,77 +522,75 @@ func TestBuildFirewallRulesWithAllowedCIDRs(t *testing.T) {
 	}
 }
 
-func TestLBInNetwork(
-	t *testing.T,
-) { //nolint:funlen // Table-driven test with comprehensive coverage
+var lbInNetworkTests = []struct {
+	name        string
+	lb          *hcloud.LoadBalancer
+	networkName string
+	expected    bool
+}{
+	{
+		name: "MatchingNetwork",
+		lb: &hcloud.LoadBalancer{
+			PrivateNet: []hcloud.LoadBalancerPrivateNet{
+				{Network: &hcloud.Network{Name: "my-cluster-network"}},
+			},
+		},
+		networkName: "my-cluster-network",
+		expected:    true,
+	},
+	{
+		name: "DifferentNetwork",
+		lb: &hcloud.LoadBalancer{
+			PrivateNet: []hcloud.LoadBalancerPrivateNet{
+				{Network: &hcloud.Network{Name: "other-cluster-network"}},
+			},
+		},
+		networkName: "my-cluster-network",
+		expected:    false,
+	},
+	{
+		name: "NoPrivateNetworks",
+		lb: &hcloud.LoadBalancer{
+			PrivateNet: nil,
+		},
+		networkName: "my-cluster-network",
+		expected:    false,
+	},
+	{
+		name: "EmptyPrivateNetworks",
+		lb: &hcloud.LoadBalancer{
+			PrivateNet: []hcloud.LoadBalancerPrivateNet{},
+		},
+		networkName: "my-cluster-network",
+		expected:    false,
+	},
+	{
+		name: "MultipleNetworks_OneMatching",
+		lb: &hcloud.LoadBalancer{
+			PrivateNet: []hcloud.LoadBalancerPrivateNet{
+				{Network: &hcloud.Network{Name: "other-network"}},
+				{Network: &hcloud.Network{Name: "my-cluster-network"}},
+			},
+		},
+		networkName: "my-cluster-network",
+		expected:    true,
+	},
+	{
+		name: "NilNetworkField",
+		lb: &hcloud.LoadBalancer{
+			PrivateNet: []hcloud.LoadBalancerPrivateNet{
+				{Network: nil},
+			},
+		},
+		networkName: "my-cluster-network",
+		expected:    false,
+	},
+}
+
+func TestLBInNetwork(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		lb          *hcloud.LoadBalancer
-		networkName string
-		expected    bool
-	}{
-		{
-			name: "MatchingNetwork",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: &hcloud.Network{Name: "my-cluster-network"}},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    true,
-		},
-		{
-			name: "DifferentNetwork",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: &hcloud.Network{Name: "other-cluster-network"}},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
-		{
-			name: "NoPrivateNetworks",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: nil,
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
-		{
-			name: "EmptyPrivateNetworks",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{},
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
-		{
-			name: "MultipleNetworks_OneMatching",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: &hcloud.Network{Name: "other-network"}},
-					{Network: &hcloud.Network{Name: "my-cluster-network"}},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    true,
-		},
-		{
-			name: "NilNetworkField",
-			lb: &hcloud.LoadBalancer{
-				PrivateNet: []hcloud.LoadBalancerPrivateNet{
-					{Network: nil},
-				},
-			},
-			networkName: "my-cluster-network",
-			expected:    false,
-		},
-	}
-
-	for _, testCase := range tests {
+	for _, testCase := range lbInNetworkTests {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -522,7 +522,9 @@ func TestBuildFirewallRulesWithAllowedCIDRs(t *testing.T) {
 	}
 }
 
-func TestLBInNetwork(t *testing.T) { //nolint:funlen // Table-driven test with comprehensive coverage
+func TestLBInNetwork(
+	t *testing.T,
+) { //nolint:funlen // Table-driven test with comprehensive coverage
 	t.Parallel()
 
 	tests := []struct {

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -551,8 +551,10 @@ func lbInNetworkTestCases() []lbInNetworkTestCase {
 		{"DifferentNetwork", mkLB(mkPrivNets(mkNet("other"))), cluster, false},
 		{"NoPrivateNetworks", mkLB(nil), cluster, false},
 		{"EmptyPrivateNetworks", mkLB(mkPrivNets()), cluster, false},
-		{"MultipleNetworks_OneMatching",
-			mkLB(mkPrivNets(mkNet("other"), mkNet(cluster))), cluster, true},
+		{
+			"MultipleNetworks_OneMatching",
+			mkLB(mkPrivNets(mkNet("other"), mkNet(cluster))), cluster, true,
+		},
 		{"NilNetworkField", mkLB(mkPrivNets(nil)), cluster, false},
 	}
 }

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -522,75 +522,82 @@ func TestBuildFirewallRulesWithAllowedCIDRs(t *testing.T) {
 	}
 }
 
-var lbInNetworkTests = []struct {
+func lbInNetworkTestCases() []struct {
 	name        string
 	lb          *hcloud.LoadBalancer
 	networkName string
 	expected    bool
-}{
-	{
-		name: "MatchingNetwork",
-		lb: &hcloud.LoadBalancer{
-			PrivateNet: []hcloud.LoadBalancerPrivateNet{
-				{Network: &hcloud.Network{Name: "my-cluster-network"}},
+} {
+	return []struct {
+		name        string
+		lb          *hcloud.LoadBalancer
+		networkName string
+		expected    bool
+	}{
+		{
+			name: "MatchingNetwork",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: &hcloud.Network{Name: "my-cluster-network"}},
+				},
 			},
+			networkName: "my-cluster-network",
+			expected:    true,
 		},
-		networkName: "my-cluster-network",
-		expected:    true,
-	},
-	{
-		name: "DifferentNetwork",
-		lb: &hcloud.LoadBalancer{
-			PrivateNet: []hcloud.LoadBalancerPrivateNet{
-				{Network: &hcloud.Network{Name: "other-cluster-network"}},
+		{
+			name: "DifferentNetwork",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: &hcloud.Network{Name: "other-cluster-network"}},
+				},
 			},
+			networkName: "my-cluster-network",
+			expected:    false,
 		},
-		networkName: "my-cluster-network",
-		expected:    false,
-	},
-	{
-		name: "NoPrivateNetworks",
-		lb: &hcloud.LoadBalancer{
-			PrivateNet: nil,
-		},
-		networkName: "my-cluster-network",
-		expected:    false,
-	},
-	{
-		name: "EmptyPrivateNetworks",
-		lb: &hcloud.LoadBalancer{
-			PrivateNet: []hcloud.LoadBalancerPrivateNet{},
-		},
-		networkName: "my-cluster-network",
-		expected:    false,
-	},
-	{
-		name: "MultipleNetworks_OneMatching",
-		lb: &hcloud.LoadBalancer{
-			PrivateNet: []hcloud.LoadBalancerPrivateNet{
-				{Network: &hcloud.Network{Name: "other-network"}},
-				{Network: &hcloud.Network{Name: "my-cluster-network"}},
+		{
+			name: "NoPrivateNetworks",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: nil,
 			},
+			networkName: "my-cluster-network",
+			expected:    false,
 		},
-		networkName: "my-cluster-network",
-		expected:    true,
-	},
-	{
-		name: "NilNetworkField",
-		lb: &hcloud.LoadBalancer{
-			PrivateNet: []hcloud.LoadBalancerPrivateNet{
-				{Network: nil},
+		{
+			name: "EmptyPrivateNetworks",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{},
 			},
+			networkName: "my-cluster-network",
+			expected:    false,
 		},
-		networkName: "my-cluster-network",
-		expected:    false,
-	},
+		{
+			name: "MultipleNetworks_OneMatching",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: &hcloud.Network{Name: "other-network"}},
+					{Network: &hcloud.Network{Name: "my-cluster-network"}},
+				},
+			},
+			networkName: "my-cluster-network",
+			expected:    true,
+		},
+		{
+			name: "NilNetworkField",
+			lb: &hcloud.LoadBalancer{
+				PrivateNet: []hcloud.LoadBalancerPrivateNet{
+					{Network: nil},
+				},
+			},
+			networkName: "my-cluster-network",
+			expected:    false,
+		},
+	}
 }
 
 func TestLBInNetwork(t *testing.T) {
 	t.Parallel()
 
-	for _, testCase := range lbInNetworkTests {
+	for _, testCase := range lbInNetworkTestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/svc/provider/hetzner/infrastructure_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_test.go
@@ -522,7 +522,7 @@ func TestBuildFirewallRulesWithAllowedCIDRs(t *testing.T) {
 	}
 }
 
-func TestLbInNetwork(t *testing.T) {
+func TestLbInNetwork(t *testing.T) { //nolint:funlen // Table-driven test with comprehensive coverage
 	t.Parallel()
 
 	tests := []struct {


### PR DESCRIPTION
When `hcloud-ccm` (Hetzner Cloud Controller Manager) provisions Hetzner Cloud Load Balancers for Kubernetes `Service` objects of type `LoadBalancer`, these resources were not cleaned up during `ksail cluster delete`. This left orphaned, billed cloud resources in the Hetzner project.

The fix adds a `deleteLoadBalancers()` step to the Hetzner provider's infrastructure cleanup. It identifies cluster-owned LBs by checking their `PrivateNet` attachment to the cluster's private network (the same identification pattern used by `serverInNetwork()` for autoscaler nodes), then deletes them with retry logic before network deletion.

## Type of change

Select the appropriate options and delete the rest:

- [x] 🪲 Bug fix