### PR TITLE
fix(autoscaler): read persisted state with legacy scalar expander

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,13 +65,15 @@ linters:
         path: pkg/utils/doc.go
   settings:
     recvcheck:
-      # controller-gen emits pointer-receiver DeepCopy methods; exclude them so types with
-      # value-receiver domain methods (e.g. ClusterSpec, LocalRegistry) are not flagged as mixing
-      # receiver styles.
+      # Some methods have their receiver style dictated by an external contract, not by choice:
+      # controller-gen emits DeepCopy* methods and json.Unmarshaler requires a pointer receiver for
+      # UnmarshalJSON. Exclude them so types with value-receiver domain methods (e.g. ClusterSpec,
+      # LocalRegistry, AutoscalerExpanderList) are not flagged as mixing receiver styles.
       exclusions:
         - "*.DeepCopyInto"
         - "*.DeepCopy"
         - "*.DeepCopyObject"
+        - "*.UnmarshalJSON"
     tagalign:
       align: false
       sort: true

--- a/pkg/apis/cluster/v1alpha1/autoscaler_test.go
+++ b/pkg/apis/cluster/v1alpha1/autoscaler_test.go
@@ -194,6 +194,7 @@ func TestAutoscalerExpanderList_UnmarshalJSON(t *testing.T) {
 		{"null", `null`, nil, false},
 		{"invalid_json", `{`, nil, true},
 		{"number", `123`, nil, true},
+		{"array_with_non_string_element", `[123]`, nil, true},
 	}
 
 	for _, testCase := range tests {

--- a/pkg/apis/cluster/v1alpha1/autoscaler_test.go
+++ b/pkg/apis/cluster/v1alpha1/autoscaler_test.go
@@ -122,21 +122,25 @@ func TestSplitAutoscalerExpanders(t *testing.T) {
 
 	leastNodes := string(v1alpha1.AutoscalerExpanderLeastNodes)
 	leastWaste := string(v1alpha1.AutoscalerExpanderLeastWaste)
+	bothInOrder := v1alpha1.AutoscalerExpanderList{
+		v1alpha1.AutoscalerExpanderLeastNodes,
+		v1alpha1.AutoscalerExpanderLeastWaste,
+	}
 
 	tests := []struct {
 		name string
 		raw  string
-		want []string
+		want v1alpha1.AutoscalerExpanderList
 	}{
-		{"empty_input", "", []string{}},
-		{"whitespace", " ", []string{}},
-		{"single", leastWaste, []string{leastWaste}},
-		{"comma_separated", leastNodes + "," + leastWaste, []string{leastNodes, leastWaste}},
+		{"empty_input", "", v1alpha1.AutoscalerExpanderList{}},
+		{"whitespace", " ", v1alpha1.AutoscalerExpanderList{}},
 		{
-			"comma_separated_spaces",
-			leastNodes + ", " + leastWaste,
-			[]string{leastNodes, leastWaste},
+			"single",
+			leastWaste,
+			v1alpha1.AutoscalerExpanderList{v1alpha1.AutoscalerExpanderLeastWaste},
 		},
+		{"comma_separated", leastNodes + "," + leastWaste, bothInOrder},
+		{"comma_separated_spaces", leastNodes + ", " + leastWaste, bothInOrder},
 	}
 
 	for _, testCase := range tests {
@@ -168,7 +172,7 @@ func TestAutoscalerExpanderList_UnmarshalJSON(t *testing.T) {
 			false,
 		},
 		{
-			"legacy_comma_separated_scalar",
+			"comma_separated_scalar",
 			`"LeastNodes,LeastWaste"`,
 			v1alpha1.AutoscalerExpanderList{
 				v1alpha1.AutoscalerExpanderLeastNodes,

--- a/pkg/apis/cluster/v1alpha1/autoscaler_test.go
+++ b/pkg/apis/cluster/v1alpha1/autoscaler_test.go
@@ -1,6 +1,7 @@
 package v1alpha1_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -112,6 +113,100 @@ func TestAutoscalerExpanderList_String(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, testCase.want, testCase.list.String())
+		})
+	}
+}
+
+func TestSplitAutoscalerExpanders(t *testing.T) {
+	t.Parallel()
+
+	leastNodes := string(v1alpha1.AutoscalerExpanderLeastNodes)
+	leastWaste := string(v1alpha1.AutoscalerExpanderLeastWaste)
+
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty_input", "", []string{}},
+		{"whitespace", " ", []string{}},
+		{"single", leastWaste, []string{leastWaste}},
+		{"comma_separated", leastNodes + "," + leastWaste, []string{leastNodes, leastWaste}},
+		{
+			"comma_separated_spaces",
+			leastNodes + ", " + leastWaste,
+			[]string{leastNodes, leastWaste},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, testCase.want, v1alpha1.SplitAutoscalerExpanders(testCase.raw))
+		})
+	}
+}
+
+// TestAutoscalerExpanderList_UnmarshalJSON verifies the list decodes from both
+// the current array form and the legacy scalar form that older ksail versions
+// persisted to cluster state, so spec.json files written before the field became
+// a list remain readable after an upgrade (regression for the
+// "cannot unmarshal string into ... AutoscalerExpanderList" load failure).
+func TestAutoscalerExpanderList_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    v1alpha1.AutoscalerExpanderList
+		wantErr bool
+	}{
+		{
+			"legacy_scalar",
+			`"LeastWaste"`,
+			v1alpha1.AutoscalerExpanderList{v1alpha1.AutoscalerExpanderLeastWaste},
+			false,
+		},
+		{
+			"legacy_comma_separated_scalar",
+			`"LeastNodes,LeastWaste"`,
+			v1alpha1.AutoscalerExpanderList{
+				v1alpha1.AutoscalerExpanderLeastNodes,
+				v1alpha1.AutoscalerExpanderLeastWaste,
+			},
+			false,
+		},
+		{
+			"array",
+			`["LeastNodes","LeastWaste"]`,
+			v1alpha1.AutoscalerExpanderList{
+				v1alpha1.AutoscalerExpanderLeastNodes,
+				v1alpha1.AutoscalerExpanderLeastWaste,
+			},
+			false,
+		},
+		{"empty_scalar", `""`, v1alpha1.AutoscalerExpanderList{}, false},
+		{"empty_array", `[]`, v1alpha1.AutoscalerExpanderList{}, false},
+		{"null", `null`, nil, false},
+		{"invalid_json", `{`, nil, true},
+		{"number", `123`, nil, true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var list v1alpha1.AutoscalerExpanderList
+
+			err := json.Unmarshal([]byte(testCase.input), &list)
+			if testCase.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, list)
 		})
 	}
 }

