### PR TITLE
fix(talos): preserve system extensions on Hetzner OS upgrade

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -303,6 +303,21 @@ func InstallerImageFromTagForTest(tag string) string {
 	return installerImageFromTag(tag)
 }
 
+// ResolveInstallerImageForTest exposes resolveInstallerImage for unit testing.
+func (p *Provisioner) ResolveInstallerImageForTest(toVersion string) string {
+	return p.resolveInstallerImage(toVersion)
+}
+
+// ResolveSchematicIDForTest exposes resolveSchematicID for unit testing.
+func (p *Provisioner) ResolveSchematicIDForTest() string {
+	return p.resolveSchematicID()
+}
+
+// HasSchematicConfiguredForTest exposes hasSchematicConfigured for unit testing.
+func (p *Provisioner) HasSchematicConfiguredForTest() bool {
+	return p.hasSchematicConfigured()
+}
+
 // RenameKubeconfigContextForTest exposes k8s.RenameKubeconfigContext for unit testing.
 func RenameKubeconfigContextForTest(kubeconfigData []byte, desiredContext string) ([]byte, error) {
 	result, err := k8s.RenameKubeconfigContext(kubeconfigData, desiredContext)

--- a/pkg/svc/provisioner/cluster/talos/installer_image_test.go
+++ b/pkg/svc/provisioner/cluster/talos/installer_image_test.go
@@ -1,0 +1,108 @@
+package talosprovisioner_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testTalosVersion = "v1.13.3"
+
+// TestResolveInstallerImageNoSchematic verifies the upgrade installer falls back
+// to the bare upstream installer when no schematic is configured (regression
+// guard for the default, extension-less cluster).
+func TestResolveInstallerImageNoSchematic(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	got := provisioner.ResolveInstallerImageForTest(testTalosVersion)
+
+	assert.Equal(t, "ghcr.io/siderolabs/installer:"+testTalosVersion, got)
+	assert.False(t, provisioner.HasSchematicConfiguredForTest())
+	assert.Empty(t, provisioner.ResolveSchematicIDForTest())
+}
+
+// TestResolveInstallerImageExplicitSchematic verifies that an explicit
+// talosOpts.SchematicID produces the Image Factory installer so the rolling OS
+// upgrade preserves system extensions (issue #5077, problem 1).
+func TestResolveInstallerImageExplicitSchematic(t *testing.T) {
+	t.Parallel()
+
+	const schematicID = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(io.Discard).
+		WithTalosOptsForTest(&v1alpha1.OptionsTalos{SchematicID: schematicID})
+
+	got := provisioner.ResolveInstallerImageForTest(testTalosVersion)
+
+	assert.Equal(
+		t,
+		"factory.talos.dev/installer/"+schematicID+":"+testTalosVersion,
+		got,
+	)
+	assert.True(t, provisioner.HasSchematicConfiguredForTest())
+	assert.Equal(t, schematicID, provisioner.ResolveSchematicIDForTest())
+}
+
+// TestResolveInstallerImageFromExtensions verifies that a schematic auto-computed
+// from spec.cluster.talos.extensions (via talosConfigs) produces the Image Factory
+// installer — the path that was previously dropped on upgrade, stripping
+// extensions like iscsi-tools/qemu-guest-agent (issue #5077, problem 1).
+func TestResolveInstallerImageFromExtensions(t *testing.T) {
+	t.Parallel()
+
+	configs, err := talosconfigmanager.
+		NewConfigManager("", "ext-upgrade", "1.32.0", "10.5.0.0/24").
+		WithExtensions([]string{"siderolabs/iscsi-tools", "siderolabs/qemu-guest-agent"}).
+		Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+
+	schematicID := configs.SchematicID()
+	require.Len(t, schematicID, 64, "extensions should auto-compute a schematic ID")
+
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).WithLogWriter(io.Discard)
+
+	got := provisioner.ResolveInstallerImageForTest(testTalosVersion)
+
+	assert.Equal(
+		t,
+		"factory.talos.dev/installer/"+schematicID+":"+testTalosVersion,
+		got,
+	)
+	assert.True(t, strings.HasPrefix(got, "factory.talos.dev/installer/"))
+	assert.Equal(t, schematicID, provisioner.ResolveSchematicIDForTest())
+}
+
+// TestResolveInstallerImageExplicitSchematicWinsOverExtensions verifies the
+// resolution precedence: an explicit talosOpts.SchematicID takes priority over a
+// schematic auto-computed from extensions, matching the snapshot/create path.
+func TestResolveInstallerImageExplicitSchematicWinsOverExtensions(t *testing.T) {
+	t.Parallel()
+
+	const explicitID = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+	configs, err := talosconfigmanager.
+		NewConfigManager("", "ext-precedence", "1.32.0", "10.5.0.0/24").
+		WithExtensions([]string{"siderolabs/iscsi-tools"}).
+		Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+	require.NotEqual(t, explicitID, configs.SchematicID())
+
+	provisioner := talosprovisioner.NewProvisioner(configs, nil).
+		WithLogWriter(io.Discard).
+		WithTalosOptsForTest(&v1alpha1.OptionsTalos{SchematicID: explicitID})
+
+	got := provisioner.ResolveInstallerImageForTest(testTalosVersion)
+
+	assert.Equal(t, "factory.talos.dev/installer/"+explicitID+":"+testTalosVersion, got)
+	assert.Equal(t, explicitID, provisioner.ResolveSchematicIDForTest())
+}

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -1371,17 +1371,5 @@ func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
 // (either explicit via talosOpts.SchematicID or auto-computed from extensions
 // via talosConfigs.SchematicID()).
 func (p *Provisioner) hasSchematicConfigured() bool {
-	if p.talosOpts != nil {
-		if strings.TrimSpace(p.talosOpts.SchematicID) != "" {
-			return true
-		}
-	}
-
-	if p.talosConfigs != nil {
-		if strings.TrimSpace(p.talosConfigs.SchematicID()) != "" {
-			return true
-		}
-	}
-
-	return false
+	return p.resolveSchematicID() != ""
 }

