### PR TITLE
fix(webui): skip unkeyable watch frames and normalize watch query

### DIFF
--- a/web/ui/src/lib/plugins/useClusterScopedList.ts
+++ b/web/ui/src/lib/plugins/useClusterScopedList.ts
@@ -59,7 +59,9 @@ export interface WatchBinding<T> {
   toItem: (raw: RawKubeObject) => T;
   // keyOf derives the stable identity (uid, fallback namespace/name) an upsert/remove matches on. The
   // fetcher's items and watched items must key identically so a MODIFIED replaces the listed row.
-  keyOf: (item: T) => string;
+  // Returns null for an unkeyable item (no uid, no name); applyWatchEvent compares against a non-null
+  // event key, so a null-keyed row never matches and is left untouched.
+  keyOf: (item: T) => string | null;
 }
 
 // applyWatchEvent returns the next items array after applying one watch event: ADDED/MODIFIED upsert the
@@ -67,6 +69,11 @@ export interface WatchBinding<T> {
 // leave the list unchanged. Pure so it composes inside a setItems updater.
 function applyWatchEvent<T>(items: T[], event: WatchEvent, binding: WatchBinding<T>): T[] {
   const key = kubeObjectKey(event.object);
+  // An object with neither uid nor name cannot be matched to a row; skip the event rather than alias
+  // it to a degenerate key, preserving the stream's "one bad frame never corrupts the list" contract.
+  if (key === null) {
+    return items;
+  }
 
   if (event.type === "DELETED") {
     return items.filter((item) => binding.keyOf(item) !== key);

--- a/web/ui/src/lib/plugins/watchStream.ts
+++ b/web/ui/src/lib/plugins/watchStream.ts
@@ -47,14 +47,22 @@ export interface WatchEvent {
 
 // kubeObjectKey derives a stable identity for a watched object: metadata.uid when present, else
 // "namespace/name" (cluster-scoped objects have no namespace, yielding "/name"). It is the key both
-// ADDED/MODIFIED upserts and DELETED removals match on, so an update replaces the right row.
-export function kubeObjectKey(object: RawKubeObject): string {
+// ADDED/MODIFIED upserts and DELETED removals match on, so an update replaces the right row. Returns
+// null for an object with neither a uid nor a name: such a frame cannot be keyed, so the caller skips
+// it rather than aliasing it to a degenerate "/" key (a single malformed frame must not corrupt the
+// list — mirroring decodeWatchEvent's skip-don't-crash contract).
+export function kubeObjectKey(object: RawKubeObject): string | null {
   const uid = object.metadata?.uid;
   if (uid) {
     return uid;
   }
 
-  return `${object.metadata?.namespace ?? ""}/${object.metadata?.name ?? ""}`;
+  const name = object.metadata?.name;
+  if (!name) {
+    return null;
+  }
+
+  return `${object.metadata?.namespace ?? ""}/${name}`;
 }
 
 // watchStreamURL builds the same-origin SSE URL for watching an apiserver collection. It mirrors
@@ -64,7 +72,10 @@ export function kubeObjectKey(object: RawKubeObject): string {
 // see kubewatch.go). Passing the same selector as the list keeps watch upserts scoped to the listed set.
 export function watchStreamURL(namespace: string, name: string, listPath: string, query = ""): string {
   const base = `/api/v1/clusters/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;
-  const suffix = query ? `?${query}` : "";
+  // Callers pass a bare selector query without a leading '?' (see listSelectorQuery); strip one
+  // defensively so a caller that includes it cannot produce a malformed "??…" suffix.
+  const normalizedQuery = query.replace(/^\?+/, "");
+  const suffix = normalizedQuery ? `?${normalizedQuery}` : "";
 
   return `${base}/watch/${listPath.replace(/^\//, "")}${suffix}`;
 }


### PR DESCRIPTION
## What

Hardens the plugin K8s live-watch substrate (`web/ui/src/lib/plugins/watchStream.ts`) against two automated code-quality findings — using the **safe, design-consistent** remedy rather than the suggested `throw`.

### Finding 1 — unkeyable watch frames (safe skip, not throw)
- `kubeObjectKey` now returns `string | null`: `metadata.uid` → else `namespace/name` when a name exists → else `null` for an object with neither uid nor name.
- `applyWatchEvent` returns the list unchanged when the key is `null`, dropping the malformed frame.
- `WatchBinding.keyOf` is widened to `string | null`. The null-guard runs before the DELETED/upsert logic, and a `null` row-key can never equal the non-null event key, so no row is ever wrongly removed or replaced.

The original suggestion was to `throw`. That would be a regression: `kubeObjectKey` runs inside a React `setItems` updater on every watch event (`applyWatchEvent` → `setItems`), so throwing would crash list rendering on a single bad frame — directly contradicting this module's stated *skip-don't-crash* contract (`decodeWatchEvent` already returns `null` "so a single bad event cannot crash the stream").

### Finding 2 — defensive query normalization
- `watchStreamURL` strips a leading `?` from the selector query before building the suffix, so a caller that includes one cannot produce a malformed `??…` suffix. This is a no-op for the only real input (`listSelectorQuery` → `URLSearchParams.toString()`, which never emits a leading `?`).

## Why

Both came from a code-quality review on `watchStream.ts`. Finding 1's suggested `throw` was unsafe in the watch hot path; this PR applies the crash-safe variant that matches the module's existing graceful-degradation design. Finding 2 is harmless defensive hardening.

## Reviewer notes

- **No behavior change for real apiserver data:** every real watch object carries a `uid`, so the `null`/fallback paths only affect genuinely malformed frames.
- **Verified with `npm run build`** (`gen:types && tsc && vite build`) — the repo's actual web/ui gate. There is **no JS/TS test runner** in the repo (web/ui CI is type-check + build only), so no unit test is included. Happy to wire up vitest + a spec (covering uid / namespace-name fallback / null-skip / leading-`?` strip) as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)