### PR TITLE
test: improve coverage and make unit suite hermetic

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,13 @@ coverage:
     patch:
       default:
         informational: true
+
+# Exclude generated code from coverage so the metric reflects hand-written code.
+# mockery mocks, generated docs, and deepcopy stubs are never meaningfully
+# "covered" and otherwise drag package/overall percentages down (e.g. the Docker
+# API mock alone is ~10k uncovered lines).
+ignore:
+  - "**/mocks.go"
+  - "**/*_generated.go"
+  - "**/zz_generated*.go"
+  - "**/doc.go"

--- a/pkg/cli/cmd/cluster/cluster_pure_test.go
+++ b/pkg/cli/cmd/cluster/cluster_pure_test.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/internal/testutil/rootcheck"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
@@ -852,6 +854,14 @@ func TestRefreshAndVerifyKubeconfig_StaleKubeconfigRefreshFailsWarns(t *testing.
 //
 //nolint:paralleltest // Mutates the global isKubeconfigStaleFunc.
 func TestRefreshAndVerifyKubeconfig_StatPermissionError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on Windows")
+	}
+
+	if rootcheck.IsRootUser() {
+		t.Skip("running as root — permission checks are bypassed")
+	}
+
 	dir := t.TempDir()
 	// Create a directory that we can't read (os.Stat on a file inside it will
 	// fail with EACCES on most Unix systems).

--- a/pkg/fsutil/configmanager/loader/loader_test.go
+++ b/pkg/fsutil/configmanager/loader/loader_test.go
@@ -3,8 +3,10 @@ package loader_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/internal/testutil/rootcheck"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/loader"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil/validator"
 	"github.com/stretchr/testify/assert"
