### PR TITLE
feat(validate): name the failing resource in kubeconform validation errors

### DIFF
--- a/pkg/client/kubeconform/client.go
+++ b/pkg/client/kubeconform/client.go
@@ -153,13 +153,16 @@ func (c *Client) validateWithRetry(ctx context.Context, validate func() error) e
 // processResults processes validation results and returns an error if validation failed.
 // Error details are included in the returned error message (not written to stderr)
 // to avoid interleaving with ProgressGroup's ANSI output.
+// Each failing resource's identity (Kind/Namespace/Name) is prefixed to its detail so
+// that, when validating a stream of many manifests (e.g. a whole Kustomize + Helm render),
+// the message points at the offending resource instead of surfacing a bare schema error.
 // The caller is responsible for including any file/source context in the wrapping error.
 func (c *Client) processResults(results []validator.Result) error {
 	var errDetails []string
 
 	for _, res := range results {
 		if res.Status == validator.Invalid || res.Status == validator.Error {
-			errDetails = append(errDetails, fmt.Sprintf("%v", res.Err))
+			errDetails = append(errDetails, formatFailure(res))
 		}
 	}
 
@@ -168,6 +171,36 @@ func (c *Client) processResults(results []validator.Result) error {
 	}
 
 	return nil
+}
+
+// formatFailure renders a single failing result as "<identity>: <detail>", falling
+// back to just the detail when the resource signature is unavailable (e.g. a document
+// missing apiVersion/kind). Preserving the original detail keeps existing error
+// substrings intact for callers that match on them.
+func formatFailure(res validator.Result) string {
+	detail := fmt.Sprintf("%v", res.Err)
+
+	if identity := resourceIdentity(res); identity != "" {
+		return identity + ": " + detail
+	}
+
+	return detail
+}
+
+// resourceIdentity returns a "<Kind>/<Namespace>/<Name>" (or "<Kind>/<Name>" for
+// cluster-scoped resources) label for a validation result, or "" when the result
+// carries no usable signature.
+func resourceIdentity(res validator.Result) string {
+	sig, err := res.Resource.Signature()
+	if err != nil || sig == nil || sig.Kind == "" {
+		return ""
+	}
+
+	if sig.Namespace != "" {
+		return fmt.Sprintf("%s/%s/%s", sig.Kind, sig.Namespace, sig.Name)
+	}
+
+	return fmt.Sprintf("%s/%s", sig.Kind, sig.Name)
 }
 
 // ValidationOptions configures validation behavior.

--- a/pkg/client/kubeconform/client_test.go
+++ b/pkg/client/kubeconform/client_test.go
@@ -319,6 +319,45 @@ func TestValidateFile_NilOptions(t *testing.T) {
 	}
 }
 
