### PR TITLE
feat(chat): first-class extension permission kinds

### DIFF
--- a/pkg/cli/ui/chat/helpers_test.go
+++ b/pkg/cli/ui/chat/helpers_test.go
@@ -28,6 +28,16 @@ func TestFormatPermissionKind_AllKinds(t *testing.T) {
 		},
 		{name: "memory", kind: copilot.PermissionRequestKindMemory, expected: "Memory"},
 		{name: "hook", kind: copilot.PermissionRequestKindHook, expected: "Hook"},
+		{
+			name:     "extension-management",
+			kind:     copilot.PermissionRequestKindExtensionManagement,
+			expected: "Extension Management",
+		},
+		{
+			name:     "extension-permission-access",
+			kind:     copilot.PermissionRequestKindExtensionPermissionAccess,
+			expected: "Extension Access",
+		},
 		{name: "empty kind", kind: "", expected: "Unknown Operation"},
 		{name: "custom kind", kind: "custom_action", expected: "Custom Action"},
 	}
@@ -132,6 +142,60 @@ func TestExtractPermissionDetails_PathAndFallback(t *testing.T) {
 			request:     &copilot.PermissionRequestMemory{},
 			wantTool:    "Memory",
 			wantCommand: "memory",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			toolName, command := chat.ExportExtractPermissionDetails(testCase.request)
+			if toolName != testCase.wantTool {
+				t.Errorf("toolName = %q, want %q", toolName, testCase.wantTool)
+			}
+
+			if command != testCase.wantCommand {
+				t.Errorf("command = %q, want %q", command, testCase.wantCommand)
+			}
+		})
+	}
+}
+
+// TestExtractPermissionDetails_Extension tests permission detail extraction for extension kinds.
+func TestExtractPermissionDetails_Extension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		request     copilot.PermissionRequest
+		wantTool    string
+		wantCommand string
+	}{
+		{
+			name: "extension management with name",
+			request: &copilot.PermissionRequestExtensionManagement{
+				ExtensionName: new("my-extension"),
+				Operation:     "scaffold",
+			},
+			wantTool:    "Extension Management",
+			wantCommand: "scaffold my-extension",
+		},
+		{
+			name: "extension management without name falls back to operation",
+			request: &copilot.PermissionRequestExtensionManagement{
+				Operation: "reload",
+			},
+			wantTool:    "Extension Management",
+			wantCommand: "reload",
+		},
+		{
+			name: "extension permission access",
+			request: &copilot.PermissionRequestExtensionPermissionAccess{
+				ExtensionName: "my-extension",
+				Capabilities:  []string{"read"},
+			},
+			wantTool:    "Extension Access",
+			wantCommand: "my-extension",
 		},
 	}
 

--- a/pkg/cli/ui/chat/permission.go
+++ b/pkg/cli/ui/chat/permission.go
@@ -262,6 +262,23 @@ func permissionDetail(request copilot.PermissionRequest) string {
 		return req.ToolName
 	}
 
+	return extensionPermissionDetail(request)
+}
+
+// extensionPermissionDetail returns the human-readable detail for the
+// extension-related permission request variants, or "" for any other type.
+func extensionPermissionDetail(request copilot.PermissionRequest) string {
+	switch req := request.(type) {
+	case *copilot.PermissionRequestExtensionManagement:
+		if name := derefString(req.ExtensionName); name != "" {
+			return req.Operation + " " + name
+		}
+
+		return req.Operation
+	case *copilot.PermissionRequestExtensionPermissionAccess:
+		return req.ExtensionName
+	}
+
 	return ""
 }
 
@@ -287,6 +304,19 @@ func permissionToolCallID(request copilot.PermissionRequest) string {
 		return derefString(req.ToolCallID)
 	}
 
+	return extensionPermissionToolCallID(request)
+}
+
+// extensionPermissionToolCallID extracts the tool-call ID from the
+// extension-related permission request variants, or "" for any other type.
+func extensionPermissionToolCallID(request copilot.PermissionRequest) string {
+	switch req := request.(type) {
+	case *copilot.PermissionRequestExtensionManagement:
+		return derefString(req.ToolCallID)
+	case *copilot.PermissionRequestExtensionPermissionAccess:
+		return derefString(req.ToolCallID)
+	}
+
 	return ""
 }
 
@@ -301,14 +331,16 @@ func derefString(s *string) string {
 
 // permissionKindLabels maps known permission kinds to human-readable tool names.
 var permissionKindLabels = map[copilot.PermissionRequestKind]string{
-	copilot.PermissionRequestKindShell:      "Shell Command",
-	copilot.PermissionRequestKindWrite:      "File Write",
-	copilot.PermissionRequestKindRead:       "File Read",
-	copilot.PermissionRequestKindURL:        "URL",
-	copilot.PermissionRequestKindMCP:        "MCP Tool",
-	copilot.PermissionRequestKindCustomTool: "Custom Tool",
-	copilot.PermissionRequestKindMemory:     "Memory",
-	copilot.PermissionRequestKindHook:       "Hook",
+	copilot.PermissionRequestKindShell:                     "Shell Command",
+	copilot.PermissionRequestKindWrite:                     "File Write",
+	copilot.PermissionRequestKindRead:                      "File Read",
+	copilot.PermissionRequestKindURL:                       "URL",
+	copilot.PermissionRequestKindMCP:                       "MCP Tool",
+	copilot.PermissionRequestKindCustomTool:                "Custom Tool",
+	copilot.PermissionRequestKindMemory:                    "Memory",
+	copilot.PermissionRequestKindHook:                      "Hook",
+	copilot.PermissionRequestKindExtensionManagement:       "Extension Management",
+	copilot.PermissionRequestKindExtensionPermissionAccess: "Extension Access",
 }
 
 // formatPermissionKind converts a permission kind to a human-readable tool name.

--- a/pkg/svc/chat/permissions.go
+++ b/pkg/svc/chat/permissions.go
@@ -126,9 +126,31 @@ func getPermissionDescription(request copilot.PermissionRequest) string {
 		return labeled("URL: ", req.URL)
 	case *copilot.PermissionRequestWrite:
 		return writePermissionDescription(req)
+	case *copilot.PermissionRequestExtensionManagement:
+		return extensionManagementDescription(req)
+	case *copilot.PermissionRequestExtensionPermissionAccess:
+		return labeled("Extension: ", req.ExtensionName)
 	default:
 		return ""
 	}
+}
+
+// extensionManagementDescription renders the operation and (when present) the
+// extension name for an extension-management permission request.
+func extensionManagementDescription(req *copilot.PermissionRequestExtensionManagement) string {
+	var parts []string
+
+	if op := labeled("Operation: ", req.Operation); op != "" {
+		parts = append(parts, op)
+	}
+
+	if req.ExtensionName != nil {
+		if name := labeled("Extension: ", *req.ExtensionName); name != "" {
+			parts = append(parts, name)
+		}
+	}
+
+	return strings.Join(parts, "\n")
 }
 
 // labeled returns "label+value" when value is non-empty, otherwise an empty string.

