### PR TITLE
test(hetzner): cover server-creation retry/fallback orchestration

### DIFF
--- a/pkg/svc/provider/hetzner/create_server_test.go
+++ b/pkg/svc/provider/hetzner/create_server_test.go
@@ -45,10 +45,10 @@ func successTestAction(id int64) isoBootTestAction {
 	return isoBootTestAction{ID: id, Status: "success", Progress: 100}
 }
 
-func serverCreateResp(serverID, actionID int64) isoBootTestServerCreateResp {
+func serverCreateResp() isoBootTestServerCreateResp {
 	return isoBootTestServerCreateResp{
-		Server: isoBootTestServerSummary{ID: serverID},
-		Action: successTestAction(actionID),
+		Server: isoBootTestServerSummary{ID: createdServerID},
+		Action: successTestAction(1),
 	}
 }
 
@@ -63,7 +63,7 @@ func registerCreateServerHandlers(
 	mux.HandleFunc("POST /servers", func(w http.ResponseWriter, r *http.Request) {
 		*createBody, _ = io.ReadAll(r.Body)
 
-		writeJSONResponse(t, w, serverCreateResp(123, 1))
+		writeJSONResponse(t, w, serverCreateResp())
 	})
 	mux.HandleFunc(
 		"POST /servers/123/actions/attach_iso",

--- a/pkg/svc/provider/hetzner/server_retry_orchestration_test.go
+++ b/pkg/svc/provider/hetzner/server_retry_orchestration_test.go
@@ -130,7 +130,7 @@ func TestCreateServerWithRetry_SuccessFirstAttempt(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, _ *http.Request) {
 		calls.Add(1)
-		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+		writeJSONResponse(t, writer, serverCreateResp())
 	})
 
 	prov := newRetryTestProvider(t, mux)
@@ -174,7 +174,7 @@ func TestCreateServerWithRetry_PlacementFallbackSucceeds(t *testing.T) {
 
 		_, hasGroup := body["placement_group"]
 		secondHadGroup.Store(hasGroup)
-		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+		writeJSONResponse(t, writer, serverCreateResp())
 	})
 
 	prov := newRetryTestProvider(t, mux)
@@ -225,7 +225,7 @@ func TestCreateServerWithRetry_LocationFallbackSucceeds(t *testing.T) {
 		}
 
 		fallbackCalls.Add(1)
-		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+		writeJSONResponse(t, writer, serverCreateResp())
 	})
 
 	prov := newRetryTestProvider(t, mux)
@@ -311,7 +311,7 @@ func TestCreateServerWithRetry_RetryThenSuccess(t *testing.T) {
 			return
 		}
 
-		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+		writeJSONResponse(t, writer, serverCreateResp())
 	})
 
 	prov := newRetryTestProvider(t, mux)

