### PR TITLE
refactor(chat): extract shared movePickerIndex helper for picker navigation

### DIFF
--- a/pkg/cli/ui/chat/command_picker.go
+++ b/pkg/cli/ui/chat/command_picker.go
@@ -166,16 +166,8 @@ func (m *Model) getRegisteredCommands() []copilot.CommandDefinition {
 // handleCommandPickerKey handles keyboard input when the command picker popup is active.
 func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "up", "k":
-		if m.commandPickerIndex > 0 {
-			m.commandPickerIndex--
-		}
-
-		return m, nil
-	case keyDown, "j":
-		if m.commandPickerIndex < len(m.filteredCommands)-1 {
-			m.commandPickerIndex++
-		}
+	case "up", "k", keyDown, "j":
+		movePickerIndex(msg.String(), &m.commandPickerIndex, len(m.filteredCommands))
 
 		return m, nil
 	case keyEnter:
@@ -209,16 +201,8 @@ func (m *Model) handleCommandPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // handleOptionPickerKey handles keyboard input when the option picker popup is active.
 func (m *Model) handleOptionPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "up", "k":
-		if m.optionPickerIndex > 0 {
-			m.optionPickerIndex--
-		}
-
-		return m, nil
-	case keyDown, "j":
-		if m.optionPickerIndex < len(m.filteredOptions)-1 {
-			m.optionPickerIndex++
-		}
+	case "up", "k", keyDown, "j":
+		movePickerIndex(msg.String(), &m.optionPickerIndex, len(m.filteredOptions))
 
 		return m, nil
 	case keyEnter:

--- a/pkg/cli/ui/chat/keyhandlers.go
+++ b/pkg/cli/ui/chat/keyhandlers.go
@@ -182,9 +182,10 @@ func (m *Model) handleQuit() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
-// movePickerIndex applies up/down (k/j) navigation to *index, clamping it to
-// [0, total). Picker key handlers share this single bounds-checked implementation
-// instead of repeating the same up/down arithmetic.
+// movePickerIndex steps *index for up/down (k/j) navigation: "up"/"k" moves it
+// toward 0 and "down"/"j" toward total-1, stopping at those bounds. It guards each
+// step from leaving [0, total) but does not re-clamp an index that is already out
+// of range. Picker key handlers share this instead of repeating the up/down arithmetic.
 func movePickerIndex(key string, index *int, total int) {
 	switch key {
 	case "up", "k":

--- a/pkg/cli/ui/chat/keyhandlers.go
+++ b/pkg/cli/ui/chat/keyhandlers.go
@@ -182,6 +182,22 @@ func (m *Model) handleQuit() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
+// movePickerIndex applies up/down (k/j) navigation to *index, clamping it to
+// [0, total). Picker key handlers share this single bounds-checked implementation
+// instead of repeating the same up/down arithmetic.
+func movePickerIndex(key string, index *int, total int) {
+	switch key {
+	case "up", "k":
+		if *index > 0 {
+			*index--
+		}
+	case keyDown, "j":
+		if *index < total-1 {
+			*index++
+		}
+	}
+}
+
 // handleEscape handles the escape key.
 func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 	if m.isStreaming {

--- a/pkg/cli/ui/chat/model_picker.go
+++ b/pkg/cli/ui/chat/model_picker.go
@@ -44,16 +44,8 @@ func (m *Model) handleModelPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.modelFilterActive = true
 
 		return m, nil
-	case "up", "k":
-		if m.modelPickerIndex > 0 {
-			m.modelPickerIndex--
-		}
-
-		return m, nil
-	case keyDown, "j":
-		if m.modelPickerIndex < totalItems-1 {
-			m.modelPickerIndex++
-		}
+	case "up", "k", keyDown, "j":
+		movePickerIndex(msg.String(), &m.modelPickerIndex, totalItems)
 
 		return m, nil
 	case keyEnter:

--- a/pkg/cli/ui/chat/reasoning_picker.go
+++ b/pkg/cli/ui/chat/reasoning_picker.go
@@ -25,16 +25,8 @@ func (m *Model) handleReasoningPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateDimensions()
 
 		return m, nil
-	case "up", "k":
-		if m.reasoningPickerIndex > 0 {
-			m.reasoningPickerIndex--
-		}
-
-		return m, nil
-	case keyDown, "j":
-		if m.reasoningPickerIndex < totalItems-1 {
-			m.reasoningPickerIndex++
-		}
+	case "up", "k", keyDown, "j":
+		movePickerIndex(msg.String(), &m.reasoningPickerIndex, totalItems)
 
 		return m, nil
 	case keyEnter:

--- a/pkg/cli/ui/chat/session_picker.go
+++ b/pkg/cli/ui/chat/session_picker.go
@@ -161,8 +161,6 @@ func (m *Model) refreshSessionList() error {
 }
 
 // handleSessionPickerNavKey handles navigation keys in the session picker.
-//
-//nolint:cyclop // keyboard dispatcher for session picker navigation
 func (m *Model) handleSessionPickerNavKey(msg tea.KeyMsg, totalItems int) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case keyEscape:
@@ -176,16 +174,8 @@ func (m *Model) handleSessionPickerNavKey(msg tea.KeyMsg, totalItems int) (tea.M
 		m.sessionFilterActive = true
 
 		return m, nil
-	case "up", "k":
-		if m.sessionPickerIndex > 0 {
-			m.sessionPickerIndex--
-		}
-
-		return m, nil
-	case keyDown, "j":
-		if m.sessionPickerIndex < totalItems-1 {
-			m.sessionPickerIndex++
-		}
+	case "up", "k", keyDown, "j":
+		movePickerIndex(msg.String(), &m.sessionPickerIndex, totalItems)
 
 		return m, nil
 	case "d", "delete", keyBackspace:


### PR DESCRIPTION
## What

Extracts a shared `movePickerIndex(key, &index, total)` helper (in `keyhandlers.go`) and uses it in all five picker key handlers — model, session, command, option, reasoning. Each picker's two near-identical navigation cases (`up`/`k` and `down`/`j`, with the same `[0, total)` clamp on a different index field) collapse into one.

## Why

The up/down index-clamp arithmetic was duplicated verbatim across five handlers — a textbook DRY violation. A single bounds-checked helper makes the navigation behaviour consistent and fixable in one place.

## Safety

Behavior-preserving — same keys, same clamping, same index fields. The helper returns nothing (so `unparam` won't flag an always-ignored result); callers invoke it for its side effect.

- per-handler `gocyclo`: session 11→8, model 10→7, command 10→7, option →6, reasoning →5
- `handleSessionPickerNavKey`'s now-unnecessary `//nolint:cyclop` auto-removed
- `go test ./pkg/cli/ui/chat/...` — **734 passed**
- `golangci-lint run --new-from-rev=origin/main` — **0 new issues**

### Observation (not changed here)

While mapping these handlers I noticed `ctrl+c` quits inconsistently: `command_picker` calls `handleQuit()` (which also `saveCurrentSession()`), whereas `model`/`session`/`reasoning` pickers inline `cleanup` + quit *without* saving. Left as-is to keep this PR behavior-preserving — worth a follow-up to decide the intended behaviour.

Part of a series of small, independent refactoring PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
