### PR TITLE
test(detector): cover serverHasIP Hetzner ownership check

### DIFF
--- a/pkg/svc/detector/cluster/cluster_serverhasip_test.go
+++ b/pkg/svc/detector/cluster/cluster_serverhasip_test.go
@@ -1,0 +1,107 @@
+package cluster_test
+
+import (
+	"net"
+	"testing"
+
+	cluster "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+// serverWith builds a Hetzner server fixture with the given public IPv4, public
+// IPv6, and private-network IPs. An empty string leaves the corresponding IP
+// nil (the field's zero value), exercising serverHasIP's nil-guard branches.
+func serverWith(publicV4, publicV6 string, privateIPs ...string) *hcloud.Server {
+	server := &hcloud.Server{}
+
+	if publicV4 != "" {
+		server.PublicNet.IPv4.IP = net.ParseIP(publicV4)
+	}
+
+	if publicV6 != "" {
+		server.PublicNet.IPv6.IP = net.ParseIP(publicV6)
+	}
+
+	for _, ip := range privateIPs {
+		var parsed net.IP
+		if ip != "" {
+			parsed = net.ParseIP(ip)
+		}
+
+		server.PrivateNet = append(server.PrivateNet, hcloud.ServerPrivateNet{IP: parsed})
+	}
+
+	return server
+}
+
+// TestServerHasIP pins serverHasIP, the Hetzner cluster-ownership check that
+// guards against attributing a cluster to a server that does not actually
+// expose the endpoint IP. It covers the public-IPv4, public-IPv6, and
+// private-network match paths (an IPv4-less control plane matches on its
+// private-network IP) plus every nil-guard and no-match fall-through branch.
+//
+//nolint:funlen // Test function with comprehensive test cases
+func TestServerHasIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		server *hcloud.Server
+		ip     string
+		want   bool
+	}{
+		{name: "nil_server", server: nil, ip: "203.0.113.5", want: false},
+		{
+			name:   "public_ipv4_match",
+			server: serverWith("203.0.113.5", ""),
+			ip:     "203.0.113.5",
+			want:   true,
+		},
+		{
+			name:   "public_ipv6_match",
+			server: serverWith("", "2001:db8::1"),
+			ip:     "2001:db8::1",
+			want:   true,
+		},
+		{
+			name:   "private_net_match",
+			server: serverWith("", "", "10.0.0.4"),
+			ip:     "10.0.0.4",
+			want:   true,
+		},
+		{
+			name:   "private_net_match_on_last",
+			server: serverWith("", "", "10.0.0.4", "10.0.0.5"),
+			ip:     "10.0.0.5",
+			want:   true,
+		},
+		{
+			name:   "no_ips_no_private_nets",
+			server: serverWith("", ""),
+			ip:     "203.0.113.5",
+			want:   false,
+		},
+		{
+			name:   "all_present_none_match",
+			server: serverWith("203.0.113.5", "2001:db8::1", "10.0.0.4"),
+			ip:     "198.51.100.9",
+			want:   false,
+		},
+		{
+			name:   "private_net_nil_ip_skipped",
+			server: serverWith("", "", "", "10.0.0.7"),
+			ip:     "203.0.113.5",
+			want:   false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := cluster.ServerHasIP(testCase.server, testCase.ip)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/pkg/svc/detector/cluster/export_test.go
+++ b/pkg/svc/detector/cluster/export_test.go
@@ -18,3 +18,6 @@ var DetectProviderFromEndpoint = detectProviderFromEndpoint
 
 // DetectFromServerURL exports detectFromServerURL for testing.
 var DetectFromServerURL = detectFromServerURL
+
+// ServerHasIP exports serverHasIP for testing.
+var ServerHasIP = serverHasIP


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

`serverHasIP` in `pkg/svc/detector/cluster/cluster.go` is the Hetzner cluster-ownership check: it reports whether a candidate server actually exposes the endpoint IP being matched (over public IPv4, public IPv6, or any private network). It guards `checkHetznerOwnership` against attributing a cluster to a server that does not own the endpoint. It was **0% covered**.

## Change

Adds a table-driven black-box test (`cluster_serverhasip_test.go`, `package cluster_test`) via the existing `export_test.go` seam (`ServerHasIP = serverHasIP`). Cases pin every branch:

- nil server → false
- public-IPv4 match → true
- public-IPv6 match → true
- private-network match → true (the IPv4-less control-plane path — a node with no public IP matches on its private-network IP, per the function's own doc)
- match on the **last** of multiple private nets → true (loop completion)
- no IPs / no private nets → false
- all three families present, none match → false (full fall-through)
- private net with a **nil** IP skipped, then no match → false (the in-loop nil guard)

## Validation

- `go test ./pkg/svc/detector/cluster/...` — green (8/8 new subtests).
- Coverage: `serverHasIP` **0% → 100%**; package `pkg/svc/detector/cluster` **82.1% → 90.6%**.
- `go vet` clean; `golangci-lint fmt` applied (gci/gofumpt/golines); `t.Parallel()` at both levels (this file is **not** in the `.golangci.yml` paralleltest path-exclusion, unlike `cluster_test.go` which mutates env vars). `//nolint:funlen` matches the sibling `TestDetectDistributionFromContext` convention for comprehensive table tests.

Behaviour-preserving — test-only; no production code touched.

Draft pending maintainer promotion.