### PR TITLE
[docs] Surface Kubernetes provider across navigation and reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ See the [feature overview](https://ksail.devantler.tech/features/) and [architec
 | 🍎 macOS                                      | arm64        |
 | ⊞ Windows (native untested; WSL2 recommended) | amd64, arm64 |
 
-| Provider | Vanilla  | K3s     | Talos | VCluster | KWOK        | EKS |
-|----------|----------|---------|-------|----------|-------------|-----|
-| Docker   | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | ❌   |
-| Hetzner  | —        | —       | ✅     | —        | —           | —   |
-| Omni     | —        | —       | ✅     | —        | —           | —   |
-| AWS      | —        | —       | —     | —        | —           | 🚧  |
+| Provider   | Vanilla  | K3s     | Talos | VCluster | KWOK        | EKS |
+|------------|----------|---------|-------|----------|-------------|-----|
+| Docker     | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | ❌   |
+| Kubernetes | ✅        | ✅       | ✅     | ✅        | ✅           | ❌   |
+| Hetzner    | —        | —       | ✅     | —        | —           | —   |
+| Omni       | —        | —       | ✅     | —        | —           | —   |
+| AWS        | —        | —       | —     | —        | —           | 🚧  |
 
 ## Community & Support
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig({
           label: "Providers",
           items: [
             { label: "Docker", link: "/providers/docker/" },
+            { label: "Kubernetes", link: "/providers/kubernetes/" },
             { label: "Hetzner", link: "/providers/hetzner/" },
             { label: "Omni (Sidero)", link: "/providers/omni/" },
             { label: "AWS", link: "/providers/aws/" },

--- a/docs/src/content/docs/concepts.mdx
+++ b/docs/src/content/docs/concepts.mdx
@@ -17,7 +17,7 @@ description: KSail builds upon established Kubernetes technologies and patterns.
 
 ## Distributions
 
-Kubernetes distributions package core components with additional tooling for specific use cases. KSail supports five distributions: Vanilla, K3s, Talos, VCluster, and KWOK. All can run on Docker; Talos can also run on Hetzner Cloud and Sidero Omni.
+Kubernetes distributions package core components with additional tooling for specific use cases. KSail supports six distributions: Vanilla, K3s, Talos, VCluster, KWOK, and EKS. All local distributions can run on Docker; Talos can also run on Hetzner Cloud, Sidero Omni, or an existing Kubernetes cluster; EKS runs on AWS.
 
 ### Vanilla (Kind)
 
@@ -38,6 +38,10 @@ Vanilla uses [Kind](https://kind.sigs.k8s.io/) to run standard upstream Kubernet
 ### KWOK (kwokctl)
 
 [KWOK](https://kwok.sigs.k8s.io/) (Kubernetes WithOut Kubelet) creates simulated Kubernetes clusters where nodes and pods exist at the API level without running real containers. KSail uses kwokctl's Docker runtime to run etcd, kube-apiserver, and the kwok-controller as Docker containers. Ideal for control-plane testing, CI/CD speed optimization, and scale testing. See [documentation](https://kwok.sigs.k8s.io/docs/), [user guide](https://kwok.sigs.k8s.io/docs/user/), and [GitHub](https://github.com/kubernetes-sigs/kwok).
+
+### EKS (eksctl)
+
+[Amazon EKS](https://aws.amazon.com/eks/) is a managed Kubernetes service on AWS. KSail uses [eksctl](https://eksctl.io/) and scaffolds a declarative `eks.yaml` (`ClusterConfig`) via `ksail cluster init`; full `ksail cluster create` support is coming. EKS requires the AWS provider and is the only cloud-only distribution — local mirror registries and local registry containers are not supported. See [EKS distribution](/distributions/eks/), [Amazon EKS docs](https://docs.aws.amazon.com/eks/), and [eksctl docs](https://eksctl.io/).
 
 ## Providers
 
@@ -60,6 +64,14 @@ Manages Talos clusters through the [Sidero Omni](https://www.siderolabs.com/omni
 
 > [!NOTE]
 > Omni provider is only supported with the `Talos` distribution.
+
+### AWS
+
+Creates managed [Amazon EKS](https://aws.amazon.com/eks/) clusters. **Supported distributions:** EKS. **Requirements:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` environment variables and an AWS account with EKS permissions. See [AWS Provider](/providers/aws/) and [AWS docs](https://docs.aws.amazon.com/eks/).
+
+### Kubernetes
+
+Runs nested Kubernetes cluster nodes as pods inside an existing host Kubernetes cluster, using Docker-in-Docker (Kind, Talos, VCluster) or direct pod execution (K3s). The nested API server is exposed through Gateway API, LoadBalancer, or NodePort — whichever is available on the host cluster. **Supported distributions:** Vanilla, K3s, Talos, VCluster, KWOK. **Requirements:** a reachable host cluster with privileged pod policy. See [Kubernetes Provider](/providers/kubernetes/).
 
 ## Container Network Interface (CNI)
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -56,6 +56,7 @@ Supported distributions run on different infrastructure providers:
 | Provider | Vanilla | K3s | Talos | VCluster | KWOK | EKS |
 |----------|---------|-----|-------|----------|------|-----|
 | Docker | ✅ (Kind) | ✅ (K3d) | ✅ | ✅ (Vind) | ✅ (kwokctl) | ❌ |
+| Kubernetes | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Hetzner | — | — | ✅ | — | — | — |
 | Omni | — | — | ✅ | — | — | — |
 | AWS | — | — | — | — | — | 🚧 |
@@ -202,6 +203,9 @@ flowchart TD
 <CardGrid>
   <Card title="Docker" icon="laptop">
     Run Kubernetes nodes as Docker containers locally. Default provider for all distributions. [Learn more →](/providers/docker/)
+  </Card>
+  <Card title="Kubernetes" icon="puzzle">
+    Run nested clusters as pods inside an existing Kubernetes cluster — no Docker Desktop required. Supports Vanilla, K3s, Talos, VCluster, and KWOK. [Learn more →](/providers/kubernetes/)
   </Card>
   <Card title="Hetzner" icon="external">
     Deploy Talos clusters on affordable Hetzner Cloud servers with real load balancers and persistent volumes. [Learn more →](/providers/hetzner/)

--- a/docs/src/content/docs/support-matrix.mdx
+++ b/docs/src/content/docs/support-matrix.mdx
@@ -7,18 +7,19 @@ KSail supports multiple Kubernetes distributions, providers, and components. Thi
 
 ## Distribution × Provider Matrix
 
-| Distribution     | Docker | Hetzner | Omni | AWS   |
-| ---------------- | ------ | ------- | ---- | ----- |
-| Vanilla (Kind)   | ✅     | ❌      | ❌   | ❌    |
-| K3s (K3d)        | ✅     | ❌      | ❌   | ❌    |
-| Talos            | ✅     | ✅      | ✅   | ❌    |
-| VCluster (Vind)  | ✅     | ❌      | ❌   | ❌    |
-| KWOK (kwokctl)   | ✅     | ❌      | ❌   | ❌    |
-| EKS              | ❌     | ❌      | ❌   | 🚧¹⁰ |
+| Distribution     | Docker | Kubernetes | Hetzner | Omni | AWS   |
+| ---------------- | ------ | ---------- | ------- | ---- | ----- |
+| Vanilla (Kind)   | ✅     | ✅         | ❌      | ❌   | ❌    |
+| K3s (K3d)        | ✅     | ✅         | ❌      | ❌   | ❌    |
+| Talos            | ✅     | ✅         | ✅      | ✅   | ❌    |
+| VCluster (Vind)  | ✅     | ✅         | ❌      | ❌   | ❌    |
+| KWOK (kwokctl)   | ✅     | ✅         | ❌      | ❌   | ❌    |
+| EKS              | ❌     | ❌         | ❌      | ❌   | 🚧¹⁰ |
 
 **Notes:**
 
 - Docker provider requires Docker Desktop or Docker Engine installed locally — see [Docker Provider](/providers/docker/) for setup details
+- Kubernetes provider runs nested cluster nodes as pods inside an existing host Kubernetes cluster; requires a reachable host cluster and privileged pod policy — see [Kubernetes Provider](/providers/kubernetes/) for setup details
 - Hetzner provider requires `HCLOUD_TOKEN` environment variable and a Talos ISO uploaded to your Hetzner account (x86: `122630`, ARM: `122629` — see [Talos options](/configuration/declarative-configuration/#distribution-and-tool-options)) — see [Hetzner Provider](/providers/hetzner/) for setup details
 - Omni provider requires a [Sidero Omni](https://www.siderolabs.com/omni/) account, an `OMNI_SERVICE_ACCOUNT_KEY` environment variable, and an Omni API endpoint configured via `spec.provider.omni.endpoint` in your KSail configuration — see [Omni Provider](/providers/omni/) for setup details
 - ¹⁰ AWS provider requires AWS credentials and an AWS account with EKS permissions — see [AWS Provider](/providers/aws/) for setup details; `ksail cluster create` is not yet functional for EKS


### PR DESCRIPTION
🤖 This PR was opened by the Daily Docs automation agent.

## Summary

The Kubernetes provider (nested clusters as pods inside an existing host Kubernetes cluster) is fully implemented in `pkg/svc/provider/kubernetes/` and has a complete documentation page at `providers/kubernetes.mdx`. However, that page was **orphaned** — it couldn't be reached via the sidebar or any reference table.

Changes made to surface it:

- **`docs/astro.config.mjs`**: Add `Kubernetes` entry to the Providers sidebar section (between Docker and Hetzner), making the page navigable
- **`support-matrix.mdx`**: Add `Kubernetes` column to the Distribution × Provider matrix — ✅ for Vanilla, K3s, Talos, VCluster, KWOK; ❌ for EKS
- **`concepts.mdx`**: Add EKS distribution section (previously "five distributions" was incorrect — EKS is the sixth); add AWS provider section; add Kubernetes provider section
- **`index.mdx`**: Add Kubernetes row to the prerequisites provider × distribution table; add a Kubernetes provider card in the Providers section
- **`README.md`**: Add Kubernetes row to the distribution × provider matrix

## Why

The Kubernetes provider was entirely invisible to users browsing the docs — no sidebar link, no mention in the support matrix, and not listed in the concepts or index prerequisites. A user would have to already know to search for `provider: Kubernetes` to find the page.

## Test plan

- [x] `npm run build` passes (170 pages built, 0 errors)
- [x] `/providers/kubernetes/index.html` is generated
- [ ] Sidebar shows "Kubernetes" under Providers section
- [ ] Support matrix shows correct ✅/❌ for Kubernetes provider column

---
_Generated by [Claude Code](https://claude.ai/code/session_012Z2TJGem5xF2a1SUdUUatc)_