### PR TITLE
ci(operator): E2E test ksail-operator chart and publish web-ui image

### DIFF
--- a/.github/actions/operator-chart-e2e/action.yml
+++ b/.github/actions/operator-chart-e2e/action.yml
@@ -1,0 +1,203 @@
+name: Operator Chart E2E
+description: |
+  Smoke + API end-to-end test of the ksail-operator Helm chart on a throwaway
+  kind cluster. Builds the operator and web UI images locally (no registry),
+  loads them into kind, installs the chart with the UI enabled in read-only
+  mode, and asserts the CRD registers, the operator and UI roll out, the REST
+  API serves /readyz and /api/v1/config, mutations are rejected (403), and the
+  UI serves its SPA and proxies /api to the operator.
+
+  Full Cluster-CR reconciliation is intentionally out of scope: the reconciler
+  provisions real Docker-based clusters, which is not feasible inside a plain
+  kind hub without privileged Docker access.
+
+  Assumes Go is already set up by the caller (actions/setup-go).
+
+inputs:
+  namespace:
+    description: Namespace to install the chart into.
+    required: false
+    default: "ksail-operator"
+  cluster-name:
+    description: Name of the throwaway kind cluster.
+    required: false
+    default: "ksail-operator-e2e"
+  operator-image:
+    description: Local tag for the operator image.
+    required: false
+    default: "ksail:e2e"
+  ui-image:
+    description: Local tag for the web UI image.
+    required: false
+    default: "ksail-web-ui:e2e"
+
+runs:
+  using: composite
+  steps:
+    - name: 🧹 Free disk space
+      shell: bash
+      run: |
+        set -euo pipefail
+        before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        sudo rm -rf \
+          /usr/local/lib/android \
+          /usr/share/dotnet \
+          /opt/ghc \
+          /usr/local/share/boost \
+          /usr/share/swift \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/powershell \
+          /usr/local/julia* || true
+        after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        echo "Free disk space on /: ${before}G -> ${after}G (gained $((after - before))G)"
+
+    - name: 🏗️ Build operator image
+      shell: bash
+      env:
+        # Match .goreleaser.yaml: a static (CGO_ENABLED=0) binary is required by
+        # the distroless/static base in the root Dockerfile. The generate +
+        # bundler hooks mirror the release build's pre-hooks so the embed
+        # directives resolve.
+        GOPROXY: "https://proxy.golang.org|direct"
+        GOMEMLIMIT: "6GiB"
+        OPERATOR_IMAGE: ${{ inputs.operator-image }}
+      run: |
+        set -euo pipefail
+        go generate ./pkg/svc/chat/...
+        go tool bundler --platform linux/amd64 --cli-version 1.0.10
+        ctx="$(mktemp -d)"
+        mkdir -p "$ctx/linux/amd64"
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+          go build -trimpath -ldflags="-s -w" -o "$ctx/linux/amd64/ksail" .
+        cp Dockerfile "$ctx/Dockerfile"
+        docker build --build-arg TARGETPLATFORM=linux/amd64 -t "$OPERATOR_IMAGE" "$ctx"
+        rm -rf "$ctx"
+
+    - name: 🏗️ Build web UI image
+      shell: bash
+      env:
+        UI_IMAGE: ${{ inputs.ui-image }}
+      run: docker build -t "$UI_IMAGE" web/ui
+
+    - name: ☸️ Create kind cluster
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+      with:
+        cluster_name: ${{ inputs.cluster-name }}
+
+    - name: 📦 Load images into kind
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        OPERATOR_IMAGE: ${{ inputs.operator-image }}
+        UI_IMAGE: ${{ inputs.ui-image }}
+      run: |
+        set -euo pipefail
+        kind load docker-image "$OPERATOR_IMAGE" "$UI_IMAGE" --name "$CLUSTER_NAME"
+
+    - name: 🚀 Install chart
+      shell: bash
+      env:
+        NS: ${{ inputs.namespace }}
+        OPERATOR_IMAGE: ${{ inputs.operator-image }}
+        UI_IMAGE: ${{ inputs.ui-image }}
+      run: |
+        set -euo pipefail
+        op_repo="${OPERATOR_IMAGE%:*}"; op_tag="${OPERATOR_IMAGE##*:}"
+        ui_repo="${UI_IMAGE%:*}";       ui_tag="${UI_IMAGE##*:}"
+        # fullnameOverride keeps resource names clean (ksail-operator,
+        # ksail-operator-ui) instead of <release>-<chart>.
+        # pullPolicy=Never forces use of the kind-loaded images and fails fast
+        # if a load broke. ui.readOnly wires --read-only onto the operator,
+        # enabling the deterministic 403 mutation assertion below.
+        helm install ksail-operator charts/ksail-operator \
+          --namespace "$NS" --create-namespace \
+          --set fullnameOverride=ksail-operator \
+          --set operator.image.repository="$op_repo" \
+          --set operator.image.tag="$op_tag" \
+          --set operator.image.pullPolicy=Never \
+          --set ui.enabled=true \
+          --set ui.readOnly=true \
+          --set ui.image.repository="$ui_repo" \
+          --set ui.image.tag="$ui_tag" \
+          --set ui.image.pullPolicy=Never \
+          --wait --timeout 5m
+
+    - name: ✅ Verify deployment and API
+      shell: bash
+      env:
+        NS: ${{ inputs.namespace }}
+      run: |
+        set -euo pipefail
+
+        wait_http() { # $1=url  $2=expected code
+          local url="$1" want="$2" code=000
+          for _ in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || true)
+            [ "$code" = "$want" ] && return 0
+            sleep 2
+          done
+          echo "❌ Timed out waiting for $url (wanted $want, last $code)"
+          return 1
+        }
+
+        echo "=== CRD registration ==="
+        kubectl wait --for=condition=Established crd/clusters.ksail.io --timeout=60s
+
+        echo "=== Rollouts ==="
+        kubectl -n "$NS" rollout status deploy/ksail-operator --timeout=180s
+        kubectl -n "$NS" rollout status deploy/ksail-operator-ui --timeout=120s
+
+        PF_OP=""; PF_UI=""
+        trap 'kill "${PF_OP:-}" "${PF_UI:-}" 2>/dev/null || true' EXIT
+
+        echo "=== Operator REST API ==="
+        kubectl -n "$NS" port-forward svc/ksail-operator 18080:8080 >/tmp/pf-operator.log 2>&1 &
+        PF_OP=$!
+        wait_http "http://127.0.0.1:18080/readyz" 200
+        echo "  ✅ /readyz"
+        wait_http "http://127.0.0.1:18080/api/v1/config" 200
+        echo "  ✅ /api/v1/config"
+
+        echo "=== Read-only enforcement ==="
+        code=$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:18080/api/v1/clusters)
+        if [ "$code" != "403" ]; then
+          echo "❌ Expected 403 from POST /api/v1/clusters in read-only mode, got $code"
+          exit 1
+        fi
+        echo "  ✅ POST /api/v1/clusters -> 403"
+
+        echo "=== Web UI ==="
+        kubectl -n "$NS" port-forward svc/ksail-operator-ui 18081:80 >/tmp/pf-ui.log 2>&1 &
+        PF_UI=$!
+        wait_http "http://127.0.0.1:18081/" 200
+        echo "  ✅ UI serves SPA"
+        wait_http "http://127.0.0.1:18081/api/v1/config" 200
+        echo "  ✅ UI proxies /api to the operator"
+
+        echo "✅ Operator chart E2E passed"
+
+    - name: 🐞 Operator/UI logs on failure
+      if: failure()
+      shell: bash
+      env:
+        NS: ${{ inputs.namespace }}
+      run: |
+        for d in ksail-operator ksail-operator-ui; do
+          echo "==== describe deploy/$d ===="
+          kubectl -n "$NS" describe deploy "$d" || true
+          echo "==== logs deploy/$d ===="
+          kubectl -n "$NS" logs "deploy/$d" --all-containers --tail=200 || true
+        done
+
+    - name: 🐞 Debug Kubernetes failure
+      if: failure()
+      uses: ./.github/actions/debug-kubernetes-failure
+      with:
+        kubectl-command: kubectl
+        namespace: ${{ inputs.namespace }}
+        show-cni: "false"
+        show-csi: "false"
+        show-gitops: "false"
+        show-policy-engine: "false"
+        show-cert-manager: "false"
+        show-metrics-server: "false"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -78,6 +78,42 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
+  # The web UI ships as a separate image (a Node-built SPA served by nginx),
+  # not part of the GoReleaser binary image. Build and push it alongside the
+  # release so the chart's default ui.image is available.
+  web-ui:
+    name: 🧩 Release Web UI Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: 🔐 Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏗️ Build and push web UI image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: web/ui
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/devantler-tech/ksail/web-ui:${{ github.ref_name }}
+            ghcr.io/devantler-tech/ksail/web-ui:latest
+
   vscode-extension:
     name: 🧩 Release VSCode Extension
     runs-on: ubuntu-latest
