### PR TITLE
docs: surface Kubernetes provider in navigation and reference pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig({
           label: "Providers",
           items: [
             { label: "Docker", link: "/providers/docker/" },
+            { label: "Kubernetes (Nested)", link: "/providers/kubernetes/" },
             { label: "Hetzner", link: "/providers/hetzner/" },
             { label: "Omni (Sidero)", link: "/providers/omni/" },
             { label: "AWS", link: "/providers/aws/" },

--- a/docs/src/content/docs/concepts.mdx
+++ b/docs/src/content/docs/concepts.mdx
@@ -54,7 +54,7 @@ Creates nodes as Hetzner Cloud servers for production-grade clusters. **Supporte
 > [!NOTE]
 > KSail only enables Hetzner-backed operations when `HCLOUD_TOKEN` is set; if it's unset, Hetzner is skipped.
 
-### Kubernetes
+### Kubernetes (Nested)
 
 Runs nested cluster nodes as pods inside an existing host Kubernetes cluster. No Docker daemon is required on the host machine — the nested cluster's API server is exposed via Gateway API (TCPRoute), LoadBalancer, or NodePort, making it routable after `ksail` exits. **Supported distributions:** Vanilla, K3s, Talos, VCluster, KWOK. See [Kubernetes Provider](/providers/kubernetes/).
 

--- a/docs/src/content/docs/concepts.mdx
+++ b/docs/src/content/docs/concepts.mdx
@@ -54,6 +54,10 @@ Creates nodes as Hetzner Cloud servers for production-grade clusters. **Supporte
 > [!NOTE]
 > KSail only enables Hetzner-backed operations when `HCLOUD_TOKEN` is set; if it's unset, Hetzner is skipped.
 
+### Kubernetes
+
+Runs nested cluster nodes as pods inside an existing host Kubernetes cluster. No Docker daemon is required on the host machine — the nested cluster's API server is exposed via Gateway API (TCPRoute), LoadBalancer, or NodePort, making it routable after `ksail` exits. **Supported distributions:** Vanilla, K3s, Talos, VCluster, KWOK. See [Kubernetes Provider](/providers/kubernetes/).
+
 ### Omni
 
 Manages Talos clusters through the [Sidero Omni](https://www.siderolabs.com/omni/) SaaS API. **Supported distributions:** Talos. **Requirements:** a Sidero Omni account, a service account key, and an Omni API endpoint. See [Omni Provider](/providers/omni/), [Omni docs](https://omni.siderolabs.com/docs/), and [Talos on Omni](https://omni.siderolabs.com/docs/how-to-guides/how-to-create-a-cluster/).

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -56,6 +56,7 @@ Supported distributions run on different infrastructure providers:
 | Provider | Vanilla | K3s | Talos | VCluster | KWOK | EKS |
 |----------|---------|-----|-------|----------|------|-----|
 | Docker | ✅ (Kind) | ✅ (K3d) | ✅ | ✅ (Vind) | ✅ (kwokctl) | ❌ |
+| Kubernetes | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Hetzner | — | — | ✅ | — | — | — |
 | Omni | — | — | ✅ | — | — | — |
 | AWS | — | — | — | — | — | 🚧 |
@@ -202,6 +203,9 @@ flowchart TD
 <CardGrid>
   <Card title="Docker" icon="laptop">
     Run Kubernetes nodes as Docker containers locally. Default provider for all distributions. [Learn more →](/providers/docker/)
+  </Card>
+  <Card title="Kubernetes (Nested)" icon="puzzle">
+    Run nested clusters as pods inside an existing Kubernetes cluster — no Docker required on the host. Supports Vanilla, K3s, Talos, VCluster, and KWOK. [Learn more →](/providers/kubernetes/)
   </Card>
   <Card title="Hetzner" icon="external">
     Deploy Talos clusters on affordable Hetzner Cloud servers with real load balancers and persistent volumes. [Learn more →](/providers/hetzner/)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -49,7 +49,7 @@ KSail works on all major operating systems and CPU architectures:
 | macOS | arm64 |
 | ⊞ Windows (native untested; WSL2 recommended) | amd64, arm64 |
 
-**Docker is required** for local clusters. Install Docker Desktop/Engine and ensure `docker ps` works.
+**Docker is required** for local clusters using the default Docker provider. Install Docker Desktop/Engine and ensure `docker ps` works. The [Kubernetes (Nested) provider](/providers/kubernetes/) is the exception — it runs clusters inside an existing host cluster and needs no Docker on the host.
 
 Supported distributions run on different infrastructure providers:
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -34,13 +34,15 @@ docker ps
 
 The supported Kubernetes distributions (x-axis) run on different infrastructure providers (y-axis). You need to have access to at least one provider for your chosen distribution.
 
-| Provider | Vanilla   | K3s      | Talos | VCluster   | KWOK         |
-| -------- | --------- | -------- | ----- | ---------- | ------------ |
-| Docker   | ✅ (Kind) | ✅ (K3d) | ✅    | ✅ (Vind)  | ✅ (kwokctl) |
-| Hetzner  | —         | —        | ✅    | —          | —            |
-| Omni     | —         | —        | ✅    | —          | —            |
+| Provider   | Vanilla   | K3s      | Talos | VCluster   | KWOK         |
+| ---------- | --------- | -------- | ----- | ---------- | ------------ |
+| Docker     | ✅ (Kind) | ✅ (K3d) | ✅    | ✅ (Vind)  | ✅ (kwokctl) |
+| Kubernetes | ✅        | ✅       | ✅    | ✅         | ✅           |
+| Hetzner    | —         | —        | ✅    | —          | —            |
+| Omni       | —         | —        | ✅    | —          | —            |
 
 > [!NOTE]
+> The Kubernetes provider runs nested clusters as pods inside an existing host cluster — no Docker required on the host. See [Kubernetes Provider](/providers/kubernetes/) for setup details.
 > Talos on Hetzner requires a Hetzner Cloud account and API token (`HCLOUD_TOKEN`). Talos on Omni requires a [Sidero Omni](https://www.siderolabs.com/omni/) account, a service account key provided via environment variable (defaults to `OMNI_SERVICE_ACCOUNT_KEY`, configurable via `spec.provider.omni.serviceAccountKeyEnvVar`), and an Omni API endpoint configured via `spec.provider.omni.endpoint` in `ksail.yaml`. See the [Support Matrix](/support-matrix/) for more details.
 
 ## Installation Methods

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -17,7 +17,7 @@ KSail works on all major operating systems and modern CPU architectures:
 |  macOS              | arm64           |
 | ⊞ Windows (native untested; WSL2 recommended) | amd64 and arm64 |
 
-### Docker (Required for Local Clusters)
+### Docker (Required for the Docker Provider)
 
 **Docker is required** to create local clusters using the Docker provider. Install Docker Desktop or Docker Engine and ensure `docker ps` works.
 

--- a/docs/src/content/docs/support-matrix.mdx
+++ b/docs/src/content/docs/support-matrix.mdx
@@ -7,18 +7,19 @@ KSail supports multiple Kubernetes distributions, providers, and components. Thi
 
 ## Distribution × Provider Matrix
 
-| Distribution     | Docker | Hetzner | Omni | AWS   |
-| ---------------- | ------ | ------- | ---- | ----- |
-| Vanilla (Kind)   | ✅     | ❌      | ❌   | ❌    |
-| K3s (K3d)        | ✅     | ❌      | ❌   | ❌    |
-| Talos            | ✅     | ✅      | ✅   | ❌    |
-| VCluster (Vind)  | ✅     | ❌      | ❌   | ❌    |
-| KWOK (kwokctl)   | ✅     | ❌      | ❌   | ❌    |
-| EKS              | ❌     | ❌      | ❌   | 🚧¹⁰ |
+| Distribution     | Docker | Kubernetes | Hetzner | Omni | AWS   |
+| ---------------- | ------ | ---------- | ------- | ---- | ----- |
+| Vanilla (Kind)   | ✅     | ✅         | ❌      | ❌   | ❌    |
+| K3s (K3d)        | ✅     | ✅         | ❌      | ❌   | ❌    |
+| Talos            | ✅     | ✅         | ✅      | ✅   | ❌    |
+| VCluster (Vind)  | ✅     | ✅         | ❌      | ❌   | ❌    |
+| KWOK (kwokctl)   | ✅     | ✅         | ❌      | ❌   | ❌    |
+| EKS              | ❌     | ❌         | ❌      | ❌   | 🚧¹⁰ |
 
 **Notes:**
 
 - Docker provider requires Docker Desktop or Docker Engine installed locally — see [Docker Provider](/providers/docker/) for setup details
+- Kubernetes provider runs nested cluster nodes as pods inside an existing host Kubernetes cluster — no Docker daemon required on the host; see [Kubernetes Provider](/providers/kubernetes/) for setup details
 - Hetzner provider requires `HCLOUD_TOKEN` environment variable and a Talos ISO uploaded to your Hetzner account (x86: `122630`, ARM: `122629` — see [Talos options](/configuration/declarative-configuration/#distribution-and-tool-options)) — see [Hetzner Provider](/providers/hetzner/) for setup details
 - Omni provider requires a [Sidero Omni](https://www.siderolabs.com/omni/) account, an `OMNI_SERVICE_ACCOUNT_KEY` environment variable, and an Omni API endpoint configured via `spec.provider.omni.endpoint` in your KSail configuration — see [Omni Provider](/providers/omni/) for setup details
 - ¹⁰ AWS provider requires AWS credentials and an AWS account with EKS permissions — see [AWS Provider](/providers/aws/) for setup details; `ksail cluster create` is not yet functional for EKS


### PR DESCRIPTION
🤖 This PR was created automatically by the Daily Docs maintenance agent.

## Summary

The Kubernetes provider (added in #4815) was fully implemented and had its own documentation page (`/providers/kubernetes/`) but was never wired into any navigation or reference entry — making it completely undiscoverable to users browsing the docs.

Changes:

- **`docs/astro.config.mjs`** — Add `Kubernetes (Nested)` entry to the Providers sidebar section
- **`docs/src/content/docs/index.mdx`** — Add Kubernetes row to the Distribution × Provider matrix; add a Kubernetes provider card to the Providers card grid
- **`docs/src/content/docs/concepts.mdx`** — Add a Kubernetes provider subsection under the Providers overview
- **`docs/src/content/docs/support-matrix.mdx`** — Add Kubernetes column to the Distribution × Provider Matrix; add a footnote explaining the provider
- **`docs/src/content/docs/installation.mdx`** — Add Kubernetes row to the provider support table with a note

## Why

The Kubernetes provider supports 5 out of 6 distributions (Vanilla, K3s, Talos, VCluster, KWOK) and enables running nested clusters without Docker. Despite having a complete documentation page, it was invisible — absent from the sidebar, support matrix, homepage, concepts overview, and installation guide. This is a structural discoverability gap, not a content gap.

## Test plan

- [x] `npm run build` succeeds (170 pages built)
- [ ] Verify `/providers/kubernetes/` appears in the Providers sidebar section
- [ ] Verify Kubernetes row appears in support matrix tables on `/support-matrix/` and `/installation/`
- [ ] Verify Kubernetes provider card appears on the homepage `/`
- [ ] Verify Kubernetes provider section appears on `/concepts/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQxtNvL78UHoJTyWmZHYMx)_