### PR TITLE
refactor(image): extract containerd ctr command constants

### DIFF
--- a/pkg/svc/image/exporter.go
+++ b/pkg/svc/image/exporter.go
@@ -21,6 +21,15 @@ import (
 // File permission constant.
 const dirPerm = 0o750
 
+const (
+	// ctrCommand is the containerd CLI binary used to manage images on cluster nodes.
+	ctrCommand = "ctr"
+	// ctrNamespaceArg selects containerd's k8s.io namespace for all ctr invocations.
+	ctrNamespaceArg = "--namespace=k8s.io"
+	// ctrImages is the ctr subcommand group for image operations.
+	ctrImages = "images"
+)
+
 // Error definitions.
 var (
 	// ErrNoNodes is returned when no cluster nodes are found.
@@ -279,7 +288,7 @@ func (e *Exporter) listImagesInNode(
 	nodeName string,
 ) ([]string, error) {
 	// Build ctr command to list images
-	cmd := []string{"ctr", "--namespace=k8s.io", "images", "list", "-q"}
+	cmd := []string{ctrCommand, ctrNamespaceArg, ctrImages, "list", "-q"}
 
 	output, err := e.executor.ExecInContainer(ctx, nodeName, cmd)
 	if err != nil {
@@ -592,9 +601,9 @@ func (e *Exporter) refreshSingleImageContent(
 
 func buildCtrImagesRmCommand(imageRef string) []string {
 	return []string{
-		"ctr",
-		"--namespace=k8s.io",
-		"images",
+		ctrCommand,
+		ctrNamespaceArg,
+		ctrImages,
 		"rm",
 		imageRef,
 	}
@@ -602,9 +611,9 @@ func buildCtrImagesRmCommand(imageRef string) []string {
 
 func buildCtrPullCommand(platform string, imageRef string) []string {
 	return []string{
-		"ctr",
-		"--namespace=k8s.io",
-		"images",
+		ctrCommand,
+		ctrNamespaceArg,
+		ctrImages,
 		"pull",
 		"--platform",
 		platform,
@@ -614,8 +623,8 @@ func buildCtrPullCommand(platform string, imageRef string) []string {
 
 func buildCtrContentFetchCommand(platform string, imageRef string) []string {
 	return []string{
-		"ctr",
-		"--namespace=k8s.io",
+		ctrCommand,
+		ctrNamespaceArg,
 		"content",
 		"fetch",
 		"--platform",
@@ -673,9 +682,9 @@ func (e *Exporter) tryExportImages(
 	cmd := make([]string, 0, 7+len(images)) //nolint:mnd // fixed args + images
 	cmd = append(
 		cmd,
-		"ctr",
-		"--namespace=k8s.io",
-		"images",
+		ctrCommand,
+		ctrNamespaceArg,
+		ctrImages,
 		"export",
 		"--platform",
 		platform,

--- a/pkg/svc/image/importer.go
+++ b/pkg/svc/image/importer.go
@@ -195,7 +195,7 @@ func (i *Importer) importImagesToNode(
 	// Note: We don't use --all-platforms because multi-platform images may have
 	// manifests for platforms whose layers aren't present, causing import to fail.
 	cmd := []string{
-		"ctr", "--namespace=k8s.io", "images", "import",
+		ctrCommand, ctrNamespaceArg, ctrImages, "import",
 		"--digests",
 		tmpPath,
 	}


### PR DESCRIPTION
## What

Extracts the repeated containerd CLI tokens used across the `ctr` command builders in `pkg/svc/image` (`exporter.go`, `importer.go`) into named constants:

- `ctrCommand = "ctr"`
- `ctrNamespaceArg = "--namespace=k8s.io"`
- `ctrImages = "images"`

## Why

These literals were duplicated across `buildCtrImagesRmCommand`, `buildCtrPullCommand`, `buildCtrContentFetchCommand`, `tryExportImages`, the image-list command, and the importer — triggering `goconst`. Centralizing them gives the containerd vocabulary one home and clears the findings.

## Behavior

Unchanged — the builders produce identical argument slices (verified by the package's command-shape tests). The preallocated `export` builder keeps its capacity hint.

## Validation

- `go build ./pkg/svc/image/...` ✓
- `go test ./pkg/svc/image/...` — 102 passing ✓
- `golangci-lint run --new-from-rev=origin/main ./pkg/svc/image/...` — 0 issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)