### PR TITLE
fix(workload): stop retry loop deterministically on context cancellation

### DIFF
--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -2037,24 +2037,9 @@ func retryOnTransientError(
 			break
 		}
 
-		delay := netretry.ExponentialDelay(attempt, baseWait, maxWait)
-
-		notify.Warningf(
-			cmd.OutOrStdout(),
-			"attempt %d/%d failed (retrying in %s): %v",
-			attempt, maxAttempts, delay, lastErr,
-		)
-
-		retryTimer := time.NewTimer(delay)
-
-		select {
-		case <-ctx.Done():
-			if !retryTimer.Stop() {
-				<-retryTimer.C
-			}
-
-			return fmt.Errorf("retry cancelled: %w", ctx.Err())
-		case <-retryTimer.C:
+		waitErr := waitBeforeRetry(ctx, cmd, attempt, maxAttempts, baseWait, maxWait, lastErr)
+		if waitErr != nil {
+			return waitErr
 		}
 	}
 
@@ -2063,6 +2048,48 @@ func retryOnTransientError(
 	}
 
 	return fmt.Errorf("failed after %d attempts: %w", maxAttempts, lastErr)
+}
+
+// waitBeforeRetry blocks for the exponential backoff delay before the next
+// retry attempt, returning a non-nil error if the context is cancelled so the
+// caller stops retrying.
+func waitBeforeRetry(
+	ctx context.Context,
+	cmd *cobra.Command,
+	attempt, maxAttempts int,
+	baseWait, maxWait time.Duration,
+	lastErr error,
+) error {
+	// Stop immediately if the operation cancelled the context. Without this
+	// check the backoff timer below races ctx.Done() in the select: when the
+	// goroutine is descheduled past the (often sub-millisecond) delay, both
+	// cases are ready and select picks one at random, sometimes running an
+	// extra attempt.
+	ctxErr := ctx.Err()
+	if ctxErr != nil {
+		return fmt.Errorf("retry cancelled: %w", ctxErr)
+	}
+
+	delay := netretry.ExponentialDelay(attempt, baseWait, maxWait)
+
+	notify.Warningf(
+		cmd.OutOrStdout(),
+		"attempt %d/%d failed (retrying in %s): %v",
+		attempt, maxAttempts, delay, lastErr,
+	)
+
+	retryTimer := time.NewTimer(delay)
+
+	select {
+	case <-ctx.Done():
+		if !retryTimer.Stop() {
+			<-retryTimer.C
+		}
+
+		return fmt.Errorf("retry cancelled: %w", ctx.Err())
+	case <-retryTimer.C:
+		return nil
+	}
 }
 
 // getKubeconfigPath returns the kubeconfig path from config or default.

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -2088,6 +2088,15 @@ func waitBeforeRetry(
 
 		return fmt.Errorf("retry cancelled: %w", ctx.Err())
 	case <-retryTimer.C:
+		// Prioritize cancellation even when the timer also fired: select picks a
+		// ready case at random, so a context cancelled during the wait can still
+		// land here. Re-checking ctx.Err() keeps cancellation deterministic and
+		// prevents one extra retry attempt.
+		ctxErr = ctx.Err()
+		if ctxErr != nil {
+			return fmt.Errorf("retry cancelled: %w", ctxErr)
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
🤖 *This is an automated response from KSail AI Assistant.*

## Summary

Fixes a select-randomness race in `retryOnTransientError` ([pkg/cli/cmd/workload/workload.go](https://github.com/devantler-tech/ksail/blob/main/pkg/cli/cmd/workload/workload.go)) that intermittently reddens CI via the flaky unit test `TestRetryOnTransientError_ContextCancelled`.

## Root cause

The retry loop waited on a `select` between `ctx.Done()` and a freshly-created backoff timer:

```go
retryTimer := time.NewTimer(delay)
select {
case <-ctx.Done():   // already closed if operation() cancelled ctx
    ...
case <-retryTimer.C: // fires after `delay` (can be sub-millisecond)
}
```

When the operation cancels the context and returns a *retryable* error, `ctx.Done()` is already closed. If the goroutine is then descheduled past the (often sub-millisecond) backoff delay — common under CI's heavy parallel load — the timer also fires, so **both** cases are ready and Go's `select` picks one at random. ~50% of the time it picks the timer and runs an extra attempt.

This was observed failing on `main` (run [26319098563](https://github.com/devantler-tech/ksail/actions/runs/26319098563), commit 48c0de2c, `Generate coverage` step):

```
--- FAIL: TestRetryOnTransientError_ContextCancelled (0.00s)
    workload_pure_test.go:989: Not equal: expected 1, got 2 ("context cancel should stop retries")
```

A standalone reproduction of the bare `select` (both channels ready) confirms the timer is chosen ~50% of the time.

Beyond the test, this also meant a cancelled `reconcile` could perform one more network operation than intended.

## Fix

Add a deterministic `ctx.Err()` check before computing the backoff, so a context cancelled *during* the operation stops retries immediately (the existing `select` still handles cancellation that arrives *during* the wait). The wait is extracted into a small `waitBeforeRetry` helper to keep `retryOnTransientError` within the repo's cyclomatic-complexity gate (cyclop max 10).

## Test plan

- [x] `go build` succeeds
- [x] `go test ./pkg/cli/cmd/workload/` passes
- [x] `GOMAXPROCS=2 go test -race -run TestRetryOnTransientError -count=3000 ./pkg/cli/cmd/workload/` passes (now deterministic)
- [x] `golangci-lint run ./pkg/cli/cmd/workload/...` clean for changed code (cyclop resolved)
- [ ] Full CI green