### PR TITLE
feat(environment): distribution-aware context repoint for add-environment (DeriveContextRewrite)

### DIFF
--- a/pkg/svc/environment/context_test.go
+++ b/pkg/svc/environment/context_test.go
@@ -1,0 +1,135 @@
+package environment_test
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveContextRewrite_PerDistribution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		distribution v1alpha1.Distribution
+		wantOld      string
+		wantNew      string
+	}{
+		{"Talos", v1alpha1.DistributionTalos, "admin@prod", "admin@staging"},
+		{"Vanilla", v1alpha1.DistributionVanilla, "kind-prod", "kind-staging"},
+		{"K3s", v1alpha1.DistributionK3s, "k3d-prod", "k3d-staging"},
+		{
+			"VCluster",
+			v1alpha1.DistributionVCluster,
+			"vcluster-docker_prod",
+			"vcluster-docker_staging",
+		},
+		{"KWOK", v1alpha1.DistributionKWOK, "kwok-prod", "kwok-staging"},
+		// EKS yields only the .eksctl.io suffix; the value-exact rewrite is still
+		// well-formed and simply no-ops against a real eksctl context (see the
+		// SourceContextNoOp test below).
+		{"EKS", v1alpha1.DistributionEKS, "prod.eksctl.io", "staging.eksctl.io"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			rewrite, ok := environment.DeriveContextRewrite(
+				testCase.distribution,
+				"prod",
+				"staging",
+			)
+			require.True(t, ok)
+			assert.Equal(t, environment.MetaFieldValue, rewrite.Kind)
+			assert.Equal(t, "context", rewrite.Field)
+			assert.Equal(t, testCase.wantOld, rewrite.Old)
+			assert.Equal(t, testCase.wantNew, rewrite.New)
+		})
+	}
+}
+
+func TestDeriveContextRewrite_SkippedWhenContextUnresolvable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		distribution v1alpha1.Distribution
+		srcName      string
+		dstName      string
+	}{
+		{"empty source name", v1alpha1.DistributionTalos, "", "staging"},
+		{"empty destination name", v1alpha1.DistributionTalos, "prod", ""},
+		{"unknown distribution", v1alpha1.Distribution("Bogus"), "prod", "staging"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			rewrite, ok := environment.DeriveContextRewrite(
+				testCase.distribution, testCase.srcName, testCase.dstName,
+			)
+			require.False(t, ok)
+			assert.Equal(t, environment.Rewrite{}, rewrite)
+		})
+	}
+}
+
+// TestDeriveContextRewrite_AppliedToConfig confirms the rewrite, composed with the
+// config-rewrite set and applied through RewriteOverlayFile, repoints the
+// connection context value-exactly while leaving sibling fields untouched.
+func TestDeriveContextRewrite_AppliedToConfig(t *testing.T) {
+	t.Parallel()
+
+	const config = `apiVersion: cluster.ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  name: prod
+spec:
+  connection:
+    context: admin@prod
+  cluster:
+    distribution: Talos
+`
+
+	rewrite, ok := environment.DeriveContextRewrite(v1alpha1.DistributionTalos, "prod", "staging")
+	require.True(t, ok)
+
+	_, newContent, err := environment.RewriteOverlayFile(
+		"ksail.prod.yaml",
+		config,
+		[]environment.Rewrite{rewrite},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, newContent, "context: admin@staging")
+	assert.NotContains(t, newContent, "admin@prod")
+	// The sibling distribution scalar must be preserved.
+	assert.Contains(t, newContent, "distribution: Talos")
+}
+
+// TestDeriveContextRewrite_SourceContextNoOp confirms the value-exact guarantee:
+// an EKS context rewrite leaves a full eksctl context (which never equals the
+// scaffold-time <name>.eksctl.io suffix) untouched.
+func TestDeriveContextRewrite_SourceContextNoOp(t *testing.T) {
+	t.Parallel()
+
+	const config = `spec:
+  connection:
+    context: user@prod.us-east-1.eksctl.io
+`
+
+	rewrite, ok := environment.DeriveContextRewrite(v1alpha1.DistributionEKS, "prod", "staging")
+	require.True(t, ok)
+
+	_, newContent, err := environment.RewriteOverlayFile(
+		"ksail.prod.yaml",
+		config,
+		[]environment.Rewrite{rewrite},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, config, newContent)
+}

--- a/pkg/svc/environment/environment.go
+++ b/pkg/svc/environment/environment.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 )
 
 // ErrInvalidRewrite is returned by RewriteOverlayFile when a rewrite is malformed
@@ -97,15 +99,50 @@ func DeriveRewrites(srcName, dstName, dstProvider, srcProvider string) []Rewrite
 //
 // The connection `context:` (e.g. `admin@<env>` for Talos, `kind-<env>` for Kind)
 // is deliberately NOT rewritten here: its format is distribution-specific, so
