### PR TITLE
fix(cluster): query configured connection.context for GitOps drift detection

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -6674,6 +6674,13 @@ func handleUpdateRunE(
 		return err
 	}
 
+	// Fail fast when the user pinned a context the kubeconfig cannot resolve, so
+	// update never reports "No changes detected" for a cluster it could not inspect.
+	err = ensureConfiguredContextResolvable(ctx.ClusterCfg)
+	if err != nil {
+		return err
+	}
+
 	// Handle version upgrades when requested
 	updateK8s := cfgManager.Viper.GetBool("update-kubernetes")
 	updateDist := cfgManager.Viper.GetBool("update-distribution")
@@ -7211,6 +7218,36 @@ func createAndVerifyProvisioner(
 	return provisioner, nil
 }
 
+// ensureConfiguredContextResolvable fails the update when the user pinned a kube
+// context in spec.cluster.connection.context that does not exist in the resolved
+// kubeconfig. Without this guard an unresolvable pinned context lets the GitOps
+// drift probes fail silently (they only warn) while the command still reports
+// "No changes detected" — falsely reassuring, because KSail could not inspect the
+// cluster it was told to manage. When no context is pinned, KSail derives one and
+// this is a no-op.
+//
+// Call this only after the kubeconfig has been refreshed (createAndVerifyProvisioner),
+// so remote providers (e.g. Omni) that materialise the context on demand are not
+// rejected prematurely.
+func ensureConfiguredContextResolvable(clusterCfg *v1alpha1.Cluster) error {
+	contextName := strings.TrimSpace(clusterCfg.Spec.Cluster.Connection.Context)
+	if contextName == "" {
+		return nil
+	}
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(clusterCfg)
+	if err != nil {
+		return fmt.Errorf("resolve kubeconfig path: %w", err)
+	}
+
+	err = k8s.ValidateContextExists(kubeconfigPath, contextName)
+	if err != nil {
+		return fmt.Errorf("configured spec.cluster.connection.context is not usable: %w", err)
+	}
+
+	return nil
+}
+
 //nolint:gochecknoglobals // dependency injection for tests
 var isKubeconfigStaleFunc = kubeconfighook.IsKubeconfigStale
 
@@ -7302,13 +7339,7 @@ func buildComponentDetector(
 		return nil
 	}
 
