### PR TITLE
ci: bump validate-go-project pin to v5.3.0 to fix actionlint code-quality false positive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,7 +273,7 @@ jobs:
   ci-go:
     name: ✅ Validate Go Project
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@45fc27ed85612da89daaf032d59266b830d7ab14 # v4.0.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@a84d9c0fe8ed4be505fb8665e94f7e9fa9c5114a # v5.3.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
`ksail` `main` CI has been **red since ~00:21Z** (the `🧹 Lint - mega-linter` job in `CI - KSail`, run [26675381199](https://github.com/devantler-tech/ksail/actions/runs/26675381199) and earlier). Root cause:

```
.github/workflows/ci.yaml:281:7: unknown permission scope "code-quality" … [permissions]
```

The GitHub-native Code Quality coverage migration added `code-quality: write` to the `ci-go` job (correct — GitHub now requires callers to grant it). But the `actionlint` bundled in MegaLinter (≤ v1.7.12) does not yet know that scope and emits a **false** "unknown permission scope" error, failing the lint job and `CI - Required Checks`.

## Fix
The shared reusable workflow already solved this: `reusable-workflows/.github/workflows/validate-go-project.yaml` sets `ACTION_ACTIONLINT_ARGUMENTS: -ignore code-quality`, released in **v5.x**. But `ksail` still pins **v4.0.0** (`45fc27e`), which predates the fix. This bumps the single `validate-go-project.yaml` pin:

- `@45fc27e # v4.0.0` → `@a84d9c0 # v5.3.0`

This is the root-cause fix — it pulls in the `-ignore code-quality` argument and unblocks `main` CI.

## Compatibility
The reusable workflow `workflow_call` interface is **identical** between v4.0.0 and v5.3.0 (same optional `pr-owner` input, same optional `APP_PRIVATE_KEY` secret); `ksail` passes no `with:` inputs, only `secrets.APP_PRIVATE_KEY`. So the major bump is interface-compatible from the caller side — the v4→v5 jump reflects internal/agent-neutral changes, not a changed call surface. The PR's own `CI - KSail` run validates the fix (mega-linter should now pass).

## Notes
- Touches only the one `validate-go-project.yaml` reference (the only reusable-workflow ref in `ci.yaml`, line 276). Other v4.x reusable-workflow pins elsewhere in the repo are not implicated in this break and are left for a separate routine bump.
- Opened as a **draft** — this sits inside the in-flight coverage migration, so promote (or supersede with your own pin bump) at your discretion.