### PR TITLE
fix(provisioner): enable MutatingAdmissionPolicy API for Calico on the k3k (Kubernetes-provider) path

### DIFF
--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -76,6 +76,12 @@ inputs:
       Only used when test-kubernetes-provider is 'true'.
     required: false
     default: "Vanilla,K3s,VCluster,Talos"
+  kubernetes-provider-cni:
+    description: |
+      Optional CNI to install in each nested Kubernetes-provider cluster (e.g.
+      "Calico"). Only used when test-kubernetes-provider is 'true'.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -376,6 +382,7 @@ runs:
       uses: ./.github/actions/ksail-test-kubernetes-provider
       with:
         distributions: ${{ inputs.kubernetes-provider-distributions }}
+        cni: ${{ inputs.kubernetes-provider-cni }}
 
     # ── Phase 5 — Debug ──────────────────────────────────────────────
 

--- a/.github/actions/ksail-test-kubernetes-provider/action.yaml
+++ b/.github/actions/ksail-test-kubernetes-provider/action.yaml
@@ -19,6 +19,13 @@ inputs:
     description: Timeout per nested cluster create (seconds)
     required: false
     default: "600"
+  cni:
+    description: |
+      Optional CNI to install in each nested cluster (e.g. "Calico"). When empty,
+      the distribution default is used. Calico exercises the k3k serverArgs path
+      that enables the MutatingAdmissionPolicy / v1beta1 admissionregistration API.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -28,6 +35,7 @@ runs:
       env:
         DISTRIBUTIONS: ${{ inputs.distributions }}
         TIMEOUT: ${{ inputs.timeout }}
+        CNI: ${{ inputs.cni }}
       run: |
         set -euo pipefail
         LOG_DIR="/tmp/ksail-system-test-logs/kubernetes-provider"
@@ -56,11 +64,14 @@ runs:
 
           # Create nested cluster
           echo "  ⏳ Creating $DIST cluster..."
+          CREATE_ARGS=(--distribution "$DIST" --provider Kubernetes --name "$NESTED_NAME")
+          if [ -n "$CNI" ]; then
+            CREATE_ARGS+=(--cni "$CNI")
+            echo "  ↳ using CNI: $CNI"
+          fi
           create_ok=false
           if timeout "$TIMEOUT" ksail cluster create \
-            --distribution "$DIST" \
-            --provider Kubernetes \
-            --name "$NESTED_NAME" \
+            "${CREATE_ARGS[@]}" \
             2>&1 | tee "$CREATE_LOG"; then
             create_ok=true
             echo "  ✅ $DIST create succeeded"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1059,6 +1059,20 @@ jobs:
             init: true
             args: ""
             test-kubernetes-provider: "true"
+          # Validate Calico on the Kubernetes (k3k) provider. Calico v3.30+'s CRD
+          # chart ships MutatingAdmissionPolicy resources that need the v1beta1
+          # admissionregistration API enabled on the embedded k3s server via the k3k
+          # Cluster serverArgs. The default test-kubernetes-provider legs above use
+          # the distribution-default CNI, so this leg is the only one exercising the
+          # k3k+Calico serverArgs path. A unique host args value keeps this as a
+          # standalone matrix combination (not merged into the args="" Vanilla leg).
+          - distribution: Vanilla
+            provider: Docker
+            init: true
+            args: "--name k3k-calico-host"
+            test-kubernetes-provider: "true"
+            kubernetes-provider-distributions: "K3s"
+            kubernetes-provider-cni: "Calico"
           # NOTE: KWOK excluded — simulated nodes cannot run real workloads (DinD pods)
     steps:
       - name: 📄 Checkout
@@ -1136,6 +1150,8 @@ jobs:
           args: ${{ matrix.args }}
           apply-overlay-path: ".github/fixtures/podinfo-overlay"
           test-kubernetes-provider: ${{ matrix.test-kubernetes-provider || 'false' }}
+          kubernetes-provider-distributions: ${{ matrix.kubernetes-provider-distributions || 'Vanilla,K3s,VCluster,Talos' }}
+          kubernetes-provider-cni: ${{ matrix.kubernetes-provider-cni || '' }}
 
           ghcr-user: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/fsutil/configmanager/k3d/helpers.go
