### PR TITLE
fix(talos): boot scaled & recreated Hetzner nodes from the cluster snapshot

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
@@ -1,5 +1,26 @@
 package talosprovisioner
 
+import "github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+
+// HetznerBootSource exposes hetznerBootSource for tests in the
+// talosprovisioner_test package.
+//
+//nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
+var HetznerBootSource = hetznerBootSource
+
+// HetznerScaleServerOptsForTest exposes hetznerScaleServerOpts for tests, defaulting
+// the per-role public-net toggles to nil (Hetzner's default).
+func (p *Provisioner) HetznerScaleServerOptsForTest(
+	clusterName, role, nodeName string,
+	nodeNumber int,
+	infra HetznerInfra,
+	imageID int64,
+) hetzner.CreateServerOpts {
+	return p.hetznerScaleServerOpts(
+		clusterName, role, nodeName, nodeNumber, infra, imageID, nil, nil,
+	)
+}
+
 // IsRetryableTalosApplyConfigError exposes the unexported helper for tests in
 // the talosprovisioner_test package.
 //

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes_export_test.go
@@ -8,17 +8,14 @@ import "github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
 var HetznerBootSource = hetznerBootSource
 
-// HetznerScaleServerOptsForTest exposes hetznerScaleServerOpts for tests, defaulting
-// the per-role public-net toggles to nil (Hetzner's default).
+// HetznerScaleServerOptsForTest exposes hetznerScaleServerOpts for tests.
 func (p *Provisioner) HetznerScaleServerOptsForTest(
 	clusterName, role, nodeName string,
 	nodeNumber int,
 	infra HetznerInfra,
 	imageID int64,
 ) hetzner.CreateServerOpts {
-	return p.hetznerScaleServerOpts(
-		clusterName, role, nodeName, nodeNumber, infra, imageID, nil, nil,
-	)
+	return p.hetznerScaleServerOpts(clusterName, role, nodeName, nodeNumber, infra, imageID)
 }
 
 // IsRetryableTalosApplyConfigError exposes the unexported helper for tests in

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -98,10 +98,10 @@ func (p *Provisioner) createHetznerNodeGroups(
 	clusterName string,
 	imageID int64,
 ) ([]*hcloud.Server, []*hcloud.Server, error) {
-	isoID := p.talosOpts.ISO
-	if imageID > 0 {
-		isoID = 0 // snapshot takes precedence; ISO is not used
-	}
+	// A snapshot image takes precedence over the maintenance-mode ISO; the same
+	// boot-source rule is shared with scale-up and rolling-recreate so all node
+	// creation paths boot the cluster's Talos version (see hetznerBootSource).
+	isoID, imageID := hetznerBootSource(p.talosOpts.ISO, imageID)
 
 	controlPlaneServers, err := p.createHetznerNodes(ctx, hzProvider, infra, HetznerNodeGroupOpts{
 		ClusterName: clusterName,

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
@@ -351,8 +351,16 @@ func (p *Provisioner) createReplacementServer(
 
 	nextIndex := nextHetznerNodeIndex(existing, clusterName, role)
 
+	// Boot the replacement from the cluster's Talos snapshot image (when configured)
+	// rather than the maintenance-mode ISO, so it runs the same Talos version as the
+	// node it replaces and can parse the cluster's machine config (see hetznerBootSource).
+	imageID, snapErr := p.ensureSnapshotImage(ctx, clusterName)
+	if snapErr != nil {
+		return nil, fmt.Errorf("failed to ensure Talos snapshot image: %w", snapErr)
+	}
+
 	creationResults, createErr := p.launchHetznerScaleCreation(
-		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, 1,
+		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, 1, imageID,
 	)
 	if createErr != nil {
 		return nil, createErr

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
@@ -356,7 +356,7 @@ func (p *Provisioner) createReplacementServer(
 	// node it replaces and can parse the cluster's machine config (see hetznerBootSource).
 	imageID, snapErr := p.ensureSnapshotImage(ctx, clusterName)
 	if snapErr != nil {
-		return nil, fmt.Errorf("failed to ensure Talos snapshot image: %w", snapErr)
+		return nil, snapErr
 	}
 
 	creationResults, createErr := p.launchHetznerScaleCreation(

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -55,8 +55,17 @@ func (p *Provisioner) addHetznerNodes(
 		return fmt.Errorf("failed to ensure Hetzner infrastructure: %w", err)
 	}
 
+	// Boot new nodes from the cluster's Talos snapshot image (built at the
+	// configured talos.version) when one is configured, exactly like initial
+	// create. Falling back to the maintenance-mode ISO here would boot an older
+	// Talos that cannot parse newer config documents (see hetznerBootSource).
+	imageID, err := p.ensureSnapshotImage(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to ensure Talos snapshot image: %w", err)
+	}
+
 	creationResults, err := p.launchHetznerScaleCreation(
-		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, count,
+		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, count, imageID,
 	)
 	if err != nil {
 		return err
@@ -87,8 +96,10 @@ func (p *Provisioner) addHetznerNodes(
 }
 
 // launchHetznerScaleCreation creates count Hetzner servers starting at nextIndex, in parallel.
-// Results are returned indexed — goroutines always return nil so group.Wait() only fails on
-// unexpected errgroup-level errors.
+// imageID is the cluster's Talos snapshot image (0 when none is configured); it takes precedence
+// over the maintenance-mode ISO so scaled and recreated nodes boot the same Talos version as the
+// rest of the cluster (see hetznerBootSource). Results are returned indexed — goroutines always
+// return nil so group.Wait() only fails on unexpected errgroup-level errors.
 func (p *Provisioner) launchHetznerScaleCreation(
 	ctx context.Context,
 	hzProvider *hetzner.Provider,
@@ -96,6 +107,7 @@ func (p *Provisioner) launchHetznerScaleCreation(
 	infra HetznerInfra,
 	retryOpts hetzner.ServerRetryOpts,
 	nextIndex, count int,
+	imageID int64,
 ) ([]hetznerNodeCreationResult, error) {
 	results := make([]hetznerNodeCreationResult, count)
 
@@ -115,19 +127,9 @@ func (p *Provisioner) launchHetznerScaleCreation(
 				// surfaced when addHetznerNodes reads results.
 				results[nodeIdx] = hetznerNodeCreationResult{name: nodeName, err: nameErr}
 			} else {
-				server, createErr := hzProvider.CreateServerWithRetry(ctx, hetzner.CreateServerOpts{
-					Name:             nodeName,
-					ServerType:       p.hetznerServerType(role),
-					ISOID:            p.talosOpts.ISO,
-					Location:         p.hetznerOpts.Location,
-					Labels:           hetzner.NodeLabels(clusterName, role, nodeNumber),
-					NetworkID:        infra.NetworkID,
-					PlacementGroupID: infra.PlacementGroupID,
-					SSHKeyID:         infra.SSHKeyID,
-					FirewallIDs:      []int64{infra.FirewallID},
-					EnableIPv4:       enableIPv4,
-					EnableIPv6:       enableIPv6,
-				}, retryOpts)
+				server, createErr := hzProvider.CreateServerWithRetry(ctx, p.hetznerScaleServerOpts(
+					clusterName, role, nodeName, nodeNumber, infra, imageID, enableIPv4, enableIPv6,
+				), retryOpts)
 
 				results[nodeIdx] = hetznerNodeCreationResult{
 					name:   nodeName,
@@ -146,6 +148,55 @@ func (p *Provisioner) launchHetznerScaleCreation(
 	}
 
 	return results, nil
+}
+
+// hetznerBootSource selects the boot source for a new Hetzner node, returning the
+// (isoID, imageID) pair to set on hetzner.CreateServerOpts. A Talos snapshot image
+// takes precedence over the maintenance-mode ISO: when imageID > 0 the ISO is
+// suppressed so the node boots directly into the cluster's Talos version. The
+// default ISO (v1alpha1.DefaultTalosISO) is an older bootstrap image (Talos 1.12.4)
+// whose machined cannot parse config documents introduced in later Talos releases
+// (e.g. ImageVerificationConfig, Talos 1.13+); booting a scaled or recreated node
+// from it makes config apply fail with `"<kind>" "v1alpha1": not registered`.
+// Initial create, scale-up, and rolling-recreate all route their boot-source
+// decision through this helper so they never diverge on the Talos version a new
+// node boots.
+func hetznerBootSource(isoID, imageID int64) (int64, int64) {
+	if imageID > 0 {
+		return 0, imageID
+	}
+
+	return isoID, 0
+}
+
+// hetznerScaleServerOpts assembles the CreateServerOpts for a single scaled-up or
+// recreated Hetzner node. It is the construction point shared by the scale-up and
+// rolling-recreate paths, so both honour the snapshot-over-ISO boot precedence
+// (hetznerBootSource) and apply identical server type, labels, networking, and
+// placement. nodeName is pre-validated by the caller (hetznerNodeName).
+func (p *Provisioner) hetznerScaleServerOpts(
+	clusterName, role, nodeName string,
+	nodeNumber int,
+	infra HetznerInfra,
+	imageID int64,
+	enableIPv4, enableIPv6 *bool,
+) hetzner.CreateServerOpts {
+	isoID, image := hetznerBootSource(p.talosOpts.ISO, imageID)
+
+	return hetzner.CreateServerOpts{
+		Name:             nodeName,
+		ServerType:       p.hetznerServerType(role),
+		ISOID:            isoID,
+		ImageID:          image,
+		Location:         p.hetznerOpts.Location,
+		Labels:           hetzner.NodeLabels(clusterName, role, nodeNumber),
+		NetworkID:        infra.NetworkID,
+		PlacementGroupID: infra.PlacementGroupID,
+		SSHKeyID:         infra.SSHKeyID,
+		FirewallIDs:      []int64{infra.FirewallID},
+		EnableIPv4:       enableIPv4,
+		EnableIPv6:       enableIPv6,
+	}
 }
 
 // configureNewHetznerNodes waits for the Talos API on new servers, applies their

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -44,41 +44,9 @@ func (p *Provisioner) addHetznerNodes(
 
 	nextIndex := nextHetznerNodeIndex(existing, clusterName, role)
 
-	// Verify server type availability before creating infrastructure
-	err = p.checkHetznerAvailabilityForRole(ctx, hzProvider, role)
-	if err != nil {
-		return err
-	}
-
-	infra, err := p.ensureHetznerInfra(ctx, hzProvider, clusterName)
-	if err != nil {
-		return fmt.Errorf("failed to ensure Hetzner infrastructure: %w", err)
-	}
-
-	// Boot new nodes from the cluster's Talos snapshot image (built at the
-	// configured talos.version) when one is configured, exactly like initial
-	// create. Falling back to the maintenance-mode ISO here would boot an older
-	// Talos that cannot parse newer config documents (see hetznerBootSource).
-	imageID, err := p.ensureSnapshotImage(ctx, clusterName)
-	if err != nil {
-		return err
-	}
-
-	creationResults, err := p.launchHetznerScaleCreation(
-		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, count, imageID,
+	servers, err := p.provisionHetznerScaleServers(
+		ctx, hzProvider, clusterName, role, nextIndex, count, result,
 	)
-	if err != nil {
-		return err
-	}
-
-	// Record all creation failures before processing so recordFailedChange is sequential.
-	for _, res := range creationResults {
-		if res.err != nil {
-			recordFailedChange(result, role, res.name, res.err)
-		}
-	}
-
-	servers, err := p.collectCreatedHetznerServers(creationResults, role)
 	if err != nil {
 		return err
 	}
@@ -93,6 +61,55 @@ func (p *Provisioner) addHetznerNodes(
 	}
 
 	return nil
+}
+
+// provisionHetznerScaleServers runs the pre-flight checks (server-type
+// availability, shared infrastructure, Talos snapshot image), creates count new
+// servers for role starting at nextIndex, and returns the ones that came up.
+// Per-node creation failures are recorded on result; the successfully created
+// servers are returned for config apply by the caller.
+func (p *Provisioner) provisionHetznerScaleServers(
+	ctx context.Context,
+	hzProvider *hetzner.Provider,
+	clusterName, role string,
+	nextIndex, count int,
+	result *clusterupdate.UpdateResult,
+) ([]*hcloud.Server, error) {
+	// Verify server type availability before creating infrastructure.
+	err := p.checkHetznerAvailabilityForRole(ctx, hzProvider, role)
+	if err != nil {
+		return nil, err
+	}
+
+	infra, err := p.ensureHetznerInfra(ctx, hzProvider, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure Hetzner infrastructure: %w", err)
+	}
+
+	// Boot new nodes from the cluster's Talos snapshot image (built at the
+	// configured talos.version) when one is configured, exactly like initial
+	// create. Falling back to the maintenance-mode ISO here would boot an older
+	// Talos that cannot parse newer config documents (see hetznerBootSource).
+	imageID, err := p.ensureSnapshotImage(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	creationResults, err := p.launchHetznerScaleCreation(
+		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, count, imageID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Record all creation failures before processing so recordFailedChange is sequential.
+	for _, res := range creationResults {
+		if res.err != nil {
+			recordFailedChange(result, role, res.name, res.err)
+		}
+	}
+
+	return p.collectCreatedHetznerServers(creationResults, role)
 }
 
 // launchHetznerScaleCreation creates count Hetzner servers starting at nextIndex, in parallel.

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -61,7 +61,7 @@ func (p *Provisioner) addHetznerNodes(
 	// Talos that cannot parse newer config documents (see hetznerBootSource).
 	imageID, err := p.ensureSnapshotImage(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to ensure Talos snapshot image: %w", err)
+		return err
 	}
 
 	creationResults, err := p.launchHetznerScaleCreation(
@@ -111,8 +111,6 @@ func (p *Provisioner) launchHetznerScaleCreation(
 ) ([]hetznerNodeCreationResult, error) {
 	results := make([]hetznerNodeCreationResult, count)
 
-	enableIPv4, enableIPv6 := p.hetznerPublicNetForRole(role)
-
 	group, _ := errgroup.WithContext(ctx)
 	group.SetLimit(maxConcurrentHetznerOps)
 
@@ -128,7 +126,7 @@ func (p *Provisioner) launchHetznerScaleCreation(
 				results[nodeIdx] = hetznerNodeCreationResult{name: nodeName, err: nameErr}
 			} else {
 				server, createErr := hzProvider.CreateServerWithRetry(ctx, p.hetznerScaleServerOpts(
-					clusterName, role, nodeName, nodeNumber, infra, imageID, enableIPv4, enableIPv6,
+					clusterName, role, nodeName, nodeNumber, infra, imageID,
 				), retryOpts)
 
 				results[nodeIdx] = hetznerNodeCreationResult{
@@ -179,9 +177,9 @@ func (p *Provisioner) hetznerScaleServerOpts(
 	nodeNumber int,
 	infra HetznerInfra,
 	imageID int64,
-	enableIPv4, enableIPv6 *bool,
 ) hetzner.CreateServerOpts {
 	isoID, image := hetznerBootSource(p.talosOpts.ISO, imageID)
+	enableIPv4, enableIPv6 := p.hetznerPublicNetForRole(role)
 
 	return hetzner.CreateServerOpts{
 		Name:             nodeName,

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner_bootsource_test.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner_bootsource_test.go
@@ -1,0 +1,84 @@
+package talosprovisioner_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHetznerBootSource_SnapshotTakesPrecedence verifies a configured snapshot image
+// suppresses the ISO so a new node boots the cluster's Talos version, and that the ISO
+// is used only when no snapshot is configured. This guards the scale-up/rolling-recreate
+// regression where new Hetzner nodes booted the older maintenance ISO (Talos 1.12.4) and
+// rejected newer config documents (e.g. ImageVerificationConfig, Talos 1.13+) with
+// `"ImageVerificationConfig" "v1alpha1": not registered`.
+func TestHetznerBootSource_SnapshotTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	const isoID, snapshotID = int64(125127), int64(424242)
+
+	iso, image := talosprovisioner.HetznerBootSource(isoID, snapshotID)
+	assert.Zero(t, iso, "ISO must be suppressed when a snapshot image is configured")
+	assert.Equal(t, snapshotID, image, "node must boot from the snapshot image")
+
+	iso, image = talosprovisioner.HetznerBootSource(isoID, 0)
+	assert.Equal(t, isoID, iso, "node must fall back to the ISO when no snapshot is configured")
+	assert.Zero(t, image, "no snapshot image when none is configured")
+}
+
+// TestHetznerScaleServerOpts_BootsFromSnapshotWhenConfigured verifies the scale-up and
+// rolling-recreate server options boot a new node from the cluster's Talos snapshot image
+// (ISO suppressed) when one is configured, rather than the default maintenance ISO. Booting
+// the ISO is what made scaling a Talos 1.13 cluster fail when its config carried a 1.13+
+// document the 1.12.4 ISO could not parse.
+func TestHetznerScaleServerOpts_BootsFromSnapshotWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	const snapshotID = int64(987654)
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(io.Discard).
+		WithTalosOptions(v1alpha1.OptionsTalos{ISO: 125127}).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{WorkerServerType: "cx43", Location: "fsn1"})
+
+	opts := prov.HetznerScaleServerOptsForTest(
+		"prod", talosprovisioner.RoleWorker, "prod-worker-4", 4,
+		talosprovisioner.HetznerInfra{NetworkID: 1, FirewallID: 2}, snapshotID,
+	)
+
+	assert.Equal(t, snapshotID, opts.ImageID, "scaled node must boot from the snapshot image")
+	assert.Zero(t, opts.ISOID, "the maintenance ISO must be suppressed when a snapshot exists")
+	assert.Equal(
+		t,
+		"cx43",
+		opts.ServerType,
+		"scaled node must use the configured worker server type",
+	)
+}
+
+// TestHetznerScaleServerOpts_FallsBackToISO verifies that without a snapshot image the
+// scaled node boots the configured maintenance ISO (legacy, schematic-less clusters).
+func TestHetznerScaleServerOpts_FallsBackToISO(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(io.Discard).
+		WithTalosOptions(v1alpha1.OptionsTalos{ISO: 125127}).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{WorkerServerType: "cx43"})
+
+	opts := prov.HetznerScaleServerOptsForTest(
+		"prod", talosprovisioner.RoleWorker, "prod-worker-4", 4,
+		talosprovisioner.HetznerInfra{}, 0,
+	)
+
+	assert.Equal(
+		t,
+		int64(125127),
+		opts.ISOID,
+		"node must boot the ISO when no snapshot is configured",
+	)
+	assert.Zero(t, opts.ImageID, "no snapshot image when none is configured")
+}


### PR DESCRIPTION
## Problem

`ksail cluster update` on a Talos × Hetzner cluster failed while creating a scaled-up worker:

```
✗ failed to apply config to prod-worker-4: ... rpc error: code = Unknown
  desc = failed to parse config: error decoding document
  v1alpha1/ImageVerificationConfig/ (line 429):
  "ImageVerificationConfig" "v1alpha1": not registered
```

## Root cause

Hetzner **scale-up** (`scale_hetzner.go`) and **rolling-recreate** (`rolling_recreate.go`) created new nodes from the maintenance-mode Talos **ISO** (`talos.iso`, default `125127` = Talos **1.12.4**) instead of the cluster's **snapshot image** built at `talos.version`. The 1.12.4 machined can't parse config documents introduced in later Talos releases, so applying a v1.13.x worker config carrying an `ImageVerificationConfig` document (Talos **1.13+**) is rejected at parse time.

Initial **create** already prefers the snapshot (`imageID > 0` suppresses the ISO — `provisioner_hetzner.go:101`); only the manual scale/recreate paths ignored it. The Cluster Autoscaler also boots from the snapshot. So KSail's own scale/recreate were the only node-creation paths that booted the wrong Talos version — meaning a cluster running a Talos version newer than the bootstrap ISO could not be scaled or have its worker server type changed.

## Fix

- Resolve the cluster's snapshot image in both scale paths via the existing `ensureSnapshotImage` (already called during `update` for the autoscaler secret, so it's available and cheap — a label lookup).
- Route **all three** node-creation paths (create, scale-up, rolling-recreate) through a shared `hetznerBootSource` helper so they never diverge on which Talos version a new node boots.
- Falls back to the ISO when no schematic/snapshot is configured (legacy clusters), so behaviour is unchanged there.

## Tests

- `hetznerBootSource`: snapshot takes precedence over the ISO; ISO used only when no snapshot.
- `hetznerScaleServerOpts`: a scaled node boots `ImageID` (ISO suppressed) when a snapshot exists, and falls back to the configured ISO otherwise.

`go build`, `go test ./pkg/svc/provisioner/cluster/talos/...` (449 + new tests), `go vet`, and `golangci-lint run --new-from-rev=HEAD` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)