@@ -389,6 +391,14 @@ func testValidateConfigMultipleErrors(t *testing.T) {
 
 func TestLoadConfigFromFilePermissionError(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on Windows")
+	}
+
+	if rootcheck.IsRootUser() {
+		t.Skip("running as root — permission checks are bypassed")
+	}
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/pkg/fsutil/generator/k3d/generator_test.go
+++ b/pkg/fsutil/generator/k3d/generator_test.go
@@ -265,9 +265,14 @@ func TestGenerateWithInvalidOutputDirectory(t *testing.T) {
 	gen := generator.NewGenerator()
 	cluster := &v1alpha5.SimpleConfig{}
 
-	// Use invalid directory path
+	// Use a path whose parent is a regular file so directory creation fails with
+	// ENOTDIR. This triggers the write error path independently of the current
+	// user's privileges (root would otherwise be able to create directories).
+	notADir := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(notADir, []byte("file"), testFilePermissions))
+
 	opts := yamlgenerator.Options{
-		Output: "/nonexistent/directory/k3d.yaml",
+		Output: filepath.Join(notADir, "k3d.yaml"),
 	}
 
 	result, err := gen.Generate(cluster, opts)

--- a/pkg/fsutil/generator/yaml/generator_test.go
+++ b/pkg/fsutil/generator/yaml/generator_test.go
@@ -232,8 +232,12 @@ func TestGenerateWithInvalidOutputDirectory(t *testing.T) {
 		"test": "value",
 	}
 
-	// Use invalid path that should cause write error
-	invalidPath := "/invalid/path/that/does/not/exist/output.yaml"
+	// Use a path whose parent is a regular file so directory creation fails with
+	// ENOTDIR. This triggers the write error path independently of the current
+	// user's privileges (root would otherwise be able to create directories).
+	notADir := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(notADir, []byte("file"), testFilePermissions))
+	invalidPath := filepath.Join(notADir, "output.yaml")
 
 	_, err := gen.Generate(model, yamlgenerator.Options{
 		Output: invalidPath,

--- a/pkg/fsutil/writer_test.go
+++ b/pkg/fsutil/writer_test.go
@@ -190,6 +190,7 @@ func runTryWriteFileErrorTests(t *testing.T) {
 
 func setupTryWriteFileStatError(t *testing.T) (string, string, bool) {
 	t.Helper()
+	skipPermissionSensitivePathTest(t)
 
 	content := "content for stat error test"
 	tempDir := t.TempDir()
@@ -202,15 +203,25 @@ func setupTryWriteFileStatError(t *testing.T) (string, string, bool) {
 	return content, outputPath, false
 }
 
-func setupTryWriteFileWriteError(_ *testing.T) (string, string, bool) {
-	content := "content for write error test"
-	invalidPath := "/invalid/nonexistent/deeply/nested/path/file.txt"
+func setupTryWriteFileWriteError(t *testing.T) (string, string, bool) {
+	t.Helper()
 
-	return content, invalidPath, false
+	content := "content for write error test"
+
+	// Use a path whose parent is a regular file so directory creation fails with
+	// ENOTDIR. This triggers the error path independently of the current user's
+	// privileges (root could otherwise create directories under "/"). force=true
+	// skips the pre-write stat so MkdirAll runs and fails.
+	notADir := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(notADir, []byte("file"), 0o600))
+	invalidPath := filepath.Join(notADir, "nested", "file.txt")
+
+	return content, invalidPath, true
 }
 
 func setupTryWriteFilePermissionError(t *testing.T) (string, string, bool) {
 	t.Helper()
+	skipPermissionSensitivePathTest(t)
 
 	content := "content for file write error test"
 	tempDir := t.TempDir()

--- a/pkg/svc/installer/cloudproviderkind/installer_test.go
+++ b/pkg/svc/installer/cloudproviderkind/installer_test.go
@@ -49,6 +49,7 @@ func skipIfDockerUnavailable(t *testing.T) dockerapi.APIClient {
 	_, err = client.Ping(ctx)
 	if err != nil {
 		_ = client.Close()
+
 		t.Skipf("Docker daemon not reachable: %v", err)
 	}
 

--- a/pkg/svc/installer/cloudproviderkind/installer_test.go
+++ b/pkg/svc/installer/cloudproviderkind/installer_test.go
@@ -79,10 +79,13 @@ func TestNewInstaller(t *testing.T) {
 	assert.NotNil(t, installer)
 }
 
+// TestCloudProviderKINDInstallerInstallAndUninstall is an integration test that
+// starts the real controller container. It shares a fixed container name and
+// network with TestCloudProviderKINDInstallerUninstallNoInstall, so the two must
+// not run concurrently.
+//
+//nolint:paralleltest // shares a fixed Docker container name and network
 func TestCloudProviderKINDInstallerInstallAndUninstall(t *testing.T) {
-	t.Parallel()
-
-	// Note: This is an integration test that actually starts the controller.
 	dockerClient := skipIfDockerUnavailable(t)
 
 	defer func() { _ = dockerClient.Close() }()
@@ -100,9 +103,8 @@ func TestCloudProviderKINDInstallerInstallAndUninstall(t *testing.T) {
 	require.NoError(t, err)
 }
 
+//nolint:paralleltest // shares a fixed Docker container name and network
 func TestCloudProviderKINDInstallerUninstallNoInstall(t *testing.T) {
-	t.Parallel()
-
 	dockerClient := skipIfDockerUnavailable(t)
 
 	defer func() { _ = dockerClient.Close() }()

--- a/pkg/svc/installer/cloudproviderkind/installer_test.go
+++ b/pkg/svc/installer/cloudproviderkind/installer_test.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	dockerclient "github.com/devantler-tech/ksail/v7/pkg/client/docker"
 	cloudproviderkindinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/cloudproviderkind"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	dockerapi "github.com/docker/docker/client"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -20,6 +22,38 @@ import (
 )
 
 const ciEnvValue = "true"
+
+// dockerPingTimeout bounds how long the Docker-availability probe waits.
+const dockerPingTimeout = 5 * time.Second
+
+// skipIfDockerUnavailable returns a real Docker client for integration tests,
+// skipping the test when Docker cannot be used. It skips in CI (where these
+// container-starting integration tests are intentionally not run) and whenever
+// the Docker daemon is unreachable (e.g. sandboxed unit-test environments), so
+// the suite stays hermetic instead of failing.
+func skipIfDockerUnavailable(t *testing.T) dockerapi.APIClient {
+	t.Helper()
+
+	if os.Getenv("CI") == ciEnvValue {
+		t.Skip("Skipping Docker integration test in CI")
+	}
+
+	client, err := dockerclient.GetDockerClient()
+	if err != nil {
+		t.Skipf("Docker client unavailable: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dockerPingTimeout)
+	defer cancel()
+
+	_, err = client.Ping(ctx)
+	if err != nil {
+		_ = client.Close()
+		t.Skipf("Docker daemon not reachable: %v", err)
+	}
+
+	return client
+}
 
 var (
 	errNotFound             = errors.New("not found")
@@ -32,11 +66,8 @@ var (
 func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 
-	// Skip in CI - requires Docker
-	if os.Getenv("CI") == ciEnvValue {
-		t.Skip("Skipping test that requires Docker in CI")
-	}
-
+	// Constructing the client does not require a running Docker daemon, so this
+	// test does not need to be gated on Docker availability.
 	dockerClient, err := dockerclient.GetDockerClient()
 	require.NoError(t, err)
 
@@ -50,14 +81,8 @@ func TestNewInstaller(t *testing.T) {
 func TestCloudProviderKINDInstallerInstallAndUninstall(t *testing.T) {
 	t.Parallel()
 
-	// Note: This is an integration test that actually starts the controller
-	// Skip in CI environments where Docker might not be available
-	if os.Getenv("CI") == ciEnvValue {
-		t.Skip("Skipping integration test in CI")
-	}
-
-	dockerClient, err := dockerclient.GetDockerClient()
-	require.NoError(t, err)
+	// Note: This is an integration test that actually starts the controller.
+	dockerClient := skipIfDockerUnavailable(t)
 
 	defer func() { _ = dockerClient.Close() }()
 
@@ -66,7 +91,7 @@ func TestCloudProviderKINDInstallerInstallAndUninstall(t *testing.T) {
 	ctx := context.Background()
 
 	// Install - this creates and starts the container
-	err = installer.Install(ctx)
+	err := installer.Install(ctx)
 	require.NoError(t, err)
 
 	// Clean up
@@ -77,20 +102,14 @@ func TestCloudProviderKINDInstallerInstallAndUninstall(t *testing.T) {
 func TestCloudProviderKINDInstallerUninstallNoInstall(t *testing.T) {
 	t.Parallel()
 
-	// Skip in CI - requires Docker
-	if os.Getenv("CI") == ciEnvValue {
-		t.Skip("Skipping test that requires Docker in CI")
-	}
-
-	dockerClient, err := dockerclient.GetDockerClient()
-	require.NoError(t, err)
+	dockerClient := skipIfDockerUnavailable(t)
 
 	defer func() { _ = dockerClient.Close() }()
 
 	installer := cloudproviderkindinstaller.NewInstaller(dockerClient)
 
 	ctx := context.Background()
-	err = installer.Uninstall(ctx)
+	err := installer.Uninstall(ctx)
 
 	// Uninstall when nothing is installed should succeed (no-op)
 	require.NoError(t, err)

--- a/pkg/svc/oidc/authenticator_helpers_test.go
+++ b/pkg/svc/oidc/authenticator_helpers_test.go
@@ -1,0 +1,267 @@
+package oidc_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/oidc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCallbackRequest(t *testing.T, query url.Values) *http.Request {
+	t.Helper()
+
+	return httptest.NewRequest(http.MethodGet, "/callback?"+query.Encode(), nil)
+}
+
+func TestValidateCallbackRequest(t *testing.T) {
+	t.Parallel()
+
+	const expectedState = "expected-state"
+
+	t.Run("returns code on success", func(t *testing.T) {
+		t.Parallel()
+
+		req := newCallbackRequest(t, url.Values{
+			"state": {expectedState},
+			"code":  {"auth-code-123"},
+		})
+
+		code, err := oidc.ValidateCallbackRequestForTest(req, expectedState)
+
+		require.NoError(t, err)
+		assert.Equal(t, "auth-code-123", code)
+	})
+
+	t.Run("returns error when provider reports error", func(t *testing.T) {
+		t.Parallel()
+
+		req := newCallbackRequest(t, url.Values{
+			"error":             {"access_denied"},
+			"error_description": {"user declined"},
+		})
+
+		_, err := oidc.ValidateCallbackRequestForTest(req, expectedState)
+
+		require.ErrorIs(t, err, oidc.ErrAuthenticationFailed)
+		assert.Contains(t, err.Error(), "access_denied")
+		assert.Contains(t, err.Error(), "user declined")
+	})
+
+	t.Run("returns error on state mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		req := newCallbackRequest(t, url.Values{
+			"state": {"wrong-state"},
+			"code":  {"auth-code-123"},
+		})
+
+		_, err := oidc.ValidateCallbackRequestForTest(req, expectedState)
+
+		require.ErrorIs(t, err, oidc.ErrAuthenticationFailed)
+		assert.Contains(t, err.Error(), "state mismatch")
+	})
+
+	t.Run("returns error when code is missing", func(t *testing.T) {
+		t.Parallel()
+
+		req := newCallbackRequest(t, url.Values{
+			"state": {expectedState},
+		})
+
+		_, err := oidc.ValidateCallbackRequestForTest(req, expectedState)
+
+		require.ErrorIs(t, err, oidc.ErrAuthenticationFailed)
+		assert.Contains(t, err.Error(), "missing authorization code")
+	})
+}
+
+func TestGeneratePKCE(t *testing.T) {
+	t.Parallel()
+
+	verifier, challenge, err := oidc.GeneratePKCEForTest()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, verifier)
+	assert.NotEmpty(t, challenge)
+	assert.NotEqual(t, verifier, challenge)
+
+	// The challenge must be the base64url-encoded SHA-256 of the verifier.
+	digest := sha256.Sum256([]byte(verifier))
+	expectedChallenge := base64.RawURLEncoding.EncodeToString(digest[:])
+	assert.Equal(t, expectedChallenge, challenge)
+
+	// Successive calls must produce different verifiers.
+	verifier2, _, err := oidc.GeneratePKCEForTest()
+	require.NoError(t, err)
+	assert.NotEqual(t, verifier, verifier2)
+}
+
+func TestGenerateState(t *testing.T) {
+	t.Parallel()
+
+	state, err := oidc.GenerateStateForTest()
+	require.NoError(t, err)
+	assert.NotEmpty(t, state)
+
+	// State must decode to 16 random bytes.
+	decoded, err := base64.RawURLEncoding.DecodeString(state)
+	require.NoError(t, err)
+	assert.Len(t, decoded, 16)
+
+	state2, err := oidc.GenerateStateForTest()
+	require.NoError(t, err)
+	assert.NotEqual(t, state, state2)
+}
+
+// writeTestCAPEM writes a freshly generated self-signed CA certificate to a temp
+// file and returns its path.
+func writeTestCAPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "ksail-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	require.NoError(t, os.WriteFile(path, pemBytes, 0o600))
+
+	return path
+}
+
+func TestBuildHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns default client when no CA file", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &oidc.Authenticator{}
+
+		client, err := auth.BuildHTTPClientForTest()
+
+		require.NoError(t, err)
+		assert.Same(t, http.DefaultClient, client)
+	})
+
+	t.Run("errors when CA file does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &oidc.Authenticator{CAFile: filepath.Join(t.TempDir(), "missing.pem")}
+
+		_, err := auth.BuildHTTPClientForTest()
+
+		require.Error(t, err)
+	})
+
+	t.Run("errors when CA file is not a valid certificate", func(t *testing.T) {
+		t.Parallel()
+
+		badPath := filepath.Join(t.TempDir(), "bad.pem")
+		require.NoError(t, os.WriteFile(badPath, []byte("not a certificate"), 0o600))
+
+		auth := &oidc.Authenticator{CAFile: badPath}
+
+		_, err := auth.BuildHTTPClientForTest()
+
+		require.ErrorIs(t, err, oidc.ErrAuthenticationFailed)
+		assert.Contains(t, err.Error(), "failed to parse CA certificate")
+	})
+
+	t.Run("builds custom client from valid CA file", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &oidc.Authenticator{CAFile: writeTestCAPEM(t)}
+
+		client, err := auth.BuildHTTPClientForTest()
+
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.NotSame(t, http.DefaultClient, client)
+
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok, "expected *http.Transport")
+		require.NotNil(t, transport.TLSClientConfig)
+		assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+	})
+}
+
+func TestNewOIDCProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("succeeds against a valid discovery document", func(t *testing.T) {
+		t.Parallel()
+
+		var issuer string
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/.well-known/openid-configuration" {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 issuer,
+					"authorization_endpoint": issuer + "/auth",
+					"token_endpoint":         issuer + "/token",
+					"jwks_uri":               issuer + "/keys",
+				})
+
+				return
+			}
+
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		issuer = server.URL
+
+		auth := &oidc.Authenticator{IssuerURL: issuer, ClientID: "kubectl"}
+
+		err := auth.NewOIDCProviderForTest(context.Background(), "http://localhost:18000/callback")
+
+		require.NoError(t, err)
+	})
+
+	t.Run("errors when discovery fails", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		auth := &oidc.Authenticator{IssuerURL: server.URL, ClientID: "kubectl"}
+
+		err := auth.NewOIDCProviderForTest(context.Background(), "http://localhost:18000/callback")
+
+		require.ErrorIs(t, err, oidc.ErrAuthenticationFailed)
+		assert.Contains(t, err.Error(), "failed to discover OIDC provider")
+	})
+}

