### PR TITLE
feat(ui): Headlamp K8s ResourceClasses, CommonComponents & app-bar actions

### DIFF
--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { Fragment, useState, type ReactNode } from "react";
 import type { Cluster, User } from "../api.ts";
 import type { Theme } from "../hooks/useTheme.ts";
 import { clusterViews, globalViews, viewTitle, type RegisteredView, type View, type ViewGates } from "../lib/views.tsx";
+import { PluginAppBarActions } from "../lib/plugins/PluginSlots.tsx";
 import { ClusterSwitcher } from "./ClusterSwitcher.tsx";
 import { KSailMark } from "./Logo.tsx";
 import { IconButton } from "./ui.tsx";
@@ -282,6 +283,8 @@ export function AppShell({
                 </kbd>
               </button>
             ) : null}
+            {/* Plugin-contributed app-bar actions (Headlamp registerAppBarAction); renders nothing until a plugin adds one. */}
+            <PluginAppBarActions />
             {headerActions}
             <IconButton
               label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}

--- a/web/ui/src/lib/plugins/PluginSlots.tsx
+++ b/web/ui/src/lib/plugins/PluginSlots.tsx
@@ -36,6 +36,29 @@ class PluginErrorBoundary extends Component<{ name?: string; children: ReactNode
   }
 }
 
+// renderExtensionList maps a registered-extension list to error-boundary-wrapped nodes — the shared
+// shape behind the detail-section and app-bar slots. It renders nothing when the list is empty (so each
+// slot is zero-cost until a plugin contributes), and keeps the two slots from duplicating the
+// guard-and-map boilerplate.
+function renderExtensionList<T extends { id: string; pluginName?: string }>(
+  items: readonly T[],
+  renderItem: (item: T) => ReactNode,
+): ReactNode {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {items.map((item) => (
+        <PluginErrorBoundary key={item.id} name={item.pluginName}>
+          {renderItem(item)}
+        </PluginErrorBoundary>
+      ))}
+    </>
+  );
+}
+
 // PluginDetailSections renders every registered details-view section for a resource, each isolated by an
 // error boundary. It renders nothing when no sections are registered (the common case), so wiring it
 // into the detail panel is zero-cost until a plugin contributes a section.
@@ -43,20 +66,19 @@ export function PluginDetailSections({ resource }: { resource: PluginResource })
   // Subscribe so newly-registered sections appear without a manual refresh.
   usePluginRegistry();
 
-  const sections = registry.getDetailsSections();
-  if (sections.length === 0) {
-    return null;
-  }
+  return renderExtensionList(registry.getDetailsSections(), (section) => (
+    <section>{section.render(resource)}</section>
+  ));
+}
 
-  return (
-    <>
-      {sections.map((section) => (
-        <PluginErrorBoundary key={section.id} name={section.pluginName}>
-          <section>{section.render(resource)}</section>
-        </PluginErrorBoundary>
-      ))}
-    </>
-  );
+// PluginAppBarActions renders every registered app-bar action (Headlamp's registerAppBarAction), each
+// isolated by an error boundary, into the top header. It renders nothing when none are registered (the
+// common case), so placing it in the header is zero-cost until a plugin contributes an action.
+export function PluginAppBarActions(): ReactNode {
+  // Subscribe so a newly-registered action appears without a manual refresh.
+  usePluginRegistry();
+
+  return renderExtensionList(registry.getAppBarActions(), (action) => action.render());
 }
 
 // PluginRouteHost renders the component registered for a plugin route path, scoped to the active

--- a/web/ui/src/lib/plugins/commonComponents.tsx
+++ b/web/ui/src/lib/plugins/commonComponents.tsx
@@ -1,0 +1,38 @@
+// commonComponents.tsx reproduces the slice of Headlamp's `CommonComponents` module that plugins lay
+// their content out with. A Headlamp plugin imports these from
+// `@kinvolk/headlamp-plugin/lib/CommonComponents`, which the build maps to `pluginLib.CommonComponents`.
+// KSail renders them with its own surface styling (Tailwind, not Material UI) so plugin content matches
+// the host UI and needs no MUI dependency — a plugin using `<SectionBox title=…>` looks native in KSail.
+
+import * as React from "react";
+
+// SectionBox is Headlamp's titled content panel — the workhorse layout primitive plugins use to group
+// detail content. The title is optional (some callers render a bare framed box).
+export function SectionBox({
+  title,
+  children,
+}: {
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+      {title === undefined ? null : (
+        <h2 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</h2>
+      )}
+      {children}
+    </section>
+  );
+}
+
+// SectionHeader renders a standalone section title, matching Headlamp's CommonComponents.SectionHeader
+// for plugins that title content without wrapping it in a SectionBox.
+export function SectionHeader({ title }: { title: React.ReactNode }): React.ReactElement {
+  return <h2 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</h2>;
+}
+
+// CommonComponents is the object assigned to pluginLib.CommonComponents (the module shape a plugin's
+// CommonComponents import resolves to).
+export const CommonComponents = { SectionBox, SectionHeader };
+
+export type CommonComponentsShape = typeof CommonComponents;