--- a/pkg/apis/cluster/v1alpha1/autoscalerexpander.go
+++ b/pkg/apis/cluster/v1alpha1/autoscalerexpander.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -85,4 +87,77 @@ func (l AutoscalerExpanderList) String() string {
 	}
 
 	return strings.Join(parts, ",")
+}
+
+// SplitAutoscalerExpanders splits a scalar expander value into its individual
+// entries, trimming surrounding whitespace from each. A comma-separated scalar
+// ("LeastNodes,LeastWaste") yields one entry per element, mirroring the upstream
+// cluster-autoscaler --expander priority-list syntax; an empty or whitespace-only
+// value yields an empty (non-nil) slice. It is the shared normaliser for the JSON
+// unmarshaler (legacy persisted scalar form) and the YAML configuration decode
+// hook, so both accept identical scalar inputs.
+func SplitAutoscalerExpanders(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{}
+	}
+
+	parts := strings.Split(raw, ",")
+	expanders := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		expanders = append(expanders, strings.TrimSpace(part))
+	}
+
+	return expanders
+}
+
+// UnmarshalJSON decodes an AutoscalerExpanderList from JSON, accepting both the
+// current priority-list form (["LeastNodes","LeastWaste"]) and the legacy scalar
+// form ("LeastWaste") that older ksail versions persisted to cluster state
+// (~/.ksail/clusters/<name>/spec.json) before this field became a list. A
+// comma-separated scalar ("LeastNodes,LeastWaste") is split into its entries,
+// matching the YAML configuration decode hook and the upstream cluster-autoscaler
+// --expander syntax. This keeps state files written before the migration readable
+// after an upgrade.
+func (l *AutoscalerExpanderList) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+
+	// JSON null leaves the list unchanged (idiomatic no-op).
+	if string(trimmed) == "null" {
+		return nil
+	}
+
+	// Current form: a JSON array of expander values. Decode into the underlying
+	// slice type to avoid recursing back into this method.
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var list []AutoscalerExpander
+
+		err := json.Unmarshal(data, &list)
+		if err != nil {
+			return fmt.Errorf("unmarshal autoscaler expander list: %w", err)
+		}
+
+		*l = list
+
+		return nil
+	}
+
+	// Legacy form: a single (optionally comma-separated) scalar string.
+	var raw string
+
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return fmt.Errorf("unmarshal autoscaler expander scalar: %w", err)
+	}
+
+	parts := SplitAutoscalerExpanders(raw)
+	expanders := make(AutoscalerExpanderList, len(parts))
+
+	for index, part := range parts {
+		expanders[index] = AutoscalerExpander(part)
+	}
+
+	*l = expanders
+
+	return nil
 }

