### PR TITLE
fix(talos): normalize endpoint in autoscaler worker template fingerprint

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -538,14 +539,17 @@ func (p *Provisioner) readAutoscalerConfigSecret(
 // in-place Change (or none) when they differ, the Secret/key is absent, or a pool
 // was added/removed.
 //
-// The comparison is over each pool's SECRETS-REDACTED worker config fingerprint —
-// not the raw Secret bytes — for the same reason machine-config drift redacts
-// (configFingerprint): the cloud-init embeds the full worker config including PKI,
-// and the local bundle's PKI legitimately differs from the running cluster's
-// (syncSecretsFromCluster realigns secrets/endpoint during apply, #4963). Comparing
-// raw bytes would report PKI-only drift on every run; redacting isolates the
-// comparison to the machine-config patches, labels, and taints this bug is about,
-// keeping idempotent re-runs at "No changes detected".
+// The comparison is over each pool's normalised worker config fingerprint — not
+// the raw Secret bytes (see redactedWorkerConfigFingerprint): the cloud-init embeds
+// the full worker config, and two fields legitimately differ between the un-synced
+// local bundle the diff phase renders and the cluster-synced bundle the apply path
+// stores, because syncSecretsFromCluster realigns both during apply (#4963) — the
+// PKI (neutralised by RedactSecrets) and the cluster control-plane endpoint
+// (CIDR-derived private IP locally vs the control-plane's public IP on the cluster,
+// neutralised by normalizeEndpointForFingerprint; the endpoint is not a secret, so
+// redaction alone left it leaking a phantom in-place diff on every run). Both
+// normalisations isolate the comparison to the machine-config patches, labels, and
+// taints this bug is about, keeping idempotent re-runs at "No changes detected".
 func autoscalerTemplateDrift(
 	existing *corev1.Secret,
 	pools []AutoscalerPoolConfig,
@@ -673,17 +677,67 @@ func decodeAutoscalerCloudInit(cloudInit string) ([]byte, error) {
 	return decompressed, nil
 }
 
+// fingerprintEndpointPlaceholder is the canonical cluster control-plane endpoint
+// substituted into a worker config before fingerprinting. The diff phase renders
+// the desired template from the un-synced local bundle (a CIDR-derived private
+// endpoint) while the apply path writes the Secret from the cluster-synced bundle
+// (the control-plane's public endpoint) — syncSecretsFromCluster realigns the
+// endpoint exactly as it realigns the PKI (#4963). The endpoint is not a secret,
+// so RedactSecrets leaves it in place; substituting a fixed value keeps an
+// endpoint-only difference from reading as drift on every run, isolating the
+// comparison to the machine-config patches, labels, and taints (see
+// autoscalerTemplateDrift).
+const fingerprintEndpointPlaceholder = "https://cluster-endpoint:6443"
+
 // redactedWorkerConfigFingerprint returns a short, stable fingerprint of a worker
 // config's secrets-redacted, canonical encoding (the same normalisation
-// configFingerprint uses), so two configs that differ only in PKI fingerprint
-// identically.
+// configFingerprint uses), with the cluster control-plane endpoint normalised to a
+// fixed placeholder, so two configs that differ only in PKI or endpoint — both
+// realigned from the running cluster during apply (#4963) — fingerprint identically.
 func redactedWorkerConfigFingerprint(workerYAML []byte) (string, error) {
 	provider, err := configloader.NewFromBytes(workerYAML)
 	if err != nil {
 		return "", fmt.Errorf("load worker config for fingerprint: %w", err)
 	}
 
+	provider, err = normalizeEndpointForFingerprint(provider)
+	if err != nil {
+		return "", err
+	}
+
 	return configFingerprint(provider), nil
+}
+
+// normalizeEndpointForFingerprint substitutes the cluster control-plane endpoint
+// with a fixed placeholder so two worker templates that differ only in endpoint
+// fingerprint identically. It is a no-op when the config carries no endpoint (the
+// structure is preserved otherwise, so a config that defines an endpoint and one
+// that does not still fingerprint differently — but both sides of the autoscaler
+// comparison come from the same bundle, so they always agree on its presence).
+func normalizeEndpointForFingerprint(
+	provider talosconfig.Provider,
+) (talosconfig.Provider, error) {
+	placeholder, err := url.Parse(fingerprintEndpointPlaceholder)
+	if err != nil {
+		return nil, fmt.Errorf("parse endpoint placeholder for fingerprint: %w", err)
+	}
+
+	patched, err := provider.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		if cfg.ClusterConfig == nil ||
+			cfg.ClusterConfig.ControlPlane == nil ||
+			cfg.ClusterConfig.ControlPlane.Endpoint == nil {
+			return nil
+		}
+
+		cfg.ClusterConfig.ControlPlane.Endpoint = &v1alpha1.Endpoint{URL: placeholder}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("normalize endpoint for fingerprint: %w", err)
+	}
+
+	return patched, nil
 }
 
 // autoscalerTemplateDigest renders a poolName→fingerprint map into a single short,

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -710,6 +711,30 @@ func workerProviderWithToken(token string) *taloscontainer.Container {
 	})
 }
 
