### PR TITLE
chore: track vCluster v0.34.0 stable in Vind provisioner

### DIFF
--- a/docs/src/content/docs/support-matrix.mdx
+++ b/docs/src/content/docs/support-matrix.mdx
@@ -171,7 +171,7 @@ KSail embeds specific versions of Kubernetes tooling:
 | Helm         | v4 (with kstatus) | Package manager            |
 | Kind         | Latest            | Vanilla clusters           |
 | K3d          | Latest            | K3s clusters               |
-| vCluster SDK | v0.33.1           | VCluster virtual clusters  |
+| vCluster SDK | v0.34.0           | VCluster virtual clusters  |
 | kwokctl      | Latest            | KWOK simulated clusters    |
 | Flux         | Latest            | GitOps toolkit             |
 | ArgoCD       | Latest            | GitOps continuous delivery |

--- a/pkg/fsutil/configmanager/vcluster/Dockerfile
+++ b/pkg/fsutil/configmanager/vcluster/Dockerfile
@@ -7,5 +7,5 @@
 # - ghcr.io/loft-sh/vcluster-pro → ChartVersion() in images.go
 # - ghcr.io/loft-sh/kubernetes → KubernetesVersion() in images.go
 
-FROM ghcr.io/loft-sh/vcluster-pro:0.33.1@sha256:29379ee7d3c41a3fb0cc5513d9b20ef856c1fe80f7311104210f20f1ab4e0a38
+FROM ghcr.io/loft-sh/vcluster-pro:0.34.0@sha256:665a7a4ed97db5ce8a6cbab99f7c92ccd6a4415affb106a29a2970270664c298
 FROM ghcr.io/loft-sh/kubernetes:v1.35.3@sha256:946d566e0f823b79a6116ab7361f87c8d3536754bb97f3da0682de2903af1944

--- a/pkg/fsutil/configmanager/vcluster/images_test.go
+++ b/pkg/fsutil/configmanager/vcluster/images_test.go
@@ -31,7 +31,7 @@ func TestChartVersion_MatchesDockerfileFormat(t *testing.T) {
 	version := vcluster.ChartVersion()
 
 	// The chart version is extracted from the Dockerfile line:
-	// FROM ghcr.io/loft-sh/vcluster-pro:0.33.1
+	// FROM ghcr.io/loft-sh/vcluster-pro:0.34.0
 	// Expected format: semver with optional pre-release suffix
 	assert.Regexp(t,
 		`^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$`,
@@ -124,10 +124,10 @@ func TestChartVersion_ExpectedValue(t *testing.T) {
 	// This test documents the current Dockerfile content.
 	// Dependabot is configured to update this image but may not track it (dependabot-core#13383);
 	// update manually if needed.
-	// FROM ghcr.io/loft-sh/vcluster-pro:0.33.1
+	// FROM ghcr.io/loft-sh/vcluster-pro:0.34.0
 	assert.Equal(
 		t,
-		"0.33.1",
+		"0.34.0",
 		version,
 		"ChartVersion should match current Dockerfile (update this test when manually bumping the version)",
 	)

--- a/pkg/svc/provisioner/cluster/vcluster/provisioner.go
+++ b/pkg/svc/provisioner/cluster/vcluster/provisioner.go
@@ -75,7 +75,7 @@ const dbusWaitInterval = 500 * time.Millisecond
 // executes and can hit the D-Bus error. KSail's recoverFromDBusError
 // workaround remains necessary.
 //
-// Audited against vCluster v0.34.0-alpha.2 (April 2026): no changes to
+// Audited against vCluster v0.34.0 (May 2026): no changes to
 // the D-Bus initialization path; the race condition persists. v0.34 adds
 // snapshot/restore support for the Docker driver (PR loft-sh/vcluster#3790)
 // and SecurityContext config for AutoUpgrade — neither affects this error.
@@ -592,10 +592,9 @@ func (p *Provisioner) Exists(ctx context.Context, name string) (bool, error) {
 // added a systemd readiness loop but it can still time out on slow CI
 // runners, so this workaround is still required.
 //
-// Audited against vCluster v0.34.0-alpha.2 (April 2026): CreateDocker,
+// Audited against vCluster v0.34.0 (May 2026): CreateDocker,
 // ConnectDocker, DeleteDocker signatures and option structs are unchanged
 // from v0.33.1. The D-Bus race persists — this workaround is still required.
-// go.mod update deferred until v0.34 reaches stable.
 func recoverFromDBusError(
 	ctx context.Context,
 	globalFlags *flags.GlobalFlags,


### PR DESCRIPTION
## Summary

Bump the embedded vcluster-pro chart image from `0.33.1` to `0.34.0` to match the `go.mod` SDK dependency (already at `v0.34.0`). Update audit comments, test expectations, and support-matrix documentation.

## Changes

- **Dockerfile**: `ghcr.io/loft-sh/vcluster-pro:0.33.1` → `0.34.0` (with updated digest)
- **Audit comments**: Updated from `v0.34.0-alpha.2` to `v0.34.0` stable
- **Test expectations**: `TestChartVersion_ExpectedValue` updated from `0.33.1` to `0.34.0`
- **Docs**: `support-matrix.mdx` updated from `v0.33.1` to `v0.34.0`

## SDK API Review

`cli.CreateDocker`, `cli.ConnectDocker`, `cli.DeleteDocker` signatures and option structs are unchanged from v0.33.x. D-Bus recovery workaround confirmed still necessary in v0.34.0.

## Verification

- ✅ Build passes
- ✅ All vCluster-related unit tests pass
- ✅ Documentation builds successfully
- ✅ No CI system test changes needed (version-agnostic matrix)

Fixes #4473