### PR TITLE
fix(ci): make ksail-cluster's registry-image pull work for external consumers

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -205,7 +205,43 @@ runs:
 
     - name: 📥 Pre-pull registry image
       if: inputs.provider == 'Docker'
-      uses: ./.github/actions/pull-registry-image
+      shell: bash
+      # Inlined rather than `uses: ./.github/actions/pull-registry-image`: a `./`
+      # path inside a composite action resolves against the *consumer's*
+      # workspace, not this repo, so the local reference breaks every external
+      # caller of ksail-cluster (actions/runner#1348). Pinning a repo-qualified
+      # ref instead would force a post-release version bump on every tag, so the
+      # logic lives here directly. Keep it in sync with the standalone
+      # .github/actions/pull-registry-image action used internally by
+      # warm-mirror-cache.
+      run: |
+        set -euo pipefail
+
+        # mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub;
+        # it is not subject to Docker Hub's per-IP anonymous rate limits, which is
+        # what causes the recurring "registry:3 pull timeout" flake on shared CI
+        # runners. Try the mirror first, then fall back to Docker Hub directly,
+        # and re-tag whichever source succeeds to the canonical registry:3.
+        obtain_registry_image() {
+          local ref attempt
+          for ref in mirror.gcr.io/library/registry:3 registry:3; do
+            for attempt in 1 2 3; do
+              if docker pull --quiet "$ref"; then
+                docker tag "$ref" registry:3
+                echo "✅ registry:3 obtained from ${ref}"
+                return 0
+              fi
+              echo "⚠️ pull ${ref} attempt ${attempt}/3 failed; retrying in $((attempt * 5))s…"
+              sleep "$((attempt * 5))"
+            done
+          done
+          return 1
+        }
+
+        if ! obtain_registry_image; then
+          echo "❌ Failed to obtain registry:3 from mirror.gcr.io and Docker Hub"
+          exit 1
+        fi
 
     - name: 📥 Pre-pull distribution images
       if: inputs.provider == 'Docker'

--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -206,42 +206,15 @@ runs:
     - name: 📥 Pre-pull registry image
       if: inputs.provider == 'Docker'
       shell: bash
-      # Inlined rather than `uses: ./.github/actions/pull-registry-image`: a `./`
-      # path inside a composite action resolves against the *consumer's*
-      # workspace, not this repo, so the local reference breaks every external
-      # caller of ksail-cluster (actions/runner#1348). Pinning a repo-qualified
-      # ref instead would force a post-release version bump on every tag, so the
-      # logic lives here directly. Keep it in sync with the standalone
-      # .github/actions/pull-registry-image action used internally by
-      # warm-mirror-cache.
-      run: |
-        set -euo pipefail
-
-        # mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub;
-        # it is not subject to Docker Hub's per-IP anonymous rate limits, which is
-        # what causes the recurring "registry:3 pull timeout" flake on shared CI
-        # runners. Try the mirror first, then fall back to Docker Hub directly,
-        # and re-tag whichever source succeeds to the canonical registry:3.
-        obtain_registry_image() {
-          local ref attempt
-          for ref in mirror.gcr.io/library/registry:3 registry:3; do
-            for attempt in 1 2 3; do
-              if docker pull --quiet "$ref"; then
-                docker tag "$ref" registry:3
-                echo "✅ registry:3 obtained from ${ref}"
-                return 0
-              fi
-              echo "⚠️ pull ${ref} attempt ${attempt}/3 failed; retrying in $((attempt * 5))s…"
-              sleep "$((attempt * 5))"
-            done
-          done
-          return 1
-        }
-
-        if ! obtain_registry_image; then
-          echo "❌ Failed to obtain registry:3 from mirror.gcr.io and Docker Hub"
-          exit 1
-        fi
+      # Runs the sibling pull-registry-image action's script directly. We can't
+      # use `uses: ./.github/actions/pull-registry-image` here: a `./` path in a
+      # composite action resolves against the *consumer's* workspace, not this
+      # repo, so it breaks every external caller of ksail-cluster
+      # (actions/runner#1348). $GITHUB_ACTION_PATH points at this action's own
+      # directory inside the fully-checked-out action repo, so
+      # `../pull-registry-image` reaches the sibling at the SAME ref — no
+      # checkout, no pinned ref, and one shared copy of the pull logic.
+      run: bash "$GITHUB_ACTION_PATH/../pull-registry-image/pull-registry-image.sh"
 
     - name: 📥 Pre-pull distribution images
       if: inputs.provider == 'Docker'

--- a/.github/actions/pull-registry-image/action.yaml
+++ b/.github/actions/pull-registry-image/action.yaml
@@ -6,41 +6,14 @@ description: >-
   this pulls from Google's Docker Hub pull-through mirror first and falls back to
   Docker Hub, re-tagging the result to registry:3 for callers.
 
-# NOTE: This pull logic is duplicated inline in
-# .github/actions/ksail-cluster/action.yml, because that action is consumed
-# externally and a `./` reference would resolve against the consumer's workspace
-# (actions/runner#1348). Keep the two copies in sync. This standalone action is
-# used internally by warm-mirror-cache, where `./` works fine.
 runs:
   using: composite
   steps:
     - name: 📥 Obtain registry:3 image
       shell: bash
