### PR TITLE
feat(validator): warn when a Talos install-image patch duplicates extensions

### DIFF
--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"sigs.k8s.io/yaml"
 )
 
 // Configs holds the loaded Talos machine configurations with patches applied.
@@ -413,6 +414,44 @@ func (c *Configs) Extensions() []string {
 	copy(result, c.extensions)
 
 	return result
+}
+
+// InstallImagePatch reports whether any user-provided patch sets machine.install.image,
+// returning the first such value. KSail derives machine.install.image from
+// spec.cluster.talos.extensions (see applySchematic), so a patch that also sets it is
+// redundant and silently overridden during config generation — callers use this to warn
+// about the resulting skew. The raw patch content is inspected (not the already-overridden
+// bundle), so the user's intent is recovered rather than KSail's computed value. Only
+// strategic-merge patches are detected; an RFC-6902 op targeting /machine/install/image is
+// not (none are scaffolded, and such a patch is unusual).
+func (c *Configs) InstallImagePatch() (string, bool) {
+	for _, patch := range c.patches {
+		if image := installImageFromPatch(patch.Content); image != "" {
+			return image, true
+		}
+	}
+
+	return "", false
+}
+
+// installImageFromPatch extracts machine.install.image from a strategic-merge patch's raw
+// YAML content. Returns an empty string when the patch does not set it, or when the content
+// is not a strategic-merge document (e.g. an RFC-6902 patch list).
+func installImageFromPatch(content []byte) string {
+	var doc struct {
+		Machine struct {
+			Install struct {
+				Image string `json:"image"`
+			} `json:"install"`
+		} `json:"machine"`
+	}
+
+	err := yaml.Unmarshal(content, &doc)
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(doc.Machine.Install.Image)
 }
 
 // IsCNIDisabled returns true if the default CNI is disabled (set to "none").

