### PR TITLE
feat(workload): add native mirror target resolution

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,11 @@ linters:
         text: "var-naming: avoid meaningless package names"
         path: pkg/utils/doc.go
   settings:
+    misspell:
+      # mirrord (metalbear) is a product name referenced in docs/comments, not a
+      # misspelling of "mirrored".
+      ignore-rules:
+        - mirrord
     goconst:
       # Repeated string literals in table-driven tests (distribution names, config
       # field paths, fixture cluster names) are idiomatic and clearer inline than

--- a/pkg/svc/mirror/doc.go
+++ b/pkg/svc/mirror/doc.go
@@ -1,0 +1,50 @@
+// Package mirror is the foundation for a native local-process ↔ cluster traffic
+// bridge (`ksail workload mirror`), letting a developer run one service locally
+// while it receives — and, later, intercepts — traffic destined for its
+// Deployment in a running cluster. It is the "developer inner-loop compression"
+// capability covered by tools like mirrord and Telepresence; see ksail#4521.
+//
+// # Design decision: native, in-process — not an external tool
+//
+// KSail implements this natively in Go, reusing the same in-process Kubernetes
+// primitives the rest of the CLI already embeds (client-go via [pkg/k8s], and
+// the embedded `k8s.io/kubectl/pkg/cmd/*` commands behind `workload forward`,
+// `workload debug`, and `workload exec`). It does NOT shell out to, or bundle a
+// daemon from, an external tool:
+//
+//   - mirrord (metalbear) is a Rust binary; integrating it means shelling out to
+//     a foreign binary — against KSail's native-Go, in-process house rule
+//     (the same rule that governs provisioning: native SDKs, never `curl | sh`
+//     or shelled binaries).
+//   - Telepresence (CNCF, Apache-2.0) and ktunnel are Go, but ship as a
+//     privileged user daemon plus a cluster-wide traffic-manager — a heavyweight
+//     external lifecycle to manage, not an in-process library.
+//
+// Reusing KSail's existing embedding pattern keeps the feature consistent with
+// `workload forward`/`debug`/`exec`, avoids a new runtime dependency, and keeps
+// all logic unit-testable against a fake clientset.
+//
+// # Phased delivery
+//
+// The capability is large (the issue marks it High-complexity), so it ships in
+// independently-valuable phases:
+//
+//   - Phase 0 — foundation (this package): resolve a Deployment to the running
+//     pods and containers a tap would attach to ([ResolveTarget]). Pure
+//     client-go, fully unit-testable, needed by every later phase regardless of
+//     the eventual tap mechanism.
+//   - Phase 1 — mirror-only: inject a read-only "tap" sidecar (reusing the
+//     ephemeral-container mechanism behind `workload debug`) that copies inbound
+//     connections and forwards a copy to the local process over a reverse tunnel
+//     built from the embedded port-forward primitive. Read-only: the local
+//     process receives mirrored traffic but does not answer back into the
+//     cluster — the lowest-risk first mode the issue itself suggests.
+//   - Phase 2 — intercept: steer a subset (or all) of the Deployment's traffic to
+//     the local process and return its responses.
+//   - Phase 3 — environment & volume projection: run the local process with the
+//     target pod's env vars and mounted volumes/secrets for cluster-equivalent
+//     context.
+//
+// Phase 1 targets the Vanilla, K3s, and VCluster distributions first (per the
+// issue's acceptance criteria); Talos/Omni follow.
+package mirror

