### PR TITLE
docs: add Kubernetes provider to README support matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Continue with the [Getting Started guide](https://ksail.devantler.tech/) for Git
 | Manifest Validation      | Kubeconform                                                 |
 | Cluster Operations       | K9s, backup & restore, multi-tenancy (`ksail tenant`)       |
 | AI Integration           | Chat assistant (Copilot SDK), MCP server, VS Code extension |
-| Infrastructure Providers | Docker (local), Hetzner Cloud, Sidero Omni, AWS             |
+| Infrastructure Providers | Docker (local), Kubernetes (nested), Hetzner Cloud, Sidero Omni, AWS |
 
 See the [feature overview](https://ksail.devantler.tech/features/) and [architecture guide](https://ksail.devantler.tech/architecture/) for details.
 
@@ -81,12 +81,13 @@ See the [feature overview](https://ksail.devantler.tech/features/) and [architec
 | 🍎 macOS                                      | arm64        |
 | ⊞ Windows (native untested; WSL2 recommended) | amd64, arm64 |
 
-| Provider | Vanilla  | K3s     | Talos | VCluster | KWOK        | EKS |
-|----------|----------|---------|-------|----------|-------------|-----|
-| Docker   | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | ❌   |
-| Hetzner  | —        | —       | ✅     | —        | —           | —   |
-| Omni     | —        | —       | ✅     | —        | —           | —   |
-| AWS      | —        | —       | —     | —        | —           | 🚧  |
+| Provider   | Vanilla  | K3s     | Talos | VCluster | KWOK        | EKS |
+|------------|----------|---------|-------|----------|-------------|-----|
+| Docker     | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | ❌   |
+| Kubernetes | ✅        | ✅       | ✅     | ✅        | ✅           | —   |
+| Hetzner    | —        | —       | ✅     | —        | —           | —   |
+| Omni       | —        | —       | ✅     | —        | —           | —   |
+| AWS        | —        | —       | —     | —        | —           | 🚧  |
 
 ## Community & Support
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ Continue with the [Getting Started guide](https://ksail.devantler.tech/) for Git
 
 ## What KSail Bundles
 
-| Category                 | Built-in Capabilities                                       |
-|--------------------------|-------------------------------------------------------------|
-| Cluster Provisioning     | Kind, K3d, Talos, VCluster (Vind), KWOK (kwokctl), EKS      |
-| Container Orchestration  | kubectl, Helm, Kustomize                                    |
-| GitOps Engines           | Flux, ArgoCD                                                |
-| Secrets Management       | SOPS with Age encryption                                    |
-| Manifest Validation      | Kubeconform                                                 |
-| Cluster Operations       | K9s, backup & restore, multi-tenancy (`ksail tenant`)       |
-| AI Integration           | Chat assistant (Copilot SDK), MCP server, VS Code extension |
+| Category                 | Built-in Capabilities                                                |
+|--------------------------|----------------------------------------------------------------------|
+| Cluster Provisioning     | Kind, K3d, Talos, VCluster (Vind), KWOK (kwokctl), EKS               |
+| Container Orchestration  | kubectl, Helm, Kustomize                                             |
+| GitOps Engines           | Flux, ArgoCD                                                         |
+| Secrets Management       | SOPS with Age encryption                                             |
+| Manifest Validation      | Kubeconform                                                          |
+| Cluster Operations       | K9s, backup & restore, multi-tenancy (`ksail tenant`)                |
+| AI Integration           | Chat assistant (Copilot SDK), MCP server, VS Code extension          |
 | Infrastructure Providers | Docker (local), Kubernetes (nested), Hetzner Cloud, Sidero Omni, AWS |
 
 See the [feature overview](https://ksail.devantler.tech/features/) and [architecture guide](https://ksail.devantler.tech/architecture/) for details.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See the [feature overview](https://ksail.devantler.tech/features/) and [architec
 | Provider   | Vanilla  | K3s     | Talos | VCluster | KWOK        | EKS |
 |------------|----------|---------|-------|----------|-------------|-----|
 | Docker     | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | ❌   |
-| Kubernetes | ✅        | ✅       | ✅     | ✅        | ✅           | —   |
+| Kubernetes | ✅        | ✅       | ✅     | ✅        | ✅           | ❌   |
 | Hetzner    | —        | —       | ✅     | —        | —           | —   |
 | Omni       | —        | —       | ✅     | —        | —           | —   |
 | AWS        | —        | —       | —     | —        | —           | 🚧  |


### PR DESCRIPTION
🤖 *This is an automated response from Repo Assist.*

The Kubernetes (nested) provider was added in #4815 and wired into the documentation site in #4846, but `README.md` was never updated. This PR closes that gap.

**What changed:**
- **Infrastructure Providers** row in *What KSail Bundles* — added `Kubernetes (nested)`
- **Distribution × Provider matrix** — added a `Kubernetes` row supporting Vanilla, K3s, Talos, VCluster, and KWOK (not EKS), mirroring `docs/src/content/docs/support-matrix.mdx`

Fixes #4768
Fixes #4821

## Type of change

- [x] 📚 Documentation update

## Test Status

Documentation-only change (README.md). No Go source touched, so `go build` / `go test` behavior is unaffected. Provider support values were cross-checked against the authoritative `docs/src/content/docs/support-matrix.mdx` and `docs/src/content/docs/index.mdx` (merged in #4846).