+// workerProviderWithEndpoint builds a minimal worker provider whose cluster
+// control-plane endpoint is set to the given URL, so two providers can differ ONLY
+// in the endpoint — the field syncSecretsFromCluster realigns during apply (#4963).
+func workerProviderWithEndpoint(t *testing.T, endpoint string) *taloscontainer.Container {
+	t.Helper()
+
+	parsed, err := url.Parse(endpoint)
+	require.NoError(t, err)
+
+	falseVal := false
+
+	return taloscontainer.NewV1Alpha1(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineInstall: &v1alpha1.InstallConfig{InstallWipe: &falseVal},
+		},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{URL: parsed},
+			},
+		},
+	})
+}
+
 // Acceptance (b): an idempotent re-run — the rendered template already matches the
 // Secret — must report no drift, so `cluster update` stays "No changes detected".
 func TestAutoscalerTemplateDrift_NoneWhenSecretMatches(t *testing.T) {
@@ -824,6 +849,38 @@ func TestAutoscalerTemplateDrift_IgnoresPKIOnlyDifference(t *testing.T) {
 	changes, err := talosprovisioner.AutoscalerTemplateDriftForTest(secret, desired)
 	require.NoError(t, err)
 	assert.Empty(t, changes, "a PKI-only difference must be redacted away, not reported as drift")
+}
+
+// The comparison must also ignore the cluster control-plane endpoint, which
+// syncSecretsFromCluster legitimately realigns during apply (#4963): the diff
+// phase renders the desired template from the un-synced local bundle (a
+// CIDR-derived private endpoint) while the apply path writes the Secret from the
+// synced bundle (the cluster's public endpoint). The endpoint is not a secret, so
+// without normalisation it leaks into the fingerprint and every `cluster update`
+// falsely reports an autoscalerWorkerTemplate in-place change that never converges.
+func TestAutoscalerTemplateDrift_IgnoresEndpointOnlyDifference(t *testing.T) {
+	t.Parallel()
+
+	// The Secret was written by a prior apply from the cluster-synced bundle (the
+	// control-plane's public endpoint); the diff phase renders the desired template
+	// from the un-synced local bundle (a CIDR-derived private endpoint).
+	storedPublicEndpoint := workerProviderWithEndpoint(t, "https://203.0.113.7:6443")
+	localPrivateEndpoint := workerProviderWithEndpoint(t, "https://10.0.0.1:6443")
+
+	secret := autoscalerSecretFor(t, "1", []talosprovisioner.AutoscalerPoolConfig{
+		autoscalerPoolFor(t, "pool1", storedPublicEndpoint, nil),
+	})
+	desired := []talosprovisioner.AutoscalerPoolConfig{
+		autoscalerPoolFor(t, "pool1", localPrivateEndpoint, nil),
+	}
+
+	changes, err := talosprovisioner.AutoscalerTemplateDriftForTest(secret, desired)
+	require.NoError(t, err)
+	assert.Empty(
+		t,
+		changes,
+		"an endpoint-only difference must be normalised away, not reported as drift",
+	)
 }
 
 // Adding a pool must surface as drift (the new pool has no template in the Secret).


### PR DESCRIPTION
## Problem

`ksail cluster update` reports the same `autoscalerWorkerTemplate` in-place change on **every** run, and it never converges:

```
🟢 autoscalerWorkerTemplate  c00b7491e0dc  58462d19b875  in-place
```

This is a **stable mismatch, not non-determinism** — the same two hashes recur every run because the desired template never matches what's stored.

## Root cause

The drift check compares two worker-config fingerprints whose only meaningful difference is the **cluster control-plane endpoint**, which is never normalized away:

- **Diff phase** (`DiffConfig` → `detectAutoscalerTemplateDrift`) renders the *desired* template from the **un-synced local bundle**, whose endpoint defaults to a **CIDR-derived private IP**.
- **Apply phase** writes the `cluster-autoscaler-config` Secret from the bundle *after* `syncSecretsFromCluster` has realigned it to the running control-plane's **public IP** (update steps 246 → 259, #4963).

So the stored Secret always carries the public endpoint while the freshly-rendered desired always carries the private one → permanent phantom diff.

`redactedWorkerConfigFingerprint` redacts **PKI** (which also legitimately differs) via `RedactSecrets`, but the **endpoint is not a secret**, so redaction left it in the canonical encoding and it leaked into the SHA-256. The existing comment even acknowledged "`syncSecretsFromCluster` realigns secrets/**endpoint**", but the mitigation only covered secrets. (Machine-config drift detection avoids this by *realigning* the desired endpoint to the running cluster's before comparing — the autoscaler path did neither.)

The Talos config encoder sorts map keys, so the fingerprint is deterministic — ruling out a map-iteration-order explanation.

## Fix

Normalize the cluster control-plane endpoint to a fixed placeholder in `redactedWorkerConfigFingerprint` (the autoscaler-specific helper) before fingerprinting — mirroring how PKI is already redacted, and scoped so machine-config drift (which realigns to the *real* endpoint via `configFingerprint`) is unaffected. An endpoint-only difference no longer registers as drift; real worker-config changes (labels/taints/patches) still do.

## Validation

- **New regression test** `TestAutoscalerTemplateDrift_IgnoresEndpointOnlyDifference` — fails on `main` (phantom in-place change), passes with this fix.
- `TestAutoscalerTemplateDrift_DetectsWorkerConfigChange` / `DetectsAddedPool` still pass → real drift is still caught (the fix neutralizes *only* the endpoint).
- Full `pkg/svc/provisioner/cluster/talos` package: **513/513** pass. `go build` clean. Changed files lint-clean (`golangci-lint`).

## Reviewer notes

- The placeholder (`https://cluster-endpoint:6443`) is only ever hashed, never applied to a node.
- No behavior change to the apply path — the Secret still gets the correct synced (public) endpoint via the unconditional `ensureAutoscalerSecretIfNeeded` step; this only stops the **diff summary** from reporting a change that isn't actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
