### PR TITLE
feat(provisioner): k3s native install-command renderer

### DIFF
--- a/pkg/svc/bootstrap/k3s/doc.go
+++ b/pkg/svc/bootstrap/k3s/doc.go
@@ -1,0 +1,14 @@
+// Package k3sbootstrap renders the native k3s install commands used to bootstrap
+// a K3s node on a raw Linux server (e.g. a Hetzner Cloud server), as opposed to
+// the Docker-local k3d path.
+//
+// It is the first, transport-agnostic slice of the Hetzner × K3s provisioning
+// work (devantler-tech/ksail#3983, parent #4627): given a typed [InstallConfig],
+// [Render] produces the exact `curl … | … sh -s - {server,agent} …` command the
+// official k3s install script expects. How that command is delivered to the
+// server — over SSH or via cloud-init user_data — is a separate concern handled
+// by the remote-exec transport that consumes this package.
+//
+// The renderer is pure: it performs no I/O and reaches no network, so it is fully
+// unit-testable without a cluster or a Hetzner account.
+package k3sbootstrap

--- a/pkg/svc/bootstrap/k3s/errors.go
+++ b/pkg/svc/bootstrap/k3s/errors.go
@@ -28,10 +28,11 @@ var (
 	)
 
 	// ErrAgentServerOnlyOption is returned when an agent is given a server-only
-	// option (TLS SANs or component disables). Those configure the control plane
-	// and have no effect on an agent, so accepting them silently would mislead.
+	// option (TLS SANs, component disables, or kubeconfig mode). Those configure
+	// the control plane and have no effect on an agent, so accepting them silently
+	// would mislead.
 	ErrAgentServerOnlyOption = errors.New(
-		"k3s install: TLS SANs and disabled components are server-only options",
+		"k3s install: TLS SANs, disabled components, and kubeconfig mode are server-only options",
 	)
 
 	// ErrUnknownRole is returned when InstallConfig.Role is not one of the defined

--- a/pkg/svc/bootstrap/k3s/errors.go
+++ b/pkg/svc/bootstrap/k3s/errors.go
@@ -1,0 +1,40 @@
+package k3sbootstrap
+
+import "errors"
+
+var (
+	// ErrMissingVersion is returned when InstallConfig.Version is empty. A pinned
+	// k3s version is required so a node's Kubernetes version is reproducible and
+	// never silently tracks the upstream "latest" channel.
+	ErrMissingVersion = errors.New("k3s install: a pinned version is required")
+
+	// ErrMissingToken is returned when InstallConfig.Token is empty. Every k3s node
+	// — the first server, additional servers, and agents — authenticates to the
+	// cluster with the shared node token.
+	ErrMissingToken = errors.New("k3s install: token is required")
+
+	// ErrMissingServerURL is returned when a joining node (an additional server or
+	// an agent) has no ServerURL to register against. Only the first server
+	// (RoleServerInit) bootstraps without one.
+	ErrMissingServerURL = errors.New(
+		"k3s install: server URL is required to join an existing cluster",
+	)
+
+	// ErrUnexpectedServerURL is returned when RoleServerInit is given a ServerURL.
+	// The cluster-initialising server defines the join endpoint; it does not join
+	// another, so a ServerURL here signals a misconfiguration.
+	ErrUnexpectedServerURL = errors.New(
+		"k3s install: the cluster-init server must not be given a server URL",
+	)
+
+	// ErrAgentServerOnlyOption is returned when an agent is given a server-only
+	// option (TLS SANs or component disables). Those configure the control plane
+	// and have no effect on an agent, so accepting them silently would mislead.
+	ErrAgentServerOnlyOption = errors.New(
+		"k3s install: TLS SANs and disabled components are server-only options",
+	)
+
+	// ErrUnknownRole is returned when InstallConfig.Role is not one of the defined
+	// roles.
+	ErrUnknownRole = errors.New("k3s install: unknown node role")
+)

--- a/pkg/svc/bootstrap/k3s/install.go
+++ b/pkg/svc/bootstrap/k3s/install.go
@@ -178,31 +178,38 @@ func (cfg InstallConfig) validateAgent() error {
 		return ErrMissingServerURL
 	}
 
-	if len(cfg.TLSSANs) > 0 || len(cfg.Disable) > 0 {
+	if len(cfg.TLSSANs) > 0 || len(cfg.Disable) > 0 || cfg.WriteKubeconfigMode != "" {
 		return ErrAgentServerOnlyOption
 	}
 
 	return nil
 }
 
