### PR TITLE
docs: drop `Copilot` from the AGENTS.md trusted-author list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,7 +387,7 @@ PR** as the checkpoint (the maintainer's promotion to "ready" is the go-signal);
 trusted-author PRs to merge** (incl. dependency major bumps) once required checks are green and
 threads resolved, **never merge external PRs** and never self-merge your own unreviewed drafts;
 trusted authors are the GitHub logins `devantler`, `ksail-bot`, `dependabot[bot]`,
-`github-actions[bot]`, `renovate[bot]`, and `Copilot`; never push to `main`. This section adds
+`github-actions[bot]`, and `renovate[bot]`; never push to `main`. This section adds
 KSail-specifics.
 
 **Recommended local validation before any PR** (matches `CONTRIBUTING.md`; CI re-runs equivalents


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

KSail's `AGENTS.md ## Maintenance` trust gate listed bare **`Copilot`** as a trusted author:

> trusted authors are the GitHub logins `devantler`, `ksail-bot`, `dependabot[bot]`, `github-actions[bot]`, `renovate[bot]`, and **`Copilot`**; never push to `main`.

This contradicts the canonical monorepo `AGENTS.md` contract, which splits Copilot into two roles: the Copilot **coding agent** (`Copilot` / `copilot-swe-agent[bot]`) is **NOT** trusted — its PRs are external (never auto-driven, merged, or run locally) — and only `copilot-pull-request-reviewer[bot]` is trusted, **solely as a reviewer**. Listing bare `Copilot` over-trusts the coding agent.

## Change

Surgical **+1 −1**: drop the `Copilot` token from the trusted-author list (`renovate[bot]`, and `Copilot` → and `renovate[bot]`). This is a **tightening** (removes over-broad trust), not a loosening.

The five legitimate prose references to GitHub Copilot — the `ksail chat` Copilot-SDK feature and "any agentic tool (Copilot, Cursor, …)" — are untouched (verified: 6 occurrences → 5 after, only the trust-gate one removed).

## Context

The same alignment was shipped for five sibling repos earlier (dotnet-template, platform, actions, reusable-workflows, homebrew-tap); KSail was missed. Docs-only; no code or behaviour change.