### PR TITLE
ci(deps): group flux-operator chart + manifests bumps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -157,6 +157,13 @@ updates:
       default-days: 7
     schedule:
       interval: daily
+    # The flux-operator chart and its manifests-distribution artifact are a MATCHED
+    # PAIR released together; bumping one without the other breaks Flux bootstrap
+    # (ksail#5595). Group them so Dependabot raises a single PR that moves both tags.
+    groups:
+      flux-operator:
+        patterns:
+          - "*flux-operator*"
 
   - package-ecosystem: docker
     registries: [ghcr]


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Refs #5595

## Why

[#5596](https://github.com/devantler-tech/ksail/pull/5596) pinned the `flux-operator-manifests` distribution artifact to `v0.52.0` as a **matched pair** with the pinned `flux-operator` chart (`0.52.0`), both in `pkg/svc/installer/flux/Dockerfile`. They are released together upstream and **must move together** — an operator/manifests skew breaks Flux bootstrap (`FluxInstance BuildFailed`, the #5595 symptom).

But Dependabot tracks the two `FROM` lines as **independent docker images**, so it immediately raised a **chart-only** bump — [#5602](https://github.com/devantler-tech/ksail/pull/5602) (`charts/flux-operator` 0.52.0 → 0.53.0) — while leaving the manifests at `v0.52.0`. That recreates the exact mismatch #5595 fixed (just inverted). The bot-tracking acceptance criterion of #5595 isn't satisfied by tracking the two tags separately — they have to bump **as a pair**.

## What

Add a `flux-operator` Dependabot **group** to the `/pkg/svc/installer/flux` docker ecosystem (pattern `*flux-operator*`, matching both `charts/flux-operator` and `flux-operator-manifests`). Dependabot then raises **one** PR that moves both tags together, keeping the matched pair intact across future bumps — and its CI Flux System Test verifies the pair before it can merge.

## Follow-up on #5602

#5602 (chart-only) should be **closed** in favour of the grouped bump this enables — left a note there. (Its own Flux System Test will fail on the skew regardless, so it can't merge alone.)

## Validation

YAML parses; the group resolves to `{flux-operator: {patterns: ["*flux-operator*"]}}`, matching the existing `kubernetes` group style in the same file.