### PR TITLE
fix(workload): serialize in-process Helm render (#5362)

### DIFF
--- a/pkg/svc/gitops/render/resolver.go
+++ b/pkg/svc/gitops/render/resolver.go
@@ -79,9 +79,11 @@ func NewHelmChartResolver(client helm.Interface) *HelmChartResolver {
 
 // Render resolves the chart source for helmRelease and templates it in-process.
 //
-// buildChartSpec is pure (in-memory) and runs concurrently, but the actual Helm
-// template call is serialized by helmRenderMu: it touches Helm's process-global
-// on-disk caches and SDK state, which concurrent renders corrupted (issue #5362).
+// buildChartSpec is pure (in-memory) and runs concurrently; the Helm template
+// call is then serialized by helmRenderMu (see its doc) because it touches
+// Helm's process-global on-disk caches, which concurrent renders corrupted
+// (issue #5362). The deferred Unlock holds the lock only across that call plus a
+// trivial error-wrap, and stays correct even if TemplateChart panics.
 func (r *HelmChartResolver) Render(
 	ctx context.Context,
 	helmRelease *helmv2.HelmRelease,
@@ -92,7 +94,10 @@ func (r *HelmChartResolver) Render(
 		return "", err
 	}
 
-	manifest, err := r.templateChart(ctx, spec)
+	helmRenderMu.Lock()
+	defer helmRenderMu.Unlock()
+
+	manifest, err := r.helm.TemplateChart(ctx, spec)
 	if err != nil {
 		return "", fmt.Errorf(
 			"template chart for HelmRelease %s/%s: %w",
@@ -101,21 +106,6 @@ func (r *HelmChartResolver) Render(
 	}
 
 	return manifest, nil
-}
-
-// templateChart performs the in-process Helm template call under helmRenderMu so
-// that concurrent renders never touch Helm's process-global on-disk caches at the
-// same time (issue #5362). The lock is held only across the cache-touching call;
-// the deferred Unlock keeps it correct even if TemplateChart panics.
-func (r *HelmChartResolver) templateChart(
-	ctx context.Context,
-	spec *helm.ChartSpec,
-) (string, error) {
-	helmRenderMu.Lock()
-	defer helmRenderMu.Unlock()
-
-	//nolint:wrapcheck // the sole caller, Render, wraps this with HelmRelease context
-	return r.helm.TemplateChart(ctx, spec)
 }
 
 // buildChartSpec maps a HelmRelease and the in-stream source objects to a

--- a/pkg/svc/gitops/render/resolver.go
+++ b/pkg/svc/gitops/render/resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -12,6 +13,22 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"sigs.k8s.io/yaml"
 )
+
+// helmRenderMu serializes the in-process Helm template step across concurrent
+// renders. Helm's chart download + render path mutates process-global on-disk
+// caches (HELM_REPOSITORY_CACHE / HELM_CONTENT_CACHE, read from shared defaults
+// by every helm.NewTemplateOnlyClient) and other shared SDK state that is not
+// safe for concurrent use. validate (and scan) render kustomizations in
+// parallel, and unserialized renders intermittently interleaved into each
+// other's manifest stream — producing malformed YAML at a random offset that
+// failed a different kustomization on each run (issue #5362). Constructing a
+// fresh client per render is not enough because the shared state lives on disk,
+// below the client. Serializing only the template step keeps the expensive
+// parallel work (kustomize build, kubeconform validation) unaffected, and keeps
+// the shared chart cache warm so each chart is downloaded at most once.
+//
+//nolint:gochecknoglobals // package-level lock guarding Helm's process-global render state
+var helmRenderMu sync.Mutex
 
 var (
 	// ErrSourceNotFound is returned when a HelmRelease references a source object
@@ -61,6 +78,10 @@ func NewHelmChartResolver(client helm.Interface) *HelmChartResolver {
 }
 
 // Render resolves the chart source for helmRelease and templates it in-process.
+//
+// buildChartSpec is pure (in-memory) and runs concurrently, but the actual Helm
+// template call is serialized by helmRenderMu: it touches Helm's process-global
+// on-disk caches and SDK state, which concurrent renders corrupted (issue #5362).
 func (r *HelmChartResolver) Render(
 	ctx context.Context,
 	helmRelease *helmv2.HelmRelease,
@@ -71,7 +92,7 @@ func (r *HelmChartResolver) Render(
 		return "", err
 	}
 
-	manifest, err := r.helm.TemplateChart(ctx, spec)
+	manifest, err := r.templateChart(ctx, spec)
 	if err != nil {
 		return "", fmt.Errorf(
 			"template chart for HelmRelease %s/%s: %w",
@@ -80,6 +101,21 @@ func (r *HelmChartResolver) Render(
 	}
 
 	return manifest, nil
+}
+
+// templateChart performs the in-process Helm template call under helmRenderMu so
+// that concurrent renders never touch Helm's process-global on-disk caches at the
+// same time (issue #5362). The lock is held only across the cache-touching call;
+// the deferred Unlock keeps it correct even if TemplateChart panics.
+func (r *HelmChartResolver) templateChart(
+	ctx context.Context,
+	spec *helm.ChartSpec,
+) (string, error) {
+	helmRenderMu.Lock()
+	defer helmRenderMu.Unlock()
+
+	//nolint:wrapcheck // the sole caller, Render, wraps this with HelmRelease context
+	return r.helm.TemplateChart(ctx, spec)
 }
 
 // buildChartSpec maps a HelmRelease and the in-stream source objects to a

--- a/pkg/svc/gitops/render/resolver_test.go
+++ b/pkg/svc/gitops/render/resolver_test.go
@@ -3,7 +3,9 @@ package render_test
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/gitops/render"
@@ -260,4 +262,74 @@ func TestReleaseNameMappedToChartSpec(t *testing.T) {
 	assert.Equal(t, "custom-release", spec.ReleaseName)
 	assert.Equal(t, "apps", spec.Namespace)
 	assert.True(t, strings.HasPrefix(spec.ChartName, "oci://"))
+}
+
+// serialProbeClient embeds helm.Interface and records the peak number of
+// TemplateChart calls running concurrently, so a test can assert that the
+// in-process Helm render step is serialized. Other interface methods are unused.
+type serialProbeClient struct {
+	helm.Interface
+
+	mu       sync.Mutex
+	inFlight int
+	maxSeen  int
+}
+
+func (c *serialProbeClient) TemplateChart(_ context.Context, _ *helm.ChartSpec) (string, error) {
+	c.mu.Lock()
+
+	c.inFlight++
+	if c.inFlight > c.maxSeen {
+		c.maxSeen = c.inFlight
+	}
+	c.mu.Unlock()
+
+	// Widen the overlap window so an unserialized render is observed as
+	// inFlight > 1 well within scheduler jitter, making the assertion reliable.
+	time.Sleep(time.Millisecond)
+
+	c.mu.Lock()
+	c.inFlight--
+	c.mu.Unlock()
+
+	return "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: rendered", nil
+}
+
+// TestRenderSerializesConcurrentHelmTemplating guards the #5362 fix. validate and
+// scan render kustomizations in parallel, each with its own HelmChartResolver, but
+// the Helm template step shares Helm's process-global on-disk caches and must be
+// serialized; without the package-level lock, concurrent renders interleaved into
+// each other's manifest stream. The probe fails if two TemplateChart calls overlap.
+func TestRenderSerializesConcurrentHelmTemplating(t *testing.T) {
+	t.Parallel()
+
+	probe := &serialProbeClient{}
+
+	const goroutines = 12
+
+	var waitGroup sync.WaitGroup
+
+	waitGroup.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer waitGroup.Done()
+
+			// A fresh resolver and inputs per goroutine mirror how validate
+			// constructs a client per kustomization; the package-level lock must
+			// serialize across independent resolvers.
+			resolver := render.NewHelmChartResolver(probe)
+
+			_, _ = resolver.Render(
+				context.Background(),
+				chartRefRelease(),
+				ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"}),
+			)
+		}()
+	}
+
+	waitGroup.Wait()
+
+	assert.Equal(t, 1, probe.maxSeen,
+		"concurrent in-process Helm renders must be serialized (issue #5362)")
 }


### PR DESCRIPTION
## Summary

Fixes #5362 — `ksail workload validate` (default in-process Helm render mode, added in #5344 / v7.66.0) non-deterministically corrupted its rendered-manifest stream, failing a *different* kustomization with a *different* YAML parse error on each run.

## Root cause

`validate` renders kustomizations concurrently (`validationConcurrency = 5`), and the only concurrent caller of `helm.TemplateChart` is `HelmChartResolver.Render`. Helm's chart download + template path reads and writes **process-global on-disk caches** (`HELM_REPOSITORY_CACHE` / `HELM_CONTENT_CACHE`, populated from shared defaults by every `helm.NewTemplateOnlyClient`) plus other shared SDK state. Constructing a fresh template client per render — the prior mitigation in #5344 — doesn't help, because the shared state lives on disk, *below* the client. Concurrent renders interleaved into each other's output → malformed YAML at a random offset.

This matches every symptom in the report: intermittent, different location/count each run, scales with HelmRelease density, and vanishes with `--skip-helm-render`. `-race` tests miss it because it's a *filesystem*-level race, and the existing concurrency test (`TestValidateRendersConcurrentlyNoRace`) uses *local* charts that Helm returns by path — bypassing the cache entirely.

## Fix

Serialize the in-process Helm template step with a package-level mutex in `pkg/svc/gitops/render` (the issue's suggested fix #2). Rationale over per-render cache isolation (suggested fix #1):

- **Correct under uncertainty** — mutual exclusion fixes *any* shared-state race in that path, not just one specific cache file.
- **Keeps the chart cache warm** — charts shared across overlays (exactly the `platform` repo pattern: `providers/{docker,hetzner}/.../controllers`) download once, not N× per kustomization. Per-render isolated caches would multiply network traffic and risk registry rate-limiting.

The lock wraps only the cache-touching `TemplateChart` call; spec-building, kustomize build, and kubeconform validation stay parallel. Image extraction (`helmutil.ImagesFromChart`) calls `TemplateChart` sequentially, so it's unaffected and the general-purpose Helm client stays policy-free.

## Test

`TestRenderSerializesConcurrentHelmTemplating` drives 12 concurrent resolvers through a probe `helm.Interface` and asserts no two `TemplateChart` calls overlap (peak in-flight == 1). Verified it **fails without the lock** (peak in-flight == 12) and **passes with it**.

## Validation

- `go test ./pkg/svc/gitops/render/... ./pkg/client/helm/... ./pkg/cli/cmd/workload/... -race` ✅
- Full `go test ./...` ✅ (only the pre-existing `pkg/cli/cmd/chat` env flake under full-suite parallel load; green in isolation)
- `golangci-lint run` ✅ (changed package clean; 0 new-from-`main`)

## Trade-off / follow-up

Helm renders now run one-at-a-time. The parallel-heavy work (kustomize build, kubeconform) is unchanged and cached templating is fast, so the impact is modest. If render throughput later proves to matter on very large repos, parallelism could be reintroduced safely via per-render isolated cache dirs — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