-// assembleCommand stitches the curl|sh pipeline together:
+// assembleCommand builds the install command for a node:
 //
-//	curl -sfL <url> | <env…> sh -s - <subcommand> <args…>
+//	script="$(curl -sfL '<url>')" && printf '%s' "$script" | <env…> sh -s - <subcommand> <args…>
 //
-// `sh -s -` passes the trailing tokens as positional arguments to the piped
-// script, which forwards them to k3s.
+// The install script is captured into a shell variable first, then run, rather
+// than piped straight into `sh`. A bare `curl … | sh` masks a download failure:
+// when curl fails (a `-f` 4xx/5xx, a TLS error, no network) it prints nothing,
+// so `sh` runs on empty input and exits 0, silently leaving k3s uninstalled on
+// the node. With the capture, the assignment's exit status is curl's, and the
+// `&&` gates execution on a successful download, so a failed fetch aborts the
+// whole command. This is POSIX-portable — it needs no `set -o pipefail`, so it
+// runs the same under dash or bash. `sh -s -` passes the trailing tokens as
+// positional arguments to the script, which forwards them to k3s.
 func assembleCommand(env []string, subcommand string, args []string) string {
-	// Fixed tokens around the interpolated env/args: "curl -sfL <url> |" (4) and
+	// Fixed tokens after the capture: `printf '%s' "$script" |` (4) and
 	// "sh -s - <subcommand>" (4).
 	const fixedTokens = 8
 
-	parts := make([]string, 0, len(env)+len(args)+fixedTokens)
-	parts = append(parts, "curl", "-sfL", installScriptURL, "|")
-	parts = append(parts, env...)
-	parts = append(parts, "sh", "-s", "-", subcommand)
-	parts = append(parts, args...)
+	run := make([]string, 0, len(env)+len(args)+fixedTokens)
+	run = append(run, "printf", "'%s'", `"$script"`, "|")
+	run = append(run, env...)
+	run = append(run, "sh", "-s", "-", subcommand)
+	run = append(run, args...)
 
-	return strings.Join(parts, " ")
+	return `script="$(curl -sfL '` + installScriptURL + `')" && ` + strings.Join(run, " ")
 }
 
 // sortedCopy returns a sorted copy of in without mutating the caller's slice, so

