### PR TITLE
fix(talos): apply changed machine-config patches (sysctls/sysfs) on update

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/detect_disruptive.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_disruptive.go
@@ -2,14 +2,11 @@ package talosprovisioner
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
-	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosconfigtypes "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	talosresconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
 const (
@@ -48,49 +45,21 @@ func (p *Provisioner) detectDisruptiveConfigChanges(
 		return nil, nil
 	}
 
-	nodes, err := p.getNodesByRole(ctx, clusterName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to discover nodes for config change detection: %w", err)
-	}
-
 	// Compare against a single control-plane node. Encryption config patches
 	// are cluster-wide (applied to all nodes from the same patch files), so
 	// checking one CP node is sufficient for detecting pending migrations.
 	// Per-node comparison would be needed for partial migration recovery
 	// (future enhancement).
-	var cpIP string
-
-	for _, node := range nodes {
-		if node.Role == RoleControlPlane {
-			cpIP = node.IP
-
-			break
-		}
+	runningConfig, found, err := p.fetchRunningControlPlaneConfig(ctx, clusterName)
+	if err != nil {
+		return nil, err
 	}
 
-	if cpIP == "" {
+	if !found {
 		return nil, nil
 	}
 
-	talosClient, err := p.createTalosClient(ctx, cpIP)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Talos client for config comparison: %w", err)
-	}
-
-	defer talosClient.Close() //nolint:errcheck
-
-	machineConfig, err := safe.StateGet[*talosresconfig.MachineConfig](
-		ctx,
-		talosClient.COSI,
-		talosresconfig.NewMachineConfig(nil).Metadata(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch running machine config from %s: %w", cpIP, err)
-	}
-
-	runningConfig := machineConfig.Config()
 	desiredConfig := p.talosConfigs.ControlPlane()
-
 	if desiredConfig == nil {
 		return nil, nil
 	}

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -6,14 +6,14 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configdiff"
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
-	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	talosresconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
@@ -30,55 +30,49 @@ const redactedSecretPlaceholder = "<redacted>"
 // change summary so it stays readable; the full config is re-applied regardless.
 const maxDriftDiffLines = 60
 
-// MachineConfigField is the change field reported when the rendered Talos
-// machine config drifts from what is running on the nodes.
+// MachineConfigField is the change field reported when the desired Talos machine
+// config patches differ from what is running on the nodes.
 const MachineConfigField = "machine.config"
 
-// detectInPlaceMachineConfigDrift reports whether the desired Talos machine
-// config differs from what is running on the control-plane node, returning a
-// single in-place change when it does.
+// detectInPlaceMachineConfigDrift reports whether applying ksail's user patches
+// to the running control-plane config would change it, returning a single
+// in-place change when it would.
 //
 // Talos patch files (everything under talos/, e.g. sysctls, kubelet config,
 // user namespaces, registries, API-server flags) are NOT part of ksail's
-// ClusterSpec, so the spec-level diff engine cannot see them. This compares the
-// desired config against the running node config, which catches any patch change
-// — additions, edits, and removals alike — rather than a hand-picked set of
-// fields. Surfacing it from DiffConfig both shows the drift in the change
-// summary and triggers applyInPlaceConfigChanges, which re-pushes the full
-// machine config to every node (NO_REBOOT).
+// ClusterSpec, so the spec-level diff engine cannot see them. This overlays the
+// user patches onto the node's *running* config and diffs the result against it,
+// which catches any patch change (additions and edits) generally — rather than a
+// hand-picked set of fields.
 //
-// The comparison uses configdiff.DiffConfigs — the same canonical, sorted-key,
-// comments-stripped diff that `talosctl apply-config --dry-run` uses — run
-// in-process. That normalisation is essential: a naive Bytes() comparison trips
-// on the doc/example comments and field ordering that a freshly-rendered config
-// carries but a node's stored config does not, producing phantom drift on an
-// unchanged cluster.
+// Comparing against the running config (rather than a freshly regenerated one)
+// is what makes this reliable: the running config already carries every
+// create-time/runtime-injected setting (registry-mirror endpoints, PKI, the
+// real cluster endpoint), so those never read as drift. Only the user patch
+// content surfaces. The diff itself uses configdiff.DiffConfigs — the canonical,
+// comments-stripped diff that `talosctl apply-config --dry-run` uses — and both
+// sides are secret-redacted as defence-in-depth and to keep the diff safe to log.
 //
-// The desired config is first realigned with the running cluster's PKI and
-// endpoint (see alignedDesiredControlPlaneConfig); without that, the
-// freshly-generated secrets and CIDR-derived endpoint that p.talosConfigs holds
-// at diff time would read as drift on every run. Secrets are additionally
-// redacted on both sides before diffing as defence-in-depth and to keep the
-// surfaced diff safe to print.
+// applyInPlaceConfigChanges applies the very same running+patches config, so
+// detection and apply are consistent.
 //
-// Caveats (accepted: ksail owns the node machine config):
-//   - Config not managed by ksail's bundle reads as drift and is reconciled away
-//     on the next apply, the same as any other config push.
-//   - A ksail/Talos version bump can change the rendered defaults, causing one
-//     benign, idempotent re-apply; it is self-limiting once applied.
+// Caveats:
+//   - Patch *removals* are not detected: strategic-merge patches add/override but
+//     do not delete keys from the running config, so dropping a key from a patch
+//     file is a no-op here (a future enhancement could diff against a full render).
 //   - Only a control-plane node is inspected (matching detectDisruptiveConfigChanges);
-//     this covers all cluster-wide patches under talos/cluster/. Worker-only
+//     cluster-wide patches under talos/cluster/ apply to every node. Worker-only
 //     patch drift is a future enhancement.
+//   - Omni-managed clusters are skipped (Omni owns node configuration).
 func (p *Provisioner) detectInPlaceMachineConfigDrift(
 	ctx context.Context,
 	clusterName string,
 ) ([]clusterupdate.Change, error) {
-	// Omni owns node configuration via its own API; skip when configs are absent.
 	if p.talosConfigs == nil || p.omniOpts != nil {
 		return nil, nil
 	}
 
-	runningConfig, found, err := p.fetchRunningControlPlaneConfig(ctx, clusterName)
+	running, found, err := p.fetchRunningControlPlaneConfig(ctx, clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -88,16 +82,12 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 		return nil, nil
 	}
 
-	desiredConfig, err := p.alignedDesiredControlPlaneConfig(runningConfig)
+	patched, err := applyUserPatches(running, p.talosConfigs.Patches(), RoleControlPlane)
 	if err != nil {
 		return nil, err
 	}
 
-	if desiredConfig == nil {
-		return nil, nil
-	}
-
-	diff, err := machineConfigDiff(runningConfig, desiredConfig)
+	diff, err := machineConfigDiff(running, patched)
 	if err != nil {
 		return nil, err
 	}
@@ -111,55 +101,84 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 	return []clusterupdate.Change{
 		{
 			Field:    MachineConfigField,
-			OldValue: configFingerprint(runningConfig),
-			NewValue: configFingerprint(desiredConfig),
+			OldValue: configFingerprint(running),
+			NewValue: configFingerprint(patched),
 			Category: clusterupdate.ChangeCategoryInPlace,
 			Reason:   "Talos machine config (patches) differs from running nodes; will be re-applied without reboot",
 		},
 	}, nil
 }
 
-// machineConfigDiff returns the Talos-native textual diff between the running and
-// desired configs, with secrets redacted. An empty string means no drift. It
-// delegates to configdiff.DiffConfigs, which encodes both sides with the
-// canonical, comments-stripped encoder before diffing.
-func machineConfigDiff(runningConfig, desiredConfig talosconfig.Provider) (string, error) {
+// applyUserPatches overlays ksail's user-authored Talos patches (scoped to the
+// node role) onto the running config and returns the result. Because the base is
+// the running node config, all create-time/runtime-injected settings (mirror
+// endpoints, PKI, endpoint) are preserved — only the user patch content is
+// applied. Returns the running config unchanged when no patches target the role.
+func applyUserPatches(
+	running talosconfig.Provider,
+	patches []talosconfigmanager.Patch,
+	role string,
+) (talosconfig.Provider, error) {
+	configPatches := make([]configpatcher.Patch, 0, len(patches))
+
+	for _, patch := range patches {
+		if !patchAppliesToRole(patch.Scope, role) {
+			continue
+		}
+
+		loaded, loadErr := configpatcher.LoadPatch(patch.Content)
+		if loadErr != nil {
+			return nil, fmt.Errorf("load patch %s: %w", patch.Path, loadErr)
+		}
+
+		configPatches = append(configPatches, loaded)
+	}
+
+	if len(configPatches) == 0 {
+		return running, nil
+	}
+
+	out, err := configpatcher.Apply(configpatcher.WithConfig(running), configPatches)
+	if err != nil {
+		return nil, fmt.Errorf("apply patches to running config: %w", err)
+	}
+
+	patched, err := out.Config()
+	if err != nil {
+		return nil, fmt.Errorf("read patched config: %w", err)
+	}
+
+	return patched, nil
+}
+
+// patchAppliesToRole reports whether a patch's scope targets the given node role.
+func patchAppliesToRole(scope talosconfigmanager.PatchScope, role string) bool {
+	switch scope {
+	case talosconfigmanager.PatchScopeCluster:
+		return true
+	case talosconfigmanager.PatchScopeControlPlane:
+		return role == RoleControlPlane
+	case talosconfigmanager.PatchScopeWorker:
+		return role == RoleWorker
+	default:
+		return false
+	}
+}
+
+// machineConfigDiff returns the Talos-native textual diff between two configs,
+// with secrets redacted. An empty string means no difference. It delegates to
+// configdiff.DiffConfigs, which encodes both sides with the canonical,
+// comments-stripped encoder before diffing.
+func machineConfigDiff(oldConfig, newConfig talosconfig.Provider) (string, error) {
 	diff, err := configdiff.DiffConfigs(
-		runningConfig.RedactSecrets(redactedSecretPlaceholder),
-		desiredConfig.RedactSecrets(redactedSecretPlaceholder),
+		oldConfig.RedactSecrets(redactedSecretPlaceholder),
+		newConfig.RedactSecrets(redactedSecretPlaceholder),
 	)
 	if err != nil {
 		return "", fmt.Errorf("compute machine config diff: %w", err)
 	}
 
 	return diff, nil
-}
-
-// alignedDesiredControlPlaneConfig rebuilds the desired control-plane config with
-// the running cluster's PKI (extracted from the running config) and endpoint, so
-// the diff reflects only patch/content drift rather than the freshly-generated
-// secrets and default endpoint that p.talosConfigs carries at diff time. This
-// mirrors syncSecretsFromCluster, which the apply phase relies on so that pushed
-// configs match the running cluster's PKI.
-func (p *Provisioner) alignedDesiredControlPlaneConfig(
-	runningConfig talosconfig.Provider,
-) (talosconfig.Provider, error) {
-	bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), runningConfig)
-
-	aligned, err := p.talosConfigs.WithSecrets(bundle)
-	if err != nil {
-		return nil, fmt.Errorf("align secrets for config drift comparison: %w", err)
-	}
-
-	endpointIP := runningConfig.Cluster().Endpoint().Hostname()
-	if endpointIP != "" {
-		aligned, err = aligned.WithEndpoint(endpointIP)
-		if err != nil {
-			return nil, fmt.Errorf("align endpoint for config drift comparison: %w", err)
-		}
-	}
-
-	return aligned.ControlPlane(), nil
 }
 
 // logMachineConfigDrift prints the (already secret-redacted) diff so operators
@@ -200,8 +219,7 @@ func configFingerprint(provider talosconfig.Provider) string {
 // fetchRunningControlPlaneConfig discovers a control-plane node and returns its
 // running Talos machine config provider. It returns (nil, false, nil) when no
 // control-plane node is reachable so callers can treat "cannot compare" as "no
-// detected drift" rather than failing the update. Shared by
-// detectDisruptiveConfigChanges and detectInPlaceMachineConfigDrift.
+// detected drift" rather than failing the update.
 func (p *Provisioner) fetchRunningControlPlaneConfig(
 	ctx context.Context,
 	clusterName string,
@@ -225,12 +243,23 @@ func (p *Provisioner) fetchRunningControlPlaneConfig(
 		return nil, false, nil
 	}
 
-	talosClient, err := p.createTalosClient(ctx, cpIP)
+	config, err := p.fetchNodeConfig(ctx, cpIP)
 	if err != nil {
-		return nil, false, fmt.Errorf(
-			"failed to create Talos client for config comparison: %w",
-			err,
-		)
+		return nil, false, err
+	}
+
+	return config, true, nil
+}
+
+// fetchNodeConfig fetches the running Talos machine config provider from a single
+// node by IP.
+func (p *Provisioner) fetchNodeConfig(
+	ctx context.Context,
+	nodeIP string,
+) (talosconfig.Provider, error) {
+	talosClient, err := p.createTalosClient(ctx, nodeIP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Talos client for %s: %w", nodeIP, err)
 	}
 
 	defer talosClient.Close() //nolint:errcheck
@@ -241,12 +270,8 @@ func (p *Provisioner) fetchRunningControlPlaneConfig(
 		talosresconfig.NewMachineConfig(nil).Metadata(),
 	)
 	if err != nil {
-		return nil, false, fmt.Errorf(
-			"failed to fetch running machine config from %s: %w",
-			cpIP,
-			err,
-		)
+		return nil, fmt.Errorf("failed to fetch running machine config from %s: %w", nodeIP, err)
 	}
 
-	return machineConfig.Provider(), true, nil
+	return machineConfig.Provider(), nil
 }

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -151,7 +151,7 @@ func configFingerprint(configBytes []byte) string {
 }
 
 // fetchRunningControlPlaneConfig discovers a control-plane node and returns its
-// running Talos machine config provider. It returns found=false when no
+// running Talos machine config provider. It returns (nil, false, nil) when no
 // control-plane node is reachable so callers can treat "cannot compare" as "no
 // detected drift" rather than failing the update. Shared by
 // detectDisruptiveConfigChanges and detectInPlaceMachineConfigDrift.

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -1,47 +1,62 @@
 package talosprovisioner
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
-	"strconv"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	talosresconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
-// detectInPlaceMachineConfigDrift compares in-place-applicable machine config
-// fields (currently machine.sysctls and machine.sysfs) between the running
-// control-plane node and the desired configuration, returning in-place changes
-// when they differ.
+// fingerprintLength is the number of hex characters shown for a machine-config
+// fingerprint in the change summary — enough to distinguish two renders at a
+// glance without dumping the whole config into the table.
+const fingerprintLength = 12
+
+// MachineConfigField is the change field reported when the rendered Talos
+// machine config drifts from what is running on the nodes.
+const MachineConfigField = "machine.config"
+
+// detectInPlaceMachineConfigDrift reports whether the desired Talos machine
+// config differs from what is running on the control-plane node, returning a
+// single in-place change when it does.
 //
-// These fields come from user-managed Talos patch files (e.g.
-// talos/cluster/sysctls.yaml) and are NOT represented in ksail's ClusterSpec, so
-// the spec-level diff engine cannot see them. Without this live comparison,
-// `ksail cluster update` has no signal that a patch file changed: the update
-// either short-circuits ("no changes") or runs without ever pushing the new
-// config to existing nodes. Surfacing the drift here (via DiffConfig) both shows
-// it in the change summary and triggers applyInPlaceConfigChanges, which
-// re-pushes the full machine config — carrying every patch — to each node.
+// Talos patch files (everything under talos/, e.g. sysctls, kubelet config,
+// user namespaces, registries, API-server flags) are NOT part of ksail's
+// ClusterSpec, so the spec-level diff engine cannot see them. This compares the
+// fully rendered desired config against the running node config, which catches
+// any patch change — additions, edits, and removals alike — rather than a
+// hand-picked set of fields. Surfacing it from DiffConfig both shows the drift
+// in the change summary and triggers applyInPlaceConfigChanges, which re-pushes
+// the full machine config to every node (NO_REBOOT).
 //
-// The comparison is intentionally secret-independent (it only inspects the
-// tunable maps), so it never false-positives on PKI differences. That matters
-// because detection runs before syncSecretsFromCluster: p.talosConfigs still
-// holds freshly-generated PKI here, but the tunables it carries are already the
-// patched, final values. By the time the change is applied, secret sync has run
-// (the in-place change makes needsSecretSync return true), so the pushed config
-// has the cluster's real PKI and the new tunables together.
+// The desired config is first realigned with the running cluster's PKI and
+// endpoint (see alignedDesiredControlPlaneConfig); without that, the
+// freshly-generated secrets and CIDR-derived endpoint that p.talosConfigs holds
+// at diff time would read as drift on every run. After alignment the only
+// remaining differences are genuine config/patch content — which is exactly
+// what cluster update should reconcile onto the nodes.
 //
-// Only a control-plane node is inspected, matching detectDisruptiveConfigChanges:
-// cluster-wide patches under talos/cluster/ apply to every node, and the apply
-// step pushes the per-role config to all nodes regardless. Worker-only patch
-// drift is not detected here (a future enhancement, like per-node comparison).
+// Caveats (accepted: ksail owns the node machine config):
+//   - Config not managed by ksail's bundle reads as drift and is reconciled away
+//     on the next apply, the same as any other config push.
+//   - A ksail/Talos version bump can change the rendered defaults, causing one
+//     benign, idempotent re-apply; it is self-limiting once applied.
+//   - Only a control-plane node is inspected (matching detectDisruptiveConfigChanges);
+//     this covers all cluster-wide patches under talos/cluster/. Worker-only
+//     patch drift is a future enhancement.
 func (p *Provisioner) detectInPlaceMachineConfigDrift(
 	ctx context.Context,
 	clusterName string,
 ) ([]clusterupdate.Change, error) {
-	// Omni owns node configuration via its own API; pushing config directly is
-	// not how Omni-managed clusters reconcile. Skip when configs are unavailable.
+	// Omni owns node configuration via its own API; skip when configs are absent.
 	if p.talosConfigs == nil || p.omniOpts != nil {
 		return nil, nil
 	}
@@ -56,115 +71,94 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 		return nil, nil
 	}
 
-	desiredConfig := p.talosConfigs.ControlPlane()
+	desiredConfig, err := p.alignedDesiredControlPlaneConfig(runningConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	if desiredConfig == nil {
 		return nil, nil
 	}
 
-	return detectInPlaceMachineConfigChanges(runningConfig, desiredConfig), nil
+	return diffMachineConfig(runningConfig, desiredConfig)
 }
 
-// detectInPlaceMachineConfigChanges compares the machine tunables that Talos can
-// apply to a running node without a reboot. Both sysctls and sysfs are written
-// live to /proc/sys and /sys respectively, so a change is classified in-place.
-func detectInPlaceMachineConfigChanges(
-	runningConfig, desiredConfig machineClusterConfig,
-) []clusterupdate.Change {
-	// At most one change per inspected field (sysctls, sysfs).
-	changes := make([]clusterupdate.Change, 0, initialChangeCapacity)
+// alignedDesiredControlPlaneConfig rebuilds the desired control-plane config with
+// the running cluster's PKI (extracted from the running config) and endpoint, so
+// a byte comparison reflects only patch/content drift rather than the
+// freshly-generated secrets and default endpoint that p.talosConfigs carries at
+// diff time. This mirrors syncSecretsFromCluster, which the apply phase relies on
+// so that pushed configs match the running cluster's PKI.
+func (p *Provisioner) alignedDesiredControlPlaneConfig(
+	runningConfig talosconfig.Provider,
+) (talosconfig.Provider, error) {
+	bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), runningConfig)
 
-	changes = append(changes, detectStringMapFieldChange(
-		"machine.sysctls",
-		"kernel sysctls re-applied to existing nodes without reboot",
-		sysctlsOf(runningConfig),
-		sysctlsOf(desiredConfig),
-	)...)
-	changes = append(changes, detectStringMapFieldChange(
-		"machine.sysfs",
-		"sysfs attributes re-applied to existing nodes without reboot",
-		sysfsOf(runningConfig),
-		sysfsOf(desiredConfig),
-	)...)
+	aligned, err := p.talosConfigs.WithSecrets(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("align secrets for config drift comparison: %w", err)
+	}
 
-	return changes
+	endpointIP := runningConfig.Cluster().Endpoint().Hostname()
+	if endpointIP != "" {
+		aligned, err = aligned.WithEndpoint(endpointIP)
+		if err != nil {
+			return nil, fmt.Errorf("align endpoint for config drift comparison: %w", err)
+		}
+	}
+
+	return aligned.ControlPlane(), nil
 }
 
-// detectStringMapFieldChange returns a single in-place change when two string
-// maps differ. OldValue/NewValue report the entry count, matching the compact
-// before/after style of the change summary table.
-func detectStringMapFieldChange(
-	field, reason string,
-	running, desired map[string]string,
-) []clusterupdate.Change {
-	if stringMapsEqual(running, desired) {
-		return nil
+// diffMachineConfig compares the rendered bytes of the running and desired
+// configs and returns a single in-place change when they differ. Both are
+// marshalled by the same Talos encoder, so semantically-equal configs produce
+// identical bytes; the fingerprints surface a before/after delta in the summary
+// without dumping the whole config.
+func diffMachineConfig(
+	runningConfig, desiredConfig talosconfig.Provider,
+) ([]clusterupdate.Change, error) {
+	runningBytes, err := runningConfig.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("marshal running machine config: %w", err)
+	}
+
+	desiredBytes, err := desiredConfig.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("marshal desired machine config: %w", err)
+	}
+
+	if bytes.Equal(runningBytes, desiredBytes) {
+		return nil, nil
 	}
 
 	return []clusterupdate.Change{
 		{
-			Field:    field,
-			OldValue: strconv.Itoa(len(running)),
-			NewValue: strconv.Itoa(len(desired)),
+			Field:    MachineConfigField,
+			OldValue: configFingerprint(runningBytes),
+			NewValue: configFingerprint(desiredBytes),
 			Category: clusterupdate.ChangeCategoryInPlace,
-			Reason:   reason,
+			Reason:   "Talos machine config (patches) differs from running nodes; re-applied without reboot",
 		},
-	}
+	}, nil
 }
 
-// stringMapsEqual reports whether two string maps have identical entries. A nil
-// map and an empty map are treated as equal (both represent "unset").
-func stringMapsEqual(left, right map[string]string) bool {
-	if len(left) != len(right) {
-		return false
-	}
+// configFingerprint returns a short, stable hex fingerprint of a rendered config.
+func configFingerprint(configBytes []byte) string {
+	sum := sha256.Sum256(configBytes)
 
-	for key, value := range left {
-		if other, ok := right[key]; !ok || other != value {
-			return false
-		}
-	}
-
-	return true
-}
-
-// sysctlsOf returns the machine sysctls map, guarding against nil config/machine
-// sections so live configs missing a machine stanza compare as "unset".
-func sysctlsOf(cfg machineClusterConfig) map[string]string {
-	if cfg == nil {
-		return nil
-	}
-
-	machine := cfg.Machine()
-	if machine == nil {
-		return nil
-	}
-
-	return machine.Sysctls()
-}
-
-// sysfsOf returns the machine sysfs map, with the same nil-safety as sysctlsOf.
-func sysfsOf(cfg machineClusterConfig) map[string]string {
-	if cfg == nil {
-		return nil
-	}
-
-	machine := cfg.Machine()
-	if machine == nil {
-		return nil
-	}
-
-	return machine.Sysfs()
+	return hex.EncodeToString(sum[:])[:fingerprintLength]
 }
 
 // fetchRunningControlPlaneConfig discovers a control-plane node and returns its
-// running Talos machine config. It returns (nil, nil) when no control-plane node
-// is reachable so callers can treat "cannot compare" as "no detected drift"
-// rather than failing the update. Shared by detectDisruptiveConfigChanges and
-// detectInPlaceMachineConfigDrift.
+// running Talos machine config provider. It returns found=false when no
+// control-plane node is reachable so callers can treat "cannot compare" as "no
+// detected drift" rather than failing the update. Shared by
+// detectDisruptiveConfigChanges and detectInPlaceMachineConfigDrift.
 func (p *Provisioner) fetchRunningControlPlaneConfig(
 	ctx context.Context,
 	clusterName string,
-) (machineClusterConfig, bool, error) {
+) (talosconfig.Provider, bool, error) {
 	nodes, err := p.getNodesByRole(ctx, clusterName)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to discover nodes for config comparison: %w", err)
@@ -207,5 +201,5 @@ func (p *Provisioner) fetchRunningControlPlaneConfig(
 		)
 	}
 
-	return machineConfig.Config(), true, nil
+	return machineConfig.Provider(), true, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -114,7 +114,7 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 			OldValue: configFingerprint(runningConfig),
 			NewValue: configFingerprint(desiredConfig),
 			Category: clusterupdate.ChangeCategoryInPlace,
-			Reason:   "Talos machine config (patches) differs from running nodes; re-applied without reboot",
+			Reason:   "Talos machine config (patches) differs from running nodes; will be re-applied without reboot",
 		},
 	}, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
