### PR TITLE
feat(cloudinit): carry declarative apt sources, packages, and files in the bootstrap transport

### DIFF
--- a/pkg/svc/bootstrap/cloudinit/cloudinit.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit.go
@@ -75,7 +75,8 @@ type Config struct {
 type AptSource struct {
 	// Name is the cloud-init sources-map key; cloud-init writes the source line to
 	// /etc/apt/sources.list.d/<Name>.list. Required; a single line with no NUL
-	// byte, and unique across a Config's AptSources (see [ErrInvalidAptSource]).
+	// byte or path separator (it is a filename, not a path), and unique across a
+	// Config's AptSources (see [ErrInvalidAptSource]).
 	Name string
 	// Source is the one-line APT source entry, e.g.
 	// "deb [signed-by=/etc/apt/keyrings/k8s.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /".
@@ -94,8 +95,9 @@ type AptSource struct {
 type File struct {
 	// Path is the absolute destination path (see [ErrInvalidFile]). Required.
 	Path string
-	// Permissions is the octal mode string cloud-init applies, e.g. "0600".
-	// Optional; defaults to [DefaultFilePermissions].
+	// Permissions is the octal mode string cloud-init applies, e.g. "0600" (three
+	// or four octal digits). Optional; defaults to [DefaultFilePermissions]. An
+	// explicit non-octal value is rejected (see [ErrInvalidFile]).
 	Permissions string
 	// Content is the file's contents, written verbatim. May be empty or span
 	// multiple lines; only a NUL byte is rejected.
@@ -315,7 +317,11 @@ func (cfg Config) validatedAptSources() (map[string]aptSource, error) {
 	sources := make(map[string]aptSource, len(cfg.AptSources))
 
 	for _, src := range cfg.AptSources {
-		if isBlankOrMultiline(src.Name) || isBlankOrMultiline(src.Source) {
+		// Name becomes the /etc/apt/sources.list.d/<Name>.list filename, so a path
+		// separator would let it escape that directory — reject it, not just blanks.
+		if isBlankOrMultiline(src.Name) ||
+			strings.ContainsAny(src.Name, `/\`) ||
+			isBlankOrMultiline(src.Source) {
 			return nil, ErrInvalidAptSource
 		}
 
@@ -334,8 +340,9 @@ func (cfg Config) validatedAptSources() (map[string]aptSource, error) {
 }
 
 // validatedFiles returns cfg.Files as write_files entries, rejecting a file with
-// a non-absolute or multi-line Path or a Content with a NUL byte, and applying
-// [DefaultFilePermissions] to an entry with no explicit mode.
+// a non-absolute or multi-line Path, a Content with a NUL byte, or an explicit
+// Permissions that is not an octal mode, and applying [DefaultFilePermissions]
+// to an entry with no explicit mode.
 func (cfg Config) validatedFiles() ([]writeFile, error) {
 	files := make([]writeFile, 0, len(cfg.Files))
 
@@ -345,6 +352,12 @@ func (cfg Config) validatedFiles() ([]writeFile, error) {
 		}
 
 		if strings.ContainsRune(file.Content, '\x00') {
+			return nil, ErrInvalidFile
+		}
+
+		// An explicit mode is passed verbatim to cloud-init, which fails the boot if
+		// it is not a valid octal string — reject a malformed one at build time.
+		if file.Permissions != "" && !isOctalMode(file.Permissions) {
 			return nil, ErrInvalidFile
 		}
 
@@ -367,6 +380,22 @@ func (cfg Config) validatedFiles() ([]writeFile, error) {
 // newline or NUL byte — the rejection shared by an apt source's Name and Source.
 func isBlankOrMultiline(s string) bool {
 	return strings.TrimSpace(s) == "" || strings.ContainsAny(s, "\n\x00")
+}
+
+// isOctalMode reports whether s is a cloud-init file mode: three or four octal
+// digits (e.g. "644" or "0600"), which is what write_files accepts.
+func isOctalMode(s string) bool {
+	if len(s) != 3 && len(s) != 4 {
+		return false
+	}
+
+	for _, r := range s {
+		if r < '0' || r > '7' {
+			return false
+		}
+	}
+
+	return true
 }
 
 // buildScript assembles the POSIX boot script: a shebang, strict-mode flags, an

--- a/pkg/svc/bootstrap/cloudinit/cloudinit.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit.go
@@ -14,6 +14,10 @@ const (
 	// DefaultLogPath is where the bootstrap script's combined output is captured on
 	// the server when Config.LogPath is empty.
 	DefaultLogPath = "/var/log/ksail-bootstrap.log"
+	// DefaultFilePermissions is the mode applied to a [File] whose Permissions is
+	// empty. cloud-init requires an explicit mode string, so a sane default keeps
+	// callers from having to spell it out for ordinary files.
+	DefaultFilePermissions = "0644"
 
 	// header is the literal first line cloud-init requires to recognise a payload
 	// as a cloud-config document; it must be the very first bytes of user_data.
@@ -24,15 +28,38 @@ const (
 	// masking the script's exit code (unlike a trailing `| tee`).
 	scriptShebang  = "#!/bin/sh"
 	scriptSetFlags = "set -eu"
+	// scriptPermissions is the mode of the generated boot script (owner rwx only:
+	// it may embed secrets such as a node token, and it is only ever run as root).
+	scriptPermissions = "0700"
 )
 
-// Config is the typed input for [BuildUserData]. It captures what to run at first
-// boot and where the boot script and its log live; it does not perform any I/O.
+// Config is the typed input for [BuildUserData]. It captures what to install and
+// run at first boot and where the boot script and its log live; it does not
+// perform any I/O.
+//
+// A Config is valid when it carries at least one directive — a command, a
+// package, an apt source, or a file (see [ErrNoCommands]). The declarative
+// fields (Packages, AptSources, Files) are rendered as cloud-init's own modules
+// so a native install needs no `curl | sh` at first boot; cloud-init runs them
+// in module order (files, then apt configure, then package install) before any
+// Command in the boot script.
 type Config struct {
-	// Commands are the shell commands run, in order, once at first boot. At least
-	// one non-empty command is required (see [ErrNoCommands]); each must be a single
-	// line with no NUL byte (see [ErrInvalidCommand]).
+	// Commands are the shell commands run, in order, once at first boot, after the
+	// declarative fields below have been applied. Optional; each must be a single
+	// line with no NUL byte (see [ErrInvalidCommand]). Blank commands are dropped.
 	Commands []string
+	// Packages are apt packages installed via cloud-init's `packages:` module
+	// before Commands run. Optional; each must be a single line with no NUL byte
+	// (see [ErrInvalidPackage]). Blank entries are dropped.
+	Packages []string
+	// AptSources are additional APT repositories configured (with their signing
+	// keys, declaratively) before packages install. Optional; see [AptSource] and
+	// [ErrInvalidAptSource].
+	AptSources []AptSource
+	// Files are files written to the server (cloud-init `write_files:`) before
+	// apt/package processing and the boot script. Optional; see [File] and
+	// [ErrInvalidFile].
+	Files []File
 	// ScriptPath overrides where the boot script is written. Optional; defaults to
 	// [DefaultScriptPath]. Must be absolute when set (see [ErrPathNotAbsolute]).
 	ScriptPath string
@@ -42,12 +69,49 @@ type Config struct {
 	LogPath string
 }
 
+// AptSource is one entry of cloud-init's `apt: sources:` module: an additional
+// APT repository configured before packages install, with its signing key
+// trusted declaratively so no key is fetched with `curl | gpg` at runtime.
+type AptSource struct {
+	// Name is the cloud-init sources-map key; cloud-init writes the source line to
+	// /etc/apt/sources.list.d/<Name>.list. Required; a single line with no NUL
+	// byte, and unique across a Config's AptSources (see [ErrInvalidAptSource]).
+	Name string
+	// Source is the one-line APT source entry, e.g.
+	// "deb [signed-by=/etc/apt/keyrings/k8s.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /".
+	// Required; a single line with no NUL byte.
+	Source string
+	// Key is the ASCII-armored public key cloud-init trusts for this source (the
+	// `key:` field). Optional; embedded verbatim so the key is trusted
+	// declaratively at first boot rather than fetched at runtime. May span
+	// multiple lines but must contain no NUL byte.
+	Key string
+}
+
+// File is one cloud-init `write_files:` entry: a file dropped onto the server
+// before apt/package processing and the boot script — e.g. a kubeadm config or
+// an apt keyring.
+type File struct {
+	// Path is the absolute destination path (see [ErrInvalidFile]). Required.
+	Path string
+	// Permissions is the octal mode string cloud-init applies, e.g. "0600".
+	// Optional; defaults to [DefaultFilePermissions].
+	Permissions string
+	// Content is the file's contents, written verbatim. May be empty or span
+	// multiple lines; only a NUL byte is rejected.
+	Content string
+}
+
 // cloudConfig is the subset of the cloud-init schema this package emits. It is
-// marshalled to YAML and prefixed with the `#cloud-config` header.
+// marshalled to YAML and prefixed with the `#cloud-config` header. Every field
+// is omitempty so a command-only Config renders exactly as it did before the
+// declarative fields existed.
 type cloudConfig struct {
 	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key "write_files".
-	WriteFiles []writeFile `yaml:"write_files"`
-	RunCmd     [][]string  `yaml:"runcmd"`
+	WriteFiles []writeFile `yaml:"write_files,omitempty"`
+	Apt        *aptConfig  `yaml:"apt,omitempty"`
+	Packages   []string    `yaml:"packages,omitempty"`
+	RunCmd     [][]string  `yaml:"runcmd,omitempty"`
 }
 
 // writeFile is one entry of cloud-init's write_files module: a file dropped onto
@@ -58,33 +122,36 @@ type writeFile struct {
 	Content     string `yaml:"content"`
 }
 
+// aptConfig is cloud-init's `apt:` module, limited to the `sources:` map this
+// package emits. The map is keyed by [AptSource.Name]; yaml.v3 marshals map keys
+// in sorted order, so the rendered document is deterministic.
+type aptConfig struct {
+	Sources map[string]aptSource `yaml:"sources"`
+}
+
+// aptSource is one value of the apt sources map.
+type aptSource struct {
+	Source string `yaml:"source"`
+	Key    string `yaml:"key,omitempty"`
+}
+
 // BuildUserData renders cfg into a cloud-init user_data document. The returned
 // string is a complete `#cloud-config` payload suitable for
-// CreateServerOpts.UserData: it writes a boot script containing cfg.Commands and
-// runs it once at first boot, capturing all output to the log path.
+// CreateServerOpts.UserData: it drops cfg.Files, configures cfg.AptSources,
+// installs cfg.Packages, then writes a boot script containing cfg.Commands and
+// runs it once at first boot, capturing that script's output to the log path.
 //
 // BuildUserData is pure and never returns a partially-valid document: any
 // configuration error (see the package's sentinel errors) is reported instead.
 func BuildUserData(cfg Config) (string, error) {
-	scriptPath, logPath, err := cfg.resolvePaths()
+	dirs, err := cfg.validate()
 	if err != nil {
 		return "", err
 	}
 
-	commands, err := cfg.validatedCommands()
+	doc, err := cfg.buildDoc(dirs)
 	if err != nil {
 		return "", err
-	}
-
-	doc := cloudConfig{
-		WriteFiles: []writeFile{{
-			Path:        scriptPath,
-			Permissions: "0700",
-			Content:     buildScript(logPath, commands),
-		}},
-		// argv form (not a shell string) so cloud-init runs the script directly and
-		// preserves its exit code; the script itself supplies the shell.
-		RunCmd: [][]string{{"/bin/sh", scriptPath}},
 	}
 
 	out, err := yaml.Marshal(doc)
@@ -96,6 +163,85 @@ func BuildUserData(cfg Config) (string, error) {
 	}
 
 	return header + string(out), nil
+}
+
+// directives are cfg's validated inputs, ready to render.
+type directives struct {
+	commands []string
+	packages []string
+	sources  map[string]aptSource
+	files    []writeFile
+}
+
+// empty reports whether there is nothing to render — no command, package, apt
+// source, or file.
+func (d directives) empty() bool {
+	return len(d.commands) == 0 &&
+		len(d.packages) == 0 &&
+		len(d.sources) == 0 &&
+		len(d.files) == 0
+}
+
+// validate returns cfg's validated directives, or the first configuration error
+// encountered. A Config with no directive at all is rejected with [ErrNoCommands].
+func (cfg Config) validate() (directives, error) {
+	commands, err := cfg.validatedCommands()
+	if err != nil {
+		return directives{}, err
+	}
+
+	packages, err := cfg.validatedPackages()
+	if err != nil {
+		return directives{}, err
+	}
+
+	sources, err := cfg.validatedAptSources()
+	if err != nil {
+		return directives{}, err
+	}
+
+	files, err := cfg.validatedFiles()
+	if err != nil {
+		return directives{}, err
+	}
+
+	dirs := directives{commands: commands, packages: packages, sources: sources, files: files}
+	if dirs.empty() {
+		return directives{}, ErrNoCommands
+	}
+
+	return dirs, nil
+}
+
+// buildDoc assembles the cloud-config from already-validated directives. Files
+// are written first, then apt sources and packages, then (when there are
+// commands) the boot script and the runcmd that executes it — matching
+// cloud-init's own module order so a package a command relies on is present
+// before the command runs.
+func (cfg Config) buildDoc(dirs directives) (cloudConfig, error) {
+	doc := cloudConfig{WriteFiles: dirs.files, Packages: dirs.packages}
+
+	if len(dirs.sources) > 0 {
+		doc.Apt = &aptConfig{Sources: dirs.sources}
+	}
+
+	if len(dirs.commands) > 0 {
+		scriptPath, logPath, err := cfg.resolvePaths()
+		if err != nil {
+			return cloudConfig{}, err
+		}
+
+		doc.WriteFiles = append(doc.WriteFiles, writeFile{
+			Path:        scriptPath,
+			Permissions: scriptPermissions,
+			Content:     buildScript(logPath, dirs.commands),
+		})
+		// argv form (not a shell string) so cloud-init runs the script directly and
+		// preserves its exit code; the script itself supplies the shell.
+		doc.RunCmd = [][]string{{"/bin/sh", scriptPath}}
+	}
+
+	return doc, nil
 }
 
 // resolvePaths returns the effective script and log paths, applying the defaults
@@ -119,9 +265,10 @@ func (cfg Config) resolvePaths() (string, string, error) {
 }
 
 // validatedCommands returns the non-empty commands of cfg in order, rejecting a
-// configuration with no runnable command or with a command that is not a single
-// line. Empty or whitespace-only commands are dropped so a stray "" in the input
-// does not emit a blank script line.
+// command that is not a single line. Empty or whitespace-only commands are
+// dropped so a stray "" in the input does not emit a blank script line. Unlike
+// the pre-declarative behaviour, an empty result is not an error here: the
+// caller checks emptiness across all directives.
 func (cfg Config) validatedCommands() ([]string, error) {
 	commands := make([]string, 0, len(cfg.Commands))
 
@@ -137,11 +284,89 @@ func (cfg Config) validatedCommands() ([]string, error) {
 		commands = append(commands, command)
 	}
 
-	if len(commands) == 0 {
-		return nil, ErrNoCommands
+	return commands, nil
+}
+
+// validatedPackages returns the non-blank package names of cfg in order,
+// rejecting a name that is not a single line. Blank entries are dropped.
+func (cfg Config) validatedPackages() ([]string, error) {
+	packages := make([]string, 0, len(cfg.Packages))
+
+	for _, pkg := range cfg.Packages {
+		if strings.ContainsAny(pkg, "\n\x00") {
+			return nil, ErrInvalidPackage
+		}
+
+		if strings.TrimSpace(pkg) == "" {
+			continue
+		}
+
+		packages = append(packages, pkg)
 	}
 
-	return commands, nil
+	return packages, nil
+}
+
+// validatedAptSources returns cfg.AptSources as a sources map keyed by Name,
+// rejecting an entry with a blank or multi-line Name or Source, a Key with a NUL
+// byte, or a duplicate Name. An empty (non-nil) map is returned when there are no
+// sources.
+func (cfg Config) validatedAptSources() (map[string]aptSource, error) {
+	sources := make(map[string]aptSource, len(cfg.AptSources))
+
+	for _, src := range cfg.AptSources {
+		if isBlankOrMultiline(src.Name) || isBlankOrMultiline(src.Source) {
+			return nil, ErrInvalidAptSource
+		}
+
+		if strings.ContainsRune(src.Key, '\x00') {
+			return nil, ErrInvalidAptSource
+		}
+
+		if _, exists := sources[src.Name]; exists {
+			return nil, ErrInvalidAptSource
+		}
+
+		sources[src.Name] = aptSource{Source: src.Source, Key: src.Key}
+	}
+
+	return sources, nil
+}
+
+// validatedFiles returns cfg.Files as write_files entries, rejecting a file with
+// a non-absolute or multi-line Path or a Content with a NUL byte, and applying
+// [DefaultFilePermissions] to an entry with no explicit mode.
+func (cfg Config) validatedFiles() ([]writeFile, error) {
+	files := make([]writeFile, 0, len(cfg.Files))
+
+	for _, file := range cfg.Files {
+		if strings.ContainsAny(file.Path, "\n\x00") || !strings.HasPrefix(file.Path, "/") {
+			return nil, ErrInvalidFile
+		}
+
+		if strings.ContainsRune(file.Content, '\x00') {
+			return nil, ErrInvalidFile
+		}
+
+		permissions := file.Permissions
+		if permissions == "" {
+			permissions = DefaultFilePermissions
+		}
+
+		files = append(files, writeFile{
+			Path:        file.Path,
+			Permissions: permissions,
+			Content:     file.Content,
+		})
+	}
+
+	return files, nil
+}
+
+// isBlankOrMultiline reports whether s is empty/whitespace-only or contains a
+// newline or NUL byte — the rejection shared by an apt source's Name and Source.
+func isBlankOrMultiline(s string) bool {
+	return strings.TrimSpace(s) == "" || strings.ContainsAny(s, "\n\x00")
 }
 
 // buildScript assembles the POSIX boot script: a shebang, strict-mode flags, an

--- a/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
@@ -18,7 +18,14 @@ type parsedConfig struct {
 		Permissions string `yaml:"permissions"`
 		Content     string `yaml:"content"`
 	} `yaml:"write_files"` //nolint:tagliatelle // cloud-init's schema mandates the snake_case key.
-	RunCmd [][]string `yaml:"runcmd"`
+	Apt struct {
+		Sources map[string]struct {
+			Source string `yaml:"source"`
+			Key    string `yaml:"key"`
+		} `yaml:"sources"`
+	} `yaml:"apt"`
+	Packages []string   `yaml:"packages"`
+	RunCmd   [][]string `yaml:"runcmd"`
 }
 
 // parse asserts the document carries the cloud-config header and is valid YAML,
@@ -163,14 +170,176 @@ func TestBuildUserDataDeterministic(t *testing.T) {
 	assert.Equal(t, first, second)
 }
 
+func TestBuildUserDataCommandOnlyOmitsDeclarativeKeys(t *testing.T) {
+	t.Parallel()
+
+	// A command-only Config must render exactly as before the declarative fields
+	// existed: no packages: and no apt: keys leak in.
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"echo hi"},
+	})
+	require.NoError(t, err)
+
+	assert.NotContains(t, userData, "packages:")
+	assert.NotContains(t, userData, "apt:")
+
+	cfg := parse(t, userData)
+	assert.Empty(t, cfg.Packages)
+	assert.Empty(t, cfg.Apt.Sources)
+	require.Len(t, cfg.WriteFiles, 1) // only the boot script
+}
+
+func TestBuildUserDataRendersPackages(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Packages: []string{"containerd", "", "kubeadm", "   ", "kubelet"},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	// Blank entries dropped, order preserved.
+	assert.Equal(t, []string{"containerd", "kubeadm", "kubelet"}, cfg.Packages)
+	// Packages-only Config needs no boot script or runcmd.
+	assert.Empty(t, cfg.WriteFiles)
+	assert.Empty(t, cfg.RunCmd)
+}
+
+func TestBuildUserDataRendersAptSources(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		AptSources: []cloudinitbootstrap.AptSource{
+			{
+				Name:   "kubernetes",
+				Source: "deb [signed-by=/etc/apt/keyrings/k8s.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /",
+				Key:    "-----BEGIN PGP PUBLIC KEY BLOCK-----\nabc\n-----END PGP PUBLIC KEY BLOCK-----",
+			},
+		},
+		Packages: []string{"kubeadm"},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	source, ok := cfg.Apt.Sources["kubernetes"]
+	require.True(t, ok, "apt source must be keyed by its Name")
+	assert.Contains(t, source.Source, "pkgs.k8s.io/core")
+	assert.Contains(t, source.Key, "BEGIN PGP PUBLIC KEY BLOCK")
+}
+
+func TestBuildUserDataAptSourceKeyOptional(t *testing.T) {
+	t.Parallel()
+
+	// A source without a key omits the key: field entirely (rather than key: "").
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		AptSources: []cloudinitbootstrap.AptSource{
+			{Name: "extra", Source: "deb https://example.test/repo /"},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.NotContains(t, userData, "key:")
+
+	cfg := parse(t, userData)
+	assert.Empty(t, cfg.Apt.Sources["extra"].Key)
+}
+
+func TestBuildUserDataAptSourcesDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// Two sources declared out of alphabetical order must still render identically
+	// every time (yaml.v3 sorts map keys), so provisioning is reproducible.
+	cfg := cloudinitbootstrap.Config{
+		AptSources: []cloudinitbootstrap.AptSource{
+			{Name: "zeta", Source: "deb https://z /"},
+			{Name: "alpha", Source: "deb https://a /"},
+		},
+	}
+
+	first, err := cloudinitbootstrap.BuildUserData(cfg)
+	require.NoError(t, err)
+
+	second, err := cloudinitbootstrap.BuildUserData(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+	assert.Less(t,
+		strings.Index(first, "alpha"), strings.Index(first, "zeta"),
+		"sources must be emitted in sorted key order",
+	)
+}
+
+func TestBuildUserDataRendersFiles(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Files: []cloudinitbootstrap.File{
+			{
+				Path:        "/etc/kubernetes/ksail/kubeadm.yaml",
+				Permissions: "0600",
+				Content:     "apiVersion: x",
+			},
+			{Path: "/etc/motd", Content: "hi"}, // no permissions -> default
+		},
+		Commands: []string{"kubeadm init"},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	// The two declared files come first, then the boot script.
+	require.Len(t, cfg.WriteFiles, 3)
+	assert.Equal(t, "/etc/kubernetes/ksail/kubeadm.yaml", cfg.WriteFiles[0].Path)
+	assert.Equal(t, "0600", cfg.WriteFiles[0].Permissions)
+	assert.Equal(t, "apiVersion: x", cfg.WriteFiles[0].Content)
+	assert.Equal(t, cloudinitbootstrap.DefaultFilePermissions, cfg.WriteFiles[1].Permissions)
+	assert.Equal(t, cloudinitbootstrap.DefaultScriptPath, cfg.WriteFiles[2].Path)
+}
+
+func TestBuildUserDataFullDeclarativeInstall(t *testing.T) {
+	t.Parallel()
+
+	// The whole point of the slice: a declarative install with no curl|sh — an apt
+	// source with its key, packages, a config file, then the install commands.
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Files: []cloudinitbootstrap.File{
+			{
+				Path:        "/etc/kubernetes/ksail/kubeadm.yaml",
+				Permissions: "0600",
+				Content:     "kind: InitConfiguration",
+			},
+		},
+		AptSources: []cloudinitbootstrap.AptSource{
+			{
+				Name:   "kubernetes",
+				Source: "deb https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /",
+				Key:    "KEY",
+			},
+		},
+		Packages: []string{"containerd", "kubeadm", "kubelet"},
+		Commands: []string{"kubeadm init --config /etc/kubernetes/ksail/kubeadm.yaml"},
+	})
+	require.NoError(t, err)
+
+	assert.NotContains(t, userData, "curl")
+
+	cfg := parse(t, userData)
+	assert.Len(t, cfg.WriteFiles, 2) // config file + boot script
+	assert.NotEmpty(t, cfg.Apt.Sources["kubernetes"].Source)
+	assert.Equal(t, []string{"containerd", "kubeadm", "kubelet"}, cfg.Packages)
+	require.Len(t, cfg.RunCmd, 1)
+	assert.Contains(t,
+		cfg.WriteFiles[1].Content,
+		"kubeadm init --config /etc/kubernetes/ksail/kubeadm.yaml\n",
+	)
+}
+
 func TestBuildUserDataErrors(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name    string
-		cfg     cloudinitbootstrap.Config
-		wantErr error
-	}{
+	tests := []errorCase{
 		{
 			name:    "no commands",
 			cfg:     cloudinitbootstrap.Config{},
@@ -214,7 +383,22 @@ func TestBuildUserDataErrors(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range tests {
+	runErrorCases(t, tests)
+}
+
+// errorCase is one BuildUserData rejection case, shared by the command-level and
+// declarative-field error tests.
+type errorCase struct {
+	name    string
+	cfg     cloudinitbootstrap.Config
+	wantErr error
+}
+
+// runErrorCases asserts each case returns its expected sentinel and no document.
+func runErrorCases(t *testing.T, cases []errorCase) {
+	t.Helper()
+
+	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -223,4 +407,95 @@ func TestBuildUserDataErrors(t *testing.T) {
 			assert.Empty(t, out, "no document should be returned on error")
 		})
 	}
+}
+
+func TestBuildUserDataDeclarativeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []errorCase{
+		{
+			name:    "package with embedded newline",
+			cfg:     cloudinitbootstrap.Config{Packages: []string{"containerd\nkubeadm"}},
+			wantErr: cloudinitbootstrap.ErrInvalidPackage,
+		},
+		{
+			name:    "package with NUL byte",
+			cfg:     cloudinitbootstrap.Config{Packages: []string{"kube\x00let"}},
+			wantErr: cloudinitbootstrap.ErrInvalidPackage,
+		},
+		{
+			name: "apt source with blank name",
+			cfg: cloudinitbootstrap.Config{
+				AptSources: []cloudinitbootstrap.AptSource{{Name: "  ", Source: "deb https://x /"}},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidAptSource,
+		},
+		{
+			name: "apt source with blank source",
+			cfg: cloudinitbootstrap.Config{
+				AptSources: []cloudinitbootstrap.AptSource{{Name: "k8s", Source: ""}},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidAptSource,
+		},
+		{
+			name: "apt source with multi-line source",
+			cfg: cloudinitbootstrap.Config{
+				AptSources: []cloudinitbootstrap.AptSource{
+					{Name: "k8s", Source: "deb a /\ndeb b /"},
+				},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidAptSource,
+		},
+		{
+			name: "apt source with NUL in key",
+			cfg: cloudinitbootstrap.Config{
+				AptSources: []cloudinitbootstrap.AptSource{
+					{Name: "k8s", Source: "deb https://x /", Key: "-----BEGIN-----\x00"},
+				},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidAptSource,
+		},
+		{
+			name: "apt sources with duplicate name",
+			cfg: cloudinitbootstrap.Config{
+				AptSources: []cloudinitbootstrap.AptSource{
+					{Name: "k8s", Source: "deb https://a /"},
+					{Name: "k8s", Source: "deb https://b /"},
+				},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidAptSource,
+		},
+	}
+
+	runErrorCases(t, tests)
+}
+
+func TestBuildUserDataFileErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []errorCase{
+		{
+			name: "file with relative path",
+			cfg: cloudinitbootstrap.Config{
+				Files: []cloudinitbootstrap.File{{Path: "etc/kubernetes/config", Content: "x"}},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidFile,
+		},
+		{
+			name: "file with multi-line path",
+			cfg: cloudinitbootstrap.Config{
+				Files: []cloudinitbootstrap.File{{Path: "/etc/a\n/etc/b", Content: "x"}},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidFile,
+		},
+		{
+			name: "file with NUL in content",
+			cfg: cloudinitbootstrap.Config{
+				Files: []cloudinitbootstrap.File{{Path: "/etc/x", Content: "a\x00b"}},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidFile,
+		},
+	}
+
+	runErrorCases(t, tests)
 }

--- a/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
@@ -409,7 +409,7 @@ func runErrorCases(t *testing.T, cases []errorCase) {
 	}
 }
 
-func TestBuildUserDataDeclarativeErrors(t *testing.T) {
+func TestBuildUserDataPackageErrors(t *testing.T) {
 	t.Parallel()
 
 	tests := []errorCase{
@@ -423,6 +423,15 @@ func TestBuildUserDataDeclarativeErrors(t *testing.T) {
 			cfg:     cloudinitbootstrap.Config{Packages: []string{"kube\x00let"}},
 			wantErr: cloudinitbootstrap.ErrInvalidPackage,
 		},
+	}
+
+	runErrorCases(t, tests)
+}
+
+func TestBuildUserDataAptSourceErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []errorCase{
 		{
 			name: "apt source with blank name",
 			cfg: cloudinitbootstrap.Config{
@@ -465,9 +474,33 @@ func TestBuildUserDataDeclarativeErrors(t *testing.T) {
 			},
 			wantErr: cloudinitbootstrap.ErrInvalidAptSource,
 		},
+		{
+			name: "apt source name with path separator",
+			cfg: cloudinitbootstrap.Config{
+				AptSources: []cloudinitbootstrap.AptSource{
+					{Name: "../evil", Source: "deb https://x /"},
+				},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidAptSource,
+		},
 	}
 
 	runErrorCases(t, tests)
+}
+
+func TestBuildUserDataAcceptsThreeDigitMode(t *testing.T) {
+	t.Parallel()
+
+	// A three-digit octal mode is valid cloud-init and must pass through verbatim.
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Files: []cloudinitbootstrap.File{{Path: "/etc/x", Permissions: "600", Content: "x"}},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	require.Len(t, cfg.WriteFiles, 1)
+	assert.Equal(t, "600", cfg.WriteFiles[0].Permissions)
 }
 
 func TestBuildUserDataFileErrors(t *testing.T) {
@@ -492,6 +525,24 @@ func TestBuildUserDataFileErrors(t *testing.T) {
 			name: "file with NUL in content",
 			cfg: cloudinitbootstrap.Config{
 				Files: []cloudinitbootstrap.File{{Path: "/etc/x", Content: "a\x00b"}},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidFile,
+		},
+		{
+			name: "file with non-octal permissions",
+			cfg: cloudinitbootstrap.Config{
+				Files: []cloudinitbootstrap.File{
+					{Path: "/etc/x", Permissions: "999", Content: "x"},
+				},
+			},
+			wantErr: cloudinitbootstrap.ErrInvalidFile,
+		},
+		{
+			name: "file with wrong-length mode",
+			cfg: cloudinitbootstrap.Config{
+				Files: []cloudinitbootstrap.File{
+					{Path: "/etc/x", Permissions: "60", Content: "x"},
+				},
 			},
 			wantErr: cloudinitbootstrap.ErrInvalidFile,
 		},

--- a/pkg/svc/bootstrap/cloudinit/doc.go
+++ b/pkg/svc/bootstrap/cloudinit/doc.go
@@ -23,8 +23,9 @@
 //
 // Everything here is pure: it performs no I/O and reaches no network, so it is
 // fully unit-testable without a cluster or a Hetzner account. Note that
-// cloud-init user_data is readable by anyone holding the Hetzner API token, so a
-// secret embedded in a directive (such as the k3s node token in a command, or an
-// apt source's key) is exposed to that audience; that is inherent to user_data
-// delivery, not a property of this package.
+// cloud-init user_data is readable by anyone holding the Hetzner API token, so
+// sensitive material embedded in a directive (such as the k3s node token in a
+// command) is exposed to that audience; that is inherent to user_data delivery,
+// not a property of this package. An apt source's Key is a public signing key,
+// so exposing it carries no such risk.
 package cloudinitbootstrap

--- a/pkg/svc/bootstrap/cloudinit/doc.go
+++ b/pkg/svc/bootstrap/cloudinit/doc.go
@@ -1,16 +1,19 @@
-// Package cloudinitbootstrap builds the cloud-init user_data that delivers a
-// node's bootstrap commands to a raw Linux server (e.g. a Hetzner Cloud server)
-// so they run once at first boot — for example the native k3s install command
-// rendered by the sibling k3sbootstrap package.
+// Package cloudinitbootstrap builds the cloud-init user_data that bootstraps a
+// raw Linux server (e.g. a Hetzner Cloud server) at first boot. It carries both
+// imperative and declarative directives: shell Commands (for example the native
+// k3s install command rendered by the sibling k3sbootstrap package) and, for a
+// fully declarative install, cloud-init's own Packages, AptSources, and Files
+// modules — so a node can install its packages and trust an APT signing key
+// without a `curl | sh` at first boot.
 //
 // It is the provision-time delivery slice of the Hetzner × K3s/Vanilla
 // provisioning work (devantler-tech/ksail#3983, parent #4627, slice #5511): a
-// raw server has no Docker daemon to install into, so the bootstrap command must
-// reach it some other way. Baking it into the server's cloud-init user_data is
-// the simplest such transport — it needs no SSH key handling or post-provision
-// connection, and it composes with provisioner-level sequencing (create the
-// cluster-init server, wait for its API, then create the joining nodes whose
-// own user_data registers against it).
+// raw server has no Docker daemon to install into, so the bootstrap directives
+// must reach it some other way. Baking them into the server's cloud-init
+// user_data is the simplest such transport — it needs no SSH key handling or
+// post-provision connection, and it composes with provisioner-level sequencing
+// (create the cluster-init server, wait for its API, then create the joining
+// nodes whose own user_data registers against it).
 //
 // [BuildUserData] is the pure builder; [Transport] wraps it as the
 // [UserDataProvider] seam the K3s × Hetzner provisioner (#5512) depends on. A
@@ -21,7 +24,7 @@
 // Everything here is pure: it performs no I/O and reaches no network, so it is
 // fully unit-testable without a cluster or a Hetzner account. Note that
 // cloud-init user_data is readable by anyone holding the Hetzner API token, so a
-// secret embedded in a bootstrap command (such as the k3s node token) is exposed
-// to that audience; that is inherent to user_data delivery, not a property of
-// this package.
+// secret embedded in a directive (such as the k3s node token in a command, or an
+// apt source's key) is exposed to that audience; that is inherent to user_data
+// delivery, not a property of this package.
 package cloudinitbootstrap

--- a/pkg/svc/bootstrap/cloudinit/errors.go
+++ b/pkg/svc/bootstrap/cloudinit/errors.go
@@ -28,19 +28,20 @@ var (
 	)
 
 	// ErrInvalidAptSource is returned when an [AptSource] has a blank or multi-line
-	// Name or Source, a Key containing a NUL byte, or a Name that duplicates
-	// another source's. cloud-init keys the sources map by Name and writes the
-	// single Source line to a .list file, so both must be present and one line, and
-	// the names must be unique.
+	// Name or Source, a Name containing a path separator, a Key containing a NUL
+	// byte, or a Name that duplicates another source's. cloud-init keys the sources
+	// map by Name and writes the single Source line to a .list file named after it,
+	// so Name must be a unique one-line filename and Source must be present.
 	ErrInvalidAptSource = errors.New(
-		"cloud-init: an apt source needs a unique single-line Name and Source",
+		"cloud-init: an apt source needs a unique single-line Name (no path separator) and Source",
 	)
 
 	// ErrInvalidFile is returned when a [File] has a non-absolute or multi-line
-	// Path or a Content containing a NUL byte. cloud-init resolves a write_files
-	// path with no defined working directory, so it must be absolute.
+	// Path, a Content containing a NUL byte, or an explicit Permissions that is not
+	// an octal mode. cloud-init resolves a write_files path with no defined working
+	// directory (so it must be absolute) and fails the boot on a malformed mode.
 	ErrInvalidFile = errors.New(
-		"cloud-init: a file needs an absolute single-line Path and NUL-free Content",
+		"cloud-init: a file needs an absolute single-line Path, NUL-free Content, and an octal mode",
 	)
 
 	// ErrPathNotAbsolute is returned when ScriptPath or LogPath is set to a

--- a/pkg/svc/bootstrap/cloudinit/errors.go
+++ b/pkg/svc/bootstrap/cloudinit/errors.go
@@ -3,11 +3,13 @@ package cloudinitbootstrap
 import "errors"
 
 var (
-	// ErrNoCommands is returned when a Config carries no non-empty bootstrap
-	// command. A user_data document with nothing to run would create a server that
-	// silently never bootstraps, so an empty command set is rejected rather than
-	// rendered.
-	ErrNoCommands = errors.New("cloud-init: at least one bootstrap command is required")
+	// ErrNoCommands is returned when a Config carries no directive at all — no
+	// command, package, apt source, or file. A user_data document with nothing to
+	// do would create a server that silently never bootstraps, so an empty Config
+	// is rejected rather than rendered.
+	ErrNoCommands = errors.New(
+		"cloud-init: a Config must carry at least one command, package, apt source, or file",
+	)
 
 	// ErrInvalidCommand is returned when a bootstrap command contains a newline or
 	// a NUL byte. Each command is written as one line of the generated boot script,
@@ -16,6 +18,29 @@ var (
 	// need multiple statements pass them as separate commands.
 	ErrInvalidCommand = errors.New(
 		"cloud-init: a bootstrap command must be a single line with no NUL byte",
+	)
+
+	// ErrInvalidPackage is returned when a package name contains a newline or a NUL
+	// byte. Each name is one element of cloud-init's packages: list, so it must be a
+	// single line.
+	ErrInvalidPackage = errors.New(
+		"cloud-init: a package name must be a single line with no NUL byte",
+	)
+
+	// ErrInvalidAptSource is returned when an [AptSource] has a blank or multi-line
+	// Name or Source, a Key containing a NUL byte, or a Name that duplicates
+	// another source's. cloud-init keys the sources map by Name and writes the
+	// single Source line to a .list file, so both must be present and one line, and
+	// the names must be unique.
+	ErrInvalidAptSource = errors.New(
+		"cloud-init: an apt source needs a unique single-line Name and Source",
+	)
+
+	// ErrInvalidFile is returned when a [File] has a non-absolute or multi-line
+	// Path or a Content containing a NUL byte. cloud-init resolves a write_files
+	// path with no defined working directory, so it must be absolute.
+	ErrInvalidFile = errors.New(
+		"cloud-init: a file needs an absolute single-line Path and NUL-free Content",
 	)
 
 	// ErrPathNotAbsolute is returned when ScriptPath or LogPath is set to a


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5620. Part of #5513 / #3983 (Hetzner × Vanilla/kubeadm provisioning).

## What

The `cloudinitbootstrap` transport (`pkg/svc/bootstrap/cloudinit`) could only render a **boot script + `runcmd`** from `Config.Commands`. This extends the pure `Config` / `BuildUserData` to also render cloud-init's own declarative modules:

- **`Packages []string`** → `packages:` (apt install before `runcmd`)
- **`AptSources []AptSource{Name, Source, Key}`** → `apt: sources:`, each with its `source:` line and an optional inline armored `key:` — the signing key is trusted **declaratively**, no runtime `curl | gpg`
- **`Files []File{Path, Permissions, Content}`** → additional `write_files:` entries (e.g. a kubeadm config dropped `0600`)

They render in cloud-init's own module order — files, then apt configure, then package install — before the boot script's commands, so a package a command relies on is already present when the command runs. This is the settled native-Go provisioning design: render the typed config in Go, install declaratively via cloud-init (`packages:`/`write_files:`), **never** `curl | sh`.

## Why this slice / scope

The Vanilla × Hetzner (kubeadm) provisioner needs the transport to carry a declarative install; the merged transport could only carry shell commands. This is the **transport primitive only** — it stays transport-agnostic (no coupling to any bootstrapper's `Install` type). The provisioner mapping (`Install{AptSources,Packages,Files,Commands}` → this `Config`) and any `UserDataProvider` seam extension are **later slices**, so this doesn't stack on the in-flight kubeadm planner/renderer drafts.

## Safety / compatibility

- **Command-only output is byte-for-byte unchanged** (new fields are `omitempty`; existing tests pass untouched, and the existing `k3shetzner` consumer is unaffected — 28 tests green).
- Deterministic document (apt sources emitted in sorted-key order).
- Every new field is validated (single-line package/apt Name+Source, absolute file paths, unique apt names, NUL-free content); a fully-empty `Config` still returns `ErrNoCommands`.

## Validation

`go build` / `go vet` / `go test` (37 tests, **98.9%** coverage — only the documented-unreachable marshal-error branch is uncovered) / `golangci-lint` (0 issues) / `deadcode -test` all clean; pure package, no I/O, no generated drift.