### PR TITLE
ci(dependabot): pin vsce npm registry to public via .npmrc

### DIFF
--- a/vsce/.npmrc
+++ b/vsce/.npmrc
@@ -1,0 +1,9 @@
+# Pin the default registry to public npm.
+#
+# Dependabot's `automatic-github-packages-auth` rollout auto-injects an
+# npm.pkg.github.com registry credential into npm jobs. Without a .npmrc (or an
+# explicit scope/replaces-base in dependabot.yaml) it aborts every npm update
+# run with `private_registry_config_not_found`, silently halting npm updates.
+# This package consumes only public packages, so declaring the public registry
+# resolves the ambiguity. See devantler-tech/.github#77.
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Implements **option 1** from devantler-tech/.github#77 (maintainer-chosen) for this repo's `vsce/` npm directory.

## Problem

Since **2026-06-26**, the `npm_and_yarn in /vsce` Dependabot job aborts before producing any PR:

```
Error during file fetching; aborting: Private npm registries require either a .npmrc
file in your repository, or explicit `scope`/`replaces-base` configuration in dependabot.yml.
Registry: npm.pkg.github.com
   → private_registry_config_not_found  { "source": "npm.pkg.github.com" }
```

Dependabot's `automatic-github-packages-auth` rollout auto-injects an `npm.pkg.github.com` registry credential (not declared in `dependabot.yaml`). With no `.npmrc` in `vsce/`, the job hard-fails — silently halting all npm updates (security advisories included) for the VS Code extension. Failing run: [28253594273](https://github.com/devantler-tech/ksail/actions/runs/28253594273). Root cause + org-wide scope: devantler-tech/.github#77.

## Fix

Add `vsce/.npmrc` pinning the default registry to public npm:

```
registry=https://registry.npmjs.org/
```

GitHub's first documented remedy ("a `.npmrc` file in your repository"). **Inert for resolution** — `vsce/` resolves only public packages, so installs/builds are unchanged. Verified locally: `npm config get registry` → `https://registry.npmjs.org/`.

**`docs/` is already covered** by its existing `docs/.npmrc` (the mere presence of a `.npmrc` satisfies Dependabot's remedy), so only `vsce/` needs this change.

## Validation

- `.npmrc` parsed by npm; registry resolves to public npm (unchanged default).
- Server-side confirmation comes from the next scheduled Dependabot run (post-merge): the `npm_and_yarn in /vsce` job should complete without `private_registry_config_not_found` and resume opening PRs.
