### PR TITLE
docs(oidc): document multi-cluster federation (shared-issuer SSO)

### DIFF
--- a/docs/src/content/docs/guides/oidc-authentication.mdx
+++ b/docs/src/content/docs/guides/oidc-authentication.mdx
@@ -242,6 +242,62 @@ subjects:
     name: "oidc:platform-admins"
 ```
 
+## Multi-Cluster OIDC (Federation)
+
+The OIDC story extends naturally to **multiple clusters**: authenticate once, then operate across every cluster that trusts the same identity provider — without managing per-cluster credentials.
+
+### Federation Model: Shared-Issuer Trust
+
+KSail's federation model is **shared-issuer trust**. Each cluster is configured independently, but when several clusters point at the **same** OIDC provider, they all accept tokens from a single identity:
+
+- Every cluster's API server is configured with the same `--oidc-issuer-url` and `--oidc-client-id`, so each one independently verifies and trusts tokens minted by that provider.
+- Usernames and groups are derived from the same JWT claims, so a single OIDC identity (and its group memberships) maps to the **same** Kubernetes subject on every federated cluster — RBAC bindings are portable across the fleet.
+
+There is no central control plane to manage: trust is established declaratively, per cluster, by pointing at a shared issuer.
+
+### Single Sign-On Across Clusters
+
+Because tokens come from one provider, **you authenticate once and the session is reused across all federated clusters**. This works today with no extra configuration: `ksail cluster oidc get-token` caches tokens in `~/.ksail/oidc/cache/` keyed by the **issuer URL, client ID, and scopes** — *not* by cluster name. The first `kubectl` call against any federated cluster opens the browser; every subsequent call against any cluster sharing that OIDC configuration reuses the cached token (and silently refreshes it when it expires).
+
+### Workflow
+
+<Steps>
+1. **Configure every cluster with the same OIDC provider**
+
+   Use identical `issuerURL`, `clientID`, and `extraScopes` in each cluster's `ksail.yaml`:
+
+   ```yaml
+   # cluster-a/ksail.yaml and cluster-b/ksail.yaml
+   spec:
+     cluster:
+       oidc:
+         issuerURL: https://dex.example.com
+         clientID: kubectl
+         extraScopes:
+           - email
+           - groups
+   ```
+
+2. **Apply portable RBAC**
+
+   Bind the same OIDC user or group on each cluster (see [RBAC Integration](#rbac-integration)). Because the username/group claims resolve identically everywhere, one set of bindings works fleet-wide.
+
+3. **Authenticate once, use everywhere**
+
+   ```bash
+   kubectl --context oidc@cluster-a get pods   # opens the browser on first use
+   kubectl --context oidc@cluster-b get pods   # reuses the cached token — no second login
+   ```
+
+</Steps>
+
+> [!NOTE]
+> The cache key intentionally excludes the cluster name, so the **same** issuer/client/scopes always share one cached session. Use a **distinct** `clientID` (or scopes) per provider if you want isolated sessions per group of clusters.
+
+### Scope & Limitations
+
+This federation model covers **identity federation** — a single authenticated identity, authorized independently on each cluster via portable RBAC. It does **not** (yet) cover **cross-cluster service-account projection** (presenting one cluster's workload identity to another cluster's API server), which is a separate, larger capability tracked on the [OIDC federation roadmap issue](https://github.com/devantler-tech/ksail/issues/4602).
+
 ## Related
 
 - [Declarative Configuration](/configuration/declarative-configuration/) — full `ksail.yaml` schema reference

--- a/pkg/svc/oidc/cache_test.go
+++ b/pkg/svc/oidc/cache_test.go
@@ -72,6 +72,42 @@ func TestCacheKeyDeterminism(t *testing.T) {
 	})
 }
 
+// TestCacheFederationSharedSession pins the multi-cluster single-sign-on
+// guarantee end to end: a token cached while authenticating against one cluster
+// is transparently reused by a different cluster that trusts the same OIDC
+// provider. The cache key is derived solely from the provider parameters
+// (issuer, client ID, scopes) and carries no cluster dimension, so federated
+// clusters share one authenticated session — authenticate once, operate across
+// the fleet (https://github.com/devantler-tech/ksail/issues/4602).
+func TestCacheFederationSharedSession(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	const (
+		issuer   = "https://dex.example.com"
+		clientID = "kubectl"
+	)
+
+	scopes := []string{"email", "groups"}
+
+	// Cluster A authenticates and caches its session.
+	clusterAKey := oidc.CacheKey(issuer, clientID, scopes)
+	expiry := time.Now().Add(time.Hour).Truncate(time.Second)
+	tok := &oidc.TokenResult{IDToken: "shared-id", RefreshToken: "shared-ref", Expiry: expiry}
+	require.NoError(t, oidc.SaveCachedToken(dir, clusterAKey, tok))
+
+	// Cluster B trusts the same provider (identical issuer/client/scopes) and
+	// therefore resolves the same key — it must find cluster A's session.
+	clusterBKey := oidc.CacheKey(issuer, clientID, scopes)
+	require.Equal(t, clusterAKey, clusterBKey,
+		"clusters sharing an OIDC provider must resolve the same cache key")
+
+	loaded := oidc.LoadCachedToken(dir, clusterBKey)
+	require.NotNil(t, loaded, "cluster B must reuse the session cached by cluster A (SSO)")
+	assert.Equal(t, "shared-id", loaded.IDToken)
+}
+
 func TestLoadSaveCachedToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5543
Part of #4602 (OIDC federation and multi-cluster auth support)

## What & why

The headline user story of #4602 is *"authenticate once and operate across all my clusters without managing per-cluster credentials."* Investigation revealed that the **single-sign-on foundation already exists**: the OIDC token cache (`pkg/svc/oidc/cache.go` `CacheKey`) is keyed by **issuer URL + client ID + scopes** with **no cluster dimension**. So clusters configured with the same OIDC provider already share one authenticated session today — it was just undocumented and not pinned by a test.

This PR makes the **shared-issuer trust** federation model explicit, which is the natural design-first first increment of #4602.

## Changes

- **Docs** — new *"Multi-Cluster OIDC (Federation)"* section in the OIDC guide: the shared-issuer trust model, the SSO mechanism (cluster-independent cache key), the configure-once-per-cluster workflow, portable RBAC, and a note that the cache key intentionally excludes the cluster name. Establishes #4602 **AC#1** (federation model) and **AC#4** (workflow docs).
- **Test** — `TestCacheFederationSharedSession` pins the cross-cluster SSO guarantee end to end: a token saved under one cluster's derived key is reused via a second cluster's identical key. Covers part of #4602 **AC#5** for the identity-federation half.

No production code changes; no regression to single-cluster OIDC auth.

## Design decision (for review)

Federation model = **shared-issuer trust** (no central control plane; trust declared per cluster by pointing at a shared issuer). This mirrors the native, no-extra-infrastructure approach taken for the sibling design-first issue #4521. The deeper **cross-cluster service-account projection** (AC#3) — presenting one cluster's workload identity to another's API server — is a separate, larger capability (likely an external-tool integration) and is **out of scope** here; it will be decomposed into its own child of #4602.

## Validation

- `go test ./pkg/svc/oidc/...` → 30 passed (incl. the new test)
- `golangci-lint run ./pkg/svc/oidc/...` → no issues
- Docs are hand-authored mdx (uses the already-imported `<Steps>` component) — no generator run required.