### PR TITLE
fix(talos): preserve per-node hostname on cluster update

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configdiff"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -184,7 +185,59 @@ func (p *Provisioner) buildDesiredNodeConfig(
 		return nil, fmt.Errorf("%w: %s", errNoRoleConfig, role)
 	}
 
-	return graftNodeManagedSections(desired, running)
+	grafted, err := graftNodeManagedSections(desired, running)
+	if err != nil {
+		return nil, err
+	}
+
+	return graftNodeHostname(grafted, running)
+}
+
+// graftNodeHostname preserves the per-node static hostname
+// (machine.network.hostname) that ksail injects post-generation on Hetzner nodes
+// via patchTalosHostname at create/scale time — so the Hetzner CCM can match the
+// Kubernetes Node to its server. That hostname is neither in the base config nor
+// in any user patch, so a freshly regenerated desired config omits it and instead
+// carries the SDK's default standalone HostnameConfig document (auto: stable).
+// Grafting it here keeps the hostname out of the drift diff and, on apply,
+// prevents the node from re-registering under a generated talos-xxxxx name on its
+// next reboot (e.g. during a Talos OS upgrade via `ksail cluster update`).
+//
+// When the running node has no static hostname (e.g. Docker nodes, which derive
+// their hostname from the container), desired is returned unchanged so its own
+// HostnameConfig document — which already matches running — is preserved.
+func graftNodeHostname(
+	desired, running talosconfig.Provider,
+) (talosconfig.Provider, error) {
+	runningRaw := running.RawV1Alpha1()
+	if runningRaw == nil {
+		return desired, nil
+	}
+
+	hostname := runningRaw.Hostname()
+	if hostname == "" {
+		return desired, nil
+	}
+
+	desiredBytes, err := desired.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("encode desired config for hostname graft: %w", err)
+	}
+
+	// patchTalosHostname sets machine.network.hostname and strips the conflicting
+	// standalone HostnameConfig document, mirroring the create-time transform so
+	// the grafted config matches what the node already runs.
+	patched, err := patchTalosHostname(desiredBytes, hostname)
+	if err != nil {
+		return nil, fmt.Errorf("graft node hostname %q: %w", hostname, err)
+	}
+
+	provider, err := configloader.NewFromBytes(patched)
+	if err != nil {
+		return nil, fmt.Errorf("reload config after hostname graft: %w", err)
+	}
+
+	return provider, nil
 }
 
 // hasControlPlanePKI reports whether a config provider carries the cluster CA
