### PR TITLE
feat(bootstrap): plan k3s install configs from a cluster topology

### DIFF
--- a/pkg/svc/bootstrap/k3s/doc.go
+++ b/pkg/svc/bootstrap/k3s/doc.go
@@ -5,10 +5,13 @@
 // It is the first, transport-agnostic slice of the Hetzner × K3s provisioning
 // work (devantler-tech/ksail#3983, parent #4627): given a typed [InstallConfig],
 // [Render] produces the exact `curl … | … sh -s - {server,agent} …` command the
-// official k3s install script expects. How that command is delivered to the
-// server — over SSH or via cloud-init user_data — is a separate concern handled
-// by the remote-exec transport that consumes this package.
+// official k3s install script expects. [Plan] sits one level up, expanding a
+// cluster topology ([PlanInput]) into the ordered per-node [InstallConfig]s a
+// provisioner bootstraps in sequence (server-init → additional servers →
+// agents). How a rendered command is delivered to the server — over SSH or via
+// cloud-init user_data — is a separate concern handled by the remote-exec
+// transport that consumes this package.
 //
-// The renderer is pure: it performs no I/O and reaches no network, so it is fully
-// unit-testable without a cluster or a Hetzner account.
+// Both the renderer and the planner are pure: they perform no I/O and reach no
+// network, so they are fully unit-testable without a cluster or a Hetzner account.
 package k3sbootstrap

--- a/pkg/svc/bootstrap/k3s/errors.go
+++ b/pkg/svc/bootstrap/k3s/errors.go
@@ -38,4 +38,16 @@ var (
 	// ErrUnknownRole is returned when InstallConfig.Role is not one of the defined
 	// roles.
 	ErrUnknownRole = errors.New("k3s install: unknown node role")
+
+	// ErrInvalidControlPlaneCount is returned by Plan when PlanInput.ControlPlaneCount
+	// is less than one. Every K3s cluster needs at least one control-plane node (the
+	// cluster-initialising server), so a count below one cannot describe a cluster.
+	ErrInvalidControlPlaneCount = errors.New(
+		"k3s plan: control-plane count must be at least one",
+	)
+
+	// ErrInvalidAgentCount is returned by Plan when PlanInput.AgentCount is negative.
+	// A cluster may have zero agents (control-plane nodes are schedulable), but a
+	// negative count is meaningless.
+	ErrInvalidAgentCount = errors.New("k3s plan: agent count must not be negative")
 )

--- a/pkg/svc/bootstrap/k3s/plan.go
+++ b/pkg/svc/bootstrap/k3s/plan.go
@@ -1,5 +1,7 @@
 package k3sbootstrap
 
+import "slices"
+
 // PlanInput describes the topology of a K3s cluster to bootstrap across a set of
 // freshly-provisioned servers (e.g. Hetzner Cloud servers). It is the typed input
 // for [Plan], which expands it into the ordered per-node [InstallConfig]s a
