### PR TITLE
test(configmanager): cover Talos ingress-firewall and EKS/KWOK config helpers

### DIFF
--- a/pkg/fsutil/configmanager/ksail/distribution_test.go
+++ b/pkg/fsutil/configmanager/ksail/distribution_test.go
@@ -1,0 +1,385 @@
+package configmanager_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFileWithParents writes content at path, creating any missing parent dirs.
+func writeFileWithParents(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// newConfigManagerWithContext builds a ConfigManager whose cluster connection
+// context is set, for testing context-derived name resolution helpers.
+func newConfigManagerWithContext(context string) *configmanager.ConfigManager {
+	mgr := configmanager.NewConfigManager(nil, "ksail.yaml")
+	mgr.Config = &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Connection: v1alpha1.Connection{
+					Context: context,
+				},
+			},
+		},
+	}
+
+	return mgr
+}
+
+// TestIngressFirewallPatchPaths verifies the three expected patch file paths are
+// constructed relative to the patches directory.
+func TestIngressFirewallPatchPaths(t *testing.T) {
+	t.Parallel()
+
+	patchesDir := filepath.Join("some", "patches")
+
+	defaultAction, cpRules, workerRules := configmanager.IngressFirewallPatchPathsForTest(
+		patchesDir,
+	)
+
+	assert.Equal(
+		t,
+		filepath.Join(patchesDir, "cluster", "ingress-firewall-default-action.yaml"),
+		defaultAction,
+	)
+	assert.Equal(
+		t,
+		filepath.Join(patchesDir, "control-planes", "ingress-firewall-rules.yaml"),
+		cpRules,
+	)
+	assert.Equal(
+		t,
+		filepath.Join(patchesDir, "workers", "ingress-firewall-rules.yaml"),
+		workerRules,
+	)
+}
+
+// TestIngressFirewallPatchFilesExist verifies the helper only reports true when
+// all three generated patch files are present on disk.
+func TestIngressFirewallPatchFilesExist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all three present returns true", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		defaultAction, cpRules, workerRules := configmanager.IngressFirewallPatchPathsForTest(dir)
+		writeFileWithParents(t, defaultAction, "a")
+		writeFileWithParents(t, cpRules, "b")
+		writeFileWithParents(t, workerRules, "c")
+
+		assert.True(t, configmanager.IngressFirewallPatchFilesExistForTest(dir))
+	})
+
+	t.Run("missing worker rules returns false", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		defaultAction, cpRules, _ := configmanager.IngressFirewallPatchPathsForTest(dir)
+		writeFileWithParents(t, defaultAction, "a")
+		writeFileWithParents(t, cpRules, "b")
+
+		assert.False(t, configmanager.IngressFirewallPatchFilesExistForTest(dir))
+	})
+
+	t.Run("empty directory returns false", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, configmanager.IngressFirewallPatchFilesExistForTest(t.TempDir()))
+	})
+}
+
+// TestKubeletPatchFilesExist verifies the helper only reports true when both
+// kubelet patch files are present.
+func TestKubeletPatchFilesExist(t *testing.T) {
+	t.Parallel()
+
+	certRotation := filepath.Join("cluster", "kubelet-cert-rotation.yaml")
+	csrApprover := filepath.Join("cluster", "kubelet-csr-approver.yaml")
+
+	t.Run("both present returns true", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		writeFileWithParents(t, filepath.Join(dir, certRotation), "a")
+		writeFileWithParents(t, filepath.Join(dir, csrApprover), "b")
+
+		assert.True(t, configmanager.KubeletPatchFilesExistForTest(dir))
+	})
+
+	t.Run("only cert rotation present returns false", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		writeFileWithParents(t, filepath.Join(dir, certRotation), "a")
+
+		assert.False(t, configmanager.KubeletPatchFilesExistForTest(dir))
+	})
+
+	t.Run("none present returns false", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, configmanager.KubeletPatchFilesExistForTest(t.TempDir()))
+	})
+}
+
+// TestIngressFirewallPatchesErrors verifies input validation for the ingress
+// firewall patch generator.
+func TestIngressFirewallPatchesErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		networkCIDR string
+		cniPort     int
+		wantErr     error
+	}{
+		{
+			name:        "empty CIDR",
+			networkCIDR: "",
+			cniPort:     8472,
+			wantErr:     configmanager.ErrIngressFirewallMissingCIDRForTest,
+		},
+		{
+			name:        "whitespace CIDR",
+			networkCIDR: "   ",
+			cniPort:     8472,
+			wantErr:     configmanager.ErrIngressFirewallMissingCIDRForTest,
+		},
+		{
+			name:        "invalid CIDR",
+			networkCIDR: "not-a-cidr",
+			cniPort:     8472,
+			wantErr:     configmanager.ErrIngressFirewallInvalidCIDRForTest,
+		},
+		{
+			name:        "port too low",
+			networkCIDR: "10.0.0.0/8",
+			cniPort:     0,
+			wantErr:     configmanager.ErrIngressFirewallInvalidPortForTest,
+		},
+		{
+			name:        "port too high",
+			networkCIDR: "10.0.0.0/8",
+			cniPort:     65536,
+			wantErr:     configmanager.ErrIngressFirewallInvalidPortForTest,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			patches, err := configmanager.IngressFirewallPatchesForTest(
+				testCase.networkCIDR,
+				testCase.cniPort,
+				nil,
+			)
+
+			require.ErrorIs(t, err, testCase.wantErr)
+			assert.Nil(t, patches)
+		})
+	}
+}
+
+// TestIngressFirewallPatchesSuccess verifies the generated patch set: three
+// patches with the expected paths and scopes, the network CIDR normalized, and
+// the control-plane rules honoring allowedCIDRs.
+func TestIngressFirewallPatchesSuccess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no allowed CIDRs defaults to allow-all", func(t *testing.T) {
+		t.Parallel()
+
+		patches, err := configmanager.IngressFirewallPatchesForTest("10.244.0.0/16", 8472, nil)
+		require.NoError(t, err)
+		require.Len(t, patches, 3)
+
+		assert.Equal(t, "ingress-firewall-default-action", patches[0].Path)
+		assert.Equal(t, talosconfigmanager.PatchScopeCluster, patches[0].Scope)
+		assert.Equal(t, "ingress-firewall-cp-rules", patches[1].Path)
+		assert.Equal(t, talosconfigmanager.PatchScopeControlPlane, patches[1].Scope)
+		assert.Equal(t, "ingress-firewall-worker-rules", patches[2].Path)
+		assert.Equal(t, talosconfigmanager.PatchScopeWorker, patches[2].Scope)
+
+		cpContent := string(patches[1].Content)
+		assert.Contains(t, cpContent, "0.0.0.0/0")
+		assert.Contains(t, cpContent, "10.244.0.0/16")
+	})
+
+	t.Run("allowed CIDRs restrict the control-plane rules", func(t *testing.T) {
+		t.Parallel()
+
+		patches, err := configmanager.IngressFirewallPatchesForTest(
+			"10.244.0.0/16",
+			8472,
+			[]string{"192.168.1.0/24"},
+		)
+		require.NoError(t, err)
+		require.Len(t, patches, 3)
+
+		cpContent := string(patches[1].Content)
+		assert.Contains(t, cpContent, "192.168.1.0/24")
+		assert.NotContains(t, cpContent, "0.0.0.0/0")
+	})
+
+	t.Run("non-canonical network CIDR is normalized", func(t *testing.T) {
+		t.Parallel()
+
+		patches, err := configmanager.IngressFirewallPatchesForTest("192.168.1.5/24", 8472, nil)
+		require.NoError(t, err)
+		require.Len(t, patches, 3)
+
+		cpContent := string(patches[1].Content)
+		assert.Contains(t, cpContent, "192.168.1.0/24")
+		assert.NotContains(t, cpContent, "192.168.1.5/24")
+	})
+}
+
+// TestReadEKSConfigMetadata verifies the eksctl config metadata reader across
+// missing-file, populated, metadata-less, and malformed-YAML cases.
+func TestReadEKSConfigMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file returns empty values and no error", func(t *testing.T) {
+		t.Parallel()
+
+		path, name, region, err := configmanager.ReadEKSConfigMetadataForTest(
+			filepath.Join(t.TempDir(), "absent.yaml"),
+		)
+		require.NoError(t, err)
+		assert.Empty(t, path)
+		assert.Empty(t, name)
+		assert.Empty(t, region)
+	})
+
+	t.Run("populated metadata is parsed", func(t *testing.T) {
+		t.Parallel()
+
+		configPath := filepath.Join(t.TempDir(), "eks.yaml")
+		writeFileWithParents(t, configPath, "apiVersion: eksctl.io/v1alpha5\n"+
+			"kind: ClusterConfig\n"+
+			"metadata:\n"+
+			"  name: my-eks\n"+
+			"  region: eu-west-1\n")
+
+		path, name, region, err := configmanager.ReadEKSConfigMetadataForTest(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, "eks.yaml", filepath.Base(path))
+		assert.Equal(t, "my-eks", name)
+		assert.Equal(t, "eu-west-1", region)
+	})
+
+	t.Run("file without metadata returns empty name and region", func(t *testing.T) {
+		t.Parallel()
+
+		configPath := filepath.Join(t.TempDir(), "eks.yaml")
+		writeFileWithParents(t, configPath, "apiVersion: eksctl.io/v1alpha5\nkind: ClusterConfig\n")
+
+		path, name, region, err := configmanager.ReadEKSConfigMetadataForTest(configPath)
+		require.NoError(t, err)
+		assert.NotEmpty(t, path)
+		assert.Empty(t, name)
+		assert.Empty(t, region)
+	})
+
+	t.Run("malformed YAML returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		configPath := filepath.Join(t.TempDir(), "eks.yaml")
+		// A tab in the indentation is invalid YAML.
+		writeFileWithParents(t, configPath, "metadata:\n\tname: my-eks\n")
+
+		_, _, _, err := configmanager.ReadEKSConfigMetadataForTest(configPath)
+		require.Error(t, err)
+	})
+}
+
+// TestResolveKWOKName verifies KWOK cluster-name resolution from the kubeconfig
+// context, with the default fallback.
+func TestResolveKWOKName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		context string
+		want    string
+	}{
+		{name: "empty context returns default", context: "", want: "kwok-default"},
+		{name: "kwok prefix extracts name", context: "kwok-my-cluster", want: "my-cluster"},
+		{
+			name:    "non-kwok context returns default",
+			context: "kind-my-cluster",
+			want:    "kwok-default",
+		},
+		{
+			name:    "kwok prefix with empty name returns default",
+			context: "kwok-",
+			want:    "kwok-default",
+		},
+		{name: "surrounding whitespace is trimmed", context: "  kwok-trimmed  ", want: "trimmed"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			mgr := newConfigManagerWithContext(testCase.context)
+			assert.Equal(t, testCase.want, mgr.ResolveKWOKNameForTest())
+		})
+	}
+}
+
+// TestResolveEKSNameFromContext verifies EKS cluster-name extraction from an
+// eksctl-style kubeconfig context, with the default fallback.
+func TestResolveEKSNameFromContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		context string
+		want    string
+	}{
+		{name: "empty context returns default", context: "", want: "eks-default"},
+		{
+			name:    "full eksctl context extracts name",
+			context: "iam-user@my-eks.eu-west-1.eksctl.io",
+			want:    "my-eks",
+		},
+		{
+			name:    "context without iam identity extracts name",
+			context: "my-eks.eu-west-1.eksctl.io",
+			want:    "my-eks",
+		},
+		{
+			name:    "non-eksctl context returns default",
+			context: "kind-my-cluster",
+			want:    "eks-default",
+		},
+		{
+			name:    "eksctl suffix with empty name returns default",
+			context: "iam-user@.eksctl.io",
+			want:    "eks-default",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			mgr := newConfigManagerWithContext(testCase.context)
+			assert.Equal(t, testCase.want, mgr.ResolveEKSNameFromContextForTest())
+		})
+	}
+}

