### PR TITLE
ci(cd): parallelize copilot-plugin & pages-build releases; gate deploy/publish on all releases

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -285,7 +285,10 @@ jobs:
     name: 🧩 Release Copilot CLI Plugin
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [goreleaser]
+    # Runs in parallel with the other releases — it only opens an auto-merging version-bump
+    # PR and consumes no GoReleaser artifact, so it does not wait on `goreleaser`. The gated
+    # `publish-release` and `pages-deploy` jobs both list it in `needs`, so a failure here
+    # still blocks the GitHub release publish and the docs deploy.
     environment: ci
     permissions:
       contents: write
@@ -457,7 +460,9 @@ jobs:
   pages-build:
     name: 📄 Build Pages
     runs-on: ubuntu-latest
-    needs: [goreleaser]
+    # Runs in parallel with the other releases (no GoReleaser artifact dependency). The
+    # gated `pages-deploy` and `publish-release` jobs both list it in `needs`, so a docs
+    # build failure blocks both the Pages deploy and the GitHub release publish.
     timeout-minutes: 10
     permissions:
       contents: read
@@ -521,7 +526,19 @@ jobs:
   pages-deploy:
     name: 🚀 Deploy Pages
     runs-on: ubuntu-latest
-    needs: [pages-build]
+    # Gate the docs deploy on ALL releases (not just `pages-build`) so a partial release
+    # failure never pushes a fresh docs site. Runs in parallel with `publish-release` —
+    # neither depends on the other; both fan in from the same set of release jobs.
+    needs:
+      [
+        goreleaser,
+        vscode-extension,
+        desktop-macos,
+        desktop,
+        copilot-plugin,
+        mcp-publish,
+        pages-build,
+      ]
     timeout-minutes: 10
     permissions:
       pages: write
@@ -535,15 +552,20 @@ jobs:
     name: 📢 Publish Release
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Gate on ALL releases so the draft is published only when every release succeeded.
+    # Runs in parallel with `pages-deploy` (it no longer lists it in `needs`) — both fan in
+    # from the same release jobs, so the GitHub release publish and the docs deploy happen
+    # concurrently. `pages-build` replaces the former `pages-deploy` edge: the release is
+    # gated on the docs *building*, not on Pages having deployed.
     needs:
       [
         goreleaser,
         vscode-extension,
         mcp-publish,
-        pages-deploy,
         copilot-plugin,
         desktop-macos,
         desktop,
+        pages-build,
       ]
     permissions:
       contents: write


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Rewires the `needs:` graph in [`.github/workflows/cd.yaml`](.github/workflows/cd.yaml) so the docs **Deploy Pages** and the **Publish Release** steps fan in from *all* release jobs and run in parallel, and so the two independent release builds no longer wait on the CLI build.

| Job | Before | After |
|---|---|---|
| `copilot-plugin` (Release Copilot CLI Plugin) | `needs: [goreleaser]` | *(none)* → parallel release |
| `pages-build` (Build Pages) | `needs: [goreleaser]` | *(none)* → parallel release |
| `pages-deploy` (Deploy Pages) | `needs: [pages-build]` | gated on **all** release jobs |
| `publish-release` (Publish Release) | `needs: [… pages-deploy …]` | gated on **all** release jobs, **no** `pages-deploy` edge → runs parallel to deploy |

## Why

Maps the pipeline to three requirements:

1. **Release Copilot CLI Plugin runs in parallel** with the other releases — it only opens an auto-merging version-bump PR and consumes no GoReleaser artifact, so there's no reason to wait on `goreleaser`.
2. **Build Pages runs in parallel** with the other releases — likewise no GoReleaser artifact dependency.
3. **Deploy Pages and Publish Release run in parallel but both depend on all releases succeeding**, so a partial-release failure never deploys a fresh docs site or flips the GitHub release public.

## Resulting DAG

```
tag push ──┬─ goreleaser (Release CLI) ──────────┐
           ├─ vscode-extension ──────────────────┤
           ├─ desktop-macos ─────────────────────┤
           ├─ desktop ───────────────────────────┼─→ pages-deploy   (Deploy Pages) ──┐
           ├─ copilot-plugin   ← now parallel ────┤                                    │
           ├─ pages-build      ← now parallel ────┤─→ publish-release (Publish Rel.) ──┴─→ homebrew
           └─ mcp-publish (needs: goreleaser) ────┘     (parallel; both gate on all 7 release jobs)
```

`pages-deploy` and `publish-release` no longer depend on each other; both list the same seven release jobs in `needs`, so they execute concurrently and either is skipped if any release fails.

## Reviewer notes

- **`mcp-publish` deliberately keeps `needs: [goreleaser]`** — it rewrites `server.json` to point at the GoReleaser-pushed `ghcr.io/devantler-tech/ksail:<tag>` image, a genuine data dependency, so it must run after the CLI release.
- **`publish-release` is gated on `pages-build`, not `pages-deploy`.** The release publish waits for the docs to *build* successfully (the meaningful failure signal) but does not block on the Pages deployment itself, letting publish and deploy proceed in parallel as required.
- **Copilot plugin gating:** per the written spec it runs in parallel and `publish-release`/`pages-deploy` gate on it (a copilot failure still blocks the release publish and docs deploy). It does **not** hold the copilot bump-PR's own merge until the other releases finish; if that stricter behavior is wanted, the job can be split homebrew-style (open draft PR in the parallel stage, mark-ready + auto-merge in a gated post-publish job).
- Validated locally with `actionlint` (passes); the `needs` graph has no cycles and no dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)