@@ -390,7 +426,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
-      [goreleaser, vscode-extension, mcp-publish, pages-deploy, copilot-plugin]
+      [
+        goreleaser,
+        web-ui,
+        vscode-extension,
+        mcp-publish,
+        pages-deploy,
+        copilot-plugin,
+      ]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,6 +131,7 @@ jobs:
       docs-deps: ${{ steps.filter.outputs.docs-deps }}
       vsce-deps: ${{ steps.filter.outputs.vsce-deps }}
       copilot-plugin: ${{ steps.filter.outputs.copilot-plugin }}
+      operator-chart: ${{ steps.filter.outputs.operator-chart }}
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -254,6 +255,19 @@ jobs:
               - 'copilot-plugin/**'
               - '.github/plugin/**'
               - '.claude-plugin/**'
+              - '.github/workflows/ci.yaml'
+            operator-chart:
+              # Operator Helm chart E2E. Covers the chart, the web UI, the
+              # operator runtime (`ksail operator` subcommand), the reconciler,
+              # the Cluster CRD types, and the image build inputs.
+              - 'charts/ksail-operator/**'
+              - 'web/ui/**'
+              - 'pkg/operator/**'
+              - 'internal/controller/**'
+              - 'pkg/cli/cmd/operator/**'
+              - 'pkg/apis/**'
+              - 'Dockerfile'
+              - '.github/actions/operator-chart-e2e/**'
               - '.github/workflows/ci.yaml'
 
   ci-go:
