### PR TITLE
ci(mirror-cache): pull busybox tar-utility via mirror.gcr.io to stop Docker Hub rate-limiting and `dckr_jti` log leak

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -188,13 +188,19 @@ runs:
       shell: bash
       run: |
         echo "📦 Importing mirror registry volumes..."
+        # Pull the tar-utility busybox via mirror.gcr.io (anonymous pull-through
+        # cache), not Docker Hub: the runner's Docker Hub login makes a direct
+        # pull count against the authenticated rate limit and leak the dckr_jti
+        # token into error logs on throttle. mirror.gcr.io is anonymous and not
+        # rate-limited. It re-serializes manifests, so the upstream digest can't
+        # be pinned through it — tag-pinned, like registry:3 in pull-registry-image.sh.
         for registry in docker.io ghcr.io quay.io registry.k8s.io; do
           if [ -f "/tmp/ksail-mirror-cache/${registry}.tar" ]; then
             docker volume create "$registry" 2>/dev/null || true
             if docker run --rm \
               -v "${registry}":/volume \
               -v /tmp/ksail-mirror-cache:/backup:ro \
-              busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+              mirror.gcr.io/library/busybox:1.37 \
               sh -c "cd /volume && tar -xf /backup/${registry}.tar"; then
               echo "  ✅ Restored $registry mirror cache"
             else
@@ -467,13 +473,15 @@ runs:
       shell: bash
       run: |
         echo "📦 Exporting mirror registry volumes for caching..."
+        # busybox via mirror.gcr.io (anonymous), not Docker Hub — avoids the
+        # authenticated rate limit and dckr_jti leak. See the import step above.
         mkdir -p /tmp/ksail-mirror-cache
         for registry in docker.io ghcr.io quay.io registry.k8s.io; do
           if docker volume inspect "$registry" > /dev/null 2>&1; then
             if docker run --rm \
               -v "${registry}":/volume:ro \
               -v /tmp/ksail-mirror-cache:/backup \
-              busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+              mirror.gcr.io/library/busybox:1.37 \
               sh -c "cd /volume && tar -cf /backup/${registry}.tar ."; then
               echo "  ✅ Exported $registry"
             else

--- a/.github/actions/restore-mirror-cache/action.yaml
+++ b/.github/actions/restore-mirror-cache/action.yaml
@@ -158,13 +158,21 @@ runs:
       run: |
         echo "📦 Importing mirror registry volumes..."
 
+        # Pull the tar-utility busybox via mirror.gcr.io (Google's anonymous
+        # pull-through cache), not Docker Hub: the runner is logged in to Docker
+        # Hub, so a direct pull counts against the authenticated rate limit and
+        # leaks the session's dckr_jti token into error logs when throttled.
+        # mirror.gcr.io is anonymous and not rate-limited. It re-serializes
+        # manifests, so the upstream digest can't be pinned through it — we pin
+        # by tag, exactly like registry:3 in pull-registry-image.sh.
+
         # Import docker.io mirror volume
         if [ -f "/tmp/mirror-cache/docker.io.tar" ]; then
           docker volume create docker.io 2>/dev/null || true
           docker run --rm \
             -v docker.io:/volume \
             -v /tmp/mirror-cache:/backup:ro \
-            busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+            mirror.gcr.io/library/busybox:1.37 \
             sh -c "cd /volume && tar -xf /backup/docker.io.tar" || echo "⚠️ Failed to import docker.io mirror"
           echo "✅ Restored docker.io mirror cache"
         fi
@@ -175,7 +183,7 @@ runs:
           docker run --rm \
             -v ghcr.io:/volume \
             -v /tmp/mirror-cache:/backup:ro \
-            busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+            mirror.gcr.io/library/busybox:1.37 \
             sh -c "cd /volume && tar -xf /backup/ghcr.io.tar" || echo "⚠️ Failed to import ghcr.io mirror"
           echo "✅ Restored ghcr.io mirror cache"
         fi
@@ -186,7 +194,7 @@ runs:
           docker run --rm \
             -v quay.io:/volume \
             -v /tmp/mirror-cache:/backup:ro \
-            busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+            mirror.gcr.io/library/busybox:1.37 \
             sh -c "cd /volume && tar -xf /backup/quay.io.tar" || echo "⚠️ Failed to import quay.io mirror"
           echo "✅ Restored quay.io mirror cache"
         fi
@@ -197,7 +205,7 @@ runs:
           docker run --rm \
             -v registry.k8s.io:/volume \
             -v /tmp/mirror-cache:/backup:ro \
-            busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+            mirror.gcr.io/library/busybox:1.37 \
             sh -c "cd /volume && tar -xf /backup/registry.k8s.io.tar" || echo "⚠️ Failed to import registry.k8s.io mirror"
           echo "✅ Restored registry.k8s.io mirror cache"
         fi

