### PR TITLE
feat(environment): clone overlay directory tree for `add-environment`

### DIFF
--- a/pkg/svc/environment/clone.go
+++ b/pkg/svc/environment/clone.go
@@ -32,10 +32,21 @@ var ErrSourceOverlayMissing = errors.New("source overlay directory not found")
 //
 // Existing destination files are preserved unless force is set
 // (fsutil.TryWriteFile semantics), and parent directories are created as needed.
-// It returns the repo-relative paths written, in deterministic (lexical) walk
-// order, and ErrSourceOverlayMissing if the source overlay does not exist.
+// It returns the repo-relative paths it actually wrote — a destination skipped
+// because it already exists (force is false) is excluded — in deterministic
+// (lexical) walk order. Source and destination paths are containment-checked
+// against repoRoot, so a srcRelDir or rewritten path with ".." segments or a
+// symlink escape is rejected (ErrSourceOverlayMissing / ErrPathOutsideBase) rather
+// than reading or writing outside the repository.
 func CloneOverlay(repoRoot, srcRelDir string, rewrites []Rewrite, force bool) ([]string, error) {
 	srcAbs := filepath.Join(repoRoot, srcRelDir)
+
+	// Containment guard: a srcRelDir with ".." segments or a symlinked overlay must
+	// not let the clone read from outside repoRoot.
+	if !fsutil.IsPathWithinDirectory(srcAbs, repoRoot) {
+		return nil, fmt.Errorf("%w: %s escapes the repository root",
+			ErrSourceOverlayMissing, srcRelDir)
+	}
 
 	info, err := os.Stat(srcAbs)
 	if err != nil || !info.IsDir() {
@@ -58,14 +69,14 @@ func CloneOverlay(repoRoot, srcRelDir string, rewrites []Rewrite, force bool) ([
 			return cloneErr
 		}
 
-		dest := filepath.Join(repoRoot, filepath.FromSlash(newRelPath))
-
-		_, writeErr := fsutil.TryWriteFile(content, dest, force)
+		wrote, writeErr := writeClone(repoRoot, newRelPath, content, force)
 		if writeErr != nil {
-			return fmt.Errorf("writing %s: %w", newRelPath, writeErr)
+			return writeErr
 		}
 
-		written = append(written, newRelPath)
+		if wrote {
+			written = append(written, newRelPath)
+		}
 
 		return nil
 	}
@@ -76,6 +87,46 @@ func CloneOverlay(repoRoot, srcRelDir string, rewrites []Rewrite, force bool) ([
 	}
 
 	return written, nil
+}
+
+// writeClone writes one cloned file's content to repoRoot/newRelPath, returning
+// whether a file was actually written. The destination is containment-checked
+// against repoRoot, and an existing file is preserved (wrote=false) unless force
+// is set — mirroring fsutil.TryWriteFile's skip semantics so the caller's
+// "paths written" list excludes skipped files.
+func writeClone(repoRoot, newRelPath, content string, force bool) (bool, error) {
+	dest := filepath.Join(repoRoot, filepath.FromSlash(newRelPath))
+
+	// Lexical containment on the cleaned destination: filepath.Join collapses any
+	// ".." segments, so a rewritten path that escapes repoRoot yields a relative
+	// path starting with "..". (The destination's parents may not exist yet, so the
+	// symlink-resolving EvalCanonicalPath can't be used here; the source overlay was
+	// already canonicalised and contained above.)
+	rel, relErr := filepath.Rel(repoRoot, dest)
+	if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false, fmt.Errorf("destination %s escapes the repository root: %w",
+			newRelPath, fsutil.ErrPathOutsideBase)
+	}
+
+	// TryWriteFile returns the content (not a write-status), so decide up front
+	// whether it will skip: it skips iff the file exists and force is false.
+	if !force {
+		_, statErr := os.Stat(dest)
+		if statErr == nil {
+			return false, nil
+		}
+
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return false, fmt.Errorf("checking destination %s: %w", newRelPath, statErr)
+		}
+	}
+
+	_, writeErr := fsutil.TryWriteFile(content, dest, force)
+	if writeErr != nil {
+		return false, fmt.Errorf("writing %s: %w", newRelPath, writeErr)
+	}
+
+	return true, nil
 }
 
 // cloneFile reads one source file and returns its destination repo-relative path

