### PR TITLE
fix(hetzner): restart cluster-autoscaler when its config secret changes on update

### DIFF
--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -1,0 +1,89 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+// RolloutRestartAnnotation is the pod-template annotation that triggers a rolling
+// restart, matching the key `kubectl rollout restart` stamps. Changing its value
+// mutates the pod template, so the Deployment controller recreates the pods — the
+// only way pods that source environment variables from a Secret or ConfigMap pick
+// up data changes, since Kubernetes does not live-reload env vars.
+const RolloutRestartAnnotation = "kubectl.kubernetes.io/restartedAt"
+
+// RolloutRestartDeploymentsByLabel triggers a rolling restart of every Deployment
+// in namespace whose labels match labelSelector, the same way
+// `kubectl rollout restart deployment -l <selector>` does: it stamps each pod
+// template's RolloutRestartAnnotation with the current time.
+//
+// Callers that rewrite a Secret or ConfigMap consumed via env-var valueFrom must
+// call this for the change to reach the running pods. A selector that matches no
+// Deployment is not an error (returns 0) — the workload may not be installed yet.
+// Returns the number of Deployments restarted.
+func RolloutRestartDeploymentsByLabel(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace string,
+	labelSelector string,
+) (int, error) {
+	deploymentsClient := client.AppsV1().Deployments(namespace)
+
+	list, err := deploymentsClient.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return 0, fmt.Errorf("listing deployments %q in %s: %w", labelSelector, namespace, err)
+	}
+
+	timestamp := time.Now().Format(time.RFC3339)
+	restarted := 0
+
+	for index := range list.Items {
+		err = restartDeployment(ctx, deploymentsClient, list.Items[index].Name, timestamp)
+		if err != nil {
+			return restarted, err
+		}
+
+		restarted++
+	}
+
+	return restarted, nil
+}
+
+// restartDeployment stamps a single Deployment's pod-template restart annotation,
+// retrying on optimistic-concurrency conflicts.
+func restartDeployment(
+	ctx context.Context,
+	deploymentsClient appsv1client.DeploymentInterface,
+	name, timestamp string,
+) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deployment, getErr := deploymentsClient.Get(ctx, name, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("getting deployment %s: %w", name, getErr)
+		}
+
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = map[string]string{}
+		}
+
+		deployment.Spec.Template.Annotations[RolloutRestartAnnotation] = timestamp
+
+		_, updateErr := deploymentsClient.Update(ctx, deployment, metav1.UpdateOptions{})
+		if updateErr != nil {
+			return fmt.Errorf("restarting deployment %s: %w", name, updateErr)
+		}
+
+		return nil
+	})
+	if retryErr != nil {
+		return fmt.Errorf("rolling restart of deployment %s: %w", name, retryErr)
+	}
+
+	return nil
+}

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -2,13 +2,13 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/client-go/util/retry"
 )
 
 // RolloutRestartAnnotation is the pod-template annotation that triggers a rolling
@@ -21,7 +21,10 @@ const RolloutRestartAnnotation = "kubectl.kubernetes.io/restartedAt"
 // RolloutRestartDeploymentsByLabel triggers a rolling restart of every Deployment
 // in namespace whose labels match labelSelector, the same way
 // `kubectl rollout restart deployment -l <selector>` does: it stamps each pod
-// template's RolloutRestartAnnotation with the current time.
+// template's RolloutRestartAnnotation with the current time via a strategic-merge
+// patch. The patch merges the annotation into any existing pod-template
+// annotations rather than replacing them, and is atomic — so, unlike a
+// get-modify-update, it needs no optimistic-concurrency retry.
 //
 // Callers that rewrite a Secret or ConfigMap consumed via env-var valueFrom must
 // call this for the change to reach the running pods. A selector that matches no
@@ -40,13 +43,25 @@ func RolloutRestartDeploymentsByLabel(
 		return 0, fmt.Errorf("listing deployments %q in %s: %w", labelSelector, namespace, err)
 	}
 