--- a/pkg/apis/cluster/v1alpha1/autoscalerexpander.go
+++ b/pkg/apis/cluster/v1alpha1/autoscalerexpander.go
@@ -93,19 +93,19 @@ func (l AutoscalerExpanderList) String() string {
 // entries, trimming surrounding whitespace from each. A comma-separated scalar
 // ("LeastNodes,LeastWaste") yields one entry per element, mirroring the upstream
 // cluster-autoscaler --expander priority-list syntax; an empty or whitespace-only
-// value yields an empty (non-nil) slice. It is the shared normaliser for the JSON
+// value yields an empty (non-nil) list. It is the shared normaliser for the JSON
 // unmarshaler (legacy persisted scalar form) and the YAML configuration decode
 // hook, so both accept identical scalar inputs.
-func SplitAutoscalerExpanders(raw string) []string {
+func SplitAutoscalerExpanders(raw string) AutoscalerExpanderList {
 	if strings.TrimSpace(raw) == "" {
-		return []string{}
+		return AutoscalerExpanderList{}
 	}
 
 	parts := strings.Split(raw, ",")
-	expanders := make([]string, 0, len(parts))
+	expanders := make(AutoscalerExpanderList, 0, len(parts))
 
 	for _, part := range parts {
-		expanders = append(expanders, strings.TrimSpace(part))
+		expanders = append(expanders, AutoscalerExpander(strings.TrimSpace(part)))
 	}
 
 	return expanders
@@ -150,14 +150,7 @@ func (l *AutoscalerExpanderList) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("unmarshal autoscaler expander scalar: %w", err)
 	}
 
-	parts := SplitAutoscalerExpanders(raw)
-	expanders := make(AutoscalerExpanderList, len(parts))
-
-	for index, part := range parts {
-		expanders[index] = AutoscalerExpander(part)
-	}
-
-	*l = expanders
+	*l = SplitAutoscalerExpanders(raw)
 
 	return nil
 }

--- a/pkg/fsutil/configmanager/ksail/decode_hooks.go
+++ b/pkg/fsutil/configmanager/ksail/decode_hooks.go
@@ -3,7 +3,6 @@ package configmanager
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -38,18 +37,11 @@ func autoscalerExpanderListDecodeHook() mapstructure.DecodeHookFuncType {
 		}
 
 		raw, ok := data.(string)
-		if !ok || strings.TrimSpace(raw) == "" {
+		if !ok {
 			return []string{}, nil
 		}
 
-		parts := strings.Split(raw, ",")
-		expanders := make([]string, 0, len(parts))
-
-		for _, part := range parts {
-			expanders = append(expanders, strings.TrimSpace(part))
-		}
-
-		return expanders, nil
+		return v1alpha1.SplitAutoscalerExpanders(raw), nil
 	}
 }
 

--- a/pkg/fsutil/configmanager/ksail/decode_hooks.go
+++ b/pkg/fsutil/configmanager/ksail/decode_hooks.go
@@ -38,7 +38,7 @@ func autoscalerExpanderListDecodeHook() mapstructure.DecodeHookFuncType {
 
 		raw, ok := data.(string)
 		if !ok {
-			return []string{}, nil
+			return v1alpha1.AutoscalerExpanderList{}, nil
 		}
 
 		return v1alpha1.SplitAutoscalerExpanders(raw), nil

--- a/pkg/svc/state/cluster_state_test.go
+++ b/pkg/svc/state/cluster_state_test.go
@@ -92,6 +92,59 @@ func TestLoadClusterSpec_NotFound(t *testing.T) {
 	}
 }
 
