### PR TITLE
fix(talos): stop injecting node-role.kubernetes.io/worker via kubelet

### DIFF
--- a/pkg/fsutil/configmanager/ksail/coverage_test.go
+++ b/pkg/fsutil/configmanager/ksail/coverage_test.go
@@ -326,7 +326,7 @@ func TestResolveVClusterName(t *testing.T) {
 func TestGetDefaultTalosPatches(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no metrics server returns worker role label only", func(t *testing.T) {
+	t.Run("no metrics server, no provider, default CNI returns no patches", func(t *testing.T) {
 		t.Parallel()
 
 		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
@@ -339,8 +339,7 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 1)
-		assert.Contains(t, string(patches[0].Content), "node-role.kubernetes.io/worker")
+		assert.Empty(t, patches)
 	})
 
 	t.Run("metrics server enabled returns kubelet patches", func(t *testing.T) {
@@ -356,10 +355,9 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 3)
+		require.Len(t, patches, 2)
 		assert.Contains(t, string(patches[0].Content), "rotate-server-certificates")
 		assert.Contains(t, string(patches[1].Content), "kubelet-serving-cert-approver")
-		assert.Contains(t, string(patches[2].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run("hetzner provider returns external cloud provider patch", func(t *testing.T) {
@@ -375,14 +373,13 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 2)
+		require.Len(t, patches, 1)
 		assert.Contains(t, string(patches[0].Content), "externalCloudProvider")
 		assert.Contains(t, string(patches[0].Content), "enabled: true")
 		assert.Contains(t, string(patches[0].Content), "cloud-provider: external")
-		assert.Contains(t, string(patches[1].Content), "node-role.kubernetes.io/worker")
 	})
 
-	t.Run("docker provider returns worker role label only", func(t *testing.T) {
+	t.Run("docker provider returns no patches", func(t *testing.T) {
 		t.Parallel()
 
 		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
@@ -395,30 +392,31 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 1)
-		assert.Contains(t, string(patches[0].Content), "node-role.kubernetes.io/worker")
+		assert.Empty(t, patches)
 	})
 
-	t.Run("hetzner with metrics server returns all three patches", func(t *testing.T) {
-		t.Parallel()
+	t.Run(
+		"hetzner with metrics server returns kubelet and cloud provider patches",
+		func(t *testing.T) {
+			t.Parallel()
 
-		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
-		mgr.Config = &v1alpha1.Cluster{
-			Spec: v1alpha1.Spec{
-				Cluster: v1alpha1.ClusterSpec{
-					Provider:      v1alpha1.ProviderHetzner,
-					MetricsServer: v1alpha1.MetricsServerEnabled,
+			mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
+			mgr.Config = &v1alpha1.Cluster{
+				Spec: v1alpha1.Spec{
+					Cluster: v1alpha1.ClusterSpec{
+						Provider:      v1alpha1.ProviderHetzner,
+						MetricsServer: v1alpha1.MetricsServerEnabled,
+					},
 				},
-			},
-		}
+			}
 
-		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 4)
-		assert.Contains(t, string(patches[0].Content), "rotate-server-certificates")
-		assert.Contains(t, string(patches[1].Content), "kubelet-serving-cert-approver")
-		assert.Contains(t, string(patches[2].Content), "externalCloudProvider")
-		assert.Contains(t, string(patches[3].Content), "node-role.kubernetes.io/worker")
-	})
+			patches := mgr.GetDefaultTalosPatchesForTest()
+			require.Len(t, patches, 3)
+			assert.Contains(t, string(patches[0].Content), "rotate-server-certificates")
+			assert.Contains(t, string(patches[1].Content), "kubelet-serving-cert-approver")
+			assert.Contains(t, string(patches[2].Content), "externalCloudProvider")
+		},
+	)
 
 	t.Run("cilium CNI returns disable CNI patch", func(t *testing.T) {
 		t.Parallel()
@@ -433,10 +431,9 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 2)
+		require.Len(t, patches, 1)
 		assert.Contains(t, string(patches[0].Content), "cni")
 		assert.Contains(t, string(patches[0].Content), "name: none")
-		assert.Contains(t, string(patches[1].Content), "node-role.kubernetes.io/worker")
 	})
 
 	t.Run("calico CNI returns disable CNI patch", func(t *testing.T) {
@@ -452,13 +449,12 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 2)
+		require.Len(t, patches, 1)
 		assert.Contains(t, string(patches[0].Content), "cni")
 		assert.Contains(t, string(patches[0].Content), "name: none")
-		assert.Contains(t, string(patches[1].Content), "node-role.kubernetes.io/worker")
 	})
 
-	t.Run("default CNI returns worker role label only", func(t *testing.T) {
+	t.Run("default CNI returns no patches", func(t *testing.T) {
 		t.Parallel()
 
 		mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
@@ -471,8 +467,7 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 		}
 
 		patches := mgr.GetDefaultTalosPatchesForTest()
-		require.Len(t, patches, 1)
-		assert.Contains(t, string(patches[0].Content), "node-role.kubernetes.io/worker")
+		assert.Empty(t, patches)
 	})
 
 	t.Run(
@@ -491,11 +486,10 @@ func TestGetDefaultTalosPatches(t *testing.T) {
 			}
 
 			patches := mgr.GetDefaultTalosPatchesForTest()
-			require.Len(t, patches, 4)
+			require.Len(t, patches, 3)
 			assert.Contains(t, string(patches[0].Content), "name: none")
 			assert.Contains(t, string(patches[1].Content), "rotate-server-certificates")
 			assert.Contains(t, string(patches[2].Content), "kubelet-serving-cert-approver")
-			assert.Contains(t, string(patches[3].Content), "node-role.kubernetes.io/worker")
 		},
 	)
 }

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -213,6 +213,13 @@ const kubeletWorkerRoleLabelPatchYAML = `machine:
       node-labels: "node-role.kubernetes.io/worker="
 `
 
+// workerRoleLabelFailureModes explains why a node-role.kubernetes.io/worker patch breaks
+// worker nodes, covering both forms ksail historically generated. Shared across the migration
+// warnings so the remediation guidance stays accurate regardless of which form is found.
+const workerRoleLabelFailureModes = "Set via kubelet --node-labels the label is rejected by " +
+	"Kubernetes 1.33+ (worker kubelets fail to start); set via machine.nodeLabels it is " +
+	"blocked by the NodeRestriction admission controller after registration."
+
 // removeWorkerRoleLabelPatch deletes a stale worker role label patch file from disk.
 //
 // ksail used to label worker nodes with node-role.kubernetes.io/worker, first via
@@ -241,8 +248,8 @@ func (m *ConfigManager) removeWorkerRoleLabelPatch(patchesDir string) {
 		// patch that may break worker kubelets.
 		m.warnWorkerRoleLabel(
 			"could not read talos/workers/worker-role-label.yaml (" + err.Error() +
-				"); if it sets node-role.kubernetes.io/worker, remove it manually — " +
-				"Kubernetes 1.33+ rejects that label and worker nodes will fail to start.",
+				"); if it sets node-role.kubernetes.io/worker, remove it manually. " +
+				workerRoleLabelFailureModes,
 		)
 
 		return
@@ -260,9 +267,8 @@ func (m *ConfigManager) removeWorkerRoleLabelPatch(patchesDir string) {
 		if removeErr != nil {
 			m.warnWorkerRoleLabel(
 				"could not delete the obsolete talos/workers/worker-role-label.yaml (" +
-					removeErr.Error() + "); remove it manually — it sets " +
-					"node-role.kubernetes.io/worker, which Kubernetes 1.33+ rejects, " +
-					"preventing worker nodes from starting.",
+					removeErr.Error() + "); it sets node-role.kubernetes.io/worker, so " +
+					"remove it manually. " + workerRoleLabelFailureModes,
 			)
 		}
 
@@ -272,9 +278,7 @@ func (m *ConfigManager) removeWorkerRoleLabelPatch(patchesDir string) {
 	if strings.Contains(contentStr, "node-role.kubernetes.io/worker") {
 		m.warnWorkerRoleLabel(
 			"talos/workers/worker-role-label.yaml sets node-role.kubernetes.io/worker; " +
-				"remove that label. Set via kubelet --node-labels it is rejected by " +
-				"Kubernetes 1.33+ (worker kubelets fail to start); set via machine.nodeLabels " +
-				"it is blocked by the NodeRestriction admission controller after registration.",
+				"remove that label. " + workerRoleLabelFailureModes,
 		)
 	}
 }

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -231,7 +231,20 @@ func (m *ConfigManager) removeWorkerRoleLabelPatch(patchesDir string) {
 
 	content, err := fsutil.ReadFileSafe(patchesDir, patchFile)
 	if err != nil {
-		// File missing (the common case) or unreadable — nothing to migrate.
+		if errors.Is(err, os.ErrNotExist) {
+			// No patch file — the common case, nothing to migrate.
+			return
+		}
+
+		// The file exists but could not be read safely (e.g. a symlink escaping
+		// patchesDir, or a permission error). Warn rather than silently leaving a
+		// patch that may break worker kubelets.
+		m.warnWorkerRoleLabel(
+			"could not read talos/workers/worker-role-label.yaml (" + err.Error() +
+				"); if it sets node-role.kubernetes.io/worker, remove it manually — " +
+				"Kubernetes 1.33+ rejects that label and worker nodes will fail to start.",
+		)
+
 		return
 	}
 
@@ -241,25 +254,39 @@ func (m *ConfigManager) removeWorkerRoleLabelPatch(patchesDir string) {
 		contentStr == strings.TrimSpace(kubeletWorkerRoleLabelPatchYAML)
 
 	if isKnownScaffold {
-		canonPath, pathErr := fsutil.EvalCanonicalPath(patchFile)
-		if pathErr != nil {
-			return
+		// Remove the entry at its declared path. os.Remove does not follow the final
+		// symlink, so a symlinked entry is unlinked instead of deleting its target.
+		removeErr := os.Remove(patchFile)
+		if removeErr != nil {
+			m.warnWorkerRoleLabel(
+				"could not delete the obsolete talos/workers/worker-role-label.yaml (" +
+					removeErr.Error() + "); remove it manually — it sets " +
+					"node-role.kubernetes.io/worker, which Kubernetes 1.33+ rejects, " +
+					"preventing worker nodes from starting.",
+			)
 		}
-
-		_ = os.Remove(canonPath)
 
 		return
 	}
 
 	if strings.Contains(contentStr, "node-role.kubernetes.io/worker") {
-		notify.WriteMessage(notify.Message{
-			Type: notify.WarningType,
-			Content: "talos/workers/worker-role-label.yaml sets node-role.kubernetes.io/worker, " +
-				"which Kubernetes 1.33+ rejects via kubelet --node-labels and will prevent worker " +
-				"nodes from starting. Remove that label from the file.",
-			Writer: m.Writer,
-		})
+		m.warnWorkerRoleLabel(
+			"talos/workers/worker-role-label.yaml sets node-role.kubernetes.io/worker; " +
+				"remove that label. Set via kubelet --node-labels it is rejected by " +
+				"Kubernetes 1.33+ (worker kubelets fail to start); set via machine.nodeLabels " +
+				"it is blocked by the NodeRestriction admission controller after registration.",
+		)
 	}
+}
+
+// warnWorkerRoleLabel emits a warning about a stale or customized worker role label patch
+// that still sets node-role.kubernetes.io/worker.
+func (m *ConfigManager) warnWorkerRoleLabel(content string) {
+	notify.WriteMessage(notify.Message{
+		Type:    notify.WarningType,
+		Content: content,
+		Writer:  m.Writer,
+	})
 }
 
 // loadAndCacheDistributionConfig loads the distribution-specific configuration based on

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -15,6 +15,7 @@ import (
 	kindconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/kind"
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	talosgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/talos"
+	"github.com/devantler-tech/ksail/v7/pkg/notify"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	k3dv1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
@@ -127,12 +128,13 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 	// (e.g., permissions), we inject the patches as a fail-safe.
 	m.addKubeletCertRotationPatches(talosManager, patchesDir)
 
-	// Inject worker role label patch at runtime when the patch file doesn't
-	// already exist on disk. Projects initialized with this version+ have
-	// the patch file; older projects or manually-managed talos/ directories
-	// may not. The runtime injection ensures worker nodes always get the
-	// node-role.kubernetes.io/worker label.
-	m.addWorkerRoleLabelPatch(talosManager, patchesDir)
+	// Migrate away the legacy worker role label patch. Older projects scaffolded a
+	// talos/workers/worker-role-label.yaml that set node-role.kubernetes.io/worker via
+	// kubelet --node-labels (or machine.nodeLabels). Kubernetes 1.33+ rejects
+	// node-role.kubernetes.io/* labels passed through kubelet --node-labels, which crashes
+	// every worker kubelet. The label is purely cosmetic and unused by ksail, so we drop it
+	// and remove the stale patch file so it is no longer applied at create time.
+	m.removeWorkerRoleLabelPatch(patchesDir)
 
 	// Wire extensions from ksail.yaml so that machine.install.image is patched
 	// to use a Talos Image Factory installer containing the requested extensions.
@@ -196,66 +198,67 @@ func (m *ConfigManager) addKubeletCertRotationPatches(
 	}
 }
 
-// legacyWorkerRoleLabelPatchYAML is the exact content of the old scaffold that
-// used machine.nodeLabels. Only files matching this content exactly are fully migrated.
-const legacyWorkerRoleLabelPatchYAML = "machine:\n  nodeLabels:\n    node-role.kubernetes.io/worker: \"\"\n"
+// legacyWorkerRoleLabelPatchYAML is the machine.nodeLabels form of the worker role label
+// patch that older ksail versions scaffolded.
+const legacyWorkerRoleLabelPatchYAML = `machine:
+  nodeLabels:
+    node-role.kubernetes.io/worker: ""
+`
 
-// addWorkerRoleLabelPatch injects the worker role label patch at runtime
-// when the patch file does not exist on disk. This ensures existing
-// scaffolded projects (created before this patch was introduced) still
-// get the node-role.kubernetes.io/worker label on worker nodes.
+// kubeletWorkerRoleLabelPatchYAML is the kubelet --node-labels form of the worker role
+// label patch that more recent ksail versions scaffolded.
+const kubeletWorkerRoleLabelPatchYAML = `machine:
+  kubelet:
+    extraArgs:
+      node-labels: "node-role.kubernetes.io/worker="
+`
+
+// removeWorkerRoleLabelPatch deletes a stale worker role label patch file from disk.
 //
-// It also migrates existing patch files that use the legacy machine.nodeLabels
-// format to the kubelet.extraArgs["node-labels"] format. The old format causes
-// the Kubernetes NodeRestriction admission controller to block ALL label updates
-// from Talos's NodeApplyController on worker nodes.
-func (m *ConfigManager) addWorkerRoleLabelPatch(
-	talosManager *talosconfigmanager.ConfigManager,
-	patchesDir string,
-) {
-	if !workerRoleLabelPatchFileExists(patchesDir) {
-		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
-
-		return
-	}
-
-	// Migrate stale patch files that use machine.nodeLabels (broken on Hetzner
-	// due to NodeRestriction blocking kubelet from setting node-role.kubernetes.io/*).
+// ksail used to label worker nodes with node-role.kubernetes.io/worker, first via
+// machine.nodeLabels and later via kubelet --node-labels. Kubernetes 1.33+ rejects
+// node-role.kubernetes.io/* labels passed through kubelet --node-labels, which prevents
+// every worker kubelet from starting and makes the cluster unusable. The label is purely
+// cosmetic (it only populates the kubectl ROLE column) and nothing in ksail depends on it,
+// so it is no longer set at all.
+//
+// The patch file is auto-discovered and applied at create time, so leaving it on disk would
+// keep breaking existing projects. We delete it only when its content exactly matches one of
+// the two known ksail-generated scaffolds. A user-customized file that still carries the label
+// is left untouched, with a warning, so hand-edited config is never destroyed.
+func (m *ConfigManager) removeWorkerRoleLabelPatch(patchesDir string) {
 	patchFile := filepath.Join(patchesDir, "workers", "worker-role-label.yaml")
 
 	content, err := fsutil.ReadFileSafe(patchesDir, patchFile)
 	if err != nil {
-		// Cannot read safely (e.g. symlink escape) — inject runtime fallback so
-		// the worker role label is still set via kubelet.extraArgs at registration.
-		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
-
+		// File missing (the common case) or unreadable — nothing to migrate.
 		return
 	}
 
 	contentStr := strings.TrimSpace(string(content))
 
-	if contentStr == strings.TrimSpace(legacyWorkerRoleLabelPatchYAML) {
-		// Exact legacy scaffold — overwrite with the new format.
+	isKnownScaffold := contentStr == strings.TrimSpace(legacyWorkerRoleLabelPatchYAML) ||
+		contentStr == strings.TrimSpace(kubeletWorkerRoleLabelPatchYAML)
+
+	if isKnownScaffold {
 		canonPath, pathErr := fsutil.EvalCanonicalPath(patchFile)
 		if pathErr != nil {
-			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
-
 			return
 		}
 
-		//nolint:mnd // standard restrictive file permission
-		writeErr := os.WriteFile(canonPath, []byte(talosgenerator.WorkerRoleLabelPatchYAML), 0o600)
-		if writeErr != nil {
-			// Write failed — inject the correct runtime patch as fallback so the
-			// worker role label is still set via kubelet.extraArgs at registration time.
-			talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
-		}
-	} else if strings.Contains(contentStr, "node-role.kubernetes.io/worker") &&
-		strings.Contains(contentStr, "nodeLabels") {
-		// Customized file still contains the legacy worker role label in nodeLabels.
-		// We cannot safely rewrite user-customized content, but we inject the runtime
-		// kubelet.extraArgs patch so the worker role is at least set at registration time.
-		talosManager.WithAdditionalPatches([]talosconfigmanager.Patch{workerRoleLabelPatch()})
+		_ = os.Remove(canonPath)
+
+		return
+	}
+
+	if strings.Contains(contentStr, "node-role.kubernetes.io/worker") {
+		notify.WriteMessage(notify.Message{
+			Type: notify.WarningType,
+			Content: "talos/workers/worker-role-label.yaml sets node-role.kubernetes.io/worker, " +
+				"which Kubernetes 1.33+ rejects via kubelet --node-labels and will prevent worker " +
+				"nodes from starting. Remove that label from the file.",
+			Writer: m.Writer,
+		})
 	}
 }
 
@@ -381,10 +384,6 @@ func (m *ConfigManager) getDefaultTalosPatches() []talosconfigmanager.Patch {
 		patches = append(patches, externalCloudProviderPatches()...)
 	}
 
-	// Always label worker nodes with node-role.kubernetes.io/worker.
-	// This is worker-scoped so it only affects worker configs.
-	patches = append(patches, workerRoleLabelPatch())
-
 	return patches
 }
 
@@ -435,16 +434,6 @@ func kubeletPatchFilesExist(patchesDir string) bool {
 	_, err2 := os.Stat(csrApprover)
 
 	return err1 == nil && err2 == nil
-}
-
-// workerRoleLabelPatchFileExists returns true when the worker role label
-// patch file exists on disk. If the file is missing or stat fails for any
-// reason, returns false so that the runtime patch is injected as a fail-safe.
-func workerRoleLabelPatchFileExists(patchesDir string) bool {
-	patchFile := filepath.Join(patchesDir, "workers", "worker-role-label.yaml")
-	_, err := os.Stat(patchFile)
-
-	return err == nil
 }
 
 // ingressFirewallPatchPaths returns the expected ingress firewall patch file paths
@@ -659,17 +648,6 @@ func externalCloudProviderPatches() []talosconfigmanager.Patch {
 			Scope:   talosconfigmanager.PatchScopeCluster,
 			Content: []byte(talosgenerator.ExternalCloudProviderPatchYAML),
 		},
-	}
-}
-
-// workerRoleLabelPatch returns a Talos machine config patch that labels worker nodes
-// with node-role.kubernetes.io/worker. Used for runtime injection when no scaffolded
-// project exists (init=false). Worker-scoped so it only affects worker configs.
-func workerRoleLabelPatch() talosconfigmanager.Patch {
-	return talosconfigmanager.Patch{
-		Path:    "worker-role-label",
-		Scope:   talosconfigmanager.PatchScopeWorker,
-		Content: []byte(talosgenerator.WorkerRoleLabelPatchYAML),
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/export_test.go
+++ b/pkg/fsutil/configmanager/ksail/export_test.go
@@ -53,13 +53,13 @@ func DistributionConfigIsOppositeDefaultForTest(
 	return distributionConfigIsOppositeDefault(current, distribution)
 }
 
-// AddWorkerRoleLabelPatchForTest exposes addWorkerRoleLabelPatch for testing.
-func (m *ConfigManager) AddWorkerRoleLabelPatchForTest(
-	talosManager *talosconfigmanager.ConfigManager,
-	patchesDir string,
-) {
-	m.addWorkerRoleLabelPatch(talosManager, patchesDir)
+// RemoveWorkerRoleLabelPatchForTest exposes removeWorkerRoleLabelPatch for testing.
+func (m *ConfigManager) RemoveWorkerRoleLabelPatchForTest(patchesDir string) {
+	m.removeWorkerRoleLabelPatch(patchesDir)
 }
 
-// LegacyWorkerRoleLabelPatchYAMLForTest exports the legacy constant for testing.
+// LegacyWorkerRoleLabelPatchYAMLForTest exports the legacy machine.nodeLabels constant for testing.
 const LegacyWorkerRoleLabelPatchYAMLForTest = legacyWorkerRoleLabelPatchYAML
+
+// KubeletWorkerRoleLabelPatchYAMLForTest exports the kubelet --node-labels constant for testing.
+const KubeletWorkerRoleLabelPatchYAMLForTest = kubeletWorkerRoleLabelPatchYAML

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -80,6 +80,42 @@ func TestRemoveWorkerRoleLabelPatch_LeavesCustomizedFileAndWarns(t *testing.T) {
 	)
 }
 
+func TestRemoveWorkerRoleLabelPatch_WarnsOnUnreadableFile(t *testing.T) {
+	t.Parallel()
+
+	patchesDir := t.TempDir()
+	workersDir := filepath.Join(patchesDir, "workers")
+	require.NoError(t, os.MkdirAll(workersDir, 0o750))
+
+	// A symlink escaping patchesDir makes ReadFileSafe return ErrPathOutsideBase
+	// (not os.ErrNotExist), which must produce a warning rather than a silent no-op.
+	outside := filepath.Join(t.TempDir(), "target.yaml")
+	require.NoError(t, os.WriteFile(outside, []byte("data"), 0o600))
+
+	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
+
+	err := os.Symlink(outside, patchFile)
+	if err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+
+	var buf bytes.Buffer
+
+	cm := &configmanager.ConfigManager{Writer: &buf}
+	cm.RemoveWorkerRoleLabelPatchForTest(patchesDir)
+
+	assert.Contains(
+		t,
+		buf.String(),
+		"worker-role-label.yaml",
+		"should warn when the file cannot be read safely",
+	)
+
+	// The symlink (and its target) must be left in place, not followed and deleted.
+	_, err = os.Lstat(patchFile)
+	require.NoError(t, err, "symlink should not be removed")
+}
+
 func TestRemoveWorkerRoleLabelPatch_NoFileIsNoop(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
@@ -114,6 +115,43 @@ func TestRemoveWorkerRoleLabelPatch_WarnsOnUnreadableFile(t *testing.T) {
 	// The symlink (and its target) must be left in place, not followed and deleted.
 	_, err = os.Lstat(patchFile)
 	require.NoError(t, err, "symlink should not be removed")
+}
+
+func TestRemoveWorkerRoleLabelPatch_WarnsWhenDeleteFails(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write permissions are not enforced the same way on Windows")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions, so os.Remove would not fail")
+	}
+
+	patchesDir, _ := writeWorkerRoleLabelPatch(
+		t,
+		configmanager.KubeletWorkerRoleLabelPatchYAMLForTest,
+	)
+	workersDir := filepath.Join(patchesDir, "workers")
+
+	// Make the parent directory non-writable (but still readable/executable) so the
+	// file can be read but os.Remove fails. Restore on cleanup so t.TempDir removal works.
+	//nolint:gosec // directory needs the execute bit; permissions are restored in cleanup
+	t.Cleanup(func() { _ = os.Chmod(workersDir, 0o700) })
+	//nolint:gosec // 0o500 keeps the dir traversable but read-only to force os.Remove to fail
+	require.NoError(t, os.Chmod(workersDir, 0o500))
+
+	var buf bytes.Buffer
+
+	cm := &configmanager.ConfigManager{Writer: &buf}
+	cm.RemoveWorkerRoleLabelPatchForTest(patchesDir)
+
+	assert.Contains(
+		t,
+		buf.String(),
+		"could not delete",
+		"should warn when the stale patch cannot be removed",
+	)
 }
 
 func TestRemoveWorkerRoleLabelPatch_NoFileIsNoop(t *testing.T) {

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -1,78 +1,94 @@
 package configmanager_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
-	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
-	talosgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/talos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddWorkerRoleLabelPatch_MigratesLegacyScaffold(t *testing.T) {
-	t.Parallel()
+func writeWorkerRoleLabelPatch(t *testing.T, content string) (string, string) {
+	t.Helper()
 
 	patchesDir := t.TempDir()
 	workersDir := filepath.Join(patchesDir, "workers")
 	require.NoError(t, os.MkdirAll(workersDir, 0o750))
 
 	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
-	require.NoError(t, os.WriteFile(
-		patchFile,
-		[]byte(configmanager.LegacyWorkerRoleLabelPatchYAMLForTest),
-		0o600,
-	))
+	require.NoError(t, os.WriteFile(patchFile, []byte(content), 0o600))
 
-	cm := &configmanager.ConfigManager{}
-	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
-
-	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
-
-	got, err := os.ReadFile(patchFile) //nolint:gosec // test reads from t.TempDir
-	require.NoError(t, err)
-	assert.Equal(t, talosgenerator.WorkerRoleLabelPatchYAML, string(got))
+	return patchesDir, patchFile
 }
 
-func TestAddWorkerRoleLabelPatch_CustomizedFileInjectsRuntime(t *testing.T) {
+func TestRemoveWorkerRoleLabelPatch_DeletesLegacyScaffold(t *testing.T) {
 	t.Parallel()
 
-	patchesDir := t.TempDir()
-	workersDir := filepath.Join(patchesDir, "workers")
-	require.NoError(t, os.MkdirAll(workersDir, 0o750))
+	patchesDir, patchFile := writeWorkerRoleLabelPatch(
+		t,
+		configmanager.LegacyWorkerRoleLabelPatchYAMLForTest,
+	)
 
-	// File contains the legacy worker role label plus additional user labels.
+	cm := &configmanager.ConfigManager{}
+	cm.RemoveWorkerRoleLabelPatchForTest(patchesDir)
+
+	_, err := os.Stat(patchFile)
+	assert.True(t, os.IsNotExist(err), "legacy nodeLabels scaffold should be deleted")
+}
+
+func TestRemoveWorkerRoleLabelPatch_DeletesKubeletScaffold(t *testing.T) {
+	t.Parallel()
+
+	patchesDir, patchFile := writeWorkerRoleLabelPatch(
+		t,
+		configmanager.KubeletWorkerRoleLabelPatchYAMLForTest,
+	)
+
+	cm := &configmanager.ConfigManager{}
+	cm.RemoveWorkerRoleLabelPatchForTest(patchesDir)
+
+	_, err := os.Stat(patchFile)
+	assert.True(t, os.IsNotExist(err), "kubelet --node-labels scaffold should be deleted")
+}
+
+func TestRemoveWorkerRoleLabelPatch_LeavesCustomizedFileAndWarns(t *testing.T) {
+	t.Parallel()
+
+	// File contains the worker role label plus additional user content, so it does not
+	// match a known scaffold exactly and must not be deleted.
 	customContent := "machine:\n  nodeLabels:\n" +
 		"    node-role.kubernetes.io/worker: \"\"\n" +
 		"    custom.label/app: \"myapp\"\n"
-	patchFile := filepath.Join(workersDir, "worker-role-label.yaml")
-	require.NoError(t, os.WriteFile(patchFile, []byte(customContent), 0o600))
+	patchesDir, patchFile := writeWorkerRoleLabelPatch(t, customContent)
 
-	cm := &configmanager.ConfigManager{}
-	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
+	var buf bytes.Buffer
 
-	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
+	cm := &configmanager.ConfigManager{Writer: &buf}
+	cm.RemoveWorkerRoleLabelPatchForTest(patchesDir)
 
-	// File should be preserved (not overwritten).
 	got, err := os.ReadFile(patchFile) //nolint:gosec // test reads from t.TempDir
 	require.NoError(t, err)
 	assert.Equal(t, customContent, string(got), "customized file should be left untouched")
+	assert.Contains(
+		t,
+		buf.String(),
+		"node-role.kubernetes.io/worker",
+		"should warn about the label",
+	)
 }
 
-func TestAddWorkerRoleLabelPatch_InjectsRuntimeWhenFileAbsent(t *testing.T) {
+func TestRemoveWorkerRoleLabelPatch_NoFileIsNoop(t *testing.T) {
 	t.Parallel()
 
 	patchesDir := t.TempDir()
 	// No workers/worker-role-label.yaml exists.
 
 	cm := &configmanager.ConfigManager{}
-	talosManager := talosconfigmanager.NewConfigManager(patchesDir, "test", "", "")
+	cm.RemoveWorkerRoleLabelPatchForTest(patchesDir)
 
-	cm.AddWorkerRoleLabelPatchForTest(talosManager, patchesDir)
-
-	// The file should remain absent — runtime injection does not write to disk.
 	_, err := os.Stat(filepath.Join(patchesDir, "workers", "worker-role-label.yaml"))
-	assert.True(t, os.IsNotExist(err), "file should not be created by runtime injection")
+	assert.True(t, os.IsNotExist(err), "no file should be created")
 }

--- a/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
+++ b/pkg/fsutil/configmanager/ksail/migration_worker_role_label_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/internal/testutil/rootcheck"
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,8 +125,8 @@ func TestRemoveWorkerRoleLabelPatch_WarnsWhenDeleteFails(t *testing.T) {
 		t.Skip("directory write permissions are not enforced the same way on Windows")
 	}
 
-	if os.Geteuid() == 0 {
-		t.Skip("root bypasses directory write permissions, so os.Remove would not fail")
+	if rootcheck.IsRootUser() {
+		t.Skip("running as root — directory write permissions are bypassed")
 	}
 
 	patchesDir, _ := writeWorkerRoleLabelPatch(

--- a/pkg/fsutil/generator/talos/generator.go
+++ b/pkg/fsutil/generator/talos/generator.go
@@ -44,8 +44,6 @@ const (
 	ingressFirewallRulesFileName = "ingress-firewall-rules.yaml"
 	// oidcFileName is the name of the OIDC API server configuration patch file.
 	oidcFileName = "oidc.yaml"
-	// workerRoleLabelFileName is the name of the worker role label patch file.
-	workerRoleLabelFileName = "worker-role-label.yaml"
 )
 
 // KubeletServingCertApproverManifestURL is the URL for the kubelet-serving-cert-approver manifest.
@@ -91,32 +89,6 @@ machine:
   kubelet:
     extraArgs:
       cloud-provider: external
-`
-
-// WorkerRoleLabelPatchYAML is the Talos machine config patch YAML that labels worker nodes
-// with the standard Kubernetes worker role. This is the single source of truth for the patch
-// content, shared between the generator (file-based scaffolding) and the runtime config manager
-// (in-memory patch injection when no scaffolded project exists).
-//
-// Talos does not set node-role.kubernetes.io/worker on worker nodes by default (unlike
-// control-plane nodes which receive node-role.kubernetes.io/control-plane automatically).
-// Without this label, kubectl shows <none> for the worker role column and operators that
-// target workers by role label cannot find them.
-//
-// This uses kubelet.extraArgs["node-labels"] instead of machine.nodeLabels because:
-//   - machine.nodeLabels is applied post-registration by Talos's NodeApplyController using
-//     the kubelet kubeconfig (limited RBAC)
-//   - The Kubernetes NodeRestriction admission controller blocks kubelet from modifying
-//     node-role.kubernetes.io/* labels after initial registration
-//   - kubelet --node-labels sets labels AT registration time, when NodeRestriction allows them
-//   - If node-role.kubernetes.io/worker is in machine.nodeLabels, the NodeApplyController
-//     fails on the entire update, blocking ALL user-defined labels (e.g. Longhorn labels)
-//
-// See: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
-const WorkerRoleLabelPatchYAML = `machine:
-  kubelet:
-    extraArgs:
-      node-labels: "node-role.kubernetes.io/worker="
 `
 
 // ErrConfigRequired is returned when a nil config is provided.
@@ -262,11 +234,6 @@ func (g *Generator) getDirectoriesWithPatches(
 		dirs["cluster"] = true
 	}
 
-	// Worker role label patch goes to workers/
-	if model.WorkerNodes > 0 {
-		dirs["workers"] = true
-	}
-
 	// Disable CNI patch goes to cluster/
 	if model.DisableDefaultCNI {
 		dirs["cluster"] = true
@@ -334,14 +301,6 @@ func (g *Generator) generateConditionalPatches(
 	// Generate allow-scheduling-on-control-planes patch when no workers are configured
 	if model.WorkerNodes == 0 {
 		err := g.generateAllowSchedulingPatch(rootPath, force)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Generate worker role label patch when workers are configured
-	if model.WorkerNodes > 0 {
-		err := g.generateWorkerRoleLabelPatch(rootPath, force)
 		if err != nil {
 			return err
 		}
@@ -556,29 +515,6 @@ func (g *Generator) generateAllowSchedulingPatch(
 	err := os.WriteFile(patchPath, []byte(patchContent), filePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create allow-scheduling-on-control-planes patch: %w", err)
-	}
-
-	return nil
-}
-
-// generateWorkerRoleLabelPatch creates a Talos patch file that labels worker nodes
-// with node-role.kubernetes.io/worker. This goes into the workers/ directory so it
-// only applies to worker machine configs.
-func (g *Generator) generateWorkerRoleLabelPatch(
-	rootPath string,
-	force bool,
-) error {
-	patchPath := filepath.Join(rootPath, "workers", workerRoleLabelFileName)
-
-	// Check if file already exists
-	_, statErr := os.Stat(patchPath)
-	if statErr == nil && !force {
-		return nil
-	}
-
-	err := os.WriteFile(patchPath, []byte(WorkerRoleLabelPatchYAML), filePerm)
-	if err != nil {
-		return fmt.Errorf("failed to create worker-role-label patch: %w", err)
 	}
 
 	return nil

--- a/pkg/fsutil/generator/talos/generator_skipexisting_test.go
+++ b/pkg/fsutil/generator/talos/generator_skipexisting_test.go
@@ -111,20 +111,6 @@ func TestGenerate_AllowSchedulingSkipExisting(t *testing.T) {
 	})
 }
 
-// TestGenerate_WorkerRoleLabelSkipExisting verifies that the worker-role-label
-// patch is not overwritten when force is false.
-func TestGenerate_WorkerRoleLabelSkipExisting(t *testing.T) {
-	t.Parallel()
-
-	assertGenerateSkipExistingPreservesContent(t, &talosgenerator.Config{
-		PatchesDir:  "talos",
-		WorkerNodes: 1, // triggers worker-role-label patch
-	}, skipExistingFile{
-		relativePath: filepath.Join("talos", "workers", "worker-role-label.yaml"),
-		content:      "original",
-	})
-}
-
 // TestGenerate_DisableCNISkipExisting verifies that the disable-cni patch is
 // not overwritten when force is false.
 func TestGenerate_DisableCNISkipExisting(t *testing.T) {

--- a/pkg/fsutil/generator/talos/generator_test.go
+++ b/pkg/fsutil/generator/talos/generator_test.go
@@ -24,8 +24,8 @@ func TestGenerator_Generate_CreatesDirectoryStructure(t *testing.T) {
 	tempDir := t.TempDir()
 	gen := talosgenerator.NewGenerator()
 
-	// With workers > 0, cluster/ and control-planes/ should have .gitkeep,
-	// but workers/ should have the worker-role-label patch instead
+	// With workers > 0, no patches are generated, so cluster/, control-planes/, and
+	// workers/ all receive a .gitkeep.
 	config := &talosgenerator.Config{
 		PatchesDir:  "talos",
 		WorkerNodes: 1,
@@ -38,10 +38,11 @@ func TestGenerator_Generate_CreatesDirectoryStructure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tempDir, "talos"), result)
 
-	// Verify directory structure - cluster/ and control-planes/ should have .gitkeep
+	// Verify directory structure - cluster/, control-planes/, and workers/ should have .gitkeep
 	gitkeepPaths := []string{
 		filepath.Join(tempDir, "talos", "cluster", ".gitkeep"),
 		filepath.Join(tempDir, "talos", "control-planes", ".gitkeep"),
+		filepath.Join(tempDir, "talos", "workers", ".gitkeep"),
 	}
 
 	for _, path := range gitkeepPaths {
@@ -49,15 +50,6 @@ func TestGenerator_Generate_CreatesDirectoryStructure(t *testing.T) {
 		require.NoError(t, err, "expected path to exist: %s", path)
 		assert.False(t, info.IsDir(), "expected file, got directory: %s", path)
 	}
-
-	// workers/ should NOT have .gitkeep since it has the worker-role-label patch
-	gitkeepPath := filepath.Join(tempDir, "talos", "workers", ".gitkeep")
-	_, err = os.Stat(gitkeepPath)
-	assert.True(
-		t,
-		os.IsNotExist(err),
-		"expected .gitkeep to not exist in workers/ when patches are generated",
-	)
 }
 
 func TestGenerator_Generate_NilConfig(t *testing.T) {
@@ -250,13 +242,9 @@ func TestGenerator_Generate_DisableDefaultCNI(t *testing.T) {
 	_, err = os.Stat(filepath.Join(tempDir, "talos", "control-planes", ".gitkeep"))
 	require.NoError(t, err, "expected .gitkeep in control-planes/")
 
-	// Verify .gitkeep was NOT created in workers/ since worker-role-label patch is generated there
+	// Verify .gitkeep WAS created in workers/ (no worker patches are generated there)
 	_, err = os.Stat(filepath.Join(tempDir, "talos", "workers", ".gitkeep"))
-	assert.True(
-		t,
-		os.IsNotExist(err),
-		"expected .gitkeep to not exist when worker patches are generated",
-	)
+	require.NoError(t, err, "expected .gitkeep in workers/")
 }
 
 func TestGenerator_Generate_NoDisableCNIPatchWhenFalse(t *testing.T) {
@@ -320,7 +308,7 @@ func TestGenerator_Generate_AllowSchedulingOnControlPlanes(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when patches are generated")
 }
 
-func TestGenerator_Generate_WorkerRoleLabel(t *testing.T) {
+func TestGenerator_Generate_WorkerRoleLabel_NotGeneratedWithWorkers(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
@@ -338,21 +326,16 @@ func TestGenerator_Generate_WorkerRoleLabel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tempDir, "talos"), result)
 
-	// Verify worker-role-label.yaml was created in workers/
-	workersDir := filepath.Join(tempDir, "talos", "workers")
-	patchPath := filepath.Join(workersDir, "worker-role-label.yaml")
-	content, err := os.ReadFile(patchPath) //nolint:gosec // Test file path is safe
-	require.NoError(t, err)
-	assert.Contains(t, string(content), "machine:")
-	assert.Contains(t, string(content), "node-labels:")
-	assert.Contains(t, string(content), `node-role.kubernetes.io/worker=`)
-	// Ensure the broken machine.nodeLabels format is NOT present (regression guard).
-	assert.NotContains(t, string(content), "nodeLabels:")
-
-	// Verify .gitkeep was NOT created in workers/ since we have a patch there
-	gitkeepPath := filepath.Join(workersDir, ".gitkeep")
-	_, err = os.Stat(gitkeepPath)
-	assert.True(t, os.IsNotExist(err), "expected .gitkeep to not exist when patches are generated")
+	// ksail no longer scaffolds a worker role label patch. Kubernetes 1.33+ rejects
+	// node-role.kubernetes.io/* labels passed via kubelet --node-labels, which prevents
+	// worker kubelets from starting. The label is cosmetic, so it is dropped entirely.
+	patchPath := filepath.Join(tempDir, "talos", "workers", "worker-role-label.yaml")
+	_, err = os.Stat(patchPath)
+	assert.True(
+		t,
+		os.IsNotExist(err),
+		"expected worker-role-label.yaml to not be generated when workers are configured",
+	)
 }
 
 func TestGenerator_Generate_WorkerRoleLabel_NotGeneratedWithoutWorkers(t *testing.T) {

--- a/pkg/fsutil/generator/talos/generator_writeerror_test.go
+++ b/pkg/fsutil/generator/talos/generator_writeerror_test.go
@@ -93,31 +93,6 @@ func TestGenerate_AllowSchedulingWriteError(t *testing.T) {
 	}, "allow-scheduling-on-control-planes")
 }
 
-func TestGenerate_WorkerRoleLabelWriteError(t *testing.T) {
-	t.Parallel()
-
-	skipPermissionWriteFailureTest(t)
-
-	config := &talosgenerator.Config{
-		PatchesDir:  "talos",
-		WorkerNodes: 1,
-	}
-
-	tempDir := t.TempDir()
-	gen := talosgenerator.NewGenerator()
-
-	_, err := gen.Generate(config, yamlgenerator.Options{Output: tempDir, Force: true})
-	require.NoError(t, err)
-
-	workersDir := filepath.Join(tempDir, "talos", "workers")
-	prepareClusterDirForWriteFailure(t, workersDir)
-
-	_, err = gen.Generate(config, yamlgenerator.Options{Output: tempDir, Force: true})
-	require.Error(t, err)
-	require.ErrorIs(t, err, fs.ErrPermission, "expected permission-denied write failure")
-	assert.Contains(t, err.Error(), "worker-role-label")
-}
-
 func TestGenerate_DisableCNIWriteError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fsutil/scaffolder/scaffolder_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_test.go
@@ -1551,7 +1551,7 @@ func TestScaffoldTalos_CreatesDirectoryStructure(t *testing.T) {
 	expectedPaths := []string{
 		filepath.Join(tempDir, scaffolder.TalosConfigDir, "cluster", ".gitkeep"),
 		filepath.Join(tempDir, scaffolder.TalosConfigDir, "control-planes", ".gitkeep"),
-		filepath.Join(tempDir, scaffolder.TalosConfigDir, "workers", "worker-role-label.yaml"),
+		filepath.Join(tempDir, scaffolder.TalosConfigDir, "workers", ".gitkeep"),
 		filepath.Join(tempDir, "ksail.yaml"),
 		filepath.Join(tempDir, "k8s", "kustomization.yaml"),
 	}


### PR DESCRIPTION
## Summary

Kubernetes 1.33+ kubelet rejects `node-role.kubernetes.io/*` labels passed through `--node-labels`. ksail injected `node-role.kubernetes.io/worker=` into Talos worker kubelets, so on K8s 1.33 every worker kubelet failed to start and the cluster was unusable (nothing schedulable).

The worker role label is purely cosmetic (it only populates the `ROLE` column in `kubectl get nodes`) and nothing in ksail depends on it as a selector, so this PR drops it entirely:

- **init**: no longer scaffolds `talos/workers/worker-role-label.yaml`.
- **runtime**: no longer injects the `kubelet --node-labels` patch into the default/worker config.
- **migration**: on config load, an existing `talos/workers/worker-role-label.yaml` whose content matches a known ksail scaffold (legacy `machine.nodeLabels` or kubelet `--node-labels`) is deleted so existing projects are healed; a user-customized file is left untouched with a warning.

Workers now register and become `Ready` on K8s 1.33, showing `<none>` in the ROLE column (same as upstream kubeadm).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- `go build ./...`, `go vet`, `gofmt`, and `golangci-lint` clean on changed packages.
- `go test ./...` passes (the only failure is a pre-existing, environment-specific `pkg/cli/cmd/chat` subprocess test, unrelated to this change).
- New unit tests cover deletion of both scaffold formats, preservation + warning for a customized file, and the no-file no-op.
- CLI smoke test: `ksail cluster init --distribution Talos` produces a scaffold with no `worker-role-label.yaml` and zero `node-labels` references.

Fixes #4834

🤖 Generated with [Claude Code](https://claude.com/claude-code)