### PR TITLE
fix(cluster): canonicalize kubeconfig path and write atomically in switch/info

### DIFF
--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -3194,7 +3194,12 @@ func buildNoInfoError(clusterName string, provErr error) error {
 //
 //nolint:gosec // G304: kubeconfigPath is resolved from trusted config or default.
 func resolveClusterContext(kubeconfigPath, clusterName string) (string, error) {
-	configBytes, err := os.ReadFile(kubeconfigPath)
+	canonicalPath, err := fsutil.EvalCanonicalPath(kubeconfigPath)
+	if err != nil {
+		return "", nil //nolint:nilerr // unresolvable kubeconfig path is non-fatal for info
+	}
+
+	configBytes, err := os.ReadFile(canonicalPath) //nolint:gosec // canonicalized above
 	if err != nil {
 		return "", nil //nolint:nilerr // unreadable kubeconfig is non-fatal for info
 	}
@@ -6069,7 +6074,12 @@ func stripParenthetical(input string) string {
 //
 //nolint:gosec // G304: kubeconfigPath is resolved from trusted config or default
 func switchContext(kubeconfigPath, clusterName string) (string, error) {
-	configBytes, err := os.ReadFile(kubeconfigPath)
+	canonicalPath, err := fsutil.EvalCanonicalPath(kubeconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read kubeconfig: %w", err)
+	}
+
+	configBytes, err := os.ReadFile(canonicalPath) //nolint:gosec // canonicalized above
 	if err != nil {
 		return "", fmt.Errorf("failed to read kubeconfig: %w", err)
 	}
@@ -6091,7 +6101,7 @@ func switchContext(kubeconfigPath, clusterName string) (string, error) {
 		return "", fmt.Errorf("failed to serialize kubeconfig: %w", err)
 	}
 
-	err = os.WriteFile(kubeconfigPath, result, switchKubeconfigFileMode)
+	err = fsutil.AtomicWriteFile(canonicalPath, result, switchKubeconfigFileMode)
 	if err != nil {
 		return "", fmt.Errorf("failed to write kubeconfig: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -3192,7 +3192,7 @@ func buildNoInfoError(clusterName string, provErr error) error {
 // than one context. Callers should surface the ambiguity error rather than
 // treating it as "not found".
 //
-//nolint:gosec // G304: kubeconfigPath is resolved from trusted config or default.
+
 func resolveClusterContext(kubeconfigPath, clusterName string) (string, error) {
 	canonicalPath, err := fsutil.EvalCanonicalPath(kubeconfigPath)
 	if err != nil {
@@ -6072,7 +6072,7 @@ func stripParenthetical(input string) string {
 
 // switchContext loads the kubeconfig, resolves the cluster name to a context, and sets current-context.
 //
-//nolint:gosec // G304: kubeconfigPath is resolved from trusted config or default
+
 func switchContext(kubeconfigPath, clusterName string) (string, error) {
 	canonicalPath, err := fsutil.EvalCanonicalPath(kubeconfigPath)
 	if err != nil {


### PR DESCRIPTION
## What

Harden kubeconfig handling in two cluster commands:

- **`switchContext`** (`cluster switch`) — canonicalize the kubeconfig path once with `fsutil.EvalCanonicalPath` and use the canonical path for **both** the read and the write; write via `fsutil.AtomicWriteFile` instead of `os.WriteFile`.
- **`resolveClusterContext`** (`cluster info`) — canonicalize the path and read from the canonical path.

Both functions previously read (and `switch` wrote) the kubeconfig directly from a path that can originate from `KUBECONFIG` or CLI/config flags, with no canonicalization — unlike `resolveClusterEntryName` in the same package, which already canonicalizes via `fsutil.EvalCanonicalPath` before reading.

## Why

- **Symlink-escape / path confusion:** canonicalizing (abs + `EvalSymlinks`) before touching the file closes the same path-traversal gap the rest of the package already guards against.
- **Atomic write:** `AtomicWriteFile` (temp-file + rename) means an interrupted `cluster switch` can no longer leave a partially-written kubeconfig — matching the established `pkg/k8s/kubeconfig.go` convention.

## Behavior-preserving

- `resolveClusterContext` keeps its **non-fatal** contract — returns `"", nil` on an unresolvable / unreadable / unparseable kubeconfig (it feeds `cluster info`).
- `switchContext` maps a canonicalization failure to the existing `"failed to read kubeconfig"` error, so the same input (e.g. `KUBECONFIG=/nonexistent/invalid/kubeconfig`) surfaces the same error string. No test changes were needed.
- `//nolint:gosec // canonicalized above` mirrors the in-file precedent; lint confirms the directive is "used" (gosec G304 flags the variable-path read).

## Notes for the reviewer

- These functions currently live in `pkg/cli/cmd/cluster/cluster.go`. PR #5036 (the structural split into `switch.go` / `diagnose.go`) is still open; whichever lands second will hit a small, mechanical conflict in just these two functions.
- This addresses a Copilot review comment on #5036 that was deferred as out of scope for that structural split.

## Validation

- `go build ./...` → success
- `go test ./pkg/cli/cmd/cluster/...` → 518 passed
- `golangci-lint run --new-from-rev=origin/main ./pkg/cli/cmd/cluster/...` → no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)