### PR TITLE
fix(ui): dedupe cluster-scoped list hook to clear jscpd clone

### DIFF
--- a/web/ui/src/lib/plugins/k8s.ts
+++ b/web/ui/src/lib/plugins/k8s.ts
@@ -6,8 +6,8 @@
 // without modification. The full Headlamp class hierarchy (useGet, apiFactory, watch, CRD classes) is
 // intentionally out of scope here — this covers the common list-and-render path.
 
-import * as React from "react";
 import type { ClusterRef } from "./pluginLib.ts";
+import { useClusterScopedList } from "./useClusterScopedList.ts";
 
 // KubeObject wraps a raw Kubernetes resource as Headlamp plugins expect: `jsonData` holds the raw
 // object and the metadata/spec/status accessors plus getName/getNamespace mirror Headlamp's KubeObject
@@ -95,44 +95,12 @@ async function proxyList(cluster: ClusterRef, listPath: string): Promise<KubeObj
 
 // makeResourceClass builds one ResourceClass whose useList hook fetches via the proxy and re-fetches
 // when the active cluster changes (keyed on the cluster's primitive name/namespace, mirroring the
-// useResourceList shim so a cluster switch reloads the data).
+// useResourceList shim so a cluster switch reloads the data). The cluster-scoped fetch-on-change effect
+// is shared with useResourceList via useClusterScopedList.
 function makeResourceClass(def: ResourceDef, getCluster: () => ClusterRef | null): ResourceClass {
   return {
     useList(): [KubeObject[], Error | null] {
-      const [items, setItems] = React.useState<KubeObject[]>([]);
-      const [error, setError] = React.useState<Error | null>(null);
-
-      const cluster = getCluster();
-      const clusterName = cluster?.name ?? null;
-      const clusterNamespace = cluster?.namespace ?? null;
-
-      React.useEffect(() => {
-        if (clusterName === null || clusterNamespace === null) {
-          setItems([]);
-
-          return undefined;
-        }
-
-        let active = true;
-
-        proxyList({ namespace: clusterNamespace, name: clusterName }, def.listPath)
-          .then((list) => {
-            if (active) {
-              setItems(list);
-            }
-          })
-          .catch((err: unknown) => {
-            if (active) {
-              setError(err instanceof Error ? err : new Error(String(err)));
-            }
-          });
-
-        return () => {
-          active = false;
-        };
-      }, [clusterName, clusterNamespace]);
-
-      return [items, error];
+      return useClusterScopedList(getCluster, (cluster) => proxyList(cluster, def.listPath));
     },
   };
 }

--- a/web/ui/src/lib/plugins/pluginLib.ts
+++ b/web/ui/src/lib/plugins/pluginLib.ts
@@ -18,6 +18,7 @@ import { listResources } from "../../api.ts";
 import { CommonComponents, type CommonComponentsShape } from "./commonComponents.tsx";
 import { makeResourceClasses, type ResourceClasses } from "./k8s.ts";
 import { registry, type PluginResource, type RouteProps } from "./registry.ts";
+import { useClusterScopedList } from "./useClusterScopedList.ts";
 
 // ClusterRef identifies the active cluster the K8s shim scopes reads to (KSail's resource API is
 // cluster-scoped). The loader supplies a live getter so the shim always reads the current cluster.
