### PR TITLE
feat(webui): cluster-scope plugins, wire resource-link drill-in, blend plugin pages

### DIFF
--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { Moon, Plus, RotateCw, Server, Sun } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
   ApiError,
   createCluster,
@@ -32,6 +32,7 @@ import { PluginsView } from "./components/PluginsView.tsx";
 import { AIAssistant } from "./components/AIAssistant.tsx";
 import { pluginNavigate } from "./lib/plugins/pluginNavigation.ts";
 import { registry } from "./lib/plugins/registry.ts";
+import { clearResourceDetail, getResourceDetailTarget, subscribeResourceDetail } from "./lib/plugins/resourceDetail.ts";
 import { usePluginLoader, usePluginRegistry } from "./lib/plugins/usePlugins.ts";
 import { setKubeWatchAvailable } from "./lib/plugins/watchStream.ts";
 import { setWSMultiplexerAvailable } from "./lib/plugins/wsMultiplexer.ts";
@@ -64,6 +65,12 @@ const DEFAULT_DISTRIBUTIONS = ["VCluster"];
 // matching the lazy-externals approach for MUI/Redux.
 const PluginRouterHost = lazy(() =>
   import("./lib/plugins/PluginRouterHost.tsx").then((module) => ({ default: module.PluginRouterHost })),
+);
+
+// HostResourceDetail is lazy-loaded so the plugin K8s data layer (kube-proxy fetch) it pulls in stays out
+// of the main bundle until a plugin link actually opens a resource-detail overlay.
+const HostResourceDetail = lazy(() =>
+  import("./components/HostResourceDetail.tsx").then((module) => ({ default: module.HostResourceDetail })),
 );
 
 // capability reads one capability flag from a (possibly null/partial) Config, defaulting to
@@ -173,6 +180,10 @@ export function App() {
   // The plugin sidebar is a parent→children tree (Headlamp plugins like Flux register a group + nested
   // entries); getSidebarTree applies any registered sidebar filters and nests children under their parent.
   const pluginEntries = registry.getSidebarTree();
+  // resourceDetailTarget is the resource a plugin link asked to open (via the resourceDetail bridge);
+  // non-null mounts the host detail overlay (HostResourceDetail) for it. Subscribed through the module
+  // singleton so a Link rendered inside the plugin router can drive KSail's chrome.
+  const resourceDetailTarget = useSyncExternalStore(subscribeResourceDetail, getResourceDetailTarget);
 
   // enterCluster drills into a cluster's workspace, landing on its Overview. Used by the Clusters list,
   // deep links, and the command palette.
@@ -220,6 +231,21 @@ export function App() {
       setView("clusters");
     }
   }, [activeClusterKey, view]);
+
+  // The plugin surface is cluster-scoped (its nav lives in the cluster workspace), so close any open
+  // plugin route when no cluster is active — leaving a cluster must not strand the user on a plugin view
+  // that targets a cluster they are no longer in.
+  useEffect(() => {
+    if (!activeClusterKey) {
+      setActivePluginRoute(null);
+    }
+  }, [activeClusterKey]);
+
+  // Close the resource-detail overlay whenever the active cluster changes — its fetched object targets the
+  // previous cluster's apiserver, so it must not linger across a switch.
+  useEffect(() => {
+    clearResourceDetail();
+  }, [activeClusterKey]);
 
   // refresh returns false when the session was lost (HTTP 401), so callers (e.g. init) can avoid
   // starting/continuing the poll while the login screen is shown.
