### PR TITLE
fix(release): make releases atomic so a published release is always complete (#5060)

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -93,15 +93,22 @@ runs:
           *)     echo "❌ Unsupported runner architecture: $RUNNER_ARCH"; exit 1 ;;
         esac
         tmpdir="$(mktemp -d)"
+        # A pinned version that resolves to a draft, deleted, or never-cut release makes
+        # `gh release download` fail with an opaque "release not found"; the same happens when a
+        # published release is missing the linux_<arch> asset. Wrap it so CI gets an actionable
+        # message naming the version and the exact failure modes instead (see #5060).
         if [ "$KSAIL_VERSION" = "latest" ]; then
-          gh release download --repo devantler-tech/ksail \
-            --pattern "ksail_*_linux_${GOARCH}.tar.gz" \
-            --dir "$tmpdir"
+          download_args=(--repo devantler-tech/ksail)
         else
-          gh release download "v${KSAIL_VERSION}" \
-            --repo devantler-tech/ksail \
-            --pattern "ksail_*_linux_${GOARCH}.tar.gz" \
-            --dir "$tmpdir"
+          download_args=("v${KSAIL_VERSION}" --repo devantler-tech/ksail)
+        fi
+        if ! gh release download "${download_args[@]}" \
+          --pattern "ksail_*_linux_${GOARCH}.tar.gz" \
+          --dir "$tmpdir"; then
+          echo "::error::Could not download KSail '${KSAIL_VERSION}' (linux_${GOARCH})." >&2
+          echo "::error::The release may not exist, may be an unpublished draft, or may be missing the linux_${GOARCH} asset." >&2
+          echo "::error::Pin a published version from https://github.com/devantler-tech/ksail/releases." >&2
+          exit 1
         fi
         tar -xzf "$tmpdir"/ksail_*_linux_${GOARCH}.tar.gz -C "$tmpdir"
         sudo install "$tmpdir/ksail" /usr/local/bin/ksail

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -556,13 +556,15 @@ jobs:
     name: 📢 Publish Release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Gate on the artifact-producing releases so the draft is published only when every asset
-    # job succeeded. Runs in parallel with `pages-deploy` and `mcp-publish` — none lists the
-    # others in `needs`, so the GitHub release publish, the docs deploy, and the MCP registry
-    # publish all happen concurrently. `mcp-publish` is excluded because it references the GHCR
-    # image (from `goreleaser`), not the GitHub release, so it need not gate the publish.
-    # `pages-build` replaces the former `pages-deploy` edge: the release is gated on the docs
-    # *building*, not on Pages having deployed.
+    # The CLI release IS the release: the `goreleaser` job creates the draft with the CLI
+    # tarballs, checksums, and Cluster CRD already attached. The VSIX and desktop archives are
+    # convenience assets attached below. Publish whenever the CLI built (`goreleaser` succeeded),
+    # regardless of the convenience-asset jobs, so a desktop/VSIX/docs/plugin failure can never
+    # strand the fully-built CLI release as a permanent, unpublished draft (see #5060). `needs`
+    # still lists every asset job so this waits for them and attaches whatever they produced — the
+    # `if` below (replacing the default all-success gate added in #4874) is what lets the publish
+    # proceed when a convenience job failed. The failed job keeps its own red status, so the CD run
+    # stays loud. Runs in parallel with `pages-deploy` and `mcp-publish`.
     needs:
       [
         goreleaser,
@@ -572,6 +574,7 @@ jobs:
         desktop,
         pages-build,
       ]
+    if: always() && needs.goreleaser.result == 'success'
     permissions:
       contents: write
     steps:
@@ -579,22 +582,52 @@ jobs:
         id: get_version
         run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
