### PR TITLE
test(k8s): clarify badPath variable name in canonicalize test

### DIFF
--- a/pkg/k8s/kubeconfig_modify_test.go
+++ b/pkg/k8s/kubeconfig_modify_test.go
@@ -106,9 +106,9 @@ func TestModifyKubeconfigCluster_CanonicalizeError(t *testing.T) {
 	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o600))
 	// The parent ("file") is a regular file, so resolving "file/config" fails
 	// with ENOTDIR (not IsNotExist) inside EvalCanonicalPath.
-	badPath := filepath.Join(notADir, "config")
+	pathWithFileParent := filepath.Join(notADir, "config")
 
-	err := k8s.ModifyKubeconfigCluster(badPath, "cluster-a", "https://x:6443")
+	err := k8s.ModifyKubeconfigCluster(pathWithFileParent, "cluster-a", "https://x:6443")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "canonicalize kubeconfig path")


### PR DESCRIPTION
## What

Renames the vague local `badPath` to `pathWithFileParent` in `TestModifyKubeconfigCluster_CanonicalizeError` (`pkg/k8s/kubeconfig_modify_test.go`).

## Why

Follow-up to a code-review nit on #5488. The name `badPath` doesn't say *why* the path is bad. The new name conveys the intent the comment two lines up already explains: the path's **parent component is a regular file, not a directory**, so resolving `file/config` fails with `ENOTDIR` inside `EvalCanonicalPath`.

Test-only, behaviour-unchanged rename. `go test ./pkg/k8s/ -run TestModifyKubeconfigCluster_CanonicalizeError` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test variable name for clarity in kubeconfig cluster modification coverage.
  * No behavior, assertions, or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->