-	timestamp := time.Now().Format(time.RFC3339)
+	patch, err := rolloutRestartPatch()
+	if err != nil {
+		return 0, err
+	}
+
 	restarted := 0
 
 	for index := range list.Items {
-		err = restartDeployment(ctx, deploymentsClient, list.Items[index].Name, timestamp)
+		name := list.Items[index].Name
+
+		_, err = deploymentsClient.Patch(
+			ctx,
+			name,
+			types.StrategicMergePatchType,
+			patch,
+			metav1.PatchOptions{},
+		)
 		if err != nil {
-			return restarted, err
+			return restarted, fmt.Errorf("restarting deployment %s: %w", name, err)
 		}
 
 		restarted++
@@ -55,35 +70,26 @@ func RolloutRestartDeploymentsByLabel(
 	return restarted, nil
 }
 
-// restartDeployment stamps a single Deployment's pod-template restart annotation,
-// retrying on optimistic-concurrency conflicts.
-func restartDeployment(
-	ctx context.Context,
-	deploymentsClient appsv1client.DeploymentInterface,
-	name, timestamp string,
-) error {
-	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		deployment, getErr := deploymentsClient.Get(ctx, name, metav1.GetOptions{})
-		if getErr != nil {
-			return fmt.Errorf("getting deployment %s: %w", name, getErr)
-		}
-
-		if deployment.Spec.Template.Annotations == nil {
-			deployment.Spec.Template.Annotations = map[string]string{}
-		}
-
-		deployment.Spec.Template.Annotations[RolloutRestartAnnotation] = timestamp
-
-		_, updateErr := deploymentsClient.Update(ctx, deployment, metav1.UpdateOptions{})
-		if updateErr != nil {
-			return fmt.Errorf("restarting deployment %s: %w", name, updateErr)
-		}
-
-		return nil
-	})
-	if retryErr != nil {
-		return fmt.Errorf("rolling restart of deployment %s: %w", name, retryErr)
+// rolloutRestartPatch builds the strategic-merge patch body that stamps the pod
+// template's RolloutRestartAnnotation with the current time, the same mutation
+// `kubectl rollout restart` applies.
+func rolloutRestartPatch() ([]byte, error) {
+	patch := map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]string{
+						RolloutRestartAnnotation: time.Now().Format(time.RFC3339),
+					},
+				},
+			},
+		},
 	}
 
-	return nil
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("building rollout-restart patch: %w", err)
+	}
+
+	return data, nil
 }

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -43,10 +42,14 @@ func RolloutRestartDeploymentsByLabel(
 		return 0, fmt.Errorf("listing deployments %q in %s: %w", labelSelector, namespace, err)
 	}
 
