### PR TITLE
feat(operator): self-register and manage the host cluster

### DIFF
--- a/charts/ksail-operator/README.md
+++ b/charts/ksail-operator/README.md
@@ -138,8 +138,8 @@ Register the redirect URL with your provider, and point `ksail.local` at your In
 
 ### Host cluster
 
-| Key                   | Description                                                                                                             | Default |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------|---------|
+| Key                   | Description                                                                                                            | Default |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------|---------|
 | `hostCluster.enabled` | Self-register the cluster the operator runs on as a `Cluster` resource named `host` so it appears in the cluster list. | `true`  |
 
 ### Web UI

--- a/charts/ksail-operator/README.md
+++ b/charts/ksail-operator/README.md
@@ -12,6 +12,7 @@ The operator reconciles `Cluster` resources (`ksail.io/v1alpha1`) so you can pro
 - **REST API** — served by the operator and consumed by the UI (toggle with `api.bindPort`).
 - **Web UI** _(optional)_ — a dashboard that talks to the REST API (`ui.enabled`).
 - **OIDC auth** _(optional)_ — app-driven OIDC login that protects the REST API and UI (`auth.oidc.enabled`).
+- **Host cluster registration** — the operator self-registers the cluster it runs on as a `Cluster` resource named `host` (labelled `ksail.io/host-cluster`) in the release namespace, so the hub itself appears in the cluster list and its workloads can be browsed in the UI — like Rancher's `local` cluster or Argo CD's `in-cluster` destination. The operator never provisions, updates, or deletes the underlying cluster for this entry, and the API rejects lifecycle mutations on it. Disable with `hostCluster.enabled=false`.
 
 > **Note:** The REST API is unauthenticated by default. Enable OIDC (`auth.oidc.enabled=true`) to require sign-in, or set `api.bindPort=0` to disable the API entirely when you don't need the UI.
 
@@ -134,6 +135,12 @@ Register the redirect URL with your provider, and point `ksail.local` at your In
 | Key            | Description                                                                                | Default |
 |----------------|--------------------------------------------------------------------------------------------|---------|
 | `api.bindPort` | Port the operator REST API listens on (consumed by the UI). Set to `0` to disable the API. | `8080`  |
+
+### Host cluster
+
+| Key                   | Description                                                                                                             | Default |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------|---------|
+| `hostCluster.enabled` | Self-register the cluster the operator runs on as a `Cluster` resource named `host` so it appears in the cluster list. | `true`  |
 
 ### Web UI
 

--- a/charts/ksail-operator/templates/deployment.yaml
+++ b/charts/ksail-operator/templates/deployment.yaml
@@ -39,14 +39,20 @@ spec:
             {{- if .Values.ui.readOnly }}
             - --read-only
             {{- end }}
+            - --host-cluster={{ .Values.hostCluster.enabled }}
             {{- if .Values.auth.oidc.enabled }}
             - --oidc-issuer-url={{ .Values.auth.oidc.issuerURL }}
             - --oidc-client-id={{ .Values.auth.oidc.clientID }}
             - --oidc-redirect-url={{ include "ksail-operator.oidc.redirectURL" . }}
             - --oidc-scopes={{ .Values.auth.oidc.scopes }}
             {{- end }}
-          {{- if .Values.auth.oidc.enabled }}
           env:
+            # POD_NAMESPACE tells the operator which namespace to register the host cluster in.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- if .Values.auth.oidc.enabled }}
             - name: KSAIL_OPERATOR_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -57,7 +63,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "ksail-operator.oidc.secretName" . }}
                   key: session-secret
-          {{- end }}
+            {{- end }}
           ports:
             {{- if .Values.api.bindPort }}
             - name: api

--- a/charts/ksail-operator/templates/rbac.yaml
+++ b/charts/ksail-operator/templates/rbac.yaml
@@ -68,6 +68,30 @@ rules:
     resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
     verbs:
       ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "bind", "escalate"]