-	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configdiff"
-	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	talosresconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
@@ -31,35 +33,35 @@ const redactedSecretPlaceholder = "<redacted>"
 const maxDriftDiffLines = 60
 
 // MachineConfigField is the change field reported when the desired Talos machine
-// config patches differ from what is running on the nodes.
+// config differs from what is running on the nodes.
 const MachineConfigField = "machine.config"
 
-// detectInPlaceMachineConfigDrift reports whether applying ksail's user patches
-// to the running control-plane config would change it, returning a single
-// in-place change when it would.
+// errNoRoleConfig is returned when the desired config has no machine config for a
+// node's role (control-plane/worker) — an unexpected state for a valid cluster.
+var errNoRoleConfig = errors.New("no Talos machine config available for node role")
+
+// detectInPlaceMachineConfigDrift reports whether the desired Talos machine
+// config (base config + current patch files) differs from what is running on the
+// control-plane node, returning a single in-place change when it does.
 //
 // Talos patch files (everything under talos/, e.g. sysctls, kubelet config,
 // user namespaces, registries, API-server flags) are NOT part of ksail's
-// ClusterSpec, so the spec-level diff engine cannot see them. This overlays the
-// user patches onto the node's *running* config and diffs the result against it,
-// which catches any patch change (additions and edits) generally — rather than a
-// hand-picked set of fields.
+// ClusterSpec, so the spec-level diff engine cannot see them. This compares the
+// fully *regenerated* desired config against the running node config, which
+// catches any patch change generally — additions, edits, AND removals (a key
+// dropped from a patch file is simply absent from the regenerated config).
 //
