### PR TITLE
refactor(installer): extract repeated helm/API constants

### DIFF
--- a/pkg/svc/installer/cni/calico/installer.go
+++ b/pkg/svc/installer/cni/calico/installer.go
@@ -41,6 +41,9 @@ const (
 	// The previous 5×10s (40s) window proved insufficient after 5+ occurrences.
 	calicoInstallRetryAttempts = 8
 	calicoInstallRetryBackoff  = 15 * time.Second
+
+	// calicoChartsRepoURL is the Tigera Helm chart repository serving the Calico charts.
+	calicoChartsRepoURL = "https://docs.tigera.io/calico/charts"
 )
 
 // NewInstaller creates a new Calico installer instance.
@@ -161,7 +164,7 @@ func (c *Installer) chartSpec() *helm.ChartSpec {
 		ChartName:       "projectcalico/tigera-operator",
 		Namespace:       "tigera-operator",
 		Version:         chartVersion(),
-		RepoURL:         "https://docs.tigera.io/calico/charts",
+		RepoURL:         calicoChartsRepoURL,
 		CreateNamespace: true,
 		SetJSONVals:     c.getCalicoValues(),
 		Timeout:         c.GetTimeout(),
@@ -179,7 +182,7 @@ func (c *Installer) crdChartSpec() *helm.ChartSpec {
 		ChartName:       "projectcalico/projectcalico.org.v3",
 		Namespace:       "tigera-operator",
 		Version:         chartVersion(),
-		RepoURL:         "https://docs.tigera.io/calico/charts",
+		RepoURL:         calicoChartsRepoURL,
 		CreateNamespace: true,
 		Timeout:         c.GetTimeout(),
 	}
@@ -210,7 +213,7 @@ func (c *Installer) installCalico(ctx context.Context) error {
 	// repeating the AddRepository call on every outer retry iteration.
 	repoEntry := &helm.RepositoryEntry{
 		Name: "projectcalico",
-		URL:  "https://docs.tigera.io/calico/charts",
+		URL:  calicoChartsRepoURL,
 	}
 
 	addErr := client.AddRepository(ctx, repoEntry, c.GetTimeout())

--- a/pkg/svc/installer/metallb/installer.go
+++ b/pkg/svc/installer/metallb/installer.go
@@ -23,6 +23,10 @@ const (
 	metallbChartName = "metallb/metallb"
 	defaultIPRange   = "172.18.255.200-172.18.255.250"
 
+	// metallbAPIGroup and metallbAPIVersion identify MetalLB's CRD GroupVersion.
+	metallbAPIGroup   = "metallb.io"
+	metallbAPIVersion = "v1beta1"
+
 	// crdPollInterval is the interval between CRD readiness checks.
 	crdPollInterval = 2 * time.Second
 	// crdPollTimeout is the maximum time to wait for MetalLB CRDs to be registered.
@@ -168,8 +172,8 @@ func (m *Installer) waitForCRDsWithOptions(
 	pollInterval, pollTimeout time.Duration,
 ) error {
 	ipAddressPoolGVR := schema.GroupVersionResource{
-		Group:    "metallb.io",
-		Version:  "v1beta1",
+		Group:    metallbAPIGroup,
+		Version:  metallbAPIVersion,
 		Resource: "ipaddresspools",
 	}
 
@@ -215,8 +219,8 @@ func (m *Installer) ensureIPAddressPool(
 	client dynamic.Interface,
 ) error {
 	gvr := schema.GroupVersionResource{
-		Group:    "metallb.io",
-		Version:  "v1beta1",
+		Group:    metallbAPIGroup,
+		Version:  metallbAPIVersion,
 		Resource: "ipaddresspools",
 	}
 
@@ -253,8 +257,8 @@ func (m *Installer) ensureL2Advertisement(
 	client dynamic.Interface,
 ) error {
 	gvr := schema.GroupVersionResource{
-		Group:    "metallb.io",
-		Version:  "v1beta1",
+		Group:    metallbAPIGroup,
+		Version:  metallbAPIVersion,
 		Resource: "l2advertisements",
 	}
 


### PR DESCRIPTION
## What

Extracts genuinely-duplicated source literals in two installers:

- **metallb** — `metallbAPIGroup = "metallb.io"` and `metallbAPIVersion = "v1beta1"`, reused across the three `GroupVersionResource` definitions.
- **calico** — `calicoChartsRepoURL = "https://docs.tigera.io/calico/charts"`, reused across the `ChartSpec` and `RepositoryEntry`.

## Why

These are the same concept repeated (one CRD GroupVersion; one Helm repo URL), so a single definition is the right DRY boundary and clears the `goconst` findings.

## Deliberately left inline

Coincidental name duplicates such as `"cilium"`, `"kyverno"`, and `"tigera-operator"` — which serve simultaneously as a Helm **release name**, **repo name**, and **namespace** — are *not* consted. They share a value by coincidence, not by concept; one shared const would imply a coupling that doesn't exist and would be a worse design than the literals. (These remain as `goconst` baseline noise.)

## Behavior

Unchanged — identical string values.

## Validation

- `go build` + `go test ./pkg/svc/installer/metallb/... ./pkg/svc/installer/cni/calico/...` — 67 passing ✓
- `golangci-lint run --new-from-rev=origin/main` on both packages — 0 issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)