+// TestValidateBytes_NamesFailingResource verifies that when a multi-document stream
+// contains a schema-invalid resource, the failure message identifies that resource by
+// Kind/Namespace/Name — so a finding in a large Kustomize+Helm render is traceable to a
+// specific object — without implicating the valid resources in the same stream.
+func TestValidateBytes_NamesFailingResource(t *testing.T) {
+	t.Parallel()
+
+	// A stream with a valid Namespace and a schema-invalid ConfigMap (data must be a
+	// map of strings, not a scalar).
+	invalidConfigMap := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: broken-config
+  namespace: demo
+data: "this is not a map"
+`
+	manifests := validNamespaceYAML + "---\n" + invalidConfigMap
+
+	client := kubeconform.NewClient()
+	opts := &kubeconform.ValidationOptions{
+		Strict:               true,
+		IgnoreMissingSchemas: true,
+	}
+
+	err := client.ValidateBytes(context.Background(), "render.yaml", []byte(manifests), opts)
+	if err == nil {
+		t.Fatal("expected the invalid ConfigMap to fail validation")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "ConfigMap/demo/broken-config") {
+		t.Fatalf("expected error to name the failing resource, got: %v", err)
+	}
+
+	if strings.Contains(msg, "test-namespace") {
+		t.Fatalf("expected error not to implicate the valid Namespace, got: %v", err)
+	}
+}
+
 // widgetCRD is a JSON schema for a fictional CRD kind that exists in neither the
 // built-in Kubernetes schemas nor the CRDs-catalog, so it can only be validated
 // via a caller-supplied schema location.

--- a/pkg/client/kubeconform/export_test.go
+++ b/pkg/client/kubeconform/export_test.go
@@ -6,6 +6,11 @@ import "time"
 // ValidateWithRetry exposes validateWithRetry for black-box tests.
 var ValidateWithRetry = (*Client).validateWithRetry
 
+// FormatFailure exposes formatFailure so black-box tests can assert the
+// resource-identity prefixing across the namespaced, cluster-scoped, and
+// no-signature branches without depending on kubeconform's status flow.
+var FormatFailure = formatFailure
+
 // SetRetryConfig overrides the internal retry-tuning fields for black-box tests.
 func (c *Client) SetRetryConfig(maxAttempts int, baseWait, maxWait time.Duration) {
 	c.maxRetryAttempts = maxAttempts

--- a/pkg/client/kubeconform/format_test.go
+++ b/pkg/client/kubeconform/format_test.go
@@ -1,0 +1,72 @@
+package kubeconform_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/kubeconform"
+	"github.com/yannh/kubeconform/pkg/resource"
+	"github.com/yannh/kubeconform/pkg/validator"
+)
+
+// errBoom is a static sentinel used as the failure detail in FormatFailure tests
+// (err113 requires a static error value rather than an inline errors.New).
+var errBoom = errors.New("boom")
+
+// TestFormatFailure exercises each identity branch of the failure formatter:
+// a namespaced resource (Kind/Namespace/Name), a cluster-scoped resource
+// (Kind/Name), and a document with no usable signature (detail only).
+func TestFormatFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		bytes string
+		want  string
+	}{
+		{
+			name: "namespaced resource is prefixed with Kind/Namespace/Name",
+			bytes: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web
+  namespace: apps
+`,
+			want: "ConfigMap/apps/web: boom",
+		},
+		{
+			name: "cluster-scoped resource is prefixed with Kind/Name",
+			bytes: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: viewer
+`,
+			want: "ClusterRole/viewer: boom",
+		},
+		{
+			name: "document missing kind falls back to the bare detail",
+			bytes: `apiVersion: v1
+metadata:
+  name: orphan
+`,
+			want: "boom",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := validator.Result{
+				Resource: resource.Resource{Bytes: []byte(testCase.bytes)},
+				Err:      errBoom,
+				Status:   validator.Error,
+			}
+
+			got := kubeconform.FormatFailure(res)
+			if got != testCase.want {
+				t.Fatalf("FormatFailure() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5618. Part of #5344 (validate/scan all GitOps layers in-process — the *per-layer attribution* cross-cutting work).

## What

`ksail workload validate` schema-validates the full Kustomize build plus the Helm-rendered children (Phase 1/2 of #5344). Until now a schema failure surfaced only kubeconform's bare detail with **no pointer to which resource failed** — on a real GitOps repo (~60 HelmReleases, ~80 operator CRs) that leaves the user hunting through the whole render.

This prefixes each failing result with its resource identity — `<Kind>/<Namespace>/<Name>` (or `<Kind>/<Name>` for cluster-scoped resources) — pulled from the `validator.Result`'s already-present signature, which `processResults` previously discarded.

```
validation failed: ConfigMap/demo/broken-config: problem validating schema. Check JSON formatting: …
```

## Why this shape

- **Message text only** — pass/fail behaviour is unchanged, and the original detail is preserved after the prefix, so `errors.Is(err, ErrValidationFailed)` and existing substring assertions keep working.
- **Graceful fallback** — a result with no usable signature (e.g. a document missing `apiVersion`/`kind`) falls back to the bare detail rather than erroring.
- **Self-contained** — entirely within `pkg/client/kubeconform`; no CLI surface, schema, or generated-file changes.

## Foundation for layer attribution

This is the decomposed **first child** of #5344's cross-cutting *per-layer attribution*. Naming the resource is the prerequisite; a follow-up child threads the render provenance (`render.Document.Provenance`) into `validate`, matches each named resource back to its `Provenance`, and appends the layer/HelmRelease tag (`… [rendered from HelmRelease apps/foo]`).

## Validation

- `go build` / `go vet` / `go test ./pkg/client/kubeconform/...` (28 pass, incl. new `TestValidateBytes_NamesFailingResource`)
- `golangci-lint run ./pkg/client/kubeconform/...` — 0 issues
- `deadcode -test` clean; no generated drift