### PR TITLE
fix(talos): align worker configs with control-plane PKI on cluster update

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -41,6 +41,17 @@ const MachineConfigField = "machine.config"
 // node's role (control-plane/worker) — an unexpected state for a valid cluster.
 var errNoRoleConfig = errors.New("no Talos machine config available for node role")
 
+// errMissingControlPlanePKI is returned when the secrets source used to realign a
+// desired config lacks the cluster CA private key. That key lives only on
+// control-plane nodes; worker configs carry certificates but no CA private keys.
+// Seeding a full config-bundle regeneration from a worker config therefore fails
+// deep inside Talos with an opaque "failed to parse PEM block" (#4963). Surfacing
+// this named error instead makes the precondition actionable.
+var errMissingControlPlanePKI = errors.New(
+	"secrets source lacks control-plane PKI (cluster CA private key); " +
+		"a control-plane node's config is required to realign worker configs",
+)
+
 // detectInPlaceMachineConfigDrift reports whether the desired Talos machine
 // config (base config + current patch files) differs from what is running on the
 // control-plane node, returning a single in-place change when it does.
@@ -85,7 +96,7 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 		return nil, nil
 	}
 
-	desired, err := p.buildDesiredNodeConfig(running, RoleControlPlane)
+	desired, err := p.buildDesiredNodeConfig(running, running, RoleControlPlane)
 	if err != nil {
 		return nil, err
 	}
@@ -121,13 +132,30 @@ func (p *Provisioner) detectInPlaceMachineConfigDrift(
 // *removals* detectable: a key dropped from a patch file is simply absent from
 // the regenerated config. The graft then restores the settings ksail injects
 // post-generation at create — which are not user patches and must not read as
-// drift. It returns an error if secret/endpoint alignment fails or the desired
-// config has no machine config for the node's role.
+// drift. secretsSource supplies the cluster PKI for realignment and must be a
+// control-plane node's config (see the body); pass nil to use running. It returns
+// an error if the secrets source lacks control-plane PKI, if secret/endpoint
+// alignment fails, or if the desired config has no machine config for the role.
 func (p *Provisioner) buildDesiredNodeConfig(
 	running talosconfig.Provider,
+	secretsSource talosconfig.Provider,
 	role string,
 ) (talosconfig.Provider, error) {
-	bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), running)
+	// The cluster PKI used to realign the regenerated config must come from a
+	// control-plane node: worker configs carry only certificates (no CA private
+	// keys, no etcd/aggregator/service-account material), so seeding the rebuild
+	// from a worker config fails inside Talos with an opaque "failed to parse PEM
+	// block" (#4963). Fall back to running only when no explicit source is given —
+	// valid when running is itself a control-plane config (e.g. drift detection).
+	if secretsSource == nil {
+		secretsSource = running
+	}
+
+	if !hasControlPlanePKI(secretsSource) {
+		return nil, errMissingControlPlanePKI
+	}
+
+	bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), secretsSource)
 
 	aligned, err := p.talosConfigs.WithSecrets(bundle)
 	if err != nil {
@@ -157,6 +185,17 @@ func (p *Provisioner) buildDesiredNodeConfig(
 	}
 
 	return graftNodeManagedSections(desired, running)
+}
+
+// hasControlPlanePKI reports whether a config provider carries the cluster CA
+// private key. That key is present only on control-plane nodes; worker configs
+// include the cluster CA certificate but not its key. Without it, regenerating a
+// full Talos config bundle (which re-issues certificates) cannot proceed and Talos
+// fails with an opaque "failed to parse PEM block".
+func hasControlPlanePKI(provider talosconfig.Provider) bool {
+	ca := provider.Cluster().IssuingCA()
+
+	return ca != nil && len(ca.Key) > 0
 }
 
 // alignKubernetesVersion renders the desired config at the Kubernetes version

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -124,7 +124,9 @@ func TestBuildDesiredNodeConfig_NoFalsePositive(t *testing.T) {
 
 	prov := talosprovisioner.NewProvisioner(configs, nil)
 
-	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
 	require.NoError(t, err)
 
 	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
@@ -166,7 +168,9 @@ func TestBuildDesiredNodeConfig_PreservesCreateInjectedMirrors(t *testing.T) {
 
 	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil)
 
-	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
 	require.NoError(t, err)
 
 	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
@@ -194,7 +198,9 @@ func TestBuildDesiredNodeConfig_DetectsRemoval(t *testing.T) {
 
 	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil)
 
-	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
 	require.NoError(t, err)
 
 	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
@@ -242,7 +248,9 @@ func TestBuildDesiredNodeConfig_PreservesRunningKubernetesVersion(t *testing.T) 
 
 	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil) // nil options => unpinned
 
-	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
 	require.NoError(t, err)
 
 	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
