### PR TITLE
fix(talos): set per-node hostname on Hetzner scale-up so nodes join

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -96,4 +96,11 @@ var (
 	ErrInsufficientControlPlanesForRoll = errors.New(
 		"too few control planes present to roll without losing etcd quorum",
 	)
+	// ErrNodeNameTooLong is returned when a generated Hetzner node name exceeds the
+	// 63-character DNS-1123 label limit. The node name doubles as the Talos
+	// hostname and the Kubernetes node name the Hetzner CCM matches against, so an
+	// over-long name would fail config apply or register a node the CCM cannot
+	// match. The cluster name is capped at 63, but appending "-<role>-<index>" can
+	// still overflow the limit.
+	ErrNodeNameTooLong = errors.New("generated node name exceeds maximum length")
 )

--- a/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
@@ -6,6 +6,7 @@ package talosprovisioner_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
@@ -121,4 +122,31 @@ func TestPatchTalosHostname_InvalidConfigErrors(t *testing.T) {
 
 	_, err := talosprovisioner.PatchTalosHostname([]byte("{"), "prod-worker-4")
 	require.Error(t, err)
+}
+
+// TestHetznerNodeName_WithinLimit verifies a normal node name is formatted and
+// accepted.
+func TestHetznerNodeName_WithinLimit(t *testing.T) {
+	t.Parallel()
+
+	name, err := talosprovisioner.HetznerNodeName("prod", "worker", 4)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-worker-4", name)
+}
+
+// TestHetznerNodeName_ExceedsLimit verifies that a cluster name which is itself
+// valid (<= 63 chars) but whose "-<role>-<index>" suffix pushes the node name
+// past the 63-character DNS-1123 label limit is rejected before provisioning —
+// the case the Hetzner CCM name-matching depends on (issue #4962 review).
+func TestHetznerNodeName_ExceedsLimit(t *testing.T) {
+	t.Parallel()
+
+	// A maximally-long but currently-valid cluster name (63 chars). Appending
+	// "-worker-1" (9 chars) yields 72 > 63.
+	clusterName := strings.Repeat("a", talosprovisioner.MaxNodeNameLength)
+
+	name, err := talosprovisioner.HetznerNodeName(clusterName, "worker", 1)
+	require.ErrorIs(t, err, talosprovisioner.ErrNodeNameTooLong)
+	assert.Contains(t, name, clusterName,
+		"formatted name is still returned so callers can use it in diagnostics")
 }