@@ -138,14 +140,19 @@ func (input PlanInput) hasJoiningNodes() bool {
 // role, carrying the shared server-only options (TLS SANs, disables, kubeconfig
 // mode). serverURL is empty for RoleServerInit and the join endpoint for
 // RoleServer.
+//
+// TLSSANs and Disable are cloned per config: a single PlanInput expands into
+// multiple server configs, and sharing the input's slice headers would let a
+// downstream mutation of one node's slice corrupt every other node's. slices.Clone
+// preserves nil, so an unset field stays nil rather than becoming an empty slice.
 func (input PlanInput) serverConfig(role Role, serverURL string) InstallConfig {
 	return InstallConfig{
 		Version:             input.Version,
 		Role:                role,
 		Token:               input.Token,
 		ServerURL:           serverURL,
-		TLSSANs:             input.TLSSANs,
-		Disable:             input.Disable,
+		TLSSANs:             slices.Clone(input.TLSSANs),
+		Disable:             slices.Clone(input.Disable),
 		WriteKubeconfigMode: input.WriteKubeconfigMode,
 	}
 }

--- a/pkg/svc/bootstrap/k3s/plan.go
+++ b/pkg/svc/bootstrap/k3s/plan.go
@@ -1,0 +1,151 @@
+package k3sbootstrap
+
+// PlanInput describes the topology of a K3s cluster to bootstrap across a set of
+// freshly-provisioned servers (e.g. Hetzner Cloud servers). It is the typed input
+// for [Plan], which expands it into the ordered per-node [InstallConfig]s a
+// provisioner renders and delivers.
+type PlanInput struct {
+	// Version pins the k3s release every node installs (INSTALL_K3S_VERSION).
+	// Required — see ErrMissingVersion.
+	Version string
+
+	// Token is the shared node token every node authenticates with (K3S_TOKEN).
+	// Required — see ErrMissingToken.
+	Token string
+
+	// ControlPlaneCount is the number of control-plane (server) nodes. Must be at
+	// least one: the first becomes the cluster-initialising server (RoleServerInit)
+	// and any further ones join it (RoleServer). See ErrInvalidControlPlaneCount.
+	ControlPlaneCount int
+
+	// AgentCount is the number of worker (agent) nodes. May be zero; must not be
+	// negative. See ErrInvalidAgentCount.
+	AgentCount int
+
+	// ServerURL is the registration endpoint joining nodes dial, e.g. the first
+	// server's address or a load balancer ("https://10.0.0.2:6443"). It is required
+	// whenever the plan contains a joining node (more than one control-plane node,
+	// or any agent) and is never applied to the cluster-initialising server. See
+	// ErrMissingServerURL.
+	ServerURL string
+
+	// TLSSANs are additional Subject Alternative Names added to every control-plane
+	// node's API server certificate (--tls-san). Applied to server roles only.
+	TLSSANs []string
+
+	// Disable lists bundled components every control-plane node disables
+	// (--disable). Applied to server roles only.
+	Disable []string
+
+	// WriteKubeconfigMode sets the generated kubeconfig's mode on every
+	// control-plane node (--write-kubeconfig-mode). Optional; server roles only.
+	WriteKubeconfigMode string
+}
+
+// Node is a single server's place in the bootstrap order together with the
+// install configuration it must run.
+type Node struct {
+	// Index is the node's zero-based position in bootstrap order: the
+	// cluster-initialising server is 0, additional servers follow, then agents.
+	Index int
+
+	// Config is the install configuration for this node, already assigned the
+	// correct Role and join settings. It is guaranteed to pass validation, so
+	// [Render] never fails for a Config returned by [Plan].
+	Config InstallConfig
+}
+
+// Plan expands a [PlanInput] into the ordered [Node]s that bootstrap the cluster:
+// the cluster-initialising server first (RoleServerInit), then any additional
+// control-plane servers (RoleServer), then the agents (RoleAgent). The order is
+// significant — joining nodes can only register once the first server has
+// initialised the cluster — so callers should provision and bootstrap the nodes
+// in the returned sequence.
+//
+// Plan is pure: it performs no I/O and reaches no network. Every returned
+// Node.Config is valid, so [Render] applied to it never returns an error. A
+// configuration error (a missing version or token, an invalid node count, or a
+// missing ServerURL when joining nodes are present) is reported instead of a
+// partial plan.
+func Plan(input PlanInput) ([]Node, error) {
+	err := input.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]Node, 0, input.ControlPlaneCount+input.AgentCount)
+
+	// The first control-plane node initialises the cluster and must not carry a
+	// ServerURL; the remaining control-plane nodes join it.
+	nodes = append(nodes, Node{Index: 0, Config: input.serverConfig(RoleServerInit, "")})
+
+	for range input.ControlPlaneCount - 1 {
+		nodes = append(nodes, Node{
+			Index:  len(nodes),
+			Config: input.serverConfig(RoleServer, input.ServerURL),
+		})
+	}
+
+	for range input.AgentCount {
+		nodes = append(nodes, Node{
+			Index: len(nodes),
+			Config: InstallConfig{
+				Version:   input.Version,
+				Role:      RoleAgent,
+				Token:     input.Token,
+				ServerURL: input.ServerURL,
+			},
+		})
+	}
+
+	return nodes, nil
+}
+
+// validate reports the first error in input, or nil when it describes a cluster
+// Plan can fully expand. ServerURL is required only when the plan contains a
+// joining node, mirroring InstallConfig.validate for the individual roles.
+func (input PlanInput) validate() error {
+	if input.Version == "" {
+		return ErrMissingVersion
+	}
+
+	if input.Token == "" {
+		return ErrMissingToken
+	}
+
+	if input.ControlPlaneCount < 1 {
+		return ErrInvalidControlPlaneCount
+	}
+
+	if input.AgentCount < 0 {
+		return ErrInvalidAgentCount
+	}
+
+	if input.hasJoiningNodes() && input.ServerURL == "" {
+		return ErrMissingServerURL
+	}
+
+	return nil
+}
+
+// hasJoiningNodes reports whether the plan contains any node that must register
+// against an existing server: an additional control-plane node or any agent.
+func (input PlanInput) hasJoiningNodes() bool {
+	return input.ControlPlaneCount > 1 || input.AgentCount > 0
+}
+
+// serverConfig builds the InstallConfig for a control-plane node in the given
+// role, carrying the shared server-only options (TLS SANs, disables, kubeconfig
+// mode). serverURL is empty for RoleServerInit and the join endpoint for
+// RoleServer.
+func (input PlanInput) serverConfig(role Role, serverURL string) InstallConfig {
+	return InstallConfig{
+		Version:             input.Version,
+		Role:                role,
+		Token:               input.Token,
+		ServerURL:           serverURL,
+		TLSSANs:             input.TLSSANs,
+		Disable:             input.Disable,
+		WriteKubeconfigMode: input.WriteKubeconfigMode,
+	}
+}

