### PR TITLE
ci: reclaim runner disk in all disk-heavy jobs to fix transient "no space left on device" failures

### DIFF
--- a/.github/actions/free-disk-space/README.md
+++ b/.github/actions/free-disk-space/README.md
@@ -1,0 +1,57 @@
+# Free Disk Space
+
+A composite action that reclaims disk on `ubuntu-latest` runners before disk-heavy CI jobs run.
+
+## Purpose
+
+Disk-heavy jobs can exhaust the stock runner's root filesystem (`/`). When `/` fills up, the runner
+process itself crashes mid-job with `System.IO.IOException: No space left on device` (while writing
+its own `_diag` logs) — a **transient, non-deterministic** failure that depends on how much free
+space the runner happened to start with. This action removes large pre-installed hosted-tooling
+directories that KSail's CI never uses, reclaiming ~30 GB of headroom up front.
+
+It centralizes the disk-reclamation step that was previously duplicated inline across the `generate`
+and `system-test-docker` jobs, so every disk-heavy job inherits the same fix (and future jobs only
+need to add a single `uses:` line).
+
+## What It Does
+
+1. Records free space on `/`.
+2. `sudo rm -rf` of the largest unused directories (Android SDK, .NET, GHC, Boost, Swift, CodeQL,
+   PyPy, Ruby, Python, Chromium, PowerShell, Julia, AWS CLI, Gradle, Azure CLI, miniconda). Each
+   removal is best-effort — missing paths are not an error.
+3. Optionally runs `docker system prune -af --volumes` (see `docker-prune`).
+4. Logs the before → after free space and the amount gained.
+
+Targeted `rm -rf` is deliberately used instead of the slower `apt-get remove` path (e.g.
+`endersonmenezes/free-disk-space`), which previously consumed 3–9 min per job.
+
+## Inputs
+
+| Name           | Required | Default | Description                                                                                             |
+| -------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `docker-prune` | No       | `false` | Also run `docker system prune -af --volumes`. Set to `true` for jobs that use the Docker daemon. |
+
+## Usage
+
+```yaml
+- name: 📄 Checkout
+  uses: actions/checkout@v6
+  with:
+    persist-credentials: false
+
+# Reclaim disk before the heavy work (build / image mirroring / cluster spin-up).
+- name: 🧹 Free disk space
+  uses: ./.github/actions/free-disk-space
+
+# Docker-based jobs that may have images/volumes to reclaim:
+- name: 🧹 Free disk space
+  uses: ./.github/actions/free-disk-space
+  with:
+    docker-prune: "true"
+```
+
+## Where It Is Used
+
+Disk-heavy jobs in [`ci.yaml`](../../workflows/ci.yaml): `build-artifact`, `generate`,
+`operator-chart-e2e`, `warm-helm-cache`, `warm-mirror-cache`, and `system-test-docker`.

--- a/.github/actions/free-disk-space/README.md
+++ b/.github/actions/free-disk-space/README.md
@@ -28,8 +28,8 @@ Targeted `rm -rf` is deliberately used instead of the slower `apt-get remove` pa
 
 ## Inputs
 
-| Name           | Required | Default | Description                                                                                             |
-| -------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| Name           | Required | Default | Description                                                                                      |
+|----------------|----------|---------|--------------------------------------------------------------------------------------------------|
 | `docker-prune` | No       | `false` | Also run `docker system prune -af --volumes`. Set to `true` for jobs that use the Docker daemon. |
 
 ## Usage

