### PR TITLE
feat(reconcile): show failed reconciliation as a root-cause tree

### DIFF
--- a/pkg/cli/cmd/workload/export_test.go
+++ b/pkg/cli/cmd/workload/export_test.go
@@ -242,6 +242,17 @@ func ExportCheckKustomizationDependencies(f *ExportFailedKustomizations, depends
 	return f.checkDependencies(dependsOn)
 }
 
+// ExportErrDependencyBlocked exposes the cascade sentinel for testing.
+func ExportErrDependencyBlocked() error { return errDependencyBlocked }
+
+// ExportErrKustomizationReconcile exposes the kustomization-reconcile sentinel for testing.
+func ExportErrKustomizationReconcile() error { return errKustomizationReconcile }
+
+// ExportIsAggregatedReconcileError exposes isAggregatedReconcileError for testing.
+func ExportIsAggregatedReconcileError(err error) bool {
+	return isAggregatedReconcileError(err)
+}
+
 // ExportPollUntilKustomizationReady exposes pollUntilKustomizationReady for testing.
 func ExportPollUntilKustomizationReady(
 	ctx context.Context,

--- a/pkg/cli/cmd/workload/workload.go
+++ b/pkg/cli/cmd/workload/workload.go
@@ -1974,6 +1974,16 @@ var errGitOpsEngineRequired = errors.New(
 		"set 'spec.gitOpsEngine: Flux|ArgoCD' in ksail.yaml",
 )
 
+// Sentinels wrapping the per-resource progress-group failures. These are the
+// verbose, multi-resource errors whose joined chain is replaced by the concise
+// diagnostics summary once the report has been printed (see
+// runReconcileWithDiagnostics). Other, more specific reconcile errors keep their
+// original actionable message.
+var (
+	errKustomizationReconcile = errors.New("reconcile kustomizations")
+	errApplicationReconcile   = errors.New("reconcile argocd applications")
+)
+
 // Shared constants for reconciliation.
 const (
 	defaultReconcileTimeout       = 5 * time.Minute
@@ -2254,23 +2264,60 @@ func runReconcileWithDiagnostics(
 			)
 		},
 	)
-	if err != nil {
-		// Skip diagnostics when the user explicitly cancelled (Ctrl+C) to avoid
-		// blocking for the diagnostic timeout after a deliberate abort.
-		if !errors.Is(cmd.Context().Err(), context.Canceled) {
-			reconcilediag.Diagnose(
-				context.WithoutCancel(cmd.Context()),
-				cmd.ErrOrStderr(),
-				kubeconfigPath,
-				gitOpsEngine,
-			)
-		}
+	if err == nil {
+		return nil
+	}
 
+	// Skip diagnostics when the user explicitly cancelled (Ctrl+C) to avoid
+	// blocking for the diagnostic timeout after a deliberate abort.
+	if errors.Is(cmd.Context().Err(), context.Canceled) {
 		return err
 	}
 
-	return nil
+	// Diagnostics render to stdout, alongside the rest of the command's progress
+	// UI, rather than stderr. The error executor redirects stderr into a buffer
+	// and re-emits it as the command error; writing the report there would bundle
+	// the whole report into the error message and re-indent it under a single
+	// symbol. Stdout keeps the report rendering with its own formatting.
+	report := reconcilediag.Diagnose(
+		context.WithoutCancel(cmd.Context()),
+		cmd.OutOrStdout(),
+		kubeconfigPath,
+		gitOpsEngine,
+	)
+
+	// For the verbose per-resource reconcile failures, replace the joined error
+	// chain with a concise one-line summary — the actionable detail is already in
+	// the diagnostics report printed above. Other, more specific errors keep their
+	// original message.
+	if summary := report.Summary(); summary != "" && isAggregatedReconcileError(err) {
+		return &reconcileSummaryError{summary: summary, cause: err}
+	}
+
+	return err
 }
+
+// isAggregatedReconcileError reports whether err is one of the per-resource
+// progress-group failures whose joined chain should be collapsed to the
+// diagnostics summary.
+func isAggregatedReconcileError(err error) bool {
+	return errors.Is(err, errKustomizationReconcile) || errors.Is(err, errApplicationReconcile)
+}
+
+// reconcileSummaryError carries a concise, de-duplicated summary of a failed
+// reconciliation for display, while preserving the underlying error chain for
+// errors.Is/errors.As consumers. The full reconciliation detail is shown in the
+// diagnostics report printed before this error is returned.
+type reconcileSummaryError struct {
+	summary string
+	cause   error
+}
+
+// Error returns the concise summary message.
+func (e *reconcileSummaryError) Error() string { return e.summary }
+
+// Unwrap exposes the underlying reconciliation error chain.
+func (e *reconcileSummaryError) Unwrap() error { return e.cause }
 
 // autoDetectGitOpsEngine detects the GitOps engine from the cluster.
 func autoDetectGitOpsEngine(
@@ -2480,6 +2527,14 @@ func resetStuckHelmReleases(
 	}
 }
 
+// errDependencyBlocked is the sentinel wrapped by cascade failures: a
+// kustomization that cannot reconcile because one of its dependencies already
+// failed. It deliberately does not embed the upstream error — repeating the
+// root-cause message at every level of a deep dependency chain is what made the
+// failure output unreadable. The upstream failure is reported on its own row in
+// the reconciliation diagnostics instead.
+var errDependencyBlocked = errors.New("blocked by failed dependency")
+
 // failedKustomizations tracks kustomizations that have permanently failed.
 // When an upstream kustomization fails, all dependents fail immediately
 // instead of waiting for the full timeout.
@@ -2492,20 +2547,14 @@ func (f *failedKustomizations) record(name string, err error) {
 	f.m.Store(name, err)
 }
 
