### PR TITLE
test(cluster): cover normalizePinnedVersion edge cases

### DIFF
--- a/pkg/cli/cmd/cluster/cluster_pure_test.go
+++ b/pkg/cli/cmd/cluster/cluster_pure_test.go
@@ -1199,3 +1199,99 @@ func TestResolveCreatedContextName(t *testing.T) {
 		})
 	}
 }
+
+// ===========================================================================
+// normalizePinnedVersion — pinned-version normalization & downgrade guard
+// ===========================================================================
+
+const (
+	// testPinCurrent is the running version used as the baseline in the
+	// normalizePinnedVersion cases; testPinNewer is a pin strictly newer than it.
+	testPinCurrent = "v1.8.0"
+	testPinNewer   = "v1.9.0"
+)
+
+func TestNormalizePinnedVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		rawPinned   string
+		current     string
+		wantVersion string
+		wantReason  cluster.ExportPinnedVersionSkipReason
+	}{
+		{
+			name:        "newer pin proceeds with upgrade",
+			rawPinned:   testPinNewer,
+			current:     testPinCurrent,
+			wantVersion: testPinNewer,
+			wantReason:  cluster.ExportPinnedVersionProceed,
+		},
+		{
+			name:        "missing v prefix is normalized",
+			rawPinned:   "1.9.0",
+			current:     testPinCurrent,
+			wantVersion: testPinNewer,
+			wantReason:  cluster.ExportPinnedVersionProceed,
+		},
+		{
+			name:        "pin equal to current is a no-op",
+			rawPinned:   testPinCurrent,
+			current:     testPinCurrent,
+			wantVersion: testPinCurrent,
+			wantReason:  cluster.ExportPinnedVersionAlreadyAtIt,
+		},
+		{
+			name:        "older pin than current skips the downgrade",
+			rawPinned:   "v1.7.0",
+			current:     testPinCurrent,
+			wantVersion: "v1.7.0",
+			wantReason:  cluster.ExportPinnedVersionNewer,
+		},
+		{
+			name:        "unparseable current version falls through to proceed",
+			rawPinned:   testPinNewer,
+			current:     "",
+			wantVersion: testPinNewer,
+			wantReason:  cluster.ExportPinnedVersionProceed,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotVersion, gotReason, err := cluster.ExportNormalizePinnedVersion(
+				testCase.rawPinned, testCase.current,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.wantVersion, gotVersion)
+			assert.Equal(t, testCase.wantReason, gotReason)
+		})
+	}
+}
+
+func TestNormalizePinnedVersion_EmptyPinReturnsError(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"", "   "} {
+		gotVersion, gotReason, err := cluster.ExportNormalizePinnedVersion(raw, testPinCurrent)
+		require.ErrorIs(t, err, cluster.ErrEmptyPinnedVersion)
+		assert.Empty(t, gotVersion)
+		assert.Equal(t, cluster.ExportPinnedVersionProceed, gotReason)
+	}
+}
+
+func TestNormalizePinnedVersion_InvalidPinReturnsError(t *testing.T) {
+	t.Parallel()
+
+	gotVersion, gotReason, err := cluster.ExportNormalizePinnedVersion(
+		"not-a-version", testPinCurrent,
+	)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, cluster.ErrEmptyPinnedVersion)
+	assert.Contains(t, err.Error(), "invalid pinned Talos version")
+	assert.Empty(t, gotVersion)
+	assert.Equal(t, cluster.ExportPinnedVersionProceed, gotReason)
+}

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -217,6 +217,23 @@ func ExportStripParenthetical(s string) string {
 	return stripParenthetical(s)
 }
 
+// ExportPinnedVersionSkipReason is a test-visible alias for pinnedVersionSkipReason.
+type ExportPinnedVersionSkipReason = pinnedVersionSkipReason
+
+// Test-visible aliases for the pinnedVersionSkipReason sentinels.
+const (
+	ExportPinnedVersionProceed     = pinnedVersionProceed
+	ExportPinnedVersionAlreadyAtIt = pinnedVersionAlreadyAtIt
+	ExportPinnedVersionNewer       = pinnedVersionNewer
+)
+
+// ExportNormalizePinnedVersion exposes normalizePinnedVersion for testing.
+func ExportNormalizePinnedVersion(
+	rawPinnedVersion, currentVersion string,
+) (string, ExportPinnedVersionSkipReason, error) {
+	return normalizePinnedVersion(rawPinnedVersion, currentVersion)
+}
+
 // ExportListResult is a test-visible alias for listResult.
 type ExportListResult = listResult
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds a table-driven unit test for `normalizePinnedVersion` in
`pkg/cli/cmd/cluster/update.go` — the pure helper that normalizes a pinned
`spec.cluster.talos.version` / `spec.cluster.kubernetesVersion` and decides
whether `cluster update` should upgrade, no-op, or refuse a downgrade.

## Why

`normalizePinnedVersion` (and its `pinnedVersionSkipReason` sentinels) is a
correctness-critical path of the **declarative version reconciliation** introduced
in #5095 (which removed the old `--update-*` flags): it gates the OS/Kubernetes
upgrade decision on every `cluster update`. It had **no direct unit test** — its
branches were only exercised indirectly. The downgrade guard in particular
(skip when the running cluster is already newer than the pin) is exactly the
edge case worth pinning so a future refactor can't silently regress it into an
accidental downgrade.

Found while triaging the now-obsolete #5094 (its proposed `--update-distribution`
hint no longer applies post-#5095, which made version reconciliation declarative
and reported). Rather than a redundant feature, this hardens the redesigned path
with coverage. No production code changes.

## Cases covered
- newer pin → proceed with upgrade
- missing `v` prefix → normalized (`1.9.0` → `v1.9.0`)
- pin equal to current → no-op (`pinnedVersionAlreadyAtIt`)
- pin older than running → downgrade guard (`pinnedVersionNewer`)
- unparseable current version → falls through to proceed
- empty / whitespace-only pin → `ErrEmptyPinnedVersion`
- invalid semver pin → wrapped parse error (not `ErrEmptyPinnedVersion`)

The unexported helper + sentinels are exposed via `export_test.go`, matching the
file's existing `Export*` test-seam convention.

## Validation
- `go test ./pkg/cli/cmd/cluster/` → all pass (528)
- `golangci-lint run --new-from-rev=origin/main ./pkg/cli/cmd/cluster/...` → 0 new issues
- `go build` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)