### PR TITLE
docs(webui): consolidate usePluginLoader comment into JSDoc

### DIFF
--- a/web/ui/src/lib/plugins/usePlugins.ts
+++ b/web/ui/src/lib/plugins/usePlugins.ts
@@ -32,10 +32,15 @@ export interface PluginLoaderState {
   reload: () => void;
 }
 
-// usePluginLoader loads the installed plugins once when `enabled` becomes true, exposing each plugin's
-// load outcome (for the Plugins view) and a reload(). getCluster supplies the active cluster to the K8s
-// data shim; it is read through a ref so switching clusters does not reload plugins — the shim reads the
-// live cluster on each fetch instead.
+/**
+ * usePluginLoader loads the installed plugins once when `enabled` becomes true, exposing each plugin's
+ * load outcome (for the Plugins view) plus a `reload()` trigger.
+ *
+ * `getCluster` is a function (rather than a `ClusterRef | null`) so the latest value can be held in a
+ * ref and read by the K8s data shim at fetch time. That keeps the active cluster out of the load
+ * dependencies, so switching clusters does not reload plugins — the shim reads the live cluster on each
+ * fetch instead.
+ */
 export function usePluginLoader(enabled: boolean, getCluster: () => ClusterRef | null): PluginLoaderState {
   const [plugins, setPlugins] = useState<LoadedPlugin[]>([]);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
## What changed

Consolidated the comment on `usePluginLoader` in `web/ui/src/lib/plugins/usePlugins.ts` into a single JSDoc block. Comment-only — no behavior change.

## Why

A code-quality review flagged that the rationale for `getCluster` being a function parameter (rather than `ClusterRef | null`) wasn't obvious from the signature. Converting the existing line comment to JSDoc:

- Surfaces the rationale as hover docs at the call site (`App.tsx`).
- Documents *why* `getCluster` is a function: the latest value is held in a ref and read by the K8s data shim at fetch time, so switching clusters doesn't become a load dependency that re-triggers plugin reloads.

The original suggestion duplicated the explanation (kept the prose comment **and** added a JSDoc); this consolidates into one block instead.

## Reviewer note — a second finding was intentionally not applied

The same review suggested calling `setPlugins([])` at the start of `reload()` to avoid showing stale plugin data on a failed load. I evaluated it and left it out, because it backfires:

- During a load, `error` is reset to `null` and `plugins` would be `[]`, so `PluginsView` renders the **"No plugins installed" empty state** on every successful manual reload until the load resolves — a worse flicker than the current spinner, and misleading on a slow load.
- The current behavior is intentional **stale-while-revalidate**: the last-known-good list stays visible during a refresh, and on failure an `ErrorBanner` with a Retry button is shown alongside it. The Reload button already signals progress via its loading spinner.

No code change is the simplest correct outcome for that finding.

## Testing

Comment-only change; no build or behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
