### PR TITLE
fix: reconcile Talos machine config before OS upgrade

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -627,7 +627,7 @@ func (p *Provisioner) DetectRoleMachineConfigDriftForTest(
 }
 
 // WithNodeConfigFetcherForTest overrides the running-config fetcher so unit tests
-// can drive the rolling-reboot staged-config rebuild (buildStagedNodeConfig)
+// can drive the per-node desired-config rebuild (fetchAndBuildDesiredNodeConfig)
 // without real Talos API connectivity.
 func (p *Provisioner) WithNodeConfigFetcherForTest(
 	fn func(ctx context.Context, nodeIP string) (talosconfig.Provider, error),
@@ -637,14 +637,26 @@ func (p *Provisioner) WithNodeConfigFetcherForTest(
 	return p
 }
 
-// BuildStagedNodeConfigForTest exposes buildStagedNodeConfig — the rolling-reboot
-// staged-config rebuild — for unit testing.
-func (p *Provisioner) BuildStagedNodeConfigForTest(
+// FetchAndBuildDesiredNodeConfigForTest exposes fetchAndBuildDesiredNodeConfig — the
+// per-node desired-config rebuild shared by the rolling-reboot staging path and the
+// pre-upgrade reconcile — for unit testing.
+func (p *Provisioner) FetchAndBuildDesiredNodeConfigForTest(
 	ctx context.Context,
 	node NodeWithRoleForTest,
 	secretsSource talosconfig.Provider,
 ) (talosconfig.Provider, error) {
-	return p.buildStagedNodeConfig(ctx, node, secretsSource)
+	return p.fetchAndBuildDesiredNodeConfig(ctx, node, secretsSource)
+}
+
+// ReconcileNodeConfigBeforeUpgradeForTest exposes reconcileNodeConfigBeforeUpgrade —
+// the NO_REBOOT config reconcile applied to a node ahead of its Talos OS upgrade
+// (issue #5294) — for unit testing.
+func (p *Provisioner) ReconcileNodeConfigBeforeUpgradeForTest(
+	ctx context.Context,
+	node NodeWithRoleForTest,
+	secretsSource talosconfig.Provider,
+) error {
+	return p.reconcileNodeConfigBeforeUpgrade(ctx, node, secretsSource)
 }
 
 // MachineConfigFieldForTest exposes the machine.config change field for unit testing.

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -163,8 +163,8 @@ type Provisioner struct {
 	nodeReachabilityCheck func(ctx context.Context, ip string) error
 	// nodeConfigFetcher returns the running Talos machine config for a node by IP.
 	// Defaults to fetchNodeConfig; tests override it via export_test.go to inject a
-	// known running config without real Talos API connectivity (used by the rolling
-	// reboot's staged-config rebuild — see buildStagedNodeConfig).
+	// known running config without real Talos API connectivity (used by the per-node
+	// desired-config rebuild — see fetchAndBuildDesiredNodeConfig).
 	nodeConfigFetcher func(ctx context.Context, nodeIP string) (talosconfig.Provider, error)
 	logWriter         io.Writer
 	logMu             sync.Mutex

--- a/pkg/svc/provisioner/cluster/talos/rolling.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling.go
@@ -426,7 +426,7 @@ func (p *Provisioner) stageNodeConfigForReboot(
 		return nil
 	}
 
-	config, err := p.buildStagedNodeConfig(ctx, node, secretsSource)
+	config, err := p.fetchAndBuildDesiredNodeConfig(ctx, node, secretsSource)
 	if err != nil {
 		return err
 	}
@@ -444,13 +444,16 @@ func (p *Provisioner) stageNodeConfigForReboot(
 	return nil
 }
 
-// buildStagedNodeConfig builds the machine config to STAGE on a node ahead of a
-// rolling reboot: the node's running config regenerated through
-// buildDesiredNodeConfig, which preserves the per-node post-generation transforms
-// (static hostname, registry mirrors, cert SANs) instead of reverting to the
-// freshly regenerated base config. secretsSource supplies the cluster PKI and must
-// be a control-plane config (see buildDesiredNodeConfig and #4963).
-func (p *Provisioner) buildStagedNodeConfig(
+// fetchAndBuildDesiredNodeConfig fetches a node's running config and rebuilds the
+// machine config KSail wants on it through buildDesiredNodeConfig, which preserves
+// the per-node post-generation transforms (static hostname, registry mirrors, cert
+// SANs) instead of reverting to the freshly regenerated base config. The caller
+// decides how to apply the result: the rolling-reboot path STAGES it
+// (stageNodeConfigForReboot), while the pre-upgrade reconcile applies it NO_REBOOT
+// so the Talos installer validates the desired config (reconcileNodeConfigBeforeUpgrade,
+// #5294). secretsSource supplies the cluster PKI and must be a control-plane config
+// (see buildDesiredNodeConfig and #4963).
+func (p *Provisioner) fetchAndBuildDesiredNodeConfig(
 	ctx context.Context,
 	node nodeWithRole,
 	secretsSource talosconfig.Provider,

--- a/pkg/svc/provisioner/cluster/talos/rolling.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling.go
@@ -422,23 +422,41 @@ func (p *Provisioner) stageNodeConfigForReboot(
 	node nodeWithRole,
 	secretsSource talosconfig.Provider,
 ) error {
+	return p.applyDesiredNodeConfig(
+		ctx, node, secretsSource,
+		machineapi.ApplyConfigurationRequest_STAGED, "Staging",
+	)
+}
+
+// applyDesiredNodeConfig rebuilds a node's desired machine config (see
+// fetchAndBuildDesiredNodeConfig) and applies it with the given mode, logging the
+// step with actionLabel (e.g. "Staging", "Reconciling"). It is the shared core of
+// the two per-node config-application paths: the rolling-reboot path STAGES the
+// config (stageNodeConfigForReboot) and the pre-upgrade reconcile applies it
+// NO_REBOOT (reconcileNodeConfigBeforeUpgrade). It is a no-op when no Talos config is
+// loaded (nothing to apply). secretsSource supplies the cluster PKI and must be a
+// control-plane config (see buildDesiredNodeConfig and #4963).
+func (p *Provisioner) applyDesiredNodeConfig(
+	ctx context.Context,
+	node nodeWithRole,
+	secretsSource talosconfig.Provider,
+	mode machineapi.ApplyConfigurationRequest_Mode,
+	actionLabel string,
+) error {
 	if p.talosConfigs == nil {
 		return nil
 	}
 
-	config, err := p.fetchAndBuildDesiredNodeConfig(ctx, node, secretsSource)
+	desired, err := p.fetchAndBuildDesiredNodeConfig(ctx, node, secretsSource)
 	if err != nil {
-		return err
+		return fmt.Errorf("build desired config: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(p.logWriter, "    Staging config on %s...\n", node.IP)
+	_, _ = fmt.Fprintf(p.logWriter, "    %s config on %s...\n", actionLabel, node.IP)
 
-	stageErr := p.applyConfigWithMode(
-		ctx, node.IP, config,
-		machineapi.ApplyConfigurationRequest_STAGED,
-	)
-	if stageErr != nil {
-		return fmt.Errorf("stage config: %w", stageErr)
+	err = p.applyConfigWithMode(ctx, node.IP, desired, mode)
+	if err != nil {
+		return fmt.Errorf("apply config: %w", err)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/talos/rolling_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_test.go
@@ -108,8 +108,8 @@ func TestRolling_SortNodesWorkersFirst(t *testing.T) { //nolint:funlen // table-
 // the raw config would strip the hostname so a Hetzner node re-registers under a
 // generated talos-xxxxx name on reboot (e.g. during a reboot-required config
 // change). This drives the actual staging-path config rebuild
-// (buildStagedNodeConfig) with the node's running config injected via the fetcher
-// seam.
+// (fetchAndBuildDesiredNodeConfig) with the node's running config injected via the
+// fetcher seam.
 func TestRolling_BuildStagedNodeConfig_PreservesNodeHostname(t *testing.T) {
 	t.Parallel()
 
@@ -139,7 +139,7 @@ func TestRolling_BuildStagedNodeConfig_PreservesNodeHostname(t *testing.T) {
 		"10.0.0.2", talosprovisioner.RoleControlPlane,
 	)
 
-	staged, err := prov.BuildStagedNodeConfigForTest(context.Background(), node, running)
+	staged, err := prov.FetchAndBuildDesiredNodeConfigForTest(context.Background(), node, running)
 	require.NoError(t, err)
 
 	assert.Equal(t, "prod-control-plane-1", staged.RawV1Alpha1().Hostname(),
@@ -189,7 +189,11 @@ func TestRolling_BuildStagedNodeConfig_PreservesWorkerHostname(t *testing.T) {
 
 	node := talosprovisioner.NewNodeWithRoleForTest("10.0.0.3", talosprovisioner.RoleWorker)
 
-	staged, err := prov.BuildStagedNodeConfigForTest(context.Background(), node, secretsSource)
+	staged, err := prov.FetchAndBuildDesiredNodeConfigForTest(
+		context.Background(),
+		node,
+		secretsSource,
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "prod-worker-1", staged.RawV1Alpha1().Hostname(),

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 )
 
 const (
@@ -320,6 +321,9 @@ func (p *Provisioner) waitForNodeReadyAfterUpgrade(
 
 // rollingUpgradeNodes performs a rolling Talos OS upgrade across all cluster
 // nodes. Workers are upgraded first, then control-planes, one node at a time.
+// Before each node's OS upgrade it reconciles the node's desired machine config so
+// the new installer validates the desired config rather than the stale committed
+// one (issue #5294, see reconcileNodeConfigBeforeUpgrade).
 func (p *Provisioner) rollingUpgradeNodes(
 	ctx context.Context,
 	clusterName, installerImage, desiredTag string,
@@ -332,11 +336,31 @@ func (p *Provisioner) rollingUpgradeNodes(
 	// Sort workers first, then control-planes for minimal disruption.
 	ordered := sortNodesWorkersFirst(nodes)
 
+	// The desired-config rebuild needs the cluster PKI, which only a control-plane
+	// node carries. Resolve one control-plane config up front and reuse it as the
+	// secrets source for every node (mirrors rollingApplyRebootChanges); all nodes
+	// are still at the old version here, and a control-plane's PKI is unchanged by an
+	// OS upgrade, so the source stays valid across the roll.
+	secretsSource := p.fetchSecretsSource(ctx, clusterName)
+
 	for i, node := range ordered {
 		_, _ = fmt.Fprintf(p.logWriter,
 			"  [%d/%d] Upgrading %s (%s)...\n",
 			i+1, len(ordered), node.IP, node.Role,
 		)
+
+		// Reconcile the desired config onto the node before upgrading it. Best-effort:
+		// a failure here must not regress upgrades that already validate cleanly
+		// against the committed config, so warn and proceed (the upgrade then behaves
+		// as it did pre-#5294, and the update's in-place reconcile re-surfaces any
+		// genuine drift afterwards).
+		configErr := p.reconcileNodeConfigBeforeUpgrade(ctx, node, secretsSource)
+		if configErr != nil {
+			_, _ = fmt.Fprintf(p.logWriter,
+				"  ⚠ Could not reconcile config on %s before upgrade: %v\n",
+				node.IP, configErr,
+			)
+		}
 
 		upgradeErr := p.upgradeNodeTalosVersion(ctx, node.IP, installerImage, desiredTag)
 		if upgradeErr != nil {
@@ -347,6 +371,50 @@ func (p *Provisioner) rollingUpgradeNodes(
 			"  ✓ Node %s (%s) upgraded successfully\n",
 			node.IP, node.Role,
 		)
+	}
+
+	return nil
+}
+
+// reconcileNodeConfigBeforeUpgrade applies a node's desired machine config with
+// NO_REBOOT mode immediately before its Talos OS upgrade, so the new installer
+// validates the desired config rather than the stale committed one (issue #5294).
+//
+// The Talos upgrade installer reads each node's *active* machine config — machined's
+// Upgrade task pipes the running config to the installer container's stdin, which it
+// validates before installing. A config change that a newer release requires as a
+// prerequisite (e.g. the v1.13.4 install-section validation in the issue) must
+// therefore be the *active* config before the upgrade runs. Merely STAGING it is not
+// enough: a staged config only becomes active on the next boot, which happens after
+// the installer has already validated and run. NO_REBOOT makes the desired config
+// active up front; the install section is immediate-apply-safe in Talos, so the
+// apply needs no reboot of its own (the upgrade reboots anyway).
+//
+// It is a no-op when no Talos config is loaded (nothing to reconcile). secretsSource
+// supplies the cluster PKI for the rebuild and must be a control-plane config (see
+// buildDesiredNodeConfig).
+func (p *Provisioner) reconcileNodeConfigBeforeUpgrade(
+	ctx context.Context,
+	node nodeWithRole,
+	secretsSource talosconfig.Provider,
+) error {
+	if p.talosConfigs == nil {
+		return nil
+	}
+
+	desired, err := p.fetchAndBuildDesiredNodeConfig(ctx, node, secretsSource)
+	if err != nil {
+		return fmt.Errorf("build desired config: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "    Reconciling config on %s before upgrade...\n", node.IP)
+
+	applyErr := p.applyConfigWithMode(
+		ctx, node.IP, desired,
+		machineapi.ApplyConfigurationRequest_NO_REBOOT,
+	)
+	if applyErr != nil {
+		return fmt.Errorf("apply %s config before upgrade: %w", node.Role, applyErr)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -337,11 +337,13 @@ func (p *Provisioner) rollingUpgradeNodes(
 	ordered := sortNodesWorkersFirst(nodes)
 
 	// The desired-config rebuild needs the cluster PKI, which only a control-plane
-	// node carries. Resolve one control-plane config up front and reuse it as the
-	// secrets source for every node (mirrors rollingApplyRebootChanges); all nodes
-	// are still at the old version here, and a control-plane's PKI is unchanged by an
-	// OS upgrade, so the source stays valid across the roll.
-	secretsSource := p.fetchSecretsSource(ctx, clusterName)
+	// node carries. Reuse the node list already fetched above (rather than re-listing
+	// via fetchSecretsSource) to resolve one control-plane config up front, then reuse
+	// it as the secrets source for every node: all nodes are still at the old version
+	// here, and a control-plane's PKI is unchanged by an OS upgrade, so the source
+	// stays valid across the roll. A nil result (no control-plane reachable) degrades
+	// to a best-effort per-node reconcile.
+	secretsSource, _, _ := p.fetchNodeConfigForRole(ctx, nodes, RoleControlPlane)
 
 	for i, node := range ordered {
 		_, _ = fmt.Fprintf(p.logWriter,
@@ -398,24 +400,8 @@ func (p *Provisioner) reconcileNodeConfigBeforeUpgrade(
 	node nodeWithRole,
 	secretsSource talosconfig.Provider,
 ) error {
-	if p.talosConfigs == nil {
-		return nil
-	}
-
-	desired, err := p.fetchAndBuildDesiredNodeConfig(ctx, node, secretsSource)
-	if err != nil {
-		return fmt.Errorf("build desired config: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(p.logWriter, "    Reconciling config on %s before upgrade...\n", node.IP)
-
-	applyErr := p.applyConfigWithMode(
-		ctx, node.IP, desired,
-		machineapi.ApplyConfigurationRequest_NO_REBOOT,
+	return p.applyDesiredNodeConfig(
+		ctx, node, secretsSource,
+		machineapi.ApplyConfigurationRequest_NO_REBOOT, "Reconciling",
 	)
-	if applyErr != nil {
-		return fmt.Errorf("apply %s config before upgrade: %w", node.Role, applyErr)
-	}
-
-	return nil
 }

--- a/pkg/svc/provisioner/cluster/talos/upgrade_test.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,8 +128,56 @@ func TestUpgradeDistribution_ContainerMode(t *testing.T) {
 		// Hetzner clusters run on real machines and upgrade in place, so neither
 		// the Docker recreate nor the skip path must fire. With no infrastructure
 		// provider wired, node listing yields an empty set and the rolling upgrade
-		// is a no-op.
+		// (including the pre-upgrade config reconcile) is a no-op.
 		require.NotErrorIs(t, err, clustererr.ErrUpgradeSkipped)
 		require.NotErrorIs(t, err, clustererr.ErrRecreationRequired)
 	})
+}
+
+// TestReconcileNodeConfigBeforeUpgrade_NoopWithoutTalosConfig verifies the
+// pre-upgrade config reconcile (issue #5294) is a no-op when no Talos config is
+// loaded: there is nothing to reconcile, so it must return without error and without
+// touching the node, letting the OS upgrade proceed unchanged.
+func TestReconcileNodeConfigBeforeUpgrade_NoopWithoutTalosConfig(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil)
+	node := talosprovisioner.NewNodeWithRoleForTest(
+		"10.0.0.2", talosprovisioner.RoleControlPlane,
+	)
+
+	err := prov.ReconcileNodeConfigBeforeUpgradeForTest(context.Background(), node, nil)
+	require.NoError(t, err)
+}
+
+// TestReconcileNodeConfigBeforeUpgrade_BuildErrorPropagates verifies that a failure
+// to build the node's desired config is surfaced (wrapped) rather than swallowed, so
+// the rolling-upgrade caller can warn before proceeding. It drives the worker-role
+// build path with no control-plane secrets source: a worker's running config carries
+// no CA private key, so the realignment fails the control-plane-PKI precondition
+// (#4963) before any live ApplyConfiguration RPC is attempted — exercising
+// reconcileNodeConfigBeforeUpgrade up to, but not including, node I/O.
+func TestReconcileNodeConfigBeforeUpgrade_BuildErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(nil)
+	require.NoError(t, err)
+
+	workerRunning := runningWithHostname(t, talosprovisioner.RoleWorker, "prod-worker-1")
+
+	prov := talosprovisioner.NewProvisioner(desiredConfigs, nil).
+		WithNodeConfigFetcherForTest(
+			func(_ context.Context, _ string) (talosconfig.Provider, error) {
+				return workerRunning, nil
+			},
+		)
+
+	node := talosprovisioner.NewNodeWithRoleForTest("10.0.0.3", talosprovisioner.RoleWorker)
+
+	err = prov.ReconcileNodeConfigBeforeUpgradeForTest(context.Background(), node, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build desired config",
+		"the build failure must be wrapped so the caller can attribute it")
+	assert.Contains(t, err.Error(), "control-plane PKI",
+		"the actionable #4963 precondition must be surfaced")
 }


### PR DESCRIPTION
## What

`ksail cluster update` ran the Talos OS upgrade **before** reconciling machine config. Because the Talos upgrade installer validates the node's **active** machine config, a config change that a newer Talos release requires as a *prerequisite* could never deploy via a single `cluster update`: the upgrade ran first, validated the stale committed config, and aborted before the config-reconcile step.

This makes `rollingUpgradeNodes` reconcile each node's desired config **before** triggering that node's OS upgrade, so the installer validates the *desired* config and a config prerequisite self-heals in one `cluster update`.

Fixes #5294.

## Why `NO_REBOOT`, not `STAGED`

The issue suggested "apply/stage" the config. I traced the vendored Talos machinery to settle which is correct:

- machined's `Upgrade` task calls `install.RunInstallerContainer(..., r.Config(), r.ConfigContainer(), ...)`.
- `RunInstallerContainer` pipes `cfgContainer.Bytes()` — the node's **active** config — to the installer container's **stdin**.
- The installer reads it with `configloader.NewFromStdin()` and runs `config.ValidateAsClient(...)` → this is the `machine configuration is invalid` error in the report.

A **`STAGED`** config only becomes active on the *next boot*, which happens **after** the installer has already validated and run — so staging would not fix this. The config must be made **active** before the upgrade, i.e. applied with **`NO_REBOOT`**. `.machine.install` is in Talos's immediate-apply allowlist (`CanApplyImmediate`), so the apply needs no reboot of its own (and the upgrade reboots anyway).

## Scope

Only **Hetzner** Talos clusters are affected — Docker-provider Talos changes the OS version by **recreation** (rebuilds config from `ksail.yaml`), and Omni upgrades are managed externally. Both short-circuit before `rollingUpgradeNodes`.

## Changes

- `rollingUpgradeNodes` resolves a control-plane secrets source once (PKI is unchanged by an OS upgrade), then before each node's upgrade calls the new `reconcileNodeConfigBeforeUpgrade`, which applies the node's desired config with `NO_REBOOT`.
- **Best-effort**: a failed pre-upgrade reconcile warns and proceeds, so it cannot regress upgrades that already validate cleanly against the committed config; the update's in-place reconcile re-surfaces any genuine drift afterwards.
- Renamed the shared per-node builder `buildStagedNodeConfig` → `fetchAndBuildDesiredNodeConfig` (now used by both the rolling-reboot `STAGED` path and the pre-upgrade `NO_REBOOT` path), with seam/comment updates.

## Tests

- New: no-op guard (no Talos config loaded) and build-error propagation for `reconcileNodeConfigBeforeUpgrade`.
- Existing routing/build tests updated and green; the `hetzner provider is not skipped or recreated` case still exercises the (now config-reconciling) rolling path as a no-op with no infra wired.
- `go build ./...`, `go test ./pkg/svc/provisioner/cluster/talos/... ./pkg/cli/cmd/cluster/...` (932 pass), and `golangci-lint run --new-from-rev=HEAD` all clean.

> [!NOTE]
> End-to-end behavior (config applied before the OS upgrade on real machines) is exercised by the Talos×Hetzner system test — the path where this bug surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