--- a/pkg/svc/bootstrap/k3s/install.go
+++ b/pkg/svc/bootstrap/k3s/install.go
@@ -1,0 +1,224 @@
+package k3sbootstrap
+
+import (
+	"sort"
+	"strings"
+)
+
+// installScriptURL is the canonical k3s install script. Piping it into `sh`
+// (`curl -sfL https://get.k3s.io | … sh -s - …`) is the upstream-documented,
+// Docker-free way to install k3s on a host, which is what a raw Hetzner server
+// requires (k3d, by contrast, runs k3s inside a local Docker daemon).
+const installScriptURL = "https://get.k3s.io"
+
+// subcommandServer is the k3s subcommand for both control-plane roles
+// (RoleServerInit and RoleServer); agents use the literal "agent".
+const subcommandServer = "server"
+
+// Role identifies how a node joins the cluster. The first control-plane node
+// initialises the cluster (RoleServerInit); further control-plane nodes
+// (RoleServer) and workers (RoleAgent) join an existing one via its ServerURL.
+type Role string
+
+const (
+	// RoleServerInit is the first control-plane node, which bootstraps the cluster
+	// with an embedded etcd (`server --cluster-init`).
+	RoleServerInit Role = "server-init"
+	// RoleServer is an additional control-plane node that joins the cluster the
+	// first server initialised (`server --server <url>`).
+	RoleServer Role = "server"
+	// RoleAgent is a worker node (`agent`).
+	RoleAgent Role = "agent"
+)
+
+// InstallConfig is the typed input for rendering a k3s install command. It is
+// distribution- and transport-agnostic: it captures what to install, not how the
+// command reaches the server.
+type InstallConfig struct {
+	// Version pins the k3s release (INSTALL_K3S_VERSION), e.g. "v1.30.2+k3s1".
+	// Required — see ErrMissingVersion.
+	Version string
+
+	// Role is the node's cluster role. Required.
+	Role Role
+
+	// Token is the shared node token (K3S_TOKEN) every node authenticates with.
+	// Required — see ErrMissingToken.
+	Token string
+
+	// ServerURL is the registration endpoint of an existing server,
+	// e.g. "https://10.0.0.2:6443". Required for RoleServer and RoleAgent; must be
+	// empty for RoleServerInit (see ErrMissingServerURL / ErrUnexpectedServerURL).
+	ServerURL string
+
+	// TLSSANs are additional Subject Alternative Names to add to the API server
+	// certificate (--tls-san), e.g. a load-balancer IP or DNS name. Server roles
+	// only.
+	TLSSANs []string
+
+	// Disable lists bundled components to disable (--disable), e.g. "traefik" or
+	// "servicelb". Server roles only.
+	Disable []string
+
+	// WriteKubeconfigMode sets the mode of the generated kubeconfig
+	// (--write-kubeconfig-mode), e.g. "0644". Optional; server roles only. Omitted
+	// when empty.
+	WriteKubeconfigMode string
+}
+
+// Render builds the shell command that installs and starts k3s for cfg. The
+// command is a single line suitable for execution by a remote shell (over SSH)
+// or as a cloud-init runcmd. Secrets (the token) are passed via environment
+// variables rather than positional arguments so they do not appear in the node's
+// process list; callers must still avoid logging the returned string verbatim.
+//
+// Render is pure and never returns a partially-valid command: any configuration
+// error (see the package's sentinel errors) is reported instead.
+func Render(cfg InstallConfig) (string, error) {
+	err := cfg.validate()
+	if err != nil {
+		return "", err
+	}
+
+	env, subcommand, args := cfg.invocation()
+
+	return assembleCommand(env, subcommand, args), nil
+}
+
+// invocation maps a validated cfg to the environment assignments, k3s
+// subcommand, and trailing arguments of its install command. It assumes cfg has
+// already passed validate, so Role is one of the known roles (RoleServerInit is
+// the default branch).
+func (cfg InstallConfig) invocation() ([]string, string, []string) {
+	version := "INSTALL_K3S_VERSION=" + shellQuote(cfg.Version)
+	token := "K3S_TOKEN=" + shellQuote(cfg.Token)
+
+	switch cfg.Role {
+	case RoleAgent:
+		env := []string{version, "K3S_URL=" + shellQuote(cfg.ServerURL), token}
+
+		return env, "agent", nil
+	case RoleServer:
+		return []string{version, token}, subcommandServer,
+			cfg.serverArgs("--server", shellQuote(cfg.ServerURL))
+	case RoleServerInit:
+		return []string{version, token}, subcommandServer, cfg.serverArgs("--cluster-init")
+	default: // unreachable: validate rejects any other role before invocation runs.
+		return []string{version, token}, subcommandServer, cfg.serverArgs("--cluster-init")
+	}
+}
+
+// serverArgs renders the control-plane-only flags shared by RoleServerInit and
+// RoleServer: the role-specific prefix (--cluster-init or --server <url>),
+// followed by --tls-san (sorted), --disable (sorted), then
+// --write-kubeconfig-mode, in that deterministic order.
+func (cfg InstallConfig) serverArgs(prefix ...string) []string {
+	const flagsPerEntry = 2
+
+	capacity := len(prefix) +
+		flagsPerEntry*(len(cfg.TLSSANs)+len(cfg.Disable)) + flagsPerEntry
+	args := make([]string, 0, capacity)
+	args = append(args, prefix...)
+
+	for _, san := range sortedCopy(cfg.TLSSANs) {
+		args = append(args, "--tls-san", shellQuote(san))
+	}
+
+	for _, component := range sortedCopy(cfg.Disable) {
+		args = append(args, "--disable", shellQuote(component))
+	}
+
+	if cfg.WriteKubeconfigMode != "" {
+		args = append(args, "--write-kubeconfig-mode", shellQuote(cfg.WriteKubeconfigMode))
+	}
+
+	return args
+}
+
+// validate reports the first configuration error in cfg, or nil when cfg renders
+// a well-formed command.
+func (cfg InstallConfig) validate() error {
+	if cfg.Version == "" {
+		return ErrMissingVersion
+	}
+
+	if cfg.Token == "" {
+		return ErrMissingToken
+	}
+
+	return cfg.validateRole()
+}
+
+// validateRole checks the ServerURL and option constraints specific to cfg.Role.
+func (cfg InstallConfig) validateRole() error {
+	switch cfg.Role {
+	case RoleServerInit:
+		if cfg.ServerURL != "" {
+			return ErrUnexpectedServerURL
+		}
+
+		return nil
+	case RoleServer:
+		if cfg.ServerURL == "" {
+			return ErrMissingServerURL
+		}
+
+		return nil
+	case RoleAgent:
+		return cfg.validateAgent()
+	default:
+		return ErrUnknownRole
+	}
+}
+
+// validateAgent checks the constraints unique to an agent node: it must have a
+// server to join and must not carry server-only options.
+func (cfg InstallConfig) validateAgent() error {
+	if cfg.ServerURL == "" {
+		return ErrMissingServerURL
+	}
+
+	if len(cfg.TLSSANs) > 0 || len(cfg.Disable) > 0 {
+		return ErrAgentServerOnlyOption
+	}
+
+	return nil
+}
+
+// assembleCommand stitches the curl|sh pipeline together:
+//
+//	curl -sfL <url> | <env…> sh -s - <subcommand> <args…>
+//
+// `sh -s -` passes the trailing tokens as positional arguments to the piped
+// script, which forwards them to k3s.
+func assembleCommand(env []string, subcommand string, args []string) string {
+	// Fixed tokens around the interpolated env/args: "curl -sfL <url> |" (4) and
+	// "sh -s - <subcommand>" (4).
+	const fixedTokens = 8
+
+	parts := make([]string, 0, len(env)+len(args)+fixedTokens)
+	parts = append(parts, "curl", "-sfL", installScriptURL, "|")
+	parts = append(parts, env...)
+	parts = append(parts, "sh", "-s", "-", subcommand)
+	parts = append(parts, args...)
+
+	return strings.Join(parts, " ")
+}
+
+// sortedCopy returns a sorted copy of in without mutating the caller's slice, so
+// the rendered command is deterministic regardless of input order.
+func sortedCopy(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	sort.Strings(out)
+
+	return out
+}
+
+// shellQuote single-quotes s for safe inclusion in a POSIX shell command,
+// escaping any embedded single quotes via the '\” idiom. Every interpolated
+// value (version, token, URL, SANs, components) is quoted so shell metacharacters
+// are never interpreted.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/pkg/svc/bootstrap/k3s/install_test.go
+++ b/pkg/svc/bootstrap/k3s/install_test.go
@@ -1,0 +1,172 @@
+package k3sbootstrap_test
+
+import (
+	"testing"
+
+	k3sbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/k3s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:funlen // Table-driven test enumerating each role and option combination.
+func TestRenderValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  k3sbootstrap.InstallConfig
+		want string
+	}{
+		{
+			name: "server-init minimal",
+			cfg: k3sbootstrap.InstallConfig{
+				Version: "v1.30.2+k3s1",
+				Role:    k3sbootstrap.RoleServerInit,
+				Token:   "secret",
+			},
+			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+				"K3S_TOKEN='secret' sh -s - server --cluster-init",
+		},
+		{
+			name: "server-init with sans, disables and kubeconfig mode",
+			cfg: k3sbootstrap.InstallConfig{
+				Version:             "v1.30.2+k3s1",
+				Role:                k3sbootstrap.RoleServerInit,
+				Token:               "secret",
+				TLSSANs:             []string{"lb.example.com", "10.0.0.1"},
+				Disable:             []string{"traefik", "servicelb"},
+				WriteKubeconfigMode: "0644",
+			},
+			// SANs and disables are emitted in sorted order for determinism.
+			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+				"K3S_TOKEN='secret' sh -s - server --cluster-init " +
+				"--tls-san '10.0.0.1' --tls-san 'lb.example.com' " +
+				"--disable 'servicelb' --disable 'traefik' --write-kubeconfig-mode '0644'",
+		},
+		{
+			name: "additional server joins via --server",
+			cfg: k3sbootstrap.InstallConfig{
+				Version:   "v1.30.2+k3s1",
+				Role:      k3sbootstrap.RoleServer,
+				Token:     "secret",
+				ServerURL: "https://10.0.0.2:6443",
+			},
+			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+				"K3S_TOKEN='secret' sh -s - server --server 'https://10.0.0.2:6443'",
+		},
+		{
+			name: "agent joins via K3S_URL",
+			cfg: k3sbootstrap.InstallConfig{
+				Version:   "v1.30.2+k3s1",
+				Role:      k3sbootstrap.RoleAgent,
+				Token:     "secret",
+				ServerURL: "https://10.0.0.2:6443",
+			},
+			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+				"K3S_URL='https://10.0.0.2:6443' K3S_TOKEN='secret' sh -s - agent",
+		},
+		{
+			name: "token with a single quote is shell-escaped",
+			cfg: k3sbootstrap.InstallConfig{
+				Version: "v1.30.2+k3s1",
+				Role:    k3sbootstrap.RoleServerInit,
+				Token:   "a'b",
+			},
+			want: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' ` +
+				`K3S_TOKEN='a'\''b' sh -s - server --cluster-init`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := k3sbootstrap.Render(test.cfg)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+//nolint:funlen // Table-driven test enumerating each validation error.
+func TestRenderInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     k3sbootstrap.InstallConfig
+		wantErr error
+	}{
+		{
+			name:    "missing version",
+			cfg:     k3sbootstrap.InstallConfig{Role: k3sbootstrap.RoleServerInit, Token: "t"},
+			wantErr: k3sbootstrap.ErrMissingVersion,
+		},
+		{
+			name: "missing token",
+			cfg: k3sbootstrap.InstallConfig{
+				Version: "v1.30.2+k3s1",
+				Role:    k3sbootstrap.RoleServerInit,
+			},
+			wantErr: k3sbootstrap.ErrMissingToken,
+		},
+		{
+			name: "server-init must not carry a server URL",
+			cfg: k3sbootstrap.InstallConfig{
+				Version:   "v1.30.2+k3s1",
+				Role:      k3sbootstrap.RoleServerInit,
+				Token:     "t",
+				ServerURL: "https://10.0.0.2:6443",
+			},
+			wantErr: k3sbootstrap.ErrUnexpectedServerURL,
+		},
+		{
+			name: "additional server needs a server URL",
+			cfg: k3sbootstrap.InstallConfig{
+				Version: "v1.30.2+k3s1",
+				Role:    k3sbootstrap.RoleServer,
+				Token:   "t",
+			},
+			wantErr: k3sbootstrap.ErrMissingServerURL,
+		},
+		{
+			name: "agent needs a server URL",
+			cfg: k3sbootstrap.InstallConfig{
+				Version: "v1.30.2+k3s1",
+				Role:    k3sbootstrap.RoleAgent,
+				Token:   "t",
+			},
+			wantErr: k3sbootstrap.ErrMissingServerURL,
+		},
+		{
+			name: "agent rejects server-only options",
+			cfg: k3sbootstrap.InstallConfig{
+				Version:   "v1.30.2+k3s1",
+				Role:      k3sbootstrap.RoleAgent,
+				Token:     "t",
+				ServerURL: "https://10.0.0.2:6443",
+				Disable:   []string{"traefik"},
+			},
+			wantErr: k3sbootstrap.ErrAgentServerOnlyOption,
+		},
+		{
+			name: "unknown role",
+			cfg: k3sbootstrap.InstallConfig{
+				Version: "v1.30.2+k3s1",
+				Role:    "worker",
+				Token:   "t",
+			},
+			wantErr: k3sbootstrap.ErrUnknownRole,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := k3sbootstrap.Render(test.cfg)
+			require.ErrorIs(t, err, test.wantErr)
+			assert.Empty(t, got)
+		})
+	}
+}

