### PR TITLE
fix(talos): neutralize CA certs and cluster ID in autoscaler template fingerprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/rancher/k3k v1.1.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	github.com/siderolabs/crypto v0.6.5
 	github.com/siderolabs/gen v0.8.6
 	github.com/siderolabs/go-kubernetes v0.2.38
 	github.com/siderolabs/go-retry v0.3.3
@@ -762,7 +763,6 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/siderolabs/crypto v0.6.5 // indirect
 	github.com/siderolabs/go-api-signature v0.3.12 // indirect
 	github.com/siderolabs/go-blockdevice/v2 v2.0.29 // indirect
 	github.com/siderolabs/go-cmd v0.2.0 // indirect

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	clusterautoscalerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/clusterautoscaler"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	x509 "github.com/siderolabs/crypto/x509"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -541,15 +542,24 @@ func (p *Provisioner) readAutoscalerConfigSecret(
 //
 // The comparison is over each pool's normalised worker config fingerprint — not
 // the raw Secret bytes (see redactedWorkerConfigFingerprint): the cloud-init embeds
-// the full worker config, and two fields legitimately differ between the un-synced
-// local bundle the diff phase renders and the cluster-synced bundle the apply path
-// stores, because syncSecretsFromCluster realigns both during apply (#4963) — the
-// PKI (neutralised by RedactSecrets) and the cluster control-plane endpoint
-// (CIDR-derived private IP locally vs the control-plane's public IP on the cluster,
-// neutralised by normalizeEndpointForFingerprint; the endpoint is not a secret, so
-// redaction alone left it leaking a phantom in-place diff on every run). Both
-// normalisations isolate the comparison to the machine-config patches, labels, and
-// taints this bug is about, keeping idempotent re-runs at "No changes detected".
+// the full worker config, and three classes of field legitimately differ between
+// the un-synced local bundle the diff phase renders and the cluster-synced bundle
+// the apply path stores, because syncSecretsFromCluster realigns all of them during
+// apply (#4963):
+//
+//   - the PKI private keys, tokens, and cluster secret (neutralised by RedactSecrets);
+//   - the cluster control-plane endpoint (CIDR-derived private IP locally vs the
+//     control-plane's public IP on the cluster); and
+//   - the cluster identity material — the CA *certificates* and the cluster ID.
+//
+// The last two are NOT secrets RedactSecrets touches (it only nulls private keys),
+// and a worker config carries the CA certs with empty keys (workers hold no CA
+// private key), so a fresh-PKI local bundle fingerprinted differently from the
+// stored Secret on every run — the phantom in-place diff that never converged.
+// normalizeForFingerprint substitutes fixed placeholders for the endpoint and the
+// cluster identity so the comparison isolates to the machine-config patches,
+// labels, and taints this bug is about, keeping idempotent re-runs at "No changes
+// detected".
 func autoscalerTemplateDrift(
 	existing *corev1.Secret,
 	pools []AutoscalerPoolConfig,
@@ -691,16 +701,18 @@ const fingerprintEndpointPlaceholder = "https://cluster-endpoint:6443"
 
 // redactedWorkerConfigFingerprint returns a short, stable fingerprint of a worker
 // config's secrets-redacted, canonical encoding (the same normalisation
-// configFingerprint uses), with the cluster control-plane endpoint normalised to a
-// fixed placeholder, so two configs that differ only in PKI or endpoint — both
-// realigned from the running cluster during apply (#4963) — fingerprint identically.
+// configFingerprint uses), with the cluster control-plane endpoint and cluster
+// identity material (CA certificates and cluster ID) normalised to fixed
+// placeholders, so two configs that differ only in PKI, endpoint, or cluster
+// identity — all realigned from the running cluster during apply (#4963) —
+// fingerprint identically.
 func redactedWorkerConfigFingerprint(workerYAML []byte) (string, error) {
 	provider, err := configloader.NewFromBytes(workerYAML)
 	if err != nil {
 		return "", fmt.Errorf("load worker config for fingerprint: %w", err)
 	}
 
-	provider, err = normalizeEndpointForFingerprint(provider)
+	provider, err = normalizeForFingerprint(provider)
 	if err != nil {
 		return "", err
 	}
@@ -708,13 +720,21 @@ func redactedWorkerConfigFingerprint(workerYAML []byte) (string, error) {
 	return configFingerprint(provider), nil
 }
 
-// normalizeEndpointForFingerprint substitutes the cluster control-plane endpoint
-// with a fixed placeholder so two worker templates that differ only in endpoint
-// fingerprint identically. It is a no-op when the config carries no endpoint (the
-// structure is preserved otherwise, so a config that defines an endpoint and one
-// that does not still fingerprint differently — but both sides of the autoscaler
-// comparison come from the same bundle, so they always agree on its presence).
-func normalizeEndpointForFingerprint(
+// normalizeForFingerprint substitutes fixed placeholders for the parts of a worker
+// config that syncSecretsFromCluster realigns from the running cluster during apply
+// (#4963) but RedactSecrets does not neutralise: the cluster control-plane endpoint
+// (CIDR-derived private IP locally vs the control-plane's public IP on the cluster)
+// and the cluster identity material (the CA certificates and the cluster ID).
+// RedactSecrets — applied later by configFingerprint — only nulls private keys,
+// tokens, and the cluster secret, never the CA certificates or the cluster ID; and
+// a worker config carries the CA certs with empty keys (workers hold no CA private
+// key), so without this step a freshly generated local bundle fingerprints
+// differently from the cluster-synced Secret on every run, leaking a phantom
+// in-place diff that never converges. Structure is otherwise preserved, so configs
+// that do and do not define a field still fingerprint differently — but both sides
+// of the autoscaler comparison come from the same bundle shape, so they always
+// agree on each field's presence.
+func normalizeForFingerprint(
 	provider talosconfig.Provider,
 ) (talosconfig.Provider, error) {
 	placeholder, err := url.Parse(fingerprintEndpointPlaceholder)
@@ -723,21 +743,72 @@ func normalizeEndpointForFingerprint(
 	}
 
 	patched, err := provider.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
-		if cfg.ClusterConfig == nil ||
-			cfg.ClusterConfig.ControlPlane == nil ||
-			cfg.ClusterConfig.ControlPlane.Endpoint == nil {
-			return nil
-		}
-
-		cfg.ClusterConfig.ControlPlane.Endpoint = &v1alpha1.Endpoint{URL: placeholder}
+		normalizeEndpoint(cfg, placeholder)
+		normalizeClusterIdentity(cfg)
 
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("normalize endpoint for fingerprint: %w", err)
+		return nil, fmt.Errorf("normalize worker config for fingerprint: %w", err)
 	}
 
 	return patched, nil
+}
+
+// normalizeEndpoint substitutes the cluster control-plane endpoint with a fixed
+// placeholder. It is a no-op when the config carries no endpoint.
+func normalizeEndpoint(cfg *v1alpha1.Config, placeholder *url.URL) {
+	if cfg.ClusterConfig == nil ||
+		cfg.ClusterConfig.ControlPlane == nil ||
+		cfg.ClusterConfig.ControlPlane.Endpoint == nil {
+		return
+	}
+
+	cfg.ClusterConfig.ControlPlane.Endpoint = &v1alpha1.Endpoint{URL: placeholder}
+}
+
+// normalizeClusterIdentity substitutes the cluster identity material — the cluster
+// ID and the machine/cluster CA certificates — with fixed placeholders, since
+// syncSecretsFromCluster realigns all of it from the running cluster during apply
+// (#4963). RedactSecrets nulls the CA private keys but never the certificates, and
+// a worker config carries no CA private key, so the certificates must be
+// neutralised here for a fresh-PKI local bundle to fingerprint identically to the
+// synced Secret. Only the CA fields a worker config actually carries (machine CA,
+// cluster CA, cluster ID) are handled; the aggregator/etcd/service-account material
+// is control-plane-only and never present in the worker configs fingerprinted here.
+func normalizeClusterIdentity(cfg *v1alpha1.Config) {
+	if cfg.MachineConfig != nil {
+		neutralizeCertificate(cfg.MachineConfig.MachineCA)
+	}
+
+	if cfg.ClusterConfig == nil {
+		return
+	}
+
+	if cfg.ClusterConfig.ClusterID != "" {
+		cfg.ClusterConfig.ClusterID = redactedSecretPlaceholder
+	}
+
+	neutralizeCertificate(cfg.ClusterConfig.ClusterCA)
+}
+
+// neutralizeCertificate replaces a CA's certificate and key bytes with a fixed
+// placeholder so two configs differing only in PKI fingerprint identically. It
+// mirrors RedactSecrets' redactBytes semantics — a no-op on an absent struct or an
+// empty field — so an empty CA key (the common worker-config case) stays empty on
+// both sides of the comparison.
+func neutralizeCertificate(cert *x509.PEMEncodedCertificateAndKey) {
+	if cert == nil {
+		return
+	}
+
+	if len(cert.Crt) > 0 {
+		cert.Crt = []byte(redactedSecretPlaceholder)
+	}
+
+	if len(cert.Key) > 0 {
+		cert.Key = []byte(redactedSecretPlaceholder)
+	}
 }
 
 // autoscalerTemplateDigest renders a poolName→fingerprint map into a single short,

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -992,14 +992,11 @@ func TestAutoscalerTemplateDrift_IgnoresFreshlyRegeneratedPKI(t *testing.T) {
 		"independent generations must differ in PKI, else the test proves nothing",
 	)
 
-	secret := autoscalerSecretFor(t, "1", []talosprovisioner.AutoscalerPoolConfig{
-		{Name: "pool1", WorkerConfigYAML: storedYAML},
-	})
-	desired := []talosprovisioner.AutoscalerPoolConfig{
-		{Name: "pool1", WorkerConfigYAML: desiredYAML},
-	}
+	secret := autoscalerSecretFor(t, "1", singlePoolConfig(storedYAML))
 
-	changes, err := talosprovisioner.AutoscalerTemplateDriftForTest(secret, desired)
+	changes, err := talosprovisioner.AutoscalerTemplateDriftForTest(
+		secret, singlePoolConfig(desiredYAML),
+	)
 	require.NoError(t, err)
 	assert.Empty(
 		t,

--- a/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_worker_config_test.go
@@ -13,9 +13,11 @@ import (
 	"strings"
 	"testing"
 
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	clusterautoscalerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/clusterautoscaler"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	x509 "github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	taloscontainer "github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -880,6 +882,129 @@ func TestAutoscalerTemplateDrift_IgnoresEndpointOnlyDifference(t *testing.T) {
 		t,
 		changes,
 		"an endpoint-only difference must be normalised away, not reported as drift",
+	)
+}
+
+// workerProviderWithIdentity builds a worker provider carrying cluster identity
+// material — the CA certificates and cluster ID — that syncSecretsFromCluster
+// realigns from the running cluster during apply (#4963). Talos's RedactSecrets
+// only nulls private *keys*, never the CA *certificates* or the cluster ID, and a
+// worker config carries the CA certs with empty keys (workers hold no CA private
+// key; see talos-worker-config-lacks-pki), so two providers differing only here
+// must still normalise to the same fingerprint.
+func workerProviderWithIdentity(
+	machineCACrt, clusterCACrt []byte,
+	clusterID string,
+) *taloscontainer.Container {
+	falseVal := false
+
+	return taloscontainer.NewV1Alpha1(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineInstall: &v1alpha1.InstallConfig{InstallWipe: &falseVal},
+			MachineCA:      &x509.PEMEncodedCertificateAndKey{Crt: machineCACrt},
+		},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ClusterID: clusterID,
+			ClusterCA: &x509.PEMEncodedCertificateAndKey{Crt: clusterCACrt},
+		},
+	})
+}
+
+// The comparison must also ignore the cluster identity material — the CA
+// certificates and the cluster ID — which syncSecretsFromCluster realigns from the
+// running cluster during apply (#4963). The diff phase renders the desired template
+// from a freshly generated local secrets bundle (new CA certs and cluster ID on
+// every run) while the Secret holds the cluster's real identity. Talos's
+// RedactSecrets only nulls private keys, not the CA *certificates*, and a worker
+// config carries no CA private key to redact — so without normalisation every
+// `cluster update` falsely reports an autoscalerWorkerTemplate in-place change
+// whose NewValue digest changes each run (the on-platform symptom that never
+// converges).
+func TestAutoscalerTemplateDrift_IgnoresCAAndClusterIDOnlyDifference(t *testing.T) {
+	t.Parallel()
+
+	// The Secret was written by a prior apply from the cluster-synced bundle (the
+	// running cluster's CA certs and ID); the diff phase renders the desired
+	// template from a freshly generated local bundle with different identity.
+	stored := workerProviderWithIdentity(
+		[]byte("machine-ca-from-running-cluster"),
+		[]byte("cluster-ca-from-running-cluster"),
+		"cluster-id-running",
+	)
+	local := workerProviderWithIdentity(
+		[]byte("machine-ca-freshly-generated"),
+		[]byte("cluster-ca-freshly-generated"),
+		"cluster-id-fresh",
+	)
+
+	secret := autoscalerSecretFor(t, "1", []talosprovisioner.AutoscalerPoolConfig{
+		autoscalerPoolFor(t, "pool1", stored, nil),
+	})
+	desired := []talosprovisioner.AutoscalerPoolConfig{
+		autoscalerPoolFor(t, "pool1", local, nil),
+	}
+
+	changes, err := talosprovisioner.AutoscalerTemplateDriftForTest(secret, desired)
+	require.NoError(t, err)
+	assert.Empty(
+		t,
+		changes,
+		"a CA-cert/cluster-ID-only difference must be normalised away, not reported as drift",
+	)
+}
+
+// Faithful end-to-end guard: two independent config generations with identical
+// patches model two `cluster update` runs, each minting fresh PKI (CA certs+keys,
+// cluster ID, tokens, bootstrap secrets) via bundle.NewBundle — exactly the
+// material syncSecretsFromCluster realigns from the running cluster on every run
+// (#4963). The stored Secret and the desired template therefore differ ONLY in
+// that regenerated identity, so drift detection must report nothing. Where the
+// hand-built CA/ID test above pins the specific fields, this one exercises the
+// whole real secrets bundle and would catch any run-specific field either misses
+// (the on-platform symptom was a NewValue digest that changed every run).
+func TestAutoscalerTemplateDrift_IgnoresFreshlyRegeneratedPKI(t *testing.T) {
+	t.Parallel()
+
+	storedConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(nil)
+	require.NoError(t, err)
+
+	desiredConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(nil)
+	require.NoError(t, err)
+
+	storedYAML, err := talosprovisioner.GenerateAutoscalerWorkerConfig(
+		storedConfigs.Worker(), nil, nil,
+	)
+	require.NoError(t, err)
+
+	desiredYAML, err := talosprovisioner.GenerateAutoscalerWorkerConfig(
+		desiredConfigs.Worker(), nil, nil,
+	)
+	require.NoError(t, err)
+
+	// Sanity: independent generations really do differ (fresh PKI), so an
+	// empty-drift result proves the normalisation worked rather than the two inputs
+	// happening to be byte-identical.
+	require.NotEqual(
+		t,
+		storedYAML,
+		desiredYAML,
+		"independent generations must differ in PKI, else the test proves nothing",
+	)
+
+	secret := autoscalerSecretFor(t, "1", []talosprovisioner.AutoscalerPoolConfig{
+		{Name: "pool1", WorkerConfigYAML: storedYAML},
+	})
+	desired := []talosprovisioner.AutoscalerPoolConfig{
+		{Name: "pool1", WorkerConfigYAML: desiredYAML},
+	}
+
+	changes, err := talosprovisioner.AutoscalerTemplateDriftForTest(secret, desired)
+	require.NoError(t, err)
+	assert.Empty(
+		t,
+		changes,
+		"freshly regenerated PKI/identity must not read as autoscalerWorkerTemplate drift",
 	)
 }
 


