### PR TITLE
fix: keep ksail-desktop running without Docker and after closing the window

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -130,6 +130,11 @@ func run() error {
 		func(event *application.ApplicationEvent) { handleDeepLink(window, event.Context().URL()) },
 	)
 
+	// This is a menu-bar app: closing the window (red button / ⌘W / menu Close) hides it to the tray
+	// instead of destroying it, so it stays reopenable via the tray's "Show KSail". Must be registered
+	// before Run(). See hideWindowOnClose.
+	hideWindowOnClose(window)
+
 	// A menu-bar/system-tray icon for quick access: show/hide the window or quit without going through
 	// the Dock. Must be configured before Run() (which blocks until shutdown).
 	installSystemTray(app, window)
@@ -169,4 +174,37 @@ func installSystemTray(app *application.App, window *application.WebviewWindow) 
 	trayMenu.AddSeparator()
 	trayMenu.Add("Quit KSail").OnClick(func(_ *application.Context) { app.Quit() })
 	tray.SetMenu(trayMenu)
+}
+
+// windowHider is the subset of *application.WebviewWindow the close-to-tray hook needs. Declaring it as
+// an interface lets the hook's behavior be unit-tested without a live Wails window (which needs a GUI).
+type windowHider interface {
+	Hide() application.Window
+}
+
+// hideWindowOnClose makes closing the window hide it to the menu bar/tray instead of destroying it, so
+// the single window stays alive and reopenable from the tray's "Show KSail" for the app's lifetime.
+// Quitting is explicit — the tray's "Quit KSail" (app.Quit) and ⌘Q both terminate the app process
+// directly, bypassing this hook.
+//
+// Wails v3's built-in WindowClosing handler is a *listener* that destroys the window: it marks it
+// destroyed, closes the native window, and removes it from the app's window registry. Once destroyed,
+// the tray's window.Show() can only try to recreate the window (a no-op on this alpha, so "nothing
+// happens"), and window.Hide() invokes hide on the freed native window, crashing the whole process —
+// exactly the two reported tray failures. A *hook* runs before listeners and, when it cancels the
+// event, short-circuits them (see WebviewWindow.HandleWindowEvent), so cancelling here skips the
+// destroy and we hide instead. On macOS the native windowShouldClose: already returns false (it never
+// closes the NSWindow itself; the Go listener did the destroying), so cancelling fully prevents it.
+func hideWindowOnClose(window *application.WebviewWindow) {
+	window.RegisterHook(events.Common.WindowClosing, hideOnCloseHook(window))
+}
+
+// hideOnCloseHook is the WindowClosing hook body: cancel the close (so Wails' destroying listener is
+// skipped) then hide the window. Split from hideWindowOnClose so it can be unit-tested against a fake
+// windowHider and a real application.WindowEvent.
+func hideOnCloseHook(window windowHider) func(*application.WindowEvent) {
+	return func(event *application.WindowEvent) {
+		event.Cancel()
+		window.Hide()
+	}
 }

--- a/desktop/window_close_test.go
+++ b/desktop/window_close_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// fakeHider records Hide() calls; it stands in for *application.WebviewWindow so the close-to-tray
+// hook can be exercised without a live Wails window (which would need a GUI).
+type fakeHider struct{ hideCalls int }
+
+func (f *fakeHider) Hide() application.Window {
+	f.hideCalls++
+
+	return nil
+}
+
+// TestHideOnCloseHook_CancelsCloseAndHides verifies the WindowClosing hook cancels the close — which
+// is what skips Wails' default window-destroying listener — and hides the window instead. Without the
+// cancel, Wails destroys the window on close, after which the tray's Show is a no-op and Hide crashes
+// the process (the two reported failures).
+func TestHideOnCloseHook_CancelsCloseAndHides(t *testing.T) {
+	t.Parallel()
+
+	hider := &fakeHider{}
+	event := application.NewWindowEvent()
+
+	hideOnCloseHook(hider)(event)
+
+	if !event.IsCancelled() {
+		t.Error("close must be cancelled so Wails does not destroy the window")
+	}
+
+	if hider.hideCalls != 1 {
+		t.Errorf(
+			"window must be hidden exactly once (close-to-tray); got %d Hide call(s)",
+			hider.hideCalls,
+		)
+	}
+}