-// Comparing against the running config (rather than a freshly regenerated one)
-// is what makes this reliable: the running config already carries every
-// create-time/runtime-injected setting (registry-mirror endpoints, PKI, the
-// real cluster endpoint), so those never read as drift. Only the user patch
-// content surfaces. The diff itself uses configdiff.DiffConfigs — the canonical,
-// comments-stripped diff that `talosctl apply-config --dry-run` uses — and both
-// sides are secret-redacted as defence-in-depth and to keep the diff safe to log.
+// The desired config is realigned with the running cluster's PKI and endpoint,
+// and the node-managed sections that ksail injects post-generation at create
+// (registry-mirror endpoints, cert SANs — see buildDesiredNodeConfig) are grafted
+// from the running config, so none of those read as drift. The diff itself uses
+// configdiff.DiffConfigs — the canonical, comments-stripped diff that
+// `talosctl apply-config --dry-run` uses — with secrets redacted on both sides.
 //
-// applyInPlaceConfigChanges applies the very same running+patches config, so
-// detection and apply are consistent.
+// applyInPlaceConfigChanges applies the very same desired config, so detection
+// and apply are consistent (including removals).
 //
 // Caveats:
-//   - Patch *removals* are not detected: strategic-merge patches add/override but
-//     do not delete keys from the running config, so dropping a key from a patch
-//     file is a no-op here (a future enhancement could diff against a full render).
 //   - Only a control-plane node is inspected (matching detectDisruptiveConfigChanges);
 //     cluster-wide patches under talos/cluster/ apply to every node. Worker-only
 //     patch drift is a future enhancement.
@@ -82,12 +84,12 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 		return nil, nil
 	}
 
-	patched, err := applyUserPatches(running, p.talosConfigs.Patches(), RoleControlPlane)
+	desired, err := p.buildDesiredNodeConfig(running, RoleControlPlane)
 	if err != nil {
 		return nil, err
 	}
 
-	diff, err := machineConfigDiff(running, patched)
+	diff, err := machineConfigDiff(running, desired)
 	if err != nil {
 		return nil, err
 	}
@@ -102,67 +104,88 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 		{
 			Field:    MachineConfigField,
 			OldValue: configFingerprint(running),
-			NewValue: configFingerprint(patched),
+			NewValue: configFingerprint(desired),
 			Category: clusterupdate.ChangeCategoryInPlace,
 			Reason:   "Talos machine config (patches) differs from running nodes; will be re-applied without reboot",
 		},
 	}, nil
 }
 
-// applyUserPatches overlays ksail's user-authored Talos patches (scoped to the
-// node role) onto the running config and returns the result. Because the base is
-// the running node config, all create-time/runtime-injected settings (mirror
-// endpoints, PKI, endpoint) are preserved — only the user patch content is
-// applied. Returns the running config unchanged when no patches target the role.
-func applyUserPatches(
+// buildDesiredNodeConfig produces the config ksail wants on a node: the freshly
+// regenerated config (base + current patch files) for the node's role, realigned
+// with the running cluster's PKI and endpoint, then with the node-managed sections
+// grafted from the running config.
+//
+// Regenerating (rather than patching the running config) is what makes patch
+// *removals* detectable: a key dropped from a patch file is simply absent from
+// the regenerated config. The graft then restores the settings ksail injects
+// post-generation at create — which are not user patches and must not read as
+// drift. It returns the running config unchanged if a role config can't be built.
+func (p *Provisioner) buildDesiredNodeConfig(
 	running talosconfig.Provider,
-	patches []talosconfigmanager.Patch,
 	role string,
 ) (talosconfig.Provider, error) {
-	configPatches := make([]configpatcher.Patch, 0, len(patches))
+	bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), running)
 
-	for _, patch := range patches {
-		if !patchAppliesToRole(patch.Scope, role) {
-			continue
-		}
-
-		loaded, loadErr := configpatcher.LoadPatch(patch.Content)
-		if loadErr != nil {
-			return nil, fmt.Errorf("load patch %s: %w", patch.Path, loadErr)
-		}
-
-		configPatches = append(configPatches, loaded)
-	}
-
-	if len(configPatches) == 0 {
-		return running, nil
-	}
-
-	out, err := configpatcher.Apply(configpatcher.WithConfig(running), configPatches)
+	aligned, err := p.talosConfigs.WithSecrets(bundle)
 	if err != nil {
-		return nil, fmt.Errorf("apply patches to running config: %w", err)
+		return nil, fmt.Errorf("align secrets for config comparison: %w", err)
 	}
 
-	patched, err := out.Config()
-	if err != nil {
-		return nil, fmt.Errorf("read patched config: %w", err)
+	endpointIP := running.Cluster().Endpoint().Hostname()
+	if endpointIP != "" {
+		aligned, err = aligned.WithEndpoint(endpointIP)
+		if err != nil {
+			return nil, fmt.Errorf("align endpoint for config comparison: %w", err)
+		}
 	}
 
-	return patched, nil
+	desired := aligned.ControlPlane()
+	if role == RoleWorker {
+		desired = aligned.Worker()
+	}
+
+	if desired == nil {
+		return nil, fmt.Errorf("%w: %s", errNoRoleConfig, role)
+	}
+
+	return graftNodeManagedSections(desired, running)
 }
 
-// patchAppliesToRole reports whether a patch's scope targets the given node role.
-func patchAppliesToRole(scope talosconfigmanager.PatchScope, role string) bool {
-	switch scope {
-	case talosconfigmanager.PatchScopeCluster:
-		return true
-	case talosconfigmanager.PatchScopeControlPlane:
-		return role == RoleControlPlane
-	case talosconfigmanager.PatchScopeWorker:
-		return role == RoleWorker
-	default:
-		return false
+// graftNodeManagedSections copies the machine-config sections that ksail injects
+// post-generation at create — registry mirrors/auth and cert SANs — from the
+// running config into the desired config, so they don't read as drift. These are
+// node/setup-managed (not user patch content); the apply re-pushes them verbatim.
+//
+// If ksail gains another post-generation machine-config transform, graft its
+// section here too (otherwise it will surface as phantom drift).
+//
+//nolint:staticcheck // MachineRegistries is deprecated but still functional in Talos v1.x
+func graftNodeManagedSections(
+	desired, running talosconfig.Provider,
+) (talosconfig.Provider, error) {
+	runningRaw := running.RawV1Alpha1()
+	if runningRaw == nil || runningRaw.MachineConfig == nil {
+		return desired, nil
 	}
+
+	grafted, err := desired.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		if cfg.MachineConfig == nil {
+			return nil
+		}
+
+		// Registry mirrors + auth: injected by ApplyMirrorRegistries at create.
+		cfg.MachineConfig.MachineRegistries = runningRaw.MachineConfig.MachineRegistries
+		// Cert SANs: appended by WithCertSANs at create (e.g. DinD exposure address).
+		cfg.MachineConfig.MachineCertSANs = runningRaw.MachineConfig.MachineCertSANs
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("graft node-managed config sections: %w", err)
+	}
+
+	return grafted, nil
 }
 
 // machineConfigDiff returns the Talos-native textual diff between two configs,

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -120,7 +120,8 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 // *removals* detectable: a key dropped from a patch file is simply absent from
 // the regenerated config. The graft then restores the settings ksail injects
 // post-generation at create — which are not user patches and must not read as
-// drift. It returns the running config unchanged if a role config can't be built.
+// drift. It returns an error if secret/endpoint alignment fails or the desired
+// config has no machine config for the node's role.
 func (p *Provisioner) buildDesiredNodeConfig(
 	running talosconfig.Provider,
 	role string,

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -1,0 +1,211 @@
+package talosprovisioner
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	talosresconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
+)
+
+// detectInPlaceMachineConfigDrift compares in-place-applicable machine config
+// fields (currently machine.sysctls and machine.sysfs) between the running
+// control-plane node and the desired configuration, returning in-place changes
+// when they differ.
+//
+// These fields come from user-managed Talos patch files (e.g.
+// talos/cluster/sysctls.yaml) and are NOT represented in ksail's ClusterSpec, so
+// the spec-level diff engine cannot see them. Without this live comparison,
+// `ksail cluster update` has no signal that a patch file changed: the update
+// either short-circuits ("no changes") or runs without ever pushing the new
+// config to existing nodes. Surfacing the drift here (via DiffConfig) both shows
+// it in the change summary and triggers applyInPlaceConfigChanges, which
+// re-pushes the full machine config — carrying every patch — to each node.
+//
+// The comparison is intentionally secret-independent (it only inspects the
+// tunable maps), so it never false-positives on PKI differences. That matters
+// because detection runs before syncSecretsFromCluster: p.talosConfigs still
+// holds freshly-generated PKI here, but the tunables it carries are already the
+// patched, final values. By the time the change is applied, secret sync has run
+// (the in-place change makes needsSecretSync return true), so the pushed config
+// has the cluster's real PKI and the new tunables together.
+//
+// Only a control-plane node is inspected, matching detectDisruptiveConfigChanges:
+// cluster-wide patches under talos/cluster/ apply to every node, and the apply
+// step pushes the per-role config to all nodes regardless. Worker-only patch
+// drift is not detected here (a future enhancement, like per-node comparison).
+func (p *Provisioner) detectInPlaceMachineConfigDrift(
+	ctx context.Context,
+	clusterName string,
+) ([]clusterupdate.Change, error) {
+	// Omni owns node configuration via its own API; pushing config directly is
+	// not how Omni-managed clusters reconcile. Skip when configs are unavailable.
+	if p.talosConfigs == nil || p.omniOpts != nil {
+		return nil, nil
+	}
+
+	runningConfig, found, err := p.fetchRunningControlPlaneConfig(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	// No reachable control-plane node (e.g. cluster not yet up): nothing to compare.
+	if !found {
+		return nil, nil
+	}
+
+	desiredConfig := p.talosConfigs.ControlPlane()
+	if desiredConfig == nil {
+		return nil, nil
+	}
+
+	return detectInPlaceMachineConfigChanges(runningConfig, desiredConfig), nil
+}
+
+// detectInPlaceMachineConfigChanges compares the machine tunables that Talos can
+// apply to a running node without a reboot. Both sysctls and sysfs are written
+// live to /proc/sys and /sys respectively, so a change is classified in-place.
+func detectInPlaceMachineConfigChanges(
+	runningConfig, desiredConfig machineClusterConfig,
+) []clusterupdate.Change {
+	// At most one change per inspected field (sysctls, sysfs).
+	changes := make([]clusterupdate.Change, 0, initialChangeCapacity)
+
+	changes = append(changes, detectStringMapFieldChange(
+		"machine.sysctls",
+		"kernel sysctls re-applied to existing nodes without reboot",
+		sysctlsOf(runningConfig),
+		sysctlsOf(desiredConfig),
+	)...)
+	changes = append(changes, detectStringMapFieldChange(
+		"machine.sysfs",
+		"sysfs attributes re-applied to existing nodes without reboot",
+		sysfsOf(runningConfig),
+		sysfsOf(desiredConfig),
+	)...)
+
+	return changes
+}
+
+// detectStringMapFieldChange returns a single in-place change when two string
+// maps differ. OldValue/NewValue report the entry count, matching the compact
+// before/after style of the change summary table.
+func detectStringMapFieldChange(
+	field, reason string,
+	running, desired map[string]string,
+) []clusterupdate.Change {
+	if stringMapsEqual(running, desired) {
+		return nil
+	}
+
+	return []clusterupdate.Change{
+		{
+			Field:    field,
+			OldValue: strconv.Itoa(len(running)),
+			NewValue: strconv.Itoa(len(desired)),
+			Category: clusterupdate.ChangeCategoryInPlace,
+			Reason:   reason,
+		},
+	}
+}
+
+// stringMapsEqual reports whether two string maps have identical entries. A nil
+// map and an empty map are treated as equal (both represent "unset").
+func stringMapsEqual(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for key, value := range left {
+		if other, ok := right[key]; !ok || other != value {
+			return false
+		}
+	}
+
+	return true
+}
+
+// sysctlsOf returns the machine sysctls map, guarding against nil config/machine
+// sections so live configs missing a machine stanza compare as "unset".
+func sysctlsOf(cfg machineClusterConfig) map[string]string {
+	if cfg == nil {
+		return nil
+	}
+
+	machine := cfg.Machine()
+	if machine == nil {
+		return nil
+	}
+
+	return machine.Sysctls()
+}
+
+// sysfsOf returns the machine sysfs map, with the same nil-safety as sysctlsOf.
+func sysfsOf(cfg machineClusterConfig) map[string]string {
+	if cfg == nil {
+		return nil
+	}
+
+	machine := cfg.Machine()
+	if machine == nil {
+		return nil
+	}
+
+	return machine.Sysfs()
+}
+
+// fetchRunningControlPlaneConfig discovers a control-plane node and returns its
+// running Talos machine config. It returns (nil, nil) when no control-plane node
+// is reachable so callers can treat "cannot compare" as "no detected drift"
+// rather than failing the update. Shared by detectDisruptiveConfigChanges and
+// detectInPlaceMachineConfigDrift.
+func (p *Provisioner) fetchRunningControlPlaneConfig(
+	ctx context.Context,
+	clusterName string,
+) (machineClusterConfig, bool, error) {
+	nodes, err := p.getNodesByRole(ctx, clusterName)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to discover nodes for config comparison: %w", err)
+	}
+
+	var cpIP string
+
+	for _, node := range nodes {
+		if node.Role == RoleControlPlane {
+			cpIP = node.IP
+
+			break
+		}
+	}
+
+	if cpIP == "" {
+		return nil, false, nil
+	}
+
+	talosClient, err := p.createTalosClient(ctx, cpIP)
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"failed to create Talos client for config comparison: %w",
+			err,
+		)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	machineConfig, err := safe.StateGet[*talosresconfig.MachineConfig](
+		ctx,
+		talosClient.COSI,
+		talosresconfig.NewMachineConfig(nil).Metadata(),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"failed to fetch running machine config from %s: %w",
+			cpIP,
+			err,
+		)
+	}
+
+	return machineConfig.Config(), true, nil
+}

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -1,16 +1,18 @@
 package talosprovisioner
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configdiff"
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	talosresconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
@@ -19,6 +21,14 @@ import (
 // fingerprint in the change summary — enough to distinguish two renders at a
 // glance without dumping the whole config into the table.
 const fingerprintLength = 12
+
+// redactedSecretPlaceholder replaces secret values before diffing/fingerprinting
+// so the comparison never trips on PKI and any surfaced diff is safe to print.
+const redactedSecretPlaceholder = "<redacted>"
+
+// maxDriftDiffLines caps how much of the machine-config diff is echoed to the
+// change summary so it stays readable; the full config is re-applied regardless.
+const maxDriftDiffLines = 60
 
 // MachineConfigField is the change field reported when the rendered Talos
 // machine config drifts from what is running on the nodes.
@@ -31,18 +41,25 @@ const MachineConfigField = "machine.config"
 // Talos patch files (everything under talos/, e.g. sysctls, kubelet config,
 // user namespaces, registries, API-server flags) are NOT part of ksail's
 // ClusterSpec, so the spec-level diff engine cannot see them. This compares the
-// fully rendered desired config against the running node config, which catches
-// any patch change — additions, edits, and removals alike — rather than a
-// hand-picked set of fields. Surfacing it from DiffConfig both shows the drift
-// in the change summary and triggers applyInPlaceConfigChanges, which re-pushes
-// the full machine config to every node (NO_REBOOT).
+// desired config against the running node config, which catches any patch change
+// — additions, edits, and removals alike — rather than a hand-picked set of
+// fields. Surfacing it from DiffConfig both shows the drift in the change
+// summary and triggers applyInPlaceConfigChanges, which re-pushes the full
+// machine config to every node (NO_REBOOT).
+//
+// The comparison uses configdiff.DiffConfigs — the same canonical, sorted-key,
+// comments-stripped diff that `talosctl apply-config --dry-run` uses — run
+// in-process. That normalisation is essential: a naive Bytes() comparison trips
+// on the doc/example comments and field ordering that a freshly-rendered config
+// carries but a node's stored config does not, producing phantom drift on an
+// unchanged cluster.
 //
 // The desired config is first realigned with the running cluster's PKI and
 // endpoint (see alignedDesiredControlPlaneConfig); without that, the
 // freshly-generated secrets and CIDR-derived endpoint that p.talosConfigs holds
-// at diff time would read as drift on every run. After alignment the only
-// remaining differences are genuine config/patch content — which is exactly
-// what cluster update should reconcile onto the nodes.
+// at diff time would read as drift on every run. Secrets are additionally
+// redacted on both sides before diffing as defence-in-depth and to keep the
+// surfaced diff safe to print.
 //
 // Caveats (accepted: ksail owns the node machine config):
 //   - Config not managed by ksail's bundle reads as drift and is reconciled away
@@ -80,15 +97,50 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 		return nil, nil
 	}
 
