### PR TITLE
feat(ui): complete cluster overview with live status and resource usage

### DIFF
--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -52,6 +52,9 @@ func NewTestService(factory FactoryFunc) *Service {
 	service := NewService()
 	service.newFactory = factory
 	service.discoverProviders = []v1alpha1.Provider{v1alpha1.ProviderDocker}
+	// Point the kubeconfig at nowhere by default so List's endpoint enrichment never reads the
+	// developer's real kubeconfig; tests that need one inject it via SetKubeconfigPathForTest.
+	service.kubeconfigPath = func() string { return "" }
 
 	return service
 }

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -218,10 +218,15 @@ func (s *Service) List(ctx context.Context) (*v1alpha1.ClusterList, error) {
 
 	sort.Strings(names)
 
+	// Endpoints come from the kubeconfig's contexts (no cluster round-trips), so the UI can show a
+	// real API server URL for clusters that have one instead of an empty status field.
+	endpoints := s.clusterEndpoints()
+
 	items := make([]v1alpha1.Cluster, 0, len(names))
 	for _, name := range names {
 		entry := merged[name]
 		cluster := newCluster(name, entry.distribution, entry.provider, entry.phase)
+		cluster.Status.Endpoint = endpoints[name]
 
 		condition, ok := jobConditionFor(entry.phase, entry.message, entry.since)
 		if ok {

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"slices"
 	"sync"
 	"testing"
@@ -22,6 +23,9 @@ import (
 const (
 	eventuallyTimeout = 2 * time.Second
 	eventuallyTick    = 10 * time.Millisecond
+
+	// devClusterName is the discovered-cluster name shared by the List tests.
+	devClusterName = "dev"
 )
 
 // Static sentinel errors used to drive provisioner failures in tests (err113 forbids inline
@@ -173,7 +177,7 @@ func TestListMapsExistingClusters(t *testing.T) {
 	t.Parallel()
 
 	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
-		v1alpha1.DistributionVanilla: {clusters: []string{"dev"}},
+		v1alpha1.DistributionVanilla: {clusters: []string{devClusterName}},
 	})
 
 	list, err := service.List(context.Background())
@@ -181,11 +185,60 @@ func TestListMapsExistingClusters(t *testing.T) {
 	require.Len(t, list.Items, 1)
 
 	got := list.Items[0]
-	assert.Equal(t, "dev", got.Name)
+	assert.Equal(t, devClusterName, got.Name)
 	assert.Equal(t, "default", got.Namespace)
 	assert.Equal(t, v1alpha1.DistributionVanilla, got.Spec.Cluster.Distribution)
 	assert.Equal(t, v1alpha1.ProviderDocker, got.Spec.Cluster.Provider)
 	assert.Equal(t, v1alpha1.ClusterPhaseReady, got.Status.Phase)
+}
+
+// TestListReportsEndpointFromKubeconfig guards the local status enrichment: a discovered cluster
+// whose kubeconfig context is detectable by name must report that context's API server URL as
+// status.endpoint, so the web UI's Status card shows a real endpoint on the local surface.
+func TestListReportsEndpointFromKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionVanilla: {clusters: []string{devClusterName}},
+	})
+
+	kubeconfig := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: kind-dev
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: kind-dev
+  context:
+    cluster: kind-dev
+    user: kind-dev
+users:
+- name: kind-dev
+  user: {}
+`), 0o600))
+	service.SetKubeconfigPathForTest(kubeconfig)
+
+	list, err := service.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+	assert.Equal(t, "https://127.0.0.1:6443", list.Items[0].Status.Endpoint)
+}
+
+// TestListWithoutKubeconfigLeavesEndpointEmpty covers the best-effort path: no kubeconfig means no
+// endpoint, never an error.
+func TestListWithoutKubeconfigLeavesEndpointEmpty(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionVanilla: {clusters: []string{devClusterName}},
+	})
+
+	list, err := service.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+	assert.Empty(t, list.Items[0].Status.Endpoint)
 }
 
 func TestListEmptyReturnsNonNilItems(t *testing.T) {

--- a/pkg/cli/clusterapi/resources.go
+++ b/pkg/cli/clusterapi/resources.go
@@ -60,6 +60,38 @@ func contextForCluster(kubeconfigPath, clusterName string) (string, error) {
 	return "", fmt.Errorf("%w: no kubeconfig context for cluster %q", api.ErrNotFound, clusterName)
 }
 
+// clusterEndpoints maps every cluster name detectable from the kubeconfig's contexts to its API
+// server URL, so List can report a real endpoint for local/discovered clusters (the operator surface
+// observes it during reconciliation instead). Best-effort and offline (one file read, no cluster
+// round-trips): an unreadable kubeconfig yields no endpoints. The first context detected for a name
+// wins, matching contextForCluster.
+func (s *Service) clusterEndpoints() map[string]string {
+	config, err := clientcmd.LoadFromFile(s.kubeconfigPath())
+	if err != nil {
+		return nil
+	}
+
+	endpoints := make(map[string]string, len(config.Contexts))
+
+	for contextName, kubeContext := range config.Contexts {
+		_, name, detectErr := clusterdetector.DetectDistributionFromContext(contextName)
+		if detectErr != nil {
+			continue
+		}
+
+		cluster, ok := config.Clusters[kubeContext.Cluster]
+		if !ok || cluster.Server == "" {
+			continue
+		}
+
+		if _, exists := endpoints[name]; !exists {
+			endpoints[name] = cluster.Server
+		}
+	}
+
+	return endpoints
+}
+
 // restConfigForCluster resolves the cluster's kubeconfig context by name and builds a *rest.Config —
 // the shared preamble for the apply (dynamic + RESTMapper) and exec (clientset) client builders.
 func restConfigForCluster(clusterName string) (*rest.Config, error) {

--- a/pkg/operator/api/resources.go
+++ b/pkg/operator/api/resources.go
@@ -90,6 +90,15 @@ func namespacedKindVersion(group, version, resource string) ResourceKind {
 	}
 }
 
+// clusterScopedKindVersion builds a cluster-scoped ResourceKind at an explicit API version — used
+// for the metrics API (metrics.k8s.io v1beta1), which is not served at v1.
+func clusterScopedKindVersion(group, version, resource string) ResourceKind {
+	return ResourceKind{
+		GVR:        schema.GroupVersionResource{Group: group, Version: version, Resource: resource},
+		Namespaced: false,
+	}
+}
+
 // resourceKindTable is the curated allowlist of resource types the read-only workload browser
 // exposes. It deliberately EXCLUDES Secrets: their values are sensitive and a redaction-aware secrets
 // view is a separate feature. New browsable kinds are added here. It is a function (not a package
@@ -122,6 +131,11 @@ func resourceKindTable() map[string]ResourceKind {
 		"GitRepository": namespacedKindVersion("source.toolkit.fluxcd.io", "v1", "gitrepositories"),
 		"OCIRepository": namespacedKindVersion("source.toolkit.fluxcd.io", "v1", "ocirepositories"),
 		"Application":   namespacedKindVersion("argoproj.io", "v1alpha1", "applications"),
+		// Live usage from the metrics API (metrics.k8s.io, served by a metrics-server). These power the
+		// Overview's resource-usage monitoring; on a cluster without a metrics-server the list fails
+		// like any other absent API and the UI degrades to capacity/requests only.
+		"NodeMetrics": clusterScopedKindVersion("metrics.k8s.io", "v1beta1", "nodes"),
+		"PodMetrics":  namespacedKindVersion("metrics.k8s.io", "v1beta1", "pods"),
 	}
 }
 

--- a/pkg/operator/api/resources_test.go
+++ b/pkg/operator/api/resources_test.go
@@ -209,6 +209,26 @@ func TestResourceKindForGitOps(t *testing.T) {
 	assert.Equal(t, "v1alpha1", app.GVR.Version)
 }
 
+func TestResourceKindForMetrics(t *testing.T) {
+	t.Parallel()
+
+	// Metrics kinds resolve at metrics.k8s.io/v1beta1 (the served version); NodeMetrics is
+	// cluster-scoped and PodMetrics is namespaced, mirroring their Node/Pod counterparts.
+	nodeMetrics, err := api.ResourceKindFor("NodeMetrics")
+	require.NoError(t, err)
+	assert.Equal(t, "metrics.k8s.io", nodeMetrics.GVR.Group)
+	assert.Equal(t, "v1beta1", nodeMetrics.GVR.Version)
+	assert.Equal(t, "nodes", nodeMetrics.GVR.Resource)
+	assert.False(t, nodeMetrics.Namespaced)
+
+	podMetrics, err := api.ResourceKindFor("PodMetrics")
+	require.NoError(t, err)
+	assert.Equal(t, "metrics.k8s.io", podMetrics.GVR.Group)
+	assert.Equal(t, "v1beta1", podMetrics.GVR.Version)
+	assert.Equal(t, "pods", podMetrics.GVR.Resource)
+	assert.True(t, podMetrics.Namespaced)
+}
+
 func TestConfigReportsWorkloadReadForResourceService(t *testing.T) {
 	t.Parallel()
 

--- a/web/ui/src/components/Card.tsx
+++ b/web/ui/src/components/Card.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { cx } from "../lib/cx.ts";
+
+// Card is the dashboard panel chrome shared by the Overview's cards (live health, spec/status,
+// resource usage): a bordered surface with an uppercase title row.
+export function Card({
+  title,
+  icon,
+  children,
+  className,
+}: {
+  title: string;
+  icon: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cx(
+        "rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900",
+        className,
+      )}
+    >
+      <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {icon}
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// Field renders a label/value row in the Spec and Status cards.
+export function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 py-1.5">
+      <dt className="shrink-0 text-xs text-slate-500 dark:text-slate-400">{label}</dt>
+      <dd className="min-w-0 truncate text-right text-sm text-slate-700 dark:text-slate-200">{children}</dd>
+    </div>
+  );
+}

--- a/web/ui/src/components/OverviewView.tsx
+++ b/web/ui/src/components/OverviewView.tsx
@@ -13,7 +13,7 @@ import {
   Trash2,
   TriangleAlert,
 } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { downloadKubeconfig, errorMessage, listResources, type Cluster, type Condition, type K8sObject } from "../api.ts";
 import { cx } from "../lib/cx.ts";
 import { formatTimestamp, relativeAge } from "../lib/format.ts";
@@ -21,14 +21,20 @@ import {
   clusterKey,
   eventFields,
   eventLastSeenMs,
+  nodeIsControlPlane,
+  nodeProblems,
   nodeReady,
+  nodeSystemInfo,
   podPhase,
   podReady,
   splitClusterKey,
   type EventFields,
 } from "../lib/k8s.ts";
 import { COMPONENT_LABELS, useMeta } from "../lib/meta.ts";
+import { buildClusterUsage, buildPodConsumption, type ClusterUsage, type PodConsumption } from "../lib/usage.ts";
+import { Card, Field } from "./Card.tsx";
 import { EventList } from "./EventList.tsx";
+import { ResourceUsagePanel } from "./ResourceUsage.tsx";
 import { StatusBadge } from "./StatusBadge.tsx";
 import { EmptyState } from "./states.tsx";
 import { Button } from "./ui.tsx";
@@ -37,14 +43,23 @@ import { useToast } from "./Toast.tsx";
 // PodSegment is one slice of the pod-health bar: a label, a count, and its bar/dot colour classes.
 type PodSegment = { key: string; label: string; count: number; bar: string; dot: string };
 
-// LiveHealth is the at-a-glance cluster health derived from the read-only resource endpoints.
+// LiveHealth is the at-a-glance cluster state derived from the read-only resource endpoints: node and
+// pod health, workload counts, live facts (version, OS, creation time) the cluster object itself does
+// not carry on the local surface, resource usage, and recent warnings.
 interface LiveHealth {
   nodesReady: number;
   nodesTotal: number;
+  controlPlanes: number;
+  kubernetesVersion: string;
+  osImage: string;
+  createdAt?: string;
   segments: PodSegment[];
   podsTotal: number;
   workloads: { label: string; count: number }[];
   warnings: EventFields[];
+  derivedConditions: Condition[];
+  usage: ClusterUsage;
+  topPods: PodConsumption[];
 }
 
 const MAX_WARNINGS = 8;
@@ -98,15 +113,105 @@ async function listKind(namespace: string, name: string, kind: string): Promise<
   }
 }
 
+// distinctSummary collapses per-node values into one display string: the value every node shares, or
+// the first plus how many differ ("v1.33.0 +2 more" on a mid-upgrade cluster).
+function distinctSummary(values: string[]): string {
+  const distinct = [...new Set(values.filter((value) => value !== ""))];
+  if (distinct.length === 0) {
+    return "";
+  }
+
+  return distinct.length === 1 ? distinct[0] : `${distinct[0]} +${distinct.length - 1} more`;
+}
+
+// clusterCreatedAt approximates the cluster's creation time as the kube-system namespace's creation
+// timestamp (it exists from first boot), falling back to the oldest namespace.
+function clusterCreatedAt(namespaces: K8sObject[]): string | undefined {
+  const stamps = namespaces
+    .map((ns) => ({ name: ns.metadata?.name, at: ns.metadata?.creationTimestamp ?? "" }))
+    .filter((entry) => entry.at !== "");
+
+  const kubeSystem = stamps.find((entry) => entry.name === "kube-system");
+  if (kubeSystem) {
+    return kubeSystem.at;
+  }
+
+  return stamps.map((entry) => entry.at).sort().at(0);
+}
+
+// segmentCount reads one segment's pod count by key.
+function segmentCount(segments: PodSegment[], key: string): number {
+  return segments.find((segment) => segment.key === key)?.count ?? 0;
+}
+
+// deriveHealthConditions synthesizes health checks from live cluster state for clusters whose backend
+// reports no status conditions (the local surface): node readiness, pod health, and the kubelets'
+// pressure/availability signals. Status follows the Kubernetes convention that True is healthy.
+function deriveHealthConditions(
+  nodes: K8sObject[],
+  segments: PodSegment[],
+  nodesReady: number,
+  podsTotal: number,
+): Condition[] {
+  const conditions: Condition[] = [];
+
+  if (nodes.length > 0) {
+    const allReady = nodesReady === nodes.length;
+    conditions.push({
+      type: "NodesReady",
+      status: allReady ? "True" : "False",
+      reason: allReady ? "AllNodesReady" : "NodesNotReady",
+      message: `${nodesReady} of ${nodes.length} nodes are ready.`,
+    });
+
+    const problems = nodes.flatMap(nodeProblems);
+    conditions.push({
+      type: "NodeConditions",
+      status: problems.length === 0 ? "True" : "False",
+      reason: problems.length === 0 ? "NoProblemsDetected" : "NodeProblems",
+      message:
+        problems.length === 0
+          ? "No node pressure or availability problems."
+          : problems.map((p) => `${p.node}: ${p.type}${p.message ? ` — ${p.message}` : ""}`).join("; "),
+      lastTransitionTime: problems.map((p) => p.lastTransitionTime ?? "").sort().at(-1) || undefined,
+    });
+  }
+
+  if (podsTotal > 0) {
+    const unhealthy = segmentCount(segments, "failed") + segmentCount(segments, "notReady");
+    const detail = [
+      { count: segmentCount(segments, "failed"), label: "failed" },
+      { count: segmentCount(segments, "notReady"), label: "not ready" },
+      { count: segmentCount(segments, "pending"), label: "pending" },
+    ]
+      .filter((entry) => entry.count > 0)
+      .map((entry) => `${entry.count} ${entry.label}`)
+      .join(", ");
+
+    conditions.push({
+      type: "PodsHealthy",
+      status: unhealthy === 0 ? "True" : "False",
+      reason: unhealthy === 0 ? "AllPodsHealthy" : "UnhealthyPods",
+      message: detail === "" ? `All ${segmentCount(segments, "running")} running pods are healthy.` : `${detail} of ${podsTotal} pods.`,
+    });
+  }
+
+  return conditions;
+}
+
 async function loadHealth(namespace: string, name: string): Promise<LiveHealth> {
-  const [nodes, pods, deployments, statefulSets, daemonSets, events] = await Promise.all([
-    listKind(namespace, name, "Node"),
-    listKind(namespace, name, "Pod"),
-    listKind(namespace, name, "Deployment"),
-    listKind(namespace, name, "StatefulSet"),
-    listKind(namespace, name, "DaemonSet"),
-    listKind(namespace, name, "Event"),
-  ]);
+  const [nodes, pods, deployments, statefulSets, daemonSets, events, namespaces, nodeMetrics, podMetrics] =
+    await Promise.all([
+      listKind(namespace, name, "Node"),
+      listKind(namespace, name, "Pod"),
+      listKind(namespace, name, "Deployment"),
+      listKind(namespace, name, "StatefulSet"),
+      listKind(namespace, name, "DaemonSet"),
+      listKind(namespace, name, "Event"),
+      listKind(namespace, name, "Namespace"),
+      listKind(namespace, name, "NodeMetrics"),
+      listKind(namespace, name, "PodMetrics"),
+    ]);
 
   const warnings = events
     .map(eventFields)
@@ -114,10 +219,18 @@ async function loadHealth(namespace: string, name: string): Promise<LiveHealth> 
     .sort((a, b) => eventLastSeenMs(b) - eventLastSeenMs(a))
     .slice(0, MAX_WARNINGS);
 
+  const segments = categorizePods(pods);
+  const nodesReady = nodes.filter(nodeReady).length;
+  const systemInfos = nodes.map(nodeSystemInfo);
+
   return {
-    nodesReady: nodes.filter(nodeReady).length,
+    nodesReady,
     nodesTotal: nodes.length,
-    segments: categorizePods(pods),
+    controlPlanes: nodes.filter(nodeIsControlPlane).length,
+    kubernetesVersion: distinctSummary(systemInfos.map((info) => info.kubeletVersion)),
+    osImage: distinctSummary(systemInfos.map((info) => info.osImage)),
+    createdAt: clusterCreatedAt(namespaces),
+    segments,
     podsTotal: pods.length,
     workloads: [
       { label: "Deployments", count: deployments.length },
@@ -126,44 +239,10 @@ async function loadHealth(namespace: string, name: string): Promise<LiveHealth> 
       { label: "Pods", count: pods.length },
     ],
     warnings,
+    derivedConditions: deriveHealthConditions(nodes, segments, nodesReady, pods.length),
+    usage: buildClusterUsage(nodes, pods, nodeMetrics),
+    topPods: buildPodConsumption(podMetrics),
   };
-}
-
-function Card({
-  title,
-  icon,
-  children,
-  className,
-}: {
-  title: string;
-  icon: ReactNode;
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <div
-      className={cx(
-        "rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900",
-        className,
-      )}
-    >
-      <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-        {icon}
-        {title}
-      </div>
-      {children}
-    </div>
-  );
-}
-
-// Field renders a label/value row in the Spec and Status cards.
-function Field({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <div className="flex items-baseline justify-between gap-3 py-1.5">
-      <dt className="shrink-0 text-xs text-slate-500 dark:text-slate-400">{label}</dt>
-      <dd className="min-w-0 truncate text-right text-sm text-slate-700 dark:text-slate-200">{children}</dd>
-    </div>
-  );
 }
 
 function CopyableEndpoint({ endpoint }: { endpoint: string }) {
@@ -192,10 +271,10 @@ function conditionIcon(status: Condition["status"]) {
     return <CircleCheck className="size-4 shrink-0 text-emerald-500" aria-hidden />;
   }
   if (status === "False") {
-    return <CircleAlert className="size-4 shrink-0 text-slate-400" aria-hidden />;
+    return <CircleAlert className="size-4 shrink-0 text-amber-500" aria-hidden />;
   }
 
-  return <CircleHelp className="size-4 shrink-0 text-amber-500" aria-hidden />;
+  return <CircleHelp className="size-4 shrink-0 text-slate-400" aria-hidden />;
 }
 
 // OverviewView is the cluster home: the cluster's spec, status, and conditions (formerly the cluster
@@ -269,8 +348,23 @@ export function OverviewView({
   const distribution = spec?.distribution || meta.distributions[0] || "—";
   const provider = spec?.provider || meta.providers[distribution]?.[0] || "—";
   const secret = status?.kubeconfigSecretRef;
-  const conditions = status?.conditions ?? [];
   const nodesHealthy = health ? health.nodesTotal > 0 && health.nodesReady === health.nodesTotal : false;
+
+  // The local surface discovers clusters and only knows their distribution/provider; a spec carrying
+  // node counts or component choices is a managed one (operator CR or form submission) whose
+  // component defaults are meaningful. For discovered clusters, live node facts fill the gaps and
+  // fabricated component defaults are not shown.
+  const specManaged =
+    spec !== undefined &&
+    (spec.controlPlanes !== undefined || spec.workers !== undefined || meta.components.some((component) => spec[component.key]));
+  const liveWorkers = health ? health.nodesTotal - health.controlPlanes : undefined;
+
+  const crConditions = status?.conditions ?? [];
+  const shownConditions = crConditions.length > 0 ? crConditions : (health?.derivedConditions ?? []);
+
+  // The backend's creation timestamp when it tracks one (operator CRs), else the live cluster's own
+  // age (kube-system's creation time).
+  const createdAt = cluster.metadata.creationTimestamp ?? health?.createdAt;
 
   return (
     <div className="mx-auto max-w-6xl space-y-5">
@@ -374,19 +468,31 @@ export function OverviewView({
         </div>
       ) : null}
 
+      {/* Resource usage: cluster-wide gauges, per-node utilisation, top consumers. */}
+      {canBrowse ? (
+        <ResourceUsagePanel usage={health?.usage ?? null} topPods={health?.topPods ?? null} loading={loading && !health} />
+      ) : null}
+
       {/* Cluster spec, status, conditions, and (when available) recent warnings. */}
       <div className="grid gap-4 lg:grid-cols-3">
         <Card title="Spec" icon={<Server className="size-3.5" aria-hidden />}>
           <dl className="divide-y divide-slate-100 dark:divide-slate-800">
             <Field label="Distribution">{distribution}</Field>
             <Field label="Provider">{provider}</Field>
-            <Field label="Control planes">{spec?.controlPlanes ?? 1}</Field>
-            <Field label="Workers">{spec?.workers ?? 0}</Field>
-            {meta.components.map((component) => (
-              <Field key={component.key} label={COMPONENT_LABELS[component.key] ?? component.key}>
-                {spec?.[component.key] || component.default}
-              </Field>
-            ))}
+            <Field label="Control planes">{spec?.controlPlanes ?? health?.controlPlanes ?? "—"}</Field>
+            <Field label="Workers">{spec?.workers ?? liveWorkers ?? "—"}</Field>
+            {specManaged ? (
+              meta.components.map((component) => (
+                <Field key={component.key} label={COMPONENT_LABELS[component.key] ?? component.key}>
+                  {spec?.[component.key] || component.default}
+                </Field>
+              ))
+            ) : (
+              <p className="pt-2 text-xs text-slate-400 dark:text-slate-500">
+                Component configuration is not tracked for discovered clusters — browse Resources to see what runs
+                here.
+              </p>
+            )}
           </dl>
         </Card>
 
@@ -394,54 +500,65 @@ export function OverviewView({
           <dl className="divide-y divide-slate-100 dark:divide-slate-800">
             <Field label="Phase">{status?.phase ?? "—"}</Field>
             <Field label="Endpoint">{status?.endpoint ? <CopyableEndpoint endpoint={status.endpoint} /> : "—"}</Field>
+            <Field label="Kubernetes">{health?.kubernetesVersion || "—"}</Field>
+            <Field label="OS">{health?.osImage || "—"}</Field>
             <Field label="Nodes">
-              {status?.nodesTotal === undefined ? "—" : `${status.nodesReady ?? 0} / ${status.nodesTotal} ready`}
-            </Field>
-            <Field label="Kubeconfig">
-              {secret ? (
-                <span className="font-mono text-xs">{(secret.namespace ? `${secret.namespace}/` : "") + secret.name}</span>
-              ) : (
-                "—"
-              )}
+              {status?.nodesTotal !== undefined
+                ? `${status.nodesReady ?? 0} / ${status.nodesTotal} ready`
+                : health
+                  ? `${health.nodesReady} / ${health.nodesTotal} ready`
+                  : "—"}
             </Field>
             <Field label="Created">
-              <span title={formatTimestamp(cluster.metadata.creationTimestamp)}>
-                {relativeAge(cluster.metadata.creationTimestamp)}
-              </span>
+              <span title={formatTimestamp(createdAt)}>{relativeAge(createdAt)}</span>
             </Field>
-            <Field label="Last reconcile">
-              <span title={formatTimestamp(status?.lastReconcileTime)}>
-                {status?.lastReconcileTime ? relativeAge(status.lastReconcileTime) : "—"}
-              </span>
-            </Field>
+            {status?.lastReconcileTime ? (
+              <Field label="Last reconcile">
+                <span title={formatTimestamp(status.lastReconcileTime)}>{relativeAge(status.lastReconcileTime)}</span>
+              </Field>
+            ) : null}
+            {secret ? (
+              <Field label="Kubeconfig">
+                <span className="font-mono text-xs">{(secret.namespace ? `${secret.namespace}/` : "") + secret.name}</span>
+              </Field>
+            ) : null}
           </dl>
         </Card>
 
         <Card title="Conditions" icon={<CircleCheck className="size-3.5" aria-hidden />}>
-          {conditions.length === 0 ? (
+          {shownConditions.length === 0 ? (
             <p className="text-sm text-slate-500 dark:text-slate-400">No conditions reported.</p>
           ) : (
-            <ul className="space-y-2">
-              {conditions.map((condition) => (
-                <li key={condition.type} className="flex items-start gap-2">
-                  {conditionIcon(condition.status)}
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="text-sm font-medium text-slate-800 dark:text-slate-100">{condition.type}</span>
-                      <span className="shrink-0 text-xs tabular-nums text-slate-400">
-                        {relativeAge(condition.lastTransitionTime)}
-                      </span>
+            <>
+              {crConditions.length === 0 ? (
+                <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                  Live health checks
+                </p>
+              ) : null}
+              <ul className="space-y-2">
+                {shownConditions.map((condition) => (
+                  <li key={condition.type} className="flex items-start gap-2">
+                    {conditionIcon(condition.status)}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-sm font-medium text-slate-800 dark:text-slate-100">{condition.type}</span>
+                        {condition.lastTransitionTime ? (
+                          <span className="shrink-0 text-xs tabular-nums text-slate-400">
+                            {relativeAge(condition.lastTransitionTime)}
+                          </span>
+                        ) : null}
+                      </div>
+                      {condition.reason ? (
+                        <p className="text-xs text-slate-500 dark:text-slate-400">{condition.reason}</p>
+                      ) : null}
+                      {condition.message ? (
+                        <p className="text-xs text-slate-500 dark:text-slate-400">{condition.message}</p>
+                      ) : null}
                     </div>
-                    {condition.reason ? (
-                      <p className="text-xs text-slate-500 dark:text-slate-400">{condition.reason}</p>
-                    ) : null}
-                    {condition.message ? (
-                      <p className="text-xs text-slate-500 dark:text-slate-400">{condition.message}</p>
-                    ) : null}
-                  </div>
-                </li>
-              ))}
-            </ul>
+                  </li>
+                ))}
+              </ul>
+            </>
           )}
         </Card>
 

--- a/web/ui/src/components/ResourceUsage.tsx
+++ b/web/ui/src/components/ResourceUsage.tsx
@@ -1,0 +1,315 @@
+import { Gauge } from "lucide-react";
+import { cx } from "../lib/cx.ts";
+import { formatBytes, formatCores, percentOf } from "../lib/quantity.ts";
+import {
+  topConsumers,
+  type ClusterUsage,
+  type NodeUsage,
+  type PodConsumption,
+  type ResourceTotals,
+} from "../lib/usage.ts";
+import { Card } from "./Card.tsx";
+
+// Dimension describes one monitored resource axis, so the cluster gauges, per-node bars, and
+// top-consumer lists all render from the same two descriptors instead of duplicated CPU/memory markup.
+interface Dimension {
+  key: "cpu" | "memory";
+  label: string;
+  format: (value: number) => string;
+}
+
+const DIMENSIONS: Dimension[] = [
+  { key: "cpu", label: "CPU", format: formatCores },
+  { key: "memory", label: "Memory", format: formatBytes },
+];
+
+const TOP_CONSUMERS = 5;
+
+// Utilisation traffic-light tones. Tailwind extracts class names statically, so the full literal
+// strings live here rather than being assembled from a colour fragment.
+const STROKE_TONES = {
+  ok: "stroke-emerald-500",
+  warn: "stroke-amber-500",
+  hot: "stroke-red-500",
+  none: "stroke-slate-300 dark:stroke-slate-600",
+} as const;
+
+const BAR_TONES = {
+  ok: "bg-emerald-500",
+  warn: "bg-amber-500",
+  hot: "bg-red-500",
+  none: "bg-slate-300 dark:bg-slate-600",
+} as const;
+
+function toneKey(percent: number | undefined): keyof typeof STROKE_TONES {
+  if (percent === undefined) {
+    return "none";
+  }
+  if (percent >= 90) {
+    return "hot";
+  }
+
+  return percent >= 75 ? "warn" : "ok";
+}
+
+// percentLabel renders a percentage for display ("—" when unknown).
+function percentLabel(percent: number | undefined): string {
+  return percent === undefined ? "—" : `${Math.round(percent)}%`;
+}
+
+// totalsTitle is the hover tooltip carrying the precise numbers behind a gauge or bar.
+function totalsTitle(dimension: Dimension, totals: ResourceTotals): string {
+  const parts = [];
+  if (totals.usage !== undefined) {
+    parts.push(`used ${dimension.format(totals.usage)}`);
+  }
+
+  parts.push(`requested ${dimension.format(totals.requests)}`);
+
+  if (totals.limits > 0) {
+    parts.push(`limits ${dimension.format(totals.limits)}`);
+  }
+
+  parts.push(`allocatable ${dimension.format(totals.allocatable)}`);
+
+  return `${dimension.label}: ${parts.join(" · ")}`;
+}
+
+// Donut is an SVG ring gauge with the percentage in its centre and explanatory lines beside it.
+function Donut({ percent, label, lines }: { percent: number | undefined; label: string; lines: string[] }) {
+  const radius = 40;
+  const circumference = 2 * Math.PI * radius;
+  const filled = ((percent ?? 0) / 100) * circumference;
+
+  return (
+    <div
+      className="flex items-center gap-3"
+      role="meter"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percent === undefined ? undefined : Math.round(percent)}
+    >
+      <div className="relative size-20 shrink-0">
+        <svg viewBox="0 0 96 96" className="size-full -rotate-90" aria-hidden>
+          <circle cx={48} cy={48} r={radius} fill="none" strokeWidth={9} className="stroke-slate-100 dark:stroke-slate-800" />
+          <circle
+            cx={48}
+            cy={48}
+            r={radius}
+            fill="none"
+            strokeWidth={9}
+            strokeLinecap="round"
+            strokeDasharray={`${filled} ${circumference - filled}`}
+            className={cx("transition-[stroke-dasharray] duration-500", STROKE_TONES[toneKey(percent)])}
+          />
+        </svg>
+        <span className="absolute inset-0 flex items-center justify-center text-sm font-semibold tabular-nums text-slate-900 dark:text-white">
+          {percentLabel(percent)}
+        </span>
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-slate-800 dark:text-slate-100">{label}</p>
+        {lines.map((line) => (
+          <p key={line} className="text-xs text-slate-500 dark:text-slate-400">
+            {line}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ClusterGauge summarizes one dimension cluster-wide: live usage when the metrics API serves it,
+// otherwise scheduled requests, always as a share of what is allocatable across all nodes.
+function ClusterGauge({ dimension, totals }: { dimension: Dimension; totals: ResourceTotals }) {
+  const usagePercent = percentOf(totals.usage, totals.allocatable);
+  const requestsPercent = percentOf(totals.requests, totals.allocatable);
+
+  const lines = [
+    totals.usage !== undefined
+      ? `${dimension.format(totals.usage)} of ${dimension.format(totals.allocatable)} used`
+      : `${dimension.format(totals.allocatable)} allocatable`,
+    `${dimension.format(totals.requests)} requested${requestsPercent === undefined ? "" : ` (${Math.round(requestsPercent)}%)`}`,
+  ];
+
+  return (
+    <div title={totalsTitle(dimension, totals)}>
+      <Donut percent={usagePercent ?? requestsPercent} label={dimension.label} lines={lines} />
+    </div>
+  );
+}
+
+// UsageBar is one node's utilisation of a dimension: fill = live usage (or requests without a
+// metrics API), tick marker = requests, both as a share of the node's allocatable.
+function UsageBar({ dimension, totals }: { dimension: Dimension; totals: ResourceTotals }) {
+  const usagePercent = percentOf(totals.usage, totals.allocatable);
+  const requestsPercent = percentOf(totals.requests, totals.allocatable);
+  const percent = usagePercent ?? requestsPercent;
+
+  return (
+    <div className="flex items-center gap-2" title={totalsTitle(dimension, totals)}>
+      <div
+        className="relative h-2 flex-1 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800"
+        role="meter"
+        aria-label={dimension.label}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percent === undefined ? undefined : Math.round(percent)}
+      >
+        <div
+          className={cx("h-full rounded-full transition-[width] duration-500", BAR_TONES[toneKey(percent)])}
+          style={{ width: `${percent ?? 0}%` }}
+        />
+        {usagePercent !== undefined && requestsPercent !== undefined ? (
+          <div
+            className="absolute inset-y-0 w-0.5 bg-slate-400 dark:bg-slate-500"
+            style={{ left: `${requestsPercent}%` }}
+            aria-hidden
+          />
+        ) : null}
+      </div>
+      <span className="w-9 shrink-0 text-right text-xs tabular-nums text-slate-500 dark:text-slate-400">
+        {percentLabel(percent)}
+      </span>
+    </div>
+  );
+}
+
+// nodeListGrid keeps the header row and node rows on the same column raster.
+const nodeListGrid = "grid grid-cols-[minmax(0,1.2fr)_1fr_1fr_3.5rem] items-center gap-3";
+
+function NodeRow({ node }: { node: NodeUsage }) {
+  return (
+    <li className={cx(nodeListGrid, "py-2")}>
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className={cx("size-1.5 shrink-0 rounded-full", node.ready ? "bg-emerald-500" : "bg-red-500")}
+          title={node.ready ? "Ready" : "Not ready"}
+        />
+        <span className="truncate font-mono text-xs text-slate-700 dark:text-slate-200" title={node.name}>
+          {node.name}
+        </span>
+        {node.controlPlane ? (
+          <span className="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+            CP
+          </span>
+        ) : null}
+      </div>
+      {DIMENSIONS.map((dimension) => (
+        <UsageBar key={dimension.key} dimension={dimension} totals={node[dimension.key]} />
+      ))}
+      <span className="text-right text-xs tabular-nums text-slate-500 dark:text-slate-400">
+        {node.pods.count}
+        {node.pods.allocatable > 0 ? ` / ${node.pods.allocatable}` : ""}
+      </span>
+    </li>
+  );
+}
+
+// ConsumerList is the top-N pods for one dimension, from the metrics API.
+function ConsumerList({ dimension, pods }: { dimension: Dimension; pods: PodConsumption[] }) {
+  return (
+    <div>
+      <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        Top pods by {dimension.label.toLowerCase()}
+      </h4>
+      {pods.length === 0 ? (
+        <p className="text-xs text-slate-500 dark:text-slate-400">No usage reported.</p>
+      ) : (
+        <ul className="space-y-1">
+          {pods.map((pod) => (
+            <li key={`${pod.namespace}/${pod.name}`} className="flex items-baseline justify-between gap-2 text-xs">
+              <span className="min-w-0 truncate text-slate-600 dark:text-slate-300" title={`${pod.namespace}/${pod.name}`}>
+                <span className="text-slate-400 dark:text-slate-500">{pod.namespace}/</span>
+                {pod.name}
+              </span>
+              <span className="shrink-0 tabular-nums text-slate-500 dark:text-slate-400">
+                {dimension.format(pod[dimension.key])}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ResourceUsagePanel is the Overview's monitoring section: cluster-wide CPU/memory/pod gauges, a
+// per-node utilisation breakdown, and the top pod consumers when a metrics API is available.
+export function ResourceUsagePanel({
+  usage,
+  topPods,
+  loading,
+}: {
+  usage: ClusterUsage | null;
+  topPods: PodConsumption[] | null;
+  loading: boolean;
+}) {
+  return (
+    <Card title="Resource usage" icon={<Gauge className="size-3.5" aria-hidden />}>
+      {!usage ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {loading ? "Loading…" : "Resource usage is unavailable."}
+        </p>
+      ) : usage.nodes.length === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">No nodes reported.</p>
+      ) : (
+        <div className="space-y-4">
+          {!usage.metricsAvailable ? (
+            <p className="rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-500 dark:bg-slate-800/60 dark:text-slate-400">
+              Live usage is unavailable on this cluster (no metrics API serving metrics.k8s.io) — gauges and bars
+              show requested resources instead.
+            </p>
+          ) : null}
+
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {DIMENSIONS.map((dimension) => (
+              <ClusterGauge key={dimension.key} dimension={dimension} totals={usage[dimension.key]} />
+            ))}
+            <Donut
+              percent={percentOf(usage.pods.count, usage.pods.allocatable)}
+              label="Pods"
+              lines={[`${usage.pods.count} of ${usage.pods.allocatable} schedulable pods`]}
+            />
+          </div>
+
+          <div>
+            <div className={cx(nodeListGrid, "border-b border-slate-100 pb-1.5 dark:border-slate-800")}>
+              {["Node", "CPU", "Memory", "Pods"].map((heading) => (
+                <span
+                  key={heading}
+                  className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 last:text-right dark:text-slate-500"
+                >
+                  {heading}
+                </span>
+              ))}
+            </div>
+            <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+              {usage.nodes.map((node) => (
+                <NodeRow key={node.name} node={node} />
+              ))}
+            </ul>
+            {usage.metricsAvailable ? (
+              <p className="mt-1.5 text-[10px] text-slate-400 dark:text-slate-500">
+                Bar = live usage · tick = requested · % of allocatable
+              </p>
+            ) : null}
+          </div>
+
+          {usage.metricsAvailable && topPods && topPods.length > 0 ? (
+            <div className="grid gap-4 border-t border-slate-100 pt-3 sm:grid-cols-2 dark:border-slate-800">
+              {DIMENSIONS.map((dimension) => (
+                <ConsumerList
+                  key={dimension.key}
+                  dimension={dimension}
+                  pods={topConsumers(topPods, dimension.key, TOP_CONSUMERS)}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/ui/src/lib/k8s.ts
+++ b/web/ui/src/lib/k8s.ts
@@ -66,18 +66,58 @@ export function eventLastSeenMs(fields: EventFields): number {
   return epochMs(fields.lastSeen);
 }
 
-// nodeReady reports whether a Node's Ready condition is True.
-export function nodeReady(node: K8sObject): boolean {
+// nodeConditions returns a Node's status conditions as loose records.
+function nodeConditions(node: K8sObject): Record<string, unknown>[] {
   const status = record(node.status);
   const conditions = Array.isArray(status?.conditions) ? status.conditions : [];
-  for (const condition of conditions) {
-    const cond = record(condition);
-    if (cond && cond.type === "Ready") {
-      return cond.status === "True";
-    }
-  }
 
-  return false;
+  return conditions.map(record).filter((cond) => cond !== undefined);
+}
+
+// nodeReady reports whether a Node's Ready condition is True.
+export function nodeReady(node: K8sObject): boolean {
+  return nodeConditions(node).some((cond) => cond.type === "Ready" && cond.status === "True");
+}
+
+// NodeProblem is a Node condition signalling trouble (e.g. MemoryPressure/DiskPressure True), kept
+// with its node so the Overview can synthesize health conditions from live state.
+export interface NodeProblem {
+  node: string;
+  type: string;
+  message: string;
+  lastTransitionTime?: string;
+}
+
+// nodeProblems returns the Node's abnormal conditions: Ready is a problem when not True, every other
+// condition (the kubelet's pressure/availability signals) is a problem when True.
+export function nodeProblems(node: K8sObject): NodeProblem[] {
+  const name = str(node.metadata?.name);
+
+  return nodeConditions(node)
+    .filter((cond) => (cond.type === "Ready" ? cond.status !== "True" : cond.status === "True"))
+    .map((cond) => ({
+      node: name,
+      type: str(cond.type),
+      message: str(cond.message) || str(cond.reason),
+      lastTransitionTime: str(cond.lastTransitionTime) || undefined,
+    }));
+}
+
+// nodeIsControlPlane reports whether a Node carries a control-plane role label (including the legacy
+// master label Talos/older clusters still use).
+export function nodeIsControlPlane(node: K8sObject): boolean {
+  const labels = node.metadata?.labels;
+  const map = record(labels) ?? {};
+
+  return "node-role.kubernetes.io/control-plane" in map || "node-role.kubernetes.io/master" in map;
+}
+
+// nodeSystemInfo extracts the kubelet version and OS image from a Node's status.nodeInfo ("" when
+// absent), surfacing the cluster's actual Kubernetes version and OS in the Overview.
+export function nodeSystemInfo(node: K8sObject): { kubeletVersion: string; osImage: string } {
+  const info = record(record(node.status)?.nodeInfo);
+
+  return { kubeletVersion: str(info?.kubeletVersion), osImage: str(info?.osImage) };
 }
 
 // podPhase returns a Pod's status.phase (e.g. "Running", "Pending"), or "Unknown" when absent.

--- a/web/ui/src/lib/quantity.ts
+++ b/web/ui/src/lib/quantity.ts
@@ -1,0 +1,83 @@
+// Kubernetes resource-quantity parsing and formatting (CPU in cores, memory in bytes), used by the
+// Overview's resource-usage monitoring. Mirrors the subset of Kubernetes quantity syntax that node
+// capacity/allocatable, pod requests/limits, and metrics.k8s.io values actually use.
+
+// QUANTITY_SCALE maps a quantity suffix to its multiplier relative to the base unit (cores for CPU,
+// bytes for memory). Decimal SI suffixes scale by powers of 1000; binary suffixes by powers of 1024.
+const QUANTITY_SCALE: Record<string, number> = {
+  "": 1,
+  n: 1e-9,
+  u: 1e-6,
+  m: 1e-3,
+  k: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+  Ki: 1024 ** 1,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+};
+
+// Two-letter binary suffixes are listed before their one-letter SI prefixes so "Mi" never half-matches
+// as "M" with a dangling "i".
+const QUANTITY_PATTERN = /^([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)(Ki|Mi|Gi|Ti|Pi|Ei|n|u|m|k|M|G|T|P|E)?$/;
+
+// parseQuantity parses a Kubernetes resource quantity ("100m", "1536Mi", "2", "16467492Ki") into a
+// number in its base unit, or undefined when absent or unparseable. Values come from unstructured
+// JSON, so any input type is tolerated.
+export function parseQuantity(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const match = QUANTITY_PATTERN.exec(value.trim());
+  if (!match) {
+    return undefined;
+  }
+
+  return Number(match[1]) * QUANTITY_SCALE[match[2] ?? ""];
+}
+
+// formatCores renders a CPU quantity in cores: millicores below one core ("250m"), otherwise a
+// compact decimal ("3.4", "12").
+export function formatCores(cores: number): string {
+  if (cores < 1) {
+    return `${Math.round(cores * 1000)}m`;
+  }
+
+  return cores >= 10 ? `${Math.round(cores)}` : `${Number(cores.toFixed(1))}`;
+}
+
+// formatBytes renders a byte quantity with a binary unit ("512 MiB", "12.4 GiB").
+export function formatBytes(bytes: number): string {
+  const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+  let value = bytes;
+  let unit = 0;
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+
+  const digits = value > 0 && value < 100 && !Number.isInteger(value) ? 1 : 0;
+
+  return `${value.toFixed(digits)} ${units[unit]}`;
+}
+
+// percentOf returns part as a 0–100 percentage of whole (clamped), or undefined when the whole is
+// unknown or zero — callers render "—" instead of a meaningless 0%.
+export function percentOf(part: number | undefined, whole: number): number | undefined {
+  if (part === undefined || whole <= 0) {
+    return undefined;
+  }
+
+  return Math.min(100, Math.max(0, (part / whole) * 100));
+}

--- a/web/ui/src/lib/usage.ts
+++ b/web/ui/src/lib/usage.ts
@@ -1,0 +1,214 @@
+// Resource-usage model for the Overview's monitoring section: combines Nodes (capacity/allocatable),
+// Pods (scheduled requests/limits), and the metrics API (live usage, when a metrics-server is
+// installed) into per-node and cluster-wide totals.
+
+import type { K8sObject } from "../api.ts";
+import { nodeIsControlPlane, nodeReady, podPhase } from "./k8s.ts";
+import { parseQuantity } from "./quantity.ts";
+
+// ResourceTotals is one resource dimension (CPU in cores or memory in bytes) for a node or the
+// cluster: what exists, what scheduled pods ask for, and live usage when the metrics API serves it.
+export interface ResourceTotals {
+  capacity: number;
+  allocatable: number;
+  requests: number;
+  limits: number;
+  usage?: number;
+}
+
+export interface NodeUsage {
+  name: string;
+  controlPlane: boolean;
+  ready: boolean;
+  cpu: ResourceTotals;
+  memory: ResourceTotals;
+  pods: { allocatable: number; count: number };
+}
+
+export interface ClusterUsage {
+  nodes: NodeUsage[];
+  cpu: ResourceTotals;
+  memory: ResourceTotals;
+  pods: { allocatable: number; count: number };
+  // metricsAvailable is true when the metrics API returned usage for at least one node; the UI
+  // otherwise falls back to requests-only visuals and explains why.
+  metricsAvailable: boolean;
+}
+
+// PodConsumption is one pod's live usage from the metrics API, for the "top consumers" lists.
+export interface PodConsumption {
+  name: string;
+  namespace: string;
+  cpu: number;
+  memory: number;
+}
+
+// asRecord narrows unstructured JSON to an object map (usage.ts reads metrics/pod shapes the loose
+// K8sObject type does not model).
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+// cpuMemory reads the cpu/memory quantities off an unstructured resource map (a node's
+// capacity/allocatable, a container's requests/limits, or a metrics usage block).
+function cpuMemory(value: unknown): { cpu: number; memory: number } {
+  const map = asRecord(value);
+
+  return {
+    cpu: parseQuantity(map?.cpu) ?? 0,
+    memory: parseQuantity(map?.memory) ?? 0,
+  };
+}
+
+// containersOf returns the containers array of a pod spec or pod-metrics object.
+function containersOf(value: unknown): Record<string, unknown>[] {
+  const containers = asRecord(value)?.containers;
+  if (!Array.isArray(containers)) {
+    return [];
+  }
+
+  return containers.map(asRecord).filter((container) => container !== undefined);
+}
+
+// sumPodResources accumulates one pod's per-container requests and limits into the per-node bucket.
+function sumPodResources(pod: K8sObject, bucket: { cpu: ResourceTotals; memory: ResourceTotals }) {
+  for (const container of containersOf(pod.spec)) {
+    const resources = asRecord(container.resources);
+    const requests = cpuMemory(resources?.requests);
+    const limits = cpuMemory(resources?.limits);
+
+    bucket.cpu.requests += requests.cpu;
+    bucket.cpu.limits += limits.cpu;
+    bucket.memory.requests += requests.memory;
+    bucket.memory.limits += limits.memory;
+  }
+}
+
+function emptyTotals(): ResourceTotals {
+  return { capacity: 0, allocatable: 0, requests: 0, limits: 0 };
+}
+
+// podIsScheduledActive reports whether a pod currently occupies node resources: it is bound to a
+// node and not in a terminal phase (matching how `kubectl describe node` counts allocated resources).
+function podIsScheduledActive(pod: K8sObject): boolean {
+  const phase = podPhase(pod);
+
+  return asRecord(pod.spec)?.nodeName !== undefined && phase !== "Succeeded" && phase !== "Failed";
+}
+
+// buildClusterUsage assembles the per-node and cluster-wide usage model. nodeMetrics may be empty
+// (no metrics-server): live usage is then omitted and metricsAvailable is false.
+export function buildClusterUsage(
+  nodes: K8sObject[],
+  pods: K8sObject[],
+  nodeMetrics: K8sObject[],
+): ClusterUsage {
+  const usageByNode = new Map<string, { cpu: number; memory: number }>();
+  for (const metric of nodeMetrics) {
+    const name = metric.metadata?.name;
+    if (typeof name === "string") {
+      usageByNode.set(name, cpuMemory(metric.usage));
+    }
+  }
+
+  const byNode = new Map<string, NodeUsage>();
+  for (const node of nodes) {
+    const name = node.metadata?.name;
+    if (typeof name !== "string") {
+      continue;
+    }
+
+    const status = asRecord(node.status);
+    const capacity = cpuMemory(status?.capacity);
+    const allocatable = cpuMemory(status?.allocatable);
+    const usage = usageByNode.get(name);
+
+    byNode.set(name, {
+      name,
+      controlPlane: nodeIsControlPlane(node),
+      ready: nodeReady(node),
+      cpu: { ...emptyTotals(), capacity: capacity.cpu, allocatable: allocatable.cpu, usage: usage?.cpu },
+      memory: {
+        ...emptyTotals(),
+        capacity: capacity.memory,
+        allocatable: allocatable.memory,
+        usage: usage?.memory,
+      },
+      pods: { allocatable: parseQuantity(asRecord(status?.allocatable)?.pods) ?? 0, count: 0 },
+    });
+  }
+
+  for (const pod of pods) {
+    if (!podIsScheduledActive(pod)) {
+      continue;
+    }
+
+    const entry = byNode.get(String(asRecord(pod.spec)?.nodeName));
+    if (!entry) {
+      continue;
+    }
+
+    entry.pods.count += 1;
+    sumPodResources(pod, entry);
+  }
+
+  // Control planes first, then workers, both alphabetically — the same order an operator scans.
+  const nodeUsages = [...byNode.values()].sort(
+    (a, b) => Number(b.controlPlane) - Number(a.controlPlane) || a.name.localeCompare(b.name),
+  );
+
+  const cluster: ClusterUsage = {
+    nodes: nodeUsages,
+    cpu: emptyTotals(),
+    memory: emptyTotals(),
+    pods: { allocatable: 0, count: 0 },
+    metricsAvailable: usageByNode.size > 0,
+  };
+
+  for (const node of nodeUsages) {
+    for (const key of ["cpu", "memory"] as const) {
+      cluster[key].capacity += node[key].capacity;
+      cluster[key].allocatable += node[key].allocatable;
+      cluster[key].requests += node[key].requests;
+      cluster[key].limits += node[key].limits;
+      if (node[key].usage !== undefined) {
+        cluster[key].usage = (cluster[key].usage ?? 0) + node[key].usage;
+      }
+    }
+
+    cluster.pods.allocatable += node.pods.allocatable;
+    cluster.pods.count += node.pods.count;
+  }
+
+  return cluster;
+}
+
+// buildPodConsumption maps pod metrics to per-pod live usage, summed across containers.
+export function buildPodConsumption(podMetrics: K8sObject[]): PodConsumption[] {
+  return podMetrics.map((metric) => {
+    const totals = { cpu: 0, memory: 0 };
+    for (const container of containersOf(metric)) {
+      const usage = cpuMemory(container.usage);
+      totals.cpu += usage.cpu;
+      totals.memory += usage.memory;
+    }
+
+    return {
+      name: metric.metadata?.name ?? "",
+      namespace: metric.metadata?.namespace ?? "",
+      ...totals,
+    };
+  });
+}
+
+// topConsumers returns the count highest-usage pods for a dimension, dropping zero-usage entries.
+export function topConsumers(
+  pods: PodConsumption[],
+  dimension: "cpu" | "memory",
+  count: number,
+): PodConsumption[] {
+  return pods
+    .filter((pod) => pod[dimension] > 0)
+    .sort((a, b) => b[dimension] - a[dimension])
+    .slice(0, count);
+}


### PR DESCRIPTION
## Why

The cluster Overview was incomplete and wrong for discovered clusters (the local `ksail ui` surface — e.g. a Talos × Hetzner cluster found via kubeconfig/discovery):

- **Spec** fabricated values discovery never knew: a 10-node production cluster showed *Control planes 1, Workers 0*, and component rows showed made-up defaults ("Cert Manager: Disabled", "GitOps Engine: None").
- **Status** was empty dashes: no endpoint, no node counts, no creation time, no version.
- **Conditions** always said "No conditions reported" — even with 46 failed pods on the cluster.
- There was no way to see actual resource usage or allocation, cluster-wide or per node.

## What

**Backend**
- The local backend now reports `status.endpoint` from the matching kubeconfig context's API server URL (one file read per `List`, no cluster round-trips, best-effort).
- `NodeMetrics`/`PodMetrics` (`metrics.k8s.io/v1beta1`) join the curated resource-kind allowlist, so both the local and operator surfaces serve live usage through the existing read-only resources endpoint.

**Overview UI**
- **Spec**: control-plane/worker counts derive from live node role labels when the spec doesn't carry them; fabricated component defaults are no longer shown for discovered clusters.
- **Status**: live Kubernetes version, OS image (e.g. "Talos (v1.13.3)"), node readiness, and cluster age (kube-system's creation timestamp). Operator-only rows (kubeconfig secret, last reconcile) hide when absent instead of dashing.
- **Conditions**: when the backend reports none, live health checks are derived instead — `NodesReady`, `NodeConditions` (kubelet pressure/availability signals), and `PodsHealthy` (failed/not-ready/pending counts), so unhealthy pods surface at a glance.
- **New Resource usage panel**: cluster-wide CPU/memory/pods donut gauges (live usage vs requests vs allocatable), a per-node breakdown with usage bars, request ticks, traffic-light tones and CP badges, plus top pod consumers by CPU and memory. Falls back gracefully to requests-only visuals (with an explanatory note) when no metrics API is installed. Pure SVG/Tailwind — no new dependencies.

## Verification

- `go build ./pkg/...`, `go test ./pkg/operator/api/... ./pkg/cli/clusterapi/...` (212 tests, including new endpoint-enrichment and metrics-kind tests), `golangci-lint run` clean on changed packages, `npm run build` (tsc + vite) clean, jscpd clean on changed files.
- Verified live against a throwaway Kind cluster with metrics-server (then deleted), and read-only against a 10-node Talos × Hetzner cluster: spec counts (3 CP / 7 workers), endpoint, v1.36.1, Talos v1.13.3, 10/10 nodes, 18d age, the 46-failed-pods condition, and per-node usage (incl. amber highlighting on a node at 75% memory) all rendered correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)