### PR TITLE
fix: merge existing node-labels when injecting worker role label patch

### DIFF
--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -209,12 +209,19 @@ const legacyWorkerRoleLabelPatchYAML = "machine:\n  nodeLabels:\n    node-role.k
 // format to the kubelet.extraArgs["node-labels"] format. The old format causes
 // the Kubernetes NodeRestriction admission controller to block ALL label updates
 // from Talos's NodeApplyController on worker nodes.
+//
+// When injecting the runtime patch, existing kubelet.extraArgs.node-labels values
+// from other worker patch files are preserved by merging them comma-separated into
+// the injected patch. This prevents the runtime patch from silently overwriting
+// user-defined labels (e.g., Longhorn disk labels).
 func (m *ConfigManager) addWorkerRoleLabelPatch(
 	talosManager *talosconfigmanager.ConfigManager,
 	patchesDir string,
 ) {
 	if !workerRoleLabelPatchFileExists(patchesDir) {
-		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{
+			mergedWorkerRoleLabelPatch(patchesDir),
+		})
 
 		return
 	}
@@ -227,7 +234,9 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 	if err != nil {
 		// Cannot read safely (e.g. symlink escape) — inject runtime fallback so
 		// the worker role label is still set via kubelet.extraArgs at registration.
-		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{
+			mergedWorkerRoleLabelPatch(patchesDir),
+		})
 
 		return
 	}
