### PR TITLE
ci(cd): gate operator-chart publish on the image build so chart and image release atomically

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -371,12 +371,17 @@ jobs:
     name: ⛵ Release Operator Chart
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Runs in parallel with the other releases. The chart is a standalone OCI artifact that only
-    # *references* the operator image (ghcr.io/devantler-tech/ksail) by tag — it neither pulls nor
-    # embeds it — so it does not wait on `goreleaser`; the matching image is pushed concurrently and
-    # exists by the time anyone installs the chart. The gated `publish-release` and `pages-deploy` jobs
-    # both list it in `needs` (just like the other publication jobs), so a chart publish failure blocks
-    # the GitHub release publish and the docs deploy.
+    # Gate on `goreleaser` (image build + cosign sign + push). The chart's appVersion is the
+    # release version and operator.image.tag defaults to it, so the chart references
+    # ghcr.io/devantler-tech/ksail:v<version>. Publishing the chart before that image exists
+    # produces an orphan chart pointing at a missing image: on the failed v7.74.1 run the
+    # `goreleaser` job failed (no image built/signed) but this job had already pushed
+    # ksail-operator:7.74.1, which downstream cosign image-verification then rejects with
+    # MANIFEST_UNKNOWN. `needs: goreleaser` keeps the chart and image release atomic — a failed
+    # or incomplete image build skips the chart publish instead of orphaning it. The gated
+    # `publish-release` and `pages-deploy` jobs both list this job in `needs`, so a chart
+    # publish failure still blocks the GitHub release publish and the docs deploy.
+    needs: [goreleaser]
     permissions:
       contents: read # checkout
       packages: write # push the chart to GHCR as an OCI artifact


### PR DESCRIPTION
## Problem

The `operator-chart` job in `cd.yaml` publishes the `ksail-operator` Helm chart **in parallel with** `goreleaser` (which builds, cosign-signs, and pushes `ghcr.io/devantler-tech/ksail:v<version>`), with **no `needs:`**. The chart's `appVersion` is the release version and `operator.image.tag` defaults to it, so the chart references that image by tag.

That assumption ("the matching image is pushed concurrently and exists") breaks when `goreleaser` **fails**:

- The `v7.74.1` tag was created and `cd.yaml` ran on it — **the run failed** (`goreleaser` errored, so no `v7.74.1` image was built/signed).
- But `operator-chart` (fast, ~30s, ungated) had **already pushed `charts/ksail-operator:7.74.1`**.
- The `v7.74.1` tag/release was later removed, but **deleting a tag doesn't delete a published GHCR artifact** → orphan chart `ksail-operator:7.74.1` pointing at an image that never existed.

### Downstream impact

`devantler-tech/platform` consumes this chart. Renovate bumped its HelmRelease to `7.74.1`; the cluster's `verify-ksail-images` cosign policy then denied the Pod (`MANIFEST_UNKNOWN: manifest unknown`), the Helm upgrade hung → timed out → rolled back → retried every ~10m, stalling the `infrastructure-controllers → infrastructure → apps` Flux layers. (Consumer-side fix: [platform#2249](https://github.com/devantler-tech/platform/pull/2249).)

## Fix

Add `needs: [goreleaser]` to the `operator-chart` job so the chart is **only** published after the image is successfully built, signed, and pushed — keeping the chart and image release **atomic**. A failed or incomplete image build now skips the chart publish (and, via the existing `needs` chain, blocks `publish-release`/`pages-deploy`) instead of orphaning a chart. The misleading "does not wait on goreleaser … exists by the time anyone installs the chart" comment is corrected to document why the gate exists.

## Validation

- `actionlint .github/workflows/cd.yaml` — clean.
- `needs` graph is acyclic and references the existing `goreleaser` job key; `publish-release`/`pages-deploy` already depend on `operator-chart`, so the chain is `goreleaser → operator-chart → publish-release`.

## Note

This prevents *future* orphans; the existing orphan `charts/ksail-operator:7.74.1` still sits in GHCR (now defused on the consumer side by platform#2249's Renovate guard). It can be deleted separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)