--- a/web/ui/src/lib/plugins/k8s.ts
+++ b/web/ui/src/lib/plugins/k8s.ts
@@ -1,0 +1,150 @@
+// k8s.ts reproduces the slice of Headlamp's `K8s` data layer that plugins consume — the
+// `ResourceClasses.<Kind>.useList()` surface and the `KubeObject` instances it yields — backed by
+// KSail's read-only kube-apiserver proxy (see pkg/cli/clusterapi/kubeproxy.go) and scoped to the live
+// active cluster. It is the faithful, minimal counterpart to `@kinvolk/headlamp-plugin/lib/K8s`: a
+// Headlamp plugin that does `const [pods] = K8s.ResourceClasses.Pod.useList()` gets live cluster data
+// without modification. The full Headlamp class hierarchy (useGet, apiFactory, watch, CRD classes) is
+// intentionally out of scope here — this covers the common list-and-render path.
+
+import * as React from "react";
+import type { ClusterRef } from "./pluginLib.ts";
+
+// KubeObject wraps a raw Kubernetes resource as Headlamp plugins expect: `jsonData` holds the raw
+// object and the metadata/spec/status accessors plus getName/getNamespace mirror Headlamp's KubeObject
+// instance API closely enough for the common read paths.
+export class KubeObject {
+  jsonData: Record<string, unknown>;
+
+  constructor(raw: Record<string, unknown>) {
+    this.jsonData = raw ?? {};
+  }
+
+  get metadata(): Record<string, unknown> {
+    return (this.jsonData.metadata as Record<string, unknown>) ?? {};
+  }
+
+  get spec(): unknown {
+    return this.jsonData.spec;
+  }
+
+  get status(): unknown {
+    return this.jsonData.status;
+  }
+
+  get kind(): unknown {
+    return this.jsonData.kind;
+  }
+
+  getName(): string {
+    return (this.metadata.name as string) ?? "";
+  }
+
+  getNamespace(): string | undefined {
+    return this.metadata.namespace as string | undefined;
+  }
+}
+
+// ResourceClass is the static surface a plugin uses: `K8s.ResourceClasses.Pod.useList()`. It is the
+// list subset of Headlamp's KubeObject class statics — enough for the common "fetch and render a table"
+// plugin pattern.
+export interface ResourceClass {
+  useList: () => [KubeObject[], Error | null];
+}
+
+export type ResourceClasses = Record<string, ResourceClass>;
+
+interface ResourceDef {
+  // listPath is the apiserver collection path the kube-proxy fetches (cluster-wide; the proxy honours
+  // the same credentials as the resource browser).
+  listPath: string;
+}
+
+// RESOURCE_DEFS maps each reproduced Headlamp ResourceClass name to its apiserver list path. The set
+// covers the core/apps/batch/networking kinds plugins most commonly list; extend as needed.
+const RESOURCE_DEFS: Record<string, ResourceDef> = {
+  Pod: { listPath: "/api/v1/pods" },
+  Service: { listPath: "/api/v1/services" },
+  ConfigMap: { listPath: "/api/v1/configmaps" },
+  Secret: { listPath: "/api/v1/secrets" },
+  Namespace: { listPath: "/api/v1/namespaces" },
+  Node: { listPath: "/api/v1/nodes" },
+  Event: { listPath: "/api/v1/events" },
+  PersistentVolumeClaim: { listPath: "/api/v1/persistentvolumeclaims" },
+  ServiceAccount: { listPath: "/api/v1/serviceaccounts" },
+  Deployment: { listPath: "/apis/apps/v1/deployments" },
+  ReplicaSet: { listPath: "/apis/apps/v1/replicasets" },
+  StatefulSet: { listPath: "/apis/apps/v1/statefulsets" },
+  DaemonSet: { listPath: "/apis/apps/v1/daemonsets" },
+  Job: { listPath: "/apis/batch/v1/jobs" },
+  CronJob: { listPath: "/apis/batch/v1/cronjobs" },
+  Ingress: { listPath: "/apis/networking.k8s.io/v1/ingresses" },
+};
+
+// proxyList fetches a collection through the kube-proxy and wraps each item as a KubeObject.
+async function proxyList(cluster: ClusterRef, listPath: string): Promise<KubeObject[]> {
+  const base = `/api/v1/clusters/${encodeURIComponent(cluster.namespace)}/${encodeURIComponent(cluster.name)}`;
+  const response = await fetch(`${base}/proxy/${listPath.replace(/^\//, "")}`);
+  if (!response.ok) {
+    throw new Error(`apiserver GET ${listPath} failed: ${response.status}`);
+  }
+
+  const body = (await response.json()) as { items?: Record<string, unknown>[] };
+
+  return (body.items ?? []).map((item) => new KubeObject(item));
+}
+
+// makeResourceClass builds one ResourceClass whose useList hook fetches via the proxy and re-fetches
+// when the active cluster changes (keyed on the cluster's primitive name/namespace, mirroring the
+// useResourceList shim so a cluster switch reloads the data).
+function makeResourceClass(def: ResourceDef, getCluster: () => ClusterRef | null): ResourceClass {
+  return {
+    useList(): [KubeObject[], Error | null] {
+      const [items, setItems] = React.useState<KubeObject[]>([]);
+      const [error, setError] = React.useState<Error | null>(null);
+
+      const cluster = getCluster();
+      const clusterName = cluster?.name ?? null;
+      const clusterNamespace = cluster?.namespace ?? null;
+
+      React.useEffect(() => {
+        if (clusterName === null || clusterNamespace === null) {
+          setItems([]);
+
+          return undefined;
+        }
+
+        let active = true;
+
+        proxyList({ namespace: clusterNamespace, name: clusterName }, def.listPath)
+          .then((list) => {
+            if (active) {
+              setItems(list);
+            }
+          })
+          .catch((err: unknown) => {
+            if (active) {
+              setError(err instanceof Error ? err : new Error(String(err)));
+            }
+          });
+
+        return () => {
+          active = false;
+        };
+      }, [clusterName, clusterNamespace]);
+
+      return [items, error];
+    },
+  };
+}
+
+// makeResourceClasses builds the Headlamp `K8s.ResourceClasses` map — a useList()-bearing entry per
+// common kind, each backed by the kube-proxy and scoped to the live active cluster.
+export function makeResourceClasses(getCluster: () => ClusterRef | null): ResourceClasses {
+  const classes: ResourceClasses = {};
+
+  for (const [kind, def] of Object.entries(RESOURCE_DEFS)) {
+    classes[kind] = makeResourceClass(def, getCluster);
+  }
+
+  return classes;
+}

