### PR TITLE
fix(hetzner): apply documented FallbackLocations default ["nbg1","hel1"]

### DIFF
--- a/docs/gen_docs_prose.go
+++ b/docs/gen_docs_prose.go
@@ -319,6 +319,7 @@ Advanced configuration options are direct fields under ` + bt + `spec.cluster` +
 - ` + bt + `networkCidr` + bt + ` – Network CIDR block (default: ` + bt + `10.0.0.0/16` + bt + `)
 - ` + bt + `sshKeyName` + bt + ` – SSH key name for server access (optional)
 - ` + bt + `tokenEnvVar` + bt + ` – Environment variable for API token (default: ` + bt + `HCLOUD_TOKEN` + bt + `)
+- ` + bt + `fallbackLocations` + bt + ` – Alternative locations to try when the primary is at capacity (default: ` + bt + `nbg1` + bt + `, ` + bt + `hel1` + bt + `)
 
 **Vanilla options (` + bt + `spec.cluster.vanilla` + bt + `):**
 

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -358,6 +358,7 @@ Advanced configuration options are direct fields under `spec.cluster`. See [Sche
 - `networkCidr` – Network CIDR block (default: `10.0.0.0/16`)
 - `sshKeyName` – SSH key name for server access (optional)
 - `tokenEnvVar` – Environment variable for API token (default: `HCLOUD_TOKEN`)
+- `fallbackLocations` – Alternative locations to try when the primary is at capacity (default: `nbg1`, `hel1`)
 
 **Vanilla options (`spec.cluster.vanilla`):**
 

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -49,6 +49,19 @@ const (
 	DefaultHetznerServerLimit int32 = 10
 )
 
+// DefaultHetznerFallbackLocations returns the default fallback datacenter
+// locations tried when server creation fails in the primary location due to
+// resource unavailability. All entries are in the eu-central network zone —
+// matching the hardcoded network subnet zone (see the Hetzner provider's
+// EnsureNetwork) and the default fsn1 primary location — so fallback servers can
+// still join the cluster's private network. Slice defaults cannot be expressed
+// via a `default:` struct tag, so this is the canonical source applied in code.
+// A fresh slice is returned on each call so callers may safely retain or mutate
+// the result without affecting the package-level default.
+func DefaultHetznerFallbackLocations() []string {
+	return []string{"nbg1", "hel1"}
+}
+
 // Talos default values — canonical source for OptionsTalos struct tag defaults.
 const (
 	// DefaultTalosISO is the default Hetzner ISO/image ID for booting Talos

--- a/pkg/apis/cluster/v1alpha1/defaults_test.go
+++ b/pkg/apis/cluster/v1alpha1/defaults_test.go
@@ -1,0 +1,27 @@
+package v1alpha1_test
+
+import (
+	"slices"
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultHetznerFallbackLocations(t *testing.T) {
+	t.Parallel()
+
+	got := v1alpha1.DefaultHetznerFallbackLocations()
+
+	// Two distinct fallbacks that exclude the primary location: otherwise the
+	// location-fallback retry path would have nothing meaningful to try.
+	assert.Len(t, got, 2)
+	assert.NotContains(t, got, v1alpha1.DefaultHetznerLocation)
+
+	// Each call must return an independent slice so a caller that retains and
+	// mutates the result cannot corrupt the package-level default.
+	want := slices.Clone(got)
+	got[0] = "mutated"
+
+	assert.Equal(t, want, v1alpha1.DefaultHetznerFallbackLocations())
+}

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -131,7 +131,7 @@ type OptionsHetzner struct {
 	// server creation fails in the primary location due to resource unavailability.
 	// Defaults to ["nbg1", "hel1"] (Nuremberg, Helsinki) as fallbacks for fsn1 (Falkenstein).
 	// All locations should be in the same network zone (eu-central) for consistency.
-	FallbackLocations []string `json:"fallbackLocations,omitzero"`
+	FallbackLocations []string `json:"fallbackLocations,omitzero" jsonschema:"description=Alternative datacenter locations to try when server creation in the primary location fails due to resource unavailability. When empty defaults to nbg1 and hel1 (both in the eu-central network zone matching the default fsn1 primary location)."` //nolint:lll
 	// PlacementGroupFallbackToNone allows automatic fallback to no placement group
 	// when spread placement constraints cannot be satisfied (e.g., due to datacenter capacity).
 	// When true and placement fails, retries server creation without a placement group.

--- a/pkg/svc/provisioner/cluster/talos/factory.go
+++ b/pkg/svc/provisioner/cluster/talos/factory.go
@@ -249,6 +249,10 @@ func applyHetznerDefaults(opts v1alpha1.OptionsHetzner) v1alpha1.OptionsHetzner 
 		opts.TokenEnvVar = v1alpha1.DefaultHetznerTokenEnvVar
 	}
 
+	if len(opts.FallbackLocations) == 0 {
+		opts.FallbackLocations = v1alpha1.DefaultHetznerFallbackLocations()
+	}
+
 	return opts
 }
 

--- a/pkg/svc/provisioner/cluster/talos/pure_logic_test.go
+++ b/pkg/svc/provisioner/cluster/talos/pure_logic_test.go
@@ -525,6 +525,31 @@ func TestApplyHetznerDefaults(t *testing.T) {
 	}
 }
 
+// TestApplyHetznerDefaults_FallbackLocations covers FallbackLocations separately
+// from TestApplyHetznerDefaults to avoid widening that test's case struct (which
+// would reformat every aligned field). It asserts the empty-slice default is
+// applied and that an explicit value is preserved.
+func TestApplyHetznerDefaults_FallbackLocations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults when empty", func(t *testing.T) {
+		t.Parallel()
+
+		result := talosprovisioner.ApplyHetznerDefaultsForTest(v1alpha1.OptionsHetzner{})
+		assert.Equal(t, v1alpha1.DefaultHetznerFallbackLocations(), result.FallbackLocations)
+	})
+
+	t.Run("preserves explicit values", func(t *testing.T) {
+		t.Parallel()
+
+		custom := []string{"loc-a", "loc-b"}
+		result := talosprovisioner.ApplyHetznerDefaultsForTest(
+			v1alpha1.OptionsHetzner{FallbackLocations: custom},
+		)
+		assert.Equal(t, custom, result.FallbackLocations)
+	})
+}
+
 // --- recordAppliedChange / recordFailedChange ---
 
 func TestRecordAppliedChange(t *testing.T) {

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -444,7 +444,8 @@
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "description": "Alternative datacenter locations to try when server creation in the primary location fails due to resource unavailability. When empty defaults to nbg1 and hel1 (both in the eu-central network zone matching the default fsn1 primary location)."
                 },
                 "placementGroupFallbackToNone": {
                   "type": "boolean"


### PR DESCRIPTION
## What

`OptionsHetzner.FallbackLocations` documented a default of `["nbg1", "hel1"]`, but that default was **never applied**. The field had no `default:` struct tag (slice defaults aren't supported by the tag-based prune/marshal mechanism in `marshal.go`, which only handles String/Int/Uint/Bool), and no code set it.

This PR makes the documented default real, applying it in code alongside the other Hetzner defaults.

## Why

With `FallbackLocations` empty, `buildLocationList` yields only the single primary location (`fsn1` by default). So both the **server availability precheck** (`CheckServerAvailability`) and the **server-creation retry** (`CreateServerWithRetry`) only ever tried one datacenter — a capacity shortage there failed `ksail cluster create`/`update` with nothing to fall back to. The entire existing fallback subsystem (`server_retry.go`, `availability.go`, `buildLocationList`, location-fallback logging, dedicated error types) was effectively **dormant by default**.

This was confirmed to be a documented-vs-implemented gap, not an intentional opt-in. Implementing the default was chosen over weakening the doc comment (it improves `create`/`update` resilience and activates machinery that was already built for exactly this purpose).

## How

- **`v1alpha1.DefaultHetznerFallbackLocations()`** — new canonical source for the default. It's a function rather than a `const` because Go slices can't be constants; it returns a fresh slice on each call so callers can't mutate the shared default.
- **`applyHetznerDefaults`** now sets `FallbackLocations` to that default when empty. This is the single provisioner construction chokepoint (`configureInfraProvider` → `WithHetznerOptions`) that feeds the availability precheck, the server-creation retry, and scaling — so **create, update, and scale** all gain the fallbacks uniformly, mirroring how `ControlPlaneServerType`/`Location`/etc. are already defaulted.
- **Schema + docs**: added a `jsonschema` description on the field (the schema reflector ignores `default:` tags and Go doc comments, so this is the only way to surface it) and a docs bullet, then regenerated via `go generate ./schemas/...` and `go generate ./docs/...`.
- **Tests**: empty-default and preserve-explicit cases for `applyHetznerDefaults`, plus the function's value/fresh-slice contract.

## Reviewer notes

- **No cross-network-zone risk.** The fallbacks (`nbg1`, `hel1`) are eu-central, matching the **hardcoded** `NetworkZoneEUCentral` subnet zone in `infrastructure.go` and the default `fsn1` primary. The provider is effectively eu-central-only today, so injecting eu-central fallbacks can't break the private network. (`buildLocationList` also dedupes, so a non-default primary like `nbg1` won't double up.)
- **Behavior change to be aware of:** by default, a capacity shortage in the primary location now retries in `nbg1`/`hel1` instead of failing — i.e. servers may land in a different datacenter than before on fallback. A user can override by setting `spec.provider.hetzner.fallbackLocations` explicitly.
- **Validation:** `go build` + all directly-related packages green (`v1alpha1`, talos provisioner, hetzner provider, schemas, docs); `golangci-lint run --new-from-rev=HEAD` reports **0** new issues. (Full `go test ./...` was green except `pkg/cli/cmd/chat`, which passes in isolation but flakes under parallel load with `signal: killed` from spawning an external Copilot CLI — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)