### PR TITLE
fix(talos): pin grubUseUKICmdline:true when folding so folded kernel args apply

### DIFF
--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -904,10 +904,12 @@ func addRegistryAuth(cfg *v1alpha1.Config, mirror MirrorRegistry) {
 // Any machine.install.extraKernelArgs the patches set on the (already generated) config are
 // folded into the Image Factory schematic — baked into the installer image alongside the
 // extensions, so they apply consistently to the static install image, the Hetzner autoscaler
-// snapshot, and the rolling-upgrade installer — and then cleared from the rendered config.
-// This keeps kernel args declared in native Talos patch files while moving off the deprecated
-// machine.install.extraKernelArgs field, and avoids the Talos >=1.13.4 rejection of that field
-// alongside the default install.grubUseUKICmdline. Folding is gated on extensions being
+// snapshot, and the rolling-upgrade installer — and then cleared from the rendered config,
+// which is simultaneously pinned to install.grubUseUKICmdline=true so the now-UKI-embedded args
+// actually take effect (false would make GRUB rebuild the cmdline host-side and silently drop
+// them). This keeps kernel args declared in native Talos patch files while moving off the
+// deprecated machine.install.extraKernelArgs field, and avoids the Talos >=1.13.4 rejection of
+// that field alongside install.grubUseUKICmdline. Folding is gated on extensions being
 // configured, the same signal that already selects a factory installer (so container-mode
 // Docker clusters, which use no factory installer, are unaffected).
 func applySchematic(extensions []string, configBundle *bundle.Bundle) (string, error) {
@@ -934,9 +936,9 @@ func applySchematic(extensions []string, configBundle *bundle.Bundle) (string, e
 	}
 
 	if len(kernelArgs) > 0 {
-		err = clearInstallExtraKernelArgs(configBundle)
+		err = reconcileFoldedKernelArgs(configBundle)
 		if err != nil {
-			return "", fmt.Errorf("failed to clear install extra kernel args: %w", err)
+			return "", fmt.Errorf("failed to reconcile folded kernel args: %w", err)
 		}
 	}
 
@@ -946,8 +948,8 @@ func applySchematic(extensions []string, configBundle *bundle.Bundle) (string, e
 // schematicKernelArgs returns the deduplicated union of machine.install.extraKernelArgs
 // across the control-plane and worker configs. A cluster-scope patch sets the same args on
 // both; a control-plane- or worker-scope patch sets them on one. These are folded into the
-// Image Factory schematic and then cleared from the rendered config by
-// clearInstallExtraKernelArgs.
+// Image Factory schematic and then reconciled out of the rendered config by
+// reconcileFoldedKernelArgs.
 func schematicKernelArgs(configBundle *bundle.Bundle) []string {
 	seen := make(map[string]struct{})
 
@@ -979,19 +981,27 @@ func schematicKernelArgs(configBundle *bundle.Bundle) []string {
 	return args
 }
 
-// clearInstallExtraKernelArgs removes machine.install.extraKernelArgs from the control-plane
-// and worker configs after they have been folded into the Image Factory schematic, so the
-// rendered config does not carry the deprecated field (which Talos >=1.13.4 rejects together
-// with the default install.grubUseUKICmdline).
-func clearInstallExtraKernelArgs(configBundle *bundle.Bundle) error {
+// reconcileFoldedKernelArgs reconciles the control-plane and worker configs after their
+// machine.install.extraKernelArgs have been folded into the Image Factory schematic. It (a)
+// clears the deprecated machine.install.extraKernelArgs field (which Talos >=1.13.4 rejects
+// together with install.grubUseUKICmdline) and (b) pins install.grubUseUKICmdline=true so the
+// args — now embedded in the installer image's UKI cmdline — actually apply. Pinning true is
+// what makes the migration safe regardless of what the patches set: a patch may carry
+// grubUseUKICmdline=false (e.g. a pre-fold workaround that let the host-built cmdline include
+// the args), but once the args live in the UKI cmdline, false would make GRUB rebuild the
+// cmdline host-side and silently drop them — so it must become true.
+func reconcileFoldedKernelArgs(configBundle *bundle.Bundle) error {
+	useUKICmdline := true
+
 	patcher := func(cfg *v1alpha1.Config) error {
 		if cfg.MachineConfig == nil || cfg.MachineConfig.MachineInstall == nil {
 			return nil
 		}
 
-		// Intentionally clearing the deprecated field after folding its values into
-		// the Image Factory schematic — this is the move OFF the deprecated field.
+		// Clear the deprecated field (folded into the schematic) and use the UKI cmdline
+		// so the folded args apply.
 		cfg.MachineConfig.MachineInstall.InstallExtraKernelArgs = nil //nolint:staticcheck
+		cfg.MachineConfig.MachineInstall.InstallGrubUseUKICmdline = &useUKICmdline
 
 		return nil
 	}
@@ -999,7 +1009,7 @@ func clearInstallExtraKernelArgs(configBundle *bundle.Bundle) error {
 	if configBundle.ControlPlaneCfg != nil {
 		patched, err := configBundle.ControlPlaneCfg.PatchV1Alpha1(patcher)
 		if err != nil {
-			return fmt.Errorf("failed to clear control plane extra kernel args: %w", err)
+			return fmt.Errorf("failed to reconcile control plane folded kernel args: %w", err)
 		}
 
 		configBundle.ControlPlaneCfg = patched
@@ -1008,7 +1018,7 @@ func clearInstallExtraKernelArgs(configBundle *bundle.Bundle) error {
 	if configBundle.WorkerCfg != nil {
 		patched, err := configBundle.WorkerCfg.PatchV1Alpha1(patcher)
 		if err != nil {
-			return fmt.Errorf("failed to clear worker extra kernel args: %w", err)
+			return fmt.Errorf("failed to reconcile worker folded kernel args: %w", err)
 		}
 
 		configBundle.WorkerCfg = patched

--- a/pkg/fsutil/configmanager/talos/schematic_test.go
+++ b/pkg/fsutil/configmanager/talos/schematic_test.go
@@ -7,6 +7,7 @@ import (
 
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -234,19 +235,36 @@ func TestConfigsFoldsKernelArgsIntoSchematic(t *testing.T) {
 		assert.Equal(t, want, folded.SchematicID())
 	})
 	t.Run(
-		"deprecated install.extraKernelArgs is cleared from the rendered config",
+		"deprecated extraKernelArgs cleared and grubUseUKICmdline pinned true",
 		func(t *testing.T) {
 			t.Parallel()
 			folded := loadWithExtensionsAndKernelArgs(t, exts, []string{"security=apparmor"})
-			assert.Empty(
-				t,
-				folded.ControlPlane().Machine().Install().ExtraKernelArgs(),
-				"control-plane install.extraKernelArgs should be folded into the schematic and cleared",
-			)
-			assert.Empty(t, folded.Worker().Machine().Install().ExtraKernelArgs(),
-				"worker install.extraKernelArgs should be folded into the schematic and cleared")
+
+			for _, cfg := range []talosconfig.Provider{folded.ControlPlane(), folded.Worker()} {
+				install := cfg.Machine().Install()
+				assert.Empty(t, install.ExtraKernelArgs(),
+					"install.extraKernelArgs should be folded into the schematic and cleared")
+				assert.True(t, install.GrubUseUKICmdline(),
+					"grubUseUKICmdline must be true so the UKI-embedded folded args apply")
+			}
 		},
 	)
+	t.Run("pins grubUseUKICmdline true even when a patch set it false", func(t *testing.T) {
+		t.Parallel()
+		// Mirrors platform's pre-fold stopgap (extraKernelArgs + grubUseUKICmdline:false).
+		// After folding into the UKI cmdline, false would silently drop the args, so KSail
+		// must flip it to true — this is what makes the migration safe with no platform change.
+		folded := loadWithExtensionsAndPatch(t, exts,
+			"machine:\n  install:\n    extraKernelArgs:\n      - security=apparmor\n"+
+				"    grubUseUKICmdline: false\n")
+
+		for _, cfg := range []talosconfig.Provider{folded.ControlPlane(), folded.Worker()} {
+			install := cfg.Machine().Install()
+			assert.Empty(t, install.ExtraKernelArgs())
+			assert.True(t, install.GrubUseUKICmdline(),
+				"grubUseUKICmdline:false from the patch must be overridden to true after folding")
+		}
+	})
 	t.Run("not folded without extensions (Docker/container-mode safe)", func(t *testing.T) {
 		t.Parallel()
 		// No extensions => no factory installer => kernel args are left untouched on
@@ -262,24 +280,38 @@ func TestConfigsFoldsKernelArgsIntoSchematic(t *testing.T) {
 func loadWithExtensionsAndKernelArgs(t *testing.T, extensions, kernelArgs []string) *talos.Configs {
 	t.Helper()
 
+	if len(kernelArgs) == 0 {
+		return loadWithExtensionsAndPatch(t, extensions, "")
+	}
+
+	var content strings.Builder
+
+	content.WriteString("machine:\n  install:\n    extraKernelArgs:\n")
+
+	for _, arg := range kernelArgs {
+		content.WriteString("      - " + arg + "\n")
+	}
+
+	return loadWithExtensionsAndPatch(t, extensions, content.String())
+}
+
+func loadWithExtensionsAndPatch(
+	t *testing.T,
+	extensions []string,
+	patchYAML string,
+) *talos.Configs {
+	t.Helper()
+
 	manager := talos.NewConfigManager("", "ext-test", "1.32.0", "10.5.0.0/24")
 	if len(extensions) > 0 {
 		manager = manager.WithExtensions(extensions)
 	}
 
-	if len(kernelArgs) > 0 {
-		var content strings.Builder
-
-		content.WriteString("machine:\n  install:\n    extraKernelArgs:\n")
-
-		for _, arg := range kernelArgs {
-			content.WriteString("      - " + arg + "\n")
-		}
-
+	if patchYAML != "" {
 		manager = manager.WithAdditionalPatches([]talos.Patch{{
 			Path:    "extra-kernel-args",
 			Scope:   talos.PatchScopeCluster,
-			Content: []byte(content.String()),
+			Content: []byte(patchYAML),
 		}})
 	}
 


### PR DESCRIPTION
> Follow-up to #5297 (now merged). That PR folds `machine.install.extraKernelArgs` into the Image Factory schematic and clears the deprecated field, but leaves `install.grubUseUKICmdline` untouched — which is a latent correctness gap this closes.

## The gap

After the fold, the kernel args live in the installer image's **UKI cmdline**. For GRUB to use that cmdline, `install.grubUseUKICmdline` must be **true**. If a patch set it **false** (a common pre-fold workaround — host-built cmdline so `extraKernelArgs` apply, e.g. the Talos ≥1.13.4 `extraKernelArgs`+`grubUseUKICmdline` conflict stopgap), then after the fold:

- `machine.install.extraKernelArgs` is cleared (folded away), **and**
- `grubUseUKICmdline:false` makes GRUB rebuild the cmdline **host-side**, **without** the UKI's args.

→ the folded args are **silently dropped**. For the real consumer (devantler-tech/platform, which carries `grubUseUKICmdline: false` + `security=apparmor`), that means **AppArmor silently turns off** the moment it bumps to a KSail with the fold.

## Fix

When KSail folds kernel args, `reconcileFoldedKernelArgs` now also **pins `install.grubUseUKICmdline: true`** on the control-plane and worker configs (renamed from `clearInstallExtraKernelArgs`). So a config that carried `grubUseUKICmdline: false` is **auto-corrected** on fold, and the folded args always apply.

This makes adoption **seamless and safe**: a consumer just bumps `KSAIL_VERSION` — no config change, no "remove the workaround" step, no break window.

## Tests
`TestConfigsFoldsKernelArgsIntoSchematic` now asserts `grubUseUKICmdline` is **true** on CP+worker after folding — including a sub-test where the patch explicitly set `grubUseUKICmdline: false` (mirrors platform's stopgap). `go build`/`golangci-lint`/`go test` pass.

## ⚠️ Sequencing
The fold (#5297) is on `main` (tag v7.60.0); the latest *published* CLI release is still v7.59.1. **This should land in the same release as the fold** — i.e. before any release that includes #5297 is consumed by platform — otherwise a `grubUseUKICmdline:false` consumer silently loses its kernel args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)