--- a/.github/actions/free-disk-space/action.yaml
+++ b/.github/actions/free-disk-space/action.yaml
@@ -1,0 +1,65 @@
+name: Free Disk Space
+description: |
+  Reclaim disk on `ubuntu-latest` runners by removing large pre-installed
+  hosted-tooling directories that KSail's CI jobs never use (Android SDK, .NET,
+  GHC, Boost, Swift, CodeQL, PyPy, Ruby, Python, Chromium, PowerShell, Julia,
+  AWS CLI, Gradle, Azure CLI, miniconda).
+
+  Disk-heavy jobs — building the embedded-CLI binary (links kubectl, helm, kind,
+  k3d, vcluster, flux, argocd, eksctl, … into one large binary), mirroring all
+  system-test container images to tarballs, and spinning up Kubernetes clusters
+  in Docker — can exhaust the stock runner's root filesystem. When `/` fills up
+  the runner process itself crashes mid-job with
+  `System.IO.IOException: No space left on device` while writing its own
+  `_diag` logs, which is a non-deterministic, transient failure: it depends on
+  how much free space the runner happened to start with. Reclaiming this space
+  up front (~30 GB) gives every disk-heavy job comfortable headroom.
+
+  Targeted `rm -rf` is used instead of the slow `apt-get remove` path (e.g.
+  endersonmenezes/free-disk-space), which previously consumed 3–9 min per job
+  with apt autoremove pulling in update-initramfs / man-db rebuilds. Each
+  removal is best-effort: missing paths are not an error.
+
+inputs:
+  docker-prune:
+    description: |
+      Also run `docker system prune -af --volumes`. Set to 'true' for jobs that
+      use the Docker daemon and may have images/volumes to reclaim.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: 🧹 Free disk space
+      shell: bash
+      env:
+        DOCKER_PRUNE: ${{ inputs.docker-prune }}
+      run: |
+        set -euo pipefail
+        before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        # Largest offenders on ubuntu-latest (sizes from
+        # https://github.com/actions/runner-images). Order by descending size.
+        sudo rm -rf \
+          /usr/local/lib/android \
+          /usr/share/dotnet \
+          /opt/ghc \
+          /usr/local/share/boost \
+          /usr/share/swift \
+          /opt/hostedtoolcache/CodeQL \
+          /opt/hostedtoolcache/PyPy \
+          /opt/hostedtoolcache/Ruby \
+          /opt/hostedtoolcache/Python \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/local/julia* \
+          /usr/local/aws-cli \
+          /usr/local/aws-sam-cli \
+          /usr/share/gradle* \
+          /usr/share/az* \
+          /usr/share/miniconda || true
+        if [ "$DOCKER_PRUNE" = "true" ]; then
+          docker system prune -af --volumes || true
+        fi
+        after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        echo "Free disk space on /: ${before}G -> ${after}G (gained $((after - before))G)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -381,6 +381,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🧹 Free disk space
+        # The KSail binary links the full embedded-CLI import graph into a large
+        # binary; the Go linker can exhaust a stock runner's disk on a cache-miss
+        # build ("no space left on device"). Reclaim space before building.
+        uses: ./.github/actions/free-disk-space
+
       - name: ⚙️ Setup Go
         id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -427,33 +433,8 @@ jobs:
         # `go generate ./docs/...` re-links the full embedded-CLI import graph
         # (kubectl, helm, kind, k3d, vcluster, flux, argocd, eksctl, …) into a
         # large binary; on a stock ubuntu-latest runner the linker can exhaust
-        # disk ("no space left on device"). Reclaim space generation does not
-        # need before Go is set up. Mirrors the system-test job's step (no
-        # `docker system prune` here — this job never touches Docker). Each
-        # removal is best-effort: missing paths are not an error.
-        run: |
-          set -euo pipefail
-          before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
-          sudo rm -rf \
-            /usr/local/lib/android \
-            /usr/share/dotnet \
-            /opt/ghc \
-            /usr/local/share/boost \
-            /usr/share/swift \
-            /opt/hostedtoolcache/CodeQL \
-            /opt/hostedtoolcache/PyPy \
-            /opt/hostedtoolcache/Ruby \
-            /opt/hostedtoolcache/Python \
-            /usr/local/share/chromium \
-            /usr/local/share/powershell \
-            /usr/local/julia* \
-            /usr/local/aws-cli \
-            /usr/local/aws-sam-cli \
-            /usr/share/gradle* \
-            /usr/share/az* \
-            /usr/share/miniconda || true
-          after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
-          echo "Free disk space on /: ${before}G -> ${after}G (gained $((after - before))G)"
+        # disk ("no space left on device"). Reclaim space before Go is set up.
+        uses: ./.github/actions/free-disk-space
 
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -991,6 +972,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🧹 Free disk space
+        # E2E builds the operator image and spins up a Kubernetes cluster in
+        # Docker — reclaim disk first to avoid runner "no space left on device".
+        uses: ./.github/actions/free-disk-space
+        with:
+          docker-prune: "true"
+
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -1022,6 +1010,11 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - name: 🧹 Free disk space
+        # Builds the ksail binary on a cache miss and pulls Helm charts —
+        # reclaim disk first to avoid runner "no space left on device".
+        uses: ./.github/actions/free-disk-space
 
       - name: ⚙️ Setup Go
         id: setup-go
@@ -1064,6 +1057,12 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - name: 🧹 Free disk space
+        # Pulls every system-test image through four mirror registries and tars
+        # the volumes (multi-GB) — the prime "no space left on device" offender
+        # (e.g. run 27774791970). Reclaim disk before warming the cache.
+        uses: ./.github/actions/free-disk-space
 
       - name: ⚙️ Setup Go
         id: setup-go
@@ -1182,37 +1181,11 @@ jobs:
           persist-credentials: false
 
       - name: 🧹 Free disk space