--- a/pkg/svc/oidc/authenticator_helpers_test.go
+++ b/pkg/svc/oidc/authenticator_helpers_test.go
@@ -223,21 +223,22 @@ func TestNewOIDCProvider(t *testing.T) {
 
 		var issuer string
 
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/.well-known/openid-configuration" {
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"issuer":                 issuer,
-					"authorization_endpoint": issuer + "/auth",
-					"token_endpoint":         issuer + "/token",
-					"jwks_uri":               issuer + "/keys",
-				})
+		server := httptest.NewServer(http.HandlerFunc(
+			func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path == "/.well-known/openid-configuration" {
+					writer.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(writer).Encode(map[string]any{
+						"issuer":                 issuer,
+						"authorization_endpoint": issuer + "/auth",
+						"token_endpoint":         issuer + "/token",
+						"jwks_uri":               issuer + "/keys",
+					})
 
-				return
-			}
+					return
+				}
 
-			http.NotFound(w, r)
-		}))
+				http.NotFound(writer, request)
+			}))
 		defer server.Close()
 
 		issuer = server.URL

--- a/pkg/svc/oidc/authenticator_helpers_test.go
+++ b/pkg/svc/oidc/authenticator_helpers_test.go
@@ -28,7 +28,12 @@ import (
 func newCallbackRequest(t *testing.T, query url.Values) *http.Request {
 	t.Helper()
 
-	return httptest.NewRequest(http.MethodGet, "/callback?"+query.Encode(), nil)
+	return httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"/callback?"+query.Encode(),
+		nil,
+	)
 }
 
 func TestValidateCallbackRequest(t *testing.T) {

--- a/pkg/svc/oidc/export_test.go
+++ b/pkg/svc/oidc/export_test.go
@@ -1,0 +1,34 @@
+package oidc
+
+import (
+	"context"
+	"net/http"
+)
+
+// ValidateCallbackRequestForTest exposes validateCallbackRequest for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
+var ValidateCallbackRequestForTest = validateCallbackRequest
+
+// GeneratePKCEForTest exposes generatePKCE for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
+var GeneratePKCEForTest = generatePKCE
+
+// GenerateStateForTest exposes generateState for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
+var GenerateStateForTest = generateState
+
+// BuildHTTPClientForTest exposes buildHTTPClient for unit testing.
+func (a *Authenticator) BuildHTTPClientForTest() (*http.Client, error) {
+	return a.buildHTTPClient()
+}
+
+// NewOIDCProviderForTest exposes newOIDCProvider for unit testing, returning
+// only the error since the result type is unexported.
+func (a *Authenticator) NewOIDCProviderForTest(ctx context.Context, redirectURL string) error {
+	_, err := a.newOIDCProvider(ctx, redirectURL)
+
+	return err
+}

--- a/pkg/svc/provisioner/cluster/k3d/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/export_test.go
@@ -1,0 +1,45 @@
+package k3dprovisioner
+
+import (
+	"context"
+
+	"github.com/devantler-tech/ksail/v7/pkg/runner"
+)
+
+// WithRunnerForTest injects a command runner so lifecycle operations can be
+// exercised without invoking the real k3d runtime.
+func (k *Provisioner) WithRunnerForTest(r runner.CommandRunner) *Provisioner {
+	k.runner = r
+
+	return k
+}
+
+// WithListClustersRawForTest injects a stub that returns canned cluster-list
+// output, so List/Exists can be tested without invoking the real k3d runtime.
+func (k *Provisioner) WithListClustersRawForTest(
+	f func(ctx context.Context) (string, error),
+) *Provisioner {
+	k.listClustersRaw = f
+
+	return k
+}
+
+// ParseClusterNamesForTest exposes parseClusterNames for unit testing.
+func ParseClusterNamesForTest(output string) ([]string, error) {
+	return parseClusterNames(output)
+}
+
+// ResolveNameForTest exposes resolveName for unit testing.
+func (k *Provisioner) ResolveNameForTest(name string) string {
+	return k.resolveName(name)
+}
+
+// AppendConfigFlagForTest exposes appendConfigFlag for unit testing.
+func (k *Provisioner) AppendConfigFlagForTest(args []string) []string {
+	return k.appendConfigFlag(args)
+}
+
+// AppendImageFlagForTest exposes appendImageFlag for unit testing.
+func (k *Provisioner) AppendImageFlagForTest(args []string) []string {
+	return k.appendImageFlag(args)
+}

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -151,6 +151,32 @@ func (k *Provisioner) List(ctx context.Context) ([]string, error) {
 	return parseClusterNames(raw)
 }
 
+// Exists returns whether the target cluster is present.
+func (k *Provisioner) Exists(ctx context.Context, name string) (bool, error) {
+	clusters, err := k.List(ctx)
+	if err != nil {
+		return false, fmt.Errorf("list: %w", err)
+	}
+
+	target := k.resolveName(name)
+	if target == "" {
+		return false, nil
+	}
+
+	return slices.Contains(clusters, target), nil
+}
+
+// WithComponentDetector sets the component detector for querying cluster state.
+func (k *Provisioner) WithComponentDetector(d *detector.ComponentDetector) {
+	k.componentDetector = d
+}
+
+// SetComponentDetector sets the component detector for querying cluster state.
+// This implements the ComponentDetectorAware interface.
+func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
+	k.WithComponentDetector(d)
+}
+
 // defaultListClustersRaw runs the k3d cluster list command and returns its raw
 // JSON output. k3d's PrintClusters writes directly to os.Stdout using
 // fmt.Println (not Cobra's cmd.OutOrStdout()), so the output is captured by
@@ -213,32 +239,6 @@ func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error
 	}
 
 	return strings.TrimSpace(outputBuf.String()), nil
