### PR TITLE
feat(operator): scale, restart, delete & reconcile resources from the operator UI

### DIFF
--- a/pkg/cli/clusterapi/resources.go
+++ b/pkg/cli/clusterapi/resources.go
@@ -3,14 +3,11 @@ package clusterapi
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/operator/api"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -100,17 +97,6 @@ func (s *Service) resolveKindAndClient(
 	return kind, client, nil
 }
 
-// requireNamespace returns an ErrInvalid-wrapped error (→ 422) when a namespaced kind is addressed
-// without a namespace, so single-resource write actions surface a clear message instead of an opaque
-// API-server 500 from an empty-namespace request.
-func requireNamespace(kind api.ResourceKind, ref api.ResourceRef) error {
-	if kind.Namespaced && ref.Namespace == "" {
-		return fmt.Errorf("%w: namespace is required for %q", api.ErrInvalid, ref.Kind)
-	}
-
-	return nil
-}
-
 // ListResources lists resources of the requested (allowlisted) kind from the named cluster. A
 // namespaced kind with an empty query namespace lists across all namespaces.
 func (s *Service) ListResources(
@@ -150,126 +136,75 @@ func (s *Service) GetResource(
 	return obj, nil
 }
 
-// ScaleResource sets the replica count of a scalable workload via a merge patch on spec.replicas.
+// ScaleResource sets the replica count of a scalable workload. The validation and merge-patch logic
+// is shared with the operator backend via api.ScaleResourceWith; only the dynamic-client resolution
+// (kubeconfig context for the named local cluster) differs.
 func (s *Service) ScaleResource(
 	ctx context.Context,
 	_, name string,
 	ref api.ResourceRef,
 	replicas int32,
 ) error {
-	if !api.ResourceKindScalable(ref.Kind) {
-		return fmt.Errorf("%w: %q is not scalable", api.ErrInvalid, ref.Kind)
-	}
-
-	if replicas < 0 {
-		return fmt.Errorf("%w: replicas must be >= 0", api.ErrInvalid)
-	}
-
-	patch := fmt.Appendf(nil, `{"spec":{"replicas":%d}}`, replicas)
-
-	return s.mergePatch(ctx, name, "scale", ref, patch)
-}
-
-// RestartResource triggers a rolling restart by stamping the pod template's restartedAt annotation —
-// the same mechanism `kubectl rollout restart` uses. The stamp is nanosecond-resolution so two
-// restarts issued within the same second still change the value and reliably roll the workload.
-func (s *Service) RestartResource(ctx context.Context, _, name string, ref api.ResourceRef) error {
-	if !api.ResourceKindRestartable(ref.Kind) {
-		return fmt.Errorf("%w: %q does not support rollout restart", api.ErrInvalid, ref.Kind)
-	}
-
-	patch := fmt.Appendf(
-		nil,
-		`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`,
-		time.Now().Format(time.RFC3339Nano),
-	)
-
-	return s.mergePatch(ctx, name, "restart", ref, patch)
-}
-
-// mergePatch resolves the kind + dynamic client for the named cluster, requires a namespace for the
-// target, and applies a JSON merge patch. verb labels the error ("scale", "restart"). Shared by the
-// scale/restart write actions so the resolve-and-patch boilerplate lives in one place.
-func (s *Service) mergePatch(
-	ctx context.Context,
-	name, verb string,
-	ref api.ResourceRef,
-	patch []byte,
-) error {
-	kind, client, err := s.resolveKindAndClient(ctx, name, ref.Kind)
+	client, err := s.newDynamicClient(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	err = requireNamespace(kind, ref)
+	err = api.ScaleResourceWith(ctx, client, ref, replicas)
 	if err != nil {
-		return err
-	}
-
-	_, err = client.Resource(kind.GVR).Namespace(ref.Namespace).
-		Patch(ctx, ref.Name, types.MergePatchType, patch, metav1.PatchOptions{})
-	if err != nil {
-		return fmt.Errorf("%s %s %q: %w", verb, ref.Kind, ref.Name, err)
+		return fmt.Errorf("scale resource in cluster %q: %w", name, err)
 	}
 
 	return nil
 }
 
-// ReconcileResource triggers an immediate GitOps reconcile by stamping the engine-specific
-// annotation — the same mechanism `flux reconcile` / an ArgoCD refresh use. Flux watches
-// reconcile.fluxcd.io/requestedAt (nanosecond stamp so repeats differ); ArgoCD watches
-// argocd.argoproj.io/refresh.
+// RestartResource triggers a rolling restart of a workload, delegating the restartedAt-annotation
+// patch to the shared api.RestartResourceWith.
+func (s *Service) RestartResource(ctx context.Context, _, name string, ref api.ResourceRef) error {
+	client, err := s.newDynamicClient(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	err = api.RestartResourceWith(ctx, client, ref)
+	if err != nil {
+		return fmt.Errorf("restart resource in cluster %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// ReconcileResource triggers an immediate GitOps reconcile of a Flux/ArgoCD resource, delegating the
+// engine-specific annotation patch to the shared api.ReconcileResourceWith.
 func (s *Service) ReconcileResource(
 	ctx context.Context,
 	_, name string,
 	ref api.ResourceRef,
 ) error {
-	if !api.ResourceKindReconcilable(ref.Kind) {
-		return fmt.Errorf("%w: %q does not support reconcile", api.ErrInvalid, ref.Kind)
+	client, err := s.newDynamicClient(ctx, name)
+	if err != nil {
+		return err
 	}
 
-	key, value := reconcileAnnotation(ref.Kind)
-	patch := fmt.Appendf(nil, `{"metadata":{"annotations":{%q:%q}}}`, key, value)
-
-	return s.mergePatch(ctx, name, "reconcile", ref, patch)
-}
-
-// reconcileAnnotation returns the metadata annotation (key, value) that triggers a reconcile for the
-// kind's GitOps engine.
-func reconcileAnnotation(kind string) (string, string) {
-	if kind == "Application" {
-		return "argocd.argoproj.io/refresh", "normal"
+	err = api.ReconcileResourceWith(ctx, client, ref)
+	if err != nil {
+		return fmt.Errorf("reconcile resource in cluster %q: %w", name, err)
 	}
 
-	return "reconcile.fluxcd.io/requestedAt", time.Now().Format(time.RFC3339Nano)
+	return nil
 }
 
-// DeleteResource deletes a namespaced allowlisted resource. Cluster-scoped kinds (Node, Namespace)
-// are intentionally NOT deletable from the workload browser — those are high-blast-radius operations
-// (a Namespace delete cascades to everything in it) better left to the CLI.
+// DeleteResource deletes a namespaced allowlisted resource, delegating the namespaced-only guard and
+// delete to the shared api.DeleteResourceWith.
 func (s *Service) DeleteResource(ctx context.Context, _, name string, ref api.ResourceRef) error {
-	kind, client, err := s.resolveKindAndClient(ctx, name, ref.Kind)
+	client, err := s.newDynamicClient(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	if !kind.Namespaced {
-		return fmt.Errorf(
-			"%w: cluster-scoped %q cannot be deleted from the workload browser",
-			api.ErrInvalid,
-			ref.Kind,
-		)
-	}
-
-	err = requireNamespace(kind, ref)
+	err = api.DeleteResourceWith(ctx, client, ref)
 	if err != nil {
-		return err
-	}
-
-	err = client.Resource(kind.GVR).Namespace(ref.Namespace).
-		Delete(ctx, ref.Name, metav1.DeleteOptions{})
-	if err != nil {
-		return fmt.Errorf("delete %s %q: %w", ref.Kind, ref.Name, err)
+		return fmt.Errorf("delete resource in cluster %q: %w", name, err)
 	}
 
 	return nil

--- a/pkg/operator/api/cr_resources.go
+++ b/pkg/operator/api/cr_resources.go
@@ -28,8 +28,12 @@ type crConnectedClusterService struct {
 	newDynamicClient childDynamicClientFunc
 }
 
-// Ensure the connected operator backend exposes the read-only resource browser.
-var _ ResourceService = (*crConnectedClusterService)(nil)
+// Ensure the connected operator backend exposes the read-only resource browser and the safe write
+// actions (scale, rollout restart, delete, GitOps reconcile).
+var (
+	_ ResourceService = (*crConnectedClusterService)(nil)
+	_ ResourceWriter  = (*crConnectedClusterService)(nil)
+)
 
 // NewCRClusterServiceWithResources returns an operator ClusterService that can also browse resources in
 // each cluster's managed child cluster, using newDynamicClient to connect to it.
@@ -79,6 +83,68 @@ func (s *crConnectedClusterService) GetResource(
 	}
 
 	return GetResourceWith(ctx, dyn, kind, ref)
+}
+
+// ScaleResource sets the replica count of a scalable workload in the named cluster's managed child
+// cluster. The validation and merge-patch logic is shared with the local backend via
+// api.ScaleResourceWith; only the dynamic-client resolution (the vcluster connection) differs.
+func (s *crConnectedClusterService) ScaleResource(
+	ctx context.Context,
+	namespace, name string,
+	ref ResourceRef,
+	replicas int32,
+) error {
+	dyn, err := s.dynamicClientForCluster(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	return ScaleResourceWith(ctx, dyn, ref, replicas)
+}
+
+// RestartResource triggers a rolling restart of a workload in the named cluster's managed child
+// cluster.
+func (s *crConnectedClusterService) RestartResource(
+	ctx context.Context,
+	namespace, name string,
+	ref ResourceRef,
+) error {
+	dyn, err := s.dynamicClientForCluster(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	return RestartResourceWith(ctx, dyn, ref)
+}
+
+// ReconcileResource triggers an immediate GitOps reconcile of a Flux/ArgoCD resource in the named
+// cluster's managed child cluster.
+func (s *crConnectedClusterService) ReconcileResource(
+	ctx context.Context,
+	namespace, name string,
+	ref ResourceRef,
+) error {
+	dyn, err := s.dynamicClientForCluster(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	return ReconcileResourceWith(ctx, dyn, ref)
+}
+
+// DeleteResource deletes a namespaced allowlisted resource from the named cluster's managed child
+// cluster.
+func (s *crConnectedClusterService) DeleteResource(
+	ctx context.Context,
+	namespace, name string,
+	ref ResourceRef,
+) error {
+	dyn, err := s.dynamicClientForCluster(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	return DeleteResourceWith(ctx, dyn, ref)
 }
 
 // dynamicClientForCluster resolves the named Cluster CR and builds a dynamic client against its managed

--- a/pkg/operator/api/cr_resources_test.go
+++ b/pkg/operator/api/cr_resources_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/operator/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -18,10 +20,44 @@ import (
 
 const (
 	kindConfigMap   = "ConfigMap"
+	kindDeployment  = "Deployment"
+	kindPod         = "Pod"
 	nsDefault       = "default"
 	configMapName   = "cfg"
+	deploymentName  = "web"
 	sampleClusterID = "c1"
 )
+
+func testDeployment(namespace, name string, replicas int32) *appsv1.Deployment {
+	count := replicas
+
+	return &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: kindDeployment, APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       appsv1.DeploymentSpec{Replicas: &count},
+	}
+}
+
+// testGitOpsCR builds an unstructured Flux/ArgoCD custom resource. The fake dynamic client guesses its
+// GVR from the GVK (Kustomization→kustomizations), matching the allowlist mapping, so a reconcile
+// merge-patch round-trips without registering real CRD schemes.
+func testGitOpsCR(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(apiVersion)
+	obj.SetKind(kind)
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+
+	return obj
+}
+
+// newConnectedService builds a connected operator service with the sample Cluster CR present in the hub
+// and the given fake dynamic client standing in for the cluster's managed child cluster.
+func newConnectedService(t *testing.T, dyn dynamic.Interface) api.ClusterService {
+	t.Helper()
+
+	return api.NewCRClusterServiceWithResources(newClient(t, sampleCluster()), childResolver(dyn))
+}
 
 var errResolveBoom = errors.New("cannot reach child cluster")
 
@@ -124,4 +160,182 @@ func TestCRPlainServiceHasNoResourceBrowser(t *testing.T) {
 	service := api.NewCRClusterService(newClient(t))
 	_, ok := service.(api.ResourceService)
 	assert.False(t, ok, "plain operator service must not implement ResourceService")
+}
+
+// TestCRPlainServiceHasNoResourceWriter documents that the plain operator backend does not advertise
+// the write actions — only the connected variant (with a child-cluster resolver) does.
+func TestCRPlainServiceHasNoResourceWriter(t *testing.T) {
+	t.Parallel()
+
+	service := api.NewCRClusterService(newClient(t))
+	_, ok := service.(api.ResourceWriter)
+	assert.False(t, ok, "plain operator service must not implement ResourceWriter")
+}
+
+func TestCRConnectedScaleResource(t *testing.T) {
+	t.Parallel()
+
+	dyn := dynamicfake.NewSimpleDynamicClient(
+		clientgoscheme.Scheme,
+		testDeployment(nsDefault, deploymentName, 1),
+	)
+	service := newConnectedService(t, dyn)
+
+	writer, ok := service.(api.ResourceWriter)
+	require.True(t, ok, "connected operator service must implement ResourceWriter")
+
+	ref := api.ResourceRef{Kind: kindDeployment, Namespace: nsDefault, Name: deploymentName}
+	require.NoError(
+		t,
+		writer.ScaleResource(context.Background(), defaultNS, sampleClusterID, ref, 4),
+	)
+
+	reader, _ := service.(api.ResourceService)
+
+	obj, err := reader.GetResource(context.Background(), defaultNS, sampleClusterID, ref)
+	require.NoError(t, err)
+
+	replicas, found, err := unstructured.NestedInt64(obj.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, int64(4), replicas)
+}
+
+func TestCRConnectedScaleRejectsNonScalableKind(t *testing.T) {
+	t.Parallel()
+
+	dyn := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	writer, _ := newConnectedService(t, dyn).(api.ResourceWriter)
+
+	err := writer.ScaleResource(
+		context.Background(), defaultNS, sampleClusterID,
+		api.ResourceRef{Kind: kindPod, Namespace: nsDefault, Name: "p1"}, 2,
+	)
+	require.ErrorIs(t, err, api.ErrInvalid)
+}
+
+func TestCRConnectedRestartStampsAnnotation(t *testing.T) {
+	t.Parallel()
+
+	dyn := dynamicfake.NewSimpleDynamicClient(
+		clientgoscheme.Scheme,
+		testDeployment(nsDefault, deploymentName, 1),
+	)
+	service := newConnectedService(t, dyn)
+	writer, _ := service.(api.ResourceWriter)
+
+	ref := api.ResourceRef{Kind: kindDeployment, Namespace: nsDefault, Name: deploymentName}
+	require.NoError(
+		t,
+		writer.RestartResource(context.Background(), defaultNS, sampleClusterID, ref),
+	)
+
+	reader, _ := service.(api.ResourceService)
+
+	obj, err := reader.GetResource(context.Background(), defaultNS, sampleClusterID, ref)
+	require.NoError(t, err)
+
+	stamp, found, err := unstructured.NestedString(
+		obj.Object, "spec", "template", "metadata", "annotations",
+		"kubectl.kubernetes.io/restartedAt",
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.NotEmpty(t, stamp)
+}
+
+func TestCRConnectedDeleteResource(t *testing.T) {
+	t.Parallel()
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: nsDefault},
+	}
+	dyn := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme, configMap)
+	service := newConnectedService(t, dyn)
+	writer, _ := service.(api.ResourceWriter)
+
+	ref := api.ResourceRef{Kind: kindConfigMap, Namespace: nsDefault, Name: configMapName}
+	require.NoError(t, writer.DeleteResource(context.Background(), defaultNS, sampleClusterID, ref))
+
+	reader, _ := service.(api.ResourceService)
+
+	list, err := reader.ListResources(
+		context.Background(), defaultNS, sampleClusterID, api.ResourceQuery{Kind: kindConfigMap},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, list.Items)
+}
+
+func TestCRConnectedDeleteRejectsClusterScopedKind(t *testing.T) {
+	t.Parallel()
+
+	dyn := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	writer, _ := newConnectedService(t, dyn).(api.ResourceWriter)
+
+	// Node is cluster-scoped: deletion is intentionally not allowed from the workload browser.
+	err := writer.DeleteResource(
+		context.Background(), defaultNS, sampleClusterID,
+		api.ResourceRef{Kind: "Node", Name: "node-1"},
+	)
+	require.ErrorIs(t, err, api.ErrInvalid)
+}
+
+func TestCRConnectedReconcileStampsFluxAnnotation(t *testing.T) {
+	t.Parallel()
+
+	dyn := dynamicfake.NewSimpleDynamicClient(
+		clientgoscheme.Scheme,
+		testGitOpsCR("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "flux-system", "apps"),
+	)
+	service := newConnectedService(t, dyn)
+	writer, _ := service.(api.ResourceWriter)
+
+	ref := api.ResourceRef{Kind: "Kustomization", Namespace: "flux-system", Name: "apps"}
+	require.NoError(
+		t,
+		writer.ReconcileResource(context.Background(), defaultNS, sampleClusterID, ref),
+	)
+
+	reader, _ := service.(api.ResourceService)
+
+	obj, err := reader.GetResource(context.Background(), defaultNS, sampleClusterID, ref)
+	require.NoError(t, err)
+
+	stamp, found, err := unstructured.NestedString(
+		obj.Object, "metadata", "annotations", "reconcile.fluxcd.io/requestedAt",
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.NotEmpty(t, stamp)
+}
+
+func TestCRConnectedReconcileRejectsNonReconcilableKind(t *testing.T) {
+	t.Parallel()
+
+	dyn := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	writer, _ := newConnectedService(t, dyn).(api.ResourceWriter)
+
+	err := writer.ReconcileResource(
+		context.Background(), defaultNS, sampleClusterID,
+		api.ResourceRef{Kind: kindPod, Namespace: nsDefault, Name: "p1"},
+	)
+	require.ErrorIs(t, err, api.ErrInvalid)
+}
+
+// TestCRConnectedWriteResolverError confirms a failure to connect to the child cluster surfaces from a
+// write action (not just the read paths).
+func TestCRConnectedWriteResolverError(t *testing.T) {
+	t.Parallel()
+
+	resolver := func(context.Context, *v1alpha1.Cluster) (dynamic.Interface, error) {
+		return nil, errResolveBoom
+	}
+	service := api.NewCRClusterServiceWithResources(newClient(t, sampleCluster()), resolver)
+	writer, _ := service.(api.ResourceWriter)
+
+	err := writer.ScaleResource(
+		context.Background(), defaultNS, sampleClusterID,
+		api.ResourceRef{Kind: kindDeployment, Namespace: nsDefault, Name: deploymentName}, 2,
+	)
+	require.ErrorIs(t, err, errResolveBoom)
 }

--- a/pkg/operator/api/resources.go
+++ b/pkg/operator/api/resources.go
@@ -3,10 +3,12 @@ package api
 import (
 	"context"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -235,4 +237,140 @@ func ResourceKindReconcilable(kind string) bool {
 	default:
 		return false
 	}
+}
+
+// requireNamespace returns an ErrInvalid-wrapped error (→ 422) when a namespaced kind is addressed
+// without a namespace, so single-resource write actions surface a clear message instead of an opaque
+// API-server 500 from an empty-namespace request.
+func requireNamespace(kind ResourceKind, ref ResourceRef) error {
+	if kind.Namespaced && ref.Namespace == "" {
+		return fmt.Errorf("%w: namespace is required for %q", ErrInvalid, ref.Kind)
+	}
+
+	return nil
+}
+
+// mergePatchWith resolves the allowlisted kind, requires a namespace for the target, and applies a
+// JSON merge patch via the dynamic client. verb labels the error ("scale", "restart", "reconcile").
+// Shared by the scale/restart/reconcile write actions so the resolve-and-patch boilerplate lives in
+// one place across the local and operator backends.
+func mergePatchWith(
+	ctx context.Context,
+	dyn dynamic.Interface,
+	verb string,
+	ref ResourceRef,
+	patch []byte,
+) error {
+	kind, err := ResourceKindFor(ref.Kind)
+	if err != nil {
+		return err
+	}
+
+	err = requireNamespace(kind, ref)
+	if err != nil {
+		return err
+	}
+
+	_, err = dyn.Resource(kind.GVR).Namespace(ref.Namespace).
+		Patch(ctx, ref.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("%s %s %q: %w", verb, ref.Kind, ref.Name, err)
+	}
+
+	return nil
+}
+
+// ScaleResourceWith sets the replica count of a scalable workload via a merge patch on spec.replicas.
+// Shared by the local and operator ResourceWriter backends; the only per-backend difference is how the
+// dynamic client is obtained.
+func ScaleResourceWith(
+	ctx context.Context,
+	dyn dynamic.Interface,
+	ref ResourceRef,
+	replicas int32,
+) error {
+	if !ResourceKindScalable(ref.Kind) {
+		return fmt.Errorf("%w: %q is not scalable", ErrInvalid, ref.Kind)
+	}
+
+	if replicas < 0 {
+		return fmt.Errorf("%w: replicas must be >= 0", ErrInvalid)
+	}
+
+	patch := fmt.Appendf(nil, `{"spec":{"replicas":%d}}`, replicas)
+
+	return mergePatchWith(ctx, dyn, "scale", ref, patch)
+}
+
+// RestartResourceWith triggers a rolling restart by stamping the pod template's restartedAt annotation
+// — the same mechanism `kubectl rollout restart` uses. The stamp is nanosecond-resolution so two
+// restarts issued within the same second still change the value and reliably roll the workload.
+func RestartResourceWith(ctx context.Context, dyn dynamic.Interface, ref ResourceRef) error {
+	if !ResourceKindRestartable(ref.Kind) {
+		return fmt.Errorf("%w: %q does not support rollout restart", ErrInvalid, ref.Kind)
+	}
+
+	patch := fmt.Appendf(
+		nil,
+		`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`,
+		time.Now().Format(time.RFC3339Nano),
+	)
+
+	return mergePatchWith(ctx, dyn, "restart", ref, patch)
+}
+
+// ReconcileResourceWith triggers an immediate GitOps reconcile by stamping the engine-specific
+// annotation — the same mechanism `flux reconcile` / an ArgoCD refresh use. Flux watches
+// reconcile.fluxcd.io/requestedAt (nanosecond stamp so repeats differ); ArgoCD watches
+// argocd.argoproj.io/refresh.
+func ReconcileResourceWith(ctx context.Context, dyn dynamic.Interface, ref ResourceRef) error {
+	if !ResourceKindReconcilable(ref.Kind) {
+		return fmt.Errorf("%w: %q does not support reconcile", ErrInvalid, ref.Kind)
+	}
+
+	key, value := reconcileAnnotation(ref.Kind)
+	patch := fmt.Appendf(nil, `{"metadata":{"annotations":{%q:%q}}}`, key, value)
+
+	return mergePatchWith(ctx, dyn, "reconcile", ref, patch)
+}
+
+// reconcileAnnotation returns the metadata annotation (key, value) that triggers a reconcile for the
+// kind's GitOps engine.
+func reconcileAnnotation(kind string) (string, string) {
+	if kind == "Application" {
+		return "argocd.argoproj.io/refresh", "normal"
+	}
+
+	return "reconcile.fluxcd.io/requestedAt", time.Now().Format(time.RFC3339Nano)
+}
+
+// DeleteResourceWith deletes a namespaced allowlisted resource. Cluster-scoped kinds (Node, Namespace)
+// are intentionally NOT deletable from the workload browser — those are high-blast-radius operations
+// (a Namespace delete cascades to everything in it) better left to the CLI. Shared by both backends.
+func DeleteResourceWith(ctx context.Context, dyn dynamic.Interface, ref ResourceRef) error {
+	kind, err := ResourceKindFor(ref.Kind)
+	if err != nil {
+		return err
+	}
+
+	if !kind.Namespaced {
+		return fmt.Errorf(
+			"%w: cluster-scoped %q cannot be deleted from the workload browser",
+			ErrInvalid,
+			ref.Kind,
+		)
+	}
+
+	err = requireNamespace(kind, ref)
+	if err != nil {
+		return err
+	}
+
+	err = dyn.Resource(kind.GVR).Namespace(ref.Namespace).
+		Delete(ctx, ref.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("delete %s %q: %w", ref.Kind, ref.Name, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## What

Brings the **operator's in-cluster dashboard** to parity with the local `ksail ui` / desktop console for **write actions on browsable resources**: scale, rollout restart, delete, and GitOps reconcile.

Until now the operator backend (`crConnectedClusterService`) implemented only the read-only resource browser ([#5180](https://github.com/devantler-tech/ksail/pull/5180)), so the OIDC-authenticated operator console could *browse* workloads but not *act* on them — even though the local backend already had all of these actions.

## How

- Implement `api.ResourceWriter` (`ScaleResource` / `RestartResource` / `DeleteResource` / `ReconcileResource`) on the connected operator backend, reusing its existing child-cluster dynamic client.
- The `workloadWrite` capability flag, the mutating routes, the read-only guard, and the SPA action affordances **all derive from the interface** — so the operator console lights up the actions automatically, with no frontend change. They remain gated by the server's read-only mode and the operator's RBAC.
- To avoid duplicating the validation + merge-patch logic across the local and operator backends (which jscpd would flag), the write logic is extracted into shared `api.{Scale,Restart,Reconcile,Delete}ResourceWith` helpers — mirroring the existing `ListResourcesWith` / `GetResourceWith`. The local backend now delegates to them too; its behavior is unchanged.

## Tests

Fake-dynamic-client unit tests for the operator scale/restart/delete/reconcile happy paths, the predicate rejections (non-scalable / non-restartable / non-reconcilable / cluster-scoped-delete), and a child-connection error. Local backend tests still pass (behavior-preserving refactor).

Validation: `go build ./...`, `go vet`, `go test -race ./pkg/operator/api/... ./pkg/cli/clusterapi/...`, `golangci-lint run --new-from-rev=HEAD` (0 issues), `jscpd` (0 clones).

> Not live-verifiable here: the operator runs in-cluster and reaches the managed (vcluster) child via its in-cluster Service DNS, which is unreachable from a dev box — same constraint as the read slice. Covered by the fake-client unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)