+{{- if .Values.hostCluster.enabled }}
+  # Host cluster browsing (hostCluster.enabled): the dashboard reads the hub itself through the
+  # operator's ServiceAccount. The workload kinds above already carry read/write verbs; these add
+  # the read-only kinds the resource browser needs (nodes, events), the metrics API powering the
+  # Overview's usage gauges, and the GitOps CRs (patched to trigger reconciles).
+  - apiGroups: [""]
+    resources: ["nodes", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+      - argoproj.io
+    resources:
+      - kustomizations
+      - helmreleases
+      - gitrepositories
+      - ocirepositories
+      - applications
+    verbs: ["get", "list", "watch", "patch"]
+{{- end }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/ksail-operator/values.yaml
+++ b/charts/ksail-operator/values.yaml
@@ -32,6 +32,15 @@ api:
   # Port the operator REST API listens on (consumed by the UI). Set to 0 to disable the API.
   bindPort: 8080
 
+# hostCluster self-registers the cluster the operator runs on as a Cluster resource (named "host",
+# labelled ksail.io/host-cluster, in the release namespace), so the hub itself appears in the
+# cluster list and its workloads can be browsed through the operator's ServiceAccount — like
+# Rancher's "local" cluster or Argo CD's "in-cluster" destination. The operator never provisions,
+# updates, or deletes the underlying cluster for this entry, and the API rejects lifecycle
+# mutations on it (kubectl-deleting the resource merely deregisters it until the next restart).
+hostCluster:
+  enabled: true
+
 # ui is the web dashboard. It is embedded in the operator binary and served by the operator itself
 # on the API port (api.bindPort) — same origin as the REST API, so there is no separate UI
 # container and no reverse proxy. Reach it via the ingress below or by port-forwarding the operator

--- a/docs/src/content/docs/cli-flags/operator/operator-root.mdx
+++ b/docs/src/content/docs/cli-flags/operator/operator-root.mdx
@@ -19,6 +19,7 @@ Flags:
       --api-bind-address string            Address the REST API binds to (empty disables it, e.g. ":8080")
       --dev-logging                        Emit human-readable console logs instead of structured JSON (for local development)
       --health-probe-bind-address string   Address the health and readiness probes bind to (default ":8081")
+      --host-cluster                       Register the cluster the operator runs on as a Cluster resource (named "host") so it appears in the cluster list (default true)
       --leader-elect                       Enable leader election to ensure only one active operator instance
       --metrics-bind-address string        Address the metrics endpoint binds to ("0" disables it) (default "0")
       --oidc-client-id string              OIDC client ID (the client secret is read from KSAIL_OPERATOR_OIDC_CLIENT_SECRET)

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -135,6 +135,11 @@ type ClusterReconciler struct {
 	// disables runtime status reporting (endpoint/nodes stay empty).
 	ObserveStatus StatusObserver
 
+	// ObserveHostStatus gathers runtime status for the self-registered host cluster (the cluster the
+	// operator runs on) through the operator's own credentials. Optional; nil disables runtime status
+	// reporting for the host cluster.
+	ObserveHostStatus StatusObserver
+
 	// InstallComponents installs the cluster's components into the provisioned child cluster.
 	// Optional; nil disables component installation.
 	InstallComponents ComponentInstaller
@@ -171,6 +176,14 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if !cluster.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, &cluster)
+	}
+
+	// The host cluster (the operator's self-registration of the cluster it runs on) is never
+	// provisioned or torn down, so it gets no finalizer and a status-only reconcile.
+	if cluster.IsHostCluster() {
+		log.Info("reconciling host cluster")
+
+		return r.reconcileHost(ctx, &cluster)
 	}
 
 	if controllerutil.AddFinalizer(&cluster, FinalizerName) {
@@ -264,6 +277,37 @@ func (r *ClusterReconciler) reconcileNormal(
 	return ctrl.Result{RequeueAfter: r.readyRequeue()}, nil
 }
 
+// reconcileHost reconciles the self-registered host cluster. The underlying cluster — the one the
+// operator runs on — already exists and is owned by whoever provisioned it, so there is nothing to
+// create, update, or delete: reconciliation only observes runtime status (node readiness, endpoint)
+// through the operator's own credentials and reports it. Component installation is intentionally
+// skipped; the host cluster's components are not the operator's to manage.
+func (r *ClusterReconciler) reconcileHost(
+	ctx context.Context,
+	cluster *v1alpha1.Cluster,
+) (ctrl.Result, error) {
+	before := cluster.Status.DeepCopy()
+
+	r.observeStatusWith(ctx, r.ObserveHostStatus, cluster)
+
+	apimeta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               v1alpha1.ConditionComponentsReady,
+		Status:             metav1.ConditionUnknown,
+		ObservedGeneration: cluster.Generation,
+		Reason:             "HostCluster",
+		Message:            "components on the host cluster are not managed by the operator",
+	})
+
+	r.markReady(cluster)
+
+	statusErr := r.updateStatusIfChanged(ctx, cluster, before)
+	if statusErr != nil {
+		return ctrl.Result{}, statusErr
+	}
+
+	return ctrl.Result{RequeueAfter: r.readyRequeue()}, nil
+}
+
 // reconcileComponents installs the cluster's components when they are not already reconciled for the
 // current generation, recording the outcome in the ComponentsReady condition. Best-effort: failures
 // are reported via the condition (not the reconcile error) and return false so the reconcile
@@ -335,14 +379,25 @@ func componentsUpToDate(cluster *v1alpha1.Cluster) bool {
 // optional StatusObserver. It is best-effort: observation errors are logged and partial results
 // applied, since a not-yet-reachable child cluster is expected shortly after provisioning.
 func (r *ClusterReconciler) observeStatus(ctx context.Context, cluster *v1alpha1.Cluster) {
-	if r.ObserveStatus == nil {
+	r.observeStatusWith(ctx, r.ObserveStatus, cluster)
+}
+
+// observeStatusWith applies the given observer's results to the cluster status. Shared by the
+// child-cluster path (ObserveStatus) and the host-cluster path (ObserveHostStatus); a nil observer
+// disables observation.
+func (r *ClusterReconciler) observeStatusWith(
+	ctx context.Context,
+	observer StatusObserver,
+	cluster *v1alpha1.Cluster,
+) {
+	if observer == nil {
 		return
 	}
 
-	observed, err := r.ObserveStatus(ctx, r.reader(), cluster)
+	observed, err := observer(ctx, r.reader(), cluster)
 	if err != nil {
 		logf.FromContext(ctx).
-			Info("observe child cluster status (best-effort)", "error", err.Error())
+			Info("observe cluster status (best-effort)", "error", err.Error())
 	}
 
 	if observed.Endpoint != "" {
@@ -365,6 +420,21 @@ func (r *ClusterReconciler) reconcileDelete(
 	cluster *v1alpha1.Cluster,
 ) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(cluster, FinalizerName) {
+		return ctrl.Result{}, nil
+	}
+
+	// Deleting the host registration must never destroy anything: the underlying cluster is the one
+	// the operator runs on. The host path adds no finalizer, but a user may have labelled a cluster
+	// that already carried one — remove it without invoking the provisioner (conservative: the
+	// underlying cluster is orphaned, not destroyed).
+	if cluster.IsHostCluster() {
+		controllerutil.RemoveFinalizer(cluster, FinalizerName)
+
+		err := r.Update(ctx, cluster)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
+		}
+
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/host_cluster_test.go
+++ b/internal/controller/host_cluster_test.go
@@ -1,0 +1,143 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/internal/controller"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	hostName      = "host"
+	hostNamespace = "default"
+)
+
+// newHostCluster returns a host-labelled Cluster, mirroring the operator's self-registration of the
+// cluster it runs on (empty spec, host-cluster label).
+func newHostCluster(withFinalizer bool) *v1alpha1.Cluster {
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       hostName,
+			Namespace:  hostNamespace,
+			Generation: 1,
+			Labels:     map[string]string{v1alpha1.HostClusterLabel: "true"},
+		},
+	}
+	if withFinalizer {
+		cluster.Finalizers = []string{controller.FinalizerName}
+	}
+
+	return cluster
+}
+
+func hostRequest() ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: hostName, Namespace: hostNamespace},
+	}
+}
+
+// newHostReconciler builds a reconciler whose provisioner builder fails the reconcile if invoked —
+// the host path must never touch a provisioner — and whose host observer reports fixed status.
+func newHostReconciler(
+	t *testing.T,
+	fakeClient client.Client,
+) *controller.ClusterReconciler {
+	t.Helper()
+
+	return &controller.ClusterReconciler{
+		Client: fakeClient,
+		Scheme: newScheme(t),
+		NewProvisioner: func(
+			_ context.Context,
+			_ *v1alpha1.Cluster,
+		) (clusterprovisioner.Provisioner, error) {
+			return nil, errBoom
+		},
+		ObserveHostStatus: func(
+			_ context.Context,
+			_ client.Reader,
+			_ *v1alpha1.Cluster,
+		) (controller.ObservedStatus, error) {
+			return controller.ObservedStatus{
+				Endpoint:      "https://10.96.0.1:443",
+				NodesReady:    2,
+				NodesTotal:    3,
+				NodesObserved: true,
+			}, nil
+		},
+	}
+}
+
+func TestReconcile_HostClusterReportsReadyWithoutProvisioner(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := newFakeClient(newScheme(t), newHostCluster(false))
+	reconciler := newHostReconciler(t, fakeClient)
+
+	res, err := reconciler.Reconcile(context.Background(), hostRequest())
+	require.NoError(t, err, "the host path must not build a provisioner")
+	assert.Positive(t, res.RequeueAfter, "the host cluster should be re-observed periodically")
+
+	var got v1alpha1.Cluster
+
+	require.NoError(t, fakeClient.Get(context.Background(), hostRequest().NamespacedName, &got))
+	assert.Equal(t, v1alpha1.ClusterPhaseReady, got.Status.Phase)
+	assert.Empty(t, got.Finalizers, "the host cluster must not get the teardown finalizer")
+	assert.Equal(t, "https://10.96.0.1:443", got.Status.Endpoint)
+	assert.Equal(t, int32(2), got.Status.NodesReady)
+	assert.Equal(t, int32(3), got.Status.NodesTotal)
+
+	ready := apimeta.FindStatusCondition(got.Status.Conditions, v1alpha1.ConditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionTrue, ready.Status)
+
+	components := apimeta.FindStatusCondition(
+		got.Status.Conditions,
+		v1alpha1.ConditionComponentsReady,
+	)
+	require.NotNil(t, components)
+	assert.Equal(t, metav1.ConditionUnknown, components.Status)
+	assert.Equal(t, "HostCluster", components.Reason)
+}
+
+func TestReconcile_HostClusterDeleteSkipsProvisioner(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	// A user may have labelled an existing cluster that already carried the finalizer; deletion must
+	// remove the finalizer without ever invoking the provisioner.
+	cluster := newHostCluster(true)
+	fakeClient := newFakeClient(scheme, cluster)
+	prov := &fakeProvisioner{exists: true}
+	reconciler := newReconciler(scheme, fakeClient, prov)
+
+	require.NoError(t, fakeClient.Delete(context.Background(), cluster))
+
+	_, err := reconciler.Reconcile(context.Background(), hostRequest())
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		0,
+		prov.deleteCalls,
+		"deleting the host registration must not tear anything down",
+	)
+
+	var got v1alpha1.Cluster
+
+	getErr := fakeClient.Get(context.Background(), hostRequest().NamespacedName, &got)
+	assert.True(
+		t,
+		apierrors.IsNotFound(getErr),
+		"the registration should be gone after finalizer removal",
+	)
+}

