### PR TITLE
ci(deps): bump validate-go-project reusable workflow v5.3.0 → v5.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,7 +285,7 @@ jobs:
   ci-go:
     name: ✅ Validate Go Project
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@a84d9c0fe8ed4be505fb8665e94f7e9fa9c5114a # v5.3.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@f3d334f61537404addfe2f9ece09b2aaa77afad2 # v5.3.2
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,7 +285,7 @@ jobs:
   ci-go:
     name: ✅ Validate Go Project
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@f3d334f61537404addfe2f9ece09b2aaa77afad2 # v5.3.2
+    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@8d882e6868d7d7207a708ec1f5ff33b1c90a1770 # v5.4.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

> [!WARNING]
> **Do not promote/merge yet — blocked by [reusable-workflows#271](https://github.com/devantler-tech/reusable-workflows/issues/271).**
> This bump fixes the govulncheck *OOM* (the scan now completes), but completing the scan reveals **4 reachable vulnerabilities with no upstream fix** (`Fixed in: N/A`) in `docker/docker` and `k8s.io/kubernetes`. So merging this turns ksail's `🛡️ Vulnerability Scan` from *OOM-red* to *vulns-found-red* and would block **every** ksail Go PR. It must wait until rw#271 lands a risk-acceptance allowlist (or the maintainer makes an explicit policy decision). Verified locally: `GOMEMLIMIT=12GiB govulncheck ./...` on ksail `main` → completes in 577s / 12.4 GB RSS, exit 3 (GO-2026-4887, GO-2026-4883, GO-2025-3547, GO-2025-3521).

---

> 🤖 Generated by the Daily AI Assistant

## What

Bump the `validate-go-project.yaml` reusable-workflow pin in `.github/workflows/ci.yaml` from **v5.3.0 → v5.3.2** (`a84d9c0` → `f3d334f`).

## Why

ksail's `🛡️ Vulnerability Scan` (`govulncheck ./...`, run inside `validate-go-project.yaml`) has been **OOM-killing the hosted runner** — the runner receives a shutdown signal mid-scan (exit 143 / "runner has received a shutdown signal") with no govulncheck output, an opaque, retry-resistant gate failure. govulncheck's default symbol scan builds a whole-program call graph whose peak memory grows with the dependency graph; ksail (Kubernetes/Flux/Talos/Omni clients) exhausts the runner's 16 GiB.

This was fixed upstream in [reusable-workflows#270](https://github.com/devantler-tech/reusable-workflows/pull/270) (`fix(validate-go): bound govulncheck memory so it stops OOM-killing the runner`), released in **v5.3.2**. This PR is the consumer-side bump so ksail inherits the fix.

Concretely, this unblocks the promoted [#4982](https://github.com/devantler-tech/ksail/pull/4982), whose only red check is this same govulncheck OOM, once it picks up `main`.

## Scope

Surgical, patch-level bump of the **one** pin carrying the fix. The other reusable-workflows pins in this repo (`create-release`, `scan-for-todo-comments`, `update-copilot-skills`, all at the older `26f77bf`) span major versions and need separate per-workflow validation — intentionally **not** touched here.
