### PR TITLE
feat(webui): render real multi-page Headlamp plugins (Flux) in KSail's own UI

### DIFF
--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -11,6 +11,8 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@headlessui/react": "^2.2.10",
+        "@iconify-json/mdi": "^1.2.3",
+        "@iconify-json/simple-icons": "^1.2.87",
         "@iconify/react": "^5.2.1",
         "@mui/icons-material": "^6.5.0",
         "@mui/material": "^6.5.0",
@@ -593,6 +595,24 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@iconify-json/mdi": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@iconify-json/mdi/-/mdi-1.2.3.tgz",
+      "integrity": "sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.87",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.87.tgz",
+      "integrity": "sha512-8YciStObhSji3OZFmWAWK6kBujyqO5bLCxeDwLxf3CR3F4PVelq7keC2LBvgTqviWzSTysj5/g4PCFLiAMVGsw==",
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
       }
     },
     "node_modules/@iconify/react": {

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -15,6 +15,8 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@headlessui/react": "^2.2.10",
+    "@iconify-json/mdi": "^1.2.3",
+    "@iconify-json/simple-icons": "^1.2.87",
     "@iconify/react": "^5.2.1",
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.5.0",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { Moon, Plus, RotateCw, Server, Sun } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ApiError,
   createCluster,
@@ -30,7 +30,7 @@ import { CommandPalette, type Command } from "./components/CommandPalette.tsx";
 import { SecretsView } from "./components/SecretsView.tsx";
 import { PluginsView } from "./components/PluginsView.tsx";
 import { AIAssistant } from "./components/AIAssistant.tsx";
-import { PluginRouteHost } from "./lib/plugins/PluginSlots.tsx";
+import { pluginNavigate } from "./lib/plugins/pluginNavigation.ts";
 import { registry } from "./lib/plugins/registry.ts";
 import { usePluginLoader, usePluginRegistry } from "./lib/plugins/usePlugins.ts";
 import { setKubeWatchAvailable } from "./lib/plugins/watchStream.ts";
@@ -58,6 +58,13 @@ import { useToast } from "./components/Toast.tsx";
 // in-cluster); the local `ksail open web` backend advertises everything it can create locally. The
 // provider matrix and component options for whatever is selected still come from /api/v1/meta.
 const DEFAULT_DISTRIBUTIONS = ["VCluster"];
+
+// PluginRouterHost is lazy-loaded so react-router (and the plugin router machinery) only download when a
+// plugin surface is opened — keeping KSail's main bundle free of react-router until a plugin needs it,
+// matching the lazy-externals approach for MUI/Redux.
+const PluginRouterHost = lazy(() =>
+  import("./lib/plugins/PluginRouterHost.tsx").then((module) => ({ default: module.PluginRouterHost })),
+);
 
 // capability reads one capability flag from a (possibly null/partial) Config, defaulting to
 // fullCapabilities — the value assumed for a backend that does not report capabilities (see api.ts).
@@ -163,11 +170,9 @@ export function App() {
   // installed plugins once the backend advertises the capability.
   usePluginRegistry();
   const pluginLoader = usePluginLoader(canPlugins, getCluster);
-  const pluginEntries = registry.getSidebarEntries().map((entry) => ({
-    id: entry.id,
-    label: entry.label,
-    route: entry.route,
-  }));
+  // The plugin sidebar is a parent→children tree (Headlamp plugins like Flux register a group + nested
+  // entries); getSidebarTree applies any registered sidebar filters and nests children under their parent.
+  const pluginEntries = registry.getSidebarTree();
 
   // enterCluster drills into a cluster's workspace, landing on its Overview. Used by the Clusters list,
   // deep links, and the command palette.
@@ -194,8 +199,12 @@ export function App() {
   }, []);
 
   // selectPlugin opens a plugin route; its content replaces the current view until a view is chosen.
+  // Marking the surface active mounts PluginRouterHost (seeding this route as its initial path); when the
+  // router is already mounted, pluginNavigate moves it there. The persistent router survives in-plugin
+  // navigation; choosing a KSail view (setActivePluginRoute(null)) leaves the surface.
   const selectPlugin = useCallback((route: string) => {
     setActivePluginRoute(route);
+    pluginNavigate(route);
   }, []);
 
   // Clear the cluster context when the active cluster disappears from the live list (e.g. deleted),
@@ -578,7 +587,9 @@ export function App() {
         onSelectPlugin={selectPlugin}
       >
         {activePluginRoute ? (
-          <PluginRouteHost path={activePluginRoute} clusterName={activeCluster?.metadata.name ?? null} />
+          <Suspense fallback={null}>
+            <PluginRouterHost initialPath={activePluginRoute} clusterName={activeCluster?.metadata.name ?? null} />
+          </Suspense>
         ) : view === "settings" ? (
           <SettingsPage onSaved={() => void reloadConfig()} />
         ) : view === "plugins" ? (

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -105,7 +105,11 @@ function PluginNavGroup({
         ) : (
           <ChevronRight className="size-4 shrink-0" aria-hidden />
         )}
-        <Puzzle className="size-4 shrink-0" aria-hidden />
+        {node.icon ? (
+          <span className="flex size-4 shrink-0 items-center justify-center">{node.icon}</span>
+        ) : (
+          <Puzzle className="size-4 shrink-0" aria-hidden />
+        )}
         <span className="truncate">{node.label}</span>
       </button>
       {expanded ? (
@@ -146,7 +150,13 @@ function PluginNavTree({
         ) : node.route === undefined ? null : (
           <NavItem
             key={node.id}
-            icon={<Puzzle className="size-4" aria-hidden />}
+            icon={
+              node.icon ? (
+                <span className="flex size-4 items-center justify-center">{node.icon}</span>
+              ) : (
+                <Puzzle className="size-4" aria-hidden />
+              )
+            }
             label={node.label}
             active={activeId === node.id}
             onClick={() => onPick(node.route as string)}

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -1,21 +1,40 @@
 import { Dialog, DialogPanel, Transition, TransitionChild } from "@headlessui/react";
-import { Lock, LogOut, Menu as MenuIcon, Moon, Puzzle, Search, Sun } from "lucide-react";
+import { ChevronDown, ChevronRight, Lock, LogOut, Menu as MenuIcon, Moon, Puzzle, Search, Sun } from "lucide-react";
 import { Fragment, useState, type ReactNode } from "react";
 import type { Cluster, User } from "../api.ts";
 import type { Theme } from "../hooks/useTheme.ts";
 import { clusterViews, globalViews, viewTitle, type RegisteredView, type View, type ViewGates } from "../lib/views.tsx";
 import { PluginAppBarActions } from "../lib/plugins/PluginSlots.tsx";
+import { activeSidebarId } from "../lib/plugins/pluginNavigation.ts";
+import type { SidebarNode } from "../lib/plugins/registry.ts";
+import { usePluginLocation } from "../lib/plugins/usePlugins.ts";
 import { ClusterSwitcher } from "./ClusterSwitcher.tsx";
 import { KSailMark } from "./Logo.tsx";
 import { IconButton } from "./ui.tsx";
 
-// PluginNavEntry is a plugin-contributed sidebar item (rendered in the Plugins nav zone). It carries
-// the route the entry navigates to and a stable id/label; the icon is uniform (a puzzle piece) so the
-// zone reads as plugin-provided.
-export interface PluginNavEntry {
-  id: string;
-  label: string;
-  route: string;
+// Plugin-contributed sidebar items render from the registry's SidebarNode tree (a parent group with
+// nested children, e.g. the Flux plugin's "Flux" group). The icon is uniform (a puzzle piece) so the
+// zone reads as plugin-provided. PluginNavTree/PluginNavGroup below render it.
+
+// findPluginLabel returns the label of the tree entry (root or child) with the given id, for the header
+// title when a plugin route is active.
+function findPluginLabel(entries: readonly SidebarNode[], id: string | null): string | undefined {
+  if (!id) {
+    return undefined;
+  }
+
+  for (const node of entries) {
+    if (node.id === id) {
+      return node.label;
+    }
+
+    const child = node.children.find((candidate) => candidate.id === id);
+    if (child) {
+      return child.label;
+    }
+  }
+
+  return undefined;
 }
 
 // isMacLike picks the platform-appropriate shortcut hint for the search button (the handler accepts
@@ -55,6 +74,86 @@ function SectionLabel({ children }: { children: ReactNode }) {
     <div className="px-3 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
       {children}
     </div>
+  );
+}
+
+// PluginNavGroup renders a collapsible parent group (e.g. the Flux plugin's "Flux") with its child nav
+// items indented beneath. Expanded by default; also forced open while one of its children is active.
+function PluginNavGroup({
+  node,
+  activeId,
+  onPick,
+}: {
+  node: SidebarNode;
+  activeId: string | null;
+  onPick: (route: string) => void;
+}) {
+  const childActive = node.children.some((child) => child.id === activeId);
+  const [open, setOpen] = useState(true);
+  const expanded = open || childActive;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/60 dark:hover:text-white"
+      >
+        {expanded ? (
+          <ChevronDown className="size-4 shrink-0" aria-hidden />
+        ) : (
+          <ChevronRight className="size-4 shrink-0" aria-hidden />
+        )}
+        <Puzzle className="size-4 shrink-0" aria-hidden />
+        <span className="truncate">{node.label}</span>
+      </button>
+      {expanded ? (
+        <div className="mt-1 space-y-1 border-l border-slate-200 pl-3 dark:border-slate-800">
+          {node.children.map((child) =>
+            child.route === undefined ? null : (
+              <NavItem
+                key={child.id}
+                icon={<span className="size-4" aria-hidden />}
+                label={child.label}
+                active={activeId === child.id}
+                onClick={() => onPick(child.route as string)}
+              />
+            ),
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// PluginNavTree renders the plugin sidebar forest: a collapsible group per parent entry, and a flat
+// NavItem per top-level leaf (KSail's existing single-entry plugins keep rendering unchanged).
+function PluginNavTree({
+  entries,
+  activeId,
+  onPick,
+}: {
+  entries: readonly SidebarNode[];
+  activeId: string | null;
+  onPick: (route: string) => void;
+}) {
+  return (
+    <>
+      {entries.map((node) =>
+        node.children.length > 0 ? (
+          <PluginNavGroup key={node.id} node={node} activeId={activeId} onPick={onPick} />
+        ) : node.route === undefined ? null : (
+          <NavItem
+            key={node.id}
+            icon={<Puzzle className="size-4" aria-hidden />}
+            label={node.label}
+            active={activeId === node.id}
+            onClick={() => onPick(node.route as string)}
+          />
+        ),
+      )}
+    </>
   );
 }
 
@@ -110,14 +209,21 @@ export function AppShell({
   surfaceLabel: string;
   onOpenCommandPalette?: () => void;
   headerActions?: ReactNode;
-  // pluginEntries are plugin-contributed sidebar items; activePluginRoute marks which one (if any) is
-  // open so its content renders in place of a view; onSelectPlugin navigates to a plugin route.
-  pluginEntries?: PluginNavEntry[];
+  // pluginEntries is the plugin sidebar tree (parent groups + children); activePluginRoute marks that the
+  // plugin surface is open (its content renders in place of a view); onSelectPlugin navigates to a leaf's
+  // route. The highlighted item + header title come from the live plugin-router location, not this prop.
+  pluginEntries?: SidebarNode[];
   activePluginRoute?: string | null;
   onSelectPlugin?: (route: string) => void;
   children: ReactNode;
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // The active plugin sidebar item + header title follow the live plugin-router location (so an in-plugin
+  // <Link> to a detail page still highlights the right section). activeSidebarId maps the current plugin
+  // location to a sidebar entry id via the matched route's `sidebar`; null when no plugin surface is open.
+  const pluginLocation = usePluginLocation();
+  const activePluginId = activePluginRoute ? activeSidebarId(pluginLocation) : null;
 
   // gates feed the registry's per-view availability predicates. AppShell only ever shows the cluster
   // zone when a cluster is active (see navContent), so the cluster-scope gate is always satisfied here.
@@ -130,10 +236,8 @@ export function AppShell({
     aiChatEnabled,
   };
 
-  // headerTitle shows the active plugin route's label when one is open, else the current view's title.
-  const activePluginLabel = activePluginRoute
-    ? pluginEntries?.find((entry) => entry.route === activePluginRoute)?.label
-    : undefined;
+  // headerTitle shows the active plugin entry's label when the plugin surface is open, else the view's.
+  const activePluginLabel = activePluginRoute ? findPluginLabel(pluginEntries ?? [], activePluginId) : undefined;
   const headerTitle = activePluginLabel ?? viewTitle(view);
 
   // renderNav renders the enabled views from one registry partition (cluster or global), in registry
@@ -175,15 +279,7 @@ export function AppShell({
         <>
           <div className="my-2 border-t border-slate-200 dark:border-slate-800" />
           <SectionLabel>Plugins</SectionLabel>
-          {pluginEntries.map((entry) => (
-            <NavItem
-              key={entry.id}
-              icon={<Puzzle className="size-4" aria-hidden />}
-              label={entry.label}
-              active={activePluginRoute === entry.route}
-              onClick={() => onPickPlugin(entry.route)}
-            />
-          ))}
+          <PluginNavTree entries={pluginEntries} activeId={activePluginId} onPick={onPickPlugin} />
         </>
       ) : null}
     </nav>

--- a/web/ui/src/lib/plugins/PluginRouterHost.tsx
+++ b/web/ui/src/lib/plugins/PluginRouterHost.tsx
@@ -1,0 +1,95 @@
+// PluginRouterHost is the single, persistent router for the plugin surface. It replaces the old
+// per-render throwaway MemoryRouter + exact-path Map lookup with ONE MemoryRouter that hosts every
+// registered plugin route in a single <Routes>. That is what makes a real multi-page plugin (e.g. the
+// Flux plugin) work: param routes (`/flux/kustomizations/:namespace/:name`) match, in-plugin
+// <Link>/useNavigate/useParams navigate within the same router, and the router persists across
+// navigations instead of being recreated each render.
+//
+// KSail is a react-router v7 app, so this host imports react-router-dom DIRECTLY (v7). Plugin code, by
+// contrast, binds to the v5-shaped shim on window.pluginLib.ReactRouter (see reactRouterCompat.ts) — the
+// two coexist because both are backed by the same v7 runtime.
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { registry } from "./registry.ts";
+import { usePluginRegistry } from "./usePlugins.ts";
+import { PluginErrorBoundary, PluginProviders } from "./PluginSlots.tsx";
+import { publishPluginLocation, setPluginNavigate } from "./pluginNavigation.ts";
+
+// PluginRouterBridge runs inside the router and publishes its navigate() + current location to the
+// pluginNavigation module, so KSail's out-of-router sidebar/header can drive and follow it.
+function PluginRouterBridge(): null {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    setPluginNavigate((to) => navigate(to));
+
+    return () => setPluginNavigate(null);
+  }, [navigate]);
+
+  useEffect(() => {
+    publishPluginLocation(location.pathname);
+  }, [location.pathname]);
+
+  return null;
+}
+
+// NoRouteNotice is the catch-all shown when the active path matches no registered plugin route (e.g. a
+// sidebar entry whose plugin failed to register its route).
+function NoRouteNotice(): ReactNode {
+  return (
+    <div className="mx-auto max-w-3xl rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+      No plugin view is registered for this route.
+    </div>
+  );
+}
+
+// PluginRoutes builds a <Route> per registered plugin route, each wrapped in an error boundary + the
+// (router-free) plugin providers. usePluginRegistry re-renders this when routes are (un)registered.
+function PluginRoutes({ clusterName }: { clusterName: string | null }): ReactNode {
+  usePluginRegistry();
+  const routes = registry.getRoutes();
+
+  return (
+    <Routes>
+      {routes.map((route) => {
+        const RouteComponent = route.component;
+
+        return (
+          <Route
+            key={route.path}
+            path={route.path}
+            element={
+              <PluginErrorBoundary name={route.pluginName}>
+                <PluginProviders>
+                  <RouteComponent clusterName={clusterName} />
+                </PluginProviders>
+              </PluginErrorBoundary>
+            }
+          />
+        );
+      })}
+      <Route path="*" element={<NoRouteNotice />} />
+    </Routes>
+  );
+}
+
+// PluginRouterHost mounts the persistent MemoryRouter for the plugin surface. initialPath seeds the
+// first view (the sidebar route the user clicked to enter the surface); subsequent navigation flows
+// through the router (sidebar clicks via pluginNavigate, in-plugin links via the router itself).
+export function PluginRouterHost({
+  initialPath,
+  clusterName,
+}: {
+  initialPath: string;
+  clusterName: string | null;
+}): ReactNode {
+  return (
+    <MemoryRouter initialEntries={[initialPath || "/"]}>
+      <PluginRouterBridge />
+      <PluginRoutes clusterName={clusterName} />
+    </MemoryRouter>
+  );
+}

--- a/web/ui/src/lib/plugins/PluginSlots.tsx
+++ b/web/ui/src/lib/plugins/PluginSlots.tsx
@@ -3,41 +3,111 @@
 // component, and the extra sections appended to a resource's detail panel. Each plugin-rendered subtree
 // is wrapped in an error boundary so a buggy or hostile plugin cannot white-screen the app.
 
-import { Component, type ComponentType, type ErrorInfo, type ReactNode } from "react";
+import { Component, useMemo, type ComponentType, type ErrorInfo, type ReactNode } from "react";
 import { registry, type PluginResource } from "./registry.ts";
 import { usePluginRegistry } from "./usePlugins.ts";
 
-// pluginStore is a minimal no-op Redux store. KSail has no Headlamp-shaped Redux state, but a plugin that
-// calls useSelector/useDispatch must run inside a react-redux <Provider> or it throws; this satisfies the
-// store contract (getState/subscribe/dispatch) so such plugins render against an empty state instead of
-// crashing. Bridging real KSail state into this store is a follow-up.
+// pluginState is the minimal Redux state a Headlamp plugin assumes the host provides. Notably
+// `filter.namespaces` is a JS Set (Headlamp's useNamespaces selects it); it is a stable module-level
+// instance so a plugin's useSelector does not see a new value each render (which would loop/warn). KSail
+// does not yet drive real state in — plugins read these defaults rather than crashing.
+const pluginState = {
+  filter: { namespaces: new Set<string>(), search: "" },
+  config: { settings: {} },
+  ui: {},
+};
+
+// pluginStore is a minimal Redux store satisfying the contract a plugin's react-redux <Provider> needs
+// (getState/subscribe/dispatch). dispatch is a no-op echo; bridging real KSail state is a follow-up.
 const pluginStore = {
-  getState: (): Record<string, unknown> => ({}),
+  getState: (): typeof pluginState => pluginState,
   subscribe: (): (() => void) => () => undefined,
   dispatch: (action: unknown): unknown => action,
 };
 
-// PluginRuntimeProviders wraps a plugin-rendered subtree in the React context real Headlamp plugins
-// assume is present: a Router (so react-router hooks such as useNavigate/useParams work) and a Redux
-// Provider (so useSelector/useDispatch work). Both come from the lazily-loaded externals on
-// window.pluginLib, present once a plugin has loaded; when one is absent the children render unwrapped.
-function PluginRuntimeProviders({ children }: { children: ReactNode }): ReactNode {
+// MuiStylesShape is the slice of @mui/material/styles (window.pluginLib.MuiStyles) PluginProviders uses
+// to build and provide the plugin theme.
+interface MuiStylesShape {
+  createTheme?: (options: unknown) => unknown;
+  ThemeProvider?: ComponentType<{ theme: unknown; children: ReactNode }>;
+  StyledEngineProvider?: ComponentType<{ injectFirst?: boolean; children: ReactNode }>;
+}
+
+// isDarkMode reads KSail's current theme from the documentElement `dark` class (Tailwind dark mode), so
+// the plugin MUI theme matches KSail's light/dark.
+function isDarkMode(): boolean {
+  return typeof document !== "undefined" && document.documentElement.classList.contains("dark");
+}
+
+// buildPluginTheme creates an MUI theme carrying Headlamp's `chartStyles` palette augmentation, which the
+// Flux Overview (and other plugins) read via useTheme().palette.chartStyles — without it those reads
+// throw. The values mirror Headlamp's light/dark chartStyles.
+function buildPluginTheme(muiStyles: MuiStylesShape, dark: boolean): unknown {
+  return muiStyles.createTheme?.({
+    palette: {
+      mode: dark ? "dark" : "light",
+      chartStyles: dark
+        ? { defaultFillColor: "rgba(20, 20, 20, 0.1)", fillColor: "#929191", labelColor: "#fff" }
+        : { defaultFillColor: "rgba(0, 0, 0, 0.08)", labelColor: "#000" },
+    },
+  });
+}
+
+// PluginProviders wraps a plugin-rendered subtree in the non-router React context real Headlamp plugins
+// assume is present: a Redux Provider (so useSelector/useDispatch work). It comes from the lazily-loaded
+// react-redux external on window.pluginLib, present once a plugin has loaded; absent it renders children
+// unwrapped. The Router context is supplied separately — by the persistent PluginRouterHost for plugin
+// routes, and by PluginRuntimeProviders for the out-of-router slots below. (The MUI ThemeProvider with
+// Headlamp's chartStyles palette is layered in here too.)
+export function PluginProviders({ children }: { children: ReactNode }): ReactNode {
   const lib = typeof window === "undefined" ? undefined : window.pluginLib;
-  const router = lib?.ReactRouter as { MemoryRouter?: ComponentType<{ children: ReactNode }> } | undefined;
   const redux = lib?.ReactRedux as
     | { Provider?: ComponentType<{ store: unknown; children: ReactNode }> }
     | undefined;
+  const muiStyles = lib?.MuiStyles as MuiStylesShape | undefined;
+  const dark = isDarkMode();
+  const theme = useMemo(
+    () => (muiStyles?.createTheme ? buildPluginTheme(muiStyles, dark) : undefined),
+    [muiStyles, dark],
+  );
 
   let tree: ReactNode = children;
+
+  // MUI ThemeProvider (carrying Headlamp's chartStyles palette) so plugin components reading the theme
+  // work; StyledEngineProvider injectFirst keeps MUI's styles overridable.
+  if (theme && muiStyles?.ThemeProvider) {
+    const ThemeProvider = muiStyles.ThemeProvider;
+    let themed: ReactNode = <ThemeProvider theme={theme}>{tree}</ThemeProvider>;
+
+    if (muiStyles.StyledEngineProvider) {
+      const StyledEngineProvider = muiStyles.StyledEngineProvider;
+      themed = <StyledEngineProvider injectFirst>{themed}</StyledEngineProvider>;
+    }
+
+    tree = themed;
+  }
 
   if (redux?.Provider) {
     const Provider = redux.Provider;
     tree = <Provider store={pluginStore}>{tree}</Provider>;
   }
 
+  return tree;
+}
+
+// PluginRuntimeProviders wraps an out-of-router plugin slot (detail-view section, app-bar action) in a
+// throwaway Router plus PluginProviders, so a slot using react-router hooks or redux does not crash.
+// Plugin *routes* instead render under PluginRouterHost's single persistent router.
+function PluginRuntimeProviders({ children }: { children: ReactNode }): ReactNode {
+  const lib = typeof window === "undefined" ? undefined : window.pluginLib;
+  const router = lib?.ReactRouter as { MemoryRouter?: ComponentType<{ children: ReactNode }> } | undefined;
+
+  const tree: ReactNode = <PluginProviders>{children}</PluginProviders>;
+
   if (router?.MemoryRouter) {
     const Router = router.MemoryRouter;
-    tree = <Router>{tree}</Router>;
+
+    return <Router>{tree}</Router>;
   }
 
   return tree;
@@ -45,7 +115,7 @@ function PluginRuntimeProviders({ children }: { children: ReactNode }): ReactNod
 
 // PluginErrorBoundary isolates a plugin's rendered subtree. A throw during render surfaces a compact
 // inline notice (attributed to the plugin) instead of crashing the surrounding KSail UI.
-class PluginErrorBoundary extends Component<{ name?: string; children: ReactNode }, { error: Error | null }> {
+export class PluginErrorBoundary extends Component<{ name?: string; children: ReactNode }, { error: Error | null }> {
   constructor(props: { name?: string; children: ReactNode }) {
     super(props);
     this.state = { error: null };
@@ -117,34 +187,6 @@ export function PluginAppBarActions(): ReactNode {
   return renderExtensionList(registry.getAppBarActions(), (action) => action.render());
 }
 
-// PluginRouteHost renders the component registered for a plugin route path, scoped to the active
-// cluster, inside an error boundary. It shows a compact not-found notice when no route matches (e.g. a
-// sidebar entry whose plugin failed to register its route).
-export function PluginRouteHost({
-  path,
-  clusterName,
-}: {
-  path: string;
-  clusterName: string | null;
-}): ReactNode {
-  usePluginRegistry();
-
-  const route = registry.getRoute(path);
-  if (!route) {
-    return (
-      <div className="mx-auto max-w-3xl rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
-        No plugin view is registered for <code className="font-mono">{path}</code>.
-      </div>
-    );
-  }
-
-  const RouteComponent = route.component;
-
-  return (
-    <PluginErrorBoundary name={route.pluginName}>
-      <PluginRuntimeProviders>
-        <RouteComponent clusterName={clusterName} />
-      </PluginRuntimeProviders>
-    </PluginErrorBoundary>
-  );
-}
+// Plugin *routes* render under the single persistent router in PluginRouterHost.tsx (which reuses the
+// PluginErrorBoundary + PluginProviders exported above); the per-route host that used to live here was
+// replaced so in-plugin navigation, param routes, and the route↔sidebar highlight work.

--- a/web/ui/src/lib/plugins/commonComponents.tsx
+++ b/web/ui/src/lib/plugins/commonComponents.tsx
@@ -7,6 +7,7 @@
 
 import * as React from "react";
 import { pluginNavigate } from "./pluginNavigation.ts";
+import { renderPluginIcon as renderIcon } from "./pluginIcon.ts";
 
 // ---------------------------------------------------------------------------
 // Section primitives
@@ -188,7 +189,7 @@ export function HoverInfoLabel({
   return (
     <span className="inline-flex items-center gap-1" title={typeof hoverInfo === "string" ? hoverInfo : undefined}>
       {label}
-      {icon ?? <span aria-hidden>ⓘ</span>}
+      {renderIcon(icon) ?? <span aria-hidden>ⓘ</span>}
     </span>
   );
 }
@@ -520,7 +521,7 @@ export function ActionButton({
       onClick={onClick}
       className="inline-flex size-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
     >
-      {icon}
+      {renderIcon(icon)}
     </button>
   );
 }

--- a/web/ui/src/lib/plugins/commonComponents.tsx
+++ b/web/ui/src/lib/plugins/commonComponents.tsx
@@ -2,37 +2,564 @@
 // their content out with. A Headlamp plugin imports these from
 // `@kinvolk/headlamp-plugin/lib/CommonComponents`, which the build maps to `pluginLib.CommonComponents`.
 // KSail renders them with its own surface styling (Tailwind, not Material UI) so plugin content matches
-// the host UI and needs no MUI dependency — a plugin using `<SectionBox title=…>` looks native in KSail.
+// the host UI without pulling Material UI — e.g. the Flux Overview's donut status cards (TileChart),
+// status pills (StatusLabel), and tables (Table) all render natively in KSail.
 
 import * as React from "react";
+import { pluginNavigate } from "./pluginNavigation.ts";
+
+// ---------------------------------------------------------------------------
+// Section primitives
+// ---------------------------------------------------------------------------
+
+// SectionBoxHeaderProps mirrors the subset of Headlamp's SectionBox headerProps plugins pass — chiefly
+// `actions`, the controls (sort/show selects, settings button) rendered on the right of the title row.
+interface SectionBoxHeaderProps {
+  actions?: React.ReactNode;
+  noPadding?: boolean;
+}
 
 // SectionBox is Headlamp's titled content panel — the workhorse layout primitive plugins use to group
-// detail content. The title is optional (some callers render a bare framed box).
+// detail content. The title is optional; headerProps.actions render on the right of the title row.
 export function SectionBox({
   title,
+  headerProps,
   children,
 }: {
   title?: React.ReactNode;
+  headerProps?: SectionBoxHeaderProps;
   children?: React.ReactNode;
 }): React.ReactElement {
+  const hasHeader = title !== undefined || headerProps?.actions !== undefined;
+
   return (
     <section className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
-      {title === undefined ? null : (
-        <h2 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</h2>
-      )}
+      {hasHeader ? (
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</h2>
+          {headerProps?.actions === undefined ? null : (
+            <div className="flex items-center gap-2">{headerProps.actions}</div>
+          )}
+        </div>
+      ) : null}
       {children}
     </section>
   );
 }
 
-// SectionHeader renders a standalone section title, matching Headlamp's CommonComponents.SectionHeader
-// for plugins that title content without wrapping it in a SectionBox.
-export function SectionHeader({ title }: { title: React.ReactNode }): React.ReactElement {
-  return <h2 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</h2>;
+// SectionHeader renders a standalone section title with optional actions, for plugins that title content
+// without wrapping it in a SectionBox.
+export function SectionHeader({
+  title,
+  actions,
+}: {
+  title: React.ReactNode;
+  actions?: React.ReactNode[];
+}): React.ReactElement {
+  return (
+    <div className="mb-3 flex items-center justify-between gap-3">
+      <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</h2>
+      {actions && actions.length > 0 ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+}
+
+// SectionFilterHeader is Headlamp's list header with a title and (optional) action controls. KSail renders
+// the title + actions; the namespace/search filter affordances are host-owned, so they are accepted but
+// not rendered here.
+export function SectionFilterHeader({
+  title,
+  actions,
+}: {
+  title?: React.ReactNode;
+  actions?: React.ReactNode[];
+  noNamespaceFilter?: boolean;
+}): React.ReactElement {
+  return <SectionHeader title={title} actions={actions} />;
+}
+
+// ---------------------------------------------------------------------------
+// Status + labels
+// ---------------------------------------------------------------------------
+
+// StatusLabel is Headlamp's colored status pill. `status` selects the color; children are the text.
+export function StatusLabel({
+  status,
+  children,
+}: {
+  status?: "success" | "warning" | "error" | "";
+  children?: React.ReactNode;
+}): React.ReactElement {
+  const tone =
+    status === "success"
+      ? "bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-emerald-500/30"
+      : status === "warning"
+        ? "bg-amber-50 text-amber-700 ring-amber-600/20 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/30"
+        : status === "error"
+          ? "bg-red-50 text-red-700 ring-red-600/20 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/30"
+          : "bg-slate-100 text-slate-600 ring-slate-500/20 dark:bg-slate-700/40 dark:text-slate-300 dark:ring-slate-500/30";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${tone}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+// localeDateString / timeAgo are small date helpers shared with Utils (pluginLib). Kept here so DateLabel
+// can format without importing the Utils object.
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  return null;
+}
+
+export function localeDate(value: unknown): string {
+  const date = toDate(value);
+
+  return date ? date.toLocaleString() : "";
+}
+
+export function timeAgo(value: unknown): string {
+  const date = toDate(value);
+  if (!date) {
+    return "";
+  }
+
+  const seconds = Math.round((Date.now() - date.getTime()) / 1000);
+  const units: [number, string][] = [
+    [60, "s"],
+    [60, "m"],
+    [24, "h"],
+    [7, "d"],
+    [4.345, "w"],
+    [12, "mo"],
+    [Number.POSITIVE_INFINITY, "y"],
+  ];
+
+  let amount = Math.max(seconds, 0);
+  let unit = "s";
+  for (const [size, label] of units) {
+    if (amount < size) {
+      unit = label;
+      break;
+    }
+    amount = Math.floor(amount / size);
+    unit = label;
+  }
+
+  return `${amount}${unit}`;
+}
+
+// DateLabel renders a relative time (with the absolute time as a tooltip), matching Headlamp's DateLabel.
+export function DateLabel({ date }: { date: unknown; format?: string }): React.ReactElement {
+  return (
+    <span title={localeDate(date)} className="text-slate-600 dark:text-slate-300">
+      {timeAgo(date)}
+    </span>
+  );
+}
+
+// ShowHideLabel renders text, truncated, with the full value as a tooltip (Headlamp's ShowHideLabel shows
+// a show/hide toggle for long values; KSail truncates with a title attribute).
+export function ShowHideLabel({ children }: { children?: React.ReactNode }): React.ReactElement {
+  return <span className="block max-w-full truncate">{children}</span>;
+}
+
+// HoverInfoLabel renders a label with an info affordance whose tooltip is `hoverInfo` (Headlamp parity).
+export function HoverInfoLabel({
+  label,
+  hoverInfo,
+  icon,
+}: {
+  label: React.ReactNode;
+  hoverInfo?: React.ReactNode;
+  icon?: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <span className="inline-flex items-center gap-1" title={typeof hoverInfo === "string" ? hoverInfo : undefined}>
+      {label}
+      {icon ?? <span aria-hidden>ⓘ</span>}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Links
+// ---------------------------------------------------------------------------
+
+// resolvePluginUrl builds the target URL for a CommonComponents.Link: an explicit `to`, or a named route
+// resolved via window.pluginLib.Router.createRouteURL (the real registry-backed resolver from pluginLib).
+function resolvePluginUrl(to?: string, routeName?: string, params?: Record<string, string>): string {
+  if (to) {
+    return to;
+  }
+  if (!routeName) {
+    return "#";
+  }
+
+  const router = window.pluginLib?.Router as
+    | { createRouteURL?: (name: string, params?: Record<string, string>) => string }
+    | undefined;
+
+  return router?.createRouteURL?.(routeName, params) ?? "#";
+}
+
+// Link is Headlamp's router link. It resolves `routeName`+`params` (or `to`) to a URL and navigates the
+// plugin router on click (via pluginNavigate, so it stays inside KSail's persistent plugin MemoryRouter).
+// An external http(s) URL renders as a normal new-tab anchor.
+export function Link({
+  to,
+  routeName,
+  params,
+  children,
+  className,
+}: {
+  to?: string;
+  routeName?: string;
+  params?: Record<string, string>;
+  activeCluster?: string;
+  children?: React.ReactNode;
+  className?: string;
+}): React.ReactElement {
+  const url = resolvePluginUrl(to, routeName, params);
+  const external = /^https?:\/\//.test(url) || url.startsWith("//");
+  const linkClass = className ?? "text-blue-600 hover:underline dark:text-blue-400";
+
+  if (external) {
+    return (
+      <a href={url} target="_blank" rel="noreferrer" className={linkClass}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={url}
+      className={linkClass}
+      onClick={(event) => {
+        event.preventDefault();
+        if (url !== "#") {
+          pluginNavigate(url);
+        }
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tables
+// ---------------------------------------------------------------------------
+
+// NameValueTable renders Headlamp's two-column name/value detail table. A row with `hide` is skipped.
+export function NameValueTable({
+  rows,
+}: {
+  rows: { name?: React.ReactNode; value?: React.ReactNode; hide?: boolean }[];
+}): React.ReactElement {
+  return (
+    <table className="w-full text-sm">
+      <tbody>
+        {rows
+          .filter((row) => !row.hide)
+          .map((row, index) => (
+            <tr key={index} className="border-b border-slate-100 last:border-0 dark:border-slate-800">
+              <th className="w-1/3 py-1.5 pr-3 text-left align-top font-medium text-slate-500 dark:text-slate-400">
+                {row.name}
+              </th>
+              <td className="py-1.5 align-top text-slate-700 dark:text-slate-200">{row.value}</td>
+            </tr>
+          ))}
+      </tbody>
+    </table>
+  );
+}
+
+// TableColumn is the subset of a material-react-table column descriptor the Flux plugin (and similar)
+// pass. `header` labels the column; the cell value comes from accessorFn(row) or accessorKey, rendered by
+// `Cell` when present (called with the MRT-shaped { row.original, cell.getValue() }).
+interface TableColumn {
+  id?: string;
+  header?: React.ReactNode;
+  accessorKey?: string;
+  accessorFn?: (row: unknown) => unknown;
+  Cell?: (info: { row: { original: unknown }; cell: { getValue: () => unknown } }) => React.ReactNode;
+}
+
+// cellValue resolves a column's raw value for a row (accessorFn wins, else accessorKey lookup).
+function cellValue(column: TableColumn, row: unknown): unknown {
+  if (column.accessorFn) {
+    return column.accessorFn(row);
+  }
+  if (column.accessorKey && row && typeof row === "object") {
+    return (row as Record<string, unknown>)[column.accessorKey];
+  }
+
+  return undefined;
+}
+
+// Table is a bounded interpreter of Headlamp's material-react-table-backed Table: it renders the rows ×
+// columns the plugin provides, honoring accessorFn/accessorKey + the Cell renderer. MRT-only props
+// (gridTemplate, muiTableBodyCellProps, virtualization, built-in filtering) are accepted and ignored —
+// enough to render the Flux resource lists natively; richer table behavior is a follow-up.
+export function Table({
+  columns,
+  data,
+  loading,
+}: {
+  columns: TableColumn[];
+  data?: unknown[];
+  loading?: boolean;
+}): React.ReactElement {
+  const rows = data ?? [];
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            {columns.map((column, index) => (
+              <th key={column.id ?? index} className="px-3 py-2 font-medium">
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            <tr>
+              <td colSpan={columns.length} className="px-3 py-6 text-center text-slate-400">
+                Loading…
+              </td>
+            </tr>
+          ) : rows.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length} className="px-3 py-6 text-center text-slate-400">
+                No items
+              </td>
+            </tr>
+          ) : (
+            rows.map((row, rowIndex) => (
+              <tr key={rowIndex} className="border-b border-slate-100 last:border-0 dark:border-slate-800">
+                {columns.map((column, colIndex) => {
+                  const value = cellValue(column, row);
+                  const content = column.Cell
+                    ? column.Cell({ row: { original: row }, cell: { getValue: () => value } })
+                    : (value as React.ReactNode);
+
+                  return (
+                    <td key={column.id ?? colIndex} className="px-3 py-2 align-top text-slate-700 dark:text-slate-200">
+                      {content}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// SimpleTable is Headlamp's lighter table: `columns` carry a label + getter (datum/cellProps). KSail maps
+// it onto the same rendering as Table.
+export function SimpleTable({
+  columns,
+  data,
+}: {
+  columns: { label?: React.ReactNode; getter?: (row: unknown) => React.ReactNode; cellProps?: unknown }[];
+  data?: unknown[];
+}): React.ReactElement {
+  const mapped: TableColumn[] = columns.map((column, index) => ({
+    id: String(index),
+    header: column.label,
+    Cell: ({ row }) => (column.getter ? column.getter(row.original) : null),
+  }));
+
+  return <Table columns={mapped} data={data} />;
+}
+
+// ---------------------------------------------------------------------------
+// Charts (SVG donut — no recharts dependency)
+// ---------------------------------------------------------------------------
+
+// ChartDatum is one donut segment: a value and its fill color (Headlamp's PercentageCircle/TileChart data).
+interface ChartDatum {
+  name?: string;
+  value: number;
+  fill?: string;
+}
+
+// PercentageCircle renders a donut from the segments, sized to `size` with ring `thickness`. The segments
+// are drawn as stroked circle arcs (dash length = fraction of the circumference), rotated to start at 12
+// o'clock. A muted track shows beneath.
+function PercentageCircle({
+  data,
+  total,
+  size = 140,
+  thickness = 14,
+}: {
+  data: ChartDatum[];
+  total?: number;
+  size?: number;
+  thickness?: number;
+}): React.ReactElement {
+  const radius = (size - thickness) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const sum = total ?? data.reduce((acc, datum) => acc + Math.max(datum.value, 0), 0);
+
+  let offset = 0;
+  const arcs = sum > 0
+    ? data
+        .filter((datum) => datum.value > 0)
+        .map((datum, index) => {
+          const length = (datum.value / sum) * circumference;
+          const arc = { key: index, length, offset, fill: datum.fill ?? "#3b82f6" };
+          offset += length;
+
+          return arc;
+        })
+    : [];
+
+  const center = size / 2;
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="-rotate-90">
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        strokeWidth={thickness}
+        className="stroke-slate-200 dark:stroke-slate-700"
+      />
+      {arcs.map((arc) => (
+        <circle
+          key={arc.key}
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={arc.fill}
+          strokeWidth={thickness}
+          strokeDasharray={`${arc.length} ${circumference - arc.length}`}
+          strokeDashoffset={-arc.offset}
+        />
+      ))}
+    </svg>
+  );
+}
+
+// TileChart is Headlamp's donut status card: a legend (the stat lines) beside a donut whose center shows
+// `label` (typically a percentage). Used across the Flux Overview (Kustomizations/HelmReleases/… cards).
+export function TileChart({
+  data,
+  total,
+  label,
+  legend,
+  title,
+}: {
+  data?: ChartDatum[];
+  total?: number;
+  label?: React.ReactNode;
+  legend?: React.ReactNode;
+  title?: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-2">
+      {title === undefined ? null : (
+        <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</h3>
+      )}
+      <div className="flex items-center justify-between gap-4">
+        {legend === undefined ? null : <div className="min-w-0 text-xs text-slate-600 dark:text-slate-300">{legend}</div>}
+        <div className="relative inline-flex shrink-0 items-center justify-center">
+          <PercentageCircle data={data ?? []} total={total} />
+          {label === undefined ? null : (
+            <div className="absolute inset-0 flex items-center justify-center text-sm font-semibold text-slate-700 dark:text-slate-200">
+              {label}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Buttons, loaders, empties
+// ---------------------------------------------------------------------------
+
+// ActionButton is Headlamp's icon button with a tooltip description.
+export function ActionButton({
+  description,
+  icon,
+  onClick,
+}: {
+  description?: string;
+  icon?: React.ReactNode;
+  onClick?: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      title={description}
+      aria-label={description}
+      onClick={onClick}
+      className="inline-flex size-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+    >
+      {icon}
+    </button>
+  );
+}
+
+// Loader is Headlamp's spinner.
+export function Loader({ title }: { title?: string; noContainer?: boolean }): React.ReactElement {
+  return (
+    <div className="flex items-center justify-center gap-2 p-6 text-sm text-slate-400" role="status" aria-label={title}>
+      <span className="size-4 animate-spin rounded-full border-2 border-slate-300 border-t-transparent dark:border-slate-600 dark:border-t-transparent" />
+      {title ? <span>{title}</span> : null}
+    </div>
+  );
+}
+
+// Empty / EmptyContent render Headlamp's empty-state placeholder.
+export function Empty({ children }: { children?: React.ReactNode }): React.ReactElement {
+  return <div className="p-6 text-center text-sm text-slate-400">{children}</div>;
 }
 
 // CommonComponents is the object assigned to pluginLib.CommonComponents (the module shape a plugin's
-// CommonComponents import resolves to).
-export const CommonComponents = { SectionBox, SectionHeader };
+// CommonComponents import resolves to). Every export above is included so a plugin importing any of them
+// from @kinvolk/headlamp-plugin/lib/CommonComponents binds to KSail's native implementation.
+export const CommonComponents = {
+  SectionBox,
+  SectionHeader,
+  SectionFilterHeader,
+  StatusLabel,
+  DateLabel,
+  ShowHideLabel,
+  HoverInfoLabel,
+  Link,
+  NameValueTable,
+  Table,
+  SimpleTable,
+  TileChart,
+  ActionButton,
+  Loader,
+  Empty,
+  EmptyContent: Empty,
+};
 
 export type CommonComponentsShape = typeof CommonComponents;

--- a/web/ui/src/lib/plugins/externals.ts
+++ b/web/ui/src/lib/plugins/externals.ts
@@ -10,6 +10,8 @@
 // works (the component/hook surfaces are stable), but deep version-specific usage may need per-plugin
 // checks. This is the unavoidable cost of running plugins on KSail's React 19 rather than Headlamp's 18.
 
+import { makeReactRouterV5Compat, type ReactRouterCompatInput } from "./reactRouterCompat.ts";
+
 // installPluginExternals augments window.pluginLib with the lazy externals. It is idempotent: it returns
 // early once MuiMaterial is present, so repeated plugin (re)loads do not re-import the chunks.
 export async function installPluginExternals(): Promise<void> {
@@ -28,11 +30,17 @@ export async function installPluginExternals(): Promise<void> {
     import("@iconify/react"),
   ]);
 
-  lib.MuiMaterial = mui;
+  // Expose the full @mui/material namespace, with @mui/material/styles attached as `.styles`: Headlamp's
+  // build externalizes the deep import `@mui/material/styles` to `pluginLib.MuiMaterial.styles` (where
+  // useTheme/ThemeProvider/createTheme live), and `@mui/material/<Component>` to `pluginLib.MuiMaterial.
+  // <Component>` — both satisfied by this merged object. (MuiStyles is kept for @mui/styles consumers.)
+  lib.MuiMaterial = { ...(mui as Record<string, unknown>), styles: muiStyles };
   lib.MuiIconsMaterial = muiIcons;
   lib.MuiStyles = muiStyles;
   lib.ReactRedux = reactRedux;
-  lib.ReactRouter = reactRouter;
+  // Install the v5-shaped react-router shim (not raw v7), so a Headlamp plugin's useHistory/Switch/
+  // Redirect — built against react-router v5 — resolve against KSail's v7 runtime (see reactRouterCompat).
+  lib.ReactRouter = makeReactRouterV5Compat(reactRouter as unknown as ReactRouterCompatInput);
   // lodash is CJS; expose its callable default (the `_` object) when present, else the namespace.
   lib.Lodash = (lodash as { default?: unknown }).default ?? lodash;
   lib.Iconify = iconify;

--- a/web/ui/src/lib/plugins/externals.ts
+++ b/web/ui/src/lib/plugins/externals.ts
@@ -44,4 +44,26 @@ export async function installPluginExternals(): Promise<void> {
   // lodash is CJS; expose its callable default (the `_` object) when present, else the namespace.
   lib.Lodash = (lodash as { default?: unknown }).default ?? lodash;
   lib.Iconify = iconify;
+
+  await registerPluginIcons(iconify);
+}
+
+// registerPluginIcons registers the bundled Iconify collections so a plugin's `<Icon icon="mdi:cog">`
+// resolves OFFLINE: KSail's CSP (default-src 'self') blocks the Iconify API (api.iconify.design) and
+// clusters may be airgapped, so the icon data must be local. mdi (functional UI icons) and simple-icons
+// (brand logos, e.g. simple-icons:flux) are the sets Headlamp plugins use. Each JSON is its own dynamic
+// chunk, fetched only here — alongside the other plugin externals — so KSail's own UI never loads them.
+async function registerPluginIcons(iconify: unknown): Promise<void> {
+  const addCollection = (iconify as { addCollection?: (collection: unknown) => void }).addCollection;
+  if (typeof addCollection !== "function") {
+    return;
+  }
+
+  const [mdi, simpleIcons] = await Promise.all([
+    import("@iconify-json/mdi/icons.json"),
+    import("@iconify-json/simple-icons/icons.json"),
+  ]);
+
+  addCollection((mdi as { default?: unknown }).default ?? mdi);
+  addCollection((simpleIcons as { default?: unknown }).default ?? simpleIcons);
 }

--- a/web/ui/src/lib/plugins/k8s.ts
+++ b/web/ui/src/lib/plugins/k8s.ts
@@ -1,25 +1,245 @@
-// k8s.ts reproduces the slice of Headlamp's `K8s` data layer that plugins consume — the
-// `ResourceClasses.<Kind>.useList()` surface and the `KubeObject` instances it yields — backed by
-// KSail's read-only kube-apiserver proxy (see pkg/cli/clusterapi/kubeproxy.go) and scoped to the live
-// active cluster. It is the faithful, minimal counterpart to `@kinvolk/headlamp-plugin/lib/K8s`: a
-// Headlamp plugin that does `const [pods] = K8s.ResourceClasses.Pod.useList()` gets live cluster data
-// without modification. The full Headlamp class hierarchy (useGet, apiFactory, watch, CRD classes) is
-// intentionally out of scope here — this covers the common list-and-render path.
+// k8s.ts reproduces the slice of Headlamp's `lib/k8s` data layer that plugins consume: the `KubeObject`
+// class hierarchy (statics-driven, so a plugin's `class Kustomization extends KubeObject { static
+// apiVersion = 'kustomize.toolkit.fluxcd.io/v1'; … }` works unmodified), the `K8s.ResourceClasses` map
+// (including `CustomResourceDefinition`, which real plugins list at load to detect installed CRDs), the
+// imperative `apiList`/`apiGet` statics, and the `useList`/`useGet` hooks — all backed by KSail's
+// read-only kube-apiserver proxy (see pkg/cli/clusterapi/kubeproxy.go) and scoped to the live active
+// cluster. It is the faithful, minimal counterpart to `@kinvolk/headlamp-plugin/lib/K8s`.
 
-import type { ClusterRef } from "./pluginLib.ts";
+import * as React from "react";
 import { useClusterScopedList, type WatchBinding } from "./useClusterScopedList.ts";
+import type { ClusterRef } from "./pluginLib.ts";
 import { kubeObjectKey, watchStreamURL, type RawKubeObject } from "./watchStream.ts";
 
-// KubeObject wraps a raw Kubernetes resource as Headlamp plugins expect: `jsonData` holds the raw
-// object and the metadata/spec/status accessors plus getName/getNamespace mirror Headlamp's KubeObject
-// instance API closely enough for the common read paths.
-export class KubeObject {
-  jsonData: Record<string, unknown>;
+// activeClusterGetter resolves the active cluster for KubeObject's static (non-hook) data methods.
+// Headlamp's KubeObject statics read an implicit active cluster; KSail mirrors that by having the loader
+// set this getter once (setActiveCluster), so `Kustomization.apiList(...)` / `.useList()` follow the live
+// cluster without each class closing over it.
+let activeClusterGetter: () => ClusterRef | null = () => null;
 
-  constructor(raw: Record<string, unknown>) {
+// setActiveCluster records the live active-cluster getter the loader supplies (read on each fetch).
+export function setActiveCluster(getter: () => ClusterRef | null): void {
+  activeClusterGetter = getter;
+}
+
+// ApiError is an Error carrying the apiserver HTTP status. Plugins branch on `error.status === 404` (e.g.
+// the Flux plugin's "is Flux installed?" check), so the status must survive from the proxy fetch to the
+// caller. useClusterScopedList preserves the thrown Error instance, so the status reaches useList's
+// [items, error] tuple unchanged.
+export class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+type KubeJSON = Record<string, unknown>;
+
+// ListOptions mirror the Headlamp useList/apiList options object (a plugin calls
+// `Pod.useList({ namespace })`). Only namespace filtering is applied today; the rest are accepted for
+// API parity.
+export interface ListOptions {
+  namespace?: string | string[];
+  cluster?: string;
+  labelSelector?: string;
+  fieldSelector?: string;
+}
+
+// ResourceEndpoint is the apiserver coordinates parsed from a class's statics.
+interface ResourceEndpoint {
+  group: string;
+  version: string;
+  plural: string;
+  namespaced: boolean;
+}
+
+// KubeObject is the statics-driven base every resource class extends. A subclass sets the four statics
+// (kind/apiName/apiVersion/isNamespaced); the static data methods derive the apiserver path from them.
+// Instances expose the metadata/spec/status accessors Headlamp plugins read.
+export class KubeObject {
+  jsonData: KubeJSON;
+  // cluster is the active cluster the object was read from (set by the fetch path); some plugin link
+  // components scope a details link to it.
+  cluster?: string;
+
+  constructor(raw: KubeJSON) {
     this.jsonData = raw ?? {};
   }
 
+  // Statics a subclass overrides. Defaults keep TypeScript happy for the base.
+  static kind = "";
+  static apiName = "";
+  static apiVersion: string | string[] = "";
+  static isNamespaced = true;
+
+  // apiEndpoint parses the (first) apiVersion into group/version plus the plural/namespaced flags.
+  static get apiEndpoint(): ResourceEndpoint {
+    const apiVersion = Array.isArray(this.apiVersion) ? (this.apiVersion[0] ?? "") : this.apiVersion;
+    const slash = apiVersion.indexOf("/");
+    const group = slash === -1 ? "" : apiVersion.slice(0, slash);
+    const version = slash === -1 ? apiVersion : apiVersion.slice(slash + 1);
+
+    return { group, version, plural: this.apiName, namespaced: this.isNamespaced };
+  }
+
+  // create wraps a raw object as an instance of the concrete subclass (so instanceof + statics hold).
+  static create(this: KubeObjectClass, raw: KubeJSON): KubeObject {
+    return new this(raw);
+  }
+
+  // apiList starts a one-shot list of the collection and invokes onList with wrapped items (filtered to
+  // opts.namespace when given). It returns a starter function; calling it begins the request and returns
+  // a canceller — matching Headlamp's `apiList(onList, onError, opts)()` shape that plugins invoke at
+  // module scope (e.g. the Flux plugin's CRD-installed probe).
+  static apiList(
+    this: KubeObjectClass,
+    onList: (items: KubeObject[]) => void,
+    onError?: (err: ApiError) => void,
+    opts?: ListOptions,
+  ): () => () => void {
+    const cls = this;
+    const listPath = collectionPath(cls.apiEndpoint);
+
+    return () => {
+      const cluster = activeClusterGetter();
+      if (!cluster) {
+        onError?.(new ApiError("pluginLib: no active cluster", 0));
+
+        return () => undefined;
+      }
+
+      let cancelled = false;
+      proxyList(cluster, listPath, cls)
+        .then((items) => {
+          if (!cancelled) {
+            onList(filterByNamespace(items, opts?.namespace));
+          }
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) {
+            onError?.(toApiError(err));
+          }
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    };
+  }
+
+  // useList is the hook list: live [items, error] scoped to the active cluster, filtered to
+  // opts.namespace when given. Plugins call `K8s.ResourceClasses.<Kind>.useList({ namespace })`; the
+  // no-arg form still works. Live updates flow through the shared watch machinery (WS multiplexer → SSE
+  // → polling), same as the rest of the plugin K8s layer.
+  static useList(this: KubeObjectClass, opts: ListOptions = {}): [KubeObject[], ApiError | null] {
+    const cls = this;
+    const listPath = collectionPath(cls.apiEndpoint);
+    const namespaceKey = Array.isArray(opts.namespace) ? opts.namespace.join(",") : opts.namespace ?? "";
+
+    const cluster = activeClusterGetter();
+    const clusterName = cluster?.name ?? null;
+    const clusterNamespace = cluster?.namespace ?? null;
+    const hasCluster = clusterName !== null && clusterNamespace !== null;
+
+    const watch: WatchBinding<KubeObject> = {
+      url: hasCluster ? watchStreamURL(clusterNamespace, clusterName, listPath) : "",
+      mux: hasCluster ? { clusterId: clusterName, path: listPath, query: "" } : undefined,
+      toItem: (raw: RawKubeObject) => cls.create(raw as KubeJSON),
+      keyOf: (item: KubeObject) => kubeObjectKey(item.jsonData as RawKubeObject),
+    };
+
+    const [items, error] = useClusterScopedList<KubeObject>(
+      activeClusterGetter,
+      async (active) => filterByNamespace(await proxyList(active, listPath, cls), opts.namespace),
+      [listPath, namespaceKey],
+      watch,
+    );
+
+    return [items, error as ApiError | null];
+  }
+
+  // apiGet starts a one-shot get of a single object (Headlamp's apiGet), returning a starter→canceller
+  // like apiList.
+  static apiGet(
+    this: KubeObjectClass,
+    onGet: (item: KubeObject) => void,
+    name: string,
+    namespace?: string,
+    onError?: (err: ApiError) => void,
+  ): () => () => void {
+    const cls = this;
+    const objPath = objectPath(cls.apiEndpoint, name, namespace);
+
+    return () => {
+      const cluster = activeClusterGetter();
+      if (!cluster) {
+        onError?.(new ApiError("pluginLib: no active cluster", 0));
+
+        return () => undefined;
+      }
+
+      let cancelled = false;
+      proxyGet(cluster, objPath, cls)
+        .then((item) => {
+          if (!cancelled) {
+            onGet(item);
+          }
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) {
+            onError?.(toApiError(err));
+          }
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    };
+  }
+
+  // useGet is the hook form of apiGet: live [item, error] for one object.
+  static useGet(
+    this: KubeObjectClass,
+    name: string,
+    namespace?: string,
+  ): [KubeObject | null, ApiError | null] {
+    const cls = this;
+    const objPath = objectPath(cls.apiEndpoint, name, namespace);
+
+    const [items, error] = useClusterScopedList<KubeObject>(
+      activeClusterGetter,
+      async (active) => [await proxyGet(active, objPath, cls)],
+      [objPath],
+    );
+
+    return [items[0] ?? null, error as ApiError | null];
+  }
+
+  // useApiList subscribes onList to the live list (Headlamp parity), implemented over useList. onError
+  // fires when the list errors.
+  static useApiList(
+    this: KubeObjectClass,
+    onList: (items: KubeObject[]) => void,
+    onError?: (err: ApiError) => void,
+    opts: ListOptions = {},
+  ): void {
+    const [items, error] = this.useList(opts);
+
+    React.useEffect(() => {
+      onList(items);
+    }, [items, onList]);
+
+    React.useEffect(() => {
+      if (error) {
+        onError?.(error);
+      }
+    }, [error, onError]);
+  }
+
+  // ---- instance accessors mirroring Headlamp's KubeObject ----
   get metadata(): Record<string, unknown> {
     return (this.jsonData.metadata as Record<string, unknown>) ?? {};
   }
@@ -43,104 +263,156 @@ export class KubeObject {
   getNamespace(): string | undefined {
     return this.metadata.namespace as string | undefined;
   }
-}
 
-// ResourceClass is the static surface a plugin uses: `K8s.ResourceClasses.Pod.useList()`. It is the
-// list subset of Headlamp's KubeObject class statics — enough for the common "fetch and render a table"
-// plugin pattern.
-export interface ResourceClass {
-  useList: () => [KubeObject[], Error | null];
-}
-
-export type ResourceClasses = Record<string, ResourceClass>;
-
-interface ResourceDef {
-  // listPath is the apiserver collection path the kube-proxy fetches (cluster-wide; the proxy honours
-  // the same credentials as the resource browser).
-  listPath: string;
-}
-
-// RESOURCE_DEFS maps each reproduced Headlamp ResourceClass name to its apiserver list path. The set
-// covers the core/apps/batch/networking kinds plugins most commonly list; extend as needed.
-const RESOURCE_DEFS: Record<string, ResourceDef> = {
-  Pod: { listPath: "/api/v1/pods" },
-  Service: { listPath: "/api/v1/services" },
-  ConfigMap: { listPath: "/api/v1/configmaps" },
-  Secret: { listPath: "/api/v1/secrets" },
-  Namespace: { listPath: "/api/v1/namespaces" },
-  Node: { listPath: "/api/v1/nodes" },
-  Event: { listPath: "/api/v1/events" },
-  PersistentVolumeClaim: { listPath: "/api/v1/persistentvolumeclaims" },
-  ServiceAccount: { listPath: "/api/v1/serviceaccounts" },
-  Deployment: { listPath: "/apis/apps/v1/deployments" },
-  ReplicaSet: { listPath: "/apis/apps/v1/replicasets" },
-  StatefulSet: { listPath: "/apis/apps/v1/statefulsets" },
-  DaemonSet: { listPath: "/apis/apps/v1/daemonsets" },
-  Job: { listPath: "/apis/batch/v1/jobs" },
-  CronJob: { listPath: "/apis/batch/v1/cronjobs" },
-  Ingress: { listPath: "/apis/networking.k8s.io/v1/ingresses" },
-};
-
-// proxyList fetches a collection through the kube-proxy and wraps each item as a KubeObject.
-async function proxyList(cluster: ClusterRef, listPath: string): Promise<KubeObject[]> {
-  const base = `/api/v1/clusters/${encodeURIComponent(cluster.namespace)}/${encodeURIComponent(cluster.name)}`;
-  const response = await fetch(`${base}/proxy/${listPath.replace(/^\//, "")}`);
-  if (!response.ok) {
-    throw new Error(`apiserver GET ${listPath} failed: ${response.status}`);
+  getValue(prop: string): unknown {
+    return this.jsonData[prop];
   }
-
-  const body = (await response.json()) as { items?: Record<string, unknown>[] };
-
-  return (body.items ?? []).map((item) => new KubeObject(item));
 }
 
-// makeResourceClass builds one ResourceClass whose useList hook fetches via the proxy and re-fetches
-// when the active cluster changes (keyed on the cluster's primitive name/namespace, mirroring the
-// useResourceList shim so a cluster switch reloads the data). The cluster-scoped fetch-on-change effect
-// is shared with useResourceList via useClusterScopedList. Live updates come from that hook's optional
-// watch binding: the Headlamp WebSocket multiplexer (mux) when the backend advertises wsMultiplexer,
-// else the per-list apiserver WATCH over SSE (url) when it advertises kubeWatch, else interval polling.
-// An absent cluster yields an empty URL and no mux binding, which disables the watch.
-function makeResourceClass(def: ResourceDef, getCluster: () => ClusterRef | null): ResourceClass {
-  return {
-    useList(): [KubeObject[], Error | null] {
-      const cluster = getCluster();
-      const clusterName = cluster?.name ?? null;
-      const clusterNamespace = cluster?.namespace ?? null;
+// KubeObjectClass is the static side of KubeObject (a plugin subclass's constructor type).
+export type KubeObjectClass = typeof KubeObject;
 
-      // The watch observes the same collection the fetcher lists, with watched objects wrapped as
-      // KubeObjects keyed identically (uid, fallback namespace/name) so an incremental event updates the
-      // right row. An absent cluster yields an empty URL and no mux binding, which disables the watch (the
-      // hook polls). When present, useClusterScopedList prefers the WebSocket multiplexer (mux) over SSE (url).
-      const hasCluster = clusterName !== null && clusterNamespace !== null;
-      const watch: WatchBinding<KubeObject> = {
-        url: hasCluster ? watchStreamURL(clusterNamespace, clusterName, def.listPath) : "",
-        // clusterId is the cluster name (the {name} the backend resolves to a kubeconfig context, matching
-        // the SSE watch path). path is the apiserver collection; query is empty (watch the whole list, as
-        // the SSE path does). These three are the key Headlamp's multiplexer correlates DATA frames on.
-        mux: hasCluster ? { clusterId: clusterName, path: def.listPath, query: "" } : undefined,
-        toItem: (raw: RawKubeObject) => new KubeObject(raw as Record<string, unknown>),
-        keyOf: (item: KubeObject) => kubeObjectKey(item.jsonData as RawKubeObject),
-      };
+// ResourceClasses is the Headlamp `K8s.ResourceClasses` map: a KubeObject subclass per kind.
+export type ResourceClasses = Record<string, KubeObjectClass>;
 
-      return useClusterScopedList(
-        getCluster,
-        (active) => proxyList(active, def.listPath),
-        [],
-        watch,
-      );
-    },
+// CustomResourceDefinition is exported by name (Headlamp parity); the Flux plugin lists it at load via
+// `K8s.ResourceClasses.CustomResourceDefinition.apiList(...)`.
+export class CustomResourceDefinition extends KubeObject {
+  static kind = "CustomResourceDefinition";
+  static apiName = "customresourcedefinitions";
+  static apiVersion = "apiextensions.k8s.io/v1";
+  static isNamespaced = false;
+}
+
+// Event is exported by name (plugins import it from lib/K8s/event); namespaced core v1 events.
+export class Event extends KubeObject {
+  static kind = "Event";
+  static apiName = "events";
+  static apiVersion = "v1";
+  static isNamespaced = true;
+}
+
+// ResourceClassDef is the minimal descriptor makeKubeObjectClass needs.
+export interface ResourceClassDef {
+  kind: string;
+  apiName: string;
+  apiVersion: string | string[];
+  isNamespaced: boolean;
+}
+
+// makeKubeObjectClass mints a KubeObject subclass with the given statics — Headlamp's makeKubeObject /
+// makeCustomResourceClass building block, used for the built-in kinds and re-exported (via
+// makeCustomResourceClass.ts) so plugins can define CRD classes.
+export function makeKubeObjectClass(def: ResourceClassDef): KubeObjectClass {
+  return class extends KubeObject {
+    static kind = def.kind;
+    static apiName = def.apiName;
+    static apiVersion = def.apiVersion;
+    static isNamespaced = def.isNamespaced;
   };
 }
 
-// makeResourceClasses builds the Headlamp `K8s.ResourceClasses` map — a useList()-bearing entry per
-// common kind, each backed by the kube-proxy and scoped to the live active cluster.
-export function makeResourceClasses(getCluster: () => ClusterRef | null): ResourceClasses {
+// BUILTIN_DEFS covers the core/apps/batch/networking kinds plugins most commonly list. CustomResource-
+// Definition and Event are added to the map from their named classes below.
+const BUILTIN_DEFS: ResourceClassDef[] = [
+  { kind: "Pod", apiName: "pods", apiVersion: "v1", isNamespaced: true },
+  { kind: "Service", apiName: "services", apiVersion: "v1", isNamespaced: true },
+  { kind: "ConfigMap", apiName: "configmaps", apiVersion: "v1", isNamespaced: true },
+  { kind: "Secret", apiName: "secrets", apiVersion: "v1", isNamespaced: true },
+  { kind: "Namespace", apiName: "namespaces", apiVersion: "v1", isNamespaced: false },
+  { kind: "Node", apiName: "nodes", apiVersion: "v1", isNamespaced: false },
+  { kind: "PersistentVolumeClaim", apiName: "persistentvolumeclaims", apiVersion: "v1", isNamespaced: true },
+  { kind: "ServiceAccount", apiName: "serviceaccounts", apiVersion: "v1", isNamespaced: true },
+  { kind: "Deployment", apiName: "deployments", apiVersion: "apps/v1", isNamespaced: true },
+  { kind: "ReplicaSet", apiName: "replicasets", apiVersion: "apps/v1", isNamespaced: true },
+  { kind: "StatefulSet", apiName: "statefulsets", apiVersion: "apps/v1", isNamespaced: true },
+  { kind: "DaemonSet", apiName: "daemonsets", apiVersion: "apps/v1", isNamespaced: true },
+  { kind: "Job", apiName: "jobs", apiVersion: "batch/v1", isNamespaced: true },
+  { kind: "CronJob", apiName: "cronjobs", apiVersion: "batch/v1", isNamespaced: true },
+  { kind: "Ingress", apiName: "ingresses", apiVersion: "networking.k8s.io/v1", isNamespaced: true },
+];
+
+// makeResourceClasses builds the Headlamp `K8s.ResourceClasses` map — a KubeObject subclass per built-in
+// kind plus the named CustomResourceDefinition/Event classes.
+export function makeResourceClasses(): ResourceClasses {
   const classes: ResourceClasses = {};
 
-  for (const [kind, def] of Object.entries(RESOURCE_DEFS)) {
-    classes[kind] = makeResourceClass(def, getCluster);
+  for (const def of BUILTIN_DEFS) {
+    classes[def.kind] = makeKubeObjectClass(def);
   }
+  classes.CustomResourceDefinition = CustomResourceDefinition;
+  classes.Event = Event;
 
   return classes;
+}
+
+// collectionPath builds the apiserver collection URL for a class (cluster-wide, or a single namespace
+// when given for a namespaced kind).
+function collectionPath(ep: ResourceEndpoint, namespace?: string): string {
+  const prefix = ep.group === "" ? `/api/${ep.version}` : `/apis/${ep.group}/${ep.version}`;
+
+  return ep.namespaced && namespace ? `${prefix}/namespaces/${namespace}/${ep.plural}` : `${prefix}/${ep.plural}`;
+}
+
+// objectPath builds the apiserver URL for a single named object.
+function objectPath(ep: ResourceEndpoint, name: string, namespace?: string): string {
+  return `${collectionPath(ep, namespace)}/${name}`;
+}
+
+// filterByNamespace keeps items in the requested namespace(s); cluster-scoped items (no namespace) always
+// pass. An empty/absent filter returns everything (cluster-wide list).
+function filterByNamespace(items: KubeObject[], namespace?: string | string[]): KubeObject[] {
+  if (namespace === undefined || (Array.isArray(namespace) && namespace.length === 0)) {
+    return items;
+  }
+
+  const wanted = new Set(Array.isArray(namespace) ? namespace : [namespace]);
+
+  return items.filter((item) => {
+    const ns = item.getNamespace();
+
+    return ns === undefined || wanted.has(ns);
+  });
+}
+
+// toApiError normalizes an unknown thrown value to an ApiError (status 0 when not from the proxy).
+function toApiError(err: unknown): ApiError {
+  if (err instanceof ApiError) {
+    return err;
+  }
+
+  return new ApiError(err instanceof Error ? err.message : String(err), 0);
+}
+
+// proxyList fetches a collection through the kube-proxy and wraps each item as the given class, throwing
+// ApiError (with the HTTP status) on a non-OK response so callers can branch on 404 etc.
+async function proxyList(cluster: ClusterRef, listPath: string, cls: KubeObjectClass): Promise<KubeObject[]> {
+  const base = `/api/v1/clusters/${encodeURIComponent(cluster.namespace)}/${encodeURIComponent(cluster.name)}`;
+  const response = await fetch(`${base}/proxy/${listPath.replace(/^\//, "")}`);
+  if (!response.ok) {
+    throw new ApiError(`apiserver GET ${listPath} failed: ${response.status}`, response.status);
+  }
+
+  const body = (await response.json()) as { items?: KubeJSON[] };
+
+  return (body.items ?? []).map((item) => {
+    const obj = cls.create(item);
+    obj.cluster = cluster.name;
+
+    return obj;
+  });
+}
+
+// proxyGet fetches a single object through the kube-proxy and wraps it as the given class.
+async function proxyGet(cluster: ClusterRef, objPath: string, cls: KubeObjectClass): Promise<KubeObject> {
+  const base = `/api/v1/clusters/${encodeURIComponent(cluster.namespace)}/${encodeURIComponent(cluster.name)}`;
+  const response = await fetch(`${base}/proxy/${objPath.replace(/^\//, "")}`);
+  if (!response.ok) {
+    throw new ApiError(`apiserver GET ${objPath} failed: ${response.status}`, response.status);
+  }
+
+  const obj = cls.create((await response.json()) as KubeJSON);
+  obj.cluster = cluster.name;
+
+  return obj;
 }

--- a/web/ui/src/lib/plugins/makeCustomResourceClass.ts
+++ b/web/ui/src/lib/plugins/makeCustomResourceClass.ts
@@ -1,0 +1,55 @@
+// makeCustomResourceClass / apiFactory are Headlamp's factory helpers for minting custom-resource
+// classes. A plugin that does not subclass KubeObject directly builds its CRD classes through these
+// (Headlamp's `@kinvolk/headlamp-plugin/lib/lib/k8s/crd`). They are thin wrappers over makeKubeObjectClass
+// so a minted class flows through the same kube-proxy + watch machinery as the built-in kinds.
+
+import { makeKubeObjectClass, type KubeObjectClass } from "./k8s.ts";
+
+// CustomResourceClassArgs mirrors Headlamp's makeCustomResourceClass argument: one or more
+// group/version pairs (the served apiVersions), the plural resource name, and the namespaced flag.
+export interface CustomResourceClassArgs {
+  apiInfo: { group: string; version: string }[];
+  pluralName: string;
+  singularName?: string;
+  kind?: string;
+  isNamespaced: boolean;
+}
+
+// apiVersionsFromInfo joins each {group, version} into an apiVersion string ("group/version", or just
+// "version" for the core group).
+function apiVersionsFromInfo(apiInfo: { group: string; version: string }[]): string | string[] {
+  const versions = apiInfo.map((info) => (info.group ? `${info.group}/${info.version}` : info.version));
+
+  return versions.length === 1 ? versions[0] : versions;
+}
+
+// makeCustomResourceClass mints a KubeObject subclass for a CRD from its apiInfo/plural/namespaced.
+export function makeCustomResourceClass(args: CustomResourceClassArgs): KubeObjectClass {
+  return makeKubeObjectClass({
+    kind: args.kind ?? args.singularName ?? args.pluralName,
+    apiName: args.pluralName,
+    apiVersion: apiVersionsFromInfo(args.apiInfo),
+    isNamespaced: args.isNamespaced,
+  });
+}
+
+// apiFactory mints a cluster-scoped resource class from a single group/version/plural (Headlamp's
+// lower-level factory). A bare-version (core group) is supported by passing group "".
+export function apiFactory(group: string, version: string, plural: string): KubeObjectClass {
+  return makeKubeObjectClass({
+    kind: plural,
+    apiName: plural,
+    apiVersion: group ? `${group}/${version}` : version,
+    isNamespaced: false,
+  });
+}
+
+// apiFactoryWithNamespace mints a namespace-scoped resource class.
+export function apiFactoryWithNamespace(group: string, version: string, plural: string): KubeObjectClass {
+  return makeKubeObjectClass({
+    kind: plural,
+    apiName: plural,
+    apiVersion: group ? `${group}/${version}` : version,
+    isNamespaced: true,
+  });
+}

--- a/web/ui/src/lib/plugins/pluginIcon.ts
+++ b/web/ui/src/lib/plugins/pluginIcon.ts
@@ -1,0 +1,19 @@
+// renderPluginIcon renders a Headlamp icon prop. Headlamp passes icon NAMES as plain strings (e.g.
+// "mdi:cog", "simple-icons:flux") in registerSidebarEntry, ActionButton, HoverInfoLabel, etc.; KSail
+// renders a string via the bundled @iconify/react `Icon` on window.pluginLib (the icon sets are
+// registered offline in externals.ts, so they resolve without the CSP-blocked Iconify API). A ReactNode
+// (the plugin already wrapped its own icon) is returned as-is; undefined stays undefined so callers can
+// fall back to a default. Shared by commonComponents.tsx and pluginLib.ts so the string→Icon handling
+// lives in one place.
+
+import * as React from "react";
+
+export function renderPluginIcon(icon: React.ReactNode): React.ReactNode {
+  if (typeof icon !== "string") {
+    return icon;
+  }
+
+  const iconify = window.pluginLib?.Iconify as { Icon?: React.ComponentType<{ icon: string }> } | undefined;
+
+  return iconify?.Icon ? React.createElement(iconify.Icon, { icon }) : undefined;
+}

--- a/web/ui/src/lib/plugins/pluginLib.ts
+++ b/web/ui/src/lib/plugins/pluginLib.ts
@@ -17,6 +17,7 @@ import * as ReactDOM from "react-dom";
 import * as ReactJSX from "react/jsx-runtime";
 import { listResources } from "../../api.ts";
 import { CommonComponents, localeDate, timeAgo, type CommonComponentsShape } from "./commonComponents.tsx";
+import { renderPluginIcon } from "./pluginIcon.ts";
 import { KubeObject, makeResourceClasses, setActiveCluster, type ResourceClasses } from "./k8s.ts";
 import { apiFactory, apiFactoryWithNamespace, makeCustomResourceClass } from "./makeCustomResourceClass.ts";
 import { registry, type PluginResource, type RouteProps, type SidebarEntryFilter } from "./registry.ts";
@@ -175,7 +176,9 @@ export function installPluginLib(getCluster: () => ClusterRef | null): void {
       // A group header (e.g. Flux's `parent: null` "Flux" entry) carries no url — leave route undefined
       // so it renders as a non-navigable collapsible group rather than a dead link.
       route: entry.url,
-      icon: entry.icon,
+      // Headlamp's sidebar icon is often a plain icon-name string (e.g. "simple-icons:flux"); wrap it in
+      // the @iconify/react Icon so the sidebar shows the plugin's logo, not the literal name as text.
+      icon: renderPluginIcon(entry.icon),
       // Headlamp passes `parent: null` for a top-level entry; normalize to undefined.
       parent: entry.parent ?? undefined,
     });

--- a/web/ui/src/lib/plugins/pluginLib.ts
+++ b/web/ui/src/lib/plugins/pluginLib.ts
@@ -16,9 +16,10 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactJSX from "react/jsx-runtime";
 import { listResources } from "../../api.ts";
-import { CommonComponents, type CommonComponentsShape } from "./commonComponents.tsx";
-import { makeResourceClasses, type ResourceClasses } from "./k8s.ts";
-import { registry, type PluginResource, type RouteProps } from "./registry.ts";
+import { CommonComponents, localeDate, timeAgo, type CommonComponentsShape } from "./commonComponents.tsx";
+import { KubeObject, makeResourceClasses, setActiveCluster, type ResourceClasses } from "./k8s.ts";
+import { apiFactory, apiFactoryWithNamespace, makeCustomResourceClass } from "./makeCustomResourceClass.ts";
+import { registry, type PluginResource, type RouteProps, type SidebarEntryFilter } from "./registry.ts";
 import { useClusterScopedList } from "./useClusterScopedList.ts";
 import { WebSocketManager } from "./wsMultiplexer.ts";
 
@@ -43,6 +44,8 @@ interface HeadlampRoute {
   path: string;
   component: React.ComponentType<RouteProps>;
   name?: string;
+  // sidebar is the id of the sidebar entry kept highlighted while this route is active (Headlamp parity).
+  sidebar?: string;
 }
 
 // A details-view section is the modern Headlamp shape: a component rendered with the resource as a
@@ -60,6 +63,7 @@ export interface PluginLib {
   // and never hit this — a real bundle did).
   ReactJSX: typeof ReactJSX;
   registerSidebarEntry: (entry: HeadlampSidebarEntry) => void;
+  registerSidebarEntryFilter: (filter: SidebarEntryFilter) => void;
   registerRoute: (route: HeadlampRoute) => void;
   registerDetailsViewSection: (section: DetailsSectionComponent) => void;
   registerAppBarAction: (action: React.ReactNode | React.ComponentType) => void;
@@ -94,12 +98,25 @@ export interface PluginLib {
   ReactRouter?: unknown;
   Lodash?: unknown;
   Iconify?: unknown;
+  // Router is the Headlamp routing namespace (createRouteURL/getRoute/getRoutePath), installed by
+  // installCompatStubs and read by CommonComponents.Link; typed loosely as it is a compat surface.
+  Router?: unknown;
   Notification: (message: string, ...rest: unknown[]) => void;
 }
 
 interface K8sShim {
   useResourceList: (kind: string, namespace?: string) => [PluginResource[], Error | null];
   ResourceClasses: ResourceClasses;
+  // KubeObject + the CRD factories let a plugin that does not subclass directly mint custom-resource
+  // classes (Headlamp's K8s.KubeObject / K8s.makeCustomResourceClass / K8s.apiFactory surface).
+  KubeObject: typeof KubeObject;
+  makeCustomResourceClass: typeof makeCustomResourceClass;
+  apiFactory: typeof apiFactory;
+  apiFactoryWithNamespace: typeof apiFactoryWithNamespace;
+  // cluster mirrors Headlamp's lib/k8s/cluster module: real plugins import `KubeObject` from there
+  // (`pluginLib.K8s.cluster.KubeObject`) to subclass it for their CRD types — read at plugin load, so it
+  // must exist or the bundle crashes.
+  cluster: { KubeObject: typeof KubeObject; KubeObjectClass: typeof KubeObject };
 }
 
 interface ApiProxyShim {
@@ -130,21 +147,51 @@ function nextId(prefix: string): string {
   return `${prefix}-${autoId}`;
 }
 
+// fillRouteParams substitutes :param segments in a route path from params — the createRouteURL fallback
+// for when react-router's generatePath is not yet on window.pluginLib. A param with no value is left as
+// the literal segment.
+function fillRouteParams(path: string, params?: Record<string, string>): string {
+  if (!params) {
+    return path;
+  }
+
+  return path.replace(/:([A-Za-z0-9_]+)\??/g, (whole, key: string) =>
+    params[key] === undefined ? whole : encodeURIComponent(params[key]),
+  );
+}
+
 // installPluginLib assigns window.pluginLib once, wiring the Headlamp register*() surface onto the
 // native registry and the K8s shim onto KSail's cluster-scoped resource API. getCluster is read live
 // on each data fetch so the shim follows the active cluster.
 export function installPluginLib(getCluster: () => ClusterRef | null): void {
+  // The KubeObject statics (apiList/useList) read the active cluster through a module-level getter; set
+  // it from the loader's live getter so a plugin's `Kustomization.apiList(...)` follows the active cluster.
+  setActiveCluster(getCluster);
+
   const registerSidebarEntry = (entry: HeadlampSidebarEntry): void => {
     registry.registerSidebarEntry({
       id: entry.name,
       label: entry.label,
-      route: entry.url ?? entry.name,
+      // A group header (e.g. Flux's `parent: null` "Flux" entry) carries no url — leave route undefined
+      // so it renders as a non-navigable collapsible group rather than a dead link.
+      route: entry.url,
       icon: entry.icon,
+      // Headlamp passes `parent: null` for a top-level entry; normalize to undefined.
+      parent: entry.parent ?? undefined,
     });
   };
 
   const registerRoute = (route: HeadlampRoute): void => {
-    registry.registerRoute({ path: route.path, component: route.component });
+    registry.registerRoute({
+      path: route.path,
+      component: route.component,
+      sidebar: route.sidebar,
+      name: route.name,
+    });
+  };
+
+  const registerSidebarEntryFilter = (filter: SidebarEntryFilter): void => {
+    registry.registerSidebarEntryFilter(filter);
   };
 
   const registerDetailsViewSection = (section: DetailsSectionComponent): void => {
@@ -159,6 +206,7 @@ export function installPluginLib(getCluster: () => ClusterRef | null): void {
     ReactDOM,
     ReactJSX,
     registerSidebarEntry,
+    registerSidebarEntryFilter,
     registerRoute,
     registerDetailsViewSection,
     registerAppBarAction: (action) => {
@@ -239,7 +287,6 @@ const UNSUPPORTED_REGISTRATIONS = [
   "registerOverviewChartsProcessor",
   "registerPluginSettings",
   "registerRouteFilter",
-  "registerSidebarEntryFilter",
   "registerUIPanel",
   "registerAddClusterProvider",
   "registerClusterProviderDialog",
@@ -263,20 +310,105 @@ function installCompatStubs(lib: PluginLib): void {
     compat[name] = noop;
   }
 
-  // Router URL helpers — return a harmless hash anchor so a plugin building a link does not break.
+  // Router URL helpers backed by the registered plugin routes. createRouteURL resolves a Headlamp route
+  // name to its URL (filling `:param` segments), so a plugin's `<Link to={Router.createRouteURL('source',
+  // {namespace, name})}>` produces a real path the persistent plugin router (PluginRouterHost) matches.
+  // generatePath is read off the lazily-loaded react-router (present once a plugin has loaded); a manual
+  // fill is the fallback. An unknown route name returns "#" so a stray link is inert rather than throwing.
   compat.Router = {
-    createRouteURL: (): string => "#",
-    getRoute: (): null => null,
-    getRoutePath: (): string => "#",
+    createRouteURL: (name: string, params?: Record<string, string>): string => {
+      const route = registry.getRouteByName(name);
+      if (!route) {
+        return "#";
+      }
+
+      const reactRouter = window.pluginLib?.ReactRouter as
+        | { generatePath?: (path: string, params?: Record<string, string>) => string }
+        | undefined;
+      if (reactRouter?.generatePath) {
+        try {
+          return reactRouter.generatePath(route.path, params ?? {});
+        } catch {
+          // Fall through to the manual fill below.
+        }
+      }
+
+      return fillRouteParams(route.path, params);
+    },
+    getRoute: (name: string): unknown => registry.getRouteByName(name) ?? null,
+    getRoutePath: (name: string): string => registry.getRouteByName(name)?.path ?? "#",
   };
 
-  // Namespaces a plugin may import (and subclass, for Plugin) even when it never exercises behaviour KSail
-  // does not implement — exposed as empty objects / base classes so the import resolves.
-  compat.Utils = {};
+  // Utils is Headlamp's lib/util surface. KSail provides the read helpers plugins commonly call:
+  // getCluster (the active cluster name), useFilterFunc (a no-op pass-through filter hook — KSail does not
+  // drive Headlamp's search/namespace filter state), and the locale/relative date formatters. Unknown
+  // filter helpers default to "keep".
+  compat.Utils = {
+    getCluster: (): string | null => lib.Headlamp.getCluster(),
+    getClusterPrefixedPath: (path?: string): string => path ?? "/",
+    useFilterFunc:
+      () =>
+      (): boolean =>
+        true,
+    localeDate: (date: unknown): string => localeDate(date),
+    timeAgo: (date: unknown): string => timeAgo(date),
+    filterResource: (): boolean => true,
+    filterGeneric: (): boolean => true,
+  };
   compat.Plugin = class {};
   compat.Activity = {};
-  compat.ConfigStore = class {};
+  // ConfigStore is Headlamp's per-plugin settings store. Real plugins construct one at load
+  // (`new ConfigStore('@headlamp-k8s/flux')`) and read it during render (`store.get()`, the
+  // `store.useConfig()()` hook), so an empty class throws "get is not a function". KSail backs it with
+  // localStorage so plugin settings persist; useConfig returns a (non-reactive) hook reading the config.
+  compat.ConfigStore = class {
+    private readonly storeKey: string;
+
+    constructor(name: string) {
+      this.storeKey = `ksail-plugin-config:${name}`;
+    }
+
+    get(): Record<string, unknown> {
+      try {
+        return JSON.parse(globalThis.localStorage?.getItem(this.storeKey) ?? "{}") as Record<string, unknown>;
+      } catch {
+        return {};
+      }
+    }
+
+    set(config: Record<string, unknown>): void {
+      try {
+        globalThis.localStorage?.setItem(this.storeKey, JSON.stringify(config ?? {}));
+      } catch {
+        // Storage unavailable — settings simply do not persist.
+      }
+    }
+
+    update(config: Record<string, unknown>): void {
+      this.set({ ...this.get(), ...(config ?? {}) });
+    }
+
+    useConfig(): () => Record<string, unknown> {
+      return (): Record<string, unknown> => this.get();
+    }
+  };
   compat.PluginManager = {};
+
+  // Crd is Headlamp's lib/k8s/crd module: real plugins call pluginLib.Crd.makeCustomResourceClass at load
+  // to mint their CRD classes (e.g. the Flux plugin's Kustomization/HelmRelease types), so it must exist
+  // and be wired to the real factories or the bundle crashes on load.
+  compat.Crd = { makeCustomResourceClass, apiFactory, apiFactoryWithNamespace };
+
+  // Externals KSail does not bundle but a real plugin references at load (passed to its UMD factory, so
+  // they must be defined objects, not undefined): a notistack snackbar shim (action notifications no-op
+  // instead of crashing) and empty Monaco editor stubs (a plugin's YAML-editor view renders nothing
+  // rather than crashing the whole plugin).
+  compat.Notistack = {
+    useSnackbar: () => ({ enqueueSnackbar: noop, closeSnackbar: noop }),
+    SnackbarProvider: ({ children }: { children?: unknown }) => children,
+  };
+  compat.MonacoEditor = {};
+  compat.ReactMonacoEditor = { default: (): null => null, Editor: (): null => null };
 
   // Misc top-level helpers from the lib's registry export.
   compat.clusterAction = noop;
@@ -304,6 +436,11 @@ function makeK8sShim(getCluster: () => ClusterRef | null): K8sShim {
         [kind, namespace],
       );
     },
-    ResourceClasses: makeResourceClasses(getCluster),
+    ResourceClasses: makeResourceClasses(),
+    KubeObject,
+    makeCustomResourceClass,
+    apiFactory,
+    apiFactoryWithNamespace,
+    cluster: { KubeObject, KubeObjectClass: KubeObject },
   };
 }

--- a/web/ui/src/lib/plugins/pluginNavigation.ts
+++ b/web/ui/src/lib/plugins/pluginNavigation.ts
@@ -1,0 +1,96 @@
+// pluginNavigation bridges KSail's chrome (its sidebar + header, which live OUTSIDE the plugin router)
+// to the single persistent plugin router in PluginRouterHost. A child rendered inside that router
+// publishes its navigate function and current location here, so the out-of-router sidebar can drive the
+// router on click and reflect the active route (highlight + header title). This is the same
+// cross-the-React-boundary module-singleton idiom KSail already uses for watch availability
+// (watchStream.setKubeWatchAvailable) and plugin context (registry.setPluginContext).
+
+import { registry } from "./registry.ts";
+
+type NavigateFn = (to: string) => void;
+
+// navigateFn is the active plugin router's navigate(), or null when the plugin surface is not mounted.
+let navigateFn: NavigateFn | null = null;
+
+// setPluginNavigate is called by the in-router bridge on mount/unmount to publish (or clear) navigate().
+export function setPluginNavigate(fn: NavigateFn | null): void {
+  navigateFn = fn;
+}
+
+// pluginNavigate asks the plugin router to navigate (e.g. from a sidebar click). A no-op when no plugin
+// router is mounted yet — the caller seeds the initial route via PluginRouterHost's initialPath instead.
+export function pluginNavigate(to: string): void {
+  navigateFn?.(to);
+}
+
+// --- current plugin location store (useSyncExternalStore-compatible) ---
+
+let currentPath = "/";
+const listeners = new Set<() => void>();
+
+// publishPluginLocation records the plugin router's current pathname (from the in-router bridge) and
+// notifies subscribers, so the sidebar highlight + header title follow in-plugin navigation (e.g. a
+// plugin <Link> to a detail page).
+export function publishPluginLocation(path: string): void {
+  if (path === currentPath) {
+    return;
+  }
+
+  currentPath = path;
+  listeners.forEach((listener) => {
+    listener();
+  });
+}
+
+export function subscribePluginLocation(listener: () => void): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getPluginLocation(): string {
+  return currentPath;
+}
+
+// pathMatches reports whether a plugin location matches a route pattern, treating `:param` segments as
+// single-segment wildcards (e.g. `/flux/kustomizations/:namespace/:name` matches
+// `/flux/kustomizations/default/podinfo`). A small inline matcher is used rather than react-router's
+// matchPath so this module — eagerly imported by KSail's chrome — does not pull react-router into the
+// main bundle (it stays a plugin-only lazy external). Highlight is best-effort, so exactness is enough.
+function pathMatches(pattern: string, path: string): boolean {
+  const normalize = (value: string): string => value.replace(/\/+$/, "");
+  if (normalize(pattern) === normalize(path)) {
+    return true;
+  }
+
+  const source = normalize(pattern)
+    .split("/")
+    .map((segment) => (segment.startsWith(":") ? "[^/]+" : segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+    .join("/");
+
+  return new RegExp(`^${source}/?$`).test(normalize(path));
+}
+
+// activeSidebarId resolves which sidebar entry should be highlighted for a plugin location: match the
+// path against each registered route; the matched route's `sidebar` (Headlamp's route→sidebar link) is
+// the active id, so a detail route under a section still highlights that section. Falls back to a
+// sidebar entry whose own route equals the path.
+export function activeSidebarId(path: string): string | null {
+  for (const route of registry.getRoutes()) {
+    if (pathMatches(route.path, path)) {
+      if (route.sidebar) {
+        return route.sidebar;
+      }
+
+      const entry = registry.getSidebarEntries().find((candidate) => candidate.route === route.path);
+
+      return entry?.id ?? null;
+    }
+  }
+
+  const entry = registry.getSidebarEntries().find((candidate) => candidate.route === path);
+
+  return entry?.id ?? null;
+}

--- a/web/ui/src/lib/plugins/reactRouterCompat.ts
+++ b/web/ui/src/lib/plugins/reactRouterCompat.ts
@@ -1,0 +1,77 @@
+// reactRouterCompat adapts react-router v7 (the version KSail bundles) to the v5 surface Headlamp
+// plugins were built against. Headlamp's plugin toolchain bundles react-router v5 and re-exports
+// `useHistory`/`Switch`/`Redirect`/`useRouteMatch`/`withRouter`; v7 removed all of those. The plugin
+// bundle binds those names to `window.pluginLib.ReactRouter`, so externals.ts installs the SHIM (not raw
+// v7) there — a plugin's `useHistory()` then works, backed by v7's useNavigate/useLocation. KSail's own
+// router code (PluginRouterHost) imports react-router-dom directly and is unaffected.
+
+import * as React from "react";
+
+// ReactRouterCompatInput is the slice of the loaded react-router v7 module the shim needs. The rest of
+// the module (Link, Route, Routes, useParams, Navigate, Outlet, generatePath, matchPath, MemoryRouter, …)
+// is preserved by spreading, so plugins importing any v7 export via pluginLib.ReactRouter still get it.
+export interface ReactRouterCompatInput {
+  useNavigate: () => (to: unknown, options?: { replace?: boolean }) => void;
+  useLocation: () => { pathname: string; search: string; hash: string; state: unknown };
+  useParams: () => Record<string, string | undefined>;
+  Navigate: React.ComponentType<{ to: unknown; replace?: boolean }>;
+  Routes: React.ComponentType<{ children?: React.ReactNode }>;
+  [key: string]: unknown;
+}
+
+// makeReactRouterV5Compat returns a react-router object exposing both the v7 surface (via spread) and the
+// v5 names plugins expect.
+export function makeReactRouterV5Compat(v7: ReactRouterCompatInput): Record<string, unknown> {
+  // useHistory returns a v5 history backed by v7 navigation. push/replace/go(Back|Forward) map onto
+  // useNavigate; `location` comes from useLocation.
+  const useHistory = (): unknown => {
+    const navigate = v7.useNavigate();
+    const location = v7.useLocation();
+
+    return {
+      push: (to: unknown) => navigate(to),
+      replace: (to: unknown) => navigate(to, { replace: true }),
+      goBack: () => navigate(-1),
+      goForward: () => navigate(1),
+      go: (delta: number) => navigate(delta),
+      location,
+    };
+  };
+
+  // Redirect maps onto v7's <Navigate replace>.
+  const Redirect = ({ to }: { to: unknown }): React.ReactElement =>
+    React.createElement(v7.Navigate, { to, replace: true });
+
+  // useRouteMatch approximates v5's match from v7 hooks (params + the current pathname). Good enough for
+  // the read paths plugins use (params + url); exhaustive path matching is not reproduced.
+  const useRouteMatch = (pattern?: string): unknown => {
+    const params = v7.useParams();
+    const location = v7.useLocation();
+
+    return { params, path: pattern ?? location.pathname, url: location.pathname, isExact: true };
+  };
+
+  // withRouter injects v5 history/location/match props via the hooks above (a class-component HOC some
+  // older plugins use).
+  const withRouter =
+    <P extends object>(Component: React.ComponentType<P>): React.FC<P> =>
+    (props: P): React.ReactElement => {
+      const history = useHistory();
+      const location = v7.useLocation();
+      const params = v7.useParams();
+
+      return React.createElement(Component, { ...props, history, location, match: { params } } as P);
+    };
+
+  return {
+    ...v7,
+    useHistory,
+    // v5 <Switch> renders the first matching child route — v7 <Routes> has the same role. (A plugin using
+    // the v5 `<Route component=>` child form inside a Switch is the one unsupported corner; Headlamp's
+    // modern plugins register routes through registerRoute instead, which KSail hosts with `element`.)
+    Switch: v7.Routes,
+    Redirect,
+    useRouteMatch,
+    withRouter,
+  };
+}

--- a/web/ui/src/lib/plugins/registry.ts
+++ b/web/ui/src/lib/plugins/registry.ts
@@ -11,19 +11,37 @@
 
 import type { ComponentType, ReactNode } from "react";
 
-// SidebarEntry is a plugin-contributed nav item shown in the AppShell's Plugins zone. Clicking it
-// navigates to its route (a registerRoute with the same `route` path renders the content).
+// SidebarEntry is a plugin-contributed nav item shown in the AppShell's Plugins zone. A leaf entry
+// navigates to its route (a registerRoute with the same `route` path renders the content); a group
+// header (Headlamp's `parent: null` entry with no `url`, e.g. "Flux") has no route and only nests its
+// children.
 export interface SidebarEntry {
   // id is the entry's stable identity (Headlamp's sidebar `name`).
   id: string;
   label: string;
   // route is the path the entry navigates to (Headlamp's `url`); a matching PluginRoute renders it.
-  route: string;
+  // Optional: a group header has no route (it only expands/collapses its children).
+  route?: string;
   // icon is an optional React node (an inline <svg> or an icon element); a default is shown if absent.
   icon?: ReactNode;
+  // parent is the id (Headlamp `name`) of the entry this one nests under (Headlamp's `parent`); a
+  // top-level entry/group has none. The nested Flux sidebar uses a parent group + children.
+  parent?: string;
   // pluginName attributes the entry to the plugin that registered it (set by the loader).
   pluginName?: string;
 }
+
+// SidebarNode is a sidebar entry with its resolved children — the shape getSidebarTree() yields for the
+// AppShell to render nested groups.
+export interface SidebarNode extends SidebarEntry {
+  children: SidebarEntry[];
+}
+
+// SidebarEntryFilter is a plugin-registered predicate (Headlamp's registerSidebarEntryFilter) that hides
+// entries when it returns a falsy value (e.g. the Flux plugin hides its children when Flux is not
+// installed). It receives the entry in a Headlamp-compatible shape (`name` aliases `id`, `url` aliases
+// `route`).
+export type SidebarEntryFilter = (entry: SidebarEntry & { name: string; url?: string }) => unknown;
 
 // RouteProps are passed to a plugin route's component so it can scope its data to the active cluster.
 export interface RouteProps {
@@ -31,10 +49,14 @@ export interface RouteProps {
   clusterName: string | null;
 }
 
-// PluginRoute renders a component for a sidebar entry's `route` path.
+// PluginRoute renders a component for a route path. `sidebar` is the id of the sidebar entry to keep
+// highlighted while the route is active (Headlamp's route `sidebar`), so a detail route under a section
+// still highlights that section; `name` is the route's stable name used by createRouteURL/getRoute.
 export interface PluginRoute {
   path: string;
   component: ComponentType<RouteProps>;
+  sidebar?: string;
+  name?: string;
   pluginName?: string;
 }
 
@@ -78,6 +100,7 @@ type Listener = () => void;
 // when the set changes, so React surfaces re-render through useSyncExternalStore without snapshot churn.
 class ExtensionRegistry {
   private sidebarEntries: SidebarEntry[] = [];
+  private sidebarFilters: SidebarEntryFilter[] = [];
   private routes = new Map<string, PluginRoute>();
   private detailsSections: DetailsViewSection[] = [];
   private appBarActions: AppBarAction[] = [];
@@ -96,6 +119,11 @@ class ExtensionRegistry {
   registerSidebarEntry(entry: SidebarEntry): void {
     const next = { ...entry, pluginName: entry.pluginName ?? this.pluginContext };
     this.sidebarEntries = [...this.sidebarEntries.filter((existing) => existing.id !== entry.id), next];
+    this.bump();
+  }
+
+  registerSidebarEntryFilter(filter: SidebarEntryFilter): void {
+    this.sidebarFilters = [...this.sidebarFilters, filter];
     this.bump();
   }
 
@@ -129,8 +157,63 @@ class ExtensionRegistry {
     return this.sidebarEntries;
   }
 
+  // getSidebarTree returns the visible sidebar entries as a parent→children forest: registered filters
+  // are applied first (a hidden entry never produces an empty group), then each entry with a known
+  // `parent` nests under it; entries with no parent (or an unknown one) become roots. Registration order
+  // is preserved at every level, so the rendered nav matches the plugin's declaration order.
+  getSidebarTree(): SidebarNode[] {
+    const visible = this.sidebarEntries.filter((entry) => this.passesFilters(entry));
+    const nodes: SidebarNode[] = visible.map((entry) => ({ ...entry, children: [] }));
+    const byId = new Map(nodes.map((node) => [node.id, node]));
+    const roots: SidebarNode[] = [];
+
+    for (const node of nodes) {
+      const parent = node.parent ? byId.get(node.parent) : undefined;
+      if (parent) {
+        parent.children.push(node);
+      } else {
+        roots.push(node);
+      }
+    }
+
+    return roots;
+  }
+
   getRoute(path: string): PluginRoute | undefined {
     return this.routes.get(path);
+  }
+
+  // getRoutes returns every registered route, for the plugin router host to build its <Routes>.
+  getRoutes(): readonly PluginRoute[] {
+    return [...this.routes.values()];
+  }
+
+  // getRouteByName finds a route by its Headlamp route `name` (used by Router.createRouteURL/getRoute).
+  getRouteByName(name: string): PluginRoute | undefined {
+    for (const route of this.routes.values()) {
+      if (route.name === name) {
+        return route;
+      }
+    }
+
+    return undefined;
+  }
+
+  // passesFilters runs every registered sidebar filter against an entry (in Headlamp shape, `name`
+  // aliasing `id`); the entry is hidden if any filter returns falsy. A throwing filter is ignored (it
+  // never hides an entry), so a buggy plugin filter cannot blank the sidebar.
+  private passesFilters(entry: SidebarEntry): boolean {
+    for (const filter of this.sidebarFilters) {
+      try {
+        if (!filter({ ...entry, name: entry.id, url: entry.route })) {
+          return false;
+        }
+      } catch {
+        // A filter that throws does not hide the entry.
+      }
+    }
+
+    return true;
   }
 
   getDetailsSections(): readonly DetailsViewSection[] {
@@ -159,6 +242,7 @@ class ExtensionRegistry {
   // current installed set rather than accumulating duplicates across reloads.
   reset(): void {
     this.sidebarEntries = [];
+    this.sidebarFilters = [];
     this.routes = new Map();
     this.detailsSections = [];
     this.appBarActions = [];

--- a/web/ui/src/lib/plugins/usePlugins.ts
+++ b/web/ui/src/lib/plugins/usePlugins.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { loadPlugins, type LoadedPlugin } from "./loader.ts";
+import { getPluginLocation, subscribePluginLocation } from "./pluginNavigation.ts";
 import type { ClusterRef } from "./pluginLib.ts";
 import { registry } from "./registry.ts";
 
@@ -14,6 +15,13 @@ export function usePluginRegistry(): number {
     () => registry.getVersion(),
     () => registry.getVersion(),
   );
+}
+
+// usePluginLocation subscribes a component to the current plugin-router pathname (published by
+// PluginRouterHost). KSail's sidebar/header use it to highlight the active plugin nav item and title,
+// following in-plugin navigation (e.g. a plugin <Link> to a detail page).
+export function usePluginLocation(): string {
+  return useSyncExternalStore(subscribePluginLocation, getPluginLocation, getPluginLocation);
 }
 
 // PluginLoaderState is the one-shot plugin load result surfaced by usePluginLoader.

--- a/web/ui/tsconfig.json
+++ b/web/ui/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Installing a Headlamp plugin (web UI or desktop) showed a **"Loaded"** status but rendered **no UI**. The Headlamp-compat facade in `web/ui/src/lib/plugins/` was only built for *simple* plugins (one flat sidebar entry + one self-contained page); a real multi-page plugin like [`headlamp-k8s-flux`](https://github.com/headlamp-k8s/plugins) needs Headlamp's full runtime contract, which the facade never implemented.

## Approach

Perfect the facade so real plugins render on KSail's **own** React 19 + Tailwind stack — **no Headlamp React-18 runtime vendored**.

- **K8s data layer** — `KubeObject` is now a statics-driven base class plugins can `extend`, with `CustomResourceDefinition`/`Event`, imperative `apiList`/`apiGet`, options-object `useList({namespace})`, a typed `ApiError{status}` (the `error.status === 404` "not installed" check), and `makeCustomResourceClass`/`apiFactory`.
- **Router + nested sidebar** — Headlamp `parent` → a collapsible sidebar group; one **persistent `MemoryRouter`** hosts every plugin route (param routes, in-plugin `<Link>`/`useNavigate`, route→sidebar highlight) replacing the per-render throwaway router; real `Router.createRouteURL`.
- **Runtime context** — a **react-router v5 shim over v7** (`useHistory`/`Switch`/`Redirect`), an MUI theme exposing `palette.chartStyles`, and a redux store with `filter.namespaces`. `pluginLib.Crd`, `K8s.cluster`, a functional `ConfigStore`, `MuiMaterial.styles`, and `Notistack`/`Monaco` stubs make a real bundle load.
- **Components** — Tailwind `CommonComponents`: an **SVG donut `TileChart`** (no recharts), a `material-react-table`-compatible `Table`, `StatusLabel`, `Link`, `NameValueTable`, the label/section helpers, and a real `Utils`.
- **Plugin icons (offline)** — Headlamp passes icon names as plain strings and KSail's strict same-origin CSP blocks the Iconify API, so plugin icons showed as literal text. Fixed **offline / airgap-safe** (no CSP relaxation): bundle the `@iconify-json/mdi` + `@iconify-json/simple-icons` collections and register them via `addCollection` (a plugin-only dynamic chunk), and render string icon props through a shared `renderPluginIcon` helper.

The decisive step was testing the **real prebuilt Flux bundle**, which surfaced 4 load-blockers hand-written test plugins can't (`pluginLib.Crd`, `K8s.cluster`, `ConfigStore.get`, `MuiMaterial.styles`).

## Verification (live, kind + `flux install` + a podinfo source)

The nested **Flux** sidebar group (with its logo), the **Overview donut status cards with live counts** (Git Repositories 100%, Kustomizations failed/red), the **Flux Checks** panel (v2.8.8, All Controllers Ready, All Checks Passed), the header **cog**/action icons, and the **Kustomizations table** all render — **zero console errors**. Frontend-only; `ksail open desktop` inherits it via the shared embedded bundle (`uiserver.NewServer` + `webui.Assets`). `tsc` + `vite build` green; no Go/backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)