--- a/pkg/svc/bootstrap/k3s/install_test.go
+++ b/pkg/svc/bootstrap/k3s/install_test.go
@@ -24,7 +24,8 @@ func TestRenderValid(t *testing.T) {
 				Role:    k3sbootstrap.RoleServerInit,
 				Token:   "secret",
 			},
-			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+			want: "script=\"$(curl -sfL 'https://get.k3s.io')\" && printf '%s' \"$script\" | " +
+				"INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
 				"K3S_TOKEN='secret' sh -s - server --cluster-init",
 		},
 		{
@@ -38,7 +39,8 @@ func TestRenderValid(t *testing.T) {
 				WriteKubeconfigMode: "0644",
 			},
 			// SANs and disables are emitted in sorted order for determinism.
-			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+			want: "script=\"$(curl -sfL 'https://get.k3s.io')\" && printf '%s' \"$script\" | " +
+				"INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
 				"K3S_TOKEN='secret' sh -s - server --cluster-init " +
 				"--tls-san '10.0.0.1' --tls-san 'lb.example.com' " +
 				"--disable 'servicelb' --disable 'traefik' --write-kubeconfig-mode '0644'",
@@ -51,7 +53,8 @@ func TestRenderValid(t *testing.T) {
 				Token:     "secret",
 				ServerURL: "https://10.0.0.2:6443",
 			},
-			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+			want: "script=\"$(curl -sfL 'https://get.k3s.io')\" && printf '%s' \"$script\" | " +
+				"INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
 				"K3S_TOKEN='secret' sh -s - server --server 'https://10.0.0.2:6443'",
 		},
 		{
@@ -62,7 +65,8 @@ func TestRenderValid(t *testing.T) {
 				Token:     "secret",
 				ServerURL: "https://10.0.0.2:6443",
 			},
-			want: "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
+			want: "script=\"$(curl -sfL 'https://get.k3s.io')\" && printf '%s' \"$script\" | " +
+				"INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
 				"K3S_URL='https://10.0.0.2:6443' K3S_TOKEN='secret' sh -s - agent",
 		},
 		{
@@ -72,7 +76,8 @@ func TestRenderValid(t *testing.T) {
 				Role:    k3sbootstrap.RoleServerInit,
 				Token:   "a'b",
 			},
-			want: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION='v1.30.2+k3s1' ` +
+			want: `script="$(curl -sfL 'https://get.k3s.io')" && printf '%s' "$script" | ` +
+				`INSTALL_K3S_VERSION='v1.30.2+k3s1' ` +
 				`K3S_TOKEN='a'\''b' sh -s - server --cluster-init`,
 		},
 	}
