### PR TITLE
ci(kwok): self-healing control-plane image cache + drift-guard test

### DIFF
--- a/.github/actions/restore-mirror-cache/action.yaml
+++ b/.github/actions/restore-mirror-cache/action.yaml
@@ -82,6 +82,13 @@ runs:
         echo "images-hash=$IMAGES_HASH" >> "$GITHUB_OUTPUT"
         echo "🔑 Images hash: $IMAGES_HASH"
 
+        # Compute the KWOK control plane image hash (must match warm-mirror-cache
+        # exactly). The KWOK pre-load tar lives in its own cache entry so it can be
+        # regenerated independently of the four mirror volumes.
+        KWOK_IMAGES_HASH=$(grep '^FROM ' pkg/svc/provisioner/cluster/kwok/Dockerfile.controlplane | sed 's/^FROM //' | sort -u | sha256sum | cut -c1-12)
+        echo "kwok-images-hash=$KWOK_IMAGES_HASH" >> "$GITHUB_OUTPUT"
+        echo "🔑 KWOK images hash: $KWOK_IMAGES_HASH"
+
     - name: 🔑 Generate cache key
       id: generate-key
       shell: bash
@@ -90,9 +97,14 @@ runs:
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
         IMAGES_HASH: ${{ steps.extract-images.outputs.images-hash }}
+        KWOK_IMAGES_HASH: ${{ steps.extract-images.outputs.kwok-images-hash }}
       run: |
         CACHE_KEY="mirror-cache-${CACHE_VERSION}-${IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
         echo "cache-key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
+
+        # Must match warm-mirror-cache's KWOK cache key exactly.
+        KWOK_CACHE_KEY="kwok-controlplane-${CACHE_VERSION}-${KWOK_IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
+        echo "kwok-cache-key=$KWOK_CACHE_KEY" >> "$GITHUB_OUTPUT"
 
     - name: 📥 Restore mirror cache
       id: restore-cache
@@ -102,6 +114,16 @@ runs:
         key: ${{ steps.generate-key.outputs.cache-key }}
         restore-keys: |
           mirror-cache-${{ inputs.cache-version }}-
+
+    - name: 📥 Restore KWOK control plane cache
+      id: restore-kwok-cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/kwok-cache
+        # Exact match only (no restore-keys): a tar from a different tag set would
+        # miss kwokctl's "docker inspect" anyway, so a miss simply falls back to a
+        # live pull (with the provisioner's create retry) rather than a stale load.
+        key: ${{ steps.generate-key.outputs.kwok-cache-key }}
 
     - name: 📦 Import mirror volumes
       if: steps.restore-cache.outputs.cache-hit == 'true'
@@ -154,16 +176,18 @@ runs:
         fi
 
     - name: 🐳 Load KWOK control plane images
-      if: steps.restore-cache.outputs.cache-hit == 'true'
+      if: steps.restore-kwok-cache.outputs.cache-hit == 'true'
       shell: bash
       run: |
         # Pre-load KWOK control plane images into Docker's local cache.
         # kwokctl's EnsureImage() calls "docker inspect <image>" before pulling;
         # if the image already exists locally, the pull is skipped entirely.
         # This avoids Google Artifact Registry rate limits when many KWOK test
-        # jobs run in parallel. See issue #4058 for context.
-        if [ -f "/tmp/mirror-cache/kwok-control-plane.tar" ]; then
-          docker load -i /tmp/mirror-cache/kwok-control-plane.tar
+        # jobs run in parallel. See issue #4058 for context. The tar is cached
+        # under its own key (see warm-mirror-cache) so it is decoupled from the
+        # four mirror volumes.
+        if [ -f "/tmp/kwok-cache/kwok-control-plane.tar" ]; then
+          docker load -i /tmp/kwok-cache/kwok-control-plane.tar
           echo "✅ KWOK control plane images pre-loaded (kwokctl will skip registry.k8s.io pulls)"
         else
           echo "⚠️ KWOK control plane tar not found in cache. KWOK tests will pull from registry.k8s.io."

