### PR TITLE
fix(talos): gzip Hetzner autoscaler user_data to fit 32 KiB limit

### DIFF
--- a/pkg/svc/installer/clusterautoscaler/installer.go
+++ b/pkg/svc/installer/clusterautoscaler/installer.go
@@ -28,7 +28,11 @@ const (
 	AutoscalerConfigHcloudImageKey = "hcloud_image"
 
 	// AutoscalerConfigHcloudCloudInitKey is the key in AutoscalerConfigSecretName that
-	// holds the base64-encoded cloud-init user-data for new autoscaler worker nodes.
+	// holds the cloud-init user-data for new autoscaler worker nodes. The value is
+	// base64(base64(gzip(workerConfig))): the autoscaler strips the outer base64
+	// layer, leaving base64(gzip(workerConfig)) as the Hetzner user_data, which the
+	// Talos hcloud platform base64-decodes and un-gzips before parsing. This keeps
+	// the payload under Hetzner's 32 KiB user_data limit (issue #5015).
 	AutoscalerConfigHcloudCloudInitKey = "hcloud_cloud_init"
 )
 

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -1,6 +1,8 @@
 package talosprovisioner
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -18,6 +20,13 @@ import (
 const (
 	autoscalerConfigSecretName      = "cluster-autoscaler-config"
 	autoscalerConfigSecretNamespace = "kube-system"
+
+	// hetznerUserDataLimitBytes is Hetzner Cloud's hard ceiling on a server's
+	// user_data field (32 KiB). The cluster-autoscaler base64-decodes the
+	// HCLOUD_CLOUD_INIT secret value exactly once and passes the result verbatim
+	// as user_data, so that post-decode payload must stay within this limit or
+	// Hetzner rejects every scale-up with "invalid input in field 'user_data'".
+	hetznerUserDataLimitBytes = 32768
 )
 
 // GenerateAutoscalerWorkerConfig generates a stripped Talos worker config
@@ -60,17 +69,72 @@ func GenerateAutoscalerWorkerConfig(workerConfig talosconfig.Provider) ([]byte, 
 	return cfgBytes, nil
 }
 
+// encodeAutoscalerCloudInit encodes a Talos worker machine config for delivery
+// to autoscaler-provisioned Hetzner nodes and returns the value to store under
+// the HCLOUD_CLOUD_INIT secret key.
+//
+// The cluster-autoscaler base64-decodes HCLOUD_CLOUD_INIT exactly once and
+// assigns the result verbatim to the new server's user_data. Two constraints
+// shape the encoding:
+//
+//   - Size: Hetzner caps user_data at 32 KiB, but a full Talos worker config is
+//     ~40 KiB of YAML and overflows it (issue #5015).
+//   - Encoding: hcloud-go JSON-marshals user_data as a string, so it must be
+//     valid UTF-8 — raw gzip bytes would be mangled by JSON's invalid-byte
+//     replacement.
+//
+// Both hold when user_data = base64(gzip(config)): gzip shrinks the config to a
+// few KiB and the base64 wrapper keeps it ASCII. The Talos hcloud platform
+// base64-decodes user_data (maybeBase64Decode) and then un-gzips it (gzip magic
+// is auto-detected) before parsing — supported by every KSail-targeted Talos
+// version (the hcloud base64 decode landed in Talos v1.8, 2024).
+//
+// The returned value is base64(user_data): the autoscaler strips this outer
+// base64 layer, leaving base64(gzip(config)) as the user_data Hetzner stores.
+func encodeAutoscalerCloudInit(workerConfigYAML []byte) (string, error) {
+	var compressed bytes.Buffer
+
+	gzipWriter := gzip.NewWriter(&compressed)
+
+	_, err := gzipWriter.Write(workerConfigYAML)
+	if err != nil {
+		return "", fmt.Errorf("gzip autoscaler worker config: %w", err)
+	}
+
+	err = gzipWriter.Close()
+	if err != nil {
+		return "", fmt.Errorf("finalize gzip autoscaler worker config: %w", err)
+	}
+
+	// userData is exactly what Hetzner stores and what its 32 KiB limit governs.
+	userData := base64.StdEncoding.EncodeToString(compressed.Bytes())
+	if len(userData) > hetznerUserDataLimitBytes {
+		return "", fmt.Errorf(
+			"%w: compressed user_data is %d bytes (limit %d)",
+			ErrAutoscalerUserDataTooLarge,
+			len(userData),
+			hetznerUserDataLimitBytes,
+		)
+	}
+
+	return base64.StdEncoding.EncodeToString([]byte(userData)), nil
+}
+
 // ApplyAutoscalerConfigSecret creates or updates the cluster-autoscaler-config
-// Secret in kube-system. The Secret holds the Hetzner snapshot image ID and a
-// base64-encoded Talos worker config that Kubernetes Cluster Autoscaler uses
-// as cloud-init user-data when provisioning new worker nodes.
+// Secret in kube-system. The Secret holds the Hetzner snapshot image ID and the
+// gzip-compressed, base64-encoded Talos worker config that Kubernetes Cluster
+// Autoscaler uses as cloud-init user-data when provisioning new worker nodes
+// (see encodeAutoscalerCloudInit for the encoding rationale).
 func ApplyAutoscalerConfigSecret(
 	ctx context.Context,
 	kubeclient kubernetes.Interface,
 	snapshotImageID string,
 	workerConfigYAML []byte,
 ) error {
-	encodedConfig := base64.StdEncoding.EncodeToString(workerConfigYAML)
+	encodedConfig, err := encodeAutoscalerCloudInit(workerConfigYAML)
+	if err != nil {
+		return err
+	}
 
 	desiredData := map[string][]byte{
 		"hcloud_image":      []byte(snapshotImageID),

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -1,8 +1,14 @@
 package talosprovisioner_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
@@ -45,6 +51,55 @@ func newTestWorkerProvider() *taloscontainer.Container {
 			},
 		},
 	})
