### PR TITLE
fix(helm): retry transient truncated repo-index parse failures

### DIFF
--- a/pkg/client/netretry/netretry.go
+++ b/pkg/client/netretry/netretry.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-// transientTextPatterns contains fixed substrings for HTTP and TCP-level
-// transient errors. Declared at package level to avoid slice allocation on
-// every IsRetryable call.
+// transientTextPatterns contains fixed substrings for HTTP, TCP-level, and
+// malformed-download transient errors. Declared at package level to avoid slice
+// allocation on every IsRetryable call.
 //
 //nolint:gochecknoglobals // avoids per-call slice allocation in hot retry path
 var transientTextPatterns = []string{
@@ -21,6 +21,15 @@ var transientTextPatterns = []string{
 	"i/o timeout", "TLS handshake timeout",
 	"unexpected EOF", "no such host",
 	"context deadline exceeded",
+	// Malformed/truncated downloaded document: a flaky upstream (e.g. a CDN or
+	// GitHub Pages) momentarily serving a partial Helm repository index.yaml
+	// surfaces as a YAML->JSON conversion failure. A repository index is
+	// server-generated, valid YAML, so a parse failure on the downloaded copy is
+	// a transient truncation rather than a genuine config error — retry it. This
+	// is specific to the sigs.k8s.io/yaml conversion wrapper used for downloaded
+	// indexes/manifests; plain "yaml: unmarshal errors" (invalid user values)
+	// lack this prefix and stay non-retryable. See #5257.
+	"error converting YAML to JSON",
 }
 
 // httpStatusCodePattern matches HTTP 429 and 5xx status codes at word boundaries
@@ -32,8 +41,10 @@ var httpStatusCodePattern = regexp.MustCompile(`\b(429|5\d{2})\b`)
 var redirectLimitPattern = regexp.MustCompile(`stopped after \d+ redirects`)
 
 // IsRetryable returns true if the error indicates a transient network error
-// that should be retried. This covers HTTP 429 and 5xx status codes and TCP-level
-// errors such as connection resets, timeouts, and unexpected EOF.
+// that should be retried. This covers HTTP 429 and 5xx status codes, TCP-level
+// errors such as connection resets, timeouts, and unexpected EOF, and a
+// truncated/malformed downloaded document (e.g. a partially-served Helm
+// repository index) surfaced as a YAML->JSON conversion failure.
 // Callers that need to handle additional domain-specific transient errors (e.g.,
 // Copilot auth "fetch failed") should augment this function with a local helper.
 func IsRetryable(err error) bool {

--- a/pkg/client/netretry/netretry_test.go
+++ b/pkg/client/netretry/netretry_test.go
@@ -56,6 +56,17 @@ var (
 	)
 	errStatus505 = errors.New("server error 505 HTTP Version Not Supported")
 	errStatus599 = errors.New("got status code 599 from proxy")
+	// Truncated/malformed Helm repository index served by a flaky upstream
+	// (#5257): surfaces via the sigs.k8s.io/yaml conversion wrapper.
+	errTruncatedIndex = errors.New(
+		"failed to download repository index file: " +
+			"error converting YAML to JSON: yaml: line 32: could not find expected ':'",
+	)
+	// Genuine invalid user-supplied values: a plain go-yaml unmarshal error with
+	// no conversion-wrapper prefix — must stay non-retryable.
+	errInvalidValuesYAML = errors.New(
+		"yaml: unmarshal errors:\n  line 3: cannot unmarshal !!str `oops` into int",
+	)
 )
 
 func TestIsRetryable(t *testing.T) {
@@ -100,6 +111,14 @@ func TestIsRetryable(t *testing.T) {
 		// Extended 5xx codes beyond original 500–504 range.
 		{name: "505 code", err: errStatus505, expected: true},
 		{name: "599 code", err: errStatus599, expected: true},
+		// Truncated/malformed downloaded Helm repository index (#5257).
+		{
+			name:     "truncated repo index (converting YAML to JSON)",
+			err:      errTruncatedIndex,
+			expected: true,
+		},
+		// Genuine invalid user values must NOT be retried (narrow-scope guard).
+		{name: "invalid values yaml not retried", err: errInvalidValuesYAML, expected: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5257

## Problem

Post-CNI component install (metrics-server, load-balancer, policy-engine, …) fetches each chart's repository `index.yaml` from a live upstream Helm repo at `ksail cluster create` time. When that upstream (a CDN / GitHub Pages) momentarily serves a **truncated/partial** index, Helm fails to parse it with:

```
error converting YAML to JSON: yaml: line 32: could not find expected ':'
```

A retry loop (5 attempts, 3s–30s exponential backoff) **already exists** around the index download (`downloadRepositoryIndex`) and the chart install (`InstallChartWithRetry`). The gap was purely **error classification**: `netretry.IsRetryable` recognised HTTP 5xx/429 and TCP-level errors but **not** this YAML-conversion failure — so the loop gave up on the first hiccup. The result was the reported `❌ cluster create failed after 1 attempts`, an opaque non-actionable error for users, and — because the CI System-Test matrix exercises this path — a wedged ksail **dependabot lane** (8 PRs stuck red on a single bad upstream-CI minute, indistinguishable from the chronic Hetzner/Omni outage).

## Fix

Add the sigs.k8s.io/yaml conversion-wrapper signature `"error converting YAML to JSON"` to the transient-pattern set in `pkg/client/netretry/netretry.go`, so the **existing** backoff loop retries a truncated/malformed downloaded index instead of aborting. A server-generated repository index is valid YAML by construction, so a parse failure on the downloaded copy is a transient truncation, not a genuine config error.

**Scope is deliberately narrow.** The match is the conversion-wrapper prefix used for *downloaded* indexes/manifests. Genuine invalid user values surface as plain `yaml: unmarshal errors: …` (no conversion-wrapper prefix) and **stay non-retryable** — pinned by a guard test (`invalid values yaml not retried`). Worst case for a *persistently* malformed upstream index is the same final failure, just after the bounded backoff rather than immediately.

## Tests

`pkg/client/netretry/netretry_test.go` — two new table cases:
- `truncated repo index (converting YAML to JSON)` → retryable (the exact #5257 signature, wrapped as the installer sees it)
- `invalid values yaml not retried` → **not** retryable (proves the narrow scope)

## Validation

- `go build` (whole module) — OK
- `go test ./pkg/client/netretry/... ./pkg/client/helm/...` — green
- `golangci-lint run --timeout 5m ./pkg/client/netretry/...` — 0 issues

## Notes / trade-offs

- **Conflict-free with the phase-* refactor sprint:** this touches only `netretry.go`'s `IsRetryable`; the open phase-2 PR (#5248) refactors `operations.go` and *adds* `netretry/do.go` but does not modify `IsRetryable`, so there is no overlap.
- A larger follow-up (pre-resolving/caching the small set of well-known component chart repos, per #4899) remains the optional "(3)" from the issue and is intentionally out of scope here — this PR is the minimal, root-cause classification fix.