@@ -818,6 +832,72 @@ jobs:
           # MCP server must point at the ksail binary
           jq -e '.mcpServers.ksail.command == "ksail"' copilot-plugin/.mcp.json >/dev/null
 
+  operator-chart-lint:
+    name: ⛵ Operator Chart Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [changes]
+    if: github.event_name != 'merge_group' && needs.changes.outputs.operator-chart == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🔍 Helm lint
+        run: helm lint charts/ksail-operator
+
+      - name: 📐 Helm template (value permutations)
+        run: |
+          set -euo pipefail
+          echo "=== defaults (operator only) ==="
+          helm template ksail-operator charts/ksail-operator >/dev/null
+          echo "=== ui.enabled ==="
+          helm template ksail-operator charts/ksail-operator \
+            --set ui.enabled=true >/dev/null
+          echo "=== auth.oidc.enabled ==="
+          # OIDC requires a redirectURL (or ui.ingress) plus a client secret;
+          # the operator does not run here, so dummy values are sufficient to
+          # exercise the secret/deployment templates.
+          helm template ksail-operator charts/ksail-operator \
+            --set ui.enabled=true \
+            --set auth.oidc.enabled=true \
+            --set auth.oidc.issuerURL=https://dex.example \
+            --set auth.oidc.clientID=ksail \
+            --set auth.oidc.clientSecret=dummy \
+            --set auth.oidc.redirectURL=https://ksail.local/api/v1/auth/callback >/dev/null
+          echo "✅ All chart template permutations rendered"
+
+  operator-chart-e2e:
+    name: ⛵ Operator Chart E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [changes]
+    # Local images only — no secrets/GHCR — so this also runs on fork PRs.
+    if: >-
+      !cancelled()
+      && (
+        (github.event_name == 'pull_request' && needs.changes.outputs.operator-chart == 'true')
+        || github.event_name == 'workflow_dispatch'
+      )
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: 🧪 Run Operator Chart E2E
+        uses: ./.github/actions/operator-chart-e2e
+
   warm-helm-cache:
     name: 🔥 Warm Helm Cache
     runs-on: ubuntu-latest
@@ -1251,6 +1331,8 @@ jobs:
         license-check,
         build-docs,
         benchmark,
+        operator-chart-lint,
+        operator-chart-e2e,
       ]
     if: ${{ always() }}
     steps:
@@ -1269,3 +1351,5 @@ jobs:
             ${{ needs.license-check.result }}
             ${{ needs.build-docs.result }}
             ${{ needs.benchmark.result }}
+            ${{ needs.operator-chart-lint.result }}
+            ${{ needs.operator-chart-e2e.result }}

--- a/.github/workflows/web-ui.yaml
+++ b/.github/workflows/web-ui.yaml
@@ -40,3 +40,45 @@ jobs:
 
       - name: 🏗️ Build
         run: npm run build
