### PR TITLE
feat(cluster): derive the multi-cluster overlay layout for cluster init

### DIFF
--- a/pkg/svc/environment/layout.go
+++ b/pkg/svc/environment/layout.go
@@ -1,0 +1,110 @@
+package environment
+
+import (
+	"errors"
+	"fmt"
+	"path"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	ktypes "sigs.k8s.io/kustomize/api/types"
+)
+
+// ClustersDir is the conventional sub-directory under a GitOps source directory
+// that holds the per-environment cluster overlays (<sourceDir>/clusters/<env>/),
+// alongside the shared base at <sourceDir>/clusters/base/. The cluster
+// add-environment command clones from <sourceDir>/clusters/<from>/, so a
+// multi-cluster scaffold seeds exactly this layout.
+const ClustersDir = "clusters"
+
+// BaseEnvName is the conventional name of the shared base overlay in a
+// multi-cluster source tree (clusters/base/). Per-environment overlays sit
+// alongside it at clusters/<env>/ and reference it, so cross-environment wiring
+// lives in one place instead of being copied into each overlay.
+const BaseEnvName = "base"
+
+// kustomizationFileName is the standard kustomize manifest filename, matching the
+// scaffolder's single-cluster output so the two layouts stay byte-consistent.
+const kustomizationFileName = "kustomization.yaml"
+
+// ErrReservedEnvironmentName is returned by DeriveMultiClusterLayout when the
+// environment name collides with the shared base directory (clusters/base/),
+// which would make the per-environment overlay overwrite the base.
+var ErrReservedEnvironmentName = errors.New("environment name is reserved")
+
+// ErrEmptyEnvironmentName is returned by DeriveMultiClusterLayout when the
+// environment name is empty: unlike a cluster config, a multi-cluster overlay has
+// no "default" environment, and an empty name would collapse the clusters/<env>/
+// path.
+var ErrEmptyEnvironmentName = errors.New("environment name must be non-empty")
+
+// LayoutFile is one file in a scaffolded multi-cluster overlay tree: the path
+// relative to the GitOps source directory and the kustomization model to render
+// there. The model is rendered by the same kustomization generator the scaffolder
+// uses for the single-cluster layout, so a multi-cluster scaffold stays
+// byte-consistent with a single-cluster one and a later increment can write these
+// files without bespoke YAML.
+type LayoutFile struct {
+	// RelPath is the file's path relative to the source directory, slash-delimited
+	// (e.g. "clusters/base/kustomization.yaml"). The writer joins it onto the
+	// resolved source directory.
+	RelPath string
+	// Kustomization is the model to render at RelPath.
+	Kustomization *ktypes.Kustomization
+}
+
+// DeriveMultiClusterLayout returns the files for a multi-cluster GitOps source
+// tree: a shared base at clusters/base/ plus one per-environment overlay at
+// clusters/<envName>/ that references the base. It is the pure, filesystem-free
+// foundation of the multi-cluster mode for cluster init — the structured
+// counterpart to [DeriveRewrites] for the clone path — so the layout can be
+// asserted in isolation before a later increment threads it through the
+// scaffolder and an init flag.
+//
+// The base kustomization starts with no resources, matching the single-cluster
+// scaffold (KSail creates the GitOps resources — FluxInstance, ArgoCD Application
+// — server-side, not in the source tree); the user fills clusters/base/ with the
+// shared workload. The environment overlay references the base via the sibling
+// path ../base, so adding a second environment is a [CloneOverlay] of an existing
+// clusters/<env>/ overlay — the layout the cluster add-environment command
+// already expects.
+//
+// envName is validated with [v1alpha1.ValidateClusterName] (defence in depth
+// ahead of any downstream containment guard) and must not be the reserved base
+// name, which would collide the overlay with the shared base. An empty name is
+// rejected explicitly because ValidateClusterName treats "" as "use the default"
+// (it returns nil), but an empty overlay name has no meaning here and would
+// collapse the clusters/<env>/ path.
+func DeriveMultiClusterLayout(envName string) ([]LayoutFile, error) {
+	if envName == "" {
+		return nil, fmt.Errorf("invalid environment name: %w", ErrEmptyEnvironmentName)
+	}
+
+	err := v1alpha1.ValidateClusterName(envName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid environment name: %w", err)
+	}
+
+	if envName == BaseEnvName {
+		return nil, fmt.Errorf(
+			"%w: %q names the shared base overlay (clusters/%s/)",
+			ErrReservedEnvironmentName, envName, BaseEnvName,
+		)
+	}
+
+	// The overlay sits at clusters/<env>/ and the base at clusters/base/, so the
+	// overlay references the base by stepping up one level to its sibling.
+	baseRef := path.Join("..", BaseEnvName)
+
+	return []LayoutFile{
+		{
+			RelPath:       path.Join(ClustersDir, BaseEnvName, kustomizationFileName),
+			Kustomization: &ktypes.Kustomization{},
+		},
+		{
+			RelPath: path.Join(ClustersDir, envName, kustomizationFileName),
+			Kustomization: &ktypes.Kustomization{
+				Resources: []string{baseRef},
+			},
+		},
+	}, nil
+}

