### PR TITLE
fix(cd): publish release before bumping Homebrew tap; build CLI and desktop in parallel

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: read
     defaults:
       run:
         working-directory: vsce
@@ -153,7 +153,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -201,7 +201,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     permissions:
-      contents: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -652,8 +652,10 @@ jobs:
               continue
             fi
             echo "Promoting ${TAP}#${pr} (${branch})"
-            gh pr ready "$pr" --repo "$TAP"
-            # Belt-and-suspenders alongside the tap's own auto-merge automation.
+            # Both gh calls are non-fatal under `set -e`: the PR may already be ready, or auto-merge
+            # may already be enabled by the tap's own automation — neither should fail the job.
+            gh pr ready "$pr" --repo "$TAP" \
+              || echo "::warning::Could not mark ${TAP}#${pr} ready; it may already be ready"
             gh pr merge "$pr" --repo "$TAP" --auto --squash \
               || echo "::warning::Could not enable auto-merge for ${TAP}#${pr}; the tap automation may still merge it"
           done

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -85,7 +85,6 @@ jobs:
     name: 🧩 Release VSCode Extension
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [goreleaser]
     permissions:
       contents: write
     defaults:
@@ -133,22 +132,26 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.version }}
 
-      - name: 📤 Upload VSIX to release
-        run: gh release upload "${GITHUB_REF#refs/tags/}" ksail_*.vsix --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 📤 Upload VSIX artifact
+        # Action inputs are workspace-relative — the job's `working-directory: vsce` default applies
+        # only to `run` steps — so the vsix lives under vsce/. publish-release attaches it to the draft.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-vscode
+          path: vsce/ksail_*.vsix
+          if-no-files-found: error
 
   # The macOS desktop app ships as a Homebrew cask. The desktop app is a separate Go module that
   # links a system webview via CGO and cannot be cross-compiled in the main release, so this job runs
   # a second GoReleaser config on a macOS runner: it builds the darwin binary, packages it as a
-  # KSail.app bundle and opens a cask PR on the homebrew tap. GoReleaser's release pipe is disabled
-  # (see .goreleaser.desktop.yaml); a separate step uploads the archive to the draft via `gh release
-  # upload`, mirroring the desktop (linux/windows) and vscode-extension jobs.
+  # KSail.app bundle and opens a *draft* cask PR on the homebrew tap (the `homebrew` job marks it ready
+  # after publication). GoReleaser's release pipe is disabled (see .goreleaser.desktop.yaml); the built
+  # archive is emitted as a workflow artifact and attached to the draft by `publish-release`. No
+  # `needs: [goreleaser]` — this builds in parallel with the CLI release.
   desktop-macos:
     name: 🧩 Release Desktop App (macOS cask)
     runs-on: macos-latest
     timeout-minutes: 40
-    needs: [goreleaser]
     permissions:
       contents: write
     steps:
@@ -179,23 +182,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
 
-      # GoReleaser's release pipe is disabled (.goreleaser.desktop.yaml), so attach the macOS archive
-      # to the existing draft here — same pattern as the desktop (linux/windows) and vscode jobs.
-      - name: 📤 Upload desktop app to release
-        shell: bash
-        run: gh release upload "${GITHUB_REF#refs/tags/}" dist-desktop/KSail_*_darwin_*.zip --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # GoReleaser's release pipe is disabled (.goreleaser.desktop.yaml). Emit the macOS archive as a
+      # workflow artifact; `publish-release` attaches it to the draft before publishing, so every asset
+      # is present before the release is locked by immutable releases (see #4874).
+      - name: 📤 Upload desktop archive artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-desktop-macos
+          path: dist-desktop/KSail_*_darwin_*.zip
+          if-no-files-found: error
 
   # Linux and Windows desktop binaries are convenience downloads (no cask). They build on native
-  # runners (CGO + the system webview) and attach to the draft release. publish-release needs: this
-  # job so every asset is attached before the draft is published — once published the release is
-  # immutable, and any upload still in flight would 422 (see #4874).
+  # runners (CGO + the system webview) in parallel with the CLI release and emit their archives as
+  # workflow artifacts; `publish-release` attaches them to the draft before publishing, so every asset
+  # is present before the release is locked by immutable releases (see #4874).
   desktop:
     name: 🧩 Release Desktop App
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
-    needs: [goreleaser]
     permissions:
       contents: write
     strategy:
@@ -270,12 +274,12 @@ jobs:
           esac
           echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
 
