### PR TITLE
fix(security): risk-accept 4 newly-published docker cp/archive + containerd-v1 advisories

### DIFF
--- a/.govulncheck-allow.txt
+++ b/.govulncheck-allow.txt
@@ -24,6 +24,18 @@
 GO-2026-4887  # Moby AuthZ plugin bypass on oversized request bodies (daemon-side; no fix)
 GO-2026-4883  # Moby off-by-one in plugin privilege validation (daemon-side; no fix)
 
+# --- github.com/docker/docker (Moby) @ v28.5.2+incompatible — cp / archive ---
+# Published 2026-06-25; daemon-side TOCTOU / symlink-swap issues in the
+# `docker cp` and `PUT /containers/{id}/archive` code paths. ksail is a Docker
+# *client* that creates/manages local clusters via the daemon API; it never
+# invokes `docker cp` or the container-archive endpoints, so these paths are
+# unreachable in practice. No fix on the v1 docker/docker module line (only
+# moby/moby/v2 >= v2.0.0-beta.14, which ksail does not import). Remove when a
+# v1 fix ships.
+GO-2026-5617  # docker cp race -> bind-mount redirection to host path (CVE-2026-42306; no fix; path unused)
+GO-2026-5668  # docker cp symlink swap -> arbitrary empty-file creation on host (CVE-2026-41568; no fix; path unused)
+GO-2026-5746  # PUT /containers/{id}/archive executes container binaries on host (CVE-2026-41567; no fix; path unused)
+
 # --- k8s.io/kubernetes @ v1.36.0 --------------------------------------------
 # Imported for client/config types only; ksail does not run kube-apiserver,
 # the kubelet, or mount GitRepo volumes. Both advisories are control-plane /
@@ -42,3 +54,4 @@ GO-2025-3521  # GitRepo volume inadvertent local repository access (node-side; n
 # transitive v1 dependency goes away or a v1 fix ships.
 GO-2026-5064  # containerd v1 CRI checkpoint/restore CDI-annotation smuggling (transitive; no v1 fix; path unused)
 GO-2026-5338  # containerd v1 CRI checkpoint import local image-tag poisoning (CVE-2026-50195; transitive; no v1 fix; path unused)
+GO-2026-5622  # containerd v1 CRI checkpoint/restore arbitrary host log read via symlink (CVE-2026-53489; transitive; no v1 fix; path unused)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Risk-accepts four **newly-published (2026-06-25)** reachable govulncheck advisories in `.govulncheck-allow.txt`, mirroring the existing entries' policy. These are now failing the `🛡️ Vulnerability Scan` gate:

| Advisory | Module | Path | Fix for ksail's pin? |
|---|---|---|---|
| GO-2026-5617 | `github.com/docker/docker` @ v28.5.2 | `docker cp` race → bind-mount redirection | **none** (only `moby/moby/v2`, not imported) |
| GO-2026-5668 | `github.com/docker/docker` @ v28.5.2 | `docker cp` symlink swap → empty-file creation | **none** |
| GO-2026-5746 | `github.com/docker/docker` @ v28.5.2 | `PUT /containers/{id}/archive` exec | **none** |
| GO-2026-5622 | `containerd` v1 @ v1.7.33 (transitive) | CRI checkpoint/restore host-log read via symlink | **none** for v1 (v2 already on 2.3.2) |

## Why this is correct (not a mask)

All four are the **same class already risk-accepted** in this file:
- The three `docker/docker` issues are **daemon-side** `docker cp` / archive-API code paths. ksail is a Docker **client** — it provisions Kind/K3d/Talos clusters via the daemon API and **never invokes `docker cp` or the container-archive endpoints**. Same rationale as the existing `GO-2026-4887`/`GO-2026-4883` daemon-AuthZ entries. No fix on the v1 `docker/docker` line (only `moby/moby/v2 ≥ v2.0.0-beta.14`, which ksail does not import).
- `GO-2026-5622` is a **CRI checkpoint/restore** path on the transitive **containerd v1** module — identical surface to the existing `GO-2026-5064`/`GO-2026-5338` entries (a node/runtime path ksail never exercises); no v1 fix exists.

Per the file's own policy these are exactly **"UNPATCHABLE findings on a path ksail does not run"**, not fixable bumps. (Contrast x/image GO-2026-5061, which *had* a fix and was bumped in #5462, not allowlisted.)

## Impact / urgency

These advisories entered the govulncheck DB **after** #5462 merged at 22:38Z (which scanned clean), so they now re-block the gate **portfolio-wide on every ksail PR and main's next scan** — already confirmed failing on dependabot #5438 (helm-controller) while #5440 (scanned ~6 min earlier) still passed. This is the same recurring "new advisory published → queue blocked" pattern as #5461/#5462; merging this unblocks the queue again.

## Maintainer decision

Risk-accepting unpatchable advisories is your compliance call — **promotion of this draft = approval**. If you'd rather hold any entry, comment and I'll adjust. The gate's logic (fail only on reachable advisories not listed) means adding exactly the CI-reported failing set makes the scan pass deterministically; the PR's own `🛡️ Vulnerability Scan` validates it.