+}
+
+// decodeAutoscalerCloudInit reverses encodeAutoscalerCloudInit the way the live
+// chain does: the cluster-autoscaler strips the outer base64 layer to form
+// user_data, the Talos hcloud platform base64-decodes user_data again
+// (maybeBase64Decode), and the platform config loader un-gzips the result before
+// parsing. The recovered bytes must equal the original worker config.
+func decodeAutoscalerCloudInit(t *testing.T, secretValue []byte) []byte {
+	t.Helper()
+
+	userData, err := base64.StdEncoding.DecodeString(string(secretValue))
+	require.NoError(t, err, "autoscaler base64 layer")
+
+	compressed, err := base64.StdEncoding.DecodeString(string(userData))
+	require.NoError(t, err, "Talos maybeBase64Decode layer")
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(compressed))
+	require.NoError(t, err, "gzip header")
+
+	defer func() { require.NoError(t, gzipReader.Close()) }()
+
+	decompressed, err := io.ReadAll(gzipReader)
+	require.NoError(t, err)
+
+	return decompressed
+}
+
+// autoscalerUserData returns the inner layer of the secret value: the exact
+// bytes Hetzner stores as user_data (base64(gzip(config))), against which the
+// 32 KiB limit is enforced.
+func autoscalerUserData(t *testing.T, secretValue []byte) []byte {
+	t.Helper()
+
+	userData, err := base64.StdEncoding.DecodeString(string(secretValue))
+	require.NoError(t, err)
+
+	return userData
+}
+
+// isASCII reports whether every byte is in the 7-bit ASCII range. user_data must
+// be ASCII so hcloud-go's JSON marshaling does not corrupt it with U+FFFD.
+func isASCII(b []byte) bool {
+	for _, c := range b {
+		if c > 0x7F {
+			return false
+		}
+	}
+
+	return true
 }
 
 // --- GenerateAutoscalerWorkerConfig ---
