### PR TITLE
refactor(notify): drop unused gosec nolint directive

### DIFF
--- a/pkg/notify/progress.go
+++ b/pkg/notify/progress.go
@@ -283,7 +283,6 @@ func NewProgressGroup(
 	termWidth := 0
 
 	if file, ok := writer.(*os.File); ok {
-		//nolint:gosec // uintptr to int conversion is safe for term.IsTerminal usage
 		fd := int(file.Fd())
 		isTTY = term.IsTerminal(fd)
 


### PR DESCRIPTION
## What

Removes the `//nolint:gosec` directive on the `uintptr`→`int` file-descriptor conversion in the progress writer (`pkg/notify/progress.go`). `nolintlint` reports the directive as **unused** — `gosec` no longer flags the `term.IsTerminal` usage, so the suppression is dead.

## Why

Part of a small series driving the `golangci-lint` baseline toward zero. Dead lint-suppression directives are noise: they imply a finding that no longer exists and can mask a real one if the surrounding code changes.

## Validation

- `go build ./pkg/notify/...` ✓
- `go test ./pkg/notify/...` — 208 passing ✓
- `golangci-lint run --new-from-rev=origin/main ./pkg/notify/...` — 0 issues ✓

Behavior is unchanged (single-line deletion of a comment directive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)