### PR TITLE
ci(release): make generated Cask desc, homepage and postflight brew-style-clean

### DIFF
--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -75,8 +75,11 @@ homebrew_casks:
       # (ksail.devantler.tech), so `brew audit --strict` requires the URL to be
       # marked `verified:` with a trusted prefix.
       verified: "github.com/devantler-tech/ksail/"
-    description: "KSail desktop app — manage local Kubernetes clusters in a native window"
-    homepage: "https://ksail.devantler.tech"
+    # `brew style` (Cask/Desc) rejects a desc that starts with the cask token
+    # ("ksail-desktop") or ends with a full stop; keep it a plain noun phrase.
+    description: "Native desktop app to manage local Kubernetes clusters"
+    # Trailing slash required by `brew style` (Cask/HomepageUrlStyling).
+    homepage: "https://ksail.devantler.tech/"
     repository:
       owner: devantler-tech
       name: homebrew-tap
@@ -98,7 +101,7 @@ homebrew_casks:
       - "#{appdir}/KSail.app/Contents/MacOS/ksail-desktop"
     hooks:
       post:
+        # Single-line body: use the modifier form so `brew style`
+        # (Style/IfUnlessModifier) is satisfied.
         install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/KSail.app"]
-          end
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/KSail.app"] if OS.mac?

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,8 +46,11 @@ homebrew_casks:
     # marked `verified:` with a trusted prefix. Applied to the default url_template.
     url:
       verified: "github.com/devantler-tech/ksail/"
-    description: "KSail is a CLI tool to manage clusters and workloads."
-    homepage: "https://ksail.devantler.tech"
+    # `brew style` (Cask/Desc) rejects a desc that starts with the cask token
+    # ("ksail") or ends with a full stop; keep it a plain noun phrase.
+    description: "CLI tool to manage Kubernetes clusters and workloads"
+    # Trailing slash required by `brew style` (Cask/HomepageUrlStyling).
+    homepage: "https://ksail.devantler.tech/"
     repository:
       owner: devantler-tech
       name: homebrew-tap
@@ -61,10 +64,10 @@ homebrew_casks:
         draft: true
     hooks:
       post:
+        # Single-line body: use the modifier form so `brew style`
+        # (Style/IfUnlessModifier) is satisfied.
         install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ksail"]
-          end
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ksail"] if OS.mac?
     commit_author:
       signing:
         enabled: true


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

While advancing the Homebrew tap roadmap ([devantler-tech/homebrew-tap#734](https://github.com/devantler-tech/homebrew-tap/issues/734), part of epic #732 — "polished, lint-clean tap"), I confirmed that the Casks GoReleaser generates here **do not pass `brew style`**. The tap's CI already runs `brew audit --strict --online`, but `brew style` can't be wired in until the generated Casks are style-clean — otherwise it would turn the tap's `main` red and block every release PR.

`brew style` on the live Casks reports **20 offenses** (19 autocorrectable). They split cleanly:

| Category | Rules | Fixable by |
|---|---|---|
| **Config-driven** (this PR) | `Cask/Desc` (starts-with-cask-name / ends-with-full-stop), `Cask/HomepageUrlStyling` (trailing slash), `Style/IfUnlessModifier` (single-line postflight) | GoReleaser config — **and `Cask/Desc` is NOT `--fix`-autocorrectable**, so it must be fixed at the source |
| **Template formatting** (out of scope) | `Cask/StanzaOrder`, `Layout/ArgumentAlignment`, `Layout/EmptyLinesAroundBlockBody`, `Homebrew/OSDependsOn` | GoReleaser's internal cask template — all `--fix`-autocorrectable → best handled by a `brew style --fix` step on the tap side |

## What

In both `.goreleaser.yaml` (ksail) and `.goreleaser.desktop.yaml` (ksail-desktop):
- **`description`** → reworded to a plain noun phrase that doesn't start with the cask token and has no trailing period.
- **`homepage`** → added the trailing slash `brew style` requires.
- **postflight hook** → collapsed the `if OS.mac? … end` body to the modifier form.

No behaviour change: the postflight still runs the same `xattr` quarantine-strip on macOS only; the homepage resolves identically (trailing slash); descriptions are equivalent in meaning.

## Validation

- `goreleaser check -f .goreleaser.yaml` and `-f .goreleaser.desktop.yaml` → both validated.
- Simulated the emitted Casks by applying exactly these `description`/`homepage`/postflight deltas to the live generated Casks and ran `brew style`:
  - `ksail.rb`: **8 → 4** offenses (remaining 4 = `ArgumentAlignment`×3 + `EmptyLinesAroundBlockBody`, all template formatting).
  - `ksail-desktop.rb`: **12 → 9** offenses (remaining = `StanzaOrder`/`OSDependsOn`/`ArgumentAlignment`/`EmptyLines`, all template formatting).
  - **All remaining offenses are `--fix`-autocorrectable** — `brew style --fix` on the config-fixed Casks → `no offenses detected` for both.

## Sequencing

This PR is the source-side half (the non-autocorrectable rules). The tap-side follow-up — a `brew style --fix` auto-commit + `brew style` check in `devantler-tech/homebrew-tap` CI — is tracked on [homebrew-tap#734](https://github.com/devantler-tech/homebrew-tap/issues/734); it should land after a release regenerates the Casks with these descriptions.