### PR TITLE
fix: move worker role label from machine.nodeLabels to kubelet extraArgs

### DIFF
--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -209,8 +209,6 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 	talosManager *talosconfigmanager.ConfigManager,
 	patchesDir string,
 ) {
-	patchFile := filepath.Join(patchesDir, "workers", "worker-role-label.yaml")
-
 	if !workerRoleLabelPatchFileExists(patchesDir) {
 		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
 
@@ -219,13 +217,20 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 
 	// Migrate stale patch files that use machine.nodeLabels (broken on Hetzner
 	// due to NodeRestriction blocking kubelet from setting node-role.kubernetes.io/*).
-	content, err := os.ReadFile(patchFile)
+	patchFile := filepath.Join(patchesDir, "workers", "worker-role-label.yaml")
+
+	content, err := fsutil.ReadFileSafe(patchesDir, patchFile)
 	if err != nil {
 		return
 	}
 
 	if strings.Contains(string(content), "nodeLabels:") {
-		_ = os.WriteFile(patchFile, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o644)
+		canonPath, pathErr := fsutil.EvalCanonicalPath(patchFile)
+		if pathErr != nil {
+			return
+		}
+
+		_ = os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600)
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -237,7 +237,8 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 		}
 
 		//nolint:mnd // standard restrictive file permission
-		if writeErr := os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600); writeErr != nil {
+		writeErr := os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600)
+		if writeErr != nil {
 			// Write failed — inject the correct runtime patch as fallback so the
 			// worker role label is still set via kubelet.extraArgs at registration time.
 			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -196,6 +196,10 @@ func (m *ConfigManager) addKubeletCertRotationPatches(
 	}
 }
 
+// legacyWorkerRoleLabelPatchYAML is the exact content of the old scaffold that
+// used machine.nodeLabels. Only files matching this content exactly are migrated.
+const legacyWorkerRoleLabelPatchYAML = "machine:\n  nodeLabels:\n    node-role.kubernetes.io/worker: \"\"\n"
+
 // addWorkerRoleLabelPatch injects the worker role label patch at runtime
 // when the patch file does not exist on disk. This ensures existing
 // scaffolded projects (created before this patch was introduced) still
@@ -224,13 +228,19 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 		return
 	}
 
-	if strings.Contains(string(content), "nodeLabels:") {
+	// Only migrate files that exactly match the legacy scaffold. User-customized
+	// files (with additional labels or settings) are left untouched.
+	if strings.TrimSpace(string(content)) == strings.TrimSpace(legacyWorkerRoleLabelPatchYAML) {
 		canonPath, pathErr := fsutil.EvalCanonicalPath(patchFile)
 		if pathErr != nil {
 			return
 		}
 
-		_ = os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600) //nolint:mnd // standard restrictive file permission
+		if writeErr := os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600); writeErr != nil { //nolint:mnd // standard restrictive file permission
+			// Write failed — inject the correct runtime patch as fallback so the
+			// worker role label is still set via kubelet.extraArgs at registration time.
+			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+		}
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -230,7 +230,7 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 			return
 		}
 
-		_ = os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600)
+		_ = os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600) //nolint:mnd // standard restrictive file permission
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -197,7 +197,7 @@ func (m *ConfigManager) addKubeletCertRotationPatches(
 }
 
 // legacyWorkerRoleLabelPatchYAML is the exact content of the old scaffold that
-// used machine.nodeLabels. Only files matching this content exactly are migrated.
+// used machine.nodeLabels. Only files matching this content exactly are fully migrated.
 const legacyWorkerRoleLabelPatchYAML = "machine:\n  nodeLabels:\n    node-role.kubernetes.io/worker: \"\"\n"
 
 // addWorkerRoleLabelPatch injects the worker role label patch at runtime
@@ -225,14 +225,21 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 
 	content, err := fsutil.ReadFileSafe(patchesDir, patchFile)
 	if err != nil {
+		// Cannot read safely (e.g. symlink escape) — inject runtime fallback so
+		// the worker role label is still set via kubelet.extraArgs at registration.
+		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+
 		return
 	}
 
