### PR TITLE
Potential fix for code scanning alert no. 2037: Uncontrolled data used in path expression

### DIFF
--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -13,8 +13,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -288,6 +290,10 @@ func (s *Service) Create(
 		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
 	}
 
+	if !isSafeClusterNamePathComponent(name) {
+		return nil, fmt.Errorf("%w: invalid name %q", api.ErrInvalid, name)
+	}
+
 	distribution := cluster.Spec.Cluster.Distribution
 	if distribution == "" {
 		return nil, fmt.Errorf("%w: distribution is required", api.ErrInvalid)
@@ -526,6 +532,22 @@ func (s *Service) runLifecycleAction(
 	}
 
 	delete(s.jobs, name)
+}
+
+func isSafeClusterNamePathComponent(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	if filepath.IsAbs(name) {
+		return false
+	}
+
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return false
+	}
+
+	return filepath.Base(name) == name
 }
 
 func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec) {

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -286,10 +286,6 @@ func (s *Service) Create(
 	cluster *v1alpha1.Cluster,
 ) (*v1alpha1.Cluster, error) {
 	name := cluster.Name
-	if name == "" {
-		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
-	}
-
 	if !isSafeClusterNamePathComponent(name) {
 		return nil, fmt.Errorf("%w: invalid name %q", api.ErrInvalid, name)
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/2037](https://github.com/devantler-tech/ksail/security/code-scanning/2037)

The best fix is to validate the user-controlled cluster name before it is ever used in path expressions. Since this value is conceptually a single identifier (cluster name), the safest non-disruptive approach is to reject names containing path separators, `..`, or absolute-path patterns. This preserves existing behavior for valid names while blocking traversal payloads.

Apply this at the trust boundary in `pkg/cli/clusterapi/local_service.go` inside `Service.Create`, immediately after reading `name := cluster.Name` and before any further processing. Add a small helper `isSafeClusterNamePathComponent(name string) bool` in the same file to centralize checks:
- reject empty (already done, keep existing check),
- reject `/` and `\`,
- reject `..`,
- reject absolute names (`filepath.IsAbs`),
- optionally enforce `filepath.Base(name) == name` as an extra guard.

This prevents tainted names from reaching downstream filesystem sinks (`rewriteKubeconfig` → `AtomicWriteFile`) without changing valid functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
