### PR TITLE
fix(provisioner): configurable nested-cluster readiness timeout (de-flake System Test)

### DIFF
--- a/.github/actions/ksail-test-kubernetes-provider/action.yaml
+++ b/.github/actions/ksail-test-kubernetes-provider/action.yaml
@@ -18,11 +18,23 @@ inputs:
   timeout:
     description: Timeout per nested cluster create (seconds)
     required: false
-    # 900s (15m): nested Talos on the Kubernetes provider (Talos-in-pod inside a
-    # vCluster/Docker host) is the heaviest combination and intermittently exceeded
-    # 600s under CI load (exit 124). Headroom over trimming coverage — see the matrix
-    # in ci.yaml and docs note on not reducing nested-distro coverage for flakes.
-    default: "900"
+    # 1200s (20m): the shell wrapper must stay ABOVE the provisioner's internal Go
+    # readiness deadline (ready-timeout, default 15m) so a slow-but-healthy nested
+    # cluster surfaces a clean Go "context deadline exceeded" rather than a shell
+    # "exit 124", and so nested Talos (Talos-in-pod inside a vCluster/Docker host —
+    # the heaviest combination, which intermittently exceeded the old 600s under CI
+    # load) keeps headroom. Headroom over trimming coverage — see #4891, the matrix
+    # in ci.yaml, and the docs note on not reducing nested-distro coverage for flakes.
+    default: "1200"
+  ready-timeout:
+    description: |
+      Go duration budget for a nested cluster to report ready (k3k "poll cluster
+      ready" / vCluster "wait for kubeconfig secret"). Exported as
+      KSAIL_NESTED_READY_TIMEOUT so a slow-but-healthy nested cluster under runner
+      contention is not failed prematurely at the 10m default (#4891). Keep the
+      `timeout` input above this value so the Go deadline wins over the shell kill.
+    required: false
+    default: "15m"
   cni:
     description: |
       Optional CNI to install in each nested cluster (e.g. "Calico"). When empty,
@@ -55,6 +67,10 @@ runs:
       env:
         DISTRIBUTIONS: ${{ inputs.distributions }}
         TIMEOUT: ${{ inputs.timeout }}
+        # Override the provisioner's internal readiness deadline (k3k poll-cluster-ready
+        # / vCluster kubeconfig-secret wait) so a slow-but-healthy nested cluster under
+        # runner contention is not failed prematurely at the 10m default. See #4891.
+        KSAIL_NESTED_READY_TIMEOUT: ${{ inputs.ready-timeout }}
         CNI: ${{ inputs.cni }}
         # Mirror proxy credentials. Exported here so ksail expands the ${...}
         # placeholders in the --mirror-registry specs from its own process env,
@@ -162,6 +178,22 @@ runs:
 
           # Restore host context in case nested cluster creation changed it.
           kubectl config use-context "$HOST_CONTEXT" 2>/dev/null || true
+
+          # Settle (bounded, best-effort, non-fatal): wait for the deleted cluster's
+          # namespaces to finish terminating before the next create. `ksail cluster
+          # delete` issues an async namespace delete (k3k-/vcluster-/ksail-<name>,
+          # each a suffix of $NESTED_NAME) and returns before finalizers complete;
+          # without this the prior cluster's still-terminating pods bleed load into the
+          # next nested create and can push k3k/vCluster readiness past its deadline (#4891).
+          echo "  ⏳ Waiting for $DIST resources to drain..."
+          SETTLE_DEADLINE=$((SECONDS + 120))
+          while [ "$SECONDS" -lt "$SETTLE_DEADLINE" ]; do
+            if [ -z "$(kubectl get ns -o name 2>/dev/null | grep -iF "$NESTED_NAME" || true)" ]; then
+              echo "  ✅ $DIST resources drained"
+              break
+            fi
+            sleep 5
+          done
 
           echo ""
         done

--- a/pkg/envvar/duration.go
+++ b/pkg/envvar/duration.go
@@ -1,0 +1,44 @@
+package envvar
+
+import (
+	"log/slog"
+	"os"
+	"time"
+)
+
+// Duration returns the time.Duration parsed from the named environment variable.
+// It falls back to fallback when the variable is unset or empty, and logs a
+// warning then falls back when the value is set but unparseable or non-positive.
+// Values use Go duration syntax (e.g. "15m", "1200s", "1h30m").
+func Duration(name string, fallback time.Duration) time.Duration {
+	raw, ok := os.LookupEnv(name)
+	if !ok || raw == "" {
+		return fallback
+	}
+
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		slog.Warn(
+			"ignoring invalid duration in environment variable; using default",
+			"name", name,
+			"value", raw,
+			"default", fallback,
+			"error", err,
+		)
+
+		return fallback
+	}
+
+	if parsed <= 0 {
+		slog.Warn(
+			"ignoring non-positive duration in environment variable; using default",
+			"name", name,
+			"value", raw,
+			"default", fallback,
+		)
+
+		return fallback
+	}
+
+	return parsed
+}

--- a/pkg/envvar/duration_test.go
+++ b/pkg/envvar/duration_test.go
@@ -1,0 +1,52 @@
+package envvar_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/envvar"
+	"github.com/stretchr/testify/assert"
+)
+
+// Note: Tests using t.Setenv cannot be run in parallel, so we run them sequentially.
+
+const durationTestEnvVar = "KSAIL_TEST_DURATION"
+
+func TestDuration(t *testing.T) {
+	fallback := 10 * time.Minute
+
+	testCases := []struct {
+		name     string
+		set      bool
+		value    string
+		expected time.Duration
+	}{
+		{name: "unset uses fallback", set: false, value: "", expected: fallback},
+		{name: "empty uses fallback", set: true, value: "", expected: fallback},
+		{name: "valid minutes", set: true, value: "15m", expected: 15 * time.Minute},
+		{name: "valid seconds", set: true, value: "1200s", expected: 1200 * time.Second},
+		{name: "valid compound", set: true, value: "1h30m", expected: 90 * time.Minute},
+		{name: "unparseable uses fallback", set: true, value: "not-a-duration", expected: fallback},
+		{name: "missing unit uses fallback", set: true, value: "20", expected: fallback},
+		{name: "zero uses fallback", set: true, value: "0", expected: fallback},
+		{name: "negative uses fallback", set: true, value: "-5m", expected: fallback},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Register cleanup to restore the original value, then put the variable
+			// into the desired state for this case.
+			t.Setenv(durationTestEnvVar, "placeholder")
+
+			if testCase.set {
+				t.Setenv(durationTestEnvVar, testCase.value)
+			} else {
+				_ = os.Unsetenv(durationTestEnvVar)
+			}
+
+			got := envvar.Duration(durationTestEnvVar, fallback)
+			assert.Equal(t, testCase.expected, got)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/k3d/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/export_test.go
@@ -2,11 +2,17 @@ package k3dprovisioner
 
 import (
 	"context"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/runner"
 	k3kv1beta1 "github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// K3kReadyTimeoutForTest exposes k3kReadyTimeout for unit testing.
+func K3kReadyTimeoutForTest() time.Duration {
+	return k3kReadyTimeout()
+}
 
 // FirstRunningPodNameForTest exposes firstRunningPodName for unit testing.
 func FirstRunningPodNameForTest(pods []corev1.Pod) string {

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+	"github.com/devantler-tech/ksail/v7/pkg/envvar"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
@@ -39,7 +40,10 @@ const (
 	k3kKubeconfigSecretSuffix = "kubeconfig"
 	// k3kKubeconfigKey is the key in the kubeconfig Secret.
 	k3kKubeconfigKey = "kubeconfig.yaml"
-	// k3kWaitTimeout is the maximum time to wait for the k3k cluster to become ready.
+	// k3kWaitTimeout is the default maximum time to wait for the k3k cluster to become
+	// ready. Overridable via the KSAIL_NESTED_READY_TIMEOUT environment variable (see
+	// nestedReadyTimeoutEnvVar / k3kReadyTimeout) so CI can grant a slow-but-healthy
+	// nested cluster more headroom under runner contention without changing the default.
 	k3kWaitTimeout = 10 * time.Minute
 	// k3kWaitInterval is the polling interval when waiting for the cluster.
 	k3kWaitInterval = 5 * time.Second
@@ -54,6 +58,10 @@ const (
 	// nestedDebugEnvVar gates opt-in nested-cluster diagnostics (matches the value the
 	// CI nested-provider test sets and the Talos provisioner checks).
 	nestedDebugEnvVar = "KSAIL_NESTED_DEBUG"
+	// nestedReadyTimeoutEnvVar overrides k3kWaitTimeout with a Go duration (e.g. "15m").
+	// Matches the value the CI nested-provider action exports; lets a slow-but-healthy
+	// nested cluster under runner contention avoid a premature context-deadline failure.
+	nestedReadyTimeoutEnvVar = "KSAIL_NESTED_READY_TIMEOUT"
 )
 
 // errNoRunningServerPod is recorded while polling for a port-forwardable k3k server
@@ -736,6 +744,12 @@ func (p *K3kProvisioner) createClusterCR(
 	return nil
 }
 
+// k3kReadyTimeout returns the readiness wait budget for nested k3k clusters,
+// honoring the KSAIL_NESTED_READY_TIMEOUT override and falling back to k3kWaitTimeout.
+func k3kReadyTimeout() time.Duration {
+	return envvar.Duration(nestedReadyTimeoutEnvVar, k3kWaitTimeout)
+}
+
 // waitForClusterReady polls the k3k Cluster status until it reports Ready.
 func (p *K3kProvisioner) waitForClusterReady(
 	ctx context.Context,
@@ -747,7 +761,7 @@ func (p *K3kProvisioner) waitForClusterReady(
 	}
 
 	err = wait.PollUntilContextTimeout(
-		ctx, k3kWaitInterval, k3kWaitTimeout, true,
+		ctx, k3kWaitInterval, k3kReadyTimeout(), true,
 		func(ctx context.Context) (bool, error) {
 			cluster := &k3kv1beta1.Cluster{}
 
@@ -825,7 +839,7 @@ func (p *K3kProvisioner) waitForKubeconfigSecret(
 	var kubeconfigData []byte
 
 	err := wait.PollUntilContextTimeout(
-		ctx, k3kWaitInterval, k3kWaitTimeout, true,
+		ctx, k3kWaitInterval, k3kReadyTimeout(), true,
 		func(ctx context.Context) (bool, error) {
 			secret, err := p.hostClientset.CoreV1().Secrets(namespace).Get(
 				ctx, secretName, metav1.GetOptions{},

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -2,7 +2,9 @@ package k3dprovisioner_test
 
 import (
 	"context"
+	"os"
 	"testing"
+	"time"
 
 	k3dconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/k3d"
 	k3dprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3d"
@@ -39,6 +41,22 @@ func TestBuildClusterCR_ServerArgs(t *testing.T) {
 		cluster := provisioner.BuildClusterCRForTest("test", "k3k-test", "10.0.0.1")
 
 		assert.Nil(t, cluster.Spec.ServerArgs)
+	})
+}
+
+func TestK3kReadyTimeout(t *testing.T) {
+	// Uses t.Setenv, so it cannot run in parallel.
+	t.Run("defaults to ten minutes when unset", func(t *testing.T) {
+		t.Setenv("KSAIL_NESTED_READY_TIMEOUT", "placeholder")
+		require.NoError(t, os.Unsetenv("KSAIL_NESTED_READY_TIMEOUT"))
+
+		assert.Equal(t, 10*time.Minute, k3dprovisioner.K3kReadyTimeoutForTest())
+	})
+
+	t.Run("honors KSAIL_NESTED_READY_TIMEOUT override", func(t *testing.T) {
+		t.Setenv("KSAIL_NESTED_READY_TIMEOUT", "15m")
+
+		assert.Equal(t, 15*time.Minute, k3dprovisioner.K3kReadyTimeoutForTest())
 	})
 }
 

--- a/pkg/svc/provisioner/cluster/vcluster/export_test.go
+++ b/pkg/svc/provisioner/cluster/vcluster/export_test.go
@@ -6,6 +6,9 @@ import "time"
 // IsTransientCreateErrorForTest exposes isTransientCreateError for unit testing.
 var IsTransientCreateErrorForTest = isTransientCreateError
 
+// VClusterReadyTimeoutForTest exposes vclusterReadyTimeout for unit testing.
+var VClusterReadyTimeoutForTest = vclusterReadyTimeout
+
 // CreateWithRetryForTest exposes createWithRetry for unit testing.
 var CreateWithRetryForTest = createWithRetry
 

--- a/pkg/svc/provisioner/cluster/vcluster/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/vcluster/kubernetes_provisioner.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/envvar"
 	vclusterconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/vcluster"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
@@ -42,13 +43,20 @@ const (
 	// in-cluster Service DNS name is not a SAN, so the served certificate is verified against this
 	// name (with the kubeconfig's CA) while connecting to the Service address.
 	vclusterInClusterServerName = "kubernetes"
-	// vclusterWaitTimeout is the maximum time to wait for vCluster readiness.
+	// vclusterWaitTimeout is the default maximum time to wait for vCluster readiness.
+	// Overridable via the KSAIL_NESTED_READY_TIMEOUT environment variable (see
+	// nestedReadyTimeoutEnvVar / vclusterReadyTimeout) so CI can grant a slow-but-healthy
+	// nested cluster more headroom under runner contention without changing the default.
 	vclusterWaitTimeout = 10 * time.Minute
 	// vclusterWaitInterval is the polling interval when waiting for the cluster.
 	vclusterWaitInterval = 5 * time.Second
 	// nestedDebugEnvVar gates opt-in nested-cluster diagnostics (matches the value the
 	// CI workflow sets to capture why a nested vCluster fails to come up on a given host).
 	nestedDebugEnvVar = "KSAIL_NESTED_DEBUG"
+	// nestedReadyTimeoutEnvVar overrides vclusterWaitTimeout with a Go duration (e.g. "15m").
+	// Matches the value the CI nested-provider action exports; lets a slow-but-healthy
+	// nested cluster under runner contention avoid a premature context-deadline failure.
+	nestedReadyTimeoutEnvVar = "KSAIL_NESTED_READY_TIMEOUT"
 )
 
 // KubernetesProvisioner provisions vCluster instances on a host Kubernetes cluster
@@ -429,6 +437,13 @@ func (p *KubernetesProvisioner) dumpNestedVClusterFailureDiagnostics(
 	_, _ = fmt.Fprint(os.Stdout, k8s.DumpNamespaceDiagnostics(ctx, p.hostClientset, namespace))
 }
 
+// vclusterReadyTimeout returns the readiness wait budget for nested vCluster
+// instances, honoring the KSAIL_NESTED_READY_TIMEOUT override and falling back
+// to vclusterWaitTimeout.
+func vclusterReadyTimeout() time.Duration {
+	return envvar.Duration(nestedReadyTimeoutEnvVar, vclusterWaitTimeout)
+}
+
 // waitForKubeconfigSecret polls for the vc-<name> Secret until it contains
 // the kubeconfig data, matching the approach used by the vCluster SDK itself.
 func (p *KubernetesProvisioner) waitForKubeconfigSecret(
@@ -439,7 +454,7 @@ func (p *KubernetesProvisioner) waitForKubeconfigSecret(
 	var kubeconfigData []byte
 
 	err := wait.PollUntilContextTimeout(
-		ctx, vclusterWaitInterval, vclusterWaitTimeout, true,
+		ctx, vclusterWaitInterval, vclusterReadyTimeout(), true,
 		func(ctx context.Context) (bool, error) {
 			secret, err := p.hostClientset.CoreV1().Secrets(namespace).Get(
 				ctx, secretName, metav1.GetOptions{},

--- a/pkg/svc/provisioner/cluster/vcluster/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/vcluster/kubernetes_provisioner_test.go
@@ -1,0 +1,27 @@
+package vclusterprovisioner_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	vclusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/vcluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVClusterReadyTimeout(t *testing.T) {
+	// Uses t.Setenv, so it cannot run in parallel.
+	t.Run("defaults to ten minutes when unset", func(t *testing.T) {
+		t.Setenv("KSAIL_NESTED_READY_TIMEOUT", "placeholder")
+		require.NoError(t, os.Unsetenv("KSAIL_NESTED_READY_TIMEOUT"))
+
+		assert.Equal(t, 10*time.Minute, vclusterprovisioner.VClusterReadyTimeoutForTest())
+	})
+
+	t.Run("honors KSAIL_NESTED_READY_TIMEOUT override", func(t *testing.T) {
+		t.Setenv("KSAIL_NESTED_READY_TIMEOUT", "15m")
+
+		assert.Equal(t, 15*time.Minute, vclusterprovisioner.VClusterReadyTimeoutForTest())
+	})
+}


### PR DESCRIPTION
## Summary

The `🧪 System Test (Docker)` base full-provider legs (`(Vanilla|K3s|VCluster|Talos, Docker, true)`) stand up a host cluster, then serially create 4 nested clusters on the Kubernetes provider. They intermittently failed 2/4 with `context deadline exceeded` on nested **k3k** (`poll cluster ready`) and **vCluster** (`wait for kubeconfig secret`). Now that every CI check is required to merge (#4864), this flaky base variant blocks every PR.

## Root cause

Both nested readiness deadlines are hardcoded `10 * time.Minute` (600s):
- `pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go` `k3kWaitTimeout`
- `pkg/svc/provisioner/cluster/vcluster/kubernetes_provisioner.go` `vclusterWaitTimeout`

#4864 raised the nested-provider action's shell `timeout` 600 → 900s (for nested Talos) but left the Go deadlines at 600s — creating an asymmetry where the **600s Go deadline is the binding constraint**, failing a slow-but-healthy nested cluster at 600s even though the shell would allow 900s.

It's a **contention tail, not a deterministic bug**: in a healthy post-#4864 run ([run 26659963968](https://github.com/devantler-tech/ksail/actions/runs/26659963968)), nested k3k reaches Ready in ~77s and vCluster in ~38s — 8–15× headroom under 600s. The flake is the slow-runner tail, made worse because `ksail cluster delete` returns before the prior nested namespace's finalizers drain, bleeding residual load into the next serial create.

## What changed

**Part A — configurable readiness deadline (default unchanged):**
- New reusable `envvar.Duration(name, fallback)` helper.
- Both provisioners resolve their deadline via `KSAIL_NESTED_READY_TIMEOUT`, falling back to the unchanged 10m default. No behavior change unless the env var is set.

**Part B — CI nested-provider action (`ksail-test-kubernetes-provider`):**
- Export `KSAIL_NESTED_READY_TIMEOUT=15m` (a +50% bump for the contention tail).
- Raise the shell `timeout` 900 → 1200s, kept above the 15m Go deadline so a clean Go `context deadline exceeded` wins over a shell `exit 124`.
- Add a bounded (~120s), best-effort, non-fatal **settle step**: after each delete, wait for the nested cluster's namespaces (`k3k-`/`vcluster-`/`ksail-<name>`, each a suffix of the nested name) to finish terminating before the next create, cutting the residual-load bleed.

`ci.yaml` is untouched: at 1200s × 4 serial creates + host/overhead ≈ 97 min, the existing `timeout-minutes: 120` budget holds.

Per the acceptance criteria this stays root-cause — no `continue-on-error`, no skipped provider, no dropping the variant from the required-checks gate.

## Test plan

- [x] `go build` + `go test ./pkg/envvar/... ./pkg/svc/provisioner/cluster/{k3d,vcluster}/...`
- [x] New regression tests: `envvar.Duration` (table-driven) + per-provisioner resolver tests asserting the `KSAIL_NESTED_READY_TIMEOUT` override and the 10m default
- [x] `golangci-lint run --new-from-rev=HEAD` → 0 new issues; shellcheck clean on the new settle step
- [ ] `🧪 System Test (Docker)` base full-provider legs pass reliably across re-runs (the real end-to-end proof — host contention can't be reproduced locally)

Fixes #4891

🤖 Generated with [Claude Code](https://claude.com/claude-code)
