### PR TITLE
feat(chat): capture optional feedback on permission denial

### DIFF
--- a/pkg/cli/ui/chat/chatkey_test.go
+++ b/pkg/cli/ui/chat/chatkey_test.go
@@ -545,7 +545,7 @@ func TestHandlePermissionKey_YApproves(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	resp := make(chan bool, 1)
+	resp := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "bash", "ls", "", resp)
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
@@ -556,31 +556,43 @@ func TestHandlePermissionKey_YApproves(t *testing.T) {
 
 	// Check the channel response
 	require.Len(t, resp, 1)
-	assert.True(t, <-resp)
+	assert.True(t, chat.ExportPermissionResponseApproved(<-resp))
 }
 
-func TestHandlePermissionKey_NDenies(t *testing.T) {
+func TestHandlePermissionKey_NOpensDenyInput(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	resp := make(chan bool, 1)
+	resp := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "bash", "rm /", "", resp)
 
+	// Pressing 'n' opens the optional-reason input rather than denying immediately.
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	m, ok := updated.(*chat.Model)
 	require.True(t, ok)
 
-	assert.False(t, chat.ExportHasPendingPermission(m))
+	assert.True(t, chat.ExportHasPendingPermission(m))
+	assert.True(t, chat.ExportIsPermissionDenyInput(m))
+	assert.Empty(t, resp, "no response should be sent until the reason is confirmed")
 
+	// Pressing Enter (with no reason) confirms the denial without feedback.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m, ok = updated.(*chat.Model)
+	require.True(t, ok)
+
+	assert.False(t, chat.ExportHasPendingPermission(m))
 	require.Len(t, resp, 1)
-	assert.False(t, <-resp)
+
+	decision := <-resp
+	assert.False(t, chat.ExportPermissionResponseApproved(decision))
+	assert.Empty(t, chat.ExportPermissionResponseFeedback(decision))
 }
 
 func TestHandlePermissionKey_CtrlC_DeniesAndQuits(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	resp := make(chan bool, 1)
+	resp := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "bash", "cmd", "", resp)
 
 	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
@@ -591,7 +603,7 @@ func TestHandlePermissionKey_CtrlC_DeniesAndQuits(t *testing.T) {
 	assert.NotNil(t, cmd)
 
 	require.Len(t, resp, 1)
-	assert.False(t, <-resp)
+	assert.False(t, chat.ExportPermissionResponseApproved(<-resp))
 }
 
 // --- handleViewportAndTextareaKey tests ---

