### PR TITLE
ci(deps): group Astro + Starlight docs bumps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -48,6 +48,18 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    # Astro, Starlight and the Starlight/Astro plugins are a co-dependent set: a
+    # Starlight major requires a matching Astro major and plugin releases that
+    # support the new Astro markdown processor. Bumping one alone breaks the docs
+    # build (ksail#5600 — Starlight 0.41 needed Astro 7 + updated peer plugins).
+    # Group them so Dependabot raises a single PR that moves the whole set together.
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "astro-*"
+          - "@astrojs/*"
+          - "starlight-*"
 
   - package-ecosystem: npm
     directory: /vsce


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Astro, Starlight and the Starlight/Astro plugins are a **co-dependent set**: a Starlight major requires a matching Astro major *and* plugin releases that support Astro's new markdown processor. Dependabot was raising them as **separate** `/docs` npm PRs, so a Starlight-only bump broke the docs build:

- #5600 (`@astrojs/starlight` 0.40→0.41) failed `📚 Build Documentation` — Starlight 0.41 needs **Astro 7** (`"chunkToString" is not exported` on Astro 6), and Astro 7's `satteri` markdown processor was then rejected by the old `starlight-links-validator`/`starlight-github-alerts`/`astro-mermaid` peers until each was bumped to its Astro-7-compatible release.

## Fix

Add an `astro` **group** to the `/docs` npm ecosystem so Dependabot moves the whole co-dependent set in one PR (core `astro`, `astro-*` plugins like `astro-mermaid`, `@astrojs/*` incl. Starlight, and `starlight-*` plugins). Independent libraries (`mermaid`, `sharp`) stay ungrouped.

This mirrors the matched-pair `flux-operator` group added in #5605 — same recurring "co-dependent packages bumped separately breaks the build" pattern, same remedy.

## Validation

`dependabot.yaml` parses cleanly; the group resolves to the four patterns above. No behavior change beyond Dependabot's PR grouping.