### PR TITLE
feat(chat): richer permission prompt details

### DIFF
--- a/pkg/cli/ui/chat/export_test.go
+++ b/pkg/cli/ui/chat/export_test.go
@@ -117,6 +117,9 @@ var ExportSetLastUsageModel = func(m *Model, model string) {
 // ExportExtractPermissionDetails exposes extractPermissionDetails for testing.
 var ExportExtractPermissionDetails = extractPermissionDetails
 
+// ExportPermissionArguments exposes permissionArguments for testing.
+var ExportPermissionArguments = permissionArguments
+
 // ExportFormatPermissionKind exposes formatPermissionKind for testing.
 var ExportFormatPermissionKind = formatPermissionKind
 

--- a/pkg/cli/ui/chat/permission.go
+++ b/pkg/cli/ui/chat/permission.go
@@ -211,7 +211,7 @@ func CreateTUIPermissionHandler(
 			toolCallID: toolCallID,
 			toolName:   toolName,
 			command:    command,
-			arguments:  "",
+			arguments:  permissionArguments(request),
 			response:   responseChan,
 		}
 
@@ -260,6 +260,35 @@ func permissionDetail(request copilot.PermissionRequest) string {
 		return req.ToolName
 	case *copilot.PermissionRequestMCP:
 		return req.ToolName
+	}
+
+	return ""
+}
+
+// permissionArguments returns a short, kind-specific line of extra context for a
+// permission request, shown to the user under the "Arguments:" label in the modal.
+// It returns "" when there's nothing useful to add for the request's kind.
+func permissionArguments(request copilot.PermissionRequest) string {
+	switch req := request.(type) {
+	case *copilot.PermissionRequestShell:
+		if warning := derefString(req.Warning); warning != "" {
+			return "⚠ " + warning
+		}
+	case *copilot.PermissionRequestMCP:
+		if req.ServerName == "" {
+			return ""
+		}
+
+		detail := "Server: " + req.ServerName
+		if req.ReadOnly {
+			detail += " (read-only)"
+		}
+
+		return detail
+	case *copilot.PermissionRequestWrite:
+		if req.NewFileContents != nil {
+			return "New file"
+		}
 	}
 
 	return ""

--- a/pkg/cli/ui/chat/permission_test.go
+++ b/pkg/cli/ui/chat/permission_test.go
@@ -346,6 +346,103 @@ func TestPermissionModal_AllowThisOperation(t *testing.T) {
 	}
 }
 
+// assertPermissionArguments runs a table of permissionArguments cases.
+func assertPermissionArguments(t *testing.T, tests []struct {
+	name    string
+	request copilot.PermissionRequest
+	want    string
+},
+) {
+	t.Helper()
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := chat.ExportPermissionArguments(testCase.request)
+			if got != testCase.want {
+				t.Errorf("permissionArguments() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestPermissionArguments_Shell tests shell-warning extraction for permission requests.
+func TestPermissionArguments_Shell(t *testing.T) {
+	t.Parallel()
+
+	assertPermissionArguments(t, []struct {
+		name    string
+		request copilot.PermissionRequest
+		want    string
+	}{
+		{
+			name: "shell with warning",
+			request: &copilot.PermissionRequestShell{
+				FullCommandText: "rm -rf /",
+				Warning:         new("dangerous"),
+			},
+			want: "⚠ dangerous",
+		},
+		{
+			name: "shell without warning",
+			request: &copilot.PermissionRequestShell{
+				FullCommandText: "ls",
+			},
+			want: "",
+		},
+		{
+			name:    "read has no extra context",
+			request: &copilot.PermissionRequestRead{Path: "/etc/config.yaml"},
+			want:    "",
+		},
+	})
+}
+
+// TestPermissionArguments_MCPAndWrite tests MCP server and write new-file extraction.
+func TestPermissionArguments_MCPAndWrite(t *testing.T) {
+	t.Parallel()
+
+	assertPermissionArguments(t, []struct {
+		name    string
+		request copilot.PermissionRequest
+		want    string
+	}{
+		{
+			name: "mcp with server name",
+			request: &copilot.PermissionRequestMCP{
+				ServerName: "ksail",
+				ToolName:   "cluster_create",
+			},
+			want: "Server: ksail",
+		},
+		{
+			name: "mcp read-only",
+			request: &copilot.PermissionRequestMCP{
+				ServerName: "ksail",
+				ToolName:   "cluster_list",
+				ReadOnly:   true,
+			},
+			want: "Server: ksail (read-only)",
+		},
+		{
+			name: "write new file",
+			request: &copilot.PermissionRequestWrite{
+				FileName:        "/tmp/output.txt",
+				NewFileContents: new("hello"),
+			},
+			want: "New file",
+		},
+		{
+			name: "write existing file",
+			request: &copilot.PermissionRequestWrite{
+				FileName: "/tmp/output.txt",
+			},
+			want: "",
+		},
+	})
+}
+
 // TestPermissionModal_AllowAlwaysSwitchesToAutopilot tests that pressing 'a' on the
 // permission prompt switches to Autopilot mode and approves the request.
 func TestPermissionModal_AllowAlwaysSwitchesToAutopilot(t *testing.T) {


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

The TUI AI-chat permission modal (`pkg/cli/ui/chat/permission.go`) already renders an `Arguments:` line when one is present, but `CreateTUIPermissionHandler` hardcoded `arguments: ""`, so the line was always empty. This populates it with concise, kind-specific context so the user sees more when approving an operation:

- **Shell** — the command warning, when present (`⚠ <warning>`).
- **MCP** — the server name (`Server: <ServerName>`), plus `(read-only)` when the tool is read-only.
- **Write** — `New file` when creating a new file (`NewFileContents != nil`).

A new `permissionArguments` helper type-switches over the copilot-sdk v1.0.0 concrete pointer request types (`*copilot.PermissionRequestShell`, `*copilot.PermissionRequestMCP`, `*copilot.PermissionRequestWrite`), reusing the existing `derefString` helper for `*string` fields, and returns `""` when there's nothing useful to add. It is wired into `CreateTUIPermissionHandler` in place of the empty string. The existing `renderPermissionModal` "Arguments: " label is unchanged.

## Changes

- `pkg/cli/ui/chat/permission.go` — add `permissionArguments`; use it in `CreateTUIPermissionHandler`.
- `pkg/cli/ui/chat/export_test.go` — add `ExportPermissionArguments` test hook.
- `pkg/cli/ui/chat/permission_test.go` — table-driven tests covering shell warning, MCP server name (+read-only), write new-file, and empty-result cases.

## Validation

- `go build ./...` — success
- `go test ./pkg/cli/ui/chat/... ./pkg/cli/cmd/chat/... ./pkg/svc/chat/... -count=1` — all pass (922 tests)
- `golangci-lint run ./pkg/cli/ui/chat/...` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)