### PR TITLE
feat(environment): clone root environment config for `add-environment`

### DIFF
--- a/pkg/svc/environment/clone.go
+++ b/pkg/svc/environment/clone.go
@@ -128,7 +128,7 @@ func CloneEnvironmentConfig(
 	}
 
 	info, err := os.Stat(srcAbs)
-	if err != nil || info.IsDir() {
+	if err != nil || !info.Mode().IsRegular() {
 		return "", false, fmt.Errorf("%w: %s", ErrSourceConfigMissing, srcConfigRel)
 	}
 

--- a/pkg/svc/environment/clone.go
+++ b/pkg/svc/environment/clone.go
@@ -21,6 +21,10 @@ const encryptedFileSuffix = ".enc.yaml"
 // not exist or is not a directory.
 var ErrSourceOverlayMissing = errors.New("source overlay directory not found")
 
+// ErrSourceConfigMissing is returned by CloneEnvironmentConfig when
+// repoRoot/srcConfigRel does not exist or is not a regular file.
+var ErrSourceConfigMissing = errors.New("source environment config not found")
+
 // CloneOverlay clones every file under repoRoot/srcRelDir into the destination
 // overlay implied by rewrites, applying the structured path+content rewrites to
 // each regular file and copying SOPS-encrypted *.enc.yaml files byte-for-byte
@@ -87,6 +91,58 @@ func CloneOverlay(repoRoot, srcRelDir string, rewrites []Rewrite, force bool) ([
 	}
 
 	return written, nil
+}
+
+// CloneEnvironmentConfig clones a single root environment config file (e.g.
+// ksail.<src>.yaml) into the destination environment's config (ksail.<dst>.yaml).
+// Pass the rewrites from [DeriveConfigRewrites] (not [DeriveRewrites]): the root
+// config carries the environment identity in its top-level `name:` field, so the
+// config-specific derivation repoints `name` and `provider` field values and swaps
+// any clusters/<env> path or content reference, while every other byte (the
+// connection context, version pins, comments, the rest of the spec) is preserved.
+// The destination filename is derived from the rewrites' PathSegment
+// (ksail.<src>.yaml -> ksail.<dst>.yaml), so the source and destination need not be
+// named by convention and the caller does not repeat the naming logic the
+// foundation already owns.
+//
+// It mirrors CloneOverlay's write semantics: the source and destination are
+// containment-checked against repoRoot, an existing destination is preserved unless
+// force is set, and parent directories are created as needed. It returns the
+// destination's repo-relative path and whether a file was actually written (false
+// when an existing destination was skipped because force is unset). A SOPS-encrypted
+// *.enc.yaml source keeps its ciphertext verbatim and only has its path repointed,
+// matching cloneFile.
+func CloneEnvironmentConfig(
+	repoRoot, srcConfigRel string,
+	rewrites []Rewrite,
+	force bool,
+) (string, bool, error) {
+	srcConfigRel = filepath.ToSlash(srcConfigRel)
+	srcAbs := filepath.Join(repoRoot, filepath.FromSlash(srcConfigRel))
+
+	// Containment guard: a srcConfigRel with ".." segments or a symlink escape must
+	// not let the clone read from outside repoRoot.
+	if !fsutil.IsPathWithinDirectory(srcAbs, repoRoot) {
+		return "", false, fmt.Errorf("%w: %s escapes the repository root",
+			ErrSourceConfigMissing, srcConfigRel)
+	}
+
+	info, err := os.Stat(srcAbs)
+	if err != nil || info.IsDir() {
+		return "", false, fmt.Errorf("%w: %s", ErrSourceConfigMissing, srcConfigRel)
+	}
+
+	newRelPath, content, err := cloneFile(repoRoot, repoRoot, srcAbs, rewrites)
+	if err != nil {
+		return "", false, err
+	}
+
+	wrote, err := writeClone(repoRoot, newRelPath, content, force)
+	if err != nil {
+		return "", false, err
+	}
+
+	return newRelPath, wrote, nil
 }
 
 // writeClone writes one cloned file's content to repoRoot/newRelPath, returning

--- a/pkg/svc/environment/clone_nonregular_test.go
+++ b/pkg/svc/environment/clone_nonregular_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package environment_test
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloneEnvironmentConfig_SourceIsNonRegularFile pins the documented contract
+// that the source must be a regular file: a FIFO (or any other non-regular node)
+// that exists and is not a directory must still be rejected, so that a clone never
+// flows a blocking node into cloneFile -> fsutil.ReadFileSafe.
+func TestCloneEnvironmentConfig_SourceIsNonRegularFile(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	fifo := filepath.Join(repoRoot, "ksail.prod.yaml")
+	require.NoError(t, syscall.Mkfifo(fifo, 0o600))
+
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	_, _, err := environment.CloneEnvironmentConfig(
+		repoRoot, "ksail.prod.yaml", rewrites, false)
+	require.ErrorIs(t, err, environment.ErrSourceConfigMissing)
+}

--- a/pkg/svc/environment/clone_test.go
+++ b/pkg/svc/environment/clone_test.go
@@ -240,3 +240,166 @@ func TestCloneOverlay_InvalidRewritePropagates(t *testing.T) {
 	_, err := environment.CloneOverlay(repoRoot, "k8s/clusters/prod", bad, false)
 	require.ErrorIs(t, err, environment.ErrInvalidRewrite)
 }
+
+// rootConfig mirrors a real platform ksail.<env>.yaml: the environment identity is
+// in the top-level metadata `name:`, a distribution-specific `context:`, and the
+// workload `kustomizationFile: clusters/<env>` — plus a node-group entry whose
+// `name:` is NOT the environment, to prove the value-exact rewrite leaves it alone.
+const rootConfig = `---
+apiVersion: cluster.ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  name: prod
+spec:
+  connection:
+    context: admin@prod
+  cluster:
+    distribution: Talos
+    provider: Hetzner
+    nodeAutoscaler:
+      nodeGroups:
+        - name: autoscale-cx33
+  workload:
+    sourceDirectory: k8s
+    kustomizationFile: clusters/prod
+`
+
+func writeRootConfig(t *testing.T, repoRoot string) {
+	t.Helper()
+
+	abs := filepath.Join(repoRoot, "ksail.prod.yaml")
+	require.NoError(t, os.WriteFile(abs, []byte(rootConfig), 0o600))
+}
+
+func TestDeriveConfigRewrites_AddsNameOnTopOfOverlayRewrites(t *testing.T) {
+	t.Parallel()
+
+	overlay := environment.DeriveRewrites("prod", "staging", "", "")
+	config := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	// The config derivation is a strict superset: every overlay rewrite is present,
+	// plus exactly one extra — the metadata `name:` field repoint.
+	require.Len(t, config, len(overlay)+1)
+	assert.Contains(t, config, environment.Rewrite{
+		Kind: environment.MetaFieldValue, Field: "name", Old: "prod", New: "staging",
+	})
+}
+
+func TestCloneEnvironmentConfig_RepointsIdentityFields(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeRootConfig(t, repoRoot)
+
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	newRel, wrote, err := environment.CloneEnvironmentConfig(
+		repoRoot, "ksail.prod.yaml", rewrites, false)
+	require.NoError(t, err)
+	assert.True(t, wrote)
+	// The destination filename is derived from the rewrites, not a convention.
+	assert.Equal(t, "ksail.staging.yaml", newRel)
+
+	clone := readClone(t, repoRoot, "ksail.staging.yaml")
+	// metadata.name is repointed to the destination environment...
+	assert.Contains(t, clone, "name: staging")
+	assert.NotContains(t, clone, "name: prod")
+	// ...the clusters/<env> reference is swapped...
+	assert.Contains(t, clone, "kustomizationFile: clusters/staging")
+	// ...the unrelated node-group name is left untouched (value-exact match)...
+	assert.Contains(t, clone, "name: autoscale-cx33")
+	// ...and the distribution-specific context is preserved (documented boundary).
+	assert.Contains(t, clone, "context: admin@prod")
+}
+
+func TestCloneEnvironmentConfig_ProviderOverride(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeRootConfig(t, repoRoot)
+
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "AWS", "Hetzner")
+
+	_, _, err := environment.CloneEnvironmentConfig(
+		repoRoot, "ksail.prod.yaml", rewrites, false)
+	require.NoError(t, err)
+
+	clone := readClone(t, repoRoot, "ksail.staging.yaml")
+	assert.Contains(t, clone, "provider: AWS")
+	assert.NotContains(t, clone, "provider: Hetzner")
+}
+
+func TestCloneEnvironmentConfig_SkipsExistingWithoutForce(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeRootConfig(t, repoRoot)
+	dest := filepath.Join(repoRoot, "ksail.staging.yaml")
+	require.NoError(t, os.WriteFile(dest, []byte("SENTINEL\n"), 0o600))
+
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	newRel, wrote, err := environment.CloneEnvironmentConfig(
+		repoRoot, "ksail.prod.yaml", rewrites, false)
+	require.NoError(t, err)
+	assert.False(t, wrote)
+	assert.Equal(t, "ksail.staging.yaml", newRel)
+	assert.Equal(t, "SENTINEL\n", readClone(t, repoRoot, "ksail.staging.yaml"))
+}
+
+func TestCloneEnvironmentConfig_OverwritesExistingWithForce(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeRootConfig(t, repoRoot)
+	dest := filepath.Join(repoRoot, "ksail.staging.yaml")
+	require.NoError(t, os.WriteFile(dest, []byte("SENTINEL\n"), 0o600))
+
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	_, wrote, err := environment.CloneEnvironmentConfig(
+		repoRoot, "ksail.prod.yaml", rewrites, true)
+	require.NoError(t, err)
+	assert.True(t, wrote)
+
+	clone := readClone(t, repoRoot, "ksail.staging.yaml")
+	assert.NotContains(t, clone, "SENTINEL")
+	assert.Contains(t, clone, "name: staging")
+}
+
+func TestCloneEnvironmentConfig_MissingSource(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	_, _, err := environment.CloneEnvironmentConfig(
+		repoRoot, "ksail.absent.yaml", rewrites, false)
+	require.ErrorIs(t, err, environment.ErrSourceConfigMissing)
+}
+
+func TestCloneEnvironmentConfig_SourceIsDirectory(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "ksail.prod.yaml"), 0o750))
+
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	// A path that exists but is a directory is rejected (the config must be a file).
+	_, _, err := environment.CloneEnvironmentConfig(
+		repoRoot, "ksail.prod.yaml", rewrites, false)
+	require.ErrorIs(t, err, environment.ErrSourceConfigMissing)
+}
+
+func TestCloneEnvironmentConfig_SourceTraversalRejected(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	rewrites := environment.DeriveConfigRewrites("prod", "staging", "", "")
+
+	// A srcConfigRel with ".." segments that escapes repoRoot must be rejected.
+	_, _, err := environment.CloneEnvironmentConfig(
+		repoRoot, "../../etc/passwd", rewrites, false)
+	require.ErrorIs(t, err, environment.ErrSourceConfigMissing)
+}

