### PR TITLE
ci: pull registry:3 via Docker Hub mirror to stop anonymous-pull flakes

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -205,22 +205,7 @@ runs:
 
     - name: 📥 Pre-pull registry image
       if: inputs.provider == 'Docker'
-      shell: bash
-      run: |
-        pulled=false
-        for attempt in 1 2 3; do
-          if docker pull registry:3; then
-            echo "✅ registry:3 image pulled successfully"
-            pulled=true
-            break
-          fi
-          echo "⚠️ registry:3 pull attempt $attempt failed, retrying in 5s…"
-          sleep 5
-        done
-        if [ "$pulled" = false ]; then
-          echo "❌ Failed to pull registry:3 after 3 attempts"
-          exit 1
-        fi
+      uses: ./.github/actions/pull-registry-image
 
     - name: 📥 Pre-pull distribution images
       if: inputs.provider == 'Docker'

--- a/.github/actions/pull-registry-image/action.yaml
+++ b/.github/actions/pull-registry-image/action.yaml
@@ -1,0 +1,41 @@
+name: Pull registry image
+description: >-
+  Reliably obtain the registry:3 image that backs KSail's local pull-through
+  mirror registries. Anonymous Docker Hub pulls from shared GitHub Actions
+  runner IPs are throttled and time out (the single most frequent CI flake), so
+  this pulls from Google's Docker Hub pull-through mirror first and falls back to
+  Docker Hub, re-tagging the result to registry:3 for callers.
+
+runs:
+  using: composite
+  steps:
+    - name: 📥 Obtain registry:3 image
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub;
+        # it is not subject to Docker Hub's per-IP anonymous rate limits, which is
+        # what causes the recurring "registry:3 pull timeout" flake on shared CI
+        # runners. Try the mirror first, then fall back to Docker Hub directly,
+        # and re-tag whichever source succeeds to the canonical registry:3.
+        obtain_registry_image() {
+          local ref attempt
+          for ref in mirror.gcr.io/library/registry:3 registry:3; do
+            for attempt in 1 2 3; do
+              if docker pull --quiet "$ref"; then
+                docker tag "$ref" registry:3
+                echo "✅ registry:3 obtained from ${ref}"
+                return 0
+              fi
+              echo "⚠️ pull ${ref} attempt ${attempt}/3 failed; retrying in $((attempt * 5))s…"
+              sleep "$((attempt * 5))"
+            done
+          done
+          return 1
+        }
+
+        if ! obtain_registry_image; then
+          echo "❌ Failed to obtain registry:3 from mirror.gcr.io and Docker Hub"
+          exit 1
+        fi

--- a/.github/actions/warm-mirror-cache/action.yaml
+++ b/.github/actions/warm-mirror-cache/action.yaml
@@ -269,6 +269,10 @@ runs:
           echo "complete=false" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: 📥 Pre-pull registry image
+      if: steps.check-cache.outputs.complete != 'true'
+      uses: ./.github/actions/pull-registry-image
+
     - name: 🐳 Create mirror registries
       id: create-mirrors
       if: steps.check-cache.outputs.complete != 'true'


### PR DESCRIPTION
## Root cause

The `🧪 System Test (Docker)` matrix flakes regularly with:

```
Get "https://registry-1.docker.io/v2/": ... Client.Timeout exceeded while awaiting headers
⚠️ registry:3 pull attempt 1/2/3 failed → ❌ Failed to pull registry:3 after 3 attempts
```

It's **not random**. The system-test job has a `🔐 Login to Docker Hub` step gated on `vars.DOCKERHUB_USERNAME`, and that variable is **unset** — so the login is `skipped` on every run and *all* Docker Hub pulls happen **anonymously**. Docker Hub throttles anonymous pulls from shared GitHub Actions runner IPs, so the `registry:3` pre-pull (which backs KSail's local pull-through mirror registries) intermittently times out and fails the whole leg. This is the failure that has made manual re-enqueues a daily ritual.

Verified on a failing run: step `🔐 Login to Docker Hub` = `skipped`, then `📥 Pre-pull registry image` = `failure` with Docker Hub connection timeouts.

## Fix

A small shared composite action, `pull-registry-image`, that obtains `registry:3` from **Google's anonymous Docker Hub pull-through mirror** (`mirror.gcr.io/library/registry:3`) first, falls back to Docker Hub, and re-tags the result to `registry:3`. `mirror.gcr.io` is not subject to Docker Hub's per-IP anonymous rate limits, so it removes the throttling root cause **without requiring Docker Hub credentials**.

Wired into both places that need the image:
- `ksail-cluster` — the `📥 Pre-pull registry image` step (was the hard failure point).
- `warm-mirror-cache` — before `🐳 Create mirror registries` (previously pulled `registry:3` implicitly via `docker run`, same anonymous-Docker-Hub exposure).

Net diff: −16 lines of duplicated retry shell, +1 shared action.

## Complementary follow-up (repo settings, not code)

Setting the **`DOCKERHUB_USERNAME` repo variable** (alongside the existing `DOCKERHUB_TOKEN` secret) would un-skip the `🔐 Login to Docker Hub` step and authenticate *all* Docker Hub pulls in CI, raising the limits further. That's a repo-settings change a maintainer must make; this PR fixes the reliability problem in code regardless.

## Validation

- `shellcheck` clean on the composite action's script.
- `actionlint` clean on the changed actions (the only repo-wide actionlint error is the pre-existing unknown `code-quality` permission scope in `ci.yaml`, unrelated to this change).
- Behaviour is unchanged on success; only the *source* of `registry:3` and its resilience change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)