### PR TITLE
ci(security): risk-accept 4 reachable-unpatched govulncheck advisories

### DIFF
--- a/.govulncheck-allow.txt
+++ b/.govulncheck-allow.txt
@@ -1,0 +1,30 @@
+# govulncheck risk-acceptance allowlist
+# ---------------------------------------------------------------------------
+# Advisory IDs listed here are KNOWN, REACHABLE govulncheck findings that are
+# explicitly risk-accepted: each has NO upstream fix available and is not
+# exploitable in ksail's role as a CLI/client. The validate-go-project gate
+# (devantler-tech/reusable-workflows >= v5.4.0) scans in JSON mode and fails
+# only on reachable advisories NOT listed here; with no file present every
+# reachable advisory blocks (strict default).
+#
+# Policy: the allowlist is for UNPATCHABLE findings only. The moment an
+# upstream fix ships, delete the entry and bump the affected module instead.
+#
+# Verified with `govulncheck ./...` against ksail main (2026-06-01):
+#   "Your code is affected by 4 vulnerabilities from 2 modules" — the 4 below,
+#   each "Fixed in: N/A". Re-validate when bumping docker or k8s.io deps.
+# ---------------------------------------------------------------------------
+
+# --- github.com/docker/docker (Moby) @ v28.5.2+incompatible -----------------
+# ksail is a Docker *client*: it calls the daemon API to create/manage local
+# clusters. Both advisories are server-side Moby *daemon* issues (authorization
+# plugin request handling) that ksail does not run. No upstream fix.
+GO-2026-4887  # Moby AuthZ plugin bypass on oversized request bodies (daemon-side; no fix)
+GO-2026-4883  # Moby off-by-one in plugin privilege validation (daemon-side; no fix)
+
+# --- k8s.io/kubernetes @ v1.36.0 --------------------------------------------
+# Imported for client/config types only; ksail does not run kube-apiserver,
+# the kubelet, or mount GitRepo volumes. Both advisories are control-plane /
+# node-side issues not exercised by ksail. No upstream fix.
+GO-2025-3547  # kube-apiserver race condition (control-plane; no fix)
+GO-2025-3521  # GitRepo volume inadvertent local repository access (node-side; no fix)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds a repo-root `.govulncheck-allow.txt` that **risk-accepts the 4 reachable govulncheck advisories that currently block every Go PR on ksail** — each has **no upstream fix** and is **not exploitable in ksail's role as a CLI/client**.

## Why now

The org-injected `🛡️ Vulnerability Scan` runs `devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@main`. As of **v5.4.0** (released 2026-06-01, carrying [reusable-workflows#272](https://github.com/devantler-tech/reusable-workflows/pull/272)) that gate scans in JSON mode and **fails only on reachable advisories not listed in a consumer-owned `.govulncheck-allow.txt`** — with no file present it stays strict (every reachable advisory blocks). Today that wedges the **entire ksail Go PR lane** (e.g. #4982).

There is **no dependency-bump path**: all 4 blocking advisories are `Fixed in: N/A`. This file is the sanctioned, version-controlled risk-acceptance mechanism for exactly that case.

## The 4 risk-accepted advisories

Verified locally with `govulncheck ./...` against ksail `main` (2026-06-01): *"Your code is affected by 4 vulnerabilities from 2 modules"* — all four below, all `Fixed in: N/A`.

| Advisory | Module | Nature | Why not exploitable here |
|---|---|---|---|
| [GO-2026-4887](https://pkg.go.dev/vuln/GO-2026-4887) | `github.com/docker/docker` v28.5.2 | Moby AuthZ plugin bypass (oversized request bodies) | **daemon-side**; ksail is a Docker *client* and does not run the daemon's authz plugin path |
| [GO-2026-4883](https://pkg.go.dev/vuln/GO-2026-4883) | `github.com/docker/docker` v28.5.2 | Moby off-by-one in plugin privilege validation | **daemon-side**; same — client-only usage |
| [GO-2025-3547](https://pkg.go.dev/vuln/GO-2025-3547) | `k8s.io/kubernetes` v1.36.0 | kube-apiserver race condition | **control-plane**; imported for client/config types only, ksail never runs kube-apiserver |
| [GO-2025-3521](https://pkg.go.dev/vuln/GO-2025-3521) | `k8s.io/kubernetes` v1.36.0 | GitRepo volume inadvertent local repo access | **node-side**; ksail does not mount GitRepo volumes |

The 3 remaining module-level findings (docker/cli GO-2026-4610 → fixable to v29.2.0, plus two aws-sdk-go v1 advisories) are **not reachable**, so the gate never trips on them and they are intentionally **not** in the allowlist.

## ⚠️ Maintainer decision — promotion = risk-acceptance

**Which advisories to accept is your security-policy call.** I have prepared the allowlist with full per-ID justification; **promoting this draft to "ready for review" is the act that accepts these 4 risks.** I will not self-promote or self-merge it. Trim the list if you'd rather keep any of them blocking.

## Validation

- File parses to exactly the 4 IDs under the gate's own parser (`sed 's/#.*//' | tr -s ' \t' '\n' | grep -E '^GO-[0-9]{4}-[0-9]+$'`).
- Ran the gate's full blocking-set computation against the captured `govulncheck -format json` output: **reachable = these 4, blocking set = empty → gate PASSES**.
- This PR's own `🛡️ Vulnerability Scan` is self-validating: its head carries the file, so a green check here confirms the mechanism end-to-end.

## Policy note

The allowlist is for **unpatchable** findings only. The moment an upstream fix ships, the entry should be deleted and the module bumped instead — the file header documents this.

## Follow-ups

- After merge, open Go PRs (#4982, #4984) pick up the file on rebase and unblock.
- **#4984** currently bumps the *pinned* `validate-go-project` caller to **v5.3.2**, which has the OOM fix but **not** the allowlist logic (only ≥ v5.4.0 does) — it should be retargeted to **v5.4.0** (it remains on HOLD until then).
