### PR TITLE
fix(flux): pin flux-operator-manifests distribution artifact (no floating :latest)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -152,7 +152,7 @@ updates:
 
   - package-ecosystem: docker
     registries: [ghcr]
-    directory: /pkg/svc/installer/flux # Flux operator chart version (OCI chart artifact)
+    directory: /pkg/svc/installer/flux # Flux operator chart + manifests-distribution versions (OCI artifacts, matched pair)
     cooldown:
       default-days: 7
     schedule:

--- a/pkg/svc/installer/flux/Dockerfile
+++ b/pkg/svc/installer/flux/Dockerfile
@@ -1,7 +1,14 @@
-# This file is the source of truth for the Flux operator chart version used in Go code.
+# This file is the source of truth for the Flux operator versions used in Go code.
 # Dependabot updates this file, and Go code reads from it via go:embed.
 #
 # Image mappings:
 # - ghcr.io/controlplaneio-fluxcd/charts/flux-operator → chart version (OCI chart artifact tag)
+# - ghcr.io/controlplaneio-fluxcd/flux-operator-manifests → FluxInstance distribution
+#   artifact (the OCI bundle the operator builds the Flux distribution from). It is
+#   released as a matched PAIR with the chart above, so the two tags MUST be bumped
+#   together — a mismatch (e.g. a floating manifests tag ahead of the pinned chart)
+#   breaks Flux bootstrap when the manifests' bundled Flux distribution restructures a
+#   CRD the operator patches (see ksail#5595).
 
 FROM ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.52.0@sha256:e25cf78b888fb82afadcb0c06bbb3dce8c5c5d0313e304ce67b6a7744977e458
+FROM ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.52.0@sha256:cb8413e9db063ebcbf7d847924dea24e10648b6b3e939cce13cb51336932c770