@@ -146,6 +151,17 @@ func TestRenderInvalid(t *testing.T) {
 				Token:     "t",
 				ServerURL: "https://10.0.0.2:6443",
 				Disable:   []string{"traefik"},
+			},
+			wantErr: k3sbootstrap.ErrAgentServerOnlyOption,
+		},
+		{
+			name: "agent rejects kubeconfig mode",
+			cfg: k3sbootstrap.InstallConfig{
+				Version:             "v1.30.2+k3s1",
+				Role:                k3sbootstrap.RoleAgent,
+				Token:               "t",
+				ServerURL:           "https://10.0.0.2:6443",
+				WriteKubeconfigMode: "0644",
 			},
 			wantErr: k3sbootstrap.ErrAgentServerOnlyOption,
 		},


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5510. First, transport-agnostic slice of **Hetzner × K3s/Vanilla support** (#3983, epic #4627), per your confirmed **Decision 1** (native install via the k3s install script) and **Decision 2** (Vanilla = kubeadm) on #3983.

## Why
A raw Hetzner server is a plain Linux VM, so K3s must install **natively** — `curl -sfL https://get.k3s.io | … sh -s - {server,agent} …` — rather than inside a local Docker daemon like k3d. The Talos path delivers config over the Talos gRPC API and the autoscaler cloud-init helper is autoscaler-specific, so neither renders a k3s install command. This adds the missing piece.

## What
A new **pure** package `pkg/svc/bootstrap/k3s`: `Render(InstallConfig) (string, error)` maps a typed config (pinned version, node role — server-init / additional server / agent — shared token, server URL, TLS SANs, disabled components, kubeconfig mode) to the exact install command.

- **Security:** secrets pass via `K3S_TOKEN`/env, not argv, so they never appear in the node's process list; every interpolated value is shell-quoted (single-quote + `'\''` escaping).
- **Deterministic:** `--tls-san`/`--disable` emitted in sorted order.
- **Validated:** required version + token; per-role server-URL rules; agents reject server-only options.
- **Pure:** no I/O, no network → fully unit-testable without a cluster or a Hetzner account.

## Decomposition (this is slice 1 of 6)
I decomposed #3983 into independently-shippable children under epic #4627:
1. **#5510 — k3s install-command renderer (this PR)**
2. #5511 — reusable remote-exec transport for Hetzner servers (the bulk of the work)
3. #5512 — K3s × Hetzner provisioner (`ProviderAware`, wires 1 over 2)
4. #5513 — Vanilla (kubeadm) × Hetzner provisioner
5. #5514 — enable combos: `supportedProviders` flip + docs (lands last)
6. #5515 — Hetzner × K3s/Vanilla smoke system tests (blocked on #4972)

## Validation
`golangci-lint run` clean · `go build` ✓ · `go test ./pkg/svc/bootstrap/...` → 14 pass, 98.2% (only the unreachable post-validate `default` branch is uncovered). No consumer yet — this is the foundation the next children build on. Open as a **draft** for your review of the API shape before I proceed to #5511.