@@ -168,46 +169,21 @@ export function installPluginLib(getCluster: () => ClusterRef | null): void {
 
 // makeK8sShim builds the minimal-but-real Kubernetes data surface plugins consume. useResourceList is a
 // React hook over KSail's allowlisted resource endpoint, returning [items, error] like Headlamp's
-// useList for the common kinds (Pods, Deployments, …). It must be called from a component render.
+// useList for the common kinds (Pods, Deployments, …). It must be called from a component render. The
+// cluster-scoped fetch-on-change effect is shared with k8s.ts's useList via useClusterScopedList; the
+// kind/namespace arguments are passed as extra deps so the list also re-fetches when they change.
 function makeK8sShim(getCluster: () => ClusterRef | null): K8sShim {
   return {
     useResourceList(kind: string, namespace?: string): [PluginResource[], Error | null] {
-      const [items, setItems] = React.useState<PluginResource[]>([]);
-      const [error, setError] = React.useState<Error | null>(null);
+      return useClusterScopedList(
+        getCluster,
+        async (cluster) => {
+          const list = await listResources(cluster.namespace, cluster.name, kind, namespace);
 
-      // Read the active cluster during render and key the effect on it, so the list re-fetches when the
-      // user switches clusters — not only when the kind/namespace arguments change.
-      const cluster = getCluster();
-      const clusterName = cluster?.name ?? null;
-      const clusterNamespace = cluster?.namespace ?? null;
-
-      React.useEffect(() => {
-        if (clusterName === null || clusterNamespace === null) {
-          setItems([]);
-
-          return undefined;
-        }
-
-        let active = true;
-
-        listResources(clusterNamespace, clusterName, kind, namespace)
-          .then((list) => {
-            if (active) {
-              setItems(list.items ?? []);
-            }
-          })
-          .catch((err: unknown) => {
-            if (active) {
-              setError(err instanceof Error ? err : new Error(String(err)));
-            }
-          });
-
-        return () => {
-          active = false;
-        };
-      }, [kind, namespace, clusterName, clusterNamespace]);
-
-      return [items, error];
+          return list.items ?? [];
+        },
+        [kind, namespace],
+      );
     },
     ResourceClasses: makeResourceClasses(getCluster),
   };

--- a/web/ui/src/lib/plugins/useClusterScopedList.ts
+++ b/web/ui/src/lib/plugins/useClusterScopedList.ts
@@ -1,0 +1,55 @@
+// useClusterScopedList is the shared React hook behind both Headlamp-compat list surfaces plugins
+// consume: `K8s.ResourceClasses.<Kind>.useList()` (k8s.ts) and `K8s.useResourceList()` (pluginLib.ts).
+// It fetches a list scoped to the active cluster and re-fetches when the cluster — or any caller-supplied
+// dependency (e.g. kind/namespace) — changes, returning [items, error] like Headlamp's useList.
+//
+// `fetchList` receives the resolved active cluster and returns its items; `deps` are extra reactive
+// inputs appended to the cluster keys so the effect also re-runs when they change. It must be called
+// from a component render (it is a hook). Both call sites previously inlined this effect verbatim,
+// differing only in the item type, the fetch call, and the extra deps — so the logic lives here once.
+
+import * as React from "react";
+import type { ClusterRef } from "./pluginLib.ts";
+
+export function useClusterScopedList<T>(
+  getCluster: () => ClusterRef | null,
+  fetchList: (cluster: ClusterRef) => Promise<T[]>,
+  deps: React.DependencyList = [],
+): [T[], Error | null] {
+  const [items, setItems] = React.useState<T[]>([]);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  // Read the active cluster during render and key the effect on its primitive name/namespace, so the
+  // list re-fetches on a cluster switch — not only when the caller's own deps change.
+  const cluster = getCluster();
+  const clusterName = cluster?.name ?? null;
+  const clusterNamespace = cluster?.namespace ?? null;
+
+  React.useEffect(() => {
+    if (clusterName === null || clusterNamespace === null) {
+      setItems([]);
+
+      return undefined;
+    }
+
+    let active = true;
+
+    fetchList({ namespace: clusterNamespace, name: clusterName })
+      .then((list) => {
+        if (active) {
+          setItems(list);
+        }
+      })
+      .catch((err: unknown) => {
+        if (active) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [clusterName, clusterNamespace, ...deps]);
+
+  return [items, error];
+}


### PR DESCRIPTION
## What

Clears the `🧹 Lint - mega-linter` failure (jscpd / COPYPASTE) that is currently failing on **every open PR**, including unrelated ones.

## Why

MegaLinter full-scans the whole repo on each PR's merge ref, and jscpd runs with a **0% clone threshold**. The Headlamp-compat list surfaces added in [#5385](https://github.com/devantler-tech/ksail/pull/5385) inlined the same cluster-scoped *fetch-on-change* React effect in two places:

- `makeResourceClass(...).useList()` in `web/ui/src/lib/plugins/k8s.ts` (lines ~105–133)
- `makeK8sShim(...).useResourceList()` in `web/ui/src/lib/plugins/pluginLib.ts` (lines ~180–208)

They differ only in the item type (`KubeObject` vs `PluginResource`), the fetch call (`proxyList` vs `listResources`), and the extra effect deps. jscpd flagged the two blocks as clones (0.02% > 0%), so the check has been red for everyone since #5385 merged.

## Change

Extract the shared effect into a generic hook, `useClusterScopedList<T>(getCluster, fetchList, deps)`, and have both call sites delegate to it. This matches the maintainer's standing preference to **dedupe** clones rather than ignore them.

Behaviour is fully preserved:
- Same `[items, error]` return shape.
- Same cluster-keyed re-fetch (effect keyed on the cluster's primitive name/namespace).
- Same extra deps — `useResourceList` still re-fetches on `kind`/`namespace` change (passed as `deps`).
- `useList` keeps its empty extra-deps set.

Also drops the now-unused `React` import from `k8s.ts`. The shared hook's `import type { ClusterRef }` from `pluginLib.ts` is type-only (erased at compile time), so no runtime import cycle is introduced.

## Validation

- `web/ui` `tsc --noEmit` (the `lint` script): clean.
- `jscpd` (same `.jscpd.json`, console reporter): **0 clones found** (was 2); 906 files scanned.

## Note

Discovered while investigating CI on an unrelated Talos PR ([#5408](https://github.com/devantler-tech/ksail/pull/5408)) — its mega-linter was red purely because of this repo-wide clone, not its own (Go-only) changes. Fixing here unblocks mega-linter across all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)