### PR TITLE
test(kubescape): cover buildScanInfo mapping and ScanDirectory context guard

### DIFF
--- a/pkg/client/kubescape/buildscaninfo_test.go
+++ b/pkg/client/kubescape/buildscaninfo_test.go
@@ -1,0 +1,174 @@
+package kubescape_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/kubescape"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+)
+
+const (
+	testPath       = "./manifests"
+	testFormatJSON = "json"
+	testOutputPath = "/tmp/results.json"
+	testFwNSA      = "nsa"
+	testFwMitre    = "mitre"
+)
+
+// TestBuildScanInfoDefaults asserts the constant base configuration applied for
+// an empty ScanOptions: the input path is scanned locally as a repo, and no
+// optional fields are populated.
+func TestBuildScanInfoDefaults(t *testing.T) {
+	t.Parallel()
+
+	info := kubescape.BuildScanInfo(testPath, &kubescape.ScanOptions{})
+
+	if len(info.InputPatterns) != 1 || info.InputPatterns[0] != testPath {
+		t.Fatalf("expected InputPatterns [%q], got %v", testPath, info.InputPatterns)
+	}
+
+	checks := []struct {
+		name string
+		ok   bool
+	}{
+		{"Local true", info.Local},
+		{"ScanType repo", info.ScanType == cautils.ScanTypeRepo},
+		{"VerboseMode false", !info.VerboseMode},
+		{"empty Format", info.Format == ""},
+		{"empty Output", info.Output == ""},
+		{"zero ComplianceThreshold", info.ComplianceThreshold == 0},
+		{"FrameworkScan false", !info.FrameworkScan},
+		{"no policy identifiers", len(info.PolicyIdentifier) == 0},
+	}
+
+	for _, check := range checks {
+		if !check.ok {
+			t.Errorf("default ScanInfo: %s assertion failed", check.name)
+		}
+	}
+}
+
+// TestBuildScanInfoVerbose asserts Verbose maps to VerboseMode.
+func TestBuildScanInfoVerbose(t *testing.T) {
+	t.Parallel()
+
+	info := kubescape.BuildScanInfo(testPath, &kubescape.ScanOptions{Verbose: true})
+
+	if !info.VerboseMode {
+		t.Error("expected VerboseMode to be true when Verbose is set")
+	}
+}
+
+// TestBuildScanInfoFormatAndOutput asserts non-empty Format/Output are forwarded.
+func TestBuildScanInfoFormatAndOutput(t *testing.T) {
+	t.Parallel()
+
+	info := kubescape.BuildScanInfo(testPath, &kubescape.ScanOptions{
+		Format: testFormatJSON,
+		Output: testOutputPath,
+	})
+
+	if info.Format != testFormatJSON {
+		t.Errorf("expected Format %q, got %q", testFormatJSON, info.Format)
+	}
+
+	if info.Output != testOutputPath {
+		t.Errorf("expected Output %q, got %q", testOutputPath, info.Output)
+	}
+}
+
+// TestBuildScanInfoComplianceThreshold asserts a positive threshold is forwarded
+// and that a zero threshold leaves the field untouched (guarded by `> 0`).
+func TestBuildScanInfoComplianceThreshold(t *testing.T) {
+	t.Parallel()
+
+	info := kubescape.BuildScanInfo(testPath, &kubescape.ScanOptions{ComplianceThreshold: 80})
+	if info.ComplianceThreshold != 80 {
+		t.Errorf("expected ComplianceThreshold 80, got %v", info.ComplianceThreshold)
+	}
+
+	zero := kubescape.BuildScanInfo(testPath, &kubescape.ScanOptions{ComplianceThreshold: 0})
+	if zero.ComplianceThreshold != 0 {
+		t.Errorf("expected ComplianceThreshold 0, got %v", zero.ComplianceThreshold)
+	}
+}
+
+// TestBuildScanInfoFrameworks asserts frameworks enable a framework scan and are
+// registered as Framework-kind policy identifiers preserving order.
+func TestBuildScanInfoFrameworks(t *testing.T) {
+	t.Parallel()
+
+	frameworks := []string{testFwNSA, testFwMitre, "cis"}
+	info := kubescape.BuildScanInfo(testPath, &kubescape.ScanOptions{Frameworks: frameworks})
+
+	if !info.FrameworkScan {
+		t.Error("expected FrameworkScan to be true when frameworks are provided")
+	}
+
+	if len(info.PolicyIdentifier) != len(frameworks) {
+		t.Fatalf(
+			"expected %d policy identifiers, got %d",
+			len(frameworks),
+			len(info.PolicyIdentifier),
+		)
+	}
+
+	for idx, want := range frameworks {
+		got := info.PolicyIdentifier[idx]
+		if got.Identifier != want {
+			t.Errorf("policy[%d]: expected identifier %q, got %q", idx, want, got.Identifier)
+		}
+
+		if got.Kind != apisv1.KindFramework {
+			t.Errorf("policy[%d]: expected kind %q, got %q", idx, apisv1.KindFramework, got.Kind)
+		}
+	}
+}
+
+// TestScanDirectoryNilOptionsCancelledContext asserts that nil options are
+// tolerated (defaulted) and that a cancelled context short-circuits the scan
+// with a wrapped context error before any kubescape runner is constructed.
+func TestScanDirectoryNilOptionsCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := kubescape.NewClient()
+
+	err := client.ScanDirectory(ctx, testPath, nil)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestScanDirectoryCancelledContext asserts the context guard fires with
+// non-nil options as well.
+func TestScanDirectoryCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := kubescape.NewClient()
+
+	err := client.ScanDirectory(
+		ctx,
+		testPath,
+		&kubescape.ScanOptions{Frameworks: []string{testFwNSA}},
+	)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}