+      # Surface any convenience-asset job that did not succeed so the published release's missing
+      # assets are explained in the run log. These are convenience downloads / side-effects that do
+      # not block the CLI release; the failed job's own red status keeps the CD run loud (see #5060).
+      - name: 🔎 Report missing convenience assets
+        if: >-
+          needs.vscode-extension.result != 'success' ||
+          needs.desktop-macos.result != 'success' ||
+          needs.desktop.result != 'success' ||
+          needs.copilot-plugin.result != 'success' ||
+          needs.pages-build.result != 'success'
+        env:
+          VSCODE: ${{ needs.vscode-extension.result }}
+          DESKTOP_MACOS: ${{ needs.desktop-macos.result }}
+          DESKTOP: ${{ needs.desktop.result }}
+          COPILOT: ${{ needs.copilot-plugin.result }}
+          PAGES: ${{ needs.pages-build.result }}
+        run: |
+          echo "::warning title=Publishing CLI release without some convenience assets::A non-CLI asset job did not succeed; the complete CLI release is being published anyway (see #5060)."
+          echo "Job outcomes: vscode-extension=$VSCODE desktop-macos=$DESKTOP_MACOS desktop=$DESKTOP copilot-plugin=$COPILOT pages-build=$PAGES"
+          echo "The CLI tarballs, checksums, and Cluster CRD are attached by GoReleaser and present. Published releases are immutable (see #4874), so adding a missing convenience asset requires a new patch release."
+
       - name: 📥 Download release asset artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-*
           merge-multiple: true
           path: dist-assets
+        # A failed convenience-asset job leaves its artifact absent; never let that block the publish.
+        continue-on-error: true
 