-      run: |
-        set -euo pipefail
-
-        # mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub;
-        # it is not subject to Docker Hub's per-IP anonymous rate limits, which is
-        # what causes the recurring "registry:3 pull timeout" flake on shared CI
-        # runners. Try the mirror first, then fall back to Docker Hub directly,
-        # and re-tag whichever source succeeds to the canonical registry:3.
-        obtain_registry_image() {
-          local ref attempt
-          for ref in mirror.gcr.io/library/registry:3 registry:3; do
-            for attempt in 1 2 3; do
-              if docker pull --quiet "$ref"; then
-                docker tag "$ref" registry:3
-                echo "✅ registry:3 obtained from ${ref}"
-                return 0
-              fi
-              echo "⚠️ pull ${ref} attempt ${attempt}/3 failed; retrying in $((attempt * 5))s…"
-              sleep "$((attempt * 5))"
-            done
-          done
-          return 1
-        }
-
-        if ! obtain_registry_image; then
-          echo "❌ Failed to obtain registry:3 from mirror.gcr.io and Docker Hub"
-          exit 1
-        fi
+      # The logic lives in the co-located pull-registry-image.sh so the
+      # ksail-cluster action can reuse the exact same script via
+      # $GITHUB_ACTION_PATH (see that action's "Pre-pull registry image" step).
+      # $GITHUB_ACTION_PATH is this action's own directory, so the script sits
+      # right beside this file.
+      run: bash "$GITHUB_ACTION_PATH/pull-registry-image.sh"

--- a/.github/actions/pull-registry-image/action.yaml
+++ b/.github/actions/pull-registry-image/action.yaml
@@ -6,6 +6,11 @@ description: >-
   this pulls from Google's Docker Hub pull-through mirror first and falls back to
   Docker Hub, re-tagging the result to registry:3 for callers.
 
+# NOTE: This pull logic is duplicated inline in
+# .github/actions/ksail-cluster/action.yml, because that action is consumed
+# externally and a `./` reference would resolve against the consumer's workspace
+# (actions/runner#1348). Keep the two copies in sync. This standalone action is
+# used internally by warm-mirror-cache, where `./` works fine.
 runs:
   using: composite
   steps:

--- a/.github/actions/pull-registry-image/pull-registry-image.sh
+++ b/.github/actions/pull-registry-image/pull-registry-image.sh
@@ -20,22 +20,22 @@ set -euo pipefail
 # runners. Try the mirror first, then fall back to Docker Hub directly,
 # and re-tag whichever source succeeds to the canonical registry:3.
 obtain_registry_image() {
-  local ref attempt
-  for ref in mirror.gcr.io/library/registry:3 registry:3; do
-    for attempt in 1 2 3; do
-      if docker pull --quiet "$ref"; then
-        docker tag "$ref" registry:3
-        echo "✅ registry:3 obtained from ${ref}"
-        return 0
-      fi
-      echo "⚠️ pull ${ref} attempt ${attempt}/3 failed; retrying in $((attempt * 5))s…"
-      sleep "$((attempt * 5))"
-    done
-  done
-  return 1
+	local ref attempt
+	for ref in mirror.gcr.io/library/registry:3 registry:3; do
+		for attempt in 1 2 3; do
+			if docker pull --quiet "$ref"; then
+				docker tag "$ref" registry:3
+				echo "✅ registry:3 obtained from ${ref}"
+				return 0
+			fi
+			echo "⚠️ pull ${ref} attempt ${attempt}/3 failed; retrying in $((attempt * 5))s…"
+			sleep "$((attempt * 5))"
+		done
+	done
+	return 1
 }
 
 if ! obtain_registry_image; then
-  echo "❌ Failed to obtain registry:3 from mirror.gcr.io and Docker Hub"
-  exit 1
+	echo "❌ Failed to obtain registry:3 from mirror.gcr.io and Docker Hub"
+	exit 1
 fi

