### PR TITLE
ci(mirror-cache): cache distribution node tars under their own self-healing key

### DIFF
--- a/.github/actions/restore-mirror-cache/action.yaml
+++ b/.github/actions/restore-mirror-cache/action.yaml
@@ -82,6 +82,17 @@ runs:
         echo "images-hash=$IMAGES_HASH" >> "$GITHUB_OUTPUT"
         echo "🔑 Images hash: $IMAGES_HASH"
 
+        # Compute the distribution node image hash (must match warm-mirror-cache
+        # exactly). The dist-node pre-load tars live in their own cache entry so they
+        # can be regenerated independently of the four mirror volumes.
+        DIST_NODE_IMAGES_HASH=$(grep -h '^FROM ' \
+          pkg/fsutil/configmanager/k3d/Dockerfile \
+          pkg/fsutil/configmanager/kind/Dockerfile \
+          pkg/fsutil/configmanager/talos/Dockerfile \
+          | sed 's/^FROM //' | sort -u | sha256sum | cut -c1-12)
+        echo "dist-node-images-hash=$DIST_NODE_IMAGES_HASH" >> "$GITHUB_OUTPUT"
+        echo "🔑 Distribution node images hash: $DIST_NODE_IMAGES_HASH"
+
     - name: 🔑 Generate cache key
       id: generate-key
       shell: bash
@@ -90,9 +101,14 @@ runs:
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
         IMAGES_HASH: ${{ steps.extract-images.outputs.images-hash }}
+        DIST_NODE_IMAGES_HASH: ${{ steps.extract-images.outputs.dist-node-images-hash }}
       run: |
         CACHE_KEY="mirror-cache-${CACHE_VERSION}-${IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
         echo "cache-key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
+
+        # Must match warm-mirror-cache's dist-node cache key exactly.
+        DIST_NODE_CACHE_KEY="dist-node-${CACHE_VERSION}-${DIST_NODE_IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
+        echo "dist-node-cache-key=$DIST_NODE_CACHE_KEY" >> "$GITHUB_OUTPUT"
 
     - name: 📥 Restore mirror cache
       id: restore-cache
@@ -102,6 +118,17 @@ runs:
         key: ${{ steps.generate-key.outputs.cache-key }}
         restore-keys: |
           mirror-cache-${{ inputs.cache-version }}-
+
+    - name: 📥 Restore distribution node cache
+      id: restore-dist-node-cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/dist-node-cache
+        # Exact match only (no restore-keys): a dist-node tar from a different tag
+        # set would miss the provisioner's pinned digest and trigger a live pull
+        # anyway, so a miss simply falls back to that live pull rather than loading
+        # a stale tar.
+        key: ${{ steps.generate-key.outputs.dist-node-cache-key }}
 
     - name: 📦 Import mirror volumes
       if: steps.restore-cache.outputs.cache-hit == 'true'
@@ -171,7 +198,7 @@ runs:
         fi
 
     - name: 🐳 Load distribution node images
-      if: steps.restore-cache.outputs.cache-hit == 'true'
+      if: steps.restore-dist-node-cache.outputs.cache-hit == 'true'
       shell: bash
       run: |
         # Pre-load distribution node images (K3s, Kind, Talos) into Docker's
@@ -188,8 +215,8 @@ runs:
         # records the repo digest mapping. Since layers are already present
         # from docker load, the re-pull is a lightweight manifest fetch only.
         for name in k3s-node kind-node talos-node; do
-          if [ -f "/tmp/mirror-cache/${name}.tar" ]; then
-            if docker load -i "/tmp/mirror-cache/${name}.tar"; then
+          if [ -f "/tmp/dist-node-cache/${name}.tar" ]; then
+            if docker load -i "/tmp/dist-node-cache/${name}.tar"; then
               echo "✅ ${name} image pre-loaded"
             else
               echo "⚠️ Failed to load ${name}.tar — provisioner will pull from upstream registry"

--- a/.github/actions/warm-mirror-cache/action.yaml
+++ b/.github/actions/warm-mirror-cache/action.yaml
@@ -147,6 +147,24 @@ runs:
         echo "images-hash=$IMAGES_HASH" >> "$GITHUB_OUTPUT"
         echo "🔑 Images hash: $IMAGES_HASH"
 
