### PR TITLE
test(kwok): cover discoverAPIServerPort parsing and applyKwokCertSANs config

### DIFF
--- a/pkg/svc/provisioner/cluster/kwok/export_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/export_test.go
@@ -28,3 +28,18 @@ func (p *Provisioner) ResolveNameForTest(name string) string {
 func (p *Provisioner) ResolveConfigPathForTest() (string, func(), error) {
 	return p.resolveConfigPath()
 }
+
+// DiscoverAPIServerPortForTest exposes discoverAPIServerPort for unit testing.
+func (p *KubernetesProvisioner) DiscoverAPIServerPortForTest(name string) (int, error) {
+	return p.discoverAPIServerPort(name)
+}
+
+// ApplyKwokCertSANsForTest exposes applyKwokCertSANs for unit testing.
+func (p *KubernetesProvisioner) ApplyKwokCertSANsForTest(address string) (func(), error) {
+	return p.applyKwokCertSANs(address)
+}
+
+// ConfigPathForTest returns the inner provisioner's configPath for assertions.
+func (p *KubernetesProvisioner) ConfigPathForTest() string {
+	return p.configPath
+}

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner_test.go
@@ -117,6 +117,11 @@ func TestApplyKwokCertSANs(t *testing.T) {
 	cleanup, err := prov.ApplyKwokCertSANsForTest("203.0.113.7")
 	require.NoError(t, err)
 	require.NotNil(t, cleanup)
+	// Guard against an early assertion failure leaving the temp config dir
+	// behind / configPath unrestored. cleanup is idempotent (RemoveAll on a
+	// gone dir is a no-op, configPath is re-set to the same value), so the
+	// explicit cleanup() call below remains safe.
+	t.Cleanup(cleanup)
 
 	dir := prov.ConfigPathForTest()
 	assert.NotEqual(t, originalConfigPath, dir, "configPath should point at the temp config dir")

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner_test.go
@@ -1,0 +1,158 @@
+package kwokprovisioner_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	kwokprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kwok"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newKubernetesProvisionerForTest builds a KubernetesProvisioner with only the
+// fields the pure helpers under test rely on (name + kubeconfig path). The
+// Kubernetes infrastructure provider is left nil because none of the tested
+// helpers exercise it.
+func newKubernetesProvisionerForTest(
+	t *testing.T,
+	name, kubeconfigPath string,
+) *kwokprovisioner.KubernetesProvisioner {
+	t.Helper()
+
+	prov, err := kwokprovisioner.NewKubernetesProvisioner(
+		kwokprovisioner.KubernetesProvisionerConfig{
+			Name:           name,
+			KubeconfigPath: kubeconfigPath,
+		},
+	)
+	require.NoError(t, err)
+
+	return prov
+}
+
+// writeKubeconfig writes a minimal kubeconfig with a single cluster entry and
+// returns its path.
+func writeKubeconfig(t *testing.T, clusterName, server string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig.yaml")
+	content := "apiVersion: v1\n" +
+		"kind: Config\n" +
+		"clusters:\n" +
+		"- name: " + clusterName + "\n" +
+		"  cluster:\n" +
+		"    server: " + server + "\n"
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+func TestDiscoverAPIServerPort_Success(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := writeKubeconfig(t, "kwok-demo", "https://127.0.0.1:38423")
+	prov := newKubernetesProvisionerForTest(t, "demo", kubeconfigPath)
+
+	port, err := prov.DiscoverAPIServerPortForTest("")
+	require.NoError(t, err)
+	assert.Equal(t, 38423, port)
+}
+
+func TestDiscoverAPIServerPort_ExplicitNameWins(t *testing.T) {
+	t.Parallel()
+
+	// The kubeconfig only holds an entry for the explicit cluster name, proving
+	// the explicit argument (not the configured name) drives the lookup.
+	kubeconfigPath := writeKubeconfig(t, "kwok-other", "https://127.0.0.1:12345")
+	prov := newKubernetesProvisionerForTest(t, "demo", kubeconfigPath)
+
+	port, err := prov.DiscoverAPIServerPortForTest("other")
+	require.NoError(t, err)
+	assert.Equal(t, 12345, port)
+}
+
+func TestDiscoverAPIServerPort_LoadError(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	prov := newKubernetesProvisionerForTest(t, "demo", missing)
+
+	_, err := prov.DiscoverAPIServerPortForTest("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load kubeconfig")
+}
+
+func TestDiscoverAPIServerPort_ClusterEntryNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Entry is keyed "kwok-present" but we resolve "kwok-absent".
+	kubeconfigPath := writeKubeconfig(t, "kwok-present", "https://127.0.0.1:6443")
+	prov := newKubernetesProvisionerForTest(t, "absent", kubeconfigPath)
+
+	_, err := prov.DiscoverAPIServerPortForTest("")
+	require.ErrorIs(t, err, k8s.ErrClusterEntryNotFound)
+}
+
+func TestDiscoverAPIServerPort_UnparseableServer(t *testing.T) {
+	t.Parallel()
+
+	// A server URL that does not match the https://127.0.0.1:<port> shape.
+	kubeconfigPath := writeKubeconfig(t, "kwok-demo", "https://example.com")
+	prov := newKubernetesProvisionerForTest(t, "demo", kubeconfigPath)
+
+	_, err := prov.DiscoverAPIServerPortForTest("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse API server port")
+}
+
+func TestApplyKwokCertSANs(t *testing.T) {
+	t.Parallel()
+
+	prov := newKubernetesProvisionerForTest(t, "demo", "")
+	originalConfigPath := prov.ConfigPathForTest()
+
+	cleanup, err := prov.ApplyKwokCertSANsForTest("203.0.113.7")
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+
+	dir := prov.ConfigPathForTest()
+	assert.NotEqual(t, originalConfigPath, dir, "configPath should point at the temp config dir")
+
+	for _, name := range []string{"kustomization.yaml", "simulation.yaml", "kwokctl.yaml"} {
+		_, statErr := os.Stat(filepath.Join(dir, name))
+		require.NoError(t, statErr, "expected %s to be written", name)
+	}
+
+	kwokctlPath := filepath.Join(dir, "kwokctl.yaml")
+	kwokctl, err := os.ReadFile(kwokctlPath) //nolint:gosec // test path under TempDir
+	require.NoError(t, err)
+	assert.Contains(
+		t,
+		string(kwokctl),
+		"203.0.113.7",
+		"the exposure address must be added to cert SANs",
+	)
+	assert.Contains(
+		t,
+		string(kwokctl),
+		"kubeApiserverPort: 6443",
+		"the API server port must be pinned",
+	)
+
+	kustomizationPath := filepath.Join(dir, "kustomization.yaml")
+	kustomization, err := os.ReadFile(kustomizationPath) //nolint:gosec // test path under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(kustomization), "kind: Kustomization")
+	assert.Contains(t, string(kustomization), "simulation.yaml")
+	assert.Contains(t, string(kustomization), "kwokctl.yaml")
+
+	// cleanup restores the original config path and removes the temp dir.
+	cleanup()
+	assert.Equal(t, originalConfigPath, prov.ConfigPathForTest())
+
+	_, statErr := os.Stat(dir)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What & why

Advance work (test coverage) on the flagship. `pkg/svc/provisioner/cluster/kwok` sat at **13.2%** — its two source files are dominated by DinD lifecycle code that needs a live host cluster, but several **pure helpers** were entirely untested. This PR pins their behaviour with meaningful assertions (no vacuous coverage padding).

## Coverage

`pkg/svc/provisioner/cluster/kwok`: **13.2% → 22.3%** of statements.

## What's tested (both previously 0%)

- **`discoverAPIServerPort`** — parses the kwokctl-written kubeconfig and extracts the mapped API-server host port:
  - success (port parsed from `https://127.0.0.1:<port>`)
  - explicit-name argument drives the lookup (not the configured name)
  - kubeconfig load error (`load kubeconfig`)
  - cluster entry missing → `k8s.ErrClusterEntryNotFound`
  - server URL not matching the expected shape → `parse API server port`
- **`applyKwokCertSANs`** — writes the temporary kwok config dir and repoints the inner provisioner at it:
  - the temp dir is created with `kustomization.yaml` / `simulation.yaml` / `kwokctl.yaml`
  - the exposure address and the pinned `kubeApiserverPort: 6443` land in `kwokctl.yaml`
  - the returned cleanup restores the original `configPath` and removes the temp dir

## Notes

- **No production code changed.** New accessors were added to `export_test.go` following the package's existing `…ForTest` pattern; tests live in the external `kwokprovisioner_test` package.
- Validated locally: `go test ./pkg/svc/provisioner/cluster/kwok/` (pass), `go vet` (clean), `golangci-lint run` (clean for the changed files), `go build` (ok).