### PR TITLE
Potential fix for code scanning alert no. 2041: Uncontrolled data used in path expression

### DIFF
--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -441,8 +442,31 @@ options:
 	}, nil
 }
 
+var safeClusterNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+func validateClusterNamePathComponent(clusterName string) error {
+	if clusterName == "" || clusterName == "." || clusterName == ".." {
+		return fmt.Errorf("invalid cluster name")
+	}
+
+	if strings.Contains(clusterName, "/") || strings.Contains(clusterName, "\\") {
+		return fmt.Errorf("invalid cluster name")
+	}
+
+	if !safeClusterNamePattern.MatchString(clusterName) {
+		return fmt.Errorf("invalid cluster name")
+	}
+
+	return nil
+}
+
 // kwokStateDir returns the absolute path to kwokctl's cluster state directory.
 func kwokStateDir(clusterName string) (string, error) {
+	err := validateClusterNamePathComponent(clusterName)
+	if err != nil {
+		return "", fmt.Errorf("validate cluster name: %w", err)
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("get home dir: %w", err)

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
@@ -2,6 +2,7 @@ package kwokprovisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -442,19 +443,22 @@ options:
 	}, nil
 }
 
-var safeClusterNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+var (
+	safeClusterNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+	errInvalidClusterName  = errors.New("invalid cluster name")
+)
 
 func validateClusterNamePathComponent(clusterName string) error {
 	if clusterName == "" || clusterName == "." || clusterName == ".." {
-		return fmt.Errorf("invalid cluster name")
+		return errInvalidClusterName
 	}
 
 	if strings.Contains(clusterName, "/") || strings.Contains(clusterName, "\\") {
-		return fmt.Errorf("invalid cluster name")
+		return errInvalidClusterName
 	}
 
 	if !safeClusterNamePattern.MatchString(clusterName) {
-		return fmt.Errorf("invalid cluster name")
+		return errInvalidClusterName
 	}
 
 	return nil


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/2041](https://github.com/devantler-tech/ksail/security/code-scanning/2041)

General fix: treat `clusterName` as untrusted and enforce a strict allowlist for path-component-safe names before joining into filesystem paths. For this case, `clusterName` should be a single path segment, so reject empty names, any path separators (`/`, `\`), `"."`, `".."`, and optionally require a safe character set.

Best targeted fix without changing intended functionality:
- Edit `pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go`.
- Add a helper validator (e.g., `validateClusterNamePathComponent`) that:
  - rejects empty / `"."` / `".."`;
  - rejects names containing `/` or `\`;
  - enforces a conservative regex like `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` (compatible with existing cluster naming expectations).
- Call this validator inside `kwokStateDir` before `filepath.Join`.
- Return an error if invalid, so existing callers already handling `err` fail safely.

No new external dependency is required; use standard library `regexp`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