--- a/.github/actions/warm-mirror-cache/action.yaml
+++ b/.github/actions/warm-mirror-cache/action.yaml
@@ -147,6 +147,18 @@ runs:
         echo "images-hash=$IMAGES_HASH" >> "$GITHUB_OUTPUT"
         echo "🔑 Images hash: $IMAGES_HASH"
 
+        # Compute a separate hash of just the KWOK control plane image refs so the
+        # KWOK pre-load tar can be cached under its own key, independent of the four
+        # mirror volumes. A GitHub Actions cache entry is immutable once saved, so a
+        # KWOK tar that failed to save (e.g. a transient registry.k8s.io error) could
+        # never be repaired in place under the shared mirror-cache key — every later
+        # KWOK leg then pulled live and stalled. With its own key the tar self-heals:
+        # it is only ever saved when produced successfully, so an absent entry is
+        # retried on the next warm run. See issues #4058 / #4069 / #4495.
+        KWOK_IMAGES_HASH=$(grep '^FROM ' pkg/svc/provisioner/cluster/kwok/Dockerfile.controlplane | sed 's/^FROM //' | sort -u | sha256sum | cut -c1-12)
+        echo "kwok-images-hash=$KWOK_IMAGES_HASH" >> "$GITHUB_OUTPUT"
+        echo "🔑 KWOK images hash: $KWOK_IMAGES_HASH"
+
         # Show images for debugging
         echo "📦 Images to cache:"
         cat "$IMAGES_FILE" | head -30
@@ -162,12 +174,20 @@ runs:
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
         IMAGES_HASH: ${{ steps.extract-images.outputs.images-hash }}
+        KWOK_IMAGES_HASH: ${{ steps.extract-images.outputs.kwok-images-hash }}
       run: |
         # Use hash of extracted image list to invalidate when images change
         # This covers both go.mod changes AND code changes affecting image extraction
         CACHE_KEY="mirror-cache-${CACHE_VERSION}-${IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
         echo "cache-key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
         echo "📦 Cache key: $CACHE_KEY"
+
+        # The KWOK control plane pre-load tar is cached under its own key (keyed on
+        # just the KWOK image refs) so it is (re)generated independently of the four
+        # mirror volumes.
+        KWOK_CACHE_KEY="kwok-controlplane-${CACHE_VERSION}-${KWOK_IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
+        echo "kwok-cache-key=$KWOK_CACHE_KEY" >> "$GITHUB_OUTPUT"
+        echo "📦 KWOK cache key: $KWOK_CACHE_KEY"
 
     - name: 📥 Restore mirror cache
       id: restore-cache
@@ -178,6 +198,16 @@ runs:
         restore-keys: |
           mirror-cache-${{ inputs.cache-version }}-
 
+    - name: 📥 Restore KWOK control plane cache
+      id: restore-kwok-cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/kwok-cache
+        # Exact match only (no restore-keys): a KWOK tar from a different tag set is
+        # useless — kwokctl's "docker inspect" would miss the new tags and pull live
+        # anyway — so a miss must trigger a fresh, correctly-tagged save below.
+        key: ${{ steps.generate-key.outputs.kwok-cache-key }}
+
     - name: 🔍 Check if cache is complete
       id: check-cache
       if: steps.restore-cache.outputs.cache-hit == 'true'
@@ -186,14 +216,14 @@ runs:
         if [ -d "/tmp/mirror-cache" ] && [ -n "$(ls -A /tmp/mirror-cache 2>/dev/null)" ]; then
           echo "✅ Cache restored, checking completeness..."
           # Check for all 4 mirror volumes (using KSail's naming convention).