@@ -181,8 +236,7 @@ func TestApplyAutoscalerConfigSecret_CreatesNewSecret(t *testing.T) {
 
 	assert.Equal(t, []byte(snapshotID), secret.Data["hcloud_image"])
 
-	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
-	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+	assert.Equal(t, workerConfig, decodeAutoscalerCloudInit(t, secret.Data["hcloud_cloud_init"]))
 }
 
 func TestApplyAutoscalerConfigSecret_PreservesExtraKeysOnUpdate(t *testing.T) {
@@ -222,8 +276,7 @@ func TestApplyAutoscalerConfigSecret_PreservesExtraKeysOnUpdate(t *testing.T) {
 	// Desired keys must be updated.
 	assert.Equal(t, []byte(snapshotID), secret.Data["hcloud_image"])
 
-	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
-	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+	assert.Equal(t, workerConfig, decodeAutoscalerCloudInit(t, secret.Data["hcloud_cloud_init"]))
 
 	// Extra key must be preserved (merge, not replace).
 	assert.Equal(t, []byte("extra-value"), secret.Data["extra_key"])
@@ -264,8 +317,7 @@ func TestApplyAutoscalerConfigSecret_UpdatesExistingSecret(t *testing.T) {
 
 	assert.Equal(t, []byte(snapshotID), secret.Data["hcloud_image"])
 
-	wantEncoded := base64.StdEncoding.EncodeToString(workerConfig)
-	assert.Equal(t, []byte(wantEncoded), secret.Data["hcloud_cloud_init"])
+	assert.Equal(t, workerConfig, decodeAutoscalerCloudInit(t, secret.Data["hcloud_cloud_init"]))
 }
 
 // newConflictClientset returns a fake clientset pre-seeded with an existing
@@ -336,6 +388,95 @@ func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.
 
 	assert.Equal(t, []byte("new-image"), updated.Data["hcloud_image"])
 
-	wantEncoded := base64.StdEncoding.EncodeToString([]byte("new-config"))
-	assert.Equal(t, []byte(wantEncoded), updated.Data["hcloud_cloud_init"])
+	assert.Equal(
+		t,
+		[]byte("new-config"),
+		decodeAutoscalerCloudInit(t, updated.Data["hcloud_cloud_init"]),
+	)
+}
+
+// largeWorkerConfigYAML builds a worker-config-shaped YAML blob larger than
+// Hetzner's 32 KiB user_data limit — the situation from issue #5015 where the
+// raw config overflowed. It mixes a high-entropy PKI chunk (incompressible) with
+// repetitive structure (compressible), mirroring a real Talos worker config.
+func largeWorkerConfigYAML(t *testing.T) []byte {
+	t.Helper()
+
+	pki := make([]byte, 3072)
+	_, err := rand.Read(pki)
+	require.NoError(t, err)
+
+	var builder strings.Builder
+
+	builder.WriteString("version: v1alpha1\nmachine:\n  type: worker\n  ca:\n    crt: ")
+	builder.WriteString(base64.StdEncoding.EncodeToString(pki))
+	builder.WriteString("\n  registries:\n    mirrors:\n")
+
+	for i := range 400 {
+		fmt.Fprintf(
+			&builder,
+			"      registry-%d.example.com:\n        endpoints:\n          - https://mirror.example.com/v2\n",
+			i,
+		)
+	}
+
+	return []byte(builder.String())
+}
+
+// A realistic ~40 KiB worker config (the size that overflowed Hetzner's raw
+// user_data limit in issue #5015) must compress to a user_data payload that is
+// both under 32 KiB and ASCII, and must round-trip back to the original config.
+func TestApplyAutoscalerConfigSecret_CompressesLargeConfigUnderLimit(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset()
+	largeConfig := largeWorkerConfigYAML(t)
+
+	require.Greater(t, len(largeConfig), 32768,
+		"test fixture must exceed Hetzner's raw user_data limit to be representative")
+
+	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(), clientset, "123456789", largeConfig,
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().Secrets("kube-system").Get(
+		context.Background(), "cluster-autoscaler-config", metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	userData := autoscalerUserData(t, secret.Data["hcloud_cloud_init"])
+
+	assert.LessOrEqual(t, len(userData), 32768,
+		"gzip must bring user_data under Hetzner's 32 KiB limit")
+	assert.True(t, isASCII(userData),
+		"user_data must be ASCII so hcloud-go JSON marshaling does not corrupt it")
+	assert.Equal(t, largeConfig, decodeAutoscalerCloudInit(t, secret.Data["hcloud_cloud_init"]),
+		"config must round-trip through the autoscaler + Talos decode chain")
+}
+
+// When even the gzip-compressed config exceeds Hetzner's 32 KiB user_data limit,
+// ApplyAutoscalerConfigSecret must fail fast (at cluster create/update) rather
+// than write a secret that would silently break the next scale-up.
+func TestApplyAutoscalerConfigSecret_RejectsOversizedConfig(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset()
+
+	// Incompressible random bytes large enough that base64(gzip(data)) still
+	// exceeds 32 KiB, exercising the fail-fast guard.
+	incompressible := make([]byte, 40000)
+	_, err := rand.Read(incompressible)
+	require.NoError(t, err)
+
+	err = talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(), clientset, "123456789", incompressible,
+	)
+	require.ErrorIs(t, err, talosprovisioner.ErrAutoscalerUserDataTooLarge)
+
+	// The guard must fire before any Secret is written.
+	_, getErr := clientset.CoreV1().Secrets("kube-system").Get(
+		context.Background(), "cluster-autoscaler-config", metav1.GetOptions{},
+	)
+	assert.True(t, apierrors.IsNotFound(getErr))
 }

--- a/pkg/svc/provisioner/cluster/talos/errors.go
+++ b/pkg/svc/provisioner/cluster/talos/errors.go
@@ -71,6 +71,16 @@ var (
 	// ErrHcloudTokenNotSet is returned when the Hetzner Cloud API token environment
 	// variable is not set but is required for autoscaler secret creation.
 	ErrHcloudTokenNotSet = errors.New("hcloud API token environment variable is not set")
+	// ErrAutoscalerUserDataTooLarge is returned when the gzip-compressed,
+	// base64-encoded autoscaler worker config still exceeds Hetzner's 32 KiB
+	// user_data limit. Hetzner would otherwise reject every scale-up with
+	// "invalid input in field 'user_data'"; failing here surfaces the problem at
+	// cluster create/update time instead of silently at the next scale-up.
+	ErrAutoscalerUserDataTooLarge = errors.New(
+		"autoscaler worker config exceeds Hetzner's 32 KiB user_data limit even after gzip " +
+			"compression: move large inline patches or extraManifests out of the Talos worker " +
+			"config and deliver them via GitOps",
+	)
 	// ErrDrainPodRetrieval is returned when listing pods for drain encounters errors.
 	ErrDrainPodRetrieval = errors.New("failed to retrieve pods for drain")
 	// ErrNodeNotFoundByIP is returned when no Kubernetes node matches the given IP.


### PR DESCRIPTION
## Summary

Fixes #5015. On Hetzner, the cluster-autoscaler embedded the **full ~40 KiB Talos worker config** as the new server's `user_data`, exceeding Hetzner's hard **32 KiB** limit, so every scale-up was rejected with `invalid input in field 'user_data'`. Autoscaling was deterministically broken.

## Approach

The fix encodes the worker config as **`base64(gzip(config))`**, chosen after tracing the full autoscaler → hcloud-go → Talos path (three external repos), because the issue's literal "gzip the config" breaks at two layers:

1. The cluster-autoscaler base64-decodes `HCLOUD_CLOUD_INIT` **once** and passes the result **verbatim** as `user_data`.
2. hcloud-go JSON-marshals `user_data` as a **string** → it must be valid UTF-8. **Raw gzip bytes are corrupted** by Go's invalid-UTF-8 → U+FFFD replacement. The base64 wrapper keeps the payload ASCII.
3. The Talos hcloud platform `maybeBase64Decode`s `user_data` (added Talos v1.8, present in every KSail-supported version), then `loadFromPlatform` un-gzips it (gzip magic auto-detected) before parsing.

So the stored secret value is `base64(base64(gzip(config)))`: the autoscaler strips the outer layer, leaving `base64(gzip(config))` as the `user_data` Hetzner stores (~6 KiB for a 40 KiB config — verified empirically). `compress/gzip` output is deterministic (MTIME=0), so the secret stays idempotent across reconciles.

A **fail-fast guard** (`ErrAutoscalerUserDataTooLarge`) rejects configs that still exceed 32 KiB even after compression, surfacing the problem at `cluster create`/`update` rather than silently at the next scale-up.

The issue's option 1 (out-of-band fetch) was rejected: it needs a persistent in-cluster config endpoint reachable when the autoscaler boots nodes (KSail isn't running then) — disproportionate given gzip's ~5x margin plus the guard.

## Changes

- `pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go` — `encodeAutoscalerCloudInit` (gzip → base64 → size guard → outer base64) + `hetznerUserDataLimitBytes`, wired into `ApplyAutoscalerConfigSecret`
- `pkg/svc/provisioner/cluster/talos/errors.go` — `ErrAutoscalerUserDataTooLarge` with an actionable message
- `pkg/svc/installer/clusterautoscaler/installer.go` — doc comment for the new encoding

## Testing

- New tests: a realistic ~40 KiB config compresses to an ASCII `user_data` under 32 KiB and round-trips through the autoscaler + Talos decode chain; an incompressible oversized config trips the guard and writes no secret.
- `go build ./...`, `go vet`, `golangci-lint` (no new findings), touched-package tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)