### PR TITLE
refactor(chat): extract spinner-tick and sub-component updates from Update

### DIFF
--- a/pkg/cli/ui/chat/model.go
+++ b/pkg/cli/ui/chat/model.go
@@ -535,29 +535,10 @@ func (m *Model) Update(
 		return m, nil
 
 	case spinner.TickMsg:
-		// Always update spinner to keep it ticking
-		var cmd tea.Cmd
-
-		m.spinner, cmd = m.spinner.Update(msg)
-		cmds = append(cmds, cmd)
-		// Update viewport content if there are active tools or streaming to animate spinners
-		if m.isStreaming || m.hasRunningTools() {
-			m.updateViewportContent()
-		}
+		cmds = append(cmds, m.handleSpinnerTick(msg))
 	}
 
-	// Update sub-components
-	if !m.isStreaming {
-		var taCmd tea.Cmd
-
-		m.textarea, taCmd = m.textarea.Update(msg)
-		cmds = append(cmds, taCmd)
-	}
-
-	var vpCmd tea.Cmd
-
-	m.viewport, vpCmd = m.viewport.Update(msg)
-	cmds = append(cmds, vpCmd)
+	cmds = append(cmds, m.updateSubcomponents(msg)...)
 
 	return m, tea.Batch(cmds...)
 }
@@ -597,6 +578,43 @@ func (m *Model) View() string {
 	output := lipgloss.JoinVertical(lipgloss.Left, sections...)
 
 	return lipgloss.NewStyle().MaxWidth(m.width).Render(output)
+}
+
+// handleSpinnerTick advances the spinner and refreshes the viewport while there
+// is animated content (active tools or an in-flight stream), returning the
+// spinner's tick command so the animation keeps running.
+func (m *Model) handleSpinnerTick(msg spinner.TickMsg) tea.Cmd {
+	var cmd tea.Cmd
+
+	m.spinner, cmd = m.spinner.Update(msg)
+
+	// Refresh the viewport so streaming/tool spinners keep animating.
+	if m.isStreaming || m.hasRunningTools() {
+		m.updateViewportContent()
+	}
+
+	return cmd
+}
+
+// updateSubcomponents forwards msg to the textarea (only when not streaming, so
+// streamed output does not capture typing) and to the viewport, returning their
+// commands.
+func (m *Model) updateSubcomponents(msg tea.Msg) []tea.Cmd {
+	var cmds []tea.Cmd
+
+	if !m.isStreaming {
+		var taCmd tea.Cmd
+
+		m.textarea, taCmd = m.textarea.Update(msg)
+		cmds = append(cmds, taCmd)
+	}
+
+	var vpCmd tea.Cmd
+
+	m.viewport, vpCmd = m.viewport.Update(msg)
+	cmds = append(cmds, vpCmd)
+
+	return cmds
 }
 
 // handleStreamEvent dispatches streaming-related events to their specific handlers.


### PR DESCRIPTION
## What

Extracts the two blocks of inline *logic* that were embedded in the chat `Update` message dispatcher (`pkg/cli/ui/chat/model.go`) into named methods:

- `handleSpinnerTick` — advances the spinner and conditionally refreshes the viewport
- `updateSubcomponents` — forwards the message to the textarea (when not streaming) and viewport

`Update` now reads as a pure dispatcher whose tail is a single `updateSubcomponents` call.

## Why

`Update` is a Bubbletea dispatcher (and stays one — it keeps its `//nolint:cyclop,funlen`), but it had non-dispatch logic inlined in the `spinner.TickMsg` case and after the switch. Pulling that into named, individually-testable methods clarifies intent.

(The dispatcher's type switch itself is intentionally left as-is — converting an idiomatic Go type switch to a reflection-keyed map would lose compile-time type safety, so that's not a real improvement.)

## Safety

Behavior-preserving — same commands appended in the same order, same `!isStreaming` guard on the textarea update, same viewport refresh condition.

- `Update` `gocyclo`: **19 → 16**; extracted methods are CC3 / CC2
- `go test ./pkg/cli/ui/chat/...` — **734 passed**
- `golangci-lint run --new-from-rev=origin/main` — **0 new issues**

Part of a series of small, independent refactoring PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
