### PR TITLE
fix(ci): stop duplicate immutable release in desktop release flow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -141,7 +141,9 @@ jobs:
   # The macOS desktop app ships as a Homebrew cask. The desktop app is a separate Go module that
   # links a system webview via CGO and cannot be cross-compiled in the main release, so this job runs
   # a second GoReleaser config on a macOS runner: it builds the darwin binary, packages it as a
-  # KSail.app bundle, uploads the archive to the release, and opens a cask PR on the homebrew tap.
+  # KSail.app bundle and opens a cask PR on the homebrew tap. GoReleaser's release pipe is disabled
+  # (see .goreleaser.desktop.yaml); a separate step uploads the archive to the draft via `gh release
+  # upload`, mirroring the desktop (linux/windows) and vscode-extension jobs.
   desktop-macos:
     name: 🧩 Release Desktop App (macOS cask)
     runs-on: macos-latest
@@ -177,9 +179,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
 
+      # GoReleaser's release pipe is disabled (.goreleaser.desktop.yaml), so attach the macOS archive
+      # to the existing draft here — same pattern as the desktop (linux/windows) and vscode jobs.
+      - name: 📤 Upload desktop app to release
+        shell: bash
+        run: gh release upload "${GITHUB_REF#refs/tags/}" dist-desktop/KSail_*_darwin_*.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Linux and Windows desktop binaries are convenience downloads (no cask). They build on native
-  # runners (CGO + the system webview) and attach to the release. Intentionally not in
-  # publish-release's needs: a hiccup here should not block the rest of the release.
+  # runners (CGO + the system webview) and attach to the draft release. publish-release needs: this
+  # job so every asset is attached before the draft is published — once published the release is
+  # immutable, and any upload still in flight would 422 (see #4874).
   desktop:
     name: 🧩 Release Desktop App
     runs-on: ${{ matrix.os }}
@@ -528,6 +539,7 @@ jobs:
         pages-deploy,
         copilot-plugin,
         desktop-macos,
+        desktop,
       ]
     permissions:
       contents: write
@@ -545,25 +557,36 @@ jobs:
           script: |
             const tag = process.env.RELEASE_TAG;
 
-            // List releases and find the one matching the tag
+            // List releases and find the one(s) matching the tag
             // Note: getReleaseByTag does not return draft releases, so we use listReleases instead
-            let release;
+            let matching;
             try {
               const { data: releases } = await github.rest.repos.listReleases({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 per_page: 100,
               });
-              release = releases.find(r => r.tag_name === tag);
+              matching = releases.filter(r => r.tag_name === tag);
             } catch (error) {
               core.setFailed(`Failed to list releases: ${error.message}`);
               throw error;
             }
 