--- a/pkg/apis/cluster/v1alpha1/labels.go
+++ b/pkg/apis/cluster/v1alpha1/labels.go
@@ -4,3 +4,17 @@ package v1alpha1
 // Cluster resource. The operator only ever deletes namespaces carrying this label, so namespaces
 // that already existed (e.g. "default" or user-managed namespaces) are never removed.
 const ManagedNamespaceLabel = "ksail.io/managed-namespace"
+
+// HostClusterLabel marks the Cluster resource the operator self-registers to represent the cluster
+// it runs ON (the hub), following the pattern of Rancher's "local" cluster and Argo CD's
+// "in-cluster" destination. The label is reserved: the operator never provisions, updates, or
+// deletes the underlying cluster for a resource carrying it — it only observes status and serves
+// resource browsing through its own in-cluster credentials — and the REST API rejects lifecycle
+// mutations on it.
+const HostClusterLabel = "ksail.io/host-cluster"
+
+// IsHostCluster reports whether this Cluster resource is the operator's self-registration of the
+// cluster it runs on (see HostClusterLabel).
+func (c *Cluster) IsHostCluster() bool {
+	return c.Labels[HostClusterLabel] == "true"
+}

--- a/pkg/cli/cmd/operator/operator.go
+++ b/pkg/cli/cmd/operator/operator.go
@@ -114,11 +114,23 @@ func bindOperatorFlags(cmd *cobra.Command, opts *operatorsvc.Options, oidc *oidc
 		"Run the REST API in read-only mode, rejecting all mutating requests",
 	)
 	cmd.Flags().BoolVar(
+		&opts.HostCluster,
+		"host-cluster",
+		true,
+		"Register the cluster the operator runs on as a Cluster resource (named \"host\") "+
+			"so it appears in the cluster list",
+	)
+	cmd.Flags().BoolVar(
 		&opts.DevLogging,
 		"dev-logging",
 		false,
 		"Emit human-readable console logs instead of structured JSON (for local development)",
 	)
