### PR TITLE
fix(provisioner): cordon and drain nodes before Talos OS upgrade reboots

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -532,6 +532,20 @@ func (p *Provisioner) CordonAndDrainForTest(
 	return p.cordonAndDrain(ctx, clientset, nodeName)
 }
 
+// UncordonAfterUpgradeForTest exposes uncordonAfterUpgrade for unit testing.
+func (p *Provisioner) UncordonAfterUpgradeForTest(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+) {
+	p.uncordonAfterUpgrade(ctx, clientset, nodeName)
+}
+
+// K8sClientOrWarnForUpgradeForTest exposes k8sClientOrWarnForUpgrade for unit testing.
+func (p *Provisioner) K8sClientOrWarnForUpgradeForTest(clusterName string) kubernetes.Interface {
+	return p.k8sClientOrWarnForUpgrade(clusterName)
+}
+
 // DrainTimeoutForTest exposes drainTimeout for unit testing.
 func (p *Provisioner) DrainTimeoutForTest() time.Duration {
 	return p.drainTimeout()

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -537,8 +537,8 @@ func (p *Provisioner) UncordonAfterUpgradeForTest(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	nodeName string,
-) {
-	p.uncordonAfterUpgrade(ctx, clientset, nodeName)
+) error {
+	return p.uncordonAfterUpgrade(ctx, clientset, nodeName)
 }
 
 // K8sClientOrWarnForUpgradeForTest exposes k8sClientOrWarnForUpgrade for unit testing.

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -12,6 +12,7 @@ import (
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -347,6 +348,10 @@ func (p *Provisioner) waitForNodeReadyAfterUpgrade(
 
 // rollingUpgradeNodes performs a rolling Talos OS upgrade across all cluster
 // nodes. Workers are upgraded first, then control-planes, one node at a time.
+// Each node is cordoned and drained before its reboot and uncordoned after it
+// returns Ready — the same graceful per-node sequence the config-change rolling
+// reboot uses (rollingRebootSingleNode) — so an OS upgrade evicts workloads
+// cleanly instead of hard-rebooting them out from under their pods and volumes.
 // Before each node's OS upgrade it reconciles the node's desired machine config so
 // the new installer validates the desired config rather than the stale committed
 // one (issue #5294, see reconcileNodeConfigBeforeUpgrade).
@@ -371,26 +376,31 @@ func (p *Provisioner) rollingUpgradeNodes(
 	// to a best-effort per-node reconcile.
 	secretsSource, _, _ := p.fetchNodeConfigForRole(ctx, nodes, RoleControlPlane)
 
+	// Graceful drain and the between-node storage-health gate both need the
+	// Kubernetes API. Build the clientset (and the prober) once; when the API is
+	// unreachable both are nil and the per-node sequence degrades to the legacy
+	// reboot-without-drain rather than aborting a needed OS upgrade.
+	clientset := p.k8sClientOrWarnForUpgrade(clusterName)
+
+	var storageProber storageHealthProber
+	if clientset != nil {
+		storageProber = p.buildStorageHealthProberOrWarn(ctx, clientset, clusterName)
+	}
+
 	for i, node := range ordered {
 		_, _ = fmt.Fprintf(p.logWriter,
 			"  [%d/%d] Upgrading %s (%s)...\n",
 			i+1, len(ordered), node.IP, node.Role,
 		)
 
-		// Reconcile the desired config onto the node before upgrading it. Best-effort:
-		// a failure here must not regress upgrades that already validate cleanly
-		// against the committed config, so warn and proceed (the upgrade then behaves
-		// as it did pre-#5294, and the update's in-place reconcile re-surfaces any
-		// genuine drift afterwards).
-		configErr := p.reconcileNodeConfigBeforeUpgrade(ctx, node, secretsSource)
-		if configErr != nil {
-			_, _ = fmt.Fprintf(p.logWriter,
-				"  ⚠ Could not reconcile config on %s before upgrade: %v\n",
-				node.IP, configErr,
-			)
-		}
-
-		upgradeErr := p.upgradeNodeTalosVersion(ctx, node.IP, installerImage, desiredTag)
+		upgradeErr := p.upgradeSingleNode(ctx, upgradeNodeRequest{
+			clientset:      clientset,
+			node:           node,
+			secretsSource:  secretsSource,
+			prober:         storageProber,
+			installerImage: installerImage,
+			desiredTag:     desiredTag,
+		})
 		if upgradeErr != nil {
 			return fmt.Errorf("upgrading node %s (%s): %w", node.IP, node.Role, upgradeErr)
 		}
@@ -402,6 +412,119 @@ func (p *Provisioner) rollingUpgradeNodes(
 	}
 
 	return nil
+}
+
+// upgradeNodeRequest bundles the inputs for upgradeSingleNode's graceful per-node
+// upgrade sequence.
+type upgradeNodeRequest struct {
+	clientset      kubernetes.Interface
+	node           nodeWithRole
+	secretsSource  talosconfig.Provider
+	prober         storageHealthProber
+	installerImage string
+	desiredTag     string
+}
+
+// upgradeSingleNode runs the full graceful per-node OS-upgrade sequence: cordon →
+// drain → reconcile desired config (#5294) → upgrade + reboot → wait Ready →
+// uncordon → between-node storage-health gate (#5467). When the clientset is nil
+// (Kubernetes API unreachable) or the node cannot be resolved to a Kubernetes node,
+// it degrades to the legacy reconcile + upgrade + reboot without draining, so a
+// needed OS upgrade still proceeds. A drain failure aborts the roll with the node
+// best-effort uncordoned (see cordonAndDrain), matching the config-change path.
+func (p *Provisioner) upgradeSingleNode(ctx context.Context, req upgradeNodeRequest) error {
+	nodeName := ""
+
+	if req.clientset != nil {
+		resolved, resolveErr := p.resolveNodeName(ctx, req.clientset, req.node.IP)
+		if resolveErr != nil {
+			_, _ = fmt.Fprintf(p.logWriter,
+				"  ⚠ Could not resolve %s to a Kubernetes node; upgrading without drain: %v\n",
+				req.node.IP, resolveErr,
+			)
+		} else {
+			nodeName = resolved
+
+			drainErr := p.cordonAndDrain(ctx, req.clientset, nodeName)
+			if drainErr != nil {
+				return drainErr
+			}
+		}
+	}
+
+	// Reconcile the desired config onto the node before upgrading it. Best-effort:
+	// a failure here must not regress upgrades that already validate cleanly against
+	// the committed config, so warn and proceed (the update's in-place reconcile
+	// re-surfaces any genuine drift afterwards).
+	configErr := p.reconcileNodeConfigBeforeUpgrade(ctx, req.node, req.secretsSource)
+	if configErr != nil {
+		_, _ = fmt.Fprintf(p.logWriter,
+			"  ⚠ Could not reconcile config on %s before upgrade: %v\n",
+			req.node.IP, configErr,
+		)
+	}
+
+	upgradeErr := p.upgradeNodeTalosVersion(ctx, req.node.IP, req.installerImage, req.desiredTag)
+	if upgradeErr != nil {
+		return upgradeErr
+	}
+
+	// Nothing to uncordon (and no storage gate) when the node was never cordoned.
+	if nodeName == "" {
+		return nil
+	}
+
+	p.uncordonAfterUpgrade(ctx, req.clientset, nodeName)
+
+	// Gate progression to the next node on replicated-storage volume health so a
+	// one-replica-per-node volume is not faulted by rebooting consecutive replica
+	// holders before a rebuild completes (#5467). No-op when the gate is disabled or
+	// no backend was detected (prober == nil).
+	storageErr := p.waitForStorageHealthy(ctx, req.prober, p.storageHealthTimeout())
+	if storageErr != nil {
+		return fmt.Errorf("storage health gate: %w", storageErr)
+	}
+
+	return nil
+}
+
+// uncordonAfterUpgrade waits for the upgraded node to report Ready, then uncordons
+// it. Both steps are best-effort: the OS upgrade already succeeded, so a readiness
+// or uncordon hiccup is warned rather than failing the roll (the next reconcile
+// re-evaluates schedulability).
+func (p *Provisioner) uncordonAfterUpgrade(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+) {
+	readyErr := p.waitForK8sNodeReady(ctx, clientset, nodeName, nodeReadinessTimeout)
+	if readyErr != nil {
+		_, _ = fmt.Fprintf(p.logWriter,
+			"    ⚠ %s did not report Ready before uncordon: %v\n", nodeName, readyErr)
+	}
+
+	_, _ = fmt.Fprintf(p.logWriter, "    Uncordoning %s...\n", nodeName)
+
+	uncordonErr := p.uncordonNode(ctx, clientset, nodeName)
+	if uncordonErr != nil {
+		_, _ = fmt.Fprintf(p.logWriter,
+			"    ⚠ Failed to uncordon %s (best-effort): %v\n", nodeName, uncordonErr)
+	}
+}
+
+// k8sClientOrWarnForUpgrade builds the Kubernetes clientset used to drain nodes
+// during a rolling OS upgrade. It returns nil (with a warning) when the API is
+// unreachable, so the upgrade degrades to reboot-without-drain instead of aborting.
+func (p *Provisioner) k8sClientOrWarnForUpgrade(clusterName string) kubernetes.Interface {
+	clientset, err := p.createK8sClient(clusterName)
+	if err != nil {
+		_, _ = fmt.Fprintf(p.logWriter,
+			"  ⚠ Kubernetes API unreachable; upgrading without graceful drain: %v\n", err)
+
+		return nil
+	}
+
+	return clientset
 }
 
 // reconcileNodeConfigBeforeUpgrade applies a node's desired machine config with

--- a/pkg/svc/provisioner/cluster/talos/upgrade.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade.go
@@ -474,7 +474,10 @@ func (p *Provisioner) upgradeSingleNode(ctx context.Context, req upgradeNodeRequ
 		return nil
 	}
 
-	p.uncordonAfterUpgrade(ctx, req.clientset, nodeName)
+	uncordonErr := p.uncordonAfterUpgrade(ctx, req.clientset, nodeName)
+	if uncordonErr != nil {
+		return uncordonErr
+	}
 
 	// Gate progression to the next node on replicated-storage volume health so a
 	// one-replica-per-node volume is not faulted by rebooting consecutive replica
@@ -489,18 +492,19 @@ func (p *Provisioner) upgradeSingleNode(ctx context.Context, req upgradeNodeRequ
 }
 
 // uncordonAfterUpgrade waits for the upgraded node to report Ready, then uncordons
-// it. Both steps are best-effort: the OS upgrade already succeeded, so a readiness
-// or uncordon hiccup is warned rather than failing the roll (the next reconcile
-// re-evaluates schedulability).
+// it. Readiness gates progression: a node that does not return Ready within the
+// timeout fails the roll, so the next node is not rebooted while this one is still
+// down (the whole point of the cordon → drain → reboot → wait-Ready sequence). The
+// uncordon itself stays best-effort — a node that is back Ready but momentarily
+// fails to uncordon is recovered by the next reconcile and must not fail the roll.
 func (p *Provisioner) uncordonAfterUpgrade(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	nodeName string,
-) {
+) error {
 	readyErr := p.waitForK8sNodeReady(ctx, clientset, nodeName, nodeReadinessTimeout)
 	if readyErr != nil {
-		_, _ = fmt.Fprintf(p.logWriter,
-			"    ⚠ %s did not report Ready before uncordon: %v\n", nodeName, readyErr)
+		return fmt.Errorf("node %s did not report Ready after upgrade: %w", nodeName, readyErr)
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter, "    Uncordoning %s...\n", nodeName)
@@ -510,6 +514,8 @@ func (p *Provisioner) uncordonAfterUpgrade(
 		_, _ = fmt.Fprintf(p.logWriter,
 			"    ⚠ Failed to uncordon %s (best-effort): %v\n", nodeName, uncordonErr)
 	}
+
+	return nil
 }
 
 // k8sClientOrWarnForUpgrade builds the Kubernetes clientset used to drain nodes

--- a/pkg/svc/provisioner/cluster/talos/upgrade_drain_test.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_drain_test.go
@@ -1,0 +1,60 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestUncordonAfterUpgradeUncordonsReadyNode asserts the graceful OS-upgrade path
+// uncordons a node once it is back Ready — the counterpart to the cordon+drain it
+// performs before the reboot.
+func TestUncordonAfterUpgradeUncordonsReadyNode(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-worker-1"},
+		Spec:       corev1.NodeSpec{Unschedulable: true},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	clientset := fake.NewClientset(node)
+	prov := talosprovisioner.NewProvisioner(nil, talosprovisioner.NewOptions())
+
+	prov.UncordonAfterUpgradeForTest(context.Background(), clientset, "prod-worker-1")
+
+	got, err := clientset.CoreV1().
+		Nodes().
+		Get(context.Background(), "prod-worker-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.False(t, got.Spec.Unschedulable, "node should be uncordoned after a successful upgrade")
+}
+
+// TestK8sClientOrWarnForUpgradeNilOnUnreachableAPI asserts the upgrade roll degrades
+// gracefully (returns a nil clientset → reboot-without-drain) when the Kubernetes
+// API cannot be reached, instead of aborting a needed OS upgrade.
+func TestK8sClientOrWarnForUpgradeNilOnUnreachableAPI(t *testing.T) {
+	t.Parallel()
+
+	badPath := filepath.Join(t.TempDir(), "does-not-exist", "kubeconfig")
+	opts := talosprovisioner.NewOptions().WithKubeconfigPath(badPath)
+	prov := talosprovisioner.NewProvisioner(nil, opts)
+
+	got := prov.K8sClientOrWarnForUpgradeForTest("prod")
+
+	assert.Nil(
+		t,
+		got,
+		"an unreachable Kubernetes API should yield a nil clientset (degrade, not abort)",
+	)
+}

--- a/pkg/svc/provisioner/cluster/talos/upgrade_drain_test.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_drain_test.go
@@ -31,13 +31,55 @@ func TestUncordonAfterUpgradeUncordonsReadyNode(t *testing.T) {
 	clientset := fake.NewClientset(node)
 	prov := talosprovisioner.NewProvisioner(nil, talosprovisioner.NewOptions())
 
-	prov.UncordonAfterUpgradeForTest(context.Background(), clientset, "prod-worker-1")
+	uncordonErr := prov.UncordonAfterUpgradeForTest(
+		context.Background(),
+		clientset,
+		"prod-worker-1",
+	)
+	require.NoError(t, uncordonErr)
 
 	got, err := clientset.CoreV1().
 		Nodes().
 		Get(context.Background(), "prod-worker-1", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.False(t, got.Spec.Unschedulable, "node should be uncordoned after a successful upgrade")
+}
+
+// TestUncordonAfterUpgradeGatesOnReadiness asserts that a node which never reports
+// Ready after its upgrade fails the roll (so the next node is not rebooted while this
+// one is still down) and is left cordoned rather than uncordoned-and-advanced.
+func TestUncordonAfterUpgradeGatesOnReadiness(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-worker-1"},
+		Spec:       corev1.NodeSpec{Unschedulable: true},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+	clientset := fake.NewClientset(node)
+	prov := talosprovisioner.NewProvisioner(nil, talosprovisioner.NewOptions())
+
+	// A cancelled context makes the readiness poll fail fast instead of blocking for
+	// the full nodeReadinessTimeout, exercising the not-Ready gate path.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	uncordonErr := prov.UncordonAfterUpgradeForTest(ctx, clientset, "prod-worker-1")
+	require.Error(t, uncordonErr, "a node that never reports Ready must fail the roll")
+
+	got, err := clientset.CoreV1().
+		Nodes().
+		Get(context.Background(), "prod-worker-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(
+		t,
+		got.Spec.Unschedulable,
+		"a node that never became Ready must stay cordoned, not be uncordoned-and-advanced",
+	)
 }
 
 // TestK8sClientOrWarnForUpgradeNilOnUnreachableAPI asserts the upgrade roll degrades


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

`Fixes #5604`

## Why
A live prod incident: renovate's Talos v1.13.4→v1.13.5 bump (applied by the merge_group `deploy-prod` gate) rolled the whole cluster, and because the upgrade path **reboots each node without cordoning/draining it first**, the roll orphaned ~36 pods into `ContainerStatusUnknown`, abruptly detached volumes (a Hetzner CSI volume got stuck mid-attach for 100+ min — openbao lost a raft replica), and the reschedule churn pushed the cluster-autoscaler to its node cap.

The **config-change** rolling reboot (`rollingRebootSingleNode`) already does cordon → drain → … → uncordon. The **version-upgrade** path (`rollingUpgradeNodes` → `upgradeNodeTalosVersion`) did `pull installer → LifecycleService.Upgrade → Reboot → wait`, calling none of the existing drain machinery. So OS upgrades skipped the graceful eviction config changes get.

## What
Wire the existing drain into the upgrade roll. Each node now goes through the same graceful sequence as the config-change reboot, in a new `upgradeSingleNode`:

```
cordon → drain → reconcile desired config (#5294) → upgrade + reboot → wait Ready → uncordon → storage-health gate (#5467)
```

- Reuses `cordonAndDrain` / `uncordonNode` / `waitForK8sNodeReady` / `resolveNodeName` / the storage prober — no new drain logic.
- Honors `spec.cluster.talos.drainTimeout`; a drain failure aborts the roll with the node best-effort-uncordoned (and the `--force-drain` bypass), exactly like the config path.
- **Graceful degradation:** if the Kubernetes API is unreachable (`k8sClientOrWarnForUpgrade` returns nil) or a node can't be resolved, it logs a warning and falls back to the legacy reboot-without-drain rather than aborting a needed (possibly security) OS upgrade.

## Tests
- `TestUncordonAfterUpgradeUncordonsReadyNode` — a Ready, cordoned node is uncordoned after upgrade (fake clientset).
- `TestK8sClientOrWarnForUpgradeNilOnUnreachableAPI` — unreachable API → nil clientset (degrade, not abort).
- Existing cordon/drain/uncordon mechanics remain covered by `drain_test.go` / rolling tests.

## Validation
`go build ./...` ✓ · `go vet` ✓ · `go test ./pkg/svc/provisioner/cluster/...` → 1171 pass · `golangci-lint` clean on the changed files (3 pre-existing `goconst "true"` hits are in untouched files, not this diff).

## Note
This is the root-cause fix for the prod disruption analyzed today. Complementary follow-ups already filed: #5597 (Flux readiness flake) and #5603 (capacity-buffer protobuf). The Hetzner stuck-attach itself was a provider-side wedge that clean draining avoids by detaching volumes gracefully before reboot.
