### PR TITLE
fix(flux): make workload reconcile readiness revision-aware

### DIFF
--- a/pkg/client/flux/gvr.go
+++ b/pkg/client/flux/gvr.go
@@ -2,6 +2,10 @@ package flux
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
+// sourceAPIGroup is the API group shared by all Flux source kinds
+// (OCIRepository, GitRepository, Bucket).
+const sourceAPIGroup = "source.toolkit.fluxcd.io"
+
 // KustomizationGVR returns the GroupVersionResource for Flux Kustomizations.
 func KustomizationGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
@@ -14,9 +18,27 @@ func KustomizationGVR() schema.GroupVersionResource {
 // OCIRepositoryGVR returns the GroupVersionResource for Flux OCIRepositories.
 func OCIRepositoryGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
-		Group:    "source.toolkit.fluxcd.io",
+		Group:    sourceAPIGroup,
 		Version:  "v1",
 		Resource: "ocirepositories",
+	}
+}
+
+// GitRepositoryGVR returns the GroupVersionResource for Flux GitRepositories.
+func GitRepositoryGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    sourceAPIGroup,
+		Version:  "v1",
+		Resource: "gitrepositories",
+	}
+}
+
+// BucketGVR returns the GroupVersionResource for Flux Buckets.
+func BucketGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    sourceAPIGroup,
+		Version:  "v1",
+		Resource: "buckets",
 	}
 }
 

--- a/pkg/client/flux/kustomization.go
+++ b/pkg/client/flux/kustomization.go
@@ -108,7 +108,13 @@ func (r *Reconciler) CheckNamedKustomizationReady(
 		return false, "", fmt.Errorf("get flux kustomization %q: %w", name, err)
 	}
 
-	return checkKustomizationStatus(kustomization)
+	// Resolve the revision the source has just made available so readiness is
+	// evaluated against the just-pushed artifact rather than a leftover Ready
+	// condition from the previous revision. An empty revision (source missing,
+	// unknown kind, no artifact) falls back to condition-only readiness.
+	sourceRevision := r.resolveSourceRevision(ctx, kustomization)
+
+	return checkKustomizationStatus(kustomization, sourceRevision)
 }
 
 // kustomizationClient returns a dynamic client for Flux Kustomizations.
