### PR TITLE
refactor(apis): extract loopback IP constant in v1alpha1

### DIFF
--- a/pkg/apis/cluster/v1alpha1/local_registry.go
+++ b/pkg/apis/cluster/v1alpha1/local_registry.go
@@ -89,7 +89,10 @@ func parseHostAndPort(spec string) (string, int32, bool) {
 	return spec, 0, false
 }
 
-const localhostHost = "localhost"
+const (
+	localhostHost = "localhost"
+	loopbackIP    = "127.0.0.1"
+)
 
 // resolveDefaultPort returns the appropriate default port based on host.
 func resolveDefaultPort(host string, hasExplicitPort bool) int32 {
@@ -97,7 +100,7 @@ func resolveDefaultPort(host string, hasExplicitPort bool) int32 {
 		return 0 // Will be set by caller
 	}
 
-	if host == localhostHost || host == "127.0.0.1" {
+	if host == localhostHost || host == loopbackIP {
 		return DefaultLocalRegistryPort
 	}
 
@@ -191,7 +194,7 @@ func (r LocalRegistry) HasCredentials() bool {
 func (r LocalRegistry) IsExternal() bool {
 	parsed := r.Parse()
 
-	return parsed.Host != "" && parsed.Host != "localhost" && parsed.Host != "127.0.0.1"
+	return parsed.Host != "" && parsed.Host != localhostHost && parsed.Host != loopbackIP
 }
 
 // ResolvedHost returns the registry host from the parsed spec, defaulting to "localhost".

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -209,8 +209,8 @@ func isLocalMirrorSpec(spec string) bool {
 	// Check for local patterns in the spec
 	// These patterns indicate local Docker container references that won't work on cloud providers
 	localPatterns := []string{
-		"localhost",
-		"127.0.0.1",
+		localhostHost,
+		loopbackIP,
 		"0.0.0.0",
 		"host.docker.internal",
 		"[::1]", // IPv6 localhost


### PR DESCRIPTION
## What

Adds a `loopbackIP = "127.0.0.1"` constant beside the existing `localhostHost` in `pkg/apis/cluster/v1alpha1` and reuses both wherever the loopback address / localhost were hard-coded:

- `resolveDefaultPort` (`local_registry.go`)
- `LocalRegistry.IsExternal` (`local_registry.go`) — also swaps the stray `"localhost"` literal for `localhostHost`
- `isLocalMirrorSpec`'s `localPatterns` (`validation.go`)

Unique patterns (`0.0.0.0`, `host.docker.internal`, `[::1]`) stay inline — that's the correct DRY boundary (`goconst` only flags repeated literals).

## Why

Clears the `goconst` findings on the duplicated source literals and removes the inconsistency of having `localhostHost` defined but not used everywhere.

## Behavior

Unchanged — same string values, same comparisons.

## Validation

- `go build ./pkg/apis/...` ✓
- `go test ./pkg/apis/cluster/v1alpha1/...` — 536 passing ✓
- `golangci-lint run --new-from-rev=origin/main ./pkg/apis/cluster/v1alpha1/...` — 0 issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)