--- a/pkg/svc/environment/environment.go
+++ b/pkg/svc/environment/environment.go
@@ -86,6 +86,28 @@ func DeriveRewrites(srcName, dstName, dstProvider, srcProvider string) []Rewrite
 	return rewrites
 }
 
+// DeriveConfigRewrites returns the substitutions for cloning a root environment
+// config (ksail.<src>.yaml -> ksail.<dst>.yaml), as opposed to an overlay file. It
+// is a superset of [DeriveRewrites]: it adds a rewrite for the config's top-level
+// metadata `name:` field — the canonical environment identity in a ksail config
+// (the overlay files instead carry the identity in a `cluster_name:` ConfigMap
+// field, which [DeriveRewrites] already covers). The `name` rewrite is value-exact
+// (only `name: <src>` lines change), so sibling list entries such as
+// `name: autoscale-cx33` are left untouched.
+//
+// The connection `context:` (e.g. `admin@<env>` for Talos, `kind-<env>` for Kind)
+// is deliberately NOT rewritten here: its format is distribution-specific, so
+// repointing it correctly needs the distribution, which the eventual
+// `cluster add-environment` command resolves. A cloned config therefore keeps the
+// source's context until the new cluster is created (or the user edits it); this
+// boundary is called out so the foundation stays distribution-agnostic.
+func DeriveConfigRewrites(srcName, dstName, dstProvider, srcProvider string) []Rewrite {
+	return append(
+		DeriveRewrites(srcName, dstName, dstProvider, srcProvider),
+		Rewrite{Kind: MetaFieldValue, Field: "name", Old: srcName, New: dstName},
+	)
+}
+
 // RewriteOverlayFile applies the rewrites to one cloned overlay file, returning the
 // file's new repository-relative path and its new contents. Only the structured
 // locations the rewrites target are changed; every other byte is preserved, so a


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5570. **Part of #5441** (multi-cluster / multi-provider GitOps scaffolding), **increment 3a** — building on the merged `pkg/svc/environment` foundations: `DeriveRewrites`/`RewriteOverlayFile` (#5563) and `CloneOverlay` (#5568, merged this run).

