### PR TITLE
test(flux): cover transient-error classifiers in the reconcile retry path

### DIFF
--- a/pkg/client/flux/export_test.go
+++ b/pkg/client/flux/export_test.go
@@ -17,3 +17,15 @@ var CheckHelmReleaseStuck = checkHelmReleaseStuck
 
 // CheckHelmReleaseStuckFunc is the function signature for checkHelmReleaseStuck.
 type CheckHelmReleaseStuckFunc = func(hr *unstructured.Unstructured) *StuckHelmRelease
+
+// IsConnectionError exports isConnectionError for testing.
+var IsConnectionError = isConnectionError
+
+// IsTransientAPIError exports isTransientAPIError for testing.
+var IsTransientAPIError = isTransientAPIError
+
+// TimeoutWaitingError exports timeoutWaitingError for testing.
+var TimeoutWaitingError = timeoutWaitingError
+
+// HandleTransientError exports handleTransientError for testing.
+var HandleTransientError = handleTransientError

--- a/pkg/client/flux/transient_test.go
+++ b/pkg/client/flux/transient_test.go
@@ -1,0 +1,154 @@
+package flux_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/flux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Static sentinel errors for the table-driven cases (err113 forbids inline
+// errors.New in tests). The transient classifiers match on the wrapped status
+// type or the rendered message, so these sentinels exercise the message paths.
+var (
+	errConflict             = errors.New("conflict")
+	errAPIDiscoveryNotFound = errors.New("the server could not find the requested resource")
+	errNoMatchesForKind     = errors.New(
+		"no matches for kind \"OCIRepository\" in version \"source.toolkit.fluxcd.io/v1\"",
+	)
+	errConnectionRefused = errors.New("dial tcp: connection refused")
+	errPermanent         = errors.New("validation failed: invalid spec")
+	errResourceNotReady  = errors.New("resource not found yet")
+)
+
+func TestIsConnectionError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		errMsg string
+		want   bool
+	}{
+		{
+			name:   "connection refused",
+			errMsg: "dial tcp 127.0.0.1:6443: connect: connection refused",
+			want:   true,
+		},
+		{name: "connection reset", errMsg: "read tcp: connection reset", want: true},
+		{name: "i/o timeout", errMsg: "dial tcp: i/o timeout", want: true},
+		{name: "EOF", errMsg: "unexpected response: EOF", want: true},
+		{name: "unrelated error", errMsg: "the requested operation is not permitted", want: false},
+		{name: "empty string", errMsg: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, flux.IsConnectionError(tt.errMsg))
+		})
+	}
+}
+
+func TestIsTransientAPIError(t *testing.T) {
+	t.Parallel()
+
+	groupResource := schema.GroupResource{
+		Group:    "source.toolkit.fluxcd.io",
+		Resource: "ocirepositories",
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{
+			name: "service unavailable",
+			err:  apierrors.NewServiceUnavailable("flux not ready"),
+			want: true,
+		},
+		{name: "timeout", err: apierrors.NewTimeoutError("request timed out", 1), want: true},
+		{name: "too many requests", err: apierrors.NewTooManyRequests("slow down", 1), want: true},
+		{
+			name: "conflict",
+			err:  apierrors.NewConflict(groupResource, "flux-system", errConflict),
+			want: true,
+		},
+		{name: "not found", err: apierrors.NewNotFound(groupResource, "flux-system"), want: true},
+		{name: "api discovery not found substring", err: errAPIDiscoveryNotFound, want: true},
+		{name: "api discovery no matches for kind", err: errNoMatchesForKind, want: true},
+		{name: "connection error message", err: errConnectionRefused, want: true},
+		{name: "permanent non-transient error", err: errPermanent, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, flux.IsTransientAPIError(tt.err))
+		})
+	}
+}
+
+func TestTimeoutWaitingError(t *testing.T) {
+	t.Parallel()
+
+	ctxErr := context.DeadlineExceeded
+
+	err := flux.TimeoutWaitingError("OCIRepository flux-system", errResourceNotReady, ctxErr)
+
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"timed out waiting for OCIRepository flux-system to be available",
+	)
+	// The message wraps both the last transient error and the context error with %w.
+	require.ErrorIs(t, err, errResourceNotReady)
+	require.ErrorIs(t, err, ctxErr)
+}
+
+func TestHandleTransientError_ContextDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Done() fires immediately.
+
+	// A long interval guarantees the ticker never wins the select race.
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	err := flux.HandleTransientError(ctx, ticker, "Kustomization flux-system", errResourceNotReady)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, errResourceNotReady)
+	assert.Contains(
+		t,
+		err.Error(),
+		"timed out waiting for Kustomization flux-system to be available",
+	)
+}
+
+func TestHandleTransientError_TickerFires(t *testing.T) {
+	t.Parallel()
+
+	// context.Background never reports Done, so the select can only proceed
+	// once the ticker fires, returning nil to continue the retry loop.
+	ctx := context.Background()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	err := flux.HandleTransientError(ctx, ticker, "Kustomization flux-system", errResourceNotReady)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The four transient-error helpers in [`pkg/client/flux/transient.go`](https://github.com/devantler-tech/ksail/blob/main/pkg/client/flux/transient.go) that gate the Flux reconcile retry loop were at **0% coverage**. They decide whether a reconcile API call is retried (transient: CRDs/controllers not ready yet, connection blips) or surfaced as a hard failure — so their branch behaviour is worth pinning:

| Function | Role |
|---|---|
| `isConnectionError` | network-error substring match |
| `isTransientAPIError` | retry-vs-fail classification of k8s API errors |
| `timeoutWaitingError` | single source of the `timed out waiting …` message (multi-`%w` wrap) |
| `handleTransientError` | inter-poll wait vs. timeout `select` |

## How

Black-box tests added via the package's existing `export_test.go` alias pattern — no source change. Every branch is covered, taking all four classifiers to **100%**:

- each connection substring (`connection refused` / `connection reset` / `i/o timeout` / `EOF`) + non-match + empty
- every transient status type (`ServiceUnavailable` / `Timeout` / `TooManyRequests` / `Conflict` / `NotFound`), both API-discovery messages, connection-message path, `nil`, and the permanent-error fall-through
- `timeoutWaitingError` wraps **both** the last transient error and the context error (`errors.Is` against each)
- both `select` arms of `handleTransientError`: context-cancelled → timeout error; ticker-fires → `nil` (continue)

## Validation

- `go test ./pkg/client/flux/...` → 177 pass; the 4 target functions report `100.0%`
- `golangci-lint run` on the package → 0 issues
- `go build` → success

Pure test-coverage addition; no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for connection-error detection and transient API error classification.
  * Verified timeout and waiting errors include useful context and remain compatible with error checks.
  * Added checks for transient-error handling in both canceled and retry-friendly scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->