### PR TITLE
ci(skills): open agent-skills PR with App token so CI runs

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -18,3 +18,10 @@ jobs:
     uses: devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml@7d3a08e3cc284c6fa14a056d5df7702ec0978d59 # v5.5.10
     with:
       dir: .agents/skills
+      # Open the PR with a GitHub App token so the caller's `on: pull_request`
+      # CI runs (a PR opened with GITHUB_TOKEN does not trigger workflows, so
+      # the required `CI - Required Checks` never reports and the PR stays
+      # blocked — see #5223). Matches platform + plugins, the other consumers.
+      use-app-token: true
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The **Update Agent Skills** workflow (`update-skills.yaml`) created its PR with the default `GITHUB_TOKEN`. By GitHub design, **a PR opened with `GITHUB_TOKEN` does not trigger the caller's `on: pull_request` / `push` workflows** — so `ci.yaml` never ran on the `deps/agent-skills-update` branch, the required **`CI - Required Checks`** context never reported, and every agent-skills PR was left **permanently `BLOCKED`**.

Concrete evidence — #5223 (`chore(deps): update agent skills`, author `github-actions[bot]`):
- `mergeStateStatus: BLOCKED`, no auto-merge armed
- Its only checks are CodeQL/Analyze (separate trigger); **zero `CI - KSail` runs** exist on the branch
- `CI - Required Checks` (the sole branch-protection required context) is **absent from the rollup** → can never go green → cannot merge

## Fix

Opt into the reusable workflow's **existing** `use-app-token` path (added for exactly this CI-trigger problem). The PR is then opened with a GitHub App token, so `ci.yaml` runs normally and `CI - Required Checks` reports.

```yaml
    with:
      dir: .agents/skills
      use-app-token: true
    secrets:
      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
```

- `APP_CLIENT_ID` (repo + org variable) and `APP_PRIVATE_KEY` (secret) are **already present** in this repo and used by `todos.yaml`.
- This matches **platform** and **plugins**, the other two consumers of `update-agent-skills.yaml` — both already set `use-app-token: true`. **ksail was the only straggler still on `GITHUB_TOKEN`** (consistency/drift fix).

## Validation

- `actionlint` clean on the changed workflow.
- Inputs/secret match the reusable workflow's declared `workflow_call` interface.

## Effect

Future agent-skills sync PRs trigger CI and become mergeable. The current #5223 predates this change — the maintainer can close it and let the next scheduled run reopen it cleanly, or re-run the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)