--- a/web/ui/src/lib/plugins/pluginLib.ts
+++ b/web/ui/src/lib/plugins/pluginLib.ts
@@ -5,16 +5,18 @@
 // surface plus a Kubernetes data shim — so an existing Headlamp plugin's register*() calls land in
 // KSail's native extension registry (see registry.ts) without modifying the plugin.
 //
-// Scope (honest): the React + register* + a real, minimal K8s.useResourceList surface are implemented.
-// The heavier Headlamp externals — Material UI, Redux, React Router, Monaco, Recharts — and the full
-// K8s/ApiProxy data layer (raw apiserver proxy, ResourceClasses, useApiGet) are STAGED, pending the
-// MUI-in-pluginLib bundle and KSail's generic cluster proxy. A plugin that uses only React + register*
-// (+ K8s.useResourceList for live data) works today; one that imports MUI/Redux/Router does not yet.
+// Scope (honest): React + register* + the K8s data layer (useResourceList, the kube-proxy-backed
+// ApiProxy, and the ResourceClasses.<Kind>.useList() class hierarchy) + CommonComponents are
+// implemented, so a Headlamp plugin that lists and renders cluster resources works unmodified. The
+// heavier UI externals — Material UI, Redux, React Router, Monaco, Recharts — are still STAGED, pending
+// the lazily-loaded MUI-in-pluginLib bundle; a plugin that imports those does not run yet.
 // See docs/BEST-KUBERNETES-UI-PLAN.md §4.3.
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { listResources } from "../../api.ts";
+import { CommonComponents, type CommonComponentsShape } from "./commonComponents.tsx";
+import { makeResourceClasses, type ResourceClasses } from "./k8s.ts";
 import { registry, type PluginResource, type RouteProps } from "./registry.ts";
 
 // ClusterRef identifies the active cluster the K8s shim scopes reads to (KSail's resource API is
