### PR TITLE
build(goreleaser): use canonical `depends_on macos` symbol in desktop cask

### DIFF
--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -93,11 +93,12 @@ homebrew_casks:
         draft: true
     # The cask schema has no first-class `app` or `depends_on` field; emit both via a custom stanza.
     # `depends_on macos` satisfies `brew style` (Homebrew/OSDependsOn) for this macOS-only GUI cask;
-    # ">= :big_sur" matches the Go toolchain's minimum supported macOS. The cd.yaml `homebrew` job
-    # runs `brew style --fix`, which reorders these stanzas into canonical position before the cask
-    # lands in the tap.
+    # the bare `:big_sur` symbol means "Big Sur or newer" (matching the Go toolchain's minimum
+    # supported macOS) and is the canonical form — the old `">= :big_sur"` string-comparison syntax
+    # is deprecated by Homebrew. The cd.yaml `homebrew` job runs `brew style --fix`, which reorders
+    # these stanzas into canonical position before the cask lands in the tap.
     custom_block: |
-      depends_on macos: ">= :big_sur"
+      depends_on macos: :big_sur
       app "KSail.app"
     # Symlink the CLI from inside the installed app (the canonical GUI-app-with-CLI cask pattern),
     # so `ksail-desktop` is on PATH and `ksail desktop` finds it. Without this, GoReleaser would


### PR DESCRIPTION
## What

Homebrew now deprecates the string-comparison form `depends_on macos: ">= :big_sur"`:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :big_sur` instead.
```

This swaps the `custom_block` in `.goreleaser.desktop.yaml` to the canonical bare-symbol form, `depends_on macos: :big_sur`.

## Why

The bare `:big_sur` symbol means **"Big Sur or newer"** — semantically identical to `">= :big_sur"` — and is the form Homebrew now expects.

The `ksail-desktop` cask is **GoReleaser-generated** (`# This file was generated by GoReleaser. DO NOT EDIT.`), so the fix has to live in the `custom_block` here. Patching the tap's `Casks/ksail-desktop.rb` directly would be overwritten on the next release.

## Effect

The warning persists locally until the **next release regenerates the cask** from this config. No release is triggered by this PR on its own (`build:` type), so the corrected cask rides out with the next `feat`/`fix` release.

## Validation

- `goreleaser check -f .goreleaser.desktop.yaml` → `1 configuration file(s) validated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)