-	return diffMachineConfig(runningConfig, desiredConfig)
+	diff, err := machineConfigDiff(runningConfig, desiredConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if diff == "" {
+		return nil, nil
+	}
+
+	p.logMachineConfigDrift(diff)
+
+	return []clusterupdate.Change{
+		{
+			Field:    MachineConfigField,
+			OldValue: configFingerprint(runningConfig),
+			NewValue: configFingerprint(desiredConfig),
+			Category: clusterupdate.ChangeCategoryInPlace,
+			Reason:   "Talos machine config (patches) differs from running nodes; re-applied without reboot",
+		},
+	}, nil
+}
+
+// machineConfigDiff returns the Talos-native textual diff between the running and
+// desired configs, with secrets redacted. An empty string means no drift. It
+// delegates to configdiff.DiffConfigs, which encodes both sides with the
+// canonical, comments-stripped encoder before diffing.
+func machineConfigDiff(runningConfig, desiredConfig talosconfig.Provider) (string, error) {
+	diff, err := configdiff.DiffConfigs(
+		runningConfig.RedactSecrets(redactedSecretPlaceholder),
+		desiredConfig.RedactSecrets(redactedSecretPlaceholder),
+	)
+	if err != nil {
+		return "", fmt.Errorf("compute machine config diff: %w", err)
+	}
+
+	return diff, nil
 }
 
 // alignedDesiredControlPlaneConfig rebuilds the desired control-plane config with
 // the running cluster's PKI (extracted from the running config) and endpoint, so
-// a byte comparison reflects only patch/content drift rather than the
-// freshly-generated secrets and default endpoint that p.talosConfigs carries at
-// diff time. This mirrors syncSecretsFromCluster, which the apply phase relies on
-// so that pushed configs match the running cluster's PKI.
+// the diff reflects only patch/content drift rather than the freshly-generated
+// secrets and default endpoint that p.talosConfigs carries at diff time. This
+// mirrors syncSecretsFromCluster, which the apply phase relies on so that pushed
+// configs match the running cluster's PKI.
 func (p *Provisioner) alignedDesiredControlPlaneConfig(
 	runningConfig talosconfig.Provider,
 ) (talosconfig.Provider, error) {
@@ -110,42 +162,37 @@ func (p *Provisioner) alignedDesiredControlPlaneConfig(
 	return aligned.ControlPlane(), nil
 }
 
-// diffMachineConfig compares the rendered bytes of the running and desired
-// configs and returns a single in-place change when they differ. Both are
-// marshalled by the same Talos encoder, so semantically-equal configs produce
-// identical bytes; the fingerprints surface a before/after delta in the summary
-// without dumping the whole config.
-func diffMachineConfig(
-	runningConfig, desiredConfig talosconfig.Provider,
-) ([]clusterupdate.Change, error) {
-	runningBytes, err := runningConfig.Bytes()
-	if err != nil {
-		return nil, fmt.Errorf("marshal running machine config: %w", err)
+// logMachineConfigDrift prints the (already secret-redacted) diff so operators
+// can see what changed, truncated to keep the change summary readable.
+func (p *Provisioner) logMachineConfigDrift(diff string) {
+	lines := strings.Split(strings.TrimRight(diff, "\n"), "\n")
+	if len(lines) > maxDriftDiffLines {
+		omitted := len(lines) - maxDriftDiffLines
+		lines = append(
+			lines[:maxDriftDiffLines],
+			fmt.Sprintf("... (%d more diff lines)", omitted),
+		)
 	}
 
-	desiredBytes, err := desiredConfig.Bytes()
-	if err != nil {
-		return nil, fmt.Errorf("marshal desired machine config: %w", err)
-	}
-
-	if bytes.Equal(runningBytes, desiredBytes) {
-		return nil, nil
-	}
-
-	return []clusterupdate.Change{
-		{
-			Field:    MachineConfigField,
-			OldValue: configFingerprint(runningBytes),
-			NewValue: configFingerprint(desiredBytes),
-			Category: clusterupdate.ChangeCategoryInPlace,
-			Reason:   "Talos machine config (patches) differs from running nodes; re-applied without reboot",
-		},
-	}, nil
+	_, _ = fmt.Fprintf(
+		p.logWriter,
+		"  Machine config drift (secrets redacted):\n%s\n",
+		strings.Join(lines, "\n"),
+	)
 }
 
-// configFingerprint returns a short, stable hex fingerprint of a rendered config.
-func configFingerprint(configBytes []byte) string {
-	sum := sha256.Sum256(configBytes)
+// configFingerprint returns a short, stable hex fingerprint of a provider's
+// redacted, canonical, comments-stripped encoding — the same normalisation
+// machineConfigDiff uses, so equal fingerprints imply an empty diff.
+func configFingerprint(provider talosconfig.Provider) string {
+	canonical, err := provider.
+		RedactSecrets(redactedSecretPlaceholder).
+		EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+	if err != nil {
+		return "unknown"
+	}
+
+	sum := sha256.Sum256(canonical)
 
 	return hex.EncodeToString(sum[:])[:fingerprintLength]
 }

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -2,14 +2,11 @@ package talosprovisioner_test
 
 import (
 	"testing"
-	"time"
 
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	taloscontainer "github.com/siderolabs/talos/pkg/machinery/config/container"
-	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,143 +14,186 @@ import (
 
 const sysctlRmemMax = "net.core.rmem_max"
 
-// wrapConfig wraps a v1alpha1.Config as a full Talos config provider (with EncodeBytes()).
+// wrapConfig wraps a v1alpha1.Config as a full Talos config provider.
 func wrapConfig(cfg *v1alpha1.Config) talosconfig.Provider {
 	return taloscontainer.NewV1Alpha1(cfg)
 }
 
-// baseConfig returns a minimal config used as the "running" baseline; tests
-// clone it and mutate individual fields to assert that any drift is detected.
-func baseConfig() *v1alpha1.Config {
-	return &v1alpha1.Config{
+// sysctlsConfig builds a running-config provider carrying the given sysctls.
+func sysctlsConfig(sysctls map[string]string) talosconfig.Provider {
+	return wrapConfig(&v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{MachineSysctls: sysctls},
+	})
+}
+
+// clusterPatch builds a cluster-scoped user patch from raw YAML content.
+func clusterPatch(content string) talosconfigmanager.Patch {
+	return talosconfigmanager.Patch{
+		Path:    "test-patch.yaml",
+		Scope:   talosconfigmanager.PatchScopeCluster,
+		Content: []byte(content),
+	}
+}
+
+func TestMachineConfigDiff(t *testing.T) {
+	t.Parallel()
+
+	base := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
+
+	identical, err := talosprovisioner.MachineConfigDiffForTest(
+		base,
+		sysctlsConfig(map[string]string{sysctlRmemMax: "1"}),
+	)
+	require.NoError(t, err)
+	assert.Empty(t, identical, "identical configs produce no diff")
+
+	differ, err := talosprovisioner.MachineConfigDiffForTest(
+		base,
+		sysctlsConfig(map[string]string{sysctlRmemMax: "2"}),
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, differ, "differing configs produce a diff")
+}
+
+// TestApplyUserPatches_DetectsAddedContent verifies a patch that adds a sysctl
+// changes the config (the platform#1618 hardening case).
+func TestApplyUserPatches_DetectsAddedContent(t *testing.T) {
+	t.Parallel()
+
+	running := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
+	patch := clusterPatch("machine:\n  sysctls:\n    kernel.kptr_restrict: \"2\"\n")
+
+	patched, err := talosprovisioner.ApplyUserPatchesForTest(
+		running,
+		[]talosconfigmanager.Patch{patch},
+		talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, patched)
+	require.NoError(t, err)
+	assert.NotEmpty(t, diff, "adding a sysctl via patch must be detected as drift")
+}
+
+// TestApplyUserPatches_NoDriftWhenAlreadyApplied is the no-false-positive guard:
+// re-applying a patch already reflected in the running config yields no drift.
+func TestApplyUserPatches_NoDriftWhenAlreadyApplied(t *testing.T) {
+	t.Parallel()
+
+	running := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
+	patch := clusterPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+
+	patched, err := talosprovisioner.ApplyUserPatchesForTest(
+		running,
+		[]talosconfigmanager.Patch{patch},
+		talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, patched)
+	require.NoError(t, err)
+	assert.Empty(t, diff, "re-applying an already-present patch must not report drift")
+}
+
+// TestApplyUserPatches_PreservesRunningOnlyFields verifies a patch that doesn't
+// mention registry mirrors leaves the running config's create-time-injected
+// mirror endpoints intact — the mirror-reversion fix.
+func TestApplyUserPatches_PreservesRunningOnlyFields(t *testing.T) {
+	t.Parallel()
+
+	const mirrorEndpoint = "http://talos-default-docker.io:5000"
+
+	running := wrapConfig(&v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
 			MachineSysctls: map[string]string{sysctlRmemMax: "1"},
+			MachineRegistries: v1alpha1.RegistriesConfig{
+				RegistryMirrors: map[string]*v1alpha1.RegistryMirrorConfig{
+					"docker.io": {MirrorEndpoints: []string{mirrorEndpoint}},
+				},
+			},
 		},
-		ClusterConfig: &v1alpha1.ClusterConfig{},
-	}
+	})
+	patch := clusterPatch("machine:\n  sysctls:\n    kernel.kptr_restrict: \"2\"\n")
+
+	patched, err := talosprovisioner.ApplyUserPatchesForTest(
+		running,
+		[]talosconfigmanager.Patch{patch},
+		talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	patchedBytes, err := patched.Bytes()
+	require.NoError(t, err)
+	assert.Contains(
+		t,
+		string(patchedBytes),
+		mirrorEndpoint,
+		"patch must preserve the running config's mirror endpoints",
+	)
 }
 
-func TestMachineConfigDiff(t *testing.T) { //nolint:funlen // table-driven tests
+// TestApplyUserPatches_RoleScoping verifies worker-scoped patches do not apply
+// to a control-plane node.
+func TestApplyUserPatches_RoleScoping(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name      string
-		mutate    func(*v1alpha1.Config)
-		wantDrift bool
-	}{
-		{
-			name:      "no drift when configs are identical",
-			mutate:    func(*v1alpha1.Config) {},
-			wantDrift: false,
-		},
-		{
-			name: "drift on sysctl added (the platform#1618 hardening case)",
-			mutate: func(c *v1alpha1.Config) {
-				c.MachineConfig.MachineSysctls["kernel.kptr_restrict"] = "2"
-			},
-			wantDrift: true,
-		},
-		{
-			name: "drift on sysctl removed",
-			mutate: func(c *v1alpha1.Config) {
-				c.MachineConfig.MachineSysctls = map[string]string{}
-			},
-			wantDrift: true,
-		},
-		{
-			name: "drift on machine.files change (not a sysctl)",
-			mutate: func(c *v1alpha1.Config) {
-				c.MachineConfig.MachineFiles = []*v1alpha1.MachineFile{
-					{FilePath: "/var/etc/foo", FileContent: "bar", FilePermissions: 0o644},
-				}
-			},
-			wantDrift: true,
-		},
-		{
-			name: "drift on cluster-level change (not machine-scoped)",
-			mutate: func(c *v1alpha1.Config) {
-				c.ClusterConfig.ClusterID = "changed-cluster-id"
-			},
-			wantDrift: true,
-		},
+	running := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
+	workerPatch := talosconfigmanager.Patch{
+		Path:    "worker.yaml",
+		Scope:   talosconfigmanager.PatchScopeWorker,
+		Content: []byte("machine:\n  sysctls:\n    worker.only: \"1\"\n"),
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
+	patched, err := talosprovisioner.ApplyUserPatchesForTest(
+		running,
+		[]talosconfigmanager.Patch{workerPatch},
+		talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
 
-			running := baseConfig()
-			desired := baseConfig()
-			testCase.mutate(desired)
-
-			diff, err := talosprovisioner.MachineConfigDiffForTest(
-				wrapConfig(running),
-				wrapConfig(desired),
-			)
-			require.NoError(t, err)
-
-			if testCase.wantDrift {
-				assert.NotEmpty(t, diff, "drift must produce a non-empty diff")
-			} else {
-				assert.Empty(t, diff, "identical configs must produce an empty diff")
-			}
-		})
-	}
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, patched)
+	require.NoError(t, err)
+	assert.Empty(t, diff, "worker-scoped patch must not apply to a control-plane node")
 }
 
-// TestMachineConfigDiff_NoFalsePositiveOnUnchangedConfig guards the
-// generation+alignment path against phantom drift: it generates a real ksail
-// Talos config, parses it back (as Talos does on apply+store+read), then runs
-// the detection's alignment (extract secrets+endpoint, regenerate) and asserts
-// the diff is empty. This catches regressions where alignment or rendering
-// introduces drift on an unchanged config. (It cannot cover node-side
-// serialization, which only the Talos system test exercises.)
-func TestMachineConfigDiff_NoFalsePositiveOnUnchangedConfig(t *testing.T) {
+func TestPatchAppliesToRole(t *testing.T) {
 	t.Parallel()
 
-	configs, err := talosconfigmanager.NewDefaultConfigs()
-	require.NoError(t, err)
-
-	appliedBytes, err := configs.ControlPlane().Bytes()
-	require.NoError(t, err)
-
-	// "running" = node-like config: a parse round-trip of what ksail applied.
-	running, err := configloader.NewFromBytes(appliedBytes)
-	require.NoError(t, err)
-
-	// Reproduce alignedDesiredControlPlaneConfig against the running config.
-	bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), running)
-	aligned, err := configs.WithSecrets(bundle)
-	require.NoError(t, err)
-
-	if endpoint := running.Cluster().Endpoint().Hostname(); endpoint != "" {
-		aligned, err = aligned.WithEndpoint(endpoint)
-		require.NoError(t, err)
-	}
-
-	diff, err := talosprovisioner.MachineConfigDiffForTest(running, aligned.ControlPlane())
-	require.NoError(t, err)
-
-	assert.Empty(t, diff, "an unchanged config must not report drift after alignment")
+	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
+		talosconfigmanager.PatchScopeCluster, talosprovisioner.RoleControlPlane))
+	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
+		talosconfigmanager.PatchScopeCluster, talosprovisioner.RoleWorker))
+	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
+		talosconfigmanager.PatchScopeControlPlane, talosprovisioner.RoleControlPlane))
+	assert.False(t, talosprovisioner.PatchAppliesToRoleForTest(
+		talosconfigmanager.PatchScopeControlPlane, talosprovisioner.RoleWorker))
+	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
+		talosconfigmanager.PatchScopeWorker, talosprovisioner.RoleWorker))
+	assert.False(t, talosprovisioner.PatchAppliesToRoleForTest(
+		talosconfigmanager.PatchScopeWorker, talosprovisioner.RoleControlPlane))
 }
 
 func TestConfigFingerprint(t *testing.T) {
 	t.Parallel()
 
-	running := wrapConfig(baseConfig())
+	running := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
+	fingerprint := talosprovisioner.ConfigFingerprintForTest(running)
 
-	changed := baseConfig()
-	changed.MachineConfig.MachineSysctls["kernel.kptr_restrict"] = "2"
-
-	fpRunning := talosprovisioner.ConfigFingerprintForTest(running)
-	fpChanged := talosprovisioner.ConfigFingerprintForTest(wrapConfig(changed))
-
-	assert.Len(t, fpRunning, 12, "fingerprint length is fixed")
+	assert.Len(t, fingerprint, 12, "fingerprint length is fixed")
 	assert.Equal(
 		t,
-		fpRunning,
-		talosprovisioner.ConfigFingerprintForTest(wrapConfig(baseConfig())),
+		fingerprint,
+		talosprovisioner.ConfigFingerprintForTest(
+			sysctlsConfig(map[string]string{sysctlRmemMax: "1"}),
+		),
 		"fingerprint is deterministic for equal configs",
 	)
-	assert.NotEqual(t, fpRunning, fpChanged, "different configs produce different fingerprints")
+	assert.NotEqual(
+		t,
+		fingerprint,
+		talosprovisioner.ConfigFingerprintForTest(
+			sysctlsConfig(map[string]string{sysctlRmemMax: "2"}),
+		),
+		"different configs produce different fingerprints",
+	)
 }

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -5,101 +5,73 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	taloscontainer "github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	sysctlRmemMax = "net.core.rmem_max"
-	sysctlKptr    = "kernel.kptr_restrict"
-	fieldSysctls  = "machine.sysctls"
-	fieldSysfs    = "machine.sysfs"
-)
+const sysctlRmemMax = "net.core.rmem_max"
 