+        # Compute a separate hash of just the distribution node image refs (k3s,
+        # kind, talos) so the dist-node pre-load tars can be cached under their own
+        # key, independent of the four mirror volumes. A GitHub Actions cache entry
+        # is immutable once saved, so a dist-node tar that failed to save (e.g. a
+        # transient Docker Hub / GHCR error) could never be repaired in place under
+        # the shared mirror-cache key — every later cluster create then pulled the
+        # node image live and risked rate limits under high CI concurrency. With its
+        # own key the tars self-heal: they are only ever saved when all three were
+        # produced successfully, so an absent entry is retried on the next warm run.
+        # See issue #4301.
+        DIST_NODE_IMAGES_HASH=$(grep -h '^FROM ' \
+          pkg/fsutil/configmanager/k3d/Dockerfile \
+          pkg/fsutil/configmanager/kind/Dockerfile \
+          pkg/fsutil/configmanager/talos/Dockerfile \
+          | sed 's/^FROM //' | sort -u | sha256sum | cut -c1-12)
+        echo "dist-node-images-hash=$DIST_NODE_IMAGES_HASH" >> "$GITHUB_OUTPUT"
+        echo "🔑 Distribution node images hash: $DIST_NODE_IMAGES_HASH"
+
         # Show images for debugging
         echo "📦 Images to cache:"
         cat "$IMAGES_FILE" | head -30
@@ -162,12 +180,20 @@ runs:
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
         IMAGES_HASH: ${{ steps.extract-images.outputs.images-hash }}
+        DIST_NODE_IMAGES_HASH: ${{ steps.extract-images.outputs.dist-node-images-hash }}
       run: |
         # Use hash of extracted image list to invalidate when images change
         # This covers both go.mod changes AND code changes affecting image extraction
         CACHE_KEY="mirror-cache-${CACHE_VERSION}-${IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
         echo "cache-key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
         echo "📦 Cache key: $CACHE_KEY"
+
+        # The distribution node pre-load tars are cached under their own key (keyed
+        # on just the k3s/kind/talos image refs) so they are (re)generated
+        # independently of the four mirror volumes.
+        DIST_NODE_CACHE_KEY="dist-node-${CACHE_VERSION}-${DIST_NODE_IMAGES_HASH}-${RUNNER_OS}-${RUNNER_ARCH}"
+        echo "dist-node-cache-key=$DIST_NODE_CACHE_KEY" >> "$GITHUB_OUTPUT"
+        echo "📦 Distribution node cache key: $DIST_NODE_CACHE_KEY"
 
     - name: 📥 Restore mirror cache
       id: restore-cache
@@ -177,6 +203,17 @@ runs:
         key: ${{ steps.generate-key.outputs.cache-key }}
         restore-keys: |
           mirror-cache-${{ inputs.cache-version }}-
+
+    - name: 📥 Restore distribution node cache
+      id: restore-dist-node-cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/dist-node-cache
+        # Exact match only (no restore-keys): a dist-node tar from a different tag
+        # set is useless — the provisioner pins exact digests, so a stale tar would
+        # miss and the node image would be pulled live anyway — so a miss must
+        # trigger a fresh, correctly-pinned save below.
+        key: ${{ steps.generate-key.outputs.dist-node-cache-key }}
 
     - name: 🔍 Check if cache is complete
       id: check-cache
@@ -399,10 +436,15 @@ runs:
 
     - name: 🐳 Save distribution node images
       id: save-distribution-images
-      if: steps.check-cache.outputs.complete != 'true'
+      # Gated on the dist-node cache (not the mirror-volume cache): regenerate the
+      # tars whenever their own cache is missing, regardless of mirror-volume state.
+      # This is the targeted re-save path — it never re-pulls or re-exports the four
+      # mirror volumes just because a dist-node tar is missing.
+      if: steps.restore-dist-node-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         echo "🐳 Saving distribution node images for Docker pre-loading on test runners..."
+        mkdir -p /tmp/dist-node-cache
 
         # Distribution node images are pulled by the host Docker daemon during
         # cluster creation (K3d, Kind, Talos). They are NOT pulled through
@@ -410,6 +452,12 @@ runs:
         # registry pulls. By docker-saving them here and docker-loading them on
         # test runners, Docker finds them locally and skips the pull entirely.
         # See issue #4301 for context.
