### PR TITLE
test(k8s): cover ModifyKubeconfigCluster error paths

### DIFF
--- a/pkg/k8s/kubeconfig_modify_test.go
+++ b/pkg/k8s/kubeconfig_modify_test.go
@@ -1,0 +1,115 @@
+package k8s_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// twoClusterKubeconfig is a kubeconfig with two cluster entries, used to verify
+// that ModifyKubeconfigCluster updates only the targeted cluster and leaves the
+// other entry untouched.
+const twoClusterKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-a:6443
+  name: cluster-a
+- cluster:
+    server: https://cluster-b:6443
+  name: cluster-b
+contexts:
+- context:
+    cluster: cluster-a
+    user: user-a
+  name: context-a
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: token-a
+`
+
+// writeKubeconfigFile writes content to a fresh temp kubeconfig and returns its path.
+func writeKubeconfigFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// TestModifyKubeconfigCluster_UpdatesTargetPreservesOthers verifies the happy
+// path: the targeted cluster's server URL is rewritten while every other entry
+// (including the second cluster) is preserved.
+func TestModifyKubeconfigCluster_UpdatesTargetPreservesOthers(t *testing.T) {
+	t.Parallel()
+
+	const newServer = "https://updated-a:7443"
+
+	path := writeKubeconfigFile(t, twoClusterKubeconfig)
+
+	err := k8s.ModifyKubeconfigCluster(path, "cluster-a", newServer)
+	require.NoError(t, err)
+
+	cfg, err := clientcmd.LoadFromFile(path)
+	require.NoError(t, err)
+
+	require.Contains(t, cfg.Clusters, "cluster-a")
+	assert.Equal(t, newServer, cfg.Clusters["cluster-a"].Server)
+	// The untargeted cluster must be left intact.
+	require.Contains(t, cfg.Clusters, "cluster-b")
+	assert.Equal(t, "https://cluster-b:6443", cfg.Clusters["cluster-b"].Server)
+	// Context and current-context are preserved.
+	assert.Equal(t, "context-a", cfg.CurrentContext)
+}
+
+// TestModifyKubeconfigCluster_ClusterNotFound verifies the ErrClusterEntryNotFound
+// sentinel is returned (and wrapped) when the cluster key is absent.
+func TestModifyKubeconfigCluster_ClusterNotFound(t *testing.T) {
+	t.Parallel()
+
+	path := writeKubeconfigFile(t, twoClusterKubeconfig)
+
+	err := k8s.ModifyKubeconfigCluster(path, "cluster-missing", "https://x:6443")
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, k8s.ErrClusterEntryNotFound)
+	assert.Contains(t, err.Error(), "cluster-missing")
+}
+
+// TestModifyKubeconfigCluster_LoadError verifies a parse failure on an existing
+// but malformed kubeconfig is surfaced as a load error.
+func TestModifyKubeconfigCluster_LoadError(t *testing.T) {
+	t.Parallel()
+
+	path := writeKubeconfigFile(t, "clusters: [unterminated\n")
+
+	err := k8s.ModifyKubeconfigCluster(path, "cluster-a", "https://x:6443")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load kubeconfig")
+}
+
+// TestModifyKubeconfigCluster_CanonicalizeError verifies a path whose parent
+// component is a regular file (not a directory) fails canonicalization.
+func TestModifyKubeconfigCluster_CanonicalizeError(t *testing.T) {
+	t.Parallel()
+
+	notADir := filepath.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o600))
+	// The parent ("file") is a regular file, so resolving "file/config" fails
+	// with ENOTDIR (not IsNotExist) inside EvalCanonicalPath.
+	badPath := filepath.Join(notADir, "config")
+
+	err := k8s.ModifyKubeconfigCluster(badPath, "cluster-a", "https://x:6443")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canonicalize kubeconfig path")
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`k8s.ModifyKubeconfigCluster` (`pkg/k8s/kubeconfig.go:127`) was the lone **0%-covered** function in an otherwise well-tested package (83.8% overall). It is used by the Talos, KWOK, and Kind provisioners to rewrite a cluster entry's server URL in-place after provisioning, and it carries several real error paths — including the public `ErrClusterEntryNotFound` sentinel — that were entirely unexercised.

## What

Adds `pkg/k8s/kubeconfig_modify_test.go` (matching the per-area `kubeconfig_*_test.go` convention), black-box (`k8s_test`), case-driven with testify:

- **success** — targeted cluster's server URL is updated while the *other* cluster entry and `current-context` are preserved (read back via `clientcmd.LoadFromFile`).
- **cluster-not-found** — returns and wraps `ErrClusterEntryNotFound` (`errors.Is` + the key in the message).
- **load error** — a malformed existing kubeconfig surfaces as a `load kubeconfig` error.
- **canonicalize error** — a path whose parent component is a regular file (ENOTDIR) fails canonicalization.

No production code changed.

## Coverage

`ModifyKubeconfigCluster` **0.0% → 85.0%** (the residual 15% is the `ExpandHomePath` / `clientcmd.Write` / `AtomicWriteFile` error returns, which aren't deterministically triggerable on Linux CI).

## Validation

- `go test ./pkg/k8s/` — 201 pass.
- `golangci-lint run ./pkg/k8s/...` — no issues.

Test-only; no flag, API, or generated-snapshot surfaces touched.