### PR TITLE
ci: drop redundant cask auto-merge arming from cd.yaml

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -656,8 +656,11 @@ jobs:
   # GoReleaser opens the Homebrew cask PRs during the build (CLI in `goreleaser`, macOS in
   # `desktop-macos`) as DRAFTS, so the tap cannot merge them while the cask still points at a draft
   # (not-yet-public, 404) release. Now that `publish-release` has made the release public, mark both
-  # PRs ready and enable auto-merge so the tap lands them — keeping the tap bump strictly after the
-  # GitHub release exists. Branch names mirror `.goreleaser*.yaml` (goreleaser/<project>-<tag>).
+  # PRs ready. That draft→ready flip is the tap's single trigger: its required `enable-auto-merge.yaml`
+  # approves + arms squash auto-merge, and its CI audits the now-public asset — so we do NOT arm
+  # auto-merge from here (one arming path avoids racing the tap's ready-time audit). Keeps the tap
+  # bump strictly after the GitHub release exists. Branches mirror `.goreleaser*.yaml`
+  # (goreleaser/<project>-<tag>).
   homebrew:
     name: 🍺 Promote Homebrew cask PRs
     runs-on: ubuntu-latest
@@ -666,7 +669,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: 🍺 Style-clean cask PRs, then mark ready and enable auto-merge
+      - name: 🍺 Style-clean cask PRs, then mark them ready
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           TAP: devantler-tech/homebrew-tap
@@ -718,12 +721,13 @@ jobs:
               echo "::warning::Could not create tempdir for brew style --fix; promoting ${name} cask as-is"
             fi
 
-            # Both gh calls are non-fatal under `set -e`: the PR may already be ready, or auto-merge
-            # may already be enabled by the tap's own automation — neither should fail the job.
+            # Mark the PR ready; the tap takes it from here. The `ready_for_review` flip triggers the
+            # tap's required `enable-auto-merge.yaml` (approve + squash auto-merge) and its Cask audit
+            # against the now-public asset. We intentionally do not enable auto-merge here, so the tap
+            # is the sole arming path and cannot race its own ready-time audit. Non-fatal under
+            # `set -e`: the PR may already be ready.
             gh pr ready "$pr" --repo "$TAP" \
               || echo "::warning::Could not mark ${TAP}#${pr} ready; it may already be ready"
-            gh pr merge "$pr" --repo "$TAP" --auto --squash \
-              || echo "::warning::Could not enable auto-merge for ${TAP}#${pr}; the tap automation may still merge it"
           done
 
   # Backstop for the immutable-release model: if the release did NOT publish — any asset job failed,


### PR DESCRIPTION
## What

Drop the `gh pr merge "$pr" --auto --squash` call from the `homebrew` job in `cd.yaml`. The job still marks the GoReleaser cask PRs ready (`gh pr ready`) and still runs the best-effort `brew style --fix`.

## Why

The tap's **required** `enable-auto-merge.yaml` already approves and arms squash auto-merge on the `ready_for_review` event — the exact flip `gh pr ready` produces. So arming auto-merge from `cd.yaml` is redundant.

It's also the only thing that could race the tap's ready-time Cask audit. [homebrew-tap#777](https://github.com/devantler-tech/homebrew-tap/pull/777) wires that audit to `ready_for_review` (skip-on-draft); this job arms auto-merge milliseconds after `gh pr ready`, *before* the new audit run registers its pending check, so auto-merge could evaluate against the stale draft-time status. Letting the tap be the **sole arming path** means auto-merge is armed as part of the same `ready_for_review` batch as the audit, so it waits for the live-asset audit. (The race was benign — promotion is post-publish, so the asset is always live — but removing it is strictly cleaner.)

## Validation

- `actionlint .github/workflows/cd.yaml` ✅
- Happy path unchanged: `gh pr ready` triggers the tap's `enable-auto-merge.yaml` (approve + arm auto-merge) and its Cask audit. Both already run this way on real releases — e.g. auto-merge was armed on tap #771 — so this only removes the redundant second arming.

Follow-up to [homebrew-tap#777](https://github.com/devantler-tech/homebrew-tap/pull/777) (audit Cask PRs on draft→ready, drop the re-audit workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
