### PR TITLE
Potential fix for code scanning alert no. 2038: Uncontrolled data used in path expression

### DIFF
--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -279,6 +279,21 @@ func (s *Service) Get(
 	return nil, fmt.Errorf("%w: %q", api.ErrNotFound, name)
 }
 
+// isSafeClusterName reports whether name is safe to use as a single filesystem path component.
+// The cluster name is a logical identifier, not a path, yet downstream code composes filesystem
+// paths from it, so reject separators and parent-directory traversal to prevent path injection.
+func isSafeClusterName(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return false
+	}
+
+	return filepath.Base(name) == name
+}
+
 // Create starts provisioning a cluster and returns immediately with the cluster in the Provisioning
 // phase. The actual provisioning runs in a background goroutine; List/Get reflect its progress.
 func (s *Service) Create(
@@ -286,16 +301,7 @@ func (s *Service) Create(
 	cluster *v1alpha1.Cluster,
 ) (*v1alpha1.Cluster, error) {
 	name := cluster.Name
-	if name == "" {
-		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
-	}
-
-	// Cluster name is a logical identifier, not a path. Reject path-like values
-	// to prevent path traversal when downstream code composes filesystem paths.
-	if strings.Contains(name, "/") ||
-		strings.Contains(name, "\\") ||
-		strings.Contains(name, "..") ||
-		filepath.Base(name) != name {
+	if !isSafeClusterName(name) {
 		return nil, fmt.Errorf("%w: invalid name %q", api.ErrInvalid, name)
 	}
 

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -13,8 +13,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -286,6 +288,15 @@ func (s *Service) Create(
 	name := cluster.Name
 	if name == "" {
 		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
+	}
+
+	// Cluster name is a logical identifier, not a path. Reject path-like values
+	// to prevent path traversal when downstream code composes filesystem paths.
+	if strings.Contains(name, "/") ||
+		strings.Contains(name, "\\") ||
+		strings.Contains(name, "..") ||
+		filepath.Base(name) != name {
+		return nil, fmt.Errorf("%w: invalid name %q", api.ErrInvalid, name)
 	}
 
 	distribution := cluster.Spec.Cluster.Distribution

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
@@ -350,7 +350,7 @@ func (p *KubernetesProvisioner) rewriteKubeconfig(name, newServer string) error 
 		return fmt.Errorf("get home dir: %w", err)
 	}
 
-	kwokKubeconfig := homeDir + "/.kwok/clusters/" + target + "/kubeconfig.yaml"
+	kwokKubeconfig := filepath.Join(homeDir, ".kwok", "clusters", target, "kubeconfig.yaml")
 
 	kwokConfig, err := clientcmd.LoadFromFile(kwokKubeconfig)
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/2038](https://github.com/devantler-tech/ksail/security/code-scanning/2038)

To fix this without changing intended functionality, validate cluster names at the trust boundary in `pkg/cli/clusterapi/local_service.go` (inside `Service.Create`) before they are used anywhere downstream. Since the name is intended to be a single logical identifier (not a path), enforce:
- non-empty (already present),
- no path separators (`/`, `\`),
- no `..`,
- equals `filepath.Base(name)` (guards traversal/odd path forms).

This preserves normal cluster names while rejecting path-like input early with `api.ErrInvalid`.

Then harden `pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go` where the path is built:
- replace string concatenation with `filepath.Join(homeDir, ".kwok", "clusters", target, "kubeconfig.yaml")`.
This avoids manual path construction mistakes and keeps behavior portable.

No changes are needed in `pkg/fsutil/atomic.go`; it should remain a generic helper.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