+	bindOIDCFlags(cmd, oidc)
+}
+
+// bindOIDCFlags registers the OIDC flags onto cmd (split from bindOperatorFlags for length).
+func bindOIDCFlags(cmd *cobra.Command, oidc *oidcFlags) {
 	cmd.Flags().StringVar(
 		&oidc.issuerURL,
 		"oidc-issuer-url",

--- a/pkg/operator/api/cr_service.go
+++ b/pkg/operator/api/cr_service.go
@@ -68,6 +68,15 @@ func (s *crClusterService) Create(
 	ctx context.Context,
 	cluster *v1alpha1.Cluster,
 ) (*v1alpha1.Cluster, error) {
+	// The host-cluster label is reserved for the operator's self-registration; a client-created
+	// cluster carrying it would just alias the hub and bypass the reconciler.
+	if cluster.IsHostCluster() {
+		return nil, fmt.Errorf(
+			"%w: the %s label is reserved for the operator",
+			ErrHostClusterProtected, v1alpha1.HostClusterLabel,
+		)
+	}
+
 	sanitized := sanitizeForWrite(cluster)
 	if sanitized.Namespace == "" {
 		sanitized.Namespace = defaultNamespace
@@ -105,6 +114,12 @@ func (s *crClusterService) Update(
 		return nil, fmt.Errorf("get cluster: %w", err)
 	}
 
+	// The host cluster's spec is not reconciled (the operator does not manage the hub's lifecycle),
+	// so spec edits through the API would only mislead.
+	if existing.IsHostCluster() {
+		return nil, ErrHostClusterProtected
+	}
+
 	existing.Spec = cluster.Spec
 
 	updateErr := s.client.Update(ctx, &existing)
@@ -119,6 +134,16 @@ func (s *crClusterService) Delete(ctx context.Context, namespace, name string) e
 	cluster := &v1alpha1.Cluster{}
 	cluster.Namespace = namespace
 	cluster.Name = name
+
+	// Deleting the host registration through the API is blocked (like Rancher's "local" cluster):
+	// "delete" reads as destroying the cluster, and the hub hosting the operator must never be a
+	// one-click casualty. kubectl remains the escape hatch — CR deletion only deregisters.
+	var existing v1alpha1.Cluster
+
+	getErr := s.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &existing)
+	if getErr == nil && existing.IsHostCluster() {
+		return ErrHostClusterProtected
+	}
 
 	err := s.client.Delete(ctx, cluster)
 	if err != nil {

--- a/pkg/operator/api/host_cluster_test.go
+++ b/pkg/operator/api/host_cluster_test.go
@@ -1,0 +1,58 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/operator/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hostCluster mirrors the operator's self-registration of the cluster it runs on: the well-known
+// host name with the reserved label and an empty spec.
+func hostCluster() *v1alpha1.Cluster {
+	cluster := &v1alpha1.Cluster{}
+	cluster.Name = "host"
+	cluster.Namespace = defaultNS
+	cluster.Labels = map[string]string{v1alpha1.HostClusterLabel: "true"}
+
+	return cluster
+}
+
+func TestCreateRejectsReservedHostClusterLabel(t *testing.T) {
+	t.Parallel()
+
+	service := api.NewCRClusterService(newClient(t))
+
+	_, err := service.Create(context.Background(), hostCluster())
+	require.ErrorIs(t, err, api.ErrHostClusterProtected)
+}
+
+func TestUpdateRejectsHostCluster(t *testing.T) {
+	t.Parallel()
+
+	service := api.NewCRClusterService(newClient(t, hostCluster()))
+
+	updated := hostCluster()
+	updated.Spec.Cluster.Distribution = v1alpha1.DistributionVCluster
+
+	_, err := service.Update(context.Background(), defaultNS, "host", updated)
+	require.ErrorIs(t, err, api.ErrHostClusterProtected)
+}
+
+func TestDeleteRejectsHostCluster(t *testing.T) {
+	t.Parallel()
+
+	hub := newClient(t, hostCluster())
+	service := api.NewCRClusterService(hub)
+
+	err := service.Delete(context.Background(), defaultNS, "host")
+	require.ErrorIs(t, err, api.ErrHostClusterProtected)
+
+	// The registration must still exist after the rejected delete.
+	still, getErr := service.Get(context.Background(), defaultNS, "host")
+	require.NoError(t, getErr)
+	assert.True(t, still.IsHostCluster())
+}

--- a/pkg/operator/api/server.go
+++ b/pkg/operator/api/server.go
@@ -949,6 +949,8 @@ func clientErrorStatus(err error) int {
 		return http.StatusUnprocessableEntity
 	case errors.Is(err, ErrNotSupported):
 		return http.StatusNotImplemented
+	case errors.Is(err, ErrHostClusterProtected):
+		return http.StatusForbidden
 	case apierrors.IsBadRequest(err):
 		return http.StatusBadRequest
 	case apierrors.IsUnauthorized(err):

--- a/pkg/operator/api/service.go
+++ b/pkg/operator/api/service.go
@@ -19,6 +19,13 @@ var (
 	ErrInvalid = errors.New("invalid cluster")
 	// ErrNotSupported indicates the backend does not support the requested operation (HTTP 501).
 	ErrNotSupported = errors.New("operation not supported")
+	// ErrHostClusterProtected indicates the request targets the operator's self-registered host
+	// cluster — the cluster the operator runs on — whose registration cannot be created, modified,
+	// or deleted through the API (HTTP 403). Disable it via the operator's host-cluster option
+	// instead.
+	ErrHostClusterProtected = errors.New(
+		"the host cluster registration cannot be modified through the API",
+	)
 )
 
 // ClusterService is the backend the REST handlers delegate to. It is expressed in the

--- a/pkg/operator/export_test.go
+++ b/pkg/operator/export_test.go
@@ -14,4 +14,6 @@ var (
 	ResolveProvider = resolveProvider
 	// RunInstallers exposes runInstallers for testing.
 	RunInstallers = runInstallers
+	// CountReadyNodes exposes countReadyNodes for testing.
+	CountReadyNodes = countReadyNodes
 )

--- a/pkg/operator/hostcluster.go
+++ b/pkg/operator/hostcluster.go
@@ -1,0 +1,192 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/internal/controller"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// HostClusterName is the well-known name of the Cluster resource the operator self-registers to
+// represent the cluster it runs ON, so the hub itself shows up in the cluster list and can be
+// browsed like any managed cluster (cf. Rancher's "local" cluster, Argo CD's "in-cluster"
+// destination, Headlamp's "main" context).
+const HostClusterName = "host"
+
+const (
+	// podNamespaceEnvVar is the downward-API environment variable the Helm chart sets with the
+	// operator pod's namespace.
+	podNamespaceEnvVar = "POD_NAMESPACE"
+	// serviceAccountNamespaceFile is the projected file holding the pod's namespace; the fallback
+	// when the downward-API env var is not set.
+	serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	// defaultHostClusterNamespace is the last-resort namespace for the host registration, used when
+	// the operator runs outside a cluster (e.g. local development against a kubeconfig).
+	defaultHostClusterNamespace = "default"
+)
+
+// Bounded retry for the startup registration: the API server may briefly refuse writes right after
+// the operator starts (e.g. webhook or cache warm-up), so transient failures are retried.
+const (
+	hostClusterRegistrationInterval = 2 * time.Second
+	hostClusterRegistrationTimeout  = time.Minute
+)
+
+// ErrHostClusterNameTaken is returned when a Cluster resource already occupies the well-known host
+// name without carrying the host-cluster label. The operator never adopts it (the user owns it);
+// registration is skipped instead.
+var ErrHostClusterNameTaken = errors.New(
+	"host cluster registration skipped: a cluster with the reserved name exists without the " +
+		v1alpha1.HostClusterLabel + " label",
+)
+
+// HostClusterNamespace resolves the namespace the host Cluster resource is registered in: the
+// operator's own namespace from the POD_NAMESPACE downward-API env var, falling back to the
+// projected ServiceAccount namespace file, then "default" (running outside a cluster).
+func HostClusterNamespace() string {
+	if namespace := os.Getenv(podNamespaceEnvVar); namespace != "" {
+		return namespace
+	}
+
+	data, err := os.ReadFile(serviceAccountNamespaceFile)
+	if err == nil {
+		if namespace := strings.TrimSpace(string(data)); namespace != "" {
+			return namespace
+		}
+	}
+
+	return defaultHostClusterNamespace
+}
+
+// EnsureHostCluster registers the host cluster: it creates the well-known host Cluster resource,
+// labelled v1alpha1.HostClusterLabel, in the given namespace when it does not exist yet. The spec
+// is left empty on purpose — the operator does not manage the host cluster's lifecycle, so the
+// resource only carries observed status. Idempotent: an existing registration is left untouched,
+// and a same-named resource without the label is never adopted (ErrHostClusterNameTaken).
+func EnsureHostCluster(ctx context.Context, hub client.Client, namespace string) error {
+	var existing v1alpha1.Cluster
+
+	key := types.NamespacedName{Namespace: namespace, Name: HostClusterName}
+
+	err := hub.Get(ctx, key, &existing)
+	if err == nil {
+		if existing.IsHostCluster() {
+			return nil
+		}
+
+		return fmt.Errorf("%w: %s/%s", ErrHostClusterNameTaken, namespace, HostClusterName)
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("check host cluster registration: %w", err)
+	}
+
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      HostClusterName,
+			Namespace: namespace,
+			Labels:    map[string]string{v1alpha1.HostClusterLabel: "true"},
+		},
+	}
+
+	createErr := hub.Create(ctx, cluster)
+	// Tolerate a concurrent registration (a competing replica created it first).
+	if createErr != nil && !apierrors.IsAlreadyExists(createErr) {
+		return fmt.Errorf("register host cluster: %w", createErr)
+	}
+
+	return nil
+}
+
+// AddHostClusterRegistration adds a startup task to the manager that ensures the host Cluster
+// resource exists. The runnable is leader-gated (only the active operator registers) and
+// best-effort: failures are retried briefly and then logged — a missing host registration only
+// means the hub does not appear in the cluster list, so it must never crash the operator.
+func AddHostClusterRegistration(mgr ctrl.Manager, namespace string) error {
+	runnable := manager.RunnableFunc(func(ctx context.Context) error {
+		log := logf.FromContext(ctx).WithName("host-cluster-registration")
+
+		err := wait.PollUntilContextTimeout(
+			ctx,
+			hostClusterRegistrationInterval,
+			hostClusterRegistrationTimeout,
+			true,
+			func(ctx context.Context) (bool, error) {
+				ensureErr := EnsureHostCluster(ctx, mgr.GetClient(), namespace)
+				if ensureErr == nil {
+					return true, nil
+				}
+
+				// A name collision is terminal: retrying cannot resolve it, the user owns the resource.
+				if errors.Is(ensureErr, ErrHostClusterNameTaken) {
+					return false, ensureErr
+				}
+
+				log.Info("retrying host cluster registration", "error", ensureErr.Error())
+
+				return false, nil
+			},
+		)
+		if err != nil {
+			log.Error(
+				err,
+				"host cluster registration failed; the host cluster will not appear in the cluster list",
+			)
+		}
+
+		return nil
+	})
+
+	err := mgr.Add(runnable)
+	if err != nil {
+		return fmt.Errorf("add host cluster registration: %w", err)
+	}
+
+	return nil
+}
+
+// NewHostStatusObserver returns a StatusObserver for the self-registered host cluster, reporting
+// the API endpoint and node readiness through the operator's own credentials (the manager's REST
+// config). The hub reader argument is unused: the host cluster is observed directly, not through a
+// published kubeconfig Secret.
+func NewHostStatusObserver(restConfig *rest.Config) controller.StatusObserver {
+	return func(
+		ctx context.Context,
+		_ client.Reader,
+		_ *v1alpha1.Cluster,
+	) (controller.ObservedStatus, error) {
+		clientset, err := kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			return controller.ObservedStatus{}, fmt.Errorf("build host clientset: %w", err)
+		}
+
+		observed := controller.ObservedStatus{Endpoint: restConfig.Host}
+
+		ready, total, err := countReadyNodes(ctx, clientset)
+		if err != nil {
+			// The endpoint is still useful; surface the node-count failure for logging.
+			return observed, fmt.Errorf("count host nodes: %w", err)
+		}
+
+		observed.NodesReady = ready
+		observed.NodesTotal = total
+		observed.NodesObserved = true
+
+		return observed, nil
+	}
+}

--- a/pkg/operator/hostcluster_test.go
+++ b/pkg/operator/hostcluster_test.go
@@ -1,0 +1,139 @@
+package operator_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/operator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const hostNamespace = "ksail-system"
+
+func newHostFakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func getHostCluster(t *testing.T, hub client.Client) *v1alpha1.Cluster {
+	t.Helper()
+
+	var cluster v1alpha1.Cluster
+
+	key := types.NamespacedName{Namespace: hostNamespace, Name: operator.HostClusterName}
+	require.NoError(t, hub.Get(context.Background(), key, &cluster))
+
+	return &cluster
+}
+
+func TestEnsureHostClusterCreatesLabelledRegistration(t *testing.T) {
+	t.Parallel()
+
+	hub := newHostFakeClient(t)
+
+	require.NoError(t, operator.EnsureHostCluster(context.Background(), hub, hostNamespace))
+
+	cluster := getHostCluster(t, hub)
+	assert.True(t, cluster.IsHostCluster(), "the registration must carry the host-cluster label")
+	assert.Empty(t, cluster.Spec.Cluster.Distribution, "the host spec is intentionally empty")
+}
+
+func TestEnsureHostClusterIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	hub := newHostFakeClient(t)
+
+	require.NoError(t, operator.EnsureHostCluster(context.Background(), hub, hostNamespace))
+	require.NoError(t, operator.EnsureHostCluster(context.Background(), hub, hostNamespace))
+
+	getHostCluster(t, hub)
+}
+
+func TestEnsureHostClusterNeverAdoptsUnlabelledCluster(t *testing.T) {
+	t.Parallel()
+
+	existing := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: operator.HostClusterName, Namespace: hostNamespace},
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{Distribution: v1alpha1.DistributionVCluster},
+		},
+	}
+	hub := newHostFakeClient(t, existing)
+
+	err := operator.EnsureHostCluster(context.Background(), hub, hostNamespace)
+	require.ErrorIs(t, err, operator.ErrHostClusterNameTaken)
+
+	cluster := getHostCluster(t, hub)
+	assert.False(t, cluster.IsHostCluster(), "the user's cluster must be left untouched")
+}
+
+func TestHostClusterNamespacePrefersDownwardAPIEnv(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", hostNamespace)
+
+	assert.Equal(t, hostNamespace, operator.HostClusterNamespace())
+}
+
+func TestHostClusterNamespaceDefaultsOutsideCluster(t *testing.T) {
+	// Empty env falls through to the ServiceAccount namespace file, which does not exist on a test
+	// machine, leaving the "default" fallback.
+	t.Setenv("POD_NAMESPACE", "")
+
+	assert.Equal(t, "default", operator.HostClusterNamespace())
+}
+
+func TestNewHostStatusObserverReportsEndpointWhenNodesUnreachable(t *testing.T) {
+	t.Parallel()
+
+	// Port 1 on localhost refuses connections immediately, so the observer's node count fails while
+	// the endpoint (known from the REST config alone) is still reported.
+	observer := operator.NewHostStatusObserver(&rest.Config{
+		Host:    "https://127.0.0.1:1",
+		Timeout: time.Second,
+	})
+
+	observed, err := observer(context.Background(), nil, &v1alpha1.Cluster{})
+	require.Error(t, err)
+	assert.Equal(t, "https://127.0.0.1:1", observed.Endpoint)
+	assert.False(t, observed.NodesObserved)
+}
+
+func TestCountReadyNodes(t *testing.T) {
+	t.Parallel()
+
+	clientset := kubefake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "ready"},
+			Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			}},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "not-ready"},
+			Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+			}},
+		},
+	)
+
+	ready, total, err := operator.CountReadyNodes(context.Background(), clientset)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), ready)
+	assert.Equal(t, int32(2), total)
+}

