### PR TITLE
fix(diff): redact registry credentials in cluster update/diff output

### DIFF
--- a/pkg/apis/cluster/v1alpha1/local_registry.go
+++ b/pkg/apis/cluster/v1alpha1/local_registry.go
@@ -32,6 +32,44 @@ func extractCredentials(credPart string) (string, string) {
 	return credPart, ""
 }
 
+// registryCredentialMask is the placeholder substituted for a registry password
+// (such as a GHCR Personal Access Token) when a registry spec is rendered in
+// diffs or other CLI output, so the secret is never printed in cleartext.
+const registryCredentialMask = "****"
+
+// RedactRegistryCredentials returns the registry spec with its password component
+// replaced by a fixed mask, so secrets such as a GHCR Personal Access Token are
+// never printed in cleartext. The username, host, port, and path are preserved so
+// diff output still shows what structurally changed. Specs without a "user:pass@"
+// credential prefix, or with an empty password, are returned unchanged.
+//
+// The credential boundaries mirror [LocalRegistry.Parse]: the credentials are the
+// segment before the first "@", and the password is everything after the first
+// ":" within that segment. Mirroring Parse guarantees that whatever
+// [LocalRegistry.ResolveCredentials] would surface as the password is exactly
+// what gets masked here.
+func RedactRegistryCredentials(registry string) string {
+	atIdx := strings.Index(registry, "@")
+	if atIdx <= 0 {
+		return registry
+	}
+
+	// Password exists only when there is a ":" within the credential segment
+	// (matching extractCredentials' colonIdx > 0 requirement).
+	colonIdx := strings.Index(registry[:atIdx], ":")
+	if colonIdx <= 0 {
+		return registry
+	}
+
+	// Empty password (e.g. "user:@host" or an unset "${TOKEN}" expanded away):
+	// nothing secret to mask, and masking would misleadingly imply a password.
+	if registry[colonIdx+1:atIdx] == "" {
+		return registry
+	}
+
+	return registry[:colonIdx+1] + registryCredentialMask + registry[atIdx:]
+}
+
 // parseHostAndPort parses the host:port portion of a registry spec.
 // Returns host, port, and whether an explicit port was provided.
 func parseHostAndPort(spec string) (string, int32, bool) {

--- a/pkg/apis/cluster/v1alpha1/local_registry_test.go
+++ b/pkg/apis/cluster/v1alpha1/local_registry_test.go
@@ -288,3 +288,43 @@ func TestLocalRegistry_ResolvedPath(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactRegistryCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		registry string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"no_credentials_with_port", "localhost:5050", "localhost:5050"},
+		{"no_credentials_with_path", "ghcr.io/org/repo", "ghcr.io/org/repo"},
+		{"username_only_no_password", "user@ghcr.io", "user@ghcr.io"},
+		{"empty_password", "user:@ghcr.io", "user:@ghcr.io"},
+		{"masks_pat", "user:ghp_secret@ghcr.io/org", "user:****@ghcr.io/org"},
+		{
+			"masks_pat_keeps_port_and_path",
+			"user:ghp_secret@ghcr.io:443/org/repo:tag",
+			"user:****@ghcr.io:443/org/repo:tag",
+		},
+		{
+			"masks_resolved_github_actor_credentials",
+			"GITHUB_ACTOR:ghp_abc123@ghcr.io/devantler-tech",
+			"GITHUB_ACTOR:****@ghcr.io/devantler-tech",
+		},
+		{"masks_password_containing_colons", "user:p:a:ss@ghcr.io", "user:****@ghcr.io"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				testCase.expected,
+				v1alpha1.RedactRegistryCredentials(testCase.registry),
+			)
+		})
+	}
+}

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -256,15 +256,22 @@ func appendChange(
 		return
 	}
 
-	change := clusterupdate.Change{
+	routeChange(result, clusterupdate.Change{
 		Field:    field,
 		OldValue: oldVal,
 		NewValue: newVal,
 		Category: category,
 		Reason:   reason,
-	}
+	})
+}
 