-          # kwok-control-plane.tar is optional: its creation is non-fatal in the
-          # warm step, so its absence must not invalidate an otherwise complete cache.
+          # The KWOK control plane tar is cached under its own key (see the KWOK
+          # cache steps), so it is intentionally not part of this completeness check.
           if [ -f "/tmp/mirror-cache/docker.io.tar" ] && \
              [ -f "/tmp/mirror-cache/ghcr.io.tar" ] && \
              [ -f "/tmp/mirror-cache/quay.io.tar" ] && \
              [ -f "/tmp/mirror-cache/registry.k8s.io.tar" ]; then
             echo "complete=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Cache complete: 4 mirror volumes present (kwok-control-plane.tar is optional)"
+            echo "✅ Cache complete: 4 mirror volumes present"
           else
             echo "complete=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ Cache incomplete, will re-warm"
@@ -368,33 +398,51 @@ runs:
 
     - name: 🐳 Save KWOK control plane images
       id: save-kwok-images
-      if: steps.check-cache.outputs.complete != 'true'
+      # Gated on the KWOK cache (not the mirror-volume cache): regenerate the tar
+      # whenever its own cache is missing, regardless of mirror-volume state. This
+      # is the targeted re-save path — it never re-pulls or re-exports the four
+      # mirror volumes just because the KWOK tar is missing.
+      if: steps.restore-kwok-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        echo "🐳 Saving KWOK control plane images for Docker pre-loading on test runners..."
+        echo "🐳 Preparing KWOK control plane images for Docker pre-loading on test runners..."
+        mkdir -p /tmp/kwok-cache
 
-        # KWOK images were pulled through registry.k8s.io-mirror as localhost:5003/...
-        # Retag them to canonical registry.k8s.io/... so kwokctl's "docker inspect" finds them.
-        # kwokctl's EnsureImage() checks "docker inspect <image>" first; if found, no pull occurs.
+        # Ensure each control plane image is present locally under its canonical
+        # registry.k8s.io reference so kwokctl's EnsureImage() ("docker inspect
+        # <image>" first; skip the pull if found) hits. During a full mirror warm the
+        # images were already pulled as localhost:5003/... and only need retagging;
+        # on a targeted refresh (mirror cache complete but KWOK cache missing) the
+        # mirror is not running, so fall back to a direct pull of just these few
+        # images. Either path avoids the parallel KWOK matrix hammering
+        # registry.k8s.io. See issue #4058.
         while IFS= read -r image; do
-          prefix_stripped="${image#registry.k8s.io/}"
-          if [ "$prefix_stripped" != "$image" ]; then
-            mirror_ref="localhost:5003/$prefix_stripped"
-            docker tag "$mirror_ref" "$image" 2>/dev/null && echo "  ✅ Tagged: $image" || echo "  ⚠️ Failed to tag: $image"
+          [ -z "$image" ] && continue
+          if docker image inspect "$image" >/dev/null 2>&1; then
+            continue
           fi
+          mirror_ref="localhost:5003/${image#registry.k8s.io/}"
+          if docker image inspect "$mirror_ref" >/dev/null 2>&1; then
+            docker tag "$mirror_ref" "$image" && echo "  ✅ Tagged from mirror: $image" && continue
+          fi
+          echo "  ⬇️ Pulling directly: $image"
+          docker pull "$image" --quiet || echo "  ⚠️ Failed to obtain: $image"
         done < <(grep '^FROM ' pkg/svc/provisioner/cluster/kwok/Dockerfile.controlplane | sed 's/^FROM //')
 
-        # Save all KWOK control plane images as a single tar for docker load on test runners.
-        # Non-fatal: if any image wasn't tagged (e.g. mirror pull failed), skip saving rather than
-        # aborting the whole cache step — kwokctl will pull missing images directly at test time.
+        # Save all KWOK control plane images as a single tar for docker load on test
+        # runners. Non-fatal: if any image is missing, skip the save (and the cache
+        # save below) rather than persisting a partial tar — kwokctl pulls the missing
+        # images directly at test time, and the next warm run retries the save.
         KWOK_IMAGES=$(grep '^FROM ' pkg/svc/provisioner/cluster/kwok/Dockerfile.controlplane | awk '{print $2}' | tr '\n' ' ')
         # shellcheck disable=SC2086