-// checkDependencies returns an error if any dependency has permanently failed.
-// Returns nil if all dependencies are still healthy or pending.
+// checkDependencies returns an error if any dependency has already failed.
+// Returns nil if all dependencies are still healthy or pending. The error names
+// only the direct dependency that blocked this kustomization; the upstream
+// failure surfaces on its own diagnostics row, so it is not repeated here.
 func (f *failedKustomizations) checkDependencies(dependsOn []string) error {
 	for _, dep := range dependsOn {
-		if val, ok := f.m.Load(dep); ok {
-			depErr, ok := val.(error)
-			if !ok {
-				continue
-			}
-
-			return fmt.Errorf(
-				"dependency %q failed: %w - fix the upstream kustomization first",
-				dep, depErr,
-			)
+		if _, ok := f.m.Load(dep); ok {
+			return fmt.Errorf("%w %q", errDependencyBlocked, dep)
 		}
 	}
 
@@ -2563,7 +2612,7 @@ func reconcileFluxKustomizationsWithProgress(
 
 	err = ksGroup.Run(deadlineCtx, tasks...)
 	if err != nil {
-		return fmt.Errorf("reconcile kustomizations: %w", err)
+		return fmt.Errorf("%w: %w", errKustomizationReconcile, err)
 	}
 
 	return nil
@@ -2836,7 +2885,7 @@ func reconcileArgoCD(
 
 	err = appGroup.Run(deadlineCtx, tasks...)
 	if err != nil {
-		return fmt.Errorf("reconcile argocd applications: %w", err)
+		return fmt.Errorf("%w: %w", errApplicationReconcile, err)
 	}
 
 	return nil

--- a/pkg/cli/cmd/workload/workload_test.go
+++ b/pkg/cli/cmd/workload/workload_test.go
@@ -3083,7 +3083,11 @@ func TestFailedKustomizationsCheckDependenciesDirectFailure(t *testing.T) {
 	err := workload.ExportCheckKustomizationDependencies(&tracker, []string{"infra"})
 
 	require.Error(t, err)
-	require.ErrorIs(t, err, errUpstreamValidation)
+	// The cascade error names the direct dependency and wraps the shared
+	// sentinel, but deliberately does NOT embed the upstream error — repeating it
+	// at every level is what made the output unreadable.
+	require.ErrorIs(t, err, workload.ExportErrDependencyBlocked())
+	require.NotErrorIs(t, err, errUpstreamValidation)
 	assert.Contains(t, err.Error(), "infra")
 }
 
@@ -3103,12 +3107,14 @@ func TestFailedKustomizationsCheckDependenciesTransitivePropagation(t *testing.T
 	// …and records itself as failed (cascade).
 	workload.ExportRecordKustomizationFailure(&tracker, "infra", infraDepErr)
 
-	// apps depends on infra: it should also fail promptly.
+	// apps depends on infra: it should also fail promptly, naming its direct
+	// dependency ("infra") without dragging along the whole upstream chain.
 	appDepErr := workload.ExportCheckKustomizationDependencies(&tracker, []string{"infra"})
 
 	require.Error(t, appDepErr)
-	require.ErrorIs(t, appDepErr, infraDepErr)
+	require.ErrorIs(t, appDepErr, workload.ExportErrDependencyBlocked())
 	assert.Contains(t, appDepErr.Error(), "infra")
+	assert.NotContains(t, appDepErr.Error(), "flux-system")
 }
 
 func TestFailedKustomizationsCheckDependenciesNoDeps(t *testing.T) {
@@ -3168,4 +3174,20 @@ func TestPollUntilKustomizationReadyRecordsCascadeFailure(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "apps")
+}
+
+func TestIsAggregatedReconcileError(t *testing.T) {
+	t.Parallel()
+
+	// The aggregated kustomization/application errors are collapsed to the
+	// diagnostics summary; other errors keep their original message.
+	kustErr := fmt.Errorf(
+		"%w: infra: permanent failure",
+		workload.ExportErrKustomizationReconcile(),
+	)
+	retried := fmt.Errorf("failed after 3 attempts: %w", kustErr)
+
+	assert.True(t, workload.ExportIsAggregatedReconcileError(kustErr))
+	assert.True(t, workload.ExportIsAggregatedReconcileError(retried))
+	assert.False(t, workload.ExportIsAggregatedReconcileError(errGenericFailed))
 }

--- a/pkg/svc/reconcilediag/argocd.go
+++ b/pkg/svc/reconcilediag/argocd.go
@@ -45,7 +45,7 @@ func (c *ArgoCDCollector) Collect(ctx context.Context) *Report {
 // safeCollectCRs handles panic recovery (e.g., when CRDs are not installed) so
 // diagnostic collection never crashes the CLI.
 func (c *ArgoCDCollector) collectFailingApplications(ctx context.Context) ResourceSection {
-	section := ResourceSection{Heading: "Failing Applications"}
+	section := ResourceSection{Heading: "Applications"}
 
 	apps := safeCollectCRs(ctx, c.Dynamic, argoCDGVRApplications(), argoCDNamespace)
 

--- a/pkg/svc/reconcilediag/argocd_test.go
+++ b/pkg/svc/reconcilediag/argocd_test.go
@@ -108,7 +108,7 @@ func TestArgoCDCollector_FailingApplication_OperationError(t *testing.T) {
 	require.Len(t, report.Sections, 1)
 
 	section := report.Sections[0]
-	assert.Equal(t, "Failing Applications", section.Heading)
+	assert.Equal(t, "Applications", section.Heading)
 	require.Len(t, section.Resources, 1)
 	assert.Equal(t, "myapp", section.Resources[0].Name)
 	assert.Equal(t, "OperationState/Error", section.Resources[0].Reason)

--- a/pkg/svc/reconcilediag/diagnose.go
+++ b/pkg/svc/reconcilediag/diagnose.go
@@ -18,20 +18,22 @@ import (
 const diagnosticTimeout = 15 * time.Second
 
 // Diagnose collects and writes a targeted diagnostic report for a failed
-// GitOps reconciliation. It is best-effort: if client creation or collection
-// fails, the error is silently swallowed to avoid masking the original
-// reconciliation error.
+// GitOps reconciliation, returning the collected report (nil when none could be
+// gathered). It is best-effort: if client creation or collection fails, the
+// error is silently swallowed to avoid masking the original reconciliation
+// error. Callers may use the returned report's Summary to produce a concise
+// command error instead of dumping the full reconciliation error chain.
 func Diagnose(
 	ctx context.Context,
 	writer io.Writer,
 	kubeconfigPath string,
 	engine v1alpha1.GitOpsEngine,
-) {
+) *Report {
 	// Guard against unsupported engines before doing any filesystem or client
 	// work — diagnostics are only meaningful for Flux and ArgoCD clusters.
 	// This makes unsupported values a cheap no-op.
 	if engine != v1alpha1.GitOpsEngineFlux && engine != v1alpha1.GitOpsEngineArgoCD {
-		return
+		return nil
 	}
 
 	diagCtx, cancel := context.WithTimeout(ctx, diagnosticTimeout)
@@ -39,7 +41,7 @@ func Diagnose(
 
 	dynClient, clientset, err := buildDiagClients(kubeconfigPath)
 	if err != nil {
-		return
+		return nil
 	}
 
 	var report *Report
@@ -58,6 +60,8 @@ func Diagnose(
 	if report != nil {
 		report.Write(writer)
 	}
+
+	return report
 }
 
 // buildDiagClients creates the Kubernetes clients needed for diagnostics.

--- a/pkg/svc/reconcilediag/flux.go
+++ b/pkg/svc/reconcilediag/flux.go
@@ -57,11 +57,11 @@ func (c *FluxCollector) Collect(ctx context.Context) *Report {
 
 	report.Sections = append(
 		report.Sections,
-		c.collectFailingCRs(ctx, "Failing Kustomizations", fluxGVRKustomizations(), fluxNamespace),
-		c.collectFailingCRs(ctx, "Failing HelmReleases", fluxGVRHelmReleases(), ""),
+		c.collectFailingCRs(ctx, "Kustomizations", fluxGVRKustomizations(), fluxNamespace),
+		c.collectFailingCRs(ctx, "HelmReleases", fluxGVRHelmReleases(), ""),
 		c.collectFailingCRs(
 			ctx,
-			"Failing OCIRepositories",
+			"OCIRepositories",
 			fluxGVROCIRepositories(),
 			fluxNamespace,
 		),

--- a/pkg/svc/reconcilediag/flux_test.go
+++ b/pkg/svc/reconcilediag/flux_test.go
@@ -32,6 +32,8 @@ const (
 	helmReleasesHeading   = "HelmReleases"
 	dependencyNotReady    = "DependencyNotReady"
 	healthCheckFailed     = "HealthCheckFailed"
+	progressingReason     = "Progressing"
+	inProgressMsg         = "in progress"
 	infraDepNotReadyMsg   = "dependency 'flux-system/infrastructure' is not ready"
 )
 

--- a/pkg/svc/reconcilediag/flux_test.go
+++ b/pkg/svc/reconcilediag/flux_test.go
@@ -25,6 +25,14 @@ const (
 	messageField      = "message"
 	kustomizeAPIGroup = "kustomize.toolkit.fluxcd.io"
 	kustomizationKind = "Kustomization"
+
+	appsName              = "apps"
+	infraControllersName  = "infrastructure-controllers"
+	kustomizationsHeading = "Kustomizations"
+	helmReleasesHeading   = "HelmReleases"
+	dependencyNotReady    = "DependencyNotReady"
+	healthCheckFailed     = "HealthCheckFailed"
+	infraDepNotReadyMsg   = "dependency 'flux-system/infrastructure' is not ready"
 )
 
 // Flux GVRs used in tests.
@@ -137,7 +145,7 @@ func TestFluxCollector_FailingKustomization(t *testing.T) {
 	require.Len(t, report.Sections, 3)
 
 	kustSection := report.Sections[0]
-	assert.Equal(t, "Failing Kustomizations", kustSection.Heading)
+	assert.Equal(t, "Kustomizations", kustSection.Heading)
 	require.Len(t, kustSection.Resources, 1)
 	assert.Equal(t, "apps", kustSection.Resources[0].Name)
 	assert.Equal(t, "HealthCheckFailed", kustSection.Resources[0].Reason)
@@ -172,7 +180,7 @@ func TestFluxCollector_FailingHelmRelease(t *testing.T) {
 	require.False(t, report.IsEmpty())
 
 	hrSection := report.Sections[1]
-	assert.Equal(t, "Failing HelmReleases", hrSection.Heading)
+	assert.Equal(t, "HelmReleases", hrSection.Heading)
 	require.Len(t, hrSection.Resources, 1)
 	assert.Equal(t, "cert-manager", hrSection.Resources[0].Name)
 	assert.Equal(t, "cert-manager", hrSection.Resources[0].Namespace)
@@ -206,7 +214,7 @@ func TestFluxCollector_FailingOCIRepository(t *testing.T) {
 	require.False(t, report.IsEmpty())
 
 	ociSection := report.Sections[2]
-	assert.Equal(t, "Failing OCIRepositories", ociSection.Heading)
+	assert.Equal(t, "OCIRepositories", ociSection.Heading)
 	require.Len(t, ociSection.Resources, 1)
 	assert.Equal(t, "OCIPullFailed", ociSection.Resources[0].Reason)
 }

--- a/pkg/svc/reconcilediag/report.go
+++ b/pkg/svc/reconcilediag/report.go
@@ -3,11 +3,63 @@ package reconcilediag
 import (
 	"fmt"
 	"io"
+	"regexp"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
 )
+
+// resourceState classifies a failing resource for display. The state controls
+// the symbol shown, the sort order (roots before cascades), and whether the
+// resource counts as a root cause in the report summary.
+type resourceState int
+
+const (
+	// stateFailed is a resource that failed on its own (e.g., HealthCheckFailed).
+	stateFailed resourceState = iota
+	// stateProgressing is a resource still actively reconciling when the snapshot
+	// was taken (e.g., a Helm upgrade in progress) — a likely root cause.
+	stateProgressing
+	// stateBlocked is a resource waiting on an unready dependency. These are
+	// cascade fallout, not root causes, so they sort last and are de-emphasized.
+	stateBlocked
+)
+
+const (
+	// symbolFailed marks a resource that failed on its own.
+	symbolFailed = "✗"
+	// symbolProgressing marks a resource still reconciling.
+	symbolProgressing = "►"
+	// symbolBlocked marks a resource blocked on a dependency.
+	symbolBlocked = "·"
+)
+
+const (
+	// maxDetailLen caps the length of a cleaned condition/event message so a
+	// single verbose Flux message cannot blow up a row.
+	maxDetailLen = 100
+	// blockedReason is the Flux condition reason for a resource waiting on a
+	// dependency. Such resources are cascade fallout, not root causes.
+	blockedReason = "DependencyNotReady"
+	// rowIndent is the leading indent for each resource row.
+	rowIndent = "    "
+	// sectionIndent is the leading indent for a section heading.
+	sectionIndent = "  "
+)
+
+// dependencyMessageRe extracts the dependency name from a "DependencyNotReady"
+// message such as: dependency 'flux-system/infrastructure' is not ready.
+var dependencyMessageRe = regexp.MustCompile(`dependency '([^']+)'`)
+
+// fractionalSecondsRe strips sub-second precision from Go durations so
+// "25m0.04814184s" renders as "25m0s" instead of a wall of digits.
+var fractionalSecondsRe = regexp.MustCompile(`(\d+)\.\d+s`)
+
+// zeroSecondsRe trims a trailing "0s" left after a minutes component so
+// "25m0s" renders as "25m".
+var zeroSecondsRe = regexp.MustCompile(`(\d+m)0s\b`)
 
 // FailingResource describes a GitOps custom resource that is not ready.
 type FailingResource struct {
@@ -23,24 +75,147 @@ type FailingResource struct {
 
 // String returns a single-line description of the failing resource.
 func (f FailingResource) String() string {
-	prefix := f.Name
+	return f.displayName() + ": " + f.detail()
+}
+
+// displayName returns "namespace/name" when a namespace is set, otherwise "name".
+func (f FailingResource) displayName() string {
 	if f.Namespace != "" {
-		prefix = f.Namespace + "/" + f.Name
+		return f.Namespace + "/" + f.Name
 	}
 
-	if f.Reason != "" && f.Message != "" {
-		return fmt.Sprintf("%s: %s — %s", prefix, f.Reason, f.Message)
+	return f.Name
+}
+
+// state classifies the resource from its condition reason.
+func (f FailingResource) state() resourceState {
+	return classifyReason(f.Reason)
+}
+
+// detail returns the right-hand description shown after the resource name.
+// Blocked resources collapse to "blocked by <dependency>"; everything else
+// shows "<Reason> · <cleaned message>".
+func (f FailingResource) detail() string {
+	if f.state() == stateBlocked {
+		if dep := extractBlocker(f.Message); dep != "" {
+			return "blocked by " + dep
+		}
+
+		return "blocked (dependency not ready)"
 	}
 
-	if f.Reason != "" {
-		return fmt.Sprintf("%s: %s", prefix, f.Reason)
+	reason := f.Reason
+	message := cleanMessage(f.Message)
+
+	switch {
+	case reason != "" && message != "":
+		return reason + " · " + message
+	case reason != "":
+		return reason
+	case message != "":
+		return message
+	default:
+		return "not ready"
+	}
+}
+
+// classifyReason maps a condition reason to a display state.
+func classifyReason(reason string) resourceState {
+	switch {
+	case strings.Contains(reason, blockedReason):
+		return stateBlocked
+	case strings.Contains(reason, "Progress"):
+		return stateProgressing
+	default:
+		return stateFailed
+	}
+}
+
+// stateSymbol returns the leading symbol for a resource state.
+func stateSymbol(state resourceState) string {
+	switch state {
+	case stateProgressing:
+		return symbolProgressing
+	case stateBlocked:
+		return symbolBlocked
+	case stateFailed:
+		return symbolFailed
+	default:
+		return symbolFailed
+	}
+}
+
+// extractBlocker pulls the dependency name from a DependencyNotReady message
+// and strips the namespace prefix (e.g., "flux-system/infra" → "infra") so the
+// row reads "blocked by infra". Returns "" when no dependency is named.
+func extractBlocker(message string) string {
+	match := dependencyMessageRe.FindStringSubmatch(message)
+	if match == nil {
+		return ""
 	}
 
-	if f.Message != "" {
-		return fmt.Sprintf("%s: %s", prefix, f.Message)
+	dep := match[1]
+	if idx := strings.LastIndex(dep, "/"); idx >= 0 {
+		dep = dep[idx+1:]
 	}
 
-	return prefix + ": not ready"
+	return dep
+}
+
+// cleanMessage normalizes a condition or event message for compact display:
+// it collapses whitespace, compresses bracketed resource lists to a count,
+// strips sub-second duration precision, and truncates to maxDetailLen.
+func cleanMessage(message string) string {
+	cleaned := strings.Join(strings.Fields(message), " ")
+	cleaned = compressBracketList(cleaned)
+	cleaned = fractionalSecondsRe.ReplaceAllString(cleaned, "${1}s")
+	cleaned = zeroSecondsRe.ReplaceAllString(cleaned, "$1")
+	cleaned = strings.TrimSpace(cleaned)
+
+	return truncate(cleaned, maxDetailLen)
+}
+
+// compressBracketList replaces a verbose bracketed list such as
+// "[HelmRelease/a status: 'InProgress', HelmRelease/b status: 'InProgress']"
+// with a short "N resources" count. Messages without a bracketed list are
+// returned unchanged.
+func compressBracketList(message string) string {
+	open := strings.Index(message, "[")
+	if open < 0 {
+		return message
+	}
+
+	closeRel := strings.Index(message[open:], "]")
+	if closeRel < 0 {
+		return message
+	}
+
+	closeIdx := open + closeRel
+	inner := strings.TrimSpace(message[open+1 : closeIdx])
+
+	count := strings.Count(inner, "status:")
+	if count == 0 && inner != "" {
+		count = strings.Count(inner, ",") + 1
+	}
+
+	before := strings.TrimRight(message[:open], " :")
+	after := message[closeIdx+1:]
+
+	if count <= 0 {
+		return strings.TrimSpace(before + after)
+	}
+
+	return fmt.Sprintf("%s %d resources%s", before, count, after)
+}
+
+// truncate shortens text to at most maxLen runes, appending an ellipsis when cut.
+func truncate(text string, maxLen int) string {
+	runes := []rune(text)
+	if len(runes) <= maxLen {
+		return text
+	}
+
+	return string(runes[:maxLen-1]) + "…"
 }
 
 // WarningEvent describes a recent warning event from Kubernetes.
@@ -57,24 +232,34 @@ type WarningEvent struct {
 	Message string
 }
 
-// String returns a single-line description of the event.
-// When Namespace is set, the object is formatted as Kind/Namespace/Name.
+// String returns a compact single-line description of the event. The message is
+// cleaned (durations trimmed, resource lists compressed) and the object is shown
+// as Kind/Name; the namespace is omitted since events are grouped per namespace.
 func (e WarningEvent) String() string {
-	obj := e.Kind + "/" + e.Name
-	if e.Namespace != "" {
-		obj = e.Kind + "/" + e.Namespace + "/" + e.Name
-	}
-
-	return fmt.Sprintf("%s ago: %s — %s", formatDuration(e.Age), obj, e.Message)
+	return fmt.Sprintf(
+		"%s ago  %s/%s  %s",
+		formatDuration(e.Age),
+		e.Kind,
+		e.Name,
+		cleanMessage(e.Message),
+	)
 }
 
 // ResourceSection groups failing resources under a heading.
 type ResourceSection struct {
-	// Heading describes the resource type (e.g., "Failing Kustomizations").
+	// Heading describes the resource type (e.g., "Kustomizations").
 	Heading string
 	// Resources are the failing resources in this section.
 	Resources []FailingResource
 }
+
+const (
+	// defaultEventLookback is the default lookback window for warning events.
+	// Both FluxCollector and ArgoCDCollector use this value.
+	defaultEventLookback = 5 * time.Minute
+	// maxDiagnosticEvents limits the number of warning events shown.
+	maxDiagnosticEvents = 20
+)
 
 // Report holds the collected diagnostic data for a failed reconciliation.
 type Report struct {
@@ -93,6 +278,10 @@ type Report struct {
 
 // IsEmpty returns true when the report contains no diagnostic data.
 func (r *Report) IsEmpty() bool {
+	if r == nil {
+		return true
+	}
+
 	for _, s := range r.Sections {
 		if len(s.Resources) > 0 {
 			return false
@@ -102,14 +291,6 @@ func (r *Report) IsEmpty() bool {
 	return strings.TrimSpace(r.FailingPods) == "" && len(r.Events) == 0
 }
 
-const (
-	// defaultEventLookback is the default lookback window for warning events.
-	// Both FluxCollector and ArgoCDCollector use this value.
-	defaultEventLookback = 5 * time.Minute
-	// maxDiagnosticEvents limits the number of warning events shown.
-	maxDiagnosticEvents = 20
-)
-
 // Write writes the diagnostic report to the given writer using the
 // notify package for consistent styling.
 func (r *Report) Write(writer io.Writer) {
@@ -117,29 +298,74 @@ func (r *Report) Write(writer io.Writer) {
 		return
 	}
 
-	notify.WriteMessage(notify.Message{
-		Type:    notify.TitleType,
-		Emoji:   "🩺",
-		Content: "Reconciliation Diagnostics",
-		Writer:  writer,
-	})
+	notify.Errorf(writer, "🩺 Reconciliation failed")
 
-	r.writeSections(writer)
+	nameWidth := r.nameColumnWidth()
+
+	r.writeSections(writer, nameWidth)
 	r.writeFailingPods(writer)
 	r.writeEvents(writer)
 }
 
-// writeSections writes the failing resource sections.
-func (r *Report) writeSections(writer io.Writer) {
+// Summary returns a concise one-line description of the failure suitable for
+// use as the command's returned error. Root causes (resources that failed or
+// are still reconciling) are named; cascade fallout is reduced to a count.
+// Returns "" when the report holds no actionable resource data.
+func (r *Report) Summary() string {
+	if r.IsEmpty() {
+		return ""
+	}
+
+	var roots []FailingResource
+
+	blocked := 0
+
+	for _, section := range r.Sections {
+		for _, res := range section.Resources {
+			if res.state() == stateBlocked {
+				blocked++
+
+				continue
+			}
+
+			roots = append(roots, res)
+		}
+	}
+
+	return formatSummary(sortedResources(roots), blocked)
+}
+
+// nameColumnWidth returns the display width to pad resource names to, so the
+// detail column aligns across every section in the report.
+func (r *Report) nameColumnWidth() int {
+	width := 0
+
+	for _, section := range r.Sections {
+		for _, res := range section.Resources {
+			if n := len([]rune(res.displayName())); n > width {
+				width = n
+			}
+		}
+	}
+
+	return width
+}
+
+// writeSections writes the failing resource sections, roots before cascades.
+func (r *Report) writeSections(writer io.Writer, nameWidth int) {
 	for _, section := range r.Sections {
 		if len(section.Resources) == 0 {
 			continue
 		}
 
-		notify.Errorf(writer, "%s:", section.Heading)
+		_, _ = fmt.Fprintf(writer, "\n%s%s\n", sectionIndent, section.Heading)
 
-		for _, res := range section.Resources {
-			_, _ = fmt.Fprintf(writer, "    %s\n", res.String())
+		for _, res := range sortedResources(section.Resources) {
+			_, _ = fmt.Fprintf(
+				writer,
+				"%s%s %-*s  %s\n",
+				rowIndent, stateSymbol(res.state()), nameWidth, res.displayName(), res.detail(),
+			)
 		}
 	}
 }
@@ -150,6 +376,8 @@ func (r *Report) writeFailingPods(writer io.Writer) {
 		return
 	}
 
+	_, _ = fmt.Fprintln(writer)
+
 	if r.EventNamespace != "" {
 		notify.Warningf(writer, "failing pods (%s):", r.EventNamespace)
 	} else {
@@ -159,7 +387,7 @@ func (r *Report) writeFailingPods(writer io.Writer) {
 	for line := range strings.SplitSeq(strings.TrimSpace(r.FailingPods), "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
-			_, _ = fmt.Fprintf(writer, "    %s\n", line)
+			_, _ = fmt.Fprintf(writer, "%s%s\n", rowIndent, line)
 		}
 	}
 }
@@ -170,6 +398,8 @@ func (r *Report) writeEvents(writer io.Writer) {
 		return
 	}
 
+	_, _ = fmt.Fprintln(writer)
+
 	lookback := r.EventLookback
 	if lookback <= 0 {
 		lookback = defaultEventLookback
@@ -178,12 +408,12 @@ func (r *Report) writeEvents(writer io.Writer) {
 	var label string
 	if r.EventNamespace != "" {
 		label = fmt.Sprintf(
-			"warning events (%s, last %s)",
+			"recent warnings (%s, last %s)",
 			r.EventNamespace,
 			formatDuration(lookback),
 		)
 	} else {
-		label = fmt.Sprintf("warning events (last %s)", formatDuration(lookback))
+		label = fmt.Sprintf("recent warnings (last %s)", formatDuration(lookback))
 	}
 
 	notify.Warningf(writer, "%s:", label)
@@ -191,16 +421,122 @@ func (r *Report) writeEvents(writer io.Writer) {
 	limit := min(len(r.Events), maxDiagnosticEvents)
 
 	for _, evt := range r.Events[:limit] {
-		_, _ = fmt.Fprintf(writer, "    %s\n", evt.String())
+		_, _ = fmt.Fprintf(writer, "%s%s\n", rowIndent, evt.String())
 	}
 
 	if len(r.Events) > maxDiagnosticEvents {
 		_, _ = fmt.Fprintf(
 			writer,
-			"    ... and %d more events\n",
+			"%s... and %d more events\n",
+			rowIndent,
 			len(r.Events)-maxDiagnosticEvents,
 		)
 	}
+}
+
+// sortedResources returns the resources ordered by state (failed, then
+// progressing, then blocked) so root causes appear above the cascade fallout
+// that depends on them. Blocked resources are further ordered by how deep they
+// sit in the dependency chain — a resource appears below whatever it is blocked
+// by — and then alphabetically.
+func sortedResources(resources []FailingResource) []FailingResource {
+	sorted := slices.Clone(resources)
+	depth := blockedDepths(sorted)
+
+	slices.SortFunc(sorted, func(left, right FailingResource) int {
+		if sl, sr := left.state(), right.state(); sl != sr {
+			return int(sl) - int(sr)
+		}
+
+		if left.state() == stateBlocked {
+			if dl, dr := depth[left.Name], depth[right.Name]; dl != dr {
+				return dl - dr
+			}
+		}
+
+		return strings.Compare(left.displayName(), right.displayName())
+	})
+
+	return sorted
+}
+
+// blockedDepths returns, for each blocked resource, the number of blocked
+// ancestors above it in the dependency chain (0 = blocked directly by a
+// root/non-blocked resource). The walk is bounded by the number of blocked
+// resources so a dependency cycle cannot loop forever.
+func blockedDepths(resources []FailingResource) map[string]int {
+	blocker := make(map[string]string)
+	blocked := make(map[string]bool)
+
+	for _, res := range resources {
+		if res.state() == stateBlocked {
+			blocked[res.Name] = true
+			blocker[res.Name] = extractBlocker(res.Message)
+		}
+	}
+
+	depth := make(map[string]int, len(blocked))
+
+	for name := range blocked {
+		steps, cur := 0, name
+
+		for range len(blocked) {
+			parent := blocker[cur]
+			if parent == "" || !blocked[parent] {
+				break
+			}
+
+			steps++
+			cur = parent
+		}
+
+		depth[name] = steps
+	}
+
+	return depth
+}
+
+// formatSummary builds the summary string from the root causes and the number
+// of blocked dependents.
+func formatSummary(roots []FailingResource, blocked int) string {
+	switch len(roots) {
+	case 0:
+		if blocked > 0 {
+			return fmt.Sprintf("reconciliation failed: %d resources not ready", blocked)
+		}
+
+		return "reconciliation failed — see diagnostics above"
+	case 1:
+		msg := "reconciliation failed: " + roots[0].displayName()
+		if reason := roots[0].Reason; reason != "" {
+			msg += " (" + reason + ")"
+		}
+
+		return msg + blockedSuffix(blocked)
+	default:
+		names := make([]string, len(roots))
+		for i, res := range roots {
+			names[i] = res.displayName()
+		}
+
+		return fmt.Sprintf(
+			"reconciliation failed: %d resources not ready (%s)%s",
+			len(roots), strings.Join(names, ", "), blockedSuffix(blocked),
+		)
+	}
+}
+
+// blockedSuffix returns the trailing "; N dependent(s) blocked" clause, or "".
+func blockedSuffix(blocked int) string {
+	if blocked <= 0 {
+		return ""
+	}
+
+	if blocked == 1 {
+		return "; 1 dependent blocked"
+	}
+
+	return fmt.Sprintf("; %d dependents blocked", blocked)
 }
 
 // minutesPerHour is used for duration formatting calculations.

--- a/pkg/svc/reconcilediag/report.go
+++ b/pkg/svc/reconcilediag/report.go
@@ -162,6 +162,22 @@ func extractBlocker(message string) string {
 	return dep
 }
 
+// dependencyKey pulls the dependency reference from a DependencyNotReady message
+// as a key that matches the dependency's displayName: the Flux default namespace
+// ("flux-system/") prefix is stripped so default-namespace resources match their
+// bare displayName, while any other namespace is preserved so same-named
+// resources in different namespaces stay distinct. Returns "" when no dependency
+// is named. Used for dependency-depth ordering; extractBlocker is used for the
+// (intentionally bare) "blocked by" row text.
+func dependencyKey(message string) string {
+	match := dependencyMessageRe.FindStringSubmatch(message)
+	if match == nil {
+		return ""
+	}
+
+	return strings.TrimPrefix(match[1], fluxNamespace+"/")
+}
+
 // cleanMessage normalizes a condition or event message for compact display:
 // it collapses whitespace, compresses bracketed resource lists to a count,
 // strips sub-second duration precision, and truncates to maxDetailLen.
@@ -449,7 +465,7 @@ func sortedResources(resources []FailingResource) []FailingResource {
 		}
 
 		if left.state() == stateBlocked {
-			if dl, dr := depth[left.Name], depth[right.Name]; dl != dr {
+			if dl, dr := depth[left.displayName()], depth[right.displayName()]; dl != dr {
 				return dl - dr
 			}
 		}
@@ -460,18 +476,20 @@ func sortedResources(resources []FailingResource) []FailingResource {
 	return sorted
 }
 
-// blockedDepths returns, for each blocked resource, the number of blocked
-// ancestors above it in the dependency chain (0 = blocked directly by a
-// root/non-blocked resource). The walk is bounded by the number of blocked
-// resources so a dependency cycle cannot loop forever.
+// blockedDepths returns, for each blocked resource (keyed by displayName), the
+// number of blocked ancestors above it in the dependency chain (0 = blocked
+// directly by a root/non-blocked resource). Keying by displayName and matching
+// edges via dependencyKey keeps same-named resources in different namespaces
+// distinct. The walk is bounded by the number of blocked resources so a
+// dependency cycle cannot loop forever.
 func blockedDepths(resources []FailingResource) map[string]int {
 	blocker := make(map[string]string)
 	blocked := make(map[string]bool)
 
 	for _, res := range resources {
 		if res.state() == stateBlocked {
-			blocked[res.Name] = true
-			blocker[res.Name] = extractBlocker(res.Message)
+			blocked[res.displayName()] = true
+			blocker[res.displayName()] = dependencyKey(res.Message)
 		}
 	}
 
@@ -502,7 +520,7 @@ func formatSummary(roots []FailingResource, blocked int) string {
 	switch len(roots) {
 	case 0:
 		if blocked > 0 {
-			return fmt.Sprintf("reconciliation failed: %d resources not ready", blocked)
+			return "reconciliation failed: " + pluralizeResources(blocked) + " not ready"
 		}
 
 		return "reconciliation failed — see diagnostics above"
@@ -520,10 +538,19 @@ func formatSummary(roots []FailingResource, blocked int) string {
 		}
 
 		return fmt.Sprintf(
-			"reconciliation failed: %d resources not ready (%s)%s",
-			len(roots), strings.Join(names, ", "), blockedSuffix(blocked),
+			"reconciliation failed: %s not ready (%s)%s",
+			pluralizeResources(len(roots)), strings.Join(names, ", "), blockedSuffix(blocked),
 		)
 	}
+}
+
+// pluralizeResources returns "1 resource" or "N resources" with correct grammar.
+func pluralizeResources(count int) string {
+	if count == 1 {
+		return "1 resource"
+	}
+
+	return fmt.Sprintf("%d resources", count)
 }
 
 // blockedSuffix returns the trailing "; N dependent(s) blocked" clause, or "".

--- a/pkg/svc/reconcilediag/report_test.go
+++ b/pkg/svc/reconcilediag/report_test.go
@@ -2,21 +2,37 @@ package reconcilediag_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/reconcilediag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestFailingResource_String(t *testing.T) {
+// failingResourceStringCase is one FailingResource.String scenario.
+type failingResourceStringCase struct {
+	name     string
+	resource reconcilediag.FailingResource
+	want     string
+}
+
+func runFailingResourceStringCases(t *testing.T, cases []failingResourceStringCase) {
+	t.Helper()
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.resource.String())
+		})
+	}
+}
+
+func TestFailingResource_String_WithDetail(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name     string
-		resource reconcilediag.FailingResource
-		want     string
-	}{
+	runFailingResourceStringCases(t, []failingResourceStringCase{
 		{
 			name: "reason and message",
 			resource: reconcilediag.FailingResource{
@@ -24,7 +40,7 @@ func TestFailingResource_String(t *testing.T) {
 				Reason:  "ReconciliationFailed",
 				Message: "validation error",
 			},
-			want: "flux-system: ReconciliationFailed — validation error",
+			want: "flux-system: ReconciliationFailed · validation error",
 		},
 		{
 			name: "with namespace",
@@ -34,39 +50,40 @@ func TestFailingResource_String(t *testing.T) {
 				Reason:    "InstallFailed",
 				Message:   "timeout",
 			},
-			want: "cert-manager/cert-manager: InstallFailed — timeout",
+			want: "cert-manager/cert-manager: InstallFailed · timeout",
 		},
 		{
-			name: "reason only",
+			name: "blocked by dependency",
 			resource: reconcilediag.FailingResource{
-				Name:   "apps",
-				Reason: "HealthCheckFailed",
+				Name:    appsName,
+				Reason:  dependencyNotReady,
+				Message: infraDepNotReadyMsg,
 			},
-			want: "apps: HealthCheckFailed",
+			want: "apps: blocked by infrastructure",
 		},
-		{
-			name: "message only",
-			resource: reconcilediag.FailingResource{
-				Name:    "infra",
-				Message: "dependency not ready",
-			},
-			want: "infra: dependency not ready",
-		},
-		{
-			name: "no reason or message",
-			resource: reconcilediag.FailingResource{
-				Name: "unknown",
-			},
-			want: "unknown: not ready",
-		},
-	}
+	})
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, tt.resource.String())
-		})
-	}
+func TestFailingResource_String_Fallbacks(t *testing.T) {
+	t.Parallel()
+
+	runFailingResourceStringCases(t, []failingResourceStringCase{
+		{
+			name:     "reason only",
+			resource: reconcilediag.FailingResource{Name: appsName, Reason: healthCheckFailed},
+			want:     "apps: HealthCheckFailed",
+		},
+		{
+			name:     "message only",
+			resource: reconcilediag.FailingResource{Name: "infra", Message: "dependency not ready"},
+			want:     "infra: dependency not ready",
+		},
+		{
+			name:     "no reason or message",
+			resource: reconcilediag.FailingResource{Name: "unknown"},
+			want:     "unknown: not ready",
+		},
+	})
 }
 
 func TestWarningEvent_String(t *testing.T) {
@@ -79,12 +96,14 @@ func TestWarningEvent_String(t *testing.T) {
 		Message: "Back-off restarting (BackOff)",
 	}
 
-	assert.Equal(t, "3m ago: Pod/controller-abc — Back-off restarting (BackOff)", evt.String())
+	assert.Equal(t, "3m ago  Pod/controller-abc  Back-off restarting (BackOff)", evt.String())
 }
 
-func TestWarningEvent_String_WithNamespace(t *testing.T) {
+func TestWarningEvent_String_OmitsNamespace(t *testing.T) {
 	t.Parallel()
 
+	// Events are grouped under a per-namespace heading, so the involved object's
+	// namespace is intentionally omitted from each line.
 	evt := reconcilediag.WarningEvent{
 		Age:       3 * time.Minute,
 		Kind:      podKind,
@@ -95,7 +114,7 @@ func TestWarningEvent_String_WithNamespace(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"3m ago: Pod/flux-system/controller-abc — Back-off restarting (BackOff)",
+		"3m ago  Pod/controller-abc  Back-off restarting (BackOff)",
 		evt.String(),
 	)
 }
@@ -110,7 +129,7 @@ func TestWarningEvent_String_Seconds(t *testing.T) {
 		Message: "install retries exhausted (Failed)",
 	}
 
-	assert.Equal(t, "45s ago: HelmRelease/nginx — install retries exhausted (Failed)", evt.String())
+	assert.Equal(t, "45s ago  HelmRelease/nginx  install retries exhausted (Failed)", evt.String())
 }
 
 func TestWarningEvent_String_Hours(t *testing.T) {
@@ -123,7 +142,29 @@ func TestWarningEvent_String_Hours(t *testing.T) {
 		Message: "OOMKilled (OOMKilled)",
 	}
 
-	assert.Equal(t, "1h30m ago: Pod/source-controller-xyz — OOMKilled (OOMKilled)", evt.String())
+	assert.Equal(t, "1h30m ago  Pod/source-controller-xyz  OOMKilled (OOMKilled)", evt.String())
+}
+
+func TestWarningEvent_String_ShortensVerboseMessage(t *testing.T) {
+	t.Parallel()
+
+	// A real Flux health-check timeout message: sub-second precision is trimmed
+	// and the bracketed resource list collapses to a count.
+	evt := reconcilediag.WarningEvent{
+		Age:  0,
+		Kind: "Kustomization",
+		Name: infraControllersName,
+		Message: "health check failed after 25m0.04814184s: timeout waiting for: " +
+			"[HelmRelease/opencost/opencost status: 'InProgress', " +
+			"HelmRelease/monitoring/loki status: 'InProgress'] (HealthCheckFailed)",
+	}
+
+	got := evt.String()
+	assert.Contains(t, got, "0s ago  Kustomization/infrastructure-controllers")
+	assert.Contains(t, got, "health check failed after 25m")
+	assert.Contains(t, got, "2 resources")
+	assert.NotContains(t, got, "0.04814184")
+	assert.NotContains(t, got, "InProgress")
 }
 
 func TestReport_IsEmpty_WhenTrue(t *testing.T) {
@@ -224,17 +265,17 @@ func TestReport_Write_FullReport(t *testing.T) {
 	report := &reconcilediag.Report{
 		Sections: []reconcilediag.ResourceSection{
 			{
-				Heading: "Failing Kustomizations",
+				Heading: kustomizationsHeading,
 				Resources: []reconcilediag.FailingResource{
 					{
-						Name:    "apps",
-						Reason:  "HealthCheckFailed",
+						Name:    appsName,
+						Reason:  healthCheckFailed,
 						Message: "Deployment/myapp not ready",
 					},
 				},
 			},
 			{
-				Heading:   "Failing HelmReleases",
+				Heading:   helmReleasesHeading,
 				Resources: nil,
 			},
 		},
@@ -249,12 +290,170 @@ func TestReport_Write_FullReport(t *testing.T) {
 	report.Write(&buf)
 
 	output := buf.String()
-	assert.Contains(t, output, "Reconciliation Diagnostics")
-	assert.Contains(t, output, "Failing Kustomizations")
-	assert.Contains(t, output, "apps: HealthCheckFailed")
-	assert.NotContains(t, output, "Failing HelmReleases")
+	assert.Contains(t, output, "Reconciliation failed")
+	assert.Contains(t, output, kustomizationsHeading)
+	assert.Contains(t, output, "✗ apps")
+	assert.Contains(t, output, "HealthCheckFailed · Deployment/myapp not ready")
+	// HelmReleases section is empty, so its heading must not be printed.
+	assert.NotContains(t, output, helmReleasesHeading)
 	assert.Contains(t, output, "failing pods")
 	assert.Contains(t, output, "CrashLoopBackOff")
-	assert.Contains(t, output, "warning events")
+	assert.Contains(t, output, "recent warnings")
 	assert.Contains(t, output, "Back-off")
+}
+
+func TestReport_Write_OrdersRootsBeforeCascades(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	// apps → infrastructure → infrastructure-controllers (the active root).
+	// Despite the input being shuffled, the output must list the root first and
+	// each blocked resource below whatever it is blocked by.
+	report := &reconcilediag.Report{
+		Sections: []reconcilediag.ResourceSection{{
+			Heading: kustomizationsHeading,
+			Resources: []reconcilediag.FailingResource{
+				{
+					Name:    appsName,
+					Reason:  dependencyNotReady,
+					Message: infraDepNotReadyMsg,
+				},
+				{
+					Name:    "infrastructure",
+					Reason:  dependencyNotReady,
+					Message: "dependency 'flux-system/infrastructure-controllers' is not ready",
+				},
+				{Name: infraControllersName, Reason: "Progressing", Message: "in progress"},
+			},
+		}},
+	}
+
+	report.Write(&buf)
+	output := buf.String()
+
+	rootIdx := strings.Index(output, "► infrastructure-controllers")
+	infraIdx := strings.Index(output, "· infrastructure ")
+	appsIdx := strings.Index(output, "· apps")
+
+	require.NotEqual(t, -1, rootIdx)
+	require.NotEqual(t, -1, infraIdx)
+	require.NotEqual(t, -1, appsIdx)
+	assert.Less(t, rootIdx, infraIdx, "active root must come before its dependents")
+	assert.Less(t, infraIdx, appsIdx, "a resource must appear below what it is blocked by")
+}
+
+// reportSummaryCase is one Report.Summary scenario.
+type reportSummaryCase struct {
+	name   string
+	report reconcilediag.Report
+	want   string
+}
+
+// kustSection builds a single-section report holding the given Kustomizations.
+func kustSection(resources ...reconcilediag.FailingResource) reconcilediag.Report {
+	return reconcilediag.Report{
+		Sections: []reconcilediag.ResourceSection{
+			{Heading: kustomizationsHeading, Resources: resources},
+		},
+	}
+}
+
+func runReportSummaryCases(t *testing.T, cases []reportSummaryCase) {
+	t.Helper()
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.report.Summary())
+		})
+	}
+}
+
+func TestReport_Summary_NamesRoots(t *testing.T) {
+	t.Parallel()
+
+	runReportSummaryCases(t, []reportSummaryCase{
+		{
+			name:   "empty report",
+			report: reconcilediag.Report{},
+			want:   "",
+		},
+		{
+			name: "single root with reason",
+			report: kustSection(
+				reconcilediag.FailingResource{
+					Name:    appsName,
+					Reason:  healthCheckFailed,
+					Message: "timed out",
+				},
+			),
+			want: "reconciliation failed: apps (HealthCheckFailed)",
+		},
+		{
+			name: "multiple roots",
+			report: reconcilediag.Report{
+				Sections: []reconcilediag.ResourceSection{{
+					Heading: helmReleasesHeading,
+					Resources: []reconcilediag.FailingResource{
+						{Name: "loki", Namespace: "monitoring", Reason: "UpgradeFailed"},
+						{Name: "alloy", Namespace: "monitoring", Reason: "InstallFailed"},
+					},
+				}},
+			},
+			want: "reconciliation failed: 2 resources not ready (monitoring/alloy, monitoring/loki)",
+		},
+	})
+}
+
+func TestReport_Summary_CountsBlockedAndFallbacks(t *testing.T) {
+	t.Parallel()
+
+	runReportSummaryCases(t, []reportSummaryCase{
+		{
+			name: "root with blocked dependents",
+			report: kustSection(
+				reconcilediag.FailingResource{
+					Name:    infraControllersName,
+					Reason:  "Progressing",
+					Message: "in progress",
+				},
+				reconcilediag.FailingResource{
+					Name:    "infrastructure",
+					Reason:  dependencyNotReady,
+					Message: "dependency 'flux-system/infrastructure-controllers' is not ready",
+				},
+				reconcilediag.FailingResource{
+					Name:    appsName,
+					Reason:  dependencyNotReady,
+					Message: infraDepNotReadyMsg,
+				},
+			),
+			want: "reconciliation failed: infrastructure-controllers (Progressing); 2 dependents blocked",
+		},
+		{
+			name: "only blocked",
+			report: kustSection(
+				reconcilediag.FailingResource{
+					Name:    appsName,
+					Reason:  dependencyNotReady,
+					Message: "dependency 'x' is not ready",
+				},
+			),
+			want: "reconciliation failed: 1 resources not ready",
+		},
+		{
+			name:   "pods only, no resources",
+			report: reconcilediag.Report{FailingPods: "controller-abc: CrashLoopBackOff"},
+			want:   "reconciliation failed — see diagnostics above",
+		},
+	})
+}
+
+func TestReport_Summary_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var report *reconcilediag.Report
+
+	assert.Empty(t, report.Summary())
 }

--- a/pkg/svc/reconcilediag/report_test.go
+++ b/pkg/svc/reconcilediag/report_test.go
@@ -324,7 +324,7 @@ func TestReport_Write_OrdersRootsBeforeCascades(t *testing.T) {
 					Reason:  dependencyNotReady,
 					Message: "dependency 'flux-system/infrastructure-controllers' is not ready",
 				},
-				{Name: infraControllersName, Reason: "Progressing", Message: "in progress"},
+				{Name: infraControllersName, Reason: progressingReason, Message: inProgressMsg},
 			},
 		}},
 	}
@@ -341,6 +341,60 @@ func TestReport_Write_OrdersRootsBeforeCascades(t *testing.T) {
 	require.NotEqual(t, -1, appsIdx)
 	assert.Less(t, rootIdx, infraIdx, "active root must come before its dependents")
 	assert.Less(t, infraIdx, appsIdx, "a resource must appear below what it is blocked by")
+}
+
+func TestReport_Write_OrdersSameNameAcrossNamespaces(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	// Two HelmReleases share the name "app" in different namespaces. Depth must be
+	// keyed by displayName (namespace-qualified), not the bare Name — otherwise the
+	// two collide and "a/app" (deeper) would sort above "z/app" (shallower) on the
+	// alphabetical tiebreak. Chain: shared/base (root) → z/app → a/app.
+	report := &reconcilediag.Report{
+		Sections: []reconcilediag.ResourceSection{{
+			Heading: helmReleasesHeading,
+			Resources: []reconcilediag.FailingResource{
+				{
+					Name:      "app",
+					Namespace: "a",
+					Reason:    dependencyNotReady,
+					Message:   "dependency 'z/app' is not ready",
+				},
+				{
+					Name:      "app",
+					Namespace: "z",
+					Reason:    dependencyNotReady,
+					Message:   "dependency 'shared/base' is not ready",
+				},
+				{
+					Name:      "base",
+					Namespace: "shared",
+					Reason:    progressingReason,
+					Message:   inProgressMsg,
+				},
+			},
+		}},
+	}
+
+	report.Write(&buf)
+	output := buf.String()
+
+	rootIdx := strings.Index(output, "► shared/base")
+	zIdx := strings.Index(output, "· z/app")
+	aIdx := strings.Index(output, "· a/app")
+
+	require.NotEqual(t, -1, rootIdx)
+	require.NotEqual(t, -1, zIdx)
+	require.NotEqual(t, -1, aIdx)
+	assert.Less(t, rootIdx, zIdx, "active root must come first")
+	assert.Less(
+		t,
+		zIdx,
+		aIdx,
+		"z/app (depth 0) must precede a/app (depth 1) despite the alphabetical tiebreak",
+	)
 }
 
 // reportSummaryCase is one Report.Summary scenario.
@@ -415,8 +469,8 @@ func TestReport_Summary_CountsBlockedAndFallbacks(t *testing.T) {
 			report: kustSection(
 				reconcilediag.FailingResource{
 					Name:    infraControllersName,
-					Reason:  "Progressing",
-					Message: "in progress",
+					Reason:  progressingReason,
+					Message: inProgressMsg,
 				},
 				reconcilediag.FailingResource{
 					Name:    "infrastructure",
@@ -440,7 +494,7 @@ func TestReport_Summary_CountsBlockedAndFallbacks(t *testing.T) {
 					Message: "dependency 'x' is not ready",
 				},
 			),
-			want: "reconciliation failed: 1 resources not ready",
+			want: "reconciliation failed: 1 resource not ready",
 		},
 		{
 			name:   "pods only, no resources",


### PR DESCRIPTION
## What

Redesigns the output of a failed `ksail workload reconcile` so it's concise, actionable, and easy to read. The old output buried one real failure under heavy duplication.

### Before
The leaf failure message printed up to **4×** and the dependency chain was re-narrated as a deeply nested error:

```
✗ 🩺 Reconciliation Diagnostics
  ✗ Failing Kustomizations:
      apps: DependencyNotReady — dependency 'flux-system/infrastructure' is not ready
      infrastructure: DependencyNotReady — dependency 'flux-system/infrastructure-controllers' is not ready
      infrastructure-controllers: Progressing — Reconciliation in progress
  ✗ Failing HelmReleases:
      monitoring/alloy: DependencyNotReady — dependency 'monitoring/loki' is not ready
      ...
  ⚠ warning events (flux-system, last 5m):
      0s ago: Kustomization/flux-system/infrastructure-controllers — health check failed after 25m0.04814184s: timeout waiting for: [HelmRelease/opencost/opencost status: 'InProgress', HelmRelease/monitoring/alloy-audit status: 'InProgress', HelmRelease/monitoring/alloy status: 'InProgress', HelmRelease/monitoring/loki status: 'InProgress', HelmRelease/monitoring/kube-prometheus-stack status: 'InProgress'] (HealthCheckFailed)
  Error: reconcile kustomizations: infrastructure-controllers: permanent failure: ... HealthCheckFailed - health check failed after 25m... timeout waiting for: [ ...5 HelmReleases... ]
  infrastructure: dependency "infrastructure-controllers" failed: ... - fix the upstream kustomization first
  apps: dependency "infrastructure" failed: dependency "infrastructure-controllers" failed: ... - fix the upstream kustomization first - fix the upstream kustomization first
```

### After

```
✗ 🩺 Reconciliation failed

  Kustomizations
    ► infrastructure-controllers        Progressing · Reconciliation in progress
    · infrastructure                    blocked by infrastructure-controllers
    · apps                              blocked by infrastructure

  HelmReleases
    ► monitoring/kube-prometheus-stack  Progressing · Running 'upgrade' action with timeout of 15m
    · monitoring/loki                   blocked by kube-prometheus-stack
    · opencost/opencost                 blocked by kube-prometheus-stack
    · monitoring/alloy                  blocked by loki
    · monitoring/alloy-audit            blocked by loki

⚠ recent warnings (flux-system, last 5m):
    0s ago  Kustomization/infrastructure-controllers  health check failed after 25m: timeout waiting for 5 resources (HealthCheckFailed)

✗ reconciliation failed: 2 resources not ready (infrastructure-controllers, monitoring/kube-prometheus-stack); 6 dependents blocked
```

## Why — three root causes

1. **Cascade-error nesting bug** (`checkDependencies`): each blocked kustomization embedded the *entire* upstream error via `%w` and re-appended `- fix the upstream kustomization first`, so a deep chain repeated the same root-cause text at every level (and doubled the hint). It now wraps a shared sentinel naming only the **direct** dependency; the upstream failure surfaces on its own diagnostics row.
2. **The report was captured into the error.** The `errorhandler.Executor` redirects stderr into a buffer and re-emits it as the command error, so the whole report was bundled and re-indented under one leading `✗`. The report now renders to **stdout** (alongside the rest of the command's progress UI), and the verbose joined reconcile error is replaced by a concise `Report.Summary()` one-liner. More specific errors (e.g. the OCIRepository "push an artifact" hint) keep their original message — only the aggregated per-resource failures are summarized.
3. **No root-cause vs. cascade distinction.** The report is now a state-classified, column-aligned tree: real failures (`✗`) and in-progress roots (`►`) sort above dependency-blocked items (`·`), which collapse to `blocked by <dep>` and are ordered by dependency depth. Verbose Flux messages are compacted (sub-second durations trimmed; bracketed resource lists reduced to a count).

## Changed files
- `pkg/svc/reconcilediag/report.go` — state classification, sorting, alignment, message cleaning, `Summary()`.
- `pkg/svc/reconcilediag/{flux,argocd}.go` — short section headings (`Kustomizations` etc.).
- `pkg/svc/reconcilediag/diagnose.go` — `Diagnose` returns `*Report`.
- `pkg/cli/cmd/workload/workload.go` — sentinel-based cascade error, report→stdout, concise summary error.

## Reviewer notes
- **Behavioral change:** cascade errors no longer satisfy `errors.Is(blockedErr, upstreamErr)` — that deep chaining *was* the duplication. No production code relied on it; the two affected unit tests are updated.
- The `⚠ recent warnings` section is kept (shortened) because it's the only place the actual `HealthCheckFailed` timeout surfaces when the live CR snapshot has already cycled back to `Progressing`. Trivial to drop if preferred.

## Validation
- `go build` ✓
- `go test ./...` — **6112 passed, 0 failed**
- `golangci-lint run --new-from-rev=HEAD` on both touched packages — **0 issues** (full-run `funlen` regression also caught and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
