### PR TITLE
test(configmanager): cover CDI and apiserver-feature-gates patch helpers

### DIFF
--- a/pkg/fsutil/configmanager/kind/cdi_test.go
+++ b/pkg/fsutil/configmanager/kind/cdi_test.go
@@ -1,0 +1,59 @@
+package kind_test
+
+import (
+	"testing"
+
+	kind "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/kind"
+	"github.com/stretchr/testify/assert"
+	kindv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+)
+
+func TestApplyCDIPatches_AppendsToEmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	kindConfig := &kindv1alpha4.Cluster{}
+
+	kind.ApplyCDIPatches(kindConfig)
+
+	assert.Equal(t, []string{kind.CDIPatch}, kindConfig.ContainerdConfigPatches)
+}
+
+func TestApplyCDIPatches_AppendsAlongsideUnrelatedPatch(t *testing.T) {
+	t.Parallel()
+
+	const unrelated = `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"`
+
+	kindConfig := &kindv1alpha4.Cluster{
+		ContainerdConfigPatches: []string{unrelated},
+	}
+
+	kind.ApplyCDIPatches(kindConfig)
+
+	assert.Equal(t, []string{unrelated, kind.CDIPatch}, kindConfig.ContainerdConfigPatches)
+}
+
+func TestApplyCDIPatches_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	kindConfig := &kindv1alpha4.Cluster{}
+
+	kind.ApplyCDIPatches(kindConfig)
+	kind.ApplyCDIPatches(kindConfig)
+
+	assert.Len(t, kindConfig.ContainerdConfigPatches, 1)
+	assert.Equal(t, []string{kind.CDIPatch}, kindConfig.ContainerdConfigPatches)
+}
+
+func TestApplyCDIPatches_SkipsWhenEnableCDIAlreadyPresent(t *testing.T) {
+	t.Parallel()
+
+	// Any existing patch containing the "enable_cdi" marker should suppress
+	// appending, even if it is not the exact CDIPatch string.
+	existing := []string{"some other patch with enable_cdi already set"}
+	kindConfig := &kindv1alpha4.Cluster{ContainerdConfigPatches: existing}
+
+	kind.ApplyCDIPatches(kindConfig)
+
+	assert.Equal(t, existing, kindConfig.ContainerdConfigPatches)
+}

--- a/pkg/fsutil/configmanager/talos/apiserver_feature_gates_test.go
+++ b/pkg/fsutil/configmanager/talos/apiserver_feature_gates_test.go
@@ -1,0 +1,24 @@
+package talos_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIServerFeatureGatesPatch(t *testing.T) {
+	t.Parallel()
+
+	patch := talos.APIServerFeatureGatesPatch()
+
+	expectedContent := "cluster:\n" +
+		"  apiServer:\n" +
+		"    extraArgs:\n" +
+		"      feature-gates: MutatingAdmissionPolicy=true\n" +
+		"      runtime-config: admissionregistration.k8s.io/v1beta1=true\n"
+
+	assert.Equal(t, "ksail-apiserver-feature-gates", patch.Path)
+	assert.Equal(t, talos.PatchScopeCluster, patch.Scope)
+	assert.Equal(t, []byte(expectedContent), patch.Content)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds black-box unit tests for two genuinely-uncovered (0.0%) exported, pure helpers in the `configmanager` family — **no source changes**:

- `kind.ApplyCDIPatches` (`pkg/fsutil/configmanager/kind/helpers.go`) — appends the CDI-enabling containerd config patch; idempotent via an `enable_cdi` substring guard.
- `talos.APIServerFeatureGatesPatch` (`pkg/fsutil/configmanager/talos/configs.go`) — builds the deterministic cluster-scope patch enabling the `MutatingAdmissionPolicy` feature gate + `admissionregistration.k8s.io/v1beta1` API (required by Calico v3.30+).

## Why

Both were exercised only incidentally (0% in the per-function coverage report) despite living in otherwise well-tested packages. These are pure, deterministic helpers — easy to pin with exact-value assertions, guarding their behaviour (including `ApplyCDIPatches`'s idempotency/dedup contract and the exact patch content/scope/path of `APIServerFeatureGatesPatch`) against silent regressions.

## Coverage / validation

- `ApplyCDIPatches` 0.0% → **100.0%**; `APIServerFeatureGatesPatch` 0.0% → **100.0%** (verified via `go tool cover -func`).
- New tests mirror the existing black-box (`package <pkg>_test`, testify) style of their sibling tests.
- `go test ./pkg/fsutil/configmanager/kind/... ./pkg/fsutil/configmanager/talos/...` — 211 pass.
- `golangci-lint run` on both packages — no issues.

Cases covered for `ApplyCDIPatches`: append-to-empty, append-alongside-unrelated-patch, idempotent (double-call), and skip-when-`enable_cdi`-already-present.