### PR TITLE
feat(bootstrap): add kubeadm topology planner

### DIFF
--- a/pkg/svc/bootstrap/kubeadm/doc.go
+++ b/pkg/svc/bootstrap/kubeadm/doc.go
@@ -32,6 +32,16 @@
 // that node. It is pure: no I/O, no network, fully unit-testable without a
 // cluster or a Hetzner account.
 //
+// [Plan] sits one level up, expanding a cluster topology ([PlanInput]) into the
+// ordered per-node [NodeConfig]s a provisioner bootstraps in sequence
+// (cluster-initialising control plane → additional control planes → agents),
+// mirroring the k3sbootstrap planner. Because kubeadm discovers a joining node's
+// API server endpoint and CA cert hashes only once the first control plane is up,
+// those are [PlanInput] fields a provisioner injects at run time before planning
+// the joining nodes — unlike k3s's pre-shared token, which needs no run-time
+// artifact. Every [Node] Plan returns carries a Config that passes validation, so
+// [Render] never fails for a planned node.
+//
 // The Kubernetes *components* (kubeadm, kubelet, the container runtime) are
 // installed at first boot by the cloud-config, not by the running node's
 // configuration; only kubernetesVersion (which pins the control-plane image set)

--- a/pkg/svc/bootstrap/kubeadm/errors.go
+++ b/pkg/svc/bootstrap/kubeadm/errors.go
@@ -15,6 +15,18 @@ var (
 	// rejected rather than rendered into a config that would fail at bring-up.
 	ErrMissingToken = errors.New("kubeadm: a bootstrap token is required")
 
+	// ErrInvalidControlPlaneCount is returned by [Plan] when a [PlanInput] requests
+	// fewer than one control-plane node. Every cluster needs a cluster-initialising
+	// control plane, so a count below one cannot describe a bootstrappable topology.
+	ErrInvalidControlPlaneCount = errors.New(
+		"kubeadm: a cluster requires at least one control-plane node",
+	)
+
+	// ErrInvalidAgentCount is returned by [Plan] when a [PlanInput] requests a
+	// negative number of agent (worker) nodes. Zero agents is a valid
+	// control-plane-only cluster; a negative count is a misconfiguration.
+	ErrInvalidAgentCount = errors.New("kubeadm: the agent count must not be negative")
+
 	// ErrServerInitWithJoinFields is returned when RoleServerInit carries a
 	// join-only field (an API server endpoint or CA cert hashes). The
 	// cluster-initialising control plane starts a new cluster and joins no existing

--- a/pkg/svc/bootstrap/kubeadm/plan.go
+++ b/pkg/svc/bootstrap/kubeadm/plan.go
@@ -1,0 +1,179 @@
+package kubeadmbootstrap
+
+import "slices"
+
+// PlanInput describes the topology of a kubeadm cluster to bootstrap across a set
+// of freshly-provisioned servers (e.g. Hetzner Cloud servers). It is the typed
+// input for [Plan], which expands it into the ordered per-node [NodeConfig]s a
+// provisioner renders and delivers. It mirrors the k3sbootstrap planner so a
+// provisioner can plan either distribution's topology from one shared shape.
+type PlanInput struct {
+	// Token is the shared bootstrap token every node authenticates with — issued on
+	// the cluster-initialising control plane and redeemed by every joining node.
+	// Required — see [ErrMissingToken].
+	Token string
+
+	// KubernetesVersion pins the control-plane image set on the
+	// cluster-initialising control plane (e.g. "v1.31.0"). Optional and
+	// cluster-wide: it is applied to the server-init node only.
+	KubernetesVersion string
+	// ControlPlaneEndpoint is the stable "host:port" the cluster advertises for its
+	// API server, enabling later control-plane nodes to join. Optional and
+	// cluster-wide: applied to the server-init node only.
+	ControlPlaneEndpoint string
+	// CertSANs are extra Subject Alternative Names added to the API server
+	// certificate. Cluster-wide: applied to the server-init node only. Cloned per
+	// node so a downstream mutation cannot corrupt another node's config.
+	CertSANs []string
+	// PodSubnet is the pod network CIDR. Cluster-wide: applied to the server-init
+	// node only.
+	PodSubnet string
+	// ServiceSubnet is the service network CIDR. Cluster-wide: applied to the
+	// server-init node only.
+	ServiceSubnet string
+
+	// ControlPlaneCount is the number of control-plane (server) nodes. Must be at
+	// least one: the first becomes the cluster-initialising control plane
+	// (RoleServerInit) and any further ones join it (RoleServer). See
+	// [ErrInvalidControlPlaneCount].
+	ControlPlaneCount int
+	// AgentCount is the number of worker (agent) nodes. May be zero; must not be
+	// negative. See [ErrInvalidAgentCount].
+	AgentCount int
+
+	// APIServerEndpoint is the "host:port" of the cluster-initialising control
+	// plane that joining nodes register against. Required whenever the plan
+	// contains a joining node (more than one control-plane node, or any agent) and
+	// is never applied to the cluster-initialising control plane. Because kubeadm
+	// discovers it only once the first control plane is up, a provisioner supplies
+	// it at run time before planning the joining nodes. See
+	// [ErrMissingAPIServerEndpoint] / [ErrInvalidAPIServerEndpoint].
+	APIServerEndpoint string
+	// CACertHashes are the pinned "sha256:<hex>" cluster-CA hashes a joining node
+	// verifies during token discovery. Required (at least one) whenever the plan
+	// contains a joining node, and — like [APIServerEndpoint] — is a run-time
+	// artifact of the cluster-initialising control plane that a provisioner injects
+	// before planning the joining nodes. Cloned per node. See
+	// [ErrMissingCACertHashes] / [ErrInvalidCACertHash].
+	CACertHashes []string
+}
+
+// Node is a single server's place in the bootstrap order together with the
+// kubeadm configuration it must run.
+type Node struct {
+	// Index is the node's zero-based position in bootstrap order: the
+	// cluster-initialising control plane is 0, additional control planes follow,
+	// then agents.
+	Index int
+
+	// Config is the kubeadm configuration for this node, already assigned the
+	// correct Role and join settings. It is guaranteed to pass validation, so
+	// [Render] never fails for a Config returned by [Plan].
+	Config NodeConfig
+}
+
+// Plan expands a [PlanInput] into the ordered [Node]s that bootstrap the cluster:
+// the cluster-initialising control plane first (RoleServerInit), then any
+// additional control-plane nodes (RoleServer), then the agents (RoleAgent). The
+// order is significant — joining nodes can only register once the first control
+// plane has initialised the cluster — so callers should provision and bootstrap
+// the nodes in the returned sequence.
+//
+// Plan is pure: it performs no I/O and reaches no network. Every returned
+// Node.Config is valid, so [Render] applied to it never returns an error. A
+// configuration error (a missing token, an invalid node count, or a missing or
+// malformed API server endpoint / CA cert hash when joining nodes are present) is
+// reported instead of a partial plan.
+func Plan(input PlanInput) ([]Node, error) {
+	err := input.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]Node, 0, input.ControlPlaneCount+input.AgentCount)
+
+	// The first control-plane node initialises the cluster and joins nothing; the
+	// remaining control-plane nodes and the agents join it.
+	nodes = append(nodes, Node{Index: 0, Config: input.serverInitConfig()})
+
+	for range input.ControlPlaneCount - 1 {
+		nodes = append(nodes, Node{Index: len(nodes), Config: input.joinConfig(RoleServer)})
+	}
+
+	for range input.AgentCount {
+		nodes = append(nodes, Node{Index: len(nodes), Config: input.joinConfig(RoleAgent)})
+	}
+
+	return nodes, nil
+}
+
+// validate reports the first error in input, or nil when it describes a cluster
+// Plan can fully expand. The API server endpoint and CA cert hashes are required
+// (and validated) only when the plan contains a joining node, mirroring
+// [NodeConfig.validate] for the individual roles so every produced Config is
+// guaranteed to render.
+func (input PlanInput) validate() error {
+	if input.Token == "" {
+		return ErrMissingToken
+	}
+
+	if input.ControlPlaneCount < 1 {
+		return ErrInvalidControlPlaneCount
+	}
+
+	if input.AgentCount < 0 {
+		return ErrInvalidAgentCount
+	}
+
+	if input.hasJoiningNodes() {
+		err := validateAPIServerEndpoint(input.APIServerEndpoint)
+		if err != nil {
+			return err
+		}
+
+		return validateCACertHashes(input.CACertHashes)
+	}
+
+	return nil
+}
+
+// hasJoiningNodes reports whether the plan contains any node that must register
+// against the cluster-initialising control plane: an additional control-plane
+// node or any agent.
+func (input PlanInput) hasJoiningNodes() bool {
+	return input.ControlPlaneCount > 1 || input.AgentCount > 0
+}
+
+// serverInitConfig builds the NodeConfig for the cluster-initialising control
+// plane, carrying the cluster-wide options (kubernetes version, control-plane
+// endpoint, cert SANs, pod/service subnets) and no join fields.
+//
+// CertSANs is cloned: a single PlanInput expands into one server-init config, but
+// sharing the input's slice header would let a downstream mutation of the node's
+// slice corrupt the caller's input. slices.Clone preserves nil, so an unset field
+// stays nil rather than becoming an empty slice.
+func (input PlanInput) serverInitConfig() NodeConfig {
+	return NodeConfig{
+		Role:                 RoleServerInit,
+		Token:                input.Token,
+		KubernetesVersion:    input.KubernetesVersion,
+		ControlPlaneEndpoint: input.ControlPlaneEndpoint,
+		CertSANs:             slices.Clone(input.CertSANs),
+		PodSubnet:            input.PodSubnet,
+		ServiceSubnet:        input.ServiceSubnet,
+	}
+}
+
+// joinConfig builds the NodeConfig for a joining node in the given role
+// (RoleServer for an additional control plane, RoleAgent for a worker), carrying
+// the shared discovery settings (API server endpoint and CA cert hashes) and no
+// cluster-wide options. CACertHashes is cloned per config so sharing the input's
+// slice header cannot let one node's config corrupt another's.
+func (input PlanInput) joinConfig(role Role) NodeConfig {
+	return NodeConfig{
+		Role:              role,
+		Token:             input.Token,
+		APIServerEndpoint: input.APIServerEndpoint,
+		CACertHashes:      slices.Clone(input.CACertHashes),
+	}
+}

