### PR TITLE
Potential fix for code scanning alert no. 2039: Uncontrolled data used in path expression

### DIFF
--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -309,10 +309,7 @@ func (s *Service) Create(
 ) (*v1alpha1.Cluster, error) {
 	name := cluster.Name
 	if !isSafeClusterName(name) {
-		return nil, fmt.Errorf(
-			"%w: name is required and must be a safe path component",
-			api.ErrInvalid,
-		)
+		return nil, fmt.Errorf("%w: invalid name %q", api.ErrInvalid, name)
 	}
 
 	distribution := cluster.Spec.Cluster.Distribution

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -13,8 +13,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -277,6 +279,28 @@ func (s *Service) Get(
 	return nil, fmt.Errorf("%w: %q", api.ErrNotFound, name)
 }
 
+func isSafeClusterName(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	// Cluster name is used as a single filesystem path component in provisioners.
+	// Reject separators and parent/current directory components to prevent traversal.
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return false
+	}
+
+	if name == "." || name == ".." || strings.Contains(name, "..") {
+		return false
+	}
+
+	if filepath.Base(name) != name {
+		return false
+	}
+
+	return true
+}
+
 // Create starts provisioning a cluster and returns immediately with the cluster in the Provisioning
 // phase. The actual provisioning runs in a background goroutine; List/Get reflect its progress.
 func (s *Service) Create(
@@ -286,6 +310,10 @@ func (s *Service) Create(
 	name := cluster.Name
 	if name == "" {
 		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
+	}
+
+	if !isSafeClusterName(name) {
+		return nil, fmt.Errorf("%w: invalid name", api.ErrInvalid)
 	}
 
 	distribution := cluster.Spec.Cluster.Distribution

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -308,12 +308,11 @@ func (s *Service) Create(
 	cluster *v1alpha1.Cluster,
 ) (*v1alpha1.Cluster, error) {
 	name := cluster.Name
-	if name == "" {
-		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
-	}
-
 	if !isSafeClusterName(name) {
-		return nil, fmt.Errorf("%w: invalid name", api.ErrInvalid)
+		return nil, fmt.Errorf(
+			"%w: name is required and must be a safe path component",
+			api.ErrInvalid,
+		)
 	}
 
 	distribution := cluster.Spec.Cluster.Distribution


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/2039](https://github.com/devantler-tech/ksail/security/code-scanning/2039)

The best fix is to validate the user-controlled cluster name **at input handling/service boundary** so it is guaranteed to be a safe single path component before any async jobs or provisioner calls use it. This preserves existing behavior while preventing path traversal and absolute/escaped path injection.

Implement the fix in `pkg/cli/clusterapi/local_service.go` inside `Service.Create` right after checking `name == ""`:

- Reject names containing `/` or `\` (path separators),
- Reject `.` and `..` components (or any `..` sequence),
- Reject names where `filepath.Base(name) != name` (defensive),
- Return `api.ErrInvalid` with a clear message.

This is the most targeted fix because:
- It stops tainted names near the source.
- It avoids changing shared low-level `AtomicWriteFile` semantics.
- It keeps cluster provisioning logic intact for valid names.

Required additions:
- Add `path/filepath` and `strings` imports in `pkg/cli/clusterapi/local_service.go`.
- Add a small helper `isSafeClusterName` in the same file.
- Call it from `Create`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