--- a/pkg/svc/provisioner/cluster/talos/upgrader.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrader.go
@@ -38,7 +38,11 @@ func (p *Provisioner) UpgradeDistribution(
 	}
 
 	clusterName = p.resolveClusterName(clusterName)
-	installerImage := installerImageFromTag(toVersion)
+	// Use the schematic-aware installer image so the rolling OS upgrade preserves
+	// configured system extensions (Image Factory installer), matching the
+	// create/snapshot/autoscaler paths. Falls back to the bare upstream installer
+	// only when no schematic is configured. See issue #5077.
+	installerImage := p.resolveInstallerImage(toVersion)
 
 	_, _ = fmt.Fprintf(p.logWriter,
 		"  Upgrading Talos from %s to %s...\n", fromVersion, toVersion,

--- a/pkg/svc/provisioner/cluster/talos/utils.go
+++ b/pkg/svc/provisioner/cluster/talos/utils.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 )
 
 // nthIPInNetwork returns the nth IP in the network (1-indexed).
@@ -87,6 +89,42 @@ const installerImageRepository = "ghcr.io/siderolabs/installer"
 // The installer image is used by the LifecycleService API for upgrades.
 func installerImageFromTag(tag string) string {
 	return installerImageRepository + ":" + tag
+}
+
+// resolveSchematicID returns the configured Talos Image Factory schematic ID,
+// preferring an explicit talosOpts.SchematicID and falling back to the schematic
+// auto-computed from spec.cluster.talos.extensions (talosConfigs.SchematicID()).
+// Returns "" when no schematic is configured. This is the single source of truth
+// for schematic resolution shared by the upgrade and snapshot/create lifecycle.
+func (p *Provisioner) resolveSchematicID() string {
+	if p.talosOpts != nil {
+		if id := strings.TrimSpace(p.talosOpts.SchematicID); id != "" {
+			return id
+		}
+	}
+
+	if p.talosConfigs != nil {
+		if id := strings.TrimSpace(p.talosConfigs.SchematicID()); id != "" {
+			return id
+		}
+	}
+
+	return ""
+}
+
+// resolveInstallerImage returns the Talos installer image reference for an OS
+// upgrade to the given version tag. When a schematic is configured (explicit
+// schematicId or auto-computed from extensions) it returns the Image Factory
+// installer factory.talos.dev/installer/<schematicID>:<tag> so the upgrade
+// preserves system extensions — matching the create/snapshot/autoscaler paths.
+// It falls back to the bare ghcr.io/siderolabs/installer:<tag> only when no
+// schematic is configured.
+func (p *Provisioner) resolveInstallerImage(toVersion string) string {
+	if schematicID := p.resolveSchematicID(); schematicID != "" {
+		return talosconfigmanager.SchematicInstallerImage(schematicID, toVersion)
+	}
+
+	return installerImageFromTag(toVersion)
 }
 
 // getRunningTalosVersion queries a Talos node for its running version tag.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5077 (problem 1, the primary data-plane-breaking bug).