-      - name: 📤 Upload desktop app to release
-        shell: bash
-        run: gh release upload "${GITHUB_REF#refs/tags/}" "$ARTIFACT" --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARTIFACT: ${{ steps.package.outputs.artifact }}
+      - name: 📤 Upload desktop archive artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-desktop-${{ matrix.goos }}
+          path: ${{ steps.package.outputs.artifact }}
+          if-no-files-found: error
 
   copilot-plugin:
     name: 🧩 Release Copilot CLI Plugin
@@ -548,6 +552,23 @@ jobs:
         id: get_version
         run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
+      - name: 📥 Download release asset artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist-assets
+
+      # Attach the desktop archives and the VSIX to the draft BEFORE publishing. Once published the
+      # release is immutable and late uploads 422 (see #4874); all asset jobs gate this one, so every
+      # artifact exists here and is attached immediately before the draft→published flip below.
+      - name: 📤 Attach assets to draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.get_version.outputs.version }}
+        run: gh release upload "$RELEASE_TAG" dist-assets/* --clobber
+
       - name: 📢 Publish draft release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -602,3 +623,37 @@ jobs:
             });
 
             console.log(`Successfully published release ${tag}`);
+
+  # GoReleaser opens the Homebrew cask PRs during the build (CLI in `goreleaser`, macOS in
+  # `desktop-macos`) as DRAFTS, so the tap cannot merge them while the cask still points at a draft
+  # (not-yet-public, 404) release. Now that `publish-release` has made the release public, mark both
+  # PRs ready and enable auto-merge so the tap lands them — keeping the tap bump strictly after the
+  # GitHub release exists. Branch names mirror `.goreleaser*.yaml` (goreleaser/<project>-<tag>).
+  homebrew:
+    name: 🍺 Promote Homebrew cask PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [publish-release]
+    permissions:
+      contents: read
+    steps:
+      - name: 🍺 Mark cask PRs ready and enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          TAP: devantler-tech/homebrew-tap
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          for name in ksail ksail-desktop; do
+            branch="goreleaser/${name}-${TAG}"
+            pr="$(gh pr list --repo "$TAP" --head "$branch" --state open --json number --jq '.[0].number // empty')"
+            if [ -z "$pr" ]; then
+              echo "::warning::No open cask PR found on $TAP for branch ${branch}; skipping"
+              continue
+            fi
+            echo "Promoting ${TAP}#${pr} (${branch})"
+            gh pr ready "$pr" --repo "$TAP"
+            # Belt-and-suspenders alongside the tap's own auto-merge automation.
+            gh pr merge "$pr" --repo "$TAP" --auto --squash \
+              || echo "::warning::Could not enable auto-merge for ${TAP}#${pr}; the tap automation may still merge it"
+          done

--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -80,6 +80,10 @@ homebrew_casks:
       branch: "goreleaser/{{ .ProjectName }}-{{ .Tag }}"
       pull_request:
         enabled: true
+        # Open as a draft so the tap cannot auto-merge it while the GitHub release is still a draft
+        # (the cask download URL would 404 for `brew install`). The cd.yaml `homebrew` job marks the
+        # PR ready after `publish-release` flips the release public, letting the tap merge it then.
+        draft: true
     # The cask schema has no first-class `app` field; install the bundle via a custom stanza.
     custom_block: |
       app "KSail.app"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,6 +48,10 @@ homebrew_casks:
       branch: "goreleaser/{{ .ProjectName }}-{{ .Tag }}"
       pull_request:
         enabled: true
+        # Open as a draft so the tap cannot auto-merge it while the GitHub release is still a draft
+        # (the cask download URL would 404 for `brew install`). The cd.yaml `homebrew` job marks the
+        # PR ready after `publish-release` flips the release public, letting the tap merge it then.
+        draft: true
     hooks:
       post:
         install: |

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.17 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.18 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
@@ -63,7 +63,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
@@ -373,7 +373,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
-	google.golang.org/grpc v1.81.0 // indirect
+	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -88,8 +88,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.16 h1:r3RJBuU7X9ibt8RHbMjWE6y60Qb
 github.com/aws/aws-sdk-go-v2/credentials v1.19.16/go.mod h1:6cx7zqDENJDbBIIWX6P8s0h6hqHC8Avbjh9Dseo27ug=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 h1:UuSfcORqNSz/ey3VPRS8TcVH2Ikf0/sC+Hdj400QI6U=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23/go.mod h1:+G/OSGiOFnSOkYloKj/9M35s74LgVAdJBSD5lsFfqKg=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.17 h1:bQ7I0tljM1HcFmzl5y+8UDo15u74HaclcftKUFa3qUw=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.17/go.mod h1:7KtocjP2hqUspQdDcmkY9Ba8tt+cyzZ0s9tusvsDzLc=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.18 h1:9XFUd2lkr7VrbE4Qtrhm7AtNhGgZeGFI5QLZtQIflj8=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.18/go.mod h1:trImuKdWelQIJALvyGj6sKolJ1W8t628JOoTdDGVL9Q=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
@@ -104,8 +104,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 h1:pbrxO/ku
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23/go.mod h1:/CMNUqoj46HpS3MNRDEDIwcgEnrtZlKRaHNaHxIFpNA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1lTAbnRg5OK528EUg744nW7F73U8DKw=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1 h1:mxuT1xE+dI54NW3RkNjP8DUT5HXqbkiAFvfdyDFwE5c=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 h1:7byT8HUWrgoRp6sXjxtZwgOKfhss5fW6SkLBtqzgRoE=
@@ -1091,8 +1091,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348/go.mod h1:Yzdzr5OOZFgSsEV2D/Xi9NL3bszpXFAg0hFJiRohcD8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 h1:pfIbyB44sWzHiCpRqIen67ZQnVXSfIxWrqUMk1qwODE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
-google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
+google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

Fixes two issues in the tag-triggered release pipeline (`cd.yaml`).

### 1. The Homebrew tap was bumped *before* the GitHub release existed

GoReleaser opens the cask PRs on `devantler-tech/homebrew-tap` during the build, and the tap auto-merges them (`botantler[bot]`, squash) within ~1 minute. But the release is created as a **draft** and only **published** at the very end by `publish-release`. The casks point at `…/releases/download/<tag>/<artifact>`, which **404s for anonymous `brew install`** until the release is public.

Measured on **v7.22.0**:

| Event | Time (UTC) |
|---|---|
| `ksail` cask merged to tap | 17:07:06 |
| `ksail-desktop` cask merged to tap | 17:13:17 |
| GitHub release **published** | **17:14:43** |

→ the `ksail` cask was live and broken for ~7.5 min.

### 2. Desktop waited for the entire CLI release

`desktop-macos` / `desktop` / `vscode-extension` declared `needs: [goreleaser]` only so the draft release existed for their `gh release upload`, serializing the long macOS build (≤40 min) behind the full CLI release (≤60 min).

## What changed

**Homebrew ordering** — `homebrew_casks.repository.pull_request.draft: true` in both GoReleaser configs. The cask PRs are still opened during the build (correctly signed/computed) but as **drafts**, which can't auto-merge. A new post-publish `homebrew` job marks both PRs ready + enables auto-merge once `publish-release` has flipped the release public, so the tap is bumped **strictly after** the release exists.

**Parallelism** — the desktop/vscode jobs drop `needs: [goreleaser]` and emit their assets as `release-*` workflow artifacts, building fully in parallel with the CLI. `publish-release` downloads and attaches them to the draft, **then** flips it public — keeping the immutable-release invariant (all assets attached before publish) in one ordered job.

## Why draft PRs (not render-cask + hand-rolled tap PR)

The tap enforces *Require signed commits*, *Restrict commit metadata*, *Restrict branch names*, *Require linear history*, and required checks. GoReleaser's own push already satisfies all of them (and the PAT owner bypasses signed-commits — that's how the unsigned `ksail-desktop` cask merges today), so reusing GoReleaser and merely flipping its draft PR to ready is far more robust than hand-rolling compliant commits. SHA correctness is preserved because GoReleaser hashes the exact archive that ends up on the release (CLI archive it uploads itself; desktop archive re-attached byte-for-byte via the artifact).

## Reviewer notes

- Preserves the #4874/#4875 design: exactly one release per tag, all assets attached while draft, publish flips last (the `>1`-release guard is unchanged).
- Validated locally: `actionlint` ✔, `yamllint -c .yamllint.yml` ✔, `goreleaser check` on both configs ✔.
- **Only verifiable at the next real release:** that GoReleaser honors `pull_request.draft: true` at runtime, and the end-to-end timing (cask PRs open as drafts; merge only after publish; `brew install --cask devantler-tech/tap/ksail` and `…/ksail-desktop` succeed).
- Minor follow-up (not done, to keep the diff focused): `desktop*`/`vscode-extension` still declare `permissions: contents: write` though they no longer upload to the release — could be tightened to `contents: read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)