### PR TITLE
test(clusterdiscovery): cover ProviderError Error and Unwrap

### DIFF
--- a/pkg/svc/clusterdiscovery/providererror_test.go
+++ b/pkg/svc/clusterdiscovery/providererror_test.go
@@ -1,0 +1,39 @@
+package clusterdiscovery_test
+
+import (
+	"errors"
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errProviderListFailed is a sentinel used to assert ProviderError preserves the
+// wrapped cause through Unwrap / errors.Is.
+var errProviderListFailed = errors.New("connection refused")
+
+func TestProviderErrorError(t *testing.T) {
+	t.Parallel()
+
+	err := clusterdiscovery.ProviderError{
+		Provider: v1alpha1.ProviderHetzner,
+		Err:      errProviderListFailed,
+	}
+
+	assert.Equal(t, "list Hetzner clusters: connection refused", err.Error())
+}
+
+func TestProviderErrorUnwrap(t *testing.T) {
+	t.Parallel()
+
+	err := clusterdiscovery.ProviderError{
+		Provider: v1alpha1.ProviderDocker,
+		Err:      errProviderListFailed,
+	}
+
+	// Unwrap returns the wrapped cause, so errors.Is can match through it.
+	require.ErrorIs(t, err, errProviderListFailed)
+	assert.Equal(t, errProviderListFailed, err.Unwrap())
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`ProviderError.Error()` (`pkg/svc/clusterdiscovery/clusterdiscovery.go:63`) and `ProviderError.Unwrap()` (`:67`) were both 0.0% covered. `ProviderError` is the non-fatal-failure wrapper discovery returns per provider — callers surface or `errors.Is`-match against it — so pinning the message format and the unwrap chain guards against a silent regression in either.

## What

Adds `providererror_test.go` (black-box) with two small tests mirroring the package's existing style:
- `TestProviderErrorError` — asserts the `"list %s clusters: %v"` format (`list Hetzner clusters: connection refused`).
- `TestProviderErrorUnwrap` — asserts `errors.Is` matches the wrapped cause and `Unwrap()` returns it.

No source change — test-only, behaviour-preserving.

## Validation

- `go test ./pkg/svc/clusterdiscovery/...` → 20 pass.
- `clusterdiscovery.go` `Error` + `Unwrap` coverage **0.0% → 100.0%** (`go tool cover -func`).
- `golangci-lint run ./pkg/svc/clusterdiscovery/...` → no issues; `gofmt` clean.