@@ -152,8 +158,15 @@ func parseDependsOn(kustomization *unstructured.Unstructured) []string {
 
 // checkKustomizationStatus checks the kustomization status and returns ready state,
 // a human-readable status string for debugging, and any permanent failure errors.
+//
+// When sourceRevision is non-empty, readiness is revision-aware: the Ready
+// condition is only trusted once the Kustomization has attempted the current
+// source revision, and success additionally requires that revision to have been
+// applied. This prevents a leftover condition from the previous revision from
+// producing a false pass/fail immediately after a source artifact is pushed.
 func checkKustomizationStatus(
 	kustomization *unstructured.Unstructured,
+	sourceRevision string,
 ) (bool, string, error) {
 	conditions := reconciler.ParseConditions(kustomization)
 	if len(conditions) == 0 {
@@ -171,7 +184,85 @@ func checkKustomizationStatus(
 			generation, observed), nil
 	}
 
-	return evaluateKustomizationConditions(conditions)
+	// Revision-aware gate: until the Kustomization has attempted the current
+	// source revision, its Ready condition describes a prior revision and must
+	// not be trusted (avoids both the false-fail on a stale permanent failure
+	// and the false-pass on a stale Ready=True).
+	if sourceRevision != "" {
+		if status, observed := revisionObservedStatus(kustomization, sourceRevision); !observed {
+			return false, status, nil
+		}
+	}
+
+	ready, status, err := evaluateKustomizationConditions(conditions)
+
+	// A Ready=True verdict is only authoritative once the current source
+	// revision has actually been applied; otherwise the apply is still in
+	// flight and we keep polling.
+	if err == nil && ready && sourceRevision != "" {
+		if applied := lastAppliedRevision(kustomization); applied != sourceRevision {
+			return false, fmt.Sprintf(
+				"waiting for revision %s to be applied (applied %s)",
+				shortRevision(sourceRevision), shortRevision(applied),
+			), nil
+		}
+	}
+
+	return ready, status, err
+}
+
+// revisionObservedStatus reports whether the Kustomization has attempted to
+// reconcile the given source revision (status.lastAttemptedRevision == target).
+// When it has not, observed is false and the returned status explains what the
+// check is waiting for. Once observed, the Ready condition may be evaluated.
+func revisionObservedStatus(
+	kustomization *unstructured.Unstructured,
+	target string,
+) (string, bool) {
+	if lastAttemptedRevision(kustomization) == target {
+		return "", true
+	}
+
+	return fmt.Sprintf(
+		"waiting for revision %s to be reconciled (attempted %s)",
+		shortRevision(target), shortRevision(lastAttemptedRevision(kustomization)),
+	), false
+}
+
+// lastAttemptedRevision returns status.lastAttemptedRevision, the source
+// revision Flux most recently tried to build/apply.
+func lastAttemptedRevision(kustomization *unstructured.Unstructured) string {
+	revision, _, _ := unstructured.NestedString(
+		kustomization.Object, "status", "lastAttemptedRevision",
+	)
+
+	return revision
+}
+
+// lastAppliedRevision returns status.lastAppliedRevision, the source revision
+// Flux most recently applied successfully.
+func lastAppliedRevision(kustomization *unstructured.Unstructured) string {
+	revision, _, _ := unstructured.NestedString(
+		kustomization.Object, "status", "lastAppliedRevision",
+	)
+
+	return revision
+}
+
+// shortRevision trims a Flux revision string for human-readable status output,
+// keeping enough of the digest to be recognisable. An empty revision renders as
+// "<none>".
+func shortRevision(revision string) string {
+	if revision == "" {
+		return "<none>"
+	}
+
+	const maxLen = 20
+	if len(revision) <= maxLen {
+		return revision
+	}
+
+	return revision[:maxLen] + "…"
 }
 
 // isStatusStale checks if the observed generation is behind the current generation.

--- a/pkg/client/flux/source_revision.go
+++ b/pkg/client/flux/source_revision.go
@@ -1,0 +1,92 @@
+package flux
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// sourceRef identifies the Flux source (OCIRepository / GitRepository / Bucket)
+// referenced by a Kustomization's spec.sourceRef.
+type sourceRef struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+// parseKustomizationSourceRef extracts spec.sourceRef from a Kustomization CR.
+// The namespace defaults to the Kustomization's own namespace when
+// sourceRef.namespace is empty (Flux's default). Returns ok=false when no
+// usable sourceRef is present.
+func parseKustomizationSourceRef(kustomization *unstructured.Unstructured) (sourceRef, bool) {
+	kind, _, _ := unstructured.NestedString(kustomization.Object, "spec", "sourceRef", "kind")
+	name, _, _ := unstructured.NestedString(kustomization.Object, "spec", "sourceRef", "name")
+
+	if kind == "" || name == "" {
+		return sourceRef{}, false
+	}
+
+	namespace, _, _ := unstructured.NestedString(
+		kustomization.Object, "spec", "sourceRef", "namespace",
+	)
+	if namespace == "" {
+		namespace = kustomization.GetNamespace()
+	}
+
+	if namespace == "" {
+		namespace = DefaultNamespace
+	}
+
+	return sourceRef{Kind: kind, Name: name, Namespace: namespace}, true
+}
+
+// sourceGVRForKind maps a Kustomization spec.sourceRef.kind to its
+// GroupVersionResource. Returns ok=false for kinds that cannot back a
+// Kustomization (e.g. HelmChart/HelmRepository).
+func sourceGVRForKind(kind string) (schema.GroupVersionResource, bool) {
+	switch kind {
+	case "OCIRepository":
+		return OCIRepositoryGVR(), true
+	case "GitRepository":
+		return GitRepositoryGVR(), true
+	case "Bucket":
+		return BucketGVR(), true
+	default:
+		return schema.GroupVersionResource{}, false
+	}
+}
+
+// resolveSourceRevision returns the current artifact revision advertised by the
+// Kustomization's source (status.artifact.revision) — the revision the source
+// has just made available (e.g. after `ksail workload push`). It returns an
+// empty string when the revision cannot be resolved (no sourceRef, unknown
+// source kind, source missing, or no artifact yet); callers treat an empty
+// revision as "revision-unaware" and fall back to condition-only readiness, so
+// the readiness check never regresses when source state is unavailable.
+func (r *Reconciler) resolveSourceRevision(
+	ctx context.Context,
+	kustomization *unstructured.Unstructured,
+) string {
+	ref, found := parseKustomizationSourceRef(kustomization)
+	if !found {
+		return ""
+	}
+
+	gvr, known := sourceGVRForKind(ref.Kind)
+	if !known {
+		return ""
+	}
+
+	source, err := r.Dynamic.Resource(gvr).
+		Namespace(ref.Namespace).
+		Get(ctx, ref.Name, metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+
+	revision, _, _ := unstructured.NestedString(source.Object, "status", "artifact", "revision")
+
+	return revision
+}

--- a/pkg/client/flux/source_revision_test.go
+++ b/pkg/client/flux/source_revision_test.go
@@ -1,0 +1,326 @@
+package flux_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/flux"
+	"github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+const (
+	oldRevision    = "latest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	pushedRevision = "latest@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	ociRepoName    = "flux-system"
+)
+
+// ociRepositoryGVR / gitRepositoryGVR are the source GVRs registered with the
+// fake dynamic client for revision-aware readiness tests.
+var (
+	ociRepositoryGVR = schema.GroupVersionResource{ //nolint:gochecknoglobals // test-scoped constant
+		Group:    "source.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "ocirepositories",
+	}
+	gitRepositoryGVR = schema.GroupVersionResource{ //nolint:gochecknoglobals // test-scoped constant
+		Group:    "source.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "gitrepositories",
+	}
+)
+
+// newTestFluxReconcilerWithSources creates a Flux Reconciler backed by a fake
+// dynamic client that supports Kustomization, OCIRepository, and GitRepository
+// resources — needed to exercise revision-aware readiness.
+func newTestFluxReconcilerWithSources(objects ...runtime.Object) *flux.Reconciler {
+	scheme := runtime.NewScheme()
+	fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			kustomizationGVR: kustomizationListKind,
+			ociRepositoryGVR: "OCIRepositoryList",
+			gitRepositoryGVR: "GitRepositoryList",
+		},
+		objects...,
+	)
+
+	return &flux.Reconciler{Base: reconciler.NewBaseWithClient(fakeClient)}
+}
+
+// newFakeKustomizationWithSource builds a Kustomization CR with a spec.sourceRef
+// (always the root flux-system source) and status.lastAttemptedRevision /
+// lastAppliedRevision, alongside the usual Ready condition — the shape needed
+// for revision-aware readiness checks.
+func newFakeKustomizationWithSource(
+	name, sourceKind string,
+	readyStatus, readyReason, readyMessage string,
+	lastAttempted, lastApplied string,
+) *unstructured.Unstructured {
+	kust := &unstructured.Unstructured{}
+	kust.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kustomize.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    kustomizationKind,
+	})
+	kust.SetName(name)
+	kust.SetNamespace(namespaceFluxSystem)
+
+	kust.Object["spec"] = map[string]any{
+		"path": "./" + name,
+		"sourceRef": map[string]any{
+			"kind": sourceKind,
+			"name": ociRepoName,
+		},
+	}
+
+	status := map[string]any{
+		statusConditions: []any{
+			map[string]any{
+				"type":    conditionTypeReady,
+				"status":  readyStatus,
+				"reason":  readyReason,
+				"message": readyMessage,
+			},
+		},
+	}
+	if lastAttempted != "" {
+		status["lastAttemptedRevision"] = lastAttempted
+	}
+
+	if lastApplied != "" {
+		status["lastAppliedRevision"] = lastApplied
+	}
+
+	kust.Object["status"] = status
+
+	return kust
+}
+
+// newFakeSource builds an OCIRepository/GitRepository CR (the root flux-system
+// source) carrying a status.artifact.revision.
+func newFakeSource(kind, revision string) *unstructured.Unstructured {
+	src := &unstructured.Unstructured{}
+	src.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "source.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    kind,
+	})
+	src.SetName(ociRepoName)
+	src.SetNamespace(namespaceFluxSystem)
+
+	if revision != "" {
+		src.Object["status"] = map[string]any{
+			"artifact": map[string]any{"revision": revision},
+		}
+	}
+
+	return src
+}
+
+//nolint:funlen // Table-driven test with comprehensive revision-aware cases.
+func TestCheckNamedKustomizationReadyRevisionAware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		objects     []runtime.Object
+		wantReady   bool
+		wantStatus  string
+		wantErr     bool
+		wantErrType error
+	}{
+		{
+			// The platform deadlock: a leftover BuildFailed from the OLD revision
+			// must NOT fail the gate when the just-pushed revision hasn't been
+			// attempted yet — keep polling so the fix can heal the layer.
+			name: "stale BuildFailed on old revision keeps polling (no false-fail)",
+			objects: []runtime.Object{
+				newFakeSource("OCIRepository", pushedRevision),
+				newFakeKustomizationWithSource(
+					statusApps, "OCIRepository",
+					statusFalse, "BuildFailed", "envsubst error on old revision",
+					oldRevision, "",
+				),
+			},
+			wantReady:  false,
+			wantStatus: "waiting for revision",
+		},
+		{
+			// A leftover Ready=True from the OLD revision must NOT pass the gate
+			// before the new (possibly broken) revision is applied.
+			name: "stale Ready=True on old revision keeps polling (no false-pass)",
+			objects: []runtime.Object{
+				newFakeSource("OCIRepository", pushedRevision),
+				newFakeKustomizationWithSource(
+					statusApps, "OCIRepository",
+					statusTrue, reasonSucceeded, "Applied revision: old",
+					oldRevision, oldRevision,
+				),
+			},
+			wantReady:  false,
+			wantStatus: "waiting for revision",
+		},
+		{
+			name: "ready on current revision passes",
+			objects: []runtime.Object{
+				newFakeSource("OCIRepository", pushedRevision),
+				newFakeKustomizationWithSource(
+					statusApps, "OCIRepository",
+					statusTrue, reasonSucceeded, "Applied revision: pushed",
+					pushedRevision, pushedRevision,
+				),
+			},
+			wantReady:  true,
+			wantStatus: conditionTypeReady,
+		},
+		{
+			// A real BuildFailed of the CURRENT revision is correctly attributed
+			// and fails the gate.
+			name: "BuildFailed on current revision fails",
+			objects: []runtime.Object{
+				newFakeSource("OCIRepository", pushedRevision),
+				newFakeKustomizationWithSource(
+					statusApps, "OCIRepository",
+					statusFalse, "BuildFailed", "envsubst error on pushed revision",
+					pushedRevision, oldRevision,
+				),
+			},
+			wantReady:   false,
+			wantErr:     true,
+			wantErrType: flux.ErrKustomizationFailed,
+		},
+		{
+			// Ready=True but applied revision still trails the source → the apply
+			// is in flight, keep polling.
+			name: "ready but applied revision trails source keeps polling",
+			objects: []runtime.Object{
+				newFakeSource("OCIRepository", pushedRevision),
+				newFakeKustomizationWithSource(
+					statusApps, "OCIRepository",
+					statusTrue, reasonSucceeded, "Applied revision: old",
+					pushedRevision, oldRevision,
+				),
+			},
+			wantReady:  false,
+			wantStatus: "waiting for revision",
+		},
+		{
+			// A never-attempted kustomization (empty lastAttemptedRevision)
+			// renders the source revision and a "<none>" attempted revision.
+			name: "never-attempted kustomization keeps polling",
+			objects: []runtime.Object{
+				newFakeSource("OCIRepository", pushedRevision),
+				newFakeKustomizationWithSource(
+					statusApps, "OCIRepository",
+					statusFalse, "Progressing", "reconciliation in progress",
+					"", "",
+				),
+			},
+			wantReady:  false,
+			wantStatus: "<none>",
+		},
+		{
+			// Short (non-digest) revisions are rendered verbatim.
+			name: "short revision ready passes",
+			objects: []runtime.Object{
+				newFakeSource("GitRepository", "v1"),
+				newFakeKustomizationWithSource(
+					statusInfra, "GitRepository",
+					statusTrue, reasonSucceeded, "Applied revision: v1",
+					"v1", "v1",
+				),
+			},
+			wantReady:  true,
+			wantStatus: conditionTypeReady,
+		},
+		{
+			// GitRepository sources are resolved the same way.
+			name: "git source ready on current revision passes",
+			objects: []runtime.Object{
+				newFakeSource("GitRepository", pushedRevision),
+				newFakeKustomizationWithSource(
+					statusInfra, "GitRepository",
+					statusTrue, reasonSucceeded, "Applied revision: pushed",
+					pushedRevision, pushedRevision,
+				),
+			},
+			wantReady:  true,
+			wantStatus: conditionTypeReady,
+		},
+		{
+			// Backward-compat: when the source has no artifact revision yet, fall
+			// back to condition-only readiness (Ready=True → ready).
+			name: "source without artifact falls back to condition-only ready",
+			objects: []runtime.Object{
+				newFakeSource("OCIRepository", ""),
+				newFakeKustomizationWithSource(
+					statusApps, "OCIRepository",
+					statusTrue, reasonSucceeded, "Applied revision: x",
+					"", "",
+				),
+			},
+			wantReady:  true,
+			wantStatus: conditionTypeReady,
+		},
+		{
+			// Backward-compat: an unknown source kind cannot be resolved → fall
+			// back to condition-only readiness.
+			name: "unknown source kind falls back to condition-only ready",
+			objects: []runtime.Object{
+				newFakeKustomizationWithSource(
+					statusApps, "HelmRepository",
+					statusTrue, reasonSucceeded, "Applied revision: x",
+					"", "",
+				),
+			},
+			wantReady:  true,
+			wantStatus: conditionTypeReady,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestFluxReconcilerWithSources(testCase.objects...)
+
+			ready, status, err := r.CheckNamedKustomizationReady(
+				context.Background(),
+				kustomizationNameForTest(testCase.objects),
+			)
+
+			if testCase.wantErr {
+				require.Error(t, err)
+
+				if testCase.wantErrType != nil {
+					require.ErrorIs(t, err, testCase.wantErrType)
+				}
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.wantReady, ready)
+			assert.Contains(t, status, testCase.wantStatus)
+		})
+	}
+}
+
+// kustomizationNameForTest returns the name of the first Kustomization object in
+// the fixture set, so each case checks the kustomization it defined.
+func kustomizationNameForTest(objects []runtime.Object) string {
+	for _, obj := range objects {
+		u, ok := obj.(*unstructured.Unstructured)
+		if ok && u.GetKind() == kustomizationKind {
+			return u.GetName()
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5576

## Problem

`ksail workload reconcile` decided each Kustomization's readiness from its **current `Ready` condition** without first confirming the Kustomization had reconciled the **source artifact revision that was just pushed**. Because `workload push` updates the OCI/Git *source* but not the Kustomization's *spec* (no `generation` bump), the existing generation-only staleness guard (`isStatusStale`) left a `Ready` condition from the **previous** revision authoritative — producing wrong verdicts in both directions:

- **False-fail** — a leftover `Ready=False (BuildFailed)` from the old revision failed the gate *immediately*, so a layer currently broken on the old revision could not be repaired by pushing a fix (a deploy-gate catch-22).
- **False-pass** — a leftover `Ready=True` from the prior healthy revision reported success before the new (possibly broken) revision was ever built/applied.

This is the root cause of the recurring **platform prod deploy-gate deadlock** (`.github/actions/deploy-prod` runs `workload push` then `workload reconcile`): the `apps` Kustomization was wedged `Ready=False (BuildFailed)`, and every merge-queue PR that pushed a fixed artifact saw `✗ apps failed` within ~0.3s — reading the *old* revision's condition — and was evicted.

## Fix

Make readiness **revision-aware** in `pkg/client/flux`:

1. **Resolve the target revision** — `resolveSourceRevision` parses the Kustomization's `spec.sourceRef` (OCIRepository / GitRepository / Bucket) and reads that source's `status.artifact.revision` (the revision just pushed). New `source_revision.go`; source GVR helpers added to `gvr.go`.
2. **Gate the condition** — in `checkKustomizationStatus`, until `status.lastAttemptedRevision == <source revision>`, the `Ready` condition describes a prior revision and is **not trusted** (keep polling). This kills both the false-fail and the false-pass.
3. **Confirm the apply** — a `Ready=True` verdict is only authoritative once `status.lastAppliedRevision == <source revision>`; otherwise the apply is still in flight, keep polling.
4. **Attribute real failures** — a `BuildFailed`/permanent failure whose `lastAttemptedRevision` *is* the current revision still fails fast (correctly attributed to the new revision).

**Backward-compatible:** when the revision can't be resolved (no `sourceRef`, unknown source kind, source missing, no artifact yet), the check falls back to the prior condition-only behavior — nothing regresses. This is the behavior platform#2356 currently reimplements by hand in the deploy gate; once this ships, that workaround can be retired.

## Validation

- `go build ./...` ✅, `go vet ./pkg/client/flux/...` ✅, `gofmt` clean, `golangci-lint run pkg/client/flux/...` → **0 issues**.
- `go test ./pkg/client/flux/...` → **204 pass**, incl. a new revision-aware table (`source_revision_test.go`) covering: stale-`BuildFailed`-no-false-fail, stale-`Ready=True`-no-false-pass, ready-on-current-revision, `BuildFailed`-on-current-revision-fails, apply-in-flight, GitRepository source, and the two fall-back paths.
- New functions ≥80% covered; `go.mod`/`go.sum` unchanged; no CLI/flag/schema surface → no generated-file regeneration.