### PR TITLE
test(configmanager): verify apiserver feature-gates patch applies to Talos config

### DIFF
--- a/pkg/fsutil/configmanager/talos/apiserver_feature_gates_test.go
+++ b/pkg/fsutil/configmanager/talos/apiserver_feature_gates_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPIServerFeatureGatesPatch(t *testing.T) {
@@ -21,4 +22,31 @@ func TestAPIServerFeatureGatesPatch(t *testing.T) {
 	assert.Equal(t, "ksail-apiserver-feature-gates", patch.Path)
 	assert.Equal(t, talos.PatchScopeCluster, patch.Scope)
 	assert.Equal(t, []byte(expectedContent), patch.Content)
+}
+
+// TestAPIServerFeatureGatesPatch_AppliesToTalosConfig verifies the patch is a
+// well-formed Talos strategic merge patch that generates and merges cleanly,
+// setting the intended kube-apiserver extraArgs on the rendered control-plane
+// config. The test above only asserts the raw bytes, so it would not catch a
+// YAML typo, a wrong key, or a Talos schema change that breaks patch
+// application — the failure mode that actually matters, since the patch is run
+// through configpatcher.LoadPatch during config generation.
+func TestAPIServerFeatureGatesPatch_AppliesToTalosConfig(t *testing.T) {
+	t.Parallel()
+
+	configs, err := talos.NewDefaultConfigsWithPatches(
+		[]talos.Patch{talos.APIServerFeatureGatesPatch()},
+	)
+	require.NoError(t, err)
+
+	controlPlane := configs.ControlPlane()
+	require.NotNil(t, controlPlane)
+
+	extraArgs := controlPlane.Cluster().APIServer().ExtraArgs()
+
+	assert.Equal(t, []string{"MutatingAdmissionPolicy=true"}, extraArgs["feature-gates"])
+	assert.Equal(t,
+		[]string{"admissionregistration.k8s.io/v1beta1=true"},
+		extraArgs["runtime-config"],
+	)
 }


### PR DESCRIPTION
## What

Adds `TestAPIServerFeatureGatesPatch_AppliesToTalosConfig` to `pkg/fsutil/configmanager/talos/apiserver_feature_gates_test.go`. It generates a real default Talos config with `APIServerFeatureGatesPatch()` applied and asserts the rendered **control-plane** config actually carries the intended kube-apiserver `extraArgs`:

- `feature-gates: MutatingAdmissionPolicy=true`
- `runtime-config: admissionregistration.k8s.io/v1beta1=true`

## Why

This responds to review feedback asking for edge-case coverage beyond the happy path. The existing `TestAPIServerFeatureGatesPatch` only asserts the raw patch **bytes**, so a YAML typo, a wrong key, or a Talos schema change would still pass while the patch fails to load/merge at runtime — it flows through `configpatcher.LoadPatch` during config generation (`patches.go:127`). The new test exercises that real apply path, which is the failure mode that actually matters.

I deliberately did **not** add the determinism / sanity / repeated-invocation tests that were also suggested: `APIServerFeatureGatesPatch()` returns a hardcoded constant built from string literals (no inputs, no maps, no state), so those tests can't meaningfully fail and their content checks are a strict subset of the existing full-content `assert.Equal`. They'd inflate coverage without testing anything new.

## Reviewer notes

- Pure test-only change; no production code touched.
- Reuses the package's own `NewDefaultConfigsWithPatches` generation path and `ControlPlane().Cluster().APIServer().ExtraArgs()` accessor (same pattern as `TestConfigs_ControlPlane`).
- Verified locally: `go test ./pkg/fsutil/configmanager/talos/` → 163 passed; `golangci-lint run --new-from-rev=HEAD` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)