### PR TITLE
docs(render): correct stale #5362 attribution in helmRenderMu comment

### DIFF
--- a/pkg/svc/gitops/render/resolver.go
+++ b/pkg/svc/gitops/render/resolver.go
@@ -19,13 +19,20 @@ import (
 // caches (HELM_REPOSITORY_CACHE / HELM_CONTENT_CACHE, read from shared defaults
 // by every helm.NewTemplateOnlyClient) and other shared SDK state that is not
 // safe for concurrent use. validate (and scan) render kustomizations in
-// parallel, and unserialized renders intermittently interleaved into each
-// other's manifest stream — producing malformed YAML at a random offset that
-// failed a different kustomization on each run (issue #5362). Constructing a
-// fresh client per render is not enough because the shared state lives on disk,
-// below the client. Serializing only the template step keeps the expensive
-// parallel work (kustomize build, kubeconform validation) unaffected, and keeps
-// the shared chart cache warm so each chart is downloaded at most once.
+// parallel, and unserialized renders corrupted that shared cache state.
+// Constructing a fresh client per render is not enough because the shared state
+// lives on disk, below the client. Serializing only the template step keeps the
+// expensive parallel work (kustomize build, kubeconform validation) unaffected,
+// and keeps the shared chart cache warm so each chart is downloaded at most once.
+//
+// This lock does not, on its own, resolve the #5362 YAML corruption. That
+// corruption's race-detector-confirmed root cause is a separate data race inside
+// kubeconform's resource.FromStream, which aliases the bufio.Scanner buffer
+// across documents it emits and validates concurrently; the large multi-resource
+// streams this in-process render produces merely widen that race (the in-process
+// render itself was a red herring). #5362 is fixed only by bumping kubeconform
+// past the FromStream fix (upstream yannh/kubeconform#363). The lock still earns
+// its place by preventing the distinct Helm shared-cache corruption above.
 //
 //nolint:gochecknoglobals // package-level lock guarding Helm's process-global render state
 var helmRenderMu sync.Mutex


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Corrects a now-stale code comment on `helmRenderMu` in
`pkg/svc/gitops/render/resolver.go`. The comment (added with the serialize
fix #5364/#5366) attributed the validate/scan YAML-corruption issue **#5362** to
the in-process Helm render's shared-cache interleaving and implied the lock
resolved it.

## Why it's wrong now

The maintainer **reopened #5362** and **race-detector-confirmed** the root cause:

> *"Definitive root cause (race-detector confirmed) — it is **not** the in-process
> Helm render. The in-process render … was a red herring — it just produces large
> multi-resource streams that widen the real race."* — #5362 (2026-06-25)

The real root cause is a separate data race **inside kubeconform's
`resource.FromStream`**, which aliases the `bufio.Scanner` buffer across documents
it emits and validates concurrently. It is fixed only by bumping kubeconform past
the `FromStream` fix — upstream **yannh/kubeconform#363** (currently open).

Leaving the comment as-is misleads the next reader (human or agent) into thinking
#5362 is already fixed by this lock, risking a premature close of #5362 or a missed
kubeconform bump.

## Change

Comment-only. The corrected text:
- keeps `helmRenderMu` accurately scoped to the **distinct** Helm process-global
  shared-cache race it genuinely guards (still required, independent of #5362);
- points #5362's root cause at the kubeconform `FromStream` race / **#363**.

No behaviour change.

## Validation

- `go build ./pkg/svc/gitops/render/...` — OK
- `gofmt` — clean
- `golangci-lint run pkg/svc/gitops/render/...` — no issues on `resolver.go`
  (two pre-existing unrelated test-file findings are not in this diff and are
  green in CI on `main`)

## Context (not part of this PR)

The actual #5362 fix — a `go.mod replace` bridging ksail to the patched
kubeconform (`devantler/kubeconform@d3ae574` = v0.8.0 + #363) until upstream
releases — was prepared but **not** shipped here: integrating a personal-namespace
fork into the build is a supply-chain decision for the maintainer, and it also
unblocks platform #2273. This PR is the low-risk accuracy fix that stands on its own.

`Refs #5362`