### PR TITLE
feat(environment): structured cluster-environment clone rewrites

### DIFF
--- a/pkg/svc/environment/doc.go
+++ b/pkg/svc/environment/doc.go
@@ -1,0 +1,42 @@
+// Package environment is the foundation for `ksail cluster add-environment
+// <name> --from <env>`, which clones an existing cluster environment overlay so
+// adding an environment to a multi-cluster ksail repository stops being a manual
+// `cp -R k8s/clusters/<env> k8s/clusters/<new>` + hand-edit recipe. It is
+// increment 1 of the multi-cluster / multi-provider GitOps scaffolding epic; see
+// ksail#5441 and ksail#5562.
+//
+// # Design decision: structured rewrites, not string replace
+//
+// Cloning an overlay is mostly a verbatim copy. A cluster environment differs
+// from its sibling only by a handful of structured values — the cluster-meta
+// ConfigMap's cluster_name / provider, and the clusters/<env>/ path segment — and
+// the replacements: block plus base wiring are byte-identical across environments.
+// A naive strings.ReplaceAll(srcName, dstName) over the copied bytes would corrupt
+// unrelated tokens: an environment named "local" also appears in "localhost", in
+// the config.kubernetes.io/local-config annotation, and in arbitrary prose. So the
+// clone must rewrite specific, structured locations and leave everything else
+// byte-identical.
+//
+// This package provides the pure-logic primitives for that, fully unit-testable
+// with no filesystem or CLI surface:
+//
+//   - [Rewrite] describes one structured substitution.
+//   - [DeriveRewrites] computes what changes between two environments.
+//   - [RewriteOverlayFile] applies those rewrites to one cloned file's relative
+//     path and contents, preserving every untargeted byte.
+//
+// # Phased delivery
+//
+// The command is large, so it ships in independently-valuable slices:
+//
+//   - Foundation (this package): the structured-rewrite primitives — what changes
+//     between two environments and how it is applied to one file. Pure logic,
+//     fully unit-tested, needed by every later slice regardless of the eventual
+//     walk and CLI.
+//   - Next: the directory walk + write that clones k8s/clusters/<from>/** to
+//     k8s/clusters/<name>/** (honouring fsutil's force/skip semantics; SOPS
+//     *.enc.yaml copied as-is), and the ksail.<env>.yaml field repoint (name,
+//     context, config paths).
+//   - Then: the cobra `cluster add-environment` command and its generated-artifact
+//     refresh (cli-flags docs, help/toolgen snapshots).
+package environment

--- a/pkg/svc/environment/environment.go
+++ b/pkg/svc/environment/environment.go
@@ -41,14 +41,23 @@ type Rewrite struct {
 	New string
 }
 
