### PR TITLE
fix(cd): drive Homebrew cask PRs to merge instead of relying on tap auto-merge

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -672,7 +672,15 @@ jobs:
   homebrew:
     name: 🍺 Promote and merge Homebrew cask PRs
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Backstop only — the script self-bounds its runtime: brew-style prep (2 clones + `brew style`,
+    # which can bootstrap rubocop on a cold Linuxbrew runner) + `sleep 30` + two sequential
+    # `merge_cask_pr` polls that are additive (each computes `SECONDS + 600`, and bash `SECONDS` is
+    # whole-job elapsed time, never reset) for up to 600s apiece = ~1230s of polling. Worst case is
+    # ~prep + 30s + 1200s, which crowds a 25-min budget; a kill mid-poll would skip the second cask's
+    # fail-soft `--auto` fallback and exit non-zero, failing an already-published release. Keep this
+    # comfortably above the script's own ceiling so its fail-soft logic — not this timeout — is the
+    # binding limit.
+    timeout-minutes: 35
     needs: [publish-release]
     permissions:
       contents: read
@@ -722,7 +730,10 @@ jobs:
           prs=()
           for name in ksail ksail-desktop; do
             branch="goreleaser/${name}-${TAG}"
-            pr="$(gh pr list --repo "$TAP" --head "$branch" --state open --json number --jq '.[0].number // empty')"
+            # `|| true` keeps the job fail-soft: a transient `gh pr list` failure (5xx, rate limit,
+            # network blip) must not abort the step under `set -e` after the release is already public —
+            # the `-z "$pr"` guard below then warns and skips, same as the no-PR-found case.
+            pr="$(gh pr list --repo "$TAP" --head "$branch" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
             if [ -z "$pr" ]; then
               echo "::warning::No open cask PR found on $TAP for branch ${branch}; skipping"
               continue

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -145,7 +145,7 @@ jobs:
   # links a system webview via CGO and cannot be cross-compiled in the main release, so this job runs
   # a second GoReleaser config on a macOS runner: it builds the darwin binary, packages it as a
   # KSail.app bundle and opens a *draft* cask PR on the homebrew tap (the `homebrew` job marks it ready
-  # after publication). GoReleaser's release pipe is disabled (see .goreleaser.desktop.yaml); the built
+  # and merges it after publication). GoReleaser's release pipe is disabled (see .goreleaser.desktop.yaml); the built
   # archive is emitted as a workflow artifact and attached to the draft by `publish-release`. No
   # `needs: [goreleaser]` — this builds in parallel with the CLI release.
   desktop-macos:
@@ -655,27 +655,71 @@ jobs:
 
   # GoReleaser opens the Homebrew cask PRs during the build (CLI in `goreleaser`, macOS in
   # `desktop-macos`) as DRAFTS, so the tap cannot merge them while the cask still points at a draft
-  # (not-yet-public, 404) release. Now that `publish-release` has made the release public, mark both
-  # PRs ready. That draft→ready flip is the tap's single trigger: its required `enable-auto-merge.yaml`
-  # approves + arms squash auto-merge, and its CI audits the now-public asset — so we do NOT arm
-  # auto-merge from here (one arming path avoids racing the tap's ready-time audit). Keeps the tap
-  # bump strictly after the GitHub release exists. Branches mirror `.goreleaser*.yaml`
+  # (not-yet-public, 404) release. Now that `publish-release` has made the release public, this job
+  # promotes both PRs and drives them to merge — the final action of a release.
+  #
+  # We do NOT rely on the tap to merge them. The tap's `enable-auto-merge.yaml` is a ruleset-injected
+  # REQUIRED workflow, and GitHub does not re-dispatch required workflows on the `ready_for_review`
+  # activity — only its draft-open run fires, and that run `if: !draft`-skips — so the tap never arms
+  # auto-merge for these PRs (they sat open until merged by hand). Instead we mark each PR ready (so
+  # the tap's Cask audit re-runs against the now-public asset; a draft also can't be merged), wait for
+  # the fresh required checks to pass, then squash-merge from here. Waiting for the post-ready status
+  # (rather than arming auto-merge right after `gh pr ready`) avoids racing the stale draft-time green
+  # status (see #5080). All gates are satisfiable: 0 required approvals, the audit passes against the
+  # public asset, and the required-workflow gate is satisfied by the draft-open skipped run. Keeps the
+  # tap bump strictly after the GitHub release exists. Branches mirror `.goreleaser*.yaml`
   # (goreleaser/<project>-<tag>).
   homebrew:
-    name: 🍺 Promote Homebrew cask PRs
+    name: 🍺 Promote and merge Homebrew cask PRs
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     needs: [publish-release]
     permissions:
       contents: read
     steps:
-      - name: 🍺 Style-clean cask PRs, then mark them ready
+      - name: 🍺 Style-clean cask PRs, then drive them to merge
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           TAP: devantler-tech/homebrew-tap
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+
+          # Poll a ready cask PR until its required checks pass (mergeStateStatus CLEAN), then
+          # squash-merge it. Fail-soft: a stuck cask must never fail an already-published release, so
+          # on timeout we arm auto-merge as a fallback (safe here — we have already waited past the
+          # stale draft-time window) and warn rather than exit non-zero.
+          merge_cask_pr() {
+            local pr="$1" deadline=$((SECONDS + 600)) info state status
+            while [ "$SECONDS" -lt "$deadline" ]; do
+              info="$(gh pr view "$pr" --repo "$TAP" \
+                --json state,mergeStateStatus --jq '.state, .mergeStateStatus' 2>/dev/null || true)"
+              state="$(printf '%s\n' "$info" | sed -n 1p)"
+              status="$(printf '%s\n' "$info" | sed -n 2p)"
+              case "$state" in
+                MERGED) echo "Merged ${TAP}#${pr}"; return 0 ;;
+                CLOSED) echo "::warning::${TAP}#${pr} was closed without merging"; return 0 ;;
+              esac
+              case "$status" in
+                CLEAN)
+                  if gh pr merge "$pr" --repo "$TAP" --squash; then
+                    echo "Merged ${TAP}#${pr}"
+                    return 0
+                  fi
+                  ;;
+                DIRTY)
+                  echo "::warning::${TAP}#${pr} has merge conflicts; merge it manually"
+                  return 0
+                  ;;
+              esac
+              sleep 20
+            done
+            echo "::warning::Timed out waiting for ${TAP}#${pr} to become mergeable; arming auto-merge as a fallback"
+            gh pr merge "$pr" --repo "$TAP" --auto --squash \
+              || echo "::warning::Could not arm auto-merge for ${TAP}#${pr}; merge it manually"
+          }
+
+          prs=()
           for name in ksail ksail-desktop; do
             branch="goreleaser/${name}-${TAG}"
             pr="$(gh pr list --repo "$TAP" --head "$branch" --state open --json number --jq '.[0].number // empty')"