@@ -269,7 +277,9 @@ func TestBuildDesiredNodeConfig_PinnedKubernetesVersionAppliesUpgrade(t *testing
 	options := talosprovisioner.NewOptions().WithKubernetesVersion("1.33.0")
 	prov := talosprovisioner.NewProvisioner(desiredConfigs, options)
 
-	desired, err := prov.BuildDesiredNodeConfigForTest(running, talosprovisioner.RoleControlPlane)
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
 	require.NoError(t, err)
 
 	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
@@ -300,4 +310,100 @@ func TestConfigFingerprint(t *testing.T) {
 		),
 		"different configs produce different fingerprints",
 	)
+}
+
+// workerRunningFromPatches generates a config and returns the WORKER side parsed
+// back, as an existing worker node would store and return it. Unlike a
+// control-plane config it carries the cluster CA certificate but no CA private
+// keys — the shape that triggered #4963.
+func workerRunningFromPatches(
+	t *testing.T,
+	patches ...talosconfigmanager.Patch,
+) talosconfig.Provider {
+	t.Helper()
+
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(patches)
+	require.NoError(t, err)
+
+	workerBytes, err := configs.Worker().Bytes()
+	require.NoError(t, err)
+
+	running, err := configloader.NewFromBytes(workerBytes)
+	require.NoError(t, err)
+
+	return running
+}
+
+// TestBuildDesiredNodeConfig_WorkerUsesControlPlaneSecrets is the regression guard
+// for issue #4963: rebuilding an existing worker's desired config must seed the
+// cluster PKI from a control-plane config, because worker configs carry no CA
+// private keys. Before the fix this failed with "align secrets for config
+// comparison: failed to create config bundle: failed to parse PEM block", silently
+// skipping in-place machine.config changes on every existing worker.
+func TestBuildDesiredNodeConfig_WorkerUsesControlPlaneSecrets(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	// running is the worker's own config (no CA private keys); the secrets source
+	// is a control-plane config (full PKI) — exactly how the apply path threads it.
+	workerBytes, err := configs.Worker().Bytes()
+	require.NoError(t, err)
+
+	workerRunning, err := configloader.NewFromBytes(workerBytes)
+	require.NoError(t, err)
+
+	cpBytes, err := configs.ControlPlane().Bytes()
+	require.NoError(t, err)
+
+	cpSecretsSource, err := configloader.NewFromBytes(cpBytes)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(configs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		workerRunning, cpSecretsSource, talosprovisioner.RoleWorker,
+	)
+	require.NoError(t, err,
+		"worker desired-config build must succeed when seeded with control-plane PKI")
+
+	desiredBytes, err := desired.Bytes()
+	require.NoError(t, err)
+	assert.Contains(t, string(desiredBytes), "type: worker",
+		"the produced config is the worker config")
+	assert.Contains(t, string(desiredBytes), sysctlRmemMax,
+		"the patched sysctl reaches the worker config")
+}
+
+// TestBuildDesiredNodeConfig_WorkerSecretsSourceIsActionable verifies that seeding
+// the rebuild from a worker config (no cluster CA private key) yields a clear,
+// named error naming the control-plane PKI requirement, rather than Talos's opaque
+// "failed to parse PEM block" (the issue's "Expected" clause).
+func TestBuildDesiredNodeConfig_WorkerSecretsSourceIsActionable(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+	workerRunning := workerRunningFromPatches(t, patch)
+
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(configs, nil)
+
+	// Worker config as both running and secrets source — the pre-fix bug shape.
+	_, err = prov.BuildDesiredNodeConfigForTest(
+		workerRunning, workerRunning, talosprovisioner.RoleWorker,
+	)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to parse PEM block",
+		"must not surface Talos's opaque PEM error")
+	assert.Contains(t, err.Error(), "control-plane",
+		"error names the control-plane PKI requirement")
 }

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -415,9 +415,10 @@ var GraftNodeManagedSectionsForTest = graftNodeManagedSections
 // BuildDesiredNodeConfigForTest exposes buildDesiredNodeConfig for unit testing.
 func (p *Provisioner) BuildDesiredNodeConfigForTest(
 	running talosconfig.Provider,
+	secretsSource talosconfig.Provider,
 	role string,
 ) (talosconfig.Provider, error) {
-	return p.buildDesiredNodeConfig(running, role)
+	return p.buildDesiredNodeConfig(running, secretsSource, role)
 }
 
 // MachineConfigFieldForTest exposes the machine.config change field for unit testing.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -430,18 +430,45 @@ func (p *Provisioner) applyInPlaceConfigChanges(
 		return nil
 	}
 
+	// The desired-config rebuild needs the cluster PKI, which only a control-plane
+	// node carries. Resolve one control-plane config up front and reuse it as the
+	// secrets source for every node — seeding the rebuild from a worker's own config
+	// fails with "failed to parse PEM block" (#4963). All control-planes share the
+	// same PKI, so any one is a valid source.
+	secretsSource := p.fetchSecretsSource(ctx, clusterName)
+
 	for _, node := range nodes {
-		p.applyNodeConfig(ctx, node, result)
+		p.applyNodeConfig(ctx, node, secretsSource, result)
 	}
 
 	return nil
 }
 
