### PR TITLE
test(autoscaler): cover the #5219 baseline-propagation routing dispatcher

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/autoscaler_propagate_baseline_test.go
+++ b/pkg/svc/provisioner/cluster/talos/autoscaler_propagate_baseline_test.go
@@ -1,0 +1,104 @@
+package talosprovisioner_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The distinctive no-op log line each propagateAutoscalerBaseline route prints when
+// there are no autoscaler nodes — what lets the routing decision be asserted with no
+// live infra.
+const (
+	recycleNoopMsg = "No autoscaler nodes to recycle"
+	rebootNoopMsg  = "No autoscaler nodes to reboot"
+	inPlaceNoopMsg = "No autoscaler nodes to reconcile"
+)
+
+type propagateRoutingCase struct {
+	name         string
+	diff         *clusterupdate.UpdateResult
+	imageChanged bool
+	wantMsg      string
+}
+
+// propagateRoutingCases enumerates the diff shapes and the convergence path each must
+// route to. Recycle (a fresh server) is reserved for an image bump or a
+// wipe/recreate/rolling-recreate diff; a reboot-required diff converges in place on
+// the SAME server (the capacity-constrained #5219 recurrence the in-place reboot path
+// was added for); everything else takes the NO_REBOOT in-place apply.
+func propagateRoutingCases() []propagateRoutingCase {
+	diffWith := func(set func(*clusterupdate.UpdateResult)) *clusterupdate.UpdateResult {
+		diff := clusterupdate.NewEmptyUpdateResult()
+		set(diff)
+
+		return diff
+	}
+
+	return []propagateRoutingCase{
+		{"image bump recycles", inPlaceDiff(), true, recycleNoopMsg},
+		{"wipe-required recycles", diffWith(func(d *clusterupdate.UpdateResult) {
+			d.WipeRequired = append(d.WipeRequired, clusterupdate.Change{})
+		}), false, recycleNoopMsg},
+		{"recreate-required recycles", diffWith(func(d *clusterupdate.UpdateResult) {
+			d.RecreateRequired = append(d.RecreateRequired, clusterupdate.Change{})
+		}), false, recycleNoopMsg},
+		{"rolling-recreate recycles", diffWith(func(d *clusterupdate.UpdateResult) {
+			d.RollingRecreate = append(d.RollingRecreate, clusterupdate.Change{})
+		}), false, recycleNoopMsg},
+		{"reboot-required reboots in place", diffWith(func(d *clusterupdate.UpdateResult) {
+			d.RebootRequired = append(d.RebootRequired, clusterupdate.Change{})
+		}), false, rebootNoopMsg},
+		{"reboot-required with image bump recycles", diffWith(func(d *clusterupdate.UpdateResult) {
+			d.RebootRequired = append(d.RebootRequired, clusterupdate.Change{})
+		}), true, recycleNoopMsg},
+		{"in-place only applies in place", inPlaceDiff(), false, inPlaceNoopMsg},
+		{"nil diff defaults to in place", nil, false, inPlaceNoopMsg},
+		{
+			"empty diff defaults to in place",
+			clusterupdate.NewEmptyUpdateResult(),
+			false,
+			inPlaceNoopMsg,
+		},
+	}
+}
+
+// TestPropagateAutoscalerBaseline_Routing pins the #5219 dispatcher: each diff shape
+// must reach the correct convergence path. With the autoscaler enabled but no pools
+// configured, listAutoscalerServers short-circuits to zero servers without ever
+// contacting Hetzner, so each route reaches its distinctive no-op log line — which is
+// how the routing decision is identified deterministically.
+func TestPropagateAutoscalerBaseline_Routing(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range propagateRoutingCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			prov := talosprovisioner.NewProvisioner(nil, nil).
+				WithLogWriter(&buf).
+				WithHetznerOptions(v1alpha1.OptionsHetzner{
+					NodeAutoscalerEnabled:   true,
+					AutoscalerNodePoolNames: nil,
+				})
+
+			err := prov.PropagateAutoscalerBaselineForTest(
+				context.Background(),
+				"test-cluster",
+				testCase.diff,
+				testCase.imageChanged,
+				clusterupdate.NewEmptyUpdateResult(),
+			)
+			require.NoError(t, err)
+			assert.Contains(t, buf.String(), testCase.wantMsg)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -774,3 +774,16 @@ func NodeMatchesServerForTest(node *corev1.Node, serverName, serverIP string) bo
 func NodeIsReadyForTest(node *corev1.Node) bool {
 	return nodeIsReady(node)
 }
+
+// PropagateAutoscalerBaselineForTest exposes propagateAutoscalerBaseline for unit
+// testing — the #5219 dispatcher routing existing autoscaler nodes to the recycle,
+// in-place reboot, or NO_REBOOT in-place path based on how disruptive the diff is.
+func (p *Provisioner) PropagateAutoscalerBaselineForTest(
+	ctx context.Context,
+	clusterName string,
+	diff *clusterupdate.UpdateResult,
+	imageChanged bool,
+	result *clusterupdate.UpdateResult,
+) error {
+	return p.propagateAutoscalerBaseline(ctx, clusterName, diff, imageChanged, result)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds a unit test pinning the **routing decision** of `propagateAutoscalerBaseline`
(`pkg/svc/provisioner/cluster/talos/autoscaler_secret.go`) — the dispatcher that
brings already-booted autoscaler nodes to a refreshed baseline by choosing the
least-disruptive convergence path. It is the core of the **#5219** fix, and it was
at **0% coverage** while its two pure classifier helpers
(`autoscalerRecycleRequired` / `autoscalerRebootRequired`) were already at 100%.

`propagateAutoscalerBaseline`: 0.0% → **100.0%**. No source change.

## Why this matters

The dispatcher encodes the safety-critical convergence policy from #5219:

- **recycle** (drain → delete → fresh server) only when unavoidable — a Talos boot-image
  bump or a wipe/recreate/rolling-recreate diff;
- **in-place reboot of the SAME server** for a reboot-required change — the path added
  specifically so a capacity-constrained project at its Hetzner server limit can still
  converge (the second #5219 recurrence);
- **NO_REBOOT in-place apply** for config-only drift.

A regression that silently re-routed (e.g. recycling on a reboot-only change) would,
on a capacity-constrained cluster, strand the autoscaler — exactly the #5219 failure
mode. This test makes that routing a pinned invariant.

## How

The three routes each emit a **distinct** no-op log line when there are no autoscaler
nodes. With the autoscaler enabled but no pools configured, `listAutoscalerServers`
short-circuits to zero servers **without any Hetzner call**, so each diff shape is
driven through the dispatcher and the route is asserted from its log line — fully
deterministic, no live infra, no mocks.

Test-only changes:
- `autoscaler_propagate_baseline_test.go` — new table-driven routing test (9 cases
  covering every classifier outcome through the dispatcher).
- `export_test.go` — one `PropagateAutoscalerBaselineForTest` seam (the package's
  established black-box test pattern).

## Validation

- `go test ./pkg/svc/provisioner/cluster/talos/` — pass (full package).
- `golangci-lint run --timeout 5m` — clean on the changed files.
- `go build ./...` — green.

Note: this **does not close #5219** (that remains gated on live recurrence-free
verification on prod); it hardens the test coverage of the logic that fix relies on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of autoscaler behavior when clusters have no node pools configured.
  * Added coverage for different update scenarios to ensure the expected scaling path is chosen consistently.
  * Reduced the chance of unexpected reconciliation behavior during cluster updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->