-// validate reports whether the rewrite is well-formed.
+// validate reports whether the rewrite is well-formed, rejecting an unknown Kind
+// so a malformed rewrite fails with ErrInvalidRewrite rather than silently
+// no-opping through RewriteOverlayFile's switch.
 func (r Rewrite) validate() error {
 	if r.Old == "" || r.New == "" {
 		return fmt.Errorf("%w: Old and New must be non-empty", ErrInvalidRewrite)
 	}
 
-	if r.Kind == MetaFieldValue && r.Field == "" {
-		return fmt.Errorf("%w: MetaFieldValue requires a Field", ErrInvalidRewrite)
+	switch r.Kind {
+	case MetaFieldValue:
+		if r.Field == "" {
+			return fmt.Errorf("%w: MetaFieldValue requires a Field", ErrInvalidRewrite)
+		}
+	case PathSegment:
+		// No extra fields required.
+	default:
+		return fmt.Errorf("%w: unknown Kind %d", ErrInvalidRewrite, r.Kind)
 	}
 
 	return nil
@@ -208,9 +217,47 @@ func rewritePathTokens(path, old, replacement string) string {
 
 // rewriteClustersPath rewrites a "clusters/<old>" path reference in file contents
 // to "clusters/<new>", matching only on a trailing boundary so "clusters/<old>x"
-// is left untouched.
+// is left untouched. It rewrites only the code portion of each line, leaving a
+// trailing "# ..." comment unchanged so a documentary reference such as
+// "# see clusters/<old>" is preserved.
 func rewriteClustersPath(content, old, replacement string) string {
 	pattern := regexp.MustCompile(`clusters/` + regexp.QuoteMeta(old) + `([/"'\s]|$)`)
+	lines := strings.Split(content, "\n")
 
-	return pattern.ReplaceAllString(content, "clusters/"+replacement+"$1")
+	for index, line := range lines {
+		code, comment := splitLineComment(line)
+		lines[index] = pattern.ReplaceAllString(code, "clusters/"+replacement+"$1") + comment
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// splitLineComment splits a line into its code portion and a trailing YAML
+// comment — a "#" at the line start or preceded by whitespace, outside any
+// quoted scalar. A line with no such comment returns the whole line and "".
+func splitLineComment(line string) (string, string) {
+	var quote byte
+
+	for index := range len(line) {
+		char := line[index]
+
+		switch {
+		case quote != 0:
+			if char == quote {
+				quote = 0
+			}
+		case char == '\'' || char == '"':
+			quote = char
+		case char == '#' && commentPrecededByBoundary(line, index):
+			return line[:index], line[index:]
+		}
+	}
+
+	return line, ""
+}
+
+// commentPrecededByBoundary reports whether the "#" at index begins a YAML
+// comment, i.e. it is at the line start or preceded by whitespace.
+func commentPrecededByBoundary(line string, index int) bool {
+	return index == 0 || line[index-1] == ' ' || line[index-1] == '\t'
 }

--- a/pkg/svc/environment/environment.go
+++ b/pkg/svc/environment/environment.go
@@ -1,0 +1,216 @@
+package environment
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ErrInvalidRewrite is returned by RewriteOverlayFile when a rewrite is malformed
+// (an empty Old/New, or a MetaFieldValue rewrite missing its Field).
+var ErrInvalidRewrite = errors.New("invalid environment rewrite")
+
+// RewriteKind classifies a structured environment-clone substitution.
+type RewriteKind int
+
+const (
+	// MetaFieldValue rewrites the value of a YAML mapping field (the cluster-meta
+	// ConfigMap's cluster_name or provider) when the field's value equals Old
+	// exactly. It is matched as a "key: value" line, so the same text under a
+	// different key, inside a comment, or as a substring is never touched.
+	MetaFieldValue RewriteKind = iota
+	// PathSegment rewrites the environment name where it functions as a path or
+	// filename component — the clusters/<env>/ directory and the ksail.<env>.yaml
+	// config file. In a relative path it matches whole '/'- and '.'-delimited
+	// tokens; in file contents it matches only after the clusters/ prefix and on a
+	// trailing boundary, so substrings such as "localhost" are never touched.
+	PathSegment
+)
+
+// Rewrite describes one structured substitution applied when cloning a
+// cluster environment overlay from a source environment to a new one.
+type Rewrite struct {
+	// Kind selects how Old/New are matched and applied.
+	Kind RewriteKind
+	// Field is the YAML mapping key whose value is rewritten (MetaFieldValue only).
+	Field string
+	// Old is the source value (MetaFieldValue) or environment name (PathSegment).
+	Old string
+	// New is the destination value or environment name.
+	New string
+}
+
+// validate reports whether the rewrite is well-formed.
+func (r Rewrite) validate() error {
+	if r.Old == "" || r.New == "" {
+		return fmt.Errorf("%w: Old and New must be non-empty", ErrInvalidRewrite)
+	}
+
+	if r.Kind == MetaFieldValue && r.Field == "" {
+		return fmt.Errorf("%w: MetaFieldValue requires a Field", ErrInvalidRewrite)
+	}
+
+	return nil
+}
+
+// DeriveRewrites returns the structured substitutions that turn a clone
+// of the srcName environment overlay into the dstName environment. cluster_name is
+// always repointed and the clusters/<env>/ path segment always swapped; the
+// provider is repointed only when dstProvider is non-empty and differs from
+// srcProvider (an empty dstProvider inherits the source environment's provider).
+func DeriveRewrites(srcName, dstName, dstProvider, srcProvider string) []Rewrite {
+	rewrites := []Rewrite{
+		{Kind: MetaFieldValue, Field: "cluster_name", Old: srcName, New: dstName},
+		{Kind: PathSegment, Old: srcName, New: dstName},
+	}
+
+	if dstProvider != "" && dstProvider != srcProvider {
+		rewrites = append(rewrites, Rewrite{
+			Kind:  MetaFieldValue,
+			Field: "provider",
+			Old:   srcProvider,
+			New:   dstProvider,
+		})
+	}
+
+	return rewrites
+}
+
+// RewriteOverlayFile applies the rewrites to one cloned overlay file, returning the
+// file's new repository-relative path and its new contents. Only the structured
+// locations the rewrites target are changed; every other byte is preserved, so a
+// cloned kustomization's replacements: block and base wiring survive intact. It
+// returns ErrInvalidRewrite if any rewrite is malformed.
+func RewriteOverlayFile(
+	relPath, content string,
+	rewrites []Rewrite,
+) (string, string, error) {
+	newRelPath := relPath
+	newContent := content
+
+	for _, rewrite := range rewrites {
+		err := rewrite.validate()
+		if err != nil {
+			return "", "", err
+		}
+
+		switch rewrite.Kind {
+		case MetaFieldValue:
+			newContent = rewriteFieldValue(newContent, rewrite.Field, rewrite.Old, rewrite.New)
+		case PathSegment:
+			newRelPath = rewritePathTokens(newRelPath, rewrite.Old, rewrite.New)
+			newContent = rewriteClustersPath(newContent, rewrite.Old, rewrite.New)
+		}
+	}
+
+	return newRelPath, newContent, nil
+}
+
+// rewriteFieldValue rewrites every "field: old" mapping line in content to
+// "field: new", preserving indentation, quoting, and any trailing comment.
+func rewriteFieldValue(content, field, old, replacement string) string {
+	lines := strings.Split(content, "\n")
+	for index, line := range lines {
+		if rewritten, ok := rewriteFieldLine(line, field, old, replacement); ok {
+			lines[index] = rewritten
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// rewriteFieldLine rewrites a single "field: old" line to "field: new" when the
+// line's scalar value matches old exactly, returning the new line and true. Any
+// other line is returned unchanged with false.
+func rewriteFieldLine(line, field, old, replacement string) (string, bool) {
+	indentLen := len(line) - len(strings.TrimLeft(line, " \t"))
+	indent, rest := line[:indentLen], line[indentLen:]
+
+	prefix := field + ":"
+	if !strings.HasPrefix(rest, prefix) {
+		return line, false
+	}
+
+	after := rest[len(prefix):]
+	if after == "" || (after[0] != ' ' && after[0] != '\t') {
+		return line, false
+	}
+
+	leadLen := len(after) - len(strings.TrimLeft(after, " \t"))
+	lead, valueRegion := after[:leadLen], after[leadLen:]
+
+	if valueRegion == "" {
+		return line, false
+	}
+
+	scalar, tail := scanScalar(valueRegion)
+
+	unquoted, quote := unquoteScalar(scalar)
+	if unquoted != old {
+		return line, false
+	}
+
+	return indent + prefix + lead + quote + replacement + quote + tail, true
+}
+
+// scanScalar splits a value region into its leading scalar token (quoted or bare)
+// and the trailing remainder (whitespace and/or a "# ..." comment).
+func scanScalar(region string) (string, string) {
+	if region[0] == '\'' || region[0] == '"' {
+		quote := region[0]
+		for index := 1; index < len(region); index++ {
+			if region[index] == quote {
+				return region[:index+1], region[index+1:]
+			}
+		}
+
+		return region, ""
+	}
+
+	if index := strings.IndexAny(region, " \t"); index != -1 {
+		return region[:index], region[index:]
+	}
+
+	return region, ""
+}
+
+// unquoteScalar strips a single pair of matching surrounding quotes, returning the
+// inner text and the quote character used (empty when the scalar is unquoted).
+func unquoteScalar(scalar string) (string, string) {
+	if len(scalar) >= 2 &&
+		(scalar[0] == '\'' || scalar[0] == '"') &&
+		scalar[len(scalar)-1] == scalar[0] {
+		return scalar[1 : len(scalar)-1], string(scalar[0])
+	}
+
+	return scalar, ""
+}
+
+// rewritePathTokens replaces every whole '/'- and '.'-delimited token equal to old
+// with replacement, so the clusters/<env>/ directory segment and the
+// ksail.<env>.yaml filename are repointed without touching substrings.
+func rewritePathTokens(path, old, replacement string) string {
+	slashParts := strings.Split(path, "/")
+	for sIndex, slashPart := range slashParts {
+		dotParts := strings.Split(slashPart, ".")
+		for dIndex, dotPart := range dotParts {
+			if dotPart == old {
+				dotParts[dIndex] = replacement
+			}
+		}
+
+		slashParts[sIndex] = strings.Join(dotParts, ".")
+	}
+
+	return strings.Join(slashParts, "/")
+}
+
+// rewriteClustersPath rewrites a "clusters/<old>" path reference in file contents
+// to "clusters/<new>", matching only on a trailing boundary so "clusters/<old>x"
+// is left untouched.
+func rewriteClustersPath(content, old, replacement string) string {
+	pattern := regexp.MustCompile(`clusters/` + regexp.QuoteMeta(old) + `([/"'\s]|$)`)
+
+	return pattern.ReplaceAllString(content, "clusters/"+replacement+"$1")
+}

--- a/pkg/svc/environment/environment_test.go
+++ b/pkg/svc/environment/environment_test.go
@@ -176,6 +176,7 @@ func TestRewriteOverlayFile_ClustersPathBoundary(t *testing.T) {
   - clusters/prod
   - clusters/prod/bootstrap
   - clusters/production
+  # documentary cross-reference to clusters/prod stays put
 `
 
 	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
@@ -187,6 +188,8 @@ func TestRewriteOverlayFile_ClustersPathBoundary(t *testing.T) {
 	assert.Contains(t, newContent, "clusters/staging/bootstrap")
 	// "clusters/production" must NOT be rewritten — "prod" is only a prefix there.
 	assert.Contains(t, newContent, "clusters/production")
+	// A documentary reference inside a comment is left unchanged.
+	assert.Contains(t, newContent, "# documentary cross-reference to clusters/prod stays put")
 }
 
 func TestRewriteOverlayFile_PreservesQuotingAndTrailingComment(t *testing.T) {
@@ -216,6 +219,9 @@ func TestRewriteOverlayFile_InvalidRewrite(t *testing.T) {
 		"empty New": {Kind: environment.PathSegment, Old: "prod", New: ""},
 		"no Field": {
 			Kind: environment.MetaFieldValue, Field: "", Old: "prod", New: "staging",
+		},
+		"unknown Kind": {
+			Kind: environment.RewriteKind(99), Old: "prod", New: "staging",
 		},
 	}
 

--- a/pkg/svc/environment/environment_test.go
+++ b/pkg/svc/environment/environment_test.go
@@ -1,0 +1,257 @@
+package environment_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// prodOverlay mirrors the shape of a real platform clusters/<env>/kustomization.yaml
+// overlay: a cluster-meta patch carrying the per-environment cluster_name/provider,
+// a byte-identical replacements: block, and prose that incidentally contains the
+// environment name as a substring ("local-config", "localhost").
+const prodOverlay = `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patches:
+  - patch: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-meta
+        namespace: flux-system
+        annotations:
+          # consumed locally only (not applied): config.kubernetes.io/local-config
+          config.kubernetes.io/local-config: "true"
+      data:
+        cluster_name: prod
+        provider: hetzner
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: cluster-meta
+      fieldPath: data.provider
+    targets:
+      - select:
+          kind: Kustomization
+          namespace: flux-system
+        fieldPaths:
+          - spec.path
+        options:
+          delimiter: "/"
+          index: 1
+`
+
+func TestDeriveRewrites_NoProviderOverride(t *testing.T) {
+	t.Parallel()
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	require.Len(t, rewrites, 2)
+	assert.Equal(t, environment.Rewrite{
+		Kind: environment.MetaFieldValue, Field: "cluster_name", Old: "prod", New: "staging",
+	}, rewrites[0])
+	assert.Equal(t, environment.Rewrite{
+		Kind: environment.PathSegment, Old: "prod", New: "staging",
+	}, rewrites[1])
+}
+
+func TestDeriveRewrites_ProviderOverride(t *testing.T) {
+	t.Parallel()
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "aws", "hetzner")
+
+	require.Len(t, rewrites, 3)
+	assert.Equal(t, environment.Rewrite{
+		Kind: environment.MetaFieldValue, Field: "provider", Old: "hetzner", New: "aws",
+	}, rewrites[2])
+}
+
+func TestDeriveRewrites_ProviderUnchangedWhenEqual(t *testing.T) {
+	t.Parallel()
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "hetzner", "hetzner")
+
+	assert.Len(t, rewrites, 2, "an unchanged provider produces no provider rewrite")
+}
+
+func TestRewriteOverlayFile_RewritesClusterNameAndPreservesEverythingElse(t *testing.T) {
+	t.Parallel()
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	newPath, newContent, err := environment.RewriteOverlayFile(
+		"k8s/clusters/prod/kustomization.yaml", prodOverlay, rewrites,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "k8s/clusters/staging/kustomization.yaml", newPath)
+	assert.Contains(t, newContent, "cluster_name: staging")
+	assert.NotContains(t, newContent, "cluster_name: prod")
+
+	// The provider was not overridden, so it is untouched.
+	assert.Contains(t, newContent, "provider: hetzner")
+
+	// The replacements: block and base wiring are byte-identical to the source.
+	_, srcReplacements, srcFound := strings.Cut(prodOverlay, "replacements:")
+	require.True(t, srcFound)
+
+	_, dstReplacements, dstFound := strings.Cut(newContent, "replacements:")
+	require.True(t, dstFound)
+	assert.Equal(t, srcReplacements, dstReplacements)
+}
+
+func TestRewriteOverlayFile_ProviderOverride(t *testing.T) {
+	t.Parallel()
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "aws", "hetzner")
+
+	_, newContent, err := environment.RewriteOverlayFile(
+		"k8s/clusters/prod/kustomization.yaml", prodOverlay, rewrites,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, newContent, "provider: aws")
+	assert.NotContains(t, newContent, "provider: hetzner")
+}
+
+func TestRewriteOverlayFile_NoSpuriousSubstringRewrites(t *testing.T) {
+	t.Parallel()
+
+	const content = `metadata:
+  annotations:
+    config.kubernetes.io/local-config: "true"
+  host: localhost
+  note: a local-first cluster, reproduced locally
+data:
+  cluster_name: local
+  unrelated_key: local
+`
+
+	rewrites := environment.DeriveRewrites("local", "edge", "", "docker")
+
+	_, newContent, err := environment.RewriteOverlayFile("ksail.local.yaml", content, rewrites)
+	require.NoError(t, err)
+
+	// Only the cluster_name field value is rewritten.
+	assert.Contains(t, newContent, "cluster_name: edge")
+	// Substrings and unrelated keys with the same value are untouched.
+	assert.Contains(t, newContent, "local-config")
+	assert.Contains(t, newContent, "host: localhost")
+	assert.Contains(t, newContent, "a local-first cluster, reproduced locally")
+	assert.Contains(t, newContent, "unrelated_key: local")
+}
+
+func TestRewriteOverlayFile_KsailConfigFilenameAndKustomizationPath(t *testing.T) {
+	t.Parallel()
+
+	const content = `apiVersion: ksail.io/v1alpha1
+kind: Cluster
+spec:
+  workload:
+    sourceDirectory: k8s
+    kustomizationFile: clusters/prod
+`
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	newPath, newContent, err := environment.RewriteOverlayFile("ksail.prod.yaml", content, rewrites)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ksail.staging.yaml", newPath)
+	assert.Contains(t, newContent, "kustomizationFile: clusters/staging")
+}
+
+func TestRewriteOverlayFile_ClustersPathBoundary(t *testing.T) {
+	t.Parallel()
+
+	const content = `paths:
+  - clusters/prod
+  - clusters/prod/bootstrap
+  - clusters/production
+`
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	_, newContent, err := environment.RewriteOverlayFile("kustomization.yaml", content, rewrites)
+	require.NoError(t, err)
+
+	assert.Contains(t, newContent, "clusters/staging\n")
+	assert.Contains(t, newContent, "clusters/staging/bootstrap")
+	// "clusters/production" must NOT be rewritten — "prod" is only a prefix there.
+	assert.Contains(t, newContent, "clusters/production")
+}
+
+func TestRewriteOverlayFile_PreservesQuotingAndTrailingComment(t *testing.T) {
+	t.Parallel()
+
+	const content = `data:
+  cluster_name: "prod"   # the environment name
+`
+
+	rewrites := []environment.Rewrite{
+		{Kind: environment.MetaFieldValue, Field: "cluster_name", Old: "prod", New: "staging"},
+	}
+
+	_, newContent, err := environment.RewriteOverlayFile("kustomization.yaml", content, rewrites)
+	require.NoError(t, err)
+
+	assert.Contains(t, newContent, `cluster_name: "staging"   # the environment name`)
+}
+
+func TestRewriteOverlayFile_InvalidRewrite(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]environment.Rewrite{
+		"empty Old": {
+			Kind: environment.MetaFieldValue, Field: "cluster_name", Old: "", New: "staging",
+		},
+		"empty New": {Kind: environment.PathSegment, Old: "prod", New: ""},
+		"no Field": {
+			Kind: environment.MetaFieldValue, Field: "", Old: "prod", New: "staging",
+		},
+	}
+
+	for name, rewrite := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := environment.RewriteOverlayFile(
+				"kustomization.yaml", "data: {}\n", []environment.Rewrite{rewrite},
+			)
+			require.ErrorIs(t, err, environment.ErrInvalidRewrite)
+		})
+	}
+}
+
+func TestRewriteOverlayFile_FieldKeyMatchingIsExact(t *testing.T) {
+	t.Parallel()
+
+	const content = `data:
+  cluster_name: prod
+  cluster_named: prod
+  cluster_name:prod
+  cluster_name:
+`
+
+	rewrites := []environment.Rewrite{
+		{Kind: environment.MetaFieldValue, Field: "cluster_name", Old: "prod", New: "staging"},
+	}
+
+	_, newContent, err := environment.RewriteOverlayFile("kustomization.yaml", content, rewrites)
+	require.NoError(t, err)
+
+	// Only the exact "cluster_name: prod" mapping line is rewritten.
+	assert.Contains(t, newContent, "  cluster_name: staging\n")
+	// A different key, a colon without a following space, and a valueless key are all left alone.
+	assert.Contains(t, newContent, "  cluster_named: prod\n")
+	assert.Contains(t, newContent, "  cluster_name:prod\n")
+	assert.Contains(t, newContent, "  cluster_name:\n")
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

Foundation slice of `ksail cluster add-environment <name> --from <env>` — **increment 1** of the multi-cluster / multi-provider GitOps scaffolding epic (#5441). Adds the pure-logic primitives for cloning a cluster environment overlay by rewriting only its **structured identifiers**, not blind string replacement.

`Fixes #5562` · `Part of #5441`

## Why structured rewrites (not `strings.ReplaceAll`)

Grounded against the motivating consumer `devantler-tech/platform` (`k8s/clusters/{base,local,prod}` + `ksail.{,prod}.yaml`): a cluster environment differs from its sibling only by a handful of structured values — the `cluster-meta` ConfigMap's `cluster_name`/`provider` and the `clusters/<env>/` path segment — while the `replacements:` block and base wiring are **byte-identical** across environments. A naive `strings.ReplaceAll(srcName, dstName)` would corrupt unrelated tokens: an env named `local` also appears in `localhost`, the `config.kubernetes.io/local-config` annotation, and prose. So the clone must rewrite specific locations and leave everything else byte-identical.

## What's in this slice

New package `pkg/svc/environment` (mirrors the proven `pkg/svc/mirror` foundation shape — pure logic, **no CLI surface yet**; the exported API passes dead-code analysis like the mirror P0 did):

- **`Rewrite` / `RewriteKind`** (`MetaFieldValue`, `PathSegment`) — one structured substitution.
- **`DeriveRewrites(srcName, dstName, dstProvider, srcProvider)`** — what changes between two environments (`cluster_name` always; `provider` only on a differing override; the `clusters/<env>/` segment always).
- **`RewriteOverlayFile(relPath, content, rewrites)`** — applies them to one cloned file's relative path + contents, preserving every untargeted byte.

Matching is deliberately precise:
- `MetaFieldValue` rewrites a `key: value` line by **exact key + exact value** (preserving indentation, quoting, and any trailing comment) — so `cluster_name: prod` is rewritten but `host: localhost`, `local-config`, an unrelated key with the same value, and prose are not.
- `PathSegment` rewrites whole `/`- and `.`-delimited path tokens (the `clusters/<env>/` dir and the `ksail.<env>.yaml` filename) and, in file contents, only `clusters/<env>` on a trailing boundary — so `clusters/production` is **not** rewritten when the env is `prod`.

## Naming note (open to redirect)

The issue's tentative names (`EnvironmentRewrite`, `DeriveEnvironmentRewrites`) stutter against the package name (revive), so they're `environment.Rewrite` / `environment.DeriveRewrites` here.

## Validation

- `go build`/`go vet` clean; `gofmt` clean.
- 13 table tests, **93.8%** coverage (incl. no-spurious-substring, path-boundary, quoting/comment-preservation, exact-key-matching, and `ErrInvalidRewrite` guards).
- `golangci-lint run pkg/svc/environment/...` → **0 issues**.
- Pure stdlib; no `go.mod`, schema, or generated-artifact drift.

## Next slices (per #5562)

The directory walk + write (clone `k8s/clusters/<from>/**`, SOPS `*.enc.yaml` copied as-is), the `ksail.<env>.yaml` field repoint (name/context), then the cobra `cluster add-environment` command + generated-artifact refresh.