+// fetchSecretsSource returns a control-plane node's running config, used to seed
+// the per-node desired-config rebuild with the cluster PKI. It returns nil when no
+// control-plane is reachable; callers then fall back to each node's own config,
+// which carries complete PKI only on control-plane nodes (see buildDesiredNodeConfig
+// and #4963).
+func (p *Provisioner) fetchSecretsSource(
+	ctx context.Context,
+	clusterName string,
+) talosconfig.Provider {
+	cpConfig, found, err := p.fetchRunningControlPlaneConfig(ctx, clusterName)
+	if err != nil || !found {
+		return nil
+	}
+
+	return cpConfig
+}
+
 // applyNodeConfig overlays the role-scoped user patches onto a node's running
-// config and applies the result (NO_REBOOT), recording success or failure.
+// config and applies the result (NO_REBOOT), recording success or failure. The
+// secretsSource (a control-plane config) supplies the cluster PKI for the rebuild;
+// see buildDesiredNodeConfig.
 func (p *Provisioner) applyNodeConfig(
 	ctx context.Context,
 	node nodeWithRole,
+	secretsSource talosconfig.Provider,
 	result *clusterupdate.UpdateResult,
 ) {
 	running, err := p.fetchNodeConfig(ctx, node.IP)
@@ -451,7 +478,7 @@ func (p *Provisioner) applyNodeConfig(
 		return
 	}
 
-	desired, err := p.buildDesiredNodeConfig(running, node.Role)
+	desired, err := p.buildDesiredNodeConfig(running, secretsSource, node.Role)
 	if err != nil {
 		p.recordNodeConfigFailure(node, result, fmt.Sprintf("build desired config: %v", err))
 


### PR DESCRIPTION
## Summary

Fixes #4963 — `ksail cluster update` on a multi-node Talos cluster (reported on Talos × Hetzner) failed to build the desired machine config for **existing worker** nodes:

```
build desired config: align secrets for config comparison: failed to create config bundle: failed to parse PEM block
```

Control-planes and brand-new workers applied fine; only the **existing-worker** secret-alignment path failed, so an intended in-place `machine.config` change (e.g. sysctls hardening) reached the control-planes but was **silently skipped on every existing worker**.

## Root cause

The in-place apply path (`applyInPlaceConfigChanges` → `applyNodeConfig` → `buildDesiredNodeConfig`) seeded the Talos secrets bundle from **each node's own running config**:

```go
bundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), running)
```

`NewBundleFromConfig` reads `Cluster().IssuingCA()`, `AggregatorCA()`, `ServiceAccount()`, `Etcd().CA()`, and `Machine().Security().IssuingCA()`. A **worker** config carries only certificates — verified field map:

| Field | Worker | Control-plane |
|---|---|---|
| cluster `IssuingCA` key | **empty** | present |
| `AggregatorCA` / `ServiceAccount` / `Etcd.CA` | **nil** | present |
| OS `IssuingCA` key | **empty** | present |

So regenerating a full config bundle from a worker config trips Talos's PEM parsing of the empty CA key. Control-planes carry full PKI (and drift detection only ever inspects a control-plane), which is why the failure was worker-only. `talosConfigs` during update holds *freshly generated* PKI — Talos persists no secrets state — so the real cluster PKI must come from a live control-plane node.

## Fix

- `buildDesiredNodeConfig` now takes an explicit `secretsSource` (a control-plane config, full PKI) separate from the per-node `running` config (still used for the endpoint and node-managed-section graft). All control-planes share the cluster PKI, so any one is a valid source.
- `applyInPlaceConfigChanges` resolves one control-plane config up front (`fetchSecretsSource`) and threads it to every node. If no control-plane is reachable it falls back to the per-node config (no regression vs. today).
- Added a `hasControlPlanePKI` guard that returns a **named, actionable** error (`errMissingControlPlanePKI`) instead of Talos's opaque `failed to parse PEM block` when a non-control-plane config is used as the secrets source — addressing the issue's "name which secret is malformed" ask.

## Tests

- `TestBuildDesiredNodeConfig_WorkerUsesControlPlaneSecrets` — regression: a worker's desired config builds cleanly when seeded with control-plane PKI, produces the worker config, and carries the patched sysctl. Fails on `main` with the exact issue error.
- `TestBuildDesiredNodeConfig_WorkerSecretsSourceIsActionable` — a worker config as the secrets source yields the named error, never the opaque PEM message.
- Existing `buildDesiredNodeConfig` tests updated to the new seam signature.

## Validation

- `go build` ✓ · `go test ./...` ✓ (only the known env-flaky `pkg/cli/cmd/chat` external-CLI tests fail under full parallel load — pass in isolation, unrelated to this Talos-only change)
- `gofmt` clean · `golangci-lint run --new-from-rev=HEAD` → 0 new issues

## Scope / notes

- Provider-agnostic (shared apply logic); helps Docker/Hetzner/Omni Talos clusters with workers alike. Single-node and control-plane-only paths are unaffected.
- The companion report (scale-up worker gets a generic hostname and never joins) is tracked separately and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)