### PR TITLE
fix(talos): preserve per-node identity on rolling-reboot config staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ See the [feature overview](https://ksail.devantler.tech/features/) and [architec
 
 | Provider   | Vanilla  | K3s     | Talos | VCluster | KWOK        | EKS |
 |------------|----------|---------|-------|----------|-------------|-----|
-| Docker     | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) |  —    |
-| Kubernetes | ✅        | ✅       | ✅     | ✅        | ✅           |  —    |
+| Docker     | ✅ (Kind) | ✅ (K3d) | ✅     | ✅ (Vind) | ✅ (kwokctl) | —   |
+| Kubernetes | ✅        | ✅       | ✅     | ✅        | ✅           | —   |
 | Hetzner    | —        | —       | ✅     | —        | —           | —   |
 | Omni       | —        | —       | ✅     | —        | —           | —   |
 | AWS        | —        | —       | —     | —        | —           | 🚧  |

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -487,6 +487,27 @@ func (p *Provisioner) BuildDesiredNodeConfigForTest(
 	return p.buildDesiredNodeConfig(running, secretsSource, role)
 }
 
+// WithNodeConfigFetcherForTest overrides the running-config fetcher so unit tests
+// can drive the rolling-reboot staged-config rebuild (buildStagedNodeConfig)
+// without real Talos API connectivity.
+func (p *Provisioner) WithNodeConfigFetcherForTest(
+	fn func(ctx context.Context, nodeIP string) (talosconfig.Provider, error),
+) *Provisioner {
+	p.nodeConfigFetcher = fn
+
+	return p
+}
+
+// BuildStagedNodeConfigForTest exposes buildStagedNodeConfig — the rolling-reboot
+// staged-config rebuild — for unit testing.
+func (p *Provisioner) BuildStagedNodeConfigForTest(
+	ctx context.Context,
+	node NodeWithRoleForTest,
+	secretsSource talosconfig.Provider,
+) (talosconfig.Provider, error) {
+	return p.buildStagedNodeConfig(ctx, node, secretsSource)
+}
+
 // MachineConfigFieldForTest exposes the machine.config change field for unit testing.
 const MachineConfigFieldForTest = MachineConfigField
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	dockerclient "github.com/docker/docker/client"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/providers"
 )
