### PR TITLE
test: extract duplicated secret manifest into a shared constant

### DIFF
--- a/pkg/client/kubeconform/client_coverage_test.go
+++ b/pkg/client/kubeconform/client_coverage_test.go
@@ -50,16 +50,7 @@ metadata:
 func TestValidateBytes_SkipKinds(t *testing.T) {
 	t.Parallel()
 
-	//nolint:gosec // G101: This is a test manifest, not a hardcoded credential
-	secretYAML := `apiVersion: v1
-kind: Secret
-metadata:
-  name: test-secret
-  namespace: default
-type: Opaque
-data:
-  key: dmFsdWU=
-`
+	secretYAML := testSecretManifest
 
 	client := kubeconform.NewClient()
 	opts := &kubeconform.ValidationOptions{
@@ -141,15 +132,7 @@ func TestValidateManifests_CancelledContext(t *testing.T) {
 func TestValidateManifests_SkipKinds(t *testing.T) {
 	t.Parallel()
 
-	yaml := `apiVersion: v1
-kind: Secret
-metadata:
-  name: test-secret
-  namespace: default
-type: Opaque
-data:
-  key: dmFsdWU=
-`
+	yaml := testSecretManifest
 
 	client := kubeconform.NewClient()
 	opts := &kubeconform.ValidationOptions{

--- a/pkg/client/kubeconform/client_test.go
+++ b/pkg/client/kubeconform/client_test.go
@@ -17,6 +17,17 @@ metadata:
   name: test-namespace
 `
 
+//nolint:gosec // G101: test manifest, not a hardcoded credential
+const testSecretManifest = `apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: default
+type: Opaque
+data:
+  key: dmFsdWU=
+`
+
 func TestNewClient(t *testing.T) {
 	t.Parallel()
 
@@ -161,16 +172,7 @@ func TestValidateFile_SkipKinds(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a Secret manifest (which we'll skip)
-	//nolint:gosec // G101: This is a test secret manifest, not a hardcoded credential
-	secretManifest := `apiVersion: v1
-kind: Secret
-metadata:
-  name: test-secret
-  namespace: default
-type: Opaque
-data:
-  key: dmFsdWU=
-`
+	secretManifest := testSecretManifest
 	manifestPath := filepath.Join(tmpDir, "secret.yaml")
 
 	err := os.WriteFile(manifestPath, []byte(secretManifest), 0o600)

--- a/pkg/client/kubeconform/client_test.go
+++ b/pkg/client/kubeconform/client_test.go
@@ -164,7 +164,6 @@ func TestValidateFile_NonExistentFile(t *testing.T) {
 	}
 }
 
-//nolint:goconst // Inline manifests keep the skip-kind cases readable.
 func TestValidateFile_SkipKinds(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
🤖 *This is an automated response from KSail AI Assistant.*

## Summary

`main` is currently **red on `golangci-lint`** at `05715ae0`. The full push-to-`main` lint run (which does **not** apply `only-new-issues` filtering) flags a `goconst` violation:

```
` ...
  name: test-secret
  namespace: default
type: Opaque
data:
  key: dmFsdWU=
` has 3 occurrences, make it a constant (goconst)
```

The identical Secret YAML manifest was defined as an inline raw-string literal **three times** in the `kubeconform_test` package — twice in `pkg/client/kubeconform/client_coverage_test.go` (`secretYAML`, `yaml`) and once in `pkg/client/kubeconform/client_test.go` (`secretManifest`). `goconst`'s default `min-occurrences: 3` trips on the third copy.

Per-PR lint passed (the lint action filters to *new* issues, and no recent PR touched these lines), so the aggregate threshold only surfaced on the unfiltered push-to-`main` run — leaving `main`'s `CI - Required Checks` rollup red.

## Fix

1. Extract the literal into a package-level `testSecretManifest` const beside the existing `validNamespaceYAML` const, and reference it from all three call sites. This collapses the literal to a single occurrence (no `goconst`) and removes the now-redundant per-call `//nolint:gosec` directives — one `//nolint:gosec` exemption remains on the const (gosec G101 keys off the `Secret`-containing identifier name).
2. Drop the now-dead `//nolint:goconst` on `TestValidateFile_SkipKinds`. It was an earlier attempt to suppress this goconst, but `goconst` reports the duplicate at its *first* occurrence (in `client_coverage_test.go`), so the function-scoped directive never covered it — which is why `main` went red despite it. With the manifest extracted, the directive is dead; removing it avoids a `nolintlint` "unused directive" failure on the unfiltered push-to-`main` lint.

Test-only change; no production code touched.

## Verification

- `go build` ✅
- `go test ./pkg/client/kubeconform/...` ✅
- `golangci-lint run --new-from-rev=main ./...` → **0 issues** (removes the `goconst`, introduces nothing new)

> Note: a full local `go test ./...` showed unrelated failures in `pkg/cli/cmd/chat` (`signal: killed` on exec'd helper binaries) that **pass in isolation** and on CI's Linux runners — a parallel-exec contention artifact of this shared macOS dev machine, not caused by this change.

## Test plan
- [ ] `🧹 Lint - golangci-lint` passes on this PR and on the resulting push to `main`
- [ ] `🧪 Test` / `📊 Code Coverage` for `pkg/client/kubeconform` stay green