### PR TITLE
feat(ui): negotiate backend capabilities and gate cluster edit

### DIFF
--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -57,8 +57,12 @@ type job struct {
 	err          error
 }
 
-// Ensure Service satisfies the operator REST API's backend contract.
-var _ api.ClusterService = (*Service)(nil)
+// Ensure Service satisfies the operator REST API's backend contract, including the optional
+// capability reporter the SPA uses to gate edit affordances.
+var (
+	_ api.ClusterService     = (*Service)(nil)
+	_ api.CapabilityReporter = (*Service)(nil)
+)
 
 // Service implements api.ClusterService over the local provider/provisioner lifecycle.
 type Service struct {
@@ -84,6 +88,14 @@ func NewService() *Service {
 	service.discoverer = &clusterdiscovery.Discoverer{DockerFactory: service.dockerFactory}
 
 	return service
+}
+
+// Capabilities reports the operations the local backend supports. In-place cluster update is not
+// supported locally — a local cluster's configuration is managed through its config files and
+// `ksail cluster update`, not the API (see Update) — so the SPA hides the edit affordance rather
+// than offering a button that returns 501.
+func (s *Service) Capabilities() api.Capabilities {
+	return api.Capabilities{ClusterUpdate: false}
 }
 
 // CreatableDistributions returns the distributions the local UI can provision. It feeds the

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -388,6 +388,16 @@ func TestUpdateIsNotSupported(t *testing.T) {
 	require.ErrorIs(t, err, api.ErrNotSupported)
 }
 
+func TestCapabilitiesReportsNoClusterUpdate(t *testing.T) {
+	t.Parallel()
+
+	// The local backend cannot update in place (see TestUpdateIsNotSupported); it must report that
+	// via CapabilityReporter so the SPA hides the edit affordance rather than offering a 501.
+	service := newTestService(nil)
+
+	assert.False(t, service.Capabilities().ClusterUpdate)
+}
+
 func TestGetIgnoresNamespaceAndReturnsNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/operator/api/server.go
+++ b/pkg/operator/api/server.go
@@ -78,6 +78,10 @@ type configResponse struct {
 	Distributions   []string       `json:"distributions,omitempty"`
 	Providers       []ProviderInfo `json:"providers,omitempty"`
 	SettingsEnabled bool           `json:"settingsEnabled,omitempty"`
+	// Capabilities reports which optional operations the serving backend supports so the SPA can gate
+	// affordances (e.g. cluster edit) it cannot fulfill. Always present (no omitempty): an absent
+	// field would force the SPA to guess, and the false zero-value is meaningful.
+	Capabilities Capabilities `json:"capabilities"`
 }
 
 // ProviderInfo reports whether an infrastructure provider is usable on the serving backend, with a
@@ -336,6 +340,7 @@ func (s *Server) handleConfig(writer http.ResponseWriter, request *http.Request)
 		AuthEnabled:     s.auth != nil,
 		Distributions:   s.Distributions,
 		SettingsEnabled: s.Settings != nil,
+		Capabilities:    serviceCapabilities(s.Service),
 	}
 
 	if s.ProviderStatus != nil {

--- a/pkg/operator/api/server_test.go
+++ b/pkg/operator/api/server_test.go
@@ -65,7 +65,11 @@ func TestConfigReportsReadOnly(t *testing.T) {
 	recorder := doRequest(server.Handler(), http.MethodGet, "/api/v1/config", "")
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.JSONEq(t, `{"readOnly":true,"authEnabled":false}`, recorder.Body.String())
+	assert.JSONEq(
+		t,
+		`{"readOnly":true,"authEnabled":false,"capabilities":{"clusterUpdate":true}}`,
+		recorder.Body.String(),
+	)
 }
 
 func TestListClusters(t *testing.T) {
@@ -111,6 +115,18 @@ func (s stubClusterService) Update(
 
 func (s stubClusterService) Delete(_ context.Context, _, _ string) error {
 	return nil
+}
+
+// capabilityStub is a ClusterService that also implements api.CapabilityReporter, so a test can
+// assert the reported capabilities flow through /api/v1/config.
+type capabilityStub struct {
+	stubClusterService
+
+	capabilities api.Capabilities
+}
+
+func (s capabilityStub) Capabilities() api.Capabilities {
+	return s.capabilities
 }
 
 func TestListClustersIncludesDefaultValuedFields(t *testing.T) {
@@ -348,7 +364,39 @@ func TestConfigDefaultsWritable(t *testing.T) {
 	recorder := doRequest(server.Handler(), http.MethodGet, "/api/v1/config", "")
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.JSONEq(t, `{"readOnly":false,"authEnabled":false}`, recorder.Body.String())
+	assert.JSONEq(
+		t,
+		`{"readOnly":false,"authEnabled":false,"capabilities":{"clusterUpdate":true}}`,
+		recorder.Body.String(),
+	)
+}
+
+func TestConfigReportsServiceCapabilities(t *testing.T) {
+	t.Parallel()
+
+	// A backend that cannot update clusters in place (the local UI/desktop backend) reports it via
+	// CapabilityReporter, and the config endpoint surfaces it so the SPA hides the edit affordance.
+	server := &api.Server{
+		Service: capabilityStub{capabilities: api.Capabilities{ClusterUpdate: false}},
+	}
+
+	recorder := doRequest(server.Handler(), http.MethodGet, "/api/v1/config", "")
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), `"capabilities":{"clusterUpdate":false}`)
+}
+
+func TestConfigDefaultsToFullCapabilities(t *testing.T) {
+	t.Parallel()
+
+	// A backend that does not implement CapabilityReporter (the operator's CR backend) is assumed to
+	// support the full surface, so clusterUpdate is true.
+	server := &api.Server{Service: api.NewCRClusterService(newClient(t))}
+
+	recorder := doRequest(server.Handler(), http.MethodGet, "/api/v1/config", "")
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), `"capabilities":{"clusterUpdate":true}`)
 }
 
 func TestStaticFSServesAssetsAndSPAFallback(t *testing.T) {

--- a/pkg/operator/api/service.go
+++ b/pkg/operator/api/service.go
@@ -46,3 +46,38 @@ type ClusterService interface {
 	// Delete removes a cluster.
 	Delete(ctx context.Context, namespace, name string) error
 }
+
+// Capabilities reports which optional operations a backend supports, so the SPA can hide affordances
+// a backend cannot fulfill instead of offering an action that fails. It is served on
+// /api/v1/config under "capabilities". New capability flags are added here as the UI surface grows
+// (e.g. workload reads, log streaming, exec), and each backend reports the subset it implements.
+type Capabilities struct {
+	// ClusterUpdate reports whether the backend can apply spec changes to an existing cluster
+	// (PUT /api/v1/clusters/{namespace}/{name}). The operator patches the Cluster custom resource and
+	// supports it; the local CLI backend manages cluster configuration via files and does not, so the
+	// SPA hides the edit affordance there rather than offering an action that returns 501.
+	ClusterUpdate bool `json:"clusterUpdate"`
+}
+
+// CapabilityReporter is an optional interface a ClusterService may implement to advertise which
+// operations it supports. A ClusterService that does not implement it is assumed to support the full
+// surface (see fullCapabilities) — the operator's controller-runtime backend relies on this default.
+type CapabilityReporter interface {
+	Capabilities() Capabilities
+}
+
+// fullCapabilities is the capability set assumed for a ClusterService that does not implement
+// CapabilityReporter: every operation is supported.
+func fullCapabilities() Capabilities {
+	return Capabilities{ClusterUpdate: true}
+}
+
+// serviceCapabilities returns the capabilities a ClusterService advertises, defaulting to the full
+// surface when it does not implement CapabilityReporter.
+func serviceCapabilities(service ClusterService) Capabilities {
+	if reporter, ok := service.(CapabilityReporter); ok {
+		return reporter.Capabilities()
+	}
+
+	return fullCapabilities()
+}

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -4,6 +4,7 @@ import {
   ApiError,
   createCluster,
   deleteCluster,
+  fullCapabilities,
   getConfig,
   getMeta,
   listClusters,
@@ -81,6 +82,9 @@ export function App() {
   const toast = useToast();
 
   const [readOnly, setReadOnly] = useState(false);
+  // canUpdate reflects the backend's clusterUpdate capability. The local UI/desktop backend cannot
+  // update a cluster in place, so the edit affordance is hidden there; the operator can, so it shows.
+  const [canUpdate, setCanUpdate] = useState(fullCapabilities.clusterUpdate);
   const [user, setUser] = useState<User | null>(null);
   const [needsLogin, setNeedsLogin] = useState(false);
   const [meta, setMeta] = useState<ClusterMeta | null>(null);
@@ -155,6 +159,7 @@ export function App() {
         return;
       }
       setReadOnly(config.readOnly);
+      setCanUpdate(config.capabilities?.clusterUpdate ?? fullCapabilities.clusterUpdate);
       setDistributions(config.distributions ?? DEFAULT_DISTRIBUTIONS);
       setProviderStatus(config.providers ?? null);
       setSettingsEnabled(config.settingsEnabled ?? false);
@@ -183,6 +188,7 @@ export function App() {
       }
 
       setReadOnly(config.readOnly);
+      setCanUpdate(config.capabilities?.clusterUpdate ?? fullCapabilities.clusterUpdate);
       setUser(config.user ?? null);
       setDistributions(config.distributions ?? DEFAULT_DISTRIBUTIONS);
       setProviderStatus(config.providers ?? null);
@@ -291,6 +297,10 @@ export function App() {
     return <LoginScreen />;
   }
 
+  // canEdit gates the edit affordance: editing requires both a writable UI and a backend that can
+  // apply spec changes in place. Delete stays gated on readOnly alone (the local backend supports it).
+  const canEdit = !readOnly && canUpdate;
+
   // Header actions (Refresh / New cluster) belong to the Clusters view only.
   const headerActions =
     view === "clusters" ? (
@@ -354,6 +364,7 @@ export function App() {
           <ClustersTable
             clusters={clusters}
             readOnly={readOnly}
+            canEdit={canEdit}
             onSelect={(cluster) => setSelectedKey(clusterKey(cluster))}
             onEdit={openEdit}
             onDelete={(cluster) => setDeleteTarget(cluster)}
@@ -366,7 +377,7 @@ export function App() {
         <ClusterDetail
           cluster={selected}
           open={selected !== null}
-          readOnly={readOnly}
+          canEdit={canEdit}
           onClose={() => setSelectedKey(null)}
           onEdit={openEdit}
         />

--- a/web/ui/src/api.ts
+++ b/web/ui/src/api.ts
@@ -94,10 +94,26 @@ export interface ProviderInfo {
   reason?: string;
 }
 
+// Capabilities reports which optional operations the serving backend supports so the SPA can gate
+// affordances it cannot fulfill. The local `ksail ui`/desktop backend manages cluster configuration
+// via files and reports clusterUpdate=false (the SPA then hides the edit affordance); the operator
+// patches the Cluster CR and reports true. New flags are added here as the UI surface grows.
+export interface Capabilities {
+  clusterUpdate: boolean;
+}
+
+// fullCapabilities mirrors the backend's default for a service that does not report capabilities:
+// the full surface is assumed. Used when config.capabilities is absent so a missing field never
+// silently disables a working action.
+export const fullCapabilities: Capabilities = { clusterUpdate: true };
+
 export interface Config {
   readOnly: boolean;
   authEnabled: boolean;
   user?: User;
+  // capabilities the serving backend supports. Absent only against an older backend; treat absence
+  // as the full surface (see fullCapabilities).
+  capabilities?: Capabilities;
   // distributions the create form should offer. Absent when the backend relies on the SPA default.
   distributions?: string[];
   // providers reports per-provider availability so the create form can gate options to providers the

--- a/web/ui/src/components/ClusterDetail.tsx
+++ b/web/ui/src/components/ClusterDetail.tsx
@@ -109,13 +109,15 @@ function SectionTitle({ children }: { children: ReactNode }) {
 export function ClusterDetail({
   cluster,
   open,
-  readOnly,
+  canEdit,
   onClose,
   onEdit,
 }: {
   cluster: Cluster | null;
   open: boolean;
-  readOnly: boolean;
+  // canEdit gates the Edit button: it requires both a writable UI and a backend that supports
+  // in-place updates (false on the local `ksail ui`/desktop backend).
+  canEdit: boolean;
   onClose: () => void;
   onEdit: (cluster: Cluster) => void;
 }) {
@@ -141,7 +143,7 @@ export function ClusterDetail({
         <div>
           <div className="mb-2 flex items-center justify-between gap-2">
             <StatusBadge phase={status?.phase} />
-            {!readOnly ? (
+            {canEdit ? (
               <Button variant="secondary" size="sm" onClick={() => onEdit(cluster)}>
                 <Pencil className="size-3.5" aria-hidden />
                 Edit

--- a/web/ui/src/components/ClustersTable.tsx
+++ b/web/ui/src/components/ClustersTable.tsx
@@ -104,12 +104,16 @@ function SortHeader({
 export function ClustersTable({
   clusters,
   readOnly,
+  canEdit,
   onSelect,
   onEdit,
   onDelete,
 }: {
   clusters: Cluster[];
   readOnly: boolean;
+  // canEdit gates the per-row edit button independently of delete: a backend may allow delete but
+  // not in-place update (the local `ksail ui`/desktop backend), so edit is hidden while delete stays.
+  canEdit: boolean;
   onSelect: (cluster: Cluster) => void;
   onEdit: (cluster: Cluster) => void;
   onDelete: (cluster: Cluster) => void;
@@ -207,31 +211,31 @@ export function ClustersTable({
                 </td>
                 <td className={cx(td, "text-right")}>
                   <div className="flex items-center justify-end gap-1">
+                    {canEdit ? (
+                      <button
+                        type="button"
+                        aria-label={`Edit ${cluster.metadata.name}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onEdit(cluster);
+                        }}
+                        className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-200"
+                      >
+                        <Pencil className="size-4" />
+                      </button>
+                    ) : null}
                     {!readOnly ? (
-                      <>
-                        <button
-                          type="button"
-                          aria-label={`Edit ${cluster.metadata.name}`}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            onEdit(cluster);
-                          }}
-                          className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-200"
-                        >
-                          <Pencil className="size-4" />
-                        </button>
-                        <button
-                          type="button"
-                          aria-label={`Delete ${cluster.metadata.name}`}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            onDelete(cluster);
-                          }}
-                          className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-500/10 dark:hover:text-red-400"
-                        >
-                          <Trash2 className="size-4" />
-                        </button>
-                      </>
+                      <button
+                        type="button"
+                        aria-label={`Delete ${cluster.metadata.name}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDelete(cluster);
+                        }}
+                        className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+                      >
+                        <Trash2 className="size-4" />
+                      </button>
                     ) : null}
                     <ChevronRight className="size-4 text-slate-300 dark:text-slate-600" aria-hidden />
                   </div>


### PR DESCRIPTION
**Phase 0 UI foundation — PR 1 of 3** (stack: **this** → `claude/ui-phase0-sse` → `claude/ui-phase0-progress`).

## Problem
The SPA always rendered an Edit affordance (when not read-only) and PUT to `/api/v1/clusters/{ns}/{name}` on submit. The operator backend supports that (it patches the `Cluster` CR), but the local `ksail ui`/desktop backend returns `501 "updating clusters is not supported locally"` — so clicking **Edit** there surfaced an error toast and never worked.

## Change
Introduce **backend capability negotiation** as the mechanism the whole UI uses to gate affordances a backend cannot fulfill:

- Add `api.Capabilities` + the optional `api.CapabilityReporter` interface. A `ClusterService` that does **not** implement it is assumed to support the full surface (the operator's CR backend relies on this default), so existing `ClusterService` implementations and mocks are unaffected.
- Serve capabilities on `/api/v1/config` under `capabilities` (always present; the `false` zero-value is meaningful).
- The local backend implements `CapabilityReporter` and reports `clusterUpdate: false`; the SPA reads it and hides the edit affordance in both the clusters table and the detail panel, while **delete stays gated on read-only alone** (the local backend supports delete).

This removes the broken button today and establishes the gating pattern later UI work (workload reads, log streaming, exec) reuses to advertise per-backend support.

## Verification
- `go build ./...`, `go test ./pkg/operator/api/... ./pkg/cli/clusterapi/...` ✓
- `golangci-lint` clean on touched packages ✓
- Frontend `tsc` + `vite build` ✓
- Live: `ksail ui` `/api/v1/config` now reports `"capabilities":{"clusterUpdate":false}` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)