### PR TITLE
ci(lychee): exclude flaky git.k8s.io redirector from link checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -43,9 +43,14 @@ exclude_path = [
 #     HTTP 500 in CI environments; content is stable, link is not broken.
 #   - starlight.astro.build: intermittently returns HTTP 500 in CI through all
 #     retries; verified reachable (200) outside CI, link is not broken.
+#   - git.k8s.io: the Kubernetes vanity redirector embedded by controller-gen in
+#     generated CRD field descriptions (the sig-architecture api-conventions
+#     links). It returns HTTP 500 for GitHub Actions runner IP ranges through all
+#     retries, while resolving (302 → 200) outside CI; the links are stable
+#     upstream references, not broken. Re-appears on every CRD, so exclude the host.
 #   - localhost / 127.0.0.1: loopback addresses used as port-forward targets in
 #     the operator chart E2E (http://127.0.0.1:18080/readyz, …); never reachable
 #     from the lychee runner.
 #   - ksail.local: placeholder OIDC redirect/ingress host in chart template
 #     permutations; an unresolvable .local address, not a real link.
-exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'localhost', '127\.0\.0\.1', 'ksail\.local', 'www\.gnu\.org/licenses/gpl-3\.0']
+exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'git\.k8s\.io', 'localhost', '127\.0\.0\.1', 'ksail\.local', 'www\.gnu\.org/licenses/gpl-3\.0']


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `🧹 Lint - mega-linter` job's **SPELL / lychee** linter is failing CI with 7 link-check errors, **all HTTP 500 Internal Server Error** — 6 of them against `https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#…` and 1 transient `https://github.com/FiloSottile/age` (already recovered to 200).

`git.k8s.io` is the Kubernetes **vanity redirector**, embedded by `controller-gen` in **generated CRD field descriptions** (the `sig-architecture` api-conventions links appear on essentially every Kubernetes CRD — here in `charts/ksail-operator/crds/ksail.io_clusters.yaml` and `pkg/svc/installer/clusterautoscaler/autoscaling.x-k8s.io_capacitybuffers.yaml`). It returns **HTTP 500 for GitHub Actions runner IP ranges** through all of lychee's retries, while resolving normally (`302 → 200`) outside CI — i.e. the links are **stable upstream references, not broken**.

Because these links live in *generated* CRDs, the failure **re-appears on every PR**. Although SPELL/lychee is not a required status check (`CI - Required Checks` is green), it feeds the repo's **`code_quality` branch ruleset**, so a lychee failure leaves PRs at `mergeStateStatus = BLOCKED`. This is currently blocking the `ksail-bot` release PR [#5367](https://github.com/devantler-tech/ksail/pull/5367) (`chore(copilot-plugin): release v7.66.3`) and will block any future PR whenever `git.k8s.io` 500s for the runner.

## Fix

Exclude the `git.k8s.io` host in `lychee.toml`, matching the **existing convention** already used for `siderolabs.com` and `starlight.astro.build` ("intermittently returns HTTP 500 in CI … verified reachable outside CI, link is not broken").

```diff
-exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'localhost', …]
+exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'git\.k8s\.io', 'localhost', …]
```

The `github.com/FiloSottile/age` error was a one-off GitHub blip (live-verified back to `200`), so no permanent ignore is warranted for it — it clears on any re-run.

## Validation

`lychee 0.24.2` against the offending files with the updated config:

```
🔍 14 Total  🔗 9 Unique  ✅ 5 OK  🚫 0 Errors  👻 9 Excluded
[EXCLUDED] https://git.k8s.io/…/api-conventions.md#resources  | This is due to your 'exclude' values
[EXCLUDED] https://git.k8s.io/…/api-conventions.md#types-kinds | …
```

All 6 `git.k8s.io` URLs are now `[EXCLUDED]`; **0 errors** (was 7). Scope is one config line + a doc comment — no behaviour change.

## Note for the release lane

Once this merges, re-running (or rebasing) [#5367](https://github.com/devantler-tech/ksail/pull/5367) clears its SPELL/lychee failure and unblocks the `v7.66.3` copilot-plugin release.