### PR TITLE
fix(talos): resolve duplicate-hostname rejection on Hetzner scale-up

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
@@ -12,10 +12,46 @@ import (
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+// nodeRuntimeMode is a minimal config.validation RuntimeMode that reports the
+// metal platform (an installation is required, not in a container). It mirrors
+// the mode a Hetzner node booted from the public Talos ISO validates a config
+// under, exercising the same container-level conflict validation that rejects a
+// HostnameConfig document coexisting with a static machine.network.hostname.
+type nodeRuntimeMode struct{}
+
+func (nodeRuntimeMode) String() string        { return "metal" }
+func (nodeRuntimeMode) RequiresInstall() bool { return true }
+func (nodeRuntimeMode) InContainer() bool     { return false }
+
+// countHostnameConfigDocs returns the number of standalone HostnameConfig
+// documents in a (possibly multi-document) Talos config YAML.
+func countHostnameConfigDocs(t *testing.T, cfgBytes []byte) int {
+	t.Helper()
+
+	decoder := yaml.NewDecoder(bytes.NewReader(cfgBytes))
+	count := 0
+
+	for {
+		var doc map[string]any
+
+		err := decoder.Decode(&doc)
+		if err != nil {
+			break
+		}
+
+		if kind, _ := doc["kind"].(string); kind == "HostnameConfig" {
+			count++
+		}
+	}
+
+	return count
+}
 
 // machineConfigView is a minimal view over a Talos MachineConfig document, used
 // to assert on the fields the hostname patch must set and preserve without
@@ -122,6 +158,76 @@ func TestPatchTalosHostname_InvalidConfigErrors(t *testing.T) {
 
 	_, err := talosprovisioner.PatchTalosHostname([]byte("{"), "prod-worker-4")
 	require.Error(t, err)
+}
+
+// TestPatchTalosHostname_NodeAccepts verifies the patched config passes the same
+// container-level validation the Talos node runs on ApplyConfiguration. Talos
+// generated configs carry a standalone HostnameConfig document (auto: stable);
+// once machine.network.hostname is set it conflicts with that document ("static
+// hostname is already set in v1alpha1 config"), which is the regression in #4969
+// that left scaled-up Hetzner workers unable to apply their config and join.
+// The patch must remove the conflicting document so exactly one hostname
+// representation remains and the node accepts the config.
+func TestPatchTalosHostname_NodeAccepts(t *testing.T) {
+	t.Parallel()
+
+	workerBytes := workerConfigBytes(t, "prod")
+	require.Positive(t, countHostnameConfigDocs(t, workerBytes),
+		"precondition: generated worker config carries a standalone HostnameConfig document")
+
+	patched, err := talosprovisioner.PatchTalosHostname(workerBytes, "prod-worker-4")
+	require.NoError(t, err)
+
+	assert.Zero(
+		t,
+		countHostnameConfigDocs(t, patched),
+		"the conflicting HostnameConfig document must be removed so only one hostname representation remains",
+	)
+
+	provider, err := configloader.NewFromBytes(patched)
+	require.NoError(t, err, "patched config must load")
+
+	_, err = provider.Validate(nodeRuntimeMode{})
+	require.NoError(
+		t,
+		err,
+		"node-side validation must accept the patched config (no static-vs-HostnameConfig conflict)",
+	)
+
+	doc := firstMachineConfigDoc(t, patched)
+	assert.Equal(t, "prod-worker-4", doc.Machine.Network.Hostname,
+		"hostname must be set to the Hetzner server name so the CCM can match the Node")
+}
+
+// TestPatchTalosHostname_Idempotent verifies that re-patching a config that
+// already has machine.network.hostname set still yields a node-acceptable config
+// with the hostname set once. This is the scale-up and rolling-recreate case:
+// applyConfigToNode is the shared chokepoint, and its base config (rebuilt from
+// the running cluster's PKI) can already carry the static hostname, so a
+// non-idempotent patch would reintroduce the #4969 conflict.
+func TestPatchTalosHostname_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	workerBytes := workerConfigBytes(t, "prod")
+
+	once, err := talosprovisioner.PatchTalosHostname(workerBytes, "prod-worker-4")
+	require.NoError(t, err)
+
+	twice, err := talosprovisioner.PatchTalosHostname(once, "prod-worker-4")
+	require.NoError(t, err)
+
+	assert.Zero(t, countHostnameConfigDocs(t, twice),
+		"re-patching must not reintroduce a HostnameConfig document")
+
+	provider, err := configloader.NewFromBytes(twice)
+	require.NoError(t, err, "re-patched config must load")
+
+	_, err = provider.Validate(nodeRuntimeMode{})
+	require.NoError(t, err, "re-patched config must remain node-acceptable")
+
+	doc := firstMachineConfigDoc(t, twice)
+	assert.Equal(t, "prod-worker-4", doc.Machine.Network.Hostname,
+		"hostname must remain the server name after re-patching")
 }
 
 // TestHetznerNodeName_WithinLimit verifies a normal node name is formatted and

