### PR TITLE
feat(provisioner): cloud-init user_data transport for native bootstrap

### DIFF
--- a/pkg/svc/bootstrap/cloudinit/cloudinit.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit.go
@@ -18,7 +18,7 @@ const (
 	// header is the literal first line cloud-init requires to recognise a payload
 	// as a cloud-config document; it must be the very first bytes of user_data.
 	header = "#cloud-config\n"
-	// scriptShebang and scriptPreamble open the generated boot script. `set -eu`
+	// scriptShebang and scriptSetFlags open the generated boot script. `set -eu`
 	// aborts on the first failing command or unset variable, and the `exec`
 	// redirect sends every subsequent line's stdout and stderr to the log without
 	// masking the script's exit code (unlike a trailing `| tee`).
@@ -146,15 +146,26 @@ func (cfg Config) validatedCommands() ([]string, error) {
 
 // buildScript assembles the POSIX boot script: a shebang, strict-mode flags, an
 // exec redirect that captures all output to logPath, then each command on its
-// own line.
+// own line. logPath is shell-quoted because it is the one config value spliced
+// into a shell context: an absolute-path check alone would still let a path with
+// a space break the redirect, or a crafted `/var/log/x; cmd` change the script's
+// behaviour. (scriptPath needs no quoting — it only ever appears as a YAML
+// scalar and a runcmd argv element, never inside a shell string.)
 func buildScript(logPath string, commands []string) string {
 	lines := make([]string, 0, len(commands)+3) //nolint:mnd // shebang + flags + exec redirect
 	lines = append(lines,
 		scriptShebang,
 		scriptSetFlags,
-		"exec >> "+logPath+" 2>&1",
+		"exec >> "+shellQuote(logPath)+" 2>&1",
 	)
 	lines = append(lines, commands...)
 
 	return strings.Join(lines, "\n") + "\n"
+}
+
+// shellQuote single-quotes s for safe inclusion in a POSIX shell command,
+// escaping any embedded single quote via the '\” idiom, so shell
+// metacharacters in the value are never interpreted.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/pkg/svc/bootstrap/cloudinit/cloudinit.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit.go
@@ -1,0 +1,160 @@
+package cloudinitbootstrap
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DefaultScriptPath is where the generated bootstrap script is written on the
+	// server when Config.ScriptPath is empty.
+	DefaultScriptPath = "/var/lib/ksail/bootstrap.sh"
+	// DefaultLogPath is where the bootstrap script's combined output is captured on
+	// the server when Config.LogPath is empty.
+	DefaultLogPath = "/var/log/ksail-bootstrap.log"
+
+	// header is the literal first line cloud-init requires to recognise a payload
+	// as a cloud-config document; it must be the very first bytes of user_data.
+	header = "#cloud-config\n"
+	// scriptShebang and scriptPreamble open the generated boot script. `set -eu`
+	// aborts on the first failing command or unset variable, and the `exec`
+	// redirect sends every subsequent line's stdout and stderr to the log without
+	// masking the script's exit code (unlike a trailing `| tee`).
+	scriptShebang  = "#!/bin/sh"
+	scriptSetFlags = "set -eu"
+)
+
+// Config is the typed input for [BuildUserData]. It captures what to run at first
+// boot and where the boot script and its log live; it does not perform any I/O.
+type Config struct {
+	// Commands are the shell commands run, in order, once at first boot. At least
+	// one non-empty command is required (see [ErrNoCommands]); each must be a single
+	// line with no NUL byte (see [ErrInvalidCommand]).
+	Commands []string
+	// ScriptPath overrides where the boot script is written. Optional; defaults to
+	// [DefaultScriptPath]. Must be absolute when set (see [ErrPathNotAbsolute]).
+	ScriptPath string
+	// LogPath overrides where the boot script's combined output is captured.
+	// Optional; defaults to [DefaultLogPath]. Must be absolute when set (see
+	// [ErrPathNotAbsolute]).
+	LogPath string
+}
+
+// cloudConfig is the subset of the cloud-init schema this package emits. It is
+// marshalled to YAML and prefixed with the `#cloud-config` header.
+type cloudConfig struct {
+	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key "write_files".
+	WriteFiles []writeFile `yaml:"write_files"`
+	RunCmd     [][]string  `yaml:"runcmd"`
+}
+
+// writeFile is one entry of cloud-init's write_files module: a file dropped onto
+// the server before runcmd executes.
+type writeFile struct {
+	Path        string `yaml:"path"`
+	Permissions string `yaml:"permissions"`
+	Content     string `yaml:"content"`
+}
+
+// BuildUserData renders cfg into a cloud-init user_data document. The returned
+// string is a complete `#cloud-config` payload suitable for
+// CreateServerOpts.UserData: it writes a boot script containing cfg.Commands and
+// runs it once at first boot, capturing all output to the log path.
+//
+// BuildUserData is pure and never returns a partially-valid document: any
+// configuration error (see the package's sentinel errors) is reported instead.
+func BuildUserData(cfg Config) (string, error) {
+	scriptPath, logPath, err := cfg.resolvePaths()
+	if err != nil {
+		return "", err
+	}
+
+	commands, err := cfg.validatedCommands()
+	if err != nil {
+		return "", err
+	}
+
+	doc := cloudConfig{
+		WriteFiles: []writeFile{{
+			Path:        scriptPath,
+			Permissions: "0700",
+			Content:     buildScript(logPath, commands),
+		}},
+		// argv form (not a shell string) so cloud-init runs the script directly and
+		// preserves its exit code; the script itself supplies the shell.
+		RunCmd: [][]string{{"/bin/sh", scriptPath}},
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		// Unreachable in practice: cloudConfig is a fixed struct of strings, which
+		// yaml.Marshal cannot fail to encode. Surfaced rather than dropped so a
+		// future schema change that breaks this is not silently ignored.
+		return "", fmt.Errorf("marshalling cloud-config: %w", err)
+	}
+
+	return header + string(out), nil
+}
+
+// resolvePaths returns the effective script and log paths, applying the defaults
+// for empty fields and rejecting any non-absolute override.
+func (cfg Config) resolvePaths() (string, string, error) {
+	scriptPath := cfg.ScriptPath
+	if scriptPath == "" {
+		scriptPath = DefaultScriptPath
+	}
+
+	logPath := cfg.LogPath
+	if logPath == "" {
+		logPath = DefaultLogPath
+	}
+
+	if !strings.HasPrefix(scriptPath, "/") || !strings.HasPrefix(logPath, "/") {
+		return "", "", ErrPathNotAbsolute
+	}
+
+	return scriptPath, logPath, nil
+}
+
+// validatedCommands returns the non-empty commands of cfg in order, rejecting a
+// configuration with no runnable command or with a command that is not a single
+// line. Empty or whitespace-only commands are dropped so a stray "" in the input
+// does not emit a blank script line.
+func (cfg Config) validatedCommands() ([]string, error) {
+	commands := make([]string, 0, len(cfg.Commands))
+
+	for _, command := range cfg.Commands {
+		if strings.ContainsAny(command, "\n\x00") {
+			return nil, ErrInvalidCommand
+		}
+
+		if strings.TrimSpace(command) == "" {
+			continue
+		}
+
+		commands = append(commands, command)
+	}
+
+	if len(commands) == 0 {
+		return nil, ErrNoCommands
+	}
+
+	return commands, nil
+}
+
+// buildScript assembles the POSIX boot script: a shebang, strict-mode flags, an
+// exec redirect that captures all output to logPath, then each command on its
+// own line.
+func buildScript(logPath string, commands []string) string {
+	lines := make([]string, 0, len(commands)+3) //nolint:mnd // shebang + flags + exec redirect
+	lines = append(lines,
+		scriptShebang,
+		scriptSetFlags,
+		"exec >> "+logPath+" 2>&1",
+	)
+	lines = append(lines, commands...)
+
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
@@ -57,11 +57,12 @@ func TestBuildUserDataDefaults(t *testing.T) {
 	// preserved by cloud-init.
 	assert.Equal(t, [][]string{{"/bin/sh", cloudinitbootstrap.DefaultScriptPath}}, cfg.RunCmd)
 
-	// Strict mode + an exec redirect to the default log, then the commands in order.
+	// Strict mode + an exec redirect to the (shell-quoted) default log, then the
+	// commands in order.
 	assert.Equal(t,
 		"#!/bin/sh\n"+
 			"set -eu\n"+
-			"exec >> "+cloudinitbootstrap.DefaultLogPath+" 2>&1\n"+
+			"exec >> '"+cloudinitbootstrap.DefaultLogPath+"' 2>&1\n"+
 			"echo first\n"+
 			"echo second\n",
 		file.Content,
@@ -83,7 +84,29 @@ func TestBuildUserDataCustomPaths(t *testing.T) {
 	require.Len(t, cfg.WriteFiles, 1)
 	assert.Equal(t, "/opt/ksail/boot.sh", cfg.WriteFiles[0].Path)
 	assert.Equal(t, [][]string{{"/bin/sh", "/opt/ksail/boot.sh"}}, cfg.RunCmd)
-	assert.Contains(t, cfg.WriteFiles[0].Content, "exec >> /var/log/custom.log 2>&1\n")
+	assert.Contains(t, cfg.WriteFiles[0].Content, "exec >> '/var/log/custom.log' 2>&1\n")
+}
+
+func TestBuildUserDataQuotesLogPath(t *testing.T) {
+	t.Parallel()
+
+	// A log path with shell metacharacters (a space, and an injection attempt) must
+	// be neutralised by quoting: it stays a single literal redirect target and
+	// cannot break the redirect or run an extra command at first boot.
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"echo hi"},
+		LogPath:  "/var/log/x; touch /tmp/pwned",
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	require.Len(t, cfg.WriteFiles, 1)
+	assert.Contains(t,
+		cfg.WriteFiles[0].Content,
+		"exec >> '/var/log/x; touch /tmp/pwned' 2>&1\n",
+	)
+	assert.NotContains(t, cfg.WriteFiles[0].Content, "touch /tmp/pwned\n")
 }
 
 func TestBuildUserDataDropsBlankCommands(t *testing.T) {
@@ -101,7 +124,7 @@ func TestBuildUserDataDropsBlankCommands(t *testing.T) {
 	assert.Equal(t,
 		"#!/bin/sh\n"+
 			"set -eu\n"+
-			"exec >> "+cloudinitbootstrap.DefaultLogPath+" 2>&1\n"+
+			"exec >> '"+cloudinitbootstrap.DefaultLogPath+"' 2>&1\n"+
 			"echo kept\n",
 		cfg.WriteFiles[0].Content,
 	)

--- a/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
@@ -1,0 +1,203 @@
+package cloudinitbootstrap_test
+
+import (
+	"strings"
+	"testing"
+
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// parsedConfig mirrors the cloud-config subset BuildUserData emits, so tests can
+// assert on the parsed document rather than on brittle substrings.
+type parsedConfig struct {
+	WriteFiles []struct {
+		Path        string `yaml:"path"`
+		Permissions string `yaml:"permissions"`
+		Content     string `yaml:"content"`
+	} `yaml:"write_files"` //nolint:tagliatelle // cloud-init's schema mandates the snake_case key.
+	RunCmd [][]string `yaml:"runcmd"`
+}
+
+// parse asserts the document carries the cloud-config header and is valid YAML,
+// returning the decoded subset.
+func parse(t *testing.T, userData string) parsedConfig {
+	t.Helper()
+
+	require.True(t,
+		strings.HasPrefix(userData, "#cloud-config\n"),
+		"user_data must begin with the #cloud-config header",
+	)
+
+	var cfg parsedConfig
+
+	require.NoError(t, yaml.Unmarshal([]byte(userData), &cfg), "user_data must be valid YAML")
+
+	return cfg
+}
+
+func TestBuildUserDataDefaults(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"echo first", "echo second"},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	require.Len(t, cfg.WriteFiles, 1)
+	file := cfg.WriteFiles[0]
+	assert.Equal(t, cloudinitbootstrap.DefaultScriptPath, file.Path)
+	assert.Equal(t, "0700", file.Permissions)
+
+	// The script runs the bootstrap directly (argv form) so its exit code is
+	// preserved by cloud-init.
+	assert.Equal(t, [][]string{{"/bin/sh", cloudinitbootstrap.DefaultScriptPath}}, cfg.RunCmd)
+
+	// Strict mode + an exec redirect to the default log, then the commands in order.
+	assert.Equal(t,
+		"#!/bin/sh\n"+
+			"set -eu\n"+
+			"exec >> "+cloudinitbootstrap.DefaultLogPath+" 2>&1\n"+
+			"echo first\n"+
+			"echo second\n",
+		file.Content,
+	)
+}
+
+func TestBuildUserDataCustomPaths(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands:   []string{"echo hi"},
+		ScriptPath: "/opt/ksail/boot.sh",
+		LogPath:    "/var/log/custom.log",
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	require.Len(t, cfg.WriteFiles, 1)
+	assert.Equal(t, "/opt/ksail/boot.sh", cfg.WriteFiles[0].Path)
+	assert.Equal(t, [][]string{{"/bin/sh", "/opt/ksail/boot.sh"}}, cfg.RunCmd)
+	assert.Contains(t, cfg.WriteFiles[0].Content, "exec >> /var/log/custom.log 2>&1\n")
+}
+
+func TestBuildUserDataDropsBlankCommands(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"", "echo kept", "   ", "\t"},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	require.Len(t, cfg.WriteFiles, 1)
+	// Only the one non-blank command survives; no empty script lines are emitted.
+	assert.Equal(t,
+		"#!/bin/sh\n"+
+			"set -eu\n"+
+			"exec >> "+cloudinitbootstrap.DefaultLogPath+" 2>&1\n"+
+			"echo kept\n",
+		cfg.WriteFiles[0].Content,
+	)
+}
+
+func TestBuildUserDataPreservesShellMetacharacters(t *testing.T) {
+	t.Parallel()
+
+	// A realistic k3s install command (pipes, quotes, env assignment) must survive
+	// YAML round-tripping byte-for-byte.
+	command := "script=\"$(curl -sfL 'https://get.k3s.io')\" && printf '%s' \"$script\" | " +
+		"INSTALL_K3S_VERSION='v1.30.2+k3s1' K3S_TOKEN='secret' sh -s - server --cluster-init"
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{command},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	require.Len(t, cfg.WriteFiles, 1)
+	assert.Contains(t, cfg.WriteFiles[0].Content, "\n"+command+"\n")
+}
+
+func TestBuildUserDataDeterministic(t *testing.T) {
+	t.Parallel()
+
+	cfg := cloudinitbootstrap.Config{Commands: []string{"echo a", "echo b", "echo c"}}
+
+	first, err := cloudinitbootstrap.BuildUserData(cfg)
+	require.NoError(t, err)
+
+	second, err := cloudinitbootstrap.BuildUserData(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+}
+
+func TestBuildUserDataErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     cloudinitbootstrap.Config
+		wantErr error
+	}{
+		{
+			name:    "no commands",
+			cfg:     cloudinitbootstrap.Config{},
+			wantErr: cloudinitbootstrap.ErrNoCommands,
+		},
+		{
+			name:    "only blank commands",
+			cfg:     cloudinitbootstrap.Config{Commands: []string{"", "  ", "\t\n"}},
+			wantErr: cloudinitbootstrap.ErrInvalidCommand, // the "\t\n" newline is rejected first
+		},
+		{
+			name:    "all-whitespace without newline",
+			cfg:     cloudinitbootstrap.Config{Commands: []string{"", "   "}},
+			wantErr: cloudinitbootstrap.ErrNoCommands,
+		},
+		{
+			name:    "command with embedded newline",
+			cfg:     cloudinitbootstrap.Config{Commands: []string{"echo a\necho b"}},
+			wantErr: cloudinitbootstrap.ErrInvalidCommand,
+		},
+		{
+			name:    "command with NUL byte",
+			cfg:     cloudinitbootstrap.Config{Commands: []string{"echo \x00"}},
+			wantErr: cloudinitbootstrap.ErrInvalidCommand,
+		},
+		{
+			name: "relative script path",
+			cfg: cloudinitbootstrap.Config{
+				Commands:   []string{"echo hi"},
+				ScriptPath: "relative/boot.sh",
+			},
+			wantErr: cloudinitbootstrap.ErrPathNotAbsolute,
+		},
+		{
+			name: "relative log path",
+			cfg: cloudinitbootstrap.Config{
+				Commands: []string{"echo hi"},
+				LogPath:  "relative.log",
+			},
+			wantErr: cloudinitbootstrap.ErrPathNotAbsolute,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := cloudinitbootstrap.BuildUserData(testCase.cfg)
+			require.ErrorIs(t, err, testCase.wantErr)
+			assert.Empty(t, out, "no document should be returned on error")
+		})
+	}
+}

--- a/pkg/svc/bootstrap/cloudinit/doc.go
+++ b/pkg/svc/bootstrap/cloudinit/doc.go
@@ -1,0 +1,27 @@
+// Package cloudinitbootstrap builds the cloud-init user_data that delivers a
+// node's bootstrap commands to a raw Linux server (e.g. a Hetzner Cloud server)
+// so they run once at first boot — for example the native k3s install command
+// rendered by the sibling k3sbootstrap package.
+//
+// It is the provision-time delivery slice of the Hetzner × K3s/Vanilla
+// provisioning work (devantler-tech/ksail#3983, parent #4627, slice #5511): a
+// raw server has no Docker daemon to install into, so the bootstrap command must
+// reach it some other way. Baking it into the server's cloud-init user_data is
+// the simplest such transport — it needs no SSH key handling or post-provision
+// connection, and it composes with provisioner-level sequencing (create the
+// cluster-init server, wait for its API, then create the joining nodes whose
+// own user_data registers against it).
+//
+// [BuildUserData] is the pure builder; [Transport] wraps it as the
+// [UserDataProvider] seam the K3s × Hetzner provisioner (#5512) depends on. A
+// future SSH transport that executes on an already-running server is a separate,
+// post-provision concern (its dial path is integration-tested behind the Hetzner
+// system-test lane, #4972).
+//
+// Everything here is pure: it performs no I/O and reaches no network, so it is
+// fully unit-testable without a cluster or a Hetzner account. Note that
+// cloud-init user_data is readable by anyone holding the Hetzner API token, so a
+// secret embedded in a bootstrap command (such as the k3s node token) is exposed
+// to that audience; that is inherent to user_data delivery, not a property of
+// this package.
+package cloudinitbootstrap

--- a/pkg/svc/bootstrap/cloudinit/errors.go
+++ b/pkg/svc/bootstrap/cloudinit/errors.go
@@ -1,0 +1,26 @@
+package cloudinitbootstrap
+
+import "errors"
+
+var (
+	// ErrNoCommands is returned when a Config carries no non-empty bootstrap
+	// command. A user_data document with nothing to run would create a server that
+	// silently never bootstraps, so an empty command set is rejected rather than
+	// rendered.
+	ErrNoCommands = errors.New("cloud-init: at least one bootstrap command is required")
+
+	// ErrInvalidCommand is returned when a bootstrap command contains a newline or
+	// a NUL byte. Each command is written as one line of the generated boot script,
+	// so an embedded newline would split it into separate (and likely malformed)
+	// statements; a NUL byte cannot appear in a shell script at all. Callers that
+	// need multiple statements pass them as separate commands.
+	ErrInvalidCommand = errors.New(
+		"cloud-init: a bootstrap command must be a single line with no NUL byte",
+	)
+
+	// ErrPathNotAbsolute is returned when ScriptPath or LogPath is set to a
+	// relative path. cloud-init resolves write_files and runcmd paths on the server
+	// with no defined working directory, so both must be absolute to be
+	// deterministic.
+	ErrPathNotAbsolute = errors.New("cloud-init: ScriptPath and LogPath must be absolute paths")
+)

--- a/pkg/svc/bootstrap/cloudinit/transport.go
+++ b/pkg/svc/bootstrap/cloudinit/transport.go
@@ -1,0 +1,50 @@
+package cloudinitbootstrap
+
+// UserDataProvider produces the cloud-init user_data that delivers a node's
+// bootstrap commands at first boot. It is the provision-time delivery seam the
+// K3s × Hetzner provisioner (devantler-tech/ksail#5512) depends on: the
+// provisioner asks for the user_data, then passes it to
+// hetzner.CreateServerOpts.UserData when creating each node.
+//
+// It is deliberately scoped to provision-time delivery. A transport that runs on
+// an already-running server (e.g. over SSH) is a separate, post-provision seam —
+// its dial path is integration-tested behind the Hetzner system-test lane (#4972)
+// — so it is not folded into this interface.
+type UserDataProvider interface {
+	// UserData returns the cloud-init user_data that runs commands once at first
+	// boot, or an error if commands is not a valid command set.
+	UserData(commands []string) (string, error)
+}
+
+// Transport is the cloud-init implementation of [UserDataProvider]. The zero
+// value is usable and applies [DefaultScriptPath] and [DefaultLogPath]; [New]
+// returns it for explicit construction.
+type Transport struct {
+	// ScriptPath overrides where the boot script is written. Optional; defaults to
+	// [DefaultScriptPath].
+	ScriptPath string
+	// LogPath overrides where the boot script's output is captured. Optional;
+	// defaults to [DefaultLogPath].
+	LogPath string
+}
+
+// New returns a cloud-init [Transport] using the default script and log paths.
+func New() *Transport {
+	return &Transport{}
+}
+
+// UserData renders commands into a cloud-init user_data document, honouring the
+// transport's script and log paths. It is pure and reaches no network, so the
+// command-construction it performs is fully unit-testable; the document it
+// returns is consumed by the provisioner at server-creation time.
+func (t *Transport) UserData(commands []string) (string, error) {
+	return BuildUserData(Config{
+		Commands:   commands,
+		ScriptPath: t.ScriptPath,
+		LogPath:    t.LogPath,
+	})
+}
+
+// staticUserDataProviderCheck asserts at compile time that Transport satisfies
+// UserDataProvider.
+var _ UserDataProvider = (*Transport)(nil)

--- a/pkg/svc/bootstrap/cloudinit/transport_test.go
+++ b/pkg/svc/bootstrap/cloudinit/transport_test.go
@@ -1,0 +1,63 @@
+package cloudinitbootstrap_test
+
+import (
+	"testing"
+
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportUserDataMatchesBuilder(t *testing.T) {
+	t.Parallel()
+
+	commands := []string{"echo hi", "echo bye"}
+
+	got, err := cloudinitbootstrap.New().UserData(commands)
+	require.NoError(t, err)
+
+	want, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{Commands: commands})
+	require.NoError(t, err)
+
+	// New() applies the default paths, so the transport and the bare builder agree.
+	assert.Equal(t, want, got)
+}
+
+func TestTransportUserDataHonoursPaths(t *testing.T) {
+	t.Parallel()
+
+	transport := &cloudinitbootstrap.Transport{
+		ScriptPath: "/opt/ksail/boot.sh",
+		LogPath:    "/var/log/custom.log",
+	}
+
+	got, err := transport.UserData([]string{"echo hi"})
+	require.NoError(t, err)
+
+	want, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands:   []string{"echo hi"},
+		ScriptPath: "/opt/ksail/boot.sh",
+		LogPath:    "/var/log/custom.log",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, want, got)
+}
+
+func TestTransportUserDataPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	out, err := cloudinitbootstrap.New().UserData(nil)
+	require.ErrorIs(t, err, cloudinitbootstrap.ErrNoCommands)
+	assert.Empty(t, out)
+}
+
+func TestTransportSatisfiesUserDataProvider(t *testing.T) {
+	t.Parallel()
+
+	var provider cloudinitbootstrap.UserDataProvider = cloudinitbootstrap.New()
+
+	out, err := provider.UserData([]string{"echo hi"})
+	require.NoError(t, err)
+	assert.Contains(t, out, "#cloud-config")
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Slice 2 (part 1) of the Hetzner × K3s/Vanilla campaign — refs #5511, child of #3983 (epic #4627). Sequenced after the native install renderer (#5510 / draft #5516).

## Why
A raw Hetzner server is a plain Linux VM with no Docker daemon to install K3s/Vanilla into. Per the maintainer's confirmed **Decision 1 (native install)** on #3983, the install command rendered by the sibling `k3sbootstrap` package must actually *reach* each server. #5511 (the remote-exec transport) is "the bulk of the work"; this PR lands its **pure, provision-time delivery core**: baking the bootstrap command into the server's cloud-init `user_data`.

Cloud-init is the simplest transport — no SSH key handling, no post-provision connection — and it composes with provisioner-level sequencing (create the cluster-init server → wait for its API → create joining nodes whose own `user_data` registers against it).

## What
New package `pkg/svc/bootstrap/cloudinit`:

- **`BuildUserData(Config) (string, error)`** — renders a typed config into a complete `#cloud-config` document. It writes a strict-mode (`set -eu`) boot script whose `exec` redirect captures all output to a log **without masking the script's exit code** (unlike a trailing `| tee`), and runs it once at first boot via a `runcmd` **argv** entry so cloud-init preserves the exit status.
- **`Transport`** — wraps the builder as the **`UserDataProvider`** seam the K3s × Hetzner provisioner (#5512) will consume, passing the result to `hetzner.CreateServerOpts.UserData` (which already accepts a raw `UserData` string).
- Validation via sentinel errors: at least one non-empty command (`ErrNoCommands`), single-line/no-NUL commands (`ErrInvalidCommand`), absolute script/log paths (`ErrPathNotAbsolute`); blank/whitespace commands are dropped.

The document is produced by marshalling a typed struct with `gopkg.in/yaml.v3` (already a direct dependency) rather than hand-building fragile block scalars, so arbitrary shell metacharacters in a command (the realistic `curl … | … sh` install line, with pipes/quotes/env) survive **byte-for-byte**.

## Scope / what's deliberately *not* here
- **Pure only** — no I/O, no network → fully unit-testable without a cluster or a Hetzner account.
- This is the cloud-init delivery seam. The **SSH-exec transport** that runs on an *already-running* server (wait-for-ready → exec → stream) is a separate, post-provision concern; its dial path is the **integration path gated behind the Hetzner system-test lane (#4972)** per #5511's acceptance criteria, so it is not in this PR.
- Independent of #5516's still-unreviewed `InstallConfig` API: this transport takes a plain command **string**, so it rests only on Decision 1, not on that PR's shape. Hence it does **not** `Fixes #5511` — it advances it.

## Security note
cloud-init `user_data` is readable by anyone holding the Hetzner API token, so a secret embedded in a bootstrap command (e.g. the k3s node token) is exposed to that audience. That is inherent to `user_data` delivery, not a property of this package, and is documented in the package doc.

## Tests
17 unit tests (`go test ./pkg/svc/bootstrap/cloudinit/...` → pass; lint clean; full module builds). They **parse the emitted YAML back** to assert structure (rather than brittle substrings), and cover: defaults + custom paths, the exact boot-script content, the `runcmd` argv form, every validation error, blank-command dropping, shell-metacharacter round-tripping, and determinism.