--- a/.github/actions/pull-registry-image/pull-registry-image.sh
+++ b/.github/actions/pull-registry-image/pull-registry-image.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Reliably obtain the registry:3 image that backs KSail's local pull-through
+# mirror registries.
+#
+# Single source of truth shared by two composite actions:
+#   - .github/actions/pull-registry-image   → bash "$GITHUB_ACTION_PATH/pull-registry-image.sh"
+#   - .github/actions/ksail-cluster         → bash "$GITHUB_ACTION_PATH/../pull-registry-image/pull-registry-image.sh"
+# ksail-cluster cannot `uses:` the sibling action directly: a `./` path in a
+# composite action resolves against the consumer's workspace, not this repo, so
+# it breaks every external caller (actions/runner#1348). Running this script via
+# $GITHUB_ACTION_PATH avoids that without duplicating the logic or pinning a ref.
+#
+# set flags must live HERE, not in the caller's step: `bash <file>` starts a
+# fresh shell, so the calling step's `set -euo pipefail` does not propagate in.
+set -euo pipefail
+
+# mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub;
+# it is not subject to Docker Hub's per-IP anonymous rate limits, which is
+# what causes the recurring "registry:3 pull timeout" flake on shared CI
+# runners. Try the mirror first, then fall back to Docker Hub directly,
+# and re-tag whichever source succeeds to the canonical registry:3.
+obtain_registry_image() {
+  local ref attempt
+  for ref in mirror.gcr.io/library/registry:3 registry:3; do
+    for attempt in 1 2 3; do
+      if docker pull --quiet "$ref"; then
+        docker tag "$ref" registry:3
+        echo "✅ registry:3 obtained from ${ref}"
+        return 0
+      fi
+      echo "⚠️ pull ${ref} attempt ${attempt}/3 failed; retrying in $((attempt * 5))s…"
+      sleep "$((attempt * 5))"
+    done
+  done
+  return 1
+}
+
+if ! obtain_registry_image; then
+  echo "❌ Failed to obtain registry:3 from mirror.gcr.io and Docker Hub"
+  exit 1
+fi


### PR DESCRIPTION
## What

The **ksail-cluster** composite action's "Pre-pull registry image" step no longer uses `uses: ./.github/actions/pull-registry-image`. The registry:3 pull logic now lives in a shared **`pull-registry-image.sh`**, invoked via `$GITHUB_ACTION_PATH` from both actions:

- `pull-registry-image/action.yaml` → `bash "$GITHUB_ACTION_PATH/pull-registry-image.sh"`
- `ksail-cluster/action.yml` → `bash "$GITHUB_ACTION_PATH/../pull-registry-image/pull-registry-image.sh"`

This keeps `pull-registry-image` as its own action, fixes external consumers, **and** removes the duplication — one script is the single source of truth.

## Why

`ksail-cluster` is a **publicly documented, externally-consumed** action (the docs reference `devantler-tech/ksail/.github/actions/ksail-cluster@<ref>` in `cicd-integration.mdx`, `use-cases.mdx`, the PR-preview guides). But a `./` path **inside a composite action resolves against the consumer's `$GITHUB_WORKSPACE`, not this repo** — confirmed open behavior in [actions/runner#1348](https://github.com/actions/runner/issues/1348). So every external caller of `ksail-cluster` hit a missing-action failure at that step.

### Why `$GITHUB_ACTION_PATH/../sibling` works where `uses: ./` doesn't

- For an external `@ref` consumer, the runner downloads the **full repo tarball** into `_actions/<owner>/<repo>/<ref>/` (confirmed by a GitHub Actions team member), so the sibling `pull-registry-image/` dir is present **at the same ref**.
- `$GITHUB_ACTION_PATH` points at this action's own dir, so `../pull-registry-image/pull-registry-image.sh` resolves to that sibling — no checkout, no pinned ref, no version skew.
- It's a `run:` step (plain bash), **not** a `uses:` reference, so the workspace-relative resolution of #1348 simply doesn't apply, and neither does the "`uses:` must be static" restriction.
- This is an **idiomatic, battle-tested** pattern — Homebrew/actions, theupdateframework/tuf-on-ci, EnricoMi/publish-unit-test-result-action, and dagster-cloud-action all reach sibling files via `$GITHUB_ACTION_PATH/..`.

### Why not the alternatives

- **Repo-qualified `@<tag>`/`@<sha>`** — a self-referential ref can't be written into `action.yml` before that tag exists, forcing a post-release bump treadmill.
- **Repo-qualified `@main`** — a consumer pinned to a release tag would silently get `main`'s pull logic (version skew); not SHA-pinnable/reproducible.
- **Inlining the script into ksail-cluster** (the first commit on this branch) — works, but duplicates the logic; the shared-script approach achieves the same fix without duplication.
- **The proposed `$/` same-repo-same-SHA syntax** — [not yet generally available](https://github.com/orgs/community/discussions/26245) as of mid-2026.

## Scope note

`warm-mirror-cache` still references `pull-registry-image` via `uses: ./`, intentionally unchanged: it is **only consumed internally** (`ci.yaml`, `system-test-omni`, `system-test-hetzner`, always after `actions/checkout`), where `./` resolves correctly. The standalone action keeps working because its `action.yaml` still exists and now just runs the shared script.

## Implementation notes

- `set -euo pipefail` lives **inside** the script — `bash <file>` starts a fresh shell, so the caller's `set` flags don't propagate in.
- Invoked via `bash <file>` so the executable bit isn't required (committed as `100755` regardless).
- `pull-registry-image.sh` documents both call sites and the rationale so a future maintainer doesn't reintroduce `uses: ./`.

## Validation

- YAML parses (`yq`); script passes `shellcheck` and `bash -n`.
- **Simulated the external `_actions/<owner>/<repo>/<ref>` tarball layout** (`git archive` of the tree) and confirmed `$GITHUB_ACTION_PATH/../pull-registry-image/pull-registry-image.sh` resolves and the script runs to success against a mock `docker`.
- Verified the internal `./` path also resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)