--- a/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
@@ -75,10 +75,10 @@ type machineConfigView struct {
 }
 
 // workerConfigBytes builds a real Talos worker machine config for a cluster.
-func workerConfigBytes(t *testing.T, clusterName string) []byte {
+func workerConfigBytes(t *testing.T) []byte {
 	t.Helper()
 
-	manager := talosconfigmanager.NewConfigManager("", clusterName, "1.32.0", "10.5.0.0/24")
+	manager := talosconfigmanager.NewConfigManager("", "prod", "1.32.0", "10.5.0.0/24")
 
 	configs, err := manager.Load(configmanager.LoadOptions{})
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func firstMachineConfigDoc(t *testing.T, cfgBytes []byte) machineConfigView {
 func TestPatchTalosHostname_SetsHostname(t *testing.T) {
 	t.Parallel()
 
-	workerBytes := workerConfigBytes(t, "prod")
+	workerBytes := workerConfigBytes(t)
 
 	patched, err := talosprovisioner.PatchTalosHostname(workerBytes, "prod-worker-4")
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestPatchTalosHostname_SetsHostname(t *testing.T) {
 func TestPatchTalosHostname_PreservesConfig(t *testing.T) {
 	t.Parallel()
 
-	workerBytes := workerConfigBytes(t, "prod")
+	workerBytes := workerConfigBytes(t)
 	before := firstMachineConfigDoc(t, workerBytes)
 	require.NotEmpty(t, before.Cluster.CA.Crt, "precondition: worker config carries a cluster CA")
 
@@ -175,7 +175,7 @@ func TestPatchTalosHostname_InvalidConfigErrors(t *testing.T) {
 func TestPatchTalosHostname_NodeAccepts(t *testing.T) {
 	t.Parallel()
 
-	workerBytes := workerConfigBytes(t, "prod")
+	workerBytes := workerConfigBytes(t)
 	require.Positive(t, countHostnameConfigDocs(t, workerBytes),
 		"precondition: generated worker config carries a standalone HostnameConfig document")
 
@@ -212,7 +212,7 @@ func TestPatchTalosHostname_NodeAccepts(t *testing.T) {
 func TestPatchTalosHostname_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	workerBytes := workerConfigBytes(t, "prod")
+	workerBytes := workerConfigBytes(t)
 
 	once, err := talosprovisioner.PatchTalosHostname(workerBytes, "prod-worker-4")
 	require.NoError(t, err)

--- a/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_hostname_test.go
@@ -6,6 +6,8 @@ package talosprovisioner_test
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -40,10 +42,12 @@ func countHostnameConfigDocs(t *testing.T, cfgBytes []byte) int {
 	for {
 		var doc map[string]any
 
-		err := decoder.Decode(&doc)
-		if err != nil {
+		decodeErr := decoder.Decode(&doc)
+		if errors.Is(decodeErr, io.EOF) {
 			break
 		}
+
+		require.NoError(t, decodeErr)
 
 		if kind, _ := doc["kind"].(string); kind == "HostnameConfig" {
 			count++

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -586,7 +586,9 @@ func patchTalosHostname(cfgBytes []byte, hostname string) ([]byte, error) {
 // a (possibly multi-document) Talos config YAML, re-encoding the remaining
 // documents. Removing it resolves the conflict with a static
 // machine.network.hostname (see patchTalosHostname). The v1alpha1 MachineConfig
-// document (and any other documents) are preserved verbatim.
+// document (and any other documents) are preserved semantically: decoding to a
+// generic map and re-encoding can reorder keys and drop comments/formatting, but
+// the configuration values the node consumes are unchanged.
 func stripHostnameConfigDocuments(cfgBytes []byte) ([]byte, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(cfgBytes))
 

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -1,10 +1,12 @@
 package talosprovisioner
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -20,7 +22,13 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/bundle"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
 )
+
+// yamlIndent is the indentation width used when re-encoding Talos config
+// documents. Talos uses 4-space indentation; matching it keeps re-encoded output
+// stylistically consistent with the original.
+const yamlIndent = 4
 
 // maxConcurrentHetznerOps caps the number of Hetzner API operations executed in parallel.
 // A value of 3 balances throughput and API rate-limit headroom.
@@ -533,6 +541,11 @@ func marshalConfigWithHostname(config talosconfig.Provider, serverName string) (
 	return cfgBytes, nil
 }
 
+// hostnameConfigKind is the document kind of the standalone Talos HostnameConfig
+// network document. Talos emits one (defaulting to `auto: stable`) in generated
+// machine configs, and it conflicts with a static machine.network.hostname.
+const hostnameConfigKind = "HostnameConfig"
+
 // patchTalosHostname overlays machine.network.hostname onto marshaled Talos
 // machine-config bytes via a strategic-merge patch, returning the patched bytes.
 // It operates on bytes rather than a shared talosconfig.Provider so it is safe to
@@ -540,6 +553,14 @@ func marshalConfigWithHostname(config talosconfig.Provider, serverName string) (
 // its own copy). The hostname is the Hetzner server name, which is DNS-1123
 // compliant by construction (<cluster>-<role>-<index>, with cluster name
 // pre-validated), so it is a valid Talos hostname.
+//
+// Talos generated machine configs carry a standalone HostnameConfig network
+// document (defaulting to `auto: stable`). Once machine.network.hostname is set,
+// that document conflicts with the v1alpha1 hostname ("static hostname is already
+// set in v1alpha1 config", #4969), so it is stripped here. This leaves the
+// hostname in a single representation, making the function idempotent: applying it
+// to a config that already has machine.network.hostname set (the scale-up and
+// rolling-recreate base config) still yields a config the node accepts.
 func patchTalosHostname(cfgBytes []byte, hostname string) ([]byte, error) {
 	patch, err := configpatcher.LoadPatch(
 		fmt.Appendf(nil, "machine:\n  network:\n    hostname: %s\n", hostname),
@@ -558,7 +579,55 @@ func patchTalosHostname(cfgBytes []byte, hostname string) ([]byte, error) {
 		return nil, fmt.Errorf("encode patched config: %w", err)
 	}
 
-	return patched, nil
+	return stripHostnameConfigDocuments(patched)
+}
+
+// stripHostnameConfigDocuments removes any standalone HostnameConfig document from
+// a (possibly multi-document) Talos config YAML, re-encoding the remaining
+// documents. Removing it resolves the conflict with a static
+// machine.network.hostname (see patchTalosHostname). The v1alpha1 MachineConfig
+// document (and any other documents) are preserved verbatim.
+func stripHostnameConfigDocuments(cfgBytes []byte) ([]byte, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(cfgBytes))
+
+	var buf bytes.Buffer
+
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(yamlIndent)
+
+	for {
+		var doc map[string]any
+
+		decodeErr := decoder.Decode(&doc)
+		if errors.Is(decodeErr, io.EOF) {
+			break
+		}
+
+		if decodeErr != nil {
+			return nil, fmt.Errorf("decode config document: %w", decodeErr)
+		}
+
+		if doc == nil {
+			continue
+		}
+
+		kind, _ := doc["kind"].(string)
+		if kind == hostnameConfigKind {
+			continue
+		}
+
+		encodeErr := encoder.Encode(doc)
+		if encodeErr != nil {
+			return nil, fmt.Errorf("re-encode config document: %w", encodeErr)
+		}
+	}
+
+	closeErr := encoder.Close()
+	if closeErr != nil {
+		return nil, fmt.Errorf("flush re-encoded config: %w", closeErr)
+	}
+
+	return buf.Bytes(), nil
 }
 
 // attemptApplyConfig creates a single-use insecure Talos client and attempts to


### PR DESCRIPTION
## Summary

Fixes #4969 — a regression of #4962 introduced by #4966.

`ksail cluster update` worker scale-up on **Talos × Hetzner** failed at config apply with:

```
configuration validation failed: 1 error occurred:
  * static hostname is already set in v1alpha1 config
```

so the new worker's server was created but its config never applied and it never joined.

## Root cause

#4966 added `patchTalosHostname`, which overlays `machine.network.hostname` (legacy v1alpha1) onto each node's config in `applyConfigToNode` — the shared chokepoint for create, scale-up, and rolling-recreate — so the hcloud CCM (`cloud-provider: external`) can match the Kubernetes Node to the server by name.

But Talos-generated machine configs already carry a standalone `HostnameConfig` document (default `auto: stable`). Talos's `HostnameConfigV1Alpha1.V1Alpha1ConflictValidate` rejects a config that sets the hostname in **both** the v1alpha1 doc and a `HostnameConfig` doc. `configpatcher.Apply` does **not** run that container-level validation (only the node does, on `ApplyConfiguration`), which is why #4966's unit tests passed while the live node rejected the config.

## Fix

After overlaying the hostname, strip any `kind: HostnameConfig` document so exactly one hostname representation remains (`stripHostnameConfigDocuments`). This also makes `patchTalosHostname` idempotent for the scale-up / rolling-recreate base config, which is rebuilt from the running cluster's PKI and can already carry the static hostname. #4966's goal (hostname == server name for CCM matching) is preserved, and the parallel-apply concurrency safety (operating on bytes, not the shared `talosconfig.Provider`) is unchanged.

## Tests

Added `TestPatchTalosHostname_NodeAccepts` and `TestPatchTalosHostname_Idempotent`, which validate the patched config with the **node-side** container validation (`configloader` + metal `RuntimeMode`) — the check the original tests did not exercise. Both fail against the pre-fix code with the exact issue error and pass after.

## Validation

- `go build ./...` ✓
- `go test ./pkg/svc/provisioner/cluster/talos/...` ✓ (all tests, incl. the two new ones)
- `golangci-lint run --new-from-rev=HEAD ./pkg/svc/provisioner/cluster/talos/...` → 0 issues ✓

> Live end-to-end on real Talos × Hetzner hardware was not run (no cloud creds). The fix is validated against the exact Talos container-level validation the node runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
