### PR TITLE
fix(talos): reboot autoscaler nodes in place instead of recycling at capacity

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/autoscaler_secret.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_secret.go
@@ -41,8 +41,9 @@ func (p *Provisioner) syncHetznerFirewallRules(
 // When the Secret changes it brings existing autoscaler nodes to the new baseline
 // — but only as disruptively as the change demands (see
 // propagateAutoscalerBaseline): a NO_REBOOT in-place apply for config-only drift,
-// a drain-and-replace recycle only when a new boot image or a reboot-class change
-// genuinely requires fresh nodes.
+// an in-place reboot of the same servers for a reboot-required change, and a
+// drain-and-replace recycle only when a new boot image or a wipe/recreate-class
+// change genuinely requires fresh nodes.
 func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
 	ctx context.Context,
 	clusterName string,
@@ -103,12 +104,18 @@ func (p *Provisioner) ensureAutoscalerSecretIfNeeded(
 }
 
 // propagateAutoscalerBaseline brings existing autoscaler nodes to the refreshed
-// baseline, choosing the least disruptive mechanism the change allows. A new boot
-// image (Talos OS bump) or a reboot/wipe/recreate-class change can only reach an
-// immutable Talos node by replacing it, so those recycle (drain → delete → the
-// autoscaler re-provisions from the new template). A config-only change that Talos
-// can apply with NO_REBOOT is pushed in place instead — no drain, so it never
-// stalls on a PodDisruptionBudget the way a recycle can.
+// baseline, choosing the least disruptive mechanism the change allows. The three
+// paths are checked most-disruptive first:
+//
+//   - recycle (drain → delete → the autoscaler re-provisions a fresh node from the
+//     new template) — only when a fresh server is unavoidable: a new boot image
+//     (Talos OS bump) or a wipe/recreate/rolling-recreate change.
+//   - in-place reboot of the SAME servers (rollingRebootAutoscalerNodes) — for a
+//     reboot-required change (CNI swap, disk-quota toggle) an already-booted node
+//     can adopt by rebooting, with no fresh server. This keeps a capacity-constrained
+//     project at its Hetzner server limit converging where a recycle could not (#5219).
+//   - in-place NO_REBOOT apply (applyInPlaceToAutoscalerNodes) — for config-only
+//     drift; no drain, so it never stalls on a PodDisruptionBudget.
 func (p *Provisioner) propagateAutoscalerBaseline(
 	ctx context.Context,
 	clusterName string,
@@ -116,19 +123,30 @@ func (p *Provisioner) propagateAutoscalerBaseline(
 	imageChanged bool,
 	result *clusterupdate.UpdateResult,
 ) error {
-	if autoscalerRecycleRequired(diff, imageChanged) {
+	switch {
+	case autoscalerRecycleRequired(diff, imageChanged):
 		return p.recycleAutoscalerNodes(ctx, clusterName)
+	case autoscalerRebootRequired(diff):
+		return p.rollingRebootAutoscalerNodes(ctx, clusterName, result)
+	default:
+		return p.applyInPlaceToAutoscalerNodes(ctx, clusterName, result)
 	}
-
-	return p.applyInPlaceToAutoscalerNodes(ctx, clusterName, result)
 }
 
 // autoscalerRecycleRequired reports whether the refreshed baseline can only reach
-// existing autoscaler nodes by replacing them. That is true when the Talos boot
-// image changed (a new snapshot an already-booted node cannot adopt in place) or
-// when the diff carries a reboot/wipe/recreate/rolling-recreate change Talos
-// cannot apply with NO_REBOOT. A nil diff (no classification available) defers to
-// the image signal alone, defaulting to the non-disruptive in-place path.
+// existing autoscaler nodes by replacing them with fresh servers. That is true when
+// the Talos boot image changed (a new snapshot an already-booted node cannot adopt
+// in place) or when the diff carries a wipe/recreate/rolling-recreate change that no
+// apply against the running server can land. A nil diff (no classification
+// available) defers to the image signal alone, defaulting to the non-disruptive
+// in-place path.
+//
+// A reboot-required change (CNI swap, disk-quota toggle) is deliberately NOT here:
+// an already-booted server can adopt it via an in-place reboot of the SAME server
+// (autoscalerRebootRequired → rollingRebootAutoscalerNodes) — no fresh server, so a
+// capacity-constrained project at its Hetzner server limit still converges (#5219).
+// Recycle is checked before the reboot path in propagateAutoscalerBaseline, so a
+// change that needs BOTH a fresh server and a reboot still recycles.
 func autoscalerRecycleRequired(diff *clusterupdate.UpdateResult, imageChanged bool) bool {
 	if imageChanged {
 		return true
@@ -138,8 +156,18 @@ func autoscalerRecycleRequired(diff *clusterupdate.UpdateResult, imageChanged bo
 		return false
 	}
 
-	return diff.HasRebootRequired() || diff.HasWipeRequired() ||
+	return diff.HasWipeRequired() ||
 		diff.HasRecreateRequired() || diff.HasRollingRecreate()
+}
+
+// autoscalerRebootRequired reports whether the refreshed baseline carries a
+// reboot-required change (CNI swap, disk-quota toggle) that an in-place NO_REBOOT
+// apply cannot land but an in-place reboot of the SAME server can — no fresh server
+// needed. Gated below autoscalerRecycleRequired in propagateAutoscalerBaseline, so a
+// change that ALSO needs a fresh server (image/wipe/recreate/rolling-recreate) still
+// recycles instead.
+func autoscalerRebootRequired(diff *clusterupdate.UpdateResult) bool {
+	return diff != nil && diff.HasRebootRequired()
 }
 
 // autoscalerSecretApplicable reports whether the cluster-autoscaler-config Secret

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -394,6 +394,11 @@ func AutoscalerRecycleRequiredForTest(diff *clusterupdate.UpdateResult, imageCha
 	return autoscalerRecycleRequired(diff, imageChanged)
 }
 
+// AutoscalerRebootRequiredForTest exposes autoscalerRebootRequired for unit testing.
+func AutoscalerRebootRequiredForTest(diff *clusterupdate.UpdateResult) bool {
+	return autoscalerRebootRequired(diff)
+}
+
 // UpdateApplyStepNamesForTest returns the ordered names of the post-PrepareUpdate
 // apply steps, so tests can assert the step ordering (notably that the autoscaler
 // baseline refresh runs before static-node scaling — #5219) without driving a
@@ -450,6 +455,15 @@ func (p *Provisioner) ApplyInPlaceToAutoscalerNodesForTest(
 	result *clusterupdate.UpdateResult,
 ) error {
 	return p.applyInPlaceToAutoscalerNodes(ctx, clusterName, result)
+}
+
+// RollingRebootAutoscalerNodesForTest exposes rollingRebootAutoscalerNodes for unit testing.
+func (p *Provisioner) RollingRebootAutoscalerNodesForTest(
+	ctx context.Context,
+	clusterName string,
+	result *clusterupdate.UpdateResult,
+) error {
+	return p.rollingRebootAutoscalerNodes(ctx, clusterName, result)
 }
 
 // RestartAutoscalerAfterConfigChangeForTest exposes restartAutoscalerAfterConfigChange

--- a/pkg/svc/provisioner/cluster/talos/reboot_autoscaler.go
+++ b/pkg/svc/provisioner/cluster/talos/reboot_autoscaler.go
@@ -1,0 +1,139 @@
+package talosprovisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"k8s.io/client-go/kubernetes"
+)
+
+// rollingRebootAutoscalerNodes brings existing autoscaler nodes to the refreshed
+// baseline by rebooting each one IN PLACE — cordon → drain → stage the desired
+// config (STAGED) → reboot the same Hetzner server → wait Ready → uncordon — the
+// same mechanism KSail-owned static nodes use for reboot-required changes
+// (rollingApplyRebootChanges). It is the propagation path for a reboot-required
+// change (CNI swap, disk-quota toggle) that a NO_REBOOT apply cannot land: unlike
+// recycleAutoscalerNodes it never deletes a server, so a capacity-constrained
+// project at its Hetzner server limit still converges (the #5219 incident) — no
+// fresh server is ever needed.
+//
+// The reboot-required classification is cluster-wide (detectDisruptiveConfigChanges
+// compares one control-plane node; the CNI/disk-quota patches apply identically to
+// workers), so this does not diff each autoscaler worker individually. A worker
+// already carrying the change just stages an equivalent config and reboots
+// harmlessly. Each node's config is rebuilt from its RUNNING config via
+// buildStagedNodeConfig → buildDesiredNodeConfig, preserving the per-node sections
+// an autoscaler node carries (server-name hostname, the ksail.io/autoscaled marker,
+// pool labels/taints) — see applyInPlaceToAutoscalerNodes.
+//
+// Draining a node can make pods pending and briefly prompt the autoscaler to add a
+// node, which it scales back down once the rebooted node returns; nodes are handled
+// one at a time to bound that transient — still strictly cheaper than recycle's hard
+// requirement of spare server headroom. waitForAutoscalerRollout first ensures any
+// such scale-up is served by the autoscaler pod already carrying the refreshed
+// template (the Secret changed and the Deployment was restarted upstream). The PKI
+// the staged-config rebuild needs is present because needsSecretSync forces a
+// secrets sync whenever the autoscaler is enabled, ahead of this step.
+func (p *Provisioner) rollingRebootAutoscalerNodes(
+	ctx context.Context,
+	clusterName string,
+	result *clusterupdate.UpdateResult,
+) error {
+	servers, err := p.listAutoscalerServers(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	if len(servers) == 0 {
+		_, _ = fmt.Fprintf(p.logWriter, "  ⓘ No autoscaler nodes to reboot\n")
+
+		return nil
+	}
+
+	clientset, err := p.createK8sClient(clusterName)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the restarted autoscaler to be ready so any scale-up a drain triggers
+	// is served from the refreshed template, not the pre-restart pod.
+	rolloutErr := p.waitForAutoscalerRollout(ctx, clientset)
+	if rolloutErr != nil {
+		return rolloutErr
+	}
+
+	// buildStagedNodeConfig rebuilds each node's config from its running config + the
+	// cluster PKI, which only a control-plane node carries; seed it once and reuse it
+	// for every node (see fetchSecretsSource / #4963). A worker source would fail
+	// "parse PEM block".
+	secretsSource := p.fetchSecretsSource(ctx, clusterName)
+
+	return p.rollingRebootAutoscalerServers(
+		ctx, clientset, sortServersByName(servers), secretsSource, result,
+	)
+}
+
+// rollingRebootAutoscalerServers reboots the given autoscaler servers in place, one
+// at a time, recording progress. A server with no usable address, or any node whose
+// reboot fails, aborts the run so a partial reboot leaves the remaining nodes
+// untouched — except a server present in Hetzner but not (yet) registered in
+// Kubernetes, which is skipped: it cannot be cordoned/drained, and wedging the whole
+// convergence on one half-joined node is the #5219 failure mode this avoids (mirrors
+// the recycle path's drainResolvedNode tolerance).
+func (p *Provisioner) rollingRebootAutoscalerServers(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	ordered []*hcloud.Server,
+	secretsSource talosconfig.Provider,
+	result *clusterupdate.UpdateResult,
+) error {
+	_, _ = fmt.Fprintf(p.logWriter,
+		"Rolling reboot of %d autoscaler node(s) in place (same servers)...\n", len(ordered))
+
+	for idx, server := range ordered {
+		serverIP, addrErr := hetznerNodeTalosAddress(server)
+		if addrErr != nil {
+			// No usable private address is a real misconfiguration, not a transient
+			// half-joined node: abort rather than silently skip (a skipped node stays
+			// stale and re-creates the stale-node-pins-project condition this fixes).
+			recordFailedChange(result, RoleWorker, server.Name, addrErr)
+
+			return fmt.Errorf("resolving address for autoscaler node %s: %w", server.Name, addrErr)
+		}
+
+		_, _ = fmt.Fprintf(
+			p.logWriter,
+			"  [%d/%d] Rolling reboot for autoscaler node %s...\n",
+			idx+1, len(ordered), server.Name,
+		)
+
+		rebootErr := p.rollingRebootSingleNode(
+			ctx, clientset, nodeWithRole{IP: serverIP, Role: RoleWorker}, secretsSource,
+		)
+		if rebootErr != nil {
+			if errors.Is(rebootErr, ErrNodeNotFoundByIP) {
+				_, _ = fmt.Fprintf(p.logWriter,
+					"  ⚠ Autoscaler node %s is not registered in Kubernetes; skipping reboot\n",
+					server.Name)
+
+				continue
+			}
+
+			recordFailedChange(result, RoleWorker, server.Name, rebootErr)
+
+			return fmt.Errorf("rolling reboot autoscaler node %s: %w", server.Name, rebootErr)
+		}
+
+		result.RebootsPerformed++
+
+		recordAppliedChange(result, RoleWorker, server.Name, "rebooted")
+
+		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Rebooted autoscaler node %s\n", server.Name)
+	}
+
+	return nil
+}

--- a/pkg/svc/provisioner/cluster/talos/reboot_autoscaler.go
+++ b/pkg/svc/provisioner/cluster/talos/reboot_autoscaler.go
@@ -43,27 +43,11 @@ func (p *Provisioner) rollingRebootAutoscalerNodes(
 	clusterName string,
 	result *clusterupdate.UpdateResult,
 ) error {
-	servers, err := p.listAutoscalerServers(ctx, clusterName)
-	if err != nil {
+	clientset, ordered, ok, err := p.prepareAutoscalerNodeConvergence(
+		ctx, clusterName, "  ⓘ No autoscaler nodes to reboot\n",
+	)
+	if err != nil || !ok {
 		return err
-	}
-
-	if len(servers) == 0 {
-		_, _ = fmt.Fprintf(p.logWriter, "  ⓘ No autoscaler nodes to reboot\n")
-
-		return nil
-	}
-
-	clientset, err := p.createK8sClient(clusterName)
-	if err != nil {
-		return err
-	}
-
-	// Wait for the restarted autoscaler to be ready so any scale-up a drain triggers
-	// is served from the refreshed template, not the pre-restart pod.
-	rolloutErr := p.waitForAutoscalerRollout(ctx, clientset)
-	if rolloutErr != nil {
-		return rolloutErr
 	}
 
 	// buildStagedNodeConfig rebuilds each node's config from its running config + the
@@ -72,9 +56,7 @@ func (p *Provisioner) rollingRebootAutoscalerNodes(
 	// "parse PEM block".
 	secretsSource := p.fetchSecretsSource(ctx, clusterName)
 
-	return p.rollingRebootAutoscalerServers(
-		ctx, clientset, sortServersByName(servers), secretsSource, result,
-	)
+	return p.rollingRebootAutoscalerServers(ctx, clientset, ordered, secretsSource, result)
 }
 
 // rollingRebootAutoscalerServers reboots the given autoscaler servers in place, one
@@ -114,25 +96,25 @@ func (p *Provisioner) rollingRebootAutoscalerServers(
 		rebootErr := p.rollingRebootSingleNode(
 			ctx, clientset, nodeWithRole{IP: serverIP, Role: RoleWorker}, secretsSource,
 		)
-		if rebootErr != nil {
-			if errors.Is(rebootErr, ErrNodeNotFoundByIP) {
-				_, _ = fmt.Fprintf(p.logWriter,
-					"  ⚠ Autoscaler node %s is not registered in Kubernetes; skipping reboot\n",
-					server.Name)
 
-				continue
-			}
+		switch {
+		case rebootErr == nil:
+			result.RebootsPerformed++
 
+			recordAppliedChange(result, RoleWorker, server.Name, "rebooted")
+
+			_, _ = fmt.Fprintf(p.logWriter, "  ✓ Rebooted autoscaler node %s\n", server.Name)
+		case errors.Is(rebootErr, ErrNodeNotFoundByIP):
+			// Present in Hetzner but not (yet) joined: it can't be drained, so skip it
+			// instead of wedging the whole convergence (mirrors drainResolvedNode).
+			_, _ = fmt.Fprintf(p.logWriter,
+				"  ⚠ Autoscaler node %s is not registered in Kubernetes; skipping reboot\n",
+				server.Name)
+		default:
 			recordFailedChange(result, RoleWorker, server.Name, rebootErr)
 
 			return fmt.Errorf("rolling reboot autoscaler node %s: %w", server.Name, rebootErr)
 		}
-
-		result.RebootsPerformed++
-
-		recordAppliedChange(result, RoleWorker, server.Name, "rebooted")
-
-		_, _ = fmt.Fprintf(p.logWriter, "  ✓ Rebooted autoscaler node %s\n", server.Name)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/talos/reboot_autoscaler_test.go
+++ b/pkg/svc/provisioner/cluster/talos/reboot_autoscaler_test.go
@@ -1,0 +1,97 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAutoscalerRebootRequired pins the reboot-in-place gate: only a reboot-required
+// diff routes to the in-place reboot path; image/wipe/recreate/rolling-recreate are
+// recycle's job (asserted in TestAutoscalerRecycleRequired) and must not be reboot.
+func TestAutoscalerRebootRequired(t *testing.T) {
+	t.Parallel()
+
+	rebootDiff := clusterupdate.NewEmptyUpdateResult()
+	rebootDiff.RebootRequired = append(rebootDiff.RebootRequired, clusterupdate.Change{})
+
+	wipeDiff := clusterupdate.NewEmptyUpdateResult()
+	wipeDiff.WipeRequired = append(wipeDiff.WipeRequired, clusterupdate.Change{})
+
+	recreateDiff := clusterupdate.NewEmptyUpdateResult()
+	recreateDiff.RecreateRequired = append(recreateDiff.RecreateRequired, clusterupdate.Change{})
+
+	rollingDiff := clusterupdate.NewEmptyUpdateResult()
+	rollingDiff.RollingRecreate = append(rollingDiff.RollingRecreate, clusterupdate.Change{})
+
+	tests := []struct {
+		name string
+		diff *clusterupdate.UpdateResult
+		want bool
+	}{
+		{"nil diff is not reboot", nil, false},
+		{"empty diff is not reboot", clusterupdate.NewEmptyUpdateResult(), false},
+		{"reboot-required is reboot", rebootDiff, true},
+		{"wipe-required is not reboot", wipeDiff, false},
+		{"recreate-required is not reboot", recreateDiff, false},
+		{"rolling-recreate is not reboot", rollingDiff, false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := talosprovisioner.AutoscalerRebootRequiredForTest(testCase.diff)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func TestRollingRebootAutoscalerNodes_NoopWhenNotHetzner(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).WithLogWriter(io.Discard)
+
+	err := prov.RollingRebootAutoscalerNodesForTest(
+		context.Background(), "test-cluster", clusterupdate.NewEmptyUpdateResult(),
+	)
+	require.NoError(t, err)
+}
+
+func TestRollingRebootAutoscalerNodes_NoopWhenAutoscalerDisabled(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(io.Discard).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{
+			NodeAutoscalerEnabled:   false,
+			AutoscalerNodePoolNames: []string{"pool-a"},
+		})
+
+	err := prov.RollingRebootAutoscalerNodesForTest(
+		context.Background(), "test-cluster", clusterupdate.NewEmptyUpdateResult(),
+	)
+	require.NoError(t, err)
+}
+
+func TestRollingRebootAutoscalerNodes_NoopWhenNoPools(t *testing.T) {
+	t.Parallel()
+
+	prov := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(io.Discard).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{
+			NodeAutoscalerEnabled:   true,
+			AutoscalerNodePoolNames: nil,
+		})
+
+	err := prov.RollingRebootAutoscalerNodesForTest(
+		context.Background(), "test-cluster", clusterupdate.NewEmptyUpdateResult(),
+	)
+	require.NoError(t, err)
+}

--- a/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
+++ b/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
@@ -25,10 +25,12 @@ const autoscalerRolloutTimeout = 5 * time.Minute
 // recycleAutoscalerNodes drains and deletes the cluster-autoscaler-managed nodes so
 // the autoscaler re-provisions any still-needed capacity from the refreshed Talos
 // snapshot + worker config. It is the disruptive propagation path, reserved for
-// changes an already-booted node cannot adopt in place: a new Talos boot image
-// (snapshot/OS bump) or a reboot/wipe/recreate-class change. Config-only drift that
-// Talos applies with NO_REBOOT goes through applyInPlaceToAutoscalerNodes instead,
-// so it never drains — see autoscalerRecycleRequired for the gate.
+// changes that can only reach an already-booted node by replacing it with a fresh
+// server: a new Talos boot image (snapshot/OS bump) or a wipe/recreate-class change.
+// A reboot-required change (CNI/disk-quota) instead reboots the same servers in
+// place via rollingRebootAutoscalerNodes, and config-only drift that Talos applies
+// with NO_REBOOT goes through applyInPlaceToAutoscalerNodes — neither needs a fresh
+// server. See autoscalerRecycleRequired / autoscalerRebootRequired for the gate.
 //
 // Why this is needed: `cluster update` upgrades only KSail-owned nodes in place
 // (control planes + static workers, listed via the ksail.owned label). Autoscaler

--- a/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
+++ b/pkg/svc/provisioner/cluster/talos/recycle_autoscaler.go
@@ -45,15 +45,11 @@ const autoscalerRolloutTimeout = 5 * time.Minute
 // demand. Compute-only autoscaler nodes hold no persistent storage and no etcd
 // membership, so replace-by-recreation is the idiomatic, lossless path.
 func (p *Provisioner) recycleAutoscalerNodes(ctx context.Context, clusterName string) error {
-	servers, err := p.listAutoscalerServers(ctx, clusterName)
-	if err != nil {
+	clientset, ordered, ok, err := p.prepareAutoscalerNodeConvergence(
+		ctx, clusterName, "  ⓘ No autoscaler nodes to recycle\n",
+	)
+	if err != nil || !ok {
 		return err
-	}
-
-	if len(servers) == 0 {
-		_, _ = fmt.Fprintf(p.logWriter, "  ⓘ No autoscaler nodes to recycle\n")
-
-		return nil
 	}
 
 	hzProvider, err := p.hetznerProvider()
@@ -61,19 +57,7 @@ func (p *Provisioner) recycleAutoscalerNodes(ctx context.Context, clusterName st
 		return err
 	}
 
-	clientset, err := p.createK8sClient(clusterName)
-	if err != nil {
-		return err
-	}
-
-	// Wait for the restarted autoscaler to be ready so any scale-up the drain
-	// triggers is served from the new template, not the pre-restart pod.
-	rolloutErr := p.waitForAutoscalerRollout(ctx, clientset)
-	if rolloutErr != nil {
-		return rolloutErr
-	}
-
-	return p.recycleAutoscalerServers(ctx, clientset, hzProvider, sortServersByName(servers))
+	return p.recycleAutoscalerServers(ctx, clientset, hzProvider, ordered)
 }
 
 // listAutoscalerServers returns the running autoscaler-managed servers for the
@@ -102,6 +86,42 @@ func (p *Provisioner) listAutoscalerServers(
 	}
 
 	return servers, nil
+}
+
+// prepareAutoscalerNodeConvergence lists the cluster's autoscaler servers and, when
+// any exist, creates a Kubernetes client and waits for the refreshed cluster-
+// autoscaler rollout — so a scale-up a subsequent drain triggers is served by the
+// autoscaler pod already carrying the new template, not the pre-restart one. It
+// returns ok=false (after logging noneMsg) when there are no autoscaler nodes, so the
+// caller no-ops. The returned servers are sorted by name for deterministic,
+// one-at-a-time processing. Shared by the recycle and rolling-reboot paths.
+func (p *Provisioner) prepareAutoscalerNodeConvergence(
+	ctx context.Context,
+	clusterName string,
+	noneMsg string,
+) (kubernetes.Interface, []*hcloud.Server, bool, error) {
+	servers, err := p.listAutoscalerServers(ctx, clusterName)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	if len(servers) == 0 {
+		_, _ = fmt.Fprint(p.logWriter, noneMsg)
+
+		return nil, nil, false, nil
+	}
+
+	clientset, err := p.createK8sClient(clusterName)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	rolloutErr := p.waitForAutoscalerRollout(ctx, clientset)
+	if rolloutErr != nil {
+		return nil, nil, false, rolloutErr
+	}
+
+	return clientset, sortServersByName(servers), true, nil
 }
 
 // applyInPlaceToAutoscalerNodes pushes the refreshed worker configuration to the

--- a/pkg/svc/provisioner/cluster/talos/recycle_autoscaler_gating_test.go
+++ b/pkg/svc/provisioner/cluster/talos/recycle_autoscaler_gating_test.go
@@ -50,7 +50,8 @@ func TestAutoscalerRecycleRequired(t *testing.T) {
 	}{
 		{"in-place only does not recycle", inPlaceDiff(), false, false},
 		{"boot image change forces recycle", inPlaceDiff(), true, true},
-		{"reboot-required recycles", rebootDiff, false, true},
+		{"reboot-required does not recycle", rebootDiff, false, false},
+		{"reboot-required with image change recycles", rebootDiff, true, true},
 		{"wipe-required recycles", wipeDiff, false, true},
 		{"recreate-required recycles", recreateDiff, false, true},
 		{"rolling-recreate recycles", rollingDiff, false, true},


### PR DESCRIPTION
## Summary

Closes the **recycle-at-capacity** gap that [#5258](https://github.com/devantler-tech/ksail/pull/5258) explicitly deferred for #5219 (Talos×Hetzner, cluster-autoscaler enabled).

When `cluster update` carries a **reboot-required** Talos change (a CNI name change or a `machine.features.diskQuotaSupport` toggle — classified `ChangeCategoryRebootRequired` in `detect_disruptive.go`), autoscaler-node convergence took the **recycle** path: drain → **delete the Hetzner server** → wait for the autoscaler to boot a fresh replacement from the refreshed template. That assumes spare server headroom. On a capacity-constrained project **at its Hetzner server limit** (the real #5219 prod incident), there is none, so the path is unsafe and can wedge.

Meanwhile KSail-owned **static** nodes already apply the very same reboot-required changes via an **in-place rolling reboot of the same server** (`rollingRebootSingleNode`: cordon → drain → stage STAGED config → reboot → wait → uncordon) — no new server is created, so no headroom is needed.

## Change

Route a **pure reboot-required** autoscaler convergence to an in-place rolling reboot of the existing servers (`rollingRebootAutoscalerNodes`), reusing the static-node reboot machinery. Recycle is now reserved for changes that genuinely require a fresh server: a new boot image (snapshot/OS bump), or a wipe/recreate/rolling-recreate change.

`propagateAutoscalerBaseline` becomes an ordered, most-disruptive-first switch:

1. `autoscalerRecycleRequired` (image / wipe / recreate / rolling-recreate) → **recycle**
2. `autoscalerRebootRequired` (reboot-required) → **in-place rolling reboot of the same servers**
3. else → **in-place NO_REBOOT apply** (config-only drift)

Recycle is checked first, so a change that needs *both* a fresh server and a reboot still recycles. Each node's config is rebuilt from its running config via `buildStagedNodeConfig` → `buildDesiredNodeConfig`, which preserves the per-node sections an autoscaler node carries (server-name hostname, the `ksail.io/autoscaled` marker, pool labels/taints) — the same machinery the existing in-place path relies on.

### Failure semantics (deliberate)

- A server with **no usable private address** → abort (a real misconfig; silently skipping would re-create the stale-node-pins-project condition this fixes).
- A server present in Hetzner but **not registered in Kubernetes** → skip with a warning and continue (it cannot be cordoned/drained; wedging the whole convergence on one half-joined node is the #5219 failure mode). Mirrors the recycle path's existing `drainResolvedNode` tolerance.
- Any other per-node reboot failure → abort, matching `rollingApplyRebootChanges`.

## Tests

- `TestAutoscalerRebootRequired` — the new reboot-in-place gate (only reboot-required routes here; image/wipe/recreate/rolling-recreate do not).
- `TestAutoscalerRecycleRequired` — flipped the `reboot-required` case to **does not recycle**, and added a `reboot-required + image change → recycles` case proving the recycle-wins precedence.
- `TestRollingRebootAutoscalerNodes_NoopWhen{NotHetzner,AutoscalerDisabled,NoPools}` — guard coverage mirroring the in-place/recycle noop tests.
- Full provisioner + lifecycle + clusterupdate suites green; `golangci-lint` / `gofmt` / `go vet` clean.

The full cordon→drain→stage→reboot→wait→uncordon flow against live nodes is E2E-only (needs a reachable Talos apid + control-plane PKI), consistent with the existing recycle path's noop-only unit coverage — so the live reboot-at-capacity behavior is verified by the weekly Talos×Hetzner E2E, not a unit test.

## Notes

- **Refs #5219, not Fixes** — leaving the issue open for the prod-build verification the maintainer outlined, consistent with #5258.
- Out of scope: a *reboot-class* change is handled in place here; a genuinely *recreate/wipe/image-class* change still recycles and still assumes headroom (an autoscaler-node OS bump at the hard server limit remains a separate edge).

Refs #5219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
