### PR TITLE
fix(kwok): make cluster create resilient to transient registry pulls

### DIFF
--- a/pkg/svc/provisioner/cluster/kwok/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/provisioner.go
@@ -2,6 +2,7 @@ package kwokprovisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,21 +48,72 @@ const createMaxAttempts = 3
 // registry rate limit time to reset.
 const createRetryDelay = 30 * time.Second
 
+// createAttemptTimeout bounds a single kwokctl create attempt. KWOK creation
+// pulls real control-plane images from registry.k8s.io; under heavy CI
+// parallelism a pull can stall (a half-open TCP connection that neither
+// progresses nor errors) and block indefinitely. Without a per-attempt
+// timeout the create would hang until the CI job's own timeout, leaving a
+// required check perpetually "in progress" and blocking the PR merge. The
+// timeout is generous enough never to interrupt a legitimately slow but
+// progressing create (healthy CI creates finish within a few minutes) while
+// still rescuing a genuine hang. On timeout the partial cluster is cleaned up
+// and the create is retried, the same as any other transient failure.
+const createAttemptTimeout = 8 * time.Minute
+
 // transientCreateErrors returns error substrings that indicate transient
-// infrastructure failures during KWOK cluster creation.
-// "toomanyrequests" / "TOOMANYREQUESTS" are returned by Docker / Google
-// Artifact Registry when per-region per-minute quota is exceeded.
-// "Quota exceeded" appears in the Google Artifact Registry error detail.
-// Network-level errors cover transient infrastructure conditions on CI runners.
+// infrastructure failures during KWOK cluster creation that may succeed on
+// retry. Almost all stem from pulling the control-plane images from
+// registry.k8s.io (Google Artifact Registry, backed by regional AWS S3
+// buckets) while many KWOK jobs pull the same images concurrently.
+//
+//   - "toomanyrequests" / "TOOMANYREQUESTS" / "Quota exceeded": Docker / Google
+//     Artifact Registry per-region per-minute quota exceeded (see #4069).
+//   - "NoSuchBucket" / "unknown blob" / "blob unknown" / "manifest unknown" /
+//     "failed to resolve reference": transient registry/CDN backend errors —
+//     e.g. an S3 bucket briefly returning NoSuchBucket mid-pull (see #4495).
+//   - "download failed" / "error pulling image" / "failed to pull" /
+//     "received unexpected HTTP status" / "registry is unavailable": generic
+//     pull failures surfaced by kwok's image puller and the Docker daemon.
+//   - "Internal Server Error" / "Bad Gateway" / "Service Unavailable" /
+//     "Gateway Timeout" / "Gateway Time-out": transient 5xx from the registry.
+//   - Network/transport errors ("i/o timeout", "connection reset by peer",
+//     "TLS handshake timeout", "unexpected EOF", "deadline exceeded",
+//     "request canceled") and DNS errors ("no such host", "server
+//     misbehaving", "temporary failure in name resolution") cover transient
+//     infrastructure conditions on CI runners.
 func transientCreateErrors() []string {
 	return []string{
+		// Registry rate limiting.
 		"toomanyrequests",
 		"TOOMANYREQUESTS",
 		"Quota exceeded",
+		// Registry / CDN backend errors.
+		"NoSuchBucket",
+		"unknown blob",
+		"blob unknown",
+		"manifest unknown",
+		"failed to resolve reference",
+		"download failed",
+		"error pulling image",
+		"failed to pull",
+		"received unexpected HTTP status",
+		"registry is unavailable",
+		// Transient registry 5xx responses.
+		"Internal Server Error",
+		"Bad Gateway",
+		"Service Unavailable",
+		"Gateway Timeout",
+		"Gateway Time-out",
+		// Network / transport errors.
 		"i/o timeout",
 		"connection reset by peer",
 		"TLS handshake timeout",
+		"unexpected EOF",
+		"deadline exceeded",
+		"request canceled",
+		// DNS errors.
 		"no such host",
+		"server misbehaving",
 		"temporary failure in name resolution",
 	}
 }
@@ -86,11 +138,14 @@ type kwokCreateFn func(ctx context.Context) error
 // kwokCleanupFn is called between retry attempts to delete a partially-created cluster.
 type kwokCleanupFn func(ctx context.Context)
 