-// machineCfgWithTunables builds a minimal Talos config carrying only the
-// in-place-applicable machine tunables (sysctls/sysfs) under test.
-func machineCfgWithTunables(sysctls, sysfs map[string]string) *v1alpha1.Config {
+// wrapConfig wraps a v1alpha1.Config as a full Talos config provider (with Bytes()).
+func wrapConfig(cfg *v1alpha1.Config) talosconfig.Provider {
+	return taloscontainer.NewV1Alpha1(cfg)
+}
+
+// baseConfig returns a minimal config used as the "running" baseline; tests
+// clone it and mutate individual fields to assert that any drift is detected.
+func baseConfig() *v1alpha1.Config {
 	return &v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
-			MachineSysctls: sysctls,
-			MachineSysfs:   sysfs,
+			MachineSysctls: map[string]string{sysctlRmemMax: "1"},
 		},
 		ClusterConfig: &v1alpha1.ClusterConfig{},
 	}
 }
 
-func TestDetectInPlaceMachineConfigChanges(t *testing.T) { //nolint:funlen // table-driven tests
+func TestDiffMachineConfig(t *testing.T) { //nolint:funlen // table-driven tests
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		running        talosprovisioner.MachineClusterConfigForTest
-		desired        talosprovisioner.MachineClusterConfigForTest
-		expectedFields []string
+		name      string
+		mutate    func(*v1alpha1.Config)
+		wantDrift bool
 	}{
 		{
-			name: "no changes when sysctls and sysfs match",
-			running: machineCfgWithTunables(
-				map[string]string{sysctlRmemMax: "1"},
-				nil,
-			),
-			desired: machineCfgWithTunables(
-				map[string]string{sysctlRmemMax: "1"},
-				nil,
-			),
-			expectedFields: nil,
+			name:      "no drift when configs are identical",
+			mutate:    func(*v1alpha1.Config) {},
+			wantDrift: false,
 		},
 		{
-			name:           "no changes when nil and empty sysctls are equivalent",
-			running:        machineCfgWithTunables(nil, nil),
-			desired:        machineCfgWithTunables(map[string]string{}, map[string]string{}),
-			expectedFields: nil,
+			name: "drift on sysctl added (the platform#1618 hardening case)",
+			mutate: func(c *v1alpha1.Config) {
+				c.MachineConfig.MachineSysctls["kernel.kptr_restrict"] = "2"
+			},
+			wantDrift: true,
 		},
 		{
-			name:    "detect sysctl added (the platform#1618 hardening case)",
-			running: machineCfgWithTunables(map[string]string{sysctlRmemMax: "1"}, nil),
-			desired: machineCfgWithTunables(map[string]string{
-				sysctlRmemMax: "1",
-				sysctlKptr:    "2",
-			}, nil),
-			expectedFields: []string{fieldSysctls},
+			name: "drift on sysctl removed",
+			mutate: func(c *v1alpha1.Config) {
+				c.MachineConfig.MachineSysctls = map[string]string{}
+			},
+			wantDrift: true,
 		},
 		{
-			name: "detect sysctl value changed",
-			running: machineCfgWithTunables(
-				map[string]string{sysctlKptr: "1"},
-				nil,
-			),
-			desired: machineCfgWithTunables(
-				map[string]string{sysctlKptr: "2"},
-				nil,
-			),
-			expectedFields: []string{fieldSysctls},
+			name: "drift on machine.files change (not a sysctl)",
+			mutate: func(c *v1alpha1.Config) {
+				c.MachineConfig.MachineFiles = []*v1alpha1.MachineFile{
+					{FilePath: "/var/etc/foo", FileContent: "bar", FilePermissions: 0o644},
+				}
+			},
+			wantDrift: true,
 		},
 		{
-			name:           "detect sysctl removed",
-			running:        machineCfgWithTunables(map[string]string{"a": "1", "b": "2"}, nil),
-			desired:        machineCfgWithTunables(map[string]string{"a": "1"}, nil),
-			expectedFields: []string{fieldSysctls},
-		},
-		{
-			name:           "detect sysfs changed",
-			running:        machineCfgWithTunables(nil, map[string]string{"x": "1"}),
-			desired:        machineCfgWithTunables(nil, map[string]string{"x": "2"}),
-			expectedFields: []string{fieldSysfs},
-		},
-		{
-			name: "detect both sysctls and sysfs changed",
-			running: machineCfgWithTunables(
-				map[string]string{"a": "1"},
-				map[string]string{"x": "1"},
-			),
-			desired: machineCfgWithTunables(
-				map[string]string{"a": "2"},
-				map[string]string{"x": "2"},
-			),
-			expectedFields: []string{fieldSysctls, fieldSysfs},
+			name: "drift on cluster-level change (not machine-scoped)",
+			mutate: func(c *v1alpha1.Config) {
+				c.ClusterConfig.ClusterID = "changed-cluster-id"
+			},
+			wantDrift: true,
 		},
 	}
 
@@ -107,72 +79,47 @@ func TestDetectInPlaceMachineConfigChanges(t *testing.T) { //nolint:funlen // ta
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			changes := talosprovisioner.DetectInPlaceMachineConfigChangesForTest(
-				testCase.running,
-				testCase.desired,
+			running := baseConfig()
+			desired := baseConfig()
+			testCase.mutate(desired)
+
+			changes, err := talosprovisioner.DiffMachineConfigForTest(
+				wrapConfig(running),
+				wrapConfig(desired),
 			)
+			require.NoError(t, err)
 
-			require.Len(t, changes, len(testCase.expectedFields))
+			if !testCase.wantDrift {
+				assert.Empty(t, changes, "identical configs must not report drift")
 
-			for i, field := range testCase.expectedFields {
-				assert.Equal(t, field, changes[i].Field)
-				assert.Equal(
-					t,
-					clusterupdate.ChangeCategoryInPlace,
-					changes[i].Category,
-					"machine tunable drift must be classified in-place (applied without reboot)",
-				)
+				return
 			}
+
+			require.Len(t, changes, 1)
+			assert.Equal(t, talosprovisioner.MachineConfigFieldForTest, changes[0].Field)
+			assert.Equal(t, clusterupdate.ChangeCategoryInPlace, changes[0].Category)
+			assert.NotEqual(
+				t,
+				changes[0].OldValue,
+				changes[0].NewValue,
+				"fingerprints must differ when configs drift",
+			)
 		})
 	}
 }
 