-}
-
-// Exists returns whether the target cluster is present.
-func (k *Provisioner) Exists(ctx context.Context, name string) (bool, error) {
-	clusters, err := k.List(ctx)
-	if err != nil {
-		return false, fmt.Errorf("list: %w", err)
-	}
-
-	target := k.resolveName(name)
-	if target == "" {
-		return false, nil
-	}
-
-	return slices.Contains(clusters, target), nil
-}
-
-// WithComponentDetector sets the component detector for querying cluster state.
-func (k *Provisioner) WithComponentDetector(d *detector.ComponentDetector) {
-	k.componentDetector = d
-}
-
-// SetComponentDetector sets the component detector for querying cluster state.
-// This implements the ComponentDetectorAware interface.
-func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
-	k.WithComponentDetector(d)
 }
 
 // runListCommand executes the k3d cluster list command and returns the output.

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -31,9 +31,14 @@ var (
 
 // Provisioner executes k3d lifecycle commands via Cobra.
 type Provisioner struct {
-	simpleCfg         *v1alpha5.SimpleConfig
-	configPath        string
-	runner            runner.CommandRunner
+	simpleCfg  *v1alpha5.SimpleConfig
+	configPath string
+	runner     runner.CommandRunner
+	// listClustersRaw returns the raw cluster-list output from k3d. It is a seam
+	// so tests can supply canned output without invoking the real k3d runtime
+	// (which calls logrus.Fatal when Docker is unavailable). Defaults to
+	// defaultListClustersRaw; tests override it via export_test.go.
+	listClustersRaw   func(ctx context.Context) (string, error)
 	componentDetector *detector.ComponentDetector
 }
 
@@ -61,6 +66,7 @@ func NewProvisioner(
 		configPath: configPath,
 		runner:     runner.NewCobraCommandRunner(nil, nil),
 	}
+	prov.listClustersRaw = prov.defaultListClustersRaw
 
 	return prov
 }
