### PR TITLE
ci(cd): publish ksail-operator as an OCI chart

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -387,6 +387,48 @@ jobs:
             echo "::warning::Auto-merge could not be enabled; the PR must be merged manually or auto-merge must be enabled in repository settings."
           fi
 
+  operator-chart:
+    name: ⛵ Release Operator Chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Runs in parallel with the other releases. The chart is a standalone OCI artifact that only
+    # *references* the operator image (ghcr.io/devantler-tech/ksail) by tag — it neither pulls nor
+    # embeds it — so it does not wait on `goreleaser`; the matching image is pushed concurrently and
+    # exists by the time anyone installs the chart. The gated `publish-release` and `pages-deploy` jobs
+    # both list it in `needs` (just like the other publication jobs), so a chart publish failure blocks
+    # the GitHub release publish and the docs deploy.
+    permissions:
+      contents: read # checkout
+      packages: write # push the chart to GHCR as an OCI artifact
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🏷️ Extract version from tag
+        id: get_version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: 🔐 Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # helm is pre-installed on ubuntu-latest runners (CI's operator-chart-lint relies on this too).
+      # Pin the chart version AND appVersion to the release version so the published chart pulls the
+      # matching operator image (operator.image.tag defaults to .Chart.AppVersion); helm bundles crds/
+      # automatically. The chart lands at ghcr.io/devantler-tech/charts/ksail-operator:<version>.
+      - name: 📦 Package and push operator chart
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+        run: |
+          set -euo pipefail
+          helm package charts/ksail-operator --version "$VERSION" --app-version "$VERSION"
+          helm push "ksail-operator-${VERSION}.tgz" oci://ghcr.io/devantler-tech/charts
+
   mcp-publish:
     name: 📤 Publish to MCP Registry
     runs-on: ubuntu-latest
@@ -541,6 +583,7 @@ jobs:
         desktop-macos,
         desktop,
         copilot-plugin,
+        operator-chart,
         pages-build,
       ]
     timeout-minutes: 10
@@ -572,6 +615,7 @@ jobs:
         copilot-plugin,
         desktop-macos,
         desktop,
+        operator-chart,
         pages-build,
       ]
     permissions:

--- a/charts/ksail-operator/README.md
+++ b/charts/ksail-operator/README.md
@@ -22,7 +22,14 @@ The operator reconciles `Cluster` resources (`ksail.io/v1alpha1`) so you can pro
 
 ## Installing
 
-The chart is installed from the repository checkout:
+Each KSail release publishes the chart as an OCI artifact to GHCR. Install a pinned version (replace `<version>` with a [release](https://github.com/devantler-tech/ksail/releases) version, e.g. `7.35.0`):
+
+```sh
+helm install ksail-operator oci://ghcr.io/devantler-tech/charts/ksail-operator \
+  --version <version> --namespace ksail-system --create-namespace
+```
+
+Or install from the repository checkout:
 
 ```sh
 helm install ksail-operator charts/ksail-operator --namespace ksail-system --create-namespace


### PR DESCRIPTION
## What

Adds an `operator-chart` job to `cd.yaml` that publishes the **ksail-operator Helm chart as an OCI artifact** to GHCR on every `v*` tag, landing at:

```
ghcr.io/devantler-tech/charts/ksail-operator:<version>
```

Install:

```sh
helm install ksail-operator oci://ghcr.io/devantler-tech/charts/ksail-operator \
  --version <version> --namespace ksail-system --create-namespace
```

## Why

The chart could previously only be installed from a repository checkout. Publishing it as a versioned OCI artifact on each release makes the operator consumable the same way as the CLI, VSIX, and desktop assets.

## How

- **New `operator-chart` job** — runs in parallel with the other release jobs (no `needs`). It logs in to GHCR with `GITHUB_TOKEN`, then `helm package … --version <v> --app-version <v>` and `helm push … oci://ghcr.io/devantler-tech/charts`.
- **Version pinning** — both `version` and `appVersion` are pinned to the release version at package time (the in-repo `Chart.yaml` stays at `0.1.0`). This matters because `operator.image.tag` defaults to `.Chart.AppVersion`, so the published chart pulls `ghcr.io/devantler-tech/ksail:<version>` — the operator image `goreleaser` builds in parallel.
- **Parallel-safe** — the chart only *references* the operator image by tag (it doesn't pull or embed it), so it doesn't need `needs: [goreleaser]`; the image exists by install time.
- **Release gating** — `operator-chart` is added to the `needs` of both `publish-release` and `pages-deploy`, mirroring how every other publication job (vscode-extension, desktop, copilot-plugin) is wired. A chart publish failure now blocks the GitHub release publish and the docs deploy.
- **Docs** — added the OCI install option to the chart README.

## Notes for reviewers

- No reusable workflow fit: the closest in `devantler-tech/reusable-workflows`, `publish-app.yaml`, builds a Docker image + pushes Flux *manifests* via `flux push artifact` — there's no Helm-OCI-chart publisher — so a dedicated job is the right call.
- `helm` is pre-installed on `ubuntu-latest` runners (CI's `operator-chart-lint` relies on this too), so no setup step is needed.
- ⚠️ **First-run registry visibility:** the first push creates a **private** GHCR package by default. Someone with org access will need to flip `ksail-operator` to public (and optionally link it to the repo) once, otherwise anonymous `helm install` from the OCI URL won't work.

## Verification

- `actionlint` passes on `cd.yaml` (validates the cross-job `needs` references).
- Local `helm package … --version 7.99.0 --app-version 7.99.0` dry-run confirmed `version`/`appVersion` are overridden and the `Cluster` CRD is bundled under `crds/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)