### PR TITLE
ci(release): make generated Homebrew casks fully brew-style-clean

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -686,10 +686,17 @@ jobs:
             # brew-style-clean — letting the tap enforce a `brew style` gate (devantler-tech/homebrew-tap#734).
             # Fail-soft throughout: a style/clone/push hiccup must never block the release; the cask
             # still lands (uncorrected) exactly as it does today.
-            work="$(mktemp -d)"
-            if git clone --depth 1 --branch "$branch" \
-                "https://x-access-token:${GH_TOKEN}@github.com/${TAP}.git" "$work" 2>/dev/null; then
-              if brew style --fix "$work/Casks/${name}.rb"; then
+            # `mktemp -d` under `set -e` would abort the job on a tempdir failure; guard it so a
+            # hiccup just skips the (best-effort) autocorrect and still promotes the cask below.
+            if work="$(mktemp -d)"; then
+              if git clone --depth 1 --branch "$branch" \
+                  "https://x-access-token:${GH_TOKEN}@github.com/${TAP}.git" "$work" 2>/dev/null; then
+                # `brew style --fix` can apply partial autocorrections yet still exit non-zero when
+                # offenses remain. Run it fail-soft and commit whatever diff it produced regardless of
+                # exit status, so partial cleanups are never discarded (and a failure never blocks the
+                # release).
+                brew style --fix "$work/Casks/${name}.rb" \
+                  || echo "::warning::brew style --fix exited non-zero for ${name}; committing any partial autocorrections"
                 if git -C "$work" diff --quiet; then
                   echo "${name} cask already brew-style-clean; nothing to autocorrect"
                 else
@@ -702,12 +709,12 @@ jobs:
                     || echo "::warning::Could not push brew style --fix autocorrections to ${branch}; promoting as-is"
                 fi
               else
-                echo "::warning::brew style --fix could not fully clean ${name}; promoting cask as-is"
+                echo "::warning::Could not clone ${TAP} branch ${branch} for brew style --fix; promoting as-is"
               fi
+              rm -rf "$work"
             else
-              echo "::warning::Could not clone ${TAP}#${branch} for brew style --fix; promoting as-is"
+              echo "::warning::Could not create tempdir for brew style --fix; promoting ${name} cask as-is"
             fi
-            rm -rf "$work"
 
             # Both gh calls are non-fatal under `set -e`: the PR may already be ready, or auto-merge
             # may already be enabled by the tap's own automation — neither should fail the job.

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -664,7 +664,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: 🍺 Mark cask PRs ready and enable auto-merge
+      - name: 🍺 Style-clean cask PRs, then mark ready and enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           TAP: devantler-tech/homebrew-tap
@@ -679,6 +679,36 @@ jobs:
               continue
             fi
             echo "Promoting ${TAP}#${pr} (${branch})"
+
+            # GoReleaser's cask template emits a few `brew style` offenses no config knob can reach
+            # (Layout/ArgumentAlignment on url/verified, Cask/StanzaOrder for the custom_block stanzas).
+            # Autocorrect them on the PR branch before promoting so the cask that lands in the tap is
+            # brew-style-clean — letting the tap enforce a `brew style` gate (devantler-tech/homebrew-tap#734).
+            # Fail-soft throughout: a style/clone/push hiccup must never block the release; the cask
+            # still lands (uncorrected) exactly as it does today.
+            work="$(mktemp -d)"
+            if git clone --depth 1 --branch "$branch" \
+                "https://x-access-token:${GH_TOKEN}@github.com/${TAP}.git" "$work" 2>/dev/null; then
+              if brew style --fix "$work/Casks/${name}.rb"; then
+                if git -C "$work" diff --quiet; then
+                  echo "${name} cask already brew-style-clean; nothing to autocorrect"
+                else
+                  git -C "$work" \
+                      -c user.name='github-actions[bot]' \
+                      -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                      commit -am 'style: brew style --fix generated cask' \
+                    && git -C "$work" push \
+                    && echo "Pushed brew style --fix autocorrections to ${branch}" \
+                    || echo "::warning::Could not push brew style --fix autocorrections to ${branch}; promoting as-is"
+                fi
+              else
+                echo "::warning::brew style --fix could not fully clean ${name}; promoting cask as-is"
+              fi
+            else
+              echo "::warning::Could not clone ${TAP}#${branch} for brew style --fix; promoting as-is"
+            fi
+            rm -rf "$work"
+
             # Both gh calls are non-fatal under `set -e`: the PR may already be ready, or auto-merge
             # may already be enabled by the tap's own automation — neither should fail the job.
             gh pr ready "$pr" --repo "$TAP" \

