### PR TITLE
docs: document registry-auth-in-Talos-patch env var pattern

### DIFF
--- a/docs/gen_docs_prose.go
+++ b/docs/gen_docs_prose.go
@@ -92,6 +92,23 @@ machine:
           - http://${REGISTRY:-localhost:5000}
 ` + cbt + `
 
+Because patch files are expanded too, you can inject **registry credentials** into the Talos
+machine config as config-as-code — keeping the secret in the environment, never committed. This is
+the supported way to give nodes registry auth (for example, so containerd can fetch cosign
+signatures for **private** packages during image verification) without passing credentials via CLI
+flags:
+
+` + cbt + `yaml
+# talos/cluster/registry-auth.yaml - Credentials are injected from the environment at load time
+machine:
+  registries:
+    config:
+      ghcr.io:
+        auth:
+          username: my-user
+          password: ${GHCR_TOKEN} # expanded at load; commit the placeholder, not the token
+` + cbt + `
+
 ### Example: Credentials
 
 ` + cbt + `yaml

--- a/docs/src/content/docs/configuration/declarative-configuration.mdx
+++ b/docs/src/content/docs/configuration/declarative-configuration.mdx
@@ -76,6 +76,23 @@ machine:
           - http://${REGISTRY:-localhost:5000}
 ```
 
+Because patch files are expanded too, you can inject **registry credentials** into the Talos
+machine config as config-as-code — keeping the secret in the environment, never committed. This is
+the supported way to give nodes registry auth (for example, so containerd can fetch cosign
+signatures for **private** packages during image verification) without passing credentials via CLI
+flags:
+
+```yaml
+# talos/cluster/registry-auth.yaml - Credentials are injected from the environment at load time
+machine:
+  registries:
+    config:
+      ghcr.io:
+        auth:
+          username: my-user
+          password: ${GHCR_TOKEN} # expanded at load; commit the placeholder, not the token
+```
+
 ### Example: Credentials
 
 ```yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

While triaging [#5132](https://github.com/devantler-tech/ksail/issues/5132) ("Expand environment variables in distribution config files") I found the requested capability is **already implemented, tested, and documented** — env vars are expanded in every distribution config-file path:

- **Talos patches** → `forEachYAMLFile` → `envvar.ExpandBytes` ([`pkg/fsutil/configmanager/talos/manager.go`](https://github.com/devantler-tech/ksail/blob/main/pkg/fsutil/configmanager/talos/manager.go) L233), since #2041; tested by `TestLoadPatches_ExpandsEnvVars`.
- **Kind / K3d** (shared loader) → `LoadConfigFromFile` → `envvar.ExpandBytes` ([`pkg/fsutil/configmanager/loader/loader.go`](https://github.com/devantler-tech/ksail/blob/main/pkg/fsutil/configmanager/loader/loader.go) L93); tested by `TestLoadConfigFromFile_ExpandsEnvVars`.

The real gap was **discoverability**: the docs Scope section showed Talos *mirror-endpoint* expansion but not the *registry-auth* pattern (`machine.registries.config.<host>.auth.password: ${TOKEN}`). That exact pattern is the one needed to give Talos nodes registry credentials for, e.g., cosign signature verification of **private** packages — and a downstream consumer ([platform#1849](https://github.com/devantler-tech/platform/pull/1849)) built a `--mirror-registry` CLI workaround on the incorrect premise that *"ksail does not env-expand machine-config patches"*. It does.

## What

Add an explicit example to the **Environment Variable Expansion → Scope** section showing registry credentials injected into a committed Talos patch via `${GHCR_TOKEN}` (placeholder committed, secret from the environment, expanded at load).

Source edited in the generator `docs/gen_docs_prose.go`; `declarative-configuration.mdx` is **regenerated** via `go generate ./docs/...` (never hand-edited).

## Validation

- `go generate ./docs/...` → only the prose source + regenerated `.mdx` change (CLI pages idempotent)
- `go test ./docs/...` → 10 passed
- `golangci-lint run ./docs/...` → no issues

Refs #5132