### PR TITLE
fix(talos): wait for new Docker nodes' Talos API before in-place reconcile

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -56,6 +56,32 @@ func (p *Provisioner) RemoveDockerNodesForTest(
 	return p.removeDockerNodes(ctx, clusterName, role, count, result)
 }
 
+// WithNodeReachabilityCheckForTest overrides the per-node Talos API reachability
+// check. Full scale-up flow tests use it to avoid real TCP dials against the
+// (unroutable) static container IPs assigned to mock-created containers.
+func (p *Provisioner) WithNodeReachabilityCheckForTest(
+	fn func(ctx context.Context, ip string) error,
+) *Provisioner {
+	p.nodeReachabilityCheck = fn
+
+	return p
+}
+
+// WaitForNewDockerNodesReachableForTest exposes waitForNewDockerNodesReachable
+// for unit testing. Each IP in nodeIPs is turned into a node spec (the IP doubles
+// as the node name in log/error output).
+func (p *Provisioner) WaitForNewDockerNodesReachableForTest(
+	ctx context.Context,
+	nodeIPs []string,
+) error {
+	specs := make([]nodeSpec, len(nodeIPs))
+	for i, ip := range nodeIPs {
+		specs[i] = nodeSpec{name: ip, ip: netip.MustParseAddr(ip)}
+	}
+
+	return p.waitForNewDockerNodesReachable(ctx, specs)
+}
+
 // CreateOmniProviderForTest exposes createOmniProvider for unit testing.
 func CreateOmniProviderForTest(opts v1alpha1.OptionsOmni) error {
 	_, err := createOmniProvider(opts)

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -398,18 +398,41 @@ func (p *Provisioner) waitForServerReachable(
 ) error {
 	serverIP := server.PublicNet.IPv4.IP.String()
 
-	err := retry.Constant(clusterReadinessTimeout, retry.WithUnits(longRetryInterval)).
+	err := dialTCPUntilReachable(ctx, serverIP, clusterReadinessTimeout, longRetryInterval)
+	if err != nil {
+		return fmt.Errorf(
+			"timeout waiting for %s to become reachable after install: %w",
+			server.Name,
+			err,
+		)
+	}
+
+	return nil
+}
+
+// dialTCPUntilReachable polls ip:talosAPIPort until a TCP connection succeeds or
+// the context is done, retrying every interval up to timeout. A successful dial
+// means the Talos apid service is accepting connections on the node. This is
+// shared by the Hetzner install/reboot wait (waitForServerReachable) and the
+// Docker scale-up wait (waitForNewDockerNodesReachable); each caller wraps the
+// returned error with its own server/node context.
+func dialTCPUntilReachable(
+	ctx context.Context,
+	nodeIP string,
+	timeout, interval time.Duration,
+) error {
+	err := retry.Constant(timeout, retry.WithUnits(interval)).
 		RetryWithContext(ctx, func(ctx context.Context) error {
 			dialer := &net.Dialer{Timeout: retryInterval}
 
 			conn, dialErr := dialer.DialContext(
 				ctx,
 				"tcp",
-				net.JoinHostPort(serverIP, strconv.Itoa(talosAPIPort)),
+				net.JoinHostPort(nodeIP, strconv.Itoa(talosAPIPort)),
 			)
 			if dialErr != nil {
 				return retry.ExpectedError(
-					fmt.Errorf("waiting for server to become reachable: %w", dialErr),
+					fmt.Errorf("waiting for Talos API to become reachable: %w", dialErr),
 				)
 			}
 
@@ -418,11 +441,7 @@ func (p *Provisioner) waitForServerReachable(
 			return nil
 		})
 	if err != nil {
-		return fmt.Errorf(
-			"timeout waiting for %s to become reachable after install: %w",
-			server.Name,
-			err,
-		)
+		return fmt.Errorf("dialing Talos API at %s: %w", nodeIP, err)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -154,9 +154,16 @@ type Provisioner struct {
 	// talosClientFactory creates a Talos client for the given node IP.
 	// Tests can override this via export_test.go to inject a mock.
 	talosClientFactory func(ctx context.Context, ip string) (kubeconfigFetcher, error)
-	logWriter          io.Writer
-	logMu              sync.Mutex
-	componentDetector  *detector.ComponentDetector
+	// nodeReachabilityCheck reports when a node's Talos API (apid) is accepting
+	// connections at ip:talosAPIPort, retrying until it succeeds or the context is
+	// done. It gates Docker scale-up: a freshly started container returns from
+	// ContainerStart before apid is listening, so the update's in-place config
+	// reconciliation must wait for it. Defaults to a TCP dial loop; tests override
+	// it via export_test.go to avoid real network I/O.
+	nodeReachabilityCheck func(ctx context.Context, ip string) error
+	logWriter             io.Writer
+	logMu                 sync.Mutex
+	componentDetector     *detector.ComponentDetector
 	// imagePullRetry controls retry behavior for Docker image pulls.
 	// Tests can override this via WithImagePullRetryConfig to use near-zero delays.
 	imagePullRetry imagePullRetryConfig
@@ -193,6 +200,10 @@ func NewProvisioner(
 
 	prov.talosClientFactory = func(ctx context.Context, ip string) (kubeconfigFetcher, error) {
 		return prov.createTalosClient(ctx, ip)
+	}
+
+	prov.nodeReachabilityCheck = func(ctx context.Context, ip string) error {
+		return dialTCPUntilReachable(ctx, ip, talosAPIWaitTimeout, retryInterval)
 	}
 
 	return prov

--- a/pkg/svc/provisioner/cluster/talos/scale_docker.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_docker.go
@@ -178,16 +178,19 @@ func (p *Provisioner) waitForNewDockerNodesReachable(
 		return nil
 	}
 
-	group, _ := errgroup.WithContext(ctx)
+	// Use the errgroup's derived context so the first failed probe cancels the
+	// siblings still waiting, rather than letting them run out their own timeout.
+	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(maxConcurrentContainerOps)
 
 	for _, spec := range specs {
 		group.Go(func() error {
-			p.logf("  Waiting for Talos API on %s (%s)...\n", spec.name, spec.ip)
+			nodeIP := spec.ip.String()
+			p.logf("  Waiting for Talos API on %s (%s)...\n", spec.name, nodeIP)
 
-			checkErr := p.nodeReachabilityCheck(ctx, spec.ip.String())
+			checkErr := p.nodeReachabilityCheck(groupCtx, nodeIP)
 			if checkErr != nil {
-				return fmt.Errorf("timeout waiting for Talos API on %s: %w", spec.name, checkErr)
+				return fmt.Errorf("waiting for Talos API on %s: %w", spec.name, checkErr)
 			}
 
 			p.logf("  ✓ Talos API reachable on %s\n", spec.name)

--- a/pkg/svc/provisioner/cluster/talos/scale_docker.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_docker.go
@@ -137,7 +137,66 @@ func (p *Provisioner) addDockerNodes(
 		return err
 	}
 
-	return p.collectResults(results, role, result)
+	return p.recordAndWaitForNewDockerNodes(ctx, results, specs, role, result)
+}
+
+// recordAndWaitForNewDockerNodes records each container-creation outcome, then —
+// when every container was created successfully — blocks until the new nodes'
+// Talos APIs are reachable. The reachability wait is the Docker-side analog of
+// the Hetzner waitForServersToBeReachable scale-up guard: ContainerStart returns
+// before apid is listening inside the container, so without it the update's
+// subsequent in-place config reconciliation (fetchNodeConfig) races the boot and
+// a just-started node yields "connection refused", recorded as a spurious failed
+// change.
+func (p *Provisioner) recordAndWaitForNewDockerNodes(
+	ctx context.Context,
+	results []nodeResult,
+	specs []nodeSpec,
+	role string,
+	result *clusterupdate.UpdateResult,
+) error {
+	collectErr := p.collectResults(results, role, result)
+	if collectErr != nil {
+		// A container that failed to create won't become reachable; the failure
+		// is already recorded, so surface it without waiting.
+		return collectErr
+	}
+
+	return p.waitForNewDockerNodesReachable(ctx, specs)
+}
+
+// waitForNewDockerNodesReachable blocks until every newly-created node's Talos
+// API (apid) is accepting connections, polling each node's container IP in
+// parallel (bounded by maxConcurrentContainerOps). It is a no-op for an empty
+// slice. This is the Docker-side analog of waitForServersToBeReachable; see
+// recordAndWaitForNewDockerNodes for why the wait is needed.
+func (p *Provisioner) waitForNewDockerNodesReachable(
+	ctx context.Context,
+	specs []nodeSpec,
+) error {
+	if len(specs) == 0 {
+		return nil
+	}
+
+	group, _ := errgroup.WithContext(ctx)
+	group.SetLimit(maxConcurrentContainerOps)
+
+	for _, spec := range specs {
+		group.Go(func() error {
+			p.logf("  Waiting for Talos API on %s (%s)...\n", spec.name, spec.ip)
+
+			checkErr := p.nodeReachabilityCheck(ctx, spec.ip.String())
+			if checkErr != nil {
+				return fmt.Errorf("timeout waiting for Talos API on %s: %w", spec.name, checkErr)
+			}
+
+			p.logf("  ✓ Talos API reachable on %s\n", spec.name)
+
+			return nil
+		})
+	}
+
+	return group.Wait() //nolint:wrapcheck // per-node errors are wrapped in the closure above
 }
 
 // preCalculateNodeSpecs determines the name and static IP for each node to be created.

--- a/pkg/svc/provisioner/cluster/talos/scale_docker_test.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_docker_test.go
@@ -31,7 +31,10 @@ func newScaleProvisioner(
 
 	return talosprovisioner.NewProvisioner(configs, talosprovisioner.NewOptions()).
 		WithDockerClient(mockClient).
-		WithLogWriter(io.Discard)
+		WithLogWriter(io.Discard).
+		// Stub the post-create Talos API reachability wait: mock-created containers
+		// get unroutable static IPs, so a real TCP dial would block until timeout.
+		WithNodeReachabilityCheckForTest(func(context.Context, string) error { return nil })
 }
 
 // loadConfigs builds a TalosConfigs from a fresh temp directory.
@@ -208,6 +211,41 @@ func TestAddDockerNodes_ListExistingFails_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to list")
 	assert.Empty(t, result.AppliedChanges)
+}
+
+// newReachabilityProvisioner builds a Provisioner that keeps the real (TCP-dial)
+// node reachability check, so the wait behavior itself is exercised.
+func newReachabilityProvisioner(t *testing.T) *talosprovisioner.Provisioner {
+	t.Helper()
+
+	return talosprovisioner.NewProvisioner(nil, talosprovisioner.NewOptions()).
+		WithLogWriter(io.Discard)
+}
+
+func TestWaitForNewDockerNodesReachable_EmptyInput_NoOp(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newReachabilityProvisioner(t)
+
+	err := provisioner.WaitForNewDockerNodesReachableForTest(context.Background(), nil)
+
+	require.NoError(t, err)
+}
+
+func TestWaitForNewDockerNodesReachable_CancelledContext_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newReachabilityProvisioner(t)
+
+	// Cancel up front so the dial loop bails immediately instead of waiting for
+	// the node to ever become reachable.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := provisioner.WaitForNewDockerNodesReachableForTest(ctx, []string{"10.255.255.1"})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "10.255.255.1")
 }
 
 func TestRemoveDockerNodes_Workers_RemovesAll(t *testing.T) {


### PR DESCRIPTION
## What

In the Talos **Docker** scale-up path, `addDockerNodes` now waits for each newly-created container's Talos API (`apid`) to be reachable on `IP:50000` before returning — closing the same structural gap that was previously fixed for Hetzner.

## Why

`createTalosContainer` does `ContainerCreate` + `ContainerStart` and returns immediately; it never waits for `apid` inside the container to finish booting. The update flow then runs `applyInPlaceConfigChanges`, whose `fetchNodeConfig` (in `detect_inplace.go`) does a single `StateGet` with **no retry**. So a just-started container whose `apid` isn't listening yet yields `rpc error: code = Unavailable ... connection refused`, recorded as a **spurious failed change**.

Hetzner already guards against this with `waitForServersToBeReachable` after config apply. Docker had the same gap with no guard. The window is much smaller for Docker (containers boot in seconds, vs. Hetzner's 3–5 min install+reboot), so it's lower severity — but a genuine latent flake, especially under loaded CI.

## How

- **`scale_docker.go`** — `addDockerNodes` → `recordAndWaitForNewDockerNodes`: records each creation outcome, and on full success calls `waitForNewDockerNodesReachable`, which polls each new container IP in parallel (bounded by `maxConcurrentContainerOps`) and is a no-op for empty input. `addDockerNodes` itself stays the same length, so `funlen` is unaffected.
- **`hetzner_nodes.go`** — extracted the TCP-dial-with-retry loop into a provider-neutral `dialTCPUntilReachable(ctx, ip, timeout, interval)`. Hetzner's `waitForServerReachable` now delegates to it (same 20-min / 10-s tuning, behavior preserved), avoiding `dupl` with the new Docker wait.
- **`provisioner.go`** — added a `nodeReachabilityCheck` injection seam (defaulting to the TCP dial with `talosAPIWaitTimeout` / `retryInterval`), mirroring the existing `talosClientFactory` / `kernelModuleLoader` pattern so unit tests don't dial real IPs.
- **Tests** — added focused tests (`empty input is a no-op`; `cancelled context surfaces a failure`, returns fast with no hang) following the existing scale-test conventions; existing full-flow create tests stub the check so they don't dial the unroutable mock container IPs.

## Testing

- `go build` — success
- `go test ./pkg/svc/provisioner/cluster/talos/` — **384 passed**, including under `-race`
- `golangci-lint run --timeout 5m pkg/svc/provisioner/cluster/talos/` — **no new issues** (`--new-from-rev=HEAD` clean); also fixed the gofmt struct-field realignment the longer field name triggered

## Reviewer notes

- The reachability check polls the **container IP** — exactly the address the subsequent `fetchNodeConfig` connects to — so it gates precisely where the in-place reconciliation can reach nodes (Linux / CI), introducing no new platform limitation.
- The shared-helper extraction touches the Hetzner `waitForServerReachable`; timeout/interval/port are unchanged and no test was coupled to its error string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
