### PR TITLE
fix(cd): keyless cosign-sign the published container image

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write # OIDC token for keyless cosign image signing (docker_signs)
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,6 +67,9 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: 🔏 Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: 🏗️ Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,6 +90,24 @@ dockers_v2:
       "org.opencontainers.image.source": "{{.GitURL}}"
       "org.opencontainers.image.licenses": "PolyForm-Shield-1.0.0"
 
+# Keyless cosign signature for the published container image (the same
+# `ghcr.io/devantler-tech/ksail` image the ksail-operator runs). Signing it
+# lets downstream consumers verify provenance at the pull layer — e.g. a Talos
+# ImageVerificationConfig rule over ghcr.io/devantler-tech/*, which otherwise
+# blocks the operator with "no valid signature found" because the image is
+# unsigned. Keyless uses the GitHub Actions OIDC identity (cd.yaml grants
+# `id-token: write` and installs cosign); the signature is pushed to GHCR
+# next to the image. Signs by digest to avoid races; `artifacts: all` covers
+# the dockers_v2 image.
+docker_signs:
+  - artifacts: all
+    cmd: cosign
+    args:
+      - "sign"
+      - "${artifact}@${digest}"
+      - "--yes"
+    output: true
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Problem

`ghcr.io/devantler-tech/ksail` — the image the **ksail-operator** runs — is published **unsigned**. Any consumer that verifies image signatures at the pull layer can't run it.

Concretely, on a Talos cluster with an `ImageVerificationConfig` rule covering `ghcr.io/devantler-tech/*`, the operator is stuck in `ImagePullBackOff`:

```
Failed to verify image "ghcr.io/devantler-tech/ksail:vX.Y.Z" with talos:
image verification failed: no valid signature found: bundle tag not found
/ legacy signature tag not found
```

The CLI/app images published via the shared `publish-app.yaml` reusable workflow are already cosign-signed; the GoReleaser-built operator image is the gap.

## Change

Sign the container image during the GoReleaser release with **keyless cosign** (Sigstore), by digest:

- **`.goreleaser.yaml`** — add a `docker_signs` block (`artifacts: all`, signs the `dockers_v2` image as `cosign sign ${artifact}@${digest} --yes`).
- **`.github/workflows/cd.yaml`** — grant the release job `id-token: write` (OIDC for keyless) and add the `sigstore/cosign-installer` step before GoReleaser.

The signature is pushed to GHCR alongside the image, verifiable by any Sigstore consumer:
- issuer `https://token.actions.githubusercontent.com`
- subject = the `cd.yaml` workflow identity (`https://github.com/devantler-tech/ksail/.github/workflows/cd.yaml@refs/tags/vX.Y.Z`)

## Validation

- `goreleaser check` passes (GoReleaser 2.16.0; `docker_signs` + `dockers_v2` supported).
- `cd.yaml` parses as valid YAML.
- Signing only runs on the tag-triggered release pipeline, so it's first exercised on the next release.

## Downstream

This unblocks node-level image verification for the ksail-operator (e.g. the devantler-tech/platform Talos `ImageVerificationConfig`). Once a signed release is out, that consumer pins the operator to the signed tag and verifies against the identity above — no need to fail-open or weaken the verification scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)