+
+  # Publish only runs on push to main, so PRs (including forks) stay build-only
+  # and need no registry credentials. Releases are tagged by cd.yaml; this keeps
+  # the floating :latest fresh between releases.
+  publish:
+    name: 📤 Publish Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build]
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🏷️ Compute short SHA
+        id: vars
+        run: echo "sha=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: ⚙️ Setup Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: 🔐 Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏗️ Build and push web UI image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: web/ui
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/devantler-tech/ksail/web-ui:latest
+            ghcr.io/devantler-tech/ksail/web-ui:sha-${{ steps.vars.outputs.sha }}

--- a/charts/ksail-operator/values.yaml
+++ b/charts/ksail-operator/values.yaml
@@ -42,7 +42,7 @@ ui:
   enabled: false
   readOnly: false
   image:
-    repository: ghcr.io/devantler-tech/ksail-ui
+    repository: ghcr.io/devantler-tech/ksail/web-ui
     tag: ""
     pullPolicy: IfNotPresent
   replicas: 1

--- a/lychee.toml
+++ b/lychee.toml
@@ -44,7 +44,11 @@ exclude_path = [
 #   - \$%7B: shell variable template URLs (${VAR} URL-encoded, not real URLs).
 #   - siderolabs.com/platform/saas-for-kubernetes: intermittently returns
 #     HTTP 500 in CI environments; content is stable, link is not broken.
-#   - localhost: loopback addresses used as GitHub API endpoint overrides in
-#     agentic workflow env vars (e.g. GITHUB_API_URL=https://localhost:18443/…);
-#     never reachable from the lychee runner.
-exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'localhost', 'www\.gnu\.org/licenses/gpl-3\.0']
+#   - localhost / 127.0.0.1: loopback addresses used as GitHub API endpoint
+#     overrides in agentic workflow env vars (e.g.
+#     GITHUB_API_URL=https://localhost:18443/…) and as port-forward targets in
+#     the operator chart E2E (http://127.0.0.1:18080/readyz, …); never reachable
+#     from the lychee runner.
+#   - ksail.local: placeholder OIDC redirect/ingress host in chart template
+#     permutations; an unresolvable .local address, not a real link.
+exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'localhost', '127\.0\.0\.1', 'ksail\.local', 'www\.gnu\.org/licenses/gpl-3\.0']


### PR DESCRIPTION
## Summary

- Adds CI coverage for `charts/ksail-operator`, gated on a new `operator-chart` paths-filter so the jobs run whenever the chart, `web/ui`, the operator runtime (`pkg/operator`, `internal/controller`, `pkg/cli/cmd/operator`), the Cluster CRD types (`pkg/apis`), or `Dockerfile` change.
  - **`operator-chart-lint`** — fast `helm lint` + `helm template` across default / `ui.enabled` / `auth.oidc.enabled` permutations.
  - **`operator-chart-e2e`** — builds the operator image (`CGO_ENABLED=0` static binary via the production `Dockerfile`) and the web UI image locally, loads both into a throwaway kind cluster (via a new `./.github/actions/operator-chart-e2e` composite action), installs the chart with the UI enabled in read-only mode, then asserts: CRD `Established`, operator + UI rollouts, REST API `/readyz` and `/api/v1/config` → 200, `POST /api/v1/clusters` → 403 (read-only), and the UI serves its SPA and proxies `/api` to the operator.
  - Both jobs are wired into the `require-checks-in-pr` gate. They use `contents: read` only (local images, no secrets) so they also run on fork PRs.
- Publishes the web UI image, **renamed** `ghcr.io/devantler-tech/ksail-ui` → `ghcr.io/devantler-tech/ksail/web-ui`:
  - Release pipeline (`cd.yaml`): multi-arch `:<tag>` + `:latest`, gating `publish-release`.
  - `web-ui.yaml`: on push to `main`, `:latest` + `:sha-<short>`; PR path stays build-only.

Full Cluster-CR reconciliation is intentionally **out of scope** — the reconciler provisions real Docker-based clusters, which isn't feasible inside a plain kind hub.

## Test plan

- [x] `helm lint charts/ksail-operator` and all three `helm template` permutations render
- [x] E2E install render verified (resource names `ksail-operator` / `ksail-operator-ui`, local image refs, `--read-only` arg)
- [x] `actionlint` + `yamllint` clean on `ci.yaml`, `cd.yaml`, `web-ui.yaml`, and the composite action
- [ ] `operator-chart-lint` and `operator-chart-e2e` pass in CI on this PR
- [ ] Confirm a docs-only change does **not** trigger these jobs

> Note: the chart's image `tag` defaults to `appVersion` (`0.1.0`), which won't match published release tags — a pre-existing inconsistency that also affects the operator image. The E2E overrides tags explicitly, so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)