--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -430,36 +430,45 @@ func (c *Configs) Extensions() []string {
 // scaffolded, and such a patch is unusual).
 func (c *Configs) InstallImagePatch() (string, bool) {
 	image := ""
-	found := false
 
 	for _, patch := range c.patches {
-		if patchImage := installImageFromPatch(patch.Content); patchImage != "" {
+		// Track field presence, not string-emptiness: the LAST patch that sets the
+		// machine.install.image field wins, even when it explicitly clears the image
+		// to "" (an earlier patch's value must not then be reported as effective).
+		if patchImage, present := installImageFromPatch(patch.Content); present {
 			image = patchImage
-			found = true
 		}
 	}
 
-	return image, found
+	// found is true only when the effective value is a real (non-empty) image — an
+	// explicit clear leaves no effective pin, so no skew warning is warranted.
+	return image, image != ""
 }
 
 // installImageFromPatch extracts machine.install.image from a strategic-merge patch's raw
-// YAML content. Returns an empty string when the patch does not set it, or when the content
+// YAML content. The bool reports whether the patch sets the machine.install.image field at
+// all (independent of the string value, so an explicit empty clear is distinguishable from
+// an absent field). Returns ("", false) when the patch does not set it, or when the content
 // is not a strategic-merge document (e.g. an RFC-6902 patch list).
-func installImageFromPatch(content []byte) string {
+func installImageFromPatch(content []byte) (string, bool) {
 	var doc struct {
-		Machine struct {
-			Install struct {
-				Image string `json:"image"`
+		Machine *struct {
+			Install *struct {
+				Image *string `json:"image"`
 			} `json:"install"`
 		} `json:"machine"`
 	}
 
 	err := yaml.Unmarshal(content, &doc)
 	if err != nil {
-		return ""
+		return "", false
 	}
 
-	return strings.TrimSpace(doc.Machine.Install.Image)
+	if doc.Machine == nil || doc.Machine.Install == nil || doc.Machine.Install.Image == nil {
+		return "", false
+	}
+
+	return strings.TrimSpace(*doc.Machine.Install.Image), true
 }
 
 // IsCNIDisabled returns true if the default CNI is disabled (set to "none").

--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -417,21 +417,29 @@ func (c *Configs) Extensions() []string {
 }
 
 // InstallImagePatch reports whether any user-provided patch sets machine.install.image,
-// returning the first such value. KSail derives machine.install.image from
+// returning the effective value. KSail derives machine.install.image from
 // spec.cluster.talos.extensions (see applySchematic), so a patch that also sets it is
 // redundant and silently overridden during config generation — callers use this to warn
 // about the resulting skew. The raw patch content is inspected (not the already-overridden
-// bundle), so the user's intent is recovered rather than KSail's computed value. Only
-// strategic-merge patches are detected; an RFC-6902 op targeting /machine/install/image is
-// not (none are scaffolded, and such a patch is unusual).
+// bundle), so the user's intent is recovered rather than KSail's computed value.
+//
+// Patches are stored in application order (LoadPatches: cluster, control-plane, worker;
+// then runtime patches appended) and a later strategic-merge patch overrides an earlier
+// one, so the LAST patch that sets the image is the effective value. Only strategic-merge
+// patches are detected; an RFC-6902 op targeting /machine/install/image is not (none are
+// scaffolded, and such a patch is unusual).
 func (c *Configs) InstallImagePatch() (string, bool) {
+	image := ""
+	found := false
+
 	for _, patch := range c.patches {
-		if image := installImageFromPatch(patch.Content); image != "" {
-			return image, true
+		if patchImage := installImageFromPatch(patch.Content); patchImage != "" {
+			image = patchImage
+			found = true
 		}
 	}
 
-	return "", false
+	return image, found
 }
 
 // installImageFromPatch extracts machine.install.image from a strategic-merge patch's raw

--- a/pkg/fsutil/configmanager/talos/install_image_patch_test.go
+++ b/pkg/fsutil/configmanager/talos/install_image_patch_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// installImagePatch builds a cluster-scope strategic-merge patch setting machine.install.image.
+func installImagePatch(name, image string) talos.Patch {
+	return talos.Patch{
+		Path:    "talos/cluster/" + name,
+		Scope:   talos.PatchScopeCluster,
+		Content: []byte("machine:\n  install:\n    image: " + image + "\n"),
+	}
+}
+
 // loadWithPatch builds a Talos Configs carrying the given additional patch content (if any).
 func loadWithPatch(t *testing.T, content string) *talos.Configs {
 	t.Helper()
@@ -62,5 +71,28 @@ func TestConfigsInstallImagePatch(t *testing.T) {
 		image, ok := configs.InstallImagePatch()
 		assert.False(t, ok)
 		assert.Empty(t, image)
+	})
+
+	t.Run("returns the effective (last) image when multiple patches set it", func(t *testing.T) {
+		t.Parallel()
+
+		manager := talos.NewConfigManager("", "patch-test", "1.32.0", "10.5.0.0/24").
+			WithAdditionalPatches([]talos.Patch{
+				installImagePatch(
+					"install-image-a.yaml",
+					"factory.talos.dev/installer/aaa:v1.13.4",
+				),
+				installImagePatch(
+					"install-image-b.yaml",
+					"factory.talos.dev/installer/bbb:v1.13.4",
+				),
+			})
+
+		configs, err := manager.Load(configmanager.LoadOptions{})
+		require.NoError(t, err)
+
+		image, ok := configs.InstallImagePatch()
+		assert.True(t, ok)
+		assert.Equal(t, "factory.talos.dev/installer/bbb:v1.13.4", image)
 	})
 }

--- a/pkg/fsutil/configmanager/talos/install_image_patch_test.go
+++ b/pkg/fsutil/configmanager/talos/install_image_patch_test.go
@@ -1,0 +1,66 @@
+package talos_test
+
+import (
+	"testing"
+
+	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadWithPatch builds a Talos Configs carrying the given additional patch content (if any).
+func loadWithPatch(t *testing.T, content string) *talos.Configs {
+	t.Helper()
+
+	manager := talos.NewConfigManager("", "patch-test", "1.32.0", "10.5.0.0/24")
+	if content != "" {
+		manager = manager.WithAdditionalPatches([]talos.Patch{{
+			Path:    "talos/cluster/patch.yaml",
+			Scope:   talos.PatchScopeCluster,
+			Content: []byte(content),
+		}})
+	}
+
+	configs, err := manager.Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+
+	return configs
+}
+
+func TestConfigsInstallImagePatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns image and true for a strategic-merge install-image patch", func(t *testing.T) {
+		t.Parallel()
+
+		configs := loadWithPatch(
+			t,
+			"machine:\n  install:\n    image: factory.talos.dev/installer/deadbeef:v1.13.4\n",
+		)
+
+		image, ok := configs.InstallImagePatch()
+		assert.True(t, ok)
+		assert.Equal(t, "factory.talos.dev/installer/deadbeef:v1.13.4", image)
+	})
+
+	t.Run("returns false for a strategic-merge patch without install image", func(t *testing.T) {
+		t.Parallel()
+
+		configs := loadWithPatch(t, "machine:\n  network:\n    hostname: node-1\n")
+
+		image, ok := configs.InstallImagePatch()
+		assert.False(t, ok)
+		assert.Empty(t, image)
+	})
+
+	t.Run("returns false when there are no additional patches", func(t *testing.T) {
+		t.Parallel()
+
+		configs := loadWithPatch(t, "")
+
+		image, ok := configs.InstallImagePatch()
+		assert.False(t, ok)
+		assert.Empty(t, image)
+	})
+}

--- a/pkg/fsutil/configmanager/talos/install_image_patch_test.go
+++ b/pkg/fsutil/configmanager/talos/install_image_patch_test.go
@@ -72,6 +72,10 @@ func TestConfigsInstallImagePatch(t *testing.T) {
 		assert.False(t, ok)
 		assert.Empty(t, image)
 	})
+}
+
+func TestConfigsInstallImagePatchLastWins(t *testing.T) {
+	t.Parallel()
 
 	t.Run("returns the effective (last) image when multiple patches set it", func(t *testing.T) {
 		t.Parallel()
@@ -94,5 +98,29 @@ func TestConfigsInstallImagePatch(t *testing.T) {
 		image, ok := configs.InstallImagePatch()
 		assert.True(t, ok)
 		assert.Equal(t, "factory.talos.dev/installer/bbb:v1.13.4", image)
+	})
+
+	t.Run("a later explicit clear wins (no effective pin)", func(t *testing.T) {
+		t.Parallel()
+
+		manager := talos.NewConfigManager("", "patch-test", "1.32.0", "10.5.0.0/24").
+			WithAdditionalPatches([]talos.Patch{
+				installImagePatch(
+					"install-image-a.yaml",
+					"factory.talos.dev/installer/aaa:v1.13.4",
+				),
+				{
+					Path:    "talos/cluster/install-image-clear.yaml",
+					Scope:   talos.PatchScopeCluster,
+					Content: []byte("machine:\n  install:\n    image: \"\"\n"),
+				},
+			})
+
+		configs, err := manager.Load(configmanager.LoadOptions{})
+		require.NoError(t, err)
+
+		image, ok := configs.InstallImagePatch()
+		assert.False(t, ok, "an explicit clear leaves no effective pin")
+		assert.Empty(t, image)
 	})
 }

--- a/pkg/fsutil/validator/ksail/validator.go
+++ b/pkg/fsutil/validator/ksail/validator.go
@@ -110,6 +110,7 @@ func (v *Validator) Validate(config *v1alpha1.Cluster) *validator.ValidationResu
 	v.validateFlux(config, result)
 	v.validateAutoscalerConfig(config, result)
 	v.validatePublicNet(config, result)
+	v.validateTalosInstallImageSkew(config, result)
 
 	return result
 }
@@ -515,6 +516,56 @@ func (v *Validator) validateTalosDefaultCNIAlignment(result *validator.Validatio
 				"or set CNI to Cilium in your ksail.yaml",
 		})
 	}