--- a/pkg/svc/mirror/mirror.go
+++ b/pkg/svc/mirror/mirror.go
@@ -1,0 +1,157 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ErrDeploymentNameEmpty is returned when ResolveTarget is called with an empty
+// deployment name.
+var ErrDeploymentNameEmpty = errors.New("deployment name is empty")
+
+// ErrDeploymentNotFound is returned when the named Deployment does not exist in
+// the namespace.
+var ErrDeploymentNotFound = errors.New("deployment not found")
+
+// ErrDeploymentNoContainers is returned when the Deployment's pod template
+// declares no containers, so there is nothing to mirror.
+var ErrDeploymentNoContainers = errors.New("deployment pod template has no containers")
+
+// ErrNoRunningPods is returned when the Deployment has no Running pods, so there
+// is no live pod for a tap to attach to.
+var ErrNoRunningPods = errors.New("deployment has no running pods")
+
+// Target describes a resolved cluster workload that a local process can mirror
+// (and, in later phases, intercept) traffic for. It is the stable contract every
+// bridge phase builds on, independent of the eventual traffic-tap mechanism: a
+// tap attaches to one of Pods, copying traffic for one of Containers back to the
+// developer's machine.
+type Target struct {
+	// Namespace is the namespace the Deployment lives in.
+	Namespace string
+	// Deployment is the name of the resolved Deployment.
+	Deployment string
+	// Pods are the names of the Running pods backing the Deployment, in the order
+	// the API returned them. Always non-empty for a successfully resolved Target.
+	Pods []string
+	// Containers are the container names declared in the Deployment's pod
+	// template, in declaration order. Always non-empty for a successfully
+	// resolved Target; a caller selects one (e.g. via a --container flag) when
+	// there is more than one.
+	Containers []string
+}
+
+// ResolveTarget resolves a Deployment to the Running pods and containers a
+// traffic tap would attach to. It is the Phase 0 foundation of the
+// `ksail workload mirror` bridge (see the package doc): pure client-go, so it is
+// fully unit-testable against a fake clientset and shared by every later phase.
+//
+// It returns ErrDeploymentNameEmpty for an empty name, a wrapped
+// ErrDeploymentNotFound when the Deployment is absent, ErrDeploymentNoContainers
+// when its pod template declares no containers, and ErrNoRunningPods when no
+// backing pod is Running. The client parameter is an interface so callers can
+// inject a fake clientset in tests.
+func ResolveTarget(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace string,
+	deployment string,
+) (*Target, error) {
+	if deployment == "" {
+		return nil, ErrDeploymentNameEmpty
+	}
+
+	dep, err := getDeployment(ctx, client, namespace, deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	containers := containerNames(dep)
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("%w: %q in %s", ErrDeploymentNoContainers, deployment, namespace)
+	}
+
+	runningPods, err := listRunningPods(ctx, client, namespace, dep)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(runningPods) == 0 {
+		return nil, fmt.Errorf("%w: %q in %s", ErrNoRunningPods, deployment, namespace)
+	}
+
+	return &Target{
+		Namespace:  namespace,
+		Deployment: deployment,
+		Pods:       runningPods,
+		Containers: containers,
+	}, nil
+}
+
+// getDeployment fetches the named Deployment, translating an API not-found into
+// the package's ErrDeploymentNotFound sentinel.
+func getDeployment(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace, deployment string,
+) (*appsv1.Deployment, error) {
+	dep, err := client.AppsV1().Deployments(namespace).Get(ctx, deployment, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: %q in %s", ErrDeploymentNotFound, deployment, namespace)
+		}
+
+		return nil, fmt.Errorf("getting deployment %q in %s: %w", deployment, namespace, err)
+	}
+
+	return dep, nil
+}
+
+// containerNames returns the Deployment pod template's container names in
+// declaration order.
+func containerNames(dep *appsv1.Deployment) []string {
+	names := make([]string, 0, len(dep.Spec.Template.Spec.Containers))
+	for index := range dep.Spec.Template.Spec.Containers {
+		names = append(names, dep.Spec.Template.Spec.Containers[index].Name)
+	}
+
+	return names
+}
+
+// listRunningPods lists the Running pods backing the Deployment, selected by the
+// Deployment's own label selector.
+func listRunningPods(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace string,
+	dep *appsv1.Deployment,
+) ([]string, error) {
+	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("building pod selector for deployment %q: %w", dep.Name, err)
+	}
+
+	podList, err := client.CoreV1().Pods(namespace).List(
+		ctx,
+		metav1.ListOptions{LabelSelector: selector.String()},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing pods for deployment %q in %s: %w", dep.Name, namespace, err)
+	}
+
+	running := make([]string, 0, len(podList.Items))
+	for index := range podList.Items {
+		if podList.Items[index].Status.Phase == corev1.PodRunning {
+			running = append(running, podList.Items[index].Name)
+		}
+	}
+
+	return running, nil
+}