@@ -52,7 +54,7 @@ export interface PluginLib {
   registerSidebarEntry: (entry: HeadlampSidebarEntry) => void;
   registerRoute: (route: HeadlampRoute) => void;
   registerDetailsViewSection: (section: DetailsSectionComponent) => void;
-  registerAppBarAction: (render: () => React.ReactNode) => void;
+  registerAppBarAction: (action: React.ReactNode | React.ComponentType) => void;
   registerResourceTableColumnsProcessor: (id: string, process: (columns: unknown[]) => unknown[]) => void;
   Registry: {
     registerSidebarEntry: (entry: HeadlampSidebarEntry) => void;
@@ -61,11 +63,13 @@ export interface PluginLib {
   };
   K8s: K8sShim;
   ApiProxy: ApiProxyShim;
+  CommonComponents: CommonComponentsShape;
   Notification: (message: string, ...rest: unknown[]) => void;
 }
 
 interface K8sShim {
   useResourceList: (kind: string, namespace?: string) => [PluginResource[], Error | null];
+  ResourceClasses: ResourceClasses;
 }
 
 interface ApiProxyShim {
@@ -118,7 +122,13 @@ export function installPluginLib(getCluster: () => ClusterRef | null): void {
     registerSidebarEntry,
     registerRoute,
     registerDetailsViewSection,
-    registerAppBarAction: (render) => {
+    registerAppBarAction: (action) => {
+      // Headlamp's registerAppBarAction takes a bare ReactNode (e.g. registerAppBarAction(<span>Hi</span>))
+      // or a component; normalize both to the registry's render() thunk so either form renders.
+      const render =
+        typeof action === "function"
+          ? (): React.ReactNode => React.createElement(action as React.ComponentType)
+          : (): React.ReactNode => action;
       registry.registerAppBarAction({ id: nextId("appbar"), render });
     },
     registerResourceTableColumnsProcessor: (id, process) => {
@@ -145,6 +155,7 @@ export function installPluginLib(getCluster: () => ClusterRef | null): void {
         return response.json();
       },
     },
+    CommonComponents,
     Notification: (message, ...rest) => {
       // Surface plugin notifications via a DOM event the SPA can later route to toasts; log meanwhile.
       window.dispatchEvent(new CustomEvent("ksail:plugin-notification", { detail: { message, rest } }));
@@ -198,5 +209,6 @@ function makeK8sShim(getCluster: () => ClusterRef | null): K8sShim {
 
       return [items, error];
     },
+    ResourceClasses: makeResourceClasses(getCluster),
   };
 }


### PR DESCRIPTION
Builds on the now-merged kube-proxy (#5379) and Headlamp plugin foundation (#5370) — both in `main`. The diff here is 5 frontend files.

## What

Extends the `window.pluginLib` Headlamp-compat facade so plugins that **list and render cluster resources** run unmodified — the next slice of Phase 4c after the proxy:

- **`K8s.ResourceClasses.<Kind>.useList()`** — the Headlamp K8s class hierarchy: a `useList()`-bearing class per common core/apps/batch/networking kind, yielding `KubeObject` instances (`metadata`/`spec`/`status`/`getName()`/`getNamespace()`), backed by the read-only kube-proxy and scoped to the live active cluster.
- **`CommonComponents.SectionBox` / `SectionHeader`** — Headlamp's titled layout panels, KSail-styled (no Material UI dependency).
- **`registerAppBarAction`** now accepts a bare `ReactNode` — the canonical `headlamp-plugin` scaffold form (`registerAppBarAction(<span>Hello</span>)`) — rendered in the app bar via a new `PluginAppBarActions` header slot (DRYed with `PluginDetailSections` through a shared helper).

## Verified live on a kind cluster

A faithful Headlamp-shaped plugin (hand-written: the `@kinvolk/headlamp-plugin` toolchain can't build under Node 26 locally, so this references the exact `pluginLib` globals a real bundle would) rendered end-to-end against a real apiserver, with **zero errors**:

- `K8s.ResourceClasses.Pod.useList()` → **9 live pods** (matched `kubectl` ground truth) inside a `SectionBox`
- the app-bar action (`registerAppBarAction(<ReactNode>)`) in the header
- sidebar entry + route, and the detail-view section (regressions)

## Scope

The heavier UI externals — **Material UI / Redux / React-Router** (a lazily-loaded `pluginLib` chunk so KSail's own bundle stays lean) — remain **staged for a follow-up increment**. A plugin that imports those does not run yet; one that uses React + `register*` + the K8s data layer + `CommonComponents` does.

`web/ui` only (MegaLinter-excluded); the gate is tsc + vite build, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