--- a/pkg/client/kubescape/client_test.go
+++ b/pkg/client/kubescape/client_test.go
@@ -20,9 +20,9 @@ func TestScanOptions(t *testing.T) {
 	t.Parallel()
 
 	opts := &kubescape.ScanOptions{
-		Frameworks:          []string{"nsa", "mitre"},
-		Format:              "json",
-		Output:              "/tmp/results.json",
+		Frameworks:          []string{testFwNSA, testFwMitre},
+		Format:              testFormatJSON,
+		Output:              testOutputPath,
 		ComplianceThreshold: 80,
 		Verbose:             true,
 	}
@@ -31,20 +31,20 @@ func TestScanOptions(t *testing.T) {
 		t.Fatalf("expected 2 frameworks, got %d", len(opts.Frameworks))
 	}
 
-	if opts.Frameworks[0] != "nsa" {
-		t.Fatalf("expected first framework to be %q, got %q", "nsa", opts.Frameworks[0])
+	if opts.Frameworks[0] != testFwNSA {
+		t.Fatalf("expected first framework to be %q, got %q", testFwNSA, opts.Frameworks[0])
 	}
 
-	if opts.Frameworks[1] != "mitre" {
-		t.Fatalf("expected second framework to be %q, got %q", "mitre", opts.Frameworks[1])
+	if opts.Frameworks[1] != testFwMitre {
+		t.Fatalf("expected second framework to be %q, got %q", testFwMitre, opts.Frameworks[1])
 	}
 
-	if opts.Format != "json" {
-		t.Fatalf("expected Format to be %q, got %q", "json", opts.Format)
+	if opts.Format != testFormatJSON {
+		t.Fatalf("expected Format to be %q, got %q", testFormatJSON, opts.Format)
 	}
 
-	if opts.Output != "/tmp/results.json" {
-		t.Fatalf("expected Output to be %q, got %q", "/tmp/results.json", opts.Output)
+	if opts.Output != testOutputPath {
+		t.Fatalf("expected Output to be %q, got %q", testOutputPath, opts.Output)
 	}
 
 	if opts.ComplianceThreshold != 80 {

--- a/pkg/client/kubescape/export_test.go
+++ b/pkg/client/kubescape/export_test.go
@@ -1,0 +1,8 @@
+package kubescape
+
+import "github.com/kubescape/kubescape/v3/core/cautils"
+
+// BuildScanInfo exports buildScanInfo for testing the option-to-ScanInfo mapping.
+func BuildScanInfo(path string, opts *ScanOptions) *cautils.ScanInfo {
+	return buildScanInfo(path, opts)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
`pkg/client/kubescape` was the lowest-covered package in the repo at **3.7%** of statements. Its existing tests (`client_test.go`) only asserted struct-field assignment on `ScanOptions` and that `NewClient()` returns non-nil — none of the package's actual logic was exercised.

## What
Meaningful tests that pin real behaviour (no coverage-chasing, no weakened assertions):

- **`buildScanInfo`** — exposed via a new `export_test.go` (matching the repo's existing `export_test.go` convention, e.g. `pkg/svc/registryresolver`). Covers:
  - the constant base config (`InputPatterns=[path]`, `Local=true`, `ScanType=repo`);
  - each conditional branch — `Verbose → VerboseMode`, `Format`/`Output` forwarding, the `ComplianceThreshold > 0` guard (set vs. zero), and `Frameworks → FrameworkScan=true` with ordered `Framework`-kind `PolicyIdentifier` registration.
- **`ScanDirectory`** — the cancelled-context short-circuit, with both `nil` and non-nil options, asserting it returns a wrapped `context.Canceled` *before* constructing the kubescape runner (so the test needs no external scanner).

## Result
- Coverage **3.7% → 59.3%**. Remaining uncovered statements are the live scan execution path (kubescape runner + `HandleResults` + the post-scan compliance-threshold check), which requires the external scanner and isn't meaningfully unit-testable here.
- `golangci-lint run` → 0 issues; `go test -race ./pkg/client/kubescape/` → pass; `go build` → ok.

Test-only change — no production behaviour touched.