### PR TITLE
fix(autoscaler): grant Deployment/ResourceQuota RBAC unconditionally

### DIFF
--- a/pkg/svc/installer/clusterautoscaler/capacitybuffers.go
+++ b/pkg/svc/installer/clusterautoscaler/capacitybuffers.go
@@ -35,14 +35,13 @@ var capacityBufferCRDYAML []byte
 //     capacity-buffer-pod-injection-enabled, so the autoscaler reconciles
 //     CapacityBuffer resources and injects virtual pods for ready buffers.
 //  2. RBAC: the chart's ClusterRole only grants provisioningrequests in the
-//     autoscaling.x-k8s.io group, so the buffer controller's access is added
-//     via the chart's rbac.additionalRules value. It needs three things the
-//     chart role omits: the CapacityBuffer CRs themselves, plus the Deployments
-//     and ResourceQuotas its translators run informers over (to size buffers
-//     from a workload's template and respect namespace quota). Without the
-//     latter two the controller logs a continuous "deployments.apps is
-//     forbidden ... cannot list/watch" / "resourcequotas is forbidden ..." and
-//     never reconciles a buffer, so its status stays empty.
+//     autoscaling.x-k8s.io group, so the buffer controller's access to the
+//     CapacityBuffer CRs themselves is added via the chart's rbac.additionalRules
+//     value. The Deployments and ResourceQuotas its translators run informers over
+//     (to size buffers from a workload's template and respect namespace quota) are
+//     already granted unconditionally by coreInformerRBACRules in the base values —
+//     the core autoscaler needs them too (ksail#5405) — so only the CapacityBuffer
+//     rule is added here.
 //  3. CRD: the chart does not ship the CapacityBuffer CRD; it is delivered via
 //     the chart's extraObjects value. NOTE: because the CRD is then part of the
 //     Helm release, `helm uninstall` removes the CRD — and with it every
@@ -51,28 +50,14 @@ func enableCapacityBuffers(vals *chartValues) error {
 	vals.ExtraArgs.CapacityBufferControllerEnabled = true
 	vals.ExtraArgs.CapacityBufferPodInjectionEnabled = true
 
-	// Read-only verbs shared by the buffer controller's Deployment and
-	// ResourceQuota informers (only marshaled to YAML, never mutated, so the
-	// shared slice is safe to reuse across both rules).
-	readVerbs := []string{"get", "list", "watch"}
-
+	// The CapacityBuffer CRs themselves; the Deployments and ResourceQuotas the
+	// buffer controller's translators run informers over are already covered by
+	// coreInformerRBACRules in the base values (the core autoscaler needs them too).
 	vals.RBAC.AdditionalRules = append(vals.RBAC.AdditionalRules,
 		chartRBACRule{
 			APIGroups: []string{"autoscaling.x-k8s.io"},
 			Resources: []string{"capacitybuffers", "capacitybuffers/status"},
 			Verbs:     []string{"get", "list", "watch", "update", "patch"},
-		},
-		// Deployments and ResourceQuotas: the chart ClusterRole covers neither,
-		// but the buffer controller runs informers over both.
-		chartRBACRule{
-			APIGroups: []string{"apps"},
-			Resources: []string{"deployments"},
-			Verbs:     readVerbs,
-		},
-		chartRBACRule{
-			APIGroups: []string{""},
-			Resources: []string{"resourcequotas"},
-			Verbs:     readVerbs,
 		},
 	)
 

--- a/pkg/svc/installer/clusterautoscaler/installer.go
+++ b/pkg/svc/installer/clusterautoscaler/installer.go
@@ -296,10 +296,38 @@ func buildChartValues(
 				Create: true,
 				Name:   "cluster-autoscaler",
 			},
+			AdditionalRules: coreInformerRBACRules(),
 		},
 		Resources: chartResources{
 			Requests: chartResourceRequests{CPU: "50m", Memory: "128Mi"},
 			Limits:   chartResourceLimits{Memory: "256Mi"},
+		},
+	}
+}
+
+// coreInformerRBACRules returns the read-only rules the cluster-autoscaler binary's
+// core informers require but the chart's ClusterRole omits. The autoscaler watches
+// Deployments (scale-down owner traversal) and ResourceQuotas (quota-aware scale-up
+// simulation) unconditionally — i.e. even with the capacity-buffer controller
+// disabled — so without these it logs a continuous "deployments.apps is forbidden" /
+// "resourcequotas is forbidden" and the informers never sync (ksail#5405). The chart
+// only grants apps/{daemonsets,replicasets,statefulsets} and exposes no values knob to
+// inject extra rules beyond rbac.additionalRules, so KSail adds them here. They are
+// granted in the base values (not gated behind capacity-buffers) because the core
+// binary needs them regardless of that feature.
+func coreInformerRBACRules() []chartRBACRule {
+	readVerbs := []string{"get", "list", "watch"}
+
+	return []chartRBACRule{
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments"},
+			Verbs:     readVerbs,
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"resourcequotas"},
+			Verbs:     readVerbs,
 		},
 	}
 }

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -11,12 +11,55 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 const (
 	envHCLOUDPublicIPv4 = "HCLOUD_PUBLIC_IPV4"
 	envHCLOUDPublicIPv6 = "HCLOUD_PUBLIC_IPV6"
 )
