### PR TITLE
feat: warn and hint `--update-distribution` on ignored Talos version pin

### DIFF
--- a/pkg/cli/cmd/cluster/cluster_test.go
+++ b/pkg/cli/cmd/cluster/cluster_test.go
@@ -4379,6 +4379,73 @@ func TestReconcileComponents_UnknownField_Skipped(t *testing.T) {
 	assert.Empty(t, result.FailedChanges, "unknown field should not be recorded as failed")
 }
 
+// TestWarnTalosVersionPinIgnored verifies that a plain `cluster update` warns and
+// hints --update-distribution when it detects a changed Talos version pin it will
+// not act on, and stays silent otherwise (issue #5094).
+func TestWarnTalosVersionPinIgnored(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		diff      *clusterupdate.UpdateResult
+		wantWarn  bool
+		wantParts []string
+	}{
+		{
+			name: "talos version pin change warns and hints the gating flag",
+			diff: &clusterupdate.UpdateResult{
+				InPlaceChanges: []clusterupdate.Change{
+					{Field: "cluster.talos.version", OldValue: "v1.8.0", NewValue: "v1.9.0"},
+				},
+			},
+			wantWarn:  true,
+			wantParts: []string{"v1.8.0", "v1.9.0", "--update-distribution"},
+		},
+		{
+			name: "unrelated change stays silent",
+			diff: &clusterupdate.UpdateResult{
+				InPlaceChanges: []clusterupdate.Change{
+					{Field: "cluster.nodes", OldValue: "1", NewValue: "3"},
+				},
+			},
+			wantWarn: false,
+		},
+		{
+			name:     "empty diff stays silent",
+			diff:     &clusterupdate.UpdateResult{},
+			wantWarn: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newReconcileTestCmd()
+
+			// The helper writes via cmd.OutOrStderr(), which cobra resolves to the
+			// out writer (then os.Stderr). Capture both to one buffer so the test
+			// sees the output regardless of cobra's fallback.
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+
+			cluster.ExportWarnTalosVersionPinIgnored(cmd, testCase.diff)
+
+			got := out.String()
+
+			if testCase.wantWarn {
+				for _, part := range testCase.wantParts {
+					assert.Contains(t, got, part,
+						"warning should mention %q", part)
+				}
+			} else {
+				assert.Empty(t, got, "no warning expected for this diff")
+			}
+		})
+	}
+}
+
 // TestReconcileComponents_RecordsFailedChange verifies that a component error is captured
 // in result.FailedChanges while processing of remaining changes continues.
 //

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -151,6 +151,11 @@ func ExportDisplayChangesSummary(cmd *cobra.Command, diff *clusterupdate.UpdateR
 	displayChangesSummary(cmd, diff)
 }
 
