### PR TITLE
test(clusterapi): cover ReconcileResource happy path (Flux + ArgoCD)

### DIFF
--- a/pkg/cli/clusterapi/resources_test.go
+++ b/pkg/cli/clusterapi/resources_test.go
@@ -24,6 +24,7 @@ const (
 	kindPod        = "Pod"
 	kindDeployment = "Deployment"
 	nameWeb        = "web"
+	nameApps       = "apps"
 )
 
 func testPod(namespace, name string) *corev1.Pod {
@@ -41,6 +42,20 @@ func testDeployment(namespace, name string, replicas int32) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec:       appsv1.DeploymentSpec{Replicas: &count},
 	}
+}
+
+// testGitOpsCR builds an unstructured Flux/ArgoCD custom resource. The fake dynamic client guesses
+// its GVR from the GVK (Kustomization→kustomizations, Application→applications), matching the
+// allowlist mapping, so reconcile (a merge-patch) round-trips without registering real CRD schemes.
+func testGitOpsCR(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}}
 }
 
 func injectFakeDynamic(service *clusterapi.Service, objects ...runtime.Object) {
@@ -177,6 +192,66 @@ func TestReconcileRejectsNonReconcilableKind(t *testing.T) {
 		api.ResourceRef{Kind: kindPod, Namespace: "x", Name: "p1"},
 	)
 	require.ErrorIs(t, err, api.ErrInvalid)
+}
+
+func TestReconcileResourceStampsFluxAnnotation(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(nil)
+	injectFakeDynamic(
+		service,
+		testGitOpsCR("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "flux-system", nameApps),
+	)
+
+	err := service.ReconcileResource(
+		context.Background(), "default", "c1",
+		api.ResourceRef{Kind: "Kustomization", Namespace: "flux-system", Name: nameApps},
+	)
+	require.NoError(t, err)
+
+	obj, err := service.GetResource(
+		context.Background(), "default", "c1",
+		api.ResourceRef{Kind: "Kustomization", Namespace: "flux-system", Name: nameApps},
+	)
+	require.NoError(t, err)
+
+	// Flux watches reconcile.fluxcd.io/requestedAt; the stamp is a non-empty RFC3339Nano timestamp.
+	stamp, found, err := unstructured.NestedString(
+		obj.Object, "metadata", "annotations", "reconcile.fluxcd.io/requestedAt",
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.NotEmpty(t, stamp)
+}
+
+func TestReconcileResourceStampsArgoCDAnnotation(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(nil)
+	injectFakeDynamic(
+		service,
+		testGitOpsCR("argoproj.io/v1alpha1", "Application", "argocd", nameApps),
+	)
+
+	err := service.ReconcileResource(
+		context.Background(), "default", "c1",
+		api.ResourceRef{Kind: "Application", Namespace: "argocd", Name: nameApps},
+	)
+	require.NoError(t, err)
+
+	obj, err := service.GetResource(
+		context.Background(), "default", "c1",
+		api.ResourceRef{Kind: "Application", Namespace: "argocd", Name: nameApps},
+	)
+	require.NoError(t, err)
+
+	// ArgoCD refreshes on argocd.argoproj.io/refresh=normal (not a timestamp like Flux).
+	refresh, found, err := unstructured.NestedString(
+		obj.Object, "metadata", "annotations", "argocd.argoproj.io/refresh",
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "normal", refresh)
 }
 
 func TestRestartRejectsNonRestartableKind(t *testing.T) {


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Follow-up to #5170. The code-coverage bot flagged `pkg/cli/clusterapi/resources.go` dropping **66% → 63%** after the reconcile feature merged: `ReconcileResource` was only exercised on its reject path and `reconcileAnnotation` not at all.

## Change

Adds two happy-path tests that round-trip a reconcile through the fake dynamic client, covering both `reconcileAnnotation` branches + the `mergePatch` call:

- **Flux** `Kustomization` → asserts the `reconcile.fluxcd.io/requestedAt` timestamp stamp.
- **ArgoCD** `Application` → asserts `argocd.argoproj.io/refresh=normal`.

A small `testGitOpsCR` helper builds the unstructured CR; the fake client guesses the GVR from the GVK (`Kustomization→kustomizations`, `Application→applications`), matching the allowlist, so no real CRD scheme registration is needed.

`ReconcileResource` and `reconcileAnnotation` are now **100%** covered.

This landed as a separate PR because #5170 auto-merged before the test commit could be added to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)