@@ -161,9 +162,14 @@ type Provisioner struct {
 	// reconciliation must wait for it. Defaults to a TCP dial loop; tests override
 	// it via export_test.go to avoid real network I/O.
 	nodeReachabilityCheck func(ctx context.Context, ip string) error
-	logWriter             io.Writer
-	logMu                 sync.Mutex
-	componentDetector     *detector.ComponentDetector
+	// nodeConfigFetcher returns the running Talos machine config for a node by IP.
+	// Defaults to fetchNodeConfig; tests override it via export_test.go to inject a
+	// known running config without real Talos API connectivity (used by the rolling
+	// reboot's staged-config rebuild — see buildStagedNodeConfig).
+	nodeConfigFetcher func(ctx context.Context, nodeIP string) (talosconfig.Provider, error)
+	logWriter         io.Writer
+	logMu             sync.Mutex
+	componentDetector *detector.ComponentDetector
 	// imagePullRetry controls retry behavior for Docker image pulls.
 	// Tests can override this via WithImagePullRetryConfig to use near-zero delays.
 	imagePullRetry imagePullRetryConfig
@@ -205,6 +211,8 @@ func NewProvisioner(
 	prov.nodeReachabilityCheck = func(ctx context.Context, ip string) error {
 		return dialTCPUntilReachable(ctx, ip, talosAPIWaitTimeout, retryInterval)
 	}
+
+	prov.nodeConfigFetcher = prov.fetchNodeConfig
 
 	return prov
 }

--- a/pkg/svc/provisioner/cluster/talos/rolling.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -257,13 +258,20 @@ func (p *Provisioner) rollingApplyRebootChanges(
 
 	ordered := sortNodesWorkersFirst(nodes)
 
+	// The staged-config rebuild needs the cluster PKI, which only a control-plane
+	// node carries. Resolve one control-plane config up front and reuse it as the
+	// secrets source for every node — seeding the rebuild from a worker's own config
+	// fails with "failed to parse PEM block" (#4963). All control-planes share the
+	// same PKI, so any one is a valid source (mirrors applyInPlaceConfigChanges).
+	secretsSource := p.fetchSecretsSource(ctx, clusterName)
+
 	for i, node := range ordered {
 		_, _ = fmt.Fprintf(p.logWriter,
 			"  [%d/%d] Rolling reboot for %s (%s)...\n",
 			i+1, len(ordered), node.IP, node.Role,
 		)
 
-		rebootErr := p.rollingRebootSingleNode(ctx, clientset, node)
+		rebootErr := p.rollingRebootSingleNode(ctx, clientset, node, secretsSource)
 		if rebootErr != nil {
 			recordFailedChange(result, node.Role, node.IP, rebootErr)
 
@@ -284,11 +292,14 @@ func (p *Provisioner) rollingApplyRebootChanges(
 }
 
 // rollingRebootSingleNode performs the cordon → drain → stage config → reboot →
-// wait → uncordon sequence for a single node.
+// wait → uncordon sequence for a single node. secretsSource is a control-plane
+// config supplying the cluster PKI for the staged-config rebuild (see
+// stageNodeConfigForReboot).
 func (p *Provisioner) rollingRebootSingleNode(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	node nodeWithRole,
+	secretsSource talosconfig.Provider,
 ) error {
 	nodeName, err := p.resolveNodeName(ctx, clientset, node.IP)
 	if err != nil {
@@ -300,24 +311,9 @@ func (p *Provisioner) rollingRebootSingleNode(
 		return drainErr
 	}
 
-	// Apply config with STAGED mode — config takes effect on next reboot.
-	if p.talosConfigs != nil {
-		config := p.talosConfigs.ControlPlane()
-		if node.Role == RoleWorker {
-			config = p.talosConfigs.Worker()
-		}
-
-		if config != nil {
-			_, _ = fmt.Fprintf(p.logWriter, "    Staging config on %s...\n", node.IP)
-
-			stageErr := p.applyConfigWithMode(
-				ctx, node.IP, config,
-				machineapi.ApplyConfigurationRequest_STAGED,
-			)
-			if stageErr != nil {
-				return fmt.Errorf("stage config: %w", stageErr)
-			}
-		}
+	stageErr := p.stageNodeConfigForReboot(ctx, node, secretsSource)
+	if stageErr != nil {
+		return stageErr
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter, "    Rebooting %s...\n", node.IP)
@@ -342,4 +338,65 @@ func (p *Provisioner) rollingRebootSingleNode(
 	}
 
 	return nil
+}
+
+// stageNodeConfigForReboot stages the node's desired machine config with STAGED
+// mode, so it takes effect on the next reboot. The config is rebuilt from the
+// node's running config through buildDesiredNodeConfig — the same machinery the
+// in-place reconcile uses — so the per-node sections ksail injects post-generation
+// at create/scale (static hostname, registry mirrors, cert SANs) survive the
+// reboot. Staging the raw regenerated talosConfigs.ControlPlane()/Worker() instead
+// would silently revert them: e.g. dropping machine.network.hostname so a Hetzner
+// node re-registers under a generated talos-xxxxx name once it reboots — the same
+// class of bug fixed for the in-place path in detect_inplace.go (graftNodeHostname).
+// It is a no-op when no Talos config is loaded (nothing to stage).
+func (p *Provisioner) stageNodeConfigForReboot(
+	ctx context.Context,
+	node nodeWithRole,
+	secretsSource talosconfig.Provider,
+) error {
+	if p.talosConfigs == nil {
+		return nil
+	}
+
+	config, err := p.buildStagedNodeConfig(ctx, node, secretsSource)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "    Staging config on %s...\n", node.IP)
+
+	stageErr := p.applyConfigWithMode(
+		ctx, node.IP, config,
+		machineapi.ApplyConfigurationRequest_STAGED,
+	)
+	if stageErr != nil {
+		return fmt.Errorf("stage config: %w", stageErr)
+	}
+
+	return nil
+}
+
+// buildStagedNodeConfig builds the machine config to STAGE on a node ahead of a
+// rolling reboot: the node's running config regenerated through
+// buildDesiredNodeConfig, which preserves the per-node post-generation transforms
+// (static hostname, registry mirrors, cert SANs) instead of reverting to the
+// freshly regenerated base config. secretsSource supplies the cluster PKI and must
+// be a control-plane config (see buildDesiredNodeConfig and #4963).
+func (p *Provisioner) buildStagedNodeConfig(
+	ctx context.Context,
+	node nodeWithRole,
+	secretsSource talosconfig.Provider,
+) (talosconfig.Provider, error) {
+	running, err := p.nodeConfigFetcher(ctx, node.IP)
+	if err != nil {
+		return nil, fmt.Errorf("fetch running config: %w", err)
+	}
+
+	desired, err := p.buildDesiredNodeConfig(running, secretsSource, node.Role)
+	if err != nil {
+		return nil, fmt.Errorf("build desired config: %w", err)
+	}
+
+	return desired, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/rolling_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_test.go
@@ -1,10 +1,14 @@
 package talosprovisioner_test
 
 import (
+	"context"
 	"testing"
 
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRolling_SortNodesWorkersFirst(t *testing.T) { //nolint:funlen // table-driven tests
@@ -93,4 +97,101 @@ func TestRolling_SortNodesWorkersFirst(t *testing.T) { //nolint:funlen // table-
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestRolling_BuildStagedNodeConfig_PreservesNodeHostname is the regression guard
+// for the rolling-reboot node-rename bug — the sibling of the in-place
+// TestBuildDesiredNodeConfig_PreservesNodeHostname. The config a rolling reboot
+// STAGES (applied on the node's next reboot) must be rebuilt through
+// buildDesiredNodeConfig so the create-injected static machine.network.hostname is
+// preserved, NOT the raw regenerated talosConfigs.ControlPlane()/Worker(). Staging
+// the raw config would strip the hostname so a Hetzner node re-registers under a
+// generated talos-xxxxx name on reboot (e.g. during a reboot-required config
+// change). This drives the actual staging-path config rebuild
+// (buildStagedNodeConfig) with the node's running config injected via the fetcher
+// seam.
+func TestRolling_BuildStagedNodeConfig_PreservesNodeHostname(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+	running := runningWithHostname(
+		t, talosprovisioner.RoleControlPlane, "prod-control-plane-1", patch,
+	)
+
+	require.Equal(t, "prod-control-plane-1", running.RawV1Alpha1().Hostname(),
+		"precondition: running config carries the create-injected static hostname")
+
+	// Desired configs are regenerated from the same patches — without the hostname,
+	// which is a create-only post-generation transform (like registry mirrors).
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil).
+		WithNodeConfigFetcherForTest(
+			func(_ context.Context, _ string) (talosconfig.Provider, error) {
+				return running, nil
+			},
+		)
+
+	node := talosprovisioner.NewNodeWithRoleForTest(
+		"10.0.0.2", talosprovisioner.RoleControlPlane,
+	)
+
+	staged, err := prov.BuildStagedNodeConfigForTest(context.Background(), node, running)
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod-control-plane-1", staged.RawV1Alpha1().Hostname(),
+		"the staged rolling-reboot config must preserve the per-node static hostname")
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, staged)
+	require.NoError(t, err)
+	assert.Empty(t, diff,
+		"a create-injected hostname must not read as drift in the staged config")
+}
+
+// TestRolling_BuildStagedNodeConfig_PreservesWorkerHostname covers the worker-role
+// branch of the staging rebuild: the worker's running config is seeded with the
+// control-plane PKI (a worker config carries no CA key — see #4963) and its
+// create-injected static hostname must likewise survive staging.
+func TestRolling_BuildStagedNodeConfig_PreservesWorkerHostname(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	// secretsSource must be a control-plane config — a worker config carries no CA
+	// key, so seeding the rebuild from the worker's own config fails ("failed to
+	// parse PEM block", #4963). It need not share a PKI bundle with workerRunning:
+	// this test asserts only that the create-injected hostname is grafted onto the
+	// rebuilt config, which is independent of PKI alignment.
+	secretsSource := runningWithHostname(
+		t, talosprovisioner.RoleControlPlane, "prod-control-plane-1", patch,
+	)
+	workerRunning := runningWithHostname(
+		t, talosprovisioner.RoleWorker, "prod-worker-1", patch,
+	)
+
+	require.Equal(t, "prod-worker-1", workerRunning.RawV1Alpha1().Hostname(),
+		"precondition: worker running config carries the create-injected static hostname")
+
+	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil).
+		WithNodeConfigFetcherForTest(
+			func(_ context.Context, _ string) (talosconfig.Provider, error) {
+				return workerRunning, nil
+			},
+		)
+
+	node := talosprovisioner.NewNodeWithRoleForTest("10.0.0.3", talosprovisioner.RoleWorker)
+
+	staged, err := prov.BuildStagedNodeConfigForTest(context.Background(), node, secretsSource)
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod-worker-1", staged.RawV1Alpha1().Hostname(),
+		"the staged rolling-reboot config must preserve the worker's static hostname")
 }


### PR DESCRIPTION
## What

Routes the Talos **rolling-reboot** staging path through `buildDesiredNodeConfig` — the same machinery the in-place reconcile uses — so per-node config survives a reboot-required `ksail cluster update`.

- `rollingApplyRebootChanges` resolves a control-plane secrets source once (`fetchSecretsSource`) and threads it to each node (mirrors `applyInPlaceConfigChanges`; same #4963 PKI rationale).
- `rollingRebootSingleNode` no longer stages the raw `talosConfigs.ControlPlane()/Worker()`. It delegates to new `stageNodeConfigForReboot` → `buildStagedNodeConfig`, which fetches the node's running config and rebuilds the staged config via `buildDesiredNodeConfig`.
- Adds a `nodeConfigFetcher` DI seam (consistent with `talosClientFactory` / `nodeReachabilityCheck`) so the rebuild is unit-testable without live Talos connectivity.

## Why

`rollingRebootSingleNode` staged the freshly **regenerated** config directly. That config omits the per-node sections ksail injects post-generation at create/scale — static `machine.network.hostname` (so the Hetzner CCM can name-match the Node to its server), registry mirrors (`MachineRegistries`), and cert SANs (`MachineCertSANs`) — so staging it and rebooting silently reverted them. On Hetzner the dropped hostname makes the node re-register under a generated `talos-xxxxx` name on its next reboot.

This is the reboot-path sibling of the in-place node-rename bug fixed by `graftNodeHostname` in this PR's base (#5099). Reached only when `diff.HasRebootRequired()` (a reboot-required config change) — **not** a pure version/OS upgrade. `buildDesiredNodeConfig` already grafts hostname + mirrors + cert SANs and aligns PKI/endpoint/Kubernetes version, so routing through it preserves all of them.

## Tests

`rolling_test.go` regression tests mirroring `TestBuildDesiredNodeConfig_PreservesNodeHostname` but driving the actual staging rebuild (`buildStagedNodeConfig`) via the fetcher seam:
- `TestRolling_BuildStagedNodeConfig_PreservesNodeHostname` — control-plane: hostname preserved + no drift.
- `TestRolling_BuildStagedNodeConfig_PreservesWorkerHostname` — worker role branch + control-plane PKI source.

Validated: `go test ./pkg/svc/provisioner/cluster/talos/...` (423 pass), `golangci-lint run --new-from-rev=HEAD` clean, `gofmt`/`go vet` clean.

## Reviewer notes

- ⚠️ **Stacked on #5099** — base is `claude/romantic-mcnulty-26a791`, **not** `main`. It depends on `graftNodeHostname` (added by #5099). Merge #5099 first, then retarget this to `main` (or merge this into #5099's branch).
- **Behavior change**: staging now errors and aborts the node's reboot if `buildDesiredNodeConfig` fails (e.g. a worker with no reachable control-plane for PKI), where before it always staged *something*. This is intentional — fail loudly rather than silently revert node identity. The window is narrow: `fetchSecretsSource` runs once up front while all control-planes are still up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)