### PR TITLE
test(fsutil): cover AtomicWriteFile happy paths and error branches

### DIFF
--- a/pkg/fsutil/atomic_test.go
+++ b/pkg/fsutil/atomic_test.go
@@ -122,8 +122,7 @@ func TestAtomicWriteFile_CreateTempError(t *testing.T) {
 	path := filepath.Join(dir, "does-not-exist", "config.yaml")
 
 	err := fsutil.AtomicWriteFile(path, []byte("data"), 0o600)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "create temp file")
+	require.ErrorContains(t, err, "create temp file")
 
 	_, statErr := os.Stat(path)
 	assert.True(t, os.IsNotExist(statErr), "no target file should be created on failure")
@@ -146,7 +145,6 @@ func TestAtomicWriteFile_RenameError(t *testing.T) {
 	require.NoError(t, os.Mkdir(path, 0o750))
 
 	err := fsutil.AtomicWriteFile(path, []byte("data"), 0o600)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "rename temp file")
+	require.ErrorContains(t, err, "rename temp file")
 	assertNoTempLeftover(t, dir)
 }

--- a/pkg/fsutil/atomic_test.go
+++ b/pkg/fsutil/atomic_test.go
@@ -1,0 +1,152 @@
+package fsutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// atomicTempGlob matches the temporary files AtomicWriteFile creates while
+// staging a write, so tests can assert they are always cleaned up.
+const atomicTempGlob = ".atomic-*.tmp"
+
+// assertNoTempLeftover fails if any staging temp file remains in dir.
+func assertNoTempLeftover(t *testing.T, dir string) {
+	t.Helper()
+
+	leftovers, globErr := filepath.Glob(filepath.Join(dir, atomicTempGlob))
+	require.NoError(t, globErr)
+	assert.Empty(t, leftovers, "AtomicWriteFile must not leave staging temp files behind")
+}
+
+// TestAtomicWriteFile_WritesContent verifies the happy path writes the exact
+// bytes to the target path and removes its staging temp file afterwards.
+func TestAtomicWriteFile_WritesContent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := []byte("kind: Cluster\nname: test\n")
+
+	err := fsutil.AtomicWriteFile(path, content, 0o600)
+	require.NoError(t, err)
+
+	got, readErr := os.ReadFile(path) //nolint:gosec // test file
+	require.NoError(t, readErr)
+	assert.Equal(t, content, got)
+	assertNoTempLeftover(t, dir)
+}
+
+// TestAtomicWriteFile_EmptyData verifies a zero-length write produces an empty
+// file rather than an error.
+func TestAtomicWriteFile_EmptyData(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty")
+
+	err := fsutil.AtomicWriteFile(path, []byte{}, 0o600)
+	require.NoError(t, err)
+
+	got, readErr := os.ReadFile(path) //nolint:gosec // test file
+	require.NoError(t, readErr)
+	assert.Empty(t, got)
+	assertNoTempLeftover(t, dir)
+}
+
+// TestAtomicWriteFile_AppliesPermissions verifies the target file ends up with
+// the requested mode. Skipped on Windows, where Unix permission bits are not
+// modelled the same way.
+func TestAtomicWriteFile_AppliesPermissions(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not modelled on Windows")
+	}
+
+	tests := []struct {
+		name string
+		perm os.FileMode
+	}{
+		{name: "private 0600", perm: 0o600},
+		{name: "world readable 0644", perm: 0o644},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "perm-check")
+
+			err := fsutil.AtomicWriteFile(path, []byte("data"), testCase.perm)
+			require.NoError(t, err)
+
+			info, statErr := os.Stat(path)
+			require.NoError(t, statErr)
+			assert.Equal(t, testCase.perm, info.Mode().Perm())
+		})
+	}
+}
+
+// TestAtomicWriteFile_OverwritesAtomically verifies an existing file is replaced
+// with the new content, exercising the all-or-nothing rename over a live target.
+func TestAtomicWriteFile_OverwritesAtomically(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte("old contents"), 0o600))
+
+	newContent := []byte("new contents")
+	err := fsutil.AtomicWriteFile(path, newContent, 0o600)
+	require.NoError(t, err)
+
+	got, readErr := os.ReadFile(path) //nolint:gosec // test file
+	require.NoError(t, readErr)
+	assert.Equal(t, newContent, got)
+	assertNoTempLeftover(t, dir)
+}
+
+// TestAtomicWriteFile_CreateTempError verifies a missing parent directory
+// surfaces as a wrapped create-temp error and writes nothing.
+func TestAtomicWriteFile_CreateTempError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist", "config.yaml")
+
+	err := fsutil.AtomicWriteFile(path, []byte("data"), 0o600)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create temp file")
+
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "no target file should be created on failure")
+}
+
+// TestAtomicWriteFile_RenameError verifies a rename failure (target path is an
+// existing directory) is surfaced as a wrapped rename error and the staging
+// temp file is still cleaned up. Skipped on Windows, where the function takes a
+// different remove-and-retry branch for an existing destination.
+func TestAtomicWriteFile_RenameError(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows takes the remove-and-retry rename branch for an existing destination")
+	}
+
+	dir := t.TempDir()
+	// The target path is an existing directory; renaming a file onto it fails.
+	path := filepath.Join(dir, "target-dir")
+	require.NoError(t, os.Mkdir(path, 0o750))
+
+	err := fsutil.AtomicWriteFile(path, []byte("data"), 0o600)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename temp file")
+	assertNoTempLeftover(t, dir)
+}

