### PR TITLE
test(reconciler): cover ParseConditions/ParseCondition status parsing

### DIFF
--- a/pkg/client/reconciler/conditions_test.go
+++ b/pkg/client/reconciler/conditions_test.go
@@ -1,0 +1,178 @@
+package reconciler_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// condMap builds a status-condition entry as it appears in an unstructured CR.
+func condMap(condType, status, reason, message string) map[string]any {
+	return map[string]any{
+		"type":    condType,
+		"status":  status,
+		"reason":  reason,
+		"message": message,
+	}
+}
+
+// objWithConditions wraps a status.conditions slice in an unstructured object.
+// Slice entries must be JSON-valid types because ParseConditions reads them via
+// unstructured.NestedSlice, which deep-copies and panics on non-JSON Go types.
+func objWithConditions(conditions []any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"status": map[string]any{
+				"conditions": conditions,
+			},
+		},
+	}
+}
+
+// TestParseConditions_NoStatus tests that an object without a status.conditions
+// path yields nil.
+func TestParseConditions_NoStatus(t *testing.T) {
+	t.Parallel()
+
+	obj := &unstructured.Unstructured{Object: map[string]any{}}
+
+	assert.Nil(t, reconciler.ParseConditions(obj))
+}
+
+// TestParseConditions_EmptySlice tests that a present-but-empty conditions slice
+// yields nil rather than an empty slice.
+func TestParseConditions_EmptySlice(t *testing.T) {
+	t.Parallel()
+
+	obj := objWithConditions([]any{})
+
+	assert.Nil(t, reconciler.ParseConditions(obj))
+}
+
+// TestParseConditions_AllValid tests that every valid condition map is parsed
+// and that the original order is preserved.
+func TestParseConditions_AllValid(t *testing.T) {
+	t.Parallel()
+
+	obj := objWithConditions([]any{
+		condMap("Ready", "True", "ReconciliationSucceeded", "applied revision main"),
+		condMap("Stalled", "False", "", ""),
+	})
+
+	got := reconciler.ParseConditions(obj)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, reconciler.Condition{
+		Type:    "Ready",
+		Status:  "True",
+		Reason:  "ReconciliationSucceeded",
+		Message: "applied revision main",
+	}, got[0])
+	assert.Equal(t, reconciler.Condition{Type: "Stalled", Status: "False"}, got[1])
+}
+
+// TestParseConditions_SkipsNonMapEntries tests that non-map entries are silently
+// skipped while valid maps are still returned in order.
+func TestParseConditions_SkipsNonMapEntries(t *testing.T) {
+	t.Parallel()
+
+	obj := objWithConditions([]any{
+		"not-a-map",
+		condMap("Ready", "True", "", ""),
+		int64(42),
+		nil,
+		condMap("Healthy", "True", "", ""),
+	})
+
+	got := reconciler.ParseConditions(obj)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "Ready", got[0].Type)
+	assert.Equal(t, "Healthy", got[1].Type)
+}
+
+// runParseConditionCases runs a ParseCondition table and asserts the parsed
+// condition and ok flag for each entry.
+func runParseConditionCases(t *testing.T, cases []struct {
+	name     string
+	entry    any
+	wantCond reconciler.Condition
+	wantOK   bool
+},
+) {
+	t.Helper()
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cond, ok := reconciler.ParseCondition(testCase.entry)
+
+			assert.Equal(t, testCase.wantOK, ok)
+			assert.Equal(t, testCase.wantCond, cond)
+		})
+	}
+}
+
+// TestParseCondition_NonMapEntries tests that entries which are not condition
+// maps are rejected without panicking.
+func TestParseCondition_NonMapEntries(t *testing.T) {
+	t.Parallel()
+
+	runParseConditionCases(t, []struct {
+		name     string
+		entry    any
+		wantCond reconciler.Condition
+		wantOK   bool
+	}{
+		{"string entry", "Ready", reconciler.Condition{}, false},
+		{"integer entry", 42, reconciler.Condition{}, false},
+		{"nil entry", nil, reconciler.Condition{}, false},
+	})
+}
+
+// TestParseCondition_MapEntries tests parsing of full, partial, empty, and
+// wrong-typed condition maps.
+func TestParseCondition_MapEntries(t *testing.T) {
+	t.Parallel()
+
+	runParseConditionCases(t, []struct {
+		name     string
+		entry    any
+		wantCond reconciler.Condition
+		wantOK   bool
+	}{
+		{
+			"full map populates every field",
+			condMap("Ready", "True", "ReconciliationSucceeded", "all good"),
+			reconciler.Condition{
+				Type:    "Ready",
+				Status:  "True",
+				Reason:  "ReconciliationSucceeded",
+				Message: "all good",
+			},
+			true,
+		},
+		{
+			"partial map defaults missing fields to empty",
+			map[string]any{"type": "Ready", "status": "True"},
+			reconciler.Condition{Type: "Ready", Status: "True"},
+			true,
+		},
+		{
+			"empty map yields a zero condition that is still valid",
+			map[string]any{},
+			reconciler.Condition{},
+			true,
+		},
+		{
+			"non-string field types are ignored without panicking",
+			map[string]any{"type": 7, "status": true, "reason": "Stalled"},
+			reconciler.Condition{Reason: "Stalled"},
+			true,
+		},
+	})
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds unit tests for `pkg/client/reconciler/conditions.go`, which was at **0% coverage**. Both exported functions are now at **100%**:

- `ParseConditions(obj *unstructured.Unstructured) []Condition` — extracts the `status.conditions` slice from a GitOps CR and parses each entry.
- `ParseCondition(entry any) (Condition, bool)` — parses one raw condition entry.

This is the pure-logic surface that turns a Flux/ArgoCD reconcile status into the typed conditions ksail surfaces to the user, so its edge cases are worth pinning.

## Why

Advance-mode coverage work on a genuine gap (verified via `go tool cover -func`, not a missing-test-file heuristic — the package already had green sibling tests in `base_test.go`/`errors_test.go`/`poll_test.go`, just none for `conditions.go`). The functions are 100% pure (no clients/I/O), making them ideal, fast, deterministic unit targets.

## Coverage

The new table-driven tests pin real behaviour and edge cases:

**`ParseConditions`**
- object with no `status.conditions` → `nil`
- present-but-empty slice → `nil` (not an empty slice)
- all-valid entries → full parse, **order preserved**
- mixed slice with non-map junk (`string`, `int64`, `nil`) → junk silently skipped, valid maps returned in order

**`ParseCondition`**
- non-map entries (`string`, `int`, `nil`) → `(Condition{}, false)`
- full map → every field populated, `true`
- partial map → missing fields default to `""`, `true`
- empty map → zero `Condition`, still `true`
- wrong-typed fields (`type: 7`, `status: true`) → ignored via `NestedString`, **no panic**, `true`

Note: junk entries in the `ParseConditions` slice tests use JSON-valid types (`string`/`int64`/`nil`) because `unstructured.NestedSlice` deep-copies and panics on non-JSON Go types — a real constraint the tests respect.

## Validation

- `go build ./pkg/client/reconciler/...` ✅
- `go test ./pkg/client/reconciler/...` → **36 passed** (was 23; added 13 cases) ✅
- `golangci-lint run ./pkg/client/reconciler/... --timeout 5m` → **No issues found** ✅ (tables kept inline + split across two functions to satisfy `funlen` without a `gochecknoglobals` global or any `//nolint`)
- Test-only change — no generated files or production code affected.