--- a/pkg/svc/installer/flux/buildinstance_test.go
+++ b/pkg/svc/installer/flux/buildinstance_test.go
@@ -83,6 +83,23 @@ func TestBuildInstance_MinimalConfig(t *testing.T) {
 	assert.Equal(t, "FluxInstance", instance.Kind)
 	assert.Equal(t, "flux", instance.Name)
 	assert.Equal(t, "flux-system", instance.Namespace)
+
+	// Regression guard for ksail#5595: the distribution artifact must stay PINNED to
+	// a specific flux-operator-manifests version (a matched pair with the embedded
+	// chart) and must never float back to ":latest" — a floating manifests tag let an
+	// upstream Receiver-CRD change break every Flux bootstrap.
+	assert.NotContains(
+		t,
+		instance.Spec.Distribution.Artifact,
+		":latest",
+		"distribution artifact must be pinned, never floating :latest",
+	)
+	assert.Regexp(
+		t,
+		`^oci://ghcr\.io/controlplaneio-fluxcd/flux-operator-manifests:v\d+\.\d+\.\d+$`,
+		instance.Spec.Distribution.Artifact,
+		"distribution artifact must be a version-pinned flux-operator-manifests reference",
+	)
 }
 
 func TestBuildInstance_WithLocalRegistryAndWorkload(t *testing.T) {

--- a/pkg/svc/installer/flux/fluxinstance_manager.go
+++ b/pkg/svc/installer/flux/fluxinstance_manager.go
@@ -28,7 +28,6 @@ const (
 	fluxIntervalFallback     = time.Minute
 	fluxDistributionVersion  = "2.x"
 	fluxDistributionRegistry = "ghcr.io/fluxcd"
-	fluxDistributionArtifact = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
 )
 
 // instanceManager handles FluxInstance lifecycle operations.
@@ -304,7 +303,7 @@ func buildInstance(
 			Distribution: Distribution{
 				Version:  fluxDistributionVersion,
 				Registry: fluxDistributionRegistry,
-				Artifact: fluxDistributionArtifact,
+				Artifact: distributionArtifact(),
 			},
 			Sync: &Sync{
 				Kind:       fluxOCIRepositoryKind,

--- a/pkg/svc/installer/flux/version.go
+++ b/pkg/svc/installer/flux/version.go
@@ -21,6 +21,22 @@ func chartVersion() string {
 	)
 }
 
+// distributionArtifact returns the FluxInstance distribution OCI artifact reference,
+// pinned to the flux-operator-manifests version extracted from the embedded Dockerfile.
+// Pinning this (rather than floating ":latest") keeps it a matched pair with the
+// chart above so an upstream manifests release cannot silently break Flux bootstrap
+// (ksail#5595). The digest in the Dockerfile is for Dependabot; the FluxInstance
+// artifact field takes the tag form.
+func distributionArtifact() string {
+	version := parser.ParseImageFromDockerfile(
+		dockerfile,
+		`FROM\s+ghcr\.io/controlplaneio-fluxcd/flux-operator-manifests:([^\s@]+)`,
+		"flux-operator manifests",
+	)
+
+	return "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:" + version
+}
+
 // distributionImages returns the Flux distribution controller images from the
 // embedded Dockerfile.distribution. These are the images that the Flux operator
 // deploys when creating a FluxInstance.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5595

## Problem

The FluxInstance distribution **artifact** floated at `flux-operator-manifests:latest` while the flux-operator **chart** was pinned (`0.52.0`, via the embedded `Dockerfile`). When upstream published **flux-operator v0.53.0** (2026-06-30 17:20Z, "comes with support for Flux v2.9.0"), the floating `:latest` + distribution `version: 2.x` pulled a manifests bundle whose Flux v2.9.0 Receiver CRD restructured the `eventSources[].kind` enum. The operator's bundled RFC-6902 patch then fails to apply:

```
build failed: add operation does not apply: doc is missing path:
"/spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-"
```

→ FluxInstance `BuildFailed` / `Stalled` → "no Flux CRDs found" → **every** `--gitops-engine Flux` System Test variant (Vanilla/K3s/Talos, all distros, `--local-registry`) red, **and** real `ksail cluster create --gitops-engine Flux` broken. Because the sources floated, this regressed with **no ksail change**.

## Fix

Pin the manifests artifact to **`v0.52.0`** — the matched pair with the already-pinned chart `0.52.0` — instead of `:latest`:

- **`Dockerfile`**: add a `FROM ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.52.0@sha256:…` line next to the existing chart `FROM`, so the version is the single source of truth and **Dependabot tracks chart + manifests as a pair** (the `/pkg/svc/installer/flux` docker ecosystem already scans this file).
- **`version.go`**: add `distributionArtifact()` parsing the pinned manifests tag from the embedded `Dockerfile`, mirroring the existing `chartVersion()` pattern.
- **`fluxinstance_manager.go`**: build `Distribution.Artifact` from `distributionArtifact()` (removed the hard-coded `:latest` const).
- **`buildinstance_test.go`**: regression guard asserting the default artifact is version-pinned and never `:latest`.
- **`dependabot.yaml`**: comment refreshed to note the directory now tracks both artifacts.

With the artifact pinned to v0.52.0 (built 2026-06-10, before Flux v2.9.0 existed), `version: 2.x` resolves deterministically within that frozen bundle to the matched Flux v2.8.x — this is the issue's sanctioned "confirm the operator manifests pin alone constrains it" path. It restores the **last-known-good** state: the manifests `:latest` at the #5578 merge run (~15:00Z, before v0.53.0's 17:20Z push) was v0.52.0 paired with the current `Dockerfile.distribution` and that E2E was green, so no `Dockerfile.distribution` change is needed.

## Acceptance criteria (#5595)

- [x] Flux distribution sources pinned (no floating `:latest` / unconstrained `2.x`) to a matched set.
- [ ] All `--gitops-engine Flux` System Test variants green again — **verified by this PR's own CI** (the failing Flux System Tests are the gate; promote once green).
- [x] A bot manager (Dependabot) tracks the pinned flux-operator manifests + chart versions (same `/pkg/svc/installer/flux` docker ecosystem entry).

## Validation

`go build ./...` ✓ · `go vet` ✓ · `go test ./pkg/svc/installer/flux/...` 202 pass ✓ · `golangci-lint run` 0 issues ✓ · no generated drift (internal install detail, no schema/CLI/docs surface).

## Impact

Unblocks the entire ksail merge pipeline — #5581 (own promoted) and the dependabot PRs (#5582–#5592) are all currently red only on this #5595 Flux System Test failure.