### PR TITLE
test(localregistry): cover parseEKSContext and EKS name/network resolution

### DIFF
--- a/pkg/cli/setup/localregistry/export_test.go
+++ b/pkg/cli/setup/localregistry/export_test.go
@@ -16,6 +16,11 @@ var ResolveClusterNameForTest = resolveClusterName
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions.
 var ResolveNetworkNameForTest = resolveNetworkName
 
+// ParseEKSContextForTest exports parseEKSContext for testing.
+//
+//nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions.
+var ParseEKSContextForTest = parseEKSContext
+
 // ResolveStageForTest exports resolveStage for testing.
 //
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions.

--- a/pkg/cli/setup/localregistry/resolve_test.go
+++ b/pkg/cli/setup/localregistry/resolve_test.go
@@ -66,6 +66,23 @@ func TestResolveClusterName(t *testing.T) {
 			distribution: v1alpha1.DistributionKWOK,
 			expected:     "kwok-default",
 		},
+		{
+			name:         "EKS extracts cluster name from eksctl context",
+			distribution: v1alpha1.DistributionEKS,
+			context:      "iam-user@my-cluster.eu-west-1.eksctl.io",
+			expected:     "my-cluster",
+		},
+		{
+			name:         "EKS with unrecognised context returns eks-default",
+			distribution: v1alpha1.DistributionEKS,
+			context:      "some-other-context",
+			expected:     "eks-default",
+		},
+		{
+			name:         "EKS with no context returns eks-default",
+			distribution: v1alpha1.DistributionEKS,
+			expected:     "eks-default",
+		},
 	}
 
 	for _, tc := range tests { //nolint:varnamelen
@@ -164,6 +181,12 @@ func TestResolveNetworkName(t *testing.T) {
 			clusterName:  "",
 			expected:     "kwok-kwok-default",
 		},
+		{
+			name:         "EKS returns empty string (no local Docker network)",
+			distribution: v1alpha1.DistributionEKS,
+			clusterName:  "my-cluster",
+			expected:     "",
+		},
 	}
 
 	for _, testCase := range tests {
@@ -179,6 +202,91 @@ func TestResolveNetworkName(t *testing.T) {
 			}
 
 			result := localregistry.ResolveNetworkNameForTest(clusterCfg, testCase.clusterName)
+			assert.Equal(t, testCase.expected, result)
+		})
+	}
+}
+
+// TestParseEKSContext exercises EKS kubeconfig context parsing, including the
+// eksctl "<iam-identity>@<name>.<region>.eksctl.io" form, the bare
+// "<name>.eksctl.io" form, and the non-EKS contexts that fall back to "".
+//
+//nolint:funlen // table-driven test
+func TestParseEKSContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		context  string
+		expected string
+	}{
+		{
+			name:     "empty context returns empty",
+			context:  "",
+			expected: "",
+		},
+		{
+			name:     "whitespace-only context returns empty",
+			context:  "   ",
+			expected: "",
+		},
+		{
+			name:     "full eksctl context with identity and region",
+			context:  "iam-user@my-cluster.eu-west-1.eksctl.io",
+			expected: "my-cluster",
+		},
+		{
+			name:     "eksctl context without identity prefix",
+			context:  "my-cluster.eu-west-1.eksctl.io",
+			expected: "my-cluster",
+		},
+		{
+			name:     "bare eksctl context without region",
+			context:  "my-cluster.eksctl.io",
+			expected: "my-cluster",
+		},
+		{
+			name:     "eksctl context with identity but no region",
+			context:  "iam-user@my-cluster.eksctl.io",
+			expected: "my-cluster",
+		},
+		{
+			name:     "surrounding whitespace is trimmed",
+			context:  "  iam-user@my-cluster.eu-west-1.eksctl.io  ",
+			expected: "my-cluster",
+		},
+		{
+			name:     "leading at-sign is handled",
+			context:  "@my-cluster.eksctl.io",
+			expected: "my-cluster",
+		},
+		{
+			name:     "non-eksctl context returns empty",
+			context:  "kind-foo",
+			expected: "",
+		},
+		{
+			name:     "dotted non-eksctl context returns empty",
+			context:  "some.other.context",
+			expected: "",
+		},
+		{
+			name:     "trailing at-sign is not treated as a separator",
+			context:  "my-cluster.eksctl.io@",
+			expected: "",
+		},
+		{
+			name:     "eksctl suffix with empty cluster name returns empty",
+			context:  ".eksctl.io",
+			expected: "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := localregistry.ParseEKSContextForTest(testCase.context)
 			assert.Equal(t, testCase.expected, result)
 		})
 	}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds focused, behaviour-preserving unit tests for the **EKS** name/network resolution path in `pkg/cli/setup/localregistry`, which was entirely untested.

- **`parseEKSContext`** (`resolve.go`) was **0% covered**. It parses an EKS kubeconfig context (the eksctl `<iam-identity>@<name>.<region>.eksctl.io` form, the bare `<name>.eksctl.io` form, or a non-EKS context that must fall back to `""`). A new `TestParseEKSContext` table (12 cases) pins every branch: identity prefix, region stripping, surrounding-whitespace trim, leading-`@`, the trailing-`@` guard (`idx+1 < len`), the empty-cluster-name `.eksctl.io` case, and the non-eksctl fall-throughs.
- **`TestResolveClusterName`** gained the three EKS cases it was missing (eksctl context → name; unrecognised context → `eks-default`; no context → `eks-default`).
- **`TestResolveNetworkName`** gained the EKS case (`return ""` — EKS uses no local Docker network).
- Exposes `parseEKSContext` via the existing `export_test.go` pattern (`ParseEKSContextForTest`).

## Why

These contexts come straight from `eksctl`-generated kubeconfigs, so the parsing rules are real behaviour worth pinning against regression. No production code changes — tests only.

## Result

- `pkg/cli/setup/localregistry` coverage **37.5% → 46.9%**.
- `parseEKSContext` **0% → 100%**; `resolveNetworkName` and `resolveClusterName` now **100%**.
- `go build`, `go vet`, and `golangci-lint run` all clean; all 36 package tests pass.

## Notes

Behaviour-preserving, test-only; no `Fixes #N` (a focused coverage fill on an identified 0%-covered pure function, in line with prior coverage PRs #5453/#5460). The remaining `resolveAuxDistributionName` gap (the VCluster branch, which needs a `VClusterConfig` fixture) is left for a separate focused pass.