+        #
+        # Two source paths feed the save: during a full mirror warm the images were
+        # already pulled as localhost:500x/... and only need retagging; on a targeted
+        # refresh (mirror cache complete but dist-node cache missing) the mirror is
+        # not running, so fall back to a direct pull of just these few images. Either
+        # path avoids the parallel test matrix hammering Docker Hub / GHCR.
 
         save_image() {
           local dockerfile="$1"
@@ -431,7 +479,7 @@ runs:
 
           if [ -z "$IMAGE" ]; then
             echo "  ⚠️ No image found in $dockerfile"
-            return
+            return 1
           fi
 
           # Normalize the image reference for Docker Hub (add docker.io/ prefix).
@@ -477,18 +525,32 @@ runs:
             fi
           fi
 
+          # Direct-pull fallback for the self-heal / targeted-refresh path: when the
+          # four mirror volumes are already cached the mirror registries were never
+          # created this run, so neither the canonical tag nor the localhost mirror
+          # ref exists locally. Pull the exact digest-pinned reference straight from
+          # upstream. docker pull of a tag+digest ref fetches by digest WITHOUT
+          # creating the tag-only reference, so tag it explicitly for the docker save
+          # below (which saves by tag).
           if ! docker image inspect "$TAG_TARGET" >/dev/null 2>&1; then
-            echo "  ⚠️ $description image not available locally: $TAG_TARGET"
-            return
+            echo "  ⬇️ Pulling directly: $NORMALIZED"
+            if docker pull "$NORMALIZED" --quiet 2>/dev/null; then
+              docker tag "$NORMALIZED" "$TAG_TARGET" 2>/dev/null || true
+            fi
           fi
 
-          if docker save "$TAG_TARGET" -o "/tmp/mirror-cache/${tar_name}.tar" 2>/dev/null; then
-            SIZE=$(du -h "/tmp/mirror-cache/${tar_name}.tar" | cut -f1)
+          if ! docker image inspect "$TAG_TARGET" >/dev/null 2>&1; then
+            echo "  ⚠️ $description image not available locally: $TAG_TARGET"
+            return 1
+          fi
+
+          if docker save "$TAG_TARGET" -o "/tmp/dist-node-cache/${tar_name}.tar" 2>/dev/null; then
+            SIZE=$(du -h "/tmp/dist-node-cache/${tar_name}.tar" | cut -f1)
             echo "  ✅ $description image saved: $TAG_TARGET ($SIZE)"
           else
             echo "  ⚠️ Failed to save $description image — provisioner will pull at test time"
-            rm -f "/tmp/mirror-cache/${tar_name}.tar"
-            return
+            rm -f "/tmp/dist-node-cache/${tar_name}.tar"
+            return 1
           fi
 
           # Verify the full digest-pinned reference resolves locally.
@@ -503,11 +565,27 @@ runs:
               echo "     Restore step will re-pull to register the digest mapping."
             fi
           fi
+
+          return 0
         }
 
-        save_image "pkg/fsutil/configmanager/k3d/Dockerfile"  "k3s-node"   "K3s"
-        save_image "pkg/fsutil/configmanager/kind/Dockerfile"  "kind-node"  "Kind"
-        save_image "pkg/fsutil/configmanager/talos/Dockerfile" "talos-node" "Talos"
+        # Save all three tars, counting successes. The dist-node cache is only saved
+        # (below) when ALL three were produced — a cache entry is immutable once
+        # written, so persisting a partial set would defeat the self-heal: the
+        # missing tar could never be repaired under this key. A short count short of
+        # three leaves the key absent so the next warm run retries from scratch.
+        SAVED_COUNT=0
+        save_image "pkg/fsutil/configmanager/k3d/Dockerfile"   "k3s-node"   "K3s"   && SAVED_COUNT=$((SAVED_COUNT + 1))
+        save_image "pkg/fsutil/configmanager/kind/Dockerfile"  "kind-node"  "Kind"  && SAVED_COUNT=$((SAVED_COUNT + 1))
+        save_image "pkg/fsutil/configmanager/talos/Dockerfile" "talos-node" "Talos" && SAVED_COUNT=$((SAVED_COUNT + 1))
+
+        if [ "$SAVED_COUNT" -eq 3 ]; then
+          echo "saved=true" >> "$GITHUB_OUTPUT"
+          echo "✅ All 3 distribution node tars produced; dist-node cache will be saved"
+        else
+          echo "saved=false" >> "$GITHUB_OUTPUT"
+          echo "⚠️ Only ${SAVED_COUNT}/3 distribution node tars produced; skipping dist-node cache save so the next warm run retries"
+        fi
 
     - name: 🔍 Verify all mirror volumes exported
       id: verify-exports
@@ -547,16 +625,6 @@ runs:
           echo "  ⚠️ kwok-control-plane.tar - MISSING (KWOK tests will pull from registry.k8s.io)"
         fi
 