--- a/pkg/svc/provider/hetzner/server_retry_orchestration_test.go
+++ b/pkg/svc/provider/hetzner/server_retry_orchestration_test.go
@@ -1,0 +1,363 @@
+package hetzner_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the server-creation retry/fallback ORCHESTRATION
+// (CreateServerWithRetry and attemptServerCreationInLocation) rather than the
+// pure predicate helpers covered by server_retry_test.go. They drive the
+// orchestration through a mock Hetzner API (httptest) so the location-fallback,
+// placement-group-fallback, retry-with-backoff and permanent-error branches are
+// covered without a live cluster.
+//
+// Error-code choice matters: hcloud's own client retries internally only on
+// conflict / rate_limit_exceeded / timeout, so those codes would be consumed by
+// the client before the ksail layer ever sees them. The ksail retry path is
+// therefore driven with "locked" — retryable at the ksail layer
+// (IsRetryableHetznerError) but NOT retried by the hcloud client — so each
+// orchestration attempt maps to exactly one mock request.
+
+const (
+	// retryTestImageID is a placeholder image ID so buildServerCreateOpts takes
+	// the image (non-ISO) path, keeping the mock to a single POST /servers route.
+	retryTestImageID = 12345
+	// retryTestNodeName is the server name used across orchestration tests.
+	retryTestNodeName = "node"
+	// retryTestFallbackLocation is the secondary location used for fallback tests.
+	retryTestFallbackLocation = "nbg1"
+	// createdServerID is the server ID returned by the mock create endpoint.
+	createdServerID = 123
+)
+
+// retryTestOpts returns baseline server-create options targeting the primary
+// location via the image path; callers override individual fields as needed.
+func retryTestOpts() hetzner.CreateServerOpts {
+	return hetzner.CreateServerOpts{
+		Name:       retryTestNodeName,
+		ServerType: retryTestServerType,
+		Location:   retryTestLocation,
+		ImageID:    retryTestImageID,
+	}
+}
+
+// writeHcloudError writes a Hetzner API error response with the given code so
+// the hcloud client surfaces an hcloud.Error{Code: code}.
+func writeHcloudError(writer http.ResponseWriter, status int, code string) {
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(status)
+	_, _ = writer.Write([]byte(
+		`{"error":{"code":"` + code + `","message":"test ` + code + `","details":null}}`,
+	))
+}
+
+// newRetryTestProvider starts an httptest server with the given handler and
+// returns a Provider whose hcloud client targets it.
+func newRetryTestProvider(t *testing.T, handler http.Handler) *hetzner.Provider {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return hetzner.NewProvider(newTestHcloudClient(srv.URL))
+}
+
+// decodeServerCreateBody parses a POST /servers request body into a generic map.
+func decodeServerCreateBody(t *testing.T, request *http.Request) map[string]any {
+	t.Helper()
+
+	var body map[string]any
+
+	require.NoError(t, json.NewDecoder(request.Body).Decode(&body))
+
+	return body
+}
+
+func TestCreateServerWithRetry_NilClient(t *testing.T) {
+	t.Parallel()
+
+	prov := hetzner.NewProvider(nil)
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		retryTestOpts(),
+		hetzner.ServerRetryOpts{},
+	)
+
+	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
+	assert.Nil(t, server)
+}
+
+func TestCreateServerWithRetry_NoLocations(t *testing.T) {
+	t.Parallel()
+
+	// Non-nil client so the nil-client guard passes, but no location is
+	// configured (empty primary, no fallbacks) so buildLocationList is empty.
+	prov := newRetryTestProvider(t, http.HandlerFunc(
+		func(_ http.ResponseWriter, _ *http.Request) {
+			t.Error("no HTTP request expected when no locations are configured")
+		},
+	))
+
+	opts := retryTestOpts()
+	opts.Location = ""
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		opts,
+		hetzner.ServerRetryOpts{},
+	)
+
+	require.ErrorIs(t, err, hetzner.ErrNoLocationsConfigured)
+	assert.Nil(t, server)
+}
+
+func TestCreateServerWithRetry_SuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+	})
+
+	prov := newRetryTestProvider(t, mux)
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		retryTestOpts(),
+		hetzner.ServerRetryOpts{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(t, int64(createdServerID), server.ID)
+	assert.Equal(
+		t,
+		int32(1),
+		calls.Load(),
+		"a successful first attempt must make exactly one request",
+	)
+}
+
+func TestCreateServerWithRetry_PlacementFallbackSucceeds(t *testing.T) {
+	t.Parallel()
+
+	var (
+		calls          atomic.Int32
+		secondHadGroup atomic.Bool
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, request *http.Request) {
+		count := calls.Add(1)
+		body := decodeServerCreateBody(t, request)
+
+		if count == 1 {
+			// First attempt carries the placement group and fails placement.
+			writeHcloudError(writer, http.StatusUnprocessableEntity, "placement_error")
+
+			return
+		}
+
+		_, hasGroup := body["placement_group"]
+		secondHadGroup.Store(hasGroup)
+		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+	})
+
+	prov := newRetryTestProvider(t, mux)
+
+	opts := retryTestOpts()
+	opts.PlacementGroupID = 555
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		opts,
+		hetzner.ServerRetryOpts{AllowPlacementFallback: true},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(
+		t,
+		int32(2),
+		calls.Load(),
+		"placement fallback should retry once without the group",
+	)
+	assert.False(
+		t,
+		secondHadGroup.Load(),
+		"retry after placement failure must drop the placement group",
+	)
+}
+
+func TestCreateServerWithRetry_LocationFallbackSucceeds(t *testing.T) {
+	t.Parallel()
+
+	var (
+		primaryCalls  atomic.Int32
+		fallbackCalls atomic.Int32
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, request *http.Request) {
+		body := decodeServerCreateBody(t, request)
+		location, _ := body["location"].(string)
+
+		if location == retryTestLocation {
+			primaryCalls.Add(1)
+			// Non-retryable, non-placement error: abandon this location.
+			writeHcloudError(writer, http.StatusNotFound, "not_found")
+
+			return
+		}
+
+		fallbackCalls.Add(1)
+		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+	})
+
+	prov := newRetryTestProvider(t, mux)
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		retryTestOpts(),
+		hetzner.ServerRetryOpts{FallbackLocations: []string{retryTestFallbackLocation}},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(
+		t,
+		int32(1),
+		primaryCalls.Load(),
+		"non-retryable error must not retry the primary location",
+	)
+	assert.Equal(
+		t,
+		int32(1),
+		fallbackCalls.Load(),
+		"fallback location should be tried after the primary fails",
+	)
+}
+
+func TestCreateServerWithRetry_AllLocationsFail(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, _ *http.Request) {
+		writeHcloudError(writer, http.StatusNotFound, "not_found")
+	})
+
+	prov := newRetryTestProvider(t, mux)
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		retryTestOpts(),
+		hetzner.ServerRetryOpts{FallbackLocations: []string{retryTestFallbackLocation}},
+	)
+
+	require.ErrorIs(t, err, hetzner.ErrAllLocationsFailed)
+	assert.Nil(t, server)
+}
+
+func TestCreateServerWithRetry_PermanentErrorNotRetried(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		writeHcloudError(writer, http.StatusForbidden, "resource_limit_exceeded")
+	})
+
+	prov := newRetryTestProvider(t, mux)
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		retryTestOpts(),
+		hetzner.ServerRetryOpts{},
+	)
+
+	require.ErrorIs(t, err, hetzner.ErrAllLocationsFailed)
+	assert.Nil(t, server)
+	assert.Equal(t, int32(1), calls.Load(), "a permanent resource-limit error must not be retried")
+}
+
+func TestCreateServerWithRetry_RetryThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			// "locked" is retryable at the ksail layer but not retried by the
+			// hcloud client, so the ksail backoff loop drives the second attempt.
+			writeHcloudError(writer, http.StatusLocked, "locked")
+
+			return
+		}
+
+		writeJSONResponse(t, writer, serverCreateResp(createdServerID, 1))
+	})
+
+	prov := newRetryTestProvider(t, mux)
+
+	server, err := prov.CreateServerWithRetry(
+		context.Background(),
+		retryTestOpts(),
+		hetzner.ServerRetryOpts{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(
+		t,
+		int32(2),
+		calls.Load(),
+		"a transient error should be retried within the same location",
+	)
+}
+
+func TestCreateServerWithRetry_ContextCancelledDuringRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var calls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /servers", func(writer http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		// Cancel before returning the transient error so the backoff wait
+		// observes a cancelled context instead of sleeping for the full delay.
+		cancel()
+		writeHcloudError(writer, http.StatusLocked, "locked")
+	})
+
+	prov := newRetryTestProvider(t, mux)
+
+	server, err := prov.CreateServerWithRetry(
+		ctx,
+		retryTestOpts(),
+		hetzner.ServerRetryOpts{},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, server)
+	assert.Equal(t, int32(1), calls.Load(), "a cancelled context must stop further retry attempts")
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds unit coverage for the Hetzner **server-creation retry/fallback orchestration** — `CreateServerWithRetry` and `attemptServerCreationInLocation` in [`pkg/svc/provider/hetzner/server_retry.go`](https://github.com/devantler-tech/ksail/blob/main/pkg/svc/provider/hetzner/server_retry.go), which were at **0% coverage**. Only the pure predicate helpers (`shouldRetryError`, `shouldDisablePlacement`, `calculateRetryDelay`) had tests; the actual orchestration that keeps cluster provisioning resilient (location fallback, placement-group fallback, transient-error retry with exponential backoff) was untested.

## How

New `server_retry_orchestration_test.go` drives the orchestration through a **mock Hetzner API** (`httptest`) over the package's existing `newTestHcloudClient` pattern — no live cluster required. Cases:

| Scenario | Asserts |
|---|---|
| nil client | `ErrProviderUnavailable` |
| no locations configured | `ErrNoLocationsConfigured` |
| success on first attempt | server returned, 1 request |
| **placement-group fallback** | `placement_error` → retry drops the group and succeeds; retried request omits `placement_group` |
| **location fallback** | non-retryable error abandons the primary; fallback location succeeds |
| all locations exhausted | `ErrAllLocationsFailed` |
| permanent error (`resource_limit_exceeded`) | not retried (exactly 1 request) |
| transient error (`locked`) | retried within the location, then succeeds |
| context cancelled during backoff wait | stops further attempts |

**Error-code choice is deliberate:** hcloud's own client retries internally only on `conflict` / `rate_limit_exceeded` / `timeout`, so those would be consumed before the ksail layer sees them. The ksail retry path is therefore driven with `locked` — retryable at the ksail layer (`IsRetryableHetznerError`) but **not** retried by the hcloud client — so each orchestration attempt maps to exactly one mock request, keeping assertions on request counts exact.

## Coverage impact

`pkg/svc/provider/hetzner` package: **36.4% → 46.5%**

- `CreateServerWithRetry`: 0% → **100%**
- `attemptServerCreationInLocation`: 0% → **95.7%** (the all-retries-exhausted-in-one-location branch is intentionally omitted — covering it requires the real 2s+4s exponential backoff, too slow for a unit test; the single-retry-then-success and context-cancellation cases already exercise the retry/wait code)
- all retry log helpers + `waitForRetryDelay`: → **100%**

## Validation

- `golangci-lint run` — new file is **clean** (0 issues attributable to it)
- `go build` — OK
- `go test ./pkg/svc/provider/hetzner/` — pass (~2.6s)

Behaviour-preserving: **tests only**, no production code changed.