--- a/pkg/svc/provisioner/cluster/k3d/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/export_test.go
@@ -5,9 +5,38 @@ import (
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/runner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	k3kv1beta1 "github.com/rancher/k3k/pkg/apis/k3k.io/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// ListAgentNodesForTest exposes listAgentNodes (the pipe+goroutine node-list path)
+// so its runtime-down behavior can be exercised.
+func (k *Provisioner) ListAgentNodesForTest(ctx context.Context, clusterName string) error {
+	_, err := k.listAgentNodes(ctx, clusterName)
+
+	return err
+}
+
+// AddAgentNodesForTest exposes addAgentNodes (a synchronous node-command site) so
+// its runtime-down behavior can be exercised.
+func (k *Provisioner) AddAgentNodesForTest(
+	ctx context.Context,
+	clusterName string,
+	count int,
+) error {
+	return k.addAgentNodes(ctx, clusterName, count, &clusterupdate.UpdateResult{})
+}
+
+// RemoveAgentNodesForTest exposes removeAgentNodes (a synchronous node-command
+// site) so its runtime-down behavior can be exercised.
+func (k *Provisioner) RemoveAgentNodesForTest(
+	ctx context.Context,
+	clusterName string,
+	count int,
+) error {
+	return k.removeAgentNodes(ctx, clusterName, count, &clusterupdate.UpdateResult{})
+}
 
 // K3kReadyTimeoutForTest exposes k3kReadyTimeout for unit testing.
 func K3kReadyTimeoutForTest() time.Duration {

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -305,15 +305,19 @@ func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error
 	_, copyErr := io.Copy(&outputBuf, pipeReader)
 	_ = pipeReader.Close()
 
+	// Wait for the command goroutine to finish BEFORE restoring os.Stdout. The
+	// channel receive is the happens-before edge with the goroutine's access to
+	// os.Stdout — k3d's docker client reads it via moby/term.StdStreams — so
+	// restoring earlier races that read under the race detector. (The pipe EOF that
+	// unblocked io.Copy is not a tracked synchronization edge.)
+	runErr := <-errChan
+
 	// Restore stdout and the loggers, then release the lock.
 	os.Stdout = originalStdout
 
 	restoreLogging()
 
 	listMutex.Unlock()
-
-	// Wait for command to complete and get any error
-	runErr := <-errChan
 
 	if copyErr != nil {
 		return "", fmt.Errorf("cluster list: read stdout pipe: %w", copyErr)

--- a/pkg/svc/provisioner/cluster/k3d/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,9 +19,22 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	clustercommand "github.com/k3d-io/k3d/v5/cmd/cluster"
 	v1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
+	k3dlogger "github.com/k3d-io/k3d/v5/pkg/logger"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+// ErrK3dRuntimeUnavailable is returned by the k3d provisioner when the k3d
+// runtime (the Docker daemon) is unavailable. k3d's embedded cobra commands react
+// to an unreachable runtime by calling logrus Fatal on their own logger, which by
+// default calls os.Exit(1) and would terminate the whole host process — fatal for
+// a long-lived host such as the desktop app or `ksail ui`, which must keep running
+// when Docker Desktop is not started. NewProvisioner permanently rewires k3d's
+// logger to raise this sentinel via panic instead, and every site that runs a k3d
+// command routes through runK3dSafely, which recovers it into this error — so a
+// Docker-down list, lifecycle, or node-scaling operation fails gracefully rather
+// than crashing.
+var ErrK3dRuntimeUnavailable = errors.New("k3d runtime unavailable (is the Docker daemon running?)")
 
 var (
 	// listMutex protects concurrent access to os.Stdout during List operations.
@@ -78,6 +92,21 @@ func NewProvisioner(
 			TimestampFormat:  "2006-01-02T15:04:05Z",
 		})
 		logrus.SetLevel(logrus.InfoLevel)
+
+		// k3d logs through its OWN logrus instance (k3dlogger.Log(), not the standard
+		// logger above), and its embedded cobra commands call logrus Fatal on it when
+		// the runtime (Docker) is unreachable — Create alone has 19 such calls. logrus
+		// Fatal invokes ExitFunc, which defaults to os.Exit(1) and would terminate the
+		// whole host process: fatal for a long-lived host such as the desktop app or
+		// `ksail ui`, where running create/delete/start/stop (or background discovery)
+		// with Docker stopped must yield an error, not a crash. Permanently replace
+		// ExitFunc with one that panics ErrK3dRuntimeUnavailable; every site that runs a
+		// k3d command routes through runK3dSafely, which recovers it into an ordinary
+		// error. Set once and never restored —
+		// embedded k3d must never os.Exit the host, and a fixed value avoids races
+		// between concurrent commands sharing this process-global logger (a long-running
+		// Create must not race a quick List save/restore of the shared ExitFunc).
+		k3dlogger.Log().ExitFunc = func(int) { panic(ErrK3dRuntimeUnavailable) }
 	})
 
 	prov := &Provisioner{
@@ -235,25 +264,28 @@ func (k *Provisioner) SetComponentDetector(d *detector.ComponentDetector) {
 // JSON output. k3d's PrintClusters writes directly to os.Stdout using
 // fmt.Println (not Cobra's cmd.OutOrStdout()), so the output is captured by
 // temporarily redirecting os.Stdout.
+//
+// k3d reacts to an unreachable runtime (Docker down) by calling logrus Fatal,
+// which by default calls os.Exit(1) and would kill the whole host process. That
+// Fatal is neutralized once in NewProvisioner (k3dlogger ExitFunc → panic
+// ErrK3dRuntimeUnavailable); the list goroutine (runListCommandToPipe) recovers
+// the panic into a normal error return, and silenceK3dLogging keeps k3d's noise
+// off the console while discovery captures the cluster JSON.
 func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error) {
-	// Lock first so that the logrus save/restore and the os.Stdout save/restore
+	// Lock first so that the logger save/restore and the os.Stdout save/restore
 	// are both protected by the same critical section. Without this ordering a
-	// second concurrent caller could read originalLogOutput as io.Discard (the
+	// second concurrent caller could read the saved output as io.Discard (the
 	// value set by the first caller) and later restore to io.Discard, leaving
-	// the global logrus logger permanently muted.
+	// the global loggers permanently muted.
 	listMutex.Lock()
 
-	// Temporarily redirect logrus to discard output during list
-	// to prevent log messages from appearing in console.
-	originalLogOutput := logrus.StandardLogger().Out
-
-	logrus.SetOutput(io.Discard)
+	restoreLogging := silenceK3dLogging()
 
 	originalStdout := os.Stdout
 
 	pipeReader, pipeWriter, err := os.Pipe()
 	if err != nil {
-		logrus.SetOutput(originalLogOutput)
+		restoreLogging()
 		listMutex.Unlock()
 
 		return "", fmt.Errorf("cluster list: create stdout pipe: %w", err)
@@ -265,13 +297,7 @@ func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error
 	// while the command is running (otherwise it may block on a full pipe buffer)
 	errChan := make(chan error, 1)
 
-	go func() {
-		_, runErr := k.runListCommand(ctx)
-		// Close write end to signal EOF to the reader
-		_ = pipeWriter.Close()
-
-		errChan <- runErr
-	}()
+	go k.runListCommandToPipe(ctx, pipeWriter, errChan)
 
 	// Read all output from the pipe (this is the JSON from k3d)
 	var outputBuf bytes.Buffer
@@ -279,10 +305,10 @@ func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error
 	_, copyErr := io.Copy(&outputBuf, pipeReader)
 	_ = pipeReader.Close()
 
-	// Restore stdout and logrus, then release the lock.
+	// Restore stdout and the loggers, then release the lock.
 	os.Stdout = originalStdout
 
-	logrus.SetOutput(originalLogOutput)
+	restoreLogging()
 
 	listMutex.Unlock()
 
@@ -298,6 +324,53 @@ func (k *Provisioner) defaultListClustersRaw(ctx context.Context) (string, error
 	}
 
 	return strings.TrimSpace(outputBuf.String()), nil
+}
+
+// runListCommandToPipe runs the k3d cluster-list command as its own goroutine (so
+// the caller can drain the pipe concurrently — k3d writes its JSON directly to
+// os.Stdout), closing pipeWriter to signal EOF and reporting the command's error
+// (or ErrK3dRuntimeUnavailable, via runK3dSafely) on errChan.
+func (k *Provisioner) runListCommandToPipe(
+	ctx context.Context,
+	pipeWriter *os.File,
+	errChan chan<- error,
+) {
+	// Always close the write end so the pipe reader (io.Copy) unblocks — whether
+	// the command returns, errors, or its runtime-down Fatal is recovered.
+	defer func() { _ = pipeWriter.Close() }()
+
+	errChan <- k.runK3dSafely(func() error {
+		_, runErr := k.runListCommand(ctx)
+
+		return runErr
+	})
+}
+
+// silenceK3dLogging mutes both the standard logrus logger and k3d's dedicated
+// logger for the duration of a list, so k3d's progress lines and its (already
+// neutralized) runtime-down Fatal message do not leak to the console while
+// discovery captures the cluster JSON from os.Stdout. It returns a function that
+// restores both, which the caller must invoke before releasing listMutex.
+//
+// The process-exiting Fatal itself is neutralized once and for all in
+// NewProvisioner (k3dlogger ExitFunc → panic ErrK3dRuntimeUnavailable), not here;
+// this only silences output. k3d logs through its own logrus instance
+// (k3dlogger.Log()), not the standard logger, so muting only
+// logrus.StandardLogger() would not suppress k3d's output — both are handled.
+func silenceK3dLogging() func() {
+	originalStdOut := logrus.StandardLogger().Out
+
+	logrus.SetOutput(io.Discard)
+
+	k3dLog := k3dlogger.Log()
+	originalK3dOut := k3dLog.Out
+
+	k3dLog.SetOutput(io.Discard)
+
+	return func() {
+		logrus.SetOutput(originalStdOut)
+		k3dLog.SetOutput(originalK3dOut)
+	}
 }
 
 // runListCommand executes the k3d cluster list command and returns the output.
@@ -399,10 +472,46 @@ func (k *Provisioner) runLifecycleCommand(
 		}
 	}
 
-	_, runErr := k.runner.Run(ctx, cmd, args)
+	runErr := k.runK3dSafely(func() error {
+		_, runErr := k.runner.Run(ctx, cmd, args)
+
+		return runErr //nolint:wrapcheck // wrapped below with the operation prefix
+	})
 	if runErr != nil {
 		return fmt.Errorf("%s: %w", errorPrefix, runErr)
 	}
 
 	return nil
+}
+
+// runK3dSafely runs action and converts the runtime-down panic raised by k3d's
+// neutralized Fatal (the ExitFunc set in NewProvisioner) into a returned
+// ErrK3dRuntimeUnavailable, so a Docker-down k3d command fails with an error
+// instead of terminating the host process (e.g. the desktop app, where these run
+// in background goroutines). It is the single recover seam every site that runs an
+// embedded k3d command routes through — List, the create/delete/start/stop
+// lifecycle commands, and the node create/delete/list commands in update.go — so
+// "embedded k3d can never exit the host" holds package-wide rather than as a
+// per-call-site checklist. A command may have partially run, so the panic is
+// surfaced as an error and execution does not continue past it; any non-sentinel
+// panic is a genuine bug and is re-raised.
+func (k *Provisioner) runK3dSafely(action func() error) (err error) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+
+		recoveredErr, ok := recovered.(error)
+		if ok && errors.Is(recoveredErr, ErrK3dRuntimeUnavailable) {
+			err = ErrK3dRuntimeUnavailable
+
+			return
+		}
+
+		// Not our sentinel: a genuine bug. Re-panic so it is not swallowed.
+		panic(recovered)
+	}()
+
+	return action()
 }