-        if docker save $KWOK_IMAGES -o /tmp/mirror-cache/kwok-control-plane.tar 2>/dev/null; then
-          SIZE=$(du -h /tmp/mirror-cache/kwok-control-plane.tar | cut -f1)
+        if docker save $KWOK_IMAGES -o /tmp/kwok-cache/kwok-control-plane.tar 2>/dev/null; then
+          SIZE=$(du -h /tmp/kwok-cache/kwok-control-plane.tar | cut -f1)
+          echo "saved=true" >> "$GITHUB_OUTPUT"
           echo "✅ KWOK control plane images saved: $SIZE"
         else
+          echo "saved=false" >> "$GITHUB_OUTPUT"
           echo "⚠️ Failed to save KWOK control plane images — they will be pulled by kwokctl at test time"
-          rm -f /tmp/mirror-cache/kwok-control-plane.tar
+          rm -f /tmp/kwok-cache/kwok-control-plane.tar
         fi
 
     - name: 🐳 Save distribution node images
@@ -539,14 +587,6 @@ runs:
           echo "✅ All 4 required mirror cache volumes exported successfully"
         fi
 
-        # Verify KWOK control plane tar (non-fatal: kwokctl falls back to live pull if missing)
-        if [ -f "/tmp/mirror-cache/kwok-control-plane.tar" ]; then
-          SIZE=$(du -h "/tmp/mirror-cache/kwok-control-plane.tar" | cut -f1)
-          echo "  ✅ kwok-control-plane.tar ($SIZE)"
-        else
-          echo "  ⚠️ kwok-control-plane.tar - MISSING (KWOK tests will pull from registry.k8s.io)"
-        fi
-
         # Verify distribution node tars (non-fatal: provisioners fall back to live pull if missing)
         for name in k3s-node kind-node talos-node; do
           if [ -f "/tmp/mirror-cache/${name}.tar" ]; then
@@ -570,3 +610,14 @@ runs:
       with:
         path: /tmp/mirror-cache
         key: ${{ steps.generate-key.outputs.cache-key }}
+
+    - name: 💾 Save KWOK control plane cache
+      # Only save when the tar was actually produced (saved == 'true'). A cache
+      # entry is immutable once written, so persisting a partial/empty tar here
+      # would defeat the self-heal: skipping the save leaves the key absent and the
+      # next warm run retries it.
+      if: steps.restore-kwok-cache.outputs.cache-hit != 'true' && steps.save-kwok-images.outputs.saved == 'true'
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/kwok-cache
+        key: ${{ steps.generate-key.outputs.kwok-cache-key }}