+// ExportWarnTalosVersionPinIgnored exports warnTalosVersionPinIgnored for testing.
+func ExportWarnTalosVersionPinIgnored(cmd *cobra.Command, diff *clusterupdate.UpdateResult) {
+	warnTalosVersionPinIgnored(cmd, diff)
+}
+
 // ExportDiffToJSON exports diffToJSON for testing.
 func ExportDiffToJSON(diff *clusterupdate.UpdateResult) DiffJSONOutput {
 	return diffToJSON(diff)

--- a/pkg/cli/cmd/cluster/update.go
+++ b/pkg/cli/cmd/cluster/update.go
@@ -217,8 +217,45 @@ func handleUpdateRunE(
 	// Display changes summary
 	displayChangesSummary(cmd, diff)
 
+	// A plain `cluster update` reports a changed Talos version pin as an in-place
+	// change, but the pin only governs future image selection / the upgrade cap —
+	// it does NOT upgrade the running OS. Without --update-distribution the bump is
+	// effectively a silent no-op, so warn and point at the gating flag.
+	if !updateDist {
+		warnTalosVersionPinIgnored(cmd, diff)
+	}
+
 	return applyOrReportChanges(cmd, cfgManager, ctx, deps, updater,
 		clusterName, currentSpec, diff, outputTimer)
+}
+
+// talosVersionField is the diff field path for the Talos OS version pin
+// (spec.cluster.talos.version), as classified by the diff engine.
+const talosVersionField = "cluster.talos.version"
+
+// warnTalosVersionPinIgnored emits a warning when a plain `cluster update`
+// (without --update-distribution) detects a changed spec.cluster.talos.version
+// pin it will not act on. The diff engine classifies the pin change as in-place
+// because it only affects future image selection and the Kubernetes upgrade cap,
+// so the running Talos OS is left at its current version. The warning makes that
+// silent no-op explicit and hints the gating flag so the operator isn't left
+// believing the OS was upgraded.
+func warnTalosVersionPinIgnored(cmd *cobra.Command, diff *clusterupdate.UpdateResult) {
+	for _, change := range diff.AllChanges() {
+		if change.Field != talosVersionField {
+			continue
+		}
+
+		notify.Warningf(cmd.OutOrStderr(),
+			"Talos version pin changed (%s → %s) but a plain update does not upgrade "+
+				"the running OS; the pin only affects future image selection.",
+			change.OldValue, change.NewValue)
+		notify.Infof(cmd.OutOrStderr(),
+			"Run 'ksail cluster update --update-distribution' to upgrade the Talos OS "+
+				"to the pinned version.")
+
+		return
+	}
 }
 
 // handleVersionUpgrades orchestrates Kubernetes and/or distribution version upgrades.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5094 (the deferred *problem 2* split out from the now-closed #5077; problem 1 — extension-stripping on `--update-distribution` — was fixed in #5079).

## Problem

A plain `ksail cluster update` (without `--update-distribution`) **computes and reports** a changed `spec.cluster.talos.version` pin in its diff, but the diff engine classifies the pin change as **in-place** (`pkg/svc/diff/engine.go` — reason: *"version pin change only affects future operations (image selection, upgrade cap)"*). So the running Talos OS is left at its current version: the distribution upgrade only happens via the `--update-distribution` path (`handleVersionUpgrades`).

The trap: an operator bumps `spec.cluster.talos.version`, runs `ksail cluster update`, sees the version change reported as an in-place (🟢) change — implying it was applied — yet **the OS is not upgraded and nothing hints** that the upgrade is gated behind `--update-distribution`.

## Change

In `handleUpdateRunE`, after the diff is displayed, when `--update-distribution` was **not** passed, scan the diff for a changed `cluster.talos.version` field and emit:

- a **warning** that a plain update does not upgrade the running OS (the pin only affects future image selection), and
- an **info hint** to re-run with `--update-distribution`.

Written to `cmd.OutOrStderr()`, so machine-readable `--output json` on stdout is unaffected. No behaviour change otherwise — no config field, flag, schema, or generated file is touched.

```
⚠ Talos version pin changed (v1.8.0 → v1.9.0) but a plain update does not upgrade the running OS; the pin only affects future image selection.
ℹ Run 'ksail cluster update --update-distribution' to upgrade the Talos OS to the pinned version.
```

## Validation

- `go build` ✅
- `go test ./pkg/cli/cmd/cluster/` ✅ (524 passed, incl. the new `TestWarnTalosVersionPinIgnored`: warns on a talos.version change with the version transition + gating flag; silent for unrelated/empty diffs)
- `golangci-lint run --new-from-merge-base=main ./pkg/cli/cmd/cluster/...` ✅ no issues

## Notes / trade-offs

- Detection is on the diff **field path** (`cluster.talos.version`), which only appears for Talos clusters — no distribution-type branching needed.
- Fires for both apply and `--dry-run` (the warning is part of the diff presentation), and is suppressed when `--update-distribution` is set (that path already handles the upgrade).
- Helper is unit-tested via a thin `export_test.go` shim, matching the existing `ExportDisplayChangesSummary` pattern.