-func TestStringMapsEqual(t *testing.T) {
+func TestConfigFingerprint(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name     string
-		left     map[string]string
-		right    map[string]string
-		expected bool
-	}{
-		{name: "both nil", left: nil, right: nil, expected: true},
-		{name: "nil and empty", left: nil, right: map[string]string{}, expected: true},
-		{
-			name:     "equal single entry",
-			left:     map[string]string{"a": "1"},
-			right:    map[string]string{"a": "1"},
-			expected: true,
-		},
-		{
-			name:     "different value",
-			left:     map[string]string{"a": "1"},
-			right:    map[string]string{"a": "2"},
-			expected: false,
-		},
-		{
-			name:     "different length",
-			left:     map[string]string{"a": "1"},
-			right:    map[string]string{"a": "1", "b": "2"},
-			expected: false,
-		},
-		{
-			name:     "different key same length",
-			left:     map[string]string{"a": "1"},
-			right:    map[string]string{"b": "1"},
-			expected: false,
-		},
-	}
+	first := talosprovisioner.ConfigFingerprintForTest([]byte("alpha"))
+	second := talosprovisioner.ConfigFingerprintForTest([]byte("beta"))
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(
-				t,
-				testCase.expected,
-				talosprovisioner.StringMapsEqualForTest(testCase.left, testCase.right),
-			)
-		})
-	}
+	assert.Len(t, first, 12, "fingerprint length is fixed")
+	assert.NotEqual(t, first, second, "different inputs produce different fingerprints")
+	assert.Equal(
+		t,
+		first,
+		talosprovisioner.ConfigFingerprintForTest([]byte("alpha")),
+		"fingerprint is deterministic",
+	)
 }

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -2,11 +2,14 @@ package talosprovisioner_test
 
 import (
 	"testing"
+	"time"
 
-	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	taloscontainer "github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +17,7 @@ import (
 
 const sysctlRmemMax = "net.core.rmem_max"
 
-// wrapConfig wraps a v1alpha1.Config as a full Talos config provider (with Bytes()).
+// wrapConfig wraps a v1alpha1.Config as a full Talos config provider (with EncodeBytes()).
 func wrapConfig(cfg *v1alpha1.Config) talosconfig.Provider {
 	return taloscontainer.NewV1Alpha1(cfg)
 }
@@ -30,7 +33,7 @@ func baseConfig() *v1alpha1.Config {
 	}
 }
 