+}
+
+// installImageSkewField is the ksail.yaml field path reported for install-image skew warnings.
+const installImageSkewField = "spec.cluster.talos.extensions"
+
+// validateTalosInstallImageSkew warns when a Talos machine config patch sets
+// machine.install.image while KSail is already deriving it from
+// spec.cluster.talos.extensions. KSail patches machine.install.image with the Image
+// Factory installer computed from the extensions list (and the schematic also drives the
+// Hetzner autoscaler snapshot), overriding any user-provided install.image during config
+// generation — so the patch is redundant and can silently drift from the extensions list.
+//
+// The check fires under the exact condition that triggers the auto-override
+// (distribution wiring): no explicit schematicId is set and the normalized extensions
+// list is non-empty. When schematicId is set it takes precedence over extensions and KSail
+// does not derive the image, so a patch is legitimate and no warning is emitted.
+func (v *Validator) validateTalosInstallImageSkew(
+	config *v1alpha1.Cluster,
+	result *validator.ValidationResult,
+) {
+	if v.talosConfig == nil {
+		return
+	}
+
+	if strings.TrimSpace(config.Spec.Cluster.Talos.SchematicID) != "" {
+		return
+	}
+
+	if len(talosconfigmanager.NormalizeExtensions(config.Spec.Cluster.Talos.Extensions)) == 0 {
+		return
+	}
+
+	image, ok := v.talosConfig.InstallImagePatch()
+	if !ok {
+		return
+	}
+
+	result.AddWarning(validator.ValidationError{
+		Field: installImageSkewField,
+		Message: fmt.Sprintf(
+			"A Talos machine config patch sets machine.install.image (%s), but KSail derives the "+
+				"installer image from spec.cluster.talos.extensions and overrides it during config "+
+				"generation. The patch is redundant and can silently drift from the extensions list.",
+			image,
+		),
+		FixSuggestion: "Remove the machine.install.image patch (e.g. talos/cluster/install-image.yaml); " +
+			"KSail computes and applies the Image Factory installer image from " +
+			"spec.cluster.talos.extensions. To pin a specific schematic instead, set " +
+			"spec.cluster.talos.schematicId.",
+	})
 }
 
 // validateGitOpsEngine ensures the GitOps engine value is supported.

