### PR TITLE
feat(hetzner): recycle autoscaler nodes on version change during cluster update

### DIFF
--- a/docs/src/content/docs/providers/hetzner.mdx
+++ b/docs/src/content/docs/providers/hetzner.mdx
@@ -338,7 +338,7 @@ To keep them on the baseline, when a `ksail cluster update` changes the Talos or
 1. Rebuilds the Talos snapshot at the new version and refreshes the `cluster-autoscaler-config` Secret (so **new** autoscaler nodes boot the new version), then restarts the cluster-autoscaler to load it.
 2. **Recycles the existing autoscaler nodes** so they follow the new baseline instead of drifting: after the restarted autoscaler is ready, each autoscaler node is cordoned and drained one at a time (through the Kubernetes eviction API, honoring PodDisruptionBudgets) and its Hetzner server is deleted. The cluster-autoscaler then provisions any still-needed capacity from the refreshed snapshot on demand.
 
-This mirrors the upstream Cluster Autoscaler model — the autoscaler owns node *creation*, so KSail removes the stale nodes and lets the autoscaler replace them rather than upgrading ephemeral, compute-only nodes in place. Recycling runs only when the version actually changes; a no-op `cluster update` leaves autoscaler nodes untouched.
+This mirrors the upstream Cluster Autoscaler model — the autoscaler owns node _creation_, so KSail removes the stale nodes and lets the autoscaler replace them rather than upgrading ephemeral, compute-only nodes in place. Recycling runs only when the version actually changes; a no-op `cluster update` leaves autoscaler nodes untouched.
 
 > [!NOTE]
 > Recycling drains nodes one at a time, so a strict PodDisruptionBudget can slow or block it. Pods that cannot be evicted within the drain timeout fail the update so the condition surfaces rather than abruptly evicting workloads.