## What

The overlay clone (`CloneOverlay`, #5568) reproduces a cluster's **overlay tree** (`k8s/clusters/<env>/**`). But a cluster environment is also its root `ksail.<env>.yaml` config, which lives *outside* that tree. This adds the root-config clone the eventual `cluster add-environment` command needs:

- **`DeriveConfigRewrites(srcName, dstName, dstProvider, srcProvider)`** — a superset of `DeriveRewrites` that adds a **value-exact `name:` repoint**. The root config keeps the environment identity in its top-level `metadata.name:` field (verified against the real `devantler-tech/platform` `ksail.prod.yaml`), unlike the overlay's `cluster_name:` ConfigMap field. The value-exact match repoints `name: prod` → `name: staging` while leaving sibling list entries like `name: autoscale-cx33` untouched.
- **`CloneEnvironmentConfig(repoRoot, srcConfigRel, rewrites, force) (newRelPath, wrote, err)`** — clones one root config file, **reusing the merged `cloneFile`/`writeClone` internals** so SOPS `*.enc.yaml` handling, repo-root containment, and force/skip semantics match `CloneOverlay` exactly (no second implementation to drift). The destination filename is derived from the rewrites' `PathSegment` (`ksail.prod.yaml` → `ksail.staging.yaml`).

## Design calls (flagged for redirect)

1. **`name` repoint lives in `DeriveConfigRewrites`, not `DeriveRewrites`** — so it never affects overlay cloning, where a bare `name: <env>` could over-match a k8s resource named for the environment.
2. **The connection `context:` is deliberately NOT repointed here.** Its format is distribution-specific (`admin@<env>` Talos, `kind-<env>` Kind, …), so a correct repoint needs the distribution — which the **command** (increment 3b) resolves. The cloned config keeps the source context until the new cluster is created. This keeps the foundation distribution-agnostic; the test asserts the boundary (`context: admin@prod` preserved).

## Why this slice

Same exported, unit-tested, **no-CLI/no-generated-surface** shape as #5563/#5568 (Dead-Code-Analysis-safe). The cobra `add-environment` command, the overlay-source-dir convention, the distribution-aware `context:` repoint, and the generated-artifact regen are **increment 3b** — kept separate so the command's design (and its snapshot/toolgen/docs churn) gets its own review.

## Validation

- `go build ./...` clean; `go vet ./pkg/svc/environment/...` clean.
- `go test ./pkg/svc/environment/...` — **32 pass**; package coverage **90.5%** (`DeriveConfigRewrites` 100%, `CloneEnvironmentConfig` 85.7%).
- `golangci-lint run ./pkg/svc/environment/...` — **no issues**.
- `go.mod` unchanged; no generated/schema/snapshot surface touched.

Opened as a **draft** for promotion review.