-	k8sContext := ctx.ClusterCfg.Spec.Cluster.Connection.Context
-	if k8sContext == "" {
-		clusterName := resolveClusterNameFromContext(ctx)
-		k8sContext = ctx.ClusterCfg.Spec.Cluster.Distribution.ContextName(clusterName)
-	}
-
-	k8sClientset, err := k8s.NewClientset(kubeconfig, k8sContext)
+	k8sClientset, err := k8s.NewClientset(kubeconfig, resolveKubeContext(ctx))
 	if err != nil {
 		notify.Warningf(cmd.OutOrStderr(),
 			"Cannot create K8s clientset for component detection, using defaults: %v", err)
@@ -7320,6 +7351,22 @@ func buildComponentDetector(
 	dockerClient, _ := docker.GetDockerClient()
 
 	return detector.NewComponentDetector(helmClient, k8sClientset, dockerClient)
+}
+
+// resolveKubeContext returns the kube context KSail should use to query the
+// cluster it manages: the pinned spec.cluster.connection.context when set,
+// otherwise the context name derived from the distribution and cluster name.
+// The component detector and the GitOps drift probes share this resolution so
+// they all target the configured cluster rather than the ambient
+// current-context (which may point elsewhere).
+func resolveKubeContext(ctx *localregistry.Context) string {
+	k8sContext := ctx.ClusterCfg.Spec.Cluster.Connection.Context
+	if k8sContext == "" {
+		clusterName := resolveClusterNameFromContext(ctx)
+		k8sContext = ctx.ClusterCfg.Spec.Cluster.Distribution.ContextName(clusterName)
+	}
+
+	return k8sContext
 }
 
 // computeUpdateDiff retrieves current config and computes the full diff.
@@ -7507,14 +7554,17 @@ func checkWorkloadTagDrift(
 	}
 
 	desiredTag := fluxinstaller.ResolveDesiredTag(ctx.ClusterCfg)
+	kubeContext := resolveKubeContext(ctx)
 
 	var currentTag string
 
 	switch gitOpsEngine { //nolint:exhaustive // None/empty already filtered above
 	case v1alpha1.GitOpsEngineFlux:
-		currentTag, err = fluxinstaller.GetCurrentSyncRef(cmd.Context(), kubeconfigPath)
+		currentTag, err = fluxinstaller.GetCurrentSyncRef(
+			cmd.Context(), kubeconfigPath, kubeContext)
 	case v1alpha1.GitOpsEngineArgoCD:
-		currentTag, err = getCurrentArgoCDTargetRevision(cmd.Context(), kubeconfigPath)
+		currentTag, err = getCurrentArgoCDTargetRevision(
+			cmd.Context(), kubeconfigPath, kubeContext)
 	default:
 		return
 	}
@@ -7559,7 +7609,8 @@ func checkFluxDistributionVersionDrift(
 		return
 	}
 
-	instance, err := fluxinstaller.GetCurrentFluxInstance(cmd.Context(), kubeconfigPath)
+	instance, err := fluxinstaller.GetCurrentFluxInstance(
+		cmd.Context(), kubeconfigPath, resolveKubeContext(ctx))
 	if err != nil {
 		notify.Warningf(cmd.OutOrStderr(),
 			"Cannot query current Flux distribution version for drift detection: %v", err)
@@ -7587,9 +7638,9 @@ func checkFluxDistributionVersionDrift(
 // targetRevision. Returns empty string if the Application does not exist.
 func getCurrentArgoCDTargetRevision(
 	goCtx context.Context,
-	kubeconfigPath string,
+	kubeconfigPath, kubeContext string,
 ) (string, error) {
-	mgr, err := argocdclient.NewManagerFromKubeconfig(kubeconfigPath)
+	mgr, err := argocdclient.NewManagerFromKubeconfig(kubeconfigPath, kubeContext)
 	if err != nil {
 		return "", fmt.Errorf("create argocd manager: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -7360,7 +7360,10 @@ func buildComponentDetector(
 // they all target the configured cluster rather than the ambient
 // current-context (which may point elsewhere).
 func resolveKubeContext(ctx *localregistry.Context) string {
-	k8sContext := ctx.ClusterCfg.Spec.Cluster.Connection.Context
+	// Trim to match ensureConfiguredContextResolvable: a whitespace-padded pinned
+	// context must resolve to the same value the guard validated, otherwise it
+	// would pass the guard yet break the REST clients the probes build.
+	k8sContext := strings.TrimSpace(ctx.ClusterCfg.Spec.Cluster.Connection.Context)
 	if k8sContext == "" {
 		clusterName := resolveClusterNameFromContext(ctx)
 		k8sContext = ctx.ClusterCfg.Spec.Cluster.Distribution.ContextName(clusterName)

--- a/pkg/cli/cmd/cluster/cluster_context_guard_test.go
+++ b/pkg/cli/cmd/cluster/cluster_context_guard_test.go
@@ -1,0 +1,99 @@
+package cluster_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const guardKubeconfigYAML = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: prod
+contexts:
+- context:
+    cluster: prod
+    user: prod
+  name: admin@prod
+current-context: admin@prod
+users:
+- name: prod
+  user:
+    token: t
+`
+
+func writeGuardKubeconfig(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(guardKubeconfigYAML), 0o600))
+
+	return path
+}
+
+func newClusterWithConnection(kubeconfigPath, contextName string) *v1alpha1.Cluster {
+	cfg := &v1alpha1.Cluster{}
+	cfg.Spec.Cluster.Connection.Kubeconfig = kubeconfigPath
+	cfg.Spec.Cluster.Connection.Context = contextName
+
+	return cfg
+}
+
+// TestEnsureConfiguredContextResolvable_NoContextConfigured verifies that when
+// no context is pinned in spec.cluster.connection.context, the guard is a no-op
+// (KSail derives the context itself, so there is nothing to validate).
+func TestEnsureConfiguredContextResolvable_NoContextConfigured(t *testing.T) {
+	t.Parallel()
+
+	cfg := newClusterWithConnection("/does/not/exist", "")
+
+	require.NoError(t, cluster.ExportEnsureConfiguredContextResolvable(cfg))
+}
+
+// TestEnsureConfiguredContextResolvable_Present verifies that a pinned context
+// present in the kubeconfig passes the guard.
+func TestEnsureConfiguredContextResolvable_Present(t *testing.T) {
+	t.Parallel()
+
+	cfg := newClusterWithConnection(writeGuardKubeconfig(t), "admin@prod")
+
+	require.NoError(t, cluster.ExportEnsureConfiguredContextResolvable(cfg))
+}
+
+// TestEnsureConfiguredContextResolvable_Missing verifies that a pinned context
+// absent from the kubeconfig fails fast with ErrKubeconfigContextNotFound,
+// rather than letting cluster update report a misleading "No changes detected"
+// after the GitOps drift probes silently fail.
+func TestEnsureConfiguredContextResolvable_Missing(t *testing.T) {
+	t.Parallel()
+
+	cfg := newClusterWithConnection(writeGuardKubeconfig(t), "admin@staging")
+
+	err := cluster.ExportEnsureConfiguredContextResolvable(cfg)
+
+	require.ErrorIs(t, err, k8s.ErrKubeconfigContextNotFound)
+	assert.Contains(t, err.Error(), "admin@staging")
+}
+
+// TestResolveKubeContext_PrefersConfiguredContext verifies that the pinned
+// spec.cluster.connection.context is what drift detection resolves to, so it
+// targets the configured cluster rather than the ambient current-context.
+func TestResolveKubeContext_PrefersConfiguredContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := &v1alpha1.Cluster{}
+	cfg.Spec.Cluster.Connection.Context = "admin@prod"
+
+	got := cluster.ExportResolveKubeContext(&localregistry.Context{ClusterCfg: cfg})
+
+	assert.Equal(t, "admin@prod", got)
+}

--- a/pkg/cli/cmd/cluster/cluster_context_guard_test.go
+++ b/pkg/cli/cmd/cluster/cluster_context_guard_test.go
@@ -97,3 +97,19 @@ func TestResolveKubeContext_PrefersConfiguredContext(t *testing.T) {
 
 	assert.Equal(t, "admin@prod", got)
 }
+
+// TestResolveKubeContext_TrimsConfiguredContext verifies that a whitespace-padded
+// pinned context is trimmed, so the value the drift probes use to build REST
+// clients matches what ensureConfiguredContextResolvable validated (which trims).
+// Otherwise " admin@prod " would pass the guard yet fail the probes, reintroducing
+// the very warnings this guard exists to remove.
+func TestResolveKubeContext_TrimsConfiguredContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := &v1alpha1.Cluster{}
+	cfg.Spec.Cluster.Connection.Context = "  admin@prod  "
+
+	got := cluster.ExportResolveKubeContext(&localregistry.Context{ClusterCfg: cfg})
+
+	assert.Equal(t, "admin@prod", got)
+}

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -50,6 +50,16 @@ func ExportResolveClusterContext(kubeconfigPath, clusterName string) (string, er
 	return resolveClusterContext(kubeconfigPath, clusterName)
 }
 
+// ExportEnsureConfiguredContextResolvable exports ensureConfiguredContextResolvable for testing.
+func ExportEnsureConfiguredContextResolvable(clusterCfg *v1alpha1.Cluster) error {
+	return ensureConfiguredContextResolvable(clusterCfg)
+}
+
+// ExportResolveKubeContext exports resolveKubeContext for testing.
+func ExportResolveKubeContext(ctx *localregistry.Context) string {
+	return resolveKubeContext(ctx)
+}
+
 // ExportResolveCreatedContextName exports resolveCreatedContextName for testing.
 func ExportResolveCreatedContextName(
 	distribution v1alpha1.Distribution,

--- a/pkg/cli/setup/install_gitops.go
+++ b/pkg/cli/setup/install_gitops.go
@@ -72,7 +72,7 @@ func EnsureArgoCDResources(
 		return fmt.Errorf("ensure argocd sops-age secret: %w", err)
 	}
 
-	mgr, err := argocdgitops.NewManagerFromKubeconfig(kubeconfigPath)
+	mgr, err := argocdgitops.NewManagerFromKubeconfig(kubeconfigPath, "")
 	if err != nil {
 		return fmt.Errorf("create argocd manager: %w", err)
 	}

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -18,7 +16,6 @@ import (
 	hcloudccminstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/hcloudccm"
 	metallbinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/metallb"
 	metricsserverinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/metricsserver"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // HelmClientForCluster creates a Helm client configured for the cluster.
@@ -59,27 +56,12 @@ func HelmClientForCluster(clusterCfg *v1alpha1.Cluster) (*helm.Client, string, e
 // validateKubeconfigContext checks that the specified context exists in the kubeconfig file.
 // Returns a descriptive error listing available contexts when the target context is missing.
 func validateKubeconfigContext(kubeconfigPath, contextName string) error {
-	config, err := clientcmd.LoadFromFile(kubeconfigPath)
+	err := k8s.ValidateContextExists(kubeconfigPath, contextName)
 	if err != nil {
-		return fmt.Errorf("failed to load kubeconfig for context validation: %w", err)
+		return fmt.Errorf("validate kubeconfig context: %w", err)
 	}
 
-	if _, exists := config.Contexts[contextName]; exists {
-		return nil
-	}
-
-	available := make([]string, 0, len(config.Contexts))
-	for name := range config.Contexts {
-		available = append(available, name)
-	}
-
-	slices.Sort(available)
-
-	return fmt.Errorf(
-		"%w: %q not found in %s (available: %s)",
-		k8s.ErrKubeconfigContextNotFound,
-		contextName, kubeconfigPath, strings.Join(available, ", "),
-	)
+	return nil
 }
 
 // NeedsMetricsServerInstall determines if metrics-server needs to be installed.

--- a/pkg/client/argocd/manager.go
+++ b/pkg/client/argocd/manager.go
@@ -31,9 +31,12 @@ func NewManager(clientset kubernetes.Interface, dyn dynamic.Interface) *ManagerI
 	return &ManagerImpl{clientset: clientset, dynamic: dyn}
 }
 
-// NewManagerFromKubeconfig creates a manager by building Kubernetes clients from kubeconfig.
-func NewManagerFromKubeconfig(kubeconfig string) (*ManagerImpl, error) {
-	restConfig, err := k8s.BuildRESTConfig(kubeconfig, "")
+// NewManagerFromKubeconfig creates a manager by building Kubernetes clients from
+// the kubeconfig and the given context. An empty context falls back to the
+// kubeconfig's current-context; drift-detection callers pass the configured
+// spec.cluster.connection.context so they target the intended cluster.
+func NewManagerFromKubeconfig(kubeconfig, kubeContext string) (*ManagerImpl, error) {
+	restConfig, err := k8s.BuildRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("build rest config: %w", err)
 	}

--- a/pkg/client/argocd/manager_from_kubeconfig_test.go
+++ b/pkg/client/argocd/manager_from_kubeconfig_test.go
@@ -1,0 +1,49 @@
+package argocd_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
+	"github.com/stretchr/testify/require"
+)
+
+const managerKubeconfigYAML = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: prod
+contexts:
+- context:
+    cluster: prod
+    user: prod
+  name: admin@prod
+current-context: admin@prod
+users:
+- name: prod
+  user:
+    token: t
+`
+
+// TestNewManagerFromKubeconfig_UsesConfiguredContext verifies that the kube
+// context argument is applied when building the REST config. A pinned context
+// absent from the kubeconfig must fail rather than silently falling back to the
+// current-context — which is what let cluster update query the wrong cluster.
+func TestNewManagerFromKubeconfig_UsesConfiguredContext(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(managerKubeconfigYAML), 0o600))
+
+	// The configured context exists -> the manager builds successfully.
+	mgr, err := argocd.NewManagerFromKubeconfig(path, "admin@prod")
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+
+	// A pinned context absent from the kubeconfig must error, proving the
+	// override is honored instead of the ambient current-context.
+	_, err = argocd.NewManagerFromKubeconfig(path, "admin@staging")
+	require.Error(t, err)
+}

--- a/pkg/k8s/rest_config.go
+++ b/pkg/k8s/rest_config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"k8s.io/client-go/kubernetes"
@@ -97,6 +99,38 @@ func BuildRESTConfig(kubeconfig, context string) (*rest.Config, error) {
 	applyDefaults(restConfig)
 
 	return restConfig, nil
+}
+
+// ValidateContextExists checks that contextName exists in the kubeconfig at
+// kubeconfigPath. It returns nil when the context is present, a wrapped
+// ErrKubeconfigContextNotFound (listing the available contexts) when it is
+// absent, and a wrapped load error when the kubeconfig cannot be read.
+//
+// This gives callers a deterministic, actionable check for a user-pinned
+// context — clearer than the generic "no configuration has been provided"
+// error client-go raises when an unresolved current-context is used.
+func ValidateContextExists(kubeconfigPath, contextName string) error {
+	config, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("load kubeconfig for context validation: %w", err)
+	}
+
+	if _, exists := config.Contexts[contextName]; exists {
+		return nil
+	}
+
+	available := make([]string, 0, len(config.Contexts))
+	for name := range config.Contexts {
+		available = append(available, name)
+	}
+
+	slices.Sort(available)
+
+	return fmt.Errorf(
+		"%w: %q not found in %s (available: %s)",
+		ErrKubeconfigContextNotFound,
+		contextName, kubeconfigPath, strings.Join(available, ", "),
+	)
 }
 
 // applyDefaults sets client-side rate limiter defaults on a REST config.

--- a/pkg/k8s/validate_context_test.go
+++ b/pkg/k8s/validate_context_test.go
@@ -1,0 +1,54 @@
+package k8s_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateContextExists_Present verifies that a context present in the
+// kubeconfig passes validation.
+func TestValidateContextExists_Present(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	err := os.WriteFile(kubeconfigPath, []byte(testKubeconfigYAML), 0o600)
+	require.NoError(t, err)
+
+	err = k8s.ValidateContextExists(kubeconfigPath, "test-context")
+
+	require.NoError(t, err)
+}
+
+// TestValidateContextExists_Missing verifies that a missing context returns
+// ErrKubeconfigContextNotFound and the error lists the available contexts so the
+// user can correct spec.cluster.connection.context.
+func TestValidateContextExists_Missing(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	err := os.WriteFile(kubeconfigPath, []byte(testKubeconfigYAML), 0o600)
+	require.NoError(t, err)
+
+	err = k8s.ValidateContextExists(kubeconfigPath, "admin@prod")
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, k8s.ErrKubeconfigContextNotFound)
+	assert.Contains(t, err.Error(), "admin@prod")
+	assert.Contains(t, err.Error(), "test-context")
+}
+
+// TestValidateContextExists_UnreadableKubeconfig verifies that an unreadable
+// kubeconfig path surfaces a load error rather than a false "not found".
+func TestValidateContextExists_UnreadableKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	err := k8s.ValidateContextExists(filepath.Join(t.TempDir(), "missing"), "test-context")
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, k8s.ErrKubeconfigContextNotFound)
+}

--- a/pkg/svc/installer/flux/export_test.go
+++ b/pkg/svc/installer/flux/export_test.go
@@ -115,7 +115,7 @@ func SetNewFluxResourcesClient(fn func(*rest.Config) (any, error)) func() {
 }
 
 // SetLoadRESTConfig allows tests to replace loadRESTConfig with a stub.
-func SetLoadRESTConfig(fn func(string) (*rest.Config, error)) func() {
+func SetLoadRESTConfig(fn func(string, string) (*rest.Config, error)) func() {
 	original := loadRESTConfig
 	loadRESTConfig = fn
 

--- a/pkg/svc/installer/flux/flux_coverage_test.go
+++ b/pkg/svc/installer/flux/flux_coverage_test.go
@@ -128,7 +128,7 @@ func TestEnsureDefaultResources_NilClusterConfig(t *testing.T) {
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestEnsureDefaultResources_NilContext(t *testing.T) {
-	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
 	})
 	defer restoreREST()
@@ -147,7 +147,7 @@ func TestEnsureDefaultResources_NilContext(t *testing.T) {
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestEnsureDefaultResources_ArtifactNotPushed(t *testing.T) {
-	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
 	})
 	defer restoreREST()
@@ -164,7 +164,7 @@ func TestEnsureDefaultResources_ArtifactNotPushed(t *testing.T) {
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestEnsureDefaultResources_LoadRESTConfigError(t *testing.T) {
-	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return nil, errors.New("config error")
 	})
 	defer restoreREST()
@@ -193,7 +193,7 @@ func TestSetupInstance_NilClusterConfig(t *testing.T) {
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestSetupInstance_NilContext(t *testing.T) {
-	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
 	})
 	defer restoreREST()
@@ -210,7 +210,7 @@ func TestSetupInstance_NilContext(t *testing.T) {
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestSetupInstance_LoadRESTConfigError(t *testing.T) {
-	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return nil, errors.New("config error")
 	})
 	defer restoreREST()
@@ -229,7 +229,7 @@ func TestSetupInstance_LoadRESTConfigError(t *testing.T) {
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestWaitForFluxReady_LoadRESTConfigError(t *testing.T) {
-	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return nil, errors.New("no config")
 	})
 	defer restoreREST()
@@ -241,7 +241,7 @@ func TestWaitForFluxReady_LoadRESTConfigError(t *testing.T) {
 
 //nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestWaitForFluxReady_NilContext(t *testing.T) {
-	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreREST := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return nil, errors.New("no config")
 	})
 	defer restoreREST()

--- a/pkg/svc/installer/flux/resources.go
+++ b/pkg/svc/installer/flux/resources.go
@@ -57,12 +57,14 @@ var (
 	fluxAPIAvailabilityPollInterval = 2 * time.Second
 )
 
-// loadRESTConfig creates a REST config from a kubeconfig path.
+// loadRESTConfig builds a REST config from a kubeconfig path and optional
+// context. An empty context falls back to the kubeconfig's current-context;
+// drift-detection callers pass the configured spec.cluster.connection.context
+// so they query the intended cluster rather than the ambient current-context.
+// It is a package var so tests can stub it via SetLoadRESTConfig.
 //
 //nolint:gochecknoglobals // Allows mocking REST config for tests
-var loadRESTConfig = func(kubeconfig string) (*rest.Config, error) {
-	return k8s.BuildRESTConfig(kubeconfig, "")
-}
+var loadRESTConfig = k8s.BuildRESTConfig
 
 // setupParams holds the components needed for Flux setup operations.
 // Context is passed separately to setupFluxCore to avoid embedding it in a struct.
@@ -145,7 +147,7 @@ func EnsureDefaultResources(
 		ctx = context.Background()
 	}
 
-	restConfig, err := loadRESTConfig(kubeconfig)
+	restConfig, err := loadRESTConfig(kubeconfig, "")
 	if err != nil {
 		return err
 	}
@@ -202,7 +204,7 @@ func SetupInstance(
 		ctx = context.Background()
 	}
 
-	restConfig, err := loadRESTConfig(kubeconfig)
+	restConfig, err := loadRESTConfig(kubeconfig, "")
 	if err != nil {
 		return err
 	}
@@ -227,7 +229,7 @@ func WaitForFluxReady(
 		ctx = context.Background()
 	}
 
-	restConfig, err := loadRESTConfig(kubeconfig)
+	restConfig, err := loadRESTConfig(kubeconfig, "")
 	if err != nil {
 		return err
 	}
@@ -254,12 +256,15 @@ func WaitForFluxReady(
 // distribution.version for drift detection on cluster update).
 //
 //nolint:contextcheck // nil-guard consistent with SetupInstance/WaitForFluxReady
-func GetCurrentFluxInstance(ctx context.Context, kubeconfig string) (*FluxInstance, error) {
+func GetCurrentFluxInstance(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+) (*FluxInstance, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	restConfig, err := loadRESTConfig(kubeconfig)
+	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("build REST config: %w", err)
 	}
@@ -290,8 +295,8 @@ func GetCurrentFluxInstance(ctx context.Context, kubeconfig string) (*FluxInstan
 // GetCurrentSyncRef queries the running FluxInstance in the cluster and returns
 // its spec.sync.ref value. Returns empty string if the FluxInstance does not exist
 // or has no sync configuration.
-func GetCurrentSyncRef(ctx context.Context, kubeconfig string) (string, error) {
-	instance, err := GetCurrentFluxInstance(ctx, kubeconfig)
+func GetCurrentSyncRef(ctx context.Context, kubeconfig, kubeContext string) (string, error) {
+	instance, err := GetCurrentFluxInstance(ctx, kubeconfig, kubeContext)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/svc/installer/flux/resources_test.go
+++ b/pkg/svc/installer/flux/resources_test.go
@@ -910,12 +910,12 @@ func TestGetCurrentFluxInstance(t *testing.T) {
 	})
 	defer restoreClient()
 
-	restoreConfig := fluxinstaller.SetLoadRESTConfig(func(string) (*rest.Config, error) {
+	restoreConfig := fluxinstaller.SetLoadRESTConfig(func(string, string) (*rest.Config, error) {
 		return &rest.Config{}, nil
 	})
 	defer restoreConfig()
 
-	instance, err := fluxinstaller.GetCurrentFluxInstance(context.Background(), "kubeconfig")
+	instance, err := fluxinstaller.GetCurrentFluxInstance(context.Background(), "kubeconfig", "")
 
 	require.NoError(t, err)
 	require.NotNil(t, instance)
@@ -940,15 +940,57 @@ func TestGetCurrentFluxInstance_NotFound(t *testing.T) {
 	})
 	defer restoreClient()
 
-	restoreConfig := fluxinstaller.SetLoadRESTConfig(func(string) (*rest.Config, error) {
+	restoreConfig := fluxinstaller.SetLoadRESTConfig(func(string, string) (*rest.Config, error) {
 		return &rest.Config{}, nil
 	})
 	defer restoreConfig()
 
-	instance, err := fluxinstaller.GetCurrentFluxInstance(context.Background(), "kubeconfig")
+	instance, err := fluxinstaller.GetCurrentFluxInstance(context.Background(), "kubeconfig", "")
 
 	require.NoError(t, err)
 	assert.Nil(t, instance)
+}
+
+// TestGetCurrentFluxInstance_ForwardsContext verifies that the kube context is
+// forwarded to the REST config builder, so drift detection queries the cluster
+// pinned in spec.cluster.connection.context rather than the ambient
+// current-context.
+//
+//nolint:paralleltest // Cannot run in parallel due to global mock
+func TestGetCurrentFluxInstance_ForwardsContext(t *testing.T) {
+	var gotContext string
+
+	restoreConfig := fluxinstaller.SetLoadRESTConfig(func(_, context string) (*rest.Config, error) {
+		gotContext = context
+
+		return nil, errors.New("stub: stop before building client")
+	})
+	defer restoreConfig()
+
+	_, err := fluxinstaller.GetCurrentFluxInstance(context.Background(), "kubeconfig", "admin@prod")
+
+	require.Error(t, err)
+	assert.Equal(t, "admin@prod", gotContext)
+}
+
+// TestGetCurrentSyncRef_ForwardsContext verifies that GetCurrentSyncRef threads
+// the kube context through to the REST config builder.
+//
+//nolint:paralleltest // Cannot run in parallel due to global mock
+func TestGetCurrentSyncRef_ForwardsContext(t *testing.T) {
+	var gotContext string
+
+	restoreConfig := fluxinstaller.SetLoadRESTConfig(func(_, context string) (*rest.Config, error) {
+		gotContext = context
+
+		return nil, errors.New("stub: stop before building client")
+	})
+	defer restoreConfig()
+
+	_, err := fluxinstaller.GetCurrentSyncRef(context.Background(), "kubeconfig", "admin@prod")
+
+	require.Error(t, err)
+	assert.Equal(t, "admin@prod", gotContext)
 }
 
 //nolint:paralleltest // Cannot run in parallel due to global mock
@@ -1071,7 +1113,7 @@ func TestWaitForFluxReady_DiagnosticsIncludedOnTimeout(t *testing.T) {
 	defer restoreFlux()
 
 	// Mock loadRESTConfig to return a dummy config without hitting the filesystem.
-	restoreLoad := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreLoad := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return &rest.Config{}, nil
 	})
 	defer restoreLoad()
@@ -1132,7 +1174,7 @@ func TestEnsureDefaultResources_DiagnosticsIncludedOnTimeout(t *testing.T) {
 	defer restoreFlux()
 
 	// Mock loadRESTConfig to avoid hitting the filesystem.
-	restoreLoad := fluxinstaller.SetLoadRESTConfig(func(_ string) (*rest.Config, error) {
+	restoreLoad := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
 		return &rest.Config{}, nil
 	})
 	defer restoreLoad()


### PR DESCRIPTION
## Problem

`ksail --config ksail.prod.yaml cluster update` (Talos × Hetzner, GitOps = Flux) printed:

```
⚠ Cannot query current GitOps sync ref for drift detection: build REST config: failed to load kubeconfig: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
⚠ Cannot query current Flux distribution version for drift detection: …
ℹ No changes detected
```

The trigger was a *wrong ambient kube context*. But the config explicitly pins the
target: `spec.cluster.connection.context: admin@prod`. So "No changes detected" was
only partially true — two of the change-detection probes silently didn't run, yet
the command reported success for a cluster it couldn't fully inspect.

## Root cause

The GitOps drift probes built their REST config with an **empty** context
(`BuildRESTConfig(kubeconfig, "")`), i.e. the kubeconfig's *current-context* —
ignoring `spec.cluster.connection.context`. The component detector (via
`HelmClientForCluster`) already honored `connection.context`, so it queried the
*correct* cluster; only the Flux/ArgoCD drift probes used the ambient context and
failed. Because those probes are best-effort ("warn and skip"), the failure was
swallowed.

This only bites `update`/`reconcile` of an existing cluster: on `create` the
freshly-written kubeconfig's current-context *is* the new cluster, so the empty
context happened to resolve.

## Changes

1. **Drift detection honors the configured context.** Thread the resolved context
   — `connection.context`, else the distribution-derived context name (the same
   resolution the component detector uses, now extracted into `resolveKubeContext`)
   — into `GetCurrentFluxInstance`/`GetCurrentSyncRef` and the ArgoCD manager. The
   probes now target the configured cluster regardless of the ambient context, so
   the reported warnings disappear and "No changes detected" becomes trustworthy.
2. **Fail fast on an unresolvable pinned context.** `cluster update` now validates
   that a pinned `connection.context` exists in the kubeconfig (after the kubeconfig
   refresh, so Omni/Hetzner aren't rejected prematurely) and returns an actionable
   error instead of "No changes detected" for a cluster it cannot inspect.
3. **Shared primitive.** Add `k8s.ValidateContextExists` (deterministic, lists the
   available contexts); the existing Helm-client context validation now reuses it.

Create/setup-time Flux/ArgoCD calls keep using current-context (passed explicitly),
since the kubeconfig there is freshly written to the new cluster — only the
read/drift path adopts the configured context.

## Tests (TDD)

- `k8s.ValidateContextExists`: present / missing (lists available) / unreadable.
- `ensureConfiguredContextResolvable`: no-op when unset, passes when present, fails
  with `ErrKubeconfigContextNotFound` when missing.
- `resolveKubeContext`: prefers the pinned `connection.context`.
- Flux `GetCurrentFluxInstance`/`GetCurrentSyncRef` forward the context to the REST
  config builder.
- ArgoCD `NewManagerFromKubeconfig` applies the context (a bogus pinned context
  errors instead of silently using current-context).

`go build ./...`, `go vet ./...`, touched-package `go test`, and `golangci-lint`
on the touched packages are clean (only the repo's pre-existing `goconst` test-literal
baseline remains, in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