-        # Verify distribution node tars (non-fatal: provisioners fall back to live pull if missing)
-        for name in k3s-node kind-node talos-node; do
-          if [ -f "/tmp/mirror-cache/${name}.tar" ]; then
-            SIZE=$(du -h "/tmp/mirror-cache/${name}.tar" | cut -f1)
-            echo "  ✅ ${name}.tar ($SIZE)"
-          else
-            echo "  ⚠️ ${name}.tar - MISSING (provisioner will pull from upstream registry)"
-          fi
-        done
-
     - name: 🧹 Cleanup containers
       if: always() && steps.check-cache.outputs.complete != 'true'
       shell: bash
@@ -570,3 +638,14 @@ runs:
       with:
         path: /tmp/mirror-cache
         key: ${{ steps.generate-key.outputs.cache-key }}
+
+    - name: 💾 Save distribution node cache
+      # Only save when all three tars were produced (saved == 'true'). A cache entry
+      # is immutable once written, so persisting a partial set here would defeat the
+      # self-heal — the missing tar could never be repaired under this key. Skipping
+      # leaves the key absent so the next warm run retries the save.
+      if: steps.restore-dist-node-cache.outputs.cache-hit != 'true' && steps.save-distribution-images.outputs.saved == 'true'
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/dist-node-cache
+        key: ${{ steps.generate-key.outputs.dist-node-cache-key }}

--- a/.github/actions/warm-mirror-cache/action.yaml
+++ b/.github/actions/warm-mirror-cache/action.yaml
@@ -507,11 +507,21 @@ runs:
         # not running, so fall back to a direct pull of just these few images. Either
         # path avoids the parallel test matrix hammering Docker Hub / GHCR.
 
+        # True when the local image referenced by $1 is recorded under the manifest
+        # digest $2 (checked against its RepoDigests). docker save exports by tag, so
+        # without this a stale tag-only image pointing at a different digest could be
+        # saved under our digest-derived cache key. See issue #4301.
+        image_has_digest() {
+          local digests
+          digests=$(docker image inspect "$1" --format '{{range .RepoDigests}}{{println .}}{{end}}' 2>/dev/null) || return 1
+          [[ "$digests" == *"@${2}"* ]]
+        }
+
         save_image() {
           local dockerfile="$1"
           local tar_name="$2"
           local description="$3"
-          local IMAGE NORMALIZED TAG_TARGET MIRROR_TAG SIZE from_line
+          local IMAGE NORMALIZED TAG_TARGET MIRROR_TAG SIZE from_line PINNED_DIGEST
 
           # Robust FROM parsing: skip optional --platform=... flags and
           # ignore trailing AS <stage>. Handles both simple and multi-stage
@@ -551,6 +561,8 @@ runs:
 
           # Strip digest generically (handles any algorithm, not just sha256)
           TAG_TARGET="${NORMALIZED%%@*}"
+          # The pinned manifest digest, if any (empty for tag-only refs)
+          case "$NORMALIZED" in *@*) PINNED_DIGEST="${NORMALIZED##*@}" ;; *) PINNED_DIGEST="" ;; esac
 
           # The image was pulled in the "Pull images through mirrors" step.
           # Try to find it either under the mirror ref or the canonical name.
@@ -576,18 +588,36 @@ runs:
           # Direct-pull fallback for the self-heal / targeted-refresh path: when the
           # four mirror volumes are already cached the mirror registries were never
           # created this run, so neither the canonical tag nor the localhost mirror
-          # ref exists locally. Pull the exact digest-pinned reference straight from
-          # upstream. docker pull of a tag+digest ref fetches by digest WITHOUT
-          # creating the tag-only reference, so tag it explicitly for the docker save
-          # below (which saves by tag).
-          if ! docker image inspect "$TAG_TARGET" >/dev/null 2>&1; then
-            echo "  ⬇️ Pulling directly: $NORMALIZED"
-            if docker pull "$NORMALIZED" --quiet 2>/dev/null; then
+          # ref exists locally. Pull the exact digest-pinned reference from upstream.
+          #
+          # For a digest-pinned ref, base the presence check on whether a LOCAL image
+          # actually carries the pinned digest — not merely whether the tag-only
+          # $TAG_TARGET exists. A stale tag-only image could point at a different
+          # digest, and saving that would persist the wrong image under a cache key
+          # derived from the pinned digest. After pulling, (re)tag the exact digest
+          # ref to $TAG_TARGET: docker pull of a tag+digest ref fetches by digest
+          # without creating the tag-only ref, and this also overwrites a stale tag.
+          if [ -n "$PINNED_DIGEST" ]; then
+            if ! image_has_digest "$TAG_TARGET" "$PINNED_DIGEST"; then
+              echo "  ⬇️ Pulling directly: $NORMALIZED"
+              docker pull "$NORMALIZED" --quiet 2>/dev/null || true
               docker tag "$NORMALIZED" "$TAG_TARGET" 2>/dev/null || true
             fi