@@ -402,4 +402,3 @@ spec:
 **`context deadline exceeded` or connection errors** — Verify `HCLOUD_TOKEN` is valid and has read/write permissions. Check connectivity with `curl -sI https://api.hetzner.cloud/v1/servers -H "Authorization: Bearer $HCLOUD_TOKEN"`.
 
 **Cluster deletion leaves orphaned resources** — If `ksail cluster delete` is interrupted, manually clean up in the [Hetzner Cloud Console](https://console.hetzner.cloud/): delete servers, load balancers, networks, and placement groups associated with your cluster name.
-

--- a/docs/src/content/docs/providers/hetzner.mdx
+++ b/docs/src/content/docs/providers/hetzner.mdx
@@ -329,6 +329,20 @@ When `spec.cluster.talos.schematicId` is set, KSail manages a Hetzner Cloud **sn
 > [!NOTE]
 > Snapshots are scoped per cluster name, so deleting one cluster does not affect snapshots used by another cluster with the same schematic.
 
+### Autoscaler Node Upgrades
+
+Autoscaler-managed nodes are provisioned by the [Cluster Autoscaler](https://github.com/kubernetes/autoscaler) itself — booting the Talos snapshot and worker config baked into the `cluster-autoscaler-config` Secret — not by KSail directly. They are therefore **not** part of the in-place rolling Talos/Kubernetes upgrade `ksail cluster update` runs against the static control planes and workers (those are matched by the `ksail.owned` label; autoscaler nodes are not).
+
+To keep them on the baseline, when a `ksail cluster update` changes the Talos or Kubernetes version, KSail:
+
+1. Rebuilds the Talos snapshot at the new version and refreshes the `cluster-autoscaler-config` Secret (so **new** autoscaler nodes boot the new version), then restarts the cluster-autoscaler to load it.
+2. **Recycles the existing autoscaler nodes** so they follow the new baseline instead of drifting: after the restarted autoscaler is ready, each autoscaler node is cordoned and drained one at a time (through the Kubernetes eviction API, honoring PodDisruptionBudgets) and its Hetzner server is deleted. The cluster-autoscaler then provisions any still-needed capacity from the refreshed snapshot on demand.
+
+This mirrors the upstream Cluster Autoscaler model — the autoscaler owns node *creation*, so KSail removes the stale nodes and lets the autoscaler replace them rather than upgrading ephemeral, compute-only nodes in place. Recycling runs only when the version actually changes; a no-op `cluster update` leaves autoscaler nodes untouched.
+
+> [!NOTE]
+> Recycling drains nodes one at a time, so a strict PodDisruptionBudget can slow or block it. Pods that cannot be evicted within the drain timeout fail the update so the condition surfaces rather than abruptly evicting workloads.
+
 ### List Clusters
 
 ```bash
@@ -349,7 +363,7 @@ Displays Kubernetes control-plane and core service endpoints for the current con
 ksail cluster update
 ```
 
-Applies in-place changes to components (CNI, GitOps engine, cert-manager, etc.). Node scaling changes for Talos are applied in-place. Changes to `hetzner.location`, `hetzner.controlPlaneServerType`, or `hetzner.networkCidr` require cluster recreation. See the [Update Behavior table](/support-matrix/#update-behavior) for details.
+Applies in-place changes to components (CNI, GitOps engine, cert-manager, etc.). Node scaling changes for Talos are applied in-place. A Talos or Kubernetes version bump rolls the static nodes in place and **recycles autoscaler nodes** so they follow the new baseline (see [Autoscaler Node Upgrades](#autoscaler-node-upgrades)). Changes to `hetzner.location`, `hetzner.controlPlaneServerType`, or `hetzner.networkCidr` require cluster recreation. See the [Update Behavior table](/support-matrix/#update-behavior) for details.
 
 ### Deploy with LoadBalancer
 

--- a/pkg/svc/provider/hetzner/autoscaler_nodes_test.go
+++ b/pkg/svc/provider/hetzner/autoscaler_nodes_test.go
@@ -1,0 +1,187 @@
+package hetzner_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	autoscalerTestCluster = "my-cluster"
+	autoscalerTestNetwork = "my-cluster-network"
+	autoscalerNetworkID   = int64(100)
+	autoscalerPoolA       = "pool-a"
+	autoscalerPoolB       = "pool-b"
+)
+
+// schemaServer builds a minimal server schema attached to the given network ID.
+func schemaServer(id int64, name string, networkID int64) schema.Server {
+	return schema.Server{
+		ID:     id,
+		Name:   name,
+		Status: "running",
+		PrivateNet: []schema.ServerPrivateNet{
+			{Network: networkID, IP: "10.0.0.2"},
+		},
+	}
+}
+
+// newAutoscalerNodesTestServer mocks the Hetzner network-lookup and server-list
+// endpoints ListAutoscalerNodes depends on. serversByPool maps a node-group pool
+// name to the servers returned for its label selector.
+func newAutoscalerNodesTestServer(
+	t *testing.T,
+	serversByPool map[string][]schema.Server,
+) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /networks", func(writer http.ResponseWriter, request *http.Request) {
+		resp := schema.NetworkListResponse{}
+		if request.URL.Query().Get("name") == autoscalerTestNetwork {
+			resp.Networks = []schema.Network{{ID: autoscalerNetworkID, Name: autoscalerTestNetwork}}
+		}
+
+		writeJSONResponse(t, writer, resp)
+	})
+
+	mux.HandleFunc("GET /servers", func(writer http.ResponseWriter, request *http.Request) {
+		selector := request.URL.Query().Get("label_selector")
+
+		resp := schema.ServerListResponse{}
+
+		for pool, servers := range serversByPool {
+			if selector == hetzner.LabelAutoscalerNodeGroup+"="+pool {
+				resp.Servers = servers
+
+				break
+			}
+		}
+
+		writeJSONResponse(t, writer, resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestListAutoscalerNodes_EmptyPoolNames(t *testing.T) {
+	t.Parallel()
+
+	client := hcloud.NewClient(hcloud.WithToken("test-token"))
+	prov := hetzner.NewProvider(client)
+
+	servers, err := prov.ListAutoscalerNodes(context.Background(), autoscalerTestCluster, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, servers)
+}
+
+func TestListAutoscalerNodes_NilClient(t *testing.T) {
+	t.Parallel()
+
+	prov := hetzner.NewProvider(nil)
+
+	_, err := prov.ListAutoscalerNodes(
+		context.Background(), autoscalerTestCluster, []string{autoscalerPoolA},
+	)
+
+	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}
+
+func TestListAutoscalerNodes_MissingNetworkReturnsNothing(t *testing.T) {
+	t.Parallel()
+
+	// No network matches the cluster name, so there is nothing to recycle.
+	srv := newAutoscalerNodesTestServer(t, map[string][]schema.Server{
+		autoscalerPoolA: {schemaServer(1, "as-1", autoscalerNetworkID)},
+	})
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	servers, err := prov.ListAutoscalerNodes(
+		context.Background(), "absent-cluster", []string{autoscalerPoolA},
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, servers)
+}
+
+func TestListAutoscalerNodes_FiltersByNetworkAndDedupes(t *testing.T) {
+	t.Parallel()
+
+	const otherNetworkID = int64(999)
+
+	srv := newAutoscalerNodesTestServer(t, map[string][]schema.Server{
+		autoscalerPoolA: {
+			schemaServer(1, "as-1", autoscalerNetworkID),
+			schemaServer(2, "as-2", otherNetworkID), // different network → excluded
+			schemaServer(3, "as-3", autoscalerNetworkID),
+		},
+		autoscalerPoolB: {
+			schemaServer(3, "as-3", autoscalerNetworkID), // duplicate across pools → once
+			schemaServer(4, "as-4", autoscalerNetworkID),
+		},
+	})
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	servers, err := prov.ListAutoscalerNodes(
+		context.Background(), autoscalerTestCluster, []string{autoscalerPoolA, autoscalerPoolB},
+	)
+
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(servers))
+	for _, server := range servers {
+		names = append(names, server.Name)
+	}
+
+	assert.ElementsMatch(t, []string{"as-1", "as-3", "as-4"}, names)
+}
+
+func TestServerInNetwork(t *testing.T) {
+	t.Parallel()
+
+	server := func(networkIDs ...int64) *hcloud.Server {
+		nets := make([]hcloud.ServerPrivateNet, 0, len(networkIDs))
+		for _, id := range networkIDs {
+			nets = append(nets, hcloud.ServerPrivateNet{Network: &hcloud.Network{ID: id}})
+		}
+
+		return &hcloud.Server{PrivateNet: nets}
+	}
+
+	tests := []struct {
+		name      string
+		server    *hcloud.Server
+		networkID int64
+		want      bool
+	}{
+		{"matching network", server(100), 100, true},
+		{"different network", server(200), 100, false},
+		{"no private networks", server(), 100, false},
+		{"multiple, one matching", server(200, 100), 100, true},
+		{"nil network field", &hcloud.Server{
+			PrivateNet: []hcloud.ServerPrivateNet{{Network: nil}},
+		}, 100, false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hetzner.ServerInNetworkForTest(testCase.server, testCase.networkID)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -45,6 +45,9 @@ var NormalizeNodeRoleForTest = normalizeNodeRole
 // LBInNetworkForTest exports lbInNetwork for testing.
 var LBInNetworkForTest = lbInNetwork
 
+// ServerInNetworkForTest exports serverInNetwork for testing.
+var ServerInNetworkForTest = serverInNetwork
+
 // AvailableLocationsForTest exports availableLocations for testing.
 var AvailableLocationsForTest = availableLocations
 

--- a/pkg/svc/provider/hetzner/provider.go
+++ b/pkg/svc/provider/hetzner/provider.go
@@ -312,13 +312,81 @@ func (p *Provider) DeleteNodes(ctx context.Context, clusterName string) error {
 	return nil
 }
 
-// DeleteAutoscalerNodes deletes all servers created by the Kubernetes Cluster
-// Autoscaler for the given cluster. Autoscaler-managed servers are identified
-// by the hcloud/node-group label matching one of the configured pool names AND
-// by membership in the cluster's private network (<clusterName>-network).
+// ListAutoscalerNodes returns the servers created by the Kubernetes Cluster
+// Autoscaler for the given cluster. Autoscaler-managed servers are identified by
+// the hcloud/node-group label matching one of the configured pool names AND by
+// membership in the cluster's private network (<clusterName>-network).
 //
-// The network guard prevents accidental cross-cluster deletion when pool names
-// are reused across clusters in the same Hetzner project.
+// The network guard prevents cross-cluster bleed when pool names are reused
+// across clusters in the same Hetzner project. Servers matched by more than one
+// pool selector are returned once. If poolNames is empty, it returns no servers
+// without making any API calls.
+func (p *Provider) ListAutoscalerNodes(
+	ctx context.Context,
+	clusterName string,
+	poolNames []string,
+) ([]*hcloud.Server, error) {
+	if len(poolNames) == 0 {
+		return nil, nil
+	}
+
+	if p.client == nil {
+		return nil, provider.ErrProviderUnavailable
+	}
+
+	networkName := clusterName + NetworkSuffix
+
+	// Resolve the cluster network's ID for the membership guard. Servers returned
+	// by a list call carry only the private network's ID (the API omits its name),
+	// so the guard must compare IDs, not names. A missing network means the cluster
+	// is gone — there is nothing to match.
+	network, _, err := p.client.Network.GetByName(ctx, networkName)
+	if err != nil {
+		return nil, fmt.Errorf("getting cluster network %s: %w", networkName, err)
+	}
+
+	if network == nil {
+		return nil, nil
+	}
+
+	seen := make(map[int64]struct{})
+
+	var autoscalerServers []*hcloud.Server
+
+	for _, poolName := range poolNames {
+		labelSelector := fmt.Sprintf("%s=%s", LabelAutoscalerNodeGroup, poolName)
+
+		servers, listErr := p.listServersByLabelSelector(ctx, labelSelector)
+		if listErr != nil {
+			return nil, fmt.Errorf(
+				"failed to list autoscaler servers for pool %s: %w",
+				poolName,
+				listErr,
+			)
+		}
+
+		for _, server := range servers {
+			// Guard: only include servers that belong to this cluster's network to
+			// avoid touching servers from another cluster that happens to use the
+			// same pool name in the same Hetzner project.
+			if !serverInNetwork(server, network.ID) {
+				continue
+			}
+
+			if _, dup := seen[server.ID]; dup {
+				continue
+			}
+
+			seen[server.ID] = struct{}{}
+			autoscalerServers = append(autoscalerServers, server)
+		}
+	}
+
+	return autoscalerServers, nil
+}
+
+// DeleteAutoscalerNodes deletes all servers created by the Kubernetes Cluster
+// Autoscaler for the given cluster (identified as in ListAutoscalerNodes).
 //
 // The method is idempotent: servers that have already been deleted are silently
 // skipped. If poolNames is empty, the method returns nil without making any API
@@ -328,53 +396,34 @@ func (p *Provider) DeleteAutoscalerNodes(
 	clusterName string,
 	poolNames []string,
 ) error {
-	if len(poolNames) == 0 {
-		return nil
+	servers, err := p.ListAutoscalerNodes(ctx, clusterName, poolNames)
+	if err != nil {
+		return err
 	}
 
-	if p.client == nil {
-		return provider.ErrProviderUnavailable
-	}
-
-	networkName := clusterName + NetworkSuffix
-
-	for _, poolName := range poolNames {
-		labelSelector := fmt.Sprintf("%s=%s", LabelAutoscalerNodeGroup, poolName)
-
-		servers, err := p.listServersByLabelSelector(ctx, labelSelector)
-		if err != nil {
-			return fmt.Errorf("failed to list autoscaler servers for pool %s: %w", poolName, err)
-		}
-
-		for _, server := range servers {
-			// Guard: only delete servers that belong to this cluster's network to
-			// avoid accidentally deleting servers from another cluster that
-			// happens to use the same pool name in the same Hetzner project.
-			if !serverInNetwork(server, networkName) {
+	for _, server := range servers {
+		_, _, deleteErr := p.client.Server.DeleteWithResult(ctx, server)
+		if deleteErr != nil {
+			var hcloudErr *hcloud.Error
+			if errors.As(deleteErr, &hcloudErr) && hcloudErr.Code == hcloud.ErrorCodeNotFound {
 				continue
 			}
 
-			_, _, deleteErr := p.client.Server.DeleteWithResult(ctx, server)
-			if deleteErr != nil {
-				var hcloudErr *hcloud.Error
-				if errors.As(deleteErr, &hcloudErr) && hcloudErr.Code == hcloud.ErrorCodeNotFound {
-					continue
-				}
-
-				return fmt.Errorf("failed to delete autoscaler server %s (cluster %s, pool %s): %w",
-					server.Name, clusterName, poolName, deleteErr)
-			}
+			return fmt.Errorf("failed to delete autoscaler server %s (cluster %s): %w",
+				server.Name, clusterName, deleteErr)
 		}
 	}
 
 	return nil
 }
 
-// serverInNetwork reports whether the given server is attached to the named
-// private network.
-func serverInNetwork(server *hcloud.Server, networkName string) bool {
+// serverInNetwork reports whether the given server is attached to the private
+// network with the given ID. Server list responses populate each PrivateNet
+// entry's Network with its ID only (the name is empty), so membership must be
+// tested by ID.
+func serverInNetwork(server *hcloud.Server, networkID int64) bool {
 	for _, privateNet := range server.PrivateNet {
-		if privateNet.Network != nil && privateNet.Network.Name == networkName {
+		if privateNet.Network != nil && privateNet.Network.ID == networkID {
 			return true
 		}
 	}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -413,6 +413,15 @@ func (p *Provisioner) WaitForAutoscalerRolloutForTest(
 	return p.waitForAutoscalerRollout(ctx, clientset)
 }
 
+// DrainResolvedNodeForTest exposes drainResolvedNode for unit testing.
+func (p *Provisioner) DrainResolvedNodeForTest(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeIP string,
+) (string, error) {
+	return p.drainResolvedNode(ctx, clientset, nodeIP)
+}
+
 // WithTalosOptsForTest sets talosOpts on the provisioner for unit testing.
 func (p *Provisioner) WithTalosOptsForTest(
 	opts *v1alpha1.OptionsTalos,

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -392,6 +392,27 @@ func (p *Provisioner) RestartAutoscalerAfterConfigChangeForTest(
 	return p.restartAutoscalerAfterConfigChange(ctx, kubeclient)
 }
 
+// SortServersByNameForTest exposes sortServersByName for unit testing.
+func SortServersByNameForTest(servers []*hcloud.Server) []*hcloud.Server {
+	return sortServersByName(servers)
+}
+
+// RecycleAutoscalerNodesForTest exposes recycleAutoscalerNodes for unit testing.
+func (p *Provisioner) RecycleAutoscalerNodesForTest(
+	ctx context.Context,
+	clusterName string,
+) error {
+	return p.recycleAutoscalerNodes(ctx, clusterName)
+}
+
+// WaitForAutoscalerRolloutForTest exposes waitForAutoscalerRollout for unit testing.
+func (p *Provisioner) WaitForAutoscalerRolloutForTest(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+) error {
+	return p.waitForAutoscalerRollout(ctx, clientset)
+}
+
 // WithTalosOptsForTest sets talosOpts on the provisioner for unit testing.
 func (p *Provisioner) WithTalosOptsForTest(
 	opts *v1alpha1.OptionsTalos,

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -253,8 +253,8 @@ func (p *Provisioner) bootstrapAndFinalize(
 
 	// Create the cluster-autoscaler-config Secret when applicable. No restart on
 	// create: the autoscaler Deployment is installed afterwards and starts with
-	// this config.
-	err = p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID, false)
+	// this config, so the changed result is irrelevant here.
+	_, err = p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID, false)
 	if err != nil {
 		return err
 	}
@@ -416,35 +416,37 @@ func (p *Provisioner) updateHcloudSecret(
 }
 
 // ensureAutoscalerSecret creates the cluster-autoscaler-config Secret when the
-// node autoscaler is enabled and bootstrap used a snapshot image.
+// node autoscaler is enabled and bootstrap used a snapshot image. It reports
+// whether the Secret's data changed.
 //
-// When restartIfChanged is true (cluster update) and the Secret's data actually
-// changed, it rolls the running cluster-autoscaler Deployment so it reloads the
-// new config — the autoscaler reads the Secret as environment variables, which
-// Kubernetes does not live-reload, so without the restart new nodes would keep
-// booting from the stale Kubernetes version / snapshot. On cluster create
-// restartIfChanged is false: the Deployment does not exist yet (the installer
-// runs afterwards and starts with the correct config).
+// When restartIfChanged is true (cluster update) and the data actually changed,
+// it rolls the running cluster-autoscaler Deployment so it reloads the new config
+// — the autoscaler reads the Secret as environment variables, which Kubernetes
+// does not live-reload, so without the restart new nodes would keep booting from
+// the stale Kubernetes version / snapshot. On cluster create restartIfChanged is
+// false: the Deployment does not exist yet (the installer runs afterwards and
+// starts with the correct config). The changed result lets callers trigger
+// follow-up work (e.g. recycling existing autoscaler nodes) only on a real change.
 func (p *Provisioner) ensureAutoscalerSecret(
 	ctx context.Context,
 	configBundle *bundle.Bundle,
 	snapshotImageID int64,
 	restartIfChanged bool,
-) error {
+) (bool, error) {
 	if p.hetznerOpts == nil || !p.hetznerOpts.NodeAutoscalerEnabled || snapshotImageID <= 0 {
-		return nil
+		return false, nil
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter, "Applying cluster-autoscaler config secret...\n")
 
 	kubeclient, err := p.newSecretKubeclient("autoscaler secret")
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	workerConfigYAML, err := GenerateAutoscalerWorkerConfig(configBundle.Worker())
 	if err != nil {
-		return fmt.Errorf("generating autoscaler worker config: %w", err)
+		return false, fmt.Errorf("generating autoscaler worker config: %w", err)
 	}
 
 	changed, err := ApplyAutoscalerConfigSecret(
@@ -454,7 +456,7 @@ func (p *Provisioner) ensureAutoscalerSecret(
 		workerConfigYAML,
 	)
 	if err != nil {
-		return fmt.Errorf("applying autoscaler config secret: %w", err)
+		return false, fmt.Errorf("applying autoscaler config secret: %w", err)
 	}
 
 	if changed {
@@ -463,11 +465,11 @@ func (p *Provisioner) ensureAutoscalerSecret(
 		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Cluster autoscaler config secret already up to date\n")
 	}
 
-	if restartIfChanged && changed {
-		return p.restartAutoscalerAfterConfigChange(ctx, kubeclient)
+	if !restartIfChanged || !changed {
+		return changed, nil
 	}
 
-	return nil
+	return changed, p.restartAutoscalerAfterConfigChange(ctx, kubeclient)
 }
 
 // restartAutoscalerAfterConfigChange rolls the cluster-autoscaler Deployment so it

--- a/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
+++ b/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
@@ -1,0 +1,197 @@
+package talosprovisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// autoscalerRolloutTimeout bounds the wait for the restarted cluster-autoscaler
+// Deployment to become ready before recycling nodes. Recycling drains nodes, which
+// can make pods pending and trigger a scale-up; waiting first ensures that scale-up
+// is served by the autoscaler pod that already carries the refreshed snapshot and
+// worker config — not the pre-restart pod still holding the old template.
+const autoscalerRolloutTimeout = 5 * time.Minute
+
+// recycleAutoscalerNodes drains and deletes the cluster-autoscaler-managed nodes so
+// the autoscaler re-provisions any still-needed capacity from the refreshed Talos
+// snapshot + worker config. It is invoked only after the cluster-autoscaler-config
+// Secret actually changed (a Talos/Kubernetes version bump), so existing autoscaler
+// nodes follow the new baseline instead of drifting on the old versions.
+//
+// Why this is needed: `cluster update` upgrades only KSail-owned nodes in place
+// (control planes + static workers, listed via the ksail.owned label). Autoscaler
+// nodes carry the hcloud/node-group label instead, so the rolling Talos/Kubernetes
+// upgrade never touches them; left alone they keep their old versions until organic
+// scale-down. Refreshing the Secret only fixes *newly* provisioned nodes.
+//
+// The design mirrors the upstream Cluster Autoscaler model: the autoscaler owns node
+// *creation*, so KSail does not provision replacements here — it removes the stale
+// nodes gracefully (cordon + drain via the eviction API, honoring PodDisruption
+// Budgets) and lets the autoscaler bring up fresh nodes from the new template on
+// demand. Compute-only autoscaler nodes hold no persistent storage and no etcd
+// membership, so replace-by-recreation is the idiomatic, lossless path.
+func (p *Provisioner) recycleAutoscalerNodes(ctx context.Context, clusterName string) error {
+	if p.hetznerOpts == nil || !p.hetznerOpts.NodeAutoscalerEnabled ||
+		len(p.hetznerOpts.AutoscalerNodePoolNames) == 0 {
+		return nil
+	}
+
+	hzProvider, err := p.hetznerProvider()
+	if err != nil {
+		return err
+	}
+
+	servers, err := hzProvider.ListAutoscalerNodes(
+		ctx, clusterName, p.hetznerOpts.AutoscalerNodePoolNames,
+	)
+	if err != nil {
+		return fmt.Errorf("listing autoscaler nodes to recycle: %w", err)
+	}
+
+	if len(servers) == 0 {
+		_, _ = fmt.Fprintf(p.logWriter, "  ⓘ No autoscaler nodes to recycle\n")
+
+		return nil
+	}
+
+	clientset, err := p.createK8sClient(clusterName)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the restarted autoscaler to be ready so any scale-up the drain
+	// triggers is served from the new template, not the pre-restart pod.
+	rolloutErr := p.waitForAutoscalerRollout(ctx, clientset)
+	if rolloutErr != nil {
+		return rolloutErr
+	}
+
+	return p.recycleAutoscalerServers(ctx, clientset, hzProvider, sortServersByName(servers))
+}
+
+// recycleAutoscalerServers recycles the given autoscaler servers one at a time,
+// reporting progress. It stops at the first failure so a partial run leaves the
+// remaining nodes untouched rather than draining the whole pool on a transient error.
+func (p *Provisioner) recycleAutoscalerServers(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	hzProvider *hetzner.Provider,
+	ordered []*hcloud.Server,
+) error {
+	_, _ = fmt.Fprintf(p.logWriter,
+		"Recycling %d autoscaler node(s) so they follow the new baseline...\n", len(ordered))
+
+	for idx, server := range ordered {
+		_, _ = fmt.Fprintf(p.logWriter,
+			"  [%d/%d] Recycling autoscaler node %s...\n", idx+1, len(ordered), server.Name)
+
+		recycleErr := p.recycleSingleAutoscalerNode(ctx, clientset, hzProvider, server)
+		if recycleErr != nil {
+			return fmt.Errorf("recycling autoscaler node %s: %w", server.Name, recycleErr)
+		}
+
+		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Recycled autoscaler node %s\n", server.Name)
+	}
+
+	return nil
+}
+
+// recycleSingleAutoscalerNode performs the cordon → drain → delete sequence for a
+// single autoscaler-managed server. It does not provision a replacement; the
+// cluster-autoscaler does that from the refreshed template when workloads need it.
+func (p *Provisioner) recycleSingleAutoscalerNode(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	hzProvider *hetzner.Provider,
+	server *hcloud.Server,
+) error {
+	serverIP, addrErr := hetznerNodeTalosAddress(server)
+	if addrErr != nil {
+		return fmt.Errorf("resolving address for %s: %w", server.Name, addrErr)
+	}
+
+	// 1. Cordon and drain the outgoing node before removing it.
+	nodeName, resolveErr := p.resolveNodeName(ctx, clientset, serverIP)
+
+	switch {
+	case resolveErr == nil:
+		drainErr := p.cordonAndDrain(ctx, clientset, nodeName)
+		if drainErr != nil {
+			return drainErr
+		}
+	case errors.Is(resolveErr, ErrNodeNotFoundByIP):
+		// The server is no longer registered in Kubernetes (e.g. the autoscaler
+		// already scaled it down, or a prior partial run removed it). Skip drain
+		// and proceed with removal.
+		_, _ = fmt.Fprintf(p.logWriter,
+			"    ⚠ %s not registered in Kubernetes; proceeding with removal\n", serverIP)
+	default:
+		// A Kubernetes API failure (not a missing node): the node likely still
+		// exists, so abort rather than deleting it undrained and evicting its
+		// workloads abruptly.
+		return fmt.Errorf("resolve Kubernetes node for %s: %w", serverIP, resolveErr)
+	}
+
+	// 2. Delete the outgoing Hetzner server.
+	deleteErr := p.deleteHetznerServer(ctx, hzProvider, server)
+	if deleteErr != nil {
+		return deleteErr
+	}
+
+	// 3. Remove the now-stale Kubernetes node object (best-effort).
+	if nodeName != "" {
+		p.deleteK8sNode(ctx, clientset, nodeName)
+	}
+
+	return nil
+}
+
+// waitForAutoscalerRollout blocks until every cluster-autoscaler Deployment matching
+// the standard instance label is ready, so a freshly restarted autoscaler is serving
+// requests before nodes are recycled. A missing Deployment is not an error — the
+// autoscaler may not be installed, in which case there is nothing to wait for.
+func (p *Provisioner) waitForAutoscalerRollout(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+) error {
+	deployments, err := clientset.AppsV1().
+		Deployments(autoscalerConfigSecretNamespace).
+		List(ctx, metav1.ListOptions{LabelSelector: autoscalerDeploymentSelector})
+	if err != nil {
+		return fmt.Errorf("listing cluster-autoscaler deployment: %w", err)
+	}
+
+	for index := range deployments.Items {
+		name := deployments.Items[index].Name
+
+		readyErr := readiness.WaitForDeploymentReady(
+			ctx, clientset, autoscalerConfigSecretNamespace, name, autoscalerRolloutTimeout,
+		)
+		if readyErr != nil {
+			return fmt.Errorf("waiting for cluster-autoscaler %s rollout: %w", name, readyErr)
+		}
+	}
+
+	return nil
+}
+
+// sortServersByName returns the servers ordered by name for deterministic,
+// one-at-a-time recycling.
+func sortServersByName(servers []*hcloud.Server) []*hcloud.Server {
+	ordered := slices.Clone(servers)
+	slices.SortFunc(ordered, func(a, b *hcloud.Server) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return ordered
+}

--- a/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
+++ b/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
@@ -2,7 +2,6 @@ package talosprovisioner
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -121,25 +120,9 @@ func (p *Provisioner) recycleSingleAutoscalerNode(
 	}
 
 	// 1. Cordon and drain the outgoing node before removing it.
-	nodeName, resolveErr := p.resolveNodeName(ctx, clientset, serverIP)
-
-	switch {
-	case resolveErr == nil:
-		drainErr := p.cordonAndDrain(ctx, clientset, nodeName)
-		if drainErr != nil {
-			return drainErr
-		}
-	case errors.Is(resolveErr, ErrNodeNotFoundByIP):
-		// The server is no longer registered in Kubernetes (e.g. the autoscaler
-		// already scaled it down, or a prior partial run removed it). Skip drain
-		// and proceed with removal.
-		_, _ = fmt.Fprintf(p.logWriter,
-			"    ⚠ %s not registered in Kubernetes; proceeding with removal\n", serverIP)
-	default:
-		// A Kubernetes API failure (not a missing node): the node likely still
-		// exists, so abort rather than deleting it undrained and evicting its
-		// workloads abruptly.
-		return fmt.Errorf("resolve Kubernetes node for %s: %w", serverIP, resolveErr)
+	nodeName, drainErr := p.drainResolvedNode(ctx, clientset, serverIP)
+	if drainErr != nil {
+		return drainErr
 	}
 
 	// 2. Delete the outgoing Hetzner server.

--- a/pkg/svc/provisioner/cluster/talos/recycle_autoscaler_test.go
+++ b/pkg/svc/provisioner/cluster/talos/recycle_autoscaler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -133,4 +134,48 @@ func TestWaitForAutoscalerRollout_NotReadyTimesOut(t *testing.T) {
 
 	err := prov.WaitForAutoscalerRolloutForTest(ctx, clientset)
 	require.Error(t, err)
+}
+
+// nodeWithIP builds a Ready Kubernetes node reachable at the given internal IP.
+func nodeWithIP(name, ip string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: ip}},
+		},
+	}
+}
+
+func TestDrainResolvedNode_NotRegisteredReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	// No node matches the IP, so the node is treated as already gone: drain is
+	// skipped and the caller is told to proceed with removal.
+	nodeName, err := prov.DrainResolvedNodeForTest(
+		context.Background(), fake.NewClientset(), "10.0.0.9",
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, nodeName)
+}
+
+func TestDrainResolvedNode_DrainsRegisteredNode(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+	clientset := fake.NewClientset(nodeWithIP("as-node", "10.0.0.5"))
+
+	nodeName, err := prov.DrainResolvedNodeForTest(context.Background(), clientset, "10.0.0.5")
+
+	require.NoError(t, err)
+	assert.Equal(t, "as-node", nodeName)
+
+	// The node must be cordoned (marked unschedulable) as part of the drain.
+	node, getErr := clientset.CoreV1().Nodes().Get(
+		context.Background(), "as-node", metav1.GetOptions{},
+	)
+	require.NoError(t, getErr)
+	assert.True(t, node.Spec.Unschedulable, "drained node must be cordoned")
 }

--- a/pkg/svc/provisioner/cluster/talos/recycle_autoscaler_test.go
+++ b/pkg/svc/provisioner/cluster/talos/recycle_autoscaler_test.go
@@ -1,0 +1,136 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	autoscalerNamespace      = "kube-system"
+	autoscalerDeploymentName = "cluster-autoscaler"
+)
+
+func TestSortServersByName(t *testing.T) {
+	t.Parallel()
+
+	servers := []*hcloud.Server{
+		{Name: "as-cx33-2"},
+		{Name: "as-cx23-1"},
+		{Name: "as-cx33-1"},
+	}
+
+	ordered := talosprovisioner.SortServersByNameForTest(servers)
+
+	names := make([]string, 0, len(ordered))
+	for _, server := range ordered {
+		names = append(names, server.Name)
+	}
+
+	assert.Equal(t, []string{"as-cx23-1", "as-cx33-1", "as-cx33-2"}, names)
+	// Input slice order must be preserved (sort operates on a clone).
+	assert.Equal(t, "as-cx33-2", servers[0].Name)
+}
+
+func TestRecycleAutoscalerNodes_NoopWhenNotHetzner(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	err := prov.RecycleAutoscalerNodesForTest(context.Background(), "test-cluster")
+	require.NoError(t, err)
+}
+
+func TestRecycleAutoscalerNodes_NoopWhenAutoscalerDisabled(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(io.Discard).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{
+			NodeAutoscalerEnabled:   false,
+			AutoscalerNodePoolNames: []string{"pool-a"},
+		})
+
+	err := prov.RecycleAutoscalerNodesForTest(context.Background(), "test-cluster")
+	require.NoError(t, err)
+}
+
+func TestRecycleAutoscalerNodes_NoopWhenNoPools(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(io.Discard).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{
+			NodeAutoscalerEnabled:   true,
+			AutoscalerNodePoolNames: nil,
+		})
+
+	err := prov.RecycleAutoscalerNodesForTest(context.Background(), "test-cluster")
+	require.NoError(t, err)
+}
+
+// autoscalerDeployment builds a cluster-autoscaler Deployment with the standard
+// instance label. When ready, its status reports one updated, available replica.
+func autoscalerDeployment(ready bool) *appsv1.Deployment {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      autoscalerDeploymentName,
+			Namespace: autoscalerNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/instance": autoscalerDeploymentName},
+		},
+	}
+
+	if ready {
+		deployment.Status = appsv1.DeploymentStatus{
+			Replicas:          1,
+			UpdatedReplicas:   1,
+			AvailableReplicas: 1,
+		}
+	}
+
+	return deployment
+}
+
+func TestWaitForAutoscalerRollout_ReadyDeployment(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+	clientset := fake.NewClientset(autoscalerDeployment(true))
+
+	err := prov.WaitForAutoscalerRolloutForTest(context.Background(), clientset)
+	require.NoError(t, err)
+}
+
+func TestWaitForAutoscalerRollout_NoDeploymentIsNoop(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	err := prov.WaitForAutoscalerRolloutForTest(context.Background(), fake.NewClientset())
+	require.NoError(t, err)
+}
+
+func TestWaitForAutoscalerRollout_NotReadyTimesOut(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+	clientset := fake.NewClientset(autoscalerDeployment(false))
+
+	// A short caller deadline bounds the wait so the never-ready Deployment surfaces
+	// an error promptly instead of blocking on the full rollout timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := prov.WaitForAutoscalerRolloutForTest(ctx, clientset)
+	require.Error(t, err)
+}

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
@@ -203,24 +203,9 @@ func (p *Provisioner) rollingReplaceSingleNode(
 	}
 
 	// 1. Cordon and drain the outgoing node before removing it.
-	oldNodeName, resolveErr := p.resolveNodeName(ctx, clientset, oldIP)
-
-	switch {
-	case resolveErr == nil:
-		drainErr := p.cordonAndDrain(ctx, clientset, oldNodeName)
-		if drainErr != nil {
-			return drainErr
-		}
-	case errors.Is(resolveErr, ErrNodeNotFoundByIP):
-		// The node is no longer registered in Kubernetes (e.g. a prior partial
-		// run already removed it). Skip drain and proceed with removal.
-		_, _ = fmt.Fprintf(p.logWriter,
-			"    ⚠ %s not registered in Kubernetes; proceeding with removal\n", oldIP)
-	default:
-		// A Kubernetes API failure (not a missing node): the node likely still
-		// exists, so abort rather than deleting it undrained and evicting its
-		// workloads abruptly.
-		return fmt.Errorf("resolve Kubernetes node for %s: %w", oldIP, resolveErr)
+	oldNodeName, drainErr := p.drainResolvedNode(ctx, clientset, oldIP)
+	if drainErr != nil {
+		return drainErr
 	}
 
 	// 2. Control-plane etcd membership cleanup before removal.
@@ -293,6 +278,38 @@ func (p *Provisioner) configureAndWaitReplacement(
 	}
 
 	return nil
+}
+
+// drainResolvedNode cordons and drains the Kubernetes node backing the given Talos
+// node IP, returning its resolved node name. It returns "" with no error when the
+// node is not registered in Kubernetes — e.g. already removed by a prior run or
+// scaled down by the autoscaler — so the caller can still remove the underlying
+// server. A node whose lookup fails for any other reason (a Kubernetes API error,
+// not a missing node) is returned as an error so callers fail closed rather than
+// deleting an undrained node and abruptly evicting its workloads.
+func (p *Provisioner) drainResolvedNode(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeIP string,
+) (string, error) {
+	nodeName, resolveErr := p.resolveNodeName(ctx, clientset, nodeIP)
+
+	switch {
+	case resolveErr == nil:
+		drainErr := p.cordonAndDrain(ctx, clientset, nodeName)
+		if drainErr != nil {
+			return "", drainErr
+		}
+
+		return nodeName, nil
+	case errors.Is(resolveErr, ErrNodeNotFoundByIP):
+		_, _ = fmt.Fprintf(p.logWriter,
+			"    ⚠ %s not registered in Kubernetes; proceeding with removal\n", nodeIP)
+
+		return "", nil
+	default:
+		return "", fmt.Errorf("resolve Kubernetes node for %s: %w", nodeIP, resolveErr)
+	}
 }
 
 // cordonAndDrain cordons then drains the named Kubernetes node.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -1367,7 +1367,21 @@ func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
 	// Restart the autoscaler when the config changed so it reloads the new
 	// Kubernetes version / snapshot baked into the Secret (read as env vars,
 	// which Kubernetes does not live-reload).
-	return p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID, true)
+	changed, err := p.ensureAutoscalerSecret(ctx, configBundle, snapshotImageID, true)
+	if err != nil {
+		return err
+	}
+
+	// When the config changed (a Talos/Kubernetes version bump), recycle the
+	// existing autoscaler nodes so they follow the new baseline instead of
+	// drifting on the old versions. The refreshed Secret alone only fixes newly
+	// provisioned nodes; the in-place rolling upgrade never touches autoscaler
+	// nodes because they are not KSail-owned. A no-op when nothing changed.
+	if !changed {
+		return nil
+	}
+
+	return p.recycleAutoscalerNodes(ctx, clusterName)
 }
 
 // hasSchematicConfigured reports whether a Talos schematic ID is available


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5105

## Problem

On Talos + Hetzner clusters with the KSail-managed Cluster Autoscaler, `ksail cluster update` upgrades only the **static** baseline (control planes + workers) when the Talos/Kubernetes version changes. **Already-running autoscaler-managed nodes keep their old Talos OS + kubelet** and drift from the baseline until the autoscaler scales them down organically (under steady load, possibly never).

Root cause: autoscaler nodes are created by the cluster-autoscaler from the snapshot + worker config in the `cluster-autoscaler-config` Secret and carry the `hcloud/node-group` label, **not** `ksail.owned`. The in-place rolling upgrade enumerates only `ksail.owned` nodes (`Provider.ListNodes`), so it never touches autoscaler nodes. Refreshing the Secret (already done on update) only fixes *newly* provisioned nodes.

## Approach — lean into the upstream Cluster Autoscaler model

The [upstream autoscaler](https://github.com/kubernetes/autoscaler) has **no in-place node-upgrade path** — it owns node *creation* and replaces nodes by draining + deleting and re-provisioning from the (updated) template. This PR follows that model.

When `cluster update` detects the autoscaler config actually changed (a version bump), it now **recycles** the existing autoscaler nodes:

1. Refresh the `cluster-autoscaler-config` Secret (new snapshot + worker config) and restart the autoscaler — existing behavior — then **wait for the new autoscaler pod to be Ready** so any drain-triggered scale-up uses the new template, not the pre-restart pod.
2. For each existing autoscaler node, **one at a time**: cordon + drain via the Kubernetes **eviction API** (honoring PodDisruptionBudgets — the same semantics CA uses for scale-down), then delete the Hetzner server. The autoscaler re-provisions still-needed capacity from the refreshed snapshot on demand.

Compute-only autoscaler nodes hold no persistent storage and no etcd membership, so replace-by-recreation is lossless. Recycling runs **only on a real version change**; a no-op `cluster update` leaves autoscaler nodes untouched. Per the maintainer's direction this is automatic on version change (no opt-in flag).

## Secondary fix (required for correctness)

`serverInNetwork` matched the cluster network by **name**, but `Server.AllWithOpts` list responses populate `PrivateNet[].Network` with the network **ID only** (name empty) — so the guard rejected every listed server, making autoscaler-node identification a no-op on real data. (Likely never hit: autoscaler scale-up was only unblocked recently by the 32 KiB user_data fix, #5015.) Now matched by **network ID**, which the list path reliably carries. This also repairs the existing `DeleteAutoscalerNodes` cleanup path.

## Changes

- `hetzner.Provider`: add `ListAutoscalerNodes` (network-ID guard + cross-pool dedup); `DeleteAutoscalerNodes` now shares it; `serverInNetwork` matches by ID.
- Talos provisioner: new `recycleAutoscalerNodes` (+ `waitForAutoscalerRollout`); `ensureAutoscalerSecret` returns whether the config changed; `ensureAutoscalerSecretIfNeeded` recycles on change.
- Reuses existing `cordonAndDrain` / `deleteHetznerServer` / `resolveNodeName` / `deleteK8sNode`.
- Tests: `ListAutoscalerNodes` (network filter + dedup, httptest), `serverInNetwork` by ID, `sortServersByName`, recycle guard no-ops, rollout-wait (ready / absent / not-ready-times-out).
- Docs: `providers/hetzner.mdx` "Autoscaler Node Upgrades" section + Update Cluster note.

## Validation

- `go build ./...` ✓
- `go test ./pkg/svc/provider/hetzner/... ./pkg/svc/provisioner/cluster/talos/...` ✓
- `golangci-lint run` ✓ (no issues in changed files)
- `cd docs && npm run build` ✓

> The behavior change ships to the platform prod cluster via its `ksail.prod.yaml` (a protected file); a companion platform docs PR updates its node-autoscaling upgrade runbook. No new config field is introduced — the recycle is automatic on version change.
