### PR TITLE
fix(clusterapi): validate web-UI cluster names against the shared DNS-1123 rule

### DIFF
--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -13,10 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -279,26 +277,15 @@ func (s *Service) Get(
 	return nil, fmt.Errorf("%w: %q", api.ErrNotFound, name)
 }
 
+// isSafeClusterName reports whether name is valid for the local backend: non-empty and DNS-1123
+// compliant per KSail's shared cluster-name rule (v1alpha1.ValidateClusterName — the same check
+// `ksail cluster init` and the JSON schema enforce, so the web UI and CLI agree on valid names).
+// DNS-1123 names are single path components, so this also blocks path traversal where the name
+// becomes a filesystem path downstream (~/.kwok/clusters/<name>, Docker container names). The local
+// service always needs an explicit name, so empty is rejected here even though the config loader
+// treats an empty name as "use the default".
 func isSafeClusterName(name string) bool {
-	if name == "" {
-		return false
-	}
-
-	// Cluster name is used as a single filesystem path component in provisioners.
-	// Reject separators and parent/current directory components to prevent traversal.
-	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
-		return false
-	}
-
-	if name == "." || name == ".." || strings.Contains(name, "..") {
-		return false
-	}
-
-	if filepath.Base(name) != name {
-		return false
-	}
-
-	return true
+	return name != "" && v1alpha1.ValidateClusterName(name) == nil
 }
 
 // Create starts provisioning a cluster and returns immediately with the cluster in the Provisioning

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -560,7 +560,15 @@ func TestCreateValidatesInput(t *testing.T) {
 	_, err := service.Create(context.Background(), clusterFor("", v1alpha1.DistributionVCluster))
 	require.ErrorIs(t, err, api.ErrInvalid)
 
-	_, err = service.Create(context.Background(), clusterFor("noDist", ""))
+	// A name that is a safe path component but not DNS-1123 (uppercase, underscore) is rejected at the
+	// trust boundary, matching `ksail cluster init` and blocking path-traversal-shaped names.
+	_, err = service.Create(
+		context.Background(),
+		clusterFor("Invalid_Name", v1alpha1.DistributionVCluster),
+	)
+	require.ErrorIs(t, err, api.ErrInvalid)
+
+	_, err = service.Create(context.Background(), clusterFor("no-dist", ""))
 	require.ErrorIs(t, err, api.ErrInvalid)
 
 	// An unknown distribution cannot be provisioned locally.

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
@@ -352,7 +352,7 @@ func (p *KubernetesProvisioner) rewriteKubeconfig(name, newServer string) error 
 		return fmt.Errorf("get home dir: %w", err)
 	}
 
-	kwokKubeconfig := homeDir + "/.kwok/clusters/" + target + "/kubeconfig.yaml"
+	kwokKubeconfig := filepath.Join(homeDir, ".kwok", "clusters", target, "kubeconfig.yaml")
 
 	kwokConfig, err := clientcmd.LoadFromFile(kwokKubeconfig)
 	if err != nil {


### PR DESCRIPTION
Follow-ups from the path-traversal code-scanning autofix PRs — the parts worth keeping after #5421 merged and #5422/#5424 were closed as redundant.

## What & why

**1. Tighten the web-UI create boundary to KSail's canonical cluster-name rule.**
The merged #5421 added an ad-hoc `isSafeClusterName` to `Service.Create` that only rejected separators and `..`. KSail already has a single source of truth for cluster names — `v1alpha1.ValidateClusterName` (DNS-1123 subdomain + length), the same check [`ksail cluster init`](https://github.com/devantler-tech/ksail/blob/main/pkg/cli/cmd/cluster/init.go) and the JSON schema use. This points the local backend at that validator so the web UI and CLI agree on what a valid cluster name is, instead of maintaining a second, looser rule. DNS-1123 names are single path components, so the path-traversal protection the autofix was after is preserved — now at parity with the rest of KSail. `isSafeClusterName` stays a `bool`, so `Service.Create` is byte-for-byte unchanged (keeps it within `funlen`/`noinlineerr`).

This was the spirit of the (closed) #5424, which used its own DNS-1123 regex; reusing the shared validator is the non-divergent version of that.

**2. Compose the kwok kubeconfig path with `filepath.Join`.**
The salvageable bit of the (closed) #5422: `rewriteKubeconfig` built its path by string concatenation; `filepath.Join` matches `kwokStateDir` (hardened in the merged #5419) and is cleaner. No behavior change — the name is already validated upstream.

## Tests
- New regression case in `TestCreateValidatesInput` for a safe-but-non-DNS-1123 name (`Invalid_Name`) → `api.ErrInvalid`.
- Fixed the missing-distribution case to use a DNS-1123-valid name (`no-dist`) so it actually exercises the distribution check instead of short-circuiting on the name.

## Verification
`go build`, `golangci-lint run` (clean), and `go test ./pkg/cli/clusterapi/... ./pkg/svc/provisioner/cluster/kwok/...` (112 pass) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)