## Problem

`ksail cluster update --update-distribution` built the rolling Talos OS upgrade image purely from the version tag:

```go
// upgrader.go (before)
installerImage := installerImageFromTag(toVersion) // -> ghcr.io/siderolabs/installer:<tag>  (NO schematic)
```

A Talos OS upgrade replaces the boot assets, so upgrading onto the **bare upstream installer** strips every Image Factory **system extension** from the nodes. On a Talos × Hetzner cluster that depends on `siderolabs/iscsi-tools` (Longhorn data plane) and `siderolabs/qemu-guest-agent` (Hetzner Cloud integration), this is a **destructive, data-plane-breaking upgrade** (Longhorn iSCSI volumes fail to attach, the guest agent disappears).

This was the **only** lifecycle path that dropped the schematic — `cluster create`, the Hetzner snapshot path, and the autoscaler all build a Factory image from the schematic.

## Fix

`UpgradeDistribution` now resolves the installer the same way the rest of the lifecycle does:

- a schematic is configured (explicit `spec.cluster.talos.schematicId` **or** auto-computed from `spec.cluster.talos.extensions`) → `factory.talos.dev/installer/<schematicID>:<tag>` (preserves extensions);
- otherwise → bare `ghcr.io/siderolabs/installer:<tag>` (unchanged default behaviour).

The duplicated schematic-resolution logic (previously inlined in three places) is extracted into one `resolveSchematicID()` helper, which also now backs `hasSchematicConfigured()` (behaviour-preserving). The new `resolveInstallerImage()` reuses the existing `talosconfigmanager.SchematicInstallerImage()` helper, so the factory-image format stays a single source of truth.

## Tests

New `installer_image_test.go` (table of focused cases), all green:
- no schematic → bare upstream installer (regression guard for the default cluster);
- explicit `talosOpts.SchematicID` → Factory installer (**the bug**);
- schematic auto-computed from `extensions` → Factory installer (the path that previously stripped extensions);
- explicit schematic wins over extensions (precedence).

Validation (worktree, isolated): `go build ./...` ✓, `go test ./pkg/svc/provisioner/cluster/talos/` → **402 passed**, `golangci-lint run` clean on the changed files. (Local golangci-lint is v2.12.2; CI pins v2.11.4 — the changed files trigger no lint findings under either.)

## Scope / follow-up

This PR fixes **problem 1** only. The issue also describes **problem 2** (a plain `cluster update` silently no-ops a changed `spec.cluster.talos.version` pin with no hint to use `--update-distribution`) — a separate UX/consistency concern. As the issue itself suggests, that is better split into its own enhancement and is intentionally out of scope here to keep this fix surgical and behaviour-preserving for the non-extension path.