+
+// coreInformerReadVerbs is the get/list/watch verb set the autoscaler's core
+// Deployment/ResourceQuota informers require (ksail#5405).
+func coreInformerReadVerbs() []string {
+	return []string{"get", "list", "watch"}
+}
+
+// renderedRBAC mirrors the rbac.additionalRules shape of the rendered chart
+// values so a test can assert the full PolicyRule (apiGroups + resources +
+// verbs), not just resource-name substrings.
+type renderedRBAC struct {
+	RBAC struct {
+		AdditionalRules []struct {
+			APIGroups []string `json:"apiGroups"`
+			Resources []string `json:"resources"`
+			Verbs     []string `json:"verbs"`
+		} `json:"additionalRules"`
+	} `json:"rbac"`
+}
+
+// assertHasRBACRule unmarshals the rendered chart values and asserts an
+// rbac.additionalRules entry matches the given apiGroups, resources, and verbs
+// EXACTLY — so a wrong apiGroups or a missing verb fails the test (ksail#5405).
+func assertHasRBACRule(t *testing.T, valuesYaml string, apiGroups, resources, verbs []string) {
+	t.Helper()
+
+	var rendered renderedRBAC
+	require.NoError(t, yaml.Unmarshal([]byte(valuesYaml), &rendered))
+
+	for _, rule := range rendered.RBAC.AdditionalRules {
+		if assert.ObjectsAreEqual(apiGroups, rule.APIGroups) &&
+			assert.ObjectsAreEqual(resources, rule.Resources) &&
+			assert.ObjectsAreEqual(verbs, rule.Verbs) {
+			return
+		}
+	}
+
+	t.Errorf(
+		"no rbac.additionalRules entry matched apiGroups=%v resources=%v verbs=%v; got %+v",
+		apiGroups, resources, verbs, rendered.RBAC.AdditionalRules,
+	)
+}
 
 func TestNewInstaller(t *testing.T) {
 	t.Parallel()
@@ -447,16 +490,22 @@ func assertValuesYamlContents(t *testing.T, valuesYaml string) {
 		"node-role.kubernetes.io/control-plane",
 		"nodeSelector:",
 		"rbac:",
-		// Core-informer RBAC rules the autoscaler binary needs unconditionally,
-		// granted even without capacity-buffers (ksail#5405).
-		"additionalRules:",
-		"- deployments",
-		"- resourcequotas",
 		"resources:",
 	}
 	for _, want := range required {
 		assert.Contains(t, valuesYaml, want)
 	}
+
+	// Core-informer RBAC rules the autoscaler binary needs unconditionally,
+	// granted even without capacity-buffers — assert the full rule shape so a
+	// wrong apiGroups or missing verb is caught, not just the resource name
+	// (ksail#5405).
+	assertHasRBACRule(
+		t, valuesYaml, []string{"apps"}, []string{"deployments"}, coreInformerReadVerbs(),
+	)
+	assertHasRBACRule(
+		t, valuesYaml, []string{""}, []string{"resourcequotas"}, coreInformerReadVerbs(),
+	)
 }
 
 // TestClusterAutoscalerInstaller_ValuesYaml_Contents verifies that the rendered