### PR DESCRIPTION
## What

Fixes a phantom in-place `autoscalerWorkerTemplate` change that `cluster update` reported on **every run** for Talos×Hetzner clusters with the node autoscaler enabled — observed repeatedly on `devantler-tech/platform`'s *Deploy to Production* job, firing on each merge-queue PR.

The tell was the contradiction in the logs: detection reports a change, but the apply path immediately says the secret is already up to date, and it never converges:

```
🟢 autoscalerWorkerTemplate  68647d0c6233  03b21200169d  in-place   ← PR 1
🟢 autoscalerWorkerTemplate  68647d0c6233  be781e74313d  in-place   ← PR 2
...
Applying cluster-autoscaler config secret...
  ✓ Cluster autoscaler config secret already up to date
```

The **OldValue digest is stable** across runs while the **NewValue digest changes every run** — the signature of run-specific material leaking into the *desired* fingerprint.

## Why (root cause)

The drift fingerprint added in #5194 relies on Talos's `RedactSecrets` plus an endpoint placeholder to ignore the fields `syncSecretsFromCluster` realigns from the running cluster during apply (#4963).

But `(*v1alpha1.Config).Redact` only nulls private **keys**, tokens, and the cluster secret — it **never touches the CA certificates (`.Crt`) or `cluster.id`**. And a worker config carries the CA certs with *empty* keys (workers hold no CA private key), so `RedactSecrets` is effectively a no-op on a worker's PKI.

