### PR TITLE
Potential fix for code scanning alert no. 2036: Uncontrolled data used in path expression

### DIFF
--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -32,6 +32,17 @@ import (
 
 var clusterNamePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
+// isSafeClusterName reports whether name is safe to use as a single filesystem path component.
+// Downstream provisioners compose paths from the cluster name (for example ~/.kwok/clusters/<name>),
+// so reject traversal/separator characters and require a DNS-1123-style single-component identifier.
+func isSafeClusterName(name string) bool {
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return false
+	}
+
+	return clusterNamePattern.MatchString(name)
+}
+
 // localNamespace is the synthetic namespace reported for local clusters. KSail has no namespace
 // concept locally, but the web UI keys rows on namespace/name and builds delete paths from it, so a
 // stable value is reported and the namespace path segment is otherwise ignored.
@@ -288,17 +299,7 @@ func (s *Service) Create(
 	cluster *v1alpha1.Cluster,
 ) (*v1alpha1.Cluster, error) {
 	name := cluster.Name
-	if name == "" {
-		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
-	}
-
-	// Name is used in filesystem paths by downstream provisioners (for example ~/.kwok/clusters/<name>).
-	// Enforce a safe single-component identifier and reject traversal/separator characters.
-	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
-		return nil, fmt.Errorf("%w: invalid cluster name %q", api.ErrInvalid, name)
-	}
-
-	if !clusterNamePattern.MatchString(name) {
+	if !isSafeClusterName(name) {
 		return nil, fmt.Errorf("%w: invalid cluster name %q", api.ErrInvalid, name)
 	}
 

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -13,8 +13,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,6 +29,8 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/webui/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var clusterNamePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 // localNamespace is the synthetic namespace reported for local clusters. KSail has no namespace
 // concept locally, but the web UI keys rows on namespace/name and builds delete paths from it, so a
@@ -286,6 +290,16 @@ func (s *Service) Create(
 	name := cluster.Name
 	if name == "" {
 		return nil, fmt.Errorf("%w: name is required", api.ErrInvalid)
+	}
+
+	// Name is used in filesystem paths by downstream provisioners (for example ~/.kwok/clusters/<name>).
+	// Enforce a safe single-component identifier and reject traversal/separator characters.
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return nil, fmt.Errorf("%w: invalid cluster name %q", api.ErrInvalid, name)
+	}
+
+	if !clusterNamePattern.MatchString(name) {
+		return nil, fmt.Errorf("%w: invalid cluster name %q", api.ErrInvalid, name)
 	}
 
 	distribution := cluster.Spec.Cluster.Distribution


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/ksail/security/code-scanning/2036](https://github.com/devantler-tech/ksail/security/code-scanning/2036)

General fix: validate and sanitize untrusted path components at trust boundaries, especially when values are expected to be a single identifier (cluster name). Reject values containing path separators, traversal markers, or characters outside an allowlist.

Best fix here without changing intended functionality: add strict cluster-name validation in `pkg/cli/clusterapi/local_service.go` inside `Service.Create`, immediately after reading `name := cluster.Name` and before any further use. Enforce:
- non-empty (already present),
- no `/` or `\`,
- no `..`,
- allow only DNS-1123-style lowercase alphanumeric plus `-`, with start/end alphanumeric.

This preserves normal cluster naming behavior while blocking traversal/path injection into downstream path operations (including `rewriteKubeconfig` and `AtomicWriteFile`).

Required edits:
- `pkg/cli/clusterapi/local_service.go`
  - Add `regexp` and `strings` imports.
  - Add a package-level compiled regex.
  - Add validation checks in `Create`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
