### PR TITLE
fix(chat): unify Ctrl+C quit handling so the session is always saved

### DIFF
--- a/pkg/cli/ui/chat/ctrlcquit_test.go
+++ b/pkg/cli/ui/chat/ctrlcquit_test.go
@@ -1,0 +1,114 @@
+package chat_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/ui/chat"
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const ctrlCSessionID = "ctrlc-test-session"
+
+// newCtrlCTestModel builds a chat model with a real session ID and one message so
+// that saveCurrentSession() has something to persist when Ctrl+C is pressed.
+func newCtrlCTestModel(t *testing.T) *chat.Model {
+	t.Helper()
+
+	params := newTestParams()
+	params.Session = &copilot.Session{SessionID: ctrlCSessionID}
+
+	model := chat.NewModel(params)
+	chat.ExportSetMessages(model, []chat.MessageForTest{
+		chat.ExportNewUserMessage("hello"),
+	})
+
+	return model
+}
+
+// ctrlCSessionFile returns the on-disk path where newCtrlCTestModel's session is
+// saved (under $HOME, which each subtest points at a fresh temp dir).
+func ctrlCSessionFile(t *testing.T) string {
+	t.Helper()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	return filepath.Join(home, ".ksail", "chat", "sessions", ctrlCSessionID+".json")
+}
+
+// ctrlCQuitCase is one UI state to enter before pressing Ctrl+C.
+type ctrlCQuitCase struct {
+	name  string
+	setup func(m *chat.Model)
+}
+
+// ctrlCQuitCases enumerates the prompt plus every picker / permission / elicitation
+// overlay that has its own Ctrl+C handler, so the regression guard covers them all.
+func ctrlCQuitCases() []ctrlCQuitCase {
+	return []ctrlCQuitCase{
+		{name: "main prompt", setup: func(_ *chat.Model) {}},
+		{name: "model picker", setup: func(m *chat.Model) {
+			chat.ExportSetShowModelPicker(m, true)
+		}},
+		{name: "model picker filter mode", setup: func(m *chat.Model) {
+			chat.ExportSetShowModelPicker(m, true)
+			chat.ExportSetModelFilterActive(m, true)
+		}},
+		{name: "session picker", setup: func(m *chat.Model) {
+			chat.ExportSetShowSessionPicker(m, true)
+		}},
+		{name: "session picker filter mode", setup: func(m *chat.Model) {
+			chat.ExportSetShowSessionPicker(m, true)
+			chat.ExportSetSessionFilterActive(m, true)
+		}},
+		{name: "reasoning picker", setup: func(m *chat.Model) {
+			chat.ExportSetShowReasoningPicker(m, true)
+		}},
+		{name: "permission prompt", setup: func(m *chat.Model) {
+			// Buffered so the handler's `response <- false` never blocks.
+			resp := make(chan bool, 1)
+			chat.ExportSetPendingPermission(m, "tool", "cmd", "args", resp)
+		}},
+		{name: "elicitation prompt", setup: func(m *chat.Model) {
+			// Buffered so cancelElicitation's response send never blocks.
+			resp := make(chan chat.ExportElicitationResponsePayload, 1)
+			m.Update(chat.ExportElicitationRequestMsg{Message: "confirm?", Response: resp})
+		}},
+	}
+}
+
+// TestCtrlC_SavesSessionFromEveryUIState is the regression guard for #5045: Ctrl+C
+// must route through the single handleQuit() helper — persisting the current session
+// and setting quitting — identically from the main prompt and from every picker /
+// permission / elicitation overlay. Before the fix, the overlays issued tea.Quit
+// inline and silently dropped the session.
+func TestCtrlC_SavesSessionFromEveryUIState(t *testing.T) {
+	for _, testCase := range ctrlCQuitCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Fresh HOME per case so the saved file proves THIS Ctrl+C wrote it.
+			t.Setenv("HOME", t.TempDir())
+
+			model := newCtrlCTestModel(t)
+			testCase.setup(model)
+
+			require.NoFileExists(t, ctrlCSessionFile(t),
+				"session file must not exist before Ctrl+C")
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+
+			chatModel, ok := updated.(*chat.Model)
+			require.True(t, ok, "expected *chat.Model after Ctrl+C")
+
+			assert.True(t, chat.ExportGetQuitting(chatModel),
+				"Ctrl+C must set quitting from %q", testCase.name)
+			assert.FileExists(t, ctrlCSessionFile(t),
+				"Ctrl+C must save the current session (handleQuit -> saveCurrentSession) from %q",
+				testCase.name)
+		})
+	}
+}

