### PR TITLE
feat(talos): bake extra kernel args into the Image Factory schematic

### DIFF
--- a/charts/ksail-operator/crds/ksail.io_clusters.yaml
+++ b/charts/ksail-operator/crds/ksail.io_clusters.yaml
@@ -463,6 +463,20 @@ spec:
                         items:
                           type: string
                         type: array
+                      extraKernelArgs:
+                        description: |-
+                          ExtraKernelArgs lists extra kernel command-line arguments to bake into the node image
+                          via the Talos Image Factory schematic (the schematic's customization.extraKernelArgs).
+                          KSail folds these into the same schematic it computes from Extensions, so they are applied
+                          consistently to the static install image, the Hetzner autoscaler snapshot, and the
+                          rolling-upgrade installer. This is the non-deprecated replacement for the Talos
+                          machine.install.extraKernelArgs config field (deprecated upstream in favour of Image
+                          Factory/imager), and it avoids that field's conflict with install.grubUseUKICmdline on
+                          Talos >= 1.13.4. Example: ["security=apparmor"].
+                          When SchematicID is set, it takes precedence and these are ignored.
+                        items:
+                          type: string
+                        type: array
                       extraPortMappings:
                         description: |-
                           ExtraPortMappings defines additional port mappings from Docker containers to the host.

--- a/pkg/apis/cluster/v1alpha1/envvar_drift_test.go
+++ b/pkg/apis/cluster/v1alpha1/envvar_drift_test.go
@@ -138,6 +138,7 @@ func skippedClusterWorkloadConfigFields() []string {
 		"Cluster.SOPS.Extract.File",
 		"Cluster.SOPS.Extract.PublicKeys[]",
 		"Cluster.Talos.Extensions[]",
+		"Cluster.Talos.ExtraKernelArgs[]",
 		"Cluster.Talos.ExtraPortMappings[].Protocol",
 		"Workload.Flux.Verify.MatchOIDCIdentity[].Issuer",
 		"Workload.Flux.Verify.MatchOIDCIdentity[].Subject",

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -70,6 +70,16 @@ type OptionsTalos struct {
 	// The Image Factory resolves extension versions automatically per Talos release.
 	// When SchematicID is also set, it takes precedence over Extensions.
 	Extensions []string `json:"extensions,omitzero"`
+	// ExtraKernelArgs lists extra kernel command-line arguments to bake into the node image
+	// via the Talos Image Factory schematic (the schematic's customization.extraKernelArgs).
+	// KSail folds these into the same schematic it computes from Extensions, so they are applied
+	// consistently to the static install image, the Hetzner autoscaler snapshot, and the
+	// rolling-upgrade installer. This is the non-deprecated replacement for the Talos
+	// machine.install.extraKernelArgs config field (deprecated upstream in favour of Image
+	// Factory/imager), and it avoids that field's conflict with install.grubUseUKICmdline on
+	// Talos >= 1.13.4. Example: ["security=apparmor"].
+	// When SchematicID is set, it takes precedence and these are ignored.
+	ExtraKernelArgs []string `json:"extraKernelArgs,omitzero"`
 	// ExtraPortMappings defines additional port mappings from Docker containers to the host.
 	// Only used with the Docker provider. Useful on macOS where MetalLB virtual IPs
 	// are not accessible from the host because Docker runs in a Linux VM.

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -711,6 +711,11 @@ func (in *OptionsTalos) DeepCopyInto(out *OptionsTalos) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExtraKernelArgs != nil {
+		in, out := &in.ExtraKernelArgs, &out.ExtraKernelArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExtraPortMappings != nil {
 		in, out := &in.ExtraPortMappings, &out.ExtraPortMappings
 		*out = make([]PortMapping, len(*in))

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -140,16 +140,8 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 	// and remove the stale patch file so it is no longer applied at create time.
 	m.removeWorkerRoleLabelPatch(patchesDir)
 
-	// Wire extensions from ksail.yaml so that machine.install.image is patched
-	// to use a Talos Image Factory installer containing the requested extensions.
-	// Skip when an explicit SchematicID is set — it takes precedence over extensions.
-	// Normalize first so whitespace-only or empty entries don't trigger schematic computation.
-	if strings.TrimSpace(m.Config.Spec.Cluster.Talos.SchematicID) == "" {
-		normalized := talosconfigmanager.NormalizeExtensions(m.Config.Spec.Cluster.Talos.Extensions)
-		if len(normalized) > 0 {
-			talosManager.WithExtensions(normalized)
-		}
-	}
+	// Wire Image Factory schematic inputs (extensions + extra kernel args) from ksail.yaml.
+	m.addSchematicInputs(talosManager)
 
 	config, err := talosManager.Load(configmanagerinterface.LoadOptions{})
 	if err != nil {
@@ -157,6 +149,30 @@ func (m *ConfigManager) loadTalosConfig() (*talosconfigmanager.Configs, error) {
 	}
 
 	return config, nil
+}
+
+// addSchematicInputs wires the Talos Image Factory schematic inputs from ksail.yaml
+// (spec.cluster.talos.extensions and .extraKernelArgs) into talosManager so that
+// machine.install.image — and, for Hetzner, the autoscaler snapshot — use a factory
+// installer carrying them. It is skipped when an explicit SchematicID is set, which
+// takes precedence over both. Inputs are normalized first so whitespace-only or empty
+// entries don't trigger schematic computation.
+func (m *ConfigManager) addSchematicInputs(talosManager *talosconfigmanager.ConfigManager) {
+	if strings.TrimSpace(m.Config.Spec.Cluster.Talos.SchematicID) != "" {
+		return
+	}
+
+	normalized := talosconfigmanager.NormalizeExtensions(m.Config.Spec.Cluster.Talos.Extensions)
+	if len(normalized) > 0 {
+		talosManager.WithExtensions(normalized)
+	}
+
+	kernelArgs := talosconfigmanager.NormalizeKernelArgs(
+		m.Config.Spec.Cluster.Talos.ExtraKernelArgs,
+	)
+	if len(kernelArgs) > 0 {
+		talosManager.WithKernelArgs(kernelArgs)
+	}
 }
 
 // addCalicoFeatureGatePatch enables the MutatingAdmissionPolicy feature gate /

--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -54,7 +54,10 @@ type Configs struct {
 	// When non-empty, machine.install.image is patched to use a factory installer
 	// image and a schematic ID is computed.
 	extensions []string
-	// schematicID is the computed schematic ID from extensions.
+	// extraKernelArgs are extra kernel command-line arguments folded into the same
+	// Image Factory schematic as extensions (customization.extraKernelArgs).
+	extraKernelArgs []string
+	// schematicID is the computed schematic ID from extensions and extraKernelArgs.
 	schematicID string
 }
 
@@ -398,7 +401,7 @@ func (c *Configs) Patches() []Patch {
 }
 
 // SchematicID returns the computed Talos Image Factory schematic ID.
-// Returns an empty string if no extensions are configured.
+// Returns an empty string if no extensions or extra kernel args are configured.
 func (c *Configs) SchematicID() string {
 	return c.schematicID
 }
@@ -411,6 +414,18 @@ func (c *Configs) Extensions() []string {
 
 	result := make([]string, len(c.extensions))
 	copy(result, c.extensions)
+
+	return result
+}
+
+// ExtraKernelArgs returns a copy of the configured extra kernel args list.
+func (c *Configs) ExtraKernelArgs() []string {
+	if c.extraKernelArgs == nil {
+		return nil
+	}
+
+	result := make([]string, len(c.extraKernelArgs))
+	copy(result, c.extraKernelArgs)
 
 	return result
 }
@@ -518,10 +533,12 @@ func newConfigs(
 		patches,
 		versionContract,
 		nil,
+		nil,
 	)
 }
 
-// newConfigsWithExtensions creates Configs from patches and optional extensions.
+// newConfigsWithExtensions creates Configs from patches and optional extensions
+// and extra kernel args (both fold into the computed Image Factory schematic).
 func newConfigsWithExtensions(
 	clusterName string,
 	kubernetesVersion string,
@@ -529,6 +546,7 @@ func newConfigsWithExtensions(
 	patches []Patch,
 	versionContract *talosconfig.VersionContract,
 	extensions []string,
+	extraKernelArgs []string,
 ) (*Configs, error) {
 	return newConfigsWithEndpointAndSecrets(
 		clusterName,
@@ -539,6 +557,7 @@ func newConfigsWithExtensions(
 		nil,
 		versionContract,
 		extensions,
+		extraKernelArgs,
 	)
 }
 
@@ -639,12 +658,58 @@ func newConfigsWithEndpointAndSecrets(
 	existingSecrets *secrets.Bundle,
 	versionContract *talosconfig.VersionContract,
 	extensions []string,
+	extraKernelArgs []string,
 ) (*Configs, error) {
 	// Default nil versionContract so the stored and generated values always match.
 	if versionContract == nil {
 		versionContract = talosconfig.TalosVersion1_12
 	}
 
+	configBundle, err := buildConfigBundle(
+		clusterName,
+		kubernetesVersion,
+		networkCIDR,
+		endpointIP,
+		patches,
+		existingSecrets,
+		versionContract,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	schematicID, err := applySchematic(extensions, extraKernelArgs, configBundle)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Configs{
+		Name:              clusterName,
+		bundle:            configBundle,
+		kubernetesVersion: kubernetesVersion,
+		networkCIDR:       networkCIDR,
+		endpoint:          endpointIP,
+		patches:           patches,
+		versionContract:   versionContract,
+		extensions:        extensions,
+		extraKernelArgs:   extraKernelArgs,
+		schematicID:       schematicID,
+	}, nil
+}
+
+// buildConfigBundle assembles the Talos config bundle from patches, endpoint, and
+// (optionally) an existing secrets bundle. It categorizes patches by scope, resolves
+// the control-plane IP, builds the generate/bundle options, and creates the bundle —
+// the shared bundle-construction half of newConfigsWithEndpointAndSecrets.
+func buildConfigBundle(
+	clusterName string,
+	kubernetesVersion string,
+	networkCIDR string,
+	endpointIP string,
+	patches []Patch,
+	existingSecrets *secrets.Bundle,
+	versionContract *talosconfig.VersionContract,
+) (*bundle.Bundle, error) {
 	clusterPatches, controlPlanePatches, workerPatches, err := categorizePatchesByScope(patches)
 	if err != nil {
 		return nil, err
@@ -675,22 +740,7 @@ func newConfigsWithEndpointAndSecrets(
 		return nil, fmt.Errorf("failed to create config bundle: %w", err)
 	}
 
-	schematicID, err := applySchematic(extensions, configBundle)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Configs{
-		Name:              clusterName,
-		bundle:            configBundle,
-		kubernetesVersion: kubernetesVersion,
-		networkCIDR:       networkCIDR,
-		endpoint:          endpointIP,
-		patches:           patches,
-		versionContract:   versionContract,
-		extensions:        extensions,
-		schematicID:       schematicID,
-	}, nil
+	return configBundle, nil
 }
 
 // MirrorRegistry represents a registry mirror configuration.
@@ -758,6 +808,7 @@ type regenParams struct {
 	secrets           *secrets.Bundle
 	versionContract   *talosconfig.VersionContract
 	extensions        []string
+	extraKernelArgs   []string
 }
 
 // snapshot captures the current Configs state as regenParams with the
@@ -784,6 +835,7 @@ func (c *Configs) snapshot() regenParams {
 		secrets:           nil,
 		versionContract:   c.versionContract,
 		extensions:        c.extensions,
+		extraKernelArgs:   c.extraKernelArgs,
 	}
 }
 
@@ -809,6 +861,7 @@ func (c *Configs) regenerate(mutate func(*regenParams) error) (*Configs, error) 
 		params.secrets,
 		params.versionContract,
 		params.extensions,
+		params.extraKernelArgs,
 	)
 }
 
@@ -898,15 +951,21 @@ func addRegistryAuth(cfg *v1alpha1.Config, mirror MirrorRegistry) {
 	}
 }
 
-// applySchematic computes a schematic ID from extensions and patches machine.install.image.
-// Returns an empty string if no extensions are configured (after normalization).
-func applySchematic(extensions []string, configBundle *bundle.Bundle) (string, error) {
+// applySchematic computes a schematic ID from extensions and extra kernel args and
+// patches machine.install.image. Returns an empty string if neither extensions nor
+// extra kernel args are configured (after normalization).
+func applySchematic(
+	extensions, extraKernelArgs []string,
+	configBundle *bundle.Bundle,
+) (string, error) {
 	normalized := NormalizeExtensions(extensions)
-	if len(normalized) == 0 {
+	kernelArgs := NormalizeKernelArgs(extraKernelArgs)
+
+	if len(normalized) == 0 && len(kernelArgs) == 0 {
 		return "", nil
 	}
 
-	schematic := NewSchematic(extensions)
+	schematic := NewSchematic(extensions, extraKernelArgs)
 
 	schematicID, err := schematic.ID()
 	if err != nil {

--- a/pkg/fsutil/configmanager/talos/manager.go
+++ b/pkg/fsutil/configmanager/talos/manager.go
@@ -58,6 +58,9 @@ type ConfigManager struct {
 	// extensions is the list of Talos Image Factory official extension names.
 	// When non-empty, machine.install.image is patched to use a factory installer.
 	extensions []string
+	// extraKernelArgs are extra kernel command-line arguments folded into the same
+	// Image Factory schematic as extensions (customization.extraKernelArgs).
+	extraKernelArgs []string
 }
 
 // NewConfigManager creates a new configuration manager for Talos patches.
@@ -127,6 +130,19 @@ func (m *ConfigManager) WithExtensions(extensions []string) *ConfigManager {
 	return m
 }
 
+// WithKernelArgs sets extra kernel command-line arguments to fold into the Talos
+// Image Factory schematic (customization.extraKernelArgs). These are baked into the
+// installer image rather than set via the deprecated machine.install.extraKernelArgs
+// config field, so they apply consistently across the static install image, the
+// Hetzner autoscaler snapshot, and the rolling-upgrade installer.
+func (m *ConfigManager) WithKernelArgs(extraKernelArgs []string) *ConfigManager {
+	m.extraKernelArgs = extraKernelArgs
+	m.config = nil
+	m.configLoaded = false
+
+	return m
+}
+
 // Load loads Talos patches from directories and creates the config bundle.
 // Returns the loaded Configs, either freshly loaded or previously cached.
 // Timer, Silent, IgnoreConfigFile, and SkipValidation options are not currently used.
@@ -153,6 +169,7 @@ func (m *ConfigManager) Load(_ configmanager.LoadOptions) (*Configs, error) {
 		patches,
 		m.versionContract,
 		m.extensions,
+		m.extraKernelArgs,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Talos configs: %w", err)

--- a/pkg/fsutil/configmanager/talos/schematic.go
+++ b/pkg/fsutil/configmanager/talos/schematic.go
@@ -15,14 +15,17 @@ const factoryInstallerRepository = "factory.talos.dev/installer"
 // Re-exported so callers don't need to import the image-factory package directly.
 type Schematic = schematic.Schematic
 
-// NewSchematic creates a Schematic from a list of official extension names.
-// The extensions are normalized (trimmed, empty entries removed, deduplicated)
-// and sorted to ensure deterministic schematic IDs.
-func NewSchematic(extensions []string) *Schematic {
+// NewSchematic creates a Schematic from a list of official extension names and
+// extra kernel arguments. The extensions are normalized (trimmed, empty entries
+// removed, deduplicated, sorted); the kernel args are only trimmed of whitespace
+// and empties, preserving order, so the schematic ID stays deterministic for a
+// given declared configuration.
+func NewSchematic(extensions, extraKernelArgs []string) *Schematic {
 	normalized := NormalizeExtensions(extensions)
 
 	return &Schematic{
 		Customization: schematic.Customization{
+			ExtraKernelArgs: NormalizeKernelArgs(extraKernelArgs),
 			SystemExtensions: schematic.SystemExtensions{
 				OfficialExtensions: normalized,
 			},
@@ -53,6 +56,32 @@ func NormalizeExtensions(extensions []string) []string {
 	}
 
 	slices.Sort(result)
+
+	return result
+}
+
+// NormalizeKernelArgs trims whitespace and drops empty entries from the extra
+// kernel argument list. Unlike extensions, kernel args are NOT deduplicated or
+// sorted: their order can be semantically meaningful (later args may override
+// earlier ones), so the user's declared order is preserved and is what gets
+// hashed into the schematic ID. Returns nil when no non-empty args remain, so an
+// empty list omits customization.extraKernelArgs entirely and leaves the
+// schematic ID identical to the extensions-only result.
+func NormalizeKernelArgs(extraKernelArgs []string) []string {
+	result := make([]string, 0, len(extraKernelArgs))
+
+	for _, arg := range extraKernelArgs {
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			continue
+		}
+
+		result = append(result, arg)
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
 
 	return result
 }

--- a/pkg/fsutil/configmanager/talos/schematic_test.go
+++ b/pkg/fsutil/configmanager/talos/schematic_test.go
@@ -54,13 +54,62 @@ func TestNewSchematic(t *testing.T) {
 	})
 }
 
+func TestNewSchematicKernelArgs(t *testing.T) {
+	t.Parallel()
+
+	exts := []string{"siderolabs/iscsi-tools"}
+
+	t.Run("kernel args change the schematic ID", func(t *testing.T) {
+		t.Parallel()
+		without := mustID(t, talos.NewSchematic(exts, nil))
+		with := mustID(t, talos.NewSchematic(exts, []string{"security=apparmor"}))
+		assert.NotEqual(t, without, with)
+	})
+	t.Run("same kernel args produce the same ID", func(t *testing.T) {
+		t.Parallel()
+		first := mustID(t, talos.NewSchematic(exts, []string{"security=apparmor"}))
+		second := mustID(t, talos.NewSchematic(exts, []string{"security=apparmor"}))
+		assert.Equal(t, first, second)
+	})
+	t.Run("kernel arg order is significant", func(t *testing.T) {
+		t.Parallel()
+		// Unlike extensions, kernel args are order-preserving (not sorted), so a
+		// different declared order is a different schematic.
+		forward := mustID(t, talos.NewSchematic(exts, []string{"a=1", "b=2"}))
+		reverse := mustID(t, talos.NewSchematic(exts, []string{"b=2", "a=1"}))
+		assert.NotEqual(t, forward, reverse)
+	})
+	t.Run("normalizes whitespace and drops empty kernel args", func(t *testing.T) {
+		t.Parallel()
+		clean := mustID(t, talos.NewSchematic(exts, []string{"security=apparmor"}))
+		messy := mustID(t, talos.NewSchematic(exts, []string{"", "  security=apparmor  ", ""}))
+		assert.Equal(t, clean, messy)
+	})
+	t.Run("kernel-args-only produces a valid hex ID", func(t *testing.T) {
+		t.Parallel()
+		id := mustID(t, talos.NewSchematic(nil, []string{"security=apparmor"}))
+		assert.Len(t, id, 64, "SHA256 hex encoding should be 64 chars")
+		_, decodeErr := hex.DecodeString(id)
+		assert.NoError(t, decodeErr, "ID should contain only valid hex characters")
+	})
+}
+
+func mustID(t *testing.T, schematic *talos.Schematic) string {
+	t.Helper()
+
+	id, err := schematic.ID()
+	require.NoError(t, err)
+
+	return id
+}
+
 func assertSameID(t *testing.T, first, second []string) {
 	t.Helper()
 
-	id1, err := talos.NewSchematic(first).ID()
+	id1, err := talos.NewSchematic(first, nil).ID()
 	require.NoError(t, err)
 
-	id2, err := talos.NewSchematic(second).ID()
+	id2, err := talos.NewSchematic(second, nil).ID()
 	require.NoError(t, err)
 
 	assert.Equal(t, id1, id2)
@@ -69,10 +118,10 @@ func assertSameID(t *testing.T, first, second []string) {
 func assertDifferentIDs(t *testing.T, first, second []string) {
 	t.Helper()
 
-	id1, err := talos.NewSchematic(first).ID()
+	id1, err := talos.NewSchematic(first, nil).ID()
 	require.NoError(t, err)
 
-	id2, err := talos.NewSchematic(second).ID()
+	id2, err := talos.NewSchematic(second, nil).ID()
 	require.NoError(t, err)
 
 	assert.NotEqual(t, id1, id2)
@@ -81,7 +130,7 @@ func assertDifferentIDs(t *testing.T, first, second []string) {
 func assertValidHexID(t *testing.T, extensions []string) {
 	t.Helper()
 
-	id, err := talos.NewSchematic(extensions).ID()
+	id, err := talos.NewSchematic(extensions, nil).ID()
 	require.NoError(t, err)
 	assert.Len(t, id, 64, "SHA256 hex encoding should be 64 chars")
 	_, decodeErr := hex.DecodeString(id)
@@ -164,4 +213,64 @@ func assertInstallerImage(t *testing.T, image, schematicID string) {
 	t.Helper()
 	assert.Contains(t, image, "factory.talos.dev/installer/")
 	assert.Contains(t, image, schematicID)
+}
+
+func TestConfigsWithKernelArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SchematicID set and install image patched with kernel-args only", func(t *testing.T) {
+		t.Parallel()
+		configs := loadWithSchematic(t, nil, []string{"security=apparmor"})
+		assert.Len(t, configs.SchematicID(), 64)
+		assert.Equal(t, []string{"security=apparmor"}, configs.ExtraKernelArgs())
+		assertInstallerImage(
+			t,
+			configs.ControlPlane().Machine().Install().Image(),
+			configs.SchematicID(),
+		)
+	})
+	t.Run("kernel args change the SchematicID vs extensions-only", func(t *testing.T) {
+		t.Parallel()
+		base := loadWithSchematic(t, []string{"siderolabs/iscsi-tools"}, nil)
+		withArgs := loadWithSchematic(
+			t,
+			[]string{"siderolabs/iscsi-tools"},
+			[]string{"security=apparmor"},
+		)
+		assert.NotEqual(t, base.SchematicID(), withArgs.SchematicID())
+	})
+	t.Run("kernel args preserved across WithName", func(t *testing.T) {
+		t.Parallel()
+		configs := loadWithSchematic(t, nil, []string{"security=apparmor"})
+		renamed, err := configs.WithName("new-name")
+		require.NoError(t, err)
+		assert.Equal(t, configs.SchematicID(), renamed.SchematicID())
+		assert.Equal(t, configs.ExtraKernelArgs(), renamed.ExtraKernelArgs())
+	})
+	t.Run("kernel args preserved across WithEndpoint", func(t *testing.T) {
+		t.Parallel()
+		configs := loadWithSchematic(t, nil, []string{"security=apparmor"})
+		updated, err := configs.WithEndpoint("1.2.3.4")
+		require.NoError(t, err)
+		assert.Equal(t, configs.SchematicID(), updated.SchematicID())
+		assert.Equal(t, configs.ExtraKernelArgs(), updated.ExtraKernelArgs())
+	})
+}
+
+func loadWithSchematic(t *testing.T, extensions, kernelArgs []string) *talos.Configs {
+	t.Helper()
+
+	manager := talos.NewConfigManager("", "ext-test", "1.32.0", "10.5.0.0/24")
+	if len(extensions) > 0 {
+		manager = manager.WithExtensions(extensions)
+	}
+
+	if len(kernelArgs) > 0 {
+		manager = manager.WithKernelArgs(kernelArgs)
+	}
+
+	configs, err := manager.Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+
+	return configs
 }

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -612,6 +612,13 @@
                   "type": "array",
                   "description": "Extensions lists Talos Image Factory official system extension names to include in the\nnode image. KSail automatically computes the Image Factory schematic ID from this list\nand sets machine.install.image to factory.talos.dev/installer/{schematicID}:{version},\nwhere {version} is derived from the Talos config bundle's existing install image tag.\nFor Hetzner, the schematic is also used for snapshot building.\nExtension names follow the Image Factory convention (e.g., \"siderolabs/iscsi-tools\").\nThe Image Factory resolves extension versions automatically per Talos release.\nWhen SchematicID is also set, it takes precedence over Extensions."
                 },
+                "extraKernelArgs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "description": "ExtraKernelArgs lists extra kernel command-line arguments to bake into the node image\nvia the Talos Image Factory schematic (the schematic's customization.extraKernelArgs).\nKSail folds these into the same schematic it computes from Extensions, so they are applied\nconsistently to the static install image, the Hetzner autoscaler snapshot, and the\nrolling-upgrade installer. This is the non-deprecated replacement for the Talos\nmachine.install.extraKernelArgs config field (deprecated upstream in favour of Image\nFactory/imager), and it avoids that field's conflict with install.grubUseUKICmdline on\nTalos \u003e= 1.13.4. Example: [\"security=apparmor\"].\nWhen SchematicID is set, it takes precedence and these are ignored."
+                },
                 "extraPortMappings": {
                   "items": {
                     "properties": {

--- a/web/ui/src/generated/ksail-config.ts
+++ b/web/ui/src/generated/ksail-config.ts
@@ -390,6 +390,18 @@ export interface KSailClusterConfiguration {
          */
         extensions?: string[];
         /**
+         * ExtraKernelArgs lists extra kernel command-line arguments to bake into the node image
+         * via the Talos Image Factory schematic (the schematic's customization.extraKernelArgs).
+         * KSail folds these into the same schematic it computes from Extensions, so they are applied
+         * consistently to the static install image, the Hetzner autoscaler snapshot, and the
+         * rolling-upgrade installer. This is the non-deprecated replacement for the Talos
+         * machine.install.extraKernelArgs config field (deprecated upstream in favour of Image
+         * Factory/imager), and it avoids that field's conflict with install.grubUseUKICmdline on
+         * Talos >= 1.13.4. Example: ["security=apparmor"].
+         * When SchematicID is set, it takes precedence and these are ignored.
+         */
+        extraKernelArgs?: string[];
+        /**
          * ExtraPortMappings defines additional port mappings from Docker containers to the host.
          * Only used with the Docker provider. Useful on macOS where MetalLB virtual IPs
          * are not accessible from the host because Docker runs in a Linux VM.


### PR DESCRIPTION
> Fixes #5295

## Problem

The only way to add kernel arguments to a KSail-managed Talos node was the Talos field `machine.install.extraKernelArgs`, which is **deprecated upstream** (`// Deprecated: Use Image Factory/imager instead to build a proper installer.`) and, on Talos **≥1.13.4**, conflicts with the `≥1.12` version-contract default `install.grubUseUKICmdline: true` — a config carrying both is rejected mid-upgrade:

```
install.extraKernelArgs and install.grubUseUKICmdline can't be used together
```

Since KSail generates configs with the `TalosVersion1_12` contract, this trips **any** KSail user who adds `machine.install.extraKernelArgs`. (Surfaced by a real prod cluster — see #5294 for the related upgrade-ordering bug it exposed.)

## Change

Add **`spec.cluster.talos.extraKernelArgs`**, folded into the same Image Factory schematic KSail already computes from `spec.cluster.talos.extensions` (the schematic's `customization.extraKernelArgs`). Because that *one* schematic ID drives every node path, the args are baked consistently into:

- `machine.install.image` for static nodes (`applySchematic`),
- the Hetzner autoscaler snapshot, and
- the rolling-upgrade installer (`resolveInstallerImage`).

This is the **non-deprecated, conflict-free** path: with the arg in the schematic/UKI, `grubUseUKICmdline: true` is fine. An explicit `schematicId` still takes precedence (kernel args ignored), exactly mirroring `extensions`.

### Behavior notes
- Kernel args are **order-preserving** (trim + drop-empties only, no sort/dedup — unlike extensions) since arg order can be semantically meaningful; the declared order is what's hashed into the schematic ID.
- An empty/absent list omits `customization.extraKernelArgs`, leaving the schematic ID **identical** to the extensions-only result — no change for existing users.

## Implementation
`NewSchematic(extensions, extraKernelArgs)` → threaded through `applySchematic` / `newConfigsWithEndpointAndSecrets` / the `Configs` regenerate-snapshot path (so args survive secret realignment) → `ConfigManager.WithKernelArgs` → wired from `spec.cluster.talos.extraKernelArgs` in the ksail config manager. Generated artifacts regenerated via `make generate` (CRD, deepcopy, JSON schema, web-UI types).

## Tests
- Schematic-level: kernel args change the ID; deterministic; order-significant; whitespace/empty normalization; kernel-args-only produces a valid ID.
- Config-level: SchematicID set + install image patched with kernel-args-only; args differ from extensions-only; **preserved across `WithName`/`WithEndpoint`** (guards the regenerate threading).
- Env-var drift test updated (kernel args are consumed verbatim into the schematic, like `extensions`).

`go build ./...`, `golangci-lint run`, and `go test ./...` pass (the unrelated `pkg/cli/cmd/chat` Copilot-CLI subprocess tests fail only in this local sandbox with `signal: killed`).

## Consumer
devantler-tech/platform will adopt `spec.cluster.talos.extraKernelArgs: [security=apparmor]` and drop its deprecated `machine.install.extraKernelArgs` patch once this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)