--- a/pkg/fsutil/configmanager/ksail/export_test.go
+++ b/pkg/fsutil/configmanager/ksail/export_test.go
@@ -69,3 +69,37 @@ const LegacyWorkerRoleLabelPatchYAMLForTest = legacyWorkerRoleLabelPatchYAML
 
 // KubeletWorkerRoleLabelPatchYAMLForTest exports the kubelet --node-labels constant for testing.
 const KubeletWorkerRoleLabelPatchYAMLForTest = kubeletWorkerRoleLabelPatchYAML
+
+// IngressFirewallPatchesForTest exposes ingressFirewallPatches for testing.
+var IngressFirewallPatchesForTest = ingressFirewallPatches
+
+// IngressFirewallPatchPathsForTest exposes ingressFirewallPatchPaths for testing.
+var IngressFirewallPatchPathsForTest = ingressFirewallPatchPaths
+
+// IngressFirewallPatchFilesExistForTest exposes ingressFirewallPatchFilesExist for testing.
+var IngressFirewallPatchFilesExistForTest = ingressFirewallPatchFilesExist
+
+// KubeletPatchFilesExistForTest exposes kubeletPatchFilesExist for testing.
+var KubeletPatchFilesExistForTest = kubeletPatchFilesExist
+
+// ReadEKSConfigMetadataForTest exposes readEKSConfigMetadata for testing.
+var ReadEKSConfigMetadataForTest = readEKSConfigMetadata
+
+// ErrIngressFirewallMissingCIDRForTest exposes errIngressFirewallMissingCIDR for testing.
+var ErrIngressFirewallMissingCIDRForTest = errIngressFirewallMissingCIDR
+
+// ErrIngressFirewallInvalidCIDRForTest exposes errIngressFirewallInvalidCIDR for testing.
+var ErrIngressFirewallInvalidCIDRForTest = errIngressFirewallInvalidCIDR
+
+// ErrIngressFirewallInvalidPortForTest exposes errIngressFirewallInvalidPort for testing.
+var ErrIngressFirewallInvalidPortForTest = errIngressFirewallInvalidPort
+
+// ResolveKWOKNameForTest exposes resolveKWOKName for testing.
+func (m *ConfigManager) ResolveKWOKNameForTest() string {
+	return m.resolveKWOKName()
+}
+
+// ResolveEKSNameFromContextForTest exposes resolveEKSNameFromContext for testing.
+func (m *ConfigManager) ResolveEKSNameFromContextForTest() string {
+	return m.resolveEKSNameFromContext()
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds focused unit coverage for seven previously **0%-covered** helpers in `pkg/fsutil/configmanager/ksail/distribution.go` — the Talos ingress-firewall patch generation/path helpers and the EKS/KWOK config-name resolution helpers. Test-only change (new `distribution_test.go` + `export_test.go` re-exports); no production code touched.

## Why

These are pure, behaviour-rich helpers (CIDR validation + normalization, port-range checks, allow-list-aware control-plane rules, context-pattern name parsing, eksctl-metadata reading) that gate how Talos clusters are firewalled and how EKS/KWOK cluster names are derived — exactly the kind of logic where a silent regression ships broken config to a cluster. They had no direct tests; their `0%` was real, not mock-noise.

## Coverage delta (per-function, `go tool cover -func`)

| Function | Before | After |
|---|---|---|
| `ingressFirewallPatches` | 0.0% | 100.0% |
| `ingressFirewallPatchPaths` | 0.0% | 100.0% |
| `ingressFirewallPatchFilesExist` | 0.0% | 100.0% |
| `kubeletPatchFilesExist` | 0.0% | 100.0% |
| `resolveKWOKName` | 0.0% | 100.0% |
| `resolveEKSNameFromContext` | 0.0% | 100.0% |
| `readEKSConfigMetadata` | 0.0% | 81.2% |

`readEKSConfigMetadata`'s remaining lines are fs-permission / path-canonicalize error branches that aren't portably triggerable in a unit test — left uncovered rather than chased with brittle, OS-specific setup.

## What's pinned

- `ingressFirewallPatches`: empty/whitespace/invalid-CIDR and out-of-range-port error identities; the 3-patch result with correct `Path`/`Scope`; **network-CIDR normalization** (`192.168.1.5/24` → `192.168.1.0/24`); and `allowedCIDRs` restricting the CP rules vs. the allow-all (`0.0.0.0/0`) default.
- The patch-file-existence helpers across all-present / one-missing / none-present (`t.TempDir()`).
- `resolveKWOKName` / `resolveEKSNameFromContext`: prefix/suffix extraction, whitespace trimming, and default fallbacks.
- `readEKSConfigMetadata`: missing-file (empty, no error), populated metadata, metadata-less file, and malformed-YAML error.

## Validation

- `go test ./pkg/fsutil/configmanager/ksail/...` → **320 pass** (36 new sub-tests).
- `golangci-lint run ./pkg/fsutil/configmanager/ksail/...` → **0 issues** (full-tree).
- **Mutation-checked ×2**: breaking the CIDR normalization (`ipNet.String()` → raw) and the KWOK name extraction (`name` → `ctx`) each make the relevant tests fail; both reverted.

Behaviour-preserving (test + export-shim only). Follows the package's existing `export_test.go` black-box idiom.