### PR TITLE
ci(cd): run MCP Registry publish in parallel with release publish and Pages deploy

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -391,6 +391,10 @@ jobs:
     name: 📤 Publish to MCP Registry
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Needs `goreleaser` for the published GHCR image that server.json points at, but runs in
+    # parallel with `publish-release` and `pages-deploy` — neither lists it in `needs`. The MCP
+    # registry publish references the container image (pushed by `goreleaser`), not the GitHub
+    # release, so it is independent of the draft→published flip and need not gate it.
     needs: [goreleaser]
     permissions:
       id-token: write
@@ -526,9 +530,10 @@ jobs:
   pages-deploy:
     name: 🚀 Deploy Pages
     runs-on: ubuntu-latest
-    # Gate the docs deploy on ALL releases (not just `pages-build`) so a partial release
-    # failure never pushes a fresh docs site. Runs in parallel with `publish-release` —
-    # neither depends on the other; both fan in from the same set of release jobs.
+    # Gate the docs deploy on the artifact-producing releases (not just `pages-build`) so a
+    # partial release failure never pushes a fresh docs site. Runs in parallel with
+    # `publish-release` and `mcp-publish` — none depends on the others. `mcp-publish` is
+    # excluded from `needs` because the MCP registry publish is independent of the docs site.
     needs:
       [
         goreleaser,
@@ -536,7 +541,6 @@ jobs:
         desktop-macos,
         desktop,
         copilot-plugin,
-        mcp-publish,
         pages-build,
       ]
     timeout-minutes: 10
@@ -552,16 +556,17 @@ jobs:
     name: 📢 Publish Release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Gate on ALL releases so the draft is published only when every release succeeded.
-    # Runs in parallel with `pages-deploy` (it no longer lists it in `needs`) — both fan in
-    # from the same release jobs, so the GitHub release publish and the docs deploy happen
-    # concurrently. `pages-build` replaces the former `pages-deploy` edge: the release is
-    # gated on the docs *building*, not on Pages having deployed.
+    # Gate on the artifact-producing releases so the draft is published only when every asset
+    # job succeeded. Runs in parallel with `pages-deploy` and `mcp-publish` — none lists the
+    # others in `needs`, so the GitHub release publish, the docs deploy, and the MCP registry
+    # publish all happen concurrently. `mcp-publish` is excluded because it references the GHCR
+    # image (from `goreleaser`), not the GitHub release, so it need not gate the publish.
+    # `pages-build` replaces the former `pages-deploy` edge: the release is gated on the docs
+    # *building*, not on Pages having deployed.
     needs:
       [
         goreleaser,
         vscode-extension,
-        mcp-publish,
         copilot-plugin,
         desktop-macos,
         desktop,


### PR DESCRIPTION
## What

Make the `mcp-publish` (📤 Publish to MCP Registry) job in `cd.yaml` run **concurrently** with `publish-release` (📢 Publish Release) and `pages-deploy` (🚀 Deploy Pages), instead of gating ahead of them.

## Why

`mcp-publish` was listed in the `needs` of both `publish-release` and `pages-deploy`, so it ran as a prerequisite — those two jobs waited for it to finish (up to 10 min with its retry loop). The MCP-registry publish only rewrites `server.json` to point at the GHCR image that `goreleaser` pushes; that image is independent of the GitHub release draft→published flip, so there's no real ordering requirement. Removing the gate lets all three jobs fan in from the release jobs and run in parallel, shortening the critical path.

## Changes

Removed the `mcp-publish` edge from two `needs` lists:

| Job | `needs` before | `needs` after |
|---|---|---|
| `mcp-publish` | `[goreleaser]` | `[goreleaser]` — unchanged (still needs the pushed GHCR image) |
| `pages-deploy` | `[…, mcp-publish, pages-build]` | `[…, pages-build]` |
| `publish-release` | `[…, mcp-publish, …, pages-build]` | `[…, pages-build]` |

`homebrew` still gates on `publish-release` (unchanged). The explanatory comments on all three affected jobs were updated to match the new topology.

## Reviewer note — behavioral change

Previously a failed MCP-registry publish **blocked** the GitHub release from being published and the docs from deploying. With this change those proceed independently: a `mcp-publish` failure still fails the overall CD run, but no longer holds back the release publish or the Pages deploy. That's the inherent trade-off of running it in parallel — happy to keep it gating the release in some other form if preferred.

## Validation

- `actionlint .github/workflows/cd.yaml` passes clean
- `yq` confirms the resolved `needs` graph above

🤖 Generated with [Claude Code](https://claude.com/claude-code)