### PR TITLE
refactor(cli): centralize cluster mutation-flag application

### DIFF
--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -90,8 +90,7 @@ func handleCreateRunE(
 		return err
 	}
 
-	applyOIDCExtraScopeFlag(cmd, ctx.ClusterCfg)
-	applyAllowedCIDRsFlag(cmd, ctx.ClusterCfg)
+	applyClusterMutationFlags(cmd, ctx.ClusterCfg)
 
 	// Re-validate OIDC after merging CLI scope flags which can change ExtraScopes
 	err = v1alpha1.ValidateOIDCConfig(&ctx.ClusterCfg.Spec.Cluster.OIDC)

--- a/pkg/cli/cmd/cluster/init.go
+++ b/pkg/cli/cmd/cluster/init.go
@@ -186,8 +186,7 @@ func HandleInitRunE(
 		return err
 	}
 
-	applyOIDCExtraScopeFlag(cmd, clusterCfg)
-	applyAllowedCIDRsFlag(cmd, clusterCfg)
+	applyClusterMutationFlags(cmd, clusterCfg)
 
 	err = validatePostFlagInitConfig(clusterCfg)
 	if err != nil {

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -110,6 +110,15 @@ func applyAllowedCIDRsFlag(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
 	clusterCfg.Spec.Provider.Hetzner.AllowedCIDRs = cidrs
 }
 
+// applyClusterMutationFlags merges the non-Viper CLI flag overrides
+// (--oidc-extra-scope and --allowed-cidrs) into the cluster config. Centralizing
+// the set keeps every mutation command (create, update, init) applying the same
+// flags; a new manually-merged flag is added here once rather than at each call site.
+func applyClusterMutationFlags(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
+	applyOIDCExtraScopeFlag(cmd, clusterCfg)
+	applyAllowedCIDRsFlag(cmd, clusterCfg)
+}
+
 // setupMutationCmdFlags creates the shared config manager and registers the
 // common flags (--mirror-registry and --name) used by cluster mutation commands.
 // Returns the config manager for further flag bindings.

--- a/pkg/cli/cmd/cluster/update.go
+++ b/pkg/cli/cmd/cluster/update.go
@@ -126,8 +126,7 @@ func handleUpdateRunE(
 		return err
 	}
 
-	applyOIDCExtraScopeFlag(cmd, ctx.ClusterCfg)
-	applyAllowedCIDRsFlag(cmd, ctx.ClusterCfg)
+	applyClusterMutationFlags(cmd, ctx.ClusterCfg)
 
 	// Re-validate OIDC after merging CLI scope flags which can change ExtraScopes
 	err = v1alpha1.ValidateOIDCConfig(&ctx.ClusterCfg.Spec.Cluster.OIDC)


### PR DESCRIPTION
## What

Extracts `applyClusterMutationFlags(cmd, clusterCfg)` in `pkg/cli/cmd/cluster/mutation.go`, replacing the identical consecutive pair

```go
applyOIDCExtraScopeFlag(cmd, cfg)
applyAllowedCIDRsFlag(cmd, cfg)
```

that appeared in the `create`, `update`, and `init` handlers.

## Why

The set of non-Viper, manually-merged CLI flags (`--oidc-extra-scope`, `--allowed-cidrs`) was duplicated across three call sites. Centralizing it means a future manually-merged flag is added in one place — removing the risk of adding a flag and forgetting one of the three commands.

## Scope / behavior

Behavior-preserving. Only the two-call pair is extracted; each command keeps its **own** distinct post-merge validation (`create`/`update` re-validate OIDC, `update` also validates allowed CIDRs, `init` runs `validatePostFlagInitConfig`) — those are intentionally *not* unified because they genuinely differ.

## Validation

- `go build ./pkg/cli/cmd/cluster/...` ✓
- `go test ./pkg/cli/cmd/cluster/...` — 520 passing ✓
- `golangci-lint run --new-from-rev=origin/main ./pkg/cli/cmd/cluster/...` — 0 issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)