-func TestDiffMachineConfig(t *testing.T) { //nolint:funlen // table-driven tests
+func TestMachineConfigDiff(t *testing.T) { //nolint:funlen // table-driven tests
 	t.Parallel()
 
 	tests := []struct {
@@ -83,43 +86,74 @@ func TestDiffMachineConfig(t *testing.T) { //nolint:funlen // table-driven tests
 			desired := baseConfig()
 			testCase.mutate(desired)
 
-			changes, err := talosprovisioner.DiffMachineConfigForTest(
+			diff, err := talosprovisioner.MachineConfigDiffForTest(
 				wrapConfig(running),
 				wrapConfig(desired),
 			)
 			require.NoError(t, err)
 
-			if !testCase.wantDrift {
-				assert.Empty(t, changes, "identical configs must not report drift")
-
-				return
+			if testCase.wantDrift {
+				assert.NotEmpty(t, diff, "drift must produce a non-empty diff")
+			} else {
+				assert.Empty(t, diff, "identical configs must produce an empty diff")
 			}
-
-			require.Len(t, changes, 1)
-			assert.Equal(t, talosprovisioner.MachineConfigFieldForTest, changes[0].Field)
-			assert.Equal(t, clusterupdate.ChangeCategoryInPlace, changes[0].Category)
-			assert.NotEqual(
-				t,
-				changes[0].OldValue,
-				changes[0].NewValue,
-				"fingerprints must differ when configs drift",
-			)
 		})
 	}
+}
+
+// TestMachineConfigDiff_NoFalsePositiveOnUnchangedConfig guards the
+// generation+alignment path against phantom drift: it generates a real ksail
+// Talos config, parses it back (as Talos does on apply+store+read), then runs
+// the detection's alignment (extract secrets+endpoint, regenerate) and asserts
+// the diff is empty. This catches regressions where alignment or rendering
+// introduces drift on an unchanged config. (It cannot cover node-side
+// serialization, which only the Talos system test exercises.)
+func TestMachineConfigDiff_NoFalsePositiveOnUnchangedConfig(t *testing.T) {
+	t.Parallel()
+
+	configs, err := talosconfigmanager.NewDefaultConfigs()
+	require.NoError(t, err)
+
+	appliedBytes, err := configs.ControlPlane().Bytes()
+	require.NoError(t, err)
+
+	// "running" = node-like config: a parse round-trip of what ksail applied.
+	running, err := configloader.NewFromBytes(appliedBytes)
+	require.NoError(t, err)
+
+	// Reproduce alignedDesiredControlPlaneConfig against the running config.
+	bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), running)
+	aligned, err := configs.WithSecrets(bundle)
+	require.NoError(t, err)
+
+	if endpoint := running.Cluster().Endpoint().Hostname(); endpoint != "" {
+		aligned, err = aligned.WithEndpoint(endpoint)
+		require.NoError(t, err)
+	}
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, aligned.ControlPlane())
+	require.NoError(t, err)
+
+	assert.Empty(t, diff, "an unchanged config must not report drift after alignment")
 }
 
 func TestConfigFingerprint(t *testing.T) {
 	t.Parallel()
 
-	first := talosprovisioner.ConfigFingerprintForTest([]byte("alpha"))
-	second := talosprovisioner.ConfigFingerprintForTest([]byte("beta"))
+	running := wrapConfig(baseConfig())
 
-	assert.Len(t, first, 12, "fingerprint length is fixed")
-	assert.NotEqual(t, first, second, "different inputs produce different fingerprints")
+	changed := baseConfig()
+	changed.MachineConfig.MachineSysctls["kernel.kptr_restrict"] = "2"
+
+	fpRunning := talosprovisioner.ConfigFingerprintForTest(running)
+	fpChanged := talosprovisioner.ConfigFingerprintForTest(wrapConfig(changed))
+
+	assert.Len(t, fpRunning, 12, "fingerprint length is fixed")
 	assert.Equal(
 		t,
-		first,
-		talosprovisioner.ConfigFingerprintForTest([]byte("alpha")),
-		"fingerprint is deterministic",
+		fpRunning,
+		talosprovisioner.ConfigFingerprintForTest(wrapConfig(baseConfig())),
+		"fingerprint is deterministic for equal configs",
 	)
+	assert.NotEqual(t, fpRunning, fpChanged, "different configs produce different fingerprints")
 }

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -1,0 +1,178 @@
+package talosprovisioner_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sysctlRmemMax = "net.core.rmem_max"
+	sysctlKptr    = "kernel.kptr_restrict"
+	fieldSysctls  = "machine.sysctls"
+	fieldSysfs    = "machine.sysfs"
+)
+
+// machineCfgWithTunables builds a minimal Talos config carrying only the
+// in-place-applicable machine tunables (sysctls/sysfs) under test.
+func machineCfgWithTunables(sysctls, sysfs map[string]string) *v1alpha1.Config {
+	return &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineSysctls: sysctls,
+			MachineSysfs:   sysfs,
+		},
+		ClusterConfig: &v1alpha1.ClusterConfig{},
+	}
+}
+
+func TestDetectInPlaceMachineConfigChanges(t *testing.T) { //nolint:funlen // table-driven tests
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		running        talosprovisioner.MachineClusterConfigForTest
+		desired        talosprovisioner.MachineClusterConfigForTest
+		expectedFields []string
+	}{
+		{
+			name: "no changes when sysctls and sysfs match",
+			running: machineCfgWithTunables(
+				map[string]string{sysctlRmemMax: "1"},
+				nil,
+			),
+			desired: machineCfgWithTunables(
+				map[string]string{sysctlRmemMax: "1"},
+				nil,
+			),
+			expectedFields: nil,
+		},
+		{
+			name:           "no changes when nil and empty sysctls are equivalent",
+			running:        machineCfgWithTunables(nil, nil),
+			desired:        machineCfgWithTunables(map[string]string{}, map[string]string{}),
+			expectedFields: nil,
+		},
+		{
+			name:    "detect sysctl added (the platform#1618 hardening case)",
+			running: machineCfgWithTunables(map[string]string{sysctlRmemMax: "1"}, nil),
+			desired: machineCfgWithTunables(map[string]string{
+				sysctlRmemMax: "1",
+				sysctlKptr:    "2",
+			}, nil),
+			expectedFields: []string{fieldSysctls},
+		},
+		{
+			name: "detect sysctl value changed",
+			running: machineCfgWithTunables(
+				map[string]string{sysctlKptr: "1"},
+				nil,
+			),
+			desired: machineCfgWithTunables(
+				map[string]string{sysctlKptr: "2"},
+				nil,
+			),
+			expectedFields: []string{fieldSysctls},
+		},
+		{
+			name:           "detect sysctl removed",
+			running:        machineCfgWithTunables(map[string]string{"a": "1", "b": "2"}, nil),
+			desired:        machineCfgWithTunables(map[string]string{"a": "1"}, nil),
+			expectedFields: []string{fieldSysctls},
+		},
+		{
+			name:           "detect sysfs changed",
+			running:        machineCfgWithTunables(nil, map[string]string{"x": "1"}),
+			desired:        machineCfgWithTunables(nil, map[string]string{"x": "2"}),
+			expectedFields: []string{fieldSysfs},
+		},
+		{
+			name: "detect both sysctls and sysfs changed",
+			running: machineCfgWithTunables(
+				map[string]string{"a": "1"},
+				map[string]string{"x": "1"},
+			),
+			desired: machineCfgWithTunables(
+				map[string]string{"a": "2"},
+				map[string]string{"x": "2"},
+			),
+			expectedFields: []string{fieldSysctls, fieldSysfs},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			changes := talosprovisioner.DetectInPlaceMachineConfigChangesForTest(
+				testCase.running,
+				testCase.desired,
+			)
+
+			require.Len(t, changes, len(testCase.expectedFields))
+
+			for i, field := range testCase.expectedFields {
+				assert.Equal(t, field, changes[i].Field)
+				assert.Equal(
+					t,
+					clusterupdate.ChangeCategoryInPlace,
+					changes[i].Category,
+					"machine tunable drift must be classified in-place (applied without reboot)",
+				)
+			}
+		})
+	}
+}
+
+func TestStringMapsEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		left     map[string]string
+		right    map[string]string
+		expected bool
+	}{
+		{name: "both nil", left: nil, right: nil, expected: true},
+		{name: "nil and empty", left: nil, right: map[string]string{}, expected: true},
+		{
+			name:     "equal single entry",
+			left:     map[string]string{"a": "1"},
+			right:    map[string]string{"a": "1"},
+			expected: true,
+		},
+		{
+			name:     "different value",
+			left:     map[string]string{"a": "1"},
+			right:    map[string]string{"a": "2"},
+			expected: false,
+		},
+		{
+			name:     "different length",
+			left:     map[string]string{"a": "1"},
+			right:    map[string]string{"a": "1", "b": "2"},
+			expected: false,
+		},
+		{
+			name:     "different key same length",
+			left:     map[string]string{"a": "1"},
+			right:    map[string]string{"b": "1"},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				testCase.expected,
+				talosprovisioner.StringMapsEqualForTest(testCase.left, testCase.right),
+			)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -132,6 +132,48 @@ func TestBuildDesiredNodeConfig_NoFalsePositive(t *testing.T) {
 	assert.Empty(t, diff, "an unchanged config must not report drift")
 }
 
+// TestBuildDesiredNodeConfig_PreservesCreateInjectedMirrors reproduces the Docker
+// system-test scenario: the running config carries registry mirrors injected at
+// create (which a regenerate lacks). An unchanged config must still report no
+// drift because the mirrors are grafted from running.
+func TestBuildDesiredNodeConfig_PreservesCreateInjectedMirrors(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+
+	runningConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	// Mirrors are injected at create only (ApplyMirrorRegistries), like the DinD flow.
+	err = runningConfigs.ApplyMirrorRegistries([]talosconfigmanager.MirrorRegistry{
+		{Host: "docker.io", Endpoints: []string{mirrorEndpoint}},
+	})
+	require.NoError(t, err)
+
+	runningBytes, err := runningConfigs.ControlPlane().Bytes()
+	require.NoError(t, err)
+
+	running, err := configloader.NewFromBytes(runningBytes)
+	require.NoError(t, err)
+
+	// Desired configs are regenerated without mirrors (create-only transform).
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
+	require.NoError(t, err)
+	assert.Empty(t, diff, "create-injected mirrors must not read as drift on an unchanged config")
+}
+
 // TestBuildDesiredNodeConfig_DetectsRemoval is the key test for the fix: a sysctl
 // removed from the patch files must be detected as drift (and thus removed on apply).
 func TestBuildDesiredNodeConfig_DetectsRemoval(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -6,33 +6,55 @@ import (
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	taloscontainer "github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const sysctlRmemMax = "net.core.rmem_max"
+const (
+	sysctlRmemMax  = "net.core.rmem_max"
+	sysctlKptr     = "kernel.kptr_restrict"
+	mirrorEndpoint = "http://talos-default-docker.io:5000"
+)
 
 // wrapConfig wraps a v1alpha1.Config as a full Talos config provider.
 func wrapConfig(cfg *v1alpha1.Config) talosconfig.Provider {
 	return taloscontainer.NewV1Alpha1(cfg)
 }
 
-// sysctlsConfig builds a running-config provider carrying the given sysctls.
+// sysctlsConfig builds a provider carrying the given sysctls.
 func sysctlsConfig(sysctls map[string]string) talosconfig.Provider {
 	return wrapConfig(&v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{MachineSysctls: sysctls},
 	})
 }
 
-// clusterPatch builds a cluster-scoped user patch from raw YAML content.
-func clusterPatch(content string) talosconfigmanager.Patch {
+// sysctlPatch builds a cluster-scoped user patch from raw YAML content.
+func sysctlPatch(content string) talosconfigmanager.Patch {
 	return talosconfigmanager.Patch{
 		Path:    "test-patch.yaml",
 		Scope:   talosconfigmanager.PatchScopeCluster,
 		Content: []byte(content),
 	}
+}
+
+// runningFromPatches generates a config from patches and parses it back, as the
+// node would store and return it.
+func runningFromPatches(t *testing.T, patches ...talosconfigmanager.Patch) talosconfig.Provider {
+	t.Helper()
+
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(patches)
+	require.NoError(t, err)
+
+	configBytes, err := configs.ControlPlane().Bytes()
+	require.NoError(t, err)
+
+	running, err := configloader.NewFromBytes(configBytes)
+	require.NoError(t, err)
+
+	return running
 }
 
 func TestMachineConfigDiff(t *testing.T) {
@@ -41,136 +63,102 @@ func TestMachineConfigDiff(t *testing.T) {
 	base := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
 
 	identical, err := talosprovisioner.MachineConfigDiffForTest(
-		base,
-		sysctlsConfig(map[string]string{sysctlRmemMax: "1"}),
+		base, sysctlsConfig(map[string]string{sysctlRmemMax: "1"}),
 	)
 	require.NoError(t, err)
 	assert.Empty(t, identical, "identical configs produce no diff")
 
 	differ, err := talosprovisioner.MachineConfigDiffForTest(
-		base,
-		sysctlsConfig(map[string]string{sysctlRmemMax: "2"}),
+		base, sysctlsConfig(map[string]string{sysctlRmemMax: "2"}),
 	)
 	require.NoError(t, err)
 	assert.NotEmpty(t, differ, "differing configs produce a diff")
 }
 
-// TestApplyUserPatches_DetectsAddedContent verifies a patch that adds a sysctl
-// changes the config (the platform#1618 hardening case).
-func TestApplyUserPatches_DetectsAddedContent(t *testing.T) {
+// TestGraftNodeManagedSections verifies the create-time-injected node-managed
+// sections (registry mirrors + cert SANs) are copied from running into desired,
+// while desired's own content is preserved — the mirror-reversion fix.
+func TestGraftNodeManagedSections(t *testing.T) {
 	t.Parallel()
-
-	running := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
-	patch := clusterPatch("machine:\n  sysctls:\n    kernel.kptr_restrict: \"2\"\n")
-
-	patched, err := talosprovisioner.ApplyUserPatchesForTest(
-		running,
-		[]talosconfigmanager.Patch{patch},
-		talosprovisioner.RoleControlPlane,
-	)
-	require.NoError(t, err)
-
-	diff, err := talosprovisioner.MachineConfigDiffForTest(running, patched)
-	require.NoError(t, err)
-	assert.NotEmpty(t, diff, "adding a sysctl via patch must be detected as drift")
-}
-
-// TestApplyUserPatches_NoDriftWhenAlreadyApplied is the no-false-positive guard:
-// re-applying a patch already reflected in the running config yields no drift.
-func TestApplyUserPatches_NoDriftWhenAlreadyApplied(t *testing.T) {
-	t.Parallel()
-
-	running := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
-	patch := clusterPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
-
-	patched, err := talosprovisioner.ApplyUserPatchesForTest(
-		running,
-		[]talosconfigmanager.Patch{patch},
-		talosprovisioner.RoleControlPlane,
-	)
-	require.NoError(t, err)
-
-	diff, err := talosprovisioner.MachineConfigDiffForTest(running, patched)
-	require.NoError(t, err)
-	assert.Empty(t, diff, "re-applying an already-present patch must not report drift")
-}
-
-// TestApplyUserPatches_PreservesRunningOnlyFields verifies a patch that doesn't
-// mention registry mirrors leaves the running config's create-time-injected
-// mirror endpoints intact — the mirror-reversion fix.
-func TestApplyUserPatches_PreservesRunningOnlyFields(t *testing.T) {
-	t.Parallel()
-
-	const mirrorEndpoint = "http://talos-default-docker.io:5000"
 
 	running := wrapConfig(&v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
-			MachineSysctls: map[string]string{sysctlRmemMax: "1"},
 			MachineRegistries: v1alpha1.RegistriesConfig{
 				RegistryMirrors: map[string]*v1alpha1.RegistryMirrorConfig{
 					"docker.io": {MirrorEndpoints: []string{mirrorEndpoint}},
 				},
 			},
+			MachineCertSANs: []string{"injected.example.com"},
 		},
 	})
-	patch := clusterPatch("machine:\n  sysctls:\n    kernel.kptr_restrict: \"2\"\n")
+	desired := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
 
-	patched, err := talosprovisioner.ApplyUserPatchesForTest(
-		running,
-		[]talosconfigmanager.Patch{patch},
-		talosprovisioner.RoleControlPlane,
-	)
+	grafted, err := talosprovisioner.GraftNodeManagedSectionsForTest(desired, running)
 	require.NoError(t, err)
 
-	patchedBytes, err := patched.Bytes()
+	graftedBytes, err := grafted.Bytes()
 	require.NoError(t, err)
+
+	assert.Contains(t, string(graftedBytes), mirrorEndpoint, "mirrors grafted from running")
 	assert.Contains(
 		t,
-		string(patchedBytes),
-		mirrorEndpoint,
-		"patch must preserve the running config's mirror endpoints",
+		string(graftedBytes),
+		"injected.example.com",
+		"certSANs grafted from running",
 	)
+	assert.Contains(t, string(graftedBytes), sysctlRmemMax, "desired's own content preserved")
 }
 
-// TestApplyUserPatches_RoleScoping verifies worker-scoped patches do not apply
-// to a control-plane node.
-func TestApplyUserPatches_RoleScoping(t *testing.T) {
+// TestBuildDesiredNodeConfig_NoFalsePositive is the no-false-positive guard: an
+// unchanged config (same patches) reports no drift after alignment + graft.
+func TestBuildDesiredNodeConfig_NoFalsePositive(t *testing.T) {
 	t.Parallel()
 
-	running := sysctlsConfig(map[string]string{sysctlRmemMax: "1"})
-	workerPatch := talosconfigmanager.Patch{
-		Path:    "worker.yaml",
-		Scope:   talosconfigmanager.PatchScopeWorker,
-		Content: []byte("machine:\n  sysctls:\n    worker.only: \"1\"\n"),
-	}
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+	running := runningFromPatches(t, patch)
 
-	patched, err := talosprovisioner.ApplyUserPatchesForTest(
-		running,
-		[]talosconfigmanager.Patch{workerPatch},
-		talosprovisioner.RoleControlPlane,
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
 	)
 	require.NoError(t, err)
 
-	diff, err := talosprovisioner.MachineConfigDiffForTest(running, patched)
+	prov := talosprovisioner.NewProvisioner(configs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
 	require.NoError(t, err)
-	assert.Empty(t, diff, "worker-scoped patch must not apply to a control-plane node")
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
+	require.NoError(t, err)
+	assert.Empty(t, diff, "an unchanged config must not report drift")
 }
 
-func TestPatchAppliesToRole(t *testing.T) {
+// TestBuildDesiredNodeConfig_DetectsRemoval is the key test for the fix: a sysctl
+// removed from the patch files must be detected as drift (and thus removed on apply).
+func TestBuildDesiredNodeConfig_DetectsRemoval(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
-		talosconfigmanager.PatchScopeCluster, talosprovisioner.RoleControlPlane))
-	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
-		talosconfigmanager.PatchScopeCluster, talosprovisioner.RoleWorker))
-	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
-		talosconfigmanager.PatchScopeControlPlane, talosprovisioner.RoleControlPlane))
-	assert.False(t, talosprovisioner.PatchAppliesToRoleForTest(
-		talosconfigmanager.PatchScopeControlPlane, talosprovisioner.RoleWorker))
-	assert.True(t, talosprovisioner.PatchAppliesToRoleForTest(
-		talosconfigmanager.PatchScopeWorker, talosprovisioner.RoleWorker))
-	assert.False(t, talosprovisioner.PatchAppliesToRoleForTest(
-		talosconfigmanager.PatchScopeWorker, talosprovisioner.RoleControlPlane))
+	// Cluster was created with two sysctls.
+	running := runningFromPatches(t, sysctlPatch(
+		"machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n    kernel.kptr_restrict: \"2\"\n",
+	))
+
+	// The patch now sets only one sysctl — kernel.kptr_restrict was removed.
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{
+			sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n"),
+		},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
+	require.NoError(t, err)
+	assert.NotEmpty(t, diff, "removing a sysctl from a patch must be detected as drift")
+	assert.Contains(t, diff, sysctlKptr, "the removed sysctl key must appear in the diff")
 }
 
 func TestConfigFingerprint(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -406,6 +406,16 @@ var MachineConfigDiffForTest = machineConfigDiff
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
 var ConfigFingerprintForTest = configFingerprint
 
+// ApplyUserPatchesForTest exposes applyUserPatches for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
+var ApplyUserPatchesForTest = applyUserPatches
+
+// PatchAppliesToRoleForTest exposes patchAppliesToRole for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
+var PatchAppliesToRoleForTest = patchAppliesToRole
+
 // MachineConfigFieldForTest exposes the machine.config change field for unit testing.
 const MachineConfigFieldForTest = MachineConfigField
 

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -396,10 +396,10 @@ var CNINameForTest = cniName
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
 var DiskQuotaEnabledForTest = diskQuotaEnabled
 
-// DiffMachineConfigForTest exposes diffMachineConfig for unit testing.
+// MachineConfigDiffForTest exposes machineConfigDiff for unit testing.
 //
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
-var DiffMachineConfigForTest = diffMachineConfig
+var MachineConfigDiffForTest = machineConfigDiff
 
 // ConfigFingerprintForTest exposes configFingerprint for unit testing.
 //

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	check "github.com/siderolabs/talos/pkg/cluster/check"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -406,15 +407,18 @@ var MachineConfigDiffForTest = machineConfigDiff
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
 var ConfigFingerprintForTest = configFingerprint
 
-// ApplyUserPatchesForTest exposes applyUserPatches for unit testing.
+// GraftNodeManagedSectionsForTest exposes graftNodeManagedSections for unit testing.
 //
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
-var ApplyUserPatchesForTest = applyUserPatches
+var GraftNodeManagedSectionsForTest = graftNodeManagedSections
 
-// PatchAppliesToRoleForTest exposes patchAppliesToRole for unit testing.
-//
-//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
-var PatchAppliesToRoleForTest = patchAppliesToRole
+// BuildDesiredNodeConfigForTest exposes buildDesiredNodeConfig for unit testing.
+func (p *Provisioner) BuildDesiredNodeConfigForTest(
+	running talosconfig.Provider,
+	role string,
+) (talosconfig.Provider, error) {
+	return p.buildDesiredNodeConfig(running, role)
+}
 
 // MachineConfigFieldForTest exposes the machine.config change field for unit testing.
 const MachineConfigFieldForTest = MachineConfigField

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -396,15 +396,18 @@ var CNINameForTest = cniName
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
 var DiskQuotaEnabledForTest = diskQuotaEnabled
 
-// DetectInPlaceMachineConfigChangesForTest exposes detectInPlaceMachineConfigChanges for unit testing.
+// DiffMachineConfigForTest exposes diffMachineConfig for unit testing.
 //
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
-var DetectInPlaceMachineConfigChangesForTest = detectInPlaceMachineConfigChanges
+var DiffMachineConfigForTest = diffMachineConfig
 
-// StringMapsEqualForTest exposes stringMapsEqual for unit testing.
+// ConfigFingerprintForTest exposes configFingerprint for unit testing.
 //
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
-var StringMapsEqualForTest = stringMapsEqual
+var ConfigFingerprintForTest = configFingerprint
+
+// MachineConfigFieldForTest exposes the machine.config change field for unit testing.
+const MachineConfigFieldForTest = MachineConfigField
 
 // ValidateCurrentContextCAForTest exposes validateCurrentContextCA for unit testing.
 //

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -396,6 +396,16 @@ var CNINameForTest = cniName
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
 var DiskQuotaEnabledForTest = diskQuotaEnabled
 
+// DetectInPlaceMachineConfigChangesForTest exposes detectInPlaceMachineConfigChanges for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
+var DetectInPlaceMachineConfigChangesForTest = detectInPlaceMachineConfigChanges
+
+// StringMapsEqualForTest exposes stringMapsEqual for unit testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.
+var StringMapsEqualForTest = stringMapsEqual
+
 // ValidateCurrentContextCAForTest exposes validateCurrentContextCA for unit testing.
 //
 //nolint:gochecknoglobals // export_test.go pattern exposes internal helpers as globals.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -316,7 +316,8 @@ func (p *Provisioner) appendInPlaceMachineConfigDrift(
 	if err != nil {
 		_, _ = fmt.Fprintf(
 			p.logWriter,
-			"  ⚠ Failed to detect machine config drift: %v\n",
+			"  ⚠ Failed to detect machine config drift for cluster %q: %v\n",
+			clusterName,
 			err,
 		)
 

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -249,9 +249,15 @@ func (p *Provisioner) applyUpdateChanges(
 }
 
 // DiffConfig computes the differences between current and desired configurations.
+//
+// Besides comparing the spec-level node counts, it performs a live comparison of
+// in-place-applicable machine tunables (sysctls/sysfs) against the running
+// control-plane node. Those come from Talos patch files that are not part of the
+// ClusterSpec, so this is the only place drift in them surfaces — both in the
+// change summary and as the trigger for re-pushing config to existing nodes.
 func (p *Provisioner) DiffConfig(
-	_ context.Context,
-	_ string,
+	ctx context.Context,
+	name string,
 	oldSpec, newSpec *v1alpha1.ClusterSpec,
 ) (*clusterupdate.UpdateResult, error) {
 	// Talos clusters support in-place changes for most config paths.
@@ -287,7 +293,37 @@ func (p *Provisioner) DiffConfig(
 		})
 	}
 
+	p.appendInPlaceMachineConfigDrift(ctx, name, result)
+
 	return result, nil
+}
+
+// appendInPlaceMachineConfigDrift detects drift in in-place-applicable machine
+// tunables (sysctls/sysfs) against the running control-plane node and appends any
+// changes to the diff. Detection failures are non-fatal and logged: they must not
+// turn DiffConfig into an error, or callers (computeUpdateDiff, the drift display)
+// would drop the spec-level diff entirely. A clean unreachable cluster yields no
+// changes (the guard short-circuits before any network call when configs are
+// absent, e.g. in unit tests).
+func (p *Provisioner) appendInPlaceMachineConfigDrift(
+	ctx context.Context,
+	name string,
+	result *clusterupdate.UpdateResult,
+) {
+	clusterName := p.resolveClusterName(name)
+
+	changes, err := p.detectInPlaceMachineConfigDrift(ctx, clusterName)
+	if err != nil {
+		_, _ = fmt.Fprintf(
+			p.logWriter,
+			"  ⚠ Failed to detect machine config drift: %v\n",
+			err,
+		)
+
+		return
+	}
+
+	result.InPlaceChanges = append(result.InPlaceChanges, changes...)
 }
 
 // applyNodeScalingChanges handles adding or removing Talos nodes.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -397,9 +397,15 @@ func (p *Provisioner) scaleByProvider(
 	return nil
 }
 
