### PR TITLE
fix(provisioner): fail fast when Talos cluster is unreachable on update

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -838,22 +838,28 @@ func (p *Provisioner) GetCurrentConfig(
 	}
 
 	// Detect installed components from the live cluster when the detector is available.
+	// A detection failure means the cluster is unreachable (kube API down, stale
+	// kubeconfig). Propagate it instead of silently falling back to a default
+	// baseline, which would make update propose a full reinstall of healthy
+	// components and only fail later mid-apply.
 	if p.componentDetector != nil {
 		detected, err := p.componentDetector.DetectComponents(
 			ctx,
 			v1alpha1.DistributionTalos,
 			provider,
 		)
-		if err == nil {
-			spec.CNI = detected.CNI
-			spec.CSI = detected.CSI
-			spec.MetricsServer = detected.MetricsServer
-			spec.LoadBalancer = detected.LoadBalancer
-			spec.CertManager = detected.CertManager
-			spec.PolicyEngine = detected.PolicyEngine
-			spec.GitOpsEngine = detected.GitOpsEngine
-			spec.Autoscaler.Node = detected.Autoscaler.Node
+		if err != nil {
+			return nil, nil, fmt.Errorf("detect components: %w", err)
 		}
+
+		spec.CNI = detected.CNI
+		spec.CSI = detected.CSI
+		spec.MetricsServer = detected.MetricsServer
+		spec.LoadBalancer = detected.LoadBalancer
+		spec.CertManager = detected.CertManager
+		spec.PolicyEngine = detected.PolicyEngine
+		spec.GitOpsEngine = detected.GitOpsEngine
+		spec.Autoscaler.Node = detected.Autoscaler.Node
 	}
 
 	// Introspect actual node counts from the running cluster

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -2,13 +2,16 @@ package talosprovisioner_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/detector"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	omniprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/omni"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
@@ -17,7 +20,9 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 //nolint:funlen // Table-driven test with multiple node topology scenarios is clearer as single function
@@ -883,4 +888,37 @@ func TestMergePersistedState_ReturnsErrorForCorruptState(t *testing.T) {
 	err = provisioner.MergePersistedStateForTest(spec, clusterName)
 	require.Error(t, err, "corrupt state should return an error")
 	assert.Contains(t, err.Error(), "load persisted cluster state")
+}
+
+// TestGetCurrentConfig_PropagatesDetectionError verifies that an unreachable
+// cluster (component detection fails) produces a hard error instead of silently
+// degrading to a default baseline, which would make `cluster update` propose a
+// full reinstall of healthy components and only fail later mid-apply.
+func TestGetCurrentConfig_PropagatesDetectionError(t *testing.T) {
+	// Not parallel: t.Setenv isolates cluster-state lookups from the real ~/.ksail.
+	t.Setenv("HOME", t.TempDir())
+
+	errUnreachable := errors.New("dial tcp 10.0.0.1:6443: connect: connection refused")
+
+	helmClient := helm.NewMockInterface(t)
+	helmClient.On("ListReleases", mock.Anything).
+		Return(nil, errUnreachable)
+	helmClient.On("ReleaseExists", mock.Anything, detector.ReleaseCilium, detector.NamespaceCilium).
+		Return(false, errUnreachable)
+
+	componentDetector := detector.NewComponentDetector(helmClient, fake.NewClientset(), nil)
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithComponentDetector(componentDetector).
+		WithLogWriter(io.Discard)
+
+	spec, providerSpec, err := provisioner.GetCurrentConfig(
+		context.Background(),
+		"unreachable-cluster",
+	)
+
+	require.Error(t, err, "detection failure must be fatal, not silently swallowed")
+	require.ErrorIs(t, err, errUnreachable)
+	assert.Nil(t, spec, "no baseline spec should be returned when the cluster is unreachable")
+	assert.Nil(t, providerSpec)
 }

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+// errClusterUnreachable simulates a kube-API connection failure for component
+// detection in GetCurrentConfig tests.
+var errClusterUnreachable = errors.New("dial tcp 10.0.0.1:6443: connect: connection refused")
+
 //nolint:funlen // Table-driven test with multiple node topology scenarios is clearer as single function
 func TestCountNodeRoles(t *testing.T) {
 	t.Parallel()
@@ -895,16 +899,13 @@ func TestMergePersistedState_ReturnsErrorForCorruptState(t *testing.T) {
 // degrading to a default baseline, which would make `cluster update` propose a
 // full reinstall of healthy components and only fail later mid-apply.
 func TestGetCurrentConfig_PropagatesDetectionError(t *testing.T) {
-	// Not parallel: t.Setenv isolates cluster-state lookups from the real ~/.ksail.
-	t.Setenv("HOME", t.TempDir())
-
-	errUnreachable := errors.New("dial tcp 10.0.0.1:6443: connect: connection refused")
+	t.Parallel()
 
 	helmClient := helm.NewMockInterface(t)
 	helmClient.On("ListReleases", mock.Anything).
-		Return(nil, errUnreachable)
+		Return(nil, errClusterUnreachable)
 	helmClient.On("ReleaseExists", mock.Anything, detector.ReleaseCilium, detector.NamespaceCilium).
-		Return(false, errUnreachable)
+		Return(false, errClusterUnreachable)
 
 	componentDetector := detector.NewComponentDetector(helmClient, fake.NewClientset(), nil)
 
@@ -914,11 +915,11 @@ func TestGetCurrentConfig_PropagatesDetectionError(t *testing.T) {
 
 	spec, providerSpec, err := provisioner.GetCurrentConfig(
 		context.Background(),
-		"unreachable-cluster",
+		"unreachable-cluster-"+t.Name(),
 	)
 
 	require.Error(t, err, "detection failure must be fatal, not silently swallowed")
-	require.ErrorIs(t, err, errUnreachable)
+	require.ErrorIs(t, err, errClusterUnreachable)
 	assert.Nil(t, spec, "no baseline spec should be returned when the cluster is unreachable")
 	assert.Nil(t, providerSpec)
 }


### PR DESCRIPTION
## Summary

`ksail cluster update` against an **unreachable** Talos cluster did not fail fast. Talos's `GetCurrentConfig` silently swallowed component-detection errors (`if err == nil` with no else branch) and fell back to a **default** baseline (`CNI=Default`, `MetricsServer=Disabled`, `CertManager=Disabled`, `PolicyEngine=None`, `GitOpsEngine=None`). The diff engine then compared that bogus baseline against the desired config and printed a confident "Detected 12 configuration changes" reinstall plan — only failing later, mid-apply, on the Talos endpoint.

Kind (`kind/update.go`) and K3d (`k3d/update.go`) already propagate this error, and `computeUpdateDiff` already treats a `GetCurrentConfig` error as fatal — aborting **before** the change summary is computed or displayed. Talos was the lone outlier.

This change makes Talos consistent: `GetCurrentConfig` now returns `detect components: %w` when detection fails, so the update aborts early with an actionable error surfacing the underlying connection failure (`connection refused` / `x509`) instead of degrading to a default baseline.

## Changes

- `pkg/svc/provisioner/cluster/talos/update.go`: propagate the `DetectComponents` error from `GetCurrentConfig` instead of swallowing it.
- `pkg/svc/provisioner/cluster/talos/update_test.go`: add `TestGetCurrentConfig_PropagatesDetectionError` — drives a failing detector and asserts a hard error with nil specs.

## Scope note

This addresses the reported scenario, which is driven by kube-API unreachability (the source of the bogus baseline). The narrower case where the kube API is reachable but only the talosconfig PKI is stale would still surface at apply time — a dedicated Talos-endpoint preflight would be a larger, separate change. The issue's third bullet (mislabeling the unknown baseline as `Default/Disabled/None`) is already filed separately.

Closes #4868

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/svc/provisioner/cluster/talos/...`
- [x] `go test ./pkg/svc/provisioner/cluster/talos/... ./pkg/svc/detector/...`
- [x] New test `TestGetCurrentConfig_PropagatesDetectionError` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)