+++ b/pkg/fsutil/configmanager/k3d/helpers.go
@@ -219,6 +219,18 @@ func APIServerFeatureGatesArgs() []string {
 	}
 }
 
+// APIServerFeatureGatesArgsForCNI returns the K3s kube-apiserver args required by the
+// given CNI, or nil when the CNI needs none. Only Calico (v3.30+, whose CRD chart ships
+// MutatingAdmissionPolicy resources) requires the MutatingAdmissionPolicy feature gate /
+// v1beta1 admissionregistration API.
+func APIServerFeatureGatesArgsForCNI(cni v1alpha1.CNI) []string {
+	if cni == v1alpha1.CNICalico {
+		return APIServerFeatureGatesArgs()
+	}
+
+	return nil
+}
+
 // ResolveNetworkName returns the Docker network name for a K3d cluster.
 // K3d uses "k3d-<clustername>" as the network naming convention.
 func ResolveNetworkName(clusterName string) string {

--- a/pkg/fsutil/configmanager/k3d/helpers.go
+++ b/pkg/fsutil/configmanager/k3d/helpers.go
@@ -207,6 +207,19 @@ func ApplyOIDCCAVolume(k3dConfig *v1alpha5.SimpleConfig, hostCAPath string) erro
 	return nil
 }
 