-      # Attach the desktop archives and the VSIX to the draft BEFORE publishing. Once published the
-      # release is immutable and late uploads 422 (see #4874); all asset jobs gate this one, so every
-      # artifact exists here and is attached immediately before the draft→published flip below.
-      - name: 📤 Attach assets to draft release
+      # Attach whatever convenience assets exist to the draft BEFORE publishing. Once published the
+      # release is immutable and late uploads 422 (see #4874), so this is the last chance to attach.
+      # Guard the glob so an empty set (every convenience job failed) still publishes the CLI release.
+      - name: 📤 Attach available assets to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.get_version.outputs.version }}
-        run: gh release upload "$RELEASE_TAG" dist-assets/* --clobber
+        run: |
+          shopt -s nullglob
+          assets=(dist-assets/*)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "::warning::No convenience assets (VSIX / desktop archives) to attach; publishing the CLI release without them."
+          else
+            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+          fi
 
       - name: 📢 Publish draft release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -556,15 +556,15 @@ jobs:
     name: 📢 Publish Release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # The CLI release IS the release: the `goreleaser` job creates the draft with the CLI
-    # tarballs, checksums, and Cluster CRD already attached. The VSIX and desktop archives are
-    # convenience assets attached below. Publish whenever the CLI built (`goreleaser` succeeded),
-    # regardless of the convenience-asset jobs, so a desktop/VSIX/docs/plugin failure can never
-    # strand the fully-built CLI release as a permanent, unpublished draft (see #5060). `needs`
-    # still lists every asset job so this waits for them and attaches whatever they produced — the
-    # `if` below (replacing the default all-success gate added in #4874) is what lets the publish
-    # proceed when a convenience job failed. The failed job keeps its own red status, so the CD run
-    # stays loud. Runs in parallel with `pages-deploy` and `mcp-publish`.
+    # Gate on EVERY artifact-producing asset job so the draft is flipped to published only when the
+    # release is COMPLETE (CLI tarballs + checksums + CRD, VSIX, and every desktop archive present).
+    # Immutable releases (see #4874) forbid adding assets after the flip, so completeness must be
+    # guaranteed before it. This is the maintainer's required invariant: a published release is always
+    # complete (#5061). The inverse failure — an asset job failing and leaving an unpublished draft —
+    # is prevented up front by the `Release` workflow, which validates every artifact BEFORE the tag is
+    # created, and backstopped by `cleanup-failed-release` below, which deletes the orphaned draft and
+    # tag if a publish is ever blocked so no empty/incomplete tag flows downstream (#5060).
+    # Runs in parallel with `pages-deploy` and `mcp-publish`.
     needs:
       [
         goreleaser,
@@ -574,7 +574,6 @@ jobs:
         desktop,
         pages-build,
       ]
-    if: always() && needs.goreleaser.result == 'success'
     permissions:
       contents: write
     steps:
@@ -582,52 +581,22 @@ jobs:
         id: get_version
         run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
-      # Surface any convenience-asset job that did not succeed so the published release's missing
-      # assets are explained in the run log. These are convenience downloads / side-effects that do
-      # not block the CLI release; the failed job's own red status keeps the CD run loud (see #5060).
-      - name: 🔎 Report missing convenience assets
-        if: >-
-          needs.vscode-extension.result != 'success' ||
-          needs.desktop-macos.result != 'success' ||
-          needs.desktop.result != 'success' ||
-          needs.copilot-plugin.result != 'success' ||
-          needs.pages-build.result != 'success'
-        env:
-          VSCODE: ${{ needs.vscode-extension.result }}
-          DESKTOP_MACOS: ${{ needs.desktop-macos.result }}
-          DESKTOP: ${{ needs.desktop.result }}
-          COPILOT: ${{ needs.copilot-plugin.result }}
-          PAGES: ${{ needs.pages-build.result }}
-        run: |
-          echo "::warning title=Publishing CLI release without some convenience assets::A non-CLI asset job did not succeed; the complete CLI release is being published anyway (see #5060)."
-          echo "Job outcomes: vscode-extension=$VSCODE desktop-macos=$DESKTOP_MACOS desktop=$DESKTOP copilot-plugin=$COPILOT pages-build=$PAGES"
-          echo "The CLI tarballs, checksums, and Cluster CRD are attached by GoReleaser and present. Published releases are immutable (see #4874), so adding a missing convenience asset requires a new patch release."
-
       - name: 📥 Download release asset artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-*
           merge-multiple: true
           path: dist-assets
-        # A failed convenience-asset job leaves its artifact absent; never let that block the publish.
-        continue-on-error: true
 
-      # Attach whatever convenience assets exist to the draft BEFORE publishing. Once published the
-      # release is immutable and late uploads 422 (see #4874), so this is the last chance to attach.
-      # Guard the glob so an empty set (every convenience job failed) still publishes the CLI release.
-      - name: 📤 Attach available assets to draft release
+      # Attach the desktop archives and the VSIX to the draft BEFORE publishing. Once published the
+      # release is immutable and late uploads 422 (see #4874); all asset jobs gate this one, so every
+      # artifact exists here and is attached immediately before the draft→published flip below.
+      - name: 📤 Attach assets to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.get_version.outputs.version }}
-        run: |
-          shopt -s nullglob
-          assets=(dist-assets/*)
-          if [ ${#assets[@]} -eq 0 ]; then
-            echo "::warning::No convenience assets (VSIX / desktop archives) to attach; publishing the CLI release without them."
-          else
-            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
-          fi
+        run: gh release upload "$RELEASE_TAG" dist-assets/* --clobber
 
       - name: 📢 Publish draft release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -756,3 +725,60 @@ jobs:
             gh pr merge "$pr" --repo "$TAP" --auto --squash \
               || echo "::warning::Could not enable auto-merge for ${TAP}#${pr}; the tap automation may still merge it"
           done
+
+  # Backstop for the immutable-release model: if the release did NOT publish — any asset job failed,
+  # or the publish step bailed (so `publish-release` is skipped or failed) — delete the orphaned draft
+  # AND the tag so an incomplete/empty release never lingers or flows downstream to tag-tracking
+  # consumers (see #5060, #5061). The `Release` workflow validates every artifact BEFORE the tag is
+  # cut, so this should rarely fire — only on a post-tag transient (a GitHub/registry blip during the
+  # real build). On the happy path `publish-release` succeeds and this is skipped. Recovery is to
+  # re-run the `Release` workflow: it recomputes the same version and re-tags after validation.
+  cleanup-failed-release:
+    name: 🧹 Clean up incomplete release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [publish-release]
+    if: always() && needs.publish-release.result != 'success'
+    permissions:
+      contents: write
+    steps:
+      - name: 🧹 Delete orphaned draft release and tag
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            const { owner, repo } = context.repo;
+
+            // listReleases returns drafts (getReleaseByTag does not), so use it to find everything
+            // attached to this tag.
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            const forTag = releases.filter(r => r.tag_name === tag);
+            const drafts = forTag.filter(r => r.draft);
+            const published = forTag.filter(r => !r.draft);
+
+            // Always remove orphaned draft releases for this tag.
+            for (const d of drafts) {
+              await github.rest.repos.deleteRelease({ owner, repo, release_id: d.id });
+              console.log(`Deleted orphaned draft release ${tag} (id=${d.id}).`);
+            }
+
+            // Never delete the tag of a release that DID publish: a published (complete) release is
+            // immutable and legitimate. Only a tag with no published release is an orphan.
+            if (published.length > 0) {
+              console.log(`A published release exists for ${tag}; keeping the tag.`);
+              return;
+            }
+
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+              console.log(`Deleted orphaned tag ${tag}; downstream tag-tracking consumers will not see an empty release.`);
+            } catch (error) {
+              if (error.status === 404 || error.status === 422) {
+                console.log(`Tag ${tag} already absent; nothing to delete.`);
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -759,17 +759,21 @@ jobs:
             const drafts = forTag.filter(r => r.draft);
             const published = forTag.filter(r => !r.draft);
 
-            // Always remove orphaned draft releases for this tag.
+            // If a published release coexists with a draft for this tag, we're in the ambiguous
+            // duplicate-release case (#4874) — the draft may hold the ONLY complete artifact set, so
+            // auto-deleting it could strand an incomplete published release as the only survivor.
+            // Leave both the draft(s) and the tag for manual investigation (mirrors publish-release's
+            // matching>1 bail), and never delete a tag that backs a published release.
+            if (published.length > 0) {
+              core.warning(`A published release exists for ${tag} alongside ${drafts.length} draft(s); leaving the draft(s) and the tag for manual cleanup (see #4874).`);
+              return;
+            }
+
+            // No published release for this tag — the draft(s), if any, are orphans from a blocked
+            // publish. Remove them and the tag so no empty/incomplete release flows downstream.
             for (const d of drafts) {
               await github.rest.repos.deleteRelease({ owner, repo, release_id: d.id });
               console.log(`Deleted orphaned draft release ${tag} (id=${d.id}).`);
-            }
-
-            // Never delete the tag of a release that DID publish: a published (complete) release is
-            // immutable and legitimate. Only a tag with no published release is an orphan.
-            if (published.length > 0) {
-              console.log(`A published release exists for ${tag}; keeping the tag.`);
-              return;
             }
 
             try {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,15 @@ concurrency:
 permissions:
   contents: read
 
+# Mirror cd.yaml's release-build environment so validation behaves exactly like the real CD build:
+# the pipe (|) in GOPROXY falls through to `direct` on ANY proxy error (incl. 403), hardening against
+# transient proxy.golang.org blips, and GOMEMLIMIT keeps GoReleaser's multi-binary linker under the
+# runner's memory. Without these a transient proxy error or a linker OOM could fail validation — and
+# thus skip tagging — even when CD would have succeeded, defeating the point of validating first.
+env:
+  GOPROXY: "https://proxy.golang.org|direct"
+  GOMEMLIMIT: "6GiB"
+
 # Validate-before-tag (see #5060, #5061): every release artifact is built in snapshot / no-publish
 # mode BEFORE `create-release` (semantic-release) computes the version and pushes the tag. A build
 # failure fails a `validate-*` job, which skips `create-release`, so the tag — and the CD build it

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,186 @@
+---
 name: Release
 on:
   workflow_dispatch:
 
+concurrency:
+  group: "Release"
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
+# Validate-before-tag (see #5060, #5061): every release artifact is built in snapshot / no-publish
+# mode BEFORE `create-release` (semantic-release) computes the version and pushes the tag. A build
+# failure fails a `validate-*` job, which skips `create-release`, so the tag — and the CD build it
+# would trigger — is never created. This makes an empty/incomplete tag impossible for the common
+# (build-failure) case; a rare post-tag transient is cleaned up by cd.yaml's `cleanup-failed-release`.
+# The `validate-*` jobs mirror the BUILD halves of cd.yaml's `goreleaser` / `desktop` / `vscode-extension`
+# / `pages-build` jobs (minus publishing) — keep them in sync when those jobs change, or a drift could
+# let a build that passes validation fail in CD and re-introduce the empty tag.
 jobs:
+  validate-cli:
+    name: 🔍 Validate CLI build (snapshot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 🧹 Cleanup node
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: ⚙️ Setup Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # `release --snapshot` builds every binary, archive, and Docker image and renders the cask WITHOUT
+      # a tag and WITHOUT publishing (no GitHub release, no Docker push, no cask PR) — the same
+      # .goreleaser.yaml CD uses, so a pass here means CD's real `goreleaser` run will build too. The
+      # cask-token envs are set empty only to keep templating safe; the publish pipes that read them are
+      # skipped in snapshot mode.
+      - name: 🏗️ Run GoReleaser (snapshot)
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ""
+          GPG_PRIVATE_KEY: ""
+
+  validate-desktop:
+    name: 🔍 Validate Desktop build (snapshot)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-latest, goos: darwin }
+          # ubuntu-22.04 ships libwebkit2gtk-4.0-dev, which webview_go's cgo requires (24.04 only has 4.1).
+          - { os: ubuntu-22.04, goos: linux }
+          - { os: windows-latest, goos: windows }
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: ⚙️ Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
+        with:
+          node-version: "24"
+
+      - name: 🐧 Install Linux webview dependencies
+        if: matrix.goos == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+
+      - name: 🏗️ Build and stage web UI
+        shell: bash
+        run: |
+          npm --prefix web/ui ci
+          npm --prefix web/ui run build
+          rm -rf pkg/webui/dist
+          mkdir -p pkg/webui/dist
+          touch pkg/webui/dist/.gitkeep
+          cp -R web/ui/dist/. pkg/webui/dist/
+
+      # Mirrors cd.yaml's desktop build (CGO + system webview). We only need it to COMPILE on every OS
+      # to guarantee CD's desktop jobs will; the binary is thrown away. CGO_ENABLED=1 matches the
+      # desktop module's webview requirement (see .goreleaser.desktop.yaml).
+      - name: 🏗️ Build desktop app
+        shell: bash
+        env:
+          CGO_ENABLED: "1"
+        run: cd desktop && go build -ldflags "-s -w" -o ksail-desktop-validate .
+
+  validate-vsix:
+    name: 🔍 Validate VSCode Extension build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: vsce
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
+        with:
+          node-version: "24"
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🏗️ Compile
+        run: npm run compile
+
+      - name: 📦 Package extension
+        run: npm run package
+
+  validate-docs:
+    name: 🔍 Validate Docs build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+
+      - name: 📦 Install dependencies
+        working-directory: docs
+        run: npm ci
+
+      - name: 🏗️ Build with Astro
+        working-directory: docs
+        run: npm run build
+
+  # Only after EVERY artifact has been validated does semantic-release compute the version and push the
+  # tag (which then triggers cd.yaml). A failed validation skips this job, so no tag is created — an
+  # empty/incomplete tag can never flow downstream from a build failure (see #5060, #5061).
   release:
+    name: 🎉 Create Release
+    needs: [validate-cli, validate-desktop, validate-vsix, validate-docs]
     uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@1dc3c2267580c42cfb138a46c46d1856d1b91b7b # v5.5.4
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5060.

## Problem

A KSail release is published in two phases: `goreleaser` builds the CLI artifacts into a `draft: true` GitHub release, then `publish-release` (in `cd.yaml`) attaches the *convenience* artifacts (desktop archives, VSIX) and flips the draft to published. Because [#4874](https://github.com/devantler-tech/ksail/pull/4874) made releases **immutable** (assets cannot be added after the flip), `publish-release` hard-`needs:` every asset job so a published release is always complete.

The failure mode this caused: when a *convenience* job fails (e.g. one desktop matrix leg), `publish-release` is skipped and the fully-built CLI draft is **never flipped to published** — it lingers as a permanent, invisible draft. But its **git tag still exists**, so tag-tracking downstream consumers (a `devantler-tech/platform` consumer hit this) see a "new version" and then get the opaque `release not found` from `gh release download`. Two such orphans exist today: `v7.22.2` and `v7.23.0`.

## Approach

The invariant the maintainer requires: **any failure blocks publish so every *published* release is COMPLETE, and an *unpublished* draft must never make downstream think a release is available.** This PR makes the release **atomic** on both ends rather than publishing an incomplete release.

**1. `release.yaml` — validate every artifact BEFORE the tag is cut (prevents the orphan up front).**
New `validate-*` jobs build every release artifact in snapshot / no-publish mode before `create-release` computes the version and pushes the tag:
- `validate-cli` — `goreleaser release --snapshot --clean` (same `.goreleaser.yaml` CD uses: all binaries, archives, Docker images, cask render — no publish).
- `validate-desktop` — desktop app build across darwin/linux/windows.
- `validate-vsix` — VSCode extension compile + package.
- `validate-docs` — Astro docs build.

`release` (semantic-release) `needs:` all four, so a build failure fails a `validate-*` job, `create-release` is skipped, and **the tag — and the CD build it would trigger — is never created.** An empty/incomplete tag is impossible for the common (build-failure) case.

**2. `cd.yaml` `publish-release` — gate on EVERY asset job (unchanged invariant, kept).**
`needs:` stays the full set `[goreleaser, vscode-extension, copilot-plugin, desktop-macos, desktop, pages-build]` with no `if: always()` bypass: the draft flips to published only when the release is complete. (This reverts the originally-proposed publish-despite-failure approach the maintainer vetoed.)

**3. `cd.yaml` `cleanup-failed-release` — backstop the rare post-tag transient.**
If `publish-release` does not succeed (a GitHub/registry blip after the tag was cut), a new `cleanup-failed-release` job (`if: always() && needs.publish-release.result != 'success'`) deletes the orphaned **draft release and its tag**, so nothing incomplete lingers or flows to tag-tracking consumers. It never deletes the tag of a release that *did* publish (immutable + legitimate). Recovery is to re-run `Release`, which recomputes the same version and re-tags after validation.

**4. `ksail-cluster` action — kill the opaque error (defense-in-depth).**
Wrap `gh release download` so a pinned version resolving to a draft / deleted / never-cut release (or a published release missing the `linux_<arch>` asset) fails with an actionable message naming the version and the three failure modes, instead of the bare `release not found`.

## Validation
- `actionlint` on `cd.yaml` + `release.yaml` → clean.
- `shellcheck` on the action's modified install-step shell → clean.

## Notes
- **`validate-*` ↔ CD drift:** the `validate-*` jobs mirror the *build* halves of cd.yaml's `goreleaser` / `desktop` / `vscode-extension` / `pages-build` jobs (minus publishing). They must be kept in sync when those jobs change, or a build that passes validation could fail in CD and re-introduce the orphan (called out in a comment in `release.yaml`).
- **Existing orphans** `v7.22.2` / `v7.23.0` are still drafts (both superseded by published patches) and can be deleted manually — kept out of this code PR.