+          elif ! docker image inspect "$TAG_TARGET" >/dev/null 2>&1; then
+            echo "  ⬇️ Pulling directly: $NORMALIZED"
+            docker pull "$NORMALIZED" --quiet 2>/dev/null || true
           fi
 
-          if ! docker image inspect "$TAG_TARGET" >/dev/null 2>&1; then
+          # Final correctness gate: for a digest-pinned ref, only proceed if
+          # $TAG_TARGET now resolves to the pinned digest (a failed pull may leave a
+          # stale image behind — never save that). Returning 1 leaves the dist-node
+          # cache unsaved so the next warm run retries.
+          if [ -n "$PINNED_DIGEST" ]; then
+            if ! image_has_digest "$TAG_TARGET" "$PINNED_DIGEST"; then
+              echo "  ⚠️ $description image not available at pinned digest: $NORMALIZED"
+              return 1
+            fi
+          elif ! docker image inspect "$TAG_TARGET" >/dev/null 2>&1; then
             echo "  ⚠️ $description image not available locally: $TAG_TARGET"
             return 1
           fi


### PR DESCRIPTION
## Problem

The CI mirror-cache actions `docker save` the distribution **node** images
(`k3s-node`, `kind-node`, `talos-node`) into the cache so test runners
`docker load` them and skip live pulls during cluster create (see #4301).
Until now those tars were written into `/tmp/mirror-cache` and persisted under
the **four-volume mirror-cache key**, which has the same latent fragility that
#5024 just fixed for the KWOK control-plane tar:

1. **Best-effort, not verified.** The "🔍 Check if cache is complete" step only
   checks the four mirror volumes (`docker.io` / `ghcr.io` / `quay.io` /
   `registry.k8s.io`), **not** the dist-node tars. A transient `docker save`
   failure leaves a dist-node tar absent without invalidating the cache.
2. **A GHA cache entry is immutable per key.** Once an incomplete cache is saved
   under the exact key, a same-hash re-run gets an exact-key hit and re-saving is
   a silent no-op — the missing tar can **never** be repaired in place. Every
   later cluster create then pulls the node image live from Docker Hub / GHCR
   (rate-limit / slowdown risk under high CI concurrency).

## Fix (same pattern as #5024)

Give the dist-node tars their **own** cache entry, decoupled from the four
mirror volumes:

- **Own key** `dist-node-<version>-<hash>-<os>-<arch>`, where `<hash>` covers
  only the three `FROM` refs from
  `pkg/fsutil/configmanager/{k3d,kind,talos}/Dockerfile`.
- **Saved only on success** — the cache `save` is gated on a `saved == 'true'`
  step output that is emitted only when **all three** tars were produced. A
  partial/failed set leaves the key absent so the next warm run retries fresh.
- **Exact-key restore** (no `restore-keys`) so a stale tar from a different
  digest set is never loaded — a miss simply falls back to a live pull.
- The save step is **re-gated on the dist-node cache miss** (not mirror-volume
  completeness). For the self-heal / targeted-refresh path (mirror cache warm
  but dist-node cache missing → mirror registries are not running), a
  **direct-pull fallback** pulls the exact digest-pinned ref. `docker pull` of a
  `tag@digest` ref fetches by digest *without* creating the tag-only reference,
  so it is `docker tag`-ed explicitly before `docker save` (verified locally).
- The hash/key derivation is **byte-identical** in `warm-mirror-cache` and
  `restore-mirror-cache`.

The four-volume mirror cache and its completeness check are **unchanged**, and
the restore side keeps re-pulling exact digest refs (`docker load` restores tags
but not repo-digest mappings).

### Behaviour across runs

| Scenario | mirror cache | dist-node cache | Result |
|---|---|---|---|
| Cold start | miss → re-warm | miss → save (via mirror retag) | both populated |
| Steady state | hit | hit | both skipped (fast) |
| **Self-heal** | hit | **miss** | dist-node re-saved via direct pull; mirror cache untouched |
| Partial save failure | (either) | <3 tars | `saved=false` → key stays absent → retried next run |

## Validation

- `yamllint -c .yamllint.yml` — clean.
- `prettier --check` — clean.
- `shellcheck` on every changed `run:` block — no new findings (pre-existing
  `SC2129`/`SC2188` in the untouched `Extract images` step are unchanged;
  MegaLinter's actionlint only scans `.github/workflows`, not `.github/actions`).

## Notes

- This is a **sibling** to #5024 (KWOK). Both touch the same two action files, so
  they will need a trivial merge once one lands; each is independently correct
  against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