--- a/pkg/svc/bootstrap/kubeadm/plan_test.go
+++ b/pkg/svc/bootstrap/kubeadm/plan_test.go
@@ -1,0 +1,210 @@
+package kubeadmbootstrap_test
+
+import (
+	"testing"
+
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// joinPlanInput returns a PlanInput with the run-time discovery fields populated,
+// the baseline for the joining-node cases.
+func joinPlanInput() kubeadmbootstrap.PlanInput {
+	return kubeadmbootstrap.PlanInput{
+		Token:             "abcdef.0123456789abcdef",
+		ControlPlaneCount: 1,
+		AgentCount:        0,
+		APIServerEndpoint: "10.0.0.2:6443",
+		CACertHashes:      []string{validCACertHash},
+	}
+}
+
+func TestPlanSingleControlPlane(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := kubeadmbootstrap.Plan(kubeadmbootstrap.PlanInput{
+		Token:             "abcdef.0123456789abcdef",
+		KubernetesVersion: "v1.31.0",
+		ControlPlaneCount: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	assert.Equal(t, 0, nodes[0].Index)
+	assert.Equal(t, kubeadmbootstrap.RoleServerInit, nodes[0].Config.Role)
+	assert.Equal(t, "v1.31.0", nodes[0].Config.KubernetesVersion)
+	// The cluster-initialising control plane joins nothing.
+	assert.Empty(t, nodes[0].Config.APIServerEndpoint)
+	assert.Empty(t, nodes[0].Config.CACertHashes)
+}
+
+func TestPlanControlPlaneAndAgents(t *testing.T) {
+	t.Parallel()
+
+	input := joinPlanInput()
+	input.ControlPlaneCount = 2
+	input.AgentCount = 3
+
+	nodes, err := kubeadmbootstrap.Plan(input)
+	require.NoError(t, err)
+	require.Len(t, nodes, 5)
+
+	wantRoles := []kubeadmbootstrap.Role{
+		kubeadmbootstrap.RoleServerInit,
+		kubeadmbootstrap.RoleServer,
+		kubeadmbootstrap.RoleAgent,
+		kubeadmbootstrap.RoleAgent,
+		kubeadmbootstrap.RoleAgent,
+	}
+
+	for index, node := range nodes {
+		assert.Equal(t, index, node.Index, "node index must match bootstrap order")
+		assert.Equal(t, wantRoles[index], node.Config.Role)
+	}
+
+	// Joining nodes carry the discovery fields; the server-init node does not.
+	assert.Empty(t, nodes[0].Config.APIServerEndpoint)
+
+	for _, node := range nodes[1:] {
+		assert.Equal(t, "10.0.0.2:6443", node.Config.APIServerEndpoint)
+		assert.Equal(t, []string{validCACertHash}, node.Config.CACertHashes)
+		// Joining nodes never carry cluster-wide options.
+		assert.Empty(t, node.Config.KubernetesVersion)
+		assert.Empty(t, node.Config.ControlPlaneEndpoint)
+	}
+}
+
+// TestPlanProducesRenderableConfigs pins Plan's central contract: every Config it
+// returns passes validation, so Render never fails for a planned node.
+func TestPlanProducesRenderableConfigs(t *testing.T) {
+	t.Parallel()
+
+	input := joinPlanInput()
+	input.KubernetesVersion = "v1.31.0"
+	input.ControlPlaneEndpoint = "cluster.example:6443"
+	input.CertSANs = []string{"cluster.example"}
+	input.PodSubnet = "10.244.0.0/16"
+	input.ControlPlaneCount = 3
+	input.AgentCount = 2
+
+	nodes, err := kubeadmbootstrap.Plan(input)
+	require.NoError(t, err)
+
+	for _, node := range nodes {
+		_, renderErr := kubeadmbootstrap.Render(node.Config)
+		require.NoErrorf(t, renderErr, "Render must not fail for planned node %d", node.Index)
+	}
+}
+
+// TestPlanClonesSlices guards against slice-header aliasing: mutating a planned
+// node's CertSANs or CACertHashes must not corrupt the caller's input or a
+// sibling node.
+func TestPlanClonesSlices(t *testing.T) {
+	t.Parallel()
+
+	sans := []string{"a.example", "b.example"}
+	hashes := []string{validCACertHash}
+
+	input := joinPlanInput()
+	input.CertSANs = sans
+	input.ControlPlaneCount = 2
+	input.AgentCount = 1
+	input.CACertHashes = hashes
+
+	nodes, err := kubeadmbootstrap.Plan(input)
+	require.NoError(t, err)
+
+	nodes[0].Config.CertSANs[0] = "mutated"
+	nodes[1].Config.CACertHashes[0] = "mutated"
+
+	assert.Equal(t, "a.example", sans[0], "input CertSANs must be unaffected")
+	assert.Equal(t, validCACertHash, hashes[0], "input CACertHashes must be unaffected")
+	assert.Equal(t, validCACertHash, nodes[2].Config.CACertHashes[0], "sibling node unaffected")
+}
+
+// invalidPlanCase is one rejected-input fixture: a mutation of the join baseline
+// and the sentinel error Plan must report for it.
+type invalidPlanCase struct {
+	mutate  func(*kubeadmbootstrap.PlanInput)
+	wantErr error
+}
+
+// invalidPlanCases returns the rejected-input fixtures, extracted from the test
+// body so the table-driven test stays within the function-length budget.
+func invalidPlanCases() map[string]invalidPlanCase {
+	return map[string]invalidPlanCase{
+		"missing token": {
+			mutate:  func(in *kubeadmbootstrap.PlanInput) { in.Token = "" },
+			wantErr: kubeadmbootstrap.ErrMissingToken,
+		},
+		"zero control planes": {
+			mutate:  func(in *kubeadmbootstrap.PlanInput) { in.ControlPlaneCount = 0 },
+			wantErr: kubeadmbootstrap.ErrInvalidControlPlaneCount,
+		},
+		"negative agents": {
+			mutate:  func(in *kubeadmbootstrap.PlanInput) { in.AgentCount = -1 },
+			wantErr: kubeadmbootstrap.ErrInvalidAgentCount,
+		},
+		"joining node missing endpoint": {
+			mutate: func(in *kubeadmbootstrap.PlanInput) {
+				in.AgentCount = 1
+				in.APIServerEndpoint = ""
+			},
+			wantErr: kubeadmbootstrap.ErrMissingAPIServerEndpoint,
+		},
+		"joining node invalid endpoint": {
+			mutate: func(in *kubeadmbootstrap.PlanInput) {
+				in.AgentCount = 1
+				in.APIServerEndpoint = "no-port"
+			},
+			wantErr: kubeadmbootstrap.ErrInvalidAPIServerEndpoint,
+		},
+		"joining node missing CA hash": {
+			mutate: func(in *kubeadmbootstrap.PlanInput) {
+				in.AgentCount = 1
+				in.CACertHashes = nil
+			},
+			wantErr: kubeadmbootstrap.ErrMissingCACertHashes,
+		},
+		"joining node invalid CA hash": {
+			mutate: func(in *kubeadmbootstrap.PlanInput) {
+				in.AgentCount = 1
+				in.CACertHashes = []string{"sha256:deadbeef"}
+			},
+			wantErr: kubeadmbootstrap.ErrInvalidCACertHash,
+		},
+	}
+}
+
+func TestPlanRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range invalidPlanCases() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			input := joinPlanInput()
+			test.mutate(&input)
+
+			nodes, err := kubeadmbootstrap.Plan(input)
+			require.Error(t, err)
+			assert.Nil(t, nodes)
+			assert.ErrorIs(t, err, test.wantErr)
+		})
+	}
+}
+
+// TestPlanAllowsValidJoinDiscovery confirms a single-control-plane plan needs no
+// discovery fields, so the no-join baseline is never rejected for missing them.
+func TestPlanAllowsNoDiscoveryWhenNoJoiners(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := kubeadmbootstrap.Plan(kubeadmbootstrap.PlanInput{
+		Token:             "abcdef.0123456789abcdef",
+		ControlPlaneCount: 1,
+		AgentCount:        0,
+	})
+	require.NoError(t, err)
+	assert.Len(t, nodes, 1)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5611. Part of #5513 (Vanilla (kubeadm) × Hetzner provisioner), #3983 (epic #4627).

## What
Adds `kubeadmbootstrap.Plan(PlanInput) → ([]Node, error)` — the topology layer that expands a cluster's node counts into the ordered per-node kubeadm configs a provisioner bootstraps in sequence:

- **cluster-initialising control plane** (`RoleServerInit`) → **additional control planes** (`RoleServer`) → **agents** (`RoleAgent`), in bootstrap order;
- every returned `Node.Config` passes validation, so `Render` never fails for a planned node (the same contract `k3sbootstrap.Plan` makes);
- pure — no I/O, no network — fully unit-testable without a cluster or a Hetzner account.

## Why
The kubeadm renderer (#5521) handles a **single** node's typed config; the K3s sibling already has the topology seam (`k3sbootstrap.Plan`) that the merged `k3shetzner` provisioner (#5594) composes. This is the matching precursor the **Vanilla (kubeadm) × Hetzner** provisioner (#5513) will consume next — the same decompose-and-start increment that landed K3s.

## Design note — kubeadm vs k3s discovery
Unlike k3s's pre-shared token (any node joins with just the token + server URL), kubeadm discovers a joining node's **API server endpoint** and **CA cert hashes** only once the first control plane has run `kubeadm init`. So those are `PlanInput` fields a provisioner injects **at run time** before planning the joining nodes; `Plan` requires and validates them only when the topology contains joiners. A single-control-plane plan needs no discovery fields. Documented on `PlanInput` and in the package doc.

## Validation
- `go build` / `go vet` ✅
- `go test -race -cover` ✅ — 31 tests; **plan.go 100%** statement coverage (package total 99.1%)
- `golangci-lint run` ✅ — 0 issues
- No generated-file surface (internal bootstrap logic; no schema/CLI/docs change) → no regen.

Opened as a **draft** for your review/promotion.