### PR TITLE
test(operator): cover cipher/secret handler error paths

### DIFF
--- a/pkg/operator/api/cipher_error_paths_test.go
+++ b/pkg/operator/api/cipher_error_paths_test.go
@@ -1,0 +1,135 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/operator/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// errCipherBackend is returned by failingCipherStub to drive the cipher handlers' error paths.
+var errCipherBackend = errors.New("cipher backend boom")
+
+// failingCipherStub implements api.CipherService and always fails, exercising the writeClientError
+// branches of the cipher/secret handlers (a generic error maps to 500).
+type failingCipherStub struct {
+	stubClusterService
+}
+
+func (failingCipherStub) EncryptSecret(_ context.Context, _, _, _ string) (string, error) {
+	return "", errCipherBackend
+}
+
+func (failingCipherStub) DecryptSecret(_ context.Context, _, _ string) (string, error) {
+	return "", errCipherBackend
+}
+
+func (failingCipherStub) CipherRecipients(_ context.Context) ([]string, error) {
+	return nil, errCipherBackend
+}
+
+// nilRecipientCipherStub returns a nil recipients slice (and succeeds otherwise) to exercise the
+// handleCipherRecipients branch that normalizes nil to an empty slice so the JSON is `[]`, not `null`.
+type nilRecipientCipherStub struct {
+	stubClusterService
+}
+
+func (nilRecipientCipherStub) EncryptSecret(_ context.Context, _, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (nilRecipientCipherStub) DecryptSecret(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (nilRecipientCipherStub) CipherRecipients(_ context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func TestCipherRecipientsServiceError(t *testing.T) {
+	t.Parallel()
+
+	server := &api.Server{Service: failingCipherStub{}}
+
+	recorder := doRequest(server.Handler(), http.MethodGet, "/api/v1/secrets/recipients", "")
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "cipher backend boom")
+}
+
+func TestCipherRecipientsNilNormalizesToEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	server := &api.Server{Service: nilRecipientCipherStub{}}
+
+	recorder := doRequest(server.Handler(), http.MethodGet, "/api/v1/secrets/recipients", "")
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), `"recipients":[]`)
+	assert.NotContains(t, recorder.Body.String(), "null")
+}
+
+func TestSecretEncryptServiceError(t *testing.T) {
+	t.Parallel()
+
+	server := &api.Server{Service: failingCipherStub{}}
+
+	recorder := doRequest(
+		server.Handler(),
+		http.MethodPost,
+		"/api/v1/secrets/encrypt",
+		`{"plaintext":"password: s3cret","recipient":"age1example"}`,
+	)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "cipher backend boom")
+}
+
+func TestSecretDecryptServiceError(t *testing.T) {
+	t.Parallel()
+
+	server := &api.Server{Service: failingCipherStub{}}
+
+	recorder := doRequest(
+		server.Handler(),
+		http.MethodPost,
+		"/api/v1/secrets/decrypt",
+		`{"encrypted":"data: ENC[sops]"}`,
+	)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "cipher backend boom")
+}
+
+func TestSecretEncryptMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := &api.Server{Service: cipherStub{}}
+
+	recorder := doRequest(
+		server.Handler(),
+		http.MethodPost,
+		"/api/v1/secrets/encrypt",
+		`{"plaintext": not-json`,
+	)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func TestSecretDecryptMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := &api.Server{Service: cipherStub{}}
+
+	recorder := doRequest(
+		server.Handler(),
+		http.MethodPost,
+		"/api/v1/secrets/decrypt",
+		`not even json`,
+	)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds error-path test coverage for the operator API cipher/secret handlers in `pkg/operator/api`, which were the lowest-covered HTTP handlers in the package.

## Why

`handleCipherRecipients` (54.5%), `handleSecretEncrypt` (61.5%) and `handleSecretDecrypt` (61.5%) only had happy-path + read-only coverage. Their error handling — a failing SOPS backend returning a proper status instead of a crash, a malformed JSON body returning 400, and nil recipients serializing as `[]` rather than `null` (which would break the UI's recipient picker) — was untested.

## Coverage

| Function | Before | After |
|---|---|---|
| `handleCipherRecipients` | 54.5% | 81.8% |
| `handleSecretEncrypt` | 61.5% | 84.6% |
| `handleSecretDecrypt` | 61.5% | 84.6% |
| `decodeJSON` | 57.1% | 100.0% |
| **`pkg/operator/api` total** | **85.1%** | **87.1%** |

## How

Two new `CipherService` stubs drive the real HTTP handlers through the existing `doRequest` helper:
- `failingCipherStub` returns a generic error from each method → asserts `500` + error body.
- `nilRecipientCipherStub` returns `(nil, nil)` from `CipherRecipients` → asserts `"recipients":[]` and no `null`.
- Malformed-JSON bodies posted to encrypt/decrypt → asserts `400`.

The residual uncovered lines in each handler are the `ErrNotSupported` guards, which are unreachable via `Handler()` (the routes only register when the backend implements `CipherService`) — belt-and-suspenders, not worth a synthetic test.

## Validation

- `go test ./pkg/operator/api/...` — pass, 87.1% coverage
- `gofmt -l` clean, `go vet` clean
- Behaviour-preserving: test-only change, no production code touched.