### PR TITLE
test(apis): cover FluxVerifySpec.Enabled pure helper

### DIFF
--- a/pkg/apis/cluster/v1alpha1/purehelpers_test.go
+++ b/pkg/apis/cluster/v1alpha1/purehelpers_test.go
@@ -10,8 +10,40 @@ import (
 
 // These black-box tests cover small, pure helper functions across the v1alpha1
 // config API that previously had no direct coverage: OIDC validation/enablement,
-// Hetzner network/CNI-port resolution, provider Docker-need predicate, node-count
-// arithmetic, and the host-cluster label predicate.
+// Flux signature-verification enablement, Hetzner network/CNI-port resolution,
+// provider Docker-need predicate, node-count arithmetic, and the host-cluster
+// label predicate.
+
+func TestFluxVerifySpecEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec v1alpha1.FluxVerifySpec
+		want bool
+	}{
+		{
+			name: "provider set is enabled",
+			spec: v1alpha1.FluxVerifySpec{Provider: "cosign"},
+			want: true,
+		},
+		{name: "empty provider is disabled", spec: v1alpha1.FluxVerifySpec{}, want: false},
+		{
+			name: "whitespace-only provider is disabled",
+			spec: v1alpha1.FluxVerifySpec{Provider: "  \t "},
+			want: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := testCase.spec
+			assert.Equal(t, testCase.want, spec.Enabled())
+		})
+	}
+}
 
 func TestOIDCSpecEnabled(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`FluxVerifySpec.Enabled()` (`pkg/apis/cluster/v1alpha1/flux_types.go:98`) was the lone uncovered (0.0%) member of the v1alpha1 config-API `Enabled()` convention — its siblings `OIDCSpec.Enabled()` and `LocalRegistry.Enabled()` are already at 100%. It is a small, pure predicate (`strings.TrimSpace(v.Provider) != ""`) that decides whether the generated `OCIRepository` gets a `spec.verify` block, so it's worth pinning.

## What

Adds `TestFluxVerifySpecEnabled` to the existing black-box `purehelpers_test.go`, mirroring the sibling `TestOIDCSpecEnabled` table-test style: provider set → enabled, empty → disabled, and whitespace-only → disabled (the meaningful edge the `TrimSpace` guards). Extends the file's doc comment to list Flux signature-verification enablement.

No source change — test-only, behaviour-preserving.

## Validation

- `go test ./pkg/apis/cluster/v1alpha1/...` → 542 pass (was 538).
- `flux_types.go:98 Enabled` coverage **0.0% → 100.0%** (`go tool cover -func`).
- `golangci-lint run ./pkg/apis/cluster/v1alpha1/...` → no issues; `gofmt` clean.