--- a/pkg/svc/environment/layout_test.go
+++ b/pkg/svc/environment/layout_test.go
@@ -1,0 +1,103 @@
+package environment_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveMultiClusterLayout_SeedsBaseAndOverlay(t *testing.T) {
+	t.Parallel()
+
+	files, err := environment.DeriveMultiClusterLayout("prod")
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+
+	base := files[0]
+	overlay := files[1]
+
+	assert.Equal(t, "clusters/base/kustomization.yaml", base.RelPath)
+	require.NotNil(t, base.Kustomization)
+	assert.Empty(t, base.Kustomization.Resources,
+		"the shared base starts empty; KSail creates GitOps resources server-side")
+
+	assert.Equal(t, "clusters/prod/kustomization.yaml", overlay.RelPath)
+	require.NotNil(t, overlay.Kustomization)
+	assert.Equal(t, []string{"../base"}, overlay.Kustomization.Resources,
+		"the overlay references the shared base via its sibling path")
+}
+
+func TestDeriveMultiClusterLayout_OverlayPathMatchesAddEnvironmentConvention(t *testing.T) {
+	t.Parallel()
+
+	// The overlay must live at clusters/<env>/ so `cluster add-environment --from
+	// <env>` (which clones <sourceDir>/clusters/<from>/) has an overlay to clone.
+	files, err := environment.DeriveMultiClusterLayout("staging")
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+
+	assert.Equal(t, "clusters/staging/kustomization.yaml", files[1].RelPath)
+}
+
+func TestDeriveMultiClusterLayout_RejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		envName string
+		wantErr error
+	}{
+		{
+			name:    "empty name",
+			envName: "",
+			wantErr: environment.ErrEmptyEnvironmentName,
+		},
+		{
+			name:    "reserved base name collides with the shared base",
+			envName: "base",
+			wantErr: environment.ErrReservedEnvironmentName,
+		},
+		{
+			name:    "path traversal token is not DNS-1123",
+			envName: "..",
+			wantErr: nil, // invalid-name error, asserted via require.Error below
+		},
+		{
+			name:    "slash is not DNS-1123",
+			envName: "a/b",
+			wantErr: nil,
+		},
+		{
+			name:    "uppercase is not DNS-1123",
+			envName: "Prod",
+			wantErr: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			files, err := environment.DeriveMultiClusterLayout(testCase.envName)
+
+			require.Error(t, err)
+			assert.Nil(t, files)
+
+			if testCase.wantErr != nil {
+				require.ErrorIs(t, err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+// TestDeriveMultiClusterLayout_ExportedConstants pins the conventional names so a
+// future scaffolder/CLI increment and the add-environment command stay aligned on
+// the clusters/<env>/ + clusters/base/ layout.
+func TestDeriveMultiClusterLayout_ExportedConstants(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "clusters", environment.ClustersDir)
+	assert.Equal(t, "base", environment.BaseEnvName)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5614 · Part of #5441 (item 2: multi-cluster mode for `cluster init`)

## Why

`ksail cluster add-environment <name> --from <env>` (#5581) clones an existing
`<sourceDir>/clusters/<from>/` overlay — but `cluster init` only scaffolds a flat
single-cluster `<sourceDir>/kustomization.yaml`, so a freshly-`init`'d repo has no
`clusters/<env>/` overlay to clone from. This is the first increment of epic
#5441's item 2: scaffold the multi-cluster `clusters/base` + `clusters/<env>`
overlay layout so the clone command becomes usable out of the box.

## What

A pure, filesystem-free `environment.DeriveMultiClusterLayout(envName)` — the
structured counterpart to the merged `DeriveRewrites`/`CloneOverlay` clone path —
returning the file set for a multi-cluster source tree:

- `clusters/base/kustomization.yaml` — the shared base (empty `resources:`,
  matching the single-cluster scaffold; KSail creates the GitOps resources
  server-side, so the user fills the base with the shared workload).
- `clusters/<env>/kustomization.yaml` — the per-environment overlay, referencing
  the base via its sibling path `../base` (the exact convention the real platform
  consumer and `add-environment` already use).

Each `LayoutFile` carries a `*ktypes.Kustomization`, so a **later increment** can
render it with the same kustomization generator the scaffolder already uses
(byte-consistent with single-cluster output) and an `init` flag can select this
layout. Kept pure and CLI-free so it's asserted in isolation, mirroring how every
prior #5441 increment landed a logic slice before its writer/command.

Validation (defence in depth ahead of any downstream containment guard): rejects
an empty name, the reserved `base` name (would overwrite the shared base), and
non-DNS-1123 names. Exported `ClustersDir`/`BaseEnvName` keep a later
scaffolder/CLI increment aligned on the layout.

## Follow-up increments (not this PR)

1. Thread the layout through the scaffolder to write the files.
2. Wire an `init --multi-cluster` flag selecting this layout.
3. Epic #5441 item 3 — declarative `environments × providers` expansion.

## Validation

- `go build`, `go vet`, `go test` (55 pass) on `pkg/svc/environment/...`
- `DeriveMultiClusterLayout` **100%** covered
- golangci-lint: 0 issues; `deadcode -test ./...` clean (CI's exact invocation)
- No generated drift (no CLI/schema/snapshot surface)