--- a/pkg/svc/provisioner/cluster/kwok/controlplane_images_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/controlplane_images_test.go
@@ -1,0 +1,82 @@
+package kwokprovisioner_test
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/image/parser"
+	kwokprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kwok"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kwok/pkg/consts"
+	"sigs.k8s.io/kwok/pkg/kwokctl/k8s"
+	"sigs.k8s.io/kwok/pkg/utils/version"
+)
+
+// controlPlaneDockerfile embeds the KWOK control plane Dockerfile so the build
+// breaks if the file is renamed or removed, and the test below catches tag drift.
+//
+// Dockerfile.controlplane is the manually-maintained source of truth that
+// .github/actions/warm-mirror-cache greps to pre-seed kwokctl's control plane
+// images into the runner's Docker daemon. It is not referenced by any production
+// Go code, so without this guard a sigs.k8s.io/kwok module bump that changes the
+// default Kubernetes/etcd/controller version would silently desync the pinned
+// tags from what kwokctl actually requests: kwokctl's "docker inspect" would
+// miss and every KWOK system-test leg would fall back to live registry.k8s.io
+// pulls (issues #4058 / #4069 / #4495). This converts that silent CI flake into
+// an actionable, at-dep-bump-time test failure.
+//
+//go:embed Dockerfile.controlplane
+var controlPlaneDockerfile string
+
+// TestControlPlaneImageTagsMatchKwokDefaults asserts the image tags pinned in
+// Dockerfile.controlplane exactly match the versions the embedded
+// sigs.k8s.io/kwok module defaults to (and the KWOK controller version KSail
+// pins in provisioner.go).
+func TestControlPlaneImageTagsMatchKwokDefaults(t *testing.T) {
+	t.Parallel()
+
+	// kube-apiserver / kube-controller-manager / kube-scheduler / kubectl track
+	// KWOK's default Kubernetes version (consts.KubeVersion, e.g. "1.33.0" → the
+	// "v1.33.0" image tag).
+	kubeTag := version.AddPrefixV(consts.KubeVersion)
+
+	// etcd tracks the version KWOK maps the Kubernetes minor release to, exactly
+	// as KWOK's own setKwokctlEtcdConfig does: k8s.GetEtcdVersion(<minor>).
+	kubeVersion, err := version.ParseVersion(consts.KubeVersion)
+	require.NoError(t, err, "kwok consts.KubeVersion must be valid semver")
+
+	etcdTag := k8s.GetEtcdVersion(kubeMinor(kubeVersion))
+
+	// kwok-controller tracks the released image version KSail pins in provisioner.go.
+	kwokTag := kwokprovisioner.KwokControllerImageVersionForTest
+
+	want := []string{
+		"registry.k8s.io/etcd:" + etcdTag,
+		"registry.k8s.io/kube-apiserver:" + kubeTag,
+		"registry.k8s.io/kube-controller-manager:" + kubeTag,
+		"registry.k8s.io/kube-scheduler:" + kubeTag,
+		"registry.k8s.io/kubectl:" + kubeTag,
+		"registry.k8s.io/kwok/kwok:" + kwokTag,
+	}
+
+	got := parser.ParseAllImagesFromDockerfile(controlPlaneDockerfile)
+
+	assert.ElementsMatch(t, want, got,
+		"Dockerfile.controlplane image tags are out of sync with the embedded kwok module "+
+			"defaults; update pkg/svc/provisioner/cluster/kwok/Dockerfile.controlplane (and let "+
+			"the CI mirror cache re-warm) when bumping sigs.k8s.io/kwok")
+}
+
+// kubeMinor returns the Kubernetes minor release as an int, mirroring KWOK's own
+// parseRelease (pkg/config/vars.go) that feeds k8s.GetEtcdVersion. The minor of a
+// Kubernetes release is always small and non-negative, so the conversion is safe.
+func kubeMinor(kubeVersion version.Version) int {
+	const minorMax = 1 << 30 // guards the uint64→int conversion against absurd input.
+
+	if kubeVersion.Minor > minorMax {
+		return minorMax
+	}
+
+	return int(kubeVersion.Minor)
+}

--- a/pkg/svc/provisioner/cluster/kwok/export_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/export_test.go
@@ -1,6 +1,9 @@
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
 package kwokprovisioner
 
+// KwokControllerImageVersionForTest exposes kwokControllerImageVersion for unit testing.
+const KwokControllerImageVersionForTest = kwokControllerImageVersion
+
 // IsTransientCreateErrorForTest exposes isTransientCreateError for unit testing.
 var IsTransientCreateErrorForTest = isTransientCreateError
 


### PR DESCRIPTION
## Summary