--- a/pkg/svc/mirror/mirror_test.go
+++ b/pkg/svc/mirror/mirror_test.go
@@ -1,0 +1,145 @@
+package mirror_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const (
+	testNamespace = "default"
+	testDeploy    = "api"
+)
+
+// selectorLabels returns the label set the test Deployment selects on. It is a
+// function rather than a package var so the linter's no-globals rule is honored
+// while keeping the labels defined once.
+func selectorLabels() map[string]string { return map[string]string{"app": "api"} }
+
+// errListFailed is a static sentinel for the List-error reactor test.
+var errListFailed = errors.New("list pods failed")
+
+// errGetFailed is a static sentinel for the Get-error reactor test.
+var errGetFailed = errors.New("get deployment failed")
+
+// newDeployment builds a Deployment whose selector matches selectorLabels()
+// and whose pod template declares the given container names.
+func newDeployment(containers ...string) *appsv1.Deployment {
+	tmpl := make([]corev1.Container, 0, len(containers))
+	for _, name := range containers {
+		tmpl = append(tmpl, corev1.Container{Name: name})
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: testDeploy, Namespace: testNamespace},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: selectorLabels()},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: tmpl},
+			},
+		},
+	}
+}
+
+// newPod builds a pod in testNamespace with the given name, labels, and phase.
+func newPod(name string, labels map[string]string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, Labels: labels},
+		Status:     corev1.PodStatus{Phase: phase},
+	}
+}
+
+func TestResolveTarget_EmptyDeploymentName(t *testing.T) {
+	t.Parallel()
+
+	_, err := mirror.ResolveTarget(context.Background(), k8sfake.NewClientset(), testNamespace, "")
+	require.ErrorIs(t, err, mirror.ErrDeploymentNameEmpty)
+}
+
+func TestResolveTarget_DeploymentNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := mirror.ResolveTarget(
+		context.Background(), k8sfake.NewClientset(), testNamespace, testDeploy,
+	)
+	require.ErrorIs(t, err, mirror.ErrDeploymentNotFound)
+}
+
+func TestResolveTarget_NoContainers(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newDeployment())
+
+	_, err := mirror.ResolveTarget(context.Background(), clientset, testNamespace, testDeploy)
+	require.ErrorIs(t, err, mirror.ErrDeploymentNoContainers)
+}
+
+func TestResolveTarget_NoRunningPods(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(
+		newDeployment("app"),
+		newPod("api-pending", selectorLabels(), corev1.PodPending),
+	)
+
+	_, err := mirror.ResolveTarget(context.Background(), clientset, testNamespace, testDeploy)
+	require.ErrorIs(t, err, mirror.ErrNoRunningPods)
+}
+
+func TestResolveTarget_ResolvesRunningPodsAndContainers(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(
+		newDeployment("app", "sidecar"),
+		newPod("api-1", selectorLabels(), corev1.PodRunning),
+		newPod("api-2", selectorLabels(), corev1.PodRunning),
+		newPod("api-old", selectorLabels(), corev1.PodSucceeded),
+		newPod("other", map[string]string{"app": "web"}, corev1.PodRunning),
+	)
+
+	target, err := mirror.ResolveTarget(context.Background(), clientset, testNamespace, testDeploy)
+	require.NoError(t, err)
+
+	assert.Equal(t, testNamespace, target.Namespace)
+	assert.Equal(t, testDeploy, target.Deployment)
+	assert.Equal(t, []string{"app", "sidecar"}, target.Containers,
+		"all pod-template containers are returned in declaration order")
+	assert.ElementsMatch(t, []string{"api-1", "api-2"}, target.Pods,
+		"only Running pods matching the Deployment selector are returned")
+}
+
+func TestResolveTarget_ListError(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newDeployment("app"))
+	clientset.PrependReactor("list", "pods",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errListFailed
+		})
+
+	_, err := mirror.ResolveTarget(context.Background(), clientset, testNamespace, testDeploy)
+	require.ErrorIs(t, err, errListFailed)
+}
+
+func TestResolveTarget_GetError(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	clientset.PrependReactor("get", "deployments",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errGetFailed
+		})
+
+	_, err := mirror.ResolveTarget(context.Background(), clientset, testNamespace, testDeploy)
+	require.ErrorIs(t, err, errGetFailed)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Part of #4521** — local-remote service mirroring (Telepresence/mirrord-style dev bridge). This is the **Phase 0 foundation** and resolves the issue's first acceptance criterion (the design decision).