The local disk bundle regenerates **fresh PKI on every run** (`ConfigManager.Load()`), so `machine.ca.crt`, `cluster.ca.crt`, and `cluster.id` differed from the cluster-synced secret every run → the desired fingerprint churned → permanent, never-converging in-place change. Apply, which compares raw secret bytes against the previously-stored (also cluster-synced) secret, correctly saw no change.

## Fix

Broaden `normalizeEndpointForFingerprint` → `normalizeForFingerprint`, which now also substitutes fixed placeholders for the worker-config identity material — the machine/cluster **CA certificates** and `cluster.id` — before fingerprinting. The endpoint normalization and `RedactSecrets` (keys/tokens/secret) are unchanged.

Aggregator/etcd/service-account CAs are control-plane-only and never present in the worker configs fingerprinted here, so they are intentionally not handled (would be uncovered dead branches).

## Tests

Both fail before the fix, pass after:

- `TestAutoscalerTemplateDrift_IgnoresCAAndClusterIDOnlyDifference` — pins the specific fields (CA certs + `cluster.id`).
- `TestAutoscalerTemplateDrift_IgnoresFreshlyRegeneratedPKI` — gold-standard end-to-end guard: generates **two real Talos secrets bundles** (`NewDefaultConfigsWithPatches(nil)` twice = two `cluster update` runs), asserts they really differ, then asserts no drift. Exercises the *whole* secrets bundle, so it catches any run-specific field the targeted test might miss.

The pre-existing `TestAutoscalerTemplateDrift_IgnoresPKIOnlyDifference` only varied `machine.token` (which *is* redacted), which is how this gap slipped through originally.

## Notes for reviewers

- `go.mod`: promotes `github.com/siderolabs/crypto` from indirect to direct (now imported for `x509.PEMEncodedCertificateAndKey`). Same version `v0.6.5`, so `go.sum` is unchanged and the separate `desktop/` module is unaffected.
- Detection-only change; no apply-path logic changed. The already-idempotent apply path does the real regeneration once `TotalChanges() > 0`.
- Follow-up to #5194 (worker-template drift detection) and #4963 (secrets/endpoint realignment during apply).

Local validation: `go build ./...`, `go test ./pkg/svc/provisioner/cluster/talos/` (551 pass), `golangci-lint run --new-from-rev=HEAD` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)