--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -91,8 +91,13 @@ homebrew_casks:
         # (the cask download URL would 404 for `brew install`). The cd.yaml `homebrew` job marks the
         # PR ready after `publish-release` flips the release public, letting the tap merge it then.
         draft: true
-    # The cask schema has no first-class `app` field; install the bundle via a custom stanza.
+    # The cask schema has no first-class `app` or `depends_on` field; emit both via a custom stanza.
+    # `depends_on macos` satisfies `brew style` (Homebrew/OSDependsOn) for this macOS-only GUI cask;
+    # ">= :big_sur" matches the Go toolchain's minimum supported macOS. The cd.yaml `homebrew` job
+    # runs `brew style --fix`, which reorders these stanzas into canonical position before the cask
+    # lands in the tap.
     custom_block: |
+      depends_on macos: ">= :big_sur"
       app "KSail.app"
     # Symlink the CLI from inside the installed app (the canonical GUI-app-with-CLI cask pattern),
     # so `ksail-desktop` is on PATH and `ksail desktop` finds it. Without this, GoReleaser would


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`Refs #4989` — completes making the GoReleaser-generated Homebrew casks (`Casks/ksail.rb`, `Casks/ksail-desktop.rb`) **`brew style`-clean** so the tap can finally enforce a `brew style` gate (devantler-tech/homebrew-tap#734).

[#4983](https://github.com/devantler-tech/ksail/pull/4983) already fixed the **config-controllable** offenses (`Cask/Desc`, `Cask/HomepageUrlStyling`, `Style/IfUnlessModifier`) in both `.goreleaser*.yaml`. Two classes of offense remained:

| Offense | Cask | Autocorrectable? | Config-reachable? |
|---|---|---|---|
| `Homebrew/OSDependsOn` | desktop | ❌ | ✅ (custom_block) |
| `Layout/ArgumentAlignment` (url/`verified:`) | both | ✅ | ❌ (GoReleaser template) |
| `Cask/StanzaOrder` (custom_block placement) | desktop | ✅ | ❌ (GoReleaser template) |

## Changes

1. **`.goreleaser.desktop.yaml`** — add `depends_on macos: ">= :big_sur"` to the cask `custom_block` (the cask schema has no first-class `depends_on` field). Satisfies `Homebrew/OSDependsOn` for this macOS-only GUI cask. The `>= :big_sur` floor matches the Go toolchain's minimum supported macOS.
2. **`.github/workflows/cd.yaml`** (`homebrew` job) — before promoting each tap cask PR, clone its branch, run `brew style --fix Casks/<name>.rb`, and commit the autocorrection to the PR branch. This handles the GoReleaser-template-intrinsic offenses (`Layout/ArgumentAlignment`, `Cask/StanzaOrder`) that no config knob can reach. **Fail-soft throughout** — a clone/style/push hiccup emits a `::warning::` and the cask still lands uncorrected, exactly as today; the release is never blocked.

## Validation

- ✅ `goreleaser check -f .goreleaser.yaml` and `-f .goreleaser.desktop.yaml` — both pass.
- ✅ `actionlint .github/workflows/cd.yaml` (runs shellcheck on the `run:` block) — clean, exit 0.

## Needs real-release confirmation (why this is a draft)

The `brew style --fix` step can only be exercised by an actual release. Before promoting, please confirm on the next release (or a dry run):

- **`brew` availability** — ubuntu-latest ships Homebrew preinstalled; `brew style` bootstraps its rubocop deps on first run (fail-soft if not).
- **Signed-commit policy** — the autocorrection commit is authored as `github-actions[bot]` (unsigned), unlike GoReleaser's GPG-signed cask commit. The tap's `goreleaser/*` PR branches are not protected, and the squash-merge re-authors the commit, so this should be fine — but worth confirming the tap doesn't reject unsigned commits on PR branches.
- **`depends_on macos` floor** — `">= :big_sur"` is a conservative, defensible default (Go's min macOS); adjust if the desktop app targets a higher floor.

Once confirmed, devantler-tech/homebrew-tap#734 can add its `brew style` gate without breaking GoReleaser release PRs.