--- a/pkg/cli/ui/chat/ctrlcquit_test.go
+++ b/pkg/cli/ui/chat/ctrlcquit_test.go
@@ -90,8 +90,13 @@ func ctrlCQuitCases() []ctrlCQuitCase {
 func TestCtrlC_SavesSessionFromEveryUIState(t *testing.T) {
 	for _, testCase := range ctrlCQuitCases() {
 		t.Run(testCase.name, func(t *testing.T) {
-			// Fresh HOME per case so the saved file proves THIS Ctrl+C wrote it.
-			t.Setenv("HOME", t.TempDir())
+			// Fresh home per case so the saved file proves THIS Ctrl+C wrote it.
+			// Set both HOME and USERPROFILE (os.UserHomeDir consults USERPROFILE on
+			// Windows) to the same dir so the test is portable, matching the
+			// internal/testutil/homeenv helper.
+			homeDir := t.TempDir()
+			t.Setenv("HOME", homeDir)
+			t.Setenv("USERPROFILE", homeDir)
 
 			model := newCtrlCTestModel(t)
 			testCase.setup(model)

--- a/pkg/cli/ui/chat/elicitation.go
+++ b/pkg/cli/ui/chat/elicitation.go
@@ -64,10 +64,8 @@ func (m *Model) handleElicitationKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.declineElicitation()
 	case keyCtrlC:
 		m.cancelElicitation()
-		m.cleanup()
-		m.quitting = true
 
-		return m, tea.Quit
+		return m.handleQuit()
 	case keyTab:
 		return m.navigateElicitationField(1)
 	case "shift+tab":

--- a/pkg/cli/ui/chat/export_test.go
+++ b/pkg/cli/ui/chat/export_test.go
@@ -372,6 +372,16 @@ var ExportGetShowSessionPicker = func(m *Model) bool {
 	return m.showSessionPicker
 }
 
+// ExportSetModelFilterActive sets Model.modelFilterActive for testing.
+var ExportSetModelFilterActive = func(m *Model, active bool) {
+	m.modelFilterActive = active
+}
+
+// ExportSetSessionFilterActive sets Model.sessionFilterActive for testing.
+var ExportSetSessionFilterActive = func(m *Model, active bool) {
+	m.sessionFilterActive = active
+}
+
 // ExportTruncateString exposes truncateString for testing.
 var ExportTruncateString = truncateString
 

--- a/pkg/cli/ui/chat/model_picker.go
+++ b/pkg/cli/ui/chat/model_picker.go
@@ -51,10 +51,7 @@ func (m *Model) handleModelPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case keyEnter:
 		return m.selectModel(totalItems)
 	case keyCtrlC:
-		m.cleanup()
-		m.quitting = true
-
-		return m, tea.Quit
+		return m.handleQuit()
 	}
 
 	return m, nil
@@ -82,10 +79,7 @@ func (m *Model) handleModelFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 	case keyCtrlC:
-		m.cleanup()
-		m.quitting = true
-
-		return m, tea.Quit
+		return m.handleQuit()
 	default:
 		if msg.Type == tea.KeyRunes {
 			m.modelFilterText += string(msg.Runes)

--- a/pkg/cli/ui/chat/permission.go
+++ b/pkg/cli/ui/chat/permission.go
@@ -37,10 +37,8 @@ func (m *Model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.pendingPermission.response <- false
 
 		m.pendingPermission = nil
-		m.cleanup()
-		m.quitting = true
 
-		return m, tea.Quit
+		return m.handleQuit()
 	}
 
 	return m, nil

--- a/pkg/cli/ui/chat/reasoning_picker.go
+++ b/pkg/cli/ui/chat/reasoning_picker.go
@@ -32,10 +32,7 @@ func (m *Model) handleReasoningPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case keyEnter:
 		return m.selectReasoningEffort()
 	case keyCtrlC:
-		m.cleanup()
-		m.quitting = true
-
-		return m, tea.Quit
+		return m.handleQuit()
 	}
 
 	return m, nil

--- a/pkg/cli/ui/chat/session_picker.go
+++ b/pkg/cli/ui/chat/session_picker.go
@@ -189,10 +189,7 @@ func (m *Model) handleSessionPickerNavKey(msg tea.KeyMsg, totalItems int) (tea.M
 	case keyEnter:
 		return m.selectSession()
 	case keyCtrlC:
-		m.cleanup()
-		m.quitting = true
-
-		return m, tea.Quit
+		return m.handleQuit()
 	}
 
 	return m, nil
@@ -236,10 +233,7 @@ func (m *Model) handleSessionFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 	case keyCtrlC:
-		m.cleanup()
-		m.quitting = true
-
-		return m, tea.Quit
+		return m.handleQuit()
 	default:
 		if msg.Type == tea.KeyRunes {
 			m.sessionFilterText += string(msg.Runes)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5045 — the maintainer-requested follow-up to #5040.

## Problem

The full quit path lives in `handleQuit()` (`pkg/cli/ui/chat/keyhandlers.go`):

```go
func (m *Model) handleQuit() (tea.Model, tea.Cmd) {
    m.cleanup()
    _ = m.saveCurrentSession() // persists the session
    m.quitting = true
    return m, tea.Quit
}
```

But every picker / sub-prompt re-implemented its own `ctrl+c` case inline as
`m.cleanup(); m.quitting = true; return m, tea.Quit` — **omitting `saveCurrentSession()`**.
So `Ctrl+C` saved the session from the main prompt but **silently dropped it** when a
model/session/reasoning picker, a permission prompt, or an elicitation prompt was open —
the same keystroke with a different outcome depending on UI state. The quit logic was also
duplicated 6+ times, inviting drift.

## Change

Route **all seven** inline sites through the single `handleQuit()` helper:

- `model_picker.go` — list + filter modes
- `session_picker.go` — list + filter modes
- `reasoning_picker.go`
- `permission.go` (keeps `response <- false; pendingPermission = nil`, then `handleQuit()`)
- `elicitation.go` (keeps `cancelElicitation()`, then `handleQuit()`)

`handleQuit()` is now the **only** place that issues `tea.Quit` for `ctrl+c` in the chat UI
(`command_picker.go`/`option_picker.go` already delegated to it). Net **−19 lines**, no
behaviour change other than the now-consistent session save.

## Acceptance criteria

- [x] A single shared quit handler is the only place that issues `tea.Quit` for `ctrl+c`.
- [x] `Ctrl+C` saves the current session identically from the prompt **and** every picker / permission / elicitation state.
- [x] Table-driven test (`ctrlcquit_test.go`) exercises `ctrl+c` from each of the 8 UI states and asserts `saveCurrentSession` ran (session file written under a per-case temp `$HOME`) + `quitting` is set — a regression guard against re-duplication. Two small test-only export setters (`ExportSetModelFilterActive` / `ExportSetSessionFilterActive`) were added to reach the filter sub-modes.

## Validation

- `go build -o /tmp/ksail .` ✅
- `go test ./pkg/cli/ui/chat/` — **744 pass** (8 new sub-cases) ✅
- `golangci-lint run --new-from-rev=origin/main ./...` — **no new issues** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)