### PR TITLE
chore(deps): remove stale multi-arch ghcr.io dependabot workaround notes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -66,7 +66,6 @@ updates:
     schedule:
       interval: daily
 
-  # Not working as-is because ghcr.io multi-arch image hits dependabot/dependabot-core#13383
   - package-ecosystem: docker
     registries: [ghcr]
     directory: /pkg/fsutil/configmanager/talos # Talos image (embedded in Go via go:embed)
@@ -91,7 +90,6 @@ updates:
     schedule:
       interval: daily
 
-  # Not working as-is because ghcr.io multi-arch image hits dependabot/dependabot-core#13383
   - package-ecosystem: docker
     registries: [ghcr]
     directory: /pkg/fsutil/configmanager/vcluster # vCluster images (embedded in Go via go:embed)


### PR DESCRIPTION
## What

Removes the two stale `# Not working as-is because ghcr.io multi-arch image hits dependabot/dependabot-core#13383` comments from `.github/dependabot.yaml` (above the Talos and vCluster `docker` entries).

## Why

The blocker for #3912 is resolved. The upstream Dependabot bug ([dependabot/dependabot-core#13383](https://github.com/dependabot/dependabot-core/issues/13383)) — a `404 Not Found` when resolving platform-specific manifest digests for multi-arch ghcr.io images (it fetched `/v2/<name>/blobs/<digest>` instead of `/v2/<name>/manifests/<digest>`) — was fixed by [dependabot/dependabot-core#14691](https://github.com/dependabot/dependabot-core/pull/14691), **merged and deployed on 2026-05-19**.

These two Dependabot entries were never actually disabled — they only carried the explanatory comment. The fix is **proven in production**: since 2026-05-19, Dependabot has successfully opened *and merged* update PRs for every affected multi-arch ghcr.io image:

| Image | Dockerfile | PR |
|---|---|---|
| `siderolabs/talos` | `pkg/fsutil/configmanager/talos` | #4908 |
| `loft-sh/vcluster-pro` | `pkg/fsutil/configmanager/vcluster` | #4943 |
| `loft-sh/kubernetes` | `pkg/fsutil/configmanager/vcluster` | #4915 |
| `fluxcd/source-controller` | `pkg/svc/installer/flux/Dockerfile.distribution` | #4914 |
| `fluxcd/kustomize-controller` | `pkg/svc/installer/flux/Dockerfile.distribution` | #4913 |
| `fluxcd/helm-controller` | `pkg/svc/installer/flux/Dockerfile.distribution` | #4916 |
| `getsops/sops` | `pkg/svc/installer/argocd/Dockerfile.sops` | #4921 |
| `postfinance/kubelet-csr-approver` | `pkg/svc/installer/kubeletcsrapprover/Dockerfile` | #4918 |

So the comments are now stale and misleading. This is exactly the cleanup prescribed in the issue's Resolution section.

## Validation

- `git diff` confirms only the two comment lines were removed; no functional config changed.
- `.github/dependabot.yaml` re-parses as valid YAML (version 2, 19 update entries, registries `dockerhub` + `ghcr`).

Fixes #3912

🤖 Generated with [Claude Code](https://claude.com/claude-code)