+// TestLoadClusterSpec_LegacyScalarExpander verifies that a spec.json written by
+// an older ksail version — which persisted autoscaler.node.expander as a scalar
+// string before the field became an ordered list — still loads after upgrade.
+// Regression for "cannot unmarshal string into Go struct field
+// NodeAutoscalerConfig.autoscaler.node.expander of type v1alpha1.AutoscalerExpanderList".
+func TestLoadClusterSpec_LegacyScalarExpander(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "test-legacy-expander-" + t.Name()
+
+	t.Cleanup(func() {
+		_ = state.DeleteClusterState(clusterName)
+	})
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir failed: %v", err)
+	}
+
+	dir := filepath.Join(home, ".ksail", "clusters", clusterName)
+
+	err = os.MkdirAll(dir, 0o700)
+	if err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	legacy := `{
+  "distribution": "Talos",
+  "provider": "Docker",
+  "autoscaler": {
+    "node": {
+      "enabled": true,
+      "expander": "LeastWaste"
+    }
+  }
+}`
+
+	err = os.WriteFile(filepath.Join(dir, "spec.json"), []byte(legacy), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	loaded, err := state.LoadClusterSpec(clusterName)
+	if err != nil {
+		t.Fatalf("LoadClusterSpec failed on legacy scalar expander: %v", err)
+	}
+
+	expander := loaded.Autoscaler.Node.Expander
+	if len(expander) != 1 || expander[0] != v1alpha1.AutoscalerExpanderLeastWaste {
+		t.Errorf("Expander: got %v, want [LeastWaste]", expander)
+	}
+}
+
 func TestDeleteClusterState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Make `AutoscalerExpanderList` decode from JSON leniently so that cluster state written by an older ksail — where `autoscaler.node.expander` was a scalar string — still loads after the field became an ordered list.

## Why

`autoscaler.node.expander` migrated from a scalar (`AutoscalerExpander`) to an ordered list (`AutoscalerExpanderList`). `ClusterSpec` is read back through **two independent paths**, and only the YAML one was made backward-compatible:

- **YAML config** (`ksail.yaml`) → mapstructure with the `autoscalerExpanderListDecodeHook` that normalises a scalar into a list. ✅
- **Persisted state** (`~/.ksail/clusters/<name>/spec.json`, written at create-time, read via plain `json.Unmarshal` in `pkg/svc/state`) → no backward-compat. ❌

So a cluster created by an older ksail (spec.json holds e.g. `"expander": "LeastWaste"`) breaks `ksail cluster update` / `info` while merging persisted state:

```
could not retrieve current cluster configuration: merge persisted state:
load persisted cluster state for "prod": failed to unmarshal cluster spec:
json: cannot unmarshal string into Go struct field
NodeAutoscalerConfig.autoscaler.node.expander of type v1alpha1.AutoscalerExpanderList
```

## How

- Add a custom `UnmarshalJSON` to `AutoscalerExpanderList` that accepts **both** the legacy scalar string (including comma-separated, e.g. `"LeastNodes,LeastWaste"`) and the current array (`["LeastNodes","LeastWaste"]`). Fixing it at the type level covers the persisted-state path and any other JSON consumer.
- Extract the scalar-splitting into a shared `SplitAutoscalerExpanders` helper and route the YAML decode hook through it, so the YAML and JSON paths share one normaliser and can't silently diverge again (which is how this bug arose).
- Marshaling is unchanged (still an array): new saves write the canonical form, old scalar saves read leniently.
- `.golangci.yml`: add `"*.UnmarshalJSON"` to the existing centralized `recvcheck.exclusions` — a pointer receiver is required by `json.Unmarshaler`, the same principle as the `DeepCopy*` exclusions already there.

## Tests

- `TestAutoscalerExpanderList_UnmarshalJSON` — scalar / comma-separated scalar / array / empty / `null` / invalid / non-string cases.
- `TestSplitAutoscalerExpanders` — the shared normaliser directly.
- `TestLoadClusterSpec_LegacyScalarExpander` — regression at the real `pkg/svc/state.LoadClusterSpec` path: a hand-written legacy `spec.json` with a scalar expander now loads.

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ (only the pre-existing env-flaky `chat` CLI tests fail under full-suite parallel load; they pass in isolation and are untouched here)
- `golangci-lint run` — zero new issues (`--new-from-rev`)

## Reviewer notes

No type/tag changes, so generated artifacts (schema/CRD/docs) are unaffected. Marshaling stays array-only; this only widens what unmarshaling accepts.