--- a/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talosprovisioner_test
+
+import (
+	"bytes"
+	"testing"
+
+	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// machineConfigView is a minimal view over a Talos MachineConfig document, used
+// to assert on the fields the hostname patch must set and preserve without
+// depending on the full machinery config interface surface.
+type machineConfigView struct {
+	Machine struct {
+		Type    string `yaml:"type"`
+		Network struct {
+			Hostname string `yaml:"hostname"`
+		} `yaml:"network"`
+	} `yaml:"machine"`
+	Cluster struct {
+		CA struct {
+			Crt string `yaml:"crt"`
+		} `yaml:"ca"`
+	} `yaml:"cluster"`
+}
+
+// workerConfigBytes builds a real Talos worker machine config for a cluster.
+func workerConfigBytes(t *testing.T, clusterName string) []byte {
+	t.Helper()
+
+	manager := talosconfigmanager.NewConfigManager("", clusterName, "1.32.0", "10.5.0.0/24")
+
+	configs, err := manager.Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, configs)
+
+	workerBytes, err := configs.Worker().Bytes()
+	require.NoError(t, err)
+
+	return workerBytes
+}
+
+// firstMachineConfigDoc parses the MachineConfig document out of a (possibly
+// multi-document) Talos config YAML. The MachineConfig is the document that
+// carries machine.type, so it is selected by the presence of that field.
+func firstMachineConfigDoc(t *testing.T, cfgBytes []byte) machineConfigView {
+	t.Helper()
+
+	decoder := yaml.NewDecoder(bytes.NewReader(cfgBytes))
+
+	for {
+		var doc machineConfigView
+
+		err := decoder.Decode(&doc)
+		if err != nil {
+			break
+		}
+
+		if doc.Machine.Type != "" {
+			return doc
+		}
+	}
+
+	t.Fatalf("no MachineConfig document found in config")
+
+	return machineConfigView{}
+}
+
+// TestPatchTalosHostname_SetsHostname verifies that PatchTalosHostname overlays
+// machine.network.hostname onto a real Talos worker config. This is the fix for
+// issue #4962: scaled-up Hetzner nodes booted from the public ISO have no cloud
+// metadata to derive their hostname from, so the hostname must be set explicitly
+// to the Hetzner server name for the Hetzner CCM to match the Node to the server.
+func TestPatchTalosHostname_SetsHostname(t *testing.T) {
+	t.Parallel()
+
+	workerBytes := workerConfigBytes(t, "prod")
+
+	patched, err := talosprovisioner.PatchTalosHostname(workerBytes, "prod-worker-4")
+	require.NoError(t, err)
+
+	doc := firstMachineConfigDoc(t, patched)
+	assert.Equal(t, "prod-worker-4", doc.Machine.Network.Hostname,
+		"hostname must match the Hetzner server name so the CCM can match the Node")
+}
+
+// TestPatchTalosHostname_PreservesConfig verifies that patching the hostname does
+// not drop other machine config — the node still carries the cluster CA and
+// remains a worker, so it can still join the existing cluster.
+func TestPatchTalosHostname_PreservesConfig(t *testing.T) {
+	t.Parallel()
+
+	workerBytes := workerConfigBytes(t, "prod")
+	before := firstMachineConfigDoc(t, workerBytes)
+	require.NotEmpty(t, before.Cluster.CA.Crt, "precondition: worker config carries a cluster CA")
+
+	patched, err := talosprovisioner.PatchTalosHostname(workerBytes, "prod-worker-4")
+	require.NoError(t, err)
+
+	after := firstMachineConfigDoc(t, patched)
+	assert.Equal(t, "worker", after.Machine.Type, "patched worker config must remain a worker")
+	assert.Equal(t, before.Cluster.CA.Crt, after.Cluster.CA.Crt,
+		"patching the hostname must not regenerate or drop the cluster CA")
+}
+
+// TestPatchTalosHostname_InvalidConfigErrors verifies that PatchTalosHostname
+// returns an error (rather than producing a node with the wrong identity) when
+// given bytes that cannot be parsed as a Talos machine config. A lone "{" is an
+// unterminated YAML flow mapping, which is a hard syntax error.
+func TestPatchTalosHostname_InvalidConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := talosprovisioner.PatchTalosHostname([]byte("{"), "prod-worker-4")
+	require.Error(t, err)
+}

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -133,25 +133,26 @@ func (p *Provisioner) createHetznerNodes(
 		group.Go(func() error {
 			nodeName, nameErr := hetznerNodeName(opts.ClusterName, opts.Role, nodeIndex+1)
 			if nameErr != nil {
+				// Validation failure: record it and skip provisioning (no billable
+				// server created). The goroutine still returns nil; the error is
+				// surfaced by collectCreatedHetznerServers reading results.
 				results[nodeIndex] = hetznerNodeCreationResult{name: nodeName, err: nameErr}
+			} else {
+				server, err := hzProvider.CreateServerWithRetry(ctx, hetzner.CreateServerOpts{
+					Name:             nodeName,
+					ServerType:       opts.ServerType,
+					ISOID:            opts.ISOID,
+					ImageID:          opts.ImageID,
+					Location:         opts.Location,
+					Labels:           hetzner.NodeLabels(opts.ClusterName, opts.Role, nodeIndex+1),
+					NetworkID:        infra.NetworkID,
+					PlacementGroupID: infra.PlacementGroupID,
+					SSHKeyID:         infra.SSHKeyID,
+					FirewallIDs:      []int64{infra.FirewallID},
+				}, retryOpts)
 
-				return nil // validation failure collected in results; skip provisioning
+				results[nodeIndex] = hetznerNodeCreationResult{name: nodeName, server: server, err: err}
 			}
-
-			server, err := hzProvider.CreateServerWithRetry(ctx, hetzner.CreateServerOpts{
-				Name:             nodeName,
-				ServerType:       opts.ServerType,
-				ISOID:            opts.ISOID,
-				ImageID:          opts.ImageID,
-				Location:         opts.Location,
-				Labels:           hetzner.NodeLabels(opts.ClusterName, opts.Role, nodeIndex+1),
-				NetworkID:        infra.NetworkID,
-				PlacementGroupID: infra.PlacementGroupID,
-				SSHKeyID:         infra.SSHKeyID,
-				FirewallIDs:      []int64{infra.FirewallID},
-			}, retryOpts)
-
-			results[nodeIndex] = hetznerNodeCreationResult{name: nodeName, server: server, err: err}
 
 			return nil // errors collected in results
 		})

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -26,6 +26,32 @@ import (
 // A value of 3 balances throughput and API rate-limit headroom.
 const maxConcurrentHetznerOps = 3
 
+// maxNodeNameLength is the maximum length of a Hetzner node name. The name is
+// used as the Hetzner server name, the Talos hostname (set in applyConfigToNode),
+// and the Kubernetes node name the Hetzner CCM matches against — all DNS-1123
+// labels capped at 63 characters. ValidateClusterName already caps the cluster
+// name at 63, but the "-<role>-<index>" suffix can push the composed name past
+// the limit, so the full node name must be validated too.
+const maxNodeNameLength = 63
+
+// hetznerNodeName formats and validates the name for a Hetzner node. It is the
+// single source of node-name construction for the create, scale-up, and
+// rolling-recreate paths, so the 63-character DNS-1123 label limit is enforced
+// consistently before any (billable) server is provisioned. The formatted name
+// is always returned, even when it is rejected, so callers can use it in
+// diagnostics and failure records.
+func hetznerNodeName(clusterName, role string, index int) (string, error) {
+	name := fmt.Sprintf("%s-%s-%d", clusterName, role, index)
+	if len(name) > maxNodeNameLength {
+		return name, fmt.Errorf(
+			"%w: %q is %d characters (max %d); shorten the cluster name",
+			ErrNodeNameTooLong, name, len(name), maxNodeNameLength,
+		)
+	}
+
+	return name, nil
+}
+
 // Apply-configuration retry defaults for transient Talos API handshake races.
 const (
 	talosApplyConfigMaxAttempts   = 3
@@ -105,7 +131,12 @@ func (p *Provisioner) createHetznerNodes(
 
 	for nodeIndex := range opts.Count {
 		group.Go(func() error {
-			nodeName := fmt.Sprintf("%s-%s-%d", opts.ClusterName, opts.Role, nodeIndex+1)
+			nodeName, nameErr := hetznerNodeName(opts.ClusterName, opts.Role, nodeIndex+1)
+			if nameErr != nil {
+				results[nodeIndex] = hetznerNodeCreationResult{name: nodeName, err: nameErr}
+
+				return nil // validation failure collected in results; skip provisioning
+			}
 
 			server, err := hzProvider.CreateServerWithRetry(ctx, hetzner.CreateServerOpts{
 				Name:             nodeName,

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -459,23 +459,9 @@ func (p *Provisioner) applyConfigToNode(
 
 	p.logf("  Applying config to %s (%s)...\n", server.Name, serverIP)
 
-	cfgBytes, err := config.Bytes()
+	cfgBytes, err := marshalConfigWithHostname(config, server.Name)
 	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
-	// Overlay the per-node hostname so it matches the Hetzner server name. The
-	// Hetzner CCM (cloud-provider: external) matches Kubernetes Nodes to servers
-	// by name, so a node that boots with the generic Talos hostname (talos-xxxxx)
-	// never gets initialized by the CCM and never joins the cluster. KSail boots
-	// scaled-up nodes from the public Talos ISO (the metal platform), which has no
-	// cloud metadata to derive the hostname from, so it must be set explicitly.
-	// Patching the marshaled bytes (rather than the shared talosconfig.Provider)
-	// keeps this safe for the parallel per-node apply, which reuses one config
-	// across goroutines.
-	cfgBytes, err = patchTalosHostname(cfgBytes, server.Name)
-	if err != nil {
-		return fmt.Errorf("failed to set hostname for %s: %w", server.Name, err)
+		return err
 	}
 
 	var lastErr error
@@ -522,6 +508,29 @@ func (p *Provisioner) applyConfigToNode(
 		server.Name,
 		errors.Join(errRetriesExhausted, lastErr),
 	)
+}
+
+// marshalConfigWithHostname marshals the role config to bytes and overlays the
+// per-node hostname so it matches the Hetzner server name. The Hetzner CCM
+// (cloud-provider: external) matches Kubernetes Nodes to servers by name, so a
+// node that boots with the generic Talos hostname (talos-xxxxx) never gets
+// initialized by the CCM and never joins the cluster. KSail boots scaled-up
+// nodes from the public Talos ISO (the metal platform), which has no cloud
+// metadata to derive the hostname from, so it must be set explicitly. Patching
+// the marshaled bytes (rather than the shared talosconfig.Provider) keeps this
+// safe for the parallel per-node apply, which reuses one config across goroutines.
+func marshalConfigWithHostname(config talosconfig.Provider, serverName string) ([]byte, error) {
+	cfgBytes, err := config.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	cfgBytes, err = patchTalosHostname(cfgBytes, serverName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set hostname for %s: %w", serverName, err)
+	}
+
+	return cfgBytes, nil
 }
 
 // patchTalosHostname overlays machine.network.hostname onto marshaled Talos

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -18,6 +18,7 @@ import (
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/bundle"
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -427,6 +428,20 @@ func (p *Provisioner) applyConfigToNode(
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
+	// Overlay the per-node hostname so it matches the Hetzner server name. The
+	// Hetzner CCM (cloud-provider: external) matches Kubernetes Nodes to servers
+	// by name, so a node that boots with the generic Talos hostname (talos-xxxxx)
+	// never gets initialized by the CCM and never joins the cluster. KSail boots
+	// scaled-up nodes from the public Talos ISO (the metal platform), which has no
+	// cloud metadata to derive the hostname from, so it must be set explicitly.
+	// Patching the marshaled bytes (rather than the shared talosconfig.Provider)
+	// keeps this safe for the parallel per-node apply, which reuses one config
+	// across goroutines.
+	cfgBytes, err = patchTalosHostname(cfgBytes, server.Name)
+	if err != nil {
+		return fmt.Errorf("failed to set hostname for %s: %w", server.Name, err)
+	}
+
 	var lastErr error
 
 	for attempt := 1; attempt <= talosApplyConfigMaxAttempts; attempt++ {
@@ -471,6 +486,34 @@ func (p *Provisioner) applyConfigToNode(
 		server.Name,
 		errors.Join(errRetriesExhausted, lastErr),
 	)
+}
+
+// patchTalosHostname overlays machine.network.hostname onto marshaled Talos
+// machine-config bytes via a strategic-merge patch, returning the patched bytes.
+// It operates on bytes rather than a shared talosconfig.Provider so it is safe to
+// call concurrently for each node during a parallel config apply (each call gets
+// its own copy). The hostname is the Hetzner server name, which is DNS-1123
+// compliant by construction (<cluster>-<role>-<index>, with cluster name
+// pre-validated), so it is a valid Talos hostname.
+func patchTalosHostname(cfgBytes []byte, hostname string) ([]byte, error) {
+	patch, err := configpatcher.LoadPatch(
+		fmt.Appendf(nil, "machine:\n  network:\n    hostname: %s\n", hostname),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load hostname patch: %w", err)
+	}
+
+	out, err := configpatcher.Apply(configpatcher.WithBytes(cfgBytes), []configpatcher.Patch{patch})
+	if err != nil {
+		return nil, fmt.Errorf("apply hostname patch: %w", err)
+	}
+
+	patched, err := out.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("encode patched config: %w", err)
+	}
+
+	return patched, nil
 }
 
 // attemptApplyConfig creates a single-use insecure Talos client and attempts to

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -151,7 +151,11 @@ func (p *Provisioner) createHetznerNodes(
 					FirewallIDs:      []int64{infra.FirewallID},
 				}, retryOpts)
 
-				results[nodeIndex] = hetznerNodeCreationResult{name: nodeName, server: server, err: err}
+				results[nodeIndex] = hetznerNodeCreationResult{
+					name:   nodeName,
+					server: server,
+					err:    err,
+				}
 			}
 
 			return nil // errors collected in results

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
@@ -11,3 +11,12 @@ var IsRetryableTalosApplyConfigError = isRetryableTalosApplyConfigError
 //
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
 var PatchTalosHostname = patchTalosHostname
+
+// HetznerNodeName exposes hetznerNodeName for tests in the
+// talosprovisioner_test package.
+//
+//nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
+var HetznerNodeName = hetznerNodeName
+
+// MaxNodeNameLength exposes maxNodeNameLength for tests.
+const MaxNodeNameLength = maxNodeNameLength

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
@@ -5,3 +5,9 @@ package talosprovisioner
 //
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
 var IsRetryableTalosApplyConfigError = isRetryableTalosApplyConfigError
+
+// PatchTalosHostname exposes patchTalosHostname for tests in the
+// talosprovisioner_test package.
+//
+//nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
+var PatchTalosHostname = patchTalosHostname

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -108,27 +108,28 @@ func (p *Provisioner) launchHetznerScaleCreation(
 
 			nodeName, nameErr := hetznerNodeName(clusterName, role, nodeNumber)
 			if nameErr != nil {
+				// Validation failure: record it and skip provisioning (no billable
+				// server created). The goroutine still returns nil; the error is
+				// surfaced when addHetznerNodes reads results.
 				results[nodeIdx] = hetznerNodeCreationResult{name: nodeName, err: nameErr}
+			} else {
+				server, createErr := hzProvider.CreateServerWithRetry(ctx, hetzner.CreateServerOpts{
+					Name:             nodeName,
+					ServerType:       p.hetznerServerType(role),
+					ISOID:            p.talosOpts.ISO,
+					Location:         p.hetznerOpts.Location,
+					Labels:           hetzner.NodeLabels(clusterName, role, nodeNumber),
+					NetworkID:        infra.NetworkID,
+					PlacementGroupID: infra.PlacementGroupID,
+					SSHKeyID:         infra.SSHKeyID,
+					FirewallIDs:      []int64{infra.FirewallID},
+				}, retryOpts)
 
-				return nil // validation failure collected in results; skip provisioning
-			}
-
-			server, createErr := hzProvider.CreateServerWithRetry(ctx, hetzner.CreateServerOpts{
-				Name:             nodeName,
-				ServerType:       p.hetznerServerType(role),
-				ISOID:            p.talosOpts.ISO,
-				Location:         p.hetznerOpts.Location,
-				Labels:           hetzner.NodeLabels(clusterName, role, nodeNumber),
-				NetworkID:        infra.NetworkID,
-				PlacementGroupID: infra.PlacementGroupID,
-				SSHKeyID:         infra.SSHKeyID,
-				FirewallIDs:      []int64{infra.FirewallID},
-			}, retryOpts)
-
-			results[nodeIdx] = hetznerNodeCreationResult{
-				name:   nodeName,
-				server: server,
-				err:    createErr,
+				results[nodeIdx] = hetznerNodeCreationResult{
+					name:   nodeName,
+					server: server,
+					err:    createErr,
+				}
 			}
 
 			return nil // errors collected in results

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -105,7 +105,13 @@ func (p *Provisioner) launchHetznerScaleCreation(
 	for nodeIdx := range count {
 		group.Go(func() error {
 			nodeNumber := nextIndex + nodeIdx
-			nodeName := fmt.Sprintf("%s-%s-%d", clusterName, role, nodeNumber)
+
+			nodeName, nameErr := hetznerNodeName(clusterName, role, nodeNumber)
+			if nameErr != nil {
+				results[nodeIdx] = hetznerNodeCreationResult{name: nodeName, err: nameErr}
+
+				return nil // validation failure collected in results; skip provisioning
+			}
 
 			server, createErr := hzProvider.CreateServerWithRetry(ctx, hetzner.CreateServerOpts{
 				Name:             nodeName,


### PR DESCRIPTION
## What

Fixes #4962 — on **Talos × Hetzner**, scaling workers up via `ksail cluster update` provisioned the server and applied its machine config, but the new node booted with the generic default Talos hostname (`talos-xxxxx`) instead of `<cluster>-worker-N`, so it never joined the cluster.

Sets `machine.network.hostname` to the Hetzner server name when applying config to each node, in `applyConfigToNode` — the single chokepoint shared by the **create**, **scale-up**, and **rolling-recreate** config-apply paths.

## Why

The Hetzner CCM runs with `cloud-provider: external` and matches Kubernetes `Node`s to Hetzner servers **by name**. A node that comes up as `talos-ljw-luc` is never initialized by the CCM, so the CNI never initializes and the node never registers — exactly the symptom in the issue (server provisions and bills, "Config applied", but the node never appears in `kubectl get nodes`).

Root cause: KSail never set `machine.network.hostname`. The **create** path happened to work because it boots nodes from the **hcloud snapshot** (the `hcloud` platform, which derives the hostname from cloud metadata). **Scale-up** and **rolling-recreate** boot from the **public Talos ISO** (the `metal` platform), which has no cloud metadata to derive a hostname from — so the node fell back to the generic default. (The Docker path was already correct: it sets the container `Hostname` per node.)

## How

`applyConfigToNode` now overlays `machine.network.hostname = <server.Name>` via a new `patchTalosHostname` helper before pushing config:

- The overlay is a **strategic-merge patch applied to the marshaled config bytes** (`configpatcher.Apply(WithBytes(...), ...)`), **not** the shared `talosconfig.Provider`. This matters because `configureNewHetznerNodes` applies one `configForRole(role)` to every new node concurrently — patching bytes gives each goroutine its own copy and avoids mutating shared state.
- `server.Name` is `<cluster>-<role>-<index>`, already DNS-1123 compliant (the cluster name is pre-validated), so it is a valid Talos hostname.
- On **create**, this sets the same value cloud metadata already produces → no behavior change there; it just makes every path deterministic and independent of boot source.

## Scope

- ✅ Hetzner workers **and** control-planes (same `scaleHetznerByRole` path), plus create and rolling-recreate (all route through `applyConfigToNode`).
- Unaffected: **Docker** (already sets `Hostname` per container) and **Omni** (node identity managed by the Omni API).
- Out of scope: companion issue #4963 (`parse PEM block` in the secret-sync path) — separate fix.

## Testing

New unit tests in `hetzner_hostname_test.go` (build a real Talos worker config via the config manager, patch, and assert on the resulting YAML):

- `TestPatchTalosHostname_SetsHostname` — `machine.network.hostname` is set to the server name.
- `TestPatchTalosHostname_PreservesConfig` — the cluster CA and worker role survive the patch (the node can still join).
- `TestPatchTalosHostname_InvalidConfigErrors` — invalid config bytes return an error rather than a wrong-identity node.

Local validation: `go build ./.` ✓ · `go vet` ✓ · `gofmt` clean · `golangci-lint run --new-from-rev=HEAD` → **0 issues** · full `talosprovisioner` package green · `go test ./...` → 139 packages ok (the only failure is the known `pkg/cli/cmd/chat` env-flake — spawns an external Copilot CLI, `signal: killed` under full parallel load, passes in isolation; unrelated to this change).

## Reviewer notes

- The fix can't be fully covered by a unit test — the real ISO-boot → CCM-join flow needs an **E2E run on a live Talos × Hetzner cluster** (scale 3 → 4 and confirm the new node joins as `<cluster>-worker-4`). Happy to extend `.github/workflows/system-test-hetzner.yaml` with a worker scale-up assertion if preferred.
- Confirmed against the pinned `siderolabs/talos/pkg/machinery v1.13.2` `configpatcher` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