--- a/pkg/fsutil/atomic_test.go
+++ b/pkg/fsutil/atomic_test.go
@@ -65,7 +65,7 @@ func TestAtomicWriteFile_EmptyData(t *testing.T) {
 func TestAtomicWriteFile_AppliesPermissions(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windowsGOOS {
 		t.Skip("Unix permission bits are not modelled on Windows")
 	}
 
@@ -136,7 +136,7 @@ func TestAtomicWriteFile_CreateTempError(t *testing.T) {
 func TestAtomicWriteFile_RenameError(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windowsGOOS {
 		t.Skip("Windows takes the remove-and-retry rename branch for an existing destination")
 	}
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`fsutil.AtomicWriteFile` is the all-or-nothing write guard behind the most safety-critical persistence in KSail, yet it had **no direct test coverage**. It backs:

- **kubeconfig writes** — 5 call sites in `pkg/k8s/kubeconfig.go` (corruption here breaks a user's cluster access)
- the **OIDC token cache** (`pkg/svc/oidc/cache.go`)
- the **cluster switch-history** file (`pkg/cli/cmd/cluster/cluster.go`)
- the **KWOK** provisioner config (`pkg/svc/provisioner/cluster/kwok/...`)
- the **talosconfig** backup + write (`pkg/svc/repairer/talosconfig/...`)

## What

Adds `pkg/fsutil/atomic_test.go` with focused, table-driven/subtest coverage of the **reachable** behaviour, taking the function from **0% → 63.3%**:

- writes the exact bytes; an empty-data write produces an empty file
- the requested file mode is applied (Unix-gated)
- an existing target is **atomically overwritten** with the new content
- a missing parent directory surfaces a wrapped `create temp file` error and writes **nothing**
- a rename failure (target path is a directory) surfaces a wrapped `rename temp file` error (Unix-gated; Windows takes the remove-and-retry branch)
- the staging temp file (`.atomic-*.tmp`) is **never left behind**, on success *or* failure

## Honest scope

The `chmod` / write / short-write / close error branches and the Windows rename-retry path are **not reachable** without injecting a custom writer (the function writes through `*os.File` directly) or running on Windows — so they are intentionally **left uncovered rather than faked**. Closing them would mean a small production refactor (inject the writer), which belongs in its own change, not a test-only PR.

Follows the package's existing test conventions (`fsutil_test` external package, `t.Parallel()`, `t.TempDir()`, testify, and the established `//nolint:gosec // test file` annotation already used in `trywritefile_edge_test.go` for G304 on test-controlled temp paths).

## Validation

- `go test ./pkg/fsutil/` → all pass (8 new subtests; 80 total in package)
- `go build` → success
- `golangci-lint run pkg/fsutil/atomic_test.go` → **No issues found**