--- a/.github/actions/warm-mirror-cache/action.yaml
+++ b/.github/actions/warm-mirror-cache/action.yaml
@@ -400,34 +400,41 @@ runs:
       shell: bash
       run: |
         echo "💾 Exporting mirror registry volumes..."
+        # Pull the tar-utility busybox via mirror.gcr.io (Google's anonymous
+        # pull-through cache), not Docker Hub: the runner is logged in to Docker
+        # Hub, so a direct pull counts against the authenticated rate limit and
+        # leaks the session's dckr_jti token into error logs when throttled.
+        # mirror.gcr.io is anonymous and not rate-limited. It re-serializes
+        # manifests, so the upstream digest can't be pinned through it — we pin
+        # by tag, exactly like registry:3 in pull-registry-image.sh.
         mkdir -p /tmp/mirror-cache
 
         # Export docker.io mirror volume
         docker run --rm \
           -v docker.io:/volume:ro \
           -v /tmp/mirror-cache:/backup \
-          busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+          mirror.gcr.io/library/busybox:1.37 \
           tar -cf /backup/docker.io.tar -C /volume . || echo "⚠️ Failed to export docker.io mirror"
 
         # Export ghcr.io mirror volume
         docker run --rm \
           -v ghcr.io:/volume:ro \
           -v /tmp/mirror-cache:/backup \
-          busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+          mirror.gcr.io/library/busybox:1.37 \
           tar -cf /backup/ghcr.io.tar -C /volume . || echo "⚠️ Failed to export ghcr.io mirror"
 
         # Export quay.io mirror volume
         docker run --rm \
           -v quay.io:/volume:ro \
           -v /tmp/mirror-cache:/backup \
-          busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+          mirror.gcr.io/library/busybox:1.37 \
           tar -cf /backup/quay.io.tar -C /volume . || echo "⚠️ Failed to export quay.io mirror"
 
         # Export registry.k8s.io mirror volume
         docker run --rm \
           -v registry.k8s.io:/volume:ro \
           -v /tmp/mirror-cache:/backup \
-          busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f \
+          mirror.gcr.io/library/busybox:1.37 \
           tar -cf /backup/registry.k8s.io.tar -C /volume . || echo "⚠️ Failed to export registry.k8s.io mirror"
 
         # Show cache size


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Switch the 10 `docker run busybox … tar …` tar-utility calls in the mirror-cache composite actions from a Docker Hub image to `mirror.gcr.io/library/busybox:1.37`:

- `.github/actions/restore-mirror-cache/action.yaml` (4 sites)
- `.github/actions/warm-mirror-cache/action.yaml` (4 sites)
- `.github/actions/ksail-cluster/action.yml` (2 sites)

## Why

These actions pack/unpack the cached registry volumes with `docker run busybox`. They're **direct daemon pulls** of a Docker Hub image that run on every job. Because CI runners are `docker login`'d to Docker Hub as `devantler`, each pull:

1. **counts against the authenticated pull-rate limit** → `toomanyrequests … as 'devantler'`, and
2. when throttled, Docker Hub embeds the session's `dckr_jti_…` JWT ID into the **public CI logs**.

Observed failure:

```
📦 Importing mirror registry volumes...
docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit
as 'devantler': dckr_jti_0pYsrwM-hmGr5O_3LaYDSjubc1Y=. ...
  ⚠️ Failed to import docker.io mirror
```

`mirror.gcr.io` is Google's **anonymous** pull-through cache for Docker Hub — not subject to Docker Hub rate limits, and it never sends Docker Hub credentials, so the throttle and the `dckr_jti` log exposure both go away. This is the same pattern already used for `registry:3` in [`pull-registry-image.sh`](https://github.com/devantler-tech/ksail/blob/main/.github/actions/pull-registry-image/pull-registry-image.sh).

> Note: `dckr_jti_…` is a session **JWT ID**, not the PAT secret (`dckr_pat_…`), so it can't authenticate on its own — but it leaked publicly and is tied to the `devantler` account, so rotating `DOCKERHUB_TOKEN` is still recommended hygiene.

## Reviewer notes

- **Tag-pinned, not digest-pinned, by necessity.** `mirror.gcr.io` re-serializes manifests, so the upstream Docker Hub `@sha256:b3255e…` digest fails verification through the mirror (`manifest verification failed`; the mirror serves OCI digest `7a3ebe…`). This is exactly why `registry:3` is also tag-pinned there. The trade-off is losing the `@sha256` supply-chain pin on this one CI utility image.
- **Cache keys unaffected.** The mirror-cache key is computed from the workload image list (+ Dockerfile `FROM` refs), not from the tar-utility busybox ref — so warm and restore stay in lockstep and existing caches remain valid.
- **Verified end-to-end locally:** `docker run mirror.gcr.io/library/busybox:1.37 sh -c "… tar -cf …"` pulls from the mirror (no Docker Hub auth) and archives a Docker volume correctly.
- All three `action.yaml` files re-validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)