### PR TITLE
fix(release): populate Homebrew ksail cask desc + homepage

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,8 @@ archives:
 
 homebrew_casks:
   - name: ksail
+    description: "KSail is a CLI tool to manage clusters and workloads."
+    homepage: "https://ksail.devantler.tech"
     repository:
       owner: devantler-tech
       name: homebrew-tap


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `homebrew_casks` block for the **ksail CLI** cask in [`.goreleaser.yaml`](.goreleaser.yaml) sets no `description`/`homepage`, so the GoReleaser-generated `Casks/ksail.rb` in [`devantler-tech/homebrew-tap`](https://github.com/devantler-tech/homebrew-tap/blob/main/Casks/ksail.rb) ships with empty fields:

```ruby
name "ksail"
desc ""
homepage ""
```

This degrades `brew info ksail` / `brew search` discoverability and **blocks `brew audit --strict`** — the gate proposed in [homebrew-tap#734](https://github.com/devantler-tech/homebrew-tap/issues/734) (epic [#732](https://github.com/devantler-tech/homebrew-tap/issues/732), "polished, lint-clean tap") cannot land while `ksail.rb` fails audit on the empty fields. `ksail.rb` is GoReleaser-generated (`DO NOT EDIT`), so the root-cause fix belongs **here**, in the template.

## Change

Add `description` + `homepage` to the ksail cask block, mirroring [`.goreleaser.desktop.yaml`](.goreleaser.desktop.yaml) which already sets both for the `ksail-desktop` cask:

```yaml
homebrew_casks:
  - name: ksail
    description: "KSail is a CLI tool to manage clusters and workloads."
    homepage: "https://ksail.devantler.tech"
```

- **Description** reuses the existing OCI image description (`org.opencontainers.image.description` further down this file) for consistency.
- **Homepage** points at the docs site, matching the desktop cask.

The next release regenerates `Casks/ksail.rb` with populated fields, unblocking homebrew-tap#734.

## Validation

`goreleaser check` → `1 configuration file(s) validated`. Config-only change; takes effect on the next `ksail` release (the tap PR is regenerated by GoReleaser).

Fixes devantler-tech/homebrew-tap#735