### PR TITLE
fix(helm): retry transient chart acquisition on the render path

### DIFF
--- a/pkg/client/helm/chart_location.go
+++ b/pkg/client/helm/chart_location.go
@@ -1,11 +1,14 @@
 package helm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/client/netretry"
 	helmv4action "helm.sh/helm/v4/pkg/action"
 	helmv4loader "helm.sh/helm/v4/pkg/chart/loader"
 	chartv2 "helm.sh/helm/v4/pkg/chart/v2"
@@ -14,6 +17,62 @@ import (
 )
 
 const chartRefParts = 2
+
+const (
+	// Retry configuration for chart acquisition on the render/template path.
+	//
+	// LocateChart downloads the repo index + chart archive (HTTP repos) or pulls
+	// the OCI blob, populating the shared Helm cache. When the cache is cold a
+	// transient 429/5xx/connection blip otherwise fails the locate outright, which
+	// leaves the HelmRelease un-rendered (a render Degradation): its children are
+	// dropped from the manifest stream, so `workload scan`/`validate` produce a
+	// different resource set — and thus a different compliance score — than a run
+	// against a warm cache (devantler-tech/ksail#5371). The install path already
+	// retries acquisition via InstallChartWithRetry; the render path did not, so
+	// mirror that here with the same transient-error policy.
+	chartLocateMaxRetries    = 5
+	chartLocateRetryBaseWait = 3 * time.Second
+	chartLocateRetryMaxWait  = 30 * time.Second
+)
+
+// locateChartWithRetry runs a chart-locate operation, retrying on transient
+// network errors (429/5xx, connection resets, timeouts, unexpected EOF) with
+// capped exponential backoff. It mirrors InstallChartWithRetry for the
+// render/template path so a cold-cache fetch blip does not silently degrade a
+// render and make scan/validate output non-deterministic (ksail#5371).
+//
+// The retry runs while chartAcquireMu is held (see loadChartAndValues): the
+// locate mutates the shared on-disk cache and must stay serialized, so the rare
+// backoff briefly delays other parallel renders rather than letting them race a
+// half-written cache. attempts/baseWait/maxWait are parameters so tests can
+// drive the retry with millisecond waits.
+func locateChartWithRetry(
+	ctx context.Context,
+	attempts int,
+	baseWait, maxWait time.Duration,
+	locate func() (string, error),
+) (string, error) {
+	var chartPath string
+
+	err := netretry.Do(
+		ctx,
+		attempts,
+		baseWait,
+		maxWait,
+		func() error {
+			var locErr error
+
+			chartPath, locErr = locate()
+
+			return locErr
+		},
+	)
+	if err != nil {
+		return "", err //nolint:wrapcheck // caller wraps with chart-specific context
+	}
+
+	return chartPath, nil
+}
 
 // chartAcquireMu serializes the whole chart-acquisition window — locate →
 // download → load → values-file reads — across the process, together with the