Hardens the KWOK control-plane image pre-seed so the CI mirror cache reliably prevents live `registry.k8s.io` pulls, closing two latent fragilities that could silently send **every** KWOK system-test leg back to live pulls (→ rate-limits/hangs that block merges — context: #4058 / #4069 / #4495).

This is the complementary optimization+guard to the already-shipped provisioner-level resilience (`createWithRetry` + per-attempt timeout in `provisioner.go`). That makes `create` *correct* regardless of cache state; this PR makes the cache reliably prevent the live-pull storm in the first place.

## Fragility 1 — version drift (guard test)

`pkg/svc/provisioner/cluster/kwok/Dockerfile.controlplane` is the manually-maintained source of truth for the control-plane image tags the warm-mirror-cache action pre-seeds, but it is referenced by **no production Go code**. A `sigs.k8s.io/kwok` module bump that changes its default Kubernetes version drifts the pinned tags, the cache holds the wrong tags, kwokctl's `docker inspect` misses, and KWOK starts "getting stuck" again.

**Fix:** a new unit test (`controlplane_images_test.go`) embeds the Dockerfile and asserts its `FROM` tags equal the embedded kwok module's *actual* defaults:

| Image | Asserted against |
|---|---|
| `kube-apiserver` / `kube-controller-manager` / `kube-scheduler` / `kubectl` | `consts.KubeVersion` (`v`-prefixed) → `v1.33.0` |
| `etcd` | `k8s.GetEtcdVersion(<kube minor>)` → `3.5.21-0` (derived exactly as kwok's own `setKwokctlEtcdConfig` does) |
| `kwok/kwok` | the `kwokControllerImageVersion` const in `provisioner.go` → `v0.7.0` |

A silent CI flake becomes a loud, actionable failure at dep-bump time. (Verified: temporarily bumping a tag fails the test with a precise diff; reverting passes.)

## Fragility 2 — silent degradation (self-healing cache)

The KWOK tar lived **inside** the four-volume mirror cache and was explicitly treated as optional — "Check if cache is complete" marked a restored cache complete even when `kwok-control-plane.tar` was absent. So a single transient warm failure persisted and made all subsequent KWOK legs pull live until the images-hash changed.

**Why not simply add the tar to the completeness check?** Because a GitHub Actions cache entry is **immutable once written**. On a same-hash re-run the warm job gets an exact key hit, and re-saving to that key is a no-op — so an incomplete entry could never be repaired in place, and the matrix jobs (which restore from the cache backend) would keep getting the incomplete cache. Forcing a full re-warm there also wouldn't persist.

**Fix:** give the tar its **own** cache entry, keyed on just the `Dockerfile.controlplane` image refs:
`kwok-controlplane-<version>-<kwok-images-hash>-<os>-<arch>`.

- **Self-heals.** The entry is only ever saved when the tar was produced successfully (`save` gated on `saved == 'true'`), so an absent/failed entry is retried and saved *fresh* on the next warm run — no immutability dead-end.
- **Targeted re-save.** Regeneration retags the few control-plane images already pulled through the mirror during a full warm, or direct-pulls just those images on a refresh when the four mirror volumes are already complete. **It never re-pulls or re-exports the four mirror volumes** just because the KWOK tar is missing.
- **Exact-key restore (no `restore-keys`).** A tar from a different tag set would miss kwokctl's `docker inspect` anyway, so a miss cleanly falls back to a live pull (covered by the provisioner's create retry) rather than loading a stale tar.

The four-volume mirror cache and its completeness check are otherwise unchanged. The omni/hetzner restore paths are unaffected (they already loaded the KWOK tar via the shared cache; now via the decoupled one).

## Validation

- `go build ./...`, `go test ./pkg/svc/provisioner/cluster/kwok/...` ✅
- `golangci-lint run --new-from-rev=HEAD` → **0 issues** (repo-wide) ✅
- Action YAML: `yamllint` (repo config) clean, `prettier --check` clean, `shellcheck` clean on all new/changed `run:` blocks; `actionlint` on the consuming workflows shows no new issues. The KWOK hash/key derivation is byte-identical in `warm-mirror-cache` and `restore-mirror-cache`. (`mega-linter-runner` isn't installed locally; its actionlint only scans `.github/workflows/`, so I ran the underlying linters directly against the composite actions.)

Opened as **draft** per the checkpoint workflow — promote to ready to green-light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
