### PR TITLE
chore(deps): bump siderolabs/omni/client to 1.8.0 + adapt SyncTemplate

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -299,7 +299,7 @@ require (
 	github.com/siderolabs/go-talos-support v0.2.1 // indirect
 	github.com/siderolabs/image-factory v1.3.1 // indirect
 	github.com/siderolabs/net v0.4.0 // indirect
-	github.com/siderolabs/omni/client v1.7.3 // indirect
+	github.com/siderolabs/omni/client v1.8.0 // indirect
 	github.com/siderolabs/proto-codec v0.1.4 // indirect
 	github.com/siderolabs/protoenc v0.2.4 // indirect
 	github.com/siderolabs/talos v1.13.3 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -748,8 +748,8 @@ github.com/siderolabs/image-factory v1.3.1 h1:mVUmlAq/QpjKNwbmE8qAYB9/9aUh/kcLgY
 github.com/siderolabs/image-factory v1.3.1/go.mod h1:rxNZztD7PEG9coMhkjyTPXt8xh5Xb9/2g7bX6OUqAIc=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
-github.com/siderolabs/omni/client v1.7.3 h1:1KPG5gpYb3Fz59vhINhFjjCCjSFyI5iLwt5NDuIXitQ=
-github.com/siderolabs/omni/client v1.7.3/go.mod h1:Rq0tbsYR6lMNMzqA6z5HFaeAEt5jwQWm9ldjaRUl+Bo=
+github.com/siderolabs/omni/client v1.8.0 h1:0dwv4cTSAf67Bf+VkdAlJ9rrl6vQSGvXFUDy8XjNgwM=
+github.com/siderolabs/omni/client v1.8.0/go.mod h1:RgiGpUKjYhwv3v5aqPJbz1Nu971tkFEqLGKfFi3WZL4=
 github.com/siderolabs/proto-codec v0.1.4 h1:AcrLot/251qAa35GYhSqDeEKF3bygOlNaYJSrl7MPNQ=
 github.com/siderolabs/proto-codec v0.1.4/go.mod h1:frX2VEBSrZwzGxEdT+AMSjiWr6ySY/rCSXJxD0z9kxQ=
 github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIGsr8Q=

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/siderolabs/go-kubernetes v0.2.37
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/image-factory v1.3.1
-	github.com/siderolabs/omni/client v1.7.3
+	github.com/siderolabs/omni/client v1.8.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -2239,8 +2239,8 @@ github.com/siderolabs/image-factory v1.3.1 h1:mVUmlAq/QpjKNwbmE8qAYB9/9aUh/kcLgY
 github.com/siderolabs/image-factory v1.3.1/go.mod h1:rxNZztD7PEG9coMhkjyTPXt8xh5Xb9/2g7bX6OUqAIc=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
-github.com/siderolabs/omni/client v1.7.3 h1:1KPG5gpYb3Fz59vhINhFjjCCjSFyI5iLwt5NDuIXitQ=
-github.com/siderolabs/omni/client v1.7.3/go.mod h1:Rq0tbsYR6lMNMzqA6z5HFaeAEt5jwQWm9ldjaRUl+Bo=
+github.com/siderolabs/omni/client v1.8.0 h1:0dwv4cTSAf67Bf+VkdAlJ9rrl6vQSGvXFUDy8XjNgwM=
+github.com/siderolabs/omni/client v1.8.0/go.mod h1:RgiGpUKjYhwv3v5aqPJbz1Nu971tkFEqLGKfFi3WZL4=
 github.com/siderolabs/proto-codec v0.1.4 h1:AcrLot/251qAa35GYhSqDeEKF3bygOlNaYJSrl7MPNQ=
 github.com/siderolabs/proto-codec v0.1.4/go.mod h1:frX2VEBSrZwzGxEdT+AMSjiWr6ySY/rCSXJxD0z9kxQ=
 github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIGsr8Q=

--- a/pkg/svc/provider/omni/provider.go
+++ b/pkg/svc/provider/omni/provider.go
@@ -220,7 +220,9 @@ func (p *Provider) CreateCluster(
 		out = io.Discard
 	}
 
-	err := operations.SyncTemplate(ctx, templateReader, out, p.st, operations.SyncOptions{})
+	// root is nil: KSail passes an in-memory template with no external file
+	// patches, so file access stays unrestricted (the pre-1.8.0 behavior).
+	err := operations.SyncTemplate(ctx, templateReader, out, p.st, operations.SyncOptions{}, nil)
 	if err != nil {
 		return fmt.Errorf("failed to sync template to Omni: %w", err)
 	}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
Dependabot #4945 bumps `github.com/siderolabs/omni/client` 1.7.3 → 1.8.0, but the bump alone **fails to compile** every build/test/lint job:

```
pkg/svc/provider/omni/provider.go:223:89: not enough arguments in call to operations.SyncTemplate
```

omni/client v1.8.0 added a trailing `root *os.Root` parameter to `operations.SyncTemplate` (and `template.Load`'s `WithRoot`) for optional file-access restriction.

## Fix
Pass `nil` for the new `root` argument. This is **behavior-preserving**: the upstream `FileContext.ReadFile` documents *"Root restricts file access to a single directory tree. When nil, no restriction is applied"* and falls back to `os.ReadFile` — exactly the pre-1.8.0 behavior. KSail's `CreateCluster` syncs an **in-memory** multi-document template with no external file patches, so no root restriction is needed.

This is the single call site of `SyncTemplate` in the codebase.

## Validation
- `go build ./...` ✅
- `go vet ./pkg/svc/provider/omni/...` ✅ clean
- `go test ./pkg/svc/provider/omni/...` ✅ 68 passed
- `golangci-lint run --new-from-rev=origin/main` ✅ no new issues
- `go mod tidy` ✅ clean

## Supersedes
Closes the compile-broken bare bump in #4945 (same version target, with the required code adaptation). #4945 can be closed once this merges.