### PR TITLE
fix(helm): serialize chart acquisition to stop concurrent render corruption

### DIFF
--- a/pkg/client/helm/chart_location.go
+++ b/pkg/client/helm/chart_location.go
@@ -15,15 +15,30 @@ import (
 
 const chartRefParts = 2
 
-// helmHTTPTimeoutMu serializes the process-global HELM_HTTP_TIMEOUT mutation in
-// locateChartFromRepo. The Helm SDK has no per-call HTTP timeout, so KSail sets
-// the env var around each repository LocateChart and restores it afterwards.
-// Without this lock, concurrent repo-based renders (e.g. rendering HelmReleases
-// across kustomizations in parallel) race on the env var, which is a data race
-// under `go test -race` and can leak one render's timeout into another.
+// chartAcquireMu serializes the whole chart-acquisition window — locate →
+// download → load → values-file reads — across the process, together with the
+// process-global HELM_HTTP_TIMEOUT mutation in locateChartFromRepo.
 //
-//nolint:gochecknoglobals // package-level lock guarding a process-global env var
-var helmHTTPTimeoutMu sync.Mutex
+// Every Helm client built by NewTemplateOnlyClient shares the SAME process-global
+// Helm directories (HELM_REPOSITORY_CACHE, HELM_CONTENT_CACHE, the registry
+// config), because helmv4cli.New() resolves them from the environment / user home
+// rather than per-client. validate and scan render HelmReleases across
+// kustomizations concurrently (pkg/cli/cmd/workload, validationConcurrency), so
+// without serialization two renders acquire charts at once and race on those
+// shared files: one download writes a chart archive / OCI blob / repo index while
+// another reads or rewrites the same path. That silently corrupts the loaded
+// chart and yields malformed, non-deterministic render output — the
+// HelmRelease-dense overlays fail at a different place on every run
+// (devantler-tech/ksail#5362). A `-race` build does not catch it because the race
+// is on the filesystem, not Go memory (the prior env-var-only fix passed `-race`
+// yet the corruption persisted in production).
+//
+// The lock is held by loadChartAndValues for acquisition only; rendering
+// (RunWithContext, operating on the already-loaded in-memory chart) runs outside
+// it and stays parallel.
+//
+//nolint:gochecknoglobals // package-level lock guarding process-global Helm state
+var chartAcquireMu sync.Mutex
 
 // chartLocator abstracts the common chart location capabilities shared by
 // helmv4action.Install and helmv4action.Upgrade.
@@ -36,6 +51,11 @@ func (c *Client) loadChartAndValues(
 	spec *ChartSpec,
 	client any,
 ) (*chartv2.Chart, map[string]any, error) {
+	// Serialize the entire acquisition window so concurrent renders never touch the
+	// shared process-global Helm cache/config at the same time. See chartAcquireMu.
+	chartAcquireMu.Lock()
+	defer chartAcquireMu.Unlock()
+
 	chartPath, chart, err := c.locateAndLoadChart(spec, client)
 	if err != nil {
 		return nil, nil, err
@@ -144,13 +164,11 @@ func (c *Client) locateChartFromRepo(spec *ChartSpec, client any) (string, error
 		timeout = DefaultTimeout
 	}
 
-	// Hold the lock across the entire set→LocateChart→restore window so concurrent
-	// repo locates never observe each other's HELM_HTTP_TIMEOUT. Deferred restore
-	// runs before the deferred Unlock (LIFO), so the env var is restored while the
-	// lock is still held.
-	helmHTTPTimeoutMu.Lock()
-	defer helmHTTPTimeoutMu.Unlock()
-
+	// chartAcquireMu (held by loadChartAndValues for the whole acquisition window)
+	// already serializes this call, so the process-global HELM_HTTP_TIMEOUT
+	// mutation below is race-free. The deferred restore runs when this function
+	// returns — still within loadChartAndValues, lock held — so no other render
+	// observes the temporary timeout.
 	originalTimeout, hadTimeout := os.LookupEnv("HELM_HTTP_TIMEOUT")
 
 	err := os.Setenv("HELM_HTTP_TIMEOUT", timeout.String())

--- a/pkg/client/helm/chart_location_race_test.go
+++ b/pkg/client/helm/chart_location_race_test.go
@@ -2,13 +2,32 @@ package helm_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 )
+
+// serializationProbeDelay widens the window during which a chart acquisition holds
+// the repo server, so overlapping acquisitions are reliably observable when the
+// serialization lock is absent.
+const serializationProbeDelay = 25 * time.Millisecond
+
+// raiseMax atomically raises target to value when value is the larger of the two.
+func raiseMax(target *atomic.Int32, value int32) {
+	for {
+		observed := target.Load()
+		if value <= observed || target.CompareAndSwap(observed, value) {
+			return
+		}
+	}
+}
 
 // TestLocateChartFromRepoConcurrentNoRace exercises repo-based chart location
 // from many goroutines at once. locateChartFromRepo mutates the process-global
@@ -56,4 +75,81 @@ func TestLocateChartFromRepoConcurrentNoRace(t *testing.T) {
 	}
 
 	waitGroup.Wait()
+}
+
+// TestChartAcquisitionSerialized verifies the fix for devantler-tech/ksail#5362:
+// chart acquisition (locate → download → load → values) is serialized across the
+// whole process, so concurrent HelmRelease renders never touch the shared,
+// process-global Helm cache/config directories at the same time. Every
+// NewTemplateOnlyClient resolves the SAME global directories (HELM_REPOSITORY_CACHE
+// etc.), so before this fix overlapping acquisitions raced on those files — one
+// download writing a chart archive / OCI blob / repo index while another read or
+// rewrote it — producing corrupt, non-deterministic render output on the
+// HelmRelease-dense overlays.
+//
+// That race is on the filesystem, so `-race` cannot observe it (the prior
+// env-var-only lock passed `-race` yet the corruption persisted). This test
+// instead asserts the serialization invariant directly: a local repo server
+// records how many acquisitions are in flight at once. With the acquisition lock
+// the maximum is exactly 1; without it, the goroutines overlap and the maximum
+// exceeds 1. Each goroutine targets a distinct chart so nothing is short-circuited
+// by a cache hit, and the handler sleeps briefly to widen the overlap window. The
+// repo 404s, so LocateChart fails fast — the assertion is on concurrency, not on a
+// successful render.
+//
+// It mutates HELM_* env vars (to keep the cache hermetic), so it does not call
+// t.Parallel and runs in the package's sequential phase, where no parallel test
+// is concurrently reading those vars.
+func TestChartAcquisitionSerialized(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("HELM_REPOSITORY_CACHE", filepath.Join(cacheDir, "cache"))
+	t.Setenv("HELM_REPOSITORY_CONFIG", filepath.Join(cacheDir, "repositories.yaml"))
+
+	var inFlight, maxInFlight atomic.Int32
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			raiseMax(&maxInFlight, inFlight.Add(1))
+			time.Sleep(serializationProbeDelay)
+			inFlight.Add(-1)
+
+			http.Error(writer, "not found", http.StatusNotFound)
+		}),
+	)
+	defer server.Close()
+
+	const goroutines = 6
+
+	var waitGroup sync.WaitGroup
+
+	waitGroup.Add(goroutines)
+
+	for index := range goroutines {
+		go func() {
+			defer waitGroup.Done()
+
+			client, err := helm.NewTemplateOnlyClient()
+			if err != nil {
+				return
+			}
+
+			// Distinct chart per goroutine so no acquisition is skipped by a cache
+			// hit; the bogus repo 404s, so this fails fast after hitting the server.
+			_, _ = client.TemplateChart(context.Background(), &helm.ChartSpec{
+				ReleaseName: "race",
+				ChartName:   fmt.Sprintf("chart-%d", index),
+				RepoURL:     server.URL,
+			})
+		}()
+	}
+
+	waitGroup.Wait()
+
+	if got := maxInFlight.Load(); got != 1 {
+		t.Fatalf(
+			"chart acquisition not serialized: max concurrent repo requests = %d, want 1 "+
+				"(concurrent renders race on the shared Helm cache — see ksail#5362)",
+			got,
+		)
+	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5362

## Problem

`ksail workload validate` (and `scan`) non-deterministically corrupt their in-process Helm render output: the same repo + same binary fails on a *different* kustomization, at a *different* line, with a *different* YAML parse error on every run (`mapping values are not allowed`, `could not find expected ':'`, …). A genuine manifest defect would fail at a fixed location. `--skip-helm-render` avoids it entirely, and the most **HelmRelease-dense** overlays are the ones that fail — the signature of a concurrency bug whose hit-rate scales with parallel renders. **Regression: v7.65.0 is clean, v7.66.0 reproduces it** (introduced by the in-process render feature, #5344).

## Root cause

`validate`/`scan` render kustomizations in parallel (`validationConcurrency = 5`), each via a fresh `helm.NewTemplateOnlyClient()`. But every such client resolves the **same process-global Helm directories** — `HELM_REPOSITORY_CACHE`, `HELM_CONTENT_CACHE`, the registry config — because `helmv4cli.New()` reads them from the environment / user home, not per-client. So concurrent chart **acquisitions race on those shared cache files**: one goroutine downloads a chart archive / OCI blob / repo index while another reads or rewrites the same path, corrupting the loaded chart and yielding malformed YAML at a random offset.

The earlier fix added a mutex around only the repo-HTTP `LocateChart` and the `HELM_HTTP_TIMEOUT` env var. That closed the **Go-memory** env-var race (the part `-race` can see) but:
- never covered the **OCI** acquisition path (`locateOCIChart`), and
- released before the chart `Load`,

so the **filesystem** cache race survived. `-race` can't observe a filesystem race, which is why CI stayed green while production kept corrupting — exactly the trap here.

## Fix

Move the lock up to `loadChartAndValues` so it serializes the **entire acquisition window** (locate → download → load → values-file reads) for **all** source kinds (repo, OCI, local). The render step itself — `RunWithContext`, operating on the already-loaded in-memory chart — stays **outside** the lock and remains parallel. The shared on-disk cache is still reused across renders (no re-download amplification); only the moments that touch it serialize.

```
loadChartAndValues        ← chartAcquireMu held (locate→download→load→values)
  locateAndLoadChart
    locateChartFromRepo / locateOCIChart   (cache writes serialized)
    helmv4loader.Load                       (cache reads serialized)
  mergeValues
RunWithContext            ← outside the lock, parallel render
```

## Trade-off

Cold-cache downloads now serialize across the 5 render workers (necessary — concurrent writes to one shared cache are the bug). Rendering, the CPU-bound part, stays parallel; warm-cache loads are fast file reads. If download throughput ever matters, the follow-up is a per-run **isolated** Helm cache dir so distinct charts can download concurrently without sharing files — noted for later, correctness first.

## Tests

- **`TestChartAcquisitionSerialized`** (new) asserts the invariant *directly* — a local repo server counts in-flight acquisitions and the max must be `1`. Because the race is on the filesystem (invisible to `-race`), this is the meaningful guard. Verified it **fails without the lock** (`max concurrent repo requests = 6, want 1`) and passes with it.
- Existing `TestLocateChartFromRepoConcurrentNoRace` (the `-race` env guard) still passes.

## Validation

- `go build ./...` ✅ · `go vet ./pkg/client/helm/...` ✅
- `golangci-lint run --fix` then `golangci-lint run --timeout 5m ./pkg/client/helm/...` → **No issues** ✅
- `go test -race ./pkg/client/helm/... ./pkg/svc/gitops/render/... ./pkg/cli/cmd/workload/...` → **673 passed** ✅

No API/generated-file changes. Once merged, the platform System Test can drop its v7.65.0 pin (devantler-tech/platform#2184).
