### PR TITLE
fix(talos): resume interrupted Talos upgrades on mixed-version clusters

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -29,6 +29,16 @@ func CountNodeRolesForTest(nodes []NodeWithRoleForTest) (int32, int32) {
 	return countNodeRoles(nodes)
 }
 
+// LowestTalosVersionForTest exposes lowestTalosVersion for unit testing.
+func LowestTalosVersionForTest(tags []string) (string, error) {
+	return lowestTalosVersion(tags)
+}
+
+// RunningVersionMatchesTargetForTest exposes runningVersionMatchesTarget for unit testing.
+func RunningVersionMatchesTargetForTest(running, target string) bool {
+	return runningVersionMatchesTarget(running, target)
+}
+
 // NewNodeWithRoleForTest creates a nodeWithRole for unit testing.
 func NewNodeWithRoleForTest(ip, role string) NodeWithRoleForTest {
 	return nodeWithRole{IP: ip, Role: role}

--- a/pkg/svc/provisioner/cluster/talos/lowest_talos_version_test.go
+++ b/pkg/svc/provisioner/cluster/talos/lowest_talos_version_test.go
@@ -1,0 +1,139 @@
+package talosprovisioner_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLowestTalosVersion verifies that the cluster's current Talos version is
+// reported as the LEAST-upgraded node. A rolling Talos upgrade replaces nodes one
+// at a time, so an interrupted upgrade leaves a mixed-version cluster; reconciling
+// from the lowest version ensures the nodes still behind the target are rolled
+// forward, instead of an already-upgraded node masking them and silently stalling
+// the upgrade (the bug this guards against).
+func TestLowestTalosVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tags []string
+		want string
+	}{
+		{
+			// Nodes are listed workers-first and upgraded first, so the already
+			// upgraded workers (v1.13.4) precede the still-old control planes
+			// (v1.13.3). The lowest — the version still to roll — must win, not the
+			// first node sampled.
+			name: "mixed cluster: upgraded workers must not mask old control planes",
+			tags: []string{"v1.13.4", "v1.13.4", "v1.13.4", "v1.13.3", "v1.13.3", "v1.13.3"},
+			want: "v1.13.3",
+		},
+		{
+			name: "uniform cluster already at target",
+			tags: []string{"v1.13.4", "v1.13.4", "v1.13.4"},
+			want: "v1.13.4",
+		},
+		{
+			name: "single node",
+			tags: []string{"v1.13.3"},
+			want: "v1.13.3",
+		},
+		{
+			name: "lowest is last",
+			tags: []string{"v1.13.4", "v1.13.3"},
+			want: "v1.13.3",
+		},
+		{
+			name: "patch ordering is numeric, not lexical",
+			tags: []string{"v1.13.10", "v1.13.9"},
+			want: "v1.13.9",
+		},
+		{
+			name: "minor version difference",
+			tags: []string{"v1.13.0", "v1.12.4"},
+			want: "v1.12.4",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := talosprovisioner.LowestTalosVersionForTest(testCase.tags)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+// TestLowestTalosVersionErrors verifies the helper fails loudly rather than
+// silently under-reporting the cluster version.
+func TestLowestTalosVersionErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input is version-undetermined", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := talosprovisioner.LowestTalosVersionForTest(nil)
+		require.ErrorIs(t, err, clustererr.ErrVersionUndetermined)
+	})
+
+	t.Run("unparseable version errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := talosprovisioner.LowestTalosVersionForTest([]string{"v1.13.4", "not-a-version"})
+		require.Error(t, err)
+	})
+}
+
+// TestRunningVersionMatchesTarget verifies the per-node skip guard: during a
+// rolling upgrade across a mixed-version cluster, a node already at the target is
+// skipped (not rebooted), while a node behind the target is still upgraded.
+func TestRunningVersionMatchesTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		running string
+		target  string
+		want    bool
+	}{
+		{name: "already at target", running: "v1.13.4", target: "v1.13.4", want: true},
+		{name: "v-prefix mismatch still matches", running: "1.13.4", target: "v1.13.4", want: true},
+		{name: "behind target is upgraded", running: "v1.13.3", target: "v1.13.4", want: false},
+		{
+			name:    "ahead of target is not skipped here",
+			running: "v1.13.5",
+			target:  "v1.13.4",
+			want:    false,
+		},
+		{
+			name:    "unparseable running errs toward upgrading",
+			running: "garbage",
+			target:  "v1.13.4",
+			want:    false,
+		},
+		{
+			name:    "unparseable target errs toward upgrading",
+			running: "v1.13.4",
+			target:  "garbage",
+			want:    false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := talosprovisioner.RunningVersionMatchesTargetForTest(
+				testCase.running,
+				testCase.target,
+			)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -44,6 +44,18 @@ func supportsLifecycleUpgradeAPI(versionTag string) bool {
 	return !parsed.Less(minVersion)
 }
 
+// runningVersionMatchesTarget reports whether a node's running Talos version is
+// already the upgrade target, compared as parsed semver so a "v"-prefix mismatch
+// does not hide an already-upgraded node. Unparseable versions return false, so an
+// undeterminable version errs toward upgrading rather than silently skipping a node
+// that may still need it.
+func runningVersionMatchesTarget(running, target string) bool {
+	runningVer, runErr := versionresolver.ParseVersion(running)
+	targetVer, tgtErr := versionresolver.ParseVersion(target)
+
+	return runErr == nil && tgtErr == nil && runningVer.Equal(targetVer)
+}
+
 // upgradeNodeTalosVersion performs a Talos OS upgrade on a single node, then
 // waits for it to come back online with the expected version. The upgrade API
 // is chosen by the node's running Talos version: nodes on Talos >= 1.13 use the
@@ -69,6 +81,20 @@ func (p *Provisioner) upgradeNodeTalosVersion(
 	runningVersion, verErr := versionTagFromClient(ctx, talosClient)
 	if verErr != nil {
 		return fmt.Errorf("determining running Talos version on %s: %w", nodeIP, verErr)
+	}
+
+	// Skip nodes already at the target. A rolling upgrade walks every node, so when
+	// resuming an interrupted or partial roll (a mixed-version cluster) it would
+	// otherwise reboot nodes that already run the desired version.
+	if runningVersionMatchesTarget(runningVersion, desiredTag) {
+		_, _ = fmt.Fprintf(
+			p.logWriter,
+			"    %s already at %s, skipping upgrade\n",
+			nodeIP,
+			desiredTag,
+		)
+
+		return nil
 	}
 
 	if supportsLifecycleUpgradeAPI(runningVersion) {

--- a/pkg/svc/provisioner/cluster/talos/upgrader.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrader.go
@@ -230,7 +230,14 @@ func (p *Provisioner) GetCurrentVersions(
 		return nil, fmt.Errorf("%w: %s", clustererr.ErrNoNodesFound, clusterName)
 	}
 
-	talosVersion, err := p.getRunningTalosVersion(ctx, nodes[0].IP)
+	// Reconcile from the cluster's LEAST-upgraded node rather than whichever node
+	// is first. An interrupted rolling upgrade leaves the cluster in a mixed-version
+	// state (some nodes already at the target, others still behind); reading a single
+	// node lets an already-upgraded one mask the laggards, so the reconciler reports
+	// "already at the pin" and silently stops — stranding the remaining nodes on the
+	// old version. Mirrors the Kubernetes path, which reconciles from the cluster-wide
+	// k8s.DetectLowestVersion.
+	talosVersion, err := p.getLowestRunningTalosVersion(ctx, nodes)
 	if err != nil {
 		return nil, fmt.Errorf("getting Talos version: %w", err)
 	}
@@ -255,6 +262,62 @@ func (p *Provisioner) GetCurrentVersions(
 		KubernetesVersion:   k8sVersion,
 		DistributionVersion: talosVersion,
 	}, nil
+}
+
+// getLowestRunningTalosVersion returns the lowest (least-upgraded) running Talos
+// OS version across all nodes. A rolling Talos upgrade replaces nodes one at a
+// time, so an interrupted upgrade (or one a caller starts against a partially
+// upgraded cluster) leaves nodes on different versions. The reconciler must treat
+// the cluster as being at its least-upgraded node so the nodes still behind the
+// target are rolled forward; sampling a single node instead reports whichever node
+// happens to be first (workers are listed and upgraded first), letting an already
+// upgraded node mask the laggards. This mirrors the Kubernetes path, which
+// reconciles from the cluster-wide k8s.DetectLowestVersion.
+func (p *Provisioner) getLowestRunningTalosVersion(
+	ctx context.Context,
+	nodes []nodeWithRole,
+) (string, error) {
+	tags := make([]string, 0, len(nodes))
+
+	for _, node := range nodes {
+		tag, err := p.getRunningTalosVersion(ctx, node.IP)
+		if err != nil {
+			return "", err
+		}
+
+		tags = append(tags, tag)
+	}
+
+	return lowestTalosVersion(tags)
+}
+
+// lowestTalosVersion returns the lowest tag in tags, compared as parsed semver.
+// It errors when tags is empty or any tag is not parseable semver, so an
+// undeterminable version fails the reconcile loudly rather than silently
+// under-reporting the cluster as already at the target version.
+func lowestTalosVersion(tags []string) (string, error) {
+	var (
+		lowestTag string
+		lowestVer versionresolver.Version
+	)
+
+	for _, tag := range tags {
+		ver, err := versionresolver.ParseVersion(tag)
+		if err != nil {
+			return "", fmt.Errorf("parsing running Talos version %q: %w", tag, err)
+		}
+
+		if lowestTag == "" || ver.Less(lowestVer) {
+			lowestTag, lowestVer = tag, ver
+		}
+	}
+
+	if lowestTag == "" {
+		return "", fmt.Errorf("no running Talos versions to compare: %w",
+			clustererr.ErrVersionUndetermined)
+	}
+
+	return lowestTag, nil
 }
 
 // KubernetesImageRef returns the Kubernetes apiserver image repository, which is


### PR DESCRIPTION
## Problem

On the Talos + Hetzner provider, a Talos OS version bump (`spec.cluster.talos.version`) can **silently never apply to existing nodes** once a cluster is in a mixed-version state. A real cluster sat with its **control planes stuck on the old Talos version** while the pin and installer image had already moved to the new one — every `ksail cluster update` reported the version change in its diff, applied config "no reboot", went green, and never actually rolled the lagging nodes.

## Root cause

Two version-detection sites disagree, and neither uses the cluster-wide minimum:

- The **upgrade reconciler** (`GetCurrentVersions`) read the running Talos version from a **single node**, `nodes[0].IP` — no role preference, no cluster-wide minimum.
- The **diff baseline** (`introspectTalosVersion`) prefers a **control-plane** node.

A rolling upgrade replaces nodes one at a time, workers first. If it is interrupted (e.g. a control-plane node fails to come back), the cluster is left **mixed**: workers already upgraded, control planes still behind. `GetCurrentVersions` then samples an already-upgraded worker, so `normalizePinnedVersion` sees `current == pin` and returns `pinnedVersionAlreadyAtIt` → the reconciler **stays silent and stops**, stranding the control planes. The diff (sampling a control-plane) still shows the drift, so each deploy re-detects it and applies config without ever upgrading.

The Kubernetes path right next door already does the right thing — it reconciles from the cluster-wide `k8s.DetectLowestVersion`. The Talos OS path didn't.

## Fix

- **`GetCurrentVersions`** now reports the **cluster-wide lowest** running Talos version (new `getLowestRunningTalosVersion` / pure `lowestTalosVersion`), so a mixed cluster reconciles from its least-upgraded node and rolls the laggards forward.
- **`upgradeNodeTalosVersion`** now **skips nodes already at the target** (new `runningVersionMatchesTarget`, reusing the version it already fetches), so resuming a partial roll doesn't needlessly reboot already-upgraded nodes.

## Testing

- New table-driven unit tests for both helpers (`lowest_talos_version_test.go`), including the exact regression: upgraded workers listed first must **not** mask still-old control planes.
- `go build ./...`, `go vet`, full `talos` package test suite, and `golangci-lint` all pass.

## Design note

`getLowestRunningTalosVersion` fails fast if any node's version can't be read (consistent with the prior single-node behavior; `getRunningTalosVersion` already retries transient API errors). If preferred, it could instead take the lowest among *reachable* nodes to avoid failing `cluster update` when one node is down — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)