-            if (!release) {
+            if (matching.length === 0) {
               core.setFailed(`Release not found for tag ${tag}`);
               return;
             }
+
+            // More than one release for a tag means an asset job created a duplicate (e.g. a second
+            // GoReleaser run that couldn't see the draft) — see #4874. Bail before publishing rather
+            // than racing an immutable release into existence; the duplicate needs manual cleanup.
+            if (matching.length > 1) {
+              const ids = matching.map(r => `${r.id} (draft=${r.draft})`).join(', ');
+              core.setFailed(`Found ${matching.length} releases for tag ${tag}: ${ids}. Expected exactly one — manual cleanup required.`);
+              return;
+            }
+
+            const release = matching[0];
 
             if (!release.draft) {
               console.log(`Release ${tag} is already published`);

--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -61,6 +61,12 @@ archives:
 homebrew_casks:
   - name: ksail-desktop
     ids: [ksail-desktop]
+    # The release pipe is disabled (see above), so GoReleaser refuses to derive the default cask
+    # download URL ("release is disabled, cannot use default url_template"). Set it explicitly to the
+    # main repo's release assets — where the cd.yaml desktop-macos job uploads the archive via
+    # `gh release upload`. This is the same URL the default would have produced.
+    url:
+      template: "https://github.com/devantler-tech/ksail/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     description: "KSail desktop app — manage local Kubernetes clusters in a native window"
     homepage: "https://ksail.devantler.tech"
     repository:

--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -10,10 +10,15 @@ project_name: ksail-desktop
 
 dist: dist-desktop
 
-# This runs as a second GoReleaser invocation (on a macOS runner) after the main release. Upload the
-# desktop archive to the release the main run already created, without touching its notes.
+# This runs as a second GoReleaser invocation (on a macOS runner) after the main release. Disable
+# GoReleaser's own release pipe entirely: `keep-existing` looks the release up via GitHub's
+# get-release-by-tag API, which does NOT return drafts, so it would not find the main run's draft and
+# would instead create a brand-new — and immediately published, hence immutable — release for the tag
+# (see #4874). The cd.yaml job uploads the built archive to the existing draft with `gh release upload`
+# instead. The Homebrew cask PR is still opened: the cask pipe builds its download URL from
+# owner/repo/tag (not from a created release object), so it works with the release pipe disabled.
 release:
-  mode: keep-existing
+  disable: true
 
 before:
   hooks:


### PR DESCRIPTION
## Summary

Fixes #4874. The `desktop-macos` CD job ran a second GoReleaser with `release.mode: keep-existing`, which resolves the release via the *get-release-by-tag* API — an API that **does not return drafts**. It therefore never found the main run's draft and created a brand-new, **immediately-published (immutable)** release for the tag. Under GitHub immutable releases that locked the tag, so the linux/windows desktop uploads (`gh release upload`) and the final `publish-release` draft→published flip both `422`'d, leaving the real CLI artifacts stuck in an unpublished draft and the user-facing release containing only the macOS desktop assets.

## What changed

- **`.goreleaser.desktop.yaml`** — replace `release.mode: keep-existing` with `release.disable: true`. GoReleaser now only builds the archive and opens the Homebrew cask PR; it no longer creates/owns a release. The cask still works because its download URL is computed from `owner/repo` + tag + artifact name, not from a created release object (`goreleaser check` confirms `release is disabled`).
- **`cd.yaml` (`desktop-macos`)** — add a `gh release upload "$TAG" dist-desktop/KSail_*_darwin_*.zip --clobber` step that attaches the macOS archive to the existing draft, mirroring the `desktop` (linux/windows) and `vscode-extension` jobs. Guarantees exactly one release per tag.
- **`cd.yaml` (`publish-release`)** — add `desktop` to `needs:` so every asset job attaches to the draft **before** it is published (and locked by immutable releases). This accepts the trade-off that a desktop linux/windows failure now blocks publication — necessary under immutable releases.
- **`cd.yaml` (`publish-release` script)** — fail if more than one release exists for the tag, catching a future duplicate-release regression **before** the tag is locked.

## Why this approach

The chain that broke: main `goreleaser` creates a draft → `desktop-macos`'s `keep-existing` can't see the draft → creates a duplicate published immutable release → everything downstream 422s. Disabling the desktop release pipe and uploading via `gh` (which *does* see drafts) collapses the flow back to a single release, and gating publication on all asset jobs ensures the asset list is complete before the release becomes immutable.

## Out of scope (manual, maintainer)

- **Recover `v7.20.0`**: real artifacts are in the unpublished draft; the published immutable release has only the macOS assets. Likely needs deleting the desktop-only published release (if immutability permits) and publishing the draft, or cutting `v7.20.1`.
- **Immutable releases setting**: confirm whether it's intentionally enabled (Settings → General). This fix makes the pipeline correct either way.

## Test plan

- [x] `actionlint .github/workflows/cd.yaml` — clean
- [x] `goreleaser check --config .goreleaser.desktop.yaml` — valid, reports `release is disabled`
- [x] YAML parse validation for both files
- [ ] First real release (e.g. `v7.20.1`) produces a **single** release carrying all 8 CLI assets + the 3 desktop archives, with the Homebrew cask PR opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)