### PR TITLE
fix(cluster): exit non-zero when cluster update changes fail to apply

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -8032,6 +8032,12 @@ func handleRecreateRequired(
 	return executeRecreateFlow(cmd, cfgManager, ctx, deps, clusterName, force)
 }
 
+// errUpdateChangesFailed signals that one or more changes failed to apply during
+// an in-place cluster update. reportFailedChanges has already printed the
+// per-change details; this sentinel exists so cobra surfaces a non-zero exit
+// (issue #4935) instead of reporting success on a partial or fully-failed apply.
+var errUpdateChangesFailed = errors.New("one or more changes failed to apply")
+
 // applyInPlaceChanges applies provisioner-level and component-level changes in-place.
 // force reflects an explicit --force/--yes (and governs partition wipes), while
 // allowRolling carries consent for rolling node replacement (via --force or an
@@ -8081,18 +8087,26 @@ func applyInPlaceChanges(
 
 	reportFailedChanges(cmd, result)
 
-	if componentErr != nil {
-		return fmt.Errorf("some component changes failed to apply: %w", componentErr)
+	// A non-empty FailedChanges set means the apply was partial or fully failed.
+	// Provisioner-level failures (e.g. a rejected Talos config) are recorded in
+	// result.FailedChanges with a nil Update error, and reconcileComponents
+	// appends component-level failures there too. Return a non-nil error so cobra
+	// exits non-zero — otherwise automation gating on the exit code treats a
+	// failed update as success (issue #4935). Skip the state save: a partial apply
+	// no longer matches the desired spec, so it must not become the saved baseline.
+	if result.HasFailedChanges() {
+		if componentErr != nil {
+			return fmt.Errorf("%w: %w", errUpdateChangesFailed, componentErr)
+		}
+
+		return errUpdateChangesFailed
 	}
 
-	// Persist the updated ClusterSpec for future update baselines.
-	// Only save when all changes applied successfully: failed changes mean
-	// the cluster state is partially applied and does not match the desired spec.
-	if len(result.FailedChanges) == 0 {
-		saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
-		if saveErr != nil {
-			notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
-		}
+	// Persist the updated ClusterSpec for future update baselines now that every
+	// change applied successfully.
+	saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
+	if saveErr != nil {
+		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
 	}
 
 	return nil

--- a/pkg/cli/cmd/cluster/cluster_test.go
+++ b/pkg/cli/cmd/cluster/cluster_test.go
@@ -4460,6 +4460,93 @@ func TestReconcileComponents_MixedKnownAndUnknown(t *testing.T) {
 	assert.Empty(t, result.FailedChanges)
 }
 
+// fakeUpdater is a test clusterprovisioner.Updater whose Update returns a preset
+// result and error, letting tests drive applyInPlaceChanges deterministically.
+type fakeUpdater struct {
+	result *clusterupdate.UpdateResult
+	err    error
+}
+
+func (f *fakeUpdater) Update(
+	_ context.Context,
+	_ string,
+	_, _ *v1alpha1.ClusterSpec,
+	_ clusterupdate.UpdateOptions,
+) (*clusterupdate.UpdateResult, error) {
+	return f.result, f.err
+}
+
+func (f *fakeUpdater) DiffConfig(
+	_ context.Context,
+	_ string,
+	_, _ *v1alpha1.ClusterSpec,
+) (*clusterupdate.UpdateResult, error) {
+	return clusterupdate.NewEmptyUpdateResult(), nil
+}
+
+func (f *fakeUpdater) GetCurrentConfig(
+	_ context.Context,
+	_ string,
+) (*v1alpha1.ClusterSpec, *v1alpha1.ProviderSpec, error) {
+	return nil, nil, nil
+}
+
+// TestApplyInPlaceChanges_FailedChangesReturnError verifies that provisioner-level
+// failures — recorded in result.FailedChanges with a nil Update error, as the
+// Talos provisioner does for a rejected machine config — make applyInPlaceChanges
+// return a non-nil error so the command exits non-zero (issue #4935). Before the
+// fix it returned nil and automation gating on the exit code saw a failed update
+// as success.
+func TestApplyInPlaceChanges_FailedChangesReturnError(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
+		Field:  "talos.config",
+		Reason: "apply control-plane config: rpc error",
+	})
+
+	// A non-component in-place change keeps reconcileComponents a no-op, so the
+	// only failure originates from the provisioner — isolating the bug's path.
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
+		Field: "controlPlanes", OldValue: "1", NewValue: "3",
+	})
+
+	ctx := &localregistry.Context{ClusterCfg: &v1alpha1.Cluster{}}
+
+	err := cluster.ExportApplyInPlaceChanges(
+		newReconcileTestCmd(), &fakeUpdater{result: result},
+		"update-exit-code-fail", &v1alpha1.ClusterSpec{}, ctx, diff,
+		nil, false, false,
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, cluster.ErrUpdateChangesFailed)
+}
+
+// TestApplyInPlaceChanges_NoFailuresSucceeds verifies the happy path: with no
+// failed changes, applyInPlaceChanges returns nil so a clean update still exits
+// zero.
+func TestApplyInPlaceChanges_NoFailuresSucceeds(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	result.AppliedChanges = append(result.AppliedChanges, clusterupdate.Change{
+		Field: "controlPlanes", OldValue: "1", NewValue: "3",
+	})
+
+	ctx := &localregistry.Context{ClusterCfg: &v1alpha1.Cluster{}}
+
+	err := cluster.ExportApplyInPlaceChanges(
+		newReconcileTestCmd(), &fakeUpdater{result: result},
+		"update-exit-code-ok", &v1alpha1.ClusterSpec{}, ctx,
+		clusterupdate.NewEmptyUpdateResult(), nil, false, false,
+	)
+
+	require.NoError(t, err)
+}
+
 // TestRestoreErrorConstants verifies that all sentinel error variables
 // defined in restore.go are non-nil and have meaningful messages.
 func TestRestoreErrorConstants(t *testing.T) {

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -18,6 +18,7 @@ import (
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/devantler-tech/ksail/v7/pkg/timer"
 	v1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -156,6 +157,30 @@ func ExportConfirmDisruptiveChanges(
 // ExportReportFailedChanges exports reportFailedChanges for testing.
 func ExportReportFailedChanges(cmd *cobra.Command, result *clusterupdate.UpdateResult) {
 	reportFailedChanges(cmd, result)
+}
+
+// ErrUpdateChangesFailed exports errUpdateChangesFailed for testing.
+var ErrUpdateChangesFailed = errUpdateChangesFailed
+
+// ExportApplyInPlaceChanges exposes applyInPlaceChanges for testing. It builds
+// the component reconciler internally so the unexported type is not needed.
+func ExportApplyInPlaceChanges(
+	cmd *cobra.Command,
+	updater clusterprovisioner.Updater,
+	clusterName string,
+	currentSpec *v1alpha1.ClusterSpec,
+	ctx *localregistry.Context,
+	diff *clusterupdate.UpdateResult,
+	outputTimer timer.Timer,
+	force bool,
+	allowRolling bool,
+) error {
+	reconciler := newComponentReconciler(cmd, ctx.ClusterCfg, clusterName)
+
+	return applyInPlaceChanges(
+		cmd, updater, reconciler, clusterName,
+		currentSpec, ctx, diff, outputTimer, force, allowRolling,
+	)
 }
 
 // ExportReportNoApplicableChanges exports reportNoApplicableChanges for testing.

--- a/pkg/svc/provisioner/cluster/clusterupdate/update.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/update.go
@@ -293,6 +293,14 @@ func (r *UpdateResult) HasUnknownBaseline() bool {
 	return len(r.UnknownBaseline) > 0
 }
 
+// HasFailedChanges returns true if one or more changes failed to apply. A
+// non-empty FailedChanges set means the live cluster only partially matches the
+// desired spec, so callers must treat the update as failed (non-zero exit)
+// rather than reporting success.
+func (r *UpdateResult) HasFailedChanges() bool {
+	return len(r.FailedChanges) > 0
+}
+
 // NeedsUserConfirmation returns true if any changes require user confirmation.
 // In-place changes can be applied silently; reboot, recreate, wipe, or rolling
 // node replacement require confirmation.

--- a/pkg/svc/provisioner/cluster/clusterupdate/update_test.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/update_test.go
@@ -243,6 +243,26 @@ func TestHasUnknownBaseline(t *testing.T) {
 	assert.Zero(t, result.TotalChanges())
 }
 
+// TestHasFailedChanges reports whether any change failed to apply. A non-empty
+// FailedChanges set must be treated as a failed update (issue #4935).
+func TestHasFailedChanges(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	assert.False(t, result.HasFailedChanges())
+
+	result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
+		Field:    "talos.config",
+		Category: clusterupdate.ChangeCategoryInPlace,
+		Reason:   "apply control-plane config: rpc error",
+	})
+
+	assert.True(t, result.HasFailedChanges())
+	// Failed changes are execution outcomes, not detected diff changes, so they
+	// are not counted by TotalChanges.
+	assert.Zero(t, result.TotalChanges())
+}
+
 // TestChangeCategory_String tests the string representation of change categories.
 func TestChangeCategory_String(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

`ksail cluster update` printed `✗ N changes failed to apply` but exited with status code **`0`**. Retry loops, CI, and GitOps automation that gate on the exit code therefore treated a fully-failed update as success.

This makes `cluster update` exit **non-zero** when one or more changes fail to apply.

Fixes #4935

## Root cause

Provisioners (Talos, K3d, …) deliberately accumulate per-change apply failures into `result.FailedChanges` and return a **nil** `Update` error — so they can attempt every change and report all failures at once. The contract is: `err` = "couldn't proceed"; `FailedChanges` = "attempted, failed, but kept going".

`applyInPlaceChanges` only surfaced `componentErr`, so a non-empty `result.FailedChanges` with a nil `Update` error (e.g. a rejected Talos machine config) fell through to `return nil` → cobra → `main.go` saw no error → exit `0`.

## Fix

- Add `UpdateResult.HasFailedChanges()` alongside the sibling `Has*` helpers.
- `applyInPlaceChanges` now returns a new `errUpdateChangesFailed` sentinel whenever `result.HasFailedChanges()` (wrapping `componentErr` when present). The per-change details are still printed by `reportFailedChanges`; the sentinel exists so cobra surfaces a non-zero exit.
- The state baseline is still persisted only on a fully-clean apply — a partial apply no longer matches the desired spec, so it must not become the saved baseline (unchanged behavior).

The exit-code decision lives at the CLI layer because `result.FailedChanges` is the common contract across all provisioners — fixing it here covers them uniformly. This mirrors the existing `cluster repair` → `errRepairsFailed` pattern.

## Test plan

- `TestHasFailedChanges` — unit test for the new helper.
- `TestApplyInPlaceChanges_FailedChangesReturnError` — regression for #4935: a provisioner-level failure (`FailedChanges` populated, nil `Update` error) now yields a non-nil error (`errors.Is(err, ErrUpdateChangesFailed)`). Confirmed **red before / green after** the fix.
- `TestApplyInPlaceChanges_NoFailuresSucceeds` — happy path still returns nil.

Verification: `go build` OK · changed packages green (isolation + full `go test ./...`) · `golangci-lint --new-from-rev=HEAD` → 0 new issues. (The only failures in the full suite were the known env-flaky `pkg/cli/cmd/chat` external-CLI tests, which pass in isolation and are unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
