### PR TITLE
ci(deps): track divergent helm charts and local-path-provisioner with dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -173,3 +173,42 @@ updates:
       default-days: 7
     schedule:
       interval: daily
+
+  - package-ecosystem: docker
+    registries: [dockerhub]
+    directory: /pkg/svc/installer/localpathstorage # local-path-provisioner image tag == release tag (embedded in Go via go:embed)
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: daily
+
+  # Helm chart version pins whose chart version diverges from the app/image tag, so they
+  # cannot be tracked via a Dockerfile FROM directive. Tracked via the native helm
+  # ecosystem reading a Chart.yaml dependency (embedded in Go via go:embed).
+  - package-ecosystem: helm
+    directory: /pkg/svc/installer/clusterautoscaler # cluster-autoscaler chart version
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: daily
+
+  - package-ecosystem: helm
+    directory: /pkg/svc/installer/hcloudccm # hcloud-cloud-controller-manager chart version
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: daily
+
+  - package-ecosystem: helm
+    directory: /pkg/svc/installer/hetznercsi # hcloud-csi chart version
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: daily
+
+  - package-ecosystem: helm
+    directory: /pkg/svc/installer/metricsserver # metrics-server chart version
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: daily

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,6 +6,11 @@ https://registry-1.docker.io/
 https://ghcr.io/
 https://quay.io/
 
+# Hetzner Helm chart repo serves the index at /index.yaml; the bare base URL
+# returns 404. The URL is the required `repository:` field in Chart.yaml for
+# the hcloud-cloud-controller-manager and hcloud-csi dependency pins.
+https://charts.hetzner.cloud/
+
 # GitHub repository paths used in kustomize (not web URLs)
 https://github.com/stefanprodan/podinfo//kustomize
 

--- a/pkg/svc/image/parser/parser.go
+++ b/pkg/svc/image/parser/parser.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"fmt"
 	"regexp"
+
+	"gopkg.in/yaml.v3"
 )
 
 // minMatchCount is the minimum number of regex matches required to extract the image reference.
@@ -32,6 +34,46 @@ func ParseImageFromDockerfile(dockerfileContent, pattern, imageName string) stri
 	}
 
 	return matches[1]
+}
+
+// ParseChartVersionFromChartYaml extracts the pinned version of the named Helm chart
+// dependency from an embedded Chart.yaml. This keeps Go code in sync with Dependabot's
+// helm ecosystem automatically, used for charts whose version diverges from their
+// app/image tag and therefore cannot be tracked via a Dockerfile FROM directive.
+// Panics if the document cannot be parsed or the named dependency is absent - this
+// catches embedding/format issues at init time.
+func ParseChartVersionFromChartYaml(chartYAMLContent, dependencyName string) string {
+	var chart struct {
+		Dependencies []struct {
+			Name    string `yaml:"name"`
+			Version string `yaml:"version"`
+		} `yaml:"dependencies"`
+	}
+
+	err := yaml.Unmarshal([]byte(chartYAMLContent), &chart)
+	if err != nil {
+		panic(
+			fmt.Sprintf(
+				"failed to parse embedded Chart.yaml for %s dependency: %v",
+				dependencyName,
+				err,
+			),
+		)
+	}
+
+	for _, dep := range chart.Dependencies {
+		if dep.Name == dependencyName {
+			return dep.Version
+		}
+	}
+
+	panic(
+		fmt.Sprintf(
+			"failed to find %s dependency version in embedded Chart.yaml - "+
+				"check that Chart.yaml exists and lists the dependency",
+			dependencyName,
+		),
+	)
 }
 
 // ParseAllImagesFromDockerfile extracts all container image references from FROM

--- a/pkg/svc/image/parser/parser_test.go
+++ b/pkg/svc/image/parser/parser_test.go
@@ -67,6 +67,50 @@ func TestParseImageFromDockerfile_EmptyDockerfile(t *testing.T) {
 	parser.ParseImageFromDockerfile(dockerfile, kindNodePattern, kindNodeImageName)
 }
 
