### PR TITLE
fix(talos): refresh autoscaler config secret before static-node scaling

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -394,6 +394,28 @@ func AutoscalerRecycleRequiredForTest(diff *clusterupdate.UpdateResult, imageCha
 	return autoscalerRecycleRequired(diff, imageChanged)
 }
 
+// UpdateApplyStepNamesForTest returns the ordered names of the post-PrepareUpdate
+// apply steps, so tests can assert the step ordering (notably that the autoscaler
+// baseline refresh runs before static-node scaling — #5219) without driving a
+// live cluster. The names do not depend on the spec/diff arguments.
+func (p *Provisioner) UpdateApplyStepNamesForTest() []string {
+	steps := p.updateApplySteps(
+		"test-cluster",
+		&v1alpha1.ClusterSpec{},
+		&v1alpha1.ClusterSpec{},
+		clusterupdate.NewEmptyUpdateResult(),
+		clusterupdate.NewEmptyUpdateResult(),
+		clusterupdate.UpdateOptions{},
+	)
+
+	names := make([]string, len(steps))
+	for index, step := range steps {
+		names[index] = step.name
+	}
+
+	return names
+}
+
 // SnapshotImageIDFromSecretForTest exposes snapshotImageIDFromSecret for unit testing.
 func SnapshotImageIDFromSecretForTest(secret *corev1.Secret) string {
 	return snapshotImageIDFromSecret(secret)

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -227,8 +227,6 @@ type updateStep struct {
 // stale machine-config template; otherwise it keeps minting broken nodes that
 // hold the project at its server limit and re-wedge every subsequent update at
 // the same failing step (#5219).
-//
-//nolint:funlen,cyclop // flat declarative step list; splitting obscures the ordering it makes explicit.
 func (p *Provisioner) updateApplySteps(
 	clusterName string,
 	oldSpec, newSpec *v1alpha1.ClusterSpec,
@@ -241,20 +239,12 @@ func (p *Provisioner) updateApplySteps(
 			return p.syncHetznerFirewallRules(ctx, clusterName)
 		}},
 		{"refresh Omni configs", func(ctx context.Context) error {
-			err := p.refreshOmniConfigsIfNeeded(ctx, clusterName)
-			if err != nil {
-				return fmt.Errorf("failed to refresh Omni configs before update: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(p.refreshOmniConfigsIfNeeded(ctx, clusterName),
+				"failed to refresh Omni configs before update")
 		}},
 		{"sync cluster secrets", func(ctx context.Context) error {
-			err := p.syncSecretsFromCluster(ctx, clusterName, oldSpec, newSpec, result)
-			if err != nil {
-				return fmt.Errorf("failed to sync cluster secrets: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(p.syncSecretsFromCluster(ctx, clusterName, oldSpec, newSpec, result),
+				"failed to sync cluster secrets")
 		}},
 		{"apply wipe-required changes", func(ctx context.Context) error {
 			// PrepareUpdate already blocks wipe-required changes without --force.
@@ -262,58 +252,47 @@ func (p *Provisioner) updateApplySteps(
 				return nil
 			}
 
-			err := p.applyWipeRequiredChanges(ctx, clusterName, result)
-			if err != nil {
-				return fmt.Errorf("failed to apply wipe-required changes: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(p.applyWipeRequiredChanges(ctx, clusterName, result),
+				"failed to apply wipe-required changes")
 		}},
 		{"ensure autoscaler config secret", func(ctx context.Context) error {
-			err := p.ensureAutoscalerSecretIfNeeded(ctx, clusterName, diff, result)
-			if err != nil {
-				return fmt.Errorf("failed to ensure autoscaler config secret: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(p.ensureAutoscalerSecretIfNeeded(ctx, clusterName, diff, result),
+				"failed to ensure autoscaler config secret")
 		}},
 		{"apply node scaling changes", func(ctx context.Context) error {
-			err := p.applyNodeScalingChanges(ctx, clusterName, oldSpec, newSpec, result)
-			if err != nil {
-				return fmt.Errorf("failed to apply node scaling changes: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(
+				p.applyNodeScalingChanges(ctx, clusterName, oldSpec, newSpec, result),
+				"failed to apply node scaling changes",
+			)
 		}},
 		{"apply rolling recreate changes", func(ctx context.Context) error {
-			err := p.applyRollingRecreateChanges(ctx, clusterName, result)
-			if err != nil {
-				return fmt.Errorf("failed to apply rolling recreate changes: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(p.applyRollingRecreateChanges(ctx, clusterName, result),
+				"failed to apply rolling recreate changes")
 		}},
 		{"apply in-place config changes", func(ctx context.Context) error {
 			if !p.shouldApplyInPlaceChanges(diff) {
 				return nil
 			}
 
-			err := p.applyInPlaceConfigChanges(ctx, clusterName, result)
-			if err != nil {
-				return fmt.Errorf("failed to apply in-place config changes: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(p.applyInPlaceConfigChanges(ctx, clusterName, result),
+				"failed to apply in-place config changes")
 		}},
 		{"apply reboot-required changes", func(ctx context.Context) error {
-			err := p.applyRebootChangesIfNeeded(ctx, clusterName, result, diff, opts)
-			if err != nil {
-				return fmt.Errorf("failed to apply reboot-required changes: %w", err)
-			}
-
-			return nil
+			return wrapStepErr(p.applyRebootChangesIfNeeded(ctx, clusterName, result, diff, opts),
+				"failed to apply reboot-required changes")
 		}},
 	}
+}
+
+// wrapStepErr annotates a failed update step's error with the step's intent,
+// returning nil when err is nil so step closures wrap-and-return in a single
+// expression instead of repeating the err-check boilerplate.
+func wrapStepErr(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%s: %w", msg, err)
 }
 
 // DiffConfig computes the differences between current and desired configurations.

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -181,9 +181,9 @@ func appendServerTypeChange(
 	}
 }
 
-// applyUpdateChanges applies all update changes after PrepareUpdate succeeds.
-//
-//nolint:cyclop // sequential update workflow with multiple change categories
+// applyUpdateChanges applies all update changes after PrepareUpdate succeeds by
+// running the ordered apply steps (see updateApplySteps) and stopping at the
+// first failure.
 func (p *Provisioner) applyUpdateChanges(
 	ctx context.Context,
 	clusterName string,
@@ -198,59 +198,122 @@ func (p *Provisioner) applyUpdateChanges(
 	// this update by setting it on the (per-invocation) provisioner here.
 	p.drainForce = opts.Force
 
-	// Sync Hetzner Cloud Firewall rules to the hardened set.
-	syncErr := p.syncHetznerFirewallRules(ctx, clusterName)
-	if syncErr != nil {
-		return result, syncErr
-	}
-
-	configErr := p.refreshOmniConfigsIfNeeded(ctx, clusterName)
-	if configErr != nil {
-		return result, fmt.Errorf("failed to refresh Omni configs before update: %w", configErr)
-	}
-
-	secretErr := p.syncSecretsFromCluster(ctx, clusterName, oldSpec, newSpec, result)
-	if secretErr != nil {
-		return result, fmt.Errorf("failed to sync cluster secrets: %w", secretErr)
-	}
-
-	// Execute wipe migration if --force was set (PrepareUpdate already blocks without --force)
-	if result.HasWipeRequired() {
-		wipeErr := p.applyWipeRequiredChanges(ctx, clusterName, result)
-		if wipeErr != nil {
-			return result, fmt.Errorf("failed to apply wipe-required changes: %w", wipeErr)
+	for _, step := range p.updateApplySteps(clusterName, oldSpec, newSpec, diff, result, opts) {
+		err := step.run(ctx)
+		if err != nil {
+			return result, err
 		}
-	}
-
-	scaleErr := p.applyNodeScalingChanges(ctx, clusterName, oldSpec, newSpec, result)
-	if scaleErr != nil {
-		return result, fmt.Errorf("failed to apply node scaling changes: %w", scaleErr)
-	}
-
-	rollErr := p.applyRollingRecreateChanges(ctx, clusterName, result)
-	if rollErr != nil {
-		return result, fmt.Errorf("failed to apply rolling recreate changes: %w", rollErr)
-	}
-
-	// Handle in-place config changes (NO_REBOOT mode).
-	if p.shouldApplyInPlaceChanges(diff) {
-		cfgErr := p.applyInPlaceConfigChanges(ctx, clusterName, result)
-		if cfgErr != nil {
-			return result, fmt.Errorf("failed to apply in-place config changes: %w", cfgErr)
-		}
-	}
-
-	rebootErr := p.applyRebootChangesIfNeeded(ctx, clusterName, result, diff, opts)
-	if rebootErr != nil {
-		return result, fmt.Errorf("failed to apply reboot-required changes: %w", rebootErr)
-	}
-
-	secretErr = p.ensureAutoscalerSecretIfNeeded(ctx, clusterName, diff, result)
-	if secretErr != nil {
-		return result, fmt.Errorf("failed to ensure autoscaler config secret: %w", secretErr)
 	}
 
 	return result, nil
+}
+
+// updateStep is one named step in the post-PrepareUpdate apply sequence. The name
+// carries error context and lets tests assert the step ordering.
+type updateStep struct {
+	name string
+	run  func(ctx context.Context) error
+}
+
+// updateApplySteps returns the ordered apply steps run after PrepareUpdate
+// succeeds. The order is significant and asserted by tests.
+//
+// The autoscaler tier baseline (ensureAutoscalerSecretIfNeeded) is refreshed
+// BEFORE static-node scaling. Autoscaler nodes are a separate, independent tier,
+// and on a capacity-constrained cluster a static scale-up can hard-fail at the
+// Hetzner project server limit — the very limit the stale autoscaler nodes pin
+// the project to. Running the autoscaler refresh first guarantees that a scaling
+// (or any later reboot/in-place) failure can never strand the autoscaler on a
+// stale machine-config template; otherwise it keeps minting broken nodes that
+// hold the project at its server limit and re-wedge every subsequent update at
+// the same failing step (#5219).
+//
+//nolint:funlen,cyclop // flat declarative step list; splitting obscures the ordering it makes explicit.
+func (p *Provisioner) updateApplySteps(
+	clusterName string,
+	oldSpec, newSpec *v1alpha1.ClusterSpec,
+	diff, result *clusterupdate.UpdateResult,
+	opts clusterupdate.UpdateOptions,
+) []updateStep {
+	return []updateStep{
+		{"sync Hetzner firewall rules", func(ctx context.Context) error {
+			// syncHetznerFirewallRules already wraps its own errors.
+			return p.syncHetznerFirewallRules(ctx, clusterName)
+		}},
+		{"refresh Omni configs", func(ctx context.Context) error {
+			err := p.refreshOmniConfigsIfNeeded(ctx, clusterName)
+			if err != nil {
+				return fmt.Errorf("failed to refresh Omni configs before update: %w", err)
+			}
+
+			return nil
+		}},
+		{"sync cluster secrets", func(ctx context.Context) error {
+			err := p.syncSecretsFromCluster(ctx, clusterName, oldSpec, newSpec, result)
+			if err != nil {
+				return fmt.Errorf("failed to sync cluster secrets: %w", err)
+			}
+
+			return nil
+		}},
+		{"apply wipe-required changes", func(ctx context.Context) error {
+			// PrepareUpdate already blocks wipe-required changes without --force.
+			if !result.HasWipeRequired() {
+				return nil
+			}
+
+			err := p.applyWipeRequiredChanges(ctx, clusterName, result)
+			if err != nil {
+				return fmt.Errorf("failed to apply wipe-required changes: %w", err)
+			}
+
+			return nil
+		}},
+		{"ensure autoscaler config secret", func(ctx context.Context) error {
+			err := p.ensureAutoscalerSecretIfNeeded(ctx, clusterName, diff, result)
+			if err != nil {
+				return fmt.Errorf("failed to ensure autoscaler config secret: %w", err)
+			}
+
+			return nil
+		}},
+		{"apply node scaling changes", func(ctx context.Context) error {
+			err := p.applyNodeScalingChanges(ctx, clusterName, oldSpec, newSpec, result)
+			if err != nil {
+				return fmt.Errorf("failed to apply node scaling changes: %w", err)
+			}
+
+			return nil
+		}},
+		{"apply rolling recreate changes", func(ctx context.Context) error {
+			err := p.applyRollingRecreateChanges(ctx, clusterName, result)
+			if err != nil {
+				return fmt.Errorf("failed to apply rolling recreate changes: %w", err)
+			}
+
+			return nil
+		}},
+		{"apply in-place config changes", func(ctx context.Context) error {
+			if !p.shouldApplyInPlaceChanges(diff) {
+				return nil
+			}
+
+			err := p.applyInPlaceConfigChanges(ctx, clusterName, result)
+			if err != nil {
+				return fmt.Errorf("failed to apply in-place config changes: %w", err)
+			}
+
+			return nil
+		}},
+		{"apply reboot-required changes", func(ctx context.Context) error {
+			err := p.applyRebootChangesIfNeeded(ctx, clusterName, result, diff, opts)
+			if err != nil {
+				return fmt.Errorf("failed to apply reboot-required changes: %w", err)
+			}
+
+			return nil
+		}},
+	}
 }
 
 // DiffConfig computes the differences between current and desired configurations.

--- a/pkg/svc/provisioner/cluster/talos/update_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -200,6 +201,43 @@ func TestUpdateDoesNotAttemptVersionUpgrade(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Empty(t, result.FailedChanges)
+}
+
+// TestUpdateApplyStepOrder_AutoscalerBeforeScaling pins the ordering invariant
+// behind the #5219 prod wedge: the autoscaler config-secret refresh must run
+// BEFORE static-node scaling. Otherwise a scaling failure (e.g. hitting the
+// Hetzner project server limit — a limit the stale autoscaler nodes themselves
+// pin the project to) aborts the update before the autoscaler template is
+// regenerated, so autoscaler nodes keep booting from a stale machine config and
+// every subsequent update re-wedges at the same failing step.
+func TestUpdateApplyStepOrder_AutoscalerBeforeScaling(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	names := provisioner.UpdateApplyStepNamesForTest()
+
+	// Full ordered sequence — a snapshot guarding against accidental reordering.
+	assert.Equal(t, []string{
+		"sync Hetzner firewall rules",
+		"refresh Omni configs",
+		"sync cluster secrets",
+		"apply wipe-required changes",
+		"ensure autoscaler config secret",
+		"apply node scaling changes",
+		"apply rolling recreate changes",
+		"apply in-place config changes",
+		"apply reboot-required changes",
+	}, names)
+
+	// The load-bearing invariant (#5219): autoscaler refresh precedes scaling.
+	autoscalerIdx := slices.Index(names, "ensure autoscaler config secret")
+	scalingIdx := slices.Index(names, "apply node scaling changes")
+
+	require.NotEqual(t, -1, autoscalerIdx, "autoscaler step must be present")
+	require.NotEqual(t, -1, scalingIdx, "node scaling step must be present")
+	assert.Less(t, autoscalerIdx, scalingIdx,
+		"autoscaler config secret must be refreshed before static-node scaling (#5219)")
 }
 
 // TestApplyNodeScalingChanges_NilSpecs verifies that nil specs short-circuit scaling without error.


### PR DESCRIPTION
## Summary

Fixes the self-reinforcing wedge behind the second recurrence of #5219: on Talos×Hetzner with the node autoscaler enabled, autoscaler-minted nodes kept booting from a **stale** machine config (missing `talos/` patches added after the `cluster-autoscaler-config` secret was first baked).

### Root cause (the new finding in the 2026-06-15 comment, confirmed in code)

`applyUpdateChanges` ran `ensureAutoscalerSecretIfNeeded` as the **last** step — *after* `applyNodeScalingChanges`. On a capacity-constrained project, a static worker scale-up hard-fails at the Hetzner project server limit (`provisionHetznerScaleServers` → `collectCreatedHetznerServers` returns a hard error on the first `resource_limit_exceeded`), so the update **aborted before the autoscaler step ever ran**.

That is self-reinforcing: the **stale autoscaler nodes are what pin the project to its server limit**, so every subsequent `cluster update` re-failed at the same scaling step and the template stayed stale indefinitely ("last baked ~22 days ago"). It also aborts before the manifest push, so a stale tier wedges the *delivery pipeline*, not just runtime.

### Fix

Refactor `applyUpdateChanges` into an explicit, ordered `[]updateStep` list and run the **autoscaler refresh before static-node scaling** (and before the later rolling-recreate / in-place / reboot steps). The autoscaler tier is independent of the static nodes, so a scaling or reboot failure can no longer strand it on a stale template. Existing autoscaler nodes still converge via the non-disruptive **in-place** path for config-only drift (the firewall / registry-auth case) — `autoscalerRecycleRequired` returns `false` for an in-place-only diff, so no drain is attempted; this reorder just guarantees that path is *reached*.

The step list also makes the ordering an explicit, **unit-testable invariant** so this regression can't silently return:

```
sync Hetzner firewall rules → refresh Omni configs → sync cluster secrets
→ apply wipe-required changes → ensure autoscaler config secret
→ apply node scaling changes → rolling recreate → in-place → reboot
```

### Tests

- `TestUpdateApplyStepOrder_AutoscalerBeforeScaling` — snapshots the full ordered sequence and asserts `autoscaler < scaling` (the load-bearing #5219 invariant), via the new `UpdateApplyStepNamesForTest` seam (no live cluster needed).
- All 1348 provisioner + lifecycle tests pass; `golangci-lint` clean on changed code; `gofmt`/`go vet` clean.

A true Hetzner-path integration test of the full ordering is infeasible as a unit test (concrete `*hetzner.Provider` type assertion + `syncSecretsFromCluster` requires a reachable control-plane), which is why the invariant is pinned at the step-plan level.

### Not in scope / notes

- The "broaden the **Impact** section to call out firewall/`NetworkRuleConfig` patches + the Longhorn/cross-node-Service blast radius" ask is a docs/issue clarification, not code — happy to fold it into the issue.
- Recycle-at-capacity (a *reboot-class* change draining nodes when there's no server headroom) remains a separate, un-addressed edge; the config-only firewall/registry incident here takes the safe in-place path.
- Leaving #5219 open (Refs, not Fixes) so the prod-build verification you outlined can confirm before closing.

Refs #5219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