--- a/pkg/cli/ui/chat/ctrlcquit_test.go
+++ b/pkg/cli/ui/chat/ctrlcquit_test.go
@@ -70,8 +70,8 @@ func ctrlCQuitCases() []ctrlCQuitCase {
 			chat.ExportSetShowReasoningPicker(m, true)
 		}},
 		{name: "permission prompt", setup: func(m *chat.Model) {
-			// Buffered so the handler's `response <- false` never blocks.
-			resp := make(chan bool, 1)
+			// Buffered so the handler's response send never blocks.
+			resp := make(chan chat.PermissionResponseForTest, 1)
 			chat.ExportSetPendingPermission(m, "tool", "cmd", "args", resp)
 		}},
 		{name: "elicitation prompt", setup: func(m *chat.Model) {

--- a/pkg/cli/ui/chat/eventhandlers_test.go
+++ b/pkg/cli/ui/chat/eventhandlers_test.go
@@ -116,7 +116,7 @@ func TestHandleStreamEvent_PermissionRequestMsg(t *testing.T) {
 	model := chat.NewModel(newTestParams())
 	chat.ExportSetStreaming(model, true)
 
-	resp := make(chan bool, 1)
+	resp := make(chan chat.PermissionResponseForTest, 1)
 	updated, _ := model.Update(chat.ExportNewPermissionRequestMsg(
 		"call-1",
 		"bash",

--- a/pkg/cli/ui/chat/export_test.go
+++ b/pkg/cli/ui/chat/export_test.go
@@ -44,8 +44,28 @@ var ExportSetReasoningPickerIndex = func(m *Model, index int) {
 	m.reasoningPickerIndex = index
 }
 
+// PermissionResponseForTest is an exported alias for permissionResponse.
+type PermissionResponseForTest = permissionResponse
+
+// ExportNewPermissionResponse creates a permissionResponse for testing.
+var ExportNewPermissionResponse = func(approved bool, feedback string) PermissionResponseForTest {
+	return permissionResponse{approved: approved, feedback: feedback}
+}
+
+// ExportPermissionResponseApproved returns the approved field of a permissionResponse.
+var ExportPermissionResponseApproved = func(r PermissionResponseForTest) bool {
+	return r.approved
+}
+
+// ExportPermissionResponseFeedback returns the feedback field of a permissionResponse.
+var ExportPermissionResponseFeedback = func(r PermissionResponseForTest) string {
+	return r.feedback
+}
+
 // ExportSetPendingPermission sets Model.pendingPermission for testing.
-var ExportSetPendingPermission = func(m *Model, toolName, command, arguments string, response chan<- bool) {
+var ExportSetPendingPermission = func(
+	m *Model, toolName, command, arguments string, response chan<- permissionResponse,
+) {
 	m.pendingPermission = &permissionRequestMsg{
 		toolName:  toolName,
 		command:   command,
@@ -57,6 +77,16 @@ var ExportSetPendingPermission = func(m *Model, toolName, command, arguments str
 // ExportHasPendingPermission returns whether Model.pendingPermission is set.
 var ExportHasPendingPermission = func(m *Model) bool {
 	return m.pendingPermission != nil
+}
+
+// ExportIsPermissionDenyInput returns whether the deny-reason input is active.
+var ExportIsPermissionDenyInput = func(m *Model) bool {
+	return m.permissionDenyInput
+}
+
+// ExportPermissionDenyValue returns the current deny-reason input value.
+var ExportPermissionDenyValue = func(m *Model) string {
+	return m.permissionDenyValue
 }
 
 // ExportSetLastQuotaSnapshots sets Model.lastQuotaSnapshots for testing.
@@ -597,7 +627,7 @@ type PermissionRequestMsgForTest = permissionRequestMsg
 
 var ExportNewPermissionRequestMsg = func(
 	toolCallID, toolName, command, arguments string,
-	response chan<- bool,
+	response chan<- permissionResponse,
 ) PermissionRequestMsgForTest {
 	return permissionRequestMsg{
 		toolCallID: toolCallID,

--- a/pkg/cli/ui/chat/help.go
+++ b/pkg/cli/ui/chat/help.go
@@ -217,7 +217,7 @@ func (m *Model) getContextHelpParts() []string {
 		return []string{m.styles.helpKey.Render(keyEscape) + " close"}
 
 	case m.pendingPermission != nil:
-		return getPermissionHelpParts(m.styles.helpKey)
+		return m.getPermissionHelpParts()
 
 	case m.showModelPicker:
 		return m.getModelPickerHelpParts()
@@ -233,8 +233,18 @@ func (m *Model) getContextHelpParts() []string {
 	}
 }
 
-// getPermissionHelpParts returns help for permission prompts.
-func getPermissionHelpParts(helpKeyStyle lipgloss.Style) []string {
+// getPermissionHelpParts returns help for permission prompts, adapting to whether the user is
+// entering an optional denial reason.
+func (m *Model) getPermissionHelpParts() []string {
+	helpKeyStyle := m.styles.helpKey
+
+	if m.permissionDenyInput {
+		return []string{
+			helpKeyStyle.Render(keyEnter) + " confirm deny",
+			helpKeyStyle.Render(keyEscape) + " back",
+		}
+	}
+
 	return []string{
 		helpKeyStyle.Render("y") + " allow",
 		helpKeyStyle.Render("n") + " deny",

--- a/pkg/cli/ui/chat/messages.go
+++ b/pkg/cli/ui/chat/messages.go
@@ -67,14 +67,22 @@ type ToolOutputChunkMsg struct {
 	Chunk  string
 }
 
+// permissionResponse carries the outcome of a TUI permission prompt back to the
+// SDK handler. When approved is false, feedback may hold an optional free-text reason
+// the user typed, which is forwarded to the agent via rpc.PermissionDecisionReject.Feedback.
+type permissionResponse struct {
+	approved bool   // true=allow, false=deny
+	feedback string // optional denial reason (only meaningful when approved is false)
+}
+
 // permissionRequestMsg carries a permission request from a tool execution.
 // The TUI will display this to the user for approval/denial.
 type permissionRequestMsg struct {
-	toolCallID string      // unique identifier for this tool call
-	toolName   string      // name of the tool requesting permission
-	command    string      // the actual command or action being requested
-	arguments  string      // formatted arguments for display
-	response   chan<- bool // channel to send user response (true=allow, false=deny)
+	toolCallID string                    // unique identifier for this tool call
+	toolName   string                    // name of the tool requesting permission
+	command    string                    // the actual command or action being requested
+	arguments  string                    // formatted arguments for display
+	response   chan<- permissionResponse // channel to send the user's decision
 }
 
 // copyFeedbackClearMsg signals that the copy feedback should be hidden.

--- a/pkg/cli/ui/chat/model.go
+++ b/pkg/cli/ui/chat/model.go
@@ -284,7 +284,9 @@ type Model struct {
 	reasoningPickerIndex int  // currently highlighted effort level in picker
 
 	// Permission request handling
-	pendingPermission *permissionRequestMsg // current permission request awaiting user response
+	pendingPermission   *permissionRequestMsg // current permission request awaiting user response
+	permissionDenyInput bool                  // true while collecting an optional denial reason
+	permissionDenyValue string                // current text of the optional denial reason
 
 	// Elicitation request handling
 	pendingElicitation *pendingElicitation // current elicitation request awaiting user response

--- a/pkg/cli/ui/chat/permission.go
+++ b/pkg/cli/ui/chat/permission.go
@@ -28,15 +28,20 @@ func (m *Model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// While collecting an optional denial reason, route keys to the deny-input handler.
+	if m.permissionDenyInput {
+		return m.handlePermissionDenyKey(msg)
+	}
+
 	switch msg.String() {
 	case "y", "Y":
 		return m.allowPermission()
 	case "a", "A":
 		return m.allowAlwaysPermission()
-	case "n", "N", "esc":
-		return m.denyPermission()
-	case "ctrl+c":
-		m.pendingPermission.response <- false
+	case "n", "N", keyEscape:
+		return m.beginDenyPermission()
+	case keyCtrlC:
+		m.sendPermissionResponse(permissionResponse{approved: false})
 
 		m.pendingPermission = nil
 
@@ -46,13 +51,67 @@ func (m *Model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// allowPermission approves the pending permission request.
-func (m *Model) allowPermission() (tea.Model, tea.Cmd) {
-	m.pendingPermission.response <- true
+// handlePermissionDenyKey handles keyboard input while collecting an optional denial reason.
+// Enter submits the reason (empty allowed), Esc cancels back to the allow/deny prompt, and
+// Ctrl+C aborts the session.
+func (m *Model) handlePermissionDenyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyEnter:
+		return m.submitDenyPermission()
+	case keyEscape:
+		// Cancel reason entry and return to the allow/deny prompt.
+		m.permissionDenyInput = false
+		m.permissionDenyValue = ""
+		m.updateDimensions()
+		m.updateViewportContent()
 
+		return m, nil
+	case keyCtrlC:
+		m.sendPermissionResponse(permissionResponse{approved: false})
+		m.resetPermissionState()
+
+		return m.handleQuit()
+	case keyBackspace:
+		if m.permissionDenyValue != "" {
+			m.permissionDenyValue = m.permissionDenyValue[:len(m.permissionDenyValue)-1]
+		}
+
+		return m, nil
+	default:
+		if len(msg.Runes) > 0 {
+			m.permissionDenyValue += string(msg.Runes)
+		}
+
+		return m, nil
+	}
+}
+
+// sendPermissionResponse forwards the decision to the waiting SDK handler, if any.
+func (m *Model) sendPermissionResponse(resp permissionResponse) {
+	if m.pendingPermission != nil {
+		m.pendingPermission.response <- resp
+	}
+}
+
+// resetPermissionState clears all permission-prompt state without recomputing layout.
+func (m *Model) resetPermissionState() {
 	m.pendingPermission = nil
+	m.permissionDenyInput = false
+	m.permissionDenyValue = ""
+}
+
+// clearPendingPermission resets all permission-prompt state and recomputes layout.
+func (m *Model) clearPendingPermission() {
+	m.resetPermissionState()
 	m.updateDimensions()
 	m.updateViewportContent()
+}
+
+// allowPermission approves the pending permission request.
+func (m *Model) allowPermission() (tea.Model, tea.Cmd) {
+	m.sendPermissionResponse(permissionResponse{approved: true})
+
+	m.clearPendingPermission()
 
 	return m, m.waitForEvent()
 }
@@ -70,13 +129,25 @@ func (m *Model) allowAlwaysPermission() (tea.Model, tea.Cmd) {
 	return m.allowPermission()
 }
 
-// denyPermission denies the pending permission request.
-func (m *Model) denyPermission() (tea.Model, tea.Cmd) {
-	m.pendingPermission.response <- false
-
-	m.pendingPermission = nil
+// beginDenyPermission switches the prompt into reason-entry mode, where the user can type an
+// optional free-text denial reason before confirming with Enter.
+func (m *Model) beginDenyPermission() (tea.Model, tea.Cmd) {
+	m.permissionDenyInput = true
+	m.permissionDenyValue = ""
 	m.updateDimensions()
 	m.updateViewportContent()
+
+	return m, nil
+}
+
+// submitDenyPermission denies the pending permission request, forwarding any typed reason as
+// feedback. An empty reason denies without feedback.
+func (m *Model) submitDenyPermission() (tea.Model, tea.Cmd) {
+	feedback := strings.TrimSpace(m.permissionDenyValue)
+
+	m.sendPermissionResponse(permissionResponse{approved: false, feedback: feedback})
+
+	m.clearPendingPermission()
 
 	return m, m.waitForEvent()
 }
@@ -121,9 +192,16 @@ func (m *Model) renderPermissionModal() string {
 		contentLines++
 	}
 
-	content.WriteString("\n" + mStyles.clipStyle.Render("Allow this operation?") + "\n")
+	if m.permissionDenyInput {
+		reasonLine := "Reason for denial (optional): " + m.permissionDenyValue
+		content.WriteString("\n" + mStyles.clipStyle.Render(reasonLine) + "\n")
 
-	contentLines += 3
+		contentLines += 3
+	} else {
+		content.WriteString("\n" + mStyles.clipStyle.Render("Allow this operation?") + "\n")
+
+		contentLines += 3
+	}
 
 	modalStyle := lipgloss.NewStyle().
 		BorderStyle(lipgloss.RoundedBorder()).
@@ -205,7 +283,7 @@ func CreateTUIPermissionHandler(
 		}
 
 		toolName, command := extractPermissionDetails(request)
-		responseChan := make(chan bool, 1)
+		responseChan := make(chan permissionResponse, 1)
 
 		eventChan <- permissionRequestMsg{
 			toolCallID: toolCallID,
@@ -215,15 +293,25 @@ func CreateTUIPermissionHandler(
 			response:   responseChan,
 		}
 
-		approved := <-responseChan
-		if approved {
+		resp := <-responseChan
+		if resp.approved {
 			dedup.markApproved(toolCallID)
 
 			return &rpc.PermissionDecisionApproveOnce{}, nil
 		}
 
-		return &rpc.PermissionDecisionReject{}, nil
+		return rejectDecision(resp.feedback), nil
 	}
+}
+
+// rejectDecision builds a rejection decision, attaching the optional feedback reason when
+// non-empty (nil otherwise).
+func rejectDecision(feedback string) rpc.PermissionDecision {
+	if feedback == "" {
+		return &rpc.PermissionDecisionReject{}
+	}
+
+	return &rpc.PermissionDecisionReject{Feedback: &feedback}
 }
 
 // extractPermissionDetails extracts human-readable tool name and command

--- a/pkg/cli/ui/chat/permission_test.go
+++ b/pkg/cli/ui/chat/permission_test.go
@@ -16,7 +16,7 @@ func TestPermissionModal_VisibleInView(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "Shell Command", "rm -rf /tmp/test", "", responseChan)
 
 	output := model.View()
@@ -39,7 +39,7 @@ func TestPermissionModal_WithArguments(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "File Edit", "/etc/config", "--force", responseChan)
 
 	output := model.View()
@@ -54,7 +54,7 @@ func TestPermissionKey_AllowWithY(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "Shell Command", "ls", "", responseChan)
 
 	var updatedModel tea.Model = model
@@ -63,8 +63,8 @@ func TestPermissionKey_AllowWithY(t *testing.T) {
 
 	// Read the response with timeout to avoid hanging on regression
 	select {
-	case approved := <-responseChan:
-		if !approved {
+	case resp := <-responseChan:
+		if !chat.ExportPermissionResponseApproved(resp) {
 			t.Error("expected permission to be approved after pressing 'y'")
 		}
 	case <-time.After(1 * time.Second):
@@ -87,7 +87,7 @@ func TestPermissionKey_AllowWithUpperY(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "Shell Command", "ls", "", responseChan)
 
 	var updatedModel tea.Model = model
@@ -95,8 +95,8 @@ func TestPermissionKey_AllowWithUpperY(t *testing.T) {
 	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
 
 	select {
-	case approved := <-responseChan:
-		if !approved {
+	case resp := <-responseChan:
+		if !chat.ExportPermissionResponseApproved(resp) {
 			t.Error("expected permission to be approved after pressing 'Y'")
 		}
 	case <-time.After(1 * time.Second):
@@ -110,53 +110,154 @@ func TestPermissionKey_AllowWithUpperY(t *testing.T) {
 	}
 }
 
-// TestPermissionKey_DenyWithN tests that pressing 'n' denies a permission request.
+// TestPermissionKey_DenyWithN tests that pressing 'n' opens the optional-reason input and that
+// confirming with Enter (no reason) denies without feedback.
 func TestPermissionKey_DenyWithN(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
+	chat.ExportSetPendingPermission(model, "Shell Command", "rm -rf /", "", responseChan)
+
+	var updatedModel tea.Model = model
+
+	// 'n' opens the reason input; nothing is sent yet.
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+
+	chatModel := requireModel(t, updatedModel)
+
+	if !chat.ExportIsPermissionDenyInput(chatModel) {
+		t.Error("expected deny-reason input to be active after pressing 'n'")
+	}
+
+	if len(responseChan) != 0 {
+		t.Error("expected no response to be sent before confirming the denial")
+	}
+
+	// Enter confirms the denial without a reason.
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	select {
+	case resp := <-responseChan:
+		if chat.ExportPermissionResponseApproved(resp) {
+			t.Error("expected permission to be denied")
+		}
+
+		if fb := chat.ExportPermissionResponseFeedback(resp); fb != "" {
+			t.Errorf("expected no feedback, got %q", fb)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for permission response after confirming denial")
+	}
+
+	if chat.ExportHasPendingPermission(requireModel(t, updatedModel)) {
+		t.Error("expected pending permission to be cleared after denial")
+	}
+}
+
+// TestPermissionKey_DenyWithReason tests that a typed reason is forwarded as denial feedback.
+func TestPermissionKey_DenyWithReason(t *testing.T) {
+	t.Parallel()
+
+	model := chat.NewModel(newTestParams())
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
+	chat.ExportSetPendingPermission(model, "Shell Command", "rm -rf /", "", responseChan)
+
+	var updatedModel tea.Model = model
+
+	// Open the reason input, type a reason, then confirm.
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	updatedModel, _ = updatedModel.Update(
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("too risky")},
+	)
+
+	if got := chat.ExportPermissionDenyValue(requireModel(t, updatedModel)); got != "too risky" {
+		t.Errorf("expected deny input value %q, got %q", "too risky", got)
+	}
+
+	_, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	select {
+	case resp := <-responseChan:
+		if chat.ExportPermissionResponseApproved(resp) {
+			t.Error("expected permission to be denied")
+		}
+
+		if fb := chat.ExportPermissionResponseFeedback(resp); fb != "too risky" {
+			t.Errorf("expected feedback %q, got %q", "too risky", fb)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for permission response after confirming denial")
+	}
+}
+
+// TestPermissionKey_DenyInputBackspace tests that backspace edits the reason input.
+func TestPermissionKey_DenyInputBackspace(t *testing.T) {
+	t.Parallel()
+
+	model := chat.NewModel(newTestParams())
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "Shell Command", "rm -rf /", "", responseChan)
 
 	var updatedModel tea.Model = model
 
 	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("noo")})
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyBackspace})
 
-	select {
-	case denied := <-responseChan:
-		if denied {
-			t.Error("expected permission to be denied after pressing 'n'")
-		}
-	case <-time.After(1 * time.Second):
-		t.Fatal("timed out waiting for permission response after pressing 'n'")
-	}
-
-	// Permission should be cleared
-	chatModel, ok := updatedModel.(*chat.Model)
-	if !ok {
-		t.Fatal("expected *chat.Model type assertion to succeed")
-	}
-
-	if chat.ExportHasPendingPermission(chatModel) {
-		t.Error("expected pending permission to be cleared after denial")
+	if got := chat.ExportPermissionDenyValue(requireModel(t, updatedModel)); got != "no" {
+		t.Errorf("expected deny input value %q after backspace, got %q", "no", got)
 	}
 }
 
-// TestPermissionKey_DenyWithEsc tests that pressing 'esc' denies a permission request.
-func TestPermissionKey_DenyWithEsc(t *testing.T) {
+// TestPermissionKey_DenyInputEscCancels tests that Esc cancels reason entry and returns to the
+// allow/deny prompt without sending a response.
+func TestPermissionKey_DenyInputEscCancels(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "Shell Command", "ls", "", responseChan)
 
 	var updatedModel tea.Model = model
 
+	// Open reason input, then cancel with Esc.
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyEsc})
 
+	chatModel := requireModel(t, updatedModel)
+
+	if chat.ExportIsPermissionDenyInput(chatModel) {
+		t.Error("expected deny-reason input to be cancelled after Esc")
+	}
+
+	if !chat.ExportHasPendingPermission(chatModel) {
+		t.Error("expected permission prompt to remain active after cancelling reason entry")
+	}
+
+	if len(responseChan) != 0 {
+		t.Error("expected no response to be sent when cancelling reason entry")
+	}
+}
+
+// TestPermissionKey_DenyWithEsc tests that pressing 'esc' opens the optional-reason input and
+// confirming with Enter denies the request.
+func TestPermissionKey_DenyWithEsc(t *testing.T) {
+	t.Parallel()
+
+	model := chat.NewModel(newTestParams())
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
+	chat.ExportSetPendingPermission(model, "Shell Command", "ls", "", responseChan)
+
+	var updatedModel tea.Model = model
+
+	// 'esc' opens the reason input; Enter confirms the denial.
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
 	select {
-	case denied := <-responseChan:
-		if denied {
+	case resp := <-responseChan:
+		if chat.ExportPermissionResponseApproved(resp) {
 			t.Error("expected permission to be denied after pressing escape")
 		}
 	case <-time.After(1 * time.Second):
@@ -298,13 +399,15 @@ func TestPermissionHandler_NilChatModeRef(t *testing.T) {
 		t.Fatal("expected permission request to be sent to event channel with nil chatModeRef")
 	}
 
-	// Feed the message through a TUI model, then press 'esc' to deny
+	// Feed the message through a TUI model, then press 'esc' to open the reason input and
+	// Enter to confirm the denial.
 	model := chat.NewModel(newTestParams())
 
 	var updatedModel tea.Model = model
 
 	updatedModel, _ = updatedModel.Update(msg)
 	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updatedModel, _ = updatedModel.Update(tea.KeyMsg{Type: tea.KeyEnter})
 
 	// Verify the handler goroutine returns rejected
 	select {
@@ -336,7 +439,7 @@ func TestPermissionModal_AllowThisOperation(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "Terminal", "npm install", "", responseChan)
 
 	output := model.View()
@@ -354,7 +457,7 @@ func TestPermissionModal_AllowAlwaysSwitchesToAutopilot(t *testing.T) {
 	model := chat.NewModel(newTestParams())
 	chat.ExportSetChatMode(model, chat.InteractiveMode)
 
-	responseChan := make(chan bool, 1)
+	responseChan := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "Terminal", "echo hello", "", responseChan)
 
 	// Press 'a' to allow always
@@ -374,8 +477,8 @@ func TestPermissionModal_AllowAlwaysSwitchesToAutopilot(t *testing.T) {
 
 	// Verify the permission was approved
 	select {
-	case approved := <-responseChan:
-		if !approved {
+	case resp := <-responseChan:
+		if !chat.ExportPermissionResponseApproved(resp) {
 			t.Error("expected permission to be approved after 'a'")
 		}
 	case <-time.After(5 * time.Second):

--- a/pkg/cli/ui/chat/viewport_render_test.go
+++ b/pkg/cli/ui/chat/viewport_render_test.go
@@ -399,7 +399,7 @@ func TestRenderInputOrModal_ShowsPermissionModal(t *testing.T) {
 	t.Parallel()
 
 	model := chat.NewModel(newTestParams())
-	resp := make(chan bool, 1)
+	resp := make(chan chat.PermissionResponseForTest, 1)
 	chat.ExportSetPendingPermission(model, "bash", "rm -rf /tmp/test", "", resp)
 
 	var updated tea.Model = model

--- a/pkg/svc/chat/permissions.go
+++ b/pkg/svc/chat/permissions.go
@@ -68,12 +68,25 @@ func promptForPermission(
 }
 
 // readPermissionResponse reads and processes the user's permission response from stdin.
+//
+// The user may approve with "y"/"yes", deny with an empty line/"n"/"no", or deny while
+// providing a free-text reason by typing anything else. A denial reason is forwarded to the
+// agent via rpc.PermissionDecisionReject.Feedback so it can adjust its next attempt.
 func readPermissionResponse(
 	writer io.Writer,
 ) (rpc.PermissionDecision, error) {
-	_, _ = fmt.Fprint(writer, "Allow this operation? [y/N]: ")
+	return readPermissionResponseFrom(writer, os.Stdin)
+}
 
-	reader := bufio.NewReader(os.Stdin)
+// readPermissionResponseFrom is the testable core of readPermissionResponse, reading the
+// user's response from the provided reader instead of os.Stdin.
+func readPermissionResponseFrom(
+	writer io.Writer,
+	stdin io.Reader,
+) (rpc.PermissionDecision, error) {
+	_, _ = fmt.Fprint(writer, "Allow this operation? [y/N, or type a reason to deny]: ")
+
+	reader := bufio.NewReader(stdin)
 
 	line, readErr := reader.ReadString('\n')
 
@@ -84,13 +97,8 @@ func readPermissionResponse(
 		return &rpc.PermissionDecisionUserNotAvailable{}, nil
 	}
 
-	if strings.TrimSpace(line) == "" {
-		return &rpc.PermissionDecisionReject{}, nil
-	}
-
-	input := strings.TrimSpace(strings.ToLower(line))
-
-	if input == "y" || input == "yes" {
+	trimmed := strings.TrimSpace(line)
+	if isApproval(trimmed) {
 		notify.WriteMessage(notify.Message{
 			Type:    notify.SuccessType,
 			Content: "Permission granted",
@@ -100,13 +108,40 @@ func readPermissionResponse(
 		return &rpc.PermissionDecisionApproveOnce{}, nil
 	}
 
+	return rejectWithOptionalFeedback(writer, trimmed), nil
+}
+
+// isApproval reports whether the trimmed response line approves the operation.
+func isApproval(trimmed string) bool {
+	switch strings.ToLower(trimmed) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// rejectWithOptionalFeedback builds a rejection decision, attaching any free-text reason the
+// user typed. A blank line, "n", or "no" rejects without feedback; anything else is treated as
+// the feedback reason.
+func rejectWithOptionalFeedback(
+	writer io.Writer,
+	trimmed string,
+) rpc.PermissionDecision {
 	notify.WriteMessage(notify.Message{
 		Type:    notify.InfoType,
 		Content: "Permission denied",
 		Writer:  writer,
 	})
 
-	return &rpc.PermissionDecisionReject{}, nil
+	switch strings.ToLower(trimmed) {
+	case "", "n", "no":
+		return &rpc.PermissionDecisionReject{}
+	default:
+		feedback := trimmed
+
+		return &rpc.PermissionDecisionReject{Feedback: &feedback}
+	}
 }
 
 // getPermissionDescription extracts a human-readable description from the permission request.

--- a/pkg/svc/chat/permissions_test.go
+++ b/pkg/svc/chat/permissions_test.go
@@ -1,11 +1,15 @@
 package chat //nolint:testpackage // white-box tests for unexported functions
 
 import (
+	"bytes"
+	"io"
 	"strings"
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/github/copilot-sdk/go/rpc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // longDiff is a diff string exceeding 200 characters, used to test truncation.
@@ -118,4 +122,83 @@ func TestGetPermissionDescription_DiffPreview(t *testing.T) {
 			assert.Equal(t, testCase.expected, result)
 		})
 	}
+}
+
+func TestReadPermissionResponseFrom_Approve(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{"y\n", "yes\n", " Y \n", "YES\n"} {
+		t.Run(strings.TrimSpace(input), func(t *testing.T) {
+			t.Parallel()
+
+			writer := &bytes.Buffer{}
+
+			decision, err := readPermissionResponseFrom(writer, strings.NewReader(input))
+			require.NoError(t, err)
+			assert.Equal(t, rpc.PermissionDecisionKindApproveOnce, decision.Kind())
+		})
+	}
+}
+
+func TestReadPermissionResponseFrom_DenyWithoutFeedback(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{"\n", "n\n", "no\n", "  \n", "NO\n"} {
+		t.Run(strings.TrimSpace(input), func(t *testing.T) {
+			t.Parallel()
+
+			writer := &bytes.Buffer{}
+
+			decision, err := readPermissionResponseFrom(writer, strings.NewReader(input))
+			require.NoError(t, err)
+
+			reject, ok := decision.(*rpc.PermissionDecisionReject)
+			require.True(t, ok, "expected a reject decision, got %T", decision)
+			assert.Nil(t, reject.Feedback, "expected no feedback for a plain denial")
+		})
+	}
+}
+
+func TestReadPermissionResponseFrom_DenyWithFeedback(t *testing.T) {
+	t.Parallel()
+
+	writer := &bytes.Buffer{}
+
+	decision, err := readPermissionResponseFrom(
+		writer, strings.NewReader("  this command is too risky  \n"),
+	)
+	require.NoError(t, err)
+
+	reject, ok := decision.(*rpc.PermissionDecisionReject)
+	require.True(t, ok, "expected a reject decision, got %T", decision)
+	require.NotNil(t, reject.Feedback, "expected feedback to be set for a typed reason")
+	assert.Equal(t, "this command is too risky", *reject.Feedback)
+}
+
+func TestReadPermissionResponseFrom_EOF(t *testing.T) {
+	t.Parallel()
+
+	writer := &bytes.Buffer{}
+
+	// An empty reader yields EOF immediately, which is treated as "user not available".
+	decision, err := readPermissionResponseFrom(writer, strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Equal(t, rpc.PermissionDecisionKindUserNotAvailable, decision.Kind())
+}
+
+// staticErrReader returns a non-EOF error on Read to exercise the I/O-error path.
+type staticErrReader struct{}
+
+func (staticErrReader) Read([]byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+func TestReadPermissionResponseFrom_ReadError(t *testing.T) {
+	t.Parallel()
+
+	writer := &bytes.Buffer{}
+
+	decision, err := readPermissionResponseFrom(writer, staticErrReader{})
+	require.NoError(t, err)
+	assert.Equal(t, rpc.PermissionDecisionKindUserNotAvailable, decision.Kind())
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

When a user denies an AI-chat tool permission request, they can now provide an **optional free-text reason**, which is forwarded to the agent via `rpc.PermissionDecisionReject.Feedback` so it can adjust its next attempt. Previously a denial always sent an empty `Reject{}` with no context.

## Implementation

**Non-TUI handler** (`pkg/svc/chat/permissions.go`)
- The denial line is parsed: a blank line, `n`, or `no` rejects **without** feedback; any other typed text becomes the feedback reason (trimmed). `y`/`yes` still approves; EOF still maps to `UserNotAvailable`.
- Prompt text updated to hint a reason can be typed: `Allow this operation? [y/N, or type a reason to deny]:`.
- Extracted a testable `readPermissionResponseFrom(writer, io.Reader)` core (the exported behavior reads from `os.Stdin`), plus small `isApproval` / `rejectWithOptionalFeedback` helpers.

**TUI handler** (`pkg/cli/ui/chat/`) — *full text-input implemented*
- `permissionRequestMsg.response` changed from `chan<- bool` to `chan<- permissionResponse` (`{approved bool; feedback string}`), defined next to the message type.
- Pressing `n`/`N`/`esc` now opens a brief **inline single-line text input** for an optional reason instead of denying immediately. `Enter` submits (empty allowed), `Esc` cancels back to the allow/deny prompt, `Backspace` edits, and `Ctrl+C` still aborts the session via the shared `handleQuit()` path. The modal renders a `Reason for denial (optional):` line, and the footer help adapts (`⏎ confirm deny` / `esc back`).
- Feedback is mapped into `&rpc.PermissionDecisionReject{Feedback: ...}` (nil when empty) in `CreateTUIPermissionHandler`; approve / allow-always send `{approved: true}`.

## Scope note
The full TUI typed-reason path **was implemented** (not just the plumbing). The interaction reuses the existing single-line-input conventions from the elicitation flow for consistency.

## Tests
- `pkg/svc/chat/permissions_test.go`: new coverage for the non-TUI handler — approve (`y`/`yes`), deny without feedback (blank/`n`/`no`, `Feedback` nil), deny **with** a reason (`Feedback` set + trimmed), EOF and a non-EOF read error both → `UserNotAvailable`.
- `pkg/cli/ui/chat/permission_test.go` + `export_test.go`: updated existing tests to the new response type and two-step deny flow; added tests for opening the reason input, denying with/without a reason, backspace editing, and Esc-cancel. Existing approve / allow-always / autopilot / dedup behaviors remain green. Adjacent test files updated for the new channel type.

## Validation
- `go build ./...` — success
- `go test ./pkg/svc/chat/... ./pkg/cli/ui/chat/... ./pkg/cli/cmd/chat/... -count=1` — 930 passed
- `golangci-lint run ./pkg/svc/chat/... ./pkg/cli/ui/chat/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)