+// APIServerFeatureGatesArgs returns the K3s kube-apiserver args that enable the
+// MutatingAdmissionPolicy feature gate and the admissionregistration.k8s.io/v1beta1
+// API. Calico v3.30+'s CRD chart ships MutatingAdmissionPolicy / MutatingAdmissionPolicyBinding
+// resources that require this API to be served. The args use K3s "--kube-apiserver-arg=..."
+// form, which is consumable both as K3d ExtraArgs (Docker provider) and as k3k Cluster
+// serverArgs (Kubernetes provider).
+func APIServerFeatureGatesArgs() []string {
+	return []string{
+		"--kube-apiserver-arg=feature-gates=MutatingAdmissionPolicy=true",
+		"--kube-apiserver-arg=runtime-config=admissionregistration.k8s.io/v1beta1=true",
+	}
+}
+
 // ResolveNetworkName returns the Docker network name for a K3d cluster.
 // K3d uses "k3d-<clustername>" as the network naming convention.
 func ResolveNetworkName(clusterName string) string {

--- a/pkg/fsutil/configmanager/k3d/helpers.go
+++ b/pkg/fsutil/configmanager/k3d/helpers.go
@@ -210,9 +210,8 @@ func ApplyOIDCCAVolume(k3dConfig *v1alpha5.SimpleConfig, hostCAPath string) erro
 // APIServerFeatureGatesArgs returns the K3s kube-apiserver args that enable the
 // MutatingAdmissionPolicy feature gate and the admissionregistration.k8s.io/v1beta1
 // API. Calico v3.30+'s CRD chart ships MutatingAdmissionPolicy / MutatingAdmissionPolicyBinding
-// resources that require this API to be served. The args use K3s "--kube-apiserver-arg=..."
-// form, which is consumable both as K3d ExtraArgs (Docker provider) and as k3k Cluster
-// serverArgs (Kubernetes provider).
+// resources that require this API to be served. The args use the K3s
+// "--kube-apiserver-arg=..." form, suitable for the k3k Cluster spec's serverArgs.
 func APIServerFeatureGatesArgs() []string {
 	return []string{
 		"--kube-apiserver-arg=feature-gates=MutatingAdmissionPolicy=true",

--- a/pkg/fsutil/configmanager/k3d/helpers_test.go
+++ b/pkg/fsutil/configmanager/k3d/helpers_test.go
@@ -456,3 +456,14 @@ func TestResolveNetworkName(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIServerFeatureGatesArgs(t *testing.T) {
+	t.Parallel()
+
+	args := k3d.APIServerFeatureGatesArgs()
+
+	assert.Equal(t, []string{
+		"--kube-apiserver-arg=feature-gates=MutatingAdmissionPolicy=true",
+		"--kube-apiserver-arg=runtime-config=admissionregistration.k8s.io/v1beta1=true",
+	}, args)
+}

--- a/pkg/fsutil/configmanager/k3d/helpers_test.go
+++ b/pkg/fsutil/configmanager/k3d/helpers_test.go
@@ -467,3 +467,22 @@ func TestAPIServerFeatureGatesArgs(t *testing.T) {
 		"--kube-apiserver-arg=runtime-config=admissionregistration.k8s.io/v1beta1=true",
 	}, args)
 }
+
+func TestAPIServerFeatureGatesArgsForCNI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns_feature_gate_args_for_calico", func(t *testing.T) {
+		t.Parallel()
+
+		args := k3d.APIServerFeatureGatesArgsForCNI(v1alpha1.CNICalico)
+
+		assert.Equal(t, k3d.APIServerFeatureGatesArgs(), args)
+	})
+
+	t.Run("returns_nil_for_non_calico", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, k3d.APIServerFeatureGatesArgsForCNI(v1alpha1.CNICilium))
+		assert.Nil(t, k3d.APIServerFeatureGatesArgsForCNI(v1alpha1.CNIDefault))
+	})
+}

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -350,8 +350,8 @@ func (f DefaultFactory) createK3dKubernetesProvisioner(
 
 	// Enable the MutatingAdmissionPolicy feature gate / v1beta1 admissionregistration
 	// API on the embedded k3s server only for Calico, whose v3.30+ CRD chart ships
-	// MutatingAdmissionPolicy resources. The Docker (K3d) path applies the equivalent
-	// flags via ExtraArgs; here they flow through the k3k Cluster spec's serverArgs.
+	// MutatingAdmissionPolicy resources that require this API. The flags flow through
+	// the k3k Cluster spec's serverArgs to the embedded k3s kube-apiserver.
 	var serverArgs []string
 	if cluster.Spec.Cluster.CNI == v1alpha1.CNICalico {
 		serverArgs = k3dconfigmanager.APIServerFeatureGatesArgs()

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -348,6 +348,15 @@ func (f DefaultFactory) createK3dKubernetesProvisioner(
 
 	workers := cluster.Spec.Cluster.Workers
 
+	// Enable the MutatingAdmissionPolicy feature gate / v1beta1 admissionregistration
+	// API on the embedded k3s server only for Calico, whose v3.30+ CRD chart ships
+	// MutatingAdmissionPolicy resources. The Docker (K3d) path applies the equivalent
+	// flags via ExtraArgs; here they flow through the k3k Cluster spec's serverArgs.
+	var serverArgs []string
+	if cluster.Spec.Cluster.CNI == v1alpha1.CNICalico {
+		serverArgs = k3dconfigmanager.APIServerFeatureGatesArgs()
+	}
+
 	provisioner, err := k3dprovisioner.NewK3kProvisioner(
 		k3dprovisioner.K3kProvisionerConfig{
 			HostClientset:    hostClient,
@@ -362,6 +371,7 @@ func (f DefaultFactory) createK3dKubernetesProvisioner(
 			Workers:          workers,
 			PodCIDR:          opts.PodCIDR,
 			ServiceCIDR:      opts.ServiceCIDR,
+			ServerArgs:       serverArgs,
 		},
 	)
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -348,14 +348,10 @@ func (f DefaultFactory) createK3dKubernetesProvisioner(
 
 	workers := cluster.Spec.Cluster.Workers
 
-	// Enable the MutatingAdmissionPolicy feature gate / v1beta1 admissionregistration
-	// API on the embedded k3s server only for Calico, whose v3.30+ CRD chart ships
-	// MutatingAdmissionPolicy resources that require this API. The flags flow through
-	// the k3k Cluster spec's serverArgs to the embedded k3s kube-apiserver.
-	var serverArgs []string
-	if cluster.Spec.Cluster.CNI == v1alpha1.CNICalico {
-		serverArgs = k3dconfigmanager.APIServerFeatureGatesArgs()
-	}
+	// Calico's v3.30+ CRD chart ships MutatingAdmissionPolicy resources that require the
+	// MutatingAdmissionPolicy feature gate / v1beta1 admissionregistration API. These flags
+	// flow through the k3k Cluster spec's serverArgs to the embedded k3s kube-apiserver.
+	serverArgs := k3dconfigmanager.APIServerFeatureGatesArgsForCNI(cluster.Spec.Cluster.CNI)
 
 	provisioner, err := k3dprovisioner.NewK3kProvisioner(
 		k3dprovisioner.K3kProvisionerConfig{

--- a/pkg/svc/provisioner/cluster/k3d/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/export_test.go
@@ -7,12 +7,6 @@ import (
 	k3kv1beta1 "github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
 
-// NewK3kProvisionerWithServerArgsForTest builds a minimal K3kProvisioner with only
-// serverArgs set, so buildClusterCR can be exercised without host-cluster clients.
-func NewK3kProvisionerWithServerArgsForTest(serverArgs []string) *K3kProvisioner {
-	return &K3kProvisioner{serverArgs: serverArgs}
-}
-
 // BuildClusterCRForTest exposes buildClusterCR for unit testing.
 func (p *K3kProvisioner) BuildClusterCRForTest(
 	clusterName, namespace, certSAN string,

--- a/pkg/svc/provisioner/cluster/k3d/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/export_test.go
@@ -4,7 +4,21 @@ import (
 	"context"
 
 	"github.com/devantler-tech/ksail/v7/pkg/runner"
+	k3kv1beta1 "github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 )
+
+// NewK3kProvisionerWithServerArgsForTest builds a minimal K3kProvisioner with only
+// serverArgs set, so buildClusterCR can be exercised without host-cluster clients.
+func NewK3kProvisionerWithServerArgsForTest(serverArgs []string) *K3kProvisioner {
+	return &K3kProvisioner{serverArgs: serverArgs}
+}
+
+// BuildClusterCRForTest exposes buildClusterCR for unit testing.
+func (p *K3kProvisioner) BuildClusterCRForTest(
+	clusterName, namespace, certSAN string,
+) *k3kv1beta1.Cluster {
+	return p.buildClusterCR(clusterName, namespace, certSAN)
+}
 
 // WithRunnerForTest injects a command runner so lifecycle operations can be
 // exercised without invoking the real k3d runtime.

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -69,6 +69,7 @@ type K3kProvisioner struct {
 	workers       int32
 	podCIDR       string
 	serviceCIDR   string
+	serverArgs    []string
 }
 
 // K3kProvisionerConfig holds configuration for creating a K3kProvisioner.
@@ -99,6 +100,9 @@ type K3kProvisionerConfig struct {
 	ServiceCIDR string
 	// HostContext is the kubeconfig context to use for the host cluster.
 	HostContext string
+	// ServerArgs are extra K3s server args (e.g. "--kube-apiserver-arg=...") passed
+	// through to the embedded k3s server via the k3k Cluster spec's serverArgs field.
+	ServerArgs []string
 }
 
 // NewK3kProvisioner creates a K3kProvisioner for managing K3s clusters via k3k.
@@ -129,6 +133,7 @@ func NewK3kProvisioner(cfg K3kProvisionerConfig) (*K3kProvisioner, error) {
 		workers:          workers,
 		podCIDR:          cfg.PodCIDR,
 		serviceCIDR:      cfg.ServiceCIDR,
+		serverArgs:       cfg.ServerArgs,
 	}, nil
 }
 
@@ -447,6 +452,10 @@ func (p *K3kProvisioner) buildClusterCR(
 			},
 			TLSSANs: tlsSANs,
 		},
+	}
+
+	if len(p.serverArgs) > 0 {
+		cluster.Spec.ServerArgs = p.serverArgs
 	}
 
 	if p.podCIDR != "" {

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -1,0 +1,34 @@
+package k3dprovisioner_test
+
+import (
+	"testing"
+
+	k3dconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/k3d"
+	k3dprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3d"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildClusterCR_ServerArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("propagates_server_args_into_cluster_spec", func(t *testing.T) {
+		t.Parallel()
+
+		serverArgs := k3dconfigmanager.APIServerFeatureGatesArgs()
+		provisioner := k3dprovisioner.NewK3kProvisionerWithServerArgsForTest(serverArgs)
+
+		cluster := provisioner.BuildClusterCRForTest("test", "k3k-test", "10.0.0.1")
+
+		assert.Equal(t, serverArgs, cluster.Spec.ServerArgs)
+	})
+
+	t.Run("omits_server_args_when_none_configured", func(t *testing.T) {
+		t.Parallel()
+
+		provisioner := k3dprovisioner.NewK3kProvisionerWithServerArgsForTest(nil)
+
+		cluster := provisioner.BuildClusterCRForTest("test", "k3k-test", "10.0.0.1")
+
+		assert.Nil(t, cluster.Spec.ServerArgs)
+	})
+}

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -6,6 +6,7 @@ import (
 	k3dconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/k3d"
 	k3dprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3d"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildClusterCR_ServerArgs(t *testing.T) {
@@ -15,7 +16,10 @@ func TestBuildClusterCR_ServerArgs(t *testing.T) {
 		t.Parallel()
 
 		serverArgs := k3dconfigmanager.APIServerFeatureGatesArgs()
-		provisioner := k3dprovisioner.NewK3kProvisionerWithServerArgsForTest(serverArgs)
+		provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
+			ServerArgs: serverArgs,
+		})
+		require.NoError(t, err)
 
 		cluster := provisioner.BuildClusterCRForTest("test", "k3k-test", "10.0.0.1")
 
@@ -25,7 +29,8 @@ func TestBuildClusterCR_ServerArgs(t *testing.T) {
 	t.Run("omits_server_args_when_none_configured", func(t *testing.T) {
 		t.Parallel()
 
-		provisioner := k3dprovisioner.NewK3kProvisionerWithServerArgsForTest(nil)
+		provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{})
+		require.NoError(t, err)
 
 		cluster := provisioner.BuildClusterCRForTest("test", "k3k-test", "10.0.0.1")
 


### PR DESCRIPTION
## Summary

Follow-up to the Copilot finding on #4864. The k3k (K3s-on-Kubernetes-provider) path returns early into `createK3dKubernetesProvisioner` at the **top** of `createK3dProvisioner`, *before* the Calico API-server feature-gate block that #4864 adds for the Docker-based distributions. As a result, a Calico cluster created via k3k never enabled the `MutatingAdmissionPolicy` feature gate / `admissionregistration.k8s.io/v1beta1` API.

Calico v3.30+'s CRD chart ships `MutatingAdmissionPolicy` / `MutatingAdmissionPolicyBinding` resources, so the install would fail with `no matches for kind "MutatingAdmissionPolicy"`. This combination was previously **untested** in CI (the Kubernetes-provider matrix legs use the distribution-default CNI).

## What changed

- **k3k provisioner** (`pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go`): added a `ServerArgs []string` field to `K3kProvisionerConfig` / `K3kProvisioner`, plumbed into the k3k `Cluster` spec's `serverArgs` (forwarded to the embedded k3s server).
- **Factory** (`pkg/svc/provisioner/cluster/factory.go`): in `createK3dKubernetesProvisioner`, set `ServerArgs` to the two `--kube-apiserver-arg=…` flags when `CNI == Calico`.
- **Shared flag source** (`pkg/fsutil/configmanager/k3d/helpers.go`): `APIServerFeatureGatesArgs()` returns the K3s-style feature-gate/runtime-config flags — single source of truth, same values the Docker (K3d) ExtraArgs path uses.
- **CI coverage**: added a `cni` input to the `ksail-test-kubernetes-provider` action, threaded `kubernetes-provider-cni` through `ksail-system-test`, and added a standalone matrix leg (`distributions: K3s`, `cni: Calico`) that exercises the k3k+Calico `serverArgs` path. A unique host `args` value keeps it as its own matrix combination.
- **Tests**: `TestAPIServerFeatureGatesArgs` and `TestBuildClusterCR_ServerArgs` (via a new `export_test` helper).

## Notes for reviewers

- Self-contained: the k3k path uses k3k's own `serverArgs` rather than #4864's K3d/Kind config helpers, so this builds and passes on the current branch independently of whether #4864 merges first.
- The flag values match the Docker path exactly: `--kube-apiserver-arg=feature-gates=MutatingAdmissionPolicy=true` and `--kube-apiserver-arg=runtime-config=admissionregistration.k8s.io/v1beta1=true`.

## Test plan

- [x] `go build ./...`
- [x] `go vet` (changed packages)
- [x] `go test ./pkg/svc/provisioner/cluster/...` + `pkg/fsutil/configmanager/k3d/...`
- [x] `golangci-lint` **v2.11.4** (pinned CI version): 0 issues
- [x] `actionlint` + `yamllint` clean on the workflow/action files
- [ ] CI: new Calico-on-Kubernetes-provider matrix leg passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)