@@ -48,6 +107,7 @@ type chartLocator interface {
 }
 
 func (c *Client) loadChartAndValues(
+	ctx context.Context,
 	spec *ChartSpec,
 	client any,
 ) (*chartv2.Chart, map[string]any, error) {
@@ -56,7 +116,7 @@ func (c *Client) loadChartAndValues(
 	chartAcquireMu.Lock()
 	defer chartAcquireMu.Unlock()
 
-	chartPath, chart, err := c.locateAndLoadChart(spec, client)
+	chartPath, chart, err := c.locateAndLoadChart(ctx, spec, client)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,6 +130,7 @@ func (c *Client) loadChartAndValues(
 }
 
 func (c *Client) locateAndLoadChart(
+	ctx context.Context,
 	spec *ChartSpec,
 	client any,
 ) (string, *chartv2.Chart, error) {
@@ -79,9 +140,9 @@ func (c *Client) locateAndLoadChart(
 
 	switch {
 	case spec.RepoURL != "":
-		chartPath, err = c.locateChartFromRepo(spec, client)
+		chartPath, err = c.locateChartFromRepo(ctx, spec, client)
 	case helmv4registry.IsOCI(spec.ChartName):
-		chartPath, err = c.locateOCIChart(spec, client)
+		chartPath, err = c.locateOCIChart(ctx, spec, client)
 	default:
 		chartPath = spec.ChartName
 	}
@@ -128,7 +189,7 @@ func applyChartPathOptions(client any, opts helmv4action.ChartPathOptions) {
 	}
 }
 
-func (c *Client) locateOCIChart(spec *ChartSpec, client any) (string, error) {
+func (c *Client) locateOCIChart(ctx context.Context, spec *ChartSpec, client any) (string, error) {
 	registryClient, err := helmv4registry.NewClient()
 	if err != nil {
 		return "", fmt.Errorf("failed to create registry client: %w", err)
@@ -143,7 +204,13 @@ func (c *Client) locateOCIChart(spec *ChartSpec, client any) (string, error) {
 
 	locator.SetRegistryClient(registryClient)
 
-	chartPath, err := locator.LocateChart(spec.ChartName, c.settings)
+	chartPath, err := locateChartWithRetry(
+		ctx,
+		chartLocateMaxRetries,
+		chartLocateRetryBaseWait,
+		chartLocateRetryMaxWait,
+		func() (string, error) { return locator.LocateChart(spec.ChartName, c.settings) },
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to locate OCI chart %q: %w", spec.ChartName, err)
 	}
@@ -151,7 +218,11 @@ func (c *Client) locateOCIChart(spec *ChartSpec, client any) (string, error) {
 	return chartPath, nil
 }
 
-func (c *Client) locateChartFromRepo(spec *ChartSpec, client any) (string, error) {
+func (c *Client) locateChartFromRepo(
+	ctx context.Context,
+	spec *ChartSpec,
+	client any,
+) (string, error) {
 	_, chartName := parseChartRef(spec.ChartName)
 	if chartName == "" {
 		chartName = spec.ChartName
@@ -187,8 +258,16 @@ func (c *Client) locateChartFromRepo(spec *ChartSpec, client any) (string, error
 	opts := buildChartPathOptions(spec, spec.RepoURL)
 	applyChartPathOptions(client, opts)
 
-	// Use LocateChart to download the chart to cache and return the local path
-	chartPath, err := opts.LocateChart(chartName, c.settings)
+	// Use LocateChart to download the chart to cache and return the local path,
+	// retrying transient network failures so a cold-cache blip does not silently
+	// degrade the render (ksail#5371).
+	chartPath, err := locateChartWithRetry(
+		ctx,
+		chartLocateMaxRetries,
+		chartLocateRetryBaseWait,
+		chartLocateRetryMaxWait,
+		func() (string, error) { return opts.LocateChart(chartName, c.settings) },
+	)
 	if err != nil {
 		return "", fmt.Errorf(
 			"failed to locate chart %q in repository %s: %w",

--- a/pkg/client/helm/chart_location_retry_test.go
+++ b/pkg/client/helm/chart_location_retry_test.go
@@ -1,0 +1,128 @@
+package helm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errTransientLocate is a transient network error string the default netretry
+// predicate (IsRetryable) classifies as retryable.
+var errTransientLocate = errors.New(
+	"failed to fetch index: Get \"https://charts.example.com/index.yaml\": " +
+		"read tcp 10.0.0.1:54321->1.2.3.4:443: read: connection reset by peer",
+)
+
+// errPermanentLocate is a non-network error the default predicate does NOT retry
+// (e.g. a real 404 / chart-not-found), so the locate must fail on the first try.
+var errPermanentLocate = errors.New("chart \"missing\" version \"1.0.0\" not found")
+
+const (
+	retryTestBaseWait = time.Millisecond
+	retryTestMaxWait  = time.Millisecond
+)
+
+// TestLocateChartWithRetry_SuccessFirstAttempt verifies the happy path: a locate
+// that succeeds immediately is called exactly once and returns its path.
+func TestLocateChartWithRetry_SuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	path, err := helm.LocateChartWithRetry(
+		context.Background(),
+		5,
+		retryTestBaseWait,
+		retryTestMaxWait,
+		func() (string, error) {
+			calls++
+
+			return "/cache/chart.tgz", nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/cache/chart.tgz", path)
+	assert.Equal(t, 1, calls, "successful locate must not retry")
+}
+
+// TestLocateChartWithRetry_RetriesTransientThenSucceeds is the core #5371
+// regression guard: a cold-cache fetch that fails twice with a transient network
+// error must be retried and ultimately succeed, instead of degrading the render.
+func TestLocateChartWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	path, err := helm.LocateChartWithRetry(
+		context.Background(),
+		5,
+		retryTestBaseWait,
+		retryTestMaxWait,
+		func() (string, error) {
+			calls++
+			if calls < 3 {
+				return "", errTransientLocate
+			}
+
+			return "/cache/chart.tgz", nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/cache/chart.tgz", path)
+	assert.Equal(t, 3, calls, "transient failures must be retried until success")
+}
+
+// TestLocateChartWithRetry_StopsOnNonRetryable verifies a permanent error (e.g.
+// chart-not-found) is not retried, so a genuine misconfiguration still fails fast.
+func TestLocateChartWithRetry_StopsOnNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	_, err := helm.LocateChartWithRetry(
+		context.Background(),
+		5,
+		retryTestBaseWait,
+		retryTestMaxWait,
+		func() (string, error) {
+			calls++
+
+			return "", errPermanentLocate
+		},
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errPermanentLocate)
+	assert.Equal(t, 1, calls, "non-retryable error must not be retried")
+}
+
+// TestLocateChartWithRetry_ExhaustsRetries verifies that a persistently transient
+// failure is retried up to the attempt budget and then returns the last error.
+func TestLocateChartWithRetry_ExhaustsRetries(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	_, err := helm.LocateChartWithRetry(
+		context.Background(),
+		3,
+		retryTestBaseWait,
+		retryTestMaxWait,
+		func() (string, error) {
+			calls++
+
+			return "", errTransientLocate
+		},
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errTransientLocate)
+	assert.Equal(t, 3, calls, "must attempt exactly the configured number of times")
+}

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -200,7 +200,7 @@ func (c *Client) TemplateChart(ctx context.Context, spec *ChartSpec) (string, er
 		client.Version = spec.Version
 	}
 
-	chart, vals, err := c.loadChartAndValues(spec, client)
+	chart, vals, err := c.loadChartAndValues(ctx, spec, client)
 	if err != nil {
 		return "", fmt.Errorf("load chart and values: %w", err)
 	}
@@ -535,7 +535,7 @@ func (c *Client) performInstall(ctx context.Context, spec *ChartSpec) (*v1.Relea
 
 	// Note: Atomic is not supported in Helm v4 Install action
 
-	chart, vals, err := c.loadChartAndValues(spec, client)
+	chart, vals, err := c.loadChartAndValues(ctx, spec, client)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (c *Client) upgradeRelease(ctx context.Context, spec *ChartSpec) (*v1.Relea
 	// Note: Atomic is not supported in Helm v4 Upgrade action
 	client.SkipCRDs = !spec.UpgradeCRDs // Inverted logic in v4
 
-	chart, vals, err := c.loadChartAndValues(spec, client)
+	chart, vals, err := c.loadChartAndValues(ctx, spec, client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/helm/export_test.go
+++ b/pkg/client/helm/export_test.go
@@ -25,6 +25,7 @@ var (
 	ReleaseToInfo            = releaseToInfo
 	ExecuteAndExtractRelease = executeAndExtractRelease
 	ApplyCommonActionConfig  = applyCommonActionConfig
+	LocateChartWithRetry     = locateChartWithRetry
 )
 
 // Expose unexported error sentinels and repository helpers for test assertions.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`ksail workload scan` (and `validate`) render Kustomize + Helm before scanning. The render path's chart acquisition was **not** retried on transient network failures, unlike the install path.

- **Install path:** `InstallOrUpgradeChart` → `InstallChartWithRetry` wraps acquisition in `netretry.Do` (retries 429/5xx, connection resets, timeouts, unexpected EOF).
- **Render/template path:** `TemplateChart` → `loadChartAndValues` → `locateChartFromRepo` / `locateOCIChart` called `LocateChart` **directly, with no retry**.

When the Helm cache is cold, a transient blip during `LocateChart` (repo-index download, chart archive, or OCI pull) fails the locate outright. `render.Expand` then records a **Degradation** and leaves that HelmRelease un-rendered, so its children drop out of the manifest stream. The scanned resource set — and the compliance score — therefore differs from a warm-cache run, where no fetch is needed and the render is stable.

## Why this is the likely root cause of #5371

#5371 reports `workload scan` rendered output is non-deterministic: **run 1 = 83.93%, runs 2 & 3 = 92.71%** on an unchanged tree, with resources "intermittently dropped from the rendered set". `--no-render` is deterministic.

I traced the scan render path and confirmed it is **fully serial within a run** (`render.Expand` is a plain `for` loop over HelmReleases — no goroutines); only `validate` renders kustomizations in parallel. So #5371 is **not** the in-process concurrency race of #5362/#5364 (those locks are no-ops under scan's serial render). The "run-1-differs-then-converges" signature instead points squarely at **cold-cache acquisition**: on the cold first run a transient fetch failure silently degrades one or more HelmReleases; on the now-warm cache (runs 2–3) every chart resolves from disk → stable.

## Fix

Wrap the render-path `LocateChart` calls in `netretry.Do` with the **same** transient-error policy the install path already uses, extracted as `locateChartWithRetry` (parameterised so tests drive it with millisecond backoff). The retry stays **inside `chartAcquireMu`** because `LocateChart` mutates the shared on-disk cache and must stay serialized; the rare backoff briefly delays other parallel renders rather than letting them race a half-written cache.

This is a correct robustness fix on its own merits (it closes a real install-vs-render retry asymmetry), independent of whether it is the *sole* cause of #5371.

## How to confirm against #5371

If this is the cause, **run 1's stderr would have shown** `skipped Helm render for HelmRelease <ns>/<name> ...` degradation warnings (non-silent). To verify on a reproduction: capture stderr across cold runs, or diff the rendered `manifests.yaml` of run 1 vs run 2 — the dropped resources should belong to the warned HelmRelease(s), which now render after retry. I've used `Refs #5371` rather than `Fixes` so the maintainer can verify-and-close against a live repro. (If a residual non-determinism remains, the next suspect is range/`*` chart-version resolution against a cache-dependent repo index — separate from this fix.)

## Validation

- `go build ./...` ✓
- `go test -race ./pkg/client/helm/...` ✓ (124 tests; includes the #5362 `TestChartAcquisitionSerialized` guard, still green — 404 is non-retryable so the serialization probe is unaffected)
- `go test ./pkg/svc/gitops/render/... ./pkg/cli/cmd/workload/...` ✓ (554 tests)
- `golangci-lint run ./pkg/client/helm/...` ✓ (0 issues)
- New `chart_location_retry_test.go`: success / retry-then-succeed / stop-on-non-retryable / exhaustion.

Refs #5371
