### PR TITLE
feat(talos): reuse lowest-available node index when provisioning (#5312)

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -34,9 +34,9 @@ func NewNodeWithRoleForTest(ip, role string) NodeWithRoleForTest {
 	return nodeWithRole{IP: ip, Role: role}
 }
 
-// NextNodeIndexFromNamesForTest exposes nextNodeIndexFromNames for unit testing.
-func NextNodeIndexFromNamesForTest(names []string, prefix string) int {
-	return nextNodeIndexFromNames(names, prefix)
+// AvailableNodeIndicesForTest exposes availableNodeIndices for unit testing.
+func AvailableNodeIndicesForTest(names []string, prefix string, count int) []int {
+	return availableNodeIndices(names, prefix, count)
 }
 
 // AddDockerNodesForTest exposes addDockerNodes for unit testing.
@@ -206,13 +206,19 @@ func CalculateNodeIPForTest(
 }
 
 // PreCalculateNodeSpecsForTest exposes preCalculateNodeSpecs for unit testing.
-// Returns node names and IPs as parallel slices (nodeSpec is unexported).
+// It builds a contiguous index range from nextIndex for backwards-compatible test
+// inputs. Returns node names and IPs as parallel slices (nodeSpec is unexported).
 func PreCalculateNodeSpecsForTest(
 	cidr netip.Prefix,
 	clusterName, role string,
 	nextIndex, count, cpCount int,
 ) ([]string, []netip.Addr, error) {
-	specs, err := preCalculateNodeSpecs(cidr, clusterName, role, nextIndex, count, cpCount)
+	indices := make([]int, count)
+	for i := range count {
+		indices[i] = nextIndex + i
+	}
+
+	specs, err := preCalculateNodeSpecs(cidr, clusterName, role, indices, cpCount)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
@@ -352,9 +352,10 @@ func (p *Provisioner) cordonAndDrain(
 	return nil
 }
 
-// createReplacementServer provisions a single new server for the role using the
-// next available node index (computed after the outgoing server was deleted, so
-// names do not collide).
+// createReplacementServer provisions a single new server for the role. The index
+// is computed after the outgoing server was deleted, so its freed slot is the
+// lowest available index and the replacement reclaims the removed node's name
+// rather than allocating a higher one (#5312).
 func (p *Provisioner) createReplacementServer(
 	ctx context.Context,
 	hzProvider *hetzner.Provider,
@@ -366,7 +367,7 @@ func (p *Provisioner) createReplacementServer(
 		return nil, fmt.Errorf("failed to list %s nodes: %w", role, listErr)
 	}
 
-	nextIndex := nextHetznerNodeIndex(existing, clusterName, role)
+	indices := availableHetznerNodeIndices(existing, clusterName, role, 1)
 
 	// Boot the replacement from the cluster's Talos snapshot image (when configured)
 	// rather than the maintenance-mode ISO, so it runs the same Talos version as the
@@ -377,7 +378,7 @@ func (p *Provisioner) createReplacementServer(
 	}
 
 	creationResults, createErr := p.launchHetznerScaleCreation(
-		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, 1, imageID,
+		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), indices, imageID,
 	)
 	if createErr != nil {
 		return nil, createErr

--- a/pkg/svc/provisioner/cluster/talos/scale_docker.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_docker.go
@@ -99,7 +99,7 @@ func (p *Provisioner) addDockerNodes(
 		return fmt.Errorf("failed to list %s nodes: %w", role, err)
 	}
 
-	nextIndex := nextDockerNodeIndex(existing, clusterName, role)
+	indices := availableDockerNodeIndices(existing, clusterName, role, count)
 
 	cidr, err := netip.ParsePrefix(p.options.NetworkCIDR)
 	if err != nil {
@@ -126,7 +126,7 @@ func (p *Provisioner) addDockerNodes(
 
 	// Pre-calculate all node names and IPs sequentially before parallelizing creation.
 	specs, err := preCalculateNodeSpecs(
-		cidr, clusterName, role, nextIndex, count, cpCount,
+		cidr, clusterName, role, indices, cpCount,
 	)
 	if err != nil {
 		return err
@@ -202,16 +202,19 @@ func (p *Provisioner) waitForNewDockerNodesReachable(
 	return group.Wait() //nolint:wrapcheck // per-node errors are wrapped in the closure above
 }
 
-// preCalculateNodeSpecs determines the name and static IP for each node to be created.
+// preCalculateNodeSpecs determines the name and static IP for each node to be
+// created, one per (0-based) index in indices. Indices may be non-contiguous when
+// reclaiming freed slots (see availableDockerNodeIndices), so each node's name and
+// IP are derived from its own index rather than a running offset.
 func preCalculateNodeSpecs(
 	cidr netip.Prefix,
 	clusterName, role string,
-	nextIndex, count, cpCount int,
+	indices []int,
+	cpCount int,
 ) ([]nodeSpec, error) {
-	specs := make([]nodeSpec, count)
+	specs := make([]nodeSpec, len(indices))
 
-	for idx := range count {
-		nodeIndex := nextIndex + idx
+	for idx, nodeIndex := range indices {
 		nodeName := dockerNodeName(clusterName, role, nodeIndex)
 
 		nodeIP, ipErr := calculateNodeIP(cidr, role, nodeIndex, cpCount)
@@ -549,11 +552,14 @@ func (p *Provisioner) configForRole(role string) talosconfig.Provider {
 	return p.talosConfigs.Worker()
 }
 
-// nextDockerNodeIndex finds the next available 0-based index for a node role.
-// It scans existing container names to find the max suffix, then converts the
-// result to the 0-based index expected by dockerNodeName (which applies +1
-// internally when formatting names).
-func nextDockerNodeIndex(containers []container.Summary, clusterName, role string) int {
+// availableDockerNodeIndices returns the next `count` 0-based indices for a node
+// role, reclaiming the lowest freed slot first so a recreated node reuses a removed
+// node's name and static IP rather than climbing to max+1 (#5312).
+func availableDockerNodeIndices(
+	containers []container.Summary,
+	clusterName, role string,
+	count int,
+) []int {
 	// Build the name prefix used by dockerNodeName (e.g. "mycluster-controlplane-").
 	// dockerNodeName(clusterName, role, 0) returns "<clusterName>-<talosRole>-1";
 	// trimming the last character gives the base prefix without the index digit.
@@ -565,11 +571,15 @@ func nextDockerNodeIndex(containers []container.Summary, clusterName, role strin
 		names[i] = containerName(ctr)
 	}
 
-	// nextNodeIndexFromNames returns the next available numeric suffix (1-based).
-	// dockerNodeName uses index+1 for the suffix, so convert: index = nextSuffix-1.
-	nextSuffix := nextNodeIndexFromNames(names, prefix)
+	// availableNodeIndices returns 1-based suffixes; dockerNodeName and
+	// calculateNodeIP expect 0-based indexes (they apply +1 internally), so
+	// convert each: index = suffix - 1.
+	indices := availableNodeIndices(names, prefix, count)
+	for i := range indices {
+		indices[i]--
+	}
 
-	return nextSuffix - 1
+	return indices
 }
 
 // dockerNodeName formats a Docker container name for a Talos node.

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -42,10 +42,10 @@ func (p *Provisioner) addHetznerNodes(
 		return err
 	}
 
-	nextIndex := nextHetznerNodeIndex(existing, clusterName, role)
+	indices := availableHetznerNodeIndices(existing, clusterName, role, count)
 
 	servers, err := p.provisionHetznerScaleServers(
-		ctx, hzProvider, clusterName, role, nextIndex, count, result,
+		ctx, hzProvider, clusterName, role, indices, result,
 	)
 	if err != nil {
 		return err
@@ -64,15 +64,15 @@ func (p *Provisioner) addHetznerNodes(
 }
 
 // provisionHetznerScaleServers runs the pre-flight checks (server-type
-// availability, shared infrastructure, Talos snapshot image), creates count new
-// servers for role starting at nextIndex, and returns the ones that came up.
+// availability, shared infrastructure, Talos snapshot image), creates one new
+// server for each index in indices, and returns the ones that came up.
 // Per-node creation failures are recorded on result; the successfully created
 // servers are returned for config apply by the caller.
 func (p *Provisioner) provisionHetznerScaleServers(
 	ctx context.Context,
 	hzProvider *hetzner.Provider,
 	clusterName, role string,
-	nextIndex, count int,
+	indices []int,
 	result *clusterupdate.UpdateResult,
 ) ([]*hcloud.Server, error) {
 	// Verify server type availability before creating infrastructure.
@@ -96,7 +96,7 @@ func (p *Provisioner) provisionHetznerScaleServers(
 	}
 
 	creationResults, err := p.launchHetznerScaleCreation(
-		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), nextIndex, count, imageID,
+		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), indices, imageID,
 	)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,10 @@ func (p *Provisioner) provisionHetznerScaleServers(
 	return p.collectCreatedHetznerServers(creationResults, role)
 }
 
-// launchHetznerScaleCreation creates count Hetzner servers starting at nextIndex, in parallel.
+// launchHetznerScaleCreation creates one Hetzner server per entry in indices, in
+// parallel. The indices are the node-name suffixes to allocate (lowest free first;
+// see availableHetznerNodeIndices), so gaps from removed nodes are reclaimed rather
+// than always appending past the highest index.
 // imageID is the cluster's Talos snapshot image (0 when none is configured); it takes precedence
 // over the maintenance-mode ISO so scaled and recreated nodes boot the same Talos version as the
 // rest of the cluster (see hetznerBootSource). Results are returned indexed — goroutines always
@@ -123,18 +126,16 @@ func (p *Provisioner) launchHetznerScaleCreation(
 	clusterName, role string,
 	infra HetznerInfra,
 	retryOpts hetzner.ServerRetryOpts,
-	nextIndex, count int,
+	indices []int,
 	imageID int64,
 ) ([]hetznerNodeCreationResult, error) {
-	results := make([]hetznerNodeCreationResult, count)
+	results := make([]hetznerNodeCreationResult, len(indices))
 
 	group, _ := errgroup.WithContext(ctx)
 	group.SetLimit(maxConcurrentHetznerOps)
 
-	for nodeIdx := range count {
+	for nodeIdx, nodeNumber := range indices {
 		group.Go(func() error {
-			nodeNumber := nextIndex + nodeIdx
-
 			nodeName, nameErr := hetznerNodeName(clusterName, role, nodeNumber)
 			if nameErr != nil {
 				// Validation failure: record it and skip provisioning (no billable
@@ -388,10 +389,15 @@ func (p *Provisioner) listHetznerNodesByRole(
 	return servers, nil
 }
 
-// nextHetznerNodeIndex finds the next available index for a node role.
-// It scans existing server names to find the max index, avoiding naming collisions
-// when there are gaps in the index sequence (e.g., nodes 1,2,4 after removing 3).
-func nextHetznerNodeIndex(servers []*hcloud.Server, clusterName, role string) int {
+// availableHetznerNodeIndices returns the next `count` 1-based indices to allocate
+// for a node role, reclaiming the lowest freed index first so a recreated node
+// reuses a removed node's name (e.g. nodes 1,3 after removing 2 yield 2) rather
+// than climbing to max+1 (#5312).
+func availableHetznerNodeIndices(
+	servers []*hcloud.Server,
+	clusterName, role string,
+	count int,
+) []int {
 	prefix := fmt.Sprintf("%s-%s-", clusterName, role)
 
 	names := make([]string, len(servers))
@@ -399,7 +405,7 @@ func nextHetznerNodeIndex(servers []*hcloud.Server, clusterName, role string) in
 		names[i] = server.Name
 	}
 
-	return nextNodeIndexFromNames(names, prefix)
+	return availableNodeIndices(names, prefix, count)
 }
 
 // deleteHetznerServer deletes a single Hetzner Cloud server.

--- a/pkg/svc/provisioner/cluster/talos/scale_shared.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_shared.go
@@ -26,31 +26,26 @@ func availableNodeIndices(names []string, prefix string, count int) []int {
 		return []int{}
 	}
 
-	used, maxIndex := scanUsedNodeIndices(names, prefix)
+	used := usedNodeIndices(names, prefix)
 	indices := make([]int, 0, count)
 
-	// Reclaim the lowest freed indices first (gaps within 1..maxIndex).
-	for index := 1; index <= maxIndex && len(indices) < count; index++ {
+	// Walk the series from 1 and take each free index. Gaps left by removed
+	// nodes are reclaimed first; once they run out, every higher index is free
+	// (nothing past the max is in `used`), so the series simply extends.
+	for index := 1; len(indices) < count; index++ {
 		if !used[index] {
 			indices = append(indices, index)
 		}
 	}
 
-	// Extend the series past the highest used index for any remaining nodes.
-	for index := maxIndex + 1; len(indices) < count; index++ {
-		indices = append(indices, index)
-	}
-
 	return indices
 }
 
-// scanUsedNodeIndices parses the 1-based numeric suffixes of names sharing the
-// given prefix, returning the set of indices in use and the highest one seen
-// (0 when no name matches). Names without the prefix or without a parsable
+// usedNodeIndices returns the set of 1-based numeric suffixes in use among names
+// sharing the given prefix. Names without the prefix or without a parsable
 // positive suffix are ignored.
-func scanUsedNodeIndices(names []string, prefix string) (map[int]bool, int) {
+func usedNodeIndices(names []string, prefix string) map[int]bool {
 	used := make(map[int]bool, len(names))
-	maxIndex := 0
 
 	for _, name := range names {
 		suffix, found := strings.CutPrefix(name, prefix)
@@ -64,12 +59,9 @@ func scanUsedNodeIndices(names []string, prefix string) (map[int]bool, int) {
 		}
 
 		used[index] = true
-		if index > maxIndex {
-			maxIndex = index
-		}
 	}
 
-	return used, maxIndex
+	return used
 }
 
 // recordAppliedChange adds an applied change to the update result.

--- a/pkg/svc/provisioner/cluster/talos/scale_shared.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_shared.go
@@ -8,30 +8,68 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 )
 
-// nextNodeIndexFromNames scans a slice of node names that share a common prefix
-// and returns the next available numeric suffix to use after that prefix.
+// availableNodeIndices scans node names that share a common prefix and returns
+// the next `count` numeric suffixes to allocate, preferring the lowest free
+// indices. Gaps left by removed nodes are reclaimed (lowest first) before the
+// series is extended past its highest used index, so a recreated node reclaims a
+// lost node's name instead of drifting to an ever-higher index (#5312). Given
+// existing indices {1, 3} and count 2 it returns [2, 4]; with no matching names
+// it returns [1, 2, ..., count].
+//
 // Each name is expected to have the form "<prefix><n>" where n is a positive
-// integer; the function computes max(n)+1 over all matching names and returns it.
-// If no matching names are found (or no parsable numeric suffix is present),
-// the function returns 1, which corresponds to the first suffix. Callers that
-// maintain separate 0-based indexes for internal data structures may still need to
-// map between this suffix and their own indexing scheme.
-func nextNodeIndexFromNames(names []string, prefix string) int {
-	maxIndex := 1
+// integer; names without the prefix or without a parsable positive suffix are
+// ignored. The returned suffixes are 1-based; callers that maintain separate
+// 0-based indexes for internal data structures map between this suffix and their
+// own indexing scheme.
+func availableNodeIndices(names []string, prefix string, count int) []int {
+	if count <= 0 {
+		return []int{}
+	}
+
+	used, maxIndex := scanUsedNodeIndices(names, prefix)
+	indices := make([]int, 0, count)
+
+	// Reclaim the lowest freed indices first (gaps within 1..maxIndex).
+	for index := 1; index <= maxIndex && len(indices) < count; index++ {
+		if !used[index] {
+			indices = append(indices, index)
+		}
+	}
+
+	// Extend the series past the highest used index for any remaining nodes.
+	for index := maxIndex + 1; len(indices) < count; index++ {
+		indices = append(indices, index)
+	}
+
+	return indices
+}
+
+// scanUsedNodeIndices parses the 1-based numeric suffixes of names sharing the
+// given prefix, returning the set of indices in use and the highest one seen
+// (0 when no name matches). Names without the prefix or without a parsable
+// positive suffix are ignored.
+func scanUsedNodeIndices(names []string, prefix string) (map[int]bool, int) {
+	used := make(map[int]bool, len(names))
+	maxIndex := 0
 
 	for _, name := range names {
-		idx, found := strings.CutPrefix(name, prefix)
+		suffix, found := strings.CutPrefix(name, prefix)
 		if !found {
 			continue
 		}
 
-		n, err := strconv.Atoi(idx)
-		if err == nil && n >= maxIndex {
-			maxIndex = n + 1
+		index, err := strconv.Atoi(suffix)
+		if err != nil || index < 1 {
+			continue
+		}
+
+		used[index] = true
+		if index > maxIndex {
+			maxIndex = index
 		}
 	}
 
-	return maxIndex
+	return used, maxIndex
 }
 
 // recordAppliedChange adds an applied change to the update result.

--- a/pkg/svc/provisioner/cluster/talos/scale_shared_test.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_shared_test.go
@@ -7,30 +7,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNextNodeIndexFromNames_EmptyList(t *testing.T) {
+func TestAvailableNodeIndices_EmptyList(t *testing.T) {
 	t.Parallel()
 
-	result := talosprovisioner.NextNodeIndexFromNamesForTest(nil, "mycluster-controlplane-")
-	assert.Equal(t, 1, result)
+	result := talosprovisioner.AvailableNodeIndicesForTest(nil, "mycluster-controlplane-", 1)
+	assert.Equal(t, []int{1}, result)
 }
 
-func TestNextNodeIndexFromNames_NoMatchingPrefix(t *testing.T) {
+func TestAvailableNodeIndices_EmptyList_MultipleNodes(t *testing.T) {
+	t.Parallel()
+
+	result := talosprovisioner.AvailableNodeIndicesForTest(nil, "mycluster-controlplane-", 3)
+	assert.Equal(t, []int{1, 2, 3}, result)
+}
+
+func TestAvailableNodeIndices_NoMatchingPrefix(t *testing.T) {
 	t.Parallel()
 
 	names := []string{"other-controlplane-1", "other-worker-1"}
-	result := talosprovisioner.NextNodeIndexFromNamesForTest(names, "mycluster-controlplane-")
-	assert.Equal(t, 1, result)
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-controlplane-", 1)
+	assert.Equal(t, []int{1}, result)
 }
 
-func TestNextNodeIndexFromNames_SingleNode(t *testing.T) {
+func TestAvailableNodeIndices_SingleNode(t *testing.T) {
 	t.Parallel()
 
 	names := []string{"mycluster-controlplane-1"}
-	result := talosprovisioner.NextNodeIndexFromNamesForTest(names, "mycluster-controlplane-")
-	assert.Equal(t, 2, result)
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-controlplane-", 1)
+	assert.Equal(t, []int{2}, result)
 }
 
-func TestNextNodeIndexFromNames_MultipleNodes(t *testing.T) {
+func TestAvailableNodeIndices_Contiguous_ExtendsPastMax(t *testing.T) {
 	t.Parallel()
 
 	names := []string{
@@ -38,11 +45,11 @@ func TestNextNodeIndexFromNames_MultipleNodes(t *testing.T) {
 		"mycluster-controlplane-2",
 		"mycluster-controlplane-3",
 	}
-	result := talosprovisioner.NextNodeIndexFromNamesForTest(names, "mycluster-controlplane-")
-	assert.Equal(t, 4, result)
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-controlplane-", 1)
+	assert.Equal(t, []int{4}, result)
 }
 
-func TestNextNodeIndexFromNames_MixedRoles(t *testing.T) {
+func TestAvailableNodeIndices_MixedRoles(t *testing.T) {
 	t.Parallel()
 
 	names := []string{
@@ -50,30 +57,88 @@ func TestNextNodeIndexFromNames_MixedRoles(t *testing.T) {
 		"mycluster-worker-1",
 		"mycluster-controlplane-2",
 	}
-	result := talosprovisioner.NextNodeIndexFromNamesForTest(names, "mycluster-controlplane-")
-	assert.Equal(t, 3, result)
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-controlplane-", 1)
+	assert.Equal(t, []int{3}, result)
 }
 
-func TestNextNodeIndexFromNames_GapInIndexes(t *testing.T) {
+// TestAvailableNodeIndices_FillsLowestGap is the core behaviour from #5312: with a
+// freed middle index, the next node reclaims that gap instead of allocating max+1.
+func TestAvailableNodeIndices_FillsLowestGap(t *testing.T) {
 	t.Parallel()
 
-	// Gaps should not affect the result — we always track the maximum seen index.
+	names := []string{
+		"mycluster-controlplane-1",
+		"mycluster-controlplane-3",
+	}
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-controlplane-", 1)
+	assert.Equal(t, []int{2}, result)
+}
+
+// TestAvailableNodeIndices_ProdRecoveryScenario reproduces the exact issue report:
+// after losing prod-control-plane-2, the restore must recreate -2, not -4.
+func TestAvailableNodeIndices_ProdRecoveryScenario(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"prod-control-plane-1", "prod-control-plane-3"}
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "prod-control-plane-", 1)
+	assert.Equal(t, []int{2}, result)
+}
+
+// TestAvailableNodeIndices_FillsGapThenExtends covers a multi-node scale-up that
+// spans a gap: index 2 is reclaimed first, then the series continues past the max.
+func TestAvailableNodeIndices_FillsGapThenExtends(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		"mycluster-worker-1",
+		"mycluster-worker-3",
+	}
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-worker-", 2)
+	assert.Equal(t, []int{2, 4}, result)
+}
+
+// TestAvailableNodeIndices_LowestOfMultipleGaps picks the lowest gap even when a
+// larger one exists higher in the series.
+func TestAvailableNodeIndices_LowestOfMultipleGaps(t *testing.T) {
+	t.Parallel()
+
 	names := []string{
 		"mycluster-worker-1",
 		"mycluster-worker-5",
 	}
-	result := talosprovisioner.NextNodeIndexFromNamesForTest(names, "mycluster-worker-")
-	assert.Equal(t, 6, result)
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-worker-", 1)
+	assert.Equal(t, []int{2}, result)
 }
 
-func TestNextNodeIndexFromNames_NonNumericSuffix(t *testing.T) {
+// TestAvailableNodeIndices_ReclaimsLeadingGap reclaims index 1 when the lowest
+// node was the one removed.
+func TestAvailableNodeIndices_ReclaimsLeadingGap(t *testing.T) {
 	t.Parallel()
 
-	// Names whose suffix after the prefix is not an integer must be ignored.
+	names := []string{
+		"mycluster-worker-2",
+		"mycluster-worker-4",
+	}
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-worker-", 3)
+	assert.Equal(t, []int{1, 3, 5}, result)
+}
+
+func TestAvailableNodeIndices_NonNumericSuffix(t *testing.T) {
+	t.Parallel()
+
+	// Names whose suffix after the prefix is not a positive integer are ignored.
 	names := []string{
 		"mycluster-worker-abc",
 		"mycluster-worker-1",
 	}
-	result := talosprovisioner.NextNodeIndexFromNamesForTest(names, "mycluster-worker-")
-	assert.Equal(t, 2, result)
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-worker-", 1)
+	assert.Equal(t, []int{2}, result)
+}
+
+func TestAvailableNodeIndices_ZeroCount(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"mycluster-worker-1"}
+	result := talosprovisioner.AvailableNodeIndicesForTest(names, "mycluster-worker-", 0)
+	assert.Empty(t, result)
 }


### PR DESCRIPTION
## What

Closes #5312.

When provisioning a replacement node during `ksail cluster update`, KSail named the new node **max(existing index) + 1** instead of filling the **lowest freed** index. After a lost node was cleanly removed (etcd `remove-member` + `hcloud server delete`), recreating it allocated a brand-new higher name (`prod-control-plane-4`) rather than reclaiming the freed `prod-control-plane-2` — so names drift ever higher (`-4`, `-7`, `-12`, …) over repeated failures.

## Change

Replace the shared `max+1` allocator (`nextNodeIndexFromNames`) with **`availableNodeIndices`**, which returns the next *N* suffixes preferring the **lowest free** indices: gaps within `1..max` are reclaimed (lowest first) before the series extends past its highest used index.

Applied uniformly via the two role-specific wrappers (`availableHetznerNodeIndices`, `availableDockerNodeIndices`) across every node-allocation path:

| Path | Function | Trigger |
|------|----------|---------|
| Hetzner scale-up | `addHetznerNodes` | `cluster update` raises node count (the reported scenario) |
| Hetzner recreate | `createReplacementServer` | rolling server-type replacement |
| Docker scale-up | `addDockerNodes` | `cluster update` raises node count |

This covers **control-plane and worker** series alike. For Docker, the reclaimed index also reclaims the freed node's **static IP** (IPs are derived from the index).

### Why a per-node index *list*

Callers now receive a list of indices (one per node) rather than a single base index plus a running `+offset`. This keeps multi-node scale-ups that span a gap collision-free — e.g. existing `{1,3}`, add 2 → `{2,4}` (not `{2,3}`, which would collide with the existing `3`).

## Behaviour example

3-node control plane loses `prod-control-plane-2`; after cleanup the cluster has `-1` and `-3`. `ksail cluster update`:

- **Before:** creates `prod-control-plane-4`
- **After:** creates `prod-control-plane-2` ✅

## Tests

- Rewrote `scale_shared_test.go` around `availableNodeIndices` with 13 cases: lowest-gap fill, the exact prod-recovery scenario, gap-then-extend multi-node, lowest-of-multiple-gaps, leading-gap reclaim, non-numeric/zero-count guards.
- `go test ./pkg/svc/provisioner/cluster/talos/...` → **519 passed**.
- Full `go test ./...` green except the known env-flaky `chat` Copilot-CLI tests (pass in isolation; unrelated to this package).
- `golangci-lint run --new-from-rev=HEAD` → clean.

## Note (out of scope)

The k3d provisioner (`pkg/svc/provisioner/cluster/k3d/update.go` `nextAgentIndex`) has the same `max+1` pattern for K3s agent nodes. Left untouched here since #5312 targets the Talos/Hetzner scenario (where name/cert/IP reclamation matters for recovery) and k3d's batch-offset logic warrants its own change + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)