### PR TITLE
fix(update): honor --dry-run when combined with --config

### DIFF
--- a/pkg/fsutil/configmanager/ksail/manager.go
+++ b/pkg/fsutil/configmanager/ksail/manager.go
@@ -266,14 +266,17 @@ func (m *ConfigManager) resolveConfigFile() error {
 
 	m.ConfigFile = cfgPath
 
-	// Re-initialize Viper with the explicit config file path so it
-	// skips directory traversal and uses the exact file.
-	v, viperErr := InitializeViper(cfgPath)
-	if viperErr != nil {
-		return fmt.Errorf("invalid --config path: %w", viperErr)
+	// Point the existing Viper at the explicit config file so it skips directory
+	// traversal and uses the exact file. Reconfigure in place rather than
+	// replacing the instance, so that flag bindings registered via BindPFlag at
+	// command construction (e.g. --dry-run, --force, --update-kubernetes) are
+	// preserved. Replacing the instance silently dropped those bindings, making
+	// such flags revert to their defaults whenever --config was passed — e.g.
+	// `cluster update --config <file> --dry-run` applied changes for real (#4934).
+	err = configureViperConfigSource(m.Viper, cfgPath)
+	if err != nil {
+		return fmt.Errorf("invalid --config path: %w", err)
 	}
-
-	m.Viper = v
 
 	return nil
 }

--- a/pkg/fsutil/configmanager/ksail/manager_test.go
+++ b/pkg/fsutil/configmanager/ksail/manager_test.go
@@ -1449,3 +1449,71 @@ func TestLazyConfigFlagResolution_DefaultDiscovery(t *testing.T) {
 
 	require.NoError(t, root.Execute())
 }
+
+// TestExplicitConfigFlagPreservesBoundFlags verifies that flag bindings registered
+// via BindPFlag at command-construction time survive the lazy --config resolution
+// performed during Load. Behavioral flags such as --dry-run are read directly via
+// cfgManager.Viper.GetBool(...); if resolving --config replaces the Viper instance
+// (dropping its bindings), those flags silently revert to their defaults.
+//
+// Regression test for https://github.com/devantler-tech/ksail/issues/4934:
+// `cluster update --dry-run` applied changes instead of previewing them when
+// combined with the global --config flag, because --dry-run read false from a
+// freshly-constructed (binding-less) Viper.
+//
+//nolint:paralleltest // Uses t.Chdir to isolate file system state for config loading.
+func TestExplicitConfigFlagPreservesBoundFlags(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	workloadDir := filepath.Join(tempDir, "k8s")
+	require.NoError(t, os.MkdirAll(workloadDir, 0o750))
+
+	kindCfg := "apiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\nname: dryrun-test\n"
+	kindPath := filepath.Join(tempDir, "kind.yaml")
+	require.NoError(t, os.WriteFile(kindPath, []byte(kindCfg), 0o600))
+
+	// Config file in a non-standard location so Load must re-resolve it from the
+	// --config flag (the code path that previously replaced the Viper instance).
+	altConfig := "apiVersion: ksail.io/v1alpha1\n" +
+		"kind: Cluster\n" +
+		"spec:\n" +
+		"  cluster:\n" +
+		"    distribution: Vanilla\n" +
+		"    distributionConfig: " + kindPath + "\n" +
+		"    connection:\n" +
+		"      context: kind-dryrun-test\n" +
+		"  workload:\n" +
+		"    sourceDirectory: k8s\n"
+	altPath := filepath.Join(tempDir, "custom-config.yaml")
+	require.NoError(t, os.WriteFile(altPath, []byte(altConfig), 0o600))
+
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("config", "", "config file")
+
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+
+	selectors := configmanager.DefaultClusterFieldSelectors()
+	mgr := configmanager.NewCommandConfigManager(child, selectors)
+
+	// Register a behavioral flag bound to Viper at construction time, mirroring
+	// how `cluster update` binds --dry-run.
+	child.Flags().Bool("dry-run", false, "preview changes")
+	require.NoError(t, mgr.Viper.BindPFlag("dry-run", child.Flags().Lookup("dry-run")))
+
+	root.SetArgs([]string{"child", "--config", altPath, "--dry-run"})
+
+	child.RunE = func(_ *cobra.Command, _ []string) error {
+		_, err := mgr.Load(configmanagerinterface.LoadOptions{Silent: true})
+		require.NoError(t, err)
+
+		// The --dry-run binding must still be readable after Load resolved --config.
+		assert.True(t, mgr.Viper.GetBool("dry-run"),
+			"--dry-run binding must survive lazy --config resolution in Load")
+
+		return nil
+	}
+
+	require.NoError(t, root.Execute())
+}

--- a/pkg/fsutil/configmanager/ksail/viper.go
+++ b/pkg/fsutil/configmanager/ksail/viper.go
@@ -29,38 +29,56 @@ const (
 func InitializeViper(configFilePath string) (*viper.Viper, error) {
 	viperInstance := viper.New()
 
-	if configFilePath != "" {
-		// Canonicalize the user-supplied path: expand ~, make absolute, resolve symlinks.
-		expanded, err := fsutil.ExpandHomePath(configFilePath)
-		if err != nil {
-			return nil, fmt.Errorf("expanding config path %q: %w", configFilePath, err)
-		}
-
-		canonical, err := fsutil.EvalCanonicalPath(expanded)
-		if err != nil {
-			return nil, fmt.Errorf("canonicalizing config path %q: %w", configFilePath, err)
-		}
-
-		configFilePath = canonical
-		// Use the explicit config file path — skip name/type/path discovery.
-		// Still set config type so Viper can decode files without a .yaml/.yml extension.
-		viperInstance.SetConfigFile(configFilePath)
-		viperInstance.SetConfigType("yaml")
-	} else {
-		// Configure file settings first (highest precedence after flags/env)
-		configureViperFileSettings(viperInstance)
-
-		// Add standard configuration paths
-		configureViperPaths(viperInstance)
-
-		// Setup directory traversal for parent directories
-		addParentDirectoriesToViperPaths(viperInstance)
+	err := configureViperConfigSource(viperInstance, configFilePath)
+	if err != nil {
+		return nil, err
 	}
 
 	// Setup environment variable handling (higher precedence than config files)
 	configureViperEnvironment(viperInstance)
 
 	return viperInstance, nil
+}
+
+// configureViperConfigSource points the given Viper instance at its configuration
+// source. When configFilePath is non-empty the exact (canonicalized) file is used
+// and directory discovery is skipped; otherwise standard name-based discovery and
+// parent-directory traversal are configured.
+//
+// It operates on an existing instance — rather than constructing a fresh one — so
+// callers can switch an already-bound Viper to an explicit --config file without
+// dropping flag bindings registered via BindPFlag.
+func configureViperConfigSource(viperInstance *viper.Viper, configFilePath string) error {
+	if configFilePath != "" {
+		// Canonicalize the user-supplied path: expand ~, make absolute, resolve symlinks.
+		expanded, err := fsutil.ExpandHomePath(configFilePath)
+		if err != nil {
+			return fmt.Errorf("expanding config path %q: %w", configFilePath, err)
+		}
+
+		canonical, err := fsutil.EvalCanonicalPath(expanded)
+		if err != nil {
+			return fmt.Errorf("canonicalizing config path %q: %w", configFilePath, err)
+		}
+
+		// Use the explicit config file path — skip name/type/path discovery.
+		// Still set config type so Viper can decode files without a .yaml/.yml extension.
+		viperInstance.SetConfigFile(canonical)
+		viperInstance.SetConfigType("yaml")
+
+		return nil
+	}
+
+	// Configure file settings first (highest precedence after flags/env)
+	configureViperFileSettings(viperInstance)
+
+	// Add standard configuration paths
+	configureViperPaths(viperInstance)
+
+	// Setup directory traversal for parent directories
+	addParentDirectoriesToViperPaths(viperInstance)
+
+	return nil
 }
 
 // configureViperFileSettings sets up file-related configuration for Viper.


### PR DESCRIPTION
## Summary

Fixes #4934 — `ksail cluster update --dry-run` performed real mutations (per-node Talos `apply config` RPCs, autoscaler `Secret` creation) instead of only previewing, when invoked together with the global `--config` flag (the issue's exact invocation: `ksail --config ksail.prod.yaml cluster update --dry-run --output json`).

## Root cause

The `cluster update` dry-run gate was already correct:

```go
// pkg/cli/cmd/cluster/cluster.go — applyOrReportChanges
dryRun := cfgManager.Viper.GetBool("dry-run")
if dryRun {
    return reportDryRun(cmd, diff) // early return, no apply
}
```

…but `Viper.GetBool("dry-run")` returned `false` despite `--dry-run` being passed, **only when `--config` was also set**.

When `--config <file>` is used, the config manager resolves the path lazily during `Load()` and then **replaced** its Viper instance with a freshly-constructed one:

```go
// pkg/fsutil/configmanager/ksail/manager.go — resolveConfigFile (before)
v, _ := InitializeViper(cfgPath)
m.Viper = v // ← discards every BindPFlag binding registered at command construction
```

The fresh instance has no pflag bindings, so behavioral flags read directly via `cfgManager.Viper.GetBool(...)` — `--dry-run`, `--force`, `--update-kubernetes`, `--update-distribution` — silently reverted to their defaults whenever `--config` was passed. For `--dry-run` that meant the gate was skipped and the update applied for real.

Config-field flags (`--distribution`, `--provider`, `--name`, …) were unaffected: they reach `m.Config` through a separate cobra-direct override path (`captureChangedFlagValues` → `applyFlagOverrides`), not the Viper key.

## Fix

Reconfigure the **existing** Viper instance in place (point it at the explicit config file) instead of replacing it, so the bindings survive:

```go
// resolveConfigFile (after)
err = configureViperConfigSource(m.Viper, cfgPath)
```

`InitializeViper` is refactored to share the new `configureViperConfigSource` helper, leaving its behavior unchanged. `viper.SetConfigFile` still takes precedence over the directory-discovery settings, so the explicit file is used and traversal is skipped exactly as before.

This also restores `--force`, `--update-kubernetes`, and `--update-distribution` when combined with `--config`.

## Testing

- Added `TestExplicitConfigFlagPreservesBoundFlags` (`pkg/fsutil/configmanager/ksail/manager_test.go`) — fails before the fix, passes after; asserts a `BindPFlag`-bound flag is still readable after `Load` resolves an explicit `--config` file.
- `go build ./...` — clean.
- `go test ./...` — green (the only failures are the pre-existing env-flaky `pkg/cli/cmd/chat` exec/diagnostic tests that `signal: killed` under full-parallel load; they pass in isolation and are untouched by this change).
- `golangci-lint run --new-from-rev=HEAD` on the changed package — 0 issues.

## Scope

Targeted fix for #4934 only. The companion reports #4935 (`cluster update` exits 0 on a failed apply) and #4936 (Kubernetes upgraded to a version incompatible with the pinned Talos version) are separate issues and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