-// applyInPlaceConfigChanges applies configuration changes that don't require reboots.
-// Uses ApplyConfiguration with NO_REBOOT mode for Talos-supported fields.
-// Control-plane nodes receive the ControlPlane() config and worker nodes receive the Worker() config.
+// applyInPlaceConfigChanges applies user patch changes to running nodes without a
+// reboot. For each node it overlays the role-scoped user patches onto the node's
+// running config and pushes the result via ApplyConfiguration (NO_REBOOT).
+//
+// Using running+patches (rather than a freshly regenerated config) preserves the
+// create-time/runtime-injected settings the node already carries — registry-mirror
+// endpoints, PKI, the real cluster endpoint — which a regenerated config would
+// drop. This mirrors detectInPlaceMachineConfigDrift, so detection and apply stay
+// consistent.
 func (p *Provisioner) applyInPlaceConfigChanges(
 	ctx context.Context,
 	clusterName string,
@@ -421,66 +427,76 @@ func (p *Provisioner) applyInPlaceConfigChanges(
 		return nil
 	}
 
-	// Apply the appropriate config to each node based on its role
 	for _, node := range nodes {
-		config := p.talosConfigs.ControlPlane()
-		if node.Role == RoleWorker {
-			config = p.talosConfigs.Worker()
-		}
-
-		if config == nil {
-			_, _ = fmt.Fprintf(
-				p.logWriter, "  ⚠ No config available for %s node %s\n",
-				node.Role, node.IP,
-			)
-
-			continue
-		}
-
-		p.applyNodeConfig(ctx, node, config, result)
+		p.applyNodeConfig(ctx, node, result)
 	}
 
 	return nil
 }
 
-// applyNodeConfig applies the appropriate config to a single node and records the result.
+// applyNodeConfig overlays the role-scoped user patches onto a node's running
+// config and applies the result (NO_REBOOT), recording success or failure.
 func (p *Provisioner) applyNodeConfig(
 	ctx context.Context,
 	node nodeWithRole,
-	config talosconfig.Provider,
 	result *clusterupdate.UpdateResult,
 ) {
-	err := p.applyConfigWithMode(
+	running, err := p.fetchNodeConfig(ctx, node.IP)
+	if err != nil {
+		p.recordNodeConfigFailure(node, result, fmt.Sprintf("fetch running config: %v", err))
+
+		return
+	}
+
+	patched, err := applyUserPatches(running, p.talosConfigs.Patches(), node.Role)
+	if err != nil {
+		p.recordNodeConfigFailure(node, result, fmt.Sprintf("apply patches: %v", err))
+
+		return
+	}
+
+	err = p.applyConfigWithMode(
 		ctx,
 		node.IP,
-		config,
+		patched,
 		machineapi.ApplyConfigurationRequest_NO_REBOOT,
 	)
 	if err != nil {
-		_, _ = fmt.Fprintf(
-			p.logWriter, "  ⚠ Failed to apply config to %s (%s): %v\n",
-			node.IP, node.Role, err,
-		)
+		p.recordNodeConfigFailure(node, result, fmt.Sprintf("apply %s config: %v", node.Role, err))
 
-		result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
-			Field:    "talos.config",
-			NewValue: node.IP,
-			Category: clusterupdate.ChangeCategoryInPlace,
-			Reason:   fmt.Sprintf("failed to apply %s config: %v", node.Role, err),
-		})
-	} else {
-		_, _ = fmt.Fprintf(
-			p.logWriter, "  ✓ Config applied to %s (%s, no reboot)\n",
-			node.IP, node.Role,
-		)
-
-		result.AppliedChanges = append(result.AppliedChanges, clusterupdate.Change{
-			Field:    "talos.config",
-			NewValue: node.IP,
-			Category: clusterupdate.ChangeCategoryInPlace,
-			Reason:   node.Role + " config applied successfully",
-		})
+		return
 	}
+
+	_, _ = fmt.Fprintf(
+		p.logWriter, "  ✓ Config applied to %s (%s, no reboot)\n",
+		node.IP, node.Role,
+	)
+
+	result.AppliedChanges = append(result.AppliedChanges, clusterupdate.Change{
+		Field:    "talos.config",
+		NewValue: node.IP,
+		Category: clusterupdate.ChangeCategoryInPlace,
+		Reason:   node.Role + " config applied successfully",
+	})
+}
+
+// recordNodeConfigFailure logs and records a failed node config application.
+func (p *Provisioner) recordNodeConfigFailure(
+	node nodeWithRole,
+	result *clusterupdate.UpdateResult,
+	reason string,
+) {
+	_, _ = fmt.Fprintf(
+		p.logWriter, "  ⚠ Failed to apply config to %s (%s): %s\n",
+		node.IP, node.Role, reason,
+	)
+
+	result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
+		Field:    "talos.config",
+		NewValue: node.IP,
+		Category: clusterupdate.ChangeCategoryInPlace,
+		Reason:   reason,
+	})
 }
 
 // applyRebootRequiredChanges applies changes that require node reboots.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -251,9 +251,11 @@ func (p *Provisioner) applyUpdateChanges(
 // DiffConfig computes the differences between current and desired configurations.
 //
 // Besides comparing the spec-level node counts, it performs a live comparison of
-// the fully rendered machine config (which embeds every Talos patch file under
-// talos/) against the running control-plane node. Those patches are not part of
-// the ClusterSpec, so this is the only place drift in them surfaces — both in the
+// the regenerated desired machine config (base config + every Talos patch file
+// under talos/, with create-time node-managed sections such as registry mirrors
+// and cert SANs preserved from the running config) against the running
+// control-plane node. Those patches are not part of the ClusterSpec, so this is
+// the only place drift in them surfaces — including patch removals — both in the
 // change summary and as the trigger for re-pushing config to existing nodes.
 func (p *Provisioner) DiffConfig(
 	ctx context.Context,
@@ -487,7 +489,7 @@ func (p *Provisioner) recordNodeConfigFailure(
 	reason string,
 ) {
 	_, _ = fmt.Fprintf(
-		p.logWriter, "  ⚠ Failed to apply config to %s (%s): %s\n",
+		p.logWriter, "  ⚠ Config update failed on %s (%s): %s\n",
 		node.IP, node.Role, reason,
 	)
 

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -251,9 +251,9 @@ func (p *Provisioner) applyUpdateChanges(
 // DiffConfig computes the differences between current and desired configurations.
 //
 // Besides comparing the spec-level node counts, it performs a live comparison of
-// in-place-applicable machine tunables (sysctls/sysfs) against the running
-// control-plane node. Those come from Talos patch files that are not part of the
-// ClusterSpec, so this is the only place drift in them surfaces — both in the
+// the fully rendered machine config (which embeds every Talos patch file under
+// talos/) against the running control-plane node. Those patches are not part of
+// the ClusterSpec, so this is the only place drift in them surfaces — both in the
 // change summary and as the trigger for re-pushing config to existing nodes.
 func (p *Provisioner) DiffConfig(
 	ctx context.Context,
@@ -298,9 +298,9 @@ func (p *Provisioner) DiffConfig(
 	return result, nil
 }
 
-// appendInPlaceMachineConfigDrift detects drift in in-place-applicable machine
-// tunables (sysctls/sysfs) against the running control-plane node and appends any
-// changes to the diff. Detection failures are non-fatal and logged: they must not
+// appendInPlaceMachineConfigDrift detects drift between the rendered Talos
+// machine config (all patch files) and the running control-plane node, appending
+// any change to the diff. Detection failures are non-fatal and logged: they must not
 // turn DiffConfig into an error, or callers (computeUpdateDiff, the drift display)
 // would drop the spec-level diff entirely. A clean unreachable cluster yields no
 // changes (the guard short-circuits before any network call when configs are

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -448,9 +448,9 @@ func (p *Provisioner) applyNodeConfig(
 		return
 	}
 
-	patched, err := applyUserPatches(running, p.talosConfigs.Patches(), node.Role)
+	desired, err := p.buildDesiredNodeConfig(running, node.Role)
 	if err != nil {
-		p.recordNodeConfigFailure(node, result, fmt.Sprintf("apply patches: %v", err))
+		p.recordNodeConfigFailure(node, result, fmt.Sprintf("build desired config: %v", err))
 
 		return
 	}
@@ -458,7 +458,7 @@ func (p *Provisioner) applyNodeConfig(
 	err = p.applyConfigWithMode(
 		ctx,
 		node.IP,
-		patched,
+		desired,
 		machineapi.ApplyConfigurationRequest_NO_REBOOT,
 	)
 	if err != nil {


### PR DESCRIPTION
## Problem

`ksail cluster update` does not re-apply changed Talos **machine-config patch files** (everything under `talos/` — sysctls, kubelet config, user namespaces, registries, API-server flags, `machine.files`, …) to running nodes.

Surfaced by [devantler-tech/platform#1618](https://github.com/devantler-tech/platform/pull/1618): a PR that extended the prod cluster's sysctls to a kernel-hardening baseline. The update ran, reported a single `cluster.talos.iso` change, synced secrets + the autoscaler secret — and never applied the new sysctls to the existing nodes.

### Root cause

Talos patches are **not** part of `ClusterSpec`, so the spec-level diff engine (`pkg/svc/diff`) cannot see them, and the provisioner's `DiffConfig` only compared node counts. A pure patch-file edit therefore produced an **empty provisioner diff**, with two failure modes:

1. **Pure patch edit (the common case):** the CLI short-circuits in `applyOrReportChanges` ("no applicable changes") and never calls `updater.Update`, so the patch is never pushed.
2. **Patch edit + an incidental spec change** (what happened in #1618, where the default `talos.iso` had bumped): the apply phase runs, but `shouldApplyInPlaceChanges` is driven by the provisioner's own recomputed diff — which doesn't include the ISO change either — so `applyInPlaceConfigChanges` is skipped.

## Fix

`DiffConfig` now performs a **live, full comparison of the rendered Talos machine config** against the running control-plane node — so **any** patch change (addition, edit, or removal of any field) is detected, not a hand-picked set:

- The desired config is first **realigned with the running cluster's PKI and endpoint** (`alignedDesiredControlPlaneConfig`, mirroring `syncSecretsFromCluster`). Without that, the freshly-generated secrets and CIDR-derived endpoint that `p.talosConfigs` holds at diff time would read as drift on every run. After alignment, only genuine patch/content drift remains.
- Drift is recorded as an **in-place** change (fingerprinted by config hash for the summary). That makes the diff non-empty, which both shows it in the change summary **and** stops the CLI short-circuit → `applyInPlaceConfigChanges` re-pushes the **full** machine config (carrying every patch) to each node via `NO_REBOOT`. Because the in-place change makes `needsSecretSync` true, secret sync runs before the apply, so the pushed config has the cluster's real PKI together with the new patches.

### Safety / tradeoffs

- **Non-fatal:** detection failures are logged and never turn `DiffConfig` into an error (otherwise `computeUpdateDiff` would drop the spec-level diff entirely).
- **Guarded:** skipped when configs are absent (`p.talosConfigs == nil` — so existing `DiffConfig` unit tests do no network) or for Omni-managed clusters (Omni owns node config).
- **Accepted tradeoff — ksail owns the node machine config:** config not in ksail's bundle (out-of-band) reads as drift and is reconciled away on the next apply (same as any config push today); a ksail/Talos version-contract bump can cause one benign, idempotent re-apply that is self-limiting once applied.
- Only a control-plane node is inspected (matching `detectDisruptiveConfigChanges`), which covers all cluster-wide patches under `talos/cluster/`; worker-only patch drift is a future enhancement. The running-config fetch is shared via `fetchRunningControlPlaneConfig`.

## Tests

- `TestDiffMachineConfig` — table-driven: identical (no drift), sysctl added (the #1618 case), sysctl removed, a non-sysctl machine field (`machine.files`), and a cluster-level field — proving generality beyond sysctls.
- `TestConfigFingerprint` — fingerprint length, determinism, distinctness.
- Existing `TestDiffConfig_*` unchanged and green (nil-configs guard ⇒ no network).

Validated: `go build ./...`, `go vet`, `go test ./pkg/svc/provisioner/cluster/talos/... ./pkg/svc/diff/... ./pkg/cli/cmd/cluster/...`, and `golangci-lint run` (changed files clean).

> Note: the two commits (field-specific → full-config) reflect review feedback; they squash-merge into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