-// repointing it correctly needs the distribution, which the eventual
-// `cluster add-environment` command resolves. A cloned config therefore keeps the
-// source's context until the new cluster is created (or the user edits it); this
-// boundary is called out so the foundation stays distribution-agnostic.
+// repointing it correctly needs the distribution. [DeriveContextRewrite] provides
+// that distribution-aware rewrite, which the `cluster add-environment` command
+// appends to this set once it has resolved the source environment's distribution.
+// Keeping the two separate lets this foundation stay distribution-agnostic.
 func DeriveConfigRewrites(srcName, dstName, dstProvider, srcProvider string) []Rewrite {
 	return append(
 		DeriveRewrites(srcName, dstName, dstProvider, srcProvider),
 		Rewrite{Kind: MetaFieldValue, Field: "name", Old: srcName, New: dstName},
 	)
+}
+
+// DeriveContextRewrite returns the distribution-aware substitution that repoints a
+// cloned root config's connection `context:` from the source environment to the
+// destination, plus a bool reporting whether a rewrite applies. It is the
+// distribution-specific complement to [DeriveConfigRewrites]: the command layer
+// resolves the source environment's distribution and appends this rewrite to the
+// distribution-agnostic set.
+//
+// The context value is derived from the distribution's own naming convention via
+// [v1alpha1.Distribution.ContextName] (Talos `admin@<name>`, Vanilla `kind-<name>`,
+// K3s `k3d-<name>`, VCluster `vcluster-docker_<name>`, KWOK `kwok-<name>`), so the
+// derivation never drifts from the rest of KSail. The rewrite is value-exact (like
+// the `name` rewrite in [DeriveConfigRewrites]): it only fires when the config's
+// `context:` scalar equals the source context exactly, so a config carrying a
+// hand-edited or post-creation context is left untouched. This also makes it safe
+// for EKS, whose `ContextName` yields only the `<name>.eksctl.io` suffix because the
+// full `<iam>@<cluster>.<region>.eksctl.io` context is unknown until the cluster
+// exists — the value-exact match simply no-ops against the real eksctl context.
+//
+// ok is false when either context name is empty (an empty environment name or an
+// unknown distribution), in which case the returned Rewrite is the zero value and
+// must not be applied.
+func DeriveContextRewrite(
+	distribution v1alpha1.Distribution,
+	srcName, dstName string,
+) (Rewrite, bool) {
+	srcContext := distribution.ContextName(srcName)
+	dstContext := distribution.ContextName(dstName)
+
+	if srcContext == "" || dstContext == "" {
+		return Rewrite{}, false
+	}
+
+	return Rewrite{Kind: MetaFieldValue, Field: "context", Old: srcContext, New: dstContext}, true
 }
 
 // RewriteOverlayFile applies the rewrites to one cloned overlay file, returning the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5574. Part of #5441 (`ksail cluster add-environment`). Increment **3b-logic** — building on the
now-merged 3a foundation (#5571, `DeriveConfigRewrites`/`CloneEnvironmentConfig`).

## What

Adds `environment.DeriveContextRewrite(distribution, srcName, dstName) (Rewrite, bool)` — the
**distribution-aware** connection-`context:` repoint that `DeriveConfigRewrites` deliberately deferred
(its doc explicitly keeps the foundation distribution-agnostic). The `cluster add-environment` command
will append this rewrite to the config-rewrite set once it has resolved the source environment's
distribution.

## Design

- **Reuses `v1alpha1.Distribution.ContextName`** so the per-distribution context convention
  (`admin@<name>` Talos, `kind-<name>` Vanilla, `k3d-<name>` K3s, `vcluster-docker_<name>` VCluster,
  `kwok-<name>` KWOK) never drifts from the rest of KSail.
- **Value-exact** (same property as the `name` rewrite in `DeriveConfigRewrites`): it only fires when
  the config's `context:` scalar equals the *source* context exactly. A config carrying a hand-edited or
  post-creation context is left untouched.
- **EKS-safe by construction**: `ContextName` for EKS yields only the `<name>.eksctl.io` suffix because
  the real `<iam>@<cluster>.<region>.eksctl.io` context is unknown until the cluster exists. The
  value-exact match simply no-ops against a real eksctl context (covered by a test) — no special-casing
  needed.
- **`ok=false`** (zero-value Rewrite) for an empty environment name or an unknown distribution.

Kept separate from `DeriveConfigRewrites` so the foundation stays distribution-agnostic; the command
composes the two.

## Validation

- `go build`/`go vet` clean; **46 tests pass**; `golangci-lint` 0 issues; `gofmt` clean; `go.mod`/`go.sum`
  unchanged (the import is the internal `v1alpha1` package).
- `DeriveContextRewrite` **100% coverage**; package total 91.4%.
- Tests cover every distribution, the skip cases (empty name / unknown distribution), applied-to-config
  repoint, and the EKS value-exact no-op.
- **No CLI/generated surface** — exported pkg function only (DCA-safe; no toolgen/snapshot/docs regen).

## Next (separate slice on #5441, anti-stacked until this merges)

The cobra `cluster add-environment <name> --from <env> [--provider][--force]` command wiring
`CloneOverlay` + `CloneEnvironmentConfig` + `DeriveConfigRewrites`+`DeriveContextRewrite` + the
overlay-source-dir convention + generated-artifact regen.