## Design decision (AC #1): native, in-process — not an external tool

KSail will implement the bridge **natively in Go**, reusing the same in-process Kubernetes primitives the CLI already embeds (`pkg/k8s` client-go helpers, and the embedded `k8s.io/kubectl/pkg/cmd/*` commands behind `workload forward`/`debug`/`exec`). It will **not** shell out to, or bundle a daemon from, an external tool:

- **mirrord** (metalbear) is a Rust binary → integrating it means shelling out to a foreign binary, against KSail's native-Go, in-process house rule (the same rule that governs provisioning).
- **Telepresence** (CNCF, Apache-2.0) and **ktunnel** are Go, but ship as a privileged user daemon + a cluster-wide traffic-manager — a heavyweight external lifecycle, not an in-process library.

Reusing the existing embedding pattern keeps the feature consistent with `workload forward`/`debug`/`exec`, avoids a new runtime dependency, and keeps all logic unit-testable against a fake clientset. The full rationale lives in the package doc (`pkg/svc/mirror/doc.go`).

## Phased delivery (decomposition of #4521)

The capability is High-complexity, so it ships in independently-valuable phases:

- **Phase 0 — foundation (this PR):** `mirror.ResolveTarget` resolves a Deployment → its Running pods + pod-template containers (the attach points every later phase needs). Pure client-go, fully unit-tested.
- **Phase 1 — mirror-only:** inject a read-only "tap" sidecar (reusing the ephemeral-container mechanism behind `workload debug`) that copies inbound connections to the local process over a reverse tunnel built from the embedded port-forward primitive. Read-only first (lowest risk; the issue's suggested starting point). Targets Vanilla/K3s/VCluster first per the AC.
- **Phase 2 — intercept:** steer a subset (or all) of the Deployment's traffic to the local process and return its responses.
- **Phase 3 — env & volume projection:** run the local process with the target pod's env vars and mounted volumes/secrets.

## What this PR adds

- `pkg/svc/mirror/` — new package: `ResolveTarget(ctx, client, namespace, deployment) (*Target, error)` returning the Running pod names + container names, with sentinel errors (`ErrDeploymentNameEmpty`, `ErrDeploymentNotFound`, `ErrDeploymentNoContainers`, `ErrNoRunningPods`), plus the design `doc.go`.
- `mirror_test.go` — 7 black-box tests (empty name, not-found, no-containers, no-running-pods, happy path incl. selector + Running-phase filtering, List/Get error paths) against a fake clientset.
- `.golangci.yml` — misspell `ignore-rules` entry for the product name **mirrord** (proper noun, not a typo for "mirrored").

**No CLI surface yet** (no `ksail workload mirror` command), so no user-facing behaviour change and no generated-artifact churn — the command lands in Phase 1 once the tap mechanism is built, avoiding a misleading not-implemented stub.

## Validation

- `go build ./pkg/svc/mirror/` — ✅
- `go test ./pkg/svc/mirror/` — ✅ 7/7
- `golangci-lint run ./pkg/svc/mirror/` — ✅ no issues

Opened as a **draft** for maintainer review of the design decision before promotion — the architecture call (native vs. external tool) is steerable here.