### PR TITLE
ci: guard against a calico/node bump with no matching tigera-operator chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,6 +133,7 @@ jobs:
       copilot-plugin: ${{ steps.filter.outputs.copilot-plugin }}
       operator-chart: ${{ steps.filter.outputs.operator-chart }}
       desktop: ${{ steps.filter.outputs.desktop }}
+      calico-cni: ${{ steps.filter.outputs.calico-cni }}
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -281,6 +282,14 @@ jobs:
               - 'desktop/**'
               - 'go.mod'
               - 'go.sum'
+              - '.github/workflows/ci.yaml'
+            calico-cni:
+              # The Calico installer derives the tigera-operator chart version
+              # from the calico/node image tag in this Dockerfile (see
+              # version.go's chartVersion()). A node-image patch can outpace the
+              # operator chart release, leaving the derived version unpublished,
+              # so guard a bump to this file with validate-calico-chart.
+              - 'pkg/svc/installer/cni/calico/Dockerfile'
               - '.github/workflows/ci.yaml'
 
   ci-go:
@@ -1506,6 +1515,57 @@ jobs:
             exit 1
           fi
 
+  validate-calico-chart:
+    name: 🔍 Validate Calico Chart Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes]
+    # Cheap pre-flight: a calico/node image bump (Dependabot updates the
+    # Dockerfile) can outpace the tigera-operator chart release, so the chart
+    # version version.go derives from the tag points at a chart that is not
+    # published. Without this, the bad pin only surfaces after the full ~30-min
+    # System Test matrix as an opaque "Calico not detected". Fail fast and
+    # legibly instead. See https://github.com/devantler-tech/ksail/issues/5463.
+    if: needs.changes.outputs.calico-cni == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🔍 Verify the derived tigera-operator chart version is published
+        run: |
+          set -euo pipefail
+          dockerfile="pkg/svc/installer/cni/calico/Dockerfile"
+          # Mirror version.go's chartVersion(): the chart version is the
+          # calico/node image tag (FROM docker.io/calico/node:<tag>@sha256:…).
+          version="$(sed -nE 's|.*docker\.io/calico/node:([^@[:space:]]+).*|\1|p' "$dockerfile" | head -1)"
+          if [ -z "$version" ]; then
+            echo "::error file=$dockerfile::Could not derive the calico/node tag from $dockerfile — has the FROM line format changed? Update this guard and version.go together."
+            exit 1
+          fi
+          echo "Derived Calico chart version: $version"
+
+          repo_url="https://docs.tigera.io/calico/charts"
+          helm repo add projectcalico "$repo_url" >/dev/null
+          helm repo update projectcalico >/dev/null
+
+          # The installer installs BOTH the operator chart and the CRD chart at
+          # this version (installer.go chartSpec/crdChartSpec); a bump that
+          # outpaces either chart leaves the install unresolvable.
+          status=0
+          for chart in tigera-operator projectcalico.org.v3; do
+            if helm show chart "projectcalico/$chart" --version "$version" >/dev/null 2>&1; then
+              echo "✅ projectcalico/$chart $version is published"
+            else
+              echo "::error file=$dockerfile::projectcalico/$chart has no published $version chart. The calico/node image tag was bumped ahead of the tigera-operator chart release — pin $dockerfile to a calico/node tag whose matching chart is published at $repo_url (the calico/node tag must equal the chart version)."
+              status=1
+            fi
+          done
+          exit "$status"
+
   require-checks-in-pr:
     name: CI - Required Checks
     runs-on: ubuntu-latest
@@ -1533,6 +1593,7 @@ jobs:
         operator-chart-lint,
         operator-chart-e2e,
         verify-desktop-tidy,
+        validate-calico-chart,
       ]
     if: ${{ always() }}
     steps:
@@ -1560,3 +1621,4 @@ jobs:
             ${{ needs.operator-chart-lint.result }}
             ${{ needs.operator-chart-e2e.result }}
             ${{ needs.verify-desktop-tidy.result }}
+            ${{ needs.validate-calico-chart.result }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5463

## Problem

The Calico CNI installer derives the **tigera-operator Helm chart version** from the `calico/node` image tag in [`pkg/svc/installer/cni/calico/Dockerfile`](https://github.com/devantler-tech/ksail/blob/main/pkg/svc/installer/cni/calico/Dockerfile) (`version.go`'s `chartVersion()` → `installer.go` installs `projectcalico/tigera-operator --version <tag>`), on the documented invariant *"calico/node tag matches chart version"*. Dependabot bumps that tag.

That invariant breaks whenever calico ships a **node-only image patch** with no matching operator-chart release — as on #5456 (`calico/node` v3.32.0→v3.32.1, when the `v3.32.1` image existed but the newest published chart was still v3.32.0). The bump made the installer request a **nonexistent** chart version, so `helm install` failed, calico never came up, and **all five Calico-variant `System Test (Docker)` jobs failed** with an opaque `Calico not detected` after a ~30-min cluster spin-up — with nothing pointing at the real cause. This recurs whenever calico patches the node image ahead of (or without) the operator chart.

## Fix — fail fast and legibly (option 1 of the issue)

A new **`validate-calico-chart`** job (path-gated on the calico `Dockerfile` via the `changes` filter) that:

1. Derives the version the **same way** `version.go` does — the `calico/node` tag from the `FROM` line.
2. Asserts that **both** charts the installer pulls — `tigera-operator` *and* `projectcalico.org.v3` (CRD chart, `crdChartSpec`) — are published at that version against the same repo the installer uses (`https://docs.tigera.io/calico/charts`).
3. On a miss, fails with an actionable `::error` that names the real cause and the remedy (pin to a `calico/node` tag whose matching chart is published).

It is hermetic (`helm show chart`, no cluster), runs in **seconds**, and only runs when the Dockerfile changes — so a bad Dependabot bump is rejected up front instead of after the full matrix. Wired into the `CI - Required Checks` rollup (`needs` + `aggregate-job-checks` `job-results` parity).

This addresses the issue's recommended cheapest-robust option (1). Options (2) (point Dependabot at the chart) and (3) (wrap the installer error) remain possible follow-ups; (3) is fragile (helm error string-matching) and the installer already fails fast on a chart-not-found error (it is not in `shouldRetryInstall`), so the gap this closes is **pre-matrix detection + legibility**.

## Validation

- Logic verified locally against the live Tigera repo: the current pin **v3.32.0** resolves both charts ✅; a nonexistent **v3.99.99** fails with `no chart version found` (the guard would correctly fail).
- Version extraction mirrors `version.go`'s regex and was checked against the real Dockerfile (`v3.32.0`).
- `actionlint` clean (the only warning, `code-quality` permission scope on a pre-existing job, is an actionlint-bundled-scope lag, not from this diff).

Opened as a **draft** for maintainer review per the engineering contract.