-        # Targeted `rm -rf` of large hosted-tooling directories that the system
-        # tests do not need. Avoids the slow `apt-get remove` path used by
-        # endersonmenezes/free-disk-space, which previously consumed 3–9 min per
-        # job (with apt autoremove pulling in update-initramfs / man-db rebuilds).
-        # Each directory removal is best-effort: missing paths are not an error.
-        run: |
-          set -euo pipefail
-          before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
-          # Largest offenders on ubuntu-latest (sizes from
-          # https://github.com/actions/runner-images). Order by descending size.
-          sudo rm -rf \
-            /usr/local/lib/android \
-            /usr/share/dotnet \
-            /opt/ghc \
-            /usr/local/share/boost \
-            /usr/share/swift \
-            /opt/hostedtoolcache/CodeQL \
-            /opt/hostedtoolcache/PyPy \
-            /opt/hostedtoolcache/Ruby \
-            /opt/hostedtoolcache/Python \
-            /usr/local/share/chromium \
-            /usr/local/share/powershell \
-            /usr/local/julia* \
-            /usr/local/aws-cli \
-            /usr/local/aws-sam-cli \
-            /usr/share/gradle* \
-            /usr/share/az* \
-            /usr/share/miniconda || true
-          docker system prune -af --volumes || true
-          after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
-          echo "Free disk space on /: ${before}G -> ${after}G (gained $((after - before))G)"
+        # Reclaim ~30 GB before pulling system-test images and spinning up
+        # clusters in Docker; docker-prune also clears the Docker daemon.
+        uses: ./.github/actions/free-disk-space
+        with:
+          docker-prune: "true"
 
       - name: 🔐 Login to Docker Hub
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}


### PR DESCRIPTION
## Root cause analysis: transient CI failures

I analysed the last 150 `ci.yaml` runs. Of the **12 that failed**, the breakdown by signature was:

| Signature | Failed runs | Fatal? | Status |
|---|---|---|---|
| `No space left on device` (runner disk exhaustion) | **4** | ✅ fatal | **fixed here** |
| `Cache save failed` | 9 | ⚠️ warning only | non-fatal; mostly downstream of disk pressure |
| Benchmark `Performance alert` (wall-clock noise) | 3 | — | already mitigated (ns/op pinned to `1` in the gate) |
| Registry rate-limit (`toomanyrequests`) | 0 | — | already mitigated (mirror-registry cache) |
| Network blip (DNS/TLS/reset) | 1 | rare | negligible, single occurrence |

The remaining failures were **genuine** code issues (e.g. the `copilot-sdk/go` v1.0.0 breaking-API bump), not transient.

### The one recurring transient failure: runner disk exhaustion

Runs [`27777582482`](https://github.com/devantler-tech/ksail/actions/runs/27777582482), [`27774791970`](https://github.com/devantler-tech/ksail/actions/runs/27774791970), [`27719502050`](https://github.com/devantler-tech/ksail/actions/runs/27719502050) and [`27718039072`](https://github.com/devantler-tech/ksail/actions/runs/27718039072) crashed with:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/.../_diag/Worker_*.log'
```

The runner filled `/` and the **runner process itself** aborted the job mid-run. This is transient and non-deterministic — it depends on how much free space the runner happened to start with — so a PR that changed nothing related still goes red, and the same job passes on re-run.

`generate` and `system-test-docker` already reclaimed ~30 GB via an inline *Free disk space* step. The other disk-heavy jobs did **not**, and those are exactly the ones that crashed:

- **`build-artifact`** — links the full embedded-CLI import graph (kubectl, helm, kind, k3d, vcluster, flux, argocd, eksctl, …) into one large binary
- **`warm-mirror-cache`** — pulls every system-test image through four mirror registries and tars the volumes (multi-GB); the prime offender — run `27774791970` had *only* this job fail, on disk
- **`warm-helm-cache`** — builds the binary on a cache miss + pulls Helm charts
- **`operator-chart-e2e`** — builds the operator image + spins up a Kubernetes cluster in Docker (added as prevention; same disk profile)

## The fix

Extract the proven reclamation step into a reusable **`free-disk-space` composite action** and use it in **all six** disk-heavy jobs, so the behaviour is consistent and any future disk-heavy job inherits it with a single `uses:` line.

- New action: `.github/actions/free-disk-space/` (`action.yaml` + `README.md`), with an optional `docker-prune` input for Docker-using jobs.
- The two existing **inline** copies (`generate`, `system-test-docker`) are replaced by the action — **net −27 lines** in `ci.yaml`. Behaviour is preserved: `system-test-docker` and `operator-chart-e2e` keep `docker system prune` via `docker-prune: "true"`; the others reclaim disk only.

This makes runner disk exhaustion structurally impossible to reintroduce per-job, addressing the goal of new PRs not failing on transient infra.

## Validation

- ✅ `actionlint` clean on the changed workflow (its only finding is a **pre-existing**, unrelated `code-quality` permission-scope note in the untouched `ci-go` job — not in this diff).
- ✅ `shellcheck` clean on the extracted script.
- ✅ YAML valid (`yq`); 6 jobs reference the action; 0 leftover inline reclaim blocks.
- This PR touches `.github/workflows/ci.yaml` and `.github/actions/**`, so its **own CI run exercises the change end-to-end** (build + warm caches + full system-test matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