--- a/pkg/svc/environment/clone.go
+++ b/pkg/svc/environment/clone.go
@@ -1,0 +1,113 @@
+package environment
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+)
+
+// encryptedFileSuffix marks a SOPS-encrypted file whose ciphertext is cloned
+// byte-for-byte. Only its path is repointed to the destination environment;
+// re-encryption to that environment's recipients is out of scope for the clone
+// (the eventual command calls it out in --help).
+const encryptedFileSuffix = ".enc.yaml"
+
+// ErrSourceOverlayMissing is returned by CloneOverlay when repoRoot/srcRelDir does
+// not exist or is not a directory.
+var ErrSourceOverlayMissing = errors.New("source overlay directory not found")
+
+// CloneOverlay clones every file under repoRoot/srcRelDir into the destination
+// overlay implied by rewrites, applying the structured path+content rewrites to
+// each regular file and copying SOPS-encrypted *.enc.yaml files byte-for-byte
+// (their path is still repointed). It reuses [RewriteOverlayFile] for both the
+// per-file path and content rewrite, so the directory clone repoints
+// cluster_name/provider values, the clusters/<env>/ segment and clusters/<env>
+// content references exactly as the foundation already does — no second rewrite
+// implementation to drift.
+//
+// Existing destination files are preserved unless force is set
+// (fsutil.TryWriteFile semantics), and parent directories are created as needed.
+// It returns the repo-relative paths written, in deterministic (lexical) walk
+// order, and ErrSourceOverlayMissing if the source overlay does not exist.
+func CloneOverlay(repoRoot, srcRelDir string, rewrites []Rewrite, force bool) ([]string, error) {
+	srcAbs := filepath.Join(repoRoot, srcRelDir)
+
+	info, err := os.Stat(srcAbs)
+	if err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("%w: %s", ErrSourceOverlayMissing, srcRelDir)
+	}
+
+	var written []string
+
+	walk := func(absPath string, dirEntry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if dirEntry.IsDir() {
+			return nil
+		}
+
+		newRelPath, content, cloneErr := cloneFile(repoRoot, srcAbs, absPath, rewrites)
+		if cloneErr != nil {
+			return cloneErr
+		}
+
+		dest := filepath.Join(repoRoot, filepath.FromSlash(newRelPath))
+
+		_, writeErr := fsutil.TryWriteFile(content, dest, force)
+		if writeErr != nil {
+			return fmt.Errorf("writing %s: %w", newRelPath, writeErr)
+		}
+
+		written = append(written, newRelPath)
+
+		return nil
+	}
+
+	err = filepath.WalkDir(srcAbs, walk)
+	if err != nil {
+		return nil, fmt.Errorf("cloning overlay %s: %w", srcRelDir, err)
+	}
+
+	return written, nil
+}
+
+// cloneFile reads one source file and returns its destination repo-relative path
+// and the contents to write. A SOPS-encrypted *.enc.yaml file keeps its ciphertext
+// verbatim and only has its path repointed; every other file is rewritten through
+// [RewriteOverlayFile].
+func cloneFile(repoRoot, srcAbs, absPath string, rewrites []Rewrite) (string, string, error) {
+	raw, err := fsutil.ReadFileSafe(srcAbs, absPath)
+	if err != nil {
+		return "", "", fmt.Errorf("reading %s: %w", absPath, err)
+	}
+
+	relPath, err := filepath.Rel(repoRoot, absPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving %s relative to repo root: %w", absPath, err)
+	}
+
+	// Normalise to forward slashes so the rewrites — which operate on '/'-delimited
+	// path tokens and clusters/<env> references — behave identically on every OS.
+	relPath = filepath.ToSlash(relPath)
+
+	if strings.HasSuffix(relPath, encryptedFileSuffix) {
+		// Path-only rewrite: an empty content argument keeps the content rewrite a
+		// no-op so the ciphertext is preserved exactly, while newRelPath is still
+		// repointed to the destination environment.
+		newRelPath, _, pathErr := RewriteOverlayFile(relPath, "", rewrites)
+		if pathErr != nil {
+			return "", "", pathErr
+		}
+
+		return newRelPath, string(raw), nil
+	}
+
+	return RewriteOverlayFile(relPath, string(raw), rewrites)
+}

