### PR TITLE
feat(hetzner): retry server-type availability precheck on transient unavailability

### DIFF
--- a/pkg/svc/provider/hetzner/availability.go
+++ b/pkg/svc/provider/hetzner/availability.go
@@ -2,12 +2,143 @@ package hetzner
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
+
+// CheckServerAvailabilityWithRetry calls CheckServerAvailability up to maxAttempts
+// times, waiting with exponential backoff between attempts whenever the requested
+// server types are temporarily unavailable in all configured locations. This gives
+// transient Hetzner capacity shortages a chance to clear before a create or
+// scale-up operation aborts.
+//
+// Permanent failures (server type not found, provider unavailable) are returned
+// immediately without retrying. Progress is reported to logWriter when non-nil.
+func (p *Provider) CheckServerAvailabilityWithRetry(
+	ctx context.Context,
+	serverTypes []string,
+	primaryLocation string,
+	fallbackLocations []string,
+	maxAttempts int,
+	logWriter io.Writer,
+) error {
+	return p.checkServerAvailabilityWithRetry(
+		ctx,
+		serverTypes,
+		primaryLocation,
+		fallbackLocations,
+		maxAttempts,
+		logWriter,
+		p.calculateRetryDelay,
+	)
+}
+
+// checkServerAvailabilityWithRetry implements CheckServerAvailabilityWithRetry with
+// an injectable delay function so tests can avoid real backoff sleeps.
+func (p *Provider) checkServerAvailabilityWithRetry(
+	ctx context.Context,
+	serverTypes []string,
+	primaryLocation string,
+	fallbackLocations []string,
+	maxAttempts int,
+	logWriter io.Writer,
+	delayFunc func(int) time.Duration,
+) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = p.CheckServerAvailability(ctx, serverTypes, primaryLocation, fallbackLocations)
+		if lastErr == nil {
+			if attempt > 1 {
+				p.logRetryf(
+					logWriter,
+					"  ✓ Server type(s) became available after %d attempt(s)\n",
+					attempt,
+				)
+			}
+
+			return nil
+		}
+
+		// Permanent failures (e.g. server type not found) won't resolve with retries.
+		if !isRetryableAvailabilityError(lastErr) {
+			return lastErr
+		}
+
+		if attempt == maxAttempts {
+			break
+		}
+
+		waitErr := p.waitForAvailabilityRetry(
+			ctx,
+			logWriter,
+			attempt,
+			maxAttempts,
+			lastErr,
+			delayFunc,
+		)
+		if waitErr != nil {
+			return waitErr
+		}
+	}
+
+	return lastErr
+}
+
+// waitForAvailabilityRetry logs the retry and waits for the backoff delay,
+// returning early if the context is cancelled.
+func (p *Provider) waitForAvailabilityRetry(
+	ctx context.Context,
+	logWriter io.Writer,
+	attempt int,
+	maxAttempts int,
+	err error,
+	delayFunc func(int) time.Duration,
+) error {
+	delay := delayFunc(attempt)
+
+	p.logRetryf(
+		logWriter,
+		"  ⚠ Server type(s) unavailable (attempt %d/%d): %v. Retrying in %v...\n",
+		attempt,
+		maxAttempts,
+		err,
+		delay,
+	)
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("context cancelled during availability retry: %w", ctx.Err())
+	case <-time.After(delay):
+		return nil
+	}
+}
+
+// isRetryableAvailabilityError reports whether an availability-check failure is
+// transient and worth retrying. Temporary unavailability of a server type in all
+// configured locations and retryable Hetzner API errors qualify; permanent
+// failures (server type not found, provider unavailable, invalid input) do not.
+func isRetryableAvailabilityError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, ErrServerTypeUnavailable) {
+		return true
+	}
+
+	return IsRetryableHetznerError(err)
+}
 
 // CheckServerAvailability verifies that every requested server type is available
 // in at least one of the configured locations (primary + fallbacks).

