### PR TITLE
fix(cluster): resolve k3k- nested K3s contexts in cluster switch

### DIFF
--- a/docs/src/content/docs/cli-flags/cluster/cluster-switch.mdx
+++ b/docs/src/content/docs/cli-flags/cluster/cluster-switch.mdx
@@ -10,7 +10,8 @@ Switch the active kubeconfig context to the named cluster.
 
 This command accepts a cluster name and automatically resolves it to the
 correct kubeconfig context by checking all supported distribution prefixes
-(kind-, k3d-, admin@, vcluster-docker_).
+(kind-, k3d-, k3k-, admin@, vcluster-docker_, kwok-). The k3k- prefix matches
+nested K3s clusters on the Kubernetes provider, and kwok- matches KWOK clusters.
 
 If multiple distributions have contexts for the same cluster name, the
 command returns an error listing the matching contexts.

--- a/pkg/cli/cmd/cluster/cluster_pure_test.go
+++ b/pkg/cli/cmd/cluster/cluster_pure_test.go
@@ -262,6 +262,35 @@ func TestStripDistributionPrefix_EmptyReturnsEmpty(t *testing.T) {
 	assert.Empty(t, cluster.ExportStripDistributionPrefix(""))
 }
 
+func TestStripDistributionPrefix_K3kReturnsClusterName(t *testing.T) {
+	t.Parallel()
+	// Nested K3s clusters (k3k operator on the Kubernetes provider) use a "k3k-"
+	// context prefix rather than the standalone "k3d-"; they must still be stripped
+	// to the bare cluster name so they appear in completion and the picker.
+	assert.Equal(t, "nested", cluster.ExportStripDistributionPrefix("k3k-nested"))
+}
+
+// ===========================================================================
+// resolveContextName — cluster name → kubeconfig context resolution
+// ===========================================================================
+
+func TestResolveContextName_K3kNestedK3sResolvesDeterministically(t *testing.T) {
+	t.Parallel()
+
+	// Nested K3s clusters (k3k operator on the Kubernetes provider) use a "k3k-"
+	// context prefix rather than the standalone "k3d-". The explicit k3k- candidate
+	// must win so resolution stays deterministic instead of falling back to substring
+	// matching — which would also match the unrelated context below and report the
+	// name as ambiguous.
+	got, err := cluster.ExportResolveContextName(
+		[]string{"k3k-nested", "external-nested-ctx"},
+		"nested",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "k3k-nested", got)
+}
+
 // ===========================================================================
 // isEmptyYAML — empty YAML detection
 // ===========================================================================

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // ExportShouldPushOCIArtifact exports ShouldPushOCIArtifact for testing.
@@ -445,6 +446,17 @@ func ExportClassifyRestoreError(err error, stderr, policy string) error {
 // ExportStripDistributionPrefix exports stripDistributionPrefix for testing.
 func ExportStripDistributionPrefix(contextName string) string {
 	return stripDistributionPrefix(contextName)
+}
+
+// ExportResolveContextName builds a kubeconfig containing the given context names
+// and resolves clusterName against it, exposing resolveContextName for testing.
+func ExportResolveContextName(contextNames []string, clusterName string) (string, error) {
+	config := clientcmdapi.NewConfig()
+	for _, name := range contextNames {
+		config.Contexts[name] = clientcmdapi.NewContext()
+	}
+
+	return resolveContextName(config, clusterName)
 }
 
 // ExportIsEmptyYAML exports isEmptyYAML for testing.

--- a/pkg/cli/cmd/cluster/switch.go
+++ b/pkg/cli/cmd/cluster/switch.go
@@ -143,7 +143,8 @@ const switchLongDesc = `Switch the active kubeconfig context to the named cluste
 
 This command accepts a cluster name and automatically resolves it to the
 correct kubeconfig context by checking all supported distribution prefixes
-(kind-, k3d-, admin@, vcluster-docker_).
+(kind-, k3d-, k3k-, admin@, vcluster-docker_, kwok-). The k3k- prefix matches
+nested K3s clusters on the Kubernetes provider, and kwok- matches KWOK clusters.
 
 If multiple distributions have contexts for the same cluster name, the
 command returns an error listing the matching contexts.
@@ -349,27 +350,7 @@ func resolveContextName(
 	// present if the name was copied from enriched list output.
 	cleanName := stripParenthetical(clusterName)
 
-	var matches []string
-
-	for _, dist := range v1alpha1.ValidDistributions() {
-		candidate := dist.ContextName(cleanName)
-
-		if _, exists := config.Contexts[candidate]; exists {
-			matches = append(matches, candidate)
-		}
-	}
-
-	// Fallback: if no distribution-prefix match was found, look for contexts
-	// that contain the cluster name as a substring. This handles providers like
-	// Omni whose kubeconfig context format (<org>-<cluster>-<sa>) doesn't
-	// follow the standard distribution prefix conventions.
-	if len(matches) == 0 {
-		for ctxName := range config.Contexts {
-			if strings.Contains(ctxName, cleanName) {
-				matches = append(matches, ctxName)
-			}
-		}
-	}
+	matches := matchContextsForName(config, cleanName)
 
 	switch len(matches) {
 	case 0:
@@ -398,6 +379,48 @@ func resolveContextName(
 			strings.Join(matches, ", "),
 		)
 	}
+}
+
+// matchContextsForName returns the kubeconfig context names that correspond to
+// the given (already cleaned) cluster name. It checks every known distribution
+// prefix plus the "k3k-" prefix used by nested K3s clusters on the Kubernetes
+// provider, then falls back to substring matching for providers (e.g. Omni)
+// whose context format doesn't follow the standard prefix conventions.
+func matchContextsForName(config *clientcmdapi.Config, cleanName string) []string {
+	var matches []string
+
+	for _, dist := range v1alpha1.ValidDistributions() {
+		candidate := dist.ContextName(cleanName)
+
+		if _, exists := config.Contexts[candidate]; exists {
+			matches = append(matches, candidate)
+		}
+	}
+
+	// K3s run via the k3k operator (Kubernetes provider) writes a "k3k-" context
+	// rather than the standalone "k3d-". Add it as an explicit candidate so nested
+	// K3s clusters resolve deterministically instead of falling back to substring
+	// matching (mirrors resolveCreatedContextName and lifecycle.ExtractClusterNameFromContext).
+	if cleanName != "" {
+		k3kCandidate := "k3k-" + cleanName
+		if _, exists := config.Contexts[k3kCandidate]; exists {
+			matches = append(matches, k3kCandidate)
+		}
+	}
+
+	// Fallback: if no distribution-prefix match was found, look for contexts
+	// that contain the cluster name as a substring. This handles providers like
+	// Omni whose kubeconfig context format (<org>-<cluster>-<sa>) doesn't
+	// follow the standard distribution prefix conventions.
+	if len(matches) == 0 {
+		for ctxName := range config.Contexts {
+			if strings.Contains(ctxName, cleanName) {
+				matches = append(matches, ctxName)
+			}
+		}
+	}
+
+	return matches
 }
 
 // stripParenthetical removes a trailing " (<text>)" suffix from input.
@@ -506,6 +529,14 @@ func stripDistributionPrefix(contextName string) string {
 		if after, found := strings.CutPrefix(contextName, prefix); found {
 			return after
 		}
+	}
+
+	// K3s run via the k3k operator (Kubernetes provider) uses a "k3k-" context
+	// rather than the standalone "k3d-"; recognize it so nested K3s clusters appear
+	// in shell completion and the interactive picker (mirrors
+	// lifecycle.ExtractClusterNameFromContext).
+	if after, found := strings.CutPrefix(contextName, "k3k-"); found {
+		return after
 	}
 
 	return ""


### PR DESCRIPTION
## What

Follow-up to #5036 that fixes the three `k3k-` (nested K3s on the Kubernetes provider) gaps Copilot flagged and #5036 deliberately deferred as out-of-scope behavior changes.

Nested K3s clusters use a `k3k-<name>` kubeconfig context (written by `resolveCreatedContextName`), but `cluster switch` only built distribution-based candidates (`k3d-` for K3s):

1. **`resolveContextName`** — adds an explicit `k3k-<name>` candidate (extracted into `matchContextsForName`) so `ksail cluster switch <name>` resolves nested K3s deterministically instead of falling back to substring matching.
2. **`stripDistributionPrefix`** — recognizes the `k3k-` prefix so nested K3s clusters appear in shell completion (`ValidArgsFunction`) and the interactive picker (`clusterNamesFromPath`), mirroring `lifecycle.ExtractClusterNameFromContext`.
3. **`switchLongDesc`** — documents the `k3k-` (nested K3s) and `kwok-` (KWOK) context prefixes.

## Tests

- `TestResolveContextName_K3kNestedK3sResolvesDeterministically` — `k3k-nested` wins over an unrelated substring-matching context (fails on the old code with an ambiguity error).
- `TestStripDistributionPrefix_K3kReturnsClusterName` — `k3k-nested` → `nested`.

## Validation

- `go build ./...`
- `go test ./pkg/cli/cmd/cluster/...`
- `golangci-lint run --new-from-rev=origin/main ./pkg/cli/cmd/cluster/...` → 0 issues (extracted `matchContextsForName` to keep `resolveContextName` under the cyclop limit).

## Note

Stacked on #5036 (`refactor/split-cluster-cmd`) since the target files only exist there. Base needs retargeting to `main` once #5036 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