@@ -235,27 +244,147 @@ func (m *ConfigManager) addWorkerRoleLabelPatch(
 	contentStr := strings.TrimSpace(string(content))
 
 	if contentStr == strings.TrimSpace(legacyWorkerRoleLabelPatchYAML) {
-		// Exact legacy scaffold — overwrite with the new format.
+		// Exact legacy scaffold — overwrite with the new format (including
+		// any node-labels from other worker patches to avoid overwriting them).
 		canonPath, pathErr := fsutil.EvalCanonicalPath(patchFile)
 		if pathErr != nil {
-			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{
+				mergedWorkerRoleLabelPatch(patchesDir),
+			})
 
 			return
 		}
 
+		mergedContent := mergedWorkerRoleLabelPatchYAML(patchesDir)
+
 		//nolint:mnd // standard restrictive file permission
-		writeErr := os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600)
+		writeErr := os.WriteFile(canonPath, []byte(mergedContent), 0o600)
 		if writeErr != nil {
 			// Write failed — inject the correct runtime patch as fallback so the
 			// worker role label is still set via kubelet.extraArgs at registration time.
-			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{
+				mergedWorkerRoleLabelPatch(patchesDir),
+			})
 		}
 	} else if strings.Contains(contentStr, "node-role.kubernetes.io/worker") &&
 		strings.Contains(contentStr, "nodeLabels") {
 		// Customized file still contains the legacy worker role label in nodeLabels.
 		// We cannot safely rewrite user-customized content, but we inject the runtime
 		// kubelet.extraArgs patch so the worker role is at least set at registration time.
-		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{
+			mergedWorkerRoleLabelPatch(patchesDir),
+		})
+	}
+}
+
+// workerRoleLabelFileName is the expected filename for the worker role label patch.
+const workerRoleLabelFileName = "worker-role-label.yaml"
+
+// nodeLabelsPartial is a minimal struct for extracting kubelet.extraArgs.node-labels
+// from Talos machine config patch YAML files.
+type nodeLabelsPartial struct {
+	Machine struct {
+		Kubelet struct {
+			ExtraArgs map[string]string `json:"extraArgs"`
+		} `json:"kubelet"`
+	} `json:"machine"`
+}
+
+// collectWorkerNodeLabelsFromPatches scans worker patch files (excluding
+// worker-role-label.yaml) for kubelet.extraArgs["node-labels"] values and
+// returns all individual labels found. Labels are comma-separated in the
+// kubelet --node-labels flag format.
+func collectWorkerNodeLabelsFromPatches(patchesDir string) []string {
+	workersDir := filepath.Join(patchesDir, "workers")
+
+	entries, err := os.ReadDir(workersDir)
+	if err != nil {
+		return nil
+	}
+
+	var labels []string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if name == workerRoleLabelFileName {
+			continue
+		}
+
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+
+		filePath := filepath.Join(workersDir, filepath.Clean(name))
+
+		//nolint:gosec // filePath is constructed from validated directory entries
+		content, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			continue
+		}
+
+		var partial nodeLabelsPartial
+		if unmarshalErr := yaml.Unmarshal(content, &partial); unmarshalErr != nil {
+			continue
+		}
+
+		if nodeLabels, ok := partial.Machine.Kubelet.ExtraArgs["node-labels"]; ok && nodeLabels != "" {
+			for _, label := range strings.Split(nodeLabels, ",") {
+				label = strings.TrimSpace(label)
+				if label != "" {
+					labels = append(labels, label)
+				}
+			}
+		}
+	}
+
+	return labels
+}
+
+// mergedWorkerRoleLabelPatchYAML returns the YAML content for a worker role label
+// patch that includes node-role.kubernetes.io/worker= combined with any existing
+// node-labels found in other worker patch files.
+func mergedWorkerRoleLabelPatchYAML(patchesDir string) string {
+	existingLabels := collectWorkerNodeLabelsFromPatches(patchesDir)
+
+	// Deduplicate and ensure worker role is present.
+	seen := make(map[string]struct{})
+	var combined []string
+
+	// Worker role label always comes first.
+	const workerRoleLabel = "node-role.kubernetes.io/worker="
+
+	seen[workerRoleLabel] = struct{}{}
+	combined = append(combined, workerRoleLabel)
+
+	for _, label := range existingLabels {
+		if _, exists := seen[label]; exists {
+			continue
+		}
+
+		seen[label] = struct{}{}
+		combined = append(combined, label)
+	}
+
+	if len(combined) == 1 {
+		// Only worker role label — use the standard constant.
+		return talosgenerator.WorkerRoleLabelPatchYAML
+	}
+
+	return fmt.Sprintf("machine:\n  kubelet:\n    extraArgs:\n      node-labels: %q\n",
+		strings.Join(combined, ","))
+}
+
+// mergedWorkerRoleLabelPatch returns a runtime patch that sets the worker role label
+// combined with any existing node-labels from other worker patch files.
+func mergedWorkerRoleLabelPatch(patchesDir string) talosconfigmanager.Patch {
+	return talosconfigmanager.Patch{
+		Path:    "worker-role-label",
+		Scope:   talosconfigmanager.PatchScopeWorker,
+		Content: []byte(mergedWorkerRoleLabelPatchYAML(patchesDir)),
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/export_test.go
+++ b/pkg/fsutil/configmanager/ksail/export_test.go
@@ -63,3 +63,13 @@ func (m *ConfigManager) AddWorkerRoleLabelPatchForTest(
 
 // LegacyWorkerRoleLabelPatchYAMLForTest exports the legacy constant for testing.
 const LegacyWorkerRoleLabelPatchYAMLForTest = legacyWorkerRoleLabelPatchYAML
+
+// CollectWorkerNodeLabelsFromPatchesForTest exposes collectWorkerNodeLabelsFromPatches for testing.
+func CollectWorkerNodeLabelsFromPatchesForTest(patchesDir string) []string {
+	return collectWorkerNodeLabelsFromPatches(patchesDir)
+}
+
+// MergedWorkerRoleLabelPatchYAMLForTest exposes mergedWorkerRoleLabelPatchYAML for testing.
+func MergedWorkerRoleLabelPatchYAMLForTest(patchesDir string) string {
+	return mergedWorkerRoleLabelPatchYAML(patchesDir)
+}

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -3,6 +3,7 @@ package configmanager_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
@@ -75,4 +76,180 @@ func TestAddWorkerRoleLabelPatch_InjectsRuntimeWhenFileAbsent(t *testing.T) {
 	// The file should remain absent — runtime injection does not write to disk.
 	_, err := os.Stat(filepath.Join(patchesDir, "workers", "worker-role-label.yaml"))
 	assert.True(t, os.IsNotExist(err), "file should not be created by runtime injection")
+}
+
+func TestAddWorkerRoleLabelPatch_MergesExistingNodeLabels(t *testing.T) {
+	t.Parallel()
+
+	patchesDir := t.TempDir()
+	workersDir := filepath.Join(patchesDir, "workers")
+	require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+	// Create a longhorn-style patch with custom node-labels.
+	longhornPatch := "machine:\n  kubelet:\n    extraArgs:\n      node-labels: node.longhorn.io/create-default-disk=true\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workersDir, "longhorn.yaml"),
+		[]byte(longhornPatch),
+		0o600,
+	))
+
+	// No worker-role-label.yaml exists → runtime injection.
+	cm := &configmanager.ConfigManager{}
+	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
+
+	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
+
+	// Verify that the merged YAML includes both labels.
+	merged := configmanager.MergedWorkerRoleLabelPatchYAMLForTest(patchesDir)
+	assert.Contains(t, merged, "node-role.kubernetes.io/worker=")
+	assert.Contains(t, merged, "node.longhorn.io/create-default-disk=true")
+}
+
+func TestAddWorkerRoleLabelPatch_LegacyMigrationMergesLabels(t *testing.T) {
+	t.Parallel()
+
+	patchesDir := t.TempDir()
+	workersDir := filepath.Join(patchesDir, "workers")
+	require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+	// Create a longhorn-style patch with custom node-labels.
+	longhornPatch := "machine:\n  kubelet:\n    extraArgs:\n      node-labels: node.longhorn.io/create-default-disk=true\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workersDir, "longhorn.yaml"),
+		[]byte(longhornPatch),
+		0o600,
+	))
+
+	// Create a legacy worker-role-label.yaml.
+	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
+	require.NoError(t, os.WriteFile(
+		patchFile,
+		[]byte(configmanager.LegacyWorkerRoleLabelPatchYAMLForTest),
+		0o600,
+	))
+
+	cm := &configmanager.ConfigManager{}
+	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
+
+	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
+
+	// After migration, the file should contain combined labels.
+	got, err := os.ReadFile(patchFile) //nolint:gosec // test reads from t.TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "node-role.kubernetes.io/worker=")
+	assert.Contains(t, string(got), "node.longhorn.io/create-default-disk=true")
+}
+
+func TestCollectWorkerNodeLabelsFromPatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no workers dir", func(t *testing.T) {
+		t.Parallel()
+
+		labels := configmanager.CollectWorkerNodeLabelsFromPatchesForTest(t.TempDir())
+		assert.Empty(t, labels)
+	})
+
+	t.Run("single file with node-labels", func(t *testing.T) {
+		t.Parallel()
+
+		patchesDir := t.TempDir()
+		workersDir := filepath.Join(patchesDir, "workers")
+		require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+		patch := "machine:\n  kubelet:\n    extraArgs:\n      node-labels: custom.io/label=value\n"
+		require.NoError(t, os.WriteFile(filepath.Join(workersDir, "custom.yaml"), []byte(patch), 0o600))
+
+		labels := configmanager.CollectWorkerNodeLabelsFromPatchesForTest(patchesDir)
+		assert.Equal(t, []string{"custom.io/label=value"}, labels)
+	})
+
+	t.Run("multiple comma-separated labels", func(t *testing.T) {
+		t.Parallel()
+
+		patchesDir := t.TempDir()
+		workersDir := filepath.Join(patchesDir, "workers")
+		require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+		patch := "machine:\n  kubelet:\n    extraArgs:\n      node-labels: \"a=1,b=2\"\n"
+		require.NoError(t, os.WriteFile(filepath.Join(workersDir, "multi.yaml"), []byte(patch), 0o600))
+
+		labels := configmanager.CollectWorkerNodeLabelsFromPatchesForTest(patchesDir)
+		assert.Equal(t, []string{"a=1", "b=2"}, labels)
+	})
+
+	t.Run("excludes worker-role-label.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		patchesDir := t.TempDir()
+		workersDir := filepath.Join(patchesDir, "workers")
+		require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+		// This file should be excluded from scanning.
+		excluded := "machine:\n  kubelet:\n    extraArgs:\n      node-labels: \"node-role.kubernetes.io/worker=\"\n"
+		require.NoError(t, os.WriteFile(filepath.Join(workersDir, "worker-role-label.yaml"), []byte(excluded), 0o600))
+
+		labels := configmanager.CollectWorkerNodeLabelsFromPatchesForTest(patchesDir)
+		assert.Empty(t, labels)
+	})
+
+	t.Run("file without node-labels", func(t *testing.T) {
+		t.Parallel()
+
+		patchesDir := t.TempDir()
+		workersDir := filepath.Join(patchesDir, "workers")
+		require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+		patch := "machine:\n  kubelet:\n    extraMounts:\n      - destination: /var/lib/data\n"
+		require.NoError(t, os.WriteFile(filepath.Join(workersDir, "mounts.yaml"), []byte(patch), 0o600))
+
+		labels := configmanager.CollectWorkerNodeLabelsFromPatchesForTest(patchesDir)
+		assert.Empty(t, labels)
+	})
+}
+
+func TestMergedWorkerRoleLabelPatchYAML(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no existing labels uses standard constant", func(t *testing.T) {
+		t.Parallel()
+
+		patchesDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(patchesDir, "workers"), 0o750))
+
+		got := configmanager.MergedWorkerRoleLabelPatchYAMLForTest(patchesDir)
+		assert.Equal(t, talosgenerator.WorkerRoleLabelPatchYAML, got)
+	})
+
+	t.Run("merges with existing labels", func(t *testing.T) {
+		t.Parallel()
+
+		patchesDir := t.TempDir()
+		workersDir := filepath.Join(patchesDir, "workers")
+		require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+		patch := "machine:\n  kubelet:\n    extraArgs:\n      node-labels: custom.io/disk=true\n"
+		require.NoError(t, os.WriteFile(filepath.Join(workersDir, "storage.yaml"), []byte(patch), 0o600))
+
+		got := configmanager.MergedWorkerRoleLabelPatchYAMLForTest(patchesDir)
+		assert.Contains(t, got, "node-role.kubernetes.io/worker=")
+		assert.Contains(t, got, "custom.io/disk=true")
+	})
+
+	t.Run("deduplicates worker role label", func(t *testing.T) {
+		t.Parallel()
+
+		patchesDir := t.TempDir()
+		workersDir := filepath.Join(patchesDir, "workers")
+		require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+		// File already has the worker role label.
+		patch := "machine:\n  kubelet:\n    extraArgs:\n      node-labels: \"node-role.kubernetes.io/worker=,custom=yes\"\n"
+		require.NoError(t, os.WriteFile(filepath.Join(workersDir, "labels.yaml"), []byte(patch), 0o600))
+
+		got := configmanager.MergedWorkerRoleLabelPatchYAMLForTest(patchesDir)
+		// Should not duplicate the worker role label.
+		assert.Equal(t, 1, strings.Count(got, "node-role.kubernetes.io/worker="))
+		assert.Contains(t, got, "custom=yes")
+	})
 }


