### PR TITLE
fix(apis): list supported providers in invalid-combination error

### DIFF
--- a/pkg/apis/cluster/v1alpha1/provider.go
+++ b/pkg/apis/cluster/v1alpha1/provider.go
@@ -119,10 +119,16 @@ func (p *Provider) ValidateForDistribution(distribution Distribution) error {
 		return nil
 	}
 
+	supportedNames := make([]string, len(supported))
+	for i, prov := range supported {
+		supportedNames[i] = string(prov)
+	}
+
 	return fmt.Errorf(
-		"%w: distribution %s does not support provider %s",
+		"%w: distribution %s does not support provider %s (supported providers: %s)",
 		ErrInvalidDistributionProviderCombination,
 		distribution,
 		*p,
+		strings.Join(supportedNames, ", "),
 	)
 }


### PR DESCRIPTION
When a distribution/provider combination is rejected — e.g. `ksail cluster init --distribution EKS`, which defaults to the Docker provider — the error named the unsupported provider but didn't tell the user which providers *are* valid:

```
✗ ...: distribution EKS does not support provider Docker
```

The `Provider`/`Distribution` flag parsers already use a helpful `(valid options: …)` pattern, so this brings the combination error in line with it:

```
✗ ...: distribution EKS does not support provider Docker (supported providers: AWS)
```

Found during manual E2E testing of the `cluster init` UX. `--distribution EKS` is a documented option but failed with no guidance toward `--provider AWS`.

Fixes N/A (no tracking issue)

## Type of change

- [x] 🪲 Bug fix