### PR TITLE
feat(operator): uninstall components removed from the cluster spec

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -356,6 +356,25 @@ func (r *ClusterReconciler) reconcileComponents(
 		return true
 	}
 
+	// Record the spec we just reconciled components for, so a later spec change that drops a component
+	// (e.g. policyEngine Kyverno→None) is detected next reconcile and the component uninstalled. A
+	// write failure keeps ComponentsReady False so it retries — the baseline must exist before the
+	// condition reads True, or a removal could go undetected.
+	recordErr := r.recordAppliedComponents(ctx, cluster)
+	if recordErr != nil {
+		logf.FromContext(ctx).
+			Info("record components baseline (best-effort)", "error", recordErr.Error())
+		setCondition(
+			cluster,
+			v1alpha1.ConditionComponentsReady,
+			metav1.ConditionFalse,
+			"BaselineRecordFailed",
+			recordErr.Error(),
+		)
+
+		return false
+	}
+
 	setCondition(
 		cluster,
 		v1alpha1.ConditionComponentsReady,

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"slices"
 	"strings"
@@ -459,6 +460,45 @@ func TestReconcile_InstallsComponentsOncePerGeneration(t *testing.T) {
 	assert.Equal(t, 1, calls, "components must not reinstall when up-to-date for the generation")
 }
 
+func TestReconcile_RecordsComponentsBaselineAfterInstall(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	fakeClient := newFakeClient(scheme, newCluster(true))
+	reconciler := newReconciler(scheme, fakeClient, &fakeProvisioner{exists: true})
+	reconciler.InstallComponents = func(
+		_ context.Context,
+		_ clusterprovisioner.Provisioner,
+		_ *v1alpha1.Cluster,
+	) (bool, []v1alpha1.ComponentStatus, error) {
+		return true, []v1alpha1.ComponentStatus{
+			{Name: "cilium", State: v1alpha1.ComponentStateReady},
+		}, nil
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), request())
+	require.NoError(t, err)
+
+	var got v1alpha1.Cluster
+
+	require.NoError(t, fakeClient.Get(context.Background(), request().NamespacedName, &got))
+
+	// After a successful apply the operator records the reconciled spec as the component-removal
+	// baseline, so a later spec change that drops a component can be detected and uninstalled.
+	baseline, ok := got.Annotations[v1alpha1.LastAppliedComponentsAnnotation]
+	require.True(t, ok, "component baseline annotation must be recorded after a successful apply")
+
+	wantBaseline, err := json.Marshal(got.Spec)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(wantBaseline), baseline, "baseline must be the full reconciled spec")
+
+	// Recording the baseline (a metadata write mid-reconcile) must not clobber the per-component
+	// status set this reconcile.
+	assert.Equal(t, []v1alpha1.ComponentStatus{
+		{Name: "cilium", State: v1alpha1.ComponentStateReady},
+	}, got.Status.Components)
+}
+
 func TestReconcile_ComponentFailureIsBestEffortAndRequeues(t *testing.T) {
 	t.Parallel()
 
@@ -540,6 +580,8 @@ func TestReconcile_ComponentsSkippedReportsUnknown(t *testing.T) {
 		"skipped install must not report True",
 	)
 	assert.Equal(t, "NotSupported", condition.Reason)
+	// A skipped install never installed anything, so no component baseline is recorded.
+	assert.NotContains(t, got.Annotations, v1alpha1.LastAppliedComponentsAnnotation)
 
 	// A second reconcile at the same generation must not re-attempt the skipped install.
 	_, err = reconciler.Reconcile(context.Background(), request())

--- a/internal/controller/drift.go
+++ b/internal/controller/drift.go
@@ -105,3 +105,47 @@ func (r *ClusterReconciler) recordAppliedSpec(
 
 	return nil
 }
+
+// recordAppliedComponents stores the full cluster spec as the baseline for component-removal
+// detection, so a later spec change that drops a component (e.g. policyEngine Kyverno→None) can be
+// detected and the component uninstalled. It persists the whole Spec (the installer factory reads
+// cluster, workload, and provider fields), under a distinct annotation from recordAppliedSpec so it
+// is owned by the component reconciler and decoupled from drift-detection timing.
+//
+// Unlike recordAppliedSpec it runs after runtime status has been observed this reconcile, so it must
+// not clobber the pending status. A plain Update would overwrite cluster.Status with the server's
+// stored status (the status subresource ignores the write but the response is decoded back into the
+// object). It therefore writes through a deep copy and propagates only the new metadata (annotations
+// + resourceVersion) back to cluster, leaving the conditions and observed status this reconcile set
+// intact for the single status update at the end of reconcileNormal. It is a no-op when the baseline
+// already matches, avoiding a needless write + watch event.
+func (r *ClusterReconciler) recordAppliedComponents(
+	ctx context.Context,
+	cluster *v1alpha1.Cluster,
+) error {
+	data, err := json.Marshal(cluster.Spec)
+	if err != nil {
+		return fmt.Errorf("marshal cluster spec for components baseline: %w", err)
+	}
+
+	if cluster.Annotations[v1alpha1.LastAppliedComponentsAnnotation] == string(data) {
+		return nil
+	}
+
+	updated := cluster.DeepCopy()
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+
+	updated.Annotations[v1alpha1.LastAppliedComponentsAnnotation] = string(data)
+
+	updateErr := r.Update(ctx, updated)
+	if updateErr != nil {
+		return fmt.Errorf("record last-applied components: %w", updateErr)
+	}
+
+	cluster.Annotations = updated.Annotations
+	cluster.ResourceVersion = updated.ResourceVersion
+
+	return nil
+}

--- a/pkg/apis/cluster/v1alpha1/labels.go
+++ b/pkg/apis/cluster/v1alpha1/labels.go
@@ -25,6 +25,17 @@ const FinalizerName = "ksail.io/finalizer"
 // share one definition and can never silently desync on a rename.
 const LastAppliedSpecAnnotation = "ksail.io/last-applied-spec"
 
+// LastAppliedComponentsAnnotation stores the JSON of the cluster spec the operator last installed
+// components for, used as the baseline to detect components the spec has since dropped (flipped to
+// None/Default) so the operator can uninstall them — the inverse of install-only reconciliation.
+// It is distinct from LastAppliedSpecAnnotation on purpose: that one is the drift-detection baseline
+// owned by the provisioner path (and rewritten as soon as an in-place update applies, before
+// components reconcile), so reusing it would race the component diff. This one is owned solely by
+// the component reconciler and written only after a successful component apply. Like the spec
+// baseline it is reconciler-owned and stripped from client-submitted objects by the REST API, so a
+// user cannot forge it.
+const LastAppliedComponentsAnnotation = "ksail.io/last-applied-components"
+
 // IsHostCluster reports whether this Cluster resource is the operator's self-registration of the
 // cluster it runs on (see HostClusterLabel).
 func (c *Cluster) IsHostCluster() bool {

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -91,21 +91,27 @@ func InstallComponents(
 		return true, nil, fmt.Errorf("build helm client for child cluster: %w", err)
 	}
 
-	factory := installer.NewFactory(
-		helmClient,
-		nil, // no Docker client: child-cluster components are Helm-based
-		kubeconfigPath,
-		"",
-		componentInstallTimeout,
-		cluster.Spec.Cluster.Distribution,
-	)
+	// Several installers are distribution-dependent, so a factory is only valid
+	// for the spec it was built for; the baseline uninstall set below rebuilds
+	// one for the previously-applied distribution rather than reusing this one.
+	newFactory := func(distribution v1alpha1.Distribution) *installer.Factory {
+		return installer.NewFactory(
+			helmClient,
+			nil, // no Docker client: child-cluster components are Helm-based
+			kubeconfigPath,
+			"",
+			componentInstallTimeout,
+			distribution,
+		)
+	}
 
-	installers, err := factory.CreateInstallersForConfig(cluster)
+	installers, err := newFactory(cluster.Spec.Cluster.Distribution).
+		CreateInstallersForConfig(cluster)
 	if err != nil {
 		return true, nil, fmt.Errorf("build installers: %w", err)
 	}
 
-	uninstallErr := uninstallRemovedComponents(ctx, factory, cluster, installers)
+	uninstallErr := uninstallRemovedComponents(ctx, newFactory, cluster, installers)
 
 	components, installErr := runInstallers(ctx, installers)
 
@@ -119,11 +125,11 @@ func InstallComponents(
 // component is returned, so it surfaces as ComponentsReady=False and requeues.
 func uninstallRemovedComponents(
 	ctx context.Context,
-	factory *installer.Factory,
+	newFactory func(v1alpha1.Distribution) *installer.Factory,
 	cluster *v1alpha1.Cluster,
 	desired map[string]installer.Installer,
 ) error {
-	removed, err := removedComponentInstallers(factory, cluster, desired)
+	removed, err := removedComponentInstallers(newFactory, cluster, desired)
 	if err != nil {
 		logf.FromContext(ctx).
 			Info("skip uninstall of removed components (best-effort)", "error", err.Error())
@@ -136,10 +142,12 @@ func uninstallRemovedComponents(
 
 // removedComponentInstallers returns the installers for components that were in the last-applied
 // component set but are no longer desired. It rebuilds the previous installer set from the baseline
-// spec via the same factory, then keeps the entries whose key is absent from the desired set. It
-// returns an empty map when no baseline is recorded (first reconcile, or an unparseable annotation).
+// spec via a factory built FOR that baseline's distribution (several installers are
+// distribution-dependent, so reusing the current cluster's factory would compute the wrong uninstall
+// set after a distribution change), then keeps the entries whose key is absent from the desired set.
+// It returns an empty map when no baseline is recorded (first reconcile, or an unparseable annotation).
 func removedComponentInstallers(
-	factory *installer.Factory,
+	newFactory func(v1alpha1.Distribution) *installer.Factory,
 	cluster *v1alpha1.Cluster,
 	desired map[string]installer.Installer,
 ) (map[string]installer.Installer, error) {
@@ -150,7 +158,8 @@ func removedComponentInstallers(
 
 	previousCluster := &v1alpha1.Cluster{Spec: *previousSpec}
 
-	previous, err := factory.CreateInstallersForConfig(previousCluster)
+	previous, err := newFactory(previousSpec.Cluster.Distribution).
+		CreateInstallersForConfig(previousCluster)
 	if err != nil {
 		return nil, fmt.Errorf("build previous installers: %w", err)
 	}

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -2,9 +2,11 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/internal/controller"
@@ -50,6 +52,11 @@ var installOrder = []string{
 // The returned components carry the per-component install outcome (one entry per declared component,
 // in install order) so the reconciler can surface per-component health in ClusterStatus. They are nil
 // on the skip path and when install never reached the installer set (kubeconfig/helm/factory errors).
+//
+// Before converging the desired set it uninstalls components the spec previously declared but has
+// since dropped (flipped to None/Default) — read from the last-applied-components baseline annotation
+// the reconciler records after each successful apply — so a removed component is torn down rather than
+// left orphaned. The uninstall is best-effort and folded into the returned error so a failure requeues.
 func InstallComponents(
 	ctx context.Context,
 	provisioner clusterprovisioner.Provisioner,
@@ -98,9 +105,124 @@ func InstallComponents(
 		return true, nil, fmt.Errorf("build installers: %w", err)
 	}
 
-	components, err := runInstallers(ctx, installers)
+	uninstallErr := uninstallRemovedComponents(ctx, factory, cluster, installers)
 
-	return true, components, err
+	components, installErr := runInstallers(ctx, installers)
+
+	return true, components, errors.Join(uninstallErr, installErr)
+}
+
+// uninstallRemovedComponents tears down components present in the last-applied-components baseline but
+// absent from the desired set (the spec flipped them to None/Default). A malformed or unbuildable
+// baseline must never block converging the desired set, so a failure to *determine* what to remove is
+// logged and swallowed (the next reconcile retries); only a failure to actually *uninstall* a resolved
+// component is returned, so it surfaces as ComponentsReady=False and requeues.
+func uninstallRemovedComponents(
+	ctx context.Context,
+	factory *installer.Factory,
+	cluster *v1alpha1.Cluster,
+	desired map[string]installer.Installer,
+) error {
+	removed, err := removedComponentInstallers(factory, cluster, desired)
+	if err != nil {
+		logf.FromContext(ctx).
+			Info("skip uninstall of removed components (best-effort)", "error", err.Error())
+
+		return nil
+	}
+
+	return runUninstallers(ctx, removed)
+}
+
+// removedComponentInstallers returns the installers for components that were in the last-applied
+// component set but are no longer desired. It rebuilds the previous installer set from the baseline
+// spec via the same factory, then keeps the entries whose key is absent from the desired set. It
+// returns an empty map when no baseline is recorded (first reconcile, or an unparseable annotation).
+func removedComponentInstallers(
+	factory *installer.Factory,
+	cluster *v1alpha1.Cluster,
+	desired map[string]installer.Installer,
+) (map[string]installer.Installer, error) {
+	previousSpec, ok := lastAppliedComponentsSpec(cluster)
+	if !ok {
+		return map[string]installer.Installer{}, nil
+	}
+
+	previousCluster := &v1alpha1.Cluster{Spec: *previousSpec}
+
+	previous, err := factory.CreateInstallersForConfig(previousCluster)
+	if err != nil {
+		return nil, fmt.Errorf("build previous installers: %w", err)
+	}
+
+	removed := make(map[string]installer.Installer)
+
+	for key, inst := range previous {
+		_, stillDesired := desired[key]
+		if !stillDesired {
+			removed[key] = inst
+		}
+	}
+
+	return removed, nil
+}
+
+// lastAppliedComponentsSpec parses the component-baseline annotation into a spec. The second return
+// is false when no baseline is recorded or the annotation is not valid JSON (treated as "no baseline"
+// so a corrupt value can never block a fresh apply).
+func lastAppliedComponentsSpec(cluster *v1alpha1.Cluster) (*v1alpha1.Spec, bool) {
+	raw, ok := cluster.Annotations[v1alpha1.LastAppliedComponentsAnnotation]
+	if !ok || raw == "" {
+		return nil, false
+	}
+
+	var spec v1alpha1.Spec
+
+	err := json.Unmarshal([]byte(raw), &spec)
+	if err != nil {
+		return nil, false
+	}
+
+	return &spec, true
+}
+
+// runUninstallers uninstalls the given components in REVERSE dependency order (GitOps first, CNI last
+// — the inverse of runInstallers), continuing past individual failures and returning their joined
+// error so one stuck uninstall does not block the rest.
+func runUninstallers(ctx context.Context, installers map[string]installer.Installer) error {
+	log := logf.FromContext(ctx)
+
+	var errs []error
+
+	done := make(map[string]bool, len(installers))
+
+	uninstall := func(key string, component installer.Installer) {
+		log.Info("uninstalling removed component", "component", key)
+
+		err := component.Uninstall(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", key, err))
+		}
+
+		done[key] = true
+	}
+
+	// Reverse dependency order: tear down GitOps first, CNI last.
+	for _, key := range slices.Backward(installOrder) {
+		component, ok := installers[key]
+		if ok {
+			uninstall(key, component)
+		}
+	}
+
+	// Uninstall any component not covered by the known order after the ordered ones.
+	for key, component := range installers {
+		if !done[key] {
+			uninstall(key, component)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // writeTempKubeconfig writes the child kubeconfig bytes to a temp file and returns its path plus a

--- a/pkg/operator/components_test.go
+++ b/pkg/operator/components_test.go
@@ -2,10 +2,13 @@ package operator_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v7/pkg/operator"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
@@ -80,11 +83,15 @@ func TestInstallComponents_KubeconfigNotReadyPropagates(t *testing.T) {
 	)
 }
 
-// recordingInstaller records the order in which installers run and optionally fails.
+// recordingInstaller records the order in which installers run and optionally fails. Install
+// failures use err; Uninstall failures use uninstallErr, and the uninstall order is recorded into
+// uninstallOrder when set (nil disables uninstall recording).
 type recordingInstaller struct {
-	name  string
-	err   error
-	order *[]string
+	name           string
+	err            error
+	uninstallErr   error
+	order          *[]string
+	uninstallOrder *[]string
 }
 
 func (r *recordingInstaller) Install(_ context.Context) error {
@@ -93,7 +100,13 @@ func (r *recordingInstaller) Install(_ context.Context) error {
 	return r.err
 }
 
-func (r *recordingInstaller) Uninstall(_ context.Context) error { return nil }
+func (r *recordingInstaller) Uninstall(_ context.Context) error {
+	if r.uninstallOrder != nil {
+		*r.uninstallOrder = append(*r.uninstallOrder, r.name)
+	}
+
+	return r.uninstallErr
+}
 
 func (r *recordingInstaller) Images(_ context.Context) ([]string, error) { return nil, nil }
 
@@ -139,4 +152,132 @@ func TestRunInstallers_AggregatesErrorsAndContinues(t *testing.T) {
 		{Name: componentCilium, State: v1alpha1.ComponentStateFailed, Message: errBoom.Error()},
 		{Name: componentFlux, State: v1alpha1.ComponentStateReady},
 	}, statuses)
+}
+
+// componentKyverno is reused across the uninstall/removal tests.
+const componentKyverno = "kyverno"
+
+func TestRunUninstallers_OrdersGitOpsFirstAndCNILast(t *testing.T) {
+	t.Parallel()
+
+	var order []string
+
+	// Uninstall is the inverse of install: GitOps must come down first, CNI last.
+	installers := map[string]installer.Installer{
+		componentCilium: &recordingInstaller{name: componentCilium, uninstallOrder: &order},
+		componentFlux:   &recordingInstaller{name: componentFlux, uninstallOrder: &order},
+		componentKyverno: &recordingInstaller{
+			name:           componentKyverno,
+			uninstallOrder: &order,
+		},
+	}
+
+	err := operator.RunUninstallers(context.Background(), installers)
+	require.NoError(t, err)
+	assert.Equal(t, []string{componentFlux, componentKyverno, componentCilium}, order)
+}
+
+func TestRunUninstallers_AggregatesErrorsAndContinues(t *testing.T) {
+	t.Parallel()
+
+	var order []string
+
+	installers := map[string]installer.Installer{
+		componentFlux: &recordingInstaller{
+			name:           componentFlux,
+			uninstallErr:   errBoom,
+			uninstallOrder: &order,
+		},
+		componentCilium: &recordingInstaller{name: componentCilium, uninstallOrder: &order},
+	}
+
+	err := operator.RunUninstallers(context.Background(), installers)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), componentFlux)
+	// cilium still uninstalled despite flux failing, in reverse order.
+	assert.Equal(t, []string{componentFlux, componentCilium}, order)
+}
+
+// newComponentFactory builds an installer factory backed by a bare helm mock — installer
+// construction does not call helm, so no expectations are needed (mirrors the factory tests).
+func newComponentFactory(t *testing.T) *installer.Factory {
+	t.Helper()
+
+	return installer.NewFactory(
+		helm.NewMockInterface(t),
+		nil,
+		"/tmp/kubeconfig",
+		"",
+		5*time.Minute,
+		v1alpha1.DistributionVanilla,
+	)
+}
+
+func TestRemovedComponentInstallers_ReturnsComponentsDroppedFromSpec(t *testing.T) {
+	t.Parallel()
+
+	factory := newComponentFactory(t)
+
+	// Baseline had Kyverno + Flux; the desired spec keeps only Flux (policyEngine flipped to None), so
+	// Kyverno must be reported as removed and Flux must not.
+	previous := &v1alpha1.Cluster{Spec: v1alpha1.Spec{Cluster: v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionVanilla,
+		PolicyEngine: v1alpha1.PolicyEngineKyverno,
+		GitOpsEngine: v1alpha1.GitOpsEngineFlux,
+	}}}
+	baseline, err := json.Marshal(previous.Spec)
+	require.NoError(t, err)
+
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.LastAppliedComponentsAnnotation: string(baseline),
+	}
+
+	desired := &v1alpha1.Cluster{Spec: v1alpha1.Spec{Cluster: v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionVanilla,
+		PolicyEngine: v1alpha1.PolicyEngineNone,
+		GitOpsEngine: v1alpha1.GitOpsEngineFlux,
+	}}}
+	desiredInstallers, err := factory.CreateInstallersForConfig(desired)
+	require.NoError(t, err)
+
+	removed, err := operator.RemovedComponentInstallers(factory, cluster, desiredInstallers)
+	require.NoError(t, err)
+	assert.Contains(t, removed, componentKyverno, "a component dropped from the spec is removed")
+	assert.NotContains(t, removed, componentFlux, "a still-desired component is not removed")
+}
+
+func TestRemovedComponentInstallers_NoBaselineReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	factory := newComponentFactory(t)
+
+	// No baseline annotation (first reconcile): nothing is considered removed.
+	removed, err := operator.RemovedComponentInstallers(
+		factory,
+		&v1alpha1.Cluster{},
+		map[string]installer.Installer{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, removed)
+}
+
+func TestRemovedComponentInstallers_UnparseableBaselineReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	factory := newComponentFactory(t)
+
+	// A corrupt baseline must never block a fresh apply: it is treated as "no baseline".
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.LastAppliedComponentsAnnotation: "{not valid json",
+	}
+
+	removed, err := operator.RemovedComponentInstallers(
+		factory,
+		cluster,
+		map[string]installer.Installer{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, removed)
 }

--- a/pkg/operator/components_test.go
+++ b/pkg/operator/components_test.go
@@ -198,25 +198,36 @@ func TestRunUninstallers_AggregatesErrorsAndContinues(t *testing.T) {
 	assert.Equal(t, []string{componentFlux, componentCilium}, order)
 }
 
-// newComponentFactory builds an installer factory backed by a bare helm mock — installer
+// newComponentFactory returns a factory builder backed by a bare helm mock — installer
 // construction does not call helm, so no expectations are needed (mirrors the factory tests).
-func newComponentFactory(t *testing.T) *installer.Factory {
+// It records each distribution it is invoked with into gotDistributions when non-nil, so tests
+// can assert which distribution the baseline factory was built for.
+func newComponentFactory(
+	t *testing.T,
+	gotDistributions *[]v1alpha1.Distribution,
+) func(v1alpha1.Distribution) *installer.Factory {
 	t.Helper()
 
-	return installer.NewFactory(
-		helm.NewMockInterface(t),
-		nil,
-		"/tmp/kubeconfig",
-		"",
-		5*time.Minute,
-		v1alpha1.DistributionVanilla,
-	)
+	return func(distribution v1alpha1.Distribution) *installer.Factory {
+		if gotDistributions != nil {
+			*gotDistributions = append(*gotDistributions, distribution)
+		}
+
+		return installer.NewFactory(
+			helm.NewMockInterface(t),
+			nil,
+			"/tmp/kubeconfig",
+			"",
+			5*time.Minute,
+			distribution,
+		)
+	}
 }
 
 func TestRemovedComponentInstallers_ReturnsComponentsDroppedFromSpec(t *testing.T) {
 	t.Parallel()
 
-	factory := newComponentFactory(t)
+	newFactory := newComponentFactory(t, nil)
 
 	// Baseline had Kyverno + Flux; the desired spec keeps only Flux (policyEngine flipped to None), so
 	// Kyverno must be reported as removed and Flux must not.
@@ -238,23 +249,57 @@ func TestRemovedComponentInstallers_ReturnsComponentsDroppedFromSpec(t *testing.
 		PolicyEngine: v1alpha1.PolicyEngineNone,
 		GitOpsEngine: v1alpha1.GitOpsEngineFlux,
 	}}}
-	desiredInstallers, err := factory.CreateInstallersForConfig(desired)
+	desiredInstallers, err := newFactory(v1alpha1.DistributionVanilla).
+		CreateInstallersForConfig(desired)
 	require.NoError(t, err)
 
-	removed, err := operator.RemovedComponentInstallers(factory, cluster, desiredInstallers)
+	removed, err := operator.RemovedComponentInstallers(newFactory, cluster, desiredInstallers)
 	require.NoError(t, err)
 	assert.Contains(t, removed, componentKyverno, "a component dropped from the spec is removed")
 	assert.NotContains(t, removed, componentFlux, "a still-desired component is not removed")
 }
 
+func TestRemovedComponentInstallers_BaselineFactoryUsesPreviousDistribution(t *testing.T) {
+	t.Parallel()
+
+	var gotDistributions []v1alpha1.Distribution
+
+	newFactory := newComponentFactory(t, &gotDistributions)
+
+	// The baseline was applied while the cluster ran K3s; the cluster has since been
+	// switched to Vanilla. The previous installer set must be rebuilt with a factory
+	// for K3s — several installers are distribution-dependent, so reusing the current
+	// (Vanilla) factory would compute the wrong uninstall set.
+	previous := &v1alpha1.Cluster{Spec: v1alpha1.Spec{Cluster: v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionK3s,
+		GitOpsEngine: v1alpha1.GitOpsEngineFlux,
+	}}}
+	baseline, err := json.Marshal(previous.Spec)
+	require.NoError(t, err)
+
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.LastAppliedComponentsAnnotation: string(baseline),
+	}
+
+	_, err = operator.RemovedComponentInstallers(
+		newFactory,
+		cluster,
+		map[string]installer.Installer{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []v1alpha1.Distribution{v1alpha1.DistributionK3s}, gotDistributions,
+		"the baseline installer set must be built for the previously-applied distribution")
+}
+
 func TestRemovedComponentInstallers_NoBaselineReturnsNil(t *testing.T) {
 	t.Parallel()
 
-	factory := newComponentFactory(t)
+	newFactory := newComponentFactory(t, nil)
 
 	// No baseline annotation (first reconcile): nothing is considered removed.
 	removed, err := operator.RemovedComponentInstallers(
-		factory,
+		newFactory,
 		&v1alpha1.Cluster{},
 		map[string]installer.Installer{},
 	)
@@ -265,7 +310,7 @@ func TestRemovedComponentInstallers_NoBaselineReturnsNil(t *testing.T) {
 func TestRemovedComponentInstallers_UnparseableBaselineReturnsNil(t *testing.T) {
 	t.Parallel()
 
-	factory := newComponentFactory(t)
+	newFactory := newComponentFactory(t, nil)
 
 	// A corrupt baseline must never block a fresh apply: it is treated as "no baseline".
 	cluster := &v1alpha1.Cluster{}
@@ -274,7 +319,7 @@ func TestRemovedComponentInstallers_UnparseableBaselineReturnsNil(t *testing.T) 
 	}
 
 	removed, err := operator.RemovedComponentInstallers(
-		factory,
+		newFactory,
 		cluster,
 		map[string]installer.Installer{},
 	)

--- a/pkg/operator/cr_service.go
+++ b/pkg/operator/cr_service.go
@@ -198,8 +198,8 @@ func (s *crClusterService) ensureNamespace(ctx context.Context, name string) err
 
 // sanitizeForWrite returns a copy of a client-supplied Cluster containing only the fields a caller
 // is allowed to set (name, namespace, labels, spec). It drops status, finalizers, resourceVersion,
-// and the operator-managed last-applied-spec annotation so the API cannot be used to interfere with
-// reconciliation or drift detection.
+// and the operator-managed last-applied baseline annotations so the API cannot be used to interfere
+// with reconciliation, drift detection, or component-removal detection.
 func sanitizeForWrite(cluster *v1alpha1.Cluster) *v1alpha1.Cluster {
 	out := &v1alpha1.Cluster{}
 	out.Name = cluster.Name
@@ -211,7 +211,8 @@ func sanitizeForWrite(cluster *v1alpha1.Cluster) *v1alpha1.Cluster {
 		annotations := make(map[string]string, len(cluster.Annotations))
 
 		for key, value := range cluster.Annotations {
-			if key == v1alpha1.LastAppliedSpecAnnotation {
+			if key == v1alpha1.LastAppliedSpecAnnotation ||
+				key == v1alpha1.LastAppliedComponentsAnnotation {
 				continue
 			}
 

--- a/pkg/operator/export_test.go
+++ b/pkg/operator/export_test.go
@@ -14,6 +14,10 @@ var (
 	ResolveProvider = resolveProvider
 	// RunInstallers exposes runInstallers for testing.
 	RunInstallers = runInstallers
+	// RunUninstallers exposes runUninstallers for testing.
+	RunUninstallers = runUninstallers
+	// RemovedComponentInstallers exposes removedComponentInstallers for testing.
+	RemovedComponentInstallers = removedComponentInstallers
 	// CountReadyNodes exposes countReadyNodes for testing.
 	CountReadyNodes = countReadyNodes
 )


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The operator's reconcile loop installs/upgrades the components a `Cluster` spec declares (CNI, CSI, metrics-server, cert-manager, load-balancer, policy-engine, GitOps), but it **never uninstalls a component the spec drops**. Flipping `policyEngine: Kyverno` → `None` (or switching CNI `Cilium` → `Calico`) left the old component's Helm release **orphaned** in the child cluster. The operator only ever called `Install`, never `Uninstall` — exactly [#4899](https://github.com/devantler-tech/ksail/issues/4899)'s open question #2 (*"Phase 1 only installs/upgrades"*).

## Change

Drive the **full desired state** instead of an install-only convergence:

- **New baseline annotation** `ksail.io/last-applied-components` — reconciler-owned, written only after a successful component apply. It records the spec the operator last installed components for. It is deliberately **distinct** from `ksail.io/last-applied-spec` (the drift baseline, which the provisioner path rewrites *before* components reconcile — reusing it would race the component diff), and is stripped from client-submitted objects (`sanitizeForWrite`) like the spec baseline so a user cannot forge it.
- **Uninstall the removed set** — on each apply, rebuild the *previous* installer set from the baseline via the same `installer.Factory`, diff its keys against the desired set, and `Uninstall` the removed components in **reverse dependency order** (GitOps first, CNI last) before converging the desired set.
  - *Determining* what to remove is best-effort: a corrupt or unbuildable baseline is logged and swallowed (the next reconcile retries) so it can never block a fresh apply.
  - An actual *uninstall failure* is folded into the returned error → surfaces as `ComponentsReady=False` and requeues.
- **Status-safe baseline write** — `recordAppliedComponents` runs after runtime status has been observed this reconcile, so a plain `Update` would clobber `cluster.Status` (the API decodes the server's stored status back into the object). It writes through a deep copy and propagates only the new annotations + `resourceVersion` back, leaving the conditions/observed status set this reconcile intact for the single status update at the end of `reconcileNormal`.

## Scope / safety

- **No CRD/schema/flag/CLI-surface changes** — annotation + operator-internal logic only, so no generated-file regeneration.
- **Happy path unchanged**: first install has no baseline → empty removed-set → behaves exactly as before. Uninstall only fires when a prior baseline contains a component absent from the desired set, and only when the generation gate re-runs component reconciliation.

## Tests

- `runUninstallers`: reverse-order teardown; error aggregation continues past a stuck uninstall.
- `removedComponentInstallers`: dropped-vs-still-desired diff; no-baseline → empty; corrupt baseline → empty (never blocks).
- Controller: baseline recorded (full reconciled spec) after a successful apply and **not** on a skip; per-component status preserved across the mid-reconcile metadata write.

Validated locally: `go build ./...`, `go vet`, `go test ./pkg/operator/... ./internal/controller/...`, and `golangci-lint run` on the changed packages all clean.

Part of #4899