-	patch, err := rolloutRestartPatch()
-	if err != nil {
-		return 0, err
-	}
+	// Build the strategic-merge patch once; every matched Deployment gets the same
+	// restart timestamp. %q on the constant annotation key and the RFC3339 timestamp
+	// yields valid JSON, the same mutation `kubectl rollout restart` applies.
+	patch := fmt.Appendf(nil,
+		`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
+		RolloutRestartAnnotation,
+		time.Now().Format(time.RFC3339),
+	)
 
 	restarted := 0
 
@@ -68,28 +71,4 @@ func RolloutRestartDeploymentsByLabel(
 	}
 
 	return restarted, nil
-}
-
-// rolloutRestartPatch builds the strategic-merge patch body that stamps the pod
-// template's RolloutRestartAnnotation with the current time, the same mutation
-// `kubectl rollout restart` applies.
-func rolloutRestartPatch() ([]byte, error) {
-	patch := map[string]any{
-		"spec": map[string]any{
-			"template": map[string]any{
-				"metadata": map[string]any{
-					"annotations": map[string]string{
-						RolloutRestartAnnotation: time.Now().Format(time.RFC3339),
-					},
-				},
-			},
-		},
-	}
-
-	data, err := json.Marshal(patch)
-	if err != nil {
-		return nil, fmt.Errorf("building rollout-restart patch: %w", err)
-	}
-
-	return data, nil
 }

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -1,0 +1,100 @@
+package k8s_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const autoscalerSelector = "app.kubernetes.io/instance=cluster-autoscaler"
+
+// errListFailed is a static sentinel for the List-error reactor test.
+var errListFailed = errors.New("list deployments failed")
+
+// newLabeledDeployment builds a Deployment in kube-system carrying the
+// cluster-autoscaler instance label, optionally pre-seeded with pod-template
+// annotations so tests can assert they are preserved.
+func newLabeledDeployment(name string, templateAnnotations map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kube-system",
+			Labels:    map[string]string{"app.kubernetes.io/instance": "cluster-autoscaler"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: templateAnnotations},
+			},
+		},
+	}
+}
+
+func TestRolloutRestartDeploymentsByLabel_StampsAnnotation(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(
+		newLabeledDeployment("cluster-autoscaler", map[string]string{"keep": "me"}),
+	)
+
+	restarted, err := k8s.RolloutRestartDeploymentsByLabel(
+		context.Background(), clientset, "kube-system", autoscalerSelector,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, restarted)
+
+	deployment, err := clientset.AppsV1().Deployments("kube-system").Get(
+		context.Background(), "cluster-autoscaler", metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	annotations := deployment.Spec.Template.Annotations
+	assert.NotEmpty(t, annotations[k8s.RolloutRestartAnnotation],
+		"restart annotation must be stamped so the Deployment controller recreates the pods")
+	assert.Equal(t, "me", annotations["keep"],
+		"existing pod-template annotations must be preserved")
+}
+
+func TestRolloutRestartDeploymentsByLabel_NoMatchIsNotError(t *testing.T) {
+	t.Parallel()
+
+	// A Deployment that does not carry the selector label must be left untouched
+	// and must not cause an error (the autoscaler may simply not be installed).
+	clientset := k8sfake.NewClientset(newLabeledDeployment("other", nil))
+
+	restarted, err := k8s.RolloutRestartDeploymentsByLabel(
+		context.Background(), clientset, "kube-system",
+		"app.kubernetes.io/instance=does-not-exist",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, restarted)
+}
+
+func TestRolloutRestartDeploymentsByLabel_ListError(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+
+	clientset.PrependReactor(
+		"list",
+		"deployments",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errListFailed
+		},
+	)
+
+	restarted, err := k8s.RolloutRestartDeploymentsByLabel(
+		context.Background(), clientset, "kube-system", autoscalerSelector,
+	)
+	require.ErrorIs(t, err, errListFailed)
+	assert.Equal(t, 0, restarted)
+}

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -21,6 +21,9 @@ const autoscalerSelector = "app.kubernetes.io/instance=cluster-autoscaler"
 // errListFailed is a static sentinel for the List-error reactor test.
 var errListFailed = errors.New("list deployments failed")
 
+// errPatchFailed is a static sentinel for the Patch-error reactor test.
+var errPatchFailed = errors.New("patch deployment failed")
+
 // newLabeledDeployment builds a Deployment in kube-system carrying the
 // cluster-autoscaler instance label, optionally pre-seeded with pod-template
 // annotations so tests can assert they are preserved.
@@ -96,5 +99,27 @@ func TestRolloutRestartDeploymentsByLabel_ListError(t *testing.T) {
 		context.Background(), clientset, "kube-system", autoscalerSelector,
 	)
 	require.ErrorIs(t, err, errListFailed)
+	assert.Equal(t, 0, restarted)
+}
+
+func TestRolloutRestartDeploymentsByLabel_PatchError(t *testing.T) {
+	t.Parallel()
+
+	// A matched Deployment whose Patch fails must surface the error and report it
+	// as not-restarted.
+	clientset := k8sfake.NewClientset(newLabeledDeployment("cluster-autoscaler", nil))
+
+	clientset.PrependReactor(
+		"patch",
+		"deployments",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errPatchFailed
+		},
+	)
+
+	restarted, err := k8s.RolloutRestartDeploymentsByLabel(
+		context.Background(), clientset, "kube-system", autoscalerSelector,
+	)
+	require.ErrorIs(t, err, errPatchFailed)
 	assert.Equal(t, 0, restarted)
 }

--- a/pkg/svc/installer/clusterautoscaler/installer.go
+++ b/pkg/svc/installer/clusterautoscaler/installer.go
@@ -18,6 +18,12 @@ const (
 	defaultScaleDownUnneededTime = "10m"
 	defaultOkTotalUnreadyCount   = 3
 
+	// ReleaseName is the Helm release name for the cluster-autoscaler chart, which
+	// the chart also stamps as the app.kubernetes.io/instance label value. The Talos
+	// provisioner selects on that label to roll the Deployment when its config Secret
+	// changes, so both derive from this single constant rather than drifting.
+	ReleaseName = "cluster-autoscaler"
+
 	// AutoscalerConfigSecretName is the Kubernetes Secret containing per-cluster
 	// autoscaler parameters (cloud-init template, base image tag). It is created by
 	// the Talos provisioner's ApplyAutoscalerConfigSecret before the installer runs.
@@ -73,7 +79,7 @@ func NewInstaller(
 
 	return &Installer{
 		Base: helmutil.NewBase(
-			"cluster-autoscaler",
+			ReleaseName,
 			client,
 			timeout,
 			&helm.RepositoryEntry{
@@ -81,7 +87,7 @@ func NewInstaller(
 				URL:  repoURL,
 			},
 			&helm.ChartSpec{
-				ReleaseName: "cluster-autoscaler",
+				ReleaseName: ReleaseName,
 				ChartName:   "autoscaler/cluster-autoscaler",
 				Namespace:   namespace,
 				Version:     chartVersion(),

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	clusterautoscalerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/clusterautoscaler"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,10 +22,10 @@ const (
 	autoscalerConfigSecretName      = "cluster-autoscaler-config"
 	autoscalerConfigSecretNamespace = "kube-system"
 
-	// autoscalerDeploymentSelector matches the cluster-autoscaler Deployment via
-	// the standard Helm instance label. It must stay in sync with the chart
-	// ReleaseName ("cluster-autoscaler") in pkg/svc/installer/clusterautoscaler.
-	autoscalerDeploymentSelector = "app.kubernetes.io/instance=cluster-autoscaler"
+	// autoscalerDeploymentSelector matches the cluster-autoscaler Deployment via the
+	// standard Helm instance label, derived from the installer's ReleaseName so the
+	// selector and the chart that stamps the label cannot drift apart.
+	autoscalerDeploymentSelector = "app.kubernetes.io/instance=" + clusterautoscalerinstaller.ReleaseName
 
 	// hetznerUserDataLimitBytes is Hetzner Cloud's hard ceiling on a server's
 	// user_data field (32 KiB). The cluster-autoscaler base64-decodes the
@@ -204,7 +205,9 @@ func createOrUpdateAutoscalerSecretOnConflict(
 // updateAutoscalerSecretIfNeeded merges the desired keys into the existing
 // Secret. It skips the update when all desired keys already match to avoid
 // unnecessary API calls. RetryOnConflict handles 409 responses from concurrent
-// updaters. It returns whether the Secret's data was changed.
+// updaters. It returns true only when it actually performed an update — if a
+// concurrent writer already applied the desired data, it reports false so the
+// caller does not roll the autoscaler for a Secret it did not change.
 func updateAutoscalerSecretIfNeeded(
 	ctx context.Context,
 	client kubernetes.Interface,
@@ -216,6 +219,7 @@ func updateAutoscalerSecretIfNeeded(
 	}
 
 	secretsClient := client.CoreV1().Secrets(autoscalerConfigSecretNamespace)
+	updated := false
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest, getErr := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
@@ -232,11 +236,13 @@ func updateAutoscalerSecretIfNeeded(
 			return fmt.Errorf("update autoscaler config secret: %w", updateErr)
 		}
 
+		updated = true
+
 		return nil
 	})
 	if retryErr != nil {
 		return false, fmt.Errorf("failed to update autoscaler config secret: %w", retryErr)
 	}
 
-	return true, nil
+	return updated, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -21,6 +21,11 @@ const (
 	autoscalerConfigSecretName      = "cluster-autoscaler-config"
 	autoscalerConfigSecretNamespace = "kube-system"
 
+	// autoscalerDeploymentSelector matches the cluster-autoscaler Deployment via
+	// the standard Helm instance label. It must stay in sync with the chart
+	// ReleaseName ("cluster-autoscaler") in pkg/svc/installer/clusterautoscaler.
+	autoscalerDeploymentSelector = "app.kubernetes.io/instance=cluster-autoscaler"
+
 	// hetznerUserDataLimitBytes is Hetzner Cloud's hard ceiling on a server's
 	// user_data field (32 KiB). The cluster-autoscaler base64-decodes the
 	// HCLOUD_CLOUD_INIT secret value exactly once and passes the result verbatim
@@ -125,15 +130,20 @@ func encodeAutoscalerCloudInit(workerConfigYAML []byte) (string, error) {
 // gzip-compressed, base64-encoded Talos worker config that Kubernetes Cluster
 // Autoscaler uses as cloud-init user-data when provisioning new worker nodes
 // (see encodeAutoscalerCloudInit for the encoding rationale).
+//
+// It returns whether the Secret's data was created or changed. The autoscaler
+// reads these keys as environment variables (valueFrom.secretKeyRef), which
+// Kubernetes does not live-reload, so a true result means callers must restart
+// the autoscaler Deployment for the new config to reach freshly provisioned nodes.
 func ApplyAutoscalerConfigSecret(
 	ctx context.Context,
 	kubeclient kubernetes.Interface,
 	snapshotImageID string,
 	workerConfigYAML []byte,
-) error {
+) (bool, error) {
 	encodedConfig, err := encodeAutoscalerCloudInit(workerConfigYAML)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	desiredData := map[string][]byte{
@@ -154,7 +164,7 @@ func ApplyAutoscalerConfigSecret(
 	existing, err := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("get autoscaler config secret: %w", err)
+			return false, fmt.Errorf("get autoscaler config secret: %w", err)
 		}
 
 		return createOrUpdateAutoscalerSecretOnConflict(ctx, kubeclient, secret)
@@ -165,43 +175,44 @@ func ApplyAutoscalerConfigSecret(
 
 // createOrUpdateAutoscalerSecretOnConflict creates the Secret. If a concurrent
 // caller already created it between the outer Get and this Create, it falls
-// back to a merge-update to stay idempotent.
+// back to a merge-update to stay idempotent. It returns whether the Secret's data
+// was created or changed.
 func createOrUpdateAutoscalerSecretOnConflict(
 	ctx context.Context,
 	client kubernetes.Interface,
 	secret *corev1.Secret,
-) error {
+) (bool, error) {
 	secretsClient := client.CoreV1().Secrets(autoscalerConfigSecretNamespace)
 
 	_, err := secretsClient.Create(ctx, secret, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("create autoscaler config secret: %w", err)
+			return false, fmt.Errorf("create autoscaler config secret: %w", err)
 		}
 
 		existing, getErr := secretsClient.Get(ctx, autoscalerConfigSecretName, metav1.GetOptions{})
 		if getErr != nil {
-			return fmt.Errorf("get autoscaler config secret after conflict: %w", getErr)
+			return false, fmt.Errorf("get autoscaler config secret after conflict: %w", getErr)
 		}
 
 		return updateAutoscalerSecretIfNeeded(ctx, client, existing, secret.Data)
 	}
 
-	return nil
+	return true, nil
 }
 
 // updateAutoscalerSecretIfNeeded merges the desired keys into the existing
 // Secret. It skips the update when all desired keys already match to avoid
 // unnecessary API calls. RetryOnConflict handles 409 responses from concurrent
-// updaters.
+// updaters. It returns whether the Secret's data was changed.
 func updateAutoscalerSecretIfNeeded(
 	ctx context.Context,
 	client kubernetes.Interface,
 	existing *corev1.Secret,
 	desiredData map[string][]byte,
-) error {
+) (bool, error) {
 	if !k8s.MergeSecretData(existing, desiredData) {
-		return nil
+		return false, nil
 	}
 
 	secretsClient := client.CoreV1().Secrets(autoscalerConfigSecretNamespace)
@@ -224,8 +235,8 @@ func updateAutoscalerSecretIfNeeded(
 		return nil
 	})
 	if retryErr != nil {
-		return fmt.Errorf("failed to update autoscaler config secret: %w", retryErr)
+		return false, fmt.Errorf("failed to update autoscaler config secret: %w", retryErr)
 	}
 
-	return nil
+	return true, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -219,7 +219,7 @@ func TestApplyAutoscalerConfigSecret_CreatesNewSecret(t *testing.T) {
 	snapshotID := "123456789"
 	workerConfig := []byte("machine:\n  type: worker\n")
 
-	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+	_, err := talosprovisioner.ApplyAutoscalerConfigSecret(
 		context.Background(),
 		clientset,
 		snapshotID,
@@ -237,6 +237,29 @@ func TestApplyAutoscalerConfigSecret_CreatesNewSecret(t *testing.T) {
 	assert.Equal(t, []byte(snapshotID), secret.Data["hcloud_image"])
 
 	assert.Equal(t, workerConfig, decodeAutoscalerCloudInit(t, secret.Data["hcloud_cloud_init"]))
+}
+
+func TestApplyAutoscalerConfigSecret_ReturnsChangedFlag(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset()
+	workerConfig := []byte("machine:\n  type: worker\n")
+
+	// First apply creates the secret => changed.
+	changed, err := talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(), clientset, "123456789", workerConfig,
+	)
+	require.NoError(t, err)
+	assert.True(t, changed, "creating the secret must report a change")
+
+	// Re-applying identical inputs is a no-op => not changed. This is what gates
+	// the autoscaler Deployment restart, so an unrelated `cluster update` does not
+	// needlessly bounce the autoscaler.
+	changed, err = talosprovisioner.ApplyAutoscalerConfigSecret(
+		context.Background(), clientset, "123456789", workerConfig,
+	)
+	require.NoError(t, err)
+	assert.False(t, changed, "re-applying identical config must report no change")
 }
 
 func TestApplyAutoscalerConfigSecret_PreservesExtraKeysOnUpdate(t *testing.T) {
@@ -258,7 +281,7 @@ func TestApplyAutoscalerConfigSecret_PreservesExtraKeysOnUpdate(t *testing.T) {
 	snapshotID := "111111111"
 	workerConfig := []byte("machine:\n  type: worker\n")
 
-	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+	_, err := talosprovisioner.ApplyAutoscalerConfigSecret(
 		context.Background(),
 		clientset,
 		snapshotID,
@@ -300,7 +323,7 @@ func TestApplyAutoscalerConfigSecret_UpdatesExistingSecret(t *testing.T) {
 	snapshotID := "987654321"
 	workerConfig := []byte("machine:\n  type: worker\n  install:\n    wipe: true\n")
 
-	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+	_, err := talosprovisioner.ApplyAutoscalerConfigSecret(
 		context.Background(),
 		clientset,
 		snapshotID,
@@ -375,7 +398,7 @@ func TestApplyAutoscalerConfigSecret_CreateConflictFallsBackToUpdate(t *testing.
 	}
 	clientset := newConflictClientset(preExisting)
 
-	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+	_, err := talosprovisioner.ApplyAutoscalerConfigSecret(
 		context.Background(), clientset, "new-image", []byte("new-config"),
 	)
 	require.NoError(t, err)
@@ -435,7 +458,7 @@ func TestApplyAutoscalerConfigSecret_CompressesLargeConfigUnderLimit(t *testing.
 	require.Greater(t, len(largeConfig), 32768,
 		"test fixture must exceed Hetzner's raw user_data limit to be representative")
 
-	err := talosprovisioner.ApplyAutoscalerConfigSecret(
+	_, err := talosprovisioner.ApplyAutoscalerConfigSecret(
 		context.Background(), clientset, "123456789", largeConfig,
 	)
 	require.NoError(t, err)
@@ -469,7 +492,7 @@ func TestApplyAutoscalerConfigSecret_RejectsOversizedConfig(t *testing.T) {
 	_, err := rand.Read(incompressible)
 	require.NoError(t, err)
 
-	err = talosprovisioner.ApplyAutoscalerConfigSecret(
+	_, err = talosprovisioner.ApplyAutoscalerConfigSecret(
 		context.Background(), clientset, "123456789", incompressible,
 	)
 	require.ErrorIs(t, err, talosprovisioner.ErrAutoscalerUserDataTooLarge)

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -16,6 +16,7 @@ import (
 	check "github.com/siderolabs/talos/pkg/cluster/check"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // NodeWithRoleForTest is the exported alias of nodeWithRole for testing.
@@ -360,6 +361,15 @@ func (p *Provisioner) EnsureAutoscalerSecretIfNeededForTest(
 	clusterName string,
 ) error {
 	return p.ensureAutoscalerSecretIfNeeded(ctx, clusterName)
+}
+
+// RestartAutoscalerAfterConfigChangeForTest exposes restartAutoscalerAfterConfigChange
+// for unit testing.
+func (p *Provisioner) RestartAutoscalerAfterConfigChangeForTest(
+	ctx context.Context,
+	kubeclient kubernetes.Interface,
+) error {
+	return p.restartAutoscalerAfterConfigChange(ctx, kubeclient)
 }
 
 // WithTalosOptsForTest sets talosOpts on the provisioner for unit testing.

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -251,8 +251,10 @@ func (p *Provisioner) bootstrapAndFinalize(
 		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster is ready\n")
 	}
 
-	// Create the cluster-autoscaler-config Secret when applicable.
-	err = p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID)
+	// Create the cluster-autoscaler-config Secret when applicable. No restart on
+	// create: the autoscaler Deployment is installed afterwards and starts with
+	// this config.
+	err = p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID, false)
 	if err != nil {
 		return err
 	}
@@ -415,10 +417,19 @@ func (p *Provisioner) updateHcloudSecret(
 
 // ensureAutoscalerSecret creates the cluster-autoscaler-config Secret when the
 // node autoscaler is enabled and bootstrap used a snapshot image.
+//
+// When restartIfChanged is true (cluster update) and the Secret's data actually
+// changed, it rolls the running cluster-autoscaler Deployment so it reloads the
+// new config — the autoscaler reads the Secret as environment variables, which
+// Kubernetes does not live-reload, so without the restart new nodes would keep
+// booting from the stale Kubernetes version / snapshot. On cluster create
+// restartIfChanged is false: the Deployment does not exist yet (the installer
+// runs afterwards and starts with the correct config).
 func (p *Provisioner) ensureAutoscalerSecret(
 	ctx context.Context,
 	configBundle *bundle.Bundle,
 	snapshotImageID int64,
+	restartIfChanged bool,
 ) error {
 	if p.hetznerOpts == nil || !p.hetznerOpts.NodeAutoscalerEnabled || snapshotImageID <= 0 {
 		return nil
@@ -436,7 +447,7 @@ func (p *Provisioner) ensureAutoscalerSecret(
 		return fmt.Errorf("generating autoscaler worker config: %w", err)
 	}
 
-	err = ApplyAutoscalerConfigSecret(
+	changed, err := ApplyAutoscalerConfigSecret(
 		ctx,
 		kubeclient,
 		strconv.FormatInt(snapshotImageID, 10),
@@ -447,6 +458,42 @@ func (p *Provisioner) ensureAutoscalerSecret(
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret created\n")
+
+	if restartIfChanged && changed {
+		return p.restartAutoscalerAfterConfigChange(ctx, kubeclient)
+	}
+
+	return nil
+}
+
+// restartAutoscalerAfterConfigChange rolls the cluster-autoscaler Deployment so it
+// reloads the cluster-autoscaler-config Secret. A missing Deployment is not an
+// error — the autoscaler may not be installed yet, in which case its next install
+// starts with the current config.
+func (p *Provisioner) restartAutoscalerAfterConfigChange(
+	ctx context.Context,
+	kubeclient kubernetes.Interface,
+) error {
+	restarted, err := k8s.RolloutRestartDeploymentsByLabel(
+		ctx,
+		kubeclient,
+		autoscalerConfigSecretNamespace,
+		autoscalerDeploymentSelector,
+	)
+	if err != nil {
+		return fmt.Errorf("restarting cluster-autoscaler after config change: %w", err)
+	}
+
+	if restarted == 0 {
+		_, _ = fmt.Fprintf(
+			p.logWriter,
+			"  ⓘ cluster-autoscaler not running; it will use the updated config when installed\n",
+		)
+
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Restarted cluster-autoscaler to load the updated config\n")
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -457,7 +457,11 @@ func (p *Provisioner) ensureAutoscalerSecret(
 		return fmt.Errorf("applying autoscaler config secret: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret created\n")
+	if changed {
+		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret applied\n")
+	} else {
+		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret already up to date\n")
+	}
 
 	if restartIfChanged && changed {
 		return p.restartAutoscalerAfterConfigChange(ctx, kubeclient)

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_test.go
@@ -1,0 +1,89 @@
+package talosprovisioner_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// errRestartList is a static sentinel for the list-error reactor test.
+var errRestartList = errors.New("list deployments failed")
+
+// TestRestartAutoscalerAfterConfigChange_RestartsWhenRunning verifies a running
+// autoscaler Deployment is rolled — its pod template gets the restart annotation —
+// and the success line is logged.
+func TestRestartAutoscalerAfterConfigChange_RestartsWhenRunning(t *testing.T) {
+	t.Parallel()
+
+	const name, namespace = "cluster-autoscaler", "kube-system"
+
+	var logBuf bytes.Buffer
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(&logBuf)
+
+	clientset := fake.NewClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app.kubernetes.io/instance": name},
+		},
+	})
+
+	err := prov.RestartAutoscalerAfterConfigChangeForTest(context.Background(), clientset)
+	require.NoError(t, err)
+	assert.Contains(t, logBuf.String(), "Restarted cluster-autoscaler")
+
+	deployment, err := clientset.AppsV1().Deployments(namespace).Get(
+		context.Background(), name, metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"],
+		"the autoscaler Deployment must be stamped with the rollout-restart annotation")
+}
+
+// TestRestartAutoscalerAfterConfigChange_NoopWhenNotInstalled verifies a missing
+// autoscaler Deployment is not an error and is reported as a no-op (the autoscaler
+// may simply not be installed yet).
+func TestRestartAutoscalerAfterConfigChange_NoopWhenNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(&logBuf)
+
+	err := prov.RestartAutoscalerAfterConfigChangeForTest(
+		context.Background(), fake.NewClientset(),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, logBuf.String(), "not running")
+}
+
+// TestRestartAutoscalerAfterConfigChange_SurfacesListError verifies an API error
+// while finding the Deployment is wrapped and returned.
+func TestRestartAutoscalerAfterConfigChange_SurfacesListError(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset()
+	clientset.PrependReactor(
+		"list",
+		"deployments",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errRestartList
+		},
+	)
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(&bytes.Buffer{})
+
+	err := prov.RestartAutoscalerAfterConfigChangeForTest(context.Background(), clientset)
+	require.ErrorIs(t, err, errRestartList)
+}

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -1364,7 +1364,10 @@ func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
 		return fmt.Errorf("looking up snapshot image for autoscaler secret: %w", err)
 	}
 
-	return p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID)
+	// Restart the autoscaler when the config changed so it reloads the new
+	// Kubernetes version / snapshot baked into the Secret (read as env vars,
+	// which Kubernetes does not live-reload).
+	return p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID, true)
 }
 
 // hasSchematicConfigured reports whether a Talos schematic ID is available


### PR DESCRIPTION
## Problem

On a Talos + Hetzner cluster with the KSail-managed Cluster Autoscaler, bumping the Kubernetes version (`spec.cluster.kubernetesVersion`) and running `ksail cluster update` upgrades the static nodes but leaves **autoscaler-provisioned nodes on the old Kubernetes version** (and old Talos snapshot).

## Root cause

`cluster update` does regenerate the `cluster-autoscaler-config` Secret with the new config:

- `hcloud_image` — the Hetzner snapshot image ID
- `hcloud_cloud_init` — the gzipped Talos worker machine config, whose `machine.kubelet.image` sets the new node's Kubernetes version

…but it never restarts the `cluster-autoscaler` Deployment. The autoscaler consumes both keys as **environment variables** via `valueFrom.secretKeyRef` (the chart's `extraEnvSecrets`), and Kubernetes does **not** live-reload env vars from a Secret. The running autoscaler therefore keeps provisioning nodes from the config it loaded at pod start — the stale Kubernetes version / snapshot — until something else restarts it.

This is autoscaler-specific: static nodes are upgraded in place, but the autoscaler is a long-running controller holding a cached copy of the config.

## Fix

- `ApplyAutoscalerConfigSecret` now reports whether the Secret's data was **created or changed**.
- On `cluster update`, when the Secret changed, KSail rolls the `cluster-autoscaler` Deployment so it reloads the env-from-secret — a `kubectl rollout restart`-style pod-template annotation, targeting the Deployment by its `app.kubernetes.io/instance=cluster-autoscaler` label (robust to the chart's fullname template).
- Gated on *changed*, so an unrelated `cluster update` (e.g. a firewall sync) never needlessly bounces the autoscaler.
- **Cluster create is unaffected**: the autoscaler installer runs after the Secret is written, so its pod starts with the correct config (the create path passes `restartIfChanged=false`).
- A missing Deployment is **not** an error — the autoscaler may not be installed yet.
- Adds a reusable `k8s.RolloutRestartDeploymentsByLabel` helper.

## Test plan

- `go build ./...` ✓
- `go vet ./pkg/k8s/... ./pkg/svc/provisioner/cluster/talos/...` ✓
- `golangci-lint run` — no new issues in changed files ✓
- `go test ./pkg/k8s/... ./pkg/svc/provisioner/cluster/talos/...` ✓
- New unit tests:
  - `k8s.RolloutRestartDeploymentsByLabel`: stamps the restart annotation (preserving existing pod-template annotations), no-match-is-not-an-error, list-error surfaced.
  - `ApplyAutoscalerConfigSecret` returns `changed=true` on create and `changed=false` when re-applying identical config.

## Manual verification suggestion

On a live Hetzner cluster: bump `spec.cluster.kubernetesVersion`, `ksail cluster update`, then confirm the `cluster-autoscaler` pod restarted and a freshly scaled-up node joins at the new version (no longer requires a manual `kubectl rollout restart deployment/cluster-autoscaler -n kube-system`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
