### PR TITLE
feat(desktop): system-tray (menu-bar) integration

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	_ "embed"
 	"log"
 
 	"github.com/devantler-tech/ksail/v7/pkg/cli/uiserver"
@@ -25,6 +26,12 @@ const (
 	windowWidth  = 1100
 	windowHeight = 820
 )
+
+// trayIcon is the menu-bar/system-tray image (the app icon). Embedded so the single binary needs no
+// external asset at runtime.
+//
+//go:embed resources/icon.png
+var trayIcon []byte
 
 func main() {
 	// Import the user's login-shell environment when launched from Finder/Dock/Spotlight (macOS
@@ -55,11 +62,23 @@ func main() {
 	// the hand-rolled Cocoa menu the previous webview_go shell required. Windows/WebView2 and
 	// Linux/WebKitGTK handle clipboard shortcuts natively.
 
-	app.Window.NewWithOptions(application.WebviewWindowOptions{
+	window := app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Title:  windowTitle,
 		Width:  windowWidth,
 		Height: windowHeight,
 	})
+
+	// A menu-bar/system-tray icon for quick access: show/hide the window or quit without going through
+	// the Dock. Must be configured before Run() (which blocks until shutdown).
+	tray := app.SystemTray.New()
+	tray.SetIcon(trayIcon)
+
+	trayMenu := app.NewMenu()
+	trayMenu.Add("Show KSail").OnClick(func(_ *application.Context) { window.Show() })
+	trayMenu.Add("Hide KSail").OnClick(func(_ *application.Context) { window.Hide() })
+	trayMenu.AddSeparator()
+	trayMenu.Add("Quit KSail").OnClick(func(_ *application.Context) { app.Quit() })
+	tray.SetMenu(trayMenu)
 
 	err := app.Run()
 	if err != nil {

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -71,6 +71,10 @@ func main() {
 	// A menu-bar/system-tray icon for quick access: show/hide the window or quit without going through
 	// the Dock. Must be configured before Run() (which blocks until shutdown).
 	tray := app.SystemTray.New()
+	// SetIcon uses the full-color app icon, scaled to the status-bar thickness. The macOS menu-bar
+	// idiom is a monochrome template image (SetTemplateIcon) that auto-inverts for light/dark bars —
+	// but that needs a dedicated alpha-only mark (the color tile cannot be reused as a template), so a
+	// proper menu-bar glyph is a branding follow-up. The color icon renders acceptably meanwhile.
 	tray.SetIcon(trayIcon)
 
 	trayMenu := app.NewMenu()


### PR DESCRIPTION
B4 (first slice): a Wails v3 **system tray** so the desktop app is reachable from the macOS menu bar (and the Windows/Linux tray) without going through its Dock entry. Branches off `main` — independent of the in-flight UI feature stack (touches only `desktop/`).

## What
- A tray icon (the embedded app icon) with a menu: **Show KSail · Hide KSail · Quit KSail**, wired to the window's `Show()`/`Hide()` and `app.Quit()`.
- Configured before `app.Run()` (which blocks). Cross-platform (no build tags). Icon embedded via `go:embed` (no external runtime asset).

## Quality
- `go -C desktop build` succeeds; the binary **launches cleanly** (Wails v3 alpha.98, AssetServer up, no panic on the tray setup).
- `go vet` + `golangci-lint` clean; no `go.mod`/`go.sum` drift.
- Visual GUI confirmation (icon rendering, menu clicks) is recommended on promotion — code + startup are verified here.

## Follow-ups (rest of B4)
- Native file dialogs (`app.Dialog.OpenFile`) wired into apply-YAML / import-kubeconfig.
- `ksail://` deep links (SingleInstance + `ApplicationLaunchedWithUrl` → SPA routing; Info.plist `CFBundleURLTypes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)