--- a/pkg/operator/manager.go
+++ b/pkg/operator/manager.go
@@ -34,6 +34,10 @@ type Options struct {
 	ReadOnly bool
 	// OIDC configures app-driven OIDC authentication for the REST API (disabled when empty).
 	OIDC api.OIDCConfig
+	// HostCluster self-registers the cluster the operator runs on as a Cluster resource (named
+	// "host", labelled ksail.io/host-cluster) so the hub itself appears in the cluster list and can
+	// be browsed through the operator's own credentials.
+	HostCluster bool
 	// LeaderElection enables leader election to ensure a single active operator.
 	LeaderElection bool
 	// LeaderElectionID overrides the leader election lease name (optional).
@@ -100,6 +104,7 @@ func setupManager(mgr ctrl.Manager, opts Options) error {
 		Scheme:            mgr.GetScheme(),
 		NewProvisioner:    BuildProvisioner,
 		ObserveStatus:     ObserveVClusterStatus,
+		ObserveHostStatus: NewHostStatusObserver(mgr.GetConfig()),
 		InstallComponents: InstallComponents,
 		APIReader:         mgr.GetAPIReader(),
 	}
@@ -107,6 +112,13 @@ func setupManager(mgr ctrl.Manager, opts Options) error {
 	reconcilerErr := reconciler.SetupWithManager(mgr)
 	if reconcilerErr != nil {
 		return fmt.Errorf("set up cluster reconciler: %w", reconcilerErr)
+	}
+
+	if opts.HostCluster {
+		hostErr := AddHostClusterRegistration(mgr, HostClusterNamespace())
+		if hostErr != nil {
+			return hostErr
+		}
 	}
 
 	healthErr := mgr.AddHealthzCheck("healthz", healthz.Ping)
@@ -120,30 +132,48 @@ func setupManager(mgr ctrl.Manager, opts Options) error {
 	}
 
 	if opts.APIBindAddress != "" {
-		hub := mgr.GetClient()
-		// Resolve a dynamic client for a cluster's managed (vcluster) child cluster, so the dashboard's
-		// resource browser works against the operator backend too — not just the local `ksail ui`.
-		newChildClient := func(ctx context.Context, cluster *v1alpha1.Cluster) (dynamic.Interface, error) {
-			return childClusterDynamicClient(ctx, hub, cluster)
+		return setupAPIServer(mgr, opts)
+	}
+
+	return nil
+}
+
+// setupAPIServer registers the REST API server (and embedded dashboard) with the manager.
+func setupAPIServer(mgr ctrl.Manager, opts Options) error {
+	hub := mgr.GetClient()
+	// Resolve a dynamic client for a cluster's managed (vcluster) child cluster, so the dashboard's
+	// resource browser works against the operator backend too — not just the local `ksail ui`. The
+	// self-registered host cluster is browsed through the operator's own credentials instead of a
+	// published kubeconfig Secret.
+	newChildClient := func(ctx context.Context, cluster *v1alpha1.Cluster) (dynamic.Interface, error) {
+		if cluster.IsHostCluster() {
+			dyn, err := dynamic.NewForConfig(mgr.GetConfig())
+			if err != nil {
+				return nil, fmt.Errorf("build host cluster dynamic client: %w", err)
+			}
+
+			return dyn, nil
 		}
 
-		server := &api.Server{
-			Service:     api.NewCRClusterServiceWithResources(hub, newChildClient),
-			ReadOnly:    opts.ReadOnly,
-			BindAddress: opts.APIBindAddress,
-			OIDC:        opts.OIDC,
-			Mode:        api.ModeOperator,
-		}
+		return childClusterDynamicClient(ctx, hub, cluster)
+	}
 
-		// Serve the dashboard from the operator itself (same origin as the API, no reverse proxy).
-		// webui.Assets always returns a filesystem; when the SPA was not built into pkg/webui/dist,
-		// it holds only a placeholder and the server renders a "UI not built" page.
-		server.StaticFS = webui.Assets()
+	server := &api.Server{
+		Service:     api.NewCRClusterServiceWithResources(hub, newChildClient),
+		ReadOnly:    opts.ReadOnly,
+		BindAddress: opts.APIBindAddress,
+		OIDC:        opts.OIDC,
+		Mode:        api.ModeOperator,
+	}
 
-		apiErr := mgr.Add(server)
-		if apiErr != nil {
-			return fmt.Errorf("add API server: %w", apiErr)
-		}
+	// Serve the dashboard from the operator itself (same origin as the API, no reverse proxy).
+	// webui.Assets always returns a filesystem; when the SPA was not built into pkg/webui/dist,
+	// it holds only a placeholder and the server renders a "UI not built" page.
+	server.StaticFS = webui.Assets()
+
+	apiErr := mgr.Add(server)
+	if apiErr != nil {
+		return fmt.Errorf("add API server: %w", apiErr)
 	}
 
 	return nil

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -102,6 +102,12 @@ func countNodes(
 		return 0, 0, fmt.Errorf("build clientset: %w", err)
 	}
 
+	return countReadyNodes(ctx, clientset)
+}
+
+// countReadyNodes returns the number of Ready and total nodes reported by the clientset. Shared by
+// the vcluster status observer and the host cluster status observer.
+func countReadyNodes(ctx context.Context, clientset kubernetes.Interface) (int32, int32, error) {
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, 0, fmt.Errorf("list nodes: %w", err)

--- a/web/ui/src/components/ClustersTable.tsx
+++ b/web/ui/src/components/ClustersTable.tsx
@@ -3,8 +3,8 @@ import { useMemo } from "react";
 import type { Cluster } from "../api.ts";
 import { cx } from "../lib/cx.ts";
 import { epochMs, relativeAge } from "../lib/format.ts";
-import { clusterKey } from "../lib/k8s.ts";
-import { StatusBadge } from "./StatusBadge.tsx";
+import { clusterKey, isHostCluster } from "../lib/k8s.ts";
+import { HostBadge, StatusBadge } from "./StatusBadge.tsx";
 import { SortHeader, td, th, useSort } from "./table.tsx";
 
 type SortKey = "name" | "namespace" | "distribution" | "provider" | "status" | "nodes" | "age";
@@ -124,7 +124,10 @@ export function ClustersTable({
                 className="cursor-pointer transition-colors hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 dark:hover:bg-slate-800/50"
               >
                 <td className={cx(td, "font-medium text-slate-900 dark:text-white")}>
-                  {cluster.metadata.name}
+                  <span className="inline-flex items-center gap-2">
+                    {cluster.metadata.name}
+                    {isHostCluster(cluster) ? <HostBadge /> : null}
+                  </span>
                 </td>
                 <td className={cx(td, "text-sm text-slate-600 dark:text-slate-300")}>
                   {cluster.metadata.namespace ?? "default"}
@@ -145,8 +148,10 @@ export function ClustersTable({
                   {relativeAge(cluster.metadata.creationTimestamp)}
                 </td>
                 <td className={cx(td, "text-right")}>
+                  {/* Lifecycle actions are hidden for the host cluster (the cluster the operator
+                      runs on); the API rejects them server-side anyway. */}
                   <div className="flex items-center justify-end gap-1">
-                    {canEdit ? (
+                    {canEdit && !isHostCluster(cluster) ? (
                       <button
                         type="button"
                         aria-label={`Edit ${cluster.metadata.name}`}
@@ -159,7 +164,7 @@ export function ClustersTable({
                         <Pencil className="size-4" />
                       </button>
                     ) : null}
-                    {!readOnly ? (
+                    {!readOnly && !isHostCluster(cluster) ? (
                       <button
                         type="button"
                         aria-label={`Delete ${cluster.metadata.name}`}

--- a/web/ui/src/components/OverviewView.tsx
+++ b/web/ui/src/components/OverviewView.tsx
@@ -21,6 +21,7 @@ import {
   clusterKey,
   eventFields,
   eventLastSeenMs,
+  isHostCluster,
   nodeIsControlPlane,
   nodeProblems,
   nodeReady,
@@ -35,7 +36,7 @@ import { buildClusterUsage, buildPodConsumption, type ClusterUsage, type PodCons
 import { Card, Field } from "./Card.tsx";
 import { EventList } from "./EventList.tsx";
 import { ResourceUsagePanel } from "./ResourceUsage.tsx";
-import { StatusBadge } from "./StatusBadge.tsx";
+import { HostBadge, StatusBadge } from "./StatusBadge.tsx";
 import { EmptyState } from "./states.tsx";
 import { Button } from "./ui.tsx";
 import { useToast } from "./Toast.tsx";
@@ -345,8 +346,11 @@ export function OverviewView({
   const status = cluster.status;
   const spec = cluster.spec?.cluster;
   const namespace = cluster.metadata.namespace ?? "default";
-  const distribution = spec?.distribution || meta.distributions[0] || "—";
-  const provider = spec?.provider || meta.providers[distribution]?.[0] || "—";
+  // The host cluster's registration carries an empty spec on purpose (the operator does not manage
+  // the hub's lifecycle), so the create-form defaults would mislabel it — show "—" instead.
+  const hostCluster = isHostCluster(cluster);
+  const distribution = spec?.distribution || (hostCluster ? "—" : meta.distributions[0] || "—");
+  const provider = spec?.provider || (hostCluster ? "—" : meta.providers[distribution]?.[0] || "—");
   const secret = status?.kubeconfigSecretRef;
   const nodesHealthy = health ? health.nodesTotal > 0 && health.nodesReady === health.nodesTotal : false;
 
@@ -374,6 +378,7 @@ export function OverviewView({
           <div className="flex items-center gap-2.5">
             <h2 className="truncate text-xl font-semibold text-slate-900 dark:text-white">{cluster.metadata.name}</h2>
             <StatusBadge phase={status?.phase} />
+            {hostCluster ? <HostBadge /> : null}
           </div>
           <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
             {distribution} · {provider} · namespace {namespace}
@@ -402,13 +407,15 @@ export function OverviewView({
               Kubeconfig
             </Button>
           ) : null}
-          {canEdit ? (
+          {/* Lifecycle actions are hidden for the host cluster (the cluster the operator runs on);
+              the API rejects them server-side anyway. */}
+          {canEdit && !hostCluster ? (
             <Button variant="secondary" size="sm" onClick={() => onEdit(cluster)}>
               <Pencil className="size-3.5" aria-hidden />
               Edit
             </Button>
           ) : null}
-          {canDelete ? (
+          {canDelete && !hostCluster ? (
             <Button variant="danger" size="sm" onClick={() => onDelete(cluster)}>
               <Trash2 className="size-3.5" aria-hidden />
               Delete
@@ -489,8 +496,8 @@ export function OverviewView({
               ))
             ) : (
               <p className="pt-2 text-xs text-slate-400 dark:text-slate-500">
-                Component configuration is not tracked for discovered clusters — browse Resources to see what runs
-                here.
+                Component configuration is not tracked for {hostCluster ? "the host cluster" : "discovered clusters"} —
+                browse Resources to see what runs here.
               </p>
             )}
           </dl>

--- a/web/ui/src/components/StatusBadge.tsx
+++ b/web/ui/src/components/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import { Circle, CircleAlert, CircleCheck, Clock, LoaderCircle, type LucideIcon } from "lucide-react";
+import { Circle, CircleAlert, CircleCheck, Clock, House, LoaderCircle, type LucideIcon } from "lucide-react";
 import { cx } from "../lib/cx.ts";
 
 type PhaseMeta = {
@@ -73,6 +73,21 @@ export function phaseMeta(phase?: string): PhaseMeta {
   }
 
   return PHASES[phase] ?? { ...FALLBACK, label: phase };
+}
+
+// HostBadge marks the operator's self-registered host cluster — the cluster the operator runs on
+// (see HOST_CLUSTER_LABEL in lib/k8s.ts). Rendered next to the cluster name wherever lifecycle
+// actions are hidden for it, so the missing edit/delete affordances are self-explanatory.
+export function HostBadge() {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-700 ring-1 ring-inset ring-sky-600/20 dark:bg-sky-500/10 dark:text-sky-400 dark:ring-sky-500/30"
+      title="The cluster the KSail operator runs on"
+    >
+      <House className="size-3.5" aria-hidden />
+      Host
+    </span>
+  );
 }
 
 export function StatusBadge({ phase }: { phase?: string }) {

--- a/web/ui/src/lib/k8s.ts
+++ b/web/ui/src/lib/k8s.ts
@@ -13,6 +13,15 @@ export function splitClusterKey(key: string): [string, string] {
   return [key.slice(0, slash), key.slice(slash + 1)];
 }
 
+// HOST_CLUSTER_LABEL marks the Cluster resource the operator self-registers for the cluster it
+// runs ON (the hub). The UI badges it and hides the lifecycle actions (edit/delete), which the API
+// rejects server-side anyway — the hub hosting the operator is not the operator's to destroy.
+export const HOST_CLUSTER_LABEL = "ksail.io/host-cluster";
+
+export function isHostCluster(cluster: Cluster): boolean {
+  return cluster.metadata.labels?.[HOST_CLUSTER_LABEL] === "true";
+}
+
 // str safely reads a string field from an unstructured value (the backend returns native Kubernetes
 // JSON, typed loosely as K8sObject), returning "" for anything that is not a string.
 function str(value: unknown): string {


### PR DESCRIPTION
## Summary

The ksail-operator now manages **the cluster it runs on**, like Headlamp's in-cluster mode, Rancher's `local` cluster, and Argo CD's `in-cluster` destination. (Omni was also surveyed but explicitly forbids self-management, so the Rancher/Argo CD/Headlamp recipe is the prior art followed here.)

On startup, a leader-gated runnable self-registers the hub as a `Cluster` resource named **`host`** (labelled `ksail.io/host-cluster: "true"`) in the operator's namespace, so the hub shows up in the dashboard's cluster list and its workloads can be browsed, scaled, restarted, and GitOps-reconciled through the operator's own ServiceAccount credentials.

## How it works

- **Registration** (`pkg/operator/hostcluster.go`): idempotent ensure of the well-known `host` resource; a same-named *unlabelled* cluster is never adopted (`ErrHostClusterNameTaken`). Namespace resolves from the `POD_NAMESPACE` downward-API env var → ServiceAccount namespace file → `default`.
- **Reconciler** (`internal/controller`): host-labelled clusters skip provisioner build/create/drift/component installation and get no teardown finalizer. Reconciliation only observes runtime status (endpoint + node readiness via the operator's REST config) and reports `Ready`; `ComponentsReady` is `Unknown` (reason `HostCluster`) since the hub's components are not the operator's to manage. Deleting a host-labelled resource never invokes a provisioner — even if a user added the label to a cluster that already carried the finalizer.
- **Resource browser**: the operator API resolves the host cluster to an in-cluster dynamic client instead of a vcluster kubeconfig Secret, so the existing workload browser/metrics/GitOps views work on the hub unchanged.
- **API guards**: `POST` (reserved label), `PUT`, and `DELETE` on the host registration return **403** (`ErrHostClusterProtected`), mirroring Rancher's admission-level delete block. `kubectl delete` remains the escape hatch and only deregisters (re-registered on next operator start while enabled).
- **Chart**: `hostCluster.enabled` (default `true`, wired as `--host-cluster`), `POD_NAMESPACE` downward-API env, and least-privilege RBAC additions for browsing the hub (nodes/events read, `metrics.k8s.io`, Flux/ArgoCD CRs read+patch) gated on the same value.
- **UI**: a "Host" badge next to the cluster name in the list and Overview; edit/delete affordances hidden for it; the Overview no longer backfills create-form defaults (distribution/provider) into the host's intentionally-empty spec.

## Verification

- `go build ./...`, full `go test ./...` (only the known env-flaky `pkg/cli/cmd/chat` exec tests failed under parallel load; they pass in isolation), `golangci-lint` clean on new code and full-lint clean on touched packages (remaining `resources.go` goconst / `auth.go` gosec findings are pre-existing baseline).
- `tsc --noEmit` + `vite build` clean; `helm lint` + `helm template` verified in both `hostCluster.enabled` modes.
- **End-to-end on a throwaway Kind cluster** (operator run locally against its kubeconfig): the `host` resource self-registers, reconciles to `Ready` with live endpoint + 1/1 node counts and `ComponentsReady=Unknown/HostCluster`, `GET .../resources?kind=Node` serves the hub's nodes, and `PUT`/`DELETE` on the registration return 403 with a clear message. Cluster fully cleaned up afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)