### PR TITLE
refactor(registryresolver): extract localhost and spec constants

### DIFF
--- a/pkg/svc/registryresolver/detect.go
+++ b/pkg/svc/registryresolver/detect.go
@@ -140,8 +140,8 @@ func DetectRegistryFromFlux(ctx context.Context) (*Info, error) {
 		},
 		namespace:  "flux-system",
 		name:       "flux",
-		urlPath:    []string{"spec", "sync", "url"},
-		refPath:    []string{"spec", "sync", "ref"},
+		urlPath:    []string{specField, "sync", "url"},
+		refPath:    []string{specField, "sync", "ref"},
 		errNoURL:   ErrFluxNoSyncURL,
 		sourceName: "FluxInstance",
 	})
@@ -157,8 +157,8 @@ func DetectRegistryFromArgoCD(ctx context.Context) (*Info, error) {
 		},
 		namespace:  "argocd",
 		name:       "ksail",
-		urlPath:    []string{"spec", "source", "repoURL"},
-		refPath:    []string{"spec", "source", "targetRevision"},
+		urlPath:    []string{specField, "source", "repoURL"},
+		refPath:    []string{specField, "source", "targetRevision"},
 		errNoURL:   ErrArgoCDNoRepoURL,
 		sourceName: "ArgoCD",
 	})
@@ -187,7 +187,7 @@ func DetectRegistryFromDocker(ctx context.Context, clusterName string) (*Info, e
 		)
 		if portErr == nil {
 			return &Info{
-				Host:       "localhost",
+				Host:       localhostHost,
 				Port:       int32(port), //nolint:gosec // port validated by Docker API
 				Repository: "",          // Will be derived from source directory
 				IsExternal: false,
@@ -216,7 +216,7 @@ func DetectRegistryFromDocker(ctx context.Context, clusterName string) (*Info, e
 	}
 
 	return &Info{
-		Host:       "localhost",
+		Host:       localhostHost,
 		Port:       int32(port), //nolint:gosec // port validated by Docker API
 		Repository: "",          // Will be derived from source directory
 		IsExternal: false,

--- a/pkg/svc/registryresolver/registry.go
+++ b/pkg/svc/registryresolver/registry.go
@@ -55,6 +55,11 @@ const (
 	// credentialParts is the expected number of parts when splitting username:password.
 	credentialParts = 2
 
+	// localhostHost is the canonical local registry host.
+	localhostHost = "localhost"
+	// specField is the top-level "spec" key navigated in GitOps custom resources.
+	specField = "spec"
+
 	// Flux stores registry credentials as a Docker config secret.
 	fluxSecretNamespace = "flux-system"
 	fluxSecretName      = "ksail-registry-credentials" //nolint:gosec // Not a credential, just a secret name
@@ -95,7 +100,7 @@ func parseHostPort(hostPort string) hostPortInfo {
 
 // isExternalHost checks if a host is external (not localhost).
 func isExternalHost(host string) bool {
-	return !strings.HasPrefix(host, "localhost") &&
+	return !strings.HasPrefix(host, localhostHost) &&
 		!strings.HasPrefix(host, "127.0.0.1") &&
 		!strings.HasSuffix(host, ".localhost")
 }
@@ -170,7 +175,7 @@ func translateInternalHostname(ctx context.Context, info *Info) error {
 	}
 
 	// Successfully resolved - update info to use localhost
-	info.Host = "localhost"
+	info.Host = localhostHost
 	info.Port = int32(port) //nolint:gosec // port validated by Docker API
 	info.IsExternal = false
 


### PR DESCRIPTION
## What

Extracts two repeated source literals in `pkg/svc/registryresolver` into named constants:

- `localhostHost = "localhost"` — used in `isExternalHost` (prefix check), the Docker-detection `Info.Host` results, and `translateInternalHostname`.
- `specField = "spec"` — the top-level key navigated in the Flux/ArgoCD GitOps resource path slices.

The `".localhost"` suffix check and the `"127.0.0.1"` literal are intentionally left as-is (distinct strings, below the duplication threshold).

## Why

Clears the `goconst` findings on the duplicated literals; `localhostHost` in particular gives the canonical local-registry host one definition.

## Behavior

Unchanged — identical string values.

## Validation

- `go build ./pkg/svc/registryresolver/...` ✓
- `go test ./pkg/svc/registryresolver/...` — 79 passing ✓
- `golangci-lint run --new-from-rev=origin/main ./pkg/svc/registryresolver/...` — 0 issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)