### PR TITLE
test(flux): cover OCIRepository status-poll helpers

### DIFF
--- a/pkg/client/flux/export_test.go
+++ b/pkg/client/flux/export_test.go
@@ -29,3 +29,12 @@ var TimeoutWaitingError = timeoutWaitingError
 
 // HandleTransientError exports handleTransientError for testing.
 var HandleTransientError = handleTransientError
+
+// IsPermanentOCIError exports isPermanentOCIError for testing.
+var IsPermanentOCIError = isPermanentOCIError
+
+// EvaluateOCIRepositoryConditions exports evaluateOCIRepositoryConditions for testing.
+var EvaluateOCIRepositoryConditions = evaluateOCIRepositoryConditions
+
+// OCITimeoutError exports ociTimeoutError for testing.
+var OCITimeoutError = ociTimeoutError

--- a/pkg/client/flux/ocirepository_test.go
+++ b/pkg/client/flux/ocirepository_test.go
@@ -1,0 +1,158 @@
+package flux_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/flux"
+	"github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Static sentinel errors for the table-driven cases (err113 forbids inline
+// errors.New in tests). isPermanentOCIError classifies on the rendered message,
+// so these sentinels exercise the substring paths.
+var (
+	errOCIManifestUnknown = errors.New("GET https://ghcr.io/...: manifest unknown")
+	errOCIDoesNotExist    = errors.New("artifact does not exist in the registry")
+	errOCIGeneric         = errors.New("dial tcp: connection refused")
+	errOCILastObserved    = errors.New("last observed transient error")
+)
+
+func newOCINotFoundError() error {
+	return apierrors.NewNotFound(
+		schema.GroupResource{Group: "source.toolkit.fluxcd.io", Resource: "ocirepositories"},
+		"flux-system",
+	)
+}
+
+func TestIsPermanentOCIError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error is not permanent", err: nil, want: false},
+		{name: "kubernetes NotFound is transient", err: newOCINotFoundError(), want: false},
+		{name: "manifest unknown is permanent", err: errOCIManifestUnknown, want: true},
+		{name: "does not exist is permanent", err: errOCIDoesNotExist, want: true},
+		{name: "generic error is not permanent", err: errOCIGeneric, want: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flux.IsPermanentOCIError(testCase.err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+//nolint:funlen // Table-driven test with comprehensive cases
+func TestEvaluateOCIRepositoryConditions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		conditions []reconciler.Condition
+		wantReady  bool
+		wantErr    bool
+	}{
+		{
+			name:       "no conditions is still progressing",
+			conditions: nil,
+			wantReady:  false,
+			wantErr:    false,
+		},
+		{
+			name: "ready true returns ready",
+			conditions: []reconciler.Condition{
+				{Type: "Ready", Status: "True"},
+			},
+			wantReady: true,
+			wantErr:   false,
+		},
+		{
+			name: "OCIPullFailed is a permanent failure",
+			conditions: []reconciler.Condition{
+				{
+					Type:    "Ready",
+					Status:  "False",
+					Reason:  "OCIPullFailed",
+					Message: "manifest unknown",
+				},
+			},
+			wantReady: false,
+			wantErr:   true,
+		},
+		{
+			name: "OCIArtifactPullFailed is a permanent failure",
+			conditions: []reconciler.Condition{
+				{
+					Type:    "Ready",
+					Status:  "False",
+					Reason:  "OCIArtifactPullFailed",
+					Message: "not found",
+				},
+			},
+			wantReady: false,
+			wantErr:   true,
+		},
+		{
+			name: "ready false with other reason keeps waiting",
+			conditions: []reconciler.Condition{
+				{Type: "Ready", Status: "False", Reason: "Progressing"},
+			},
+			wantReady: false,
+			wantErr:   false,
+		},
+		{
+			name: "non-ready condition type is skipped",
+			conditions: []reconciler.Condition{
+				{Type: "Stalled", Status: "True", Reason: "SomeReason"},
+			},
+			wantReady: false,
+			wantErr:   false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ready, err := flux.EvaluateOCIRepositoryConditions(testCase.conditions)
+
+			assert.Equal(t, testCase.wantReady, ready)
+
+			if testCase.wantErr {
+				require.ErrorIs(t, err, flux.ErrOCIRepositoryNotReady)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOCITimeoutError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil last error falls back to ErrOCIRepositoryNotReady", func(t *testing.T) {
+		t.Parallel()
+
+		err := flux.OCITimeoutError(nil)
+		require.ErrorIs(t, err, flux.ErrOCIRepositoryNotReady)
+	})
+
+	t.Run("non-nil last error is returned verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		err := flux.OCITimeoutError(errOCILastObserved)
+		require.ErrorIs(t, err, errOCILastObserved)
+	})
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds black-box unit coverage for three OCIRepository readiness helpers in `pkg/client/flux` that drive the `WaitForOCIRepositoryReady` poll loop and were previously at **0%** unit coverage (only exercised via live-cluster integration paths):

| Function | Before | After |
|---|---|---|
| `isPermanentOCIError` | 0% | 100% |
| `evaluateOCIRepositoryConditions` | 0% | 100% |
| `ociTimeoutError` | 0% | 100% |

## Why

These helpers encode the OCI-vs-transient failure classification that decides whether the poll loop keeps waiting or fails fast — exactly the logic a regression would silently break. They are pure/near-pure and trivially testable, yet sat uncovered because the surrounding `Wait*` flow needs a live cluster. Mirrors the existing transient-error-classifier coverage in `transient_test.go`.

## How

- Black-box tests via the package’s existing `export_test.go` idiom (no production code changed).
- Table-driven, `t.Parallel()`, err113-compliant static sentinels — consistent with `transient_test.go` / `reconciler_test.go`.
- Cases cover every branch: nil / k8s `NotFound`-transient / `manifest unknown` / `does not exist` / generic classification; `Ready=True`, `OCIPullFailed` & `OCIArtifactPullFailed` permanent failures, other non-ready waits, non-`Ready` condition skip, empty conditions; timeout fallback vs verbatim passthrough.

## Validation

- `go build` ✓ · `go test ./pkg/client/flux/` ✓ (193 pass) · `golangci-lint run ./pkg/client/flux/...` ✓ (no issues)
- Behaviour-preserving: test-only, additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for OCI error handling and repository condition evaluation.
  * Verified timeout handling, permanent vs. temporary failures, and readiness outcomes across multiple scenarios.
  * Expanded test support to expose a few internal OCI-related helpers for external test packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->