### PR TITLE
ci(release): re-enable auto-release on push to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,13 @@
 name: Release
 on:
   workflow_dispatch:
+  # Auto-release: every push to main runs semantic-release (create-release.yaml).
+  # Its commit-analyzer cuts a new vX.Y.Z tag only when the merged commits warrant
+  # one (fix: → patch, feat: → minor, BREAKING CHANGE/! → major) and no-ops otherwise
+  # (chore:/docs:/ci:). The tag push then triggers cd.yaml's GoReleaser publish.
+  push:
+    branches:
+      - main
 
 concurrency:
   group: "Release"


### PR DESCRIPTION
## Why

Auto-release was disabled in #4263 (6 weeks ago), which removed the `push: branches: [main]` trigger from `release.yaml`, leaving it `workflow_dispatch`-only. Since then every patch/feature release had to be cut by hand — the exact toil this reverses.

## What

Restore the `push: branches: [main]` trigger on the **Release** workflow (keeping `workflow_dispatch` for ad-hoc manual runs):

- `create-release.yaml` (semantic-release) now runs on every merge to `main`.
- Its commit-analyzer cuts a `vX.Y.Z` tag **only** when the merged commits warrant one — `fix:` → patch, `feat:` → minor, `BREAKING CHANGE`/`!` → major — and **no-ops** on `chore:`/`docs:`/`ci:`.
- The tag push then triggers `cd.yaml`'s GoReleaser publish exactly as before. No CD changes.

## Doc alignment

This is also a drift fix. Both already state releases run on pushes to `main`, dating from the #4263 disable:
- `CONTRIBUTING.md` → *Release Process* ("runs on pushes to `main`")
- `docs/src/content/docs/development.mdx` ("push to `main` triggers tagging")

No doc edits needed — the workflow now matches what's documented.

## Validation

- `actionlint .github/workflows/release.yaml` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)