--- a/pkg/fsutil/validator/ksail/validator.go
+++ b/pkg/fsutil/validator/ksail/validator.go
@@ -529,14 +529,19 @@ const installImageSkewField = "spec.cluster.talos.extensions"
 // generation — so the patch is redundant and can silently drift from the extensions list.
 //
 // The check fires under the exact condition that triggers the auto-override
-// (distribution wiring): no explicit schematicId is set and the normalized extensions
-// list is non-empty. When schematicId is set it takes precedence over extensions and KSail
-// does not derive the image, so a patch is legitimate and no warning is emitted.
+// (distribution wiring): the distribution is Talos, no explicit schematicId is set, and
+// the normalized extensions list is non-empty. When schematicId is set it takes precedence
+// over extensions and KSail does not derive the image, so a patch is legitimate and no
+// warning is emitted.
 func (v *Validator) validateTalosInstallImageSkew(
 	config *v1alpha1.Cluster,
 	result *validator.ValidationResult,
 ) {
 	if v.talosConfig == nil {
+		return
+	}
+
+	if config.Spec.Cluster.Distribution != v1alpha1.DistributionTalos {
 		return
 	}
 

--- a/pkg/fsutil/validator/ksail/validator_install_image_test.go
+++ b/pkg/fsutil/validator/ksail/validator_install_image_test.go
@@ -56,19 +56,50 @@ func installImageSkewWarning(result *validator.ValidationResult) (validator.Vali
 	return validator.ValidationError{}, false
 }
 
+type skewCase struct {
+	name         string
+	distribution v1alpha1.Distribution
+	extensions   []string
+	schematicID  string
+	withPatch    bool
+	noTalos      bool
+	wantWarning  bool
+}
+
+func runSkewCase(t *testing.T, testCase skewCase) {
+	t.Helper()
+
+	distribution := testCase.distribution
+	if distribution == "" {
+		distribution = v1alpha1.DistributionTalos
+	}
+
+	config := createValidKSailConfig(distribution)
+	config.Spec.Cluster.Talos.Extensions = testCase.extensions
+	config.Spec.Cluster.Talos.SchematicID = testCase.schematicID
+
+	validatorInstance := ksailvalidator.NewValidator()
+
+	if !testCase.noTalos {
+		talosConfig := loadTalosConfigsForSkew(t, testCase.extensions, testCase.withPatch)
+		validatorInstance = ksailvalidator.NewValidatorForTalos(talosConfig)
+	}
+
+	warning, ok := installImageSkewWarning(validatorInstance.Validate(config))
+	assert.Equal(t, testCase.wantWarning, ok)
+
+	if testCase.wantWarning {
+		assert.Contains(t, warning.Message, "factory.talos.dev/installer/deadbeef:v1.13.4")
+		assert.Contains(t, warning.FixSuggestion, "spec.cluster.talos.extensions")
+	}
+}
+
 func TestValidateTalosInstallImageSkew(t *testing.T) {
 	t.Parallel()
 
 	exts := []string{"siderolabs/iscsi-tools"}
 
-	tests := []struct {
-		name        string
-		extensions  []string
-		schematicID string
-		withPatch   bool
-		noTalos     bool
-		wantWarning bool
-	}{
+	tests := []skewCase{
 		{
 			name:        "patch coexists with extensions",
 			extensions:  exts,
@@ -84,32 +115,18 @@ func TestValidateTalosInstallImageSkew(t *testing.T) {
 		{name: "no extensions configured", withPatch: true},
 		{name: "no install-image patch", extensions: exts},
 		{name: "no Talos config", extensions: exts, noTalos: true},
+		{
+			name:         "non-Talos distribution with a Talos-backed validator",
+			distribution: v1alpha1.DistributionVanilla,
+			extensions:   exts,
+			withPatch:    true,
+		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-
-			config := createValidKSailConfig(v1alpha1.DistributionTalos)
-			config.Spec.Cluster.Talos.Extensions = testCase.extensions
-			config.Spec.Cluster.Talos.SchematicID = testCase.schematicID
-
-			validatorInstance := ksailvalidator.NewValidator()
-
-			if !testCase.noTalos {
-				talosConfig := loadTalosConfigsForSkew(t, testCase.extensions, testCase.withPatch)
-				validatorInstance = ksailvalidator.NewValidatorForTalos(talosConfig)
-			}
-
-			result := validatorInstance.Validate(config)
-
-			warning, ok := installImageSkewWarning(result)
-			assert.Equal(t, testCase.wantWarning, ok)
-
-			if testCase.wantWarning {
-				assert.Contains(t, warning.Message, "factory.talos.dev/installer/deadbeef:v1.13.4")
-				assert.Contains(t, warning.FixSuggestion, "spec.cluster.talos.extensions")
-			}
+			runSkewCase(t, testCase)
 		})
 	}
 }

--- a/pkg/fsutil/validator/ksail/validator_install_image_test.go
+++ b/pkg/fsutil/validator/ksail/validator_install_image_test.go
@@ -1,0 +1,115 @@
+package ksail_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil/validator"
+	ksailvalidator "github.com/devantler-tech/ksail/v7/pkg/fsutil/validator/ksail"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const installImageSkewField = "spec.cluster.talos.extensions"
+
+// loadTalosConfigsForSkew builds a Talos Configs, optionally with extensions and a
+// user-provided machine.install.image patch.
+func loadTalosConfigsForSkew(
+	t *testing.T,
+	extensions []string,
+	withInstallImagePatch bool,
+) *talosconfigmanager.Configs {
+	t.Helper()
+
+	manager := talosconfigmanager.NewConfigManager("", "skew-test", "1.32.0", "10.5.0.0/24")
+	if len(extensions) > 0 {
+		manager = manager.WithExtensions(extensions)
+	}
+
+	if withInstallImagePatch {
+		manager = manager.WithAdditionalPatches([]talosconfigmanager.Patch{{
+			Path:  "talos/cluster/install-image.yaml",
+			Scope: talosconfigmanager.PatchScopeCluster,
+			Content: []byte(
+				"machine:\n  install:\n    image: factory.talos.dev/installer/deadbeef:v1.13.4\n",
+			),
+		}})
+	}
+
+	configs, err := manager.Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+
+	return configs
+}
+
+func installImageSkewWarning(result *validator.ValidationResult) (validator.ValidationError, bool) {
+	for _, warning := range result.Warnings {
+		if warning.Field == installImageSkewField &&
+			strings.Contains(warning.Message, "machine.install.image") {
+			return warning, true
+		}
+	}
+
+	return validator.ValidationError{}, false
+}
+
+func TestValidateTalosInstallImageSkew(t *testing.T) {
+	t.Parallel()
+
+	exts := []string{"siderolabs/iscsi-tools"}
+
+	tests := []struct {
+		name        string
+		extensions  []string
+		schematicID string
+		withPatch   bool
+		noTalos     bool
+		wantWarning bool
+	}{
+		{
+			name:        "patch coexists with extensions",
+			extensions:  exts,
+			withPatch:   true,
+			wantWarning: true,
+		},
+		{
+			name:        "schematicId takes precedence",
+			extensions:  exts,
+			schematicID: "abc123",
+			withPatch:   true,
+		},
+		{name: "no extensions configured", withPatch: true},
+		{name: "no install-image patch", extensions: exts},
+		{name: "no Talos config", extensions: exts, noTalos: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := createValidKSailConfig(v1alpha1.DistributionTalos)
+			config.Spec.Cluster.Talos.Extensions = testCase.extensions
+			config.Spec.Cluster.Talos.SchematicID = testCase.schematicID
+
+			validatorInstance := ksailvalidator.NewValidator()
+
+			if !testCase.noTalos {
+				talosConfig := loadTalosConfigsForSkew(t, testCase.extensions, testCase.withPatch)
+				validatorInstance = ksailvalidator.NewValidatorForTalos(talosConfig)
+			}
+
+			result := validatorInstance.Validate(config)
+
+			warning, ok := installImageSkewWarning(result)
+			assert.Equal(t, testCase.wantWarning, ok)
+
+			if testCase.wantWarning {
+				assert.Contains(t, warning.Message, "factory.talos.dev/installer/deadbeef:v1.13.4")
+				assert.Contains(t, warning.FixSuggestion, "spec.cluster.talos.extensions")
+			}
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5442

## What I found (re-triage)

Issue #5442 asked KSail to derive `machine.install.image` from `spec.cluster.talos.extensions` so consumers stop hand-maintaining a parallel installer-image patch. **Verifying against the live code, option 1 (emit `install.image` from extensions) is already implemented**: `applySchematic` (pkg/fsutil/configmanager/talos/configs.go) computes the Image Factory schematic ID from the normalized extensions list and patches `machine.install.image` onto both control-plane and worker configs — applied **after** user patches, so it overrides any hand-written `install-image.yaml`.

**The DRY/skew hazard the issue warns about is already live on `devantler-tech/platform`:**
- `ksail.prod.yaml` lists 3 extensions (`iscsi-tools`, `util-linux-tools`, `qemu-guest-agent`) and `talos/cluster/install-image.yaml` hardcodes schematic `e187c9b9…`.
- The factory canonical ID for those 3 extensions (which KSail computes, because `NormalizeExtensions` sorts them) is `88d1f7a5…` — a **different** schematic ID for the same extension set (the factory hash is order-sensitive; the hand-written file used the comment's order).
- So KSail silently deploys `88d1f7a5…` while the committed patch pins `e187c9b9…`. The patch is redundant *and* skewed.

This is the genuine remainder of #5442: **option 3 — detect and warn about the skew** so consumers know the patch is dead config they can delete.

## Change

- `Configs.InstallImagePatch()` — scans the raw strategic-merge patches for `machine.install.image` (recovers the user's intent, not KSail's already-overridden value).
- `validateTalosInstallImageSkew` in the ksail validator — emits a **warning** (non-blocking) when a Talos patch sets `machine.install.image` while KSail is deriving it from extensions. Fires under the **exact** auto-override condition (no explicit `schematicId`, non-empty normalized `extensions`); when `schematicId` is set it takes precedence and KSail does not derive the image, so a patch is legitimate and no warning fires.

Pure validation — **no config field, CLI flag, or schema change**, so no generated-file regeneration.

## Validation

- `go test ./pkg/fsutil/configmanager/talos/... ./pkg/fsutil/validator/ksail/...` — 276 pass (new tests cover patch detection + all five skew gating paths).
- `golangci-lint run` on both packages — no issues.
- `go build ./...` — success.

## Follow-up (separate, not in this PR)

`devantler-tech/platform` can now delete `talos/cluster/install-image.yaml` and drop the "must match the schematic" maintenance burden from `ksail.prod.yaml` — KSail derives and applies the installer image from the extensions list. I'll file/spin that up separately so this PR stays a focused ksail change.