### PR TITLE
fix(desktop): inherit shell env on GUI launch and add macOS edit menu

### DIFF
--- a/desktop/env_darwin.go
+++ b/desktop/env_darwin.go
@@ -1,0 +1,154 @@
+//go:build darwin
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	envProbeTimeout = 5 * time.Second
+	envStartMarker  = "__KSAIL_ENV_START__"
+	envEndMarker    = "__KSAIL_ENV_END__"
+)
+
+// hydrateLoginShellEnv imports environment variables from the user's interactive login shell when
+// the app is launched from the macOS GUI (Finder, Dock, Spotlight, or `open -a KSail`, which is how
+// the `ksail desktop` command starts it). Such launches go through LaunchServices/launchd, which do
+// not source the user's shell profile, so variables exported there — HCLOUD_TOKEN,
+// OMNI_SERVICE_ACCOUNT_KEY, KUBECONFIG, PATH additions, … — are missing. The cluster providers that
+// depend on them then silently report nothing (e.g. Hetzner clusters never appear), even though
+// `ksail ui` from a terminal works because the shell already exported them.
+//
+// Variables already present are never overwritten (PATH is merged), so it is effectively a no-op
+// when the environment is already populated. It is skipped entirely unless the process was launched
+// from a bundle, so running the raw binary from a terminal pays no startup cost.
+func hydrateLoginShellEnv() {
+	if !launchedFromBundle() {
+		return
+	}
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/zsh"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), envProbeTimeout)
+	defer cancel()
+
+	// -i sources ~/.zshrc / ~/.bashrc and -l sources ~/.zprofile / ~/.profile, the two places users
+	// export credentials. The markers fence the env dump so any shell startup banner is ignored.
+	script := "echo " + envStartMarker + "; /usr/bin/env; echo " + envEndMarker
+
+	var stdout bytes.Buffer
+
+	//nolint:gosec // Runs the user's own login shell to import its environment; same trust as a terminal.
+	cmd := exec.CommandContext(ctx, shell, "-ilc", script)
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		return // Best effort: a missing token surfaces as "no clusters", never a crash.
+	}
+
+	mergeShellEnv(parseEnvDump(stdout.String()))
+}
+
+// launchedFromBundle reports whether the process was started from a macOS application bundle.
+// LaunchServices sets __CFBundleIdentifier in the environment for bundle launches; it is absent when
+// the binary is run directly from a shell, which already inherits the shell environment.
+func launchedFromBundle() bool {
+	return os.Getenv("__CFBundleIdentifier") != ""
+}
+
+// parseEnvDump extracts KEY=VALUE pairs printed by `env` between the markers.
+func parseEnvDump(out string) map[string]string {
+	env := make(map[string]string)
+
+	scanner := bufio.NewScanner(strings.NewReader(out))
+
+	inBlock := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		switch {
+		case line == envStartMarker:
+			inBlock = true
+		case line == envEndMarker:
+			inBlock = false
+		case inBlock:
+			key, value, found := strings.Cut(line, "=")
+			if found && isEnvName(key) {
+				env[key] = value
+			}
+		}
+	}
+
+	return env
+}
+
+// isEnvName reports whether s is a plausible environment variable name. It guards against multi-line
+// values (such as exported shell functions) being mistaken for new variables.
+func isEnvName(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for i, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r == '_':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+// mergeShellEnv applies shell-sourced variables to the process without clobbering any already set.
+// PATH is merged so GUI launches can still find CLIs (docker, kubectl, …) on the user's shell PATH.
+func mergeShellEnv(shellEnv map[string]string) {
+	for key, value := range shellEnv {
+		if key == "PATH" {
+			_ = os.Setenv("PATH", mergePath(os.Getenv("PATH"), value))
+
+			continue
+		}
+
+		_, present := os.LookupEnv(key)
+		if !present {
+			_ = os.Setenv(key, value)
+		}
+	}
+}
+
+// mergePath appends shell PATH entries missing from the current PATH, keeping current precedence.
+func mergePath(current, shell string) string {
+	if current == "" {
+		return shell
+	}
+
+	seen := make(map[string]bool)
+	for dir := range strings.SplitSeq(current, ":") {
+		seen[dir] = true
+	}
+
+	merged := []string{current}
+
+	for dir := range strings.SplitSeq(shell, ":") {
+		if dir != "" && !seen[dir] {
+			merged = append(merged, dir)
+			seen[dir] = true
+		}
+	}
+
+	return strings.Join(merged, ":")
+}

--- a/desktop/env_darwin_test.go
+++ b/desktop/env_darwin_test.go
@@ -1,0 +1,95 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseEnvDump(t *testing.T) {
+	t.Parallel()
+
+	out := "noise before the block\n" +
+		envStartMarker + "\n" +
+		"HCLOUD_TOKEN=secret-value\n" +
+		"PATH=/usr/local/bin:/usr/bin\n" +
+		"EMPTY=\n" +
+		"not an env line\n" +
+		"123BAD=skip\n" +
+		envEndMarker + "\n" +
+		"AFTER=ignored\n"
+
+	got := parseEnvDump(out)
+
+	if got["HCLOUD_TOKEN"] != "secret-value" {
+		t.Errorf("HCLOUD_TOKEN = %q, want %q", got["HCLOUD_TOKEN"], "secret-value")
+	}
+
+	if got["PATH"] != "/usr/local/bin:/usr/bin" {
+		t.Errorf("PATH = %q, want %q", got["PATH"], "/usr/local/bin:/usr/bin")
+	}
+
+	value, ok := got["EMPTY"]
+	if !ok || value != "" {
+		t.Errorf("EMPTY = %q (present=%v), want \"\" present=true", value, ok)
+	}
+
+	if _, ok := got["AFTER"]; ok {
+		t.Error("AFTER is outside the marker block and must be ignored")
+	}
+
+	if _, ok := got["123BAD"]; ok {
+		t.Error("123BAD is not a valid env name and must be skipped")
+	}
+}
+
+func TestIsEnvName(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"PATH", "HCLOUD_TOKEN", "_X", "A1", "aB_3"}
+	for _, name := range valid {
+		if !isEnvName(name) {
+			t.Errorf("isEnvName(%q) = false, want true", name)
+		}
+	}
+
+	invalid := []string{"", "1A", "A-B", "A B", "A.B"}
+	for _, name := range invalid {
+		if isEnvName(name) {
+			t.Errorf("isEnvName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestMergePath(t *testing.T) {
+	t.Parallel()
+
+	got := mergePath("/usr/bin:/bin", "/opt/homebrew/bin:/usr/bin:/usr/local/bin")
+	want := "/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin"
+
+	if got != want {
+		t.Errorf("mergePath = %q, want %q", got, want)
+	}
+
+	if got := mergePath("", "/opt/bin"); got != "/opt/bin" {
+		t.Errorf("mergePath with empty current = %q, want %q", got, "/opt/bin")
+	}
+}
+
+func TestMergeShellEnvDoesNotOverwriteExisting(t *testing.T) {
+	t.Setenv("KSAIL_TEST_EXISTING", "original")
+
+	mergeShellEnv(map[string]string{
+		"KSAIL_TEST_EXISTING": "from-shell",
+		"KSAIL_TEST_NEW":      "added",
+	})
+
+	if got := os.Getenv("KSAIL_TEST_EXISTING"); got != "original" {
+		t.Errorf("existing var was overwritten: got %q, want %q", got, "original")
+	}
+
+	if got := os.Getenv("KSAIL_TEST_NEW"); got != "added" {
+		t.Errorf("new var was not added: got %q, want %q", got, "added")
+	}
+}

--- a/desktop/env_other.go
+++ b/desktop/env_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package main
+
+// hydrateLoginShellEnv is a no-op on non-macOS platforms. The GUI-launch environment problem it
+// addresses is specific to how macOS LaunchServices starts application bundles without sourcing the
+// user's shell profile.
+func hydrateLoginShellEnv() {}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -39,6 +39,10 @@ func main() {
 }
 
 func run() error {
+	// Import the user's shell environment when launched from the macOS GUI, before the UI server
+	// and the cluster providers it drives read credentials such as HCLOUD_TOKEN from it.
+	hydrateLoginShellEnv()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -62,6 +66,7 @@ func run() error {
 
 	view.SetTitle(windowTitle)
 	view.SetSize(windowWidth, windowHeight, webview.HintNone)
+	installNativeMenu()
 	view.Navigate(url)
 	view.Run() // blocks until the window is closed
 

--- a/desktop/menu_darwin.go
+++ b/desktop/menu_darwin.go
@@ -1,0 +1,56 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+#import <Cocoa/Cocoa.h>
+
+// installEditMenu attaches a standard menu bar to the running NSApplication. The webview backend
+// (github.com/webview/webview_go) creates a bare NSWindow with no menu, and on macOS the
+// Cmd-C/Cmd-V/Cmd-X/Cmd-A clipboard shortcuts are delivered as menu key equivalents: with no Edit
+// menu carrying the standard editing selectors there is nothing to route them to, so copy and paste
+// silently do nothing inside the web view. Each item uses a nil target so the action travels the
+// responder chain to the focused WKWebView, which implements cut:/copy:/paste:/selectAll:.
+static void installEditMenu(void) {
+	@autoreleasepool {
+		NSApplication *app = [NSApplication sharedApplication];
+
+		NSMenu *menubar = [[NSMenu alloc] init];
+		[app setMainMenu:menubar];
+
+		// Application menu — also wires up the conventional Hide/Quit shortcuts.
+		NSMenuItem *appMenuItem = [[NSMenuItem alloc] init];
+		[menubar addItem:appMenuItem];
+		NSMenu *appMenu = [[NSMenu alloc] init];
+		[appMenuItem setSubmenu:appMenu];
+		[appMenu addItemWithTitle:@"Hide KSail" action:@selector(hide:) keyEquivalent:@"h"];
+		[appMenu addItem:[NSMenuItem separatorItem]];
+		[appMenu addItemWithTitle:@"Quit KSail" action:@selector(terminate:) keyEquivalent:@"q"];
+
+		// Edit menu — enables clipboard and selection shortcuts inside the web view.
+		NSMenuItem *editMenuItem = [[NSMenuItem alloc] init];
+		[menubar addItem:editMenuItem];
+		NSMenu *editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+		[editMenuItem setSubmenu:editMenu];
+		[editMenu addItemWithTitle:@"Undo" action:@selector(undo:) keyEquivalent:@"z"];
+		[editMenu addItemWithTitle:@"Redo" action:@selector(redo:) keyEquivalent:@"Z"];
+		[editMenu addItem:[NSMenuItem separatorItem]];
+		[editMenu addItemWithTitle:@"Cut" action:@selector(cut:) keyEquivalent:@"x"];
+		[editMenu addItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"c"];
+		[editMenu addItemWithTitle:@"Paste" action:@selector(paste:) keyEquivalent:@"v"];
+		[editMenu addItem:[NSMenuItem separatorItem]];
+		[editMenu addItemWithTitle:@"Select All" action:@selector(selectAll:) keyEquivalent:@"a"];
+	}
+}
+// installEditMenu runs once at startup and the menu persists for the process lifetime.
+*/
+import "C"
+
+// installNativeMenu installs the macOS application menu bar so clipboard and selection keyboard
+// shortcuts work inside the web view. It must run on the main thread, alongside the other webview
+// window setup calls.
+func installNativeMenu() {
+	C.installEditMenu()
+}

--- a/desktop/menu_other.go
+++ b/desktop/menu_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package main
+
+// installNativeMenu is a no-op on platforms whose webview backend already provides clipboard
+// shortcuts: WebView2 on Windows and WebKitGTK on Linux both handle Cut/Copy/Paste natively.
+func installNativeMenu() {}


### PR DESCRIPTION
## Problem

Two macOS-specific issues in the `desktop/` app (the `webview/webview_go` window around the in-process `ksail ui` server), both stemming from how a `.app` bundle is launched:

1. **Cloud clusters never appear.** When `KSail.app` is launched from the GUI (Finder/Dock/Spotlight, or `open -a KSail` as `ksail desktop` does), launchd does not source the user's shell profile, so `HCLOUD_TOKEN`, `OMNI_SERVICE_ACCOUNT_KEY`, `KUBECONFIG` and PATH additions are absent. Cluster discovery (`pkg/svc/clusterdiscovery/cloud.go`) reads `HCLOUD_TOKEN` and, when empty, skips the Hetzner provider **silently** — so Hetzner/cloud clusters don't show, with no error. `ksail ui` from a terminal works because the shell already exported them.
2. **Copy/paste does nothing.** `webview/webview_go` creates a bare `NSWindow` with no menu bar. On macOS the ⌘C/⌘V/⌘X/⌘A clipboard shortcuts are menu key-equivalents, so with no Edit menu bound to `copy:`/`paste:`/`cut:`/`selectAll:` they route nowhere inside the `WKWebView`.

## Fix

- `desktop/env_darwin.go` — `hydrateLoginShellEnv()` imports the environment from the user's interactive login shell on bundle launch (detected via `__CFBundleIdentifier`), before the UI server starts. Variables already set are never overwritten; PATH is merged. Skipped entirely when run from a terminal.
- `desktop/menu_darwin.go` — `installNativeMenu()` (cgo/Cocoa) installs a standard App + Edit `NSMenu` (Cut/Copy/Paste/Select All/Undo/Redo + Hide/Quit) before the webview runs.
- `desktop/env_other.go` / `desktop/menu_other.go` — no-op stubs for non-darwin (WebView2/WebKitGTK handle clipboard natively).
- `desktop/env_darwin_test.go` — unit tests for the env parse/merge helpers.
- `desktop/main.go` wires both into `run()`.

Both behaviours are darwin-only; **no dependency changes** (the desktop-tidy gate stays green).

## Validation (darwin)

- `gofmt` clean
- `golangci-lint run` → **0 issues**
- `go build` (CGO) → ok
- `go test ./...` → ok

## Note

The env fix sources the user's **login/interactive** shell, so the token must be exported in `~/.zshrc` or `~/.zprofile` (i.e. present in a fresh terminal), not just set ad-hoc in one session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
