### PR TITLE
fix(oidc): emit kubeadm v1beta4 list form for Kind apiserver OIDC flags

### DIFF
--- a/pkg/fsutil/configmanager/kind/helpers.go
+++ b/pkg/fsutil/configmanager/kind/helpers.go
@@ -199,35 +199,49 @@ func ApplyOIDCPatches(kindConfig *kindv1alpha4.Cluster, oidc *v1alpha1.OIDCSpec)
 }
 
 // buildOIDCKubeadmPatch generates a kubeadm ClusterConfiguration patch with API server OIDC flags.
-// kubeadm v1beta4 apiServer.extraArgs is map[string]string, so values are plain strings.
+// kubeadm v1beta4 apiServer.extraArgs is a list of {name, value} entries (not a map); the map form
+// is silently ignored, so the flags must be emitted as list items for kubeadm to apply them.
 func buildOIDCKubeadmPatch(oidc *v1alpha1.OIDCSpec) string {
+	type arg struct {
+		name  string
+		value string
+	}
+
+	args := []arg{
+		{name: "oidc-issuer-url", value: oidc.IssuerURL},
+		{name: "oidc-client-id", value: oidc.ClientID},
+	}
+
+	if oidc.UsernameClaim != "" {
+		args = append(args, arg{name: "oidc-username-claim", value: oidc.UsernameClaim})
+	}
+
+	if oidc.UsernamePrefix != "" {
+		args = append(args, arg{name: "oidc-username-prefix", value: oidc.UsernamePrefix})
+	}
+
+	if oidc.GroupsClaim != "" {
+		args = append(args, arg{name: "oidc-groups-claim", value: oidc.GroupsClaim})
+	}
+
+	if oidc.GroupsPrefix != "" {
+		args = append(args, arg{name: "oidc-groups-prefix", value: oidc.GroupsPrefix})
+	}
+
+	if oidc.CAFile != "" {
+		args = append(args, arg{name: "oidc-ca-file", value: v1alpha1.OIDCCAContainerPath})
+	}
+
 	var builder strings.Builder
 
 	_, _ = fmt.Fprintf(&builder, "apiVersion: kubeadm.k8s.io/v1beta4\n")
 	_, _ = fmt.Fprintf(&builder, "kind: ClusterConfiguration\n")
 	_, _ = fmt.Fprintf(&builder, "apiServer:\n")
 	_, _ = fmt.Fprintf(&builder, "  extraArgs:\n")
-	_, _ = fmt.Fprintf(&builder, "    oidc-issuer-url: %q\n", oidc.IssuerURL)
-	_, _ = fmt.Fprintf(&builder, "    oidc-client-id: %q\n", oidc.ClientID)
 
-	if oidc.UsernameClaim != "" {
-		_, _ = fmt.Fprintf(&builder, "    oidc-username-claim: %q\n", oidc.UsernameClaim)
-	}
-
-	if oidc.UsernamePrefix != "" {
-		_, _ = fmt.Fprintf(&builder, "    oidc-username-prefix: %q\n", oidc.UsernamePrefix)
-	}
-
-	if oidc.GroupsClaim != "" {
-		_, _ = fmt.Fprintf(&builder, "    oidc-groups-claim: %q\n", oidc.GroupsClaim)
-	}
-
-	if oidc.GroupsPrefix != "" {
-		_, _ = fmt.Fprintf(&builder, "    oidc-groups-prefix: %q\n", oidc.GroupsPrefix)
-	}
-
-	if oidc.CAFile != "" {
-		_, _ = fmt.Fprintf(&builder, "    oidc-ca-file: %q\n", v1alpha1.OIDCCAContainerPath)
+	for _, a := range args {
+		_, _ = fmt.Fprintf(&builder, "    - name: %s\n", a.name)
+		_, _ = fmt.Fprintf(&builder, "      value: %q\n", a.value)
 	}
 
 	return builder.String()

--- a/pkg/fsutil/configmanager/kind/helpers_test.go
+++ b/pkg/fsutil/configmanager/kind/helpers_test.go
@@ -1,12 +1,16 @@
 package kind_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	kind "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/kind"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	kindv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/yaml"
 )
 
 func TestResolveClusterName_NilConfigs(t *testing.T) {
@@ -292,4 +296,115 @@ func TestApplyImageVerificationPatches(t *testing.T) {
 		assert.Len(t, kindConfig.ContainerdConfigPatches, 1,
 			"calling ApplyImageVerificationPatches twice should not duplicate the patch")
 	})
+}
+
+// oidcExtraArgs unmarshals a generated kubeadm patch and returns its
+// apiServer.extraArgs as a name->value map. Parsing into a list of {name,value}
+// entries fails unless the patch uses the v1beta4 list form, so a successful
+// parse doubles as an assertion that the map form was not emitted.
+func oidcExtraArgs(t *testing.T, patch string) map[string]string {
+	t.Helper()
+
+	var parsed struct {
+		APIServer struct {
+			ExtraArgs []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"extraArgs"`
+		} `json:"apiServer"`
+	}
+
+	require.NoError(t, yaml.Unmarshal([]byte(patch), &parsed))
+
+	got := make(map[string]string, len(parsed.APIServer.ExtraArgs))
+	for _, a := range parsed.APIServer.ExtraArgs {
+		got[a.Name] = a.Value
+	}
+
+	return got
+}
+
+func TestApplyOIDCPatches_NilAddsNoPatch(t *testing.T) {
+	t.Parallel()
+
+	kindConfig := &kindv1alpha4.Cluster{
+		Nodes: []kindv1alpha4.Node{{Role: kindv1alpha4.ControlPlaneRole}},
+	}
+
+	require.NoError(t, kind.ApplyOIDCPatches(kindConfig, nil))
+	assert.Empty(t, kindConfig.Nodes[0].KubeadmConfigPatches)
+}
+
+func TestApplyOIDCPatches_DisabledAddsNoPatch(t *testing.T) {
+	t.Parallel()
+
+	kindConfig := &kindv1alpha4.Cluster{
+		Nodes: []kindv1alpha4.Node{{Role: kindv1alpha4.ControlPlaneRole}},
+	}
+
+	require.NoError(t, kind.ApplyOIDCPatches(kindConfig, &v1alpha1.OIDCSpec{}))
+	assert.Empty(t, kindConfig.Nodes[0].KubeadmConfigPatches)
+}
+
+func TestApplyOIDCPatches_EmitsV1beta4ListForm(t *testing.T) {
+	t.Parallel()
+
+	oidc := &v1alpha1.OIDCSpec{
+		IssuerURL:      "https://dex.example.com",
+		ClientID:       "ksail",
+		UsernameClaim:  "email",
+		UsernamePrefix: "oidc:",
+		GroupsClaim:    "groups",
+		GroupsPrefix:   "oidc:",
+	}
+
+	kindConfig := &kindv1alpha4.Cluster{
+		Nodes: []kindv1alpha4.Node{{Role: kindv1alpha4.ControlPlaneRole}},
+	}
+
+	require.NoError(t, kind.ApplyOIDCPatches(kindConfig, oidc))
+	require.Len(t, kindConfig.Nodes[0].KubeadmConfigPatches, 1)
+
+	patch := kindConfig.Nodes[0].KubeadmConfigPatches[0]
+
+	// kubeadm v1beta4 silently ignores the map form ("    oidc-issuer-url: ..."),
+	// so guard against regressing to it.
+	assert.NotContains(t, patch, "\n    oidc-issuer-url:")
+	assert.Contains(t, patch, "apiVersion: kubeadm.k8s.io/v1beta4")
+
+	assert.Equal(t, map[string]string{
+		"oidc-issuer-url":      "https://dex.example.com",
+		"oidc-client-id":       "ksail",
+		"oidc-username-claim":  "email",
+		"oidc-username-prefix": "oidc:",
+		"oidc-groups-claim":    "groups",
+		"oidc-groups-prefix":   "oidc:",
+	}, oidcExtraArgs(t, patch))
+}
+
+func TestApplyOIDCPatches_CAFileAddsArgAndMounts(t *testing.T) {
+	t.Parallel()
+
+	caFile := filepath.Join(t.TempDir(), "oidc-ca.crt")
+	require.NoError(t, os.WriteFile(caFile, []byte("test-ca"), 0o600))
+
+	oidc := &v1alpha1.OIDCSpec{
+		IssuerURL: "https://dex.example.com",
+		ClientID:  "ksail",
+		CAFile:    caFile,
+	}
+
+	kindConfig := &kindv1alpha4.Cluster{
+		Nodes: []kindv1alpha4.Node{{Role: kindv1alpha4.ControlPlaneRole}},
+	}
+
+	require.NoError(t, kind.ApplyOIDCPatches(kindConfig, oidc))
+	require.Len(t, kindConfig.Nodes[0].KubeadmConfigPatches, 1)
+
+	args := oidcExtraArgs(t, kindConfig.Nodes[0].KubeadmConfigPatches[0])
+	assert.Equal(t, v1alpha1.OIDCCAContainerPath, args["oidc-ca-file"])
+
+	require.Len(t, kindConfig.Nodes[0].ExtraMounts, 1)
+	mount := kindConfig.Nodes[0].ExtraMounts[0]
+	assert.Equal(t, v1alpha1.OIDCCAContainerPath, mount.ContainerPath)
 }


### PR DESCRIPTION
## Summary

`buildOIDCKubeadmPatch` (in [pkg/fsutil/configmanager/kind/helpers.go](pkg/fsutil/configmanager/kind/helpers.go)) generated a kubeadm `ClusterConfiguration` patch that set `apiServer.extraArgs` using **map syntax** (`oidc-issuer-url: "..."`).

kubeadm `v1beta4` (used by k8s 1.35 / current `kindest/node`) changed `apiServer.extraArgs` from a `map[string]string` to a **list of `{name, value}` entries** (`Arg{Name, Value}`). The map form is silently ignored, so the OIDC apiserver flags were **never applied** to Kind (Vanilla) clusters.

This PR switches the patch to the v1beta4 list form:

```yaml
apiServer:
  extraArgs:
    - name: oidc-issuer-url
      value: "https://..."
```

## Why

- The map form was introduced in #4528 (the original OIDC feature) and never changed since — `git blame` confirms it was never validated against a real Kind apiserver.
- There is **no CI system-test leg combining Kind + OIDC**, so this was untested in CI. The same v1beta4 map→list breakage was observed for a feature-gate patch (kube-apiserver never received the flags).

## What changed

- `buildOIDCKubeadmPatch` now emits each OIDC flag as a `- name: / value:` list item instead of a map key.
- Added `TestApplyOIDCPatches_*` tests (none existed before). The key test parses the generated patch into a typed `[]{name,value}` struct — which only succeeds for the list form — directly guarding against regressing to the map form. Coverage includes the disabled/nil no-op cases, all six OIDC args, and the CA-file arg + extra mount.

## Reviewer notes

- Verified locally: `go build ./...`, `go test ./pkg/fsutil/configmanager/kind/...`, `go vet`, and `go tool golangci-lint run ./pkg/fsutil/configmanager/kind/...` (0 issues).
- Since CI has no Kind+OIDC system test, the new unit test is the structural guard. Consider whether a system-test leg combining Kind + OIDC is worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)