### PR TITLE
test(operator): convert auth tests to black-box api_test

### DIFF
--- a/pkg/operator/api/auth_flow_test.go
+++ b/pkg/operator/api/auth_flow_test.go
@@ -1,4 +1,4 @@
-package api //nolint:testpackage // white-box tests for the unexported OIDC flow
+package api_test
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/operator/api"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
@@ -148,18 +149,18 @@ func findCookie(cookies []*http.Cookie, name string) *http.Cookie {
 func TestEnabled(t *testing.T) {
 	t.Parallel()
 
-	assert.False(t, OIDCConfig{}.Enabled())
-	assert.True(t, OIDCConfig{IssuerURL: "https://issuer.example"}.Enabled())
+	assert.False(t, api.OIDCConfig{}.Enabled())
+	assert.True(t, api.OIDCConfig{IssuerURL: "https://issuer.example"}.Enabled())
 }
 
 func TestNewAuthenticatorRequiresConfig(t *testing.T) {
 	t.Parallel()
 
-	_, err := newAuthenticator(
+	_, err := api.NewAuthenticator(
 		context.Background(),
-		OIDCConfig{IssuerURL: "https://issuer.example"},
+		api.OIDCConfig{IssuerURL: "https://issuer.example"},
 	)
-	require.ErrorIs(t, err, ErrOIDCConfig)
+	require.ErrorIs(t, err, api.ErrOIDCConfig)
 }
 
 func TestOIDCLoginCallbackFlow(t *testing.T) {
@@ -168,7 +169,7 @@ func TestOIDCLoginCallbackFlow(t *testing.T) {
 	idp := newMockIDP(t)
 	secret := []byte(flowSecret)
 
-	auth, err := newAuthenticator(context.Background(), OIDCConfig{
+	auth, err := api.NewAuthenticator(context.Background(), api.OIDCConfig{
 		IssuerURL:     idp.server.URL,
 		ClientID:      idp.clientID,
 		ClientSecret:  "client-secret",
@@ -181,18 +182,18 @@ func TestOIDCLoginCallbackFlow(t *testing.T) {
 
 	// 1. Login redirects to the provider and sets a signed state cookie.
 	loginRec := httptest.NewRecorder()
-	auth.handleLogin(loginRec, httptest.NewRequestWithContext(
-		context.Background(), http.MethodGet, loginPath, nil,
+	auth.HandleLogin(loginRec, httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, api.LoginPath, nil,
 	))
 	require.Equal(t, http.StatusFound, loginRec.Code)
 
-	stateCookie := findCookie(loginRec.Result().Cookies(), stateCookieName)
+	stateCookie := findCookie(loginRec.Result().Cookies(), api.StateCookieName)
 	require.NotNil(t, stateCookie)
 
-	statePayload, err := verifySignedValue(secret, stateCookie.Value)
+	statePayload, err := api.VerifySignedValue(secret, stateCookie.Value)
 	require.NoError(t, err)
 
-	var state stateData
+	var state api.StateData
 
 	require.NoError(t, json.Unmarshal(statePayload, &state))
 	assert.Contains(t, loginRec.Header().Get("Location"), "state="+state.State)
@@ -210,10 +211,10 @@ func TestOIDCLoginCallbackFlow(t *testing.T) {
 	callbackReq.AddCookie(stateCookie)
 
 	callbackRec := httptest.NewRecorder()
-	auth.handleCallback(callbackRec, callbackReq)
+	auth.HandleCallback(callbackRec, callbackReq)
 	require.Equal(t, http.StatusFound, callbackRec.Code, callbackRec.Body.String())
 
-	sessionCookie := findCookie(callbackRec.Result().Cookies(), sessionCookieName)
+	sessionCookie := findCookie(callbackRec.Result().Cookies(), api.SessionCookieName)
 	require.NotNil(t, sessionCookie)
 
 	// 3. The session cookie authenticates subsequent requests.
@@ -222,7 +223,7 @@ func TestOIDCLoginCallbackFlow(t *testing.T) {
 	)
 	authedReq.AddCookie(sessionCookie)
 
-	claims, ok := auth.currentUser(authedReq)
+	claims, ok := auth.CurrentUser(authedReq)
 	require.True(t, ok)
 	assert.Equal(t, testSubject, claims.Subject)
 	assert.Equal(t, "alice@example.com", claims.Email)
@@ -232,11 +233,11 @@ func TestHandleCallbackRejectsBadRequests(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte(flowSecret)
-	auth := &authenticator{config: OIDCConfig{SessionSecret: secret, SessionTTL: time.Hour}}
+	auth := api.NewConfigAuthenticator(api.OIDCConfig{SessionSecret: secret, SessionTTL: time.Hour})
 
-	goodState := auth.signedCookie(
-		stateCookieName,
-		mustMarshal(stateData{State: "good", Nonce: "n"}),
+	goodState := auth.SignedCookie(
+		api.StateCookieName,
+		api.MustMarshal(api.StateData{State: "good", Nonce: "n"}),
 		"/api/v1/auth",
 		600,
 	)
@@ -271,7 +272,7 @@ func TestHandleCallbackRejectsBadRequests(t *testing.T) {
 			}
 
 			rec := httptest.NewRecorder()
-			auth.handleCallback(rec, req)
+			auth.HandleCallback(rec, req)
 			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		})
 	}
@@ -280,16 +281,16 @@ func TestHandleCallbackRejectsBadRequests(t *testing.T) {
 func TestHandleLogoutClearsSession(t *testing.T) {
 	t.Parallel()
 
-	auth := &authenticator{config: OIDCConfig{SessionSecret: []byte(flowSecret)}}
+	auth := api.NewConfigAuthenticator(api.OIDCConfig{SessionSecret: []byte(flowSecret)})
 
 	rec := httptest.NewRecorder()
-	auth.handleLogout(rec, httptest.NewRequestWithContext(
+	auth.HandleLogout(rec, httptest.NewRequestWithContext(
 		context.Background(), http.MethodPost, "/api/v1/auth/logout", nil,
 	))
 
 	require.Equal(t, http.StatusNoContent, rec.Code)
 
-	cleared := findCookie(rec.Result().Cookies(), sessionCookieName)
+	cleared := findCookie(rec.Result().Cookies(), api.SessionCookieName)
 	require.NotNil(t, cleared)
 	assert.Negative(t, cleared.MaxAge)
 }

--- a/pkg/operator/api/auth_test.go
+++ b/pkg/operator/api/auth_test.go
@@ -1,4 +1,4 @@
-package api //nolint:testpackage // white-box tests for unexported cookie-signing helpers
+package api_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/operator/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,9 +30,9 @@ func TestSignedValueRoundTrip(t *testing.T) {
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	payload := []byte(`{"sub":"alice"}`)
 
-	value := signValue(secret, payload)
+	value := api.SignValue(secret, payload)
 
-	got, err := verifySignedValue(secret, value)
+	got, err := api.VerifySignedValue(secret, value)
 	require.NoError(t, err)
 	assert.Equal(t, payload, got)
 }
@@ -40,28 +41,28 @@ func TestVerifySignedValueRejectsTampering(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	value := signValue(secret, []byte(`{"sub":"alice"}`))
+	value := api.SignValue(secret, []byte(`{"sub":"alice"}`))
 
-	_, err := verifySignedValue([]byte("a-different-secret-of-the-key-len"), value)
-	require.ErrorIs(t, err, errInvalidCookie)
+	_, err := api.VerifySignedValue([]byte("a-different-secret-of-the-key-len"), value)
+	require.ErrorIs(t, err, api.ErrInvalidCookie)
 
-	_, err = verifySignedValue(secret, value+"x")
-	require.ErrorIs(t, err, errInvalidCookie)
+	_, err = api.VerifySignedValue(secret, value+"x")
+	require.ErrorIs(t, err, api.ErrInvalidCookie)
 
-	_, err = verifySignedValue(secret, "no-separator")
-	require.ErrorIs(t, err, errInvalidCookie)
+	_, err = api.VerifySignedValue(secret, "no-separator")
+	require.ErrorIs(t, err, api.ErrInvalidCookie)
 }
 
 func TestCurrentUserRejectsExpiredSession(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	auth := &authenticator{config: OIDCConfig{SessionSecret: secret, SessionTTL: time.Hour}}
+	auth := api.NewConfigAuthenticator(api.OIDCConfig{SessionSecret: secret, SessionTTL: time.Hour})
 
-	expired := auth.signedCookie(
-		sessionCookieName,
-		mustMarshal(
-			sessionClaims{Subject: testSubject, Expiry: time.Now().Add(-time.Minute).Unix()},
+	expired := auth.SignedCookie(
+		api.SessionCookieName,
+		api.MustMarshal(
+			api.SessionClaims{Subject: testSubject, Expiry: time.Now().Add(-time.Minute).Unix()},
 		),
 		"/",
 		0,
@@ -69,7 +70,7 @@ func TestCurrentUserRejectsExpiredSession(t *testing.T) {
 
 	request := requestWithCookie(expired)
 
-	_, ok := auth.currentUser(request)
+	_, ok := auth.CurrentUser(request)
 	assert.False(t, ok, "expired session must be rejected")
 }
 
@@ -77,16 +78,18 @@ func TestCurrentUserAcceptsValidSession(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	auth := &authenticator{config: OIDCConfig{SessionSecret: secret, SessionTTL: time.Hour}}
+	auth := api.NewConfigAuthenticator(api.OIDCConfig{SessionSecret: secret, SessionTTL: time.Hour})
 
-	valid := auth.signedCookie(
-		sessionCookieName,
-		mustMarshal(sessionClaims{Subject: testSubject, Expiry: time.Now().Add(time.Hour).Unix()}),
+	valid := auth.SignedCookie(
+		api.SessionCookieName,
+		api.MustMarshal(
+			api.SessionClaims{Subject: testSubject, Expiry: time.Now().Add(time.Hour).Unix()},
+		),
 		"/",
 		3600,
 	)
 
-	claims, ok := auth.currentUser(requestWithCookie(valid))
+	claims, ok := auth.CurrentUser(requestWithCookie(valid))
 	require.True(t, ok)
 	assert.Equal(t, testSubject, claims.Subject)
 }

--- a/pkg/operator/api/export_test.go
+++ b/pkg/operator/api/export_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -26,4 +27,77 @@ func (s *Server) NewSessionCookie(subject string) *http.Cookie {
 		"/",
 		int(time.Hour.Seconds()),
 	)
+}
+
+// Test seam for black-box (api_test) coverage of the OIDC authenticator internals.
+
+// Authenticator aliases the unexported authenticator type for use in black-box tests.
+type Authenticator = authenticator
+
+// SessionClaims aliases the authenticated identity persisted in the session cookie.
+type SessionClaims = sessionClaims
+
+// StateData aliases the CSRF state and OIDC nonce persisted in the state cookie.
+type StateData = stateData
+
+// Cookie names and the login path used by the OIDC flow, re-exported for tests.
+const (
+	SessionCookieName = sessionCookieName
+	StateCookieName   = stateCookieName
+	LoginPath         = loginPath
+)
+
+// ErrInvalidCookie is the sentinel returned by VerifySignedValue for a malformed/tampered cookie.
+var ErrInvalidCookie = errInvalidCookie
+
+// SignValue HMAC-signs a payload, exposing the unexported helper to black-box tests.
+func SignValue(secret, payload []byte) string { return signValue(secret, payload) }
+
+// VerifySignedValue verifies and returns a signed cookie payload (or ErrInvalidCookie).
+func VerifySignedValue(secret []byte, value string) ([]byte, error) {
+	return verifySignedValue(secret, value)
+}
+
+// MustMarshal JSON-encodes a value, exposing the unexported helper to black-box tests.
+func MustMarshal(value any) []byte { return mustMarshal(value) }
+
+// NewAuthenticator discovers the OIDC provider and builds an authenticator (network I/O).
+func NewAuthenticator(ctx context.Context, cfg OIDCConfig) (*authenticator, error) {
+	return newAuthenticator(ctx, cfg)
+}
+
+// NewConfigAuthenticator builds an authenticator from config alone (no OIDC discovery), for tests
+// that exercise cookie/session/callback behavior without a live provider.
+func NewConfigAuthenticator(cfg OIDCConfig) *authenticator {
+	return &authenticator{config: cfg}
+}
+
+// SignedCookie exposes the unexported cookie-signing method to black-box tests.
+func (a *authenticator) SignedCookie(
+	name string,
+	payload []byte,
+	path string,
+	maxAge int,
+) *http.Cookie {
+	return a.signedCookie(name, payload, path, maxAge)
+}
+
+// CurrentUser exposes the unexported session-resolution method to black-box tests.
+func (a *authenticator) CurrentUser(request *http.Request) (SessionClaims, bool) {
+	return a.currentUser(request)
+}
+
+// HandleLogin exposes the unexported login handler to black-box tests.
+func (a *authenticator) HandleLogin(writer http.ResponseWriter, request *http.Request) {
+	a.handleLogin(writer, request)
+}
+
+// HandleCallback exposes the unexported callback handler to black-box tests.
+func (a *authenticator) HandleCallback(writer http.ResponseWriter, request *http.Request) {
+	a.handleCallback(writer, request)
+}
+
+// HandleLogout exposes the unexported logout handler to black-box tests.
+func (a *authenticator) HandleLogout(writer http.ResponseWriter, request *http.Request) {
+	a.handleLogout(writer, request)
 }

--- a/pkg/operator/api/export_test.go
+++ b/pkg/operator/api/export_test.go
@@ -62,13 +62,13 @@ func VerifySignedValue(secret []byte, value string) ([]byte, error) {
 func MustMarshal(value any) []byte { return mustMarshal(value) }
 
 // NewAuthenticator discovers the OIDC provider and builds an authenticator (network I/O).
-func NewAuthenticator(ctx context.Context, cfg OIDCConfig) (*authenticator, error) {
+func NewAuthenticator(ctx context.Context, cfg OIDCConfig) (*Authenticator, error) {
 	return newAuthenticator(ctx, cfg)
 }
 
 // NewConfigAuthenticator builds an authenticator from config alone (no OIDC discovery), for tests
 // that exercise cookie/session/callback behavior without a live provider.
-func NewConfigAuthenticator(cfg OIDCConfig) *authenticator {
+func NewConfigAuthenticator(cfg OIDCConfig) *Authenticator {
 	return &authenticator{config: cfg}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4824 (merged). Converts the two OIDC auth test files to the repo's black-box testing convention, dropping the `//nolint:testpackage` white-box exception:

- `pkg/operator/api/auth_test.go` and `auth_flow_test.go` → `package api_test`
- The internals these tests exercise are now exposed through the `export_test.go` seam: `SignValue`/`VerifySignedValue`/`MustMarshal`/`NewAuthenticator`, exported wrappers for the `authenticator` cookie/session/flow methods (`SignedCookie`, `CurrentUser`, `HandleLogin`/`HandleCallback`/`HandleLogout`), type aliases (`Authenticator`/`SessionClaims`/`StateData`), the cookie-name/login-path constants, `ErrInvalidCookie`, and a `NewConfigAuthenticator` constructor for provider-less tests.

No production code or test behavior changes — purely a test-package/visibility refactor so the auth tests match the black-box convention used elsewhere (e.g. `server_test.go`).

## Why

[#4824](https://github.com/devantler-tech/ksail/pull/4824) review flagged the white-box `package api` + `//nolint:testpackage` as a deviation from the repo convention. The branch merged before this could land there, so it's delivered here.

## Test plan

- [x] `go test ./pkg/operator/api/...` passes
- [x] `golangci-lint run ./pkg/operator/api/...` clean (no `testpackage`/`gochecknoglobals`/`revive` findings)
- [x] `golangci-lint fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code) — automated PR-merge agent