--- a/pkg/svc/bootstrap/k3s/plan_test.go
+++ b/pkg/svc/bootstrap/k3s/plan_test.go
@@ -169,6 +169,47 @@ func TestPlanConfigsRender(t *testing.T) {
 	}
 }
 
+// TestPlanServerConfigsCloneSlices guards the per-config deep copy of the
+// server-only slices. A single PlanInput expands into multiple server configs, so
+// they must not share TLSSANs/Disable backing arrays: mutating one server's slice
+// (or the caller's input) must never leak into the others.
+func TestPlanServerConfigsCloneSlices(t *testing.T) {
+	t.Parallel()
+
+	tlsSANs := []string{"lb.example.com"}
+	disable := []string{"traefik"}
+
+	nodes, err := k3sbootstrap.Plan(k3sbootstrap.PlanInput{
+		Version:           "v1.30.2+k3s1",
+		Token:             "secret",
+		ControlPlaneCount: 2,
+		ServerURL:         "https://10.0.0.2:6443",
+		TLSSANs:           tlsSANs,
+		Disable:           disable,
+	})
+	require.NoError(t, err)
+
+	// Mutating the first server's slices must not affect the second server's.
+	nodes[0].Config.TLSSANs[0] = "evil.example.com"
+	nodes[0].Config.Disable[0] = "servicelb"
+	assert.Equal(
+		t,
+		[]string{"lb.example.com"},
+		nodes[1].Config.TLSSANs,
+		"second server TLS SANs must be independent",
+	)
+	assert.Equal(
+		t,
+		[]string{"traefik"},
+		nodes[1].Config.Disable,
+		"second server disables must be independent",
+	)
+
+	// The caller's input slices must also be untouched.
+	assert.Equal(t, []string{"lb.example.com"}, tlsSANs, "input TLS SANs must not be aliased")
+	assert.Equal(t, []string{"traefik"}, disable, "input disables must not be aliased")
+}
+
 func TestPlanErrors(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/bootstrap/k3s/plan_test.go
+++ b/pkg/svc/bootstrap/k3s/plan_test.go
@@ -1,0 +1,229 @@
+package k3sbootstrap_test
+
+import (
+	"testing"
+
+	k3sbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/k3s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// roleAt is a tiny helper that returns the role of the node at index i, keeping
+// the table assertions readable.
+func roleAt(nodes []k3sbootstrap.Node, i int) k3sbootstrap.Role {
+	return nodes[i].Config.Role
+}
+
+//nolint:funlen // Table-driven test enumerating each cluster topology.
+func TestPlanRolesAndOrdering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     k3sbootstrap.PlanInput
+		wantRoles []k3sbootstrap.Role
+	}{
+		{
+			name: "single control-plane node, no agents",
+			input: k3sbootstrap.PlanInput{
+				Version:           "v1.30.2+k3s1",
+				Token:             "secret",
+				ControlPlaneCount: 1,
+			},
+			wantRoles: []k3sbootstrap.Role{k3sbootstrap.RoleServerInit},
+		},
+		{
+			name: "ha control plane, no agents",
+			input: k3sbootstrap.PlanInput{
+				Version:           "v1.30.2+k3s1",
+				Token:             "secret",
+				ControlPlaneCount: 3,
+				ServerURL:         "https://10.0.0.2:6443",
+			},
+			wantRoles: []k3sbootstrap.Role{
+				k3sbootstrap.RoleServerInit,
+				k3sbootstrap.RoleServer,
+				k3sbootstrap.RoleServer,
+			},
+		},
+		{
+			name: "single control plane with agents",
+			input: k3sbootstrap.PlanInput{
+				Version:           "v1.30.2+k3s1",
+				Token:             "secret",
+				ControlPlaneCount: 1,
+				AgentCount:        2,
+				ServerURL:         "https://10.0.0.2:6443",
+			},
+			wantRoles: []k3sbootstrap.Role{
+				k3sbootstrap.RoleServerInit,
+				k3sbootstrap.RoleAgent,
+				k3sbootstrap.RoleAgent,
+			},
+		},
+		{
+			name: "ha control plane with agents",
+			input: k3sbootstrap.PlanInput{
+				Version:           "v1.30.2+k3s1",
+				Token:             "secret",
+				ControlPlaneCount: 3,
+				AgentCount:        2,
+				ServerURL:         "https://10.0.0.2:6443",
+			},
+			wantRoles: []k3sbootstrap.Role{
+				k3sbootstrap.RoleServerInit,
+				k3sbootstrap.RoleServer,
+				k3sbootstrap.RoleServer,
+				k3sbootstrap.RoleAgent,
+				k3sbootstrap.RoleAgent,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes, err := k3sbootstrap.Plan(test.input)
+			require.NoError(t, err)
+			require.Len(t, nodes, len(test.wantRoles))
+
+			for i, wantRole := range test.wantRoles {
+				assert.Equalf(t, i, nodes[i].Index, "node %d index", i)
+				assert.Equalf(t, wantRole, roleAt(nodes, i), "node %d role", i)
+			}
+		})
+	}
+}
+
+func TestPlanJoinSettings(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := k3sbootstrap.Plan(k3sbootstrap.PlanInput{
+		Version:           "v1.30.2+k3s1",
+		Token:             "secret",
+		ControlPlaneCount: 2,
+		AgentCount:        1,
+		ServerURL:         "https://10.0.0.2:6443",
+	})
+	require.NoError(t, err)
+	require.Len(t, nodes, 3)
+
+	// The cluster-initialising server must not carry a ServerURL.
+	assert.Empty(t, nodes[0].Config.ServerURL, "server-init must not have a server URL")
+	// Joining nodes register against the provided endpoint.
+	assert.Equal(t, "https://10.0.0.2:6443", nodes[1].Config.ServerURL, "additional server URL")
+	assert.Equal(t, "https://10.0.0.2:6443", nodes[2].Config.ServerURL, "agent server URL")
+}
+
+func TestPlanServerOnlyOptions(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := k3sbootstrap.Plan(k3sbootstrap.PlanInput{
+		Version:             "v1.30.2+k3s1",
+		Token:               "secret",
+		ControlPlaneCount:   2,
+		AgentCount:          1,
+		ServerURL:           "https://10.0.0.2:6443",
+		TLSSANs:             []string{"lb.example.com"},
+		Disable:             []string{"traefik"},
+		WriteKubeconfigMode: "0644",
+	})
+	require.NoError(t, err)
+
+	// Both control-plane roles carry the server-only options.
+	for _, i := range []int{0, 1} {
+		assert.Equalf(t, []string{"lb.example.com"}, nodes[i].Config.TLSSANs, "node %d TLS SANs", i)
+		assert.Equalf(t, []string{"traefik"}, nodes[i].Config.Disable, "node %d disables", i)
+		assert.Equalf(t, "0644", nodes[i].Config.WriteKubeconfigMode, "node %d kubeconfig mode", i)
+	}
+
+	// The agent must not inherit server-only options (Render rejects them).
+	agent := nodes[2].Config
+	assert.Empty(t, agent.TLSSANs, "agent must not carry TLS SANs")
+	assert.Empty(t, agent.Disable, "agent must not carry disables")
+	assert.Empty(t, agent.WriteKubeconfigMode, "agent must not carry kubeconfig mode")
+}
+
+// TestPlanConfigsRender is the key invariant: every node a valid Plan produces
+// must Render without error, since Plan promises Render-ready configs.
+func TestPlanConfigsRender(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := k3sbootstrap.Plan(k3sbootstrap.PlanInput{
+		Version:             "v1.30.2+k3s1",
+		Token:               "secret",
+		ControlPlaneCount:   3,
+		AgentCount:          2,
+		ServerURL:           "https://10.0.0.2:6443",
+		TLSSANs:             []string{"lb.example.com"},
+		Disable:             []string{"servicelb"},
+		WriteKubeconfigMode: "0644",
+	})
+	require.NoError(t, err)
+
+	for _, node := range nodes {
+		cmd, renderErr := k3sbootstrap.Render(node.Config)
+		require.NoErrorf(t, renderErr, "node %d must render", node.Index)
+		assert.NotEmptyf(t, cmd, "node %d command", node.Index)
+	}
+}
+
+func TestPlanErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   k3sbootstrap.PlanInput
+		wantErr error
+	}{
+		{
+			name:    "missing version",
+			input:   k3sbootstrap.PlanInput{Token: "secret", ControlPlaneCount: 1},
+			wantErr: k3sbootstrap.ErrMissingVersion,
+		},
+		{
+			name:    "missing token",
+			input:   k3sbootstrap.PlanInput{Version: "v1.30.2+k3s1", ControlPlaneCount: 1},
+			wantErr: k3sbootstrap.ErrMissingToken,
+		},
+		{
+			name: "zero control-plane nodes",
+			input: k3sbootstrap.PlanInput{
+				Version: "v1.30.2+k3s1", Token: "secret", ControlPlaneCount: 0,
+			},
+			wantErr: k3sbootstrap.ErrInvalidControlPlaneCount,
+		},
+		{
+			name: "negative agent count",
+			input: k3sbootstrap.PlanInput{
+				Version: "v1.30.2+k3s1", Token: "secret", ControlPlaneCount: 1, AgentCount: -1,
+			},
+			wantErr: k3sbootstrap.ErrInvalidAgentCount,
+		},
+		{
+			name: "additional servers without a server URL",
+			input: k3sbootstrap.PlanInput{
+				Version: "v1.30.2+k3s1", Token: "secret", ControlPlaneCount: 3,
+			},
+			wantErr: k3sbootstrap.ErrMissingServerURL,
+		},
+		{
+			name: "agents without a server URL",
+			input: k3sbootstrap.PlanInput{
+				Version: "v1.30.2+k3s1", Token: "secret", ControlPlaneCount: 1, AgentCount: 2,
+			},
+			wantErr: k3sbootstrap.ErrMissingServerURL,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes, err := k3sbootstrap.Plan(test.input)
+			require.ErrorIs(t, err, test.wantErr)
+			assert.Nil(t, nodes, "no plan on error")
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Child increment of #3983 (epic #4627), advancing **#5512** (K3s × Hetzner provisioner). `Refs #5512`.

## What
Adds `k3sbootstrap.Plan`, the **topology layer** that sits above the install-command renderer (#5510 / #5516). It expands a `PlanInput` — version, token, control-plane/agent counts, the join `ServerURL`, and the shared server-only options — into the ordered per-node `InstallConfig`s a provisioner bootstraps in sequence:

1. the cluster-initialising server first (`RoleServerInit`, no `ServerURL`),
2. then any additional control-plane servers (`RoleServer`, joining the first),
3. then the agents (`RoleAgent`).

Server-only options (TLS SANs, `--disable`, kubeconfig mode) are applied to control-plane roles only, so **every returned config is `Render`-ready** — a key invariant the tests pin (`TestPlanConfigsRender`). `Plan` validates up front (missing version/token, control-plane count < 1, negative agent count, missing `ServerURL` when joining nodes exist) and returns no partial plan on error.

## Why this slice
`#5512`'s acceptance criteria require a *working* cluster on Hetzner servers, which is integration work gated on the Hetzner system-test lane (#4972 — `HCLOUD_TOKEN`). This slice carves out the part that needs none of that: translating a cluster topology into the exact ordered install configs. It is **pure** (no I/O, no network) and fully unit-tested — 100% statement coverage on `plan.go`, 30 package tests green.

The remaining provisioner work (making the K3s provisioner `ProviderAware`, server lifecycle via `pkg/svc/provider/hetzner`, delivering each command via the cloud-init transport / #5518, and fetching the kubeconfig) is the integration layer that follows.

## Stacked on #5516
The `pkg/svc/bootstrap/k3s` package lands in **#5516** (the renderer, `Fixes #5510`), so this PR is **based on `claude/hetzner-bootstrap-runner`** and its diff shows only the planner. Merge #5516 first; this will rebase onto `main` and retarget.

## Validation
- `go build ./pkg/svc/bootstrap/k3s/...` ✔
- `go test ./pkg/svc/bootstrap/k3s/...` — 30 passed; `plan.go` 100% statement coverage
- `golangci-lint run ./pkg/svc/bootstrap/k3s/...` — no issues; `gofumpt` clean

Draft for maintainer promotion.