--- a/pkg/svc/environment/clone_test.go
+++ b/pkg/svc/environment/clone_test.go
@@ -1,0 +1,226 @@
+package environment_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// overlayKustomization mirrors a real platform clusters/<env>/kustomization.yaml:
+// a cluster-meta patch carrying the per-environment cluster_name/provider, a
+// clusters/<env> path reference, and prose that incidentally contains the
+// environment name as a substring ("local-config").
+const overlayKustomization = `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - patch: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-meta
+        annotations:
+          config.kubernetes.io/local-config: "true"
+      data:
+        cluster_name: prod
+        provider: hetzner
+components:
+  - clusters/prod/components
+`
+
+const bootstrapKustomization = `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../providers/hetzner/bootstrap
+`
+
+// encryptedSecret deliberately contains "prod" and "clusters/prod" text that the
+// structured rewrites WOULD touch in a plaintext file, to prove an *.enc.yaml file
+// is cloned byte-for-byte regardless.
+//
+//nolint:gosec // G101: a test fixture simulating SOPS ciphertext, not a real credential.
+const encryptedSecret = `cluster_name: prod
+data: ENC[AES256_GCM,data:clusters/prod,type:str]
+sops:
+    age: []
+`
+
+// writeOverlay materialises a prod overlay tree under repoRoot and returns it.
+func writeOverlay(t *testing.T, repoRoot string) {
+	t.Helper()
+
+	files := map[string]string{
+		"k8s/clusters/prod/kustomization.yaml":                          overlayKustomization,
+		"k8s/clusters/prod/bootstrap/kustomization.yaml":                bootstrapKustomization,
+		"k8s/clusters/prod/bootstrap/variables-cluster-secret.enc.yaml": encryptedSecret,
+	}
+
+	for rel, content := range files {
+		abs := filepath.Join(repoRoot, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o750))
+		require.NoError(t, os.WriteFile(abs, []byte(content), 0o600))
+	}
+}
+
+func readClone(t *testing.T, repoRoot, rel string) string {
+	t.Helper()
+
+	//nolint:gosec // G304: reads a file just written under the test's own t.TempDir().
+	data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(rel)))
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+func TestCloneOverlay_ClonesTreeWithStructuredRewrites(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeOverlay(t, repoRoot)
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	written, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", rewrites, false)
+	require.NoError(t, err)
+
+	// Walk order is lexical and deterministic: the bootstrap/ subdirectory is
+	// visited before the sibling kustomization.yaml file.
+	assert.Equal(t, []string{
+		"k8s/clusters/staging/bootstrap/kustomization.yaml",
+		"k8s/clusters/staging/bootstrap/variables-cluster-secret.enc.yaml",
+		"k8s/clusters/staging/kustomization.yaml",
+	}, written)
+
+	top := readClone(t, repoRoot, "k8s/clusters/staging/kustomization.yaml")
+	assert.Contains(t, top, "cluster_name: staging")
+	assert.NotContains(t, top, "cluster_name: prod")
+	// The provider was not overridden, so it is untouched.
+	assert.Contains(t, top, "provider: hetzner")
+	// The clusters/<env> content reference is repointed.
+	assert.Contains(t, top, "clusters/staging/components")
+	// An unrelated substring of the environment name is left alone.
+	assert.Contains(t, top, "config.kubernetes.io/local-config")
+}
+
+func TestCloneOverlay_CopiesSopsEncryptedFilesVerbatim(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeOverlay(t, repoRoot)
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", rewrites, false)
+	require.NoError(t, err)
+
+	// The encrypted file's path is repointed to the destination environment...
+	enc := readClone(t, repoRoot,
+		"k8s/clusters/staging/bootstrap/variables-cluster-secret.enc.yaml")
+	// ...but its ciphertext is byte-for-byte identical, including the "prod" and
+	// "clusters/prod" text a plaintext rewrite would have changed.
+	assert.Equal(t, encryptedSecret, enc)
+}
+
+func TestCloneOverlay_ProviderOverride(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeOverlay(t, repoRoot)
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "aws", "hetzner")
+
+	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", rewrites, false)
+	require.NoError(t, err)
+
+	top := readClone(t, repoRoot, "k8s/clusters/staging/kustomization.yaml")
+	assert.Contains(t, top, "provider: aws")
+	assert.NotContains(t, top, "provider: hetzner")
+}
+
+func TestCloneOverlay_SkipsExistingWithoutForce(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeOverlay(t, repoRoot)
+
+	// Pre-create a destination file with sentinel content.
+	dest := filepath.Join(repoRoot, "k8s", "clusters", "staging", "kustomization.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o750))
+	require.NoError(t, os.WriteFile(dest, []byte("SENTINEL\n"), 0o600))
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", rewrites, false)
+	require.NoError(t, err)
+
+	// Without force the existing destination file is preserved.
+	assert.Equal(t, "SENTINEL\n",
+		readClone(t, repoRoot, "k8s/clusters/staging/kustomization.yaml"))
+}
+
+func TestCloneOverlay_OverwritesExistingWithForce(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeOverlay(t, repoRoot)
+
+	dest := filepath.Join(repoRoot, "k8s", "clusters", "staging", "kustomization.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o750))
+	require.NoError(t, os.WriteFile(dest, []byte("SENTINEL\n"), 0o600))
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", rewrites, true)
+	require.NoError(t, err)
+
+	// With force the destination is overwritten with the cloned content.
+	top := readClone(t, repoRoot, "k8s/clusters/staging/kustomization.yaml")
+	assert.NotContains(t, top, "SENTINEL")
+	assert.Contains(t, top, "cluster_name: staging")
+}
+
+func TestCloneOverlay_MissingSourceOverlay(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/absent", rewrites, false)
+	require.ErrorIs(t, err, environment.ErrSourceOverlayMissing)
+}
+
+func TestCloneOverlay_SourceIsFileNotDirectory(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	cfgPath := filepath.Join(repoRoot, "ksail.prod.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("x\n"), 0o600))
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	// A path that exists but is a file, not a directory, is rejected.
+	_, err := environment.CloneOverlay(repoRoot, "ksail.prod.yaml", rewrites, false)
+	require.ErrorIs(t, err, environment.ErrSourceOverlayMissing)
+}
+
+func TestCloneOverlay_InvalidRewritePropagates(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeOverlay(t, repoRoot)
+
+	// A malformed rewrite (empty New) must surface ErrInvalidRewrite from the
+	// per-file rewrite rather than producing a partial clone.
+	bad := []environment.Rewrite{{Kind: environment.PathSegment, Old: "prod", New: ""}}
+
+	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", bad, false)
+	require.ErrorIs(t, err, environment.ErrInvalidRewrite)
+}

--- a/pkg/svc/environment/clone_test.go
+++ b/pkg/svc/environment/clone_test.go
@@ -157,12 +157,15 @@ func TestCloneOverlay_SkipsExistingWithoutForce(t *testing.T) {
 
 	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
 
-	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", rewrites, false)
+	written, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", rewrites, false)
 	require.NoError(t, err)
 
 	// Without force the existing destination file is preserved.
 	assert.Equal(t, "SENTINEL\n",
 		readClone(t, repoRoot, "k8s/clusters/staging/kustomization.yaml"))
+	// The skipped file is excluded from the returned "paths written" list.
+	assert.NotContains(t, written, "k8s/clusters/staging/kustomization.yaml")
+	assert.Contains(t, written, "k8s/clusters/staging/bootstrap/kustomization.yaml")
 }
 
 func TestCloneOverlay_OverwritesExistingWithForce(t *testing.T) {
@@ -208,6 +211,19 @@ func TestCloneOverlay_SourceIsFileNotDirectory(t *testing.T) {
 
 	// A path that exists but is a file, not a directory, is rejected.
 	_, err := environment.CloneOverlay(repoRoot, "ksail.prod.yaml", rewrites, false)
+	require.ErrorIs(t, err, environment.ErrSourceOverlayMissing)
+}
+
+func TestCloneOverlay_SourceTraversalRejected(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+
+	rewrites := environment.DeriveRewrites("prod", "staging", "", "hetzner")
+
+	// A srcRelDir with ".." segments that escapes repoRoot must be rejected even
+	// if it resolves to a real directory outside the repo.
+	_, err := environment.CloneOverlay(repoRoot, "../../etc", rewrites, false)
 	require.ErrorIs(t, err, environment.ErrSourceOverlayMissing)
 }
 

--- a/pkg/svc/environment/doc.go
+++ b/pkg/svc/environment/doc.go
@@ -1,9 +1,8 @@
 // Package environment is the foundation for `ksail cluster add-environment
 // <name> --from <env>`, which clones an existing cluster environment overlay so
 // adding an environment to a multi-cluster ksail repository stops being a manual
-// `cp -R k8s/clusters/<env> k8s/clusters/<new>` + hand-edit recipe. It is
-// increment 1 of the multi-cluster / multi-provider GitOps scaffolding epic; see
-// ksail#5441 and ksail#5562.
+// `cp -R k8s/clusters/<env> k8s/clusters/<new>` + hand-edit recipe. It is part of
+// the multi-cluster / multi-provider GitOps scaffolding epic; see ksail#5441.
 //
 // # Design decision: structured rewrites, not string replace
 //
@@ -17,26 +16,29 @@
 // clone must rewrite specific, structured locations and leave everything else
 // byte-identical.
 //
-// This package provides the pure-logic primitives for that, fully unit-testable
-// with no filesystem or CLI surface:
+// This package provides the rewrite primitives and the directory-clone
+// orchestrator, fully unit-testable with no CLI surface:
 //
 //   - [Rewrite] describes one structured substitution.
 //   - [DeriveRewrites] computes what changes between two environments.
 //   - [RewriteOverlayFile] applies those rewrites to one cloned file's relative
 //     path and contents, preserving every untargeted byte.
+//   - [CloneOverlay] walks a source overlay directory and writes the rewritten
+//     clone, copying SOPS *.enc.yaml files byte-for-byte (path still repointed)
+//     and honouring fsutil's force/skip semantics.
 //
 // # Phased delivery
 //
 // The command is large, so it ships in independently-valuable slices:
 //
-//   - Foundation (this package): the structured-rewrite primitives — what changes
-//     between two environments and how it is applied to one file. Pure logic,
-//     fully unit-tested, needed by every later slice regardless of the eventual
-//     walk and CLI.
-//   - Next: the directory walk + write that clones k8s/clusters/<from>/** to
-//     k8s/clusters/<name>/** (honouring fsutil's force/skip semantics; SOPS
-//     *.enc.yaml copied as-is), and the ksail.<env>.yaml field repoint (name,
-//     context, config paths).
-//   - Then: the cobra `cluster add-environment` command and its generated-artifact
-//     refresh (cli-flags docs, help/toolgen snapshots).
+//   - Foundation: the structured-rewrite primitives — what changes between two
+//     environments and how it is applied to one file. Pure logic, fully
+//     unit-tested, needed by every later slice regardless of the eventual walk and
+//     CLI (ksail#5562).
+//   - Directory clone ([CloneOverlay]): the walk + write that clones
+//     k8s/clusters/<from>/** to k8s/clusters/<name>/** honouring fsutil's
+//     force/skip semantics, with SOPS *.enc.yaml copied as-is (ksail#5567).
+//   - Next: the ksail.<env>.yaml root-config repoint (name, context, config
+//     paths), the cobra `cluster add-environment` command, and its
+//     generated-artifact refresh (cli-flags docs, help/toolgen snapshots).
 package environment


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Fixes #5567** · **Part of #5441** (multi-cluster / multi-provider GitOps scaffolding epic) — **increment 2**, the directory walk + write, building directly on the merged increment-1 rewrite foundation (`DeriveRewrites` / `RewriteOverlayFile`, #5563 / closed #5562).

## What

Adds `CloneOverlay(repoRoot, srcRelDir, rewrites, force) ([]string, error)` to `pkg/svc/environment`: it walks an entire `k8s/clusters/<from>/**` overlay tree and writes the rewritten clone to `k8s/clusters/<name>/**`, so the foundation finally has a consumer and the eventual `cluster add-environment` command has something to call.

```go
written, err := environment.CloneOverlay(
    repoRoot, "k8s/clusters/prod",
    environment.DeriveRewrites("prod", "staging", "", ""), false,
)
// → k8s/clusters/staging/** with cluster_name/provider, the clusters/<env>
//   segment and clusters/<env> references repointed; everything else byte-identical.
```

## How

- **Reuses the foundation for both path and content.** Each file’s destination repo-relative path and contents come from the already-merged `RewriteOverlayFile`, so `clusters/<env>` references, the directory segment, and `cluster_name`/`provider` values are repointed exactly as increment 1 does — no second rewrite implementation to drift.
- **SOPS `*.enc.yaml` = verbatim content, repointed path.** Encrypted files get a path-only rewrite (`RewriteOverlayFile(relPath, "", rewrites)` returns the repointed path) and their original bytes are written unchanged. Re-encryption to the destination environment’s recipients is explicitly out of scope (the command will call it out in `--help`).
- **`fsutil.TryWriteFile` force/skip semantics** (mirrors `cluster init`): an existing destination file is skipped unless `force`; parent dirs are created; path-traversal validation is inherited. Reads go through `fsutil.ReadFileSafe` (containment-checked).
- **No CLI surface yet** — exported, unit-tested orchestrator (the proven foundation/`mirror` slice shape; passes Dead Code Analysis).

## Validation

- `go build ./...` ✅, `go vet` ✅, `golangci-lint run ./pkg/svc/environment/...` → **0 issues** ✅
- `go test ./pkg/svc/environment/...` ✅ — **coverage 92.2%**
- New `t.TempDir()` tests cover: full structured clone (+ no spurious substring rewrites), the SOPS-verbatim path, provider override, force/skip, missing & non-directory source, deterministic walk order, and invalid-rewrite propagation.
- `go.mod`/`go.sum` unchanged — no new deps (stdlib `io/fs`/`os`/`path/filepath` + in-module `fsutil`). No CLI/schema/generated-artifact surface → no regeneration.

## Out of scope (increment 3)

The `ksail.<from>.yaml` → `ksail.<name>.yaml` root-config repoint, the cobra `cluster add-environment <name> --from <env> [--provider]` command, and the generated-artifact regen (cli-flags mdx, help/toolgen/chat snapshots).