### PR DESCRIPTION
## Summary

When `addWorkerRoleLabelPatch` injects a runtime worker role label patch, it now scans other worker patch files for existing `kubelet.extraArgs.node-labels` values and combines them comma-separated with the worker role label.

## Problem

The runtime worker-role-label patch set `node-labels` to only `"node-role.kubernetes.io/worker="`, which silently **overwrote** any user-defined labels (e.g., Longhorn's `node.longhorn.io/create-default-disk=true`) because Talos strategic merge replaces same-key string values with the last writer.

This manifests when a user has worker patch files (like `longhorn.yaml`) that set `kubelet.extraArgs.node-labels` AND no `worker-role-label.yaml` file exists on disk — KSail's runtime injection always won as the last patch applied.

## Fix

- Added `collectWorkerNodeLabelsFromPatches()` — scans worker patch files (excluding `worker-role-label.yaml`) for existing `kubelet.extraArgs.node-labels` values
- Added `mergedWorkerRoleLabelPatchYAML()` — combines all existing labels with `node-role.kubernetes.io/worker=` (deduplicating)
- Modified all injection paths in `addWorkerRoleLabelPatch` to use merged patches instead of the static single-label patch
- Legacy file migration now also writes combined labels

## Testing

- Added tests for `collectWorkerNodeLabelsFromPatches` (empty dir, single file, multi-label, exclusion, non-label files)
- Added tests for `mergedWorkerRoleLabelPatchYAML` (no existing labels, merge, deduplication)
- Added integration tests for the merge behavior in `addWorkerRoleLabelPatch` (runtime injection and legacy migration)