--- a/pkg/svc/provider/hetzner/availability_retry_test.go
+++ b/pkg/svc/provider/hetzner/availability_retry_test.go
@@ -1,0 +1,266 @@
+package hetzner_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// retryTestServerType is the server type served by the counting test server.
+	retryTestServerType = "cx22"
+	// retryTestLocation is the primary location used across retry tests.
+	retryTestLocation = "fsn1"
+)
+
+// noDelay is a delay function that never sleeps, keeping retry tests fast.
+func noDelay(int) time.Duration { return 0 }
+
+// newCountingAvailabilityServer returns a test server that reports
+// retryTestServerType as available only once it has been queried at least
+// availableAfter times. Every call increments calls so tests can assert how many
+// attempts were made. When availableAfter is 0 the type is never reported available.
+func newCountingAvailabilityServer(
+	t *testing.T,
+	availableAfter int32,
+	calls *atomic.Int32,
+) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /server_types", func(writer http.ResponseWriter, r *http.Request) {
+		count := calls.Add(1)
+		available := availableAfter > 0 && count >= availableAfter
+
+		resp := serverTypeListResp{}
+		if r.URL.Query().Get("name") == retryTestServerType {
+			resp.ServerTypes = []serverTypeSchema{
+				{ID: 1, Name: retryTestServerType, Locations: []serverTypeLocSchema{
+					{ID: 1, Name: retryTestLocation, Available: available},
+				}},
+			}
+		}
+
+		writeJSONResponse(t, writer, resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestCheckServerAvailabilityWithRetry_SucceedsAfterRetry(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	srv := newCountingAvailabilityServer(t, 3, &calls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	err := prov.CheckServerAvailabilityWithRetryForTest(
+		context.Background(),
+		[]string{retryTestServerType},
+		retryTestLocation,
+		nil,
+		5,
+		io.Discard,
+		noDelay,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), calls.Load(), "should retry until available on the third attempt")
+}
+
+func TestCheckServerAvailabilityWithRetry_ExhaustsRetries(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	// availableAfter 0 => never available, so every attempt fails.
+	srv := newCountingAvailabilityServer(t, 0, &calls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	err := prov.CheckServerAvailabilityWithRetryForTest(
+		context.Background(),
+		[]string{retryTestServerType},
+		retryTestLocation,
+		nil,
+		3,
+		io.Discard,
+		noDelay,
+	)
+
+	require.ErrorIs(t, err, hetzner.ErrServerTypeUnavailable)
+	assert.Equal(t, int32(3), calls.Load(), "should attempt exactly maxAttempts times")
+}
+
+func TestCheckServerAvailabilityWithRetry_PermanentErrorNotRetried(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	// The queried type is never returned, so the lookup yields ErrServerTypeNotFound.
+	srv := newCountingAvailabilityServer(t, 1, &calls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	err := prov.CheckServerAvailabilityWithRetryForTest(
+		context.Background(),
+		[]string{"nonexistent"},
+		retryTestLocation,
+		nil,
+		5,
+		io.Discard,
+		noDelay,
+	)
+
+	require.ErrorIs(t, err, hetzner.ErrServerTypeNotFound)
+	assert.Equal(t, int32(1), calls.Load(), "permanent errors must not be retried")
+}
+
+func TestCheckServerAvailabilityWithRetry_ContextCancelledDuringWait(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	srv := newCountingAvailabilityServer(t, 0, &calls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel the context during the backoff wait of the first attempt.
+	cancelDuringDelay := func(int) time.Duration {
+		cancel()
+
+		return time.Hour
+	}
+
+	err := prov.CheckServerAvailabilityWithRetryForTest(
+		ctx,
+		[]string{retryTestServerType},
+		retryTestLocation,
+		nil,
+		5,
+		io.Discard,
+		cancelDuringDelay,
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), calls.Load(), "should stop after the cancelled backoff")
+}
+
+func TestCheckServerAvailabilityWithRetry_ClampsNonPositiveMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	srv := newCountingAvailabilityServer(t, 0, &calls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	err := prov.CheckServerAvailabilityWithRetryForTest(
+		context.Background(),
+		[]string{retryTestServerType},
+		retryTestLocation,
+		nil,
+		0,
+		io.Discard,
+		noDelay,
+	)
+
+	require.ErrorIs(t, err, hetzner.ErrServerTypeUnavailable)
+	assert.Equal(t, int32(1), calls.Load(), "maxAttempts < 1 should clamp to a single attempt")
+}
+
+func TestCheckServerAvailabilityWithRetry_PublicWrapperSucceeds(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	srv := newCountingAvailabilityServer(t, 1, &calls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	// maxAttempts of 1 means the public wrapper never sleeps even though it uses
+	// the real backoff delay function.
+	err := prov.CheckServerAvailabilityWithRetry(
+		context.Background(),
+		[]string{retryTestServerType},
+		retryTestLocation,
+		nil,
+		1,
+		io.Discard,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestCheckServerAvailabilityWithRetry_NilClient(t *testing.T) {
+	t.Parallel()
+
+	prov := hetzner.NewProvider(nil)
+
+	err := prov.CheckServerAvailabilityWithRetry(
+		context.Background(),
+		[]string{retryTestServerType},
+		retryTestLocation,
+		nil,
+		hetzner.DefaultMaxAvailabilityCheckRetries,
+		io.Discard,
+	)
+
+	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}
+
+func TestIsRetryableAvailabilityError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "Nil", err: nil, want: false},
+		{name: "ServerTypeUnavailable", err: hetzner.ErrServerTypeUnavailable, want: true},
+		{
+			name: "WrappedServerTypeUnavailable",
+			err:  fmt.Errorf("check: %w", hetzner.ErrServerTypeUnavailable),
+			want: true,
+		},
+		{name: "ServerTypeNotFound", err: hetzner.ErrServerTypeNotFound, want: false},
+		{
+			name: "RetryableHcloudError",
+			err:  hcloud.Error{Code: hcloud.ErrorCodeResourceUnavailable},
+			want: true,
+		},
+		{
+			name: "WrappedRateLimit",
+			err:  fmt.Errorf("lookup: %w", hcloud.Error{Code: hcloud.ErrorCodeRateLimitExceeded}),
+			want: true,
+		},
+		{
+			name: "ForbiddenNotRetryable",
+			err:  hcloud.Error{Code: hcloud.ErrorCodeForbidden},
+			want: false,
+		},
+		{name: "ProviderUnavailable", err: provider.ErrProviderUnavailable, want: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hetzner.IsRetryableAvailabilityErrorForTest(testCase.err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -2,6 +2,7 @@
 package hetzner
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -52,6 +53,31 @@ var DeduplicateServerTypesForTest = deduplicateServerTypes
 
 // BuildLocationListForTest exports buildLocationList for testing.
 var BuildLocationListForTest = buildLocationList
+
+// IsRetryableAvailabilityErrorForTest exports isRetryableAvailabilityError for testing.
+var IsRetryableAvailabilityErrorForTest = isRetryableAvailabilityError
+
+// CheckServerAvailabilityWithRetryForTest exposes the internal availability retry
+// loop with an injectable delay function so tests avoid real backoff sleeps.
+func (p *Provider) CheckServerAvailabilityWithRetryForTest(
+	ctx context.Context,
+	serverTypes []string,
+	primaryLocation string,
+	fallbackLocations []string,
+	maxAttempts int,
+	logWriter io.Writer,
+	delayFunc func(int) time.Duration,
+) error {
+	return p.checkServerAvailabilityWithRetry(
+		ctx,
+		serverTypes,
+		primaryLocation,
+		fallbackLocations,
+		maxAttempts,
+		logWriter,
+		delayFunc,
+	)
+}
 
 // NewSnapshotManagerWithUploaderForTest creates a SnapshotManager with a custom uploader,
 // allowing tests to inject a mock without hitting real Hetzner upload infrastructure.

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -31,6 +31,11 @@ const (
 	IPv6CIDRBits = 128
 	// DefaultMaxServerCreateRetries is the number of retry attempts for server creation.
 	DefaultMaxServerCreateRetries = 3
+	// DefaultMaxAvailabilityCheckRetries is the number of attempts for the server-type
+	// availability precheck. When a server type is temporarily unavailable in all
+	// configured locations, the check is retried with backoff so transient Hetzner
+	// capacity shortages have a chance to clear before create/scale operations abort.
+	DefaultMaxAvailabilityCheckRetries = 5
 	// DefaultRetryBaseDelay is the base delay for exponential backoff.
 	DefaultRetryBaseDelay = 2 * time.Second
 	// DefaultRetryMaxDelay is the maximum delay between retry attempts.

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -603,11 +603,13 @@ func (p *Provisioner) checkHetznerAvailability(
 
 	_, _ = fmt.Fprintf(p.logWriter, "Checking server type availability...\n")
 
-	err := hzProvider.CheckServerAvailability(
+	err := hzProvider.CheckServerAvailabilityWithRetry(
 		ctx,
 		serverTypes,
 		p.hetznerOpts.Location,
 		p.hetznerOpts.FallbackLocations,
+		hetzner.DefaultMaxAvailabilityCheckRetries,
+		p.logWriter,
 	)
 	if err != nil {
 		return fmt.Errorf("server availability check failed: %w", err)

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -360,11 +360,13 @@ func (p *Provisioner) checkHetznerAvailabilityForRole(
 
 	_, _ = fmt.Fprintf(p.logWriter, "Checking server type availability for %s...\n", role)
 
-	err := hzProvider.CheckServerAvailability(
+	err := hzProvider.CheckServerAvailabilityWithRetry(
 		ctx,
 		[]string{serverType},
 		p.hetznerOpts.Location,
 		p.hetznerOpts.FallbackLocations,
+		hetzner.DefaultMaxAvailabilityCheckRetries,
+		p.logWriter,
 	)
 	if err != nil {
 		return fmt.Errorf("server availability check failed for %s: %w", role, err)


### PR DESCRIPTION
## Problem

Increasing worker or control-plane node count and running `ksail cluster update` on Hetzner **aborts immediately when there are availability issues**, instead of retrying.

Root cause: the scale-up path runs a fail-fast availability precheck *before* attempting any node creation:

`update` → `scaleByProvider` → `scaleHetznerByRole` → `addHetznerNodes` → `checkHetznerAvailabilityForRole` → `CheckServerAvailability`

When Hetzner has a capacity shortage, the server type's per-location `Available` flag is `false`, so the precheck (added in #4700) returns `ErrServerTypeUnavailable` immediately and aborts the whole update — **no node creation, no retry**. The existing per-server creation retry (`CreateServerWithRetry`) never runs because the precheck short-circuits first.

## Fix

Add `CheckServerAvailabilityWithRetry` to the Hetzner provider. It retries the precheck with exponential backoff while the server type is **temporarily** unavailable, giving Hetzner capacity time to recover, but still fails fast on **permanent** errors (server-type-not-found, provider-unavailable). Wired into both the scale-up and initial-create precheck paths, so increasing either worker or control-plane count now retries.

- **Default: 5 attempts** (`DefaultMaxAvailabilityCheckRetries`), ~24s window using the existing 2s→10s backoff.
- Preserves the precheck's original "don't create infra that needs cleanup" intent — it only proceeds to create network/firewall/servers once availability is confirmed.
- Reports progress to the user, e.g. `⚠ Server type(s) unavailable (attempt 2/5): ... Retrying in 4s...`.

## Changes

- `pkg/svc/provider/hetzner/availability.go` — `CheckServerAvailabilityWithRetry` + `isRetryableAvailabilityError`
- `pkg/svc/provider/hetzner/provider.go` — `DefaultMaxAvailabilityCheckRetries = 5`
- `pkg/svc/provisioner/cluster/talos/{scale_hetzner,provisioner_hetzner}.go` — call the retry variant in both precheck paths
- `pkg/svc/provider/hetzner/availability_retry_test.go` — 8 tests (retry-then-succeed, exhaust, permanent-no-retry, ctx-cancel, clamp, public wrapper, nil client, error classification); injectable delay func keeps them instant

## Validation

- `go build ./...` ✅
- `go test ./pkg/svc/provider/hetzner/... ./pkg/svc/provisioner/cluster/talos/...` ✅ (new tests pass 10× under `-race`)
- `golangci-lint run` ✅ (0 new issues)

## Notes

- The retry count is a constant rather than a `ksail.yaml` knob, to keep the change focused — easy to expose as config later if desired.
- Related (separate): `OptionsHetzner.FallbackLocations` documents a default of `["nbg1","hel1"]` that is **not actually applied**, so by default only the primary datacenter is tried. Fixing that would make this retry meaningfully more effective; flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)