@@ -686,6 +735,20 @@ func assertCapacityBuffersValuesYaml(
 
 				for _, omit := range wantOmit {
 					assert.NotContains(t, spec.ValuesYaml, omit)
+				}
+
+				// Core-informer rules are granted unconditionally; assert their
+				// full shape regardless of the capacity-buffers toggle (ksail#5405).
+				assertHasRBACRule(t, spec.ValuesYaml,
+					[]string{"apps"}, []string{"deployments"}, coreInformerReadVerbs())
+				assertHasRBACRule(t, spec.ValuesYaml,
+					[]string{""}, []string{"resourcequotas"}, coreInformerReadVerbs())
+
+				if enabled {
+					assertHasRBACRule(t, spec.ValuesYaml,
+						[]string{"autoscaling.x-k8s.io"},
+						[]string{"capacitybuffers", "capacitybuffers/status"},
+						[]string{"get", "list", "watch", "update", "patch"})
 				}
 
 				return true

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -447,6 +447,11 @@ func assertValuesYamlContents(t *testing.T, valuesYaml string) {
 		"node-role.kubernetes.io/control-plane",
 		"nodeSelector:",
 		"rbac:",
+		// Core-informer RBAC rules the autoscaler binary needs unconditionally,
+		// granted even without capacity-buffers (ksail#5405).
+		"additionalRules:",
+		"- deployments",
+		"- resourcequotas",
 		"resources:",
 	}
 	for _, want := range required {
@@ -627,12 +632,17 @@ func TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers(t *testing.T) {
 		{
 			name:    "DisabledOmitsFlagsAndCRD",
 			enabled: false,
+			wantContain: []string{
+				// Core-informer rules are granted unconditionally, even with
+				// capacity-buffers disabled (ksail#5405).
+				"additionalRules:",
+				"- deployments",
+				"- resourcequotas",
+			},
 			wantOmit: []string{
 				"capacity-buffer-controller-enabled",
 				"capacity-buffer-pod-injection-enabled",
 				"capacitybuffers",
-				"- deployments",
-				"- resourcequotas",
 				"kind: CustomResourceDefinition",
 			},
 		},


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The KSail-managed Hetzner cluster-autoscaler floods its logs with RBAC `forbidden` errors — `system:serviceaccount:kube-system:cluster-autoscaler` cannot `list`/`watch` `apps/deployments` or `core/resourcequotas`, so those informers never sync. On prod this was ~5.5 lines/min, 24/7, masking real errors and tripping Coroot "Log errors" alerting.

## Root cause (verified live on prod)

The cluster-autoscaler binary (`v1.35.0`) sets up Deployment (scale-down owner traversal) and ResourceQuota (quota-aware scale-up simulation) informers **unconditionally** — even with the capacity-buffer controller disabled. The chart's `ClusterRole` grants only `apps/{daemonsets,replicasets,statefulsets}` and there is no Helm values knob to inject extra rules beyond `rbac.additionalRules`.

[#5446](https://github.com/devantler-tech/ksail/pull/5446) added exactly these two rules, **but only inside `enableCapacityBuffers`** — so they're absent unless `spec.cluster.autoscaler.node.capacityBuffers` is on. A default ksail Hetzner cluster runs with capacity-buffers **off**, so the gap persisted.

I confirmed this against the live prod cluster:
- autoscaler deployment has **no** `--capacity-buffer-controller-enabled` flag (buffers off), image `v1.35.0`;
- the chart `ClusterRole/cluster-autoscaler-hetzner-cluster-autoscaler` still lacks `deployments` + `resourcequotas`;
- the flood is currently silenced only by a **temporary hotfix `ClusterRole`** (`cluster-autoscaler-capacitybuffer-rbac-hotfix`, `managed-by: daily-ai-engineer`) applied 2026-06-25. Its annotation cited #5446 as the durable fix, but because #5446 is gated behind capacity-buffers, deleting the hotfix after the next cluster update would bring the flood back. This PR is the actual durable fix.

## Change

- Add `coreInformerRBACRules()` (`apps/deployments` + `core/resourcequotas`, `get,list,watch`) to the **base** chart values in `buildChartValues`, so the rules are granted whenever the autoscaler is installed, independent of capacity-buffers.
- Drop those two rules from `enableCapacityBuffers`; it now adds only the `capacitybuffers` CR rule (the base already covers the rest, which the buffer controller's translators also rely on).

## Validation

- `go build` + `go test ./pkg/svc/installer/clusterautoscaler/...` → 28 pass.
- `golangci-lint run ./pkg/svc/installer/clusterautoscaler/...` → 0 issues.
- Tests pin the new invariant: the base values render `additionalRules` with `deployments`/`resourcequotas` **even when capacity-buffers is disabled** (the `DisabledOmitsFlagsAndCRD` case now asserts they are present; only the buffer flags + CRD + `capacitybuffers` CR rule are omitted).

## Follow-up (live op, after this ships + a cluster update)

Once a cluster update reconciles the chart with these rules in the base ClusterRole, the temporary hotfix ClusterRole can be deleted. No live action is taken in this PR.

Fixes #5405
