### PR TITLE
fix(cluster): cap VCluster update target at the SDK-pinned version

### DIFF
--- a/pkg/cli/cmd/cluster/cluster_pure_test.go
+++ b/pkg/cli/cmd/cluster/cluster_pure_test.go
@@ -1243,6 +1243,24 @@ func TestNormalizePinnedVersion(t *testing.T) {
 			wantReason:  cluster.ExportPinnedVersionAlreadyAtIt,
 		},
 		{
+			// Regression for the VCluster phantom-upgrade bug: an unprefixed SDK pin
+			// ("0.34.1", VCluster's ChartVersion()) must still match an unprefixed
+			// current of the same version via parsed-semver equality, not raw strings.
+			name:        "unprefixed pin equal to unprefixed current is a no-op",
+			rawPinned:   "0.34.1",
+			current:     "0.34.1",
+			wantVersion: "v0.34.1",
+			wantReason:  cluster.ExportPinnedVersionAlreadyAtIt,
+		},
+		{
+			// Cross-prefix equality: pin normalizes to "v..." while current is raw.
+			name:        "unprefixed pin equal to v-prefixed current is a no-op",
+			rawPinned:   "0.34.1",
+			current:     "v0.34.1",
+			wantVersion: "v0.34.1",
+			wantReason:  cluster.ExportPinnedVersionAlreadyAtIt,
+		},
+		{
 			name:        "older pin than current skips the downgrade",
 			rawPinned:   "v1.7.0",
 			current:     testPinCurrent,

--- a/pkg/cli/cmd/cluster/cluster_pure_test.go
+++ b/pkg/cli/cmd/cluster/cluster_pure_test.go
@@ -1209,18 +1209,25 @@ const (
 	// normalizePinnedVersion cases; testPinNewer is a pin strictly newer than it.
 	testPinCurrent = "v1.8.0"
 	testPinNewer   = "v1.9.0"
+	// testPinSDKRaw is the unprefixed SDK pin (VCluster's ChartVersion()) used in
+	// the phantom-upgrade regression cases; testPinSDKNorm is its normalized form.
+	testPinSDKRaw  = "0.34.1"
+	testPinSDKNorm = "v0.34.1"
 )
 
-func TestNormalizePinnedVersion(t *testing.T) {
-	t.Parallel()
+// normalizePinnedVersionCase is one ExportNormalizePinnedVersion table case.
+type normalizePinnedVersionCase struct {
+	name        string
+	rawPinned   string
+	current     string
+	wantVersion string
+	wantReason  cluster.ExportPinnedVersionSkipReason
+}
 
-	tests := []struct {
-		name        string
-		rawPinned   string
-		current     string
-		wantVersion string
-		wantReason  cluster.ExportPinnedVersionSkipReason
-	}{
+// normalizePinnedVersionCases returns the happy-path normalization/downgrade
+// cases. Kept separate from the test body so the table doesn't trip funlen.
+func normalizePinnedVersionCases() []normalizePinnedVersionCase {
+	return []normalizePinnedVersionCase{
 		{
 			name:        "newer pin proceeds with upgrade",
 			rawPinned:   testPinNewer,
@@ -1247,17 +1254,17 @@ func TestNormalizePinnedVersion(t *testing.T) {
 			// ("0.34.1", VCluster's ChartVersion()) must still match an unprefixed
 			// current of the same version via parsed-semver equality, not raw strings.
 			name:        "unprefixed pin equal to unprefixed current is a no-op",
-			rawPinned:   "0.34.1",
-			current:     "0.34.1",
-			wantVersion: "v0.34.1",
+			rawPinned:   testPinSDKRaw,
+			current:     testPinSDKRaw,
+			wantVersion: testPinSDKNorm,
 			wantReason:  cluster.ExportPinnedVersionAlreadyAtIt,
 		},
 		{
 			// Cross-prefix equality: pin normalizes to "v..." while current is raw.
 			name:        "unprefixed pin equal to v-prefixed current is a no-op",
-			rawPinned:   "0.34.1",
-			current:     "v0.34.1",
-			wantVersion: "v0.34.1",
+			rawPinned:   testPinSDKRaw,
+			current:     testPinSDKNorm,
+			wantVersion: testPinSDKNorm,
 			wantReason:  cluster.ExportPinnedVersionAlreadyAtIt,
 		},
 		{
@@ -1275,8 +1282,12 @@ func TestNormalizePinnedVersion(t *testing.T) {
 			wantReason:  cluster.ExportPinnedVersionProceed,
 		},
 	}
+}
 
-	for _, testCase := range tests {
+func TestNormalizePinnedVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range normalizePinnedVersionCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/cmd/cluster/update.go
+++ b/pkg/cli/cmd/cluster/update.go
@@ -307,7 +307,15 @@ func reconcileKubernetesVersion(
 	currentVersions *clusterupdate.VersionInfo,
 	force, dryRun bool,
 ) (bool, error) {
-	if pin := strings.TrimSpace(ctx.ClusterCfg.Spec.Cluster.KubernetesVersion); pin != "" {
+	// An explicit spec.cluster.kubernetesVersion wins; otherwise the upgrader may
+	// pin the Kubernetes version implicitly (VCluster bakes it into the embedded SDK
+	// image, so it cannot be reached by a discovery-driven recreation).
+	pin := strings.TrimSpace(ctx.ClusterCfg.Spec.Cluster.KubernetesVersion)
+	if pin == "" {
+		pin = strings.TrimSpace(upgrader.PinnedKubernetesVersion())
+	}
+
+	if pin != "" {
 		return executePinnedKubernetesUpgrade(
 			cmd, cfgManager, ctx, deps, upgrader, clusterName, pin,
 			currentVersions.KubernetesVersion, force, dryRun,
@@ -714,12 +722,17 @@ func normalizePinnedVersion(
 		)
 	}
 
-	if currentVersion == pinnedVersion {
+	// Already at the pin is a no-op. Compare parsed semver, not raw strings, so a
+	// v-prefix mismatch does not hide the no-op — e.g. a distribution whose pin is
+	// the unprefixed SDK version "0.34.1" against a current "0.34.1" (VCluster's
+	// ChartVersion()) must still resolve to "already at it" rather than triggering a
+	// phantom upgrade.
+	current, curErr := versionresolver.ParseVersion(currentVersion)
+	if currentVersion == pinnedVersion || (curErr == nil && pinned.Equal(current)) {
 		return pinnedVersion, pinnedVersionAlreadyAtIt, nil
 	}
 
 	// Guard against downgrades: skip if the cluster is already newer than the pin.
-	current, curErr := versionresolver.ParseVersion(currentVersion)
 	if curErr == nil && pinned.Less(current) {
 		return pinnedVersion, pinnedVersionNewer, nil
 	}

--- a/pkg/svc/provisioner/cluster/clusterupdate/update.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/update.go
@@ -441,12 +441,20 @@ type Upgrader interface {
 	// Returns empty string if the distribution version equals the Kubernetes version.
 	DistributionImageRef() string
 
-	// PinnedDistributionVersion returns the distribution version pinned in
-	// configuration (e.g. spec.cluster.talos.version for Talos), or "" when no
-	// distribution version is pinned and the cluster should follow the latest
-	// supported version. Distributions whose version is the Kubernetes version
-	// (Kind/K3d/VCluster) always return "" — pin them via spec.cluster.kubernetesVersion.
+	// PinnedDistributionVersion returns the distribution version pinned for the
+	// cluster, or "" when the distribution version is OCI-discovered and the
+	// cluster should follow the latest supported version. Talos pins it via
+	// spec.cluster.talos.version; VCluster pins it implicitly to the embedded SDK
+	// chart version (it cannot be changed by recreation). Kind/K3d have no separate
+	// distribution image (their version is the Kubernetes version) and return "".
 	PinnedDistributionVersion() string
+
+	// PinnedKubernetesVersion returns the Kubernetes version pinned implicitly by
+	// the distribution itself (independently of spec.cluster.kubernetesVersion), or
+	// "" when the Kubernetes version is OCI-discovered. VCluster bakes its
+	// Kubernetes version into the embedded SDK image, so it cannot be reached by a
+	// discovery-driven recreation and is reported here; Talos/Kind/K3d return "".
+	PinnedKubernetesVersion() string
 
 	// VersionSuffix returns the tag suffix used by the distribution (e.g., "k3s" for K3s).
 	// Returns empty string for distributions that use plain semver tags.

--- a/pkg/svc/provisioner/cluster/k3d/upgrader.go
+++ b/pkg/svc/provisioner/cluster/k3d/upgrader.go
@@ -62,6 +62,13 @@ func (p *Provisioner) PinnedDistributionVersion() string {
 	return ""
 }
 
+// PinnedKubernetesVersion returns "" because K3d follows the OCI-discovered
+// Kubernetes version (or spec.cluster.kubernetesVersion when set); recreation can
+// legitimately reach the discovered K3s image version.
+func (p *Provisioner) PinnedKubernetesVersion() string {
+	return ""
+}
+
 // VersionSuffix returns "k3s" to match K3s image tags like "v1.35.3-k3s1".
 func (p *Provisioner) VersionSuffix() string {
 	return "k3s"

--- a/pkg/svc/provisioner/cluster/k3d/upgrader_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/upgrader_test.go
@@ -152,6 +152,16 @@ func TestPinnedDistributionVersion_Empty(t *testing.T) {
 	}
 }
 
+func TestPinnedKubernetesVersion_Empty(t *testing.T) {
+	t.Parallel()
+
+	provisioner := k3dprovisioner.NewProvisioner(nil, "")
+
+	if got := provisioner.PinnedKubernetesVersion(); got != "" {
+		t.Errorf("PinnedKubernetesVersion() = %q, want %q", got, "")
+	}
+}
+
 func TestVersionSuffix_K3s(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/kind/upgrader.go
+++ b/pkg/svc/provisioner/cluster/kind/upgrader.go
@@ -63,6 +63,13 @@ func (k *Provisioner) PinnedDistributionVersion() string {
 	return ""
 }
 
+// PinnedKubernetesVersion returns "" because Kind follows the OCI-discovered
+// Kubernetes version (or spec.cluster.kubernetesVersion when set); recreation can
+// legitimately reach the discovered node-image version.
+func (k *Provisioner) PinnedKubernetesVersion() string {
+	return ""
+}
+
 // VersionSuffix returns an empty string because Kind uses plain semver tags.
 func (k *Provisioner) VersionSuffix() string {
 	return ""

--- a/pkg/svc/provisioner/cluster/kind/upgrader_test.go
+++ b/pkg/svc/provisioner/cluster/kind/upgrader_test.go
@@ -161,6 +161,16 @@ func TestPinnedDistributionVersion_Empty(t *testing.T) {
 	}
 }
 
+func TestPinnedKubernetesVersion_Empty(t *testing.T) {
+	t.Parallel()
+
+	provisioner := kindprovisioner.NewProvisioner(nil, "", nil, nil)
+
+	if got := provisioner.PinnedKubernetesVersion(); got != "" {
+		t.Errorf("PinnedKubernetesVersion() = %q, want %q", got, "")
+	}
+}
+
 func TestVersionSuffix_Empty(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/talos/provisioner_builder_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_builder_test.go
@@ -83,6 +83,14 @@ func TestProvisioner_PinnedDistributionVersion(t *testing.T) {
 	assert.Equal(t, "v1.13.3", pinned.PinnedDistributionVersion())
 }
 
+func TestProvisioner_PinnedKubernetesVersion(t *testing.T) {
+	t.Parallel()
+
+	// Talos has no SDK-embedded Kubernetes pin; it follows OCI discovery /
+	// spec.cluster.kubernetesVersion.
+	assert.Empty(t, talosprovisioner.NewProvisioner(nil, nil).PinnedKubernetesVersion())
+}
+
 func TestProvisioner_WithDockerClient(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/talos/upgrader.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrader.go
@@ -242,6 +242,13 @@ func (p *Provisioner) PinnedDistributionVersion() string {
 	return strings.TrimSpace(p.talosOpts.Version)
 }
 
+// PinnedKubernetesVersion returns "" because Talos follows the OCI-discovered
+// Kubernetes version (or spec.cluster.kubernetesVersion when set), not an
+// SDK-embedded pin.
+func (p *Provisioner) PinnedKubernetesVersion() string {
+	return ""
+}
+
 // VersionSuffix returns an empty string since Talos uses plain semver tags.
 func (p *Provisioner) VersionSuffix() string {
 	return ""

--- a/pkg/svc/provisioner/cluster/vcluster/upgrader.go
+++ b/pkg/svc/provisioner/cluster/vcluster/upgrader.go
@@ -58,10 +58,22 @@ func (p *Provisioner) DistributionImageRef() string {
 	return distributionImageRepository
 }
 
-// PinnedDistributionVersion always returns "" because VCluster exposes no
-// user-facing distribution version pin; it follows the latest supported version.
+// PinnedDistributionVersion returns the embedded VCluster chart version
+// (ChartVersion). VCluster's deployable version is baked into the SDK/Dockerfile
+// and cannot be changed by cluster recreation, so the update flow must cap the
+// distribution target at this pin rather than OCI-discovering the latest tag —
+// otherwise it phantom-upgrades to a newer upstream release it cannot deliver and
+// triggers a destructive no-op recreation that breaks update idempotency.
 func (p *Provisioner) PinnedDistributionVersion() string {
-	return ""
+	return vclusterconfigmanager.ChartVersion()
+}
+
+// PinnedKubernetesVersion returns the embedded VCluster Kubernetes version
+// (DefaultKubernetesVersion). Like the chart version it is baked into the SDK
+// image and unreachable by recreation, so it is capped here to keep
+// `ksail cluster update` idempotent across upstream Kubernetes releases.
+func (p *Provisioner) PinnedKubernetesVersion() string {
+	return vclusterconfigmanager.DefaultKubernetesVersion
 }
 
 // VersionSuffix returns an empty string since VCluster uses plain semver tags.

--- a/pkg/svc/provisioner/cluster/vcluster/upgrader_test.go
+++ b/pkg/svc/provisioner/cluster/vcluster/upgrader_test.go
@@ -87,13 +87,37 @@ func TestDistributionImageRef(t *testing.T) {
 	}
 }
 
-func TestPinnedDistributionVersion_Empty(t *testing.T) {
+func TestPinnedDistributionVersion_ChartVersion(t *testing.T) {
 	t.Parallel()
 
 	provisioner := vclusterprovisioner.NewProvisioner("test", "", false, nil)
 
-	if got := provisioner.PinnedDistributionVersion(); got != "" {
-		t.Errorf("PinnedDistributionVersion() = %q, want %q", got, "")
+	// VCluster's distribution version is SDK/Dockerfile-pinned to ChartVersion();
+	// the update flow caps the target at this pin to avoid phantom OCI upgrades.
+	want := vclusterconfigmanager.ChartVersion()
+	if want == "" {
+		t.Fatal("ChartVersion() unexpectedly empty")
+	}
+
+	if got := provisioner.PinnedDistributionVersion(); got != want {
+		t.Errorf("PinnedDistributionVersion() = %q, want %q", got, want)
+	}
+}
+
+func TestPinnedKubernetesVersion_DefaultKubernetesVersion(t *testing.T) {
+	t.Parallel()
+
+	provisioner := vclusterprovisioner.NewProvisioner("test", "", false, nil)
+
+	// VCluster's Kubernetes version is likewise SDK-pinned, matching what
+	// GetCurrentVersions reports so the pinned path short-circuits to "already at it".
+	want := vclusterconfigmanager.DefaultKubernetesVersion
+	if want == "" {
+		t.Fatal("DefaultKubernetesVersion unexpectedly empty")
+	}
+
+	if got := provisioner.PinnedKubernetesVersion(); got != want {
+		t.Errorf("PinnedKubernetesVersion() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5187.

## Problem

`ksail cluster update` does **live OCI version discovery** for VCluster, but VCluster's deployable version is **compile-time pinned** to the embedded SDK/Dockerfile (`ChartVersion()` / `DefaultKubernetesVersion`). When loft-sh publishes a newer tag than the embedded pin, the update flow proposes — and on `--force` performs — an upgrade it structurally cannot deliver, **recreating the cluster back to the same SDK-pinned version**. This:

- breaks `ksail cluster update` idempotency (a real user gets a destructive no-op recreation on every upstream release), and
- turns the VCluster `System Test (Docker)` legs red on every PR branched off the current pin, gating `CI - Required Checks` and **wedging the ksail merge queue** (e.g. #5184 + dependabot #5157/#5158/#5161/#5162).

## Root cause

VCluster is the only recreation-based distribution with a **separate** distribution image (`ghcr.io/loft-sh/vcluster-pro`) distinct from its Kubernetes image (`ghcr.io/loft-sh/kubernetes`), and **both** are SDK/Dockerfile-pinned (unreachable by recreation). Yet the no-pin path OCI-discovered the latest tag for both dimensions — unlike Talos, which already special-cases its pin via `executePinnedDistributionUpgrade`.

Note `GetCurrentVersions()` for VCluster returns the *embedded* versions, so `current == pin` always holds — the pinned path short-circuits to "already at it" with no recreation, and there is no genuine-upgrade regression (a real version change comes from a Dependabot Dockerfile bump, not from `update` discovery).

## Fix — treat VCluster like Talos (cap at the embedded pin), for **both** dimensions

- `VCluster.PinnedDistributionVersion()` → `ChartVersion()` (was `""`).
- New symmetric `Upgrader.PinnedKubernetesVersion()`: VCluster returns `DefaultKubernetesVersion`; **Talos/Kind/K3d return `""`** (unchanged — they legitimately reach the OCI-discovered version via rolling upgrade / node-image recreation). The K8s dimension had to be handled too: once the distribution dimension stops recreating, `reconcileKubernetesVersion` becomes reachable and would otherwise phantom-upgrade on `loft-sh/kubernetes`.
- `reconcileKubernetesVersion` falls back to the upgrader's K8s pin when `spec.cluster.kubernetesVersion` is unset.
- `normalizePinnedVersion`'s "already at it" check now compares **parsed semver**, not raw strings, so the unprefixed SDK pin `0.34.1` matches an unprefixed current `0.34.1` (it previously v-prefixed the pin → `"0.34.1" != "v0.34.1"` → fell through to a phantom upgrade).

The optional "a newer upstream version is available" hint from the issue is deliberately **omitted** — it would add an OCI-discovery call purely for an informational message; the idempotency fix doesn't need it.

## Tests

- `normalizePinnedVersion`: regression cases for unprefixed-pin vs unprefixed/v-prefixed current → `AlreadyAtIt` (the bug's exact signature).
- VCluster: `PinnedDistributionVersion == ChartVersion()`, `PinnedKubernetesVersion == DefaultKubernetesVersion`.
- Talos/Kind/K3d: `PinnedKubernetesVersion == ""` (behaviour unchanged).

## Validation

`go build` · `go test` (1382 pass in the touched packages) · `gofmt` · `go vet` · `golangci-lint` full-tree (0 issues) + `--new-from-merge-base` (0 new) · `jscpd` (0 new clones — the one reported clone is the pre-existing `reconcileDistributionVersion`/`reconcileKubernetesVersion` signature similarity, slightly *reduced* by this diff). No `pkg/apis`/CLI/schema surface touched, so no generated-file regeneration needed.

## Acceptance criteria (from #5187)

- [x] `ksail cluster update` on an unchanged VCluster config reports no changes / no recreation even when a newer upstream version exists.
- [x] VCluster System Test legs decoupled from upstream publish timing (both dimensions capped at the embedded pin).
- [x] Regression test for "current == SDK pin, newer tag upstream → no upgrade, no recreation".
- [x] Talos pin behaviour unchanged; Kind/K3d discovery-based recreation unchanged.