-// createWithRetry calls create and retries on transient errors. Between
-// attempts, cleanup is called to remove the partially-created cluster,
-// followed by a delay to allow rate limits to reset.
+// createWithRetry calls create and retries on transient errors. Each attempt
+// is bounded by attemptTimeout so a stalled image pull is interrupted and
+// retried instead of hanging indefinitely. Between attempts, cleanup is called
+// to remove the partially-created cluster, followed by a delay to allow rate
+// limits to reset.
 func createWithRetry(
 	ctx context.Context,
+	attemptTimeout time.Duration,
 	retryDelay time.Duration,
 	create kwokCreateFn,
 	cleanup kwokCleanupFn,
@@ -113,9 +168,24 @@ func createWithRetry(
 			}
 		}
 
-		lastErr = create(ctx)
+		var timedOut bool
+
+		timedOut, lastErr = runCreateAttempt(ctx, attemptTimeout, create)
 		if lastErr == nil {
 			return nil
+		}
+
+		if timedOut {
+			fmt.Fprintf(
+				os.Stderr,
+				"KWOK cluster create attempt %d/%d timed out after %s (treating as transient): %v\n",
+				attempt+1,
+				createMaxAttempts,
+				attemptTimeout,
+				lastErr,
+			)
+
+			continue
 		}
 
 		if !isTransientCreateError(lastErr) {
@@ -132,6 +202,30 @@ func createWithRetry(
 		"failed to create KWOK cluster after %d attempts: %w",
 		createMaxAttempts, lastErr,
 	)
+}
+
+// runCreateAttempt runs a single create attempt under a timeout derived from
+// ctx. It returns whether the attempt was aborted by its own timeout and the
+// create error (if any). A timeout is reported only when the per-attempt
+// deadline fired while the parent context was still alive — a stalled create
+// that should be retried — and not when the parent context itself was
+// cancelled, which must propagate and stop the retry loop.
+func runCreateAttempt(
+	ctx context.Context,
+	attemptTimeout time.Duration,
+	create kwokCreateFn,
+) (bool, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+	defer cancel()
+
+	err := create(attemptCtx)
+	if err == nil {
+		return false, nil
+	}
+
+	timedOut := errors.Is(attemptCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil
+
+	return timedOut, err
 }
 
 // globalMu serialises access to process-global state that kwokctl
@@ -230,7 +324,13 @@ func (p *Provisioner) CreateCluster(ctx context.Context, name string) error {
 		}
 	}
 
-	return createWithRetry(ctx, createRetryDelay, createAttempt, cleanupAttempt)
+	return createWithRetry(
+		ctx,
+		createAttemptTimeout,
+		createRetryDelay,
+		createAttempt,
+		cleanupAttempt,
+	)
 }
 
 // ScaleNodes creates one simulated node so the kube-scheduler can place pods.

