### PR TITLE
fix(update): show "Unknown" baseline when cluster state can't be read

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6708,6 +6708,7 @@ type DiffJSONOutput struct {
 	RebootRequired       []ChangeJSON `json:"rebootRequired"`
 	RecreateRequired     []ChangeJSON `json:"recreateRequired"`
 	WipeRequired         []ChangeJSON `json:"wipeRequired"`
+	UnknownBaseline      []ChangeJSON `json:"unknownBaseline"`
 	RequiresConfirmation bool         `json:"requiresConfirmation"`
 }
 
@@ -6768,6 +6769,7 @@ func diffToJSON(diff *clusterupdate.UpdateResult) DiffJSONOutput {
 		RebootRequired:       convertChanges(diff.RebootRequired),
 		RecreateRequired:     convertChanges(diff.RecreateRequired),
 		WipeRequired:         convertChanges(diff.WipeRequired),
+		UnknownBaseline:      convertChanges(diff.UnknownBaseline),
 		RequiresConfirmation: diff.NeedsUserConfirmation(),
 	}
 }
@@ -6929,7 +6931,13 @@ func handleUpdateRunE(
 		// before falling back to recreation. No-op when nothing changed.
 		specDiff := computeSpecOnlyDiff(cmd, ctx)
 		if specDiff.TotalChanges() == 0 {
-			notify.Infof(cmd.OutOrStdout(), "No changes detected")
+			// Surface any unknown-baseline components so the user sees that the
+			// current state could not be read, then exit without recreating.
+			if specDiff.HasUnknownBaseline() {
+				displayChangesSummary(cmd, specDiff)
+			}
+
+			reportNoApplicableChanges(cmd, specDiff)
 
 			return nil
 		}
@@ -7608,9 +7616,12 @@ func computeSpecOnlyDiff(
 		if err != nil {
 			notify.Warningf(
 				cmd.ErrOrStderr(),
-				"Cannot detect live cluster components (drift detection may be incomplete): %v",
+				"Cannot detect live cluster components; baseline shown as Unknown: %v",
 				err,
 			)
+			// Mark detector-derived fields unknown so the diff surfaces them as
+			// "Unknown" rather than a confident diff against default values.
+			clusterupdate.MarkComponentsUnknown(currentSpec)
 		} else {
 			currentSpec.CNI = detected.CNI
 			currentSpec.CSI = detected.CSI
@@ -7785,7 +7796,7 @@ func applyOrReportChanges(
 	}
 
 	if !diff.HasInPlaceChanges() && !diff.HasRebootRequired() {
-		notify.Infof(cmd.OutOrStdout(), "No changes detected")
+		reportNoApplicableChanges(cmd, diff)
 
 		return nil
 	}
@@ -7823,14 +7834,35 @@ func applyOrReportChanges(
 	)
 }
 
+// reportNoApplicableChanges prints the appropriate message when there are no
+// changes to apply. It distinguishes a genuinely clean cluster from one whose
+// current state could not be read (unknown baseline), so the latter is not
+// reported as "No changes detected". Any unknown-baseline table is rendered by
+// the caller via displayChangesSummary before this is invoked.
+func reportNoApplicableChanges(cmd *cobra.Command, diff *clusterupdate.UpdateResult) {
+	if diff != nil && diff.HasUnknownBaseline() {
+		notify.Warningf(
+			cmd.ErrOrStderr(),
+			"Current cluster state could not be read for %d component(s); shown as "+
+				"Unknown. No changes applied.",
+			len(diff.UnknownBaseline),
+		)
+
+		return
+	}
+
+	notify.Infof(cmd.OutOrStdout(), "No changes detected")
+}
+
 // reportDryRun prints a summary for dry-run mode and confirms no changes were applied.
 // When --output json is set, emits machine-readable JSON only for the empty-diff case
-// (displayChangesSummary already emits JSON when TotalChanges() > 0).
+// (displayChangesSummary already emits JSON when there is anything to report).
 func reportDryRun(cmd *cobra.Command, diff *clusterupdate.UpdateResult) error {
 	if getOutputFormat(cmd) == outputFormatJSON {
-		// displayChangesSummary already emitted JSON when TotalChanges() > 0.
-		// Only emit JSON here for the empty-diff case so CI/MCP still get a result.
-		if diff != nil && diff.TotalChanges() == 0 {
+		// displayChangesSummary already emitted JSON when there were changes or an
+		// unknown baseline. Only emit JSON here for the genuinely empty case so
+		// CI/MCP still get a result.
+		if diff != nil && diff.TotalChanges() == 0 && !diff.HasUnknownBaseline() {
 			emitDiffJSON(cmd, diff)
 		}
 
@@ -7838,7 +7870,7 @@ func reportDryRun(cmd *cobra.Command, diff *clusterupdate.UpdateResult) error {
 	}
 
 	if diff != nil && diff.TotalChanges() == 0 {
-		notify.Infof(cmd.OutOrStdout(), "No changes detected")
+		reportNoApplicableChanges(cmd, diff)
 
 		return nil
 	}
@@ -7949,9 +7981,7 @@ func applyInPlaceChanges(
 // Fields with no change are omitted.
 // When --output json is set, emits machine-readable JSON instead of the table.
 func displayChangesSummary(cmd *cobra.Command, diff *clusterupdate.UpdateResult) {
-	totalChanges := diff.TotalChanges()
-
-	if totalChanges == 0 {
+	if diff.TotalChanges() == 0 && !diff.HasUnknownBaseline() {
 		return
 	}
 
@@ -7965,7 +7995,7 @@ func displayChangesSummary(cmd *cobra.Command, diff *clusterupdate.UpdateResult)
 
 	notify.Infof(
 		cmd.OutOrStdout(),
-		formatDiffTable(diff, totalChanges),
+		formatDiffTable(diff),
 	)
 }
 
@@ -7989,6 +8019,8 @@ func categoryIcon(cat clusterupdate.ChangeCategory) string {
 		return "🟡"
 	case clusterupdate.ChangeCategoryInPlace:
 		return "🟢"
+	case clusterupdate.ChangeCategoryUnknown:
+		return "⚪"
 	default:
 		return "⚪"
 	}
@@ -7996,12 +8028,13 @@ func categoryIcon(cat clusterupdate.ChangeCategory) string {
 
 // formatDiffTable builds the formatted diff table string.
 // The table has four columns: Component, Before, After, Impact.
-// Rows are ordered by severity: 🔴 recreate → ⚠️ wipe → 🟡 reboot → 🟢 in-place.
+// Rows are ordered by severity: 🔴 recreate → ⚠️ wipe → 🟡 reboot → 🟢 in-place → ⚪ unknown.
 func formatDiffTable(
 	diff *clusterupdate.UpdateResult,
-	totalChanges int,
 ) string {
-	rows := collectDiffRows(diff, totalChanges)
+	realChanges := diff.TotalChanges()
+	unknownCount := len(diff.UnknownBaseline)
+	rows := collectDiffRows(diff, realChanges+unknownCount)
 
 	// Column headers
 	const (
@@ -8023,9 +8056,9 @@ func formatDiffTable(
 
 	const perRowPadding = 16 // spacing + emoji + newline
 
-	block.Grow((totalChanges + tableOverheadRows) * (colW + colB + colA + colI + perRowPadding))
+	block.Grow((len(rows) + tableOverheadRows) * (colW + colB + colA + colI + perRowPadding))
 
-	writeSummaryLine(&block, totalChanges)
+	writeSummaryLine(&block, realChanges, unknownCount)
 	writeHeaderRow(&block, colW, colB, colA, hdrComponent, hdrBefore, hdrAfter, hdrImpact)
 	writeSeparatorRow(&block, colW, colB, colA, colI)
 	writeDataRows(&block, rows, colW, colB, colA)
@@ -8046,16 +8079,17 @@ func appendChangesAsRows(rows []diffRow, changes []clusterupdate.Change) []diffR
 }
 
 // collectDiffRows builds an ordered list of diff rows.
-// Order: 🔴 recreate-required → ⚠️ wipe-required → 🟡 reboot-required → 🟢 in-place.
+// Order: 🔴 recreate-required → ⚠️ wipe-required → 🟡 reboot-required → 🟢 in-place → ⚪ unknown.
 func collectDiffRows(
 	diff *clusterupdate.UpdateResult,
-	totalChanges int,
+	totalRows int,
 ) []diffRow {
-	rows := make([]diffRow, 0, totalChanges)
+	rows := make([]diffRow, 0, totalRows)
 	rows = appendChangesAsRows(rows, diff.RecreateRequired)
 	rows = appendChangesAsRows(rows, diff.WipeRequired)
 	rows = appendChangesAsRows(rows, diff.RebootRequired)
 	rows = appendChangesAsRows(rows, diff.InPlaceChanges)
+	rows = appendChangesAsRows(rows, diff.UnknownBaseline)
 
 	return rows
 }
@@ -8091,8 +8125,20 @@ func computeColumnWidths(
 	return widthComp, widthBefore, widthAfter, widthImpact
 }
 
-func writeSummaryLine(block *strings.Builder, totalChanges int) {
-	fmt.Fprintf(block, "Detected %d configuration changes:\n\n", totalChanges)
+func writeSummaryLine(block *strings.Builder, realChanges, unknownCount int) {
+	switch {
+	case unknownCount > 0 && realChanges > 0:
+		fmt.Fprintf(block,
+			"Detected %d configuration change(s); %d component(s) have an unknown "+
+				"baseline (current cluster state could not be read):\n\n",
+			realChanges, unknownCount)
+	case unknownCount > 0:
+		fmt.Fprintf(block,
+			"Current cluster state could not be read; %d component(s) shown as Unknown:\n\n",
+			unknownCount)
+	default:
+		fmt.Fprintf(block, "Detected %d configuration changes:\n\n", realChanges)
+	}
 }
 
 // headerIndent is the number of leading spaces in the header and separator rows.
@@ -8417,7 +8463,7 @@ func handleDiffRunE(
 	// This adds distribution-specific changes (e.g., node counts, Talos config).
 	mergeProvisionerDiff(cmd, ctx, diff)
 
-	if diff.TotalChanges() == 0 {
+	if diff.TotalChanges() == 0 && !diff.HasUnknownBaseline() {
 		if format == outputFormatJSON {
 			emitDiffJSON(cmd, diff)
 		} else {
@@ -8430,7 +8476,9 @@ func handleDiffRunE(
 	displayDiffResult(cmd, diff, format)
 
 	if exitCodeFlag {
-		return &DriftExitError{Changes: diff.TotalChanges()}
+		// An unknown baseline is treated as drift: the tool cannot confirm the
+		// cluster matches the desired configuration.
+		return &DriftExitError{Changes: diff.TotalChanges() + len(diff.UnknownBaseline)}
 	}
 
 	return nil
@@ -8452,7 +8500,7 @@ func displayDiffResult(
 
 	notify.Infof(
 		cmd.OutOrStdout(),
-		formatDiffTable(diff, diff.TotalChanges()),
+		formatDiffTable(diff),
 	)
 }
 

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -7607,7 +7607,14 @@ func computeSpecOnlyDiff(
 
 	// Use component detection when available to get more accurate baseline.
 	componentDetector := buildComponentDetector(cmd, ctx)
-	if componentDetector != nil {
+	if componentDetector == nil {
+		// The detector's clients (Helm/K8s) could not be constructed, so live
+		// cluster state cannot be read at all. Treat this like a detection
+		// failure and mark the baseline Unknown rather than fabricating a
+		// confident diff against defaults. buildComponentDetector already logged
+		// the underlying reason.
+		clusterupdate.MarkComponentsUnknown(currentSpec)
+	} else {
 		detected, err := componentDetector.DetectComponents(
 			cmd.Context(),
 			ctx.ClusterCfg.Spec.Cluster.Distribution,

--- a/pkg/cli/cmd/cluster/cluster_deep_test.go
+++ b/pkg/cli/cmd/cluster/cluster_deep_test.go
@@ -450,3 +450,98 @@ func TestDisplayChangesSummary_EmptyChanges(t *testing.T) {
 	output := buf.String()
 	assert.Empty(t, output, "empty changes should produce no output")
 }
+
+func TestDiffToJSON_UnknownBaseline(t *testing.T) {
+	t.Parallel()
+
+	diff := &clusterupdate.UpdateResult{
+		UnknownBaseline: []clusterupdate.Change{
+			{
+				Field:    "cluster.cni",
+				OldValue: clusterupdate.UnknownBaselineValue,
+				NewValue: "Cilium",
+				Category: clusterupdate.ChangeCategoryUnknown,
+				Reason:   "current cluster state could not be read; baseline is unknown",
+			},
+		},
+	}
+
+	out := cluster.ExportDiffToJSON(diff)
+
+	// Unknown-baseline entries are surfaced separately and never counted as
+	// applicable changes.
+	assert.Equal(t, 0, out.TotalChanges)
+	assert.Len(t, out.UnknownBaseline, 1)
+	assert.Equal(t, "cluster.cni", out.UnknownBaseline[0].Field)
+	assert.Equal(t, "Unknown", out.UnknownBaseline[0].OldValue)
+	assert.Equal(t, "unknown", out.UnknownBaseline[0].Category)
+	assert.False(t, out.RequiresConfirmation)
+}
+
+func TestDisplayChangesSummary_UnknownBaselineOnly(t *testing.T) {
+	t.Parallel()
+
+	diff := &clusterupdate.UpdateResult{
+		UnknownBaseline: []clusterupdate.Change{
+			{
+				Field:    "cluster.gitOpsEngine",
+				OldValue: clusterupdate.UnknownBaselineValue,
+				NewValue: "Flux",
+				Category: clusterupdate.ChangeCategoryUnknown,
+			},
+		},
+	}
+	cmd := &cobra.Command{}
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	cluster.ExportDisplayChangesSummary(cmd, diff)
+
+	output := buf.String()
+	assert.Contains(t, output, "Change summary")
+	assert.Contains(t, output, "cluster.gitOpsEngine")
+	assert.Contains(t, output, "Unknown")
+	assert.Contains(t, output, "could not be read")
+}
+
+func TestReportNoApplicableChanges_UnknownVsClean(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clean cluster", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+
+		var out bytes.Buffer
+
+		cmd.SetOut(&out)
+
+		cluster.ExportReportNoApplicableChanges(cmd, clusterupdate.NewEmptyUpdateResult())
+		assert.Contains(t, out.String(), "No changes detected")
+	})
+
+	t.Run("unknown baseline", func(t *testing.T) {
+		t.Parallel()
+
+		diff := clusterupdate.NewEmptyUpdateResult()
+		diff.UnknownBaseline = append(diff.UnknownBaseline, clusterupdate.Change{
+			Field:    "cluster.cni",
+			OldValue: clusterupdate.UnknownBaselineValue,
+			NewValue: "Cilium",
+			Category: clusterupdate.ChangeCategoryUnknown,
+		})
+
+		cmd := &cobra.Command{}
+
+		var errOut bytes.Buffer
+
+		cmd.SetErr(&errOut)
+
+		cluster.ExportReportNoApplicableChanges(cmd, diff)
+
+		got := errOut.String()
+		assert.Contains(t, got, "could not be read")
+		assert.NotContains(t, got, "No changes detected")
+	})
+}

--- a/pkg/cli/cmd/cluster/cluster_pure_test.go
+++ b/pkg/cli/cmd/cluster/cluster_pure_test.go
@@ -194,6 +194,60 @@ func TestFormatDiffTable_MultipleRows(t *testing.T) {
 	assert.Contains(t, got, "c")
 }
 
+func TestFormatDiffTable_UnknownBaselineOnly(t *testing.T) {
+	t.Parallel()
+
+	diff := &clusterupdate.UpdateResult{
+		UnknownBaseline: []clusterupdate.Change{
+			{
+				Field:    "cluster.cni",
+				OldValue: clusterupdate.UnknownBaselineValue,
+				NewValue: "Cilium",
+				Category: clusterupdate.ChangeCategoryUnknown,
+			},
+		},
+	}
+	got := cluster.ExportFormatDiffTable(diff, 0)
+
+	assert.Contains(t, got, "cluster.cni")
+	assert.Contains(t, got, "Unknown")
+	assert.Contains(t, got, "Cilium")
+	assert.Contains(t, got, "⚪")
+	// The summary line must not claim confident configuration changes.
+	assert.Contains(t, got, "could not be read")
+	assert.NotContains(t, got, "Detected 0 configuration changes")
+}
+
+func TestFormatDiffTable_RealAndUnknownTogether(t *testing.T) {
+	t.Parallel()
+
+	diff := &clusterupdate.UpdateResult{
+		InPlaceChanges: []clusterupdate.Change{
+			{
+				Field:    "cluster.workers",
+				OldValue: "1",
+				NewValue: "3",
+				Category: clusterupdate.ChangeCategoryInPlace,
+			},
+		},
+		UnknownBaseline: []clusterupdate.Change{
+			{
+				Field:    "cluster.gitOpsEngine",
+				OldValue: clusterupdate.UnknownBaselineValue,
+				NewValue: "Flux",
+				Category: clusterupdate.ChangeCategoryUnknown,
+			},
+		},
+	}
+	got := cluster.ExportFormatDiffTable(diff, 1)
+
+	assert.Contains(t, got, "cluster.workers")
+	assert.Contains(t, got, "cluster.gitOpsEngine")
+	assert.Contains(t, got, "🟢")
+	assert.Contains(t, got, "⚪")
+	assert.Contains(t, got, "unknown baseline")
+}
+
 // ===========================================================================
 // stripDistributionPrefix — context name prefix stripping
 // ===========================================================================

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -142,8 +142,10 @@ const ExportOutputFormatJSON = outputFormatJSON
 const ExportOutputFormatText = outputFormatText
 
 // ExportFormatDiffTable exports formatDiffTable for benchmarking.
-func ExportFormatDiffTable(diff *clusterupdate.UpdateResult, totalChanges int) string {
-	return formatDiffTable(diff, totalChanges)
+// The trailing int is vestigial (formatDiffTable now derives counts from diff)
+// and is retained so existing benchmark call sites compile unchanged.
+func ExportFormatDiffTable(diff *clusterupdate.UpdateResult, _ int) string {
+	return formatDiffTable(diff)
 }
 
 // ExportStripParenthetical exports stripParenthetical for testing.

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -135,6 +135,11 @@ func ExportDiffToJSON(diff *clusterupdate.UpdateResult) DiffJSONOutput {
 	return diffToJSON(diff)
 }
 
+// ExportReportNoApplicableChanges exports reportNoApplicableChanges for testing.
+func ExportReportNoApplicableChanges(cmd *cobra.Command, diff *clusterupdate.UpdateResult) {
+	reportNoApplicableChanges(cmd, diff)
+}
+
 // ExportOutputFormatJSON exports outputFormatJSON for testing.
 const ExportOutputFormatJSON = outputFormatJSON
 

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -263,6 +263,10 @@ func appendChange(
 		result.RebootRequired = append(result.RebootRequired, change)
 	case clusterupdate.ChangeCategoryWipeRequired:
 		result.WipeRequired = append(result.WipeRequired, change)
+	case clusterupdate.ChangeCategoryUnknown:
+		// Unknown-baseline entries are produced by appendUnknownIfChanged, not
+		// here; route defensively so the category is never silently dropped.
+		result.UnknownBaseline = append(result.UnknownBaseline, change)
 	}
 }
 
@@ -278,15 +282,71 @@ func (e *Engine) applyFieldRules(
 			continue
 		}
 
+		oldVal := rule.getVal(oldSpec)
+
+		// The baseline value could not be read from the cluster. Surface the
+		// field as Unknown instead of computing a confident diff against the
+		// default value (which would mislead the user into reinstalling
+		// components that may already be healthy).
+		if oldVal == clusterupdate.UnknownBaselineValue {
+			e.appendUnknownIfChanged(result, rule, newVal)
+
+			continue
+		}
+
 		cat := rule.category
 		if rule.categoryFn != nil {
 			cat = rule.categoryFn()
 		}
 
 		appendChange(result, rule.field,
-			rule.getVal(oldSpec), newVal,
+			oldVal, newVal,
 			rule.defaultVal, rule.reason, cat)
 	}
+}
+
+// appendUnknownIfChanged appends an Unknown-baseline entry for a field whose
+// current value could not be read. To avoid noise, it only emits an entry when
+// the field's *default* baseline differs from the desired value — i.e. exactly
+// when a normal diff would have reported a change. Fields the user left at their
+// defaults produce no entry, since they would not have shown a change either.
+func (e *Engine) appendUnknownIfChanged(
+	result *clusterupdate.UpdateResult,
+	rule fieldRule,
+	newVal string,
+) {
+	defaultOld := rule.getVal(clusterupdate.DefaultCurrentSpec(e.distribution, e.provider))
+
+	// Mirror appendChange's default-value substitution so the comparison matches
+	// what a normal diff would have evaluated.
+	if rule.defaultVal != "" {
+		if defaultOld == "" {
+			defaultOld = rule.defaultVal
+		}
+
+		if newVal == "" {
+			newVal = rule.defaultVal
+		}
+	}
+
+	if defaultOld == newVal {
+		return
+	}
+
+	result.UnknownBaseline = append(result.UnknownBaseline, clusterupdate.Change{
+		Field:    rule.field,
+		OldValue: clusterupdate.UnknownBaselineValue,
+		NewValue: newVal,
+		Category: clusterupdate.ChangeCategoryUnknown,
+		Reason:   "current cluster state could not be read; baseline is unknown",
+	})
+}
+
+// componentBaselineUnknown reports whether the spec's detector-derived component
+// fields were marked unknown (see clusterupdate.MarkComponentsUnknown). Checking
+// CNI is sufficient because the marker sets all component fields together.
+func (e *Engine) componentBaselineUnknown(spec *v1alpha1.ClusterSpec) bool {
+	return string(spec.CNI) == clusterupdate.UnknownBaselineValue
 }
 
 // localRegistryReasonMap maps each distribution to the reason and category for a local registry change.
@@ -528,6 +588,16 @@ func (e *Engine) checkAutoscalerOptionsChange(
 	oldSpec, newSpec *v1alpha1.ClusterSpec,
 	result *clusterupdate.UpdateResult,
 ) {
+	// The node autoscaler is detector-derived. When the component baseline could
+	// not be read, skip its diff entirely (an unknown baseline is not "disabled")
+	// rather than fabricating an in-place install change. The pod autoscaler is
+	// config-only and unaffected.
+	if e.componentBaselineUnknown(oldSpec) {
+		e.checkAutoscalerPodScalarsChange(oldSpec.Autoscaler.Pod, newSpec.Autoscaler.Pod, result)
+
+		return
+	}
+
 	oldNode := oldSpec.Autoscaler.Node
 	newNode := newSpec.Autoscaler.Node
 

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -1526,3 +1526,97 @@ func TestEngine_TalosVersion_ChangeWhenOldEmptyNewSet(t *testing.T) {
 		clusterupdate.ChangeCategoryInPlace,
 	)
 }
+
+// findChange returns the first change with the given field, or nil.
+func findChange(changes []clusterupdate.Change, field string) *clusterupdate.Change {
+	for i := range changes {
+		if changes[i].Field == field {
+			return &changes[i]
+		}
+	}
+
+	return nil
+}
+
+func TestEngine_UnknownBaseline_SurfacesUnknownInsteadOfInPlace(t *testing.T) {
+	t.Parallel()
+
+	// Baseline could not be read from the cluster: every detector-derived
+	// component field is the Unknown sentinel.
+	old := clusterupdate.DefaultCurrentSpec(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	clusterupdate.MarkComponentsUnknown(old)
+
+	// Desired config requests several active components, and leaves the load
+	// balancer and CSI at their defaults.
+	newer := clusterupdate.DefaultCurrentSpec(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	newer.CNI = v1alpha1.CNICilium
+	newer.MetricsServer = v1alpha1.MetricsServerEnabled
+	newer.CertManager = v1alpha1.CertManagerEnabled
+	newer.PolicyEngine = v1alpha1.PolicyEngineKyverno
+	newer.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	// No fabricated in-place / reboot / recreate changes from the unknown baseline.
+	require.Zero(t, result.TotalChanges(),
+		"unknown baseline must not produce applicable changes")
+	require.True(t, result.HasUnknownBaseline())
+
+	wantFields := []string{
+		"cluster.cni",
+		"cluster.metricsServer",
+		"cluster.certManager",
+		"cluster.policyEngine",
+		"cluster.gitOpsEngine",
+	}
+	require.Len(t, result.UnknownBaseline, len(wantFields))
+
+	for _, field := range wantFields {
+		change := findChange(result.UnknownBaseline, field)
+		require.NotNilf(t, change, "expected unknown-baseline entry for %s", field)
+		require.Equal(t, clusterupdate.UnknownBaselineValue, change.OldValue)
+		require.Equal(t, clusterupdate.ChangeCategoryUnknown, change.Category)
+		require.NotEqual(t, clusterupdate.UnknownBaselineValue, change.NewValue)
+	}
+
+	// Components left at their defaults must not be reported, even as Unknown.
+	require.Nil(t, findChange(result.UnknownBaseline, "cluster.loadBalancer"))
+	require.Nil(t, findChange(result.UnknownBaseline, "cluster.csi"))
+}
+
+func TestEngine_UnknownBaseline_NoNoiseWhenDesiredMatchesDefaults(t *testing.T) {
+	t.Parallel()
+
+	old := clusterupdate.DefaultCurrentSpec(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	clusterupdate.MarkComponentsUnknown(old)
+
+	// Desired config leaves every component at its default.
+	newer := clusterupdate.DefaultCurrentSpec(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	require.Zero(t, result.TotalChanges())
+	require.False(t, result.HasUnknownBaseline(),
+		"defaults on both sides must not produce Unknown rows")
+}
+
+func TestEngine_UnknownBaseline_SkipsNodeAutoscalerDiff(t *testing.T) {
+	t.Parallel()
+
+	old := clusterupdate.DefaultCurrentSpec(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	clusterupdate.MarkComponentsUnknown(old)
+
+	newer := clusterupdate.DefaultCurrentSpec(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	newer.Autoscaler.Node.Enabled = true
+	newer.Autoscaler.Node.MaxNodesTotal = 5
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	// The node autoscaler is detector-derived; an unknown baseline must not
+	// fabricate an in-place "enable autoscaler" change.
+	require.Nil(t, findChange(result.InPlaceChanges, "cluster.autoscaler.node.enabled"))
+	require.Nil(t, findChange(result.UnknownBaseline, "cluster.autoscaler.node.enabled"))
+}

--- a/pkg/svc/provisioner/cluster/clusterupdate/update.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/update.go
@@ -19,6 +19,14 @@ var ErrWipeRequired = errors.New("partition wipe required")
 // GetCurrentConfig to prevent false-positive diffs.
 const DefaultLocalRegistryAddress = "localhost:5050"
 
+// UnknownBaselineValue is the sentinel value assigned to a component field whose
+// current cluster state could not be read (e.g. the Kubernetes API was
+// unreachable). It is deliberately not a valid value for any component enum, so
+// it never collides with a genuine configuration value. The diff engine detects
+// this sentinel and surfaces the field as an "Unknown" baseline instead of
+// fabricating a confident diff against the default value. See MarkComponentsUnknown.
+const UnknownBaselineValue = "Unknown"
+
 // ApplyGitOpsLocalRegistryDefault mirrors the config system's GitOps-aware
 // default: when a GitOps engine is detected but no local registry is configured,
 // default to "localhost:5050". This prevents false-positive diffs when the update
@@ -57,6 +65,25 @@ func DefaultCurrentSpec(
 	}
 }
 
+// MarkComponentsUnknown sets every component field that the detector probes from
+// the live cluster to the UnknownBaselineValue sentinel. Callers invoke this when
+// component detection fails (e.g. the Kubernetes API is unreachable) so that the
+// diff engine surfaces these fields as "Unknown" rather than fabricating a
+// confident diff from default values for components that may already be installed.
+func MarkComponentsUnknown(spec *v1alpha1.ClusterSpec) {
+	if spec == nil {
+		return
+	}
+
+	spec.CNI = v1alpha1.CNI(UnknownBaselineValue)
+	spec.CSI = v1alpha1.CSI(UnknownBaselineValue)
+	spec.MetricsServer = v1alpha1.MetricsServer(UnknownBaselineValue)
+	spec.LoadBalancer = v1alpha1.LoadBalancer(UnknownBaselineValue)
+	spec.CertManager = v1alpha1.CertManager(UnknownBaselineValue)
+	spec.PolicyEngine = v1alpha1.PolicyEngine(UnknownBaselineValue)
+	spec.GitOpsEngine = v1alpha1.GitOpsEngine(UnknownBaselineValue)
+}
+
 // ChangeCategory classifies the impact of a configuration change.
 type ChangeCategory int
 
@@ -77,6 +104,13 @@ const (
 	// Examples: disk encryption migration (LUKS2), changes requiring formatted partitions.
 	// These changes are more disruptive than reboots but don't require full cluster recreation.
 	ChangeCategoryWipeRequired
+
+	// ChangeCategoryUnknown indicates the current value of a field could not be
+	// read from the cluster, so its baseline is unknown. Such entries are
+	// informational only: they are displayed in the change summary but never
+	// drive an in-place apply or a cluster recreation, because the tool cannot
+	// know whether a real change is required.
+	ChangeCategoryUnknown
 )
 
 // String returns a human-readable name for the change category.
@@ -90,6 +124,8 @@ func (c ChangeCategory) String() string {
 		return "recreate-required"
 	case ChangeCategoryWipeRequired:
 		return "wipe-required"
+	case ChangeCategoryUnknown:
+		return "unknown"
 	default:
 		return "unknown"
 	}
@@ -119,6 +155,9 @@ type UpdateResult struct {
 	RecreateRequired []Change
 	// WipeRequired lists changes that require partition wiping.
 	WipeRequired []Change
+	// UnknownBaseline lists fields whose current value could not be read from the
+	// cluster. These are informational only and never drive an apply or recreate.
+	UnknownBaseline []Change
 	// AppliedChanges lists changes that were successfully applied.
 	AppliedChanges []Change
 	// FailedChanges lists changes that failed to apply.
@@ -138,6 +177,7 @@ func NewEmptyUpdateResult() *UpdateResult {
 		RebootRequired:   make([]Change, 0),
 		RecreateRequired: make([]Change, 0),
 		WipeRequired:     make([]Change, 0),
+		UnknownBaseline:  make([]Change, 0),
 		AppliedChanges:   make([]Change, 0),
 		FailedChanges:    make([]Change, 0),
 	}
@@ -160,6 +200,7 @@ func NewUpdateResultFromDiff(diff *UpdateResult) *UpdateResult {
 		RebootRequired:   diff.RebootRequired,
 		RecreateRequired: diff.RecreateRequired,
 		WipeRequired:     diff.WipeRequired,
+		UnknownBaseline:  diff.UnknownBaseline,
 		AppliedChanges:   make([]Change, 0),
 		FailedChanges:    make([]Change, 0),
 	}
@@ -183,6 +224,12 @@ func (r *UpdateResult) HasRecreateRequired() bool {
 // HasWipeRequired returns true if there are changes requiring partition wipes.
 func (r *UpdateResult) HasWipeRequired() bool {
 	return len(r.WipeRequired) > 0
+}
+
+// HasUnknownBaseline returns true if any field's current value could not be read
+// from the cluster. Such entries are informational and never drive an apply.
+func (r *UpdateResult) HasUnknownBaseline() bool {
+	return len(r.UnknownBaseline) > 0
 }
 
 // NeedsUserConfirmation returns true if any changes require user confirmation.

--- a/pkg/svc/provisioner/cluster/clusterupdate/update.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/update.go
@@ -65,11 +65,18 @@ func DefaultCurrentSpec(
 	}
 }
 
-// MarkComponentsUnknown sets every component field that the detector probes from
-// the live cluster to the UnknownBaselineValue sentinel. Callers invoke this when
-// component detection fails (e.g. the Kubernetes API is unreachable) so that the
-// diff engine surfaces these fields as "Unknown" rather than fabricating a
-// confident diff from default values for components that may already be installed.
+// MarkComponentsUnknown sets each scalar component-enum field that the detector
+// probes from the live cluster (CNI, CSI, MetricsServer, LoadBalancer,
+// CertManager, PolicyEngine, GitOpsEngine) to the UnknownBaselineValue sentinel.
+// Callers invoke this when component detection fails (e.g. the Kubernetes API is
+// unreachable) so that the diff engine surfaces these fields as "Unknown" rather
+// than fabricating a confident diff from default values for components that may
+// already be installed.
+//
+// The node autoscaler (Autoscaler.Node) is also detector-derived but is
+// intentionally left unmodified here: it is a nested struct rather than a single
+// enum, so the diff engine instead skips its diff entirely when the component
+// baseline is unknown (see Engine.checkAutoscalerOptionsChange).
 func MarkComponentsUnknown(spec *v1alpha1.ClusterSpec) {
 	if spec == nil {
 		return

--- a/pkg/svc/provisioner/cluster/clusterupdate/update_test.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/update_test.go
@@ -190,6 +190,57 @@ func TestDefaultCurrentSpec_TalosHetzner(t *testing.T) {
 	assert.Equal(t, v1alpha1.ProviderHetzner, spec.Provider)
 }
 
+// TestMarkComponentsUnknown sets the sentinel on every detector-derived component.
+func TestMarkComponentsUnknown(t *testing.T) {
+	t.Parallel()
+
+	spec := clusterupdate.DefaultCurrentSpec(
+		v1alpha1.DistributionTalos,
+		v1alpha1.ProviderHetzner,
+	)
+
+	clusterupdate.MarkComponentsUnknown(spec)
+
+	sentinel := clusterupdate.UnknownBaselineValue
+	assert.Equal(t, sentinel, string(spec.CNI))
+	assert.Equal(t, sentinel, string(spec.CSI))
+	assert.Equal(t, sentinel, string(spec.MetricsServer))
+	assert.Equal(t, sentinel, string(spec.LoadBalancer))
+	assert.Equal(t, sentinel, string(spec.CertManager))
+	assert.Equal(t, sentinel, string(spec.PolicyEngine))
+	assert.Equal(t, sentinel, string(spec.GitOpsEngine))
+
+	// Distribution and provider must remain known.
+	assert.Equal(t, v1alpha1.DistributionTalos, spec.Distribution)
+	assert.Equal(t, v1alpha1.ProviderHetzner, spec.Provider)
+}
+
+// TestMarkComponentsUnknown_NilIsSafe ensures the helper tolerates a nil spec.
+func TestMarkComponentsUnknown_NilIsSafe(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { clusterupdate.MarkComponentsUnknown(nil) })
+}
+
+// TestHasUnknownBaseline reports unknown-baseline entries.
+func TestHasUnknownBaseline(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	assert.False(t, result.HasUnknownBaseline())
+
+	result.UnknownBaseline = append(result.UnknownBaseline, clusterupdate.Change{
+		Field:    "cluster.cni",
+		OldValue: clusterupdate.UnknownBaselineValue,
+		NewValue: "Cilium",
+		Category: clusterupdate.ChangeCategoryUnknown,
+	})
+
+	assert.True(t, result.HasUnknownBaseline())
+	// Unknown entries are informational and never counted as applicable changes.
+	assert.Zero(t, result.TotalChanges())
+}
+
 // TestChangeCategory_String tests the string representation of change categories.
 func TestChangeCategory_String(t *testing.T) {
 	t.Parallel()
@@ -203,7 +254,8 @@ func TestChangeCategory_String(t *testing.T) {
 		{"reboot-required", clusterupdate.ChangeCategoryRebootRequired, "reboot-required"},
 		{"recreate-required", clusterupdate.ChangeCategoryRecreateRequired, "recreate-required"},
 		{"wipe-required", clusterupdate.ChangeCategoryWipeRequired, "wipe-required"},
-		{"unknown", clusterupdate.ChangeCategory(999), "unknown"},
+		{"unknown-category", clusterupdate.ChangeCategoryUnknown, "unknown"},
+		{"out-of-range", clusterupdate.ChangeCategory(999), "unknown"},
 	}
 
 	for _, testCase := range tests {

--- a/pkg/svc/provisioner/cluster/talos/detect_disruptive_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_disruptive_test.go
@@ -570,7 +570,8 @@ func TestClassifyMachineConfigChanges(t *testing.T) { //nolint:funlen // table-d
 				case clusterupdate.ChangeCategoryRebootRequired:
 					rebootCount++
 				case clusterupdate.ChangeCategoryInPlace,
-					clusterupdate.ChangeCategoryRecreateRequired:
+					clusterupdate.ChangeCategoryRecreateRequired,
+					clusterupdate.ChangeCategoryUnknown:
 					// not counted in this test
 				}
 			}

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -853,6 +853,11 @@ func (p *Provisioner) GetCurrentConfig(
 			spec.PolicyEngine = detected.PolicyEngine
 			spec.GitOpsEngine = detected.GitOpsEngine
 			spec.Autoscaler.Node = detected.Autoscaler.Node
+		} else {
+			// Component detection failed (e.g. the Kubernetes API is unreachable).
+			// Mark these fields unknown so the diff surfaces them as "Unknown"
+			// rather than a confident diff against the default baseline.
+			clusterupdate.MarkComponentsUnknown(spec)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the misleading change summary `ksail cluster update` produces when it **cannot read the current cluster state** (e.g. the Kubernetes API is unreachable). Previously the "Before" column fabricated a confident `Default`/`Disabled`/`None` baseline and reported "in-place" changes to reinstall CNI, metrics-server, cert-manager, the policy engine, Flux, etc. — components that are very likely already installed and healthy on a live cluster.

Now an undetectable baseline is represented distinctly:

- Detector-derived component fields are marked with an `Unknown` sentinel when component detection fails (Talos `GetCurrentConfig` and the spec-only/drift path).
- The diff engine surfaces these as an `Unknown → desired` row in a new, non-applicable `ChangeCategoryUnknown` bucket — but **only where a real diff would otherwise have been computed** (fields left at defaults produce no noise).
- Unknown entries are **never** classified `in-place` and never drive an apply or recreate. `TotalChanges()` excludes them, so the unreachable case no longer proposes a risky reinstall.
- The node autoscaler diff (also detector-derived) is skipped when the baseline is unknown, mirroring the existing local-registry "unknown ≠ none" precedent.
- Output, messaging, and `--output json` are updated: the table shows a `⚪` row with `Unknown` in the Before column, the summary line reads honestly ("current cluster state could not be read"), `No changes detected` is replaced by a clear warning, and JSON gains an `unknownBaseline` field.

### Before (unreachable cluster)

```
🔍 Change summary
ℹ Detected 12 configuration changes:
  🟢 cluster.cni            Default   Cilium   in-place
  🟢 cluster.metricsServer  Disabled  Enabled  in-place
  🟢 cluster.policyEngine   None      Kyverno  in-place
  ...
```

### After

```
🔍 Change summary
ℹ Current cluster state could not be read; 5 component(s) shown as Unknown:
  ⚪ cluster.cni            Unknown   Cilium   unknown
  ⚪ cluster.metricsServer  Unknown   Enabled  unknown
  ⚪ cluster.policyEngine   Unknown   Kyverno  unknown
  ...
⚠ Current cluster state could not be read for 5 component(s); shown as Unknown. No changes applied.
```

Closes #4869. Complements #4868 (failing fast on an unreachable cluster) — together they prevent both the misleading plan and the risky apply. Failing fast and the node-count introspection fallback are intentionally out of scope here.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/svc/diff/ ./pkg/svc/provisioner/cluster/clusterupdate/ ./pkg/svc/provisioner/cluster/talos/ ./pkg/cli/cmd/cluster/`
- [x] `golangci-lint run` — no new findings (fixed `exhaustive` cases for the new category)
- New unit tests: engine unknown-baseline behavior (surface / no-noise-on-defaults / autoscaler-skip), `MarkComponentsUnknown` + `HasUnknownBaseline` + category string, and table rendering (unknown-only and mixed real+unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)