--- a/pkg/svc/chat/permissions_test.go
+++ b/pkg/svc/chat/permissions_test.go
@@ -23,6 +23,12 @@ func TestIsReadOperation(t *testing.T) {
 		{"url kind", copilot.PermissionRequestKindURL, true},
 		{"write kind", copilot.PermissionRequestKindWrite, false},
 		{"shell kind", copilot.PermissionRequestKindShell, false},
+		{"extension management kind", copilot.PermissionRequestKindExtensionManagement, false},
+		{
+			"extension permission access kind",
+			copilot.PermissionRequestKindExtensionPermissionAccess,
+			false,
+		},
 		{"empty kind", "", false},
 		{"unknown kind", "unknown", false},
 	}
@@ -82,6 +88,49 @@ func TestGetPermissionDescription_BasicFields(t *testing.T) {
 			} else {
 				assert.Contains(t, result, testCase.expected)
 			}
+		})
+	}
+}
+
+func TestGetPermissionDescription_Extension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		request  copilot.PermissionRequest
+		expected string
+	}{
+		{
+			name: "extension management with name",
+			request: &copilot.PermissionRequestExtensionManagement{
+				ExtensionName: new("my-extension"),
+				Operation:     "scaffold",
+			},
+			expected: "Operation: scaffold\nExtension: my-extension",
+		},
+		{
+			name: "extension management without name",
+			request: &copilot.PermissionRequestExtensionManagement{
+				Operation: "reload",
+			},
+			expected: "Operation: reload",
+		},
+		{
+			name: "extension permission access",
+			request: &copilot.PermissionRequestExtensionPermissionAccess{
+				ExtensionName: "my-extension",
+				Capabilities:  []string{"read"},
+			},
+			expected: "Extension: my-extension",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := getPermissionDescription(testCase.request)
+			assert.Equal(t, testCase.expected, result)
 		})
 	}
 }

--- a/pkg/svc/chat/systemcontext.go
+++ b/pkg/svc/chat/systemcontext.go
@@ -161,7 +161,9 @@ func IsReadOperation(kind copilot.PermissionRequestKind) bool {
 		copilot.PermissionRequestKindMCP,
 		copilot.PermissionRequestKindMemory,
 		copilot.PermissionRequestKindWrite,
-		copilot.PermissionRequestKindHook:
+		copilot.PermissionRequestKindHook,
+		copilot.PermissionRequestKindExtensionManagement,
+		copilot.PermissionRequestKindExtensionPermissionAccess:
 		return false
 	default:
 		return false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Copilot SDK v1.0.0 introduced two permission kinds that KSail's AI chat handled only via default fallthrough (require-confirmation, title-cased label). This makes them first-class:

- **`PermissionRequestKindExtensionManagement`** (`PermissionRequestExtensionManagement{ ExtensionName *string, Operation string, ToolCallID *string }`)
- **`PermissionRequestKindExtensionPermissionAccess`** (`PermissionRequestExtensionPermissionAccess{ Capabilities []string, ExtensionName string, ToolCallID *string }`)

### Changes

- `pkg/svc/chat/systemcontext.go` — `IsReadOperation` now explicitly classifies both kinds as **non-read** (they require user confirmation).
- `pkg/cli/ui/chat/permission.go` (TUI):
  - `permissionKindLabels` gains `"Extension Management"` and `"Extension Access"`.
  - `permissionDetail` surfaces the operation (with extension name when present) for management requests, and the extension name for permission-access requests.
  - `permissionToolCallID` resolves the `ToolCallID` for both kinds so deduplication works.
- `pkg/svc/chat/permissions.go` (non-TUI) — `getPermissionDescription` renders a labeled description (operation + extension name) for both kinds, reusing the existing `labeled` helper.

The two new extension cases are factored into small helper functions so the existing type-switch functions stay within the cyclomatic-complexity limit.

### Tests

- `pkg/svc/chat/permissions_test.go` — extended `TestIsReadOperation` (both kinds → false) and added `TestGetPermissionDescription_Extension`.
- `pkg/cli/ui/chat/helpers_test.go` — extended `TestFormatPermissionKind_AllKinds` and added `TestExtractPermissionDetails_Extension`.

## Validation

- `go build ./...` — clean
- `go test ./pkg/svc/chat/... ./pkg/cli/ui/chat/... ./pkg/cli/cmd/chat/... -count=1` — 925 passed
- `golangci-lint run ./pkg/svc/chat/... ./pkg/cli/ui/chat/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)