--- a/pkg/svc/provisioner/cluster/kwok/retry_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/retry_test.go
@@ -28,6 +28,23 @@ var (
 	errDNSTransient = errors.New(
 		"dial tcp: lookup registry.k8s.io: temporary failure in name resolution",
 	)
+	errNoSuchBucket = errors.New(
+		"saving tarball: <Error><Code>NoSuchBucket</Code>" +
+			"<Message>The specified bucket does not exist</Message>",
+	)
+	errUnknownBlob = errors.New(
+		"error pulling image configuration: download failed after attempts=1: unknown blob",
+	)
+	errManifestUnknown = errors.New(
+		"failed to pull image: manifest unknown: manifest unknown",
+	)
+	errRegistry5xx = errors.New(
+		"received unexpected HTTP status: 503 Service Unavailable",
+	)
+	errUnexpectedEOF  = errors.New("failed to pull image: unexpected EOF")
+	errDNSMisbehaving = errors.New(
+		"dial tcp: lookup registry.k8s.io: server misbehaving",
+	)
 	errExitStatus1 = errors.New("exit status 1")
 	errPermission  = errors.New("permission denied")
 	errEmpty       = errors.New("")
@@ -51,6 +68,12 @@ func TestIsTransientCreateError(t *testing.T) {
 		{"tls_handshake_timeout_is_transient", errTLSTimeout, true},
 		{"no_such_host_is_transient", errNoSuchHost, true},
 		{"dns_temporary_failure_is_transient", errDNSTransient, true},
+		{"no_such_bucket_is_transient", errNoSuchBucket, true},
+		{"unknown_blob_is_transient", errUnknownBlob, true},
+		{"manifest_unknown_is_transient", errManifestUnknown, true},
+		{"registry_5xx_is_transient", errRegistry5xx, true},
+		{"unexpected_eof_is_transient", errUnexpectedEOF, true},
+		{"dns_server_misbehaving_is_transient", errDNSMisbehaving, true},
 		{"exit_status_1_is_not_transient", errExitStatus1, false},
 		{"permission_denied_is_not_transient", errPermission, false},
 		{"empty_error_is_not_transient", errEmpty, false},
@@ -65,6 +88,11 @@ func TestIsTransientCreateError(t *testing.T) {
 }
 
 // --- createWithRetry tests ---
+
+// testCreateAttemptTimeout is a per-attempt timeout large enough that it never
+// fires for tests that exercise the error-classification paths (where create
+// returns promptly). Timeout behaviour is covered by the dedicated tests below.
+const testCreateAttemptTimeout = time.Minute
 
 func TestCreateWithRetry_Success(t *testing.T) {
 	t.Parallel()
@@ -82,6 +110,7 @@ func TestCreateWithRetry_Success(t *testing.T) {
 
 	err := kwokprovisioner.CreateWithRetryForTest(
 		context.Background(),
+		testCreateAttemptTimeout,
 		time.Millisecond,
 		create, cleanup,
 	)
@@ -110,6 +139,7 @@ func TestCreateWithRetry_TransientErrorRetries(t *testing.T) {
 
 	err := kwokprovisioner.CreateWithRetryForTest(
 		context.Background(),
+		testCreateAttemptTimeout,
 		time.Millisecond,
 		create, cleanup,
 	)
@@ -136,6 +166,7 @@ func TestCreateWithRetry_TransientErrorExhaustsAttempts(t *testing.T) {
 
 	err := kwokprovisioner.CreateWithRetryForTest(
 		context.Background(),
+		testCreateAttemptTimeout,
 		time.Millisecond,
 		create, cleanup,
 	)
@@ -163,6 +194,7 @@ func TestCreateWithRetry_NonTransientErrorFailsImmediately(t *testing.T) {
 
 	err := kwokprovisioner.CreateWithRetryForTest(
 		context.Background(),
+		testCreateAttemptTimeout,
 		time.Millisecond,
 		create, cleanup,
 	)
@@ -194,6 +226,7 @@ func TestCreateWithRetry_ContextCancellation(t *testing.T) {
 
 	err := kwokprovisioner.CreateWithRetryForTest(
 		ctx,
+		testCreateAttemptTimeout,
 		time.Second,
 		create, cleanup,
 	)
@@ -202,4 +235,115 @@ func TestCreateWithRetry_ContextCancellation(t *testing.T) {
 	require.ErrorContains(t, err, "context cancelled during create retry")
 	assert.Equal(t, 1, createCalls, "create should be called once before context is cancelled")
 	assert.Equal(t, 1, cleanupCalls, "cleanup should be called before the cancelled retry delay")
+}
+
+func TestCreateWithRetry_TimeoutIsRetriedThenExhausts(t *testing.T) {
+	t.Parallel()
+
+	const tinyAttemptTimeout = 10 * time.Millisecond
+
+	createCalls := 0
+	// Simulate a hung create: block until the per-attempt deadline fires, then
+	// return the deadline error (as a context-aware kwokctl command would).
+	create := func(ctx context.Context) error {
+		createCalls++
+
+		<-ctx.Done()
+
+		return ctx.Err()
+	}
+
+	cleanupCalls := 0
+	cleanup := func(_ context.Context) {
+		cleanupCalls++
+	}
+
+	err := kwokprovisioner.CreateWithRetryForTest(
+		context.Background(),
+		tinyAttemptTimeout,
+		time.Millisecond,
+		create, cleanup,
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to create KWOK cluster after 3 attempts")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 3, createCalls, "a hung create should be retried up to maxAttempts")
+	assert.Equal(t, 2, cleanupCalls, "cleanup should run before retries 2 and 3")
+}
+
+func TestCreateWithRetry_TimeoutThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	const tinyAttemptTimeout = 10 * time.Millisecond
+
+	createCalls := 0
+	// First attempt hangs until its deadline; the second returns promptly.
+	create := func(ctx context.Context) error {
+		createCalls++
+		if createCalls == 1 {
+			<-ctx.Done()
+
+			return ctx.Err()
+		}
+
+		return nil
+	}
+
+	cleanupCalls := 0
+	cleanup := func(_ context.Context) {
+		cleanupCalls++
+	}
+
+	err := kwokprovisioner.CreateWithRetryForTest(
+		context.Background(),
+		tinyAttemptTimeout,
+		time.Millisecond,
+		create, cleanup,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, createCalls, "create should be retried once after the timeout, then succeed")
+	assert.Equal(t, 1, cleanupCalls, "cleanup should run before the single retry")
+}
+
+// TestCreateWithRetry_ParentCancelNotTreatedAsAttemptTimeout ensures that a
+// create whose parent context is cancelled is not misclassified as a
+// per-attempt timeout (which would otherwise retry). Parent cancellation
+// propagates as context.Canceled and stops the retry loop immediately.
+func TestCreateWithRetry_ParentCancelNotTreatedAsAttemptTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	createCalls := 0
+	create := func(attemptCtx context.Context) error {
+		createCalls++
+
+		cancel() // cancel the PARENT mid-attempt
+		<-attemptCtx.Done()
+
+		return attemptCtx.Err()
+	}
+
+	cleanup := func(_ context.Context) {
+		t.Error("cleanup should not be called when the parent context is cancelled")
+	}
+
+	err := kwokprovisioner.CreateWithRetryForTest(
+		ctx,
+		testCreateAttemptTimeout,
+		time.Millisecond,
+		create, cleanup,
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(
+		t,
+		1,
+		createCalls,
+		"create should not be retried after the parent context is cancelled",
+	)
 }


### PR DESCRIPTION
## Problem

KWOK cluster creation transiently **gets stuck in CI, blocking PR merges**.

KWOK creation pulls **real control-plane images** (etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kubectl, kwok-controller) from `registry.k8s.io` at create time via kwokctl's Docker runtime. Under CI's parallel matrix, these concurrent pulls hit:

- **Google Artifact Registry per-minute rate limits** (`toomanyrequests` / `Quota exceeded` — #4069), and
- **transient registry/S3 backend errors** (`NoSuchBucket`, `unknown blob`, `download failed` — #4495).

The `warm-mirror-cache` that pre-seeds these images so kwokctl's `docker inspect` short-circuits the pull is **best-effort** (`kwok-control-plane.tar` is explicitly optional), so legs frequently fall back to live pulls. The provisioner's `createWithRetry` safety net (added in #4152) is the layer that must absorb these failures, but it had two gaps:

1. Its transient-error matcher **missed** the registry/CDN backend signatures (`NoSuchBucket`, `unknown blob`, `manifest unknown`, `download failed`, 5xx, `unexpected EOF`, …) → those **failed the leg immediately** instead of retrying.
2. It had **no per-attempt timeout** → a stalled pull (half-open TCP that neither progresses nor errors) **hung until the 120-minute job timeout**, leaving the required check perpetually "in progress" and **blocking the merge** — the "stuck."

## Fix — `pkg/svc/provisioner/cluster/kwok/provisioner.go`

1. **Expanded `transientCreateErrors()`** to cover the registry/transport errors actually observed in CI (#4495/#4069) plus transient 5xx and network/DNS errors — so they're retried rather than fatal.
2. **Per-attempt timeout** (`createAttemptTimeout = 8m`) via a new `runCreateAttempt` helper: a timed-out attempt is cleaned up and retried (a stalled registry pull is transient), converting "stuck for 120 min" into "retry, then a bounded clear failure." Genuine parent-context cancellation is distinguished from a per-attempt timeout and still propagates.

This works because kwokctl's pull is fully context-aware (`utilsimage.Pull(ctx, …)` + `exec.CommandContext`) and the runner uses `cmd.SetContext`/`ExecuteContext`, so the timeout genuinely interrupts a hung `docker pull`. The fix lives in the universal provisioner layer, so it also benefits real users on flaky networks — not just CI.

## Validation

- `go build ./...`, `go vet`, and all `pkg/svc/provisioner/...` tests pass.
- `golangci-lint --new-from-rev=HEAD`: **0 issues** on new code.
- New tests in `retry_test.go` (timeout-retried-then-exhausts, timeout-then-success, parent-cancel-not-a-timeout, + 6 new transient-error cases) — **100% coverage** of all four changed functions.
- **Live smoke test**: real KWOK `cluster create` → `✔ cluster created` → deleted cleanly (no stray containers), confirming the happy path is unaffected.

## Follow-up (not in this PR)

Complementary CI-side hardening is worth a separate change: make `kwok-control-plane.tar` non-silent in `warm-mirror-cache`'s completeness check, and add a drift-guard unit test asserting `Dockerfile.controlplane`'s pinned tags match the kwok module's actual default versions (`consts.KubeVersion`, `k8s.GetEtcdVersion`). That removes the latent recurrence vector where the cache silently holds wrong/absent tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)