### PR TITLE
feat(ui): polish a11y, branding, and UX; fix log-follow and stale-state bugs

### DIFF
--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="KSail — manage local Kubernetes clusters and GitOps workloads." />
+    <!-- Match the page background (slate-50 / slate-950) so browser chrome blends with the theme. -->
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f8fafc" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#020617" />
     <title>KSail</title>
     <!-- Render-blocking, same-origin theme init (no inline script, so it passes the operator CSP). -->
     <script src="/theme-init.js"></script>

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -1,7 +1,6 @@
 import { Dialog, DialogPanel, Transition, TransitionChild } from "@headlessui/react";
 import {
   Activity,
-  Boxes,
   KeyRound,
   Layers,
   LayoutDashboard,
@@ -18,7 +17,12 @@ import { Fragment, useState, type ReactNode } from "react";
 import type { Cluster, User } from "../api.ts";
 import type { Theme } from "../hooks/useTheme.ts";
 import { ClusterSwitcher } from "./ClusterSwitcher.tsx";
+import { KSailMark } from "./Logo.tsx";
 import { IconButton } from "./ui.tsx";
+
+// isMacLike picks the platform-appropriate shortcut hint for the search button (the handler accepts
+// both ⌘K and Ctrl+K regardless; this only affects the displayed kbd).
+const isMacLike = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
 
 // View is the top-level SPA section. Cluster-scoped views (overview/resources/events) operate on the
 // active cluster; the rest are global. Routing is view-state (no router dependency).
@@ -77,7 +81,7 @@ function SectionLabel({ children }: { children: ReactNode }) {
 function Brand() {
   return (
     <div className="flex h-14 items-center gap-2 border-b border-slate-200 px-5 dark:border-slate-800">
-      <Boxes className="size-6 text-blue-600 dark:text-blue-500" aria-hidden />
+      <KSailMark className="size-6" />
       <span className="text-lg font-semibold tracking-tight text-slate-900 dark:text-white">KSail</span>
     </div>
   );
@@ -153,7 +157,7 @@ export function AppShell({
   // navContent renders the two zones — the cluster workspace (switcher + scoped nav, only when a
   // cluster is active) above the always-present global zone. onPick lets the drawer close on navigate.
   const navContent = (onPick: (next: View) => void) => (
-    <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-3">
+    <nav className="flex flex-1 flex-col gap-1 overflow-y-auto overscroll-contain p-3">
       {activeClusterKey ? (
         <>
           <div className="pb-1">
@@ -174,6 +178,13 @@ export function AppShell({
 
   return (
     <div className="flex h-full">
+      {/* Keyboard users can jump straight past the chrome to the active view's content. */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[80] focus:rounded-md focus:bg-blue-600 focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
+      >
+        Skip to content
+      </a>
       {/* Persistent sidebar at md+; replaced by the drawer below md. */}
       <aside className="hidden w-64 shrink-0 flex-col border-r border-slate-200 bg-white md:flex dark:border-slate-800 dark:bg-slate-900">
         <Brand />
@@ -245,7 +256,7 @@ export function AppShell({
                 <Search className="size-4" aria-hidden />
                 <span className="hidden lg:inline">Search</span>
                 <kbd className="hidden rounded border border-slate-300 px-1 font-sans text-[10px] text-slate-400 sm:inline dark:border-slate-600">
-                  ⌘K
+                  {isMacLike ? "⌘K" : "Ctrl K"}
                 </kbd>
               </button>
             ) : null}
@@ -269,7 +280,7 @@ export function AppShell({
           </div>
         </header>
 
-        <main className="flex-1 overflow-y-auto p-4 md:p-6">{children}</main>
+        <main id="main-content" className="flex-1 overflow-y-auto p-4 md:p-6">{children}</main>
       </div>
     </div>
   );

--- a/web/ui/src/components/ApplyManifestsDialog.tsx
+++ b/web/ui/src/components/ApplyManifestsDialog.tsx
@@ -28,7 +28,9 @@ export function ApplyManifestsDialog({
   const [manifests, setManifests] = useState("");
   const [results, setResults] = useState<ApplyResult[] | null>(null);
   const [lastDryRun, setLastDryRun] = useState(false);
-  const [busy, setBusy] = useState(false);
+  // busy tracks WHICH action is running (null = idle) so only the clicked button shows its spinner
+  // while both stay disabled.
+  const [busy, setBusy] = useState<"validate" | "apply" | null>(null);
   // A hidden file input drives the "Load from file…" button. In the desktop webview (WKWebView /
   // WebView2 / WebKitGTK) this opens the OS-native file picker; in a browser it opens the browser's —
   // so manifests can be loaded from disk on every surface with no Wails-specific binding.
@@ -70,7 +72,7 @@ export function ApplyManifestsDialog({
       return;
     }
 
-    setBusy(true);
+    setBusy(dryRun ? "validate" : "apply");
     setResults(null);
     applyManifests(clusterNamespace, clusterName, manifests, dryRun)
       .then((response) => {
@@ -92,7 +94,7 @@ export function ApplyManifestsDialog({
         }
       })
       .catch((err: unknown) => toast.error(errorMessage(err)))
-      .finally(() => setBusy(false));
+      .finally(() => setBusy(null));
   }
 
   return (
@@ -108,6 +110,7 @@ export function ApplyManifestsDialog({
           onChange={(event) => setManifests(event.target.value)}
           placeholder={PLACEHOLDER}
           spellCheck={false}
+          aria-label="Kubernetes manifests (multi-document YAML)"
           rows={16}
           className="w-full rounded-lg border border-slate-300 bg-white p-3 font-mono text-xs text-slate-800 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
         />
@@ -127,13 +130,18 @@ export function ApplyManifestsDialog({
           }}
         />
         <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => fileInputRef.current?.click()}>
+          <Button variant="secondary" onClick={() => fileInputRef.current?.click()} disabled={busy !== null}>
             Load from file…
           </Button>
-          <Button variant="secondary" onClick={() => run(true)} loading={busy}>
+          <Button
+            variant="secondary"
+            onClick={() => run(true)}
+            loading={busy === "validate"}
+            disabled={busy !== null}
+          >
             Validate (dry run)
           </Button>
-          <Button onClick={() => run(false)} loading={busy}>
+          <Button onClick={() => run(false)} loading={busy === "apply"} disabled={busy !== null}>
             Apply
           </Button>
         </div>

--- a/web/ui/src/components/ClusterFormDialog.tsx
+++ b/web/ui/src/components/ClusterFormDialog.tsx
@@ -138,7 +138,7 @@ function createDefaults(
     name: "",
     namespace: "default",
     distribution,
-    provider: preferredProvider(availableProviders(meta.providers[distribution] ?? [], providerStatus)),
+    provider: preferredProvider(availableProviders(meta.providers[distribution] ?? [], providerStatus), providerStatus),
     controlPlanes: "1",
     workers: "0",
     cni: defaults.cni ?? "",
@@ -244,7 +244,7 @@ export function ClusterFormDialog({
     setValues((current) => ({
       ...current,
       distribution: value,
-      provider: preferredProvider(availableProviders(meta.providers[value] ?? [], providerStatus)),
+      provider: preferredProvider(availableProviders(meta.providers[value] ?? [], providerStatus), providerStatus),
     }));
   }
 
@@ -255,7 +255,10 @@ export function ClusterFormDialog({
     setValues({
       ...base,
       distribution: template.distribution,
-      provider: preferredProvider(availableProviders(meta.providers[template.distribution] ?? [], providerStatus)),
+      provider: preferredProvider(
+        availableProviders(meta.providers[template.distribution] ?? [], providerStatus),
+        providerStatus,
+      ),
       ...template.overrides,
     });
   }
@@ -352,38 +355,26 @@ export function ClusterFormDialog({
         {yamlEnabled ? (
           <div className="flex justify-end">
             <div className="inline-flex overflow-hidden rounded-md ring-1 ring-inset ring-slate-300 dark:ring-slate-700">
-              <button
-                type="button"
-                onClick={() => {
-                  if (view !== "form") {
-                    showForm();
-                  }
-                }}
-                className={cx(
-                  "px-3 py-1 text-xs font-medium",
-                  view === "form"
-                    ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
-                    : "bg-white text-slate-600 dark:bg-slate-800 dark:text-slate-300",
-                )}
-              >
-                Form
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  if (view !== "yaml") {
-                    showYaml();
-                  }
-                }}
-                className={cx(
-                  "px-3 py-1 text-xs font-medium",
-                  view === "yaml"
-                    ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
-                    : "bg-white text-slate-600 dark:bg-slate-800 dark:text-slate-300",
-                )}
-              >
-                YAML
-              </button>
+              {(["form", "yaml"] as const).map((target) => (
+                <button
+                  key={target}
+                  type="button"
+                  aria-pressed={view === target}
+                  onClick={() => {
+                    if (view !== target) {
+                      (target === "form" ? showForm : showYaml)();
+                    }
+                  }}
+                  className={cx(
+                    "px-3 py-1 text-xs font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-blue-600",
+                    view === target
+                      ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
+                      : "bg-white text-slate-600 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700",
+                  )}
+                >
+                  {target === "form" ? "Form" : "YAML"}
+                </button>
+              ))}
             </div>
           </div>
         ) : null}
@@ -427,17 +418,28 @@ export function ClusterFormDialog({
             ) : null}
             <TextField
               label="Name"
+              name="cluster-name"
               value={values.name}
               autoFocus={!isEdit}
               disabled={isEdit}
+              required={!isEdit}
+              // RFC 1123 DNS label, like the API enforces — surfaces as inline native validation
+              // instead of a silent no-op submit.
+              pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+              title="Lowercase letters, digits, and hyphens; must start and end with a letter or digit"
+              autoComplete="off"
+              spellCheck={false}
               placeholder="my-cluster"
               onChange={(event) => setField("name", event.target.value)}
             />
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <TextField
                 label="Namespace"
+                name="cluster-namespace"
                 value={values.namespace}
                 disabled={isEdit}
+                autoComplete="off"
+                spellCheck={false}
                 onChange={(event) => setField("namespace", event.target.value)}
               />
               <SelectField
@@ -493,6 +495,7 @@ export function ClusterFormDialog({
                       label="Control planes"
                       type="number"
                       min={0}
+                      inputMode="numeric"
                       value={values.controlPlanes}
                       onChange={(event) => setField("controlPlanes", event.target.value)}
                     />
@@ -500,6 +503,7 @@ export function ClusterFormDialog({
                       label="Workers"
                       type="number"
                       min={0}
+                      inputMode="numeric"
                       value={values.workers}
                       onChange={(event) => setField("workers", event.target.value)}
                     />

--- a/web/ui/src/components/ClusterSwitcher.tsx
+++ b/web/ui/src/components/ClusterSwitcher.tsx
@@ -42,8 +42,11 @@ export function ClusterSwitcher({
         </span>
         <ChevronsUpDown className="size-4 shrink-0 text-slate-400" aria-hidden />
       </MenuButton>
-      <MenuItems className="absolute z-30 mt-1 w-full origin-top overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg focus:outline-none dark:border-slate-700 dark:bg-slate-800">
-        <div className="max-h-72 overflow-y-auto p-1">
+      <MenuItems
+        transition
+        className="absolute z-30 mt-1 w-full origin-top overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg transition duration-100 ease-out focus:outline-none data-[closed]:scale-95 data-[closed]:opacity-0 dark:border-slate-700 dark:bg-slate-800"
+      >
+        <div className="max-h-72 overflow-y-auto overscroll-contain p-1">
           {clusters.map((cluster) => {
             const key = clusterKey(cluster);
 

--- a/web/ui/src/components/ClustersTable.tsx
+++ b/web/ui/src/components/ClustersTable.tsx
@@ -154,7 +154,7 @@ export function ClustersTable({
                           event.stopPropagation();
                           onEdit(cluster);
                         }}
-                        className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-200"
+                        className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-600 dark:hover:bg-slate-700 dark:hover:text-slate-200"
                       >
                         <Pencil className="size-4" />
                       </button>
@@ -167,7 +167,7 @@ export function ClustersTable({
                           event.stopPropagation();
                           onDelete(cluster);
                         }}
-                        className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+                        className="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-red-600 dark:hover:bg-red-500/10 dark:hover:text-red-400"
                       >
                         <Trash2 className="size-4" />
                       </button>

--- a/web/ui/src/components/CommandPalette.tsx
+++ b/web/ui/src/components/CommandPalette.tsx
@@ -86,13 +86,16 @@ export function CommandPalette({
                   <Search className="size-4 shrink-0 text-slate-400" aria-hidden />
                   <ComboboxInput
                     autoFocus
+                    aria-label="Search commands and clusters"
+                    autoComplete="off"
+                    spellCheck={false}
                     className="w-full bg-transparent py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none dark:text-white"
                     placeholder="Search commands and clusters…"
                     displayValue={() => ""}
                     onChange={(event) => setQuery(event.target.value)}
                   />
                 </div>
-                <ComboboxOptions static className="max-h-80 overflow-y-auto p-2">
+                <ComboboxOptions static className="max-h-80 overflow-y-auto overscroll-contain p-2">
                   {filtered.length === 0 ? (
                     <div className="px-3 py-6 text-center text-sm text-slate-500 dark:text-slate-400">No matches</div>
                   ) : (

--- a/web/ui/src/components/EventsView.tsx
+++ b/web/ui/src/components/EventsView.tsx
@@ -1,4 +1,4 @@
-import { RotateCw } from "lucide-react";
+import { Activity, RotateCw } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { Cluster } from "../api.ts";
 import { useResourceList } from "../hooks/useResourceList.ts";
@@ -56,7 +56,8 @@ export function EventsView({ cluster }: { cluster: Cluster | null }) {
         </SelectField>
         <TextField
           label="Search"
-          placeholder="reason, object, message"
+          type="search"
+          placeholder="reason, object, message…"
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           className="min-w-52"
@@ -73,6 +74,7 @@ export function EventsView({ cluster }: { cluster: Cluster | null }) {
         empty={rows.length === 0}
         emptyTitle="No events"
         emptyDescription="Nothing to show for this selection."
+        emptyIcon={<Activity className="size-6" aria-hidden />}
         onRetry={refresh}
       >
         <TableCard>

--- a/web/ui/src/components/LogViewer.tsx
+++ b/web/ui/src/components/LogViewer.tsx
@@ -1,3 +1,4 @@
+import { ArrowDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { logsEventSourceURL } from "../api.ts";
 
@@ -5,10 +6,16 @@ import { logsEventSourceURL } from "../api.ts";
 // lines scroll off (kubectl-logs-style tail).
 const MAX_LINES = 5000;
 
+// FOLLOW_THRESHOLD_PX is how close to the bottom (in px) the pane must be to count as "following".
+// Slightly generous so sub-line rounding or a trailing partial scroll doesn't silently stop the tail.
+const FOLLOW_THRESHOLD_PX = 40;
+
 type StreamStatus = "streaming" | "ended" | "error";
 
-// LogViewer streams a pod container's logs over SSE and renders them in a scrollable, auto-following
-// pane. It reconnects to a fresh stream whenever the target (cluster, pod, container) changes.
+// LogViewer streams a pod container's logs over SSE and renders them in a scrollable pane that
+// follows the tail. Scrolling up pauses the follow so scrollback can be read without the next line
+// yanking the view back down; scrolling to the bottom (or the Follow button) resumes it. It
+// reconnects to a fresh stream whenever the target (cluster, pod, container) changes.
 export function LogViewer({
   clusterNamespace,
   clusterName,
@@ -24,11 +31,15 @@ export function LogViewer({
 }) {
   const [lines, setLines] = useState<string[]>([]);
   const [status, setStatus] = useState<StreamStatus>("streaming");
-  const endRef = useRef<HTMLDivElement>(null);
+  // following mirrors "is the pane scrolled to the bottom"; it drives both the auto-scroll and the
+  // Follow affordance shown while paused.
+  const [following, setFollowing] = useState(true);
+  const paneRef = useRef<HTMLPreElement>(null);
 
   useEffect(() => {
     setLines([]);
     setStatus("streaming");
+    setFollowing(true);
 
     const source = new EventSource(logsEventSourceURL(clusterNamespace, clusterName, podNamespace, pod, container));
 
@@ -53,20 +64,58 @@ export function LogViewer({
     return () => source.close();
   }, [clusterNamespace, clusterName, podNamespace, pod, container]);
 
-  // Auto-scroll to the newest line as lines arrive.
+  // Keep the tail in view as lines arrive — but only while the user is at the bottom.
   useEffect(() => {
-    endRef.current?.scrollIntoView({ block: "end" });
-  }, [lines]);
+    const pane = paneRef.current;
+    if (following && pane) {
+      pane.scrollTop = pane.scrollHeight;
+    }
+  }, [lines, following]);
+
+  // handleScroll keeps `following` in sync with where the user scrolled the pane.
+  function handleScroll() {
+    const pane = paneRef.current;
+    if (!pane) {
+      return;
+    }
+
+    setFollowing(pane.scrollHeight - pane.scrollTop - pane.clientHeight < FOLLOW_THRESHOLD_PX);
+  }
+
+  function resumeFollow() {
+    const pane = paneRef.current;
+    if (pane) {
+      pane.scrollTop = pane.scrollHeight;
+    }
+    setFollowing(true);
+  }
 
   const statusLabel = status === "streaming" ? "Streaming…" : status === "ended" ? "Stream ended" : "Disconnected";
 
   return (
     <div className="space-y-2">
-      <pre className="h-[60vh] w-full overflow-auto rounded-lg bg-slate-900 p-3 font-mono text-xs leading-relaxed text-slate-100">
-        {lines.length === 0 ? <span className="text-slate-500">No log output yet…</span> : lines.join("\n")}
-        <div ref={endRef} />
-      </pre>
-      <p className="text-xs text-slate-500 dark:text-slate-400">{statusLabel}</p>
+      <div className="relative">
+        <pre
+          ref={paneRef}
+          onScroll={handleScroll}
+          className="h-[60vh] w-full overflow-auto overscroll-contain rounded-lg bg-slate-900 p-3 font-mono text-xs leading-relaxed text-slate-100"
+        >
+          {lines.length === 0 ? <span className="text-slate-500">No log output yet…</span> : lines.join("\n")}
+        </pre>
+        {!following && status === "streaming" ? (
+          <button
+            type="button"
+            onClick={resumeFollow}
+            className="absolute bottom-3 right-3 inline-flex items-center gap-1.5 rounded-full bg-slate-700/90 px-3 py-1.5 text-xs font-medium text-white shadow-lg transition-colors hover:bg-slate-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            <ArrowDown className="size-3.5" aria-hidden />
+            Follow
+          </button>
+        ) : null}
+      </div>
+      <p className="text-xs text-slate-500 dark:text-slate-400" role="status">
+        {statusLabel}
+      </p>
     </div>
   );
 }

--- a/web/ui/src/components/LoginScreen.tsx
+++ b/web/ui/src/components/LoginScreen.tsx
@@ -1,20 +1,23 @@
-import { Boxes } from "lucide-react";
 import { loginPath } from "../api.ts";
+import { KSailMark } from "./Logo.tsx";
 
 export function LoginScreen() {
   return (
-    <div className="flex min-h-full items-center justify-center p-6">
-      <div className="w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <span className="mx-auto flex size-12 items-center justify-center rounded-xl bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-500">
-          <Boxes className="size-7" aria-hidden />
-        </span>
+    <div className="relative flex min-h-full items-center justify-center overflow-hidden p-6">
+      {/* Soft brand-tinted glow behind the card — atmosphere only, so it is hidden from AT. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(36rem_24rem_at_50%_30%,rgba(46,196,230,0.12),transparent_70%)]"
+      />
+      <div className="relative w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <KSailMark className="mx-auto size-12" />
         <h1 className="mt-4 text-xl font-semibold text-slate-900 dark:text-white">KSail</h1>
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
           Sign in to manage your clusters.
         </p>
         <a
           href={loginPath}
-          className="mt-6 inline-flex w-full items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500"
+          className="mt-6 inline-flex w-full items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
         >
           Sign in
         </a>

--- a/web/ui/src/components/Logo.tsx
+++ b/web/ui/src/components/Logo.tsx
@@ -1,0 +1,18 @@
+// KSailMark is the KSail brand mark — the twin-sail sloop on its navy badge, matching
+// docs/src/assets/logo.svg and the desktop app icon — inlined so the SPA chrome (sidebar brand,
+// login screen) carries the real product identity on every surface without an asset fetch.
+export function KSailMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 512 512" className={className} aria-hidden="true" focusable="false">
+      <rect x="24" y="24" width="464" height="464" rx="108" fill="#143150" />
+      <g transform="translate(256 258) scale(1.12) translate(-256 -258)">
+        <path d="M266 340 L266 142 Q360 224 364 340 Z" fill="#f3f9fd" />
+        <path d="M246 340 L246 172 Q178 244 150 340 Z" fill="#2ec4e6" />
+        <path
+          d="M124 352 C170 338 202 366 256 352 C310 338 342 366 388 352 L388 374 C342 388 310 360 256 374 C202 388 170 360 124 374 Z"
+          fill="#2ec4e6"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/web/ui/src/components/OverviewView.tsx
+++ b/web/ui/src/components/OverviewView.tsx
@@ -49,6 +49,15 @@ interface LiveHealth {
 
 const MAX_WARNINGS = 8;
 
+// WORKLOAD_PLACEHOLDERS keeps the Workloads card's layout stable while live health is still loading
+// (counts render as an em dash instead of a blank card).
+const WORKLOAD_PLACEHOLDERS: { label: string; count?: number }[] = [
+  { label: "Deployments" },
+  { label: "StatefulSets" },
+  { label: "DaemonSets" },
+  { label: "Pods" },
+];
+
 function categorizePods(pods: K8sObject[]): PodSegment[] {
   const counts = { running: 0, notReady: 0, pending: 0, succeeded: 0, failed: 0, other: 0 };
 
@@ -168,7 +177,7 @@ function CopyableEndpoint({ endpoint }: { endpoint: string }) {
         navigator.clipboard
           ?.writeText(endpoint)
           .then(() => toast.success("Endpoint copied"))
-          .catch(() => undefined);
+          .catch(() => toast.error("Copy failed"));
       }}
       className="group inline-flex max-w-full items-center gap-1.5"
     >
@@ -331,7 +340,10 @@ export function OverviewView({
             </div>
             <div className="mt-3 h-2 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
               <div
-                className={cx("h-full rounded-full", nodesHealthy ? "bg-emerald-500" : "bg-amber-500")}
+                className={cx(
+                  "h-full rounded-full transition-[width] duration-500",
+                  nodesHealthy ? "bg-emerald-500" : "bg-amber-500",
+                )}
                 style={{
                   width: health && health.nodesTotal > 0 ? `${(health.nodesReady / health.nodesTotal) * 100}%` : "0%",
                 }}
@@ -340,15 +352,21 @@ export function OverviewView({
           </Card>
 
           <Card title="Pod health" icon={<Activity className="size-3.5" aria-hidden />}>
-            <PodHealth segments={health?.segments ?? []} total={health?.podsTotal ?? 0} />
+            {health ? (
+              <PodHealth segments={health.segments} total={health.podsTotal} />
+            ) : (
+              <p className="text-sm text-slate-500 dark:text-slate-400">Loading…</p>
+            )}
           </Card>
 
           <Card title="Workloads" icon={<Layers className="size-3.5" aria-hidden />}>
             <dl className="grid grid-cols-2 gap-3">
-              {(health?.workloads ?? []).map((workload) => (
+              {(health?.workloads ?? WORKLOAD_PLACEHOLDERS).map((workload) => (
                 <div key={workload.label}>
                   <dt className="text-xs text-slate-500 dark:text-slate-400">{workload.label}</dt>
-                  <dd className="text-xl font-semibold tabular-nums text-slate-900 dark:text-white">{workload.count}</dd>
+                  <dd className="text-xl font-semibold tabular-nums text-slate-900 dark:text-white">
+                    {workload.count ?? "—"}
+                  </dd>
                 </div>
               ))}
             </dl>
@@ -454,7 +472,11 @@ function PodHealth({ segments, total }: { segments: PodSegment[]; total: number 
     <div>
       <div className="flex h-2 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
         {visible.map((segment) => (
-          <div key={segment.key} className={segment.bar} style={{ width: `${(segment.count / total) * 100}%` }} />
+          <div
+            key={segment.key}
+            className={cx(segment.bar, "transition-[width] duration-500")}
+            style={{ width: `${(segment.count / total) * 100}%` }}
+          />
         ))}
       </div>
       <ul className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">

--- a/web/ui/src/components/ResourcesView.tsx
+++ b/web/ui/src/components/ResourcesView.tsx
@@ -1,4 +1,4 @@
-import { Copy, FileCode, RotateCw, ScrollText, SquareTerminal } from "lucide-react";
+import { Copy, FileCode, Layers, RotateCw, ScrollText, SquareTerminal } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import yaml from "js-yaml";
 import {
@@ -306,6 +306,17 @@ export function ResourcesView({
     }
   }, [selected]);
 
+  // Switching the active cluster (sidebar switcher) keeps this view mounted, so close anything still
+  // targeting the previous cluster — a detail panel, log stream, exec session, or confirm dialog —
+  // rather than letting it operate on (or stream from) the wrong cluster.
+  useEffect(() => {
+    setSelected(null);
+    setLogPod(null);
+    setExecPod(null);
+    setDeleteOpen(false);
+    setApplyOpen(false);
+  }, [clusterId]);
+
   // Fetch the events targeting the selected resource (its own namespace, matched by involvedObject),
   // for the detail panel's "Related events" section. Skipped for Events themselves and unnamed
   // objects. Best-effort: a failure just yields no related events.
@@ -453,6 +464,7 @@ export function ResourcesView({
         empty={filtered.length === 0}
         emptyTitle={`No ${kind} resources`}
         emptyDescription="Nothing to show for this selection."
+        emptyIcon={<Layers className="size-6" aria-hidden />}
         onRetry={refresh}
       >
         <TableCard>
@@ -540,14 +552,17 @@ export function ResourcesView({
                       );
                     }}
                   >
-                    <span className="text-xs text-slate-500 dark:text-slate-400">Replicas</span>
-                    <input
-                      type="number"
-                      min={0}
-                      value={scaleValue}
-                      onChange={(event) => setScaleValue(event.target.value)}
-                      className="w-20 rounded-md border border-slate-300 bg-white px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
-                    />
+                    <label className="flex items-center gap-1.5">
+                      <span className="text-xs text-slate-500 dark:text-slate-400">Replicas</span>
+                      <input
+                        type="number"
+                        min={0}
+                        inputMode="numeric"
+                        value={scaleValue}
+                        onChange={(event) => setScaleValue(event.target.value)}
+                        className="w-20 rounded-md border border-slate-300 bg-white px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                      />
+                    </label>
                     <Button type="submit" size="sm" variant="secondary" loading={actionBusy}>
                       Scale
                     </Button>
@@ -644,7 +659,7 @@ export function ResourcesView({
                       onClick={() => setDetailFormat(format)}
                       aria-pressed={detailFormat === format}
                       className={cx(
-                        "px-2.5 py-1 text-xs font-medium transition-colors",
+                        "px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-blue-600",
                         detailFormat === format
                           ? "bg-blue-600 text-white"
                           : "bg-white text-slate-600 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700",

--- a/web/ui/src/components/SecretsView.tsx
+++ b/web/ui/src/components/SecretsView.tsx
@@ -123,7 +123,7 @@ export function SecretsView() {
   return (
     <div className="mx-auto max-w-5xl space-y-5">
       <div className="grid gap-6 lg:grid-cols-2">
-        <section className="space-y-3 rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+        <section className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Encrypt</h2>
           <FormatSelect value={encryptFormat} onChange={setEncryptFormat} />
           <SelectField
@@ -143,6 +143,7 @@ export function SecretsView() {
             onChange={(event) => setPlaintext(event.target.value)}
             placeholder={"password: s3cret\napiKey: abc123"}
             spellCheck={false}
+            aria-label="Plaintext document to encrypt"
             rows={10}
             className={textareaClass}
           />
@@ -152,7 +153,7 @@ export function SecretsView() {
           <OutputBlock label="Encrypted (SOPS)" value={encrypted} />
         </section>
 
-        <section className="space-y-3 rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+        <section className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Decrypt</h2>
           <FormatSelect value={decryptFormat} onChange={setDecryptFormat} />
           <textarea
@@ -160,6 +161,7 @@ export function SecretsView() {
             onChange={(event) => setEncryptedInput(event.target.value)}
             placeholder="Paste a SOPS-encrypted document…"
             spellCheck={false}
+            aria-label="SOPS-encrypted document to decrypt"
             rows={10}
             className={textareaClass}
           />

--- a/web/ui/src/components/Toast.tsx
+++ b/web/ui/src/components/Toast.tsx
@@ -70,8 +70,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
           return (
             <div
               key={toast.id}
-              role="status"
-              className="pointer-events-auto flex items-start gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-lg dark:border-slate-700 dark:bg-slate-800"
+              // Errors interrupt (assertive); success/info announce politely.
+              role={toast.kind === "error" ? "alert" : "status"}
+              className="pointer-events-auto flex animate-[toast-in_150ms_ease-out] items-start gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-lg dark:border-slate-700 dark:bg-slate-800"
             >
               <Icon className={cx("mt-0.5 size-5 shrink-0", accent)} aria-hidden />
               <p className="flex-1 break-words text-sm text-slate-700 dark:text-slate-200">

--- a/web/ui/src/components/states.tsx
+++ b/web/ui/src/components/states.tsx
@@ -6,18 +6,22 @@ export function EmptyState({
   title,
   description,
   action,
+  icon,
 }: {
   title: string;
   description: string;
   action?: ReactNode;
+  // icon replaces the default Server glyph so an empty state can match its subject (events,
+  // resources, …).
+  icon?: ReactNode;
 }) {
   return (
     <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center dark:border-slate-700 dark:bg-slate-900">
       <span className="flex size-12 items-center justify-center rounded-full bg-slate-100 text-slate-400 dark:bg-slate-800">
-        <Server className="size-6" aria-hidden />
+        {icon ?? <Server className="size-6" aria-hidden />}
       </span>
-      <h3 className="mt-4 text-sm font-semibold text-slate-900 dark:text-white">{title}</h3>
-      <p className="mt-1 max-w-sm text-sm text-slate-500 dark:text-slate-400">{description}</p>
+      <h3 className="mt-4 text-sm font-semibold text-balance text-slate-900 dark:text-white">{title}</h3>
+      <p className="mt-1 max-w-sm text-sm text-pretty text-slate-500 dark:text-slate-400">{description}</p>
       {action ? <div className="mt-5">{action}</div> : null}
     </div>
   );
@@ -25,7 +29,10 @@ export function EmptyState({
 
 export function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => void }) {
   return (
-    <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300"
+    >
       <CircleAlert className="mt-0.5 size-5 shrink-0 text-red-500" aria-hidden />
       <p className="flex-1 break-words">{message}</p>
       {onRetry ? (

--- a/web/ui/src/components/table.tsx
+++ b/web/ui/src/components/table.tsx
@@ -55,7 +55,7 @@ export function SortHeader<K extends string>({
       <button
         type="button"
         onClick={() => onSort(sortKey)}
-        className="group inline-flex items-center gap-1 uppercase tracking-wide hover:text-slate-700 dark:hover:text-slate-200"
+        className="group inline-flex items-center gap-1 rounded uppercase tracking-wide hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:hover:text-slate-200"
       >
         {label}
         <Indicator
@@ -86,6 +86,7 @@ export function DataStates({
   empty,
   emptyTitle,
   emptyDescription,
+  emptyIcon,
   onRetry,
   children,
 }: {
@@ -94,6 +95,8 @@ export function DataStates({
   empty: boolean;
   emptyTitle: string;
   emptyDescription: string;
+  // emptyIcon lets the view match the empty state to its subject (events, resources, …).
+  emptyIcon?: ReactNode;
   onRetry: () => void;
   children: ReactNode;
 }) {
@@ -104,7 +107,7 @@ export function DataStates({
     return <TableSkeleton />;
   }
   if (empty) {
-    return <EmptyState title={emptyTitle} description={emptyDescription} />;
+    return <EmptyState title={emptyTitle} description={emptyDescription} icon={emptyIcon} />;
   }
 
   return <>{children}</>;

--- a/web/ui/src/components/ui.tsx
+++ b/web/ui/src/components/ui.tsx
@@ -16,11 +16,11 @@ const VARIANT: Record<Variant, string> = {
   primary:
     "bg-blue-600 text-white hover:bg-blue-500 focus-visible:outline-blue-600 disabled:opacity-60",
   secondary:
-    "bg-white text-slate-700 ring-1 ring-inset ring-slate-300 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700",
+    "bg-white text-slate-700 ring-1 ring-inset ring-slate-300 hover:bg-slate-50 focus-visible:outline-blue-600 disabled:opacity-60 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700",
   danger:
     "bg-red-600 text-white hover:bg-red-500 focus-visible:outline-red-600 disabled:opacity-60",
   ghost:
-    "text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
+    "text-slate-600 hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-blue-600 disabled:opacity-60 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
 };
 
 const SIZE: Record<Size, string> = {
@@ -52,6 +52,7 @@ export function Button({
         className,
       )}
       disabled={disabled || loading}
+      aria-busy={loading || undefined}
       {...props}
     >
       {loading ? <LoaderCircle className="size-4 animate-spin" aria-hidden /> : null}
@@ -134,7 +135,7 @@ export function Modal({
             {/* Cap the panel at the viewport height and scroll the body so tall forms stay usable on
                 small screens, while the footer (Cancel/Save) remains pinned and reachable. */}
             <DialogPanel className="flex max-h-[calc(100dvh-2rem)] w-full max-w-md flex-col rounded-xl bg-white shadow-2xl ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
-              <div className="overflow-y-auto p-5">
+              <div className="overflow-y-auto overscroll-contain p-5">
                 <div className="flex items-start gap-3">
                   {icon}
                   <div className="min-w-0 flex-1">
@@ -208,7 +209,7 @@ export function SlideOver({
                     <X className="size-5" />
                   </IconButton>
                 </div>
-                <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
+                <div className="flex-1 overflow-y-auto overscroll-contain px-5 py-4">{children}</div>
               </DialogPanel>
             </TransitionChild>
           </div>

--- a/web/ui/src/hooks/useTheme.ts
+++ b/web/ui/src/hooks/useTheme.ts
@@ -12,9 +12,9 @@ function prefersDark(): boolean {
   }
 }
 
-function initialTheme(): Theme {
-  // localStorage access can throw in privacy mode, sandboxed frames, or when storage is blocked;
-  // fall back to the system preference instead of crashing the initial render.
+// storedTheme reads the persisted choice. localStorage access can throw in privacy mode, sandboxed
+// frames, or when storage is blocked; treat that as "no stored choice" instead of crashing.
+function storedTheme(): Theme | null {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === "light" || stored === "dark") {
@@ -24,26 +24,50 @@ function initialTheme(): Theme {
     /* ignore: storage unavailable */
   }
 
-  return prefersDark() ? "dark" : "light";
+  return null;
 }
 
-// useTheme tracks the active light/dark theme, persists the choice, and toggles the `dark` class on
-// <html> so Tailwind's class-based dark variant applies. The no-flash init in index.html sets the
-// initial class before paint; this keeps it in sync as the user toggles.
+// useTheme tracks the active light/dark theme and toggles the `dark` class on <html> so Tailwind's
+// class-based dark variant applies. Until the user explicitly toggles, the theme follows the system
+// preference live (including OS-level changes while the app is open); a toggle pins the choice and
+// persists it. The no-flash init in index.html applies the same resolution before first paint.
 export function useTheme(): { theme: Theme; toggle: () => void } {
-  const [theme, setTheme] = useState<Theme>(initialTheme);
+  const [pinned, setPinned] = useState<boolean>(() => storedTheme() !== null);
+  const [theme, setTheme] = useState<Theme>(() => storedTheme() ?? (prefersDark() ? "dark" : "light"));
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", theme === "dark");
-    try {
-      localStorage.setItem(STORAGE_KEY, theme);
-    } catch {
-      /* ignore: storage unavailable (theme still applies for this session) */
-    }
   }, [theme]);
 
+  // Follow live OS theme changes while the user has not chosen explicitly.
+  useEffect(() => {
+    if (pinned) {
+      return undefined;
+    }
+
+    try {
+      const query = window.matchMedia("(prefers-color-scheme: dark)");
+      const onChange = () => setTheme(query.matches ? "dark" : "light");
+      query.addEventListener("change", onChange);
+
+      return () => query.removeEventListener("change", onChange);
+    } catch {
+      return undefined; /* matchMedia unavailable: stay on the initial theme */
+    }
+  }, [pinned]);
+
   const toggle = useCallback(() => {
-    setTheme((current) => (current === "dark" ? "light" : "dark"));
+    setPinned(true);
+    setTheme((current) => {
+      const next = current === "dark" ? "light" : "dark";
+      try {
+        localStorage.setItem(STORAGE_KEY, next);
+      } catch {
+        /* ignore: storage unavailable (theme still applies for this session) */
+      }
+
+      return next;
+    });
   }, []);
 
   return { theme, toggle };

--- a/web/ui/src/index.css
+++ b/web/ui/src/index.css
@@ -18,4 +18,43 @@
   #root {
     height: 100%;
   }
+
+  /* Remove the 300ms double-tap-zoom delay and the grey tap flash on touch devices; the UI provides
+     its own hover/active feedback. */
+  button,
+  a,
+  label,
+  select,
+  [role="button"] {
+    touch-action: manipulation;
+  }
+
+  body {
+    -webkit-tap-highlight-color: transparent;
+  }
+}
+
+/* toast-in slides a new toast up into place; disabled (with all other motion) under
+   prefers-reduced-motion below. */
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Honor prefers-reduced-motion globally: collapse animations and transitions (Tailwind utilities,
+   Headless UI dialog/menu transitions, spinners, skeleton pulses) to effectively instant. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/web/ui/src/lib/meta.ts
+++ b/web/ui/src/lib/meta.ts
@@ -26,12 +26,17 @@ export const COMPONENT_LABELS: Record<string, string> = {
   gitOpsEngine: "GitOps Engine",
 };
 
-// preferredProvider picks the provider to pre-select for a distribution in the create form. The
-// operator runs in-cluster, so the Kubernetes (nested) provider is the zero-config choice when a
-// distribution supports it; otherwise fall back to the first provider the server lists. This is a
-// UX default only — the full set of valid providers still comes from the /meta matrix.
-export function preferredProvider(providers: string[]): string {
-  return providers.includes("Kubernetes") ? "Kubernetes" : (providers[0] ?? "");
+// preferredProvider picks the provider to pre-select for a distribution in the create form. Which
+// provider is the zero-config choice depends on the surface: the local `ksail ui`/desktop backend
+// (recognizable by its per-provider availability report) is Docker-first — Docker is KSail's only
+// required local dependency — while the operator (no gating report) runs in-cluster, so the
+// Kubernetes (nested) provider is its zero-config choice. Falls back to the first provider the
+// server lists. This is a UX default only — the full set of valid providers still comes from the
+// /meta matrix.
+export function preferredProvider(providers: string[], status?: ProviderInfo[] | null): string {
+  const preferred = status ? "Docker" : "Kubernetes";
+
+  return providers.includes(preferred) ? preferred : (providers[0] ?? "");
 }
 
 // availableProviders narrows the providers valid for a distribution (from /api/v1/meta) to those the


### PR DESCRIPTION
## Summary

UI/UX polish and bug-fix pass over the shared web UI (the SPA served by the KSail operator, `ksail ui`, and the desktop app), reviewed against the Web Interface Guidelines. The desktop Go wrapper was audited too — no defects found there.

### Bug fixes
- **LogViewer follow behavior**: scrolling up to read scrollback no longer gets yanked back down by each new line — auto-follow pauses when the user leaves the bottom and a floating **Follow** button resumes it. Also removes an invalid `<div>` nested inside `<pre>`.
- **Stale state on cluster switch**: switching the active cluster while on Resources closes any open detail panel, log stream, exec session, or confirm dialog so they can't target (or stream from) the previous cluster.
- **Apply YAML dialog**: only the clicked action (Validate vs Apply) shows its spinner; both stay disabled while busy.
- **Overview loading states**: "Pod health" no longer claims *No pods.* and the Workloads card no longer renders blank while live health is still loading.
- **Create form validation**: cluster name is required + RFC 1123-validated inline (was a silent no-op submit).
- **Provider default per surface**: the local `ksail ui`/desktop create form now preselects **Docker** (KSail's only required local dependency); the operator keeps its zero-config in-cluster **Kubernetes** default.
- **Theme**: follows live OS appearance changes until the user explicitly toggles (the choice is then pinned + persisted, matching the existing no-flash init).
- Endpoint copy failures now surface an error toast instead of being swallowed.

### Accessibility & guideline compliance
- Labels for the replicas input, secrets/apply textareas, and command-palette input; `aria-pressed` on segmented toggles; `aria-busy` on loading buttons.
- Visible `:focus-visible` states for sort headers, row actions, format toggles, the login link, and secondary/ghost buttons.
- `prefers-reduced-motion` honored globally; `overscroll-behavior: contain` in modals/drawers/menus; skip-to-content link; error banners/toasts announced via `role="alert"`.
- Platform-aware shortcut hint (⌘K vs Ctrl K), `theme-color` metas for both schemes, `touch-action: manipulation`.

### Branding & polish
- The sidebar brand and login screen now carry the real KSail twin-sail sloop mark (new shared `Logo.tsx`, matching `docs/src/assets/logo.svg` and the desktop icon) instead of a generic lucide *Boxes* icon; subtle brand-tinted glow on the login screen.
- Toast slide-in animation, cluster-switcher menu transition, animated node/pod health bars, contextual empty-state icons, `type="search"` on the events filter.

## Testing
- `npm run build` (gen:types + `tsc` + Vite) — clean.
- `go build` with the staged SPA embedded — clean; `go -C desktop test ./...` + `go -C desktop vet ./...` — pass.
- Verified live via `ksail ui --no-browser` in a headless browser: clusters list, drill-in Overview (health cards), command palette (labeled, focused, all commands), create dialog (validation attrs, template list, Docker preselected, blocked-provider note), theme toggle persistence, both themes, zero console errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)