### PR TITLE
test(apis): cover toggle-enum String/Type and SOPS tri-state predicates

### DIFF
--- a/pkg/apis/cluster/v1alpha1/toggle_test.go
+++ b/pkg/apis/cluster/v1alpha1/toggle_test.go
@@ -190,3 +190,83 @@ func TestToggleEnumTypesAcceptCoercedValues(t *testing.T) {
 		})
 	}
 }
+
+// TestSOPSEnabled_StringAndType pins the pflag.Value surface of SOPSEnabled:
+// String round-trips the underlying value verbatim (including the empty zero
+// value) and Type reports the stable name pflag prints in `--help`.
+func TestSOPSEnabled_StringAndType(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []v1alpha1.SOPSEnabled{
+		v1alpha1.SOPSEnabledDefault,
+		v1alpha1.SOPSEnabledEnabled,
+		v1alpha1.SOPSEnabledDisabled,
+		v1alpha1.SOPSEnabled(""),
+	} {
+		state := value
+		assert.Equal(t, string(value), state.String())
+	}
+
+	zero := v1alpha1.SOPSEnabled("")
+	assert.Equal(t, "SOPSEnabled", zero.Type())
+}
+
+// TestSOPSEnabled_StateClassifiers locks the tri-state predicates that stand in
+// for the field's previous *bool encoding. The empty (unset) zero value MUST
+// classify as auto-detect — it mirrors the old nil pointer, so the SOPS secret
+// boundary only requires an Age key when the user explicitly enabled it.
+func TestSOPSEnabled_StateClassifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		value           v1alpha1.SOPSEnabled
+		wantExplicitOn  bool
+		wantExplicitOff bool
+		wantAutoDetect  bool
+	}{
+		{"default is auto-detect", v1alpha1.SOPSEnabledDefault, false, false, true},
+		{"empty zero value is auto-detect", v1alpha1.SOPSEnabled(""), false, false, true},
+		{"enabled is explicit on", v1alpha1.SOPSEnabledEnabled, true, false, false},
+		{"disabled is explicit off", v1alpha1.SOPSEnabledDisabled, false, true, false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := testCase.value
+			assert.Equal(
+				t,
+				testCase.wantExplicitOn,
+				state.IsExplicitlyEnabled(),
+				"IsExplicitlyEnabled",
+			)
+			assert.Equal(
+				t,
+				testCase.wantExplicitOff,
+				state.IsExplicitlyDisabled(),
+				"IsExplicitlyDisabled",
+			)
+			assert.Equal(t, testCase.wantAutoDetect, state.IsAutoDetect(), "IsAutoDetect")
+		})
+	}
+}
+
+// TestNodeAutoscalerEnabled_StringAndType pins the pflag.Value surface of
+// NodeAutoscalerEnabled, mirroring TestSOPSEnabled_StringAndType.
+func TestNodeAutoscalerEnabled_StringAndType(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []v1alpha1.NodeAutoscalerEnabled{
+		v1alpha1.NodeAutoscalerEnabledEnabled,
+		v1alpha1.NodeAutoscalerEnabledDisabled,
+		v1alpha1.NodeAutoscalerEnabled(""),
+	} {
+		state := value
+		assert.Equal(t, string(value), state.String())
+	}
+
+	zero := v1alpha1.NodeAutoscalerEnabled("")
+	assert.Equal(t, "NodeAutoscalerEnabled", zero.Type())
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds black-box tests to `pkg/apis/cluster/v1alpha1/toggle_test.go` covering the pure methods of the tri-state toggle enums that had **0% coverage**:

- `SOPSEnabled`: `String`, `Type`, `IsExplicitlyEnabled`, `IsExplicitlyDisabled`, `IsAutoDetect`
- `NodeAutoscalerEnabled`: `String`, `Type`

All seven go **0% → 100%**. Test-only, behaviour-preserving — no production code touched.

## Why

These are part of the public cluster-spec API surface. The `Set`/`Default`/`ValidValues`/`UnmarshalJSON` methods of both enums were already covered by the shared toggle tests, but the `pflag.Value` `String`/`Type` methods and the SOPS tri-state predicates were exercised by nothing.

The predicates encode real, load-bearing semantics that replaced the field's former `*bool` encoding — in particular **the empty (unset) zero value must classify as auto-detect** (mirroring the old nil pointer, so the SOPS secret boundary only requires an Age key when the user explicitly opted in). `TestSOPSEnabled_StateClassifiers` pins that branch directly with a dedicated case so a future refactor can't silently flip unset → explicit.

## Validation

- `go test ./pkg/apis/cluster/v1alpha1/` — **500 pass**
- `go vet` clean; `golangci-lint run` (full repo config) — **0 issues**; `gofumpt`/`golines` clean
- Coverage confirmed via `go tool cover -func`: all 7 targeted methods at 100%

Tests follow the existing `toggle_test.go` conventions (black-box `v1alpha1_test`, `t.Parallel()`, testify, descriptive `Test<Type>_<Aspect>` names) and live in the same file as the sibling enum tests. No `Fixes #N` — a focused coverage fill (precedent: #5468/#5469).