### PR TITLE
fix(k3d): bump default K3s image to v1.36.2-k3s1

### DIFF
--- a/pkg/fsutil/configmanager/k3d/Dockerfile
+++ b/pkg/fsutil/configmanager/k3d/Dockerfile
@@ -4,4 +4,4 @@
 # Image mappings:
 # - rancher/k3s → DefaultK3sImage in this package
 
-FROM rancher/k3s:v1.36.1-k3s1@sha256:08fdebd14db9ab7d5ea821d5bfa95d02341a6ef886842fcc8d9dfd0e9fa9e0cd
+FROM rancher/k3s:v1.36.2-k3s1@sha256:6a47cea22c4b834d4ba72c89d291696b79ebe406251f90b446e4dff03513dd87


### PR DESCRIPTION
## Problem

The `🧪 System Test (Docker) (K3s, …)` leg started failing fleet-wide with:

```
❌ ERROR: Unexpected changes detected during update after cluster creation
```

`ksail cluster create` uses the pinned default K3s image (the embedded source-of-truth `pkg/fsutil/configmanager/k3d/Dockerfile`, `v1.36.1-k3s1`), while `ksail cluster update` discovers the latest from `rancher/k3s` upstream. k3s **v1.36.2+k3s1 published today**, so update proposes a `1.36.1 → 1.36.2` upgrade (which requires recreation) immediately after create — breaking the create→update no-op assertion. `main` was green at 06:30 UTC (pre-release) and fails on its next run; every open PR's K3s leg is affected (this is **not** caused by any individual PR's changes).

## Fix

Bump the embedded source-of-truth Dockerfile to `rancher/k3s:v1.36.2-k3s1` (digest `sha256:6a47cea…`, via `docker buildx imagetools inspect`), exactly as Dependabot would. This realigns `create` with what `update` discovers, so the idempotency check is a no-op again.

`go build ./...` and `go test ./pkg/fsutil/configmanager/k3d/...` pass; the K3s system test in CI validates the create→update no-op end-to-end.

> 🤖 Generated by the Daily AI Assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)