### PR TITLE
fix: bump Go to 1.26.4 to clear reachable stdlib vulnerabilities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,7 +285,7 @@ jobs:
   ci-go:
     name: ✅ Validate Go Project
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@8d882e6868d7d7207a708ec1f5ff33b1c90a1770 # v5.4.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@bfb04968a21911d080d082e54cef52e0216cffef # v5.4.6
     permissions:
       contents: write
       issues: write

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 run:
   allow-parallel-runners: true
   modules-download-mode: readonly
-  go: "1.26.3"
+  go: "1.26.4"
 formatters:
   enable:
     - gci

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -1,6 +1,6 @@
 module github.com/devantler-tech/ksail/desktop
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/devantler-tech/ksail/v7 => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devantler-tech/ksail/v7
 
-go 1.26.3
+go 1.26.4
 
 // Exclude the standalone google.golang.org/grpc/stats/opentelemetry module to avoid
 // ambiguous import errors. The opentelemetry stats package is included in the main


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `validate-go-project` **🛡️ Vulnerability Scan** gate (govulncheck) reports **three reachable Go standard-library advisories** that are **fixed in Go 1.26.4**, and they are **not** in `.govulncheck-allow.txt` (correctly — they are patchable, unlike the four unpatchable advisories that are allowlisted). So the scan fails on every Go-touching PR, **wedging the dependabot Go queue** — #5003, #5002, #5001, #4945, #4905 are all BLOCKED on this check, plus any future Go PR.

| Advisory | CVE | stdlib package |
|---|---|---|
| GO-2026-5037 | CVE-2026-27145 | `crypto/x509` — inefficient candidate-hostname parsing |
| GO-2026-5038 | CVE-2026-42504 | `mime` — quadratic complexity in `WordDecoder.DecodeHeader` |
| GO-2026-5039 | CVE-2026-42507 | `net/textproto` — unescaped arbitrary inputs in errors |

ksail's modules pin `go 1.26.3`; CI installs the toolchain via `setup-go` with `go-version-file: go.mod`, so the scan builds against the **vulnerable 1.26.3 stdlib**.

## Fix

Bump the `go` directive in **both** modules (`go.mod`, `desktop/go.mod`) from `1.26.3` → `1.26.4`. `setup-go` then builds with the patched toolchain and all three advisories drop out of the **reachable (called)** set.

## Validation (local, go1.26.4)

- `go build ./...` — **green**
- `go mod tidy` — **no drift** (only the version directive changes)
- govulncheck reachable-called advisories = **exactly the four already-allowlisted** unpatchable ones (`GO-2025-3521`, `GO-2025-3547`, `GO-2026-4883`, `GO-2026-4887`); the three `GO-2026-503x` advisories have **zero** reachable findings under 1.26.4
- Replicated the exact CI blocking computation (reachable-called **minus** allowlist) → **empty blocking set ✅**

Minimal, behaviour-preserving (toolchain-floor bump only). Unwedges the Go lane; the listed dependabot PRs will pass Vuln Scan once rebased onto this.

## Update — keep the post-merge push run green

The PR-side **🛡️ Vulnerability Scan** runs via the org ruleset *"Require workflows to pass before merging for Go"*, which pins `validate-go-project.yaml@refs/heads/main` — now carrying [reusable-workflows#284](https://github.com/devantler-tech/reusable-workflows/pull/284) (released **v5.4.6**), which scans under the **go.mod** Go version instead of setup-go `stable`. Before that fix, bumping `go.mod` to 1.26.4 produced an *operational* error (`go.mod requires go >= 1.26.4; running go 1.26.3; GOTOOLCHAIN=local`) because `stable` still resolves to 1.26.3.

The separate **push-to-main** `ci-go` job in `ci.yaml` still pinned `validate-go-project@v5.4.0`, so after merge it would hit the same operational error on `main`. Second commit bumps that pin to **v5.4.6** so the post-merge run stays green too.
