### PR TITLE
docs: Update references to renamed agent-skills repo

### DIFF
--- a/.agents/skills/ways-of-working/SKILL.md
+++ b/.agents/skills/ways-of-working/SKILL.md
@@ -10,7 +10,7 @@ license: Apache-2.0
 metadata:
     github-path: ways-of-working/SKILL.md
     github-ref: refs/tags/v1.0.0
-    github-repo: https://github.com/devantler-tech/skills
+    github-repo: https://github.com/devantler-tech/agent-skills
     github-tree-sha: 9a47a2db8c9bdf70402d1790fd3004af517cafe3
 ---
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -2,7 +2,7 @@
   "version": 1,
   "skills": {
     "ways-of-working": {
-      "source": "devantler-tech/skills",
+      "source": "devantler-tech/agent-skills",
       "sourceType": "github",
       "skillPath": "ways-of-working/SKILL.md",
       "computedHash": "bc7d1c82bb68c3eb40146859c36cd526dd996407ba6a33472aad4f961b5fcb89"


### PR DESCRIPTION
## What

The `devantler-tech/skills` repository was renamed to `devantler-tech/agent-skills` (and `devantler-tech/plugins` → `devantler-tech/agent-plugins`). This PR updates the stale references to the old name within this repo.

## Changes

- **`skills-lock.json`** — updated the `"source"` value for the `ways-of-working` skill: `devantler-tech/skills` → `devantler-tech/agent-skills`.
- **`.agents/skills/ways-of-working/SKILL.md`** — updated the `github-repo:` metadata URL: `https://github.com/devantler-tech/skills` → `https://github.com/devantler-tech/agent-skills`.

## Notes

- No `devantler-tech/plugins` references were found in this repo, so only the skills references needed updating.
- Only the repo-name reference **values** were changed. The `.agents/skills/` directory and the `skills-lock.json` filename are generic gh-skill concept names (not the repo name) and were intentionally left untouched.
- `.agents/skills/ways-of-working/SKILL.md` is synced from the agent-skills repo via template-sync; updating the current stale copy here is correct. The source repo is being fixed separately.
- `skills-lock.json` remains valid JSON. A re-grep confirms no old references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)