### PR TITLE
fix(release): mark Homebrew cask download URLs as verified

### DIFF
--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -71,6 +71,10 @@ homebrew_casks:
     # `gh release upload`. This is the same URL the default would have produced.
     url:
       template: "https://github.com/devantler-tech/ksail/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+      # The download URL host (github.com) differs from the homepage host
+      # (ksail.devantler.tech), so `brew audit --strict` requires the URL to be
+      # marked `verified:` with a trusted prefix.
+      verified: "github.com/devantler-tech/ksail/"
     description: "KSail desktop app — manage local Kubernetes clusters in a native window"
     homepage: "https://ksail.devantler.tech"
     repository:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,11 @@ archives:
 
 homebrew_casks:
   - name: ksail
+    # The download URL host (github.com) differs from the homepage host
+    # (ksail.devantler.tech), so `brew audit --strict` requires the URL to be
+    # marked `verified:` with a trusted prefix. Applied to the default url_template.
+    url:
+      verified: "github.com/devantler-tech/ksail/"
     description: "KSail is a CLI tool to manage clusters and workloads."
     homepage: "https://ksail.devantler.tech"
     repository:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Every Cask this repo's GoReleaser pipeline generates (`ksail`, `ksail-desktop`) currently **fails `brew audit --strict --online`**:

```
audit for ksail: failed
 - The URL's domain github.com does not match the homepage domain ksail.devantler.tech,
   a 'verified' parameter has to be added to the 'url' stanza.
```

Both Casks set `homepage "https://ksail.devantler.tech"` but download artifacts from `github.com`. Once `homepage` was populated (ksail#4971 + the empty-`desc`/`homepage` upstream fix), `brew audit --strict` began requiring the cross-host download URL to carry a [`verified:`](https://docs.brew.sh/Cask-Cookbook#when-url-and-homepage-domains-differ-add-verified) prefix. The generated files are `# DO NOT EDIT`, so the fix belongs here in the GoReleaser config, not in the tap.

This is the upstream blocker for [devantler-tech/homebrew-tap#734](https://github.com/devantler-tech/homebrew-tap/issues/734) (add `brew audit --strict` as a CI gate on the tap) — that gate cannot go green until the generated Casks are audit-clean.

## Change

Add `url.verified: "github.com/devantler-tech/ksail/"` to both cask configs:

- **`.goreleaser.yaml`** (`ksail`): the cask had no `url:` block, so add one with only `verified:`. GoReleaser keeps the **default** `url_template` and appends `verified:` underneath (confirmed below).
- **`.goreleaser.desktop.yaml`** (`ksail-desktop`): `verified:` sits beside the existing explicit `url.template`.

The trusted prefix `github.com/devantler-tech/ksail/` matches every release-download URL (CLI tarballs and the desktop zip both live under the main repo's releases).

## Validation (local)

1. **`goreleaser check`** passes on both configs.
2. **`url.verified` without `template` keeps the default URL** — confirmed with a minimal GoReleaser snapshot: the generated stanza is `url "<default github.com URL>", verified: "..."`, not an empty URL.
3. **Resulting Casks pass `brew audit --strict --online`** — hand-applied the verified param to copies of the current v7.23.3 Casks in a throwaway tap; both `ksail` and `ksail-desktop` audit **exit 0** (the domain-mismatch error is gone).

The real generation runs in the release CI (`cd.yaml`); this change only augments the cask metadata, so the next release regenerates both Casks audit-clean.

## Scope / follow-ups (out of scope here)

`brew audit` is now clean; **`brew style`** still reports template-ordering nits on the generated output (`Cask/StanzaOrder`, `Homebrew/OSDependsOn`, `Style/IfUnlessModifier`, `Layout/EmptyLinesAroundBlockBody`). Those are GoReleaser cask-template formatting, not config fields, so they're a separate concern — tracked for homebrew-tap#734's `brew style` portion (which should sequence after `brew audit`).