### PR TITLE
docs: professionalize docs — document web UI/operator/day-2 ops, fix site-wide table rendering

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,6 +5,11 @@ import starlightGithubAlerts from "starlight-github-alerts";
 
 export default defineConfig({
   site: "https://ksail.devantler.tech",
+  // GFM (tables, strikethrough, autolinks) is on by default, but on Astro 6.4.x
+  // the implicit default is lost when integrations use the deprecated
+  // markdown.remarkPlugins hook — leaving every table rendered as literal pipe
+  // text. Pin it explicitly so the site never silently loses table rendering.
+  markdown: { gfm: true },
   redirects: {
     "/getting-started/vanilla/": "/distributions/vanilla/",
     "/getting-started/k3s/": "/distributions/k3s/",
@@ -85,6 +90,7 @@ export default defineConfig({
           items: [
             { label: "Overview", link: "/features/" },
             { label: "Cluster Provisioning", link: "/features/cluster-provisioning/" },
+            { label: "Day-2 Operations", link: "/features/day-2-operations/" },
             { label: "Ephemeral Clusters (--ttl)", link: "/features/ephemeral-clusters/" },
             { label: "Workload Management", link: "/features/workload-management/" },
             { label: "GitOps Workflows", link: "/features/gitops-workflows/" },
@@ -93,6 +99,8 @@ export default defineConfig({
             { label: "Secret Management", link: "/features/secret-management/" },
             { label: "Backup & Restore", link: "/features/backup-restore/" },
             { label: "CI/CD Integration", link: "/features/cicd-integration/" },
+            { label: "Web UI & Desktop App", link: "/features/web-ui/", badge: { text: "New", variant: "tip" } },
+            { label: "Kubernetes Operator", link: "/features/operator/", badge: { text: "New", variant: "tip" } },
           ],
         },
         { label: "Concepts", link: "/concepts/" },

--- a/docs/src/content/docs/concepts.mdx
+++ b/docs/src/content/docs/concepts.mdx
@@ -17,7 +17,7 @@ description: KSail builds upon established Kubernetes technologies and patterns.
 
 ## Distributions
 
-Kubernetes distributions package core components with additional tooling for specific use cases. KSail supports five distributions: Vanilla, K3s, Talos, VCluster, and KWOK. All can run on Docker; Talos can also run on Hetzner Cloud and Sidero Omni.
+Kubernetes distributions package core components with additional tooling for specific use cases. KSail supports six distributions: Vanilla, K3s, Talos, VCluster, KWOK, and EKS. The first five run on Docker; Talos can also run on Hetzner Cloud and Sidero Omni, and EKS targets AWS (scaffolding available; cluster provisioning is in progress).
 
 ### Vanilla (Kind)
 
@@ -38,6 +38,10 @@ Vanilla uses [Kind](https://kind.sigs.k8s.io/) to run standard upstream Kubernet
 ### KWOK (kwokctl)
 
 [KWOK](https://kwok.sigs.k8s.io/) (Kubernetes WithOut Kubelet) creates simulated Kubernetes clusters where nodes and pods exist at the API level without running real containers. KSail uses kwokctl's Docker runtime to run etcd, kube-apiserver, and the kwok-controller as Docker containers. Ideal for control-plane testing, CI/CD speed optimization, and scale testing. See [documentation](https://kwok.sigs.k8s.io/docs/), [user guide](https://kwok.sigs.k8s.io/docs/user/), and [GitHub](https://github.com/kubernetes-sigs/kwok).
+
+### EKS (eksctl)
+
+[Amazon EKS](https://aws.amazon.com/eks/) is AWS's managed Kubernetes service. KSail embeds [eksctl](https://eksctl.io/) Go libraries to scaffold EKS projects (`ksail cluster init`); cluster provisioning support is in progress. See [EKS Distribution](/distributions/eks/), [EKS docs](https://docs.aws.amazon.com/eks/), and [eksctl docs](https://eksctl.io/).
 
 ## Providers
 
@@ -64,6 +68,10 @@ Manages Talos clusters through the [Sidero Omni](https://www.siderolabs.com/omni
 
 > [!NOTE]
 > Omni provider is only supported with the `Talos` distribution.
+
+### AWS
+
+Manages [Amazon EKS](https://aws.amazon.com/eks/) clusters on Amazon Web Services. **Supported distributions:** EKS (scaffolding available; provisioning in progress). **Requirements:** AWS credentials and an account with EKS permissions. See [AWS Provider](/providers/aws/).
 
 ## Container Network Interface (CNI)
 

--- a/docs/src/content/docs/features/backup-restore.mdx
+++ b/docs/src/content/docs/features/backup-restore.mdx
@@ -1,19 +1,94 @@
 ---
 title: Backup & Restore
-description: Export cluster resources to a compressed archive and restore to any cluster.
+description: Export cluster resources to a compressed archive and restore them to any cluster — with dependency-ordered restore, scoping flags, and dry-run.
 ---
 
-Export cluster resources to a compressed archive and restore to any cluster. Backups capture YAML in dependency order, strip server metadata, and include a manifest inventory.
+import { Steps } from "@astrojs/starlight/components";
+
+Export cluster resources to a compressed archive and restore them to any cluster — even one running a different distribution. Because backups capture portable YAML rather than disk images, they double as a migration path between Vanilla, K3s, Talos, and VCluster clusters.
 
 ```bash
 ksail cluster backup --output ./backup.tar.gz
 ksail cluster restore --input ./backup.tar.gz
-ksail cluster restore -i ./backup.tar.gz --existing-resource-policy update --dry-run
 ```
 
 > [!NOTE]
-> This feature backs up resource manifests (YAML) only. Persistent volume data is not included.
+> This feature backs up resource manifests (YAML) only. Persistent volume **data** is not included.
+
+## What's in the Archive
+
+A backup is a compressed tarball (`.tar.gz`) with resources organized by type, server-side metadata stripped so the manifests apply cleanly elsewhere, and a manifest inventory that restore operations use to apply everything in dependency order.
+
+## Scoping a Backup
+
+By default everything is captured (minus `events`). Narrow the scope when you need less:
+
+```bash
+# Only specific namespaces
+ksail cluster backup -o ./backup.tar.gz --namespaces default,kube-system
+
+# Skip noisy or ephemeral resource types
+ksail cluster backup -o ./backup.tar.gz --exclude-types events,pods
+
+# Trade speed for size with the gzip level (-1 = default, 9 = smallest)
+ksail cluster backup -o ./backup.tar.gz --compression 9
+```
+
+## Restoring
+
+Resources are restored in dependency order — CRDs first, then namespaces, storage, and finally workloads — so nothing lands before what it depends on. When a resource already exists in the target cluster, `--existing-resource-policy` decides what happens:
+
+| Policy | Behavior |
+|--------|----------|
+| `none` (default) | Skip resources that already exist |
+| `update` | Patch existing resources to match the backup |
+
+Preview before you commit:
+
+```bash
+ksail cluster restore -i ./backup.tar.gz --dry-run
+ksail cluster restore -i ./backup.tar.gz --existing-resource-policy update
+```
+
+## Migrating Between Clusters
+
+<Steps>
+
+1. **Back up the source cluster:**
+
+   ```bash
+   ksail cluster backup -o ./migrate.tar.gz --exclude-types events,pods
+   ```
+
+2. **Create the target cluster** — any distribution works:
+
+   ```bash
+   ksail cluster init --name new-home --distribution K3s
+   ksail cluster create
+   ```
+
+3. **Dry-run the restore** to spot conflicts early:
+
+   ```bash
+   ksail cluster restore -i ./migrate.tar.gz --dry-run
+   ```
+
+4. **Restore for real:**
+
+   ```bash
+   ksail cluster restore -i ./migrate.tar.gz
+   ```
+
+</Steps>
+
+> [!TIP]
+> Take a backup before a risky `ksail cluster update` — if the change goes sideways, recreate the cluster and restore in minutes.
 
 ## CLI Reference
 
 [`ksail cluster backup`](/cli-flags/cluster/cluster-backup/), [`ksail cluster restore`](/cli-flags/cluster/cluster-restore/)
+
+## Related
+
+- [Day-2 Operations](/features/day-2-operations/) — diagnose and repair running clusters
+- [Cluster Provisioning](/features/cluster-provisioning/) — updating clusters and drift detection

--- a/docs/src/content/docs/features/cicd-integration.mdx
+++ b/docs/src/content/docs/features/cicd-integration.mdx
@@ -1,9 +1,11 @@
 ---
 title: CI/CD Integration
-description: Provision KSail clusters in GitHub Actions with the official composite action.
+description: Provision KSail clusters in GitHub Actions with the official composite action — installation, caching, GitOps push, security scanning, and cleanup built in.
 ---
 
-Provision KSail clusters in GitHub Actions with the official `ksail-cluster` composite action. It handles installation, Helm chart caching, mirror registry caching, and image pre-pulling automatically.
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+
+Provision real Kubernetes clusters inside GitHub Actions with the official `ksail-cluster` composite action. One step installs KSail from releases, scaffolds and creates the cluster, and wires up caching — Helm charts and mirror registry volumes persist between runs, so repeat builds skip the slow image pulls entirely.
 
 ```yaml
 - uses: devantler-tech/ksail/.github/actions/ksail-cluster@v7.2.2
@@ -11,7 +13,92 @@ Provision KSail clusters in GitHub Actions with the official `ksail-cluster` com
     distribution: K3s
 ```
 
+The action outputs `kubeconfig` — the path to the kubeconfig for the provisioned cluster — so follow-up steps can talk to the cluster with any tool.
+
+## Common Recipes
+
+<Tabs>
+  <TabItem label="Integration tests">
+    ```yaml
+    jobs:
+      integration:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: devantler-tech/ksail/.github/actions/ksail-cluster@v7.2.2
+            id: cluster
+            with:
+              distribution: Vanilla
+          - name: Run tests against the cluster
+            env:
+              KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig }}
+            run: go test ./... -tags=integration
+    ```
+  </TabItem>
+  <TabItem label="Full GitOps pipeline">
+    Validate manifests, create the cluster, push manifests to the local registry, and wait for the GitOps engine to reconcile — all from inputs:
+
+    ```yaml
+    - uses: devantler-tech/ksail/.github/actions/ksail-cluster@v7.2.2
+      with:
+        distribution: K3s
+        validate: "true"     # ksail workload validate before create
+        push: "true"         # ksail workload push after create
+        reconcile: "true"    # ksail workload reconcile and wait
+        sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+    ```
+  </TabItem>
+  <TabItem label="Security scanning">
+    Run [Kubescape](https://kubescape.io) against your manifests and upload results to GitHub Code Scanning:
+
+    ```yaml
+    - uses: devantler-tech/ksail/.github/actions/ksail-cluster@v7.2.2
+      with:
+        distribution: Vanilla
+        scan: "true"
+        scan-framework: nsa,mitre
+        scan-format: sarif
+        scan-output: results.sarif
+    - uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: results.sarif
+    ```
+  </TabItem>
+</Tabs>
+
+## Key Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `distribution` | `Vanilla` | Distribution to provision (Vanilla, K3s, Talos, VCluster) |
+| `provider` | `Docker` | Infrastructure provider; cloud providers need credentials via env vars (`HCLOUD_TOKEN`, `OMNI_SERVICE_ACCOUNT_KEY`) |
+| `ksail-version` | `latest` | Pin a released KSail version for reproducible pipelines |
+| `args` | — | Extra CLI arguments passed to `cluster init` |
+| `config` | — | Use an existing `ksail.yaml` instead of scaffolding (`init: "false"` skips init entirely) |
+| `cache` | `true` | Cache Helm charts and mirror registry volumes between runs |
+| `sops-age-key` | — | SOPS Age key for decrypting secrets during Flux setup |
+| `validate` / `scan` | `false` | Pre-create manifest validation and Kubescape scanning |
+| `push` / `reconcile` | `false` | GitOps push and reconcile after create |
+| `delete` | `false` | Tear the cluster down at the end (runs even on failure) |
+
+See the [action source](https://github.com/devantler-tech/ksail/tree/main/.github/actions/ksail-cluster) for the complete input list, including scan thresholds and host customization.
+
+> [!TIP]
+> On hosted runners the cluster disappears with the VM, so `delete` defaults to `false`. Set `delete: "true"` on self-hosted runners — and always for cloud providers like Hetzner, where leaked clusters cost real money.
+
+## Beyond GitHub Actions
+
+The composite action is a convenience, not a requirement — KSail is a single static binary, so any CI system works. [Install it](/installation/) on the runner image and run the same two commands:
+
+```bash
+ksail cluster init --distribution K3s
+ksail cluster create
+```
+
+Combine with [`--ttl`](/features/ephemeral-clusters/) so clusters self-destruct even when a job is cancelled mid-run.
+
 ## Related
 
 - [PR Preview Clusters](/guides/pr-preview-clusters/) — end-to-end guide for per-PR ephemeral clusters in GitHub Actions
+- [Ephemeral Clusters](/features/ephemeral-clusters/) — TTL-based auto-destruction for CI safety nets
 - [Testing in CI/CD](/use-cases/#testing-in-cicd) — integration test patterns

--- a/docs/src/content/docs/features/cluster-provisioning.mdx
+++ b/docs/src/content/docs/features/cluster-provisioning.mdx
@@ -5,7 +5,7 @@ description: Create and manage local Kubernetes clusters with a single command â
 
 Create and manage local Kubernetes clusters with a single command. KSail:
 
-- Supports [Vanilla, K3s, Talos, VCluster, and KWOK](/concepts/#distributions) distributions
+- Supports [Vanilla, K3s, Talos, VCluster, and KWOK](/concepts/#distributions) distributions, with [EKS](/distributions/eks/) scaffolding available
 - Generates native config files (`kind.yaml`, `k3d.yaml`, Talos patches, `vcluster.yaml`, `kwok/`) that work directly with upstream tools
 - Auto-configures [CNI](/concepts/#container-network-interface-cni), [CSI](/concepts/#container-storage-interface-csi), [metrics-server](/concepts/#metrics-server), [cert-manager](/concepts/#cert-manager), and [policy engines](/concepts/#policy-engines) with automatic retry and exponential backoff
 

--- a/docs/src/content/docs/features/day-2-operations.mdx
+++ b/docs/src/content/docs/features/day-2-operations.mdx
@@ -1,0 +1,62 @@
+---
+title: Day-2 Operations
+description: Inspect, diagnose, and repair running clusters — health scoring with cluster diagnose, fast context switching, and self-healing state files.
+---
+
+A cluster that exists is only half the story — day-2 is where you live. KSail bundles the commands you reach for after `cluster create`:
+
+| You want to… | Run |
+|--------------|-----|
+| See cluster status and endpoints | [`ksail cluster info`](/cli-flags/cluster/cluster-info/) |
+| List all clusters across providers | [`ksail cluster list`](/cli-flags/cluster/cluster-list/) |
+| Jump to another cluster's context | [`ksail cluster switch`](/cli-flags/cluster/cluster-switch/) |
+| Browse the cluster interactively | [`ksail cluster connect`](/cli-flags/cluster/cluster-connect/) (K9s) |
+| Find out *why* something is failing | [`ksail cluster diagnose`](/cli-flags/cluster/cluster-diagnose/) |
+| Check config drift before it bites | [`ksail cluster diff`](/cli-flags/cluster/cluster-diff/) — see [Drift Detection](/features/cluster-provisioning/#drift-detection) |
+| Fix corrupted local state files | [`ksail cluster repair`](/cli-flags/cluster/cluster-repair/) |
+
+## Diagnosing a Failing Cluster
+
+`ksail cluster diagnose` inspects the live cluster via the Kubernetes API and reports pods that are not running successfully, nodes that are not `Ready`, and PersistentVolumeClaims stuck in `Pending`. Each finding carries a severity, and known failure patterns come with a proactive remediation suggestion.
+
+A **health score (0–100)** summarizes the whole picture: each critical finding deducts 25 points, each warning deducts 10.
+
+```bash
+ksail cluster diagnose                 # human-readable findings + health score
+ksail cluster diagnose --output json  # structured output for scripts and CI
+```
+
+The output is intentionally compact so it can be consumed by people *and* machines — the [AI chat assistant](/ai-chat/) and [MCP server](/mcp/) expose `diagnose` through the `cluster_read` tool and feed the findings back to the model as context for root-cause analysis.
+
+> [!TIP]
+> Exit code 0 is returned even when failures are reported — a non-zero exit means the Kubernetes API itself could not be queried (cluster unreachable or insufficient permissions). Gate CI on the JSON output, not the exit code.
+
+## Switching Between Clusters
+
+Running several clusters side by side is the norm with KSail — `cluster switch` makes hopping between them painless. Give it a cluster name and it resolves the right kubeconfig context automatically, checking all distribution prefixes (`kind-`, `k3d-`, `k3k-`, `admin@`, `vcluster-docker_`, `kwok-`) so you never type a prefixed context name by hand:
+
+```bash
+ksail cluster switch dev       # resolves to kind-dev, k3d-dev, … automatically
+ksail cluster switch           # interactive picker
+```
+
+Called without arguments, an interactive picker opens with your **five most recently used clusters at the top**, followed by the rest alphabetically (history persists to `~/.ksail/switch-history.json`). Press <kbd>/</kbd> to filter the list by keyword, <kbd>Esc</kbd> to clear the filter.
+
+If two distributions both have a cluster with the same name, the command errors with the matching contexts rather than guessing.
+
+## Repairing Local State
+
+`ksail cluster repair` detects and fixes known corruption patterns in local state files. Every repair is idempotent and writes a timestamped backup of any file it modifies before touching it.
+
+```bash
+ksail cluster repair
+```
+
+Currently supported: `talosconfig-ca` — fixes a single-byte BasicConstraints corruption in the Talos `talosconfig` CA that prevents `cluster update` from establishing a Talos client.
+
+## Related
+
+- [Cluster Provisioning](/features/cluster-provisioning/) — create, update, drift detection, and version upgrades
+- [Backup & Restore](/features/backup-restore/) — snapshot resources before risky changes
+- [Troubleshooting](/troubleshooting/) — common issues and solutions
+- [AI Chat Assistant](/ai-chat/) — let Copilot interpret `diagnose` findings for you

--- a/docs/src/content/docs/features/index.mdx
+++ b/docs/src/content/docs/features/index.mdx
@@ -1,23 +1,92 @@
 ---
 title: Features
-description: Overview of KSail's core features — cluster provisioning, workload management, GitOps, tenant management, registries, secrets, backup, and CI/CD.
+description: Everything KSail does, organized by journey — run clusters, ship workloads, and scale out to teams, CI, and in-cluster operation.
 ---
 
-KSail bundles Kubernetes tooling into a single binary. Each feature is documented on its own page — click through for details, usage examples, and CLI references.
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
-## Core Features
+KSail bundles Kubernetes tooling into a single binary. Each feature has its own page with details, usage examples, and CLI references — organized here by the journey you're on.
 
-| Feature | Description |
-|---------|-------------|
-| [Cluster Provisioning](/features/cluster-provisioning/) | Create and manage clusters across Vanilla, K3s, Talos, VCluster, and KWOK distributions with automatic component installation. |
-| [Ephemeral Clusters](/features/ephemeral-clusters/) | Time-limited clusters that auto-destroy via `--ttl` for debugging, demos, and temporary access. |
-| [Workload Management](/features/workload-management/) | Deploy, inspect, and manage Kubernetes workloads using familiar kubectl and Helm patterns. |
-| [GitOps Workflows](/features/gitops-workflows/) | Declarative Git-driven deployments with built-in Flux or ArgoCD support. |
-| [Tenant Management](/features/tenant-management/) | Onboard teams with RBAC isolation, GitOps sync resources, and optional repository scaffolding. |
-| [Registry Management](/features/registry-management/) | Run local OCI registries and configure mirror registries for faster image pulls. |
-| [Secret Management](/features/secret-management/) | Encrypt and decrypt secrets using SOPS with age, PGP, and cloud KMS providers. |
-| [Backup & Restore](/features/backup-restore/) | Export cluster resources to compressed archives and restore to any cluster. |
-| [CI/CD Integration](/features/cicd-integration/) | Provision clusters in GitHub Actions with the official composite action. |
+## Run Clusters
+
+Create them, keep them healthy, and recover when things go wrong.
+
+<CardGrid>
+  <LinkCard
+    title="Cluster Provisioning"
+    href="/features/cluster-provisioning/"
+    description="Create and manage clusters across Vanilla, K3s, Talos, VCluster, and KWOK with automatic component installation."
+  />
+  <LinkCard
+    title="Day-2 Operations"
+    href="/features/day-2-operations/"
+    description="Health-scored diagnostics, fast context switching, and self-healing state files for running clusters."
+  />
+  <LinkCard
+    title="Ephemeral Clusters"
+    href="/features/ephemeral-clusters/"
+    description="Time-limited clusters that auto-destroy via --ttl — for debugging, demos, and temporary access."
+  />
+  <LinkCard
+    title="Backup & Restore"
+    href="/features/backup-restore/"
+    description="Export cluster resources to compressed archives and restore to any cluster — or migrate between distributions."
+  />
+</CardGrid>
+
+## Ship Workloads
+
+Deploy, secure, and continuously reconcile what runs on the cluster.
+
+<CardGrid>
+  <LinkCard
+    title="Workload Management"
+    href="/features/workload-management/"
+    description="Deploy, inspect, debug, and operate workloads using familiar kubectl and Helm patterns."
+  />
+  <LinkCard
+    title="GitOps Workflows"
+    href="/features/gitops-workflows/"
+    description="Declarative Git-driven deployments with built-in Flux or ArgoCD support."
+  />
+  <LinkCard
+    title="Registry Management"
+    href="/features/registry-management/"
+    description="A local OCI registry for your artifacts, and pull-through mirrors that beat rate limits."
+  />
+  <LinkCard
+    title="Secret Management"
+    href="/features/secret-management/"
+    description="Encrypt and decrypt secrets using SOPS with age, PGP, and cloud KMS providers."
+  />
+</CardGrid>
+
+## Scale Out
+
+From a laptop workflow to teams, pipelines, and clusters that manage clusters.
+
+<CardGrid>
+  <LinkCard
+    title="Tenant Management"
+    href="/features/tenant-management/"
+    description="Onboard teams with RBAC isolation, GitOps sync resources, and optional repository scaffolding."
+  />
+  <LinkCard
+    title="CI/CD Integration"
+    href="/features/cicd-integration/"
+    description="Provision clusters in GitHub Actions with the official composite action — caching and scanning included."
+  />
+  <LinkCard
+    title="Web UI & Desktop App"
+    href="/features/web-ui/"
+    description="Manage clusters visually — in the browser, as a native app, or served in-cluster."
+  />
+  <LinkCard
+    title="Kubernetes Operator"
+    href="/features/operator/"
+    description="Reconcile Cluster custom resources from inside Kubernetes, with an optional OIDC-protected UI."
+  />
+</CardGrid>
 
 ## Also See
 
@@ -26,4 +95,5 @@ These features have dedicated pages in other sections:
 - [Declarative Configuration](/configuration/declarative-configuration/) — complete `ksail.yaml` reference
 - [OIDC Authentication](/guides/oidc-authentication/) — native OIDC exec credential plugin across all distributions
 - [AI Chat Assistant](/ai-chat/) — interactive AI-powered chat for configuration and troubleshooting
+- [MCP Server](/mcp/) — expose KSail's commands as tools for AI assistants
 - [VSCode Extension](/vscode-extension/) — manage clusters from Visual Studio Code

--- a/docs/src/content/docs/features/operator.mdx
+++ b/docs/src/content/docs/features/operator.mdx
@@ -1,0 +1,115 @@
+---
+title: Kubernetes Operator
+description: Manage KSail clusters declaratively from inside Kubernetes — the operator reconciles Cluster custom resources, with an optional web UI and OIDC-protected REST API.
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+The KSail operator brings declarative cluster management *into* Kubernetes. It reconciles `Cluster` custom resources (`ksail.io/v1alpha1`), so you can provision and manage KSail-supported distributions with `kubectl apply` — or let your GitOps engine do it for you. An optional [web UI](/features/web-ui/) and OIDC-authenticated REST API are included.
+
+## What the Chart Deploys
+
+| Component | Description | Toggle |
+|-----------|-------------|--------|
+| Operator | Controller that reconciles `Cluster` custom resources | `operator.enabled` (default `true`) |
+| `Cluster` CRD | Installed automatically from the chart's `crds/` directory | — |
+| RBAC | ServiceAccount plus the (Cluster)Role and binding the operator needs | `serviceAccount.create` |
+| REST API | Served by the operator, consumed by the UI | `api.bindPort` (`0` disables) |
+| Web UI | Dashboard that talks to the REST API | `ui.enabled` (default `false`) |
+| OIDC auth | App-driven login protecting the REST API and UI | `auth.oidc.enabled` (default `false`) |
+
+> [!WARNING]
+> The REST API is unauthenticated by default. Enable OIDC (`auth.oidc.enabled=true`) to require sign-in, or set `api.bindPort=0` to disable the API entirely when you don't need the UI.
+
+## Getting Started
+
+Requires Kubernetes 1.27+ and Helm 3.8+.
+
+<Steps>
+
+1. **Install the chart.** Each KSail release publishes it as an OCI artifact to GHCR — pin a [release version](https://github.com/devantler-tech/ksail/releases):
+
+   ```bash
+   helm install ksail-operator oci://ghcr.io/devantler-tech/charts/ksail-operator \
+     --version <version> --namespace ksail-system --create-namespace
+   ```
+
+2. **Apply a `Cluster` resource.** The operator picks it up and provisions the cluster:
+
+   ```yaml
+   apiVersion: ksail.io/v1alpha1
+   kind: Cluster
+   metadata:
+     name: my-cluster
+     namespace: ksail-system
+   spec:
+     cluster:
+       distribution: VCluster
+   ```
+
+3. **Watch it reconcile:**
+
+   ```bash
+   kubectl get clusters -n ksail-system -w
+   ```
+
+</Steps>
+
+Distributions that run nested inside the host cluster (VCluster, K3s) work out of the box. Docker-based distributions (Vanilla/Kind, K3d) need the host Docker socket mounted via `operator.dockerSocket.enabled=true` — this is privileged and single-node, so prefer nested distributions in-cluster. See the [Kubernetes (Nested) provider](/providers/kubernetes/) for how nested clusters run as pods.
+
+## Enabling the Web UI
+
+```bash
+helm upgrade --install ksail-operator oci://ghcr.io/devantler-tech/charts/ksail-operator \
+  --version <version> --namespace ksail-system --create-namespace \
+  --set ui.enabled=true
+```
+
+Without an Ingress, port-forward to reach it (the Service is named `<release-name>-ksail-operator-ui`):
+
+```bash
+kubectl port-forward -n ksail-system svc/ksail-operator-ksail-operator-ui 8080:80
+```
+
+Set `ui.readOnly=true` in GitOps-enforced environments so the Git repository stays the single source of truth — the operator enforces read-only mode server-side, not just in the frontend.
+
+## Securing with OIDC
+
+OIDC closes the otherwise-unauthenticated REST API. The API owns the login/callback flow as a confidential client, so the client secret stays server-side. The provider must reach the API's callback at a stable URL — typically through an Ingress:
+
+```bash
+helm upgrade --install ksail-operator oci://ghcr.io/devantler-tech/charts/ksail-operator \
+  --version <version> --namespace ksail-system --create-namespace \
+  --set ui.enabled=true \
+  --set ui.ingress.enabled=true \
+  --set ui.ingress.hosts[0].host=ksail.example.com \
+  --set auth.oidc.enabled=true \
+  --set auth.oidc.issuerURL=https://dex.example.com \
+  --set auth.oidc.clientID=ksail \
+  --set-string auth.oidc.clientSecret=CLIENT_SECRET \
+  --set auth.oidc.redirectURL=https://ksail.example.com/api/v1/auth/callback
+```
+
+Register the redirect URL with your provider. To keep secrets out of `--set` and values files, pre-create a Secret with keys `client-secret` and `session-secret` and reference it via `auth.oidc.existingSecret`.
+
+## Uninstalling
+
+```bash
+helm uninstall ksail-operator --namespace ksail-system
+```
+
+Helm does **not** remove CRDs installed from `crds/`. Delete the `Cluster` CRD manually if you no longer need it — this also deletes all `Cluster` resources:
+
+```bash
+kubectl delete crd clusters.ksail.io
+```
+
+## Configuration Reference
+
+The full values reference — images, replicas, leader election, resources, Ingress, and OIDC — lives in the [chart README](https://github.com/devantler-tech/ksail/tree/main/charts/ksail-operator).
+
+## Related
+
+- [Web UI & Desktop App](/features/web-ui/) — the same UI, running locally instead of in-cluster
+- [Kubernetes (Nested) provider](/providers/kubernetes/) — how nested clusters run as pods inside a host cluster
+- [GitOps Workflows](/features/gitops-workflows/) — drive `Cluster` resources from Git with Flux or ArgoCD

--- a/docs/src/content/docs/features/registry-management.mdx
+++ b/docs/src/content/docs/features/registry-management.mdx
@@ -1,19 +1,73 @@
 ---
 title: Registry Management
-description: Run local OCI registries and configure mirror registries for faster image pulls and GitOps integration.
+description: Run a local OCI registry for your images and GitOps artifacts, and pull-through mirror registries that beat rate limits and survive cluster recreation.
 ---
 
-Run local [OCI registries](/concepts/#oci-registries) for faster image pulls and GitOps integration. Docker-based clusters (Vanilla, K3s, Talos-on-Docker, VCluster, KWOK) enable `docker.io`, `ghcr.io`, `quay.io`, and `registry.k8s.io` mirrors by default; Talos on Hetzner requires explicit mirror configuration.
+KSail manages two kinds of [OCI registries](/concepts/#oci-registries), each solving a different problem:
+
+| | Local registry | Mirror registries |
+|---|----------------|-------------------|
+| **Purpose** | Push *your* images and GitOps artifacts | Cache *upstream* images (pull-through) |
+| **Direction** | You push, the cluster pulls | The cluster pulls, the mirror caches |
+| **Why** | Fast inner-loop builds, [`workload push`](/features/gitops-workflows/) targets | Avoid rate limits; images survive cluster recreation |
+
+## Local Registry
+
+The local registry is where your own artifacts live: application images you build during development, and the OCI artifacts `ksail workload push` publishes for [GitOps reconciliation](/features/gitops-workflows/).
 
 ```bash
-# Local registry
 ksail cluster init --local-registry localhost:5050
 ksail cluster create
+
 docker build -t localhost:5050/my-app .
 docker push localhost:5050/my-app
+```
 
-# Authenticated mirror: [user:pass@]host[=endpoint]
+Or declaratively in `ksail.yaml` — external registries with credentials work too:
+
+```yaml
+spec:
+  cluster:
+    localRegistry:
+      # Format: [user:pass@]host[:port][/path]
+      registry: "${REGISTRY_USER}:${REGISTRY_PASS}@ghcr.io/myorg/myrepo"
+```
+
+> `${VAR}` placeholders are resolved by KSail from the environment, not by your shell — quote them (single quotes on the CLI) so they reach KSail verbatim. This keeps credentials out of version-controlled files.
+
+## Mirror Registries
+
+Mirror registries are pull-through caches that sit between your cluster and upstream registries. The first pull fetches from upstream and caches the image in a Docker volume; every later pull — from *any* KSail cluster on the machine — is served locally. Recreating a cluster does not empty the cache.
+
+Docker-based clusters (Vanilla, K3s, Talos-on-Docker, VCluster, KWOK) enable mirrors for `docker.io`, `ghcr.io`, `quay.io`, and `registry.k8s.io` by default. Talos on Hetzner requires explicit mirror configuration.
+
+```bash
+# Format: [user:pass@]host[=upstream]
+# host     — the registry the cluster's image pulls are redirected from
+# upstream — the endpoint the mirror fetches from on a cache miss
+
+# Mirror Docker Hub through its real upstream endpoint
+ksail cluster init --mirror-registry docker.io=https://registry-1.docker.io
+
+# Authenticated mirror — higher rate limits, private images
 ksail cluster init --mirror-registry '${GITHUB_USER}:${GITHUB_TOKEN}@ghcr.io=https://ghcr.io'
 ```
 
-> `${GITHUB_USER}` and `${GITHUB_TOKEN}` are placeholders resolved by KSail (replace with your GitHub username and a personal access token). They are not expanded by the shell — the single quotes ensure the shell passes the value verbatim so KSail can interpolate it.
+What this buys you:
+
+- **No more rate limits.** Anonymous Docker Hub pulls are throttled aggressively in CI and shared networks; a mirror pulls once and serves everyone.
+- **Store images once.** Multiple clusters on the same machine share one cache instead of each pulling its own copy.
+- **Fast recreate loops.** `ksail cluster delete && ksail cluster create` reuses every cached image — the second create is dramatically faster.
+
+> [!TIP]
+> In GitHub Actions, the [`ksail-cluster` composite action](/features/cicd-integration/) persists mirror registry volumes between workflow runs (`cache: "true"`), extending the same speedup to CI.
+
+## CLI Reference
+
+[`ksail cluster init`](/cli-flags/cluster/cluster-init/) (`--local-registry`, `--mirror-registry`)
+
+## Related
+
+- [GitOps Workflows](/features/gitops-workflows/) — push manifests as OCI artifacts to the local registry
+- [Declarative Configuration](/configuration/declarative-configuration/#localregistry) — `spec.cluster.localRegistry` reference
+- [CI/CD Integration](/features/cicd-integration/) — registry caching in GitHub Actions

--- a/docs/src/content/docs/features/web-ui.mdx
+++ b/docs/src/content/docs/features/web-ui.mdx
@@ -1,0 +1,87 @@
+---
+title: Web UI & Desktop App
+description: Provision and manage clusters visually — in your browser with ksail ui, as a native desktop app, or served in-cluster by the KSail operator.
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+
+KSail ships one web UI that runs in three places: locally in your browser, as a native desktop window, or inside a cluster served by the [KSail operator](/features/operator/). All three talk to the same REST API, so the experience is identical — pick the surface that fits how you work.
+
+```mermaid
+flowchart LR
+    UI["🖥️ KSail Web UI"]
+
+    UI --- Local["ksail ui<br/>local server · 127.0.0.1"]
+    UI --- Desktop["ksail desktop<br/>native window"]
+    UI --- Operator["KSail operator<br/>in-cluster · OIDC optional"]
+
+    Local -->|"REST API"| Docker["🐳 Local clusters via Docker"]
+    Desktop -->|"REST API"| Docker
+    Operator -->|"REST API"| CRs["☸️ Cluster custom resources"]
+
+    style UI fill:#2ec4e622,stroke:#2ec4e6
+    style Local fill:#10b98122,stroke:#10b981
+    style Desktop fill:#10b98122,stroke:#10b981
+    style Operator fill:#7c3aed22,stroke:#7c3aed
+```
+
+## Choosing a Surface
+
+| Surface | Command | Best for |
+|---------|---------|----------|
+| Browser | `ksail ui` | Quick visual management of local clusters without installing anything extra |
+| Desktop app | `ksail desktop` | A dedicated window outside the browser, launchable from your dock |
+| In-cluster | Helm chart with `ui.enabled=true` | Team-shared dashboards over [operator-managed clusters](/features/operator/), with optional OIDC sign-in |
+
+## Running Locally
+
+<Tabs>
+  <TabItem label="Browser (ksail ui)">
+    `ksail ui` starts a small local web server and opens the UI in your browser. The server binds to `127.0.0.1` only — it is never exposed to your network — and serves both the UI and a REST API backed by your local cluster lifecycle. It runs until you press <kbd>Ctrl</kbd>+<kbd>C</kbd>.
+
+    ```bash
+    ksail ui              # pick a free port and open the browser
+    ksail ui --port 8080  # serve on a fixed port
+    ksail ui --no-browser # start the server without opening a browser
+    ```
+
+    This is the same UI the KSail operator serves in-cluster, but here it provisions and manages clusters locally via Docker.
+  </TabItem>
+  <TabItem label="Desktop app (ksail desktop)">
+    The desktop app wraps the web UI in a native window — no browser required. It ships as a separate download from the [releases page](https://github.com/devantler-tech/ksail/releases), or build it from source with `make desktop`.
+
+    ```bash
+    ksail desktop
+    ```
+
+    `ksail desktop` launches the app from, in order: a `ksail-desktop` binary next to the `ksail` executable, the same binary on your `PATH`, or (on macOS) an installed **KSail** app.
+  </TabItem>
+  <TabItem label="In-cluster (operator)">
+    Enable the UI when installing the [KSail operator](/features/operator/) Helm chart:
+
+    ```bash
+    helm upgrade --install ksail-operator oci://ghcr.io/devantler-tech/charts/ksail-operator \
+      --namespace ksail-system --create-namespace \
+      --set ui.enabled=true
+    ```
+
+    The in-cluster UI manages `Cluster` custom resources instead of local Docker containers, and supports OIDC authentication and a server-enforced read-only mode. See [Kubernetes Operator](/features/operator/) for the full setup.
+  </TabItem>
+</Tabs>
+
+## Read-Only Mode for GitOps
+
+In GitOps-enforced environments the Git repository should stay the single source of truth. Deploy the in-cluster UI with `ui.readOnly=true` to lock it to inspection: the restriction is enforced server-side by the REST API, not just hidden in the frontend.
+
+> [!NOTE]
+> The operator's REST API is unauthenticated by default. Enable OIDC (`auth.oidc.enabled=true`) to require sign-in, or set `api.bindPort=0` to disable the API entirely when you don't need the UI. The local `ksail ui` server avoids this concern by binding to `127.0.0.1` only.
+
+## CLI Reference
+
+[`ksail ui`](/cli-flags/ui/ui-root/), [`ksail desktop`](/cli-flags/desktop/desktop-root/)
+
+## Related
+
+- [Kubernetes Operator](/features/operator/) — deploy the UI in-cluster with OIDC and read-only mode
+- [OIDC Authentication](/guides/oidc-authentication/) — KSail's native OIDC support for cluster access
+- [VSCode Extension](/vscode-extension/) — manage clusters from your editor instead

--- a/docs/src/content/docs/features/workload-management.mdx
+++ b/docs/src/content/docs/features/workload-management.mdx
@@ -1,21 +1,9 @@
 ---
 title: Workload Management
-description: Deploy, inspect, and manage Kubernetes workloads using familiar kubectl and Helm patterns.
+description: Deploy, inspect, debug, and operate Kubernetes workloads with one command family — kubectl and Helm patterns, plus validation, scanning, and GitOps built in.
 ---
 
-Deploy and manage Kubernetes workloads using familiar kubectl and Helm patterns:
-
-- **Apply** [Kustomize](/concepts/#kustomize) directories, [Helm](/concepts/#helm) charts, or raw YAML
-- **Manage** resources: create, edit, and delete
-- **Inspect** resources with get, describe, logs, exec, and explain
-- **Debug** pods and nodes interactively — see [`ksail workload debug`](/cli-flags/workload/workload-debug/) for ephemeral containers, pod copies, and host-level debugging
-- **Forward** local ports to in-cluster pods or services — see [`ksail workload forward`](/cli-flags/workload/workload-forward/) for supported resource types and port mapping syntax
-- **Expose** services
-- **Export and import** container images
-- **Validate** manifests against schemas — see [Substitution Expansion in `workload validate`](/configuration/workload-validate/) for Flux `${VAR}` expansion behavior
-- **Generate** resources — see [`ksail workload gen` reference](/cli-flags/workload/workload-gen-root/) for supported types
-- **Watch** directories for automatic live reconciliation — see the [`ksail workload watch` reference](/cli-flags/workload/workload-watch/) for the canonical behavior and supported options
-- **Scan** manifests for security issues using [Kubescape](https://kubescape.io) — see [`ksail workload scan`](/cli-flags/workload/workload-scan/) for supported frameworks and output formats
+Everything you do to workloads lives under one command family: `ksail workload`. The subcommands follow familiar kubectl and Helm patterns, so existing muscle memory transfers — and because the tooling is embedded, there is nothing else to install.
 
 ```bash
 ksail workload apply -k k8s/
@@ -24,6 +12,79 @@ ksail workload logs deployment/my-app
 ksail workload gen deployment my-app --image=nginx --port=80
 ```
 
+## Command Map
+
+**Deploy & generate**
+
+| Command | What it does |
+|---------|--------------|
+| [`apply`](/cli-flags/workload/workload-apply-root/) | Apply [Kustomize](/concepts/#kustomize) directories, raw YAML, or stdin |
+| [`install`](/cli-flags/workload/workload-install/) | Install [Helm](/concepts/#helm) charts |
+| [`create`](/cli-flags/workload/workload-create-root/) | Create resources imperatively (kubectl-style) |
+| [`gen`](/cli-flags/workload/workload-gen-root/) | Generate manifest YAML for 30+ resource types |
+
+**Inspect & debug**
+
+| Command | What it does |
+|---------|--------------|
+| [`get`](/cli-flags/workload/workload-get/) / [`describe`](/cli-flags/workload/workload-describe/) / [`explain`](/cli-flags/workload/workload-explain/) | Query resources and API documentation |
+| [`logs`](/cli-flags/workload/workload-logs/) / [`exec`](/cli-flags/workload/workload-exec/) | Stream container logs, run commands in containers |
+| [`debug`](/cli-flags/workload/workload-debug/) | Ephemeral containers, pod copies, and host-level debugging |
+| [`forward`](/cli-flags/workload/workload-forward/) | Forward local ports to in-cluster pods or services |
+| [`expose`](/cli-flags/workload/workload-expose/) | Expose a resource as a service |
+
+**Operate**
+
+| Command | What it does |
+|---------|--------------|
+| [`scale`](/cli-flags/workload/workload-scale/) | Scale deployments and other scalable resources |
+| [`rollout`](/cli-flags/workload/workload-rollout-root/) | Manage rollouts — status, history, pause, resume, restart, undo |
+| [`wait`](/cli-flags/workload/workload-wait/) | Block until a condition is met (great for scripts and CI) |
+| [`edit`](/cli-flags/workload/workload-edit/) / [`delete`](/cli-flags/workload/workload-delete/) | Modify or remove resources |
+
+**Validate & secure**
+
+| Command | What it does |
+|---------|--------------|
+| [`validate`](/cli-flags/workload/workload-validate/) | Validate manifests against schemas, with [Flux `${VAR}` substitution expansion](/configuration/workload-validate/) |
+| [`scan`](/cli-flags/workload/workload-scan/) | Scan manifests for security issues with [Kubescape](https://kubescape.io) — NSA, MITRE, and other frameworks |
+
+**Images**
+
+| Command | What it does |
+|---------|--------------|
+| [`images`](/cli-flags/workload/workload-images/) | List the container images your workloads require |
+| [`export`](/cli-flags/workload/workload-export/) / [`import`](/cli-flags/workload/workload-import/) | Move images as tar archives — air-gapped environments, CI caching |
+
+**GitOps**
+
+| Command | What it does |
+|---------|--------------|
+| [`push`](/cli-flags/workload/workload-push/) | Package manifests as an OCI artifact and push to the [registry](/features/registry-management/) |
+| [`reconcile`](/cli-flags/workload/workload-reconcile/) | Trigger the GitOps engine to sync, and wait for the result |
+| [`watch`](/cli-flags/workload/workload-watch/) | Watch a directory and auto-apply (or auto-push) on every change |
+
+## Inner Loop, Two Ways
+
+Imperative — apply directly and iterate:
+
+```bash
+ksail workload watch          # auto-apply k8s/ on every file save
+```
+
+Declarative — let [Flux or ArgoCD](/features/gitops-workflows/) do the deploying:
+
+```bash
+ksail workload push           # publish manifests as an OCI artifact
+ksail workload reconcile      # sync now and wait for healthy
+```
+
 ## CLI Reference
 
 [`ksail workload`](/cli-flags/workload/workload-root/)
+
+## Related
+
+- [GitOps Workflows](/features/gitops-workflows/) — Flux and ArgoCD setup, push and reconcile in depth
+- [Registry Management](/features/registry-management/) — where `push` artifacts and your images live
+- [Secret Management](/features/secret-management/) — SOPS-encrypted secrets in your manifests

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -39,7 +39,7 @@ From nothing to a running Kubernetes cluster, a deployed workload, and a clean t
 
 export const features = [
   { icon: "📦", title: "One Binary", body: "Embeds cluster provisioning, GitOps engines, and deployment tooling. No tool sprawl." },
-  { icon: "☸️", title: "Simple Clusters", body: "Spin up Vanilla, K3s, Talos, VCluster, KWOK, or EKS clusters with one command. Same workflow across distributions." },
+  { icon: "☸️", title: "Simple Clusters", body: "Spin up Vanilla, K3s, Talos, VCluster, or KWOK clusters with one command — EKS scaffolding included. Same workflow across distributions." },
   { icon: "🔓", title: "No Lock-In", body: "Uses native configs (<code>kind.yaml</code>, <code>k3d.yaml</code>, Talos patches, <code>vcluster.yaml</code>, <code>kwok/</code>). Run clusters with or without KSail." },
   { icon: "📥", title: "Mirror Registries", body: "Avoid rate limits, and store images once. Same mirrors used by different clusters." },
   { icon: "📄", title: "Everything as Code", body: "Cluster settings, distribution configs, and workloads in version-controlled files." },
@@ -48,6 +48,9 @@ export const features = [
   { icon: "⚙️", title: "Customizable Stack", body: "Select your CNI, CSI, policy engine, cert-manager, and mirror registries." },
   { icon: "🔐", title: "SOPS Built In", body: "Encrypt, decrypt, and edit secrets with integrated cipher commands." },
   { icon: "💾", title: "Backup & Restore", body: "Export cluster resources to a compressed archive and restore to any cluster with provenance labels." },
+  { icon: "🩺", title: "Built-In Diagnostics", body: "Health-scored cluster diagnostics with remediation hints via <code>ksail cluster diagnose</code>." },
+  { icon: "🖥️", title: "Web UI & Desktop", body: "Manage clusters visually with <code>ksail ui</code> in the browser or the native desktop app." },
+  { icon: "⚓", title: "Kubernetes Operator", body: "Reconcile <code>Cluster</code> custom resources in-cluster, with an optional OIDC-protected dashboard." },
   { icon: "🤖", title: "AI Assistant", body: "Interactive chat powered by GitHub Copilot for configuration and troubleshooting." },
   { icon: "💻", title: "VS Code Extension", body: "Manage clusters from VS Code via the Kubernetes extension (Cloud Explorer and Cluster Explorer), wizards, and command palette." },
 ];
@@ -259,6 +262,9 @@ flowchart TD
   </Card>
   <Card title="MCP Server" icon="puzzle">
     Expose KSail as an MCP server for AI assistants and automation tools. [Learn more →](/mcp/)
+  </Card>
+  <Card title="AI Assistant Plugins" icon="add-document">
+    Install the KSail plugin for GitHub Copilot CLI or Claude Code — MCP server and skill included. [Learn more →](/ai-plugins/)
   </Card>
 </CardGrid>
 

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -222,6 +222,10 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .hero img { animation: none; }
   html { scroll-behavior: auto; }
+
+  .card,
+  .sl-link-card,
+  .sl-link-button { transition: none; }
 }
 
 /* ----------------------------------------------------------------------- */
@@ -285,6 +289,36 @@ body {
 .card .title {
   font-family: var(--ksail-font-display);
   letter-spacing: -0.01em;
+}
+
+/* LinkCards (feature overview) share the Card surface treatment. */
+.sl-link-card {
+  border: 1px solid var(--ksail-border);
+  border-radius: 1rem;
+  background: color-mix(in oklab, var(--ksail-surface) 75%, transparent);
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.sl-link-card:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in oklab, var(--ksail-cyan) 55%, var(--ksail-border));
+  box-shadow: var(--ksail-glow);
+}
+
+.sl-link-card a {
+  font-family: var(--ksail-font-display);
+  letter-spacing: -0.01em;
+}
+
+/* Keyboard keys in prose (e.g. Ctrl+C). */
+.sl-markdown-content kbd {
+  padding: 0.1em 0.45em;
+  font-family: var(--sl-font-mono);
+  font-size: 0.8em;
+  border: 1px solid var(--ksail-border);
+  border-bottom-width: 2px;
+  border-radius: 0.35rem;
+  background: var(--sl-color-bg-inline-code);
 }
 
 /* ----------------------------------------------------------------------- */

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -305,7 +305,7 @@ body {
   box-shadow: var(--ksail-glow);
 }
 
-.sl-link-card a {
+.sl-link-card .title {
   font-family: var(--ksail-font-display);
   letter-spacing: -0.01em;
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

A documentation professionalization pass: closes the biggest content gaps, fixes stale claims, upgrades presentation — and fixes a site-wide rendering regression found along the way.

### 🐛 Site-wide fix: GFM tables broken in production

Every markdown table on the published site currently renders as **literal pipe text** (see the [live support matrix](https://ksail.devantler.tech/support-matrix/)). On Astro 6.4.x the implicit GFM default is dropped when integrations use the deprecated `markdown.remarkPlugins` hook. Pinning `markdown: { gfm: true }` in `astro.config.mjs` restores tables everywhere (verified: support-matrix goes from 0 to 8 `<table>` elements).

### 📄 New pages (previously undocumented features)

- **Web UI & Desktop App** — `ksail ui`, `ksail desktop`, and the in-cluster UI; one UI, three surfaces, with a mermaid overview and read-only/OIDC guidance
- **Kubernetes Operator** — Helm chart install, `Cluster` CRD usage, web UI enablement, OIDC, uninstall caveats
- **Day-2 Operations** — `cluster diagnose` (health scoring, JSON output, AI integration), `cluster switch` (picker, history, filtering), `cluster repair`

### ✍️ Stub pages expanded with real content

- **Backup & Restore** — scoping flags, restore policies, dependency ordering, migration walkthrough
- **CI/CD Integration** — composite action inputs/outputs, GitOps + security-scanning recipes, cleanup guidance
- **Registry Management** — local vs mirror registries contrasted, `[user:pass@]host[=upstream]` syntax explained, declarative config
- **Workload Management** — full command map grouped by task (deploy / inspect / operate / validate / images / GitOps)

### 🧭 Freshness & presentation

- Concepts now lists all six distributions (EKS added) and the AWS provider
- Homepage: EKS claim qualified, new tiles for diagnostics / web UI / operator, AI plugins card added
- Features overview reorganized into journey-grouped LinkCards (Run Clusters / Ship Workloads / Scale Out)
- Theme-matched LinkCard + `<kbd>` styling, reduced-motion guards; sidebar gains the new pages

## Validation

- `npm run build` succeeds (176 pages); all changed pages verified to contain rendered `<table>` elements
- Visually verified via local preview: dark + light themes, desktop + mobile viewports, mermaid render, sidebar badges
- All internal links checked against existing slugs (generated `cli-flags/` pages untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)