### PR TITLE
fix(web): generate UI config types via API instead of npx

### DIFF
--- a/web/ui/scripts/gen-types.mjs
+++ b/web/ui/scripts/gen-types.mjs
@@ -4,10 +4,10 @@
 // The conditionals (distribution x provider constraints) only restrict valid value
 // combinations for editors validating ksail.yaml — they never define fields — so
 // the generated TypeScript types are identical to the unconstrained shape.
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { compileFromFile } from "json-schema-to-typescript";
 
 const CONDITIONAL_KEYWORDS = new Set(["allOf", "if", "then", "else"]);
 
@@ -38,6 +38,13 @@ const schema = JSON.parse(
 );
 const tmpFile = join(mkdtempSync(join(tmpdir(), "ksail-schema-")), "ksail-config.schema.json");
 writeFileSync(tmpFile, JSON.stringify(strip(schema)));
-execFileSync("npx", ["json2ts", "-i", tmpFile, "-o", "src/generated/ksail-config.ts"], {
-  stdio: "inherit",
-});
+
+// Call json-schema-to-typescript's API directly instead of spawning `npx json2ts`.
+// Spawning npx fails on Windows CI — execFileSync cannot resolve the `npx.cmd`
+// shim without a shell (ENOENT), which broke the Windows desktop release job and,
+// via the release-cleanup cascade, blocked publishing every new version. The CLI
+// is a thin wrapper over compileFromFile, so the generated output is byte-identical
+// while the cross-platform subprocess is removed entirely.
+const outFile = "src/generated/ksail-config.ts";
+mkdirSync(dirname(outFile), { recursive: true });
+writeFileSync(outFile, await compileFromFile(tmpFile));


### PR DESCRIPTION
## Problem

`cd.yaml` has failed to publish a release since **v7.58.3** — every `v7.59.0` run fails, and the version tag is re-cut on each push to main, looping CD into repeated failures.

## Root cause — one failure, cascading

The web UI type generator `web/ui/scripts/gen-types.mjs` (run by the desktop build's `stage-webui.sh`) spawns the json2ts CLI with:

```js
execFileSync("npx", ["json2ts", "-i", tmpFile, "-o", "src/generated/ksail-config.ts"], { stdio: "inherit" });
```

On Windows runners `npx` is the `npx.cmd` shim. `execFileSync` resolves the literal name on `PATH` and **cannot** find `npx.cmd` without a shell → `spawnSync npx ENOENT`. So **`🧩 Release Desktop App (windows-latest, …)` fails on every CD run** (Linux/macOS pass — there `npx` is a real binary). This is the single failure common to *all* failed runs.

It then cascades into a full release outage:

1. `publish-release` `needs: [goreleaser, vscode-extension, copilot-plugin, desktop-macos, **desktop**, operator-chart, pages-build]` — the failed Windows `desktop` job blocks the draft→published flip.
2. `cleanup-failed-release` (`if: always() && needs.publish-release.result != 'success'`) fires and **deletes the orphaned draft release *and* the git tag** (`deleteRef tags/vX.Y.Z`, #5060).
3. The parallel `mcp-publish` job (`needs: [goreleaser]` only) then checks out the just-deleted tag → **`fatal: couldn't find remote ref refs/tags/v7.59.0`**. (This is why MCP fails in *some* runs — it's a race with the cleanup, not an independent bug.)
4. Tag deleted → next push to main makes semantic-release **re-cut the same version** → new CD run → fails again. Hence 5+ `v7.59.0` runs today.

## Fix

Call `json-schema-to-typescript`'s `compileFromFile` API directly instead of spawning `npx json2ts`. It's already a declared devDependency (`^15.0.4`), and the CLI is a thin wrapper over this exact function — so the generated `src/generated/ksail-config.ts` is **byte-identical** while the cross-platform subprocess (and the Windows `ENOENT`) is removed entirely.

Fixing this one job unblocks the whole chain: all `publish-release` needs pass → draft is published → `cleanup-failed-release` doesn't run → the tag survives → `mcp-publish` finds it → semantic-release stops re-cutting.

## Validation

- `npm run gen:types` with the API produces **0-diff** output vs. the committed generated file (verified against the npx baseline on the same machine).
- `npm run build` (the full `gen:types && tsc && vite build` chain `stage-webui.sh` runs) passes.
- `gen-types.mjs` is the only `npx`/subprocess caller in the webui/desktop build path (the rest use npm-resolved local bins, which are cross-platform); prettier-clean.
- The fix has no platform-specific code path, so it is inherently correct on Windows (no npx, no `.cmd`, no shell, no `EINVAL`-on-`.cmd` pitfall).

## Note (not in this PR)

`mcp-publish` checking out a tag that a sibling cleanup job can delete is a latent fragility that only surfaces when another asset job fails. This PR removes the trigger; hardening that checkout to `ref: ${{ github.sha }}` would be a reasonable independent follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
