### PR TITLE
docs(agents): migrate copilot-instructions.md to shared AGENTS.md standard

### DIFF
--- a/.github/agents/write-docs.agent.md
+++ b/.github/agents/write-docs.agent.md
@@ -53,7 +53,7 @@ Documentation‑as‑Code, transparency, single source of truth, continuous impr
      - Internal architecture details, package structure, and design decisions belong here (not in `docs/`)
      - Keep accurate with the current codebase
 
-   - **.github/copilot-instructions.md** (audience: contributor / AI assistants)
+   - **AGENTS.md** (audience: contributor / AI assistants)
      - Architecture overview, build commands, project structure, and package layout for AI assistant guidance
      - Update when significant project changes occur
 

--- a/.github/workflows/daily-docs.md
+++ b/.github/workflows/daily-docs.md
@@ -99,7 +99,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
 - **Progressive disclosure**: High-level concepts first, detailed examples second.
 - **Voice**: Active voice, plain English, developer-friendly. Empathetic toward both newcomers and power users.
 - **Diátaxis alignment**: Tutorials (getting-started), how-to guides (guides), reference (cli-flags, configuration), explanation (concepts, architecture).
-- **Audience**: Documentation pages under `docs/` are for **end-users**. Source code architecture, internal package structure, and implementation details belong in `CONTRIBUTING.md`, `.github/copilot-instructions.md`, or code comments — not in user-facing docs. User docs may reference internals at a high level (e.g., "KSail embeds Kind as a Go library") but must not describe internal APIs, package paths, or design decisions.
+- **Audience**: Documentation pages under `docs/` are for **end-users**. Source code architecture, internal package structure, and implementation details belong in `CONTRIBUTING.md`, `AGENTS.md`, or code comments — not in user-facing docs. User docs may reference internals at a high level (e.g., "KSail embeds Kind as a Go library") but must not describe internal APIs, package paths, or design decisions.
 
 ### Your Workflow
 
@@ -115,12 +115,12 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
    find docs/src/content/docs -type f \( -name '*.md' -o -name '*.mdx' \) ! \( -path '*/cli-flags/*/*' -a ! -name 'index.md' -a ! -name 'index.mdx' \) | sort
    ```
 
-   - Read every listed file, plus `README.md`, `CONTRIBUTING.md`, `vsce/README.md`, `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, and `copilot-plugin/skills/ksail/SKILL.md`
+   - Read every listed file, plus `README.md`, `CONTRIBUTING.md`, `vsce/README.md`, `AGENTS.md`, `.github/instructions/*.instructions.md`, and `copilot-plugin/skills/ksail/SKILL.md`
    - CLI flags per-command detail pages under `docs/src/content/docs/cli-flags/*/` are excluded from this listing; consult them separately only if you need to understand overall CLI flag documentation patterns
    - For each page you do read, determine: what topics it covers, what it should not cover, and where content boundaries lie
    - Build a page ownership map as a table with columns: `Page`, `Audience`, `Owns`, `Does NOT cover`
