### PR TITLE
fix(clusterautoscaler): force JSON API content-type when capacity buffers enabled

### DIFF
--- a/pkg/svc/installer/clusterautoscaler/capacitybuffers.go
+++ b/pkg/svc/installer/clusterautoscaler/capacitybuffers.go
@@ -33,7 +33,12 @@ var capacityBufferCRDYAML []byte
 //
 //  1. Flags: capacity-buffer-controller-enabled and
 //     capacity-buffer-pod-injection-enabled, so the autoscaler reconciles
-//     CapacityBuffer resources and injects virtual pods for ready buffers.
+//     CapacityBuffer resources and injects virtual pods for ready buffers; plus
+//     kube-api-content-type=application/json, because the buffer controller's
+//     client defaults to protobuf (the autoscaler's built-in-type encoding) which
+//     the CapacityBuffer CRD cannot satisfy — without JSON the controller errors
+//     and never writes buffer status, silently disabling over-provisioning
+//     (ksail#5603).
 //  2. RBAC: the chart's ClusterRole only grants provisioningrequests in the
 //     autoscaling.x-k8s.io group, so the buffer controller's access to the
 //     CapacityBuffer CRs themselves is added via the chart's rbac.additionalRules
@@ -49,6 +54,12 @@ var capacityBufferCRDYAML []byte
 func enableCapacityBuffers(vals *chartValues) error {
 	vals.ExtraArgs.CapacityBufferControllerEnabled = true
 	vals.ExtraArgs.CapacityBufferPodInjectionEnabled = true
+	// The CapacityBuffer controller reconciles a CRD, but the autoscaler's client
+	// defaults to protobuf (built-in-type encoding) which CRDs cannot satisfy — force
+	// JSON for the whole autoscaler client. Negligible overhead on the small clusters
+	// that use capacity buffers; without it buffer status never populates and
+	// over-provisioning is silently a no-op (ksail#5603).
+	vals.ExtraArgs.KubeAPIContentType = "application/json"
 
 	// The CapacityBuffer CRs themselves; the Deployments and ResourceQuotas the
 	// buffer controller's translators run informers over are already covered by

--- a/pkg/svc/installer/clusterautoscaler/installer.go
+++ b/pkg/svc/installer/clusterautoscaler/installer.go
@@ -148,6 +148,15 @@ type chartExtraArgs struct {
 	// see no values drift.
 	CapacityBufferControllerEnabled   bool `json:"capacity-buffer-controller-enabled,omitempty"`
 	CapacityBufferPodInjectionEnabled bool `json:"capacity-buffer-pod-injection-enabled,omitempty"`
+	// KubeAPIContentType forces the autoscaler's Kubernetes client to negotiate the
+	// given content type. capacity-buffers require application/json: the CapacityBuffer
+	// controller's client would otherwise negotiate protobuf (the autoscaler default for
+	// built-in types), but CapacityBuffer is a CRD and cannot be protobuf-encoded, so the
+	// controller fails ("does not implement the protobuf marshalling interface") and never
+	// writes buffer status — silently disabling over-provisioning (ksail#5603). omitempty
+	// keeps it out of the rendered values unless capacityBuffers is enabled, so existing
+	// releases see no values drift.
+	KubeAPIContentType string `json:"kube-api-content-type,omitempty"`
 }
 
 type chartSecretRef struct {

--- a/pkg/svc/installer/clusterautoscaler/installer_test.go
+++ b/pkg/svc/installer/clusterautoscaler/installer_test.go
@@ -670,6 +670,10 @@ func TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers(t *testing.T) {
 			wantContain: []string{
 				"capacity-buffer-controller-enabled: true",
 				"capacity-buffer-pod-injection-enabled: true",
+				// JSON encoding is required so the CapacityBuffer CRD client works
+				// (the autoscaler defaults to protobuf, which CRDs cannot satisfy) —
+				// ksail#5603.
+				"kube-api-content-type: application/json",
 				"additionalRules:",
 				"capacitybuffers",
 				"- deployments",
@@ -691,6 +695,7 @@ func TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers(t *testing.T) {
 			wantOmit: []string{
 				"capacity-buffer-controller-enabled",
 				"capacity-buffer-pod-injection-enabled",
+				"kube-api-content-type",
 				"capacitybuffers",
 				"kind: CustomResourceDefinition",
 			},


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5603

## Problem
With `autoscaler.node.capacityBuffers: true`, KSail installs the cluster-autoscaler with the CapacityBuffer controller enabled. That controller reconciles the `CapacityBuffer` **CRD**, but the autoscaler's Kubernetes client negotiates **protobuf** (its default for built-in types). CRDs cannot be protobuf-encoded, so the controller fails continuously:

```
object *v1beta1.CapacityBuffer does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message
```

It never writes CapacityBuffer status → the autoscaler injects **0** fake pods → **over-provisioning is silently non-functional** (no warm spare node), as observed live on prod.

## Fix
Set `--kube-api-content-type=application/json` on the generated cluster-autoscaler args whenever `capacityBuffers` is enabled — the standard client-go protobuf-vs-CRD workaround (negligible overhead on the small clusters that use buffers). Implemented as a new `KubeAPIContentType` field on the chart's `extraArgs`, set in `enableCapacityBuffers`, kept behind `omitempty` so releases **without** capacity buffers render identical values (no drift).

## Acceptance criteria
- [x] No `does not implement the protobuf marshalling interface` errors expected — the autoscaler client now speaks JSON, so the CRD client works and buffer status populates.
- [x] Test coverage: `TestClusterAutoscalerInstaller_ValuesYaml_CapacityBuffers` now asserts `kube-api-content-type: application/json` is rendered when enabled **and** omitted when disabled.
- [ ] Live confirmation that a warm spare node is provisioned — needs a prod cluster-update to consume the chart (post-merge).

## Validation
- `go build ./pkg/svc/installer/clusterautoscaler/...` clean
- `go test ./pkg/svc/installer/clusterautoscaler/...` ✅
- `golangci-lint run ./pkg/svc/installer/clusterautoscaler/...` → 0 issues
- No generated-file drift (internal Helm-values generation; not a CLI flag / spec field)