### PR TITLE
fix(chat): retry Copilot CLI exec on ETXTBSY race

### DIFF
--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -293,6 +293,7 @@ func verifyCopilotCLI(ctx context.Context, cliPath string, env []string) error {
 
 	err := runCopilotCmdWithRetry(verifyCtx, func() *exec.Cmd {
 		output.Reset()
+
 		cmd := exec.CommandContext(verifyCtx, cliPath, "--version")
 		cmd.Env = env
 		cmd.Stdout = &output
@@ -365,6 +366,7 @@ func diagnoseCLIStartupFailure(
 
 	_ = runCopilotCmdWithRetry(diagCtx, func() *exec.Cmd {
 		stderr.Reset()
+
 		cmd := exec.CommandContext(diagCtx, cliPath, args...)
 		cmd.Env = diagEnv
 		cmd.Stderr = &stderr
@@ -385,20 +387,21 @@ func diagnoseCLIStartupFailure(
 func runCopilotCmdWithRetry(ctx context.Context, newCmd func() *exec.Cmd) error {
 	for attempt := 0; ; attempt++ {
 		err := newCmd().Run()
-		if !errors.Is(err, syscall.ETXTBSY) || attempt >= copilotExecMaxRetries {
-			return err
+		if errors.Is(err, syscall.ETXTBSY) && attempt < copilotExecMaxRetries {
+			// Interruptible backoff: respect context cancellation immediately
+			// rather than sleeping out the remaining window.
+			timer := time.NewTimer(copilotExecRetryBackoff)
+			select {
+			case <-timer.C:
+				continue
+			case <-ctx.Done():
+				timer.Stop()
+			}
 		}
 
-		// Interruptible backoff: respect context cancellation immediately
-		// rather than sleeping out the remaining window.
-		timer := time.NewTimer(copilotExecRetryBackoff)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-
-			return err
-		case <-timer.C:
-		}
+		// Callers wrap (or intentionally ignore) this error; the helper is a
+		// thin retry wrapper around the exec.Cmd.Run() they would call directly.
+		return err //nolint:wrapcheck // callers wrap; thin exec.Cmd.Run retry pass-through
 	}
 }
 

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -383,18 +383,22 @@ func diagnoseCLIStartupFailure(
 // execve before any I/O, so re-launching is safe; an exec.Cmd is single-use, so
 // each attempt builds a fresh one via newCmd. ctx bounds the total retry window.
 func runCopilotCmdWithRetry(ctx context.Context, newCmd func() *exec.Cmd) error {
-	var err error
-
 	for attempt := 0; ; attempt++ {
-		err = newCmd().Run()
-		if errors.Is(err, syscall.ETXTBSY) &&
-			attempt < copilotExecMaxRetries && ctx.Err() == nil {
-			time.Sleep(copilotExecRetryBackoff)
-
-			continue
+		err := newCmd().Run()
+		if !errors.Is(err, syscall.ETXTBSY) || attempt >= copilotExecMaxRetries {
+			return err
 		}
 
-		return err
+		// Interruptible backoff: respect context cancellation immediately
+		// rather than sleeping out the remaining window.
+		timer := time.NewTimer(copilotExecRetryBackoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return err
+		case <-timer.C:
+		}
 	}
 }
 

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -58,6 +58,14 @@ const (
 	// Kept intentionally short: ksail chat is interactive, so a brief wait on
 	// failure to surface the real root cause is an acceptable trade-off.
 	diagnoseTimeout = 3 * time.Second
+	// copilotExecMaxRetries bounds re-attempts when launching the Copilot CLI
+	// races a concurrent fork. The SDK writes the CLI into its cache directory
+	// at runtime, so a fork that inherited a still-open write fd can make the
+	// kernel report the freshly written binary as "text file busy" (ETXTBSY).
+	copilotExecMaxRetries = 5
+	// copilotExecRetryBackoff is the pause between ETXTBSY re-attempts; the
+	// write fd is closed almost immediately, so a short wait clears the race.
+	copilotExecRetryBackoff = 10 * time.Millisecond
 	// startupErrFmt is the static format string for Copilot client startup errors.
 	// %w is the underlying error; %s is an optional diagnostic block (empty or
 	// "CLI diagnostic output:\n  ...\n\n").
@@ -281,17 +289,24 @@ func verifyCopilotCLI(ctx context.Context, cliPath string, env []string) error {
 	verifyCtx, cancel := context.WithTimeout(ctx, verifyTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(verifyCtx, cliPath, "--version")
-	cmd.Env = env
+	var output bytes.Buffer
 
-	output, err := cmd.CombinedOutput()
+	err := runCopilotCmdWithRetry(verifyCtx, func() *exec.Cmd {
+		output.Reset()
+		cmd := exec.CommandContext(verifyCtx, cliPath, "--version")
+		cmd.Env = env
+		cmd.Stdout = &output
+		cmd.Stderr = &output
+
+		return cmd
+	})
 	if err != nil {
 		return fmt.Errorf(
 			"copilot CLI at %q failed pre-flight check: %w (output: %s)\n\n"+
 				"To fix:\n"+
 				"  - Install or reinstall the Copilot CLI: npm install -g @github/copilot\n"+
 				"  - Or set COPILOT_CLI_PATH to a working copilot binary",
-			cliPath, err, strings.TrimSpace(string(output)),
+			cliPath, err, strings.TrimSpace(output.String()),
 		)
 	}
 
@@ -346,16 +361,41 @@ func diagnoseCLIStartupFailure(
 		diagEnv = append(append([]string{}, diagEnv...), "COPILOT_SDK_AUTH_TOKEN="+githubToken)
 	}
 
-	cmd := exec.CommandContext(diagCtx, cliPath, args...)
-	cmd.Env = diagEnv
-
 	var stderr bytes.Buffer
 
-	cmd.Stderr = &stderr
+	_ = runCopilotCmdWithRetry(diagCtx, func() *exec.Cmd {
+		stderr.Reset()
+		cmd := exec.CommandContext(diagCtx, cliPath, args...)
+		cmd.Env = diagEnv
+		cmd.Stderr = &stderr
 
-	_ = cmd.Run()
+		return cmd
+	})
 
 	return strings.TrimSpace(stderr.String())
+}
+
+// runCopilotCmdWithRetry runs the command produced by newCmd, rebuilding and
+// retrying it when launching the binary fails with ETXTBSY. The Copilot SDK
+// writes its CLI into a cache directory at runtime, so exec can race a
+// concurrent fork that inherited a still-open write fd and have the kernel
+// report the freshly written binary as "text file busy". ETXTBSY surfaces at
+// execve before any I/O, so re-launching is safe; an exec.Cmd is single-use, so
+// each attempt builds a fresh one via newCmd. ctx bounds the total retry window.
+func runCopilotCmdWithRetry(ctx context.Context, newCmd func() *exec.Cmd) error {
+	var err error
+
+	for attempt := 0; ; attempt++ {
+		err = newCmd().Run()
+		if errors.Is(err, syscall.ETXTBSY) &&
+			attempt < copilotExecMaxRetries && ctx.Err() == nil {
+			time.Sleep(copilotExecRetryBackoff)
+
+			continue
+		}
+
+		return err
+	}
 }
 
 // filterEnvVars returns a copy of env with the specified variable names removed.
@@ -654,12 +694,14 @@ func hasNonBinarySuffix(name string) bool {
 // runCopilotAuthLogin spawns `copilot auth login` as an interactive subprocess.
 // cliPath is trusted user input from COPILOT_CLI_PATH or the Copilot SDK directory.
 func runCopilotAuthLogin(ctx context.Context, cliPath string) error {
-	cmd := exec.CommandContext(ctx, cliPath, "auth", "login")
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	err := runCopilotCmdWithRetry(ctx, func() *exec.Cmd {
+		cmd := exec.CommandContext(ctx, cliPath, "auth", "login")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 
-	err := cmd.Run()
+		return cmd
+	})
 	if err != nil {
 		return fmt.Errorf("copilot auth login failed: %w", err)
 	}

--- a/pkg/cli/cmd/chat/chat.go
+++ b/pkg/cli/cmd/chat/chat.go
@@ -388,14 +388,17 @@ func runCopilotCmdWithRetry(ctx context.Context, newCmd func() *exec.Cmd) error 
 	for attempt := 0; ; attempt++ {
 		err := newCmd().Run()
 		if errors.Is(err, syscall.ETXTBSY) && attempt < copilotExecMaxRetries {
-			// Interruptible backoff: respect context cancellation immediately
-			// rather than sleeping out the remaining window.
+			// Interruptible backoff: a cancelled or expired context aborts the
+			// loop and surfaces the cancellation reason rather than waiting out
+			// the timer and reporting the transient ETXTBSY.
 			timer := time.NewTimer(copilotExecRetryBackoff)
 			select {
 			case <-timer.C:
 				continue
 			case <-ctx.Done():
 				timer.Stop()
+
+				return ctx.Err() //nolint:wrapcheck // propagate cancellation as-is
 			}
 		}
 

--- a/pkg/cli/cmd/chat/chat_exec_retry_test.go
+++ b/pkg/cli/cmd/chat/chat_exec_retry_test.go
@@ -1,0 +1,204 @@
+package chat_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/chat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeExecutable writes a runnable script that is also writable by its owner
+// (0o700), so tests can open it O_WRONLY to provoke a deterministic ETXTBSY.
+func writeExecutable(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "prog")
+
+	err := os.WriteFile(path, []byte(content), 0o700) //nolint:gosec // test fixture
+	require.NoError(t, err)
+
+	return path
+}
+
+// openWriteLockedExecutable writes a script and holds it open for writing for
+// the test's lifetime. On Linux, exec'ing a file open for writing fails with
+// ETXTBSY deterministically, which lets us drive the retry branch.
+func openWriteLockedExecutable(t *testing.T) string {
+	t.Helper()
+
+	path := writeExecutable(t, "#!/bin/sh\nexit 0\n")
+
+	file, err := os.OpenFile(path, os.O_WRONLY, 0) //nolint:gosec // test fixture
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	return path
+}
+
+func TestVerifyCopilotCLI(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("test relies on shell scripts")
+	}
+
+	verify := chat.GetVerifyCopilotCLI()
+
+	t.Run("returns nil when the CLI exits zero", func(t *testing.T) {
+		t.Parallel()
+
+		script := writeExecutable(t, "#!/bin/sh\necho 'copilot 1.2.3'\nexit 0\n")
+
+		require.NoError(t, verify(context.Background(), script, os.Environ()))
+	})
+
+	t.Run("wraps a pre-flight failure with the CLI output", func(t *testing.T) {
+		t.Parallel()
+
+		script := writeExecutable(t, "#!/bin/sh\necho 'broken install' >&2\nexit 1\n")
+
+		err := verify(context.Background(), script, os.Environ())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pre-flight check")
+		assert.Contains(t, err.Error(), "broken install")
+	})
+}
+
+func TestRunCopilotAuthLogin(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("test relies on shell scripts")
+	}
+
+	login := chat.GetRunCopilotAuthLogin()
+
+	t.Run("returns nil when login succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		script := writeExecutable(t, "#!/bin/sh\nexit 0\n")
+
+		require.NoError(t, login(context.Background(), script))
+	})
+
+	t.Run("wraps a login failure", func(t *testing.T) {
+		t.Parallel()
+
+		script := writeExecutable(t, "#!/bin/sh\nexit 3\n")
+
+		err := login(context.Background(), script)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth login failed")
+	})
+}
+
+func TestRunCopilotCmdWithRetry(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("test relies on shell scripts")
+	}
+
+	run := chat.GetRunCopilotCmdWithRetry()
+
+	t.Run("returns nil and runs once on success", func(t *testing.T) {
+		t.Parallel()
+
+		script := writeExecutable(t, "#!/bin/sh\nexit 0\n")
+		attempts := 0
+
+		err := run(context.Background(), func() *exec.Cmd {
+			attempts++
+
+			return exec.CommandContext(context.Background(), script)
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, attempts, "a successful launch must not retry")
+	})
+
+	t.Run("does not retry a non-ETXTBSY failure", func(t *testing.T) {
+		t.Parallel()
+
+		script := writeExecutable(t, "#!/bin/sh\nexit 1\n")
+		attempts := 0
+
+		err := run(context.Background(), func() *exec.Cmd {
+			attempts++
+
+			return exec.CommandContext(context.Background(), script)
+		})
+
+		require.Error(t, err)
+		require.NotErrorIs(t, err, syscall.ETXTBSY)
+		assert.Equal(t, 1, attempts, "an ordinary exit error must not retry")
+	})
+}
+
+// TestRunCopilotCmdWithRetryETXTBSYExhaustion drives the retry branch with a
+// deterministic ETXTBSY (a binary held open for writing cannot be exec'd).
+// Linux enforces this reliably; macOS does not, so it is gated to Linux, which
+// is both where the guarded race occurs and where CI measures coverage.
+func TestRunCopilotCmdWithRetryETXTBSYExhaustion(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("ETXTBSY on exec of a write-open file is only reliable on Linux")
+	}
+
+	run := chat.GetRunCopilotCmdWithRetry()
+	path := openWriteLockedExecutable(t)
+	attempts := 0
+	start := time.Now()
+
+	err := run(context.Background(), func() *exec.Cmd {
+		attempts++
+
+		return exec.CommandContext(context.Background(), path)
+	})
+
+	require.ErrorIs(t, err, syscall.ETXTBSY)
+	assert.Equal(t, chat.CopilotExecMaxRetries+1, attempts,
+		"should make one initial attempt plus the bounded retries")
+	assert.GreaterOrEqual(t, time.Since(start),
+		time.Duration(chat.CopilotExecMaxRetries)*chat.CopilotExecRetryBackoff,
+		"should wait the cumulative backoff between attempts")
+}
+
+// TestRunCopilotCmdWithRetryCancelDuringBackoff verifies that cancelling the
+// context during the backoff window stops further attempts immediately and
+// surfaces the cancellation reason rather than the transient ETXTBSY. The
+// command's own context stays live so the launch still fails with ETXTBSY; only
+// the retry context is cancelled.
+func TestRunCopilotCmdWithRetryCancelDuringBackoff(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("ETXTBSY on exec of a write-open file is only reliable on Linux")
+	}
+
+	run := chat.GetRunCopilotCmdWithRetry()
+	path := openWriteLockedExecutable(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+
+	err := run(ctx, func() *exec.Cmd {
+		attempts++
+		// Cancel after the first failed launch so the backoff select observes
+		// ctx.Done() instead of waiting out the timer.
+		cancel()
+
+		return exec.CommandContext(context.Background(), path)
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, attempts, "cancellation during backoff must stop further attempts")
+}

--- a/pkg/cli/cmd/chat/export_test.go
+++ b/pkg/cli/cmd/chat/export_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"os/exec"
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -47,6 +48,27 @@ func GetDiagnoseCLIStartupFailure() func(context.Context, string, string, []stri
 func GetBuildDiagnosticBlock() func(context.Context, string, string, []string) string {
 	return buildDiagnosticBlock
 }
+
+// GetRunCopilotCmdWithRetry returns the runCopilotCmdWithRetry helper for testing.
+func GetRunCopilotCmdWithRetry() func(context.Context, func() *exec.Cmd) error {
+	return runCopilotCmdWithRetry
+}
+
+// GetVerifyCopilotCLI returns the verifyCopilotCLI function for testing.
+func GetVerifyCopilotCLI() func(context.Context, string, []string) error {
+	return verifyCopilotCLI
+}
+
+// GetRunCopilotAuthLogin returns the runCopilotAuthLogin function for testing.
+func GetRunCopilotAuthLogin() func(context.Context, string) error {
+	return runCopilotAuthLogin
+}
+
+// CopilotExecMaxRetries exports copilotExecMaxRetries for testing.
+const CopilotExecMaxRetries = copilotExecMaxRetries
+
+// CopilotExecRetryBackoff exports copilotExecRetryBackoff for testing.
+const CopilotExecRetryBackoff = copilotExecRetryBackoff
 
 // FormatDiagnosticOutput exposes the formatDiagnosticOutput formatting helper for
 // deterministic unit tests that verify block layout without subprocess execution.


### PR DESCRIPTION
## Summary

Fixes a flaky `TestDiagnoseCLIStartupFailure` (intermittent empty captured stderr) and the underlying production race.

**Root cause:** the Copilot SDK writes its CLI binary into a cache directory at runtime. Launching it can race a concurrent `fork` that inherited a still-open write fd, so the kernel reports the freshly written executable as "text file busy" (`ETXTBSY`). The error surfaces at `execve` before any I/O runs, leaving captured stderr empty. This is the classic Go fork/exec race ([golang/go#22315](https://github.com/golang/go/issues/22315)) — `os.WriteFile` does not hold `ForkLock`.

This showed up as a flake in the **Linux Code Coverage CI job** (heavier parallel interleaving) while passing in the Test job on the same commit and passing locally on macOS — macOS does not enforce `ETXTBSY` for this case, which explains the platform split.

It is not test-only: production resolves the binary from the SDK cache dir (`~/.cache/copilot-sdk/...`), so the race is real in production too.

## What changed

- Added `runCopilotCmdWithRetry`: rebuilds the single-use `exec.Cmd` and retries briefly (5 attempts × 10ms, ctx-bounded) when launch fails with `errors.Is(err, syscall.ETXTBSY)`. `ETXTBSY` occurs before any I/O, so re-launching is safe.
- Routed all three CLI exec sites through it: `diagnoseCLIStartupFailure`, `verifyCopilotCLI` (pre-flight `--version`), and `runCopilotAuthLogin`.
- The flaky test is left unchanged — the production fix makes it deterministic.

## Verification

- **Linux stress repro:** the same 19,200 fresh-exec runs that produced **1286/1286** `ETXTBSY` empties now produce **0**.
- **Linux package tests** (`go test -count=20 -parallel 16` of the chat diagnostic tests, `golang:1.26`): pass.
- **macOS full chat package** (`go test -count=5`): pass.
- `go build` + `go vet`: clean.

## Test plan

- [ ] CI green (especially the Code Coverage job, where the flake originated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)