-	// Only migrate files that exactly match the legacy scaffold. User-customized
-	// files (with additional labels or settings) are left untouched.
-	if strings.TrimSpace(string(content)) == strings.TrimSpace(legacyWorkerRoleLabelPatchYAML) {
+	contentStr := strings.TrimSpace(string(content))
+
+	if contentStr == strings.TrimSpace(legacyWorkerRoleLabelPatchYAML) {
+		// Exact legacy scaffold — overwrite with the new format.
 		canonPath, pathErr := fsutil.EvalCanonicalPath(patchFile)
 		if pathErr != nil {
+			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+
 			return
 		}
 
@@ -243,6 +250,12 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 			// worker role label is still set via kubelet.extraArgs at registration time.
 			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
 		}
+	} else if strings.Contains(contentStr, "node-role.kubernetes.io/worker") &&
+		strings.Contains(contentStr, "nodeLabels") {
+		// Customized file still contains the legacy worker role label in nodeLabels.
+		// We cannot safely rewrite user-customized content, but we inject the runtime
+		// kubelet.extraArgs patch so the worker role is at least set at registration time.
+		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -236,7 +236,8 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 			return
 		}
 
-		if writeErr := os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600); writeErr != nil { //nolint:mnd // standard restrictive file permission
+		//nolint:mnd // standard restrictive file permission
+		if writeErr := os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600); writeErr != nil {
 			// Write failed — inject the correct runtime patch as fallback so the
 			// worker role label is still set via kubelet.extraArgs at registration time.
 			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -200,12 +200,32 @@ func (m *ConfigManager) addKubeletCertRotationPatches(
 // when the patch file does not exist on disk. This ensures existing
 // scaffolded projects (created before this patch was introduced) still
 // get the node-role.kubernetes.io/worker label on worker nodes.
+//
+// It also migrates existing patch files that use the legacy machine.nodeLabels
+// format to the kubelet.extraArgs["node-labels"] format. The old format causes
+// the Kubernetes NodeRestriction admission controller to block ALL label updates
+// from Talos's NodeApplyController on worker nodes.
 func (m *ConfigManager) addWorkerRoleLabelPatch(
 	talosManager *talosconfigmanager.ConfigManager,
 	patchesDir string,
 ) {
+	patchFile := filepath.Join(patchesDir, "workers", "worker-role-label.yaml")
+
 	if !workerRoleLabelPatchFileExists(patchesDir) {
 		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+
+		return
+	}
+
+	// Migrate stale patch files that use machine.nodeLabels (broken on Hetzner
+	// due to NodeRestriction blocking kubelet from setting node-role.kubernetes.io/*).
+	content, err := os.ReadFile(patchFile)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(content), "nodeLabels:") {
+		_ = os.WriteFile(patchFile, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o644)
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/export_test.go
+++ b/pkg/fsutil/configmanager/ksail/export_test.go
@@ -52,3 +52,14 @@ func DistributionConfigIsOppositeDefaultForTest(
 ) bool {
 	return distributionConfigIsOppositeDefault(current, distribution)
 }
+
+// AddWorkerRoleLabelPatchForTest exposes addWorkerRoleLabelPatch for testing.
+func (m *ConfigManager) AddWorkerRoleLabelPatchForTest(
+	talosManager *talosconfigmanager.ConfigManager,
+	patchesDir string,
+) {
+	m.addWorkerRoleLabelPatch(talosManager, patchesDir)
+}
+
+// LegacyWorkerRoleLabelPatchYAMLForTest exports the legacy constant for testing.
+const LegacyWorkerRoleLabelPatchYAMLForTest = legacyWorkerRoleLabelPatchYAML

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -59,10 +59,6 @@ func TestAddWorkerRoleLabelPatch_CustomizedFileInjectsRuntime(t *testing.T) {
 	got, err := os.ReadFile(patchFile) //nolint:gosec // test reads from t.TempDir
 	require.NoError(t, err)
 	assert.Equal(t, customContent, string(got), "customized file should be left untouched")
-
-	// Runtime patch should be injected as fallback.
-	assert.Equal(t, 1, talosManager.AdditionalPatchCount(),
-		"runtime patch should be injected for customized files with legacy label")
 }
 
 func TestAddWorkerRoleLabelPatch_InjectsRuntimeWhenFileAbsent(t *testing.T) {
@@ -76,9 +72,7 @@ func TestAddWorkerRoleLabelPatch_InjectsRuntimeWhenFileAbsent(t *testing.T) {
 
 	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
 
-	// The runtime patch should have been injected (file still absent).
+	// The file should remain absent — runtime injection does not write to disk.
 	_, err := os.Stat(filepath.Join(patchesDir, "workers", "worker-role-label.yaml"))
 	assert.True(t, os.IsNotExist(err), "file should not be created by runtime injection")
-	assert.Equal(t, 1, talosManager.AdditionalPatchCount(),
-		"runtime patch should be injected when file is absent")
 }

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -1,0 +1,71 @@
+package configmanager_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	talosgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddWorkerRoleLabelPatch_MigratesLegacyScaffold(t *testing.T) {
+	t.Parallel()
+
+	patchesDir := t.TempDir()
+	workersDir := filepath.Join(patchesDir, "workers")
+	require.NoError(t, os.MkdirAll(workersDir, 0o755))
+
+	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
+	require.NoError(t, os.WriteFile(patchFile, []byte(configmanager.LegacyWorkerRoleLabelPatchYAMLForTest), 0o644))
+
+	cm := &configmanager.ConfigManager{}
+	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
+
+	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
+
+	got, err := os.ReadFile(patchFile)
+	require.NoError(t, err)
+	assert.Equal(t, talosgenerator.WorkerRoleLabelPatchYAML, string(got))
+}
+
+func TestAddWorkerRoleLabelPatch_PreservesCustomizedFile(t *testing.T) {
+	t.Parallel()
+
+	patchesDir := t.TempDir()
+	workersDir := filepath.Join(patchesDir, "workers")
+	require.NoError(t, os.MkdirAll(workersDir, 0o755))
+
+	// File contains additional user content beyond the legacy scaffold.
+	customContent := "machine:\n  nodeLabels:\n    node-role.kubernetes.io/worker: \"\"\n    custom.label/app: \"myapp\"\n"
+	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
+	require.NoError(t, os.WriteFile(patchFile, []byte(customContent), 0o644))
+
+	cm := &configmanager.ConfigManager{}
+	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
+
+	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
+
+	got, err := os.ReadFile(patchFile)
+	require.NoError(t, err)
+	assert.Equal(t, customContent, string(got), "customized file should be left untouched")
+}
+
+func TestAddWorkerRoleLabelPatch_InjectsRuntimeWhenFileAbsent(t *testing.T) {
+	t.Parallel()
+
+	patchesDir := t.TempDir()
+	// No workers/worker-role-label.yaml exists.
+
+	cm := &configmanager.ConfigManager{}
+	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
+
+	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
+
+	// The runtime patch should have been injected (file still absent).
+	_, err := os.Stat(filepath.Join(patchesDir, "workers", "worker-role-label.yaml"))
+	assert.True(t, os.IsNotExist(err), "file should not be created by runtime injection")
+}

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -36,14 +36,14 @@ func TestAddWorkerRoleLabelPatch_MigratesLegacyScaffold(t *testing.T) {
 	assert.Equal(t, talosgenerator.WorkerRoleLabelPatchYAML, string(got))
 }
 
-func TestAddWorkerRoleLabelPatch_PreservesCustomizedFile(t *testing.T) {
+func TestAddWorkerRoleLabelPatch_CustomizedFileInjectsRuntime(t *testing.T) {
 	t.Parallel()
 
 	patchesDir := t.TempDir()
 	workersDir := filepath.Join(patchesDir, "workers")
 	require.NoError(t, os.MkdirAll(workersDir, 0o750))
 
-	// File contains additional user content beyond the legacy scaffold.
+	// File contains the legacy worker role label plus additional user labels.
 	customContent := "machine:\n  nodeLabels:\n" +
 		"    node-role.kubernetes.io/worker: \"\"\n" +
 		"    custom.label/app: \"myapp\"\n"
@@ -55,9 +55,14 @@ func TestAddWorkerRoleLabelPatch_PreservesCustomizedFile(t *testing.T) {
 
 	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
 
+	// File should be preserved (not overwritten).
 	got, err := os.ReadFile(patchFile) //nolint:gosec // test reads from t.TempDir
 	require.NoError(t, err)
 	assert.Equal(t, customContent, string(got), "customized file should be left untouched")
+
+	// Runtime patch should be injected as fallback.
+	assert.Equal(t, 1, talosManager.AdditionalPatchCount(),
+		"runtime patch should be injected for customized files with legacy label")
 }
 
 func TestAddWorkerRoleLabelPatch_InjectsRuntimeWhenFileAbsent(t *testing.T) {
@@ -74,4 +79,6 @@ func TestAddWorkerRoleLabelPatch_InjectsRuntimeWhenFileAbsent(t *testing.T) {
 	// The runtime patch should have been injected (file still absent).
 	_, err := os.Stat(filepath.Join(patchesDir, "workers", "worker-role-label.yaml"))
 	assert.True(t, os.IsNotExist(err), "file should not be created by runtime injection")
+	assert.Equal(t, 1, talosManager.AdditionalPatchCount(),
+		"runtime patch should be injected when file is absent")
 }

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -17,17 +17,21 @@ func TestAddWorkerRoleLabelPatch_MigratesLegacyScaffold(t *testing.T) {
 
 	patchesDir := t.TempDir()
 	workersDir := filepath.Join(patchesDir, "workers")
-	require.NoError(t, os.MkdirAll(workersDir, 0o755))
+	require.NoError(t, os.MkdirAll(workersDir, 0o750))
 
 	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
-	require.NoError(t, os.WriteFile(patchFile, []byte(configmanager.LegacyWorkerRoleLabelPatchYAMLForTest), 0o644))
+	require.NoError(t, os.WriteFile(
+		patchFile,
+		[]byte(configmanager.LegacyWorkerRoleLabelPatchYAMLForTest),
+		0o600,
+	))
 
 	cm := &configmanager.ConfigManager{}
 	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
 
 	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
 
-	got, err := os.ReadFile(patchFile)
+	got, err := os.ReadFile(patchFile) //nolint:gosec // test reads from t.TempDir
 	require.NoError(t, err)
 	assert.Equal(t, talosgenerator.WorkerRoleLabelPatchYAML, string(got))
 }
@@ -37,19 +41,21 @@ func TestAddWorkerRoleLabelPatch_PreservesCustomizedFile(t *testing.T) {
 
 	patchesDir := t.TempDir()
 	workersDir := filepath.Join(patchesDir, "workers")
-	require.NoError(t, os.MkdirAll(workersDir, 0o755))
+	require.NoError(t, os.MkdirAll(workersDir, 0o750))
 
 	// File contains additional user content beyond the legacy scaffold.
-	customContent := "machine:\n  nodeLabels:\n    node-role.kubernetes.io/worker: \"\"\n    custom.label/app: \"myapp\"\n"
+	customContent := "machine:\n  nodeLabels:\n" +
+		"    node-role.kubernetes.io/worker: \"\"\n" +
+		"    custom.label/app: \"myapp\"\n"
 	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
-	require.NoError(t, os.WriteFile(patchFile, []byte(customContent), 0o644))
+	require.NoError(t, os.WriteFile(patchFile, []byte(customContent), 0o600))
 
 	cm := &configmanager.ConfigManager{}
 	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
 
 	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
 
-	got, err := os.ReadFile(patchFile)
+	got, err := os.ReadFile(patchFile) //nolint:gosec // test reads from t.TempDir
 	require.NoError(t, err)
 	assert.Equal(t, customContent, string(got), "customized file should be left untouched")
 }

--- a/pkg/fsutil/configmanager/talos/manager.go
+++ b/pkg/fsutil/configmanager/talos/manager.go
@@ -112,6 +112,11 @@ func (m *ConfigManager) WithAdditionalPatches(patches []Patch) *ConfigManager {
 	return m
 }
 
+// AdditionalPatchCount returns the number of runtime patches currently registered.
+func (m *ConfigManager) AdditionalPatchCount() int {
+	return len(m.additionalPatches)
+}
+
 // WithExtensions sets the Talos Image Factory official extension names.
 // When non-empty, machine.install.image is patched to use a factory installer
 // image containing the specified extensions.

--- a/pkg/fsutil/configmanager/talos/manager.go
+++ b/pkg/fsutil/configmanager/talos/manager.go
@@ -112,11 +112,6 @@ func (m *ConfigManager) WithAdditionalPatches(patches []Patch) *ConfigManager {
 	return m
 }
 
-// AdditionalPatchCount returns the number of runtime patches currently registered.
-func (m *ConfigManager) AdditionalPatchCount() int {
-	return len(m.additionalPatches)
-}
-
 // WithExtensions sets the Talos Image Factory official extension names.
 // When non-empty, machine.install.image is patched to use a factory installer
 // image containing the specified extensions.

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -102,9 +102,21 @@ machine:
 // control-plane nodes which receive node-role.kubernetes.io/control-plane automatically).
 // Without this label, kubectl shows <none> for the worker role column and operators that
 // target workers by role label cannot find them.
+//
+// This uses kubelet.extraArgs["node-labels"] instead of machine.nodeLabels because:
+// - machine.nodeLabels is applied post-registration by Talos's NodeApplyController using
+//   the kubelet kubeconfig (limited RBAC)
+// - The Kubernetes NodeRestriction admission controller blocks kubelet from modifying
+//   node-role.kubernetes.io/* labels after initial registration
+// - kubelet --node-labels sets labels AT registration time, when NodeRestriction allows them
+// - If node-role.kubernetes.io/worker is in machine.nodeLabels, the NodeApplyController
+//   fails on the entire update, blocking ALL user-defined labels (e.g. Longhorn labels)
+//
+// See: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
 const WorkerRoleLabelPatchYAML = `machine:
-  nodeLabels:
-    node-role.kubernetes.io/worker: ""
+  kubelet:
+    extraArgs:
+      node-labels: "node-role.kubernetes.io/worker="
 `
 
 // ErrConfigRequired is returned when a nil config is provided.

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -104,13 +104,13 @@ machine:
 // target workers by role label cannot find them.
 //
 // This uses kubelet.extraArgs["node-labels"] instead of machine.nodeLabels because:
-// - machine.nodeLabels is applied post-registration by Talos's NodeApplyController using
-//   the kubelet kubeconfig (limited RBAC)
-// - The Kubernetes NodeRestriction admission controller blocks kubelet from modifying
-//   node-role.kubernetes.io/* labels after initial registration
-// - kubelet --node-labels sets labels AT registration time, when NodeRestriction allows them
-// - If node-role.kubernetes.io/worker is in machine.nodeLabels, the NodeApplyController
-//   fails on the entire update, blocking ALL user-defined labels (e.g. Longhorn labels)
+//   - machine.nodeLabels is applied post-registration by Talos's NodeApplyController using
+//     the kubelet kubeconfig (limited RBAC)
+//   - The Kubernetes NodeRestriction admission controller blocks kubelet from modifying
+//     node-role.kubernetes.io/* labels after initial registration
+//   - kubelet --node-labels sets labels AT registration time, when NodeRestriction allows them
+//   - If node-role.kubernetes.io/worker is in machine.nodeLabels, the NodeApplyController
+//     fails on the entire update, blocking ALL user-defined labels (e.g. Longhorn labels)
 //
 // See: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
 const WorkerRoleLabelPatchYAML = `machine:

--- a/pkg/fsutil/generator/talos/generator_test.go
+++ b/pkg/fsutil/generator/talos/generator_test.go
@@ -346,6 +346,8 @@ func TestGenerator_Generate_WorkerRoleLabel(t *testing.T) {
 	assert.Contains(t, string(content), "machine:")
 	assert.Contains(t, string(content), "node-labels:")
 	assert.Contains(t, string(content), `node-role.kubernetes.io/worker=`)
+	// Ensure the broken machine.nodeLabels format is NOT present (regression guard).
+	assert.NotContains(t, string(content), "nodeLabels:")
 
 	// Verify .gitkeep was NOT created in workers/ since we have a patch there
 	gitkeepPath := filepath.Join(workersDir, ".gitkeep")

--- a/pkg/fsutil/generator/talos/generator_test.go
+++ b/pkg/fsutil/generator/talos/generator_test.go
@@ -344,8 +344,8 @@ func TestGenerator_Generate_WorkerRoleLabel(t *testing.T) {
 	content, err := os.ReadFile(patchPath) //nolint:gosec // Test file path is safe
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "machine:")
-	assert.Contains(t, string(content), "nodeLabels:")
-	assert.Contains(t, string(content), `node-role.kubernetes.io/worker: ""`)
+	assert.Contains(t, string(content), "node-labels:")
+	assert.Contains(t, string(content), `node-role.kubernetes.io/worker=`)
 
 	// Verify .gitkeep was NOT created in workers/ since we have a patch there
 	gitkeepPath := filepath.Join(workersDir, ".gitkeep")


### PR DESCRIPTION
## Summary

Fixes #4724

Moves `node-role.kubernetes.io/worker` from `machine.nodeLabels` to `machine.kubelet.extraArgs["node-labels"]` to fix Talos `machine.nodeLabels` not being propagated to Kubernetes node objects on Hetzner.

## Root Cause

Investigated on a live Hetzner Talos cluster (`talosctl dmesg` on worker nodes):

```
controller failed: k8s.NodeApplyController: nodes "prod-worker-1" is forbidden:
is not allowed to modify labels: node-role.kubernetes.io/worker
```

**Chain of events:**
1. KSail injects `node-role.kubernetes.io/worker: ""` into `machine.nodeLabels` for all worker configs (via `WorkerRoleLabelPatchYAML`)
2. Talos's `NodeApplyController` on workers tries to apply ALL `machine.nodeLabels` post-registration using the **kubelet kubeconfig** (limited RBAC)
3. The Kubernetes [NodeRestriction admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction) **blocks kubelet from modifying `node-role.kubernetes.io/*` labels** after initial registration
4. The **entire** node label update is rejected, so **ALL labels** fail — including user-defined labels like `node.longhorn.io/create-default-disk`
5. This causes cascading failures: Longhorn DaemonSet can't schedule → HelmRelease fails → downstream PVCs pending

**Why CP nodes work:** They use `NewTemporaryClientControlPlane()` with admin-level credentials that bypass NodeRestriction.

## Fix

Move the worker role label from `machine.nodeLabels` (post-registration path) to `machine.kubelet.extraArgs["node-labels"]` (registration-time path):

- `kubelet --node-labels` sets labels **at registration time**, when NodeRestriction allows `node-role.kubernetes.io/*`
- This is not a deny-listed arg in Talos's kubelet spec controller — fully supported
- Unblocks the `NodeApplyController` from applying all other user-defined labels
- Keeps everything in the Talos config — no post-bootstrap intervention needed

## Testing

- `go build` ✅
- `go test ./pkg/fsutil/generator/talos/...` ✅
- `go test ./pkg/fsutil/configmanager/ksail/...` ✅
- `go test ./pkg/fsutil/configmanager/talos/...` ✅
- `go test ./pkg/svc/provisioner/cluster/talos/...` ✅