@@ -700,6 +726,19 @@ export function App() {
           onConfirm={handleDelete}
           onClose={() => setDeleteTarget(null)}
         />
+
+        {/* Resource-detail overlay opened when a plugin links to a resource (resourceDetail bridge). Renders
+            over whatever surface is active; fetches the target through the kube-proxy for the active cluster. */}
+        {resourceDetailTarget ? (
+          <Suspense fallback={null}>
+            <HostResourceDetail
+              target={resourceDetailTarget}
+              clusterNamespace={activeCluster?.metadata.namespace ?? "default"}
+              clusterName={activeCluster?.metadata.name ?? null}
+              onClose={clearResourceDetail}
+            />
+          </Suspense>
+        ) : null}
 
         <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} commands={commands} />
       </AppShell>

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -272,6 +272,9 @@ export function AppShell({
 
   // navContent renders the two zones — the cluster workspace (switcher + scoped nav, only when a
   // cluster is active) above the always-present global zone. onPick lets the drawer close on navigate.
+  // Plugin-contributed nav is cluster-scoped: it lives inside the cluster workspace (so installed
+  // plugins are only reachable once a cluster is selected), while the global "Plugins" management view
+  // (install/configure) stays in the always-present global zone below.
   const navContent = (onPick: (next: View) => void, onPickPlugin: (route: string) => void) => (
     <nav className="flex flex-1 flex-col gap-1 overflow-y-auto overscroll-contain p-3">
       {activeClusterKey ? (
@@ -280,18 +283,18 @@ export function AppShell({
             <ClusterSwitcher clusters={clusters} activeKey={activeClusterKey} onSelect={onSelectCluster} />
           </div>
           {renderNav(clusterViews, onPick)}
+          {pluginEntries && pluginEntries.length > 0 ? (
+            <>
+              <div className="my-2 border-t border-slate-200 dark:border-slate-800" />
+              <SectionLabel>Plugins</SectionLabel>
+              <PluginNavTree entries={pluginEntries} activeId={activePluginId} onPick={onPickPlugin} />
+            </>
+          ) : null}
           <div className="my-2 border-t border-slate-200 dark:border-slate-800" />
           <SectionLabel>Manage</SectionLabel>
         </>
       ) : null}
       {renderNav(globalViews, onPick)}
-      {pluginEntries && pluginEntries.length > 0 ? (
-        <>
-          <div className="my-2 border-t border-slate-200 dark:border-slate-800" />
-          <SectionLabel>Plugins</SectionLabel>
-          <PluginNavTree entries={pluginEntries} activeId={activePluginId} onPick={onPickPlugin} />
-        </>
-      ) : null}
     </nav>
   );
 

--- a/web/ui/src/components/HostResourceDetail.tsx
+++ b/web/ui/src/components/HostResourceDetail.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { errorMessage, type K8sObject } from "../api.ts";
+import { getObjectByTarget, type ResourceTarget } from "../lib/plugins/k8s.ts";
+import { ResourceDetailContent } from "./ResourceDetailPanel.tsx";
+import { SlideOver } from "./ui.tsx";
+
+// HostResourceDetail is the app-level resource-detail overlay opened when a Headlamp plugin links to a
+// resource (a built-in kind or a custom resource). The plugin Link calls openResourceDetail (the
+// resourceDetail bridge); App.tsx renders this for the active target. It fetches the object through the
+// kube-proxy (getObjectByTarget) for the active cluster and renders the shared read-only
+// ResourceDetailContent — the same body KSail's own resource browser uses — so a plugin "zoom into
+// resource" link lands in KSail's native detail view instead of a dead link. It is read-only (no action
+// bar): the object is reached by reference, outside the resource browser's write-action wiring.
+//
+// clusterNamespace/clusterName are the active cluster's coordinates passed as primitives (not an object)
+// so the fetch effect's deps are stable across App re-renders — passing a fresh getCluster() object would
+// refetch on every render.
+export function HostResourceDetail({
+  target,
+  clusterNamespace,
+  clusterName,
+  onClose,
+}: {
+  target: ResourceTarget;
+  clusterNamespace: string | null;
+  clusterName: string | null;
+  onClose: () => void;
+}) {
+  const [obj, setObj] = useState<K8sObject | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [detailFormat, setDetailFormat] = useState<"yaml" | "json">("yaml");
+
+  useEffect(() => {
+    if (!clusterName || !clusterNamespace) {
+      setObj(null);
+      setError("No active cluster");
+
+      return undefined;
+    }
+
+    let cancelled = false;
+    setObj(null);
+    setError(null);
+
+    getObjectByTarget({ namespace: clusterNamespace, name: clusterName }, target)
+      .then((raw) => {
+        if (!cancelled) {
+          setObj(raw as K8sObject);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(errorMessage(err));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clusterNamespace, clusterName, target]);
+
+  const subtitle = `${target.kind}${target.namespace ? ` · ${target.namespace}` : ""}`;
+
+  return (
+    <SlideOver open onClose={onClose} title={target.name} subtitle={subtitle}>
+      {error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          {error}
+        </div>
+      ) : obj ? (
+        <ResourceDetailContent
+          obj={obj}
+          relatedEvents={[]}
+          detailFormat={detailFormat}
+          onDetailFormatChange={setDetailFormat}
+        />
+      ) : (
+        <div className="p-4 text-sm text-slate-500 dark:text-slate-400">Loading…</div>
+      )}
+    </SlideOver>
+  );
+}

--- a/web/ui/src/components/ResourceDetailPanel.tsx
+++ b/web/ui/src/components/ResourceDetailPanel.tsx
@@ -8,7 +8,9 @@ import {
   type ResourceAction,
 } from "../api.ts";
 import { cx } from "../lib/cx.ts";
+import { relativeAge } from "../lib/format.ts";
 import { PluginDetailSections } from "../lib/plugins/PluginSlots.tsx";
+import { openResourceDetail } from "../lib/plugins/resourceDetail.ts";
 import type { ResourceKindLists } from "../lib/meta.ts";
 import { buildResourceTarget, objectConditions, toYaml } from "../lib/resources.ts";
 import type { EventFields } from "../lib/k8s.ts";
@@ -78,6 +80,152 @@ function RelatedEvents({ events }: { events: EventFields[] }) {
   );
 }
 
+// MetadataRow is one label/value row in the MetadataOverview two-column table.
+function MetadataRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <tr className="border-b border-slate-100 last:border-0 dark:border-slate-800">
+      <th className="w-1/3 py-1.5 pr-3 text-left align-top text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {label}
+      </th>
+      <td className="py-1.5 align-top text-slate-700 dark:text-slate-200">{children}</td>
+    </tr>
+  );
+}
+
+// Chips renders a key/value map (labels or annotations) as small pills, or an em dash when empty.
+function Chips({ entries }: { entries: [string, string][] }) {
+  if (entries.length === 0) {
+    return <span className="text-slate-400">—</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map(([key, value]) => (
+        <span
+          key={key}
+          title={`${key}: ${value}`}
+          className="inline-block max-w-full truncate rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+        >
+          {key}: {value}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// MetadataOverview renders the resource's identity + metadata (name, namespace, age, labels, annotations)
+// the way Headlamp's detail pages do, so KSail's native panel reads as a full resource view rather than a
+// bare manifest dump. The namespace links into its own detail (openResourceDetail) for further drill-in.
+function MetadataOverview({ obj }: { obj: K8sObject }) {
+  const metadata = obj.metadata ?? {};
+  const labels = Object.entries((metadata.labels as Record<string, string> | undefined) ?? {});
+  const annotations = Object.entries((metadata.annotations as Record<string, string> | undefined) ?? {});
+  const namespace = metadata.namespace;
+  const created = metadata.creationTimestamp;
+
+  return (
+    <section>
+      <table className="w-full text-sm">
+        <tbody>
+          <MetadataRow label="Name">{metadata.name ?? "—"}</MetadataRow>
+          {namespace ? (
+            <MetadataRow label="Namespace">
+              <button
+                type="button"
+                onClick={() =>
+                  openResourceDetail({ apiVersion: "v1", kind: "Namespace", plural: "namespaces", name: namespace })
+                }
+                className="text-blue-600 hover:underline dark:text-blue-400"
+              >
+                {namespace}
+              </button>
+            </MetadataRow>
+          ) : null}
+          {created ? (
+            <MetadataRow label="Created">
+              <span title={new Date(created as string).toLocaleString()}>{relativeAge(created as string)}</span>
+            </MetadataRow>
+          ) : null}
+          <MetadataRow label="Labels">
+            <Chips entries={labels} />
+          </MetadataRow>
+          <MetadataRow label="Annotations">
+            <Chips entries={annotations} />
+          </MetadataRow>
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+// ResourceDetailContent is the read-only detail body shared by the in-browser ResourceDetailPanel and the
+// host overlay that opens when a plugin links to a resource (HostResourceDetail): the metadata overview,
+// status conditions, related events, any plugin-contributed sections, and the manifest viewer. The action
+// bar (scale/restart/logs/…) is the ResourceDetailPanel wrapper's concern, so it is not rendered here.
+export function ResourceDetailContent({
+  obj,
+  relatedEvents,
+  detailFormat,
+  onDetailFormatChange,
+}: {
+  obj: K8sObject;
+  relatedEvents: EventFields[];
+  detailFormat: "yaml" | "json";
+  onDetailFormatChange: (format: "yaml" | "json") => void;
+}) {
+  const toast = useToast();
+
+  // The resource serialized for the manifest viewer, in the chosen format.
+  const manifestText = useMemo(
+    () => (detailFormat === "yaml" ? toYaml(obj) : JSON.stringify(obj, null, 2)),
+    [obj, detailFormat],
+  );
+
+  // copyManifest copies the serialized manifest to the clipboard and toasts the outcome.
+  function copyManifest() {
+    if (!navigator.clipboard) {
+      toast.error("Clipboard unavailable");
+
+      return;
+    }
+
+    navigator.clipboard
+      .writeText(manifestText)
+      .then(() => toast.success("Copied to clipboard"))
+      .catch(() => toast.error("Copy failed"));
+  }
+
+  return (
+    <div className="space-y-3">
+      <MetadataOverview obj={obj} />
+      <ConditionsTable obj={obj} />
+      <RelatedEvents events={relatedEvents} />
+      {/* Plugin-contributed detail sections (Headlamp registerDetailsViewSection). Renders nothing until a
+          plugin registers a section, so this is zero-cost by default. */}
+      <PluginDetailSections resource={obj} />
+      <section>
+        <div className="mb-2 flex items-center justify-between">
+          <SegmentedControl
+            options={[
+              { value: "yaml", label: "YAML" },
+              { value: "json", label: "JSON" },
+            ]}
+            value={detailFormat}
+            onChange={onDetailFormatChange}
+          />
+          <Button variant="ghost" size="sm" onClick={copyManifest}>
+            <Copy className="size-3.5" aria-hidden />
+            Copy
+          </Button>
+        </div>
+        <pre className="overflow-x-auto rounded-lg bg-slate-50 p-3 text-xs leading-relaxed text-slate-800 dark:bg-slate-800/50 dark:text-slate-200">
+          {manifestText}
+        </pre>
+      </section>
+    </div>
+  );
+}
+
 // SimpleAction is one button-shaped write action (Restart/Reconcile): a button label, the toast verb,
 // the kinds it applies to, and the API call it issues against the resource target. Scale is excluded
 // (it carries a replicas input, so it is rendered as a form below).
@@ -138,30 +286,6 @@ export function ResourceDetailPanel({
   onRequestDelete: () => void;
 }) {
   const toast = useToast();
-
-  // The selected resource serialized for the manifest viewer, in the chosen format.
-  const manifestText = useMemo(() => {
-    if (!selected) {
-      return "";
-    }
-
-    return detailFormat === "yaml" ? toYaml(selected) : JSON.stringify(selected, null, 2);
-  }, [selected, detailFormat]);
-
-  // copyManifest copies the serialized manifest to the clipboard and toasts the outcome.
-  function copyManifest() {
-    if (!navigator.clipboard) {
-      toast.error("Clipboard unavailable");
-
-      return;
-    }
-
-    navigator.clipboard
-      .writeText(manifestText)
-      .then(() => toast.success("Copied to clipboard"))
-      .catch(() => toast.error("Copy failed"));
-  }
-
   const isPod = kind === "Pod";
   const showActionBar = canWrite || ((canLogs || canExec) && isPod);
 
@@ -240,30 +364,12 @@ export function ResourceDetailPanel({
               ) : null}
             </div>
           ) : null}
-          <ConditionsTable obj={selected} />
-          <RelatedEvents events={relatedEvents} />
-          {/* Plugin-contributed detail sections (Headlamp registerDetailsViewSection). Renders nothing
-              until a plugin registers a section, so this is zero-cost by default. */}
-          <PluginDetailSections resource={selected} />
-          <section>
-            <div className="mb-2 flex items-center justify-between">
-              <SegmentedControl
-                options={[
-                  { value: "yaml", label: "YAML" },
-                  { value: "json", label: "JSON" },
-                ]}
-                value={detailFormat}
-                onChange={onDetailFormatChange}
-              />
-              <Button variant="ghost" size="sm" onClick={copyManifest}>
-                <Copy className="size-3.5" aria-hidden />
-                Copy
-              </Button>
-            </div>
-            <pre className="overflow-x-auto rounded-lg bg-slate-50 p-3 text-xs leading-relaxed text-slate-800 dark:bg-slate-800/50 dark:text-slate-200">
-              {manifestText}
-            </pre>
-          </section>
+          <ResourceDetailContent
+            obj={selected}
+            relatedEvents={relatedEvents}
+            detailFormat={detailFormat}
+            onDetailFormatChange={onDetailFormatChange}
+          />
         </div>
       ) : null}
     </SlideOver>

--- a/web/ui/src/lib/plugins/PluginSlots.tsx
+++ b/web/ui/src/lib/plugins/PluginSlots.tsx
@@ -39,17 +39,41 @@ function isDarkMode(): boolean {
   return typeof document !== "undefined" && document.documentElement.classList.contains("dark");
 }
 
-// buildPluginTheme creates an MUI theme carrying Headlamp's `chartStyles` palette augmentation, which the
-// Flux Overview (and other plugins) read via useTheme().palette.chartStyles — without it those reads
-// throw. The values mirror Headlamp's light/dark chartStyles.
+// KSAIL_FONT mirrors Tailwind's default sans stack (KSail sets no custom font), so MUI-rendered plugin
+// text matches KSail's typography instead of MUI's Roboto default.
+const KSAIL_FONT =
+  'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"';
+
+// buildPluginTheme creates an MUI theme matching KSail's design tokens — the Tailwind slate/blue palette,
+// an 8px radius, and KSail's font — so MUI-rendered plugin chrome (Paper/Card/Button/Typography) blends
+// into KSail's UI instead of reading as default Material. MuiPaper's dark elevation overlay is removed so
+// plugin cards stay flat like KSail's. It also carries Headlamp's `chartStyles` palette augmentation,
+// which the Flux Overview reads via useTheme().palette.chartStyles (absent it, those reads throw).
 function buildPluginTheme(muiStyles: MuiStylesShape, dark: boolean): unknown {
   return muiStyles.createTheme?.({
-    palette: {
-      mode: dark ? "dark" : "light",
-      chartStyles: dark
-        ? { defaultFillColor: "rgba(20, 20, 20, 0.1)", fillColor: "#929191", labelColor: "#fff" }
-        : { defaultFillColor: "rgba(0, 0, 0, 0.08)", labelColor: "#000" },
+    shape: { borderRadius: 8 },
+    typography: { fontFamily: KSAIL_FONT },
+    components: {
+      // Flatten Paper so MUI cards match KSail's flat surfaces (no dark-mode elevation tint).
+      MuiPaper: { styleOverrides: { root: { backgroundImage: "none" } } },
     },
+    palette: dark
+      ? {
+          mode: "dark",
+          primary: { main: "#3b82f6" }, // blue-500
+          background: { default: "#0f172a", paper: "#0f172a" }, // slate-900
+          text: { primary: "#f8fafc", secondary: "#94a3b8" }, // slate-50 / slate-400
+          divider: "#1e293b", // slate-800
+          chartStyles: { defaultFillColor: "rgba(20, 20, 20, 0.1)", fillColor: "#475569", labelColor: "#f8fafc" },
+        }
+      : {
+          mode: "light",
+          primary: { main: "#2563eb" }, // blue-600
+          background: { default: "#ffffff", paper: "#ffffff" },
+          text: { primary: "#0f172a", secondary: "#475569" }, // slate-900 / slate-600
+          divider: "#e2e8f0", // slate-200
+          chartStyles: { defaultFillColor: "rgba(0, 0, 0, 0.08)", fillColor: "#cbd5e1", labelColor: "#0f172a" },
+        },
   });
 }
 

--- a/web/ui/src/lib/plugins/commonComponents.tsx
+++ b/web/ui/src/lib/plugins/commonComponents.tsx
@@ -6,7 +6,9 @@
 // status pills (StatusLabel), and tables (Table) all render natively in KSail.
 
 import * as React from "react";
+import type { ResourceTarget } from "./k8s.ts";
 import { pluginNavigate } from "./pluginNavigation.ts";
+import { decodeResourceDetailURL, encodeResourceDetailURL, openResourceDetail } from "./resourceDetail.ts";
 import { renderPluginIcon as renderIcon } from "./pluginIcon.ts";
 
 // ---------------------------------------------------------------------------
@@ -198,41 +200,89 @@ export function HoverInfoLabel({
 // Links
 // ---------------------------------------------------------------------------
 
-// resolvePluginUrl builds the target URL for a CommonComponents.Link: an explicit `to`, or a named route
-// resolved via window.pluginLib.Router.createRouteURL (the real registry-backed resolver from pluginLib).
-function resolvePluginUrl(to?: string, routeName?: string, params?: Record<string, string>): string {
+// targetFromKubeObject derives a resource-detail target from a Headlamp KubeObject passed to
+// `<Link kubeObject={…}>` (table name cells and inventory rows use this form). It reads the object's own
+// apiVersion/kind/metadata and the plural from the class statics (apiName, set by makeKubeObjectClass).
+// Returns null when any coordinate is missing, so the Link falls back to an inert anchor rather than
+// misnavigating.
+function targetFromKubeObject(kubeObject: unknown): ResourceTarget | null {
+  if (!kubeObject || typeof kubeObject !== "object") {
+    return null;
+  }
+
+  const holder = kubeObject as {
+    jsonData?: { apiVersion?: string; kind?: string; metadata?: { name?: string; namespace?: string } };
+    constructor?: { apiName?: string; apiVersion?: string | string[] };
+  };
+  const json = holder.jsonData ?? (kubeObject as NonNullable<typeof holder.jsonData>);
+  const staticApiVersion = Array.isArray(holder.constructor?.apiVersion)
+    ? holder.constructor?.apiVersion[0]
+    : holder.constructor?.apiVersion;
+  const apiVersion = json?.apiVersion ?? staticApiVersion;
+  const kind = json?.kind;
+  const name = json?.metadata?.name;
+  const plural = holder.constructor?.apiName;
+  if (!apiVersion || !kind || !name || !plural) {
+    return null;
+  }
+
+  return { apiVersion, kind, plural, name, namespace: json?.metadata?.namespace };
+}
+
+// resolvePluginUrl builds the target URL for a CommonComponents.Link: an explicit `to`, a named route
+// resolved via window.pluginLib.Router.createRouteURL (which returns a ksail-detail: URL for Headlamp's
+// built-in resource routes), or a kubeObject resolved straight to a ksail-detail: URL.
+function resolvePluginUrl({
+  to,
+  routeName,
+  params,
+  kubeObject,
+}: {
+  to?: string;
+  routeName?: string;
+  params?: Record<string, string>;
+  kubeObject?: unknown;
+}): string {
   if (to) {
     return to;
   }
-  if (!routeName) {
-    return "#";
+  if (routeName) {
+    const router = window.pluginLib?.Router as
+      | { createRouteURL?: (name: string, params?: Record<string, string>) => string }
+      | undefined;
+
+    return router?.createRouteURL?.(routeName, params) ?? "#";
+  }
+  if (kubeObject) {
+    const target = targetFromKubeObject(kubeObject);
+
+    return target ? encodeResourceDetailURL(target) : "#";
   }
 
-  const router = window.pluginLib?.Router as
-    | { createRouteURL?: (name: string, params?: Record<string, string>) => string }
-    | undefined;
-
-  return router?.createRouteURL?.(routeName, params) ?? "#";
+  return "#";
 }
 
-// Link is Headlamp's router link. It resolves `routeName`+`params` (or `to`) to a URL and navigates the
-// plugin router on click (via pluginNavigate, so it stays inside KSail's persistent plugin MemoryRouter).
-// An external http(s) URL renders as a normal new-tab anchor.
+// Link is Headlamp's router link. It resolves `routeName`+`params`, a `kubeObject`, or an explicit `to` to
+// a URL. A ksail-detail: URL (a built-in K8s resource) opens KSail's native resource-detail overlay
+// (openResourceDetail); a plugin-route path navigates the persistent plugin MemoryRouter (pluginNavigate);
+// an external http(s) URL renders as a normal new-tab anchor.
 export function Link({
   to,
   routeName,
   params,
+  kubeObject,
   children,
   className,
 }: {
   to?: string;
   routeName?: string;
   params?: Record<string, string>;
+  kubeObject?: unknown;
   activeCluster?: string;
   children?: React.ReactNode;
   className?: string;
 }): React.ReactElement {
-  const url = resolvePluginUrl(to, routeName, params);
+  const url = resolvePluginUrl({ to, routeName, params, kubeObject });
   const external = /^https?:\/\//.test(url) || url.startsWith("//");
   const linkClass = className ?? "text-blue-600 hover:underline dark:text-blue-400";
 
@@ -250,6 +300,12 @@ export function Link({
       className={linkClass}
       onClick={(event) => {
         event.preventDefault();
+        const target = decodeResourceDetailURL(url);
+        if (target) {
+          openResourceDetail(target);
+
+          return;
+        }
         if (url !== "#") {
           pluginNavigate(url);
         }
@@ -327,33 +383,36 @@ export function Table({
   const rows = data ?? [];
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
       <table className="w-full text-left text-sm">
-        <thead>
-          <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400">
+        <thead className="bg-slate-50 dark:bg-slate-800/50">
+          <tr className="border-b border-slate-200 dark:border-slate-700">
             {columns.map((column, index) => (
-              <th key={column.id ?? index} className="px-3 py-2 font-medium">
+              <th
+                key={column.id ?? index}
+                className="px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+              >
                 {column.header}
               </th>
             ))}
           </tr>
         </thead>
-        <tbody>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
           {loading ? (
             <tr>
-              <td colSpan={columns.length} className="px-3 py-6 text-center text-slate-400">
+              <td colSpan={columns.length} className="px-4 py-6 text-center text-slate-400">
                 Loading…
               </td>
             </tr>
           ) : rows.length === 0 ? (
             <tr>
-              <td colSpan={columns.length} className="px-3 py-6 text-center text-slate-400">
+              <td colSpan={columns.length} className="px-4 py-6 text-center text-slate-400">
                 No items
               </td>
             </tr>
           ) : (
             rows.map((row, rowIndex) => (
-              <tr key={rowIndex} className="border-b border-slate-100 last:border-0 dark:border-slate-800">
+              <tr key={rowIndex} className="transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50">
                 {columns.map((column, colIndex) => {
                   const value = cellValue(column, row);
                   const content = column.Cell
@@ -361,7 +420,7 @@ export function Table({
                     : (value as React.ReactNode);
 
                   return (
-                    <td key={column.id ?? colIndex} className="px-3 py-2 align-top text-slate-700 dark:text-slate-200">
+                    <td key={column.id ?? colIndex} className="px-4 py-3 align-top text-slate-700 dark:text-slate-200">
                       {content}
                     </td>
                   );
@@ -456,6 +515,7 @@ function PercentageCircle({
           fill="none"
           stroke={arc.fill}
           strokeWidth={thickness}
+          strokeLinecap="round"
           strokeDasharray={`${arc.length} ${circumference - arc.length}`}
           strokeDashoffset={-arc.offset}
         />

--- a/web/ui/src/lib/plugins/k8s.ts
+++ b/web/ui/src/lib/plugins/k8s.ts
@@ -39,8 +39,10 @@ export class ApiError extends Error {
 type KubeJSON = Record<string, unknown>;
 
 // ListOptions mirror the Headlamp useList/apiList options object (a plugin calls
-// `Pod.useList({ namespace })`). Only namespace filtering is applied today; the rest are accepted for
-// API parity.
+// `Pod.useList({ namespace })`). namespace narrows the apiserver collection path (single namespace) or is
+// applied client-side (multiple); labelSelector/fieldSelector are forwarded to the kube-proxy (and the
+// watch), which relay them to the apiserver — so a plugin's `Deployment.useList({ labelSelector })` filters
+// server-side exactly like Headlamp (the Flux Overview's controller/resource counts depend on this).
 export interface ListOptions {
   namespace?: string | string[];
   cluster?: string;
@@ -101,7 +103,8 @@ export class KubeObject {
     opts?: ListOptions,
   ): () => () => void {
     const cls = this;
-    const listPath = collectionPath(cls.apiEndpoint);
+    const listPath = collectionPath(cls.apiEndpoint, singleNamespace(opts?.namespace));
+    const query = listSelectorQuery(opts);
 
     return () => {
       const cluster = activeClusterGetter();
@@ -112,7 +115,7 @@ export class KubeObject {
       }
 
       let cancelled = false;
-      proxyList(cluster, listPath, cls)
+      proxyList(cluster, listPath, query, cls)
         .then((items) => {
           if (!cancelled) {
             onList(filterByNamespace(items, opts?.namespace));
@@ -136,7 +139,8 @@ export class KubeObject {
   // → polling), same as the rest of the plugin K8s layer.
   static useList(this: KubeObjectClass, opts: ListOptions = {}): [KubeObject[], ApiError | null] {
     const cls = this;
-    const listPath = collectionPath(cls.apiEndpoint);
+    const listPath = collectionPath(cls.apiEndpoint, singleNamespace(opts.namespace));
+    const query = listSelectorQuery(opts);
     const namespaceKey = Array.isArray(opts.namespace) ? opts.namespace.join(",") : opts.namespace ?? "";
 
     const cluster = activeClusterGetter();
@@ -145,16 +149,16 @@ export class KubeObject {
     const hasCluster = clusterName !== null && clusterNamespace !== null;
 
     const watch: WatchBinding<KubeObject> = {
-      url: hasCluster ? watchStreamURL(clusterNamespace, clusterName, listPath) : "",
-      mux: hasCluster ? { clusterId: clusterName, path: listPath, query: "" } : undefined,
+      url: hasCluster ? watchStreamURL(clusterNamespace, clusterName, listPath, query) : "",
+      mux: hasCluster ? { clusterId: clusterName, path: listPath, query } : undefined,
       toItem: (raw: RawKubeObject) => cls.create(raw as KubeJSON),
       keyOf: (item: KubeObject) => kubeObjectKey(item.jsonData as RawKubeObject),
     };
 
     const [items, error] = useClusterScopedList<KubeObject>(
       activeClusterGetter,
-      async (active) => filterByNamespace(await proxyList(active, listPath, cls), opts.namespace),
-      [listPath, namespaceKey],
+      async (active) => filterByNamespace(await proxyList(active, listPath, query, cls), opts.namespace),
+      [listPath, namespaceKey, query],
       watch,
     );
 
@@ -359,6 +363,32 @@ function objectPath(ep: ResourceEndpoint, name: string, namespace?: string): str
   return `${collectionPath(ep, namespace)}/${name}`;
 }
 
+// listSelectorQuery builds the apiserver selector query string (without a leading '?') from ListOptions.
+// Only label/field selectors go on the wire; namespace is handled via the collection path (single) or
+// client-side filterByNamespace (multiple). Empty when neither selector is set.
+function listSelectorQuery(opts?: ListOptions): string {
+  const params = new URLSearchParams();
+  if (opts?.labelSelector) {
+    params.set("labelSelector", opts.labelSelector);
+  }
+  if (opts?.fieldSelector) {
+    params.set("fieldSelector", opts.fieldSelector);
+  }
+
+  return params.toString();
+}
+
+// singleNamespace returns the one namespace to scope the apiserver collection path to, or undefined when
+// the request is cluster-wide or spans multiple namespaces — those list cluster-wide and are narrowed
+// client-side by filterByNamespace (the apiserver lists one namespace or all, not an arbitrary subset).
+function singleNamespace(namespace?: string | string[]): string | undefined {
+  if (typeof namespace === "string") {
+    return namespace;
+  }
+
+  return Array.isArray(namespace) && namespace.length === 1 ? namespace[0] : undefined;
+}
+
 // filterByNamespace keeps items in the requested namespace(s); cluster-scoped items (no namespace) always
 // pass. An empty/absent filter returns everything (cluster-wide list).
 function filterByNamespace(items: KubeObject[], namespace?: string | string[]): KubeObject[] {
@@ -385,10 +415,18 @@ function toApiError(err: unknown): ApiError {
 }
 
 // proxyList fetches a collection through the kube-proxy and wraps each item as the given class, throwing
-// ApiError (with the HTTP status) on a non-OK response so callers can branch on 404 etc.
-async function proxyList(cluster: ClusterRef, listPath: string, cls: KubeObjectClass): Promise<KubeObject[]> {
+// ApiError (with the HTTP status) on a non-OK response so callers can branch on 404 etc. `query` is the
+// apiserver selector query (without the leading '?', built by listSelectorQuery); the kube-proxy relays
+// it to the apiserver, so label/field selectors filter server-side.
+async function proxyList(
+  cluster: ClusterRef,
+  listPath: string,
+  query: string,
+  cls: KubeObjectClass,
+): Promise<KubeObject[]> {
   const base = `/api/v1/clusters/${encodeURIComponent(cluster.namespace)}/${encodeURIComponent(cluster.name)}`;
-  const response = await fetch(`${base}/proxy/${listPath.replace(/^\//, "")}`);
+  const suffix = query ? `?${query}` : "";
+  const response = await fetch(`${base}/proxy/${listPath.replace(/^\//, "")}${suffix}`);
   if (!response.ok) {
     throw new ApiError(`apiserver GET ${listPath} failed: ${response.status}`, response.status);
   }
@@ -415,4 +453,41 @@ async function proxyGet(cluster: ClusterRef, objPath: string, cls: KubeObjectCla
   obj.cluster = cluster.name;
 
   return obj;
+}
+
+// ResourceTarget addresses a single object to fetch through the kube-proxy — the shape the resource-detail
+// bridge (resourceDetail.ts) carries when a plugin link is followed. apiVersion is "group/version" (or
+// "v1" for core); plural is the apiserver resource name; namespace is omitted for cluster-scoped kinds.
+// kind is carried for display (the detail panel's subtitle).
+export interface ResourceTarget {
+  apiVersion: string;
+  kind: string;
+  plural: string;
+  namespace?: string;
+  name: string;
+}
+
+// getObjectByTarget fetches one object (raw apiserver JSON) through the kube-proxy for the given cluster +
+// target. It is the host-side counterpart to the class-based useGet: KSail's resource-detail overlay
+// (App.tsx) calls it to load whatever resource a plugin link points at, without needing a registered
+// KubeObject subclass for that kind. The returned object is the unstructured manifest the detail panel
+// renders (structurally a K8sObject).
+export async function getObjectByTarget(cluster: ClusterRef, target: ResourceTarget): Promise<KubeJSON> {
+  const slash = target.apiVersion.indexOf("/");
+  const group = slash === -1 ? "" : target.apiVersion.slice(0, slash);
+  const version = slash === -1 ? target.apiVersion : target.apiVersion.slice(slash + 1);
+  const endpoint: ResourceEndpoint = {
+    group,
+    version,
+    plural: target.plural,
+    namespaced: target.namespace !== undefined,
+  };
+  const path = objectPath(endpoint, target.name, target.namespace);
+  const base = `/api/v1/clusters/${encodeURIComponent(cluster.namespace)}/${encodeURIComponent(cluster.name)}`;
+  const response = await fetch(`${base}/proxy/${path.replace(/^\//, "")}`);
+  if (!response.ok) {
+    throw new ApiError(`apiserver GET ${path} failed: ${response.status}`, response.status);
+  }
+
+  return (await response.json()) as KubeJSON;
 }

--- a/web/ui/src/lib/plugins/pluginLib.ts
+++ b/web/ui/src/lib/plugins/pluginLib.ts
@@ -21,6 +21,7 @@ import { renderPluginIcon } from "./pluginIcon.ts";
 import { KubeObject, makeResourceClasses, setActiveCluster, type ResourceClasses } from "./k8s.ts";
 import { apiFactory, apiFactoryWithNamespace, makeCustomResourceClass } from "./makeCustomResourceClass.ts";
 import { registry, type PluginResource, type RouteProps, type SidebarEntryFilter } from "./registry.ts";
+import { builtinRouteTarget, encodeResourceDetailURL } from "./resourceDetail.ts";
 import { useClusterScopedList } from "./useClusterScopedList.ts";
 import { WebSocketManager } from "./wsMultiplexer.ts";
 
@@ -320,23 +321,30 @@ function installCompatStubs(lib: PluginLib): void {
   // fill is the fallback. An unknown route name returns "#" so a stray link is inert rather than throwing.
   compat.Router = {
     createRouteURL: (name: string, params?: Record<string, string>): string => {
+      // A plugin-registered route wins (a plugin may define its own detail page, e.g. the Flux plugin's
+      // Kustomization view): resolve it to its in-plugin path so the persistent plugin router matches it.
       const route = registry.getRouteByName(name);
-      if (!route) {
-        return "#";
-      }
-
-      const reactRouter = window.pluginLib?.ReactRouter as
-        | { generatePath?: (path: string, params?: Record<string, string>) => string }
-        | undefined;
-      if (reactRouter?.generatePath) {
-        try {
-          return reactRouter.generatePath(route.path, params ?? {});
-        } catch {
-          // Fall through to the manual fill below.
+      if (route) {
+        const reactRouter = window.pluginLib?.ReactRouter as
+          | { generatePath?: (path: string, params?: Record<string, string>) => string }
+          | undefined;
+        if (reactRouter?.generatePath) {
+          try {
+            return reactRouter.generatePath(route.path, params ?? {});
+          } catch {
+            // Fall through to the manual fill below.
+          }
         }
+
+        return fillRouteParams(route.path, params);
       }
 
-      return fillRouteParams(route.path, params);
+      // Otherwise a Headlamp built-in resource route (namespace/pod/deployment/customresource/…). KSail
+      // has no in-plugin page for those — it renders resource detail in its native overlay — so emit a
+      // ksail-detail: URL that CommonComponents.Link opens via openResourceDetail. Unknown names stay "#".
+      const target = builtinRouteTarget(name, params);
+
+      return target ? encodeResourceDetailURL(target) : "#";
     },
     getRoute: (name: string): unknown => registry.getRouteByName(name) ?? null,
     getRoutePath: (name: string): string => registry.getRouteByName(name)?.path ?? "#",

--- a/web/ui/src/lib/plugins/resourceDetail.ts
+++ b/web/ui/src/lib/plugins/resourceDetail.ts
@@ -1,0 +1,171 @@
+// resourceDetail bridges a plugin's resource links (rendered inside the plugin MemoryRouter) to KSail's
+// own resource-detail overlay (rendered by App.tsx, OUTSIDE that router). Headlamp plugins link to a
+// resource by a built-in route NAME (e.g. <Link routeName="namespace" params={{name}}>); Headlamp ships
+// detail routes for every kind, but KSail renders resource detail in its native slide-over instead. So:
+//   1. createRouteURL (pluginLib.ts) resolves a built-in route name to a `ksail-detail:` sentinel URL
+//      (encodeResourceDetailURL) carrying the resource's coordinates.
+//   2. CommonComponents.Link recognizes that sentinel and calls openResourceDetail() instead of navigating
+//      the plugin router.
+//   3. App.tsx subscribes (subscribeResourceDetail) and renders the native ResourceDetailPanel for the
+//      target, fetching it via the kube-proxy (k8s.getObjectByTarget).
+// This is the same cross-the-React-boundary module-singleton idiom as pluginNavigation.ts /
+// watchStream.setKubeWatchAvailable.
+
+import type { ResourceTarget } from "./k8s.ts";
+
+// RESOURCE_DETAIL_SCHEME marks a URL as "open the native resource-detail overlay" rather than a plugin
+// route path. It is an unknown URL scheme, so a stray `<a href>` to it is an inert no-op (the browser
+// cannot navigate to it) — the Link's onClick is what actually opens the overlay.
+export const RESOURCE_DETAIL_SCHEME = "ksail-detail:";
+
+// encodeResourceDetailURL serializes a ResourceTarget into a ksail-detail: URL (query-string body).
+export function encodeResourceDetailURL(target: ResourceTarget): string {
+  const params = new URLSearchParams({
+    apiVersion: target.apiVersion,
+    kind: target.kind,
+    plural: target.plural,
+    name: target.name,
+  });
+  if (target.namespace) {
+    params.set("namespace", target.namespace);
+  }
+
+  return `${RESOURCE_DETAIL_SCHEME}${params.toString()}`;
+}
+
+// decodeResourceDetailURL parses a ksail-detail: URL back into a ResourceTarget, or null if the URL is not
+// one (or is missing required coordinates), so the Link can fall through to plugin-router navigation.
+export function decodeResourceDetailURL(url: string): ResourceTarget | null {
+  if (!url.startsWith(RESOURCE_DETAIL_SCHEME)) {
+    return null;
+  }
+
+  const params = new URLSearchParams(url.slice(RESOURCE_DETAIL_SCHEME.length));
+  const apiVersion = params.get("apiVersion");
+  const plural = params.get("plural");
+  const name = params.get("name");
+  if (!apiVersion || !plural || !name) {
+    return null;
+  }
+
+  return {
+    apiVersion,
+    kind: params.get("kind") ?? plural,
+    plural,
+    name,
+    namespace: params.get("namespace") ?? undefined,
+  };
+}
+
+// BuiltinKind describes a built-in Kubernetes kind KSail can resolve a Headlamp route name to.
+interface BuiltinKind {
+  kind: string;
+  apiVersion: string;
+  plural: string;
+  namespaced: boolean;
+}
+
+// BUILTIN_ROUTE_KINDS maps Headlamp's built-in detail route names to their kind. These are the routes
+// Headlamp ships for core/apps/batch/networking kinds; a plugin links to them by name (e.g. a table cell's
+// namespace link is routeName "namespace"). The generic "customresource" route is handled separately
+// (its kind comes from params). Names match Headlamp's createRouteURL route names.
+const BUILTIN_ROUTE_KINDS: Record<string, BuiltinKind> = {
+  namespace: { kind: "Namespace", apiVersion: "v1", plural: "namespaces", namespaced: false },
+  node: { kind: "Node", apiVersion: "v1", plural: "nodes", namespaced: false },
+  persistentVolume: { kind: "PersistentVolume", apiVersion: "v1", plural: "persistentvolumes", namespaced: false },
+  pod: { kind: "Pod", apiVersion: "v1", plural: "pods", namespaced: true },
+  service: { kind: "Service", apiVersion: "v1", plural: "services", namespaced: true },
+  configMap: { kind: "ConfigMap", apiVersion: "v1", plural: "configmaps", namespaced: true },
+  secret: { kind: "Secret", apiVersion: "v1", plural: "secrets", namespaced: true },
+  persistentVolumeClaim: {
+    kind: "PersistentVolumeClaim",
+    apiVersion: "v1",
+    plural: "persistentvolumeclaims",
+    namespaced: true,
+  },
+  serviceAccount: { kind: "ServiceAccount", apiVersion: "v1", plural: "serviceaccounts", namespaced: true },
+  deployment: { kind: "Deployment", apiVersion: "apps/v1", plural: "deployments", namespaced: true },
+  daemonSet: { kind: "DaemonSet", apiVersion: "apps/v1", plural: "daemonsets", namespaced: true },
+  statefulSet: { kind: "StatefulSet", apiVersion: "apps/v1", plural: "statefulsets", namespaced: true },
+  replicaSet: { kind: "ReplicaSet", apiVersion: "apps/v1", plural: "replicasets", namespaced: true },
+  job: { kind: "Job", apiVersion: "batch/v1", plural: "jobs", namespaced: true },
+  cronJob: { kind: "CronJob", apiVersion: "batch/v1", plural: "cronjobs", namespaced: true },
+  ingress: { kind: "Ingress", apiVersion: "networking.k8s.io/v1", plural: "ingresses", namespaced: true },
+};
+
+// builtinRouteTarget resolves a Headlamp built-in route name + params to a ResourceTarget, or null when the
+// name is not a known built-in (so createRouteURL falls back to plugin-registered routes). The generic
+// "customresource" route carries its kind in params (group/version/pluralName); the rest are fixed kinds
+// keyed by route name.
+export function builtinRouteTarget(name: string, params?: Record<string, string>): ResourceTarget | null {
+  if (name === "customresource" || name === "customResource") {
+    const group = params?.group ?? "";
+    const version = params?.version ?? "";
+    const plural = params?.pluralName ?? params?.plural ?? "";
+    const objectName = params?.name ?? params?.crName ?? "";
+    if (!version || !plural || !objectName) {
+      return null;
+    }
+
+    return {
+      apiVersion: group ? `${group}/${version}` : version,
+      kind: params?.kind ?? plural,
+      plural,
+      namespace: params?.namespace,
+      name: objectName,
+    };
+  }
+
+  const builtin = BUILTIN_ROUTE_KINDS[name];
+  const objectName = params?.name ?? "";
+  if (!builtin || !objectName) {
+    return null;
+  }
+
+  return {
+    apiVersion: builtin.apiVersion,
+    kind: builtin.kind,
+    plural: builtin.plural,
+    namespace: builtin.namespaced ? params?.namespace : undefined,
+    name: objectName,
+  };
+}
+
+// --- current resource-detail target store (useSyncExternalStore-compatible) ---
+
+let current: ResourceTarget | null = null;
+const listeners = new Set<() => void>();
+
+// openResourceDetail records the target to inspect and notifies subscribers (App.tsx), which renders the
+// native detail overlay for it. Called by CommonComponents.Link on a built-in resource link, and by the
+// detail panel itself to drill into a related resource.
+export function openResourceDetail(target: ResourceTarget): void {
+  current = target;
+  listeners.forEach((listener) => {
+    listener();
+  });
+}
+
+// clearResourceDetail closes the overlay (App.tsx passes this as the panel's onClose).
+export function clearResourceDetail(): void {
+  if (current === null) {
+    return;
+  }
+
+  current = null;
+  listeners.forEach((listener) => {
+    listener();
+  });
+}
+
+export function subscribeResourceDetail(listener: () => void): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getResourceDetailTarget(): ResourceTarget | null {
+  return current;
+}

--- a/web/ui/src/lib/plugins/watchStream.ts
+++ b/web/ui/src/lib/plugins/watchStream.ts
@@ -59,11 +59,14 @@ export function kubeObjectKey(object: RawKubeObject): string {
 
 // watchStreamURL builds the same-origin SSE URL for watching an apiserver collection. It mirrors
 // proxyList's URL (the kube-proxy GET) with /proxy swapped for /watch, so the watch observes exactly the
-// collection the initial fetch listed. watch=true is forced server-side, so no query is needed here.
-export function watchStreamURL(namespace: string, name: string, listPath: string): string {
+// collection the initial fetch listed — including any label/field selector `query` (without a leading
+// '?'), which the watch handler relays to the apiserver (it forces watch=true while preserving selectors,
+// see kubewatch.go). Passing the same selector as the list keeps watch upserts scoped to the listed set.
+export function watchStreamURL(namespace: string, name: string, listPath: string, query = ""): string {
   const base = `/api/v1/clusters/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;
+  const suffix = query ? `?${query}` : "";
 
-  return `${base}/watch/${listPath.replace(/^\//, "")}`;
+  return `${base}/watch/${listPath.replace(/^\//, "")}${suffix}`;
 }
 
 // WatchStreamHandlers are the callbacks watchStream invokes as events arrive. onEvent fires once per


### PR DESCRIPTION
## Why

Three gaps in KSail's Headlamp-compatible plugin UX (all visible when comparing KSail's plugin rendering to Headlamp's):

1. **Plugins were global, not cluster-scoped** — plugin sidebar entries showed even with no cluster selected.
2. **Resource links were dead** — clicking e.g. a Kustomization's namespace did nothing; you couldn't "zoom into" a resource the way Headlamp does.
3. **Plugin pages didn't look native** — the Flux Overview's donut status-card grid was missing, "Controllers" showed *No items*, and MUI-rendered chrome clashed with KSail's slate/blue design.

## What changed (all `web/ui/src`, no Go changes)

**Cluster-scope plugin navigation** — plugin-contributed nav now renders only inside the cluster workspace (`AppShell.tsx`); install/configure stays in the always-available global **Plugins** view. Leaving/switching a cluster closes the plugin surface and any open detail overlay (`App.tsx`). Plugins still load globally so the management view shows status without a cluster.

**Resource links → native detail overlay** (reuse KSail's native panel, made more Headlamp-like) — a new module-singleton bridge (`lib/plugins/resourceDetail.ts`) maps Headlamp's built-in route names (`namespace`, `pod`, `deployment`, …, `customresource`) and `kubeObject` links to a `ksail-detail:` sentinel URL. `createRouteURL` (`pluginLib.ts`) emits it; `Link` (`commonComponents.tsx`) routes it to a lazy `HostResourceDetail.tsx` overlay that fetches the object via the kube-proxy (`k8s.getObjectByTarget`). Plugin-owned detail routes still navigate in-plugin. The native panel (`ResourceDetailPanel.tsx`) gained a Headlamp-style **metadata overview** (name, clickable namespace, created, labels/annotations) shared with the overlay via an extracted `ResourceDetailContent`.

**Blend plugin pages into KSail** — `buildPluginTheme` (`PluginSlots.tsx`) now matches KSail's tokens (blue-600/500 primary, slate bg/paper/text/divider per mode, 8px radius, Tailwind font, flat Paper). Donut charts get rounded caps; the plugin `Table` matches KSail's table styling.

**Fix missing Overview cards / "No items" controllers** — the plugin K8s data layer (`k8s.ts`) silently dropped `labelSelector`/`fieldSelector`. It now scopes single-namespace lists to the namespaced collection path and forwards selectors to the list fetch, the SSE watch (`watchStream.ts`), and the WebSocket multiplexer — all of which already relay query params to the apiserver.

## Verification

Live on a kind cluster + `flux install` + a podinfo source/kustomization, with the real `headlamp-k8s-flux` 0.6.0 plugin, driven through the preview server — **zero console errors**:

- No cluster selected → no Flux nav (global Plugins view still present); enter cluster → Flux group appears in the cluster zone.
- Flux Overview renders the donut status cards and **Controllers shows "All Controllers Ready"** (was *No items*).
- Clicking a Kustomization's `flux-system` namespace (href `ksail-detail:…namespace…`) opens the native overlay with metadata/labels/manifest.
- Native Resources Pod detail unchanged (action bar + new metadata overview).

Gates: `tsc` clean · `vite build` · jscpd 0 clones · `go build` · `go test ./pkg/webui/... ./pkg/cli/clusterapi/...` (294 pass; no Go changed).

## Known limitations / follow-ups

- A plugin that builds links with a raw MUI `<Link>` + `createRouteURL` (instead of `CommonComponents.Link`) isn't intercepted.
- Generic owner-ref / children "related resources" drill-in in the native panel is deferred (the namespace link and the metadata overview land here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