-	switch category {
+// routeChange appends a fully-formed change to the result slice matching its
+// category. Unlike appendChange it performs no equality check or default
+// substitution, so callers that have already decided a change occurred (and may
+// have transformed the displayed values, e.g. redacting secrets) can route it
+// without the value-based short-circuit dropping the entry.
+func routeChange(result *clusterupdate.UpdateResult, change clusterupdate.Change) {
+	switch change.Category {
 	case clusterupdate.ChangeCategoryRecreateRequired:
 		result.RecreateRequired = append(result.RecreateRequired, change)
 	case clusterupdate.ChangeCategoryInPlace:
@@ -423,11 +430,33 @@ func (e *Engine) checkLocalRegistryChange(
 		return
 	}
 
-	if rc, ok := localRegistryReasonMap[e.distribution]; ok {
-		appendChange(result, "cluster.localRegistry.registry",
-			oldSpec.LocalRegistry.Registry, newSpec.LocalRegistry.Registry,
-			"", rc.reason, rc.category)
+	reasonCategory, ok := localRegistryReasonMap[e.distribution]
+	if !ok {
+		return
 	}
+
+	oldRegistry := oldSpec.LocalRegistry.Registry
+	newRegistry := newSpec.LocalRegistry.Registry
+
+	// Detect the change on the raw specs so a credentials-only change (e.g. a
+	// rotated registry password / GHCR PAT) is still reported, then route it with
+	// the password redacted. The registry spec embeds credentials in
+	// [user:pass@]host form and is env-expanded before diffing, so emitting it
+	// verbatim would leak the resolved secret into the diff table, JSON output,
+	// and recreate/reboot warnings. This Change is display-only — apply logic
+	// resolves credentials from the spec, never from the diff — so redacting the
+	// stored value here is safe.
+	if oldRegistry == newRegistry {
+		return
+	}
+
+	routeChange(result, clusterupdate.Change{
+		Field:    "cluster.localRegistry.registry",
+		OldValue: v1alpha1.RedactRegistryCredentials(oldRegistry),
+		NewValue: v1alpha1.RedactRegistryCredentials(newRegistry),
+		Category: reasonCategory.category,
+		Reason:   reasonCategory.reason,
+	})
 }
 
 // checkVanillaOptionsChange checks Vanilla (Kind) specific option changes.

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -236,7 +236,7 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 // Both applyFieldRules and applyProviderFieldRules delegate to this helper to
 // avoid duplicating the default-value substitution and category dispatch logic.
 //
-//nolint:cyclop // single dispatch switch over change categories
+
 func appendChange(
 	result *clusterupdate.UpdateResult,
 	field, oldVal, newVal, defaultVal, reason string,

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -412,6 +412,55 @@ func TestEngine_LocalRegistryChange_OldEmpty_Skipped(t *testing.T) {
 	}
 }
 
+func TestEngine_LocalRegistryChange_RedactsPassword(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	old.LocalRegistry.Registry = "GITHUB_ACTOR:ghp_oldsecret@ghcr.io/org"
+
+	newer := clone(old)
+	newer.LocalRegistry.Registry = "GITHUB_ACTOR:ghp_newsecret@ghcr.io/neworg"
+
+	engine := diff.NewEngine(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	// Vanilla registry changes are recreate-required; the PAT must be masked while
+	// the username, host, and path stay visible.
+	assertSingleChange(t, result.RecreateRequired, "cluster.localRegistry.registry",
+		"GITHUB_ACTOR:****@ghcr.io/org", "GITHUB_ACTOR:****@ghcr.io/neworg",
+		clusterupdate.ChangeCategoryRecreateRequired)
+
+	// Defense-in-depth: the resolved PAT must not appear in any emitted change value.
+	for _, change := range result.AllChanges() {
+		if strings.Contains(change.OldValue, "ghp_oldsecret") ||
+			strings.Contains(change.NewValue, "ghp_newsecret") {
+			t.Errorf("registry diff leaked PAT: old=%q new=%q", change.OldValue, change.NewValue)
+		}
+	}
+}
+
+func TestEngine_LocalRegistryChange_PasswordOnly_StillDetected(t *testing.T) {
+	t.Parallel()
+
+	// Only the password (PAT) rotates; host, user, and path are unchanged. The
+	// change must still be detected even though both redacted values are identical,
+	// because detection runs on the raw specs before redaction.
+	old := newBaseSpec()
+	old.Distribution = v1alpha1.DistributionTalos
+	old.LocalRegistry.Registry = "user:OLDPAT@ghcr.io/org"
+
+	newer := clone(old)
+	newer.LocalRegistry.Registry = "user:NEWPAT@ghcr.io/org"
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	change := findChange(result.InPlaceChanges, "cluster.localRegistry.registry")
+	require.NotNil(t, change, "a credentials-only registry change must still be detected")
+	require.Equal(t, "user:****@ghcr.io/org", change.OldValue)
+	require.Equal(t, "user:****@ghcr.io/org", change.NewValue)
+}
+
 func TestEngine_VanillaOptionsChange(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

`ksail cluster update` (dry-run **and** real run) and `ksail cluster diff` printed the configured registry **password — e.g. a GHCR Personal Access Token — in cleartext**.

`cluster.localRegistry.registry` holds the registry spec as `[user:pass@]host[:port][/path]`, and `Cluster.ExpandEnvVars()` resolves `${GITHUB_TOKEN}`-style placeholders **before** the diff runs — so the before/after view carried the *resolved* secret. It leaked through four output paths:

- the diff table
- the `--output json` payload
- the recreate-required warning (Kind/Vanilla registry changes are recreate-required)
- the reboot-required warning

## Fix

Redact the password at the single source — the diff engine's `checkLocalRegistryChange` (`pkg/svc/diff/engine.go`):

- Change **detection** still runs on the raw specs, so a credentials-only rotation is still reported.
- The **routed** value masks only the password: `GITHUB_ACTOR:****@ghcr.io/org` — username, host, port, and path stay visible so the diff remains useful.
- The registry `Change` is display-only (apply logic resolves credentials from the spec, never from the diff), so redacting at the engine covers all four output paths at once.

New `v1alpha1.RedactRegistryCredentials` (`pkg/apis/cluster/v1alpha1/local_registry.go`) does the masking, mirroring `Parse()`'s credential boundaries so it masks exactly what `ResolveCredentials()` would surface. It's a no-op for credential-free specs (`localhost:5050`, `ghcr.io/org/repo`).

### Scope decisions
- **Always redact** — no opt-out / reveal flag.
- **Password only** — username/host/port/path stay visible.

## Tests
- `TestRedactRegistryCredentials` — 9 cases (PAT, no-creds, username-only, empty password, colons-in-password, resolved-actor form, port+path).
- `TestEngine_LocalRegistryChange_RedactsPassword` — both columns masked; raw PAT absent from every emitted change value.
- `TestEngine_LocalRegistryChange_PasswordOnly_StillDetected` — a credentials-only rotation is still detected even though both redacted columns are identical.
- `go build ./...`, `go test` (changed packages + `pkg/cli/cmd/cluster`), and `golangci-lint run --new-from-rev=HEAD` all pass.

## Follow-up (not in this PR)
The same resolved PAT is also written **to disk** by `SaveClusterSpec` (`~/.ksail/clusters/<name>/spec.json`), which is the update diff baseline. That at-rest leak is separate from this display fix and needs its own change (store the un-expanded reference vs. redact-on-save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