@@ -232,7 +285,9 @@ func (p *Provisioner) alignKubernetesVersion(
 // node/setup-managed (not user patch content); the apply re-pushes them verbatim.
 //
 // If ksail gains another post-generation machine-config transform, graft its
-// section here too (otherwise it will surface as phantom drift).
+// section here too (otherwise it will surface as phantom drift). The per-node
+// hostname is a separate-document transform, so it is grafted in graftNodeHostname
+// rather than here.
 //
 //nolint:staticcheck // MachineRegistries is deprecated but still functional in Talos v1.x
 func graftNodeManagedSections(

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -287,6 +287,111 @@ func TestBuildDesiredNodeConfig_PinnedKubernetesVersionAppliesUpgrade(t *testing
 	assert.NotEmpty(t, diff, "a pinned version differing from running must be detected")
 }
 
+// runningWithHostname renders a config for the given role and injects the static
+// machine.network.hostname the same way create does on Hetzner (PatchTalosHostname:
+// set machine.network.hostname, strip the conflicting standalone HostnameConfig
+// document), then parses it back as a node would store and return it.
+func runningWithHostname(
+	t *testing.T,
+	role, hostname string,
+	patches ...talosconfigmanager.Patch,
+) talosconfig.Provider {
+	t.Helper()
+
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(patches)
+	require.NoError(t, err)
+
+	roleConfig := configs.ControlPlane()
+	if role == talosprovisioner.RoleWorker {
+		roleConfig = configs.Worker()
+	}
+
+	roleBytes, err := roleConfig.Bytes()
+	require.NoError(t, err)
+
+	withHostname, err := talosprovisioner.PatchTalosHostname(roleBytes, hostname)
+	require.NoError(t, err)
+
+	running, err := configloader.NewFromBytes(withHostname)
+	require.NoError(t, err)
+
+	return running
+}
+
+// TestBuildDesiredNodeConfig_PreservesNodeHostname is the regression guard for the
+// node-rename bug: on Hetzner the per-node static hostname (machine.network.hostname)
+// is injected post-generation at create (PatchTalosHostname) so the Hetzner CCM can
+// match the Kubernetes Node to its server. It is neither in the base config nor in
+// any user patch, so a freshly regenerated desired config omits it and instead
+// carries the SDK's default standalone HostnameConfig document (auto: stable).
+// Without grafting the running hostname, an update (a) surfaces the hostname as
+// phantom drift and (b) strips the static hostname when applied, so the node
+// re-registers under a generated talos-xxxxx name on its next reboot (e.g. during a
+// Talos OS upgrade via `ksail cluster update`).
+func TestBuildDesiredNodeConfig_PreservesNodeHostname(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+	running := runningWithHostname(
+		t, talosprovisioner.RoleControlPlane, "prod-control-plane-1", patch,
+	)
+
+	require.Equal(t, "prod-control-plane-1", running.RawV1Alpha1().Hostname(),
+		"precondition: running config carries the create-injected static hostname")
+
+	// Desired configs are regenerated from the same patches — without the hostname,
+	// which is a create-only post-generation transform (like registry mirrors).
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod-control-plane-1", desired.RawV1Alpha1().Hostname(),
+		"the per-node static hostname must be preserved so the node keeps its name on reboot")
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
+	require.NoError(t, err)
+	assert.Empty(t, diff,
+		"a create-injected hostname must not read as drift on an unchanged config")
+}
+
+// TestBuildDesiredNodeConfig_NoHostnameLeavesConfigUnchanged verifies the Docker
+// path is unaffected: a node with no static machine.network.hostname (it derives
+// its hostname from the container) keeps the regenerated config's own hostname
+// representation, so grafting is a no-op and reports no drift.
+func TestBuildDesiredNodeConfig_NoHostnameLeavesConfigUnchanged(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+	running := runningFromPatches(t, patch)
+
+	require.Empty(t, running.RawV1Alpha1().Hostname(),
+		"precondition: a non-Hetzner node carries no static hostname")
+
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
+	require.NoError(t, err)
+	assert.Empty(t, diff, "a node without a static hostname must not report drift")
+}
+
 func TestConfigFingerprint(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -356,10 +356,102 @@ func TestBuildDesiredNodeConfig_PreservesNodeHostname(t *testing.T) {
 	assert.Equal(t, "prod-control-plane-1", desired.RawV1Alpha1().Hostname(),
 		"the per-node static hostname must be preserved so the node keeps its name on reboot")
 
+	// The fix hinges on stripping the conflicting standalone HostnameConfig
+	// document: the grafted config must carry the static hostname in exactly one
+	// representation, so the node accepts it (no "static hostname is already set"
+	// conflict, #4969) on ApplyConfiguration.
+	desiredBytes, err := desired.Bytes()
+	require.NoError(t, err)
+	assert.Zero(t, countHostnameConfigDocs(t, desiredBytes),
+		"the conflicting HostnameConfig document must be stripped after grafting")
+
+	_, err = desired.Validate(nodeRuntimeMode{})
+	require.NoError(t, err,
+		"grafted config must pass node-side validation (no static-vs-HostnameConfig conflict)")
+
 	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
 	require.NoError(t, err)
 	assert.Empty(t, diff,
 		"a create-injected hostname must not read as drift on an unchanged config")
+}
+
+// TestBuildDesiredNodeConfig_PreservesNodeHostname_Worker is the worker-role
+// counterpart: the rename bug affects workers too. On Hetzner, workers also get a
+// create-injected static hostname (marshalConfigWithHostname is applied to worker
+// servers), and applyInPlaceConfigChanges rebuilds each worker's config via
+// buildDesiredNodeConfig. A worker's own config carries no CA private keys, so the
+// rebuild is seeded from a control-plane secrets source (#4963) — exactly how the
+// apply path threads it.
+func TestBuildDesiredNodeConfig_PreservesNodeHostname_Worker(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+
+	// One cluster bundle backs the running worker, the control-plane secrets source,
+	// and the provisioner's desired configs — modelling reality, where every node
+	// shares the cluster PKI. (Distinct bundles would diff on CA certs, not hostname.)
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	// The worker's running config carries the create-injected static hostname.
+	workerBytes, err := configs.Worker().Bytes()
+	require.NoError(t, err)
+
+	workerWithHostname, err := talosprovisioner.PatchTalosHostname(workerBytes, "prod-worker-1")
+	require.NoError(t, err)
+
+	workerRunning, err := configloader.NewFromBytes(workerWithHostname)
+	require.NoError(t, err)
+
+	require.Equal(t, "prod-worker-1", workerRunning.RawV1Alpha1().Hostname(),
+		"precondition: running worker config carries the create-injected static hostname")
+
+	// Workers carry no CA private keys; the rebuild is seeded from a control-plane
+	// config of the same cluster (matching PKI), as the apply path threads it (#4963).
+	cpBytes, err := configs.ControlPlane().Bytes()
+	require.NoError(t, err)
+
+	cpSecretsSource, err := configloader.NewFromBytes(cpBytes)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(configs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		workerRunning, cpSecretsSource, talosprovisioner.RoleWorker,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod-worker-1", desired.RawV1Alpha1().Hostname(),
+		"the worker's per-node static hostname must be preserved so it keeps its name on reboot")
+
+	desiredBytes, err := desired.Bytes()
+	require.NoError(t, err)
+	assert.Zero(
+		t,
+		countHostnameConfigDocs(t, desiredBytes),
+		"the conflicting HostnameConfig document must be stripped after grafting the worker hostname",
+	)
+
+	_, err = desired.Validate(nodeRuntimeMode{})
+	require.NoError(
+		t,
+		err,
+		"grafted worker config must pass node-side validation (no static-vs-HostnameConfig conflict)",
+	)
+
+	// Scope the drift check to the hostname: the empty-diff guarantee is covered by
+	// the control-plane test. A worker config carries no apiserver image, so
+	// buildDesiredNodeConfig cannot realign its Kubernetes version (see
+	// alignKubernetesVersion / #4936) — an orthogonal, pre-existing difference that
+	// must not mask, nor be conflated with, the hostname assertion.
+	diff, err := talosprovisioner.MachineConfigDiffForTest(workerRunning, desired)
+	require.NoError(t, err)
+	assert.NotContains(t, diff, "HostnameConfig",
+		"the grafted worker config must not reintroduce a standalone HostnameConfig document")
+	assert.NotContains(t, diff, "hostname:",
+		"the worker's static hostname must not drift (no add/remove of machine.network.hostname)")
 }
 
 // TestBuildDesiredNodeConfig_NoHostnameLeavesConfigUnchanged verifies the Docker


### PR DESCRIPTION
## What

On Hetzner, `ksail cluster update` was renaming Talos nodes to `talos-<rand>-<rand>` (e.g. `prod-worker-1` → `talos-6jk-4yw`). The in-place config reconcile was silently stripping each node's static hostname.

Fix: graft the running node's static `machine.network.hostname` onto the regenerated desired config in `buildDesiredNodeConfig`, so an update never drops it.

## Why

On Hetzner the per-node hostname (`machine.network.hostname` = the server name) is injected **post-generation** at create/scale via `patchTalosHostname`, so the Hetzner CCM can name-match the Kubernetes Node to its server. It is neither in the base config nor in any user patch, and the SDK's standalone `HostnameConfig` document is stripped at the same time.

`buildDesiredNodeConfig` *regenerates* the desired config from base + patches, so the regenerated config:
- **lacks** the static hostname, and
- re-adds the SDK's default `HostnameConfig` document (`auto: stable`).

So every Hetzner `cluster update`:
1. reported the hostname as **phantom machine-config drift**, and
2. on apply, **stripped the static hostname** → the node re-registered under a generated `talos-xxxxx` name on its next reboot.

Within a single `cluster update` the OS upgrade runs first and the config reconcile second, so the rename surfaces on a reboot — which is exactly why it showed up during a Talos OS upgrade (v1.12.4 → v1.13.3).

## How

- New `graftNodeHostname(desired, running)`, called at the end of `buildDesiredNodeConfig`. It reads `running.RawV1Alpha1().Hostname()`; if non-empty, re-applies it to the desired config via the existing `patchTalosHostname` (sets `machine.network.hostname` **and** strips the conflicting `HostnameConfig` document), then reloads via `configloader.NewFromBytes`.
- Nodes with no static hostname (e.g. Docker, which derives its hostname from the container) are returned unchanged — guarded, no-op, no behavior change.
- Mirrors the existing `graftNodeManagedSections` pattern for registry mirrors / cert SANs; its docstring already predicted this gap ("graft its section here too").

## Tests

- `TestBuildDesiredNodeConfig_PreservesNodeHostname` — reproduces the rename (fails before the fix: desired drops `hostname: prod-control-plane-1` and adds a `HostnameConfig` doc), passes after.
- `TestBuildDesiredNodeConfig_NoHostnameLeavesConfigUnchanged` — Docker-path guard: a node without a static hostname reports no drift and is left unchanged.
- Full `pkg/svc/provisioner/cluster/talos` suite (421) + provisioner/cluster-cmd packages (1455) pass; `golangci-lint --new-from-rev` and `go vet` clean.

## Reviewer notes

- This prevents **new** renames. A node already renamed by a prior buggy update has lost its static hostname on disk, so the graft sees nothing to preserve — those need the hostname re-applied (scale/recreate of that node) to recover.
- **Related latent bug, not fixed here:** the reboot-required apply path `rollingRebootSingleNode` (`rolling.go`) stages a raw regenerated config that drops hostname **and** registry mirrors **and** cert SANs. It is only reached when `diff.HasRebootRequired()` (not a version-only upgrade), so it is not the reported regression. It should be routed through `buildDesiredNodeConfig` too in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)