@@ -137,6 +143,19 @@ func (k *Provisioner) Stop(ctx context.Context, name string) error {
 
 // List returns cluster names reported by the Cobra command.
 func (k *Provisioner) List(ctx context.Context) ([]string, error) {
+	raw, err := k.listClustersRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseClusterNames(raw)
+}
+
+// defaultListClustersRaw runs the k3d cluster list command and returns its raw
+// JSON output. k3d's PrintClusters writes directly to os.Stdout using
+// fmt.Println (not Cobra's cmd.OutOrStdout()), so the output is captured by
+// temporarily redirecting os.Stdout.
+func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error) {
 	// Temporarily redirect logrus to discard output during list
 	// to prevent log messages from appearing in console
 	originalLogOutput := logrus.StandardLogger().Out
@@ -147,16 +166,13 @@ func (k *Provisioner) List(ctx context.Context) ([]string, error) {
 	// Lock to prevent concurrent modifications of os.Stdout
 	listMutex.Lock()
 
-	// Setup stdout redirection - k3d's PrintClusters writes directly to os.Stdout
-	// using fmt.Println, not through Cobra's cmd.OutOrStdout(), so we must
-	// capture from os.Stdout directly.
 	originalStdout := os.Stdout
 
 	pipeReader, pipeWriter, err := os.Pipe()
 	if err != nil {
 		listMutex.Unlock()
 
-		return nil, fmt.Errorf("cluster list: create stdout pipe: %w", err)
+		return "", fmt.Errorf("cluster list: create stdout pipe: %w", err)
 	}
 
 	os.Stdout = pipeWriter
@@ -189,14 +205,14 @@ func (k *Provisioner) List(ctx context.Context) ([]string, error) {
 	runErr := <-errChan
 
 	if copyErr != nil {
-		return nil, fmt.Errorf("cluster list: read stdout pipe: %w", copyErr)
+		return "", fmt.Errorf("cluster list: read stdout pipe: %w", copyErr)
 	}
 
 	if runErr != nil {
-		return nil, fmt.Errorf("cluster list: %w", runErr)
+		return "", fmt.Errorf("cluster list: %w", runErr)
 	}
 
-	return parseClusterNames(strings.TrimSpace(outputBuf.String()))
+	return strings.TrimSpace(outputBuf.String()), nil
 }
 
 // Exists returns whether the target cluster is present.

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -182,20 +182,24 @@ func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
 // fmt.Println (not Cobra's cmd.OutOrStdout()), so the output is captured by
 // temporarily redirecting os.Stdout.
 func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error) {
+	// Lock first so that the logrus save/restore and the os.Stdout save/restore
+	// are both protected by the same critical section. Without this ordering a
+	// second concurrent caller could read originalLogOutput as io.Discard (the
+	// value set by the first caller) and later restore to io.Discard, leaving
+	// the global logrus logger permanently muted.
+	listMutex.Lock()
+
 	// Temporarily redirect logrus to discard output during list
-	// to prevent log messages from appearing in console
+	// to prevent log messages from appearing in console.
 	originalLogOutput := logrus.StandardLogger().Out
 
 	logrus.SetOutput(io.Discard)
-	defer logrus.SetOutput(originalLogOutput)
-
-	// Lock to prevent concurrent modifications of os.Stdout
-	listMutex.Lock()
 
 	originalStdout := os.Stdout
 
 	pipeReader, pipeWriter, err := os.Pipe()
 	if err != nil {
+		logrus.SetOutput(originalLogOutput)
 		listMutex.Unlock()
 
 		return "", fmt.Errorf("cluster list: create stdout pipe: %w", err)
@@ -221,10 +225,10 @@ func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error
 	_, copyErr := io.Copy(&outputBuf, pipeReader)
 	_ = pipeReader.Close()
 
-	// Restore stdout while still holding the lock
+	// Restore stdout and logrus, then release the lock.
 	os.Stdout = originalStdout
+	logrus.SetOutput(originalLogOutput)
 
-	// Unlock mutex after restoring stdout
 	listMutex.Unlock()
 
 	// Wait for command to complete and get any error

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -227,6 +227,7 @@ func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error
 
 	// Restore stdout and logrus, then release the lock.
 	os.Stdout = originalStdout
+
 	logrus.SetOutput(originalLogOutput)
 
 	listMutex.Unlock()

--- a/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
@@ -142,12 +142,13 @@ func TestProvisioner_NewProvisioner(t *testing.T) {
 }
 
 // TestProvisioner_Create verifies the create command is dispatched with the
-// expected flags and that runner errors are wrapped.
+// expected flags and that runner errors are wrapped. The subtests are not run
+// in parallel: both call runLifecycleCommand, which constructs k3d's
+// NewCmdClusterCreate. That builder mutates package-level Viper state, so
+// concurrent calls race under -race.
 //
-//nolint:paralleltest // subtests call runLifecycleCommand which constructs k3d's NewCmdClusterCreate; that builder mutates package-level Viper state and is not safe to call concurrently
+//nolint:paralleltest // k3d command builder mutates package-level Viper state
 func TestProvisioner_Create(t *testing.T) {
-	t.Parallel()
-
 	t.Run("runs create with config flag", func(t *testing.T) {
 		var capturedArgs []string
 

--- a/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
@@ -143,12 +143,12 @@ func TestProvisioner_NewProvisioner(t *testing.T) {
 
 // TestProvisioner_Create verifies the create command is dispatched with the
 // expected flags and that runner errors are wrapped.
+//
+//nolint:paralleltest // subtests call runLifecycleCommand which constructs k3d's NewCmdClusterCreate; that builder mutates package-level Viper state and is not safe to call concurrently
 func TestProvisioner_Create(t *testing.T) {
 	t.Parallel()
 
 	t.Run("runs create with config flag", func(t *testing.T) {
-		t.Parallel()
-
 		var capturedArgs []string
 
 		mockRunner := runner.NewMockCommandRunner(t)
@@ -176,8 +176,6 @@ func TestProvisioner_Create(t *testing.T) {
 	})
 
 	t.Run("wraps runner error", func(t *testing.T) {
-		t.Parallel()
-
 		mockRunner := runner.NewMockCommandRunner(t)
 		mockRunner.EXPECT().
 			Run(mock.Anything, mock.Anything, mock.Anything).

--- a/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
@@ -242,17 +242,17 @@ func TestProvisioner_StartStop(t *testing.T) {
 
 	tests := []struct {
 		name string
-		call func(p *k3dprovisioner.Provisioner, ctx context.Context) error
+		call func(ctx context.Context, p *k3dprovisioner.Provisioner) error
 	}{
 		{
 			name: "start",
-			call: func(p *k3dprovisioner.Provisioner, ctx context.Context) error {
+			call: func(ctx context.Context, p *k3dprovisioner.Provisioner) error {
 				return p.Start(ctx, "alpha")
 			},
 		},
 		{
 			name: "stop",
-			call: func(p *k3dprovisioner.Provisioner, ctx context.Context) error {
+			call: func(ctx context.Context, p *k3dprovisioner.Provisioner) error {
 				return p.Stop(ctx, "alpha")
 			},
 		},
@@ -270,7 +270,7 @@ func TestProvisioner_StartStop(t *testing.T) {
 			prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "").
 				WithRunnerForTest(mockRunner)
 
-			require.NoError(t, testCase.call(prov, context.Background()))
+			require.NoError(t, testCase.call(context.Background(), prov))
 		})
 
 		t.Run(testCase.name+" propagates error", func(t *testing.T) {
@@ -284,7 +284,7 @@ func TestProvisioner_StartStop(t *testing.T) {
 			prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "").
 				WithRunnerForTest(mockRunner)
 
-			require.ErrorIs(t, testCase.call(prov, context.Background()), errRunnerBoom)
+			require.ErrorIs(t, testCase.call(context.Background(), prov), errRunnerBoom)
 		})
 	}
 }
@@ -301,7 +301,11 @@ func TestParseClusterNames(t *testing.T) {
 	}{
 		{name: "empty", output: "", want: nil},
 		{name: "two clusters", output: twoClusterJSON, want: []string{"alpha", "beta"}},
-		{name: "skips empty names", output: `[{"name":"alpha"},{"name":""}]`, want: []string{"alpha"}},
+		{
+			name:   "skips empty names",
+			output: `[{"name":"alpha"},{"name":""}]`,
+			want:   []string{"alpha"},
+		},
 		{name: "invalid json", output: "{not json", wantErr: true},
 	}
 
@@ -380,7 +384,8 @@ func TestAppendFlags(t *testing.T) {
 	t.Run("image flag appended from config when no config path", func(t *testing.T) {
 		t.Parallel()
 
-		prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{Image: "rancher/k3s:v1.30"}, "")
+		cfg := &v1alpha5.SimpleConfig{Image: "rancher/k3s:v1.30"}
+		prov := k3dprovisioner.NewProvisioner(cfg, "")
 		args := prov.AppendImageFlagForTest(nil)
 		assert.True(t, slices.Contains(args, "--image"))
 		assert.True(t, slices.Contains(args, "rancher/k3s:v1.30"))

--- a/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner_test.go
@@ -2,78 +2,121 @@ package k3dprovisioner_test
 
 import (
 	"context"
+	"errors"
+	"slices"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/pkg/runner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	k3dprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3d"
+	k3dtypes "github.com/k3d-io/k3d/v5/pkg/config/types"
+	v1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
-// TestProvisioner_List tests the List method of Provisioner.
-//
-//nolint:paralleltest // Cannot use t.Parallel() because List() modifies global os.Stdout.
-func TestProvisioner_List(t *testing.T) {
-	// Test with nil config
-	t.Run("list with nil config", func(t *testing.T) {
-		provisioner := k3dprovisioner.NewProvisioner(nil, "")
-		result, err := provisioner.List(context.Background())
+var errRunnerBoom = errors.New("runner boom")
 
-		// In test environment without k3d binary, this may return an error or empty list
-		// We just verify the method can be called without panicking
-		if err != nil {
-			// If there's an error, result may be nil which is acceptable
-			t.Logf("List returned error (expected without k3d): %v", err)
-		} else {
-			// If no error, result should be a slice (possibly nil or empty)
-			// In Go, nil slices and empty slices are both valid for "no elements"
-			t.Logf("List succeeded with %d clusters", len(result))
-		}
+const twoClusterJSON = `[{"name":"alpha"},{"name":"beta"}]`
+
+// namedConfig builds a SimpleConfig with the given cluster name. The name lives
+// on the embedded ObjectMeta, so it cannot be set in a flat struct literal.
+func namedConfig(name string) *v1alpha5.SimpleConfig {
+	return &v1alpha5.SimpleConfig{ObjectMeta: k3dtypes.ObjectMeta{Name: name}}
+}
+
+// TestProvisioner_List verifies that List parses the cluster-list output into
+// cluster names and propagates listing errors.
+func TestProvisioner_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses cluster names", func(t *testing.T) {
+		t.Parallel()
+
+		prov := k3dprovisioner.NewProvisioner(nil, "").
+			WithListClustersRawForTest(func(_ context.Context) (string, error) {
+				return twoClusterJSON, nil
+			})
+
+		result, err := prov.List(context.Background())
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"alpha", "beta"}, result)
 	})
 
-	// Test with empty config path
-	t.Run("list with empty config path", func(t *testing.T) {
-		provisioner := k3dprovisioner.NewProvisioner(nil, "")
-		result, err := provisioner.List(context.Background())
+	t.Run("empty output yields no clusters", func(t *testing.T) {
+		t.Parallel()
 
-		// In test environment without k3d binary, this may return an error or empty list
-		// We just verify the method can be called without panicking
-		if err != nil {
-			// If there's an error, result may be nil which is acceptable
-			t.Logf("List returned error (expected without k3d): %v", err)
-		} else {
-			// If no error, result should be a slice (possibly nil or empty)
-			// In Go, nil slices and empty slices are both valid for "no elements"
-			t.Logf("List succeeded with %d clusters", len(result))
-		}
+		prov := k3dprovisioner.NewProvisioner(nil, "").
+			WithListClustersRawForTest(func(_ context.Context) (string, error) {
+				return "", nil
+			})
+
+		result, err := prov.List(context.Background())
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("propagates listing error", func(t *testing.T) {
+		t.Parallel()
+
+		prov := k3dprovisioner.NewProvisioner(nil, "").
+			WithListClustersRawForTest(func(_ context.Context) (string, error) {
+				return "", errRunnerBoom
+			})
+
+		_, err := prov.List(context.Background())
+
+		require.ErrorIs(t, err, errRunnerBoom)
 	})
 }
 
-// TestProvisioner_Exists tests the Exists method.
-//
-//nolint:paralleltest // Cannot use t.Parallel() because Exists() calls List() which modifies global os.Stdout.
+// TestProvisioner_Exists verifies membership checks against the listed clusters.
 func TestProvisioner_Exists(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		clusterName string
+		listOutput  string
+		want        bool
 	}{
-		{
-			name:        "check existence with cluster name",
-			clusterName: "test-cluster",
-		},
-		{
-			name:        "check existence without cluster name",
-			clusterName: "",
-		},
+		{name: "present", clusterName: "alpha", listOutput: twoClusterJSON, want: true},
+		{name: "absent", clusterName: "gamma", listOutput: twoClusterJSON, want: false},
+		{name: "empty name", clusterName: "", listOutput: twoClusterJSON, want: false},
 	}
 
 	for _, testCase := range tests {
-		t.Run(testCase.name, func(_ *testing.T) {
-			provisioner := k3dprovisioner.NewProvisioner(nil, "")
-			_, _ = provisioner.Exists(context.Background(), testCase.clusterName)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-			// In test environment without actual k3d clusters, this may return an error
-			// We just verify the method can be called without panicking
+			prov := k3dprovisioner.NewProvisioner(nil, "").
+				WithListClustersRawForTest(func(_ context.Context) (string, error) {
+					return testCase.listOutput, nil
+				})
+
+			got, err := prov.Exists(context.Background(), testCase.clusterName)
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
 		})
 	}
+}
+
+func TestProvisioner_Exists_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	prov := k3dprovisioner.NewProvisioner(nil, "").
+		WithListClustersRawForTest(func(_ context.Context) (string, error) {
+			return "", errRunnerBoom
+		})
+
+	_, err := prov.Exists(context.Background(), "alpha")
+
+	require.ErrorIs(t, err, errRunnerBoom)
 }
 
 // TestProvisioner_NewProvisioner tests the constructor.
@@ -84,14 +127,8 @@ func TestProvisioner_NewProvisioner(t *testing.T) {
 		name       string
 		configPath string
 	}{
-		{
-			name:       "create with config path",
-			configPath: "/path/to/config",
-		},
-		{
-			name:       "create with empty config path",
-			configPath: "",
-		},
+		{name: "create with config path", configPath: "/path/to/config"},
+		{name: "create with empty config path", configPath: ""},
 	}
 
 	for _, testCase := range tests {
@@ -104,34 +141,256 @@ func TestProvisioner_NewProvisioner(t *testing.T) {
 	}
 }
 
-// TestProvisioner_Create tests the Create method.
+// TestProvisioner_Create verifies the create command is dispatched with the
+// expected flags and that runner errors are wrapped.
 func TestProvisioner_Create(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("Skipping Create test - k3d binary not available in test environment")
+	t.Run("runs create with config flag", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedArgs []string
+
+		mockRunner := runner.NewMockCommandRunner(t)
+		mockRunner.EXPECT().
+			Run(mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(
+				_ context.Context,
+				_ *cobra.Command,
+				args []string,
+			) (runner.CommandResult, error) {
+				capturedArgs = args
+
+				return runner.CommandResult{}, nil
+			})
+
+		prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "/tmp/k3d.yaml").
+			WithRunnerForTest(mockRunner)
+
+		err := prov.Create(context.Background(), "my-cluster")
+
+		require.NoError(t, err)
+		assert.Contains(t, capturedArgs, "--config")
+		assert.Contains(t, capturedArgs, "/tmp/k3d.yaml")
+		assert.Contains(t, capturedArgs, "my-cluster")
+	})
+
+	t.Run("wraps runner error", func(t *testing.T) {
+		t.Parallel()
+
+		mockRunner := runner.NewMockCommandRunner(t)
+		mockRunner.EXPECT().
+			Run(mock.Anything, mock.Anything, mock.Anything).
+			Return(runner.CommandResult{}, errRunnerBoom)
+
+		prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "").
+			WithRunnerForTest(mockRunner)
+
+		err := prov.Create(context.Background(), "my-cluster")
+
+		require.ErrorIs(t, err, errRunnerBoom)
+		assert.Contains(t, err.Error(), "cluster create")
+	})
 }
 
-// TestProvisioner_Delete tests the Delete method.
+// TestProvisioner_Delete verifies existence is checked before deletion and that
+// a missing cluster yields ErrClusterNotFound without running the delete command.
 func TestProvisioner_Delete(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("Skipping Delete test - k3d binary not available in test environment")
+	t.Run("deletes existing cluster", func(t *testing.T) {
+		t.Parallel()
+
+		mockRunner := runner.NewMockCommandRunner(t)
+		mockRunner.EXPECT().
+			Run(mock.Anything, mock.Anything, mock.Anything).
+			Return(runner.CommandResult{}, nil)
+
+		prov := k3dprovisioner.NewProvisioner(namedConfig("alpha"), "").
+			WithRunnerForTest(mockRunner).
+			WithListClustersRawForTest(func(_ context.Context) (string, error) {
+				return twoClusterJSON, nil
+			})
+
+		err := prov.Delete(context.Background(), "alpha")
+
+		require.NoError(t, err)
+	})
+
+	t.Run("missing cluster returns ErrClusterNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		// No runner expectations: delete must not run when the cluster is absent.
+		mockRunner := runner.NewMockCommandRunner(t)
+
+		prov := k3dprovisioner.NewProvisioner(namedConfig("missing"), "").
+			WithRunnerForTest(mockRunner).
+			WithListClustersRawForTest(func(_ context.Context) (string, error) {
+				return twoClusterJSON, nil
+			})
+
+		err := prov.Delete(context.Background(), "missing")
+
+		require.ErrorIs(t, err, clustererr.ErrClusterNotFound)
+	})
 }
 
-// TestProvisioner_Start tests the Start method.
-func TestProvisioner_Start(t *testing.T) {
+// TestProvisioner_StartStop verifies the start/stop commands dispatch to the
+// runner and propagate errors.
+func TestProvisioner_StartStop(t *testing.T) {
 	t.Parallel()
 
-	t.Skip(
-		"Skipping Start test - k3d binary not available in test environment and may cause fatal errors",
-	)
+	tests := []struct {
+		name string
+		call func(p *k3dprovisioner.Provisioner, ctx context.Context) error
+	}{
+		{
+			name: "start",
+			call: func(p *k3dprovisioner.Provisioner, ctx context.Context) error {
+				return p.Start(ctx, "alpha")
+			},
+		},
+		{
+			name: "stop",
+			call: func(p *k3dprovisioner.Provisioner, ctx context.Context) error {
+				return p.Stop(ctx, "alpha")
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name+" succeeds", func(t *testing.T) {
+			t.Parallel()
+
+			mockRunner := runner.NewMockCommandRunner(t)
+			mockRunner.EXPECT().
+				Run(mock.Anything, mock.Anything, mock.Anything).
+				Return(runner.CommandResult{}, nil)
+
+			prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "").
+				WithRunnerForTest(mockRunner)
+
+			require.NoError(t, testCase.call(prov, context.Background()))
+		})
+
+		t.Run(testCase.name+" propagates error", func(t *testing.T) {
+			t.Parallel()
+
+			mockRunner := runner.NewMockCommandRunner(t)
+			mockRunner.EXPECT().
+				Run(mock.Anything, mock.Anything, mock.Anything).
+				Return(runner.CommandResult{}, errRunnerBoom)
+
+			prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "").
+				WithRunnerForTest(mockRunner)
+
+			require.ErrorIs(t, testCase.call(prov, context.Background()), errRunnerBoom)
+		})
+	}
 }
 
-// TestProvisioner_Stop tests the Stop method.
-func TestProvisioner_Stop(t *testing.T) {
+// TestParseClusterNames covers the JSON parsing helper directly.
+func TestParseClusterNames(t *testing.T) {
 	t.Parallel()
 
-	t.Skip(
-		"Skipping Stop test - k3d binary not available in test environment and may cause fatal errors",
-	)
+	tests := []struct {
+		name    string
+		output  string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", output: "", want: nil},
+		{name: "two clusters", output: twoClusterJSON, want: []string{"alpha", "beta"}},
+		{name: "skips empty names", output: `[{"name":"alpha"},{"name":""}]`, want: []string{"alpha"}},
+		{name: "invalid json", output: "{not json", wantErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := k3dprovisioner.ParseClusterNamesForTest(testCase.output)
+
+			if testCase.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+// TestResolveName covers name resolution precedence.
+func TestResolveName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		argName   string
+		configCfg *v1alpha5.SimpleConfig
+		want      string
+	}{
+		{
+			name:      "explicit name wins",
+			argName:   "explicit",
+			configCfg: namedConfig("cfg"),
+			want:      "explicit",
+		},
+		{
+			name:      "falls back to config name",
+			argName:   "",
+			configCfg: namedConfig("cfg"),
+			want:      "cfg",
+		},
+		{name: "empty when nothing set", argName: "", configCfg: nil, want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			prov := k3dprovisioner.NewProvisioner(testCase.configCfg, "")
+			assert.Equal(t, testCase.want, prov.ResolveNameForTest(testCase.argName))
+		})
+	}
+}
+
+// TestAppendFlags covers the config/image flag helpers.
+func TestAppendFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("config flag appended when path set", func(t *testing.T) {
+		t.Parallel()
+
+		prov := k3dprovisioner.NewProvisioner(nil, "/tmp/k3d.yaml")
+		args := prov.AppendConfigFlagForTest(nil)
+		assert.Equal(t, []string{"--config", "/tmp/k3d.yaml"}, args)
+	})
+
+	t.Run("config flag omitted when path empty", func(t *testing.T) {
+		t.Parallel()
+
+		prov := k3dprovisioner.NewProvisioner(nil, "")
+		assert.Empty(t, prov.AppendConfigFlagForTest(nil))
+	})
+
+	t.Run("image flag appended from config when no config path", func(t *testing.T) {
+		t.Parallel()
+
+		prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{Image: "rancher/k3s:v1.30"}, "")
+		args := prov.AppendImageFlagForTest(nil)
+		assert.True(t, slices.Contains(args, "--image"))
+		assert.True(t, slices.Contains(args, "rancher/k3s:v1.30"))
+	})
+
+	t.Run("image flag omitted when config path set", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &v1alpha5.SimpleConfig{Image: "rancher/k3s:v1.30"}
+		prov := k3dprovisioner.NewProvisioner(cfg, "/tmp/k3d.yaml")
+		assert.Empty(t, prov.AppendImageFlagForTest(nil))
+	})
 }

--- a/pkg/svc/provisioner/cluster/kwok/export_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/export_test.go
@@ -6,3 +6,25 @@ var IsTransientCreateErrorForTest = isTransientCreateError
 
 // CreateWithRetryForTest exposes createWithRetry for unit testing.
 var CreateWithRetryForTest = createWithRetry
+
+// TransientCreateErrorsForTest exposes transientCreateErrors for unit testing.
+var TransientCreateErrorsForTest = transientCreateErrors
+
+// KwokContainerNamesForTest exposes kwokContainerNames for unit testing.
+var KwokContainerNamesForTest = kwokContainerNames
+
+// KwokStateDirForTest exposes kwokStateDir for unit testing.
+var KwokStateDirForTest = kwokStateDir
+
+// SetDefaultClusterForTest exposes setDefaultCluster for unit testing.
+var SetDefaultClusterForTest = setDefaultCluster
+
+// ResolveNameForTest exposes resolveName for unit testing.
+func (p *Provisioner) ResolveNameForTest(name string) string {
+	return p.resolveName(name)
+}
+
+// ResolveConfigPathForTest exposes resolveConfigPath for unit testing.
+func (p *Provisioner) ResolveConfigPathForTest() (string, func(), error) {
+	return p.resolveConfigPath()
+}

--- a/pkg/svc/provisioner/cluster/kwok/helpers_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/helpers_test.go
@@ -1,0 +1,141 @@
+package kwokprovisioner_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	kwokprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kwok"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kwok/pkg/config"
+)
+
+func TestTransientCreateErrors(t *testing.T) {
+	t.Parallel()
+
+	errs := kwokprovisioner.TransientCreateErrorsForTest()
+
+	assert.Contains(t, errs, "toomanyrequests")
+	assert.Contains(t, errs, "Quota exceeded")
+	assert.Contains(t, errs, "i/o timeout")
+	assert.Contains(t, errs, "no such host")
+}
+
+func TestKwokContainerNames(t *testing.T) {
+	t.Parallel()
+
+	names := kwokprovisioner.KwokContainerNamesForTest("demo")
+
+	assert.Equal(t, []string{
+		"kwok-demo-kube-apiserver",
+		"kwok-demo-kube-controller-manager",
+		"kwok-demo-kube-scheduler",
+		"kwok-demo-kwok-controller",
+	}, names)
+}
+
+func TestKwokStateDir(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	dir, err := kwokprovisioner.KwokStateDirForTest("demo")
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(home, ".kwok", "clusters", "demo"), dir)
+}
+
+func TestResolveName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		configured  string
+		argument    string
+		wantResolve string
+	}{
+		{
+			name:        "explicit argument wins",
+			configured:  "configured",
+			argument:    "explicit",
+			wantResolve: "explicit",
+		},
+		{
+			name:        "falls back to configured name",
+			configured:  "configured",
+			argument:    "",
+			wantResolve: "configured",
+		},
+		{name: "empty when nothing set", configured: "", argument: "", wantResolve: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			prov := kwokprovisioner.NewProvisioner(testCase.configured, "", nil)
+			assert.Equal(t, testCase.wantResolve, prov.ResolveNameForTest(testCase.argument))
+		})
+	}
+}
+
+// TestSetDefaultCluster mutates the process-global config.DefaultCluster, so it
+// must not run in parallel with other tests touching that global.
+//
+//nolint:paralleltest // Mutates process-global config.DefaultCluster.
+func TestSetDefaultCluster(t *testing.T) {
+	original := config.DefaultCluster
+
+	t.Cleanup(func() { config.DefaultCluster = original })
+
+	restore := kwokprovisioner.SetDefaultClusterForTest("temp-cluster")
+	assert.Equal(t, "temp-cluster", config.DefaultCluster)
+
+	restore()
+	assert.Equal(t, original, config.DefaultCluster)
+}
+
+func TestResolveConfigPath_ExplicitPath(t *testing.T) {
+	t.Parallel()
+
+	prov := kwokprovisioner.NewProvisioner("demo", "/explicit/kwok.yaml", nil)
+
+	path, cleanup, err := prov.ResolveConfigPathForTest()
+
+	require.NoError(t, err)
+	assert.Equal(t, "/explicit/kwok.yaml", path)
+	assert.Nil(t, cleanup, "explicit config path needs no cleanup")
+}
+
+func TestResolveConfigPath_GeneratesDefault(t *testing.T) {
+	t.Parallel()
+
+	prov := kwokprovisioner.NewProvisioner("demo", "", nil)
+
+	path, cleanup, err := prov.ResolveConfigPathForTest()
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+
+	defer cleanup()
+
+	// A temp directory containing kustomization.yaml and simulation.yaml is created.
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	kustomization, err := os.ReadFile(filepath.Join(path, "kustomization.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(kustomization), "kind: Kustomization")
+	assert.Contains(t, string(kustomization), "simulation.yaml")
+
+	simulation, err := os.ReadFile(filepath.Join(path, "simulation.yaml"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, simulation)
+
+	// cleanup removes the generated directory.
+	cleanup()
+	_, statErr := os.Stat(path)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}

--- a/pkg/svc/provisioner/cluster/kwok/helpers_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/helpers_test.go
@@ -91,9 +91,11 @@ func TestSetDefaultCluster(t *testing.T) {
 	t.Cleanup(func() { config.DefaultCluster = original })
 
 	restore := kwokprovisioner.SetDefaultClusterForTest("temp-cluster")
+
 	assert.Equal(t, "temp-cluster", config.DefaultCluster)
 
 	restore()
+
 	assert.Equal(t, original, config.DefaultCluster)
 }
 
@@ -125,17 +127,20 @@ func TestResolveConfigPath_GeneratesDefault(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
 
-	kustomization, err := os.ReadFile(filepath.Join(path, "kustomization.yaml"))
+	kustomizationPath := filepath.Join(path, "kustomization.yaml")
+	kustomization, err := os.ReadFile(kustomizationPath) //nolint:gosec // Test file path is safe
 	require.NoError(t, err)
 	assert.Contains(t, string(kustomization), "kind: Kustomization")
 	assert.Contains(t, string(kustomization), "simulation.yaml")
 
-	simulation, err := os.ReadFile(filepath.Join(path, "simulation.yaml"))
+	simulationPath := filepath.Join(path, "simulation.yaml")
+	simulation, err := os.ReadFile(simulationPath) //nolint:gosec // Test file path is safe
 	require.NoError(t, err)
 	assert.NotEmpty(t, simulation)
 
 	// cleanup removes the generated directory.
 	cleanup()
+
 	_, statErr := os.Stat(path)
 	require.ErrorIs(t, statErr, os.ErrNotExist)
 }

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -3,6 +3,7 @@ package talosprovisioner
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/netip"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -418,4 +419,14 @@ func (p *Provisioner) MergePersistedStateForTest(
 	clusterName string,
 ) error {
 	return p.mergePersistedState(spec, clusterName)
+}
+
+// WithKernelModuleLoaderForTest overrides the kernel module loader so unit tests
+// can exercise the Docker provisioning path without invoking modprobe.
+func (p *Provisioner) WithKernelModuleLoaderForTest(
+	f func(ctx context.Context, logWriter io.Writer) error,
+) *Provisioner {
+	p.kernelModuleLoader = f
+
+	return p
 }

--- a/pkg/svc/provisioner/cluster/talos/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/kubernetes_provisioner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
-	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kernelmod"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/access"
@@ -157,7 +156,7 @@ func (p *KubernetesProvisioner) Create(ctx context.Context, name string) error {
 
 	p.inner.WithDockerClient(dindClient)
 
-	err = kernelmod.EnsureBrNetfilter(ctx, p.inner.logWriter)
+	err = p.inner.kernelModuleLoader(ctx, p.inner.logWriter)
 	if err != nil {
 		return fmt.Errorf("kernel module check: %w", err)
 	}

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	dockerprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/docker"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kernelmod"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	dockerclient "github.com/docker/docker/client"
@@ -146,6 +147,10 @@ type Provisioner struct {
 	// omniOpts holds Omni-specific options when using the Omni provider.
 	omniOpts           *v1alpha1.OptionsOmni
 	provisionerFactory func(ctx context.Context) (provision.Provisioner, error)
+	// kernelModuleLoader ensures required kernel modules are loaded before
+	// Docker-based provisioning. Defaults to kernelmod.EnsureBrNetfilter; tests
+	// override it via export_test.go to avoid invoking modprobe.
+	kernelModuleLoader func(ctx context.Context, logWriter io.Writer) error
 	// talosClientFactory creates a Talos client for the given node IP.
 	// Tests can override this via export_test.go to inject a mock.
 	talosClientFactory func(ctx context.Context, ip string) (kubeconfigFetcher, error)
@@ -181,8 +186,9 @@ func NewProvisioner(
 		provisionerFactory: func(ctx context.Context) (provision.Provisioner, error) {
 			return providers.Factory(ctx, TalosProviderName)
 		},
-		logWriter:      os.Stdout,
-		imagePullRetry: defaultImagePullRetryConfig(),
+		kernelModuleLoader: kernelmod.EnsureBrNetfilter,
+		logWriter:          os.Stdout,
+		imagePullRetry:     defaultImagePullRetryConfig(),
 	}
 
 	prov.talosClientFactory = func(ctx context.Context, ip string) (kubeconfigFetcher, error) {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_docker.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_docker.go
@@ -10,7 +10,6 @@ import (
 	docker "github.com/devantler-tech/ksail/v7/pkg/client/docker"
 	"github.com/devantler-tech/ksail/v7/pkg/client/netretry"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
-	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kernelmod"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/go-connections/nat"
@@ -26,7 +25,7 @@ func (p *Provisioner) createDockerCluster(ctx context.Context, clusterName strin
 	provisionStart := time.Now()
 
 	// Ensure required kernel modules are loaded (Linux only)
-	err := kernelmod.EnsureBrNetfilter(ctx, p.logWriter)
+	err := p.kernelModuleLoader(ctx, p.logWriter)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrKernelModuleLoadFailed, err)
 	}

--- a/pkg/svc/provisioner/cluster/talos/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_test.go
@@ -33,6 +33,12 @@ var (
 	errRepoNotFound   = errors.New("repository not found: 404 Not Found")
 )
 
+// noopKernelModuleLoader is a kernel module loader stub that succeeds without
+// invoking modprobe, so Docker provisioning tests are hermetic.
+func noopKernelModuleLoader(_ context.Context, _ io.Writer) error {
+	return nil
+}
+
 // createTestTalosConfigs creates a minimal TalosConfigs for testing.
 func createTestTalosConfigs(t *testing.T, clusterName string) *talosconfigmanager.Configs {
 	t.Helper()
@@ -115,7 +121,8 @@ func TestProvisioner_Create_NoDockerClient(t *testing.T) {
 	t.Parallel()
 
 	configs := createTestTalosConfigs(t, "test-cluster")
-	provisioner := talosprovisioner.NewProvisioner(configs, nil)
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).
+		WithKernelModuleLoaderForTest(noopKernelModuleLoader)
 
 	ctx := context.Background()
 	err := provisioner.Create(ctx, "")
@@ -145,7 +152,8 @@ func TestProvisioner_Create_ClusterAlreadyExists(t *testing.T) {
 
 	configs := createTestTalosConfigs(t, "existing-cluster")
 	provisioner := talosprovisioner.NewProvisioner(configs, nil).
-		WithDockerClient(mockClient)
+		WithDockerClient(mockClient).
+		WithKernelModuleLoaderForTest(noopKernelModuleLoader)
 
 	ctx := context.Background()
 	err := provisioner.Create(ctx, "existing-cluster")
@@ -189,7 +197,8 @@ func TestProvisioner_Create_Success(t *testing.T) {
 		WithProvisionerFactory(func(_ context.Context) (provision.Provisioner, error) {
 			return mockProvisioner, nil
 		}).
-		WithLogWriter(io.Discard)
+		WithLogWriter(io.Discard).
+		WithKernelModuleLoaderForTest(noopKernelModuleLoader)
 
 	ctx := context.Background()
 	err := provisioner.Create(ctx, "test-cluster")
@@ -235,7 +244,8 @@ func TestProvisioner_Create_WithPatches(t *testing.T) {
 		WithProvisionerFactory(func(_ context.Context) (provision.Provisioner, error) {
 			return mockProvisioner, nil
 		}).
-		WithLogWriter(io.Discard)
+		WithLogWriter(io.Discard).
+		WithKernelModuleLoaderForTest(noopKernelModuleLoader)
 
 	ctx := context.Background()
 	err := provisioner.Create(ctx, "test-cluster-patches")
@@ -291,7 +301,8 @@ func TestProvisioner_Create_ImagePullRetryOnTransientError(t *testing.T) {
 			return mockTalosProvisioner, nil
 		}).
 		WithImagePullRetryConfig(3, 0, 0).
-		WithLogWriter(io.Discard)
+		WithLogWriter(io.Discard).
+		WithKernelModuleLoaderForTest(noopKernelModuleLoader)
 
 	ctx := context.Background()
 	err := provisioner.Create(ctx, "test-cluster-retry")
@@ -325,7 +336,8 @@ func TestProvisioner_Create_ImagePullNonRetryableError(t *testing.T) {
 	provisioner := talosprovisioner.NewProvisioner(configs, nil).
 		WithDockerClient(mockClient).
 		WithImagePullRetryConfig(3, 0, 0).
-		WithLogWriter(io.Discard)
+		WithLogWriter(io.Discard).
+		WithKernelModuleLoaderForTest(noopKernelModuleLoader)
 
 	ctx := context.Background()
 	err := provisioner.Create(ctx, "test-cluster-nonretry")


### PR DESCRIPTION
Address the gaps surfaced by the test-coverage analysis:

- oidc: add unit tests for the pure authenticator helpers
  (validateCallbackRequest, generatePKCE, generateState, buildHTTPClient)
  and newOIDCProvider against an httptest discovery server (16.5% -> 38.5%).
- kwok provisioner: add unit tests for the pure helpers (resolveName,
  kwokContainerNames, kwokStateDir, setDefaultCluster, resolveConfigPath,
  transientCreateErrors) (5.9% -> 14.2%).
- k3d provisioner: make the command runner and cluster listing injectable
  via export_test seams and replace the no-assertion smoke tests (which
  crashed via logrus.Fatal without Docker) with behavior-asserting tests.
- talos provisioner: make the kernel-module loader injectable so the
  Docker-path Create tests run without modprobe.
- Make permission-error tests hermetic: skip under root (reusing
  rootcheck) or trigger failures via ENOTDIR instead of relying on
  unwritable paths, and gate cloudproviderkind integration tests on
  actual Docker availability instead of the CI env var.
- codecov: ignore generated files (mocks.go, *_generated.go,
  zz_generated*.go, doc.go) so coverage reflects hand-written code.

https://claude.ai/code/session_01KKPvNLUKN5Yfk9S2hRXB9K