+const chartYAMLFixture = `apiVersion: v2
+name: ksail-metricsserver-pin
+version: 0.0.0
+dependencies:
+  - name: metrics-server
+    version: 3.13.0
+    repository: https://kubernetes-sigs.github.io/metrics-server/
+`
+
+func TestParseChartVersionFromChartYaml_Success(t *testing.T) {
+	t.Parallel()
+
+	result := parser.ParseChartVersionFromChartYaml(chartYAMLFixture, "metrics-server")
+	expected := "3.13.0"
+
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}
+
+func TestParseChartVersionFromChartYaml_DependencyNotFound(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic but got none")
+		}
+	}()
+
+	parser.ParseChartVersionFromChartYaml(chartYAMLFixture, "nonexistent-chart")
+}
+
+func TestParseChartVersionFromChartYaml_InvalidYAML(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic but got none")
+		}
+	}()
+
+	parser.ParseChartVersionFromChartYaml("\tnot: [valid", "metrics-server")
+}
+
 func TestParseAllImagesFromDockerfile_MultipleImages(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/clusterautoscaler/Chart.yaml
+++ b/pkg/svc/installer/clusterautoscaler/Chart.yaml
@@ -1,0 +1,15 @@
+# This file is the source of truth for the cluster-autoscaler Helm chart version used
+# in Go code. Dependabot's helm ecosystem updates the dependency version below, and Go
+# code reads it via go:embed + parser.ParseChartVersionFromChartYaml.
+#
+# This is not a deployable chart - it exists solely so Dependabot can track the pinned
+# chart version. The chart version diverges from the cluster-autoscaler image version,
+# so it cannot be tracked via a Dockerfile FROM directive like the image-pinned installers.
+apiVersion: v2
+name: ksail-clusterautoscaler-pin
+description: Dependabot version pin for the cluster-autoscaler Helm chart (not a deployable chart).
+version: 0.0.0
+dependencies:
+  - name: cluster-autoscaler
+    version: 9.46.6
+    repository: https://kubernetes.github.io/autoscaler

--- a/pkg/svc/installer/clusterautoscaler/version.go
+++ b/pkg/svc/installer/clusterautoscaler/version.go
@@ -1,7 +1,18 @@
 package clusterautoscalerinstaller
 
-// chartVersion returns the pinned Cluster Autoscaler chart version.
-// This must be updated manually when upgrading the chart.
+import (
+	_ "embed"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/image/parser"
+)
+
+//go:embed Chart.yaml
+var chartYAML string
+
+// chartVersion returns the pinned Cluster Autoscaler chart version extracted from the
+// embedded Chart.yaml (kept in sync by Dependabot's helm ecosystem). The chart version
+// diverges from the cluster-autoscaler image version, so it cannot be tracked via a
+// Dockerfile image tag.
 func chartVersion() string {
-	return "9.46.6"
+	return parser.ParseChartVersionFromChartYaml(chartYAML, "cluster-autoscaler")
 }

--- a/pkg/svc/installer/hcloudccm/Chart.yaml
+++ b/pkg/svc/installer/hcloudccm/Chart.yaml
@@ -1,0 +1,15 @@
+# This file is the source of truth for the hcloud-cloud-controller-manager Helm chart
+# version used in Go code. Dependabot's helm ecosystem updates the dependency version
+# below, and Go code reads it via go:embed + parser.ParseChartVersionFromChartYaml.
+#
+# This is not a deployable chart - it exists solely so Dependabot can track the pinned
+# chart version. The chart version diverges from the CCM image version, so it cannot be
+# tracked via a Dockerfile FROM directive like the image-pinned installers.
+apiVersion: v2
+name: ksail-hcloudccm-pin
+description: Dependabot version pin for the hcloud-cloud-controller-manager Helm chart (not a deployable chart).
+version: 0.0.0
+dependencies:
+  - name: hcloud-cloud-controller-manager
+    version: 1.29.2
+    repository: https://charts.hetzner.cloud

--- a/pkg/svc/installer/hcloudccm/version.go
+++ b/pkg/svc/installer/hcloudccm/version.go
@@ -1,8 +1,18 @@
 package hcloudccminstaller
 
-// chartVersion returns the pinned Hetzner Cloud Controller Manager chart version.
-// The chart version diverges from the CCM image version, so it cannot be
-// tracked via a Dockerfile image tag. This constant must be updated manually.
+import (
+	_ "embed"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/image/parser"
+)
+
+//go:embed Chart.yaml
+var chartYAML string
+
+// chartVersion returns the pinned Hetzner Cloud Controller Manager chart version
+// extracted from the embedded Chart.yaml (kept in sync by Dependabot's helm ecosystem).
+// The chart version diverges from the CCM image version, so it cannot be tracked via a
+// Dockerfile image tag.
 func chartVersion() string {
-	return "1.29.2"
+	return parser.ParseChartVersionFromChartYaml(chartYAML, "hcloud-cloud-controller-manager")
 }

--- a/pkg/svc/installer/hetznercsi/Chart.yaml
+++ b/pkg/svc/installer/hetznercsi/Chart.yaml
@@ -1,0 +1,15 @@
+# This file is the source of truth for the hcloud-csi Helm chart version used in Go
+# code. Dependabot's helm ecosystem updates the dependency version below, and Go code
+# reads it via go:embed + parser.ParseChartVersionFromChartYaml.
+#
+# This is not a deployable chart - it exists solely so Dependabot can track the pinned
+# chart version. The chart version diverges from the CSI driver image version, so it
+# cannot be tracked via a Dockerfile FROM directive like the image-pinned installers.
+apiVersion: v2
+name: ksail-hetznercsi-pin
+description: Dependabot version pin for the hcloud-csi Helm chart (not a deployable chart).
+version: 0.0.0
+dependencies:
+  - name: hcloud-csi
+    version: 2.18.3
+    repository: https://charts.hetzner.cloud

--- a/pkg/svc/installer/hetznercsi/version.go
+++ b/pkg/svc/installer/hetznercsi/version.go
@@ -1,8 +1,17 @@
 package hetznercsiinstaller
 
-// chartVersion returns the pinned Hetzner CSI chart version.
-// The chart version diverges from the CSI driver image version, so it cannot be
-// tracked via a Dockerfile image tag. This constant must be updated manually.
+import (
+	_ "embed"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/image/parser"
+)
+
+//go:embed Chart.yaml
+var chartYAML string
+
+// chartVersion returns the pinned Hetzner CSI chart version extracted from the embedded
+// Chart.yaml (kept in sync by Dependabot's helm ecosystem). The chart version diverges
+// from the CSI driver image version, so it cannot be tracked via a Dockerfile image tag.
 func chartVersion() string {
-	return "2.18.3"
+	return parser.ParseChartVersionFromChartYaml(chartYAML, "hcloud-csi")
 }

--- a/pkg/svc/installer/localpathstorage/Dockerfile
+++ b/pkg/svc/installer/localpathstorage/Dockerfile
@@ -1,0 +1,12 @@
+# This file is the source of truth for the Rancher local-path-provisioner version used
+# in Go code. Dependabot updates this file, and Go code reads from it via go:embed.
+#
+# The image tag matches the upstream release tag, which also names the path in the
+# manifest URL that KSail applies
+# (raw.githubusercontent.com/rancher/local-path-provisioner/<tag>/deploy/...). Bumping
+# the image therefore bumps the applied manifest in lockstep.
+#
+# Image mappings:
+# - docker.io/rancher/local-path-provisioner → localPathProvisionerVersion (release tag)
+
+FROM docker.io/rancher/local-path-provisioner:v0.0.32@sha256:9289da488b07912cb4128eb96928a331a5f3e60c28c5cfc5790f354a4ad0cc68

--- a/pkg/svc/installer/localpathstorage/installer.go
+++ b/pkg/svc/installer/localpathstorage/installer.go
@@ -2,6 +2,7 @@ package localpathstorageinstaller
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -14,20 +15,33 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/image"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/image/parser"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
+//go:embed Dockerfile
+var dockerfile string
+
 // ErrManifestFetchFailed is returned when the manifest cannot be fetched from the remote URL.
 var ErrManifestFetchFailed = errors.New("failed to fetch manifest")
 
-const (
-	// localPathProvisionerVersion is the version of Rancher local-path-provisioner to install.
-	localPathProvisionerVersion = "v0.0.32"
-	// localPathProvisionerManifestURL is the URL to the local-path-provisioner manifest.
-	localPathProvisionerManifestURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/" +
-		localPathProvisionerVersion + "/deploy/local-path-storage.yaml"
-)
+// localPathProvisionerVersion returns the pinned Rancher local-path-provisioner version,
+// extracted from the embedded Dockerfile (kept in sync by Dependabot). The image tag
+// matches the upstream release tag used in the manifest URL path.
+func localPathProvisionerVersion() string {
+	return parser.ParseImageFromDockerfile(
+		dockerfile,
+		`FROM\s+docker\.io/rancher/local-path-provisioner:([^\s@]+)`,
+		"local-path-provisioner",
+	)
+}
+
+// localPathProvisionerManifestURL returns the upstream manifest URL for the pinned version.
+func localPathProvisionerManifestURL() string {
+	return "https://raw.githubusercontent.com/rancher/local-path-provisioner/" +
+		localPathProvisionerVersion() + "/deploy/local-path-storage.yaml"
+}
 
 // Installer installs local-path-provisioner on Kind and Talos clusters.
 type Installer struct {
@@ -78,7 +92,7 @@ func (l *Installer) Images(ctx context.Context) ([]string, error) {
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
-		localPathProvisionerManifestURL,
+		localPathProvisionerManifestURL(),
 		nil,
 	)
 	if err != nil {
@@ -147,7 +161,7 @@ func (l *Installer) applyManifest(ctx context.Context) error {
 
 	applyCmd := kubectlClient.CreateApplyCommand(l.kubeconfig)
 
-	args := []string{"-f", localPathProvisionerManifestURL}
+	args := []string{"-f", localPathProvisionerManifestURL()}
 	if l.context != "" {
 		args = append(args, "--context", l.context)
 	}

--- a/pkg/svc/installer/metricsserver/Chart.yaml
+++ b/pkg/svc/installer/metricsserver/Chart.yaml
@@ -1,0 +1,15 @@
+# This file is the source of truth for the metrics-server Helm chart version used in
+# Go code. Dependabot's helm ecosystem updates the dependency version below, and Go
+# code reads it via go:embed + parser.ParseChartVersionFromChartYaml.
+#
+# This is not a deployable chart - it exists solely so Dependabot can track the pinned
+# chart version. The chart version (3.x) diverges from the app/image version (0.x), so
+# it cannot be tracked via a Dockerfile FROM directive like the image-pinned installers.
+apiVersion: v2
+name: ksail-metricsserver-pin
+description: Dependabot version pin for the metrics-server Helm chart (not a deployable chart).
+version: 0.0.0
+dependencies:
+  - name: metrics-server
+    version: 3.13.0
+    repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/pkg/svc/installer/metricsserver/version.go
+++ b/pkg/svc/installer/metricsserver/version.go
@@ -1,8 +1,18 @@
 package metricsserverinstaller
 
-// chartVersion returns the pinned metrics-server chart version.
-// The chart version (3.x) diverges from the app version (0.x), so it cannot be
-// tracked via a Dockerfile image tag. This constant must be updated manually.
+import (
+	_ "embed"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/image/parser"
+)
+
+//go:embed Chart.yaml
+var chartYAML string
+
+// chartVersion returns the pinned metrics-server chart version extracted from the
+// embedded Chart.yaml (kept in sync by Dependabot's helm ecosystem). The chart version
+// (3.x) diverges from the app version (0.x), so it cannot be tracked via a Dockerfile
+// image tag.
 func chartVersion() string {
-	return "3.13.0"
+	return parser.ParseChartVersionFromChartYaml(chartYAML, "metrics-server")
 }


### PR DESCRIPTION
## What

Closes the last five untracked third-party version pins so every embedded chart, distribution image, and deployment manifest is bumped by Dependabot.

| Pin | Was | Now tracked via |
|---|---|---|
| `cluster-autoscaler` 9.46.6 | hardcoded const | `helm` ecosystem reading [`pkg/svc/installer/clusterautoscaler/Chart.yaml`](pkg/svc/installer/clusterautoscaler/Chart.yaml) |
| `hcloud-cloud-controller-manager` 1.29.2 | hardcoded const | `helm` ecosystem reading [`pkg/svc/installer/hcloudccm/Chart.yaml`](pkg/svc/installer/hcloudccm/Chart.yaml) |
| `hcloud-csi` 2.18.3 | hardcoded const | `helm` ecosystem reading [`pkg/svc/installer/hetznercsi/Chart.yaml`](pkg/svc/installer/hetznercsi/Chart.yaml) |
| `metrics-server` 3.13.0 | hardcoded const | `helm` ecosystem reading [`pkg/svc/installer/metricsserver/Chart.yaml`](pkg/svc/installer/metricsserver/Chart.yaml) |
| `rancher/local-path-provisioner` v0.0.32 | hardcoded const + URL template | `docker` ecosystem reading [`pkg/svc/installer/localpathstorage/Dockerfile`](pkg/svc/installer/localpathstorage/Dockerfile) |

## Why

These five were unreachable by the existing Dockerfile-as-source-of-truth convention (docker ecosystem + `go:embed` + `parser.ParseImageFromDockerfile`):
- The four Helm charts have a chart version that diverges from the underlying app/image tag, so a `FROM <image>:<tag>` pin can't double as the chart version. Each `version.go` file explicitly documented this as "must be updated manually."
- `local-path-provisioner` lived only as a hardcoded const because nothing was wired up — but its image tag, release tag, and manifest URL path are all the same string, so the standard Dockerfile convention fits cleanly.

Dependabot added a native `helm` ecosystem in [April 2025](https://github.blog/changelog/2025-04-09-dependabot-version-updates-now-support-helm/). Per the verbatim source of [`helm/file_parser.rb`](https://github.com/dependabot/dependabot-core/blob/main/helm/lib/dependabot/helm/file_parser.rb), it reads `dependencies[].{name, version, repository}` from `Chart.yaml` — exactly the shape needed. Each new `Chart.yaml` is a minimal, non-deployable pin file; Go reads it via the new `parser.ParseChartVersionFromChartYaml` helper, mirroring how `parser.ParseImageFromDockerfile` is used in [`pkg/svc/installer/cni/calico/version.go`](pkg/svc/installer/cni/calico/version.go).

## Already-tracked things double-checked

I verified upstream [`docker/file_fetcher.rb`](https://github.com/dependabot/dependabot-core/blob/main/docker/lib/dependabot/docker/file_fetcher.rb): `DOCKER_REGEXP = /dockerfile|containerfile/i` is unanchored and applied via `f.name.match?(...)`, so the `Dockerfile.app` / `Dockerfile.sops` / `Dockerfile.gateway-api` / `Dockerfile.distribution` siblings are already picked up by their parent directory's existing entry — no extra config needed.

## Intentionally left manual (no fix needed)

- **KWOK control-plane images** in `pkg/svc/provisioner/cluster/kwok/Dockerfile.controlplane` — slaved to `sigs.k8s.io/kwok`'s `KubeVersion`; #5024's drift-guard test enforces the link.
- **`kubelet-serving-cert-approver:main`** in `pkg/fsutil/generator/talos/csrapprover/Dockerfile` — upstream stopped publishing versioned images after 0.6.1.
- **`charts/ksail-operator/`** — references only KSail's own image (defaulted to chart `appVersion`); no third-party `dependencies[]`.

Each is already documented as such in its file header.

## Verification

- `go build` ✓
- `go test ./pkg/svc/image/... ./pkg/svc/installer/...` (22 packages) ✓
- `gofmt` clean
- `golangci-lint --timeout 5m --new-from-rev=HEAD` → 0 new issues
- All 5 version readers return the exact pre-change pinned values (spot-tested against the committed files).
- `.github/dependabot.yaml` and all 4 new `Chart.yaml` files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)