--- a/pkg/svc/provisioner/cluster/k3d/provisioner_runtime_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/provisioner_runtime_test.go
@@ -1,0 +1,116 @@
+package k3dprovisioner_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	k3dprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3d"
+	v1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
+	k3dlogger "github.com/k3d-io/k3d/v5/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProvisioner_List_RuntimeUnavailableDoesNotExitProcess drives the REAL k3d
+// cluster-list path (no stubbed seam) against a Docker socket that does not
+// exist. k3d reacts to an unreachable runtime by calling logrus Fatal, which
+// defaults to os.Exit(1); before the fix that terminated the whole host process
+// — crashing, for example, the desktop app on boot when Docker Desktop is not
+// running. The fix recovers it into ErrK3dRuntimeUnavailable. Simply reaching the
+// assertions below proves the process was NOT exited.
+func TestProvisioner_List_RuntimeUnavailableDoesNotExitProcess(t *testing.T) {
+	// Not parallel: t.Setenv forbids it, and List mutates process-global os.Stdout
+	// and the k3d/logrus loggers under an internal mutex.
+	t.Setenv("DOCKER_HOST", "unix:///nonexistent/ksail-k3d-runtime-test.sock")
+
+	prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "")
+
+	_, err := prov.List(context.Background())
+
+	require.Error(
+		t,
+		err,
+		"List must return an error when the Docker daemon is unavailable, not exit",
+	)
+	require.ErrorIs(t, err, k3dprovisioner.ErrK3dRuntimeUnavailable)
+
+	// The loggers must be restored after List, so k3d's process-exiting Fatal and
+	// its console output are not left neutralized/muted for later operations.
+	assert.NotEqual(t, io.Discard, k3dlogger.Log().Out,
+		"k3d logger output must be restored after List")
+}
+
+// TestProvisioner_Commands_RuntimeUnavailableDoesNotExitProcess drives every k3d
+// command the provisioner runs — the create/delete/start/stop lifecycle commands
+// and the add/remove/list agent-node commands used by `cluster update` (update.go)
+// — through the REAL runtime against a Docker socket that does not exist. k3d's
+// cobra commands call logrus Fatal (os.Exit(1) by default) when the runtime is
+// unreachable (Create alone has 19 such calls), and listAgentNodes runs one in its
+// OWN goroutine where an unrecovered panic would be uncatchable. Before they routed
+// through runK3dSafely, a Docker-down create — or a `cluster update` on a k3d
+// cluster — crashed the whole host process (e.g. the desktop app, where these run
+// in background goroutines). Reaching the assertions at all proves the process was
+// NOT exited.
+func TestProvisioner_Commands_RuntimeUnavailableDoesNotExitProcess(t *testing.T) {
+	// Not parallel: t.Setenv forbids it, and these exercise the process-global k3d
+	// logger and runner.
+	t.Setenv("DOCKER_HOST", "unix:///nonexistent/ksail-k3d-commands-test.sock")
+
+	// k3d's commands log to k3d's own logger (the lifecycle/node paths, unlike List,
+	// deliberately leave that output visible in production). Mute it for the duration
+	// of the test so the real runtime-down output does not clutter the test log.
+	k3dLog := k3dlogger.Log()
+	originalOut := k3dLog.Out
+	k3dLog.SetOutput(io.Discard)
+
+	t.Cleanup(func() { k3dLog.SetOutput(originalOut) })
+
+	const clusterName = "ksail-runtime-test"
+
+	commands := []struct {
+		name string
+		run  func(p *k3dprovisioner.Provisioner) error
+	}{
+		{"Create", func(p *k3dprovisioner.Provisioner) error {
+			return p.Create(context.Background(), clusterName)
+		}},
+		{"Delete", func(p *k3dprovisioner.Provisioner) error {
+			return p.Delete(context.Background(), clusterName)
+		}},
+		{"Start", func(p *k3dprovisioner.Provisioner) error {
+			return p.Start(context.Background(), clusterName)
+		}},
+		{"Stop", func(p *k3dprovisioner.Provisioner) error {
+			return p.Stop(context.Background(), clusterName)
+		}},
+		{"ListAgentNodes", func(p *k3dprovisioner.Provisioner) error {
+			return p.ListAgentNodesForTest(context.Background(), clusterName)
+		}},
+		{"AddAgentNodes", func(p *k3dprovisioner.Provisioner) error {
+			return p.AddAgentNodesForTest(context.Background(), clusterName, 1)
+		}},
+		{"RemoveAgentNodes", func(p *k3dprovisioner.Provisioner) error {
+			return p.RemoveAgentNodesForTest(context.Background(), clusterName, 1)
+		}},
+	}
+
+	// Subtests share the parent's DOCKER_HOST (t.Setenv) and the process-global k3d
+	// logger, so they must run serially, not in parallel.
+	//nolint:paralleltest // serial by design: shared env + process-global k3d logger
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			prov := k3dprovisioner.NewProvisioner(&v1alpha5.SimpleConfig{}, "")
+
+			err := command.run(prov)
+
+			require.Error(
+				t,
+				err,
+				"%s must return an error when the Docker daemon is unavailable, not exit",
+				command.name,
+			)
+			require.ErrorIs(t, err, k3dprovisioner.ErrK3dRuntimeUnavailable)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/k3d/update.go
+++ b/pkg/svc/provisioner/cluster/k3d/update.go
@@ -170,7 +170,11 @@ func (k *Provisioner) addAgentNodes(
 		nodeRunner := runner.NewCobraCommandRunner(io.Discard, io.Discard)
 		cmd := nodecommand.NewCmdNodeCreate()
 
-		_, runErr := nodeRunner.Run(ctx, cmd, args)
+		runErr := k.runK3dSafely(func() error {
+			_, e := nodeRunner.Run(ctx, cmd, args)
+
+			return e //nolint:wrapcheck // wrapped below
+		})
 		if runErr != nil {
 			result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
 				Field:  "k3d.agents",
@@ -214,7 +218,11 @@ func (k *Provisioner) removeAgentNodes(
 		nodeRunner := runner.NewCobraCommandRunner(io.Discard, io.Discard)
 		cmd := nodecommand.NewCmdNodeDelete()
 
-		_, err := nodeRunner.Run(ctx, cmd, []string{nodeName})
+		err := k.runK3dSafely(func() error {
+			_, e := nodeRunner.Run(ctx, cmd, []string{nodeName})
+
+			return e //nolint:wrapcheck // wrapped below
+		})
 		if err != nil {
 			result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
 				Field:  "k3d.agents",
@@ -294,11 +302,15 @@ func (k *Provisioner) listClusterNodes(
 	errChan := make(chan error, 1)
 
 	go func() {
-		_, runErr := nodeRunner.Run(ctx, cmd, []string{"--output", "json"})
-		// Close write end to signal EOF to the reader
-		_ = pipeWriter.Close()
+		// Always close the write end so the pipe reader (io.Copy) unblocks — whether
+		// the command returns, errors, or its runtime-down Fatal is recovered.
+		defer func() { _ = pipeWriter.Close() }()
 
-		errChan <- runErr
+		errChan <- k.runK3dSafely(func() error {
+			_, runErr := nodeRunner.Run(ctx, cmd, []string{"--output", "json"})
+
+			return runErr //nolint:wrapcheck // wrapped by the caller with "failed to list nodes:"
+		})
 	}()
 
 	// Read all output from the pipe (this is the JSON from k3d)

--- a/pkg/svc/provisioner/cluster/k3d/update.go
+++ b/pkg/svc/provisioner/cluster/k3d/update.go
@@ -319,13 +319,16 @@ func (k *Provisioner) listClusterNodes(
 	_, copyErr := io.Copy(&buf, pipeReader)
 	_ = pipeReader.Close()
 
-	// Restore stdout while still holding the lock
+	// Wait for the command goroutine to finish BEFORE restoring os.Stdout: the
+	// channel receive is the happens-before edge with the goroutine's read of
+	// os.Stdout (k3d's docker client reads it via moby/term.StdStreams), so
+	// restoring earlier races that read under the race detector.
+	runErr := <-errChan
+
+	// Restore stdout while still holding the lock.
 	os.Stdout = origStdout
 
 	listMutex.Unlock()
-
-	// Wait for command to complete and get any error
-	runErr := <-errChan
 
 	if copyErr != nil {
 		return nil, fmt.Errorf("failed to read node list output: %w", copyErr)


### PR DESCRIPTION
## Summary

Two reliability fixes for **ksail-desktop**, both reported this session (the first also fixes `ksail ui`, which shares the backend):

1. It **crashed on boot when Docker Desktop wasn't running**.
2. The menu-bar tray's **Show/Hide were broken after closing the window** (Show did nothing; Hide killed the process).

### `fix(k3d)`: never `os.Exit` the host when Docker is unavailable
k3d's embedded cobra commands call `logrus.Fatal` → `os.Exit(1)` on their **own** logger (`k3dlogger.Log()`, not the standard logger) when the Docker daemon is unreachable, killing the whole host process. This crashed ksail-desktop on boot / `ksail ui` on first request (cluster discovery enumerates k3d clusters), and would also crash a Docker-down `cluster create`/`update`.

- Permanently replace k3d's logger `ExitFunc` (once, in `NewProvisioner`) with one that panics a sentinel `ErrK3dRuntimeUnavailable`.
- Route **every** k3d-command site through one recover seam, `runK3dSafely`, that converts the sentinel panic into a returned error and re-raises genuine bugs. Because the `ExitFunc` is process-global it must cover every site: List/discovery, the create/delete/start/stop lifecycle commands, and the add/remove/list agent-node commands used by `cluster update` — one of which runs in its own goroutine, where an unrecovered panic is uncatchable.
- Other distributions are unaffected: kind/talos/vcluster use SDKs, and kwok's kwokctl commands use cobra `RunE` (returning errors). k3d is the only distribution embedding `Fatal`-calling commands.

### `fix(desktop)`: hide window to tray on close instead of destroying it
Wails v3's default `WindowClosing` listener destroys the window; afterwards the tray's "Show KSail" does nothing and "Hide KSail" crashes the process (hide on a freed window). A `WindowClosing` hook now cancels the close and hides instead — hooks run before listeners and short-circuit them on cancel, so the single window stays alive and reopenable. "Quit KSail" / ⌘Q still quit (they call `app.Quit()`, bypassing the hook).

## Testing
- **Real-runtime regression tests** point `DOCKER_HOST` at a dead socket and assert List + all seven k3d command sites return an error instead of exiting; each was verified to *fail* (process crash) without the fix.
- **Desktop**: unit test for the cancel-and-hide hook; manually verified the close → Show → Hide → Quit flow in a bundled `.app`.
- `go build ./...`, the affected package tests, the desktop module tests, and `golangci-lint` (`--new-from-rev=HEAD`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
