### PR TITLE
Potential fix for code scanning alert no. 2040: Uncontrolled data used in path expression

### DIFF
--- a/pkg/svc/provisioner/cluster/kwok/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/provisioner.go
@@ -530,11 +530,22 @@ func (p *Provisioner) existsWithContext(kwokCtx context.Context, target string) 
 }
 
 func (p *Provisioner) resolveName(name string) string {
-	if name != "" {
-		return name
+	if name == "" {
+		return p.name
 	}
 
-	return p.name
+	// Defensive validation: cluster names are expected to be a single logical identifier,
+	// never a filesystem path.
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return ""
+	}
+
+	cleaned := filepath.Clean(name)
+	if cleaned == "." || cleaned == ".." || filepath.IsAbs(cleaned) {
+		return ""
+	}
+
+	return name
 }
 
 // setDefaultCluster sets config.DefaultCluster and returns a function that


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/2040](https://github.com/devantler-tech/ksail/security/code-scanning/2040)

To fix this safely without changing intended behavior, validate cluster names in the KWOK provisioner name-resolution path so user-controlled names cannot contain path traversal or separators.

Best single fix:
- Update `resolveName` in `pkg/svc/provisioner/cluster/kwok/provisioner.go` to sanitize/validate the input.
- Reject names containing `/`, `\`, `..`, or that normalize to absolute/current/parent forms.
- Fall back to `p.name` only when `name == ""` (existing behavior).
- If invalid, return empty string so callers fail safely when they attempt operations with that name rather than writing to unintended paths.

Because current `resolveName` returns only `string` (not `(string, error)`), we should keep signature unchanged to avoid larger refactors; enforce strict filtering there.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
