### PR TITLE
fix(ci): retarget skills update to renamed update-agent-skills workflow

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -1,4 +1,4 @@
-name: Update Copilot Skills
+name: Update Agent Skills
 on:
   workflow_dispatch:
   schedule:
@@ -11,10 +11,10 @@ concurrency:
 permissions: {}
 
 jobs:
-  update-copilot-skills:
+  update-agent-skills:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@ad99c16f59e9e205d1cbd4d511c949aa353670b7 # v1.39.0+ (post skills-lock refactor)
+    uses: devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml@d4d382168eeef3d08606ed7c6fb2671e3d4170fc # v5.5.2
     with:
       dir: .agents/skills


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
The daily scheduled **Update Skills** workflow ([run 26871110941](https://github.com/devantler-tech/ksail/actions/runs/26871110941), 2026-06-03 06:00 UTC) failed with *"This run likely failed because of a workflow file issue"* — no jobs ran, no logs. It had succeeded every prior day.

## Root cause
Dependabot [#4995](https://github.com/devantler-tech/ksail/pull/4995) bumped the reusable-workflow ref on the `uses:` line to `ad99c16f`, which is the **breaking rename** commit `feat!: rename update-copilot-skills -> update-agent-skills` ([reusable-workflows#246](https://github.com/devantler-tech/reusable-workflows/pull/246)). Dependabot only bumps the SHA — it left the **old path** `update-copilot-skills.yaml`, which **404s** at that ref (the file was renamed to `update-agent-skills.yaml`), so GitHub can't resolve the called workflow.

This is a missed consumer-propagation from the agent-neutral skills rename.

## Fix
- Retarget to the renamed `update-agent-skills.yaml`, pinned to **v5.5.2** (`d4d3821`).
- Align the workflow `name:` and job id to the agent-neutral naming.
- `dir: .agents/skills` is unchanged (the renamed workflow still exposes the `dir` input).

## Validation
- Confirmed `update-agent-skills.yaml` exists at the pinned SHA and accepts `dir`.
- `actionlint` clean.