### PR TITLE
fix(autoscaler): grant capacity-buffer controller RBAC for Deployments and ResourceQuotas

### DIFF
--- a/pkg/svc/installer/clusterautoscaler/capacitybuffers.go
+++ b/pkg/svc/installer/clusterautoscaler/capacitybuffers.go
@@ -35,8 +35,14 @@ var capacityBufferCRDYAML []byte
 //     capacity-buffer-pod-injection-enabled, so the autoscaler reconciles
 //     CapacityBuffer resources and injects virtual pods for ready buffers.
 //  2. RBAC: the chart's ClusterRole only grants provisioningrequests in the
-//     autoscaling.x-k8s.io group, so CapacityBuffer access is added via the
-//     chart's rbac.additionalRules value.
+//     autoscaling.x-k8s.io group, so the buffer controller's access is added
+//     via the chart's rbac.additionalRules value. It needs three things the
+//     chart role omits: the CapacityBuffer CRs themselves, plus the Deployments
+//     and ResourceQuotas its translators run informers over (to size buffers
+//     from a workload's template and respect namespace quota). Without the
+//     latter two the controller logs a continuous "deployments.apps is
+//     forbidden ... cannot list/watch" / "resourcequotas is forbidden ..." and
+//     never reconciles a buffer, so its status stays empty.
 //  3. CRD: the chart does not ship the CapacityBuffer CRD; it is delivered via
 //     the chart's extraObjects value. NOTE: because the CRD is then part of the
 //     Helm release, `helm uninstall` removes the CRD — and with it every
@@ -45,11 +51,30 @@ func enableCapacityBuffers(vals *chartValues) error {
 	vals.ExtraArgs.CapacityBufferControllerEnabled = true
 	vals.ExtraArgs.CapacityBufferPodInjectionEnabled = true
 
-	vals.RBAC.AdditionalRules = append(vals.RBAC.AdditionalRules, chartRBACRule{
-		APIGroups: []string{"autoscaling.x-k8s.io"},
-		Resources: []string{"capacitybuffers", "capacitybuffers/status"},
-		Verbs:     []string{"get", "list", "watch", "update", "patch"},
-	})
+	// Read-only verbs shared by the buffer controller's Deployment and
+	// ResourceQuota informers (only marshaled to YAML, never mutated, so the
+	// shared slice is safe to reuse across both rules).
+	readVerbs := []string{"get", "list", "watch"}
+
+	vals.RBAC.AdditionalRules = append(vals.RBAC.AdditionalRules,
+		chartRBACRule{
+			APIGroups: []string{"autoscaling.x-k8s.io"},
+			Resources: []string{"capacitybuffers", "capacitybuffers/status"},
+			Verbs:     []string{"get", "list", "watch", "update", "patch"},
+		},
+		// Deployments and ResourceQuotas: the chart ClusterRole covers neither,
+		// but the buffer controller runs informers over both.
+		chartRBACRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments"},
+			Verbs:     readVerbs,
+		},
+		chartRBACRule{
+			APIGroups: []string{""},
+			Resources: []string{"resourcequotas"},
+			Verbs:     readVerbs,
+		},
+	)
 
 	// The embedded CRD is a single YAML document; unmarshal it into a generic
 	// object for the chart's extraObjects values list (sigs.k8s.io/yaml routes

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -596,9 +596,11 @@ func TestClusterAutoscalerInstaller_ValuesYaml_MaxNodesTotalOmittedWhenZero(t *t
 }
 
 // TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers verifies that
-// enabling capacityBuffers renders the two feature flags, the CapacityBuffer
-// RBAC rule, and the embedded CapacityBuffer CRD via extraObjects — and that all
-// three are omitted from the values when the feature is disabled.
+// enabling capacityBuffers renders the two feature flags, the buffer
+// controller's RBAC rules (CapacityBuffer CRs plus the Deployment and
+// ResourceQuota read access its informers require), and the embedded
+// CapacityBuffer CRD via extraObjects — and that all of them are omitted from
+// the values when the feature is disabled.
 func TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers(t *testing.T) {
 	t.Parallel()
 
@@ -616,6 +618,8 @@ func TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers(t *testing.T) {
 				"capacity-buffer-pod-injection-enabled: true",
 				"additionalRules:",
 				"capacitybuffers",
+				"- deployments",
+				"- resourcequotas",
 				"kind: CustomResourceDefinition",
 				"name: capacitybuffers.autoscaling.x-k8s.io",
 			},
@@ -627,6 +631,8 @@ func TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers(t *testing.T) {
 				"capacity-buffer-controller-enabled",
 				"capacity-buffer-pod-injection-enabled",
 				"capacitybuffers",
+				"- deployments",
+				"- resourcequotas",
 				"kind: CustomResourceDefinition",
 			},
 		},


### PR DESCRIPTION
## Problem

On the prod Talos/Hetzner cluster, the Cluster Autoscaler logs a continuous stream of RBAC-forbidden errors (~150/hr, surfaced as a Coroot "new error in the logs" alert):

```
E ... reflector.go:204] "Failed to watch" err="failed to list *v1.Deployment:
  deployments.apps is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\"
  cannot list resource \"deployments\" in API group \"apps\" at the cluster scope"
E ... reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceQuota:
  resourcequotas is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\"
  cannot list resource \"resourcequotas\" ..."
```

## Root cause

When `spec.cluster.autoscaler.node.capacityBuffers` is enabled, `enableCapacityBuffers` turns on the capacity-buffer controller (`--capacity-buffer-controller-enabled` + `--capacity-buffer-pod-injection-enabled`) but only added `rbac.additionalRules` for the **CapacityBuffer CRs**. That controller (Cluster Autoscaler 1.34+) also runs **Deployment** and **ResourceQuota** informers — neither of which the chart's own ClusterRole grants — so the informers fail to list/watch on every resync.

Observed impact on the live cluster: the `overprovisioning` CapacityBuffer CR has an **empty `status`** — the controller can't reconcile it, so the reserved scale-up headroom the buffer is supposed to provide is inactive.

## Fix

Append two read-only (`get`/`list`/`watch`) rules — `apps/deployments` and `core/resourcequotas` — to the chart's `rbac.additionalRules`, next to the existing CapacityBuffer rule. Read-only is sufficient (the controller only runs informers over them); a shared verbs slice keeps it DRY.

## Validation

- `go build ./...` — OK
- `go test ./pkg/svc/installer/clusterautoscaler/...` — 28 passed (extended `..._CapacityBuffers` asserts `- deployments` / `- resourcequotas` render when enabled and are omitted when disabled)
- `golangci-lint run --timeout 5m ./pkg/svc/installer/clusterautoscaler/...` — no issues

Once released and reconciled by KSail, the autoscaler ServiceAccount gains the two rules, the forbidden-watch spam stops, and the CapacityBuffer controller can reconcile (status populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
