### PR TITLE
fix(ci): repoint required-checks gate to renamed aggregate-job-checks action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1371,7 +1371,7 @@ jobs:
       ]
     if: ${{ always() }}
     steps:
-      - uses: devantler-tech/actions/require-checks-in-pr@61ae89ec83b943bd3a486fdcaf91cb66fd6b8760 # feat/require-checks-in-pr
+      - uses: devantler-tech/actions/aggregate-job-checks@3556694b57702d81bfc5fb1d79a9ee0b4e53aca7 # v5.0.0
         with:
           job-results: >-
             ${{ needs.rate-limit-gate.result }}


### PR DESCRIPTION
## Problem

Dependabot's `github_actions` update job was failing entirely with:

```
git branch --remotes --contains 61ae89ec83b943bd3a486fdcaf91cb66fd6b8760
error: no such commit 61ae89ec83b943bd3a486fdcaf91cb66fd6b8760
Error processing devantler-tech/actions (unknown_error)
```

## Root cause

`.github/workflows/ci.yaml` pinned the required-checks step to a commit on a **feature branch**, not a release tag:

```yaml
- uses: devantler-tech/actions/require-checks-in-pr@61ae89e # feat/require-checks-in-pr
```

Upstream then:
1. Renamed the action `require-checks-in-pr` → `aggregate-job-checks` ([devantler-tech/actions#154](https://github.com/devantler-tech/actions/pull/154), merged 2026-05-01), and
2. Deleted the `feat/require-checks-in-pr` branch.

With the branch gone, commit `61ae89e` no longer exists on any remote branch. Dependabot resolves pinned refs via `git branch --remotes --contains <sha>`, which exits 129 ("no such commit") and aborts the whole update job — so *no* GitHub Actions updates could be proposed.

## Fix

Repoint to the renamed action, pinned to the latest release tag (matching the repo's `# vX.Y.Z` convention):

```yaml
- uses: devantler-tech/actions/aggregate-job-checks@3556694 # v5.0.0
```

The `job-results` input is unchanged (a space-separated list); the breaking-change PR that would have switched it to a YAML array was closed, not merged. The job's `name: CI - Required Checks` is untouched, so the branch-protection required check behaves identically.

## Validation

- `actionlint` passes on the changed line (the only finding is a pre-existing `code-quality` permission-scope warning from a newer GitHub feature, unrelated to this change).
- Confirmed `aggregate-job-checks/action.yaml` exists at `v5.0.0` and still exposes `job-results` + optional `check-name` (default `CI - Required Checks`).

## Follow-up (optional, out of scope)

The original failure mode was caused by pinning to a *branch* commit rather than a tag. A lint/policy check that requires third-party action pins to resolve to a tag (not a transient branch) would prevent recurrence.