@@ -721,13 +765,24 @@ jobs:
               echo "::warning::Could not create tempdir for brew style --fix; promoting ${name} cask as-is"
             fi
 
-            # Mark the PR ready; the tap takes it from here. The `ready_for_review` flip triggers the
-            # tap's required `enable-auto-merge.yaml` (approve + squash auto-merge) and its Cask audit
-            # against the now-public asset. We intentionally do not enable auto-merge here, so the tap
-            # is the sole arming path and cannot race its own ready-time audit. Non-fatal under
+            # Mark the PR ready so its Cask audit re-runs against the now-public asset and the PR
+            # becomes mergeable; the merge itself is driven below by `merge_cask_pr`. Non-fatal under
             # `set -e`: the PR may already be ready.
             gh pr ready "$pr" --repo "$TAP" \
               || echo "::warning::Could not mark ${TAP}#${pr} ready; it may already be ready"
+            prs+=("$pr")
+          done
+
+          # Let the ready_for_review-triggered required checks register as pending before polling, so
+          # the first status read can't catch the stale draft-time CLEAN status (see #5080). Marking
+          # all PRs ready first lets their audits run in parallel.
+          if [ "${#prs[@]}" -gt 0 ]; then
+            sleep 30
+          fi
+
+          # Drive each ready PR to merge — the last thing the release does.
+          for pr in "${prs[@]}"; do
+            merge_cask_pr "$pr"
           done
 
   # Backstop for the immutable-release model: if the release did NOT publish — any asset job failed,


### PR DESCRIPTION
## What

The `homebrew` job at the end of `cd.yaml` now **drives the GoReleaser cask PRs to merge itself**, instead of marking them ready and trusting the tap to auto-merge them.

## Why

The cask PRs were sitting open after each release and getting merged by hand. Root cause, confirmed against tap PR [#782](https://github.com/devantler-tech/homebrew-tap/pull/782)'s head check-runs:

- The tap's `enable-auto-merge.yaml` is a **ruleset-injected required workflow** (not a normal tap workflow).
- **GitHub does not re-dispatch required workflows on the `ready_for_review` activity.** Its only run is the draft-open one, which `if: !draft`-**skips** — so the `auto-merge` check shows only a `skipped` run and auto-merge is never armed.
- The tap's *own* `ci.yaml` Cask audit *does* re-run on ready (normal workflow), so the PR becomes mergeable — but nothing merges it.

This reverses [#5080](https://github.com/devantler-tech/ksail/pull/5080), which dropped CD's `gh pr merge --auto` on the (incorrect) premise that the draft→ready flip arms the tap's auto-merge.

## How

After publish (`needs: [publish-release]`), the job:

1. Marks both cask PRs ready — still required: re-runs the tap's Cask audit against the now-public asset, and a draft can't be merged.
2. `sleep 30` so the ready-triggered required checks register as **pending** before polling — this is what avoids the stale draft-time green-status race that #5080 was concerned about, so auto-merge does **not** have to be armed right after `gh pr ready`.
3. `merge_cask_pr()` polls each PR (`gh pr view --json state,mergeStateStatus`) until `CLEAN`, then `gh pr merge --squash` (600s per-PR deadline).
4. **Fail-soft:** on timeout it arms `--auto --squash` as a fallback (safe at that point — checks are already green) and warns; conflicts/closed PRs warn and move on. A stuck cask never fails the already-published release.

This is possible because the tap's merge gates are all satisfiable from CD: **0 required approvals**, the audit passes against the public asset, and the `EnableAutoMerge` required-workflow gate is satisfied by its skipped draft-open run (`skipped` = pass).

Also: renamed the job to "Promote and merge Homebrew cask PRs" and bumped `timeout-minutes` 10 → 25 to cover the wait.

## Reviewer notes

- This path only exercises on the next `v*` tag (a real release) — it can't be dry-run without cutting one. Validated statically: `actionlint` (which shellchecks the `run:` block) and a standalone `shellcheck` of the script both pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)