-   - **Audience values**: `end-user` (docs pages, README.md), `contributor` (CONTRIBUTING.md, .github/copilot-instructions.md, .github/instructions/), `ai-user` (copilot-plugin/skills/), or compound values using `+` (e.g., `end-user+contributor` for pages that serve both end-users and contributors)
-   - Use the audience column when deciding where content belongs: end-user content goes in `docs/`, contributor content goes in `CONTRIBUTING.md`, `.github/copilot-instructions.md`, or `.github/instructions/`, AI-user skill content goes in `copilot-plugin/`
+   - **Audience values**: `end-user` (docs pages, README.md), `contributor` (CONTRIBUTING.md, AGENTS.md, .github/instructions/), `ai-user` (copilot-plugin/skills/), or compound values using `+` (e.g., `end-user+contributor` for pages that serve both end-users and contributors)
+   - Use the audience column when deciding where content belongs: end-user content goes in `docs/`, contributor content goes in `CONTRIBUTING.md`, `AGENTS.md`, or `.github/instructions/`, AI-user skill content goes in `copilot-plugin/`
    - Save the map to cache memory for future runs:
 
    ```bash
@@ -133,7 +133,7 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
    | README.md                              | end-user    | GitHub landing page, badges, feature bullets, link to docs                            | Tutorials, detailed config, architecture internals |
    | docs/src/content/docs/index.mdx        | end-user    | Docs home, hero, full onboarding, navigation                                          | Contributor workflows, internal APIs               |
    | CONTRIBUTING.md                        | contributor | Build commands, prerequisites, contribution guidelines, internal architecture         | End-user tutorials, feature explanations           |
-   | .github/copilot-instructions.md        | contributor | AI assistant guidance, project structure, package layout                              | End-user docs                                      |
+   | AGENTS.md                              | contributor | AI assistant guidance, project structure, package layout                              | End-user docs                                      |
    | .github/instructions/*.instructions.md | contributor | File-pattern-scoped coding conventions (Go code, Go testing, docs, agentic workflows) | End-user docs, project-wide architecture           |
    | copilot-plugin/skills/ksail/SKILL.md   | ai-user     | Copilot CLI skill: when to invoke, command groups, typical flows, safety notes        | Internal APIs, contributor workflows               |
    | vsce/README.md                         | end-user    | VS Code Marketplace description, install link                                         | Full extension docs (link to /vscode-extension/)   |
@@ -161,8 +161,8 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
    - **Distribution × Provider matrix parity**: The provider/distribution matrix in `README.md` must list the same distributions and providers as `docs/src/content/docs/index.mdx`. When a new distribution or provider is added (for example, when a new provisioner or provider package lands under `pkg/svc/provisioner/` or `pkg/svc/provider/`), both matrices must be updated in lockstep.
    - **Top-level command parity**: If `README.md` names specific top-level commands, they must match the output of `go run . --help` (Available Commands section). New top-level commands (like `tenant`) must be reflected.
    - **`vsce/README.md`**: must remain a concise marketplace description that links to `/vscode-extension/` — never a full docs page copy.
-   - **`CONTRIBUTING.md` and `.github/copilot-instructions.md`**: must not contain end-user tutorials or feature marketing; those belong in `docs/`.
-   - **`.github/instructions/*.instructions.md`**: must stay scoped to their declared `applyTo` file pattern; must not duplicate content from `.github/copilot-instructions.md` or `CONTRIBUTING.md`; conventions must match the current codebase.
+   - **`CONTRIBUTING.md` and `AGENTS.md`**: must not contain end-user tutorials or feature marketing; those belong in `docs/`.
+   - **`.github/instructions/*.instructions.md`**: must stay scoped to their declared `applyTo` file pattern; must not duplicate content from `AGENTS.md` or `CONTRIBUTING.md`; conventions must match the current codebase.
    - **`copilot-plugin/skills/ksail/SKILL.md`**: must accurately reflect available CLI commands (`go run . --help`), supported distributions, and providers; must link to the docs site for details rather than paraphrasing; must not contain contributor-only or internal API content.
 
    If every root-file check passes and the diff surfaces no doc impact, call `noop` with a summary of what was checked. Do not claim `noop` without running these checks.
@@ -190,21 +190,21 @@ Ensure every code-level change is mirrored by clear, accurate, and stylistically
      - Internal architecture details, package structure, and design decisions belong here (not in `docs/`)
      - Keep accurate with the current codebase
 
-   - **.github/copilot-instructions.md** (audience: contributor / AI assistants)
+   - **AGENTS.md** (audience: contributor / AI assistants)
      - Architecture overview, build commands, project structure, and package layout for AI assistant guidance
      - **Do NOT add, maintain, or re-create a "Recent Changes" section** — this section has been intentionally removed
 
    - **.github/instructions/*.instructions.md** (audience: contributor / AI assistants)
      - File-pattern-scoped coding conventions and rules (e.g., Go code conventions, Go testing conventions, docs conventions, agentic workflow conventions)
      - Each file declares an `applyTo` glob pattern in its frontmatter — keep the pattern accurate when file structures change
-     - Must stay focused on their declared scope; broader project-wide guidance belongs in `.github/copilot-instructions.md`
+     - Must stay focused on their declared scope; broader project-wide guidance belongs in `AGENTS.md`
      - Keep conventions in sync with current codebase practices (e.g., if a testing library is replaced, update the testing instructions)
 
    - **copilot-plugin/skills/ksail/SKILL.md** (audience: AI users / Copilot CLI)
      - Skill description, trigger conditions, command group summaries, typical flows, and safety notes for Copilot CLI users
      - Must accurately list available command groups and distributions — cross-reference against `ksail --help` output
      - Link to the docs site (`https://ksail.devantler.tech`) for detailed flag docs and guides rather than paraphrasing
-     - Do NOT include contributor-facing content (internal package paths, design decisions) — those belong in `.github/copilot-instructions.md`
+     - Do NOT include contributor-facing content (internal package paths, design decisions) — those belong in `AGENTS.md`
 
 5. **Create or Update Documentation**
 
@@ -277,7 +277,7 @@ Bloat is content that does not serve the reader's goal on **that specific page**
 1. **Cross-page duplication**: The same information appears on multiple pages (e.g., installation steps in both README.md and installation.mdx). Keep it on the canonical page; replace duplicates with cross-reference links.
 2. **Within-page duplication**: The same information repeated in different sections of one page.
 3. **Scope creep**: A page covers topics that belong on another page per the page ownership map.
-4. **Contributor content in user docs**: Implementation details (package paths, internal function names, Go module structure) that belong in CONTRIBUTING.md, .github/copilot-instructions.md, or .github/instructions/, not in end-user documentation.
+4. **Contributor content in user docs**: Implementation details (package paths, internal function names, Go module structure) that belong in CONTRIBUTING.md, AGENTS.md, or .github/instructions/, not in end-user documentation.
 5. **Redundant examples**: Multiple examples showing the same concept without adding new information.
 6. **Wall-of-text paragraphs**: A single paragraph covering 5+ distinct topics. Break into subsections, lists, or tables — do not compress it into fewer words.
 7. **Missing structure**: Content that would be clearer as a table, admonition, or headed subsection but is currently buried in prose.
@@ -310,14 +310,14 @@ find docs/src/content/docs -type f \( -name '*.md' -o -name '*.mdx' \) ! \( -pat
 
 #### 3. Find Candidate Files
 
-Candidates include **both** user-facing docs under `docs/` **and** root documentation files. Root files (`README.md`, `vsce/README.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `copilot-plugin/skills/ksail/SKILL.md`) are scanned here because Doc Sync mode only runs on code pushes — the daily schedule is what catches root-file bloat.
+Candidates include **both** user-facing docs under `docs/` **and** root documentation files. Root files (`README.md`, `vsce/README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `.github/instructions/*.instructions.md`, `copilot-plugin/skills/ksail/SKILL.md`) are scanned here because Doc Sync mode only runs on code pushes — the daily schedule is what catches root-file bloat.
 
 ```bash
 # User-facing docs (excluding auto-generated + blog)
 find docs/src/content/docs -path 'docs/src/content/docs/blog' -prune -o \( -name '*.md' -o -name '*.mdx' \) -type f ! -name 'frontmatter-full.md' -print
 
 # Root documentation files
-ls README.md vsce/README.md CONTRIBUTING.md .github/copilot-instructions.md .github/instructions/*.instructions.md copilot-plugin/skills/ksail/SKILL.md 2>/dev/null
+ls README.md vsce/README.md CONTRIBUTING.md AGENTS.md .github/instructions/*.instructions.md copilot-plugin/skills/ksail/SKILL.md 2>/dev/null
 ```
 
 **Exclude**:
@@ -332,8 +332,8 @@ ls README.md vsce/README.md CONTRIBUTING.md .github/copilot-instructions.md .git
 
 - `README.md` — `wc -l README.md` must report ≤ 250 lines, must not duplicate `docs/src/content/docs/index.mdx` (no Mermaid diagrams, full init flag reference, Native Configuration Files walkthrough, Presentations list, Blog Posts list), and must keep its Distribution × Provider matrix in sync with `docs/src/content/docs/index.mdx`.
 - `vsce/README.md` — concise marketplace description only; full usage belongs on `/vscode-extension/`.
-- `CONTRIBUTING.md` / `.github/copilot-instructions.md` — contributor content only; no end-user tutorials or marketing.
-- `.github/instructions/*.instructions.md` — scoped coding conventions only; must not duplicate `.github/copilot-instructions.md` or `CONTRIBUTING.md`.
+- `CONTRIBUTING.md` / `AGENTS.md` — contributor content only; no end-user tutorials or marketing.
+- `.github/instructions/*.instructions.md` — scoped coding conventions only; must not duplicate `AGENTS.md` or `CONTRIBUTING.md`.
 - `copilot-plugin/skills/ksail/SKILL.md` — accurate command groups and distributions; link to docs site for details; no contributor internals.
 
 {{#if ${{ github.event.pull_request.number }}}}
@@ -355,7 +355,7 @@ Choose the file most in need of improvement based on: cross-page duplication sev
 - **Resolve cross-page duplication** — if this file duplicates content from another page, keep it on the canonical page (per your page ownership map) and replace the duplicate with a cross-reference link
 - **Eliminate within-page duplicates** — remove repeated information within the file
 - **Fix scope creep** — move content that belongs on another page and replace it with a link
-- **Relocate contributor content** — if the page contains implementation details (package paths, internal function names, Go module structure), move them to CONTRIBUTING.md, .github/copilot-instructions.md, or the appropriate `.github/instructions/` file and replace with a cross-reference
+- **Relocate contributor content** — if the page contains implementation details (package paths, internal function names, Go module structure), move them to CONTRIBUTING.md, AGENTS.md, or the appropriate `.github/instructions/` file and replace with a cross-reference
 - **Break up wall-of-text paragraphs** — if a paragraph covers 5+ distinct topics, restructure it into subsections, lists, or tables
 - **Add missing structure** — convert buried prose into tables, admonitions, or headed subsections when it would aid scanning
 - **Condense verbose text** — make descriptions direct, remove filler words

--- a/.github/workflows/daily-workflow-maintenance.md
+++ b/.github/workflows/daily-workflow-maintenance.md
@@ -316,7 +316,7 @@ To decide which deep-mode phase to perform:
    c. Check for existing optimization PRs (especially yours with "${{ github.workflow }}" prefix). Avoid duplicate work.
    d. If plan needs updating, comment on discussion with revised plan.
    e. Select a goal from the plan. Alternate between structural CI/CD optimizations and prompt enhancement/simplification work. Prefer small, incremental changes.
-   f. Review `.github/copilot-instructions.md` for guidance on workflow conventions.
+   f. Review `AGENTS.md` for guidance on workflow conventions.
 
 2. **Work towards your selected goal**.
 

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -218,7 +218,7 @@ Always be:
 
 ## KSail-Specific Conventions
 
-**Before any code changes**, read `.github/copilot-instructions.md` and `AGENTS.md` (if present) for project conventions.
+**Before any code changes**, read `AGENTS.md` for project conventions.
 
 **Build & validation requirements for all PRs:**
 

--- a/.github/workflows/weekly-strategy.md
+++ b/.github/workflows/weekly-strategy.md
@@ -46,7 +46,7 @@ Your mission: thoroughly research the local Kubernetes development tool market a
 
 Before any external research, deeply understand KSail's current state:
 
-1. Read `README.md`, `.github/copilot-instructions.md`, and key documentation in `docs/` to understand:
+1. Read `README.md`, `AGENTS.md`, and key documentation in `docs/` to understand:
    - What KSail does today (supported distributions, providers, features)
    - Its architecture (provider/provisioner model, embedded tools, GitOps support)
    - Its target audience and value proposition

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -28,5 +28,5 @@ FILTER_REGEX_EXCLUDE: (megalinter-reports/.*)
 JSON_V8R_FILTER_REGEX_EXCLUDE: (\.github/workflows/.*\.lock\.yml)
 MARKDOWN_MARKDOWN_TABLE_FORMATTER_FILTER_REGEX_EXCLUDE: .github/(agents|prompts)
 MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: (.github/(agents|prompts)|\.github/workflows/.*\.lock\.yml)
-SPELL_LYCHEE_FILTER_REGEX_EXCLUDE: (.github/copilot-instructions\.md|.*\.mdx|docs/src/.*\.md|\.github/workflows/.*\.md)
+SPELL_LYCHEE_FILTER_REGEX_EXCLUDE: (AGENTS\.md|.*\.mdx|docs/src/.*\.md|\.github/workflows/.*\.md)
 YAML_V8R_FILTER_REGEX_EXCLUDE: .github/workflows/.*\.lock\.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,7 +383,7 @@ The Daily Docs agentic workflow (`daily-docs.lock.yml`) is designed to fill docu
 
 ## Benchmark Pipeline Consistency
 
-When changing `-count` in the `go test -bench` command in CI, always update the awk averaging/filtering step in "Prepare benchmark regression gate input" to produce exactly one result line per benchmark name. Failing to do so causes false-positive performance regression alerts for all benchmarks, even ones unrelated to the PR. The comparison tool (`github-action-benchmark`) expects the file it reads to contain exactly one result line per benchmark name, so repeated entries for the same benchmark must be consolidated before comparison. See [docs/BENCHMARK-REGRESSION.md](../docs/BENCHMARK-REGRESSION.md) for details.
+When changing `-count` in the `go test -bench` command in CI, always update the awk averaging/filtering step in "Prepare benchmark regression gate input" to produce exactly one result line per benchmark name. Failing to do so causes false-positive performance regression alerts for all benchmarks, even ones unrelated to the PR. The comparison tool (`github-action-benchmark`) expects the file it reads to contain exactly one result line per benchmark name, so repeated entries for the same benchmark must be consolidated before comparison. See [docs/BENCHMARK-REGRESSION.md](docs/BENCHMARK-REGRESSION.md) for details.
 
 ## CI Doctor Issue Linking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you have questions, don't hesitate to ask in [GitHub Discussions](https://git
 
 To get started with contributing to KSail, you'll need to set up your development environment, and understand the codebase, the CI setup and its requirements.
 
-To understand the codebase it is recommended to read the [AGENTS.md](AGENTS.md) file, which provides an overview of the project structure and key components. You can also use GitHub Copilot to assist you in navigating the codebase and understanding its functionality.
+To understand the codebase, it is recommended to read the [AGENTS.md](AGENTS.md) file, which provides an overview of the project structure and key components. You can also use GitHub Copilot to assist you in navigating the codebase and understanding its functionality.
 
 For a deeper dive into KSail's design and internals, refer to:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you have questions, don't hesitate to ask in [GitHub Discussions](https://git
 
 To get started with contributing to KSail, you'll need to set up your development environment, and understand the codebase, the CI setup and its requirements.
 
-To understand the codebase it is recommended to read the [.github/copilot-instructions.md](.github/copilot-instructions.md) file, which provides an overview of the project structure and key components. You can also use GitHub Copilot to assist you in navigating the codebase and understanding its functionality.
+To understand the codebase it is recommended to read the [AGENTS.md](AGENTS.md) file, which provides an overview of the project structure and key components. You can also use GitHub Copilot to assist you in navigating the codebase and understanding its functionality.
 
 For a deeper dive into KSail's design and internals, refer to:
 


### PR DESCRIPTION
Move .github/copilot-instructions.md to a root AGENTS.md so a single
source of truth is read by both GitHub Copilot (native AGENTS.md support)
and Claude Code (via a CLAUDE.md @AGENTS.md import). Update references in
CONTRIBUTING.md, .mega-linter.yml, and the agentic workflow/agent prompts.

https://claude.ai/code/session_01PyEACHSPRp1XfFjwH2ZgJZ