### PR TITLE
refactor(cli): extract shared cluster-config flag helpers into clusterflags

### DIFF
--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -9,6 +9,7 @@ import (
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/annotations"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/flags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
@@ -89,7 +90,7 @@ func handleCreateRunE(
 		return err
 	}
 
-	applyClusterMutationFlags(cmd, ctx.ClusterCfg)
+	clusterflags.ApplyClusterMutationFlags(cmd, ctx.ClusterCfg)
 
 	err = validatePostMutationFlags(ctx)
 	if err != nil {

--- a/pkg/cli/cmd/cluster/diff.go
+++ b/pkg/cli/cmd/cluster/diff.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/annotations"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
@@ -75,7 +76,7 @@ func NewDiffCmd() *cobra.Command {
 		"Also report distribution/Kubernetes version drift the next 'cluster update' "+
 			"would reconcile (performs OCI registry lookups; off by default)")
 
-	registerNameFlag(cmd, cfgManager)
+	clusterflags.RegisterNameFlag(cmd, cfgManager)
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		// Validate output format before entering WrapHandler to avoid unnecessary

--- a/pkg/cli/cmd/cluster/init.go
+++ b/pkg/cli/cmd/cluster/init.go
@@ -6,6 +6,7 @@ import (
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/annotations"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/flags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/mirrorregistry"
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
@@ -95,10 +96,10 @@ func bindInitLocalFlags(cmd *cobra.Command, cfgManager *ksailconfigmanager.Confi
 	cmd.Flags().Bool("no-devcontainer", false, "Skip scaffolding .devcontainer/devcontainer.json")
 	_ = cfgManager.Viper.BindPFlag("no-devcontainer", cmd.Flags().Lookup("no-devcontainer"))
 
-	registerMirrorRegistryFlag(cmd)
-	registerNameFlag(cmd, cfgManager)
-	registerOIDCExtraScopeFlag(cmd)
-	registerAllowedCIDRsFlag(cmd)
+	clusterflags.RegisterMirrorRegistryFlag(cmd)
+	clusterflags.RegisterNameFlag(cmd, cfgManager)
+	clusterflags.RegisterOIDCExtraScopeFlag(cmd)
+	clusterflags.RegisterAllowedCIDRsFlag(cmd)
 }
 
 // InitDeps holds dependencies injected into HandleInitRunE.
@@ -171,7 +172,7 @@ func HandleInitRunE(
 		return err
 	}
 
-	applyClusterMutationFlags(cmd, clusterCfg)
+	clusterflags.ApplyClusterMutationFlags(cmd, clusterCfg)
 
 	err = validatePostFlagInitConfig(clusterCfg)
 	if err != nil {

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
@@ -47,23 +48,6 @@ func defaultClusterMutationFieldSelectors() []ksailconfigmanager.FieldSelector[v
 	)
 }
 
-// registerMirrorRegistryFlag adds the --mirror-registry flag to a command.
-// The flag is intentionally NOT bound to Viper to allow custom merge logic
-// via getMirrorRegistriesWithDefaults() in setup/mirrorregistry.
-func registerMirrorRegistryFlag(cmd *cobra.Command) {
-	cmd.Flags().StringSlice("mirror-registry", []string{},
-		"Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. "+
-			"Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). "+
-			"Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'")
-}
-
-// registerNameFlag adds the --name flag to a command and binds it to Viper.
-func registerNameFlag(cmd *cobra.Command, cfgManager *ksailconfigmanager.ConfigManager) {
-	cmd.Flags().StringP("name", "n", "",
-		"Cluster name used for container names, registry names, and kubeconfig context")
-	_ = cfgManager.Viper.BindPFlag("name", cmd.Flags().Lookup("name"))
-}
-
 // hideConfigOnlyFlags hides the config-loading flags that a command needs for
 // defaults and validation but does not expose in its help (distribution,
 // distribution-config, gitops-engine, local-registry). Shared by connect and
@@ -78,69 +62,8 @@ func hideConfigOnlyFlags(cmd *cobra.Command) {
 	}
 }
 
-// registerOIDCExtraScopeFlag adds the --oidc-extra-scope flag to a command.
-// Like --mirror-registry, this is a string slice flag that is NOT bound to Viper
-// and instead merged manually after config loading.
-func registerOIDCExtraScopeFlag(cmd *cobra.Command) {
-	cmd.Flags().StringSlice("oidc-extra-scope", []string{},
-		"Additional OIDC scopes beyond openid (repeatable)")
-}
-
-// applyOIDCExtraScopeFlag merges --oidc-extra-scope flag values into the cluster config.
-// CLI flag values take precedence over config file values when explicitly set.
-func applyOIDCExtraScopeFlag(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
-	scopeFlag := cmd.Flags().Lookup("oidc-extra-scope")
-	if scopeFlag == nil || !scopeFlag.Changed {
-		return
-	}
-
-	scopes, err := cmd.Flags().GetStringSlice("oidc-extra-scope")
-	if err != nil {
-		return
-	}
-
-	// When the flag is explicitly set, always assign — even if empty — so the
-	// user can clear extraScopes from a config file via CLI.
-	clusterCfg.Spec.Cluster.OIDC.ExtraScopes = scopes
-}
-
-// registerAllowedCIDRsFlag adds the --allowed-cidrs flag to a command.
-// Like --mirror-registry, this is a string slice flag NOT bound to Viper
-// and merged manually via applyAllowedCIDRsFlag.
-func registerAllowedCIDRsFlag(cmd *cobra.Command) {
-	cmd.Flags().StringSlice("allowed-cidrs", []string{},
-		"CIDR blocks allowed to access the Kubernetes API and Talos API on control-plane nodes. "+
-			"When empty, both APIs are open to 0.0.0.0/0 and ::/0 (all IPv4 and IPv6). "+
-			"Example: --allowed-cidrs 203.0.113.0/24 --allowed-cidrs 198.51.100.0/24")
-}
-
-// applyAllowedCIDRsFlag merges --allowed-cidrs flag values into the cluster config.
-// CLI flag values take precedence over config file values when explicitly set.
-func applyAllowedCIDRsFlag(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
-	cidrFlag := cmd.Flags().Lookup("allowed-cidrs")
-	if cidrFlag == nil || !cidrFlag.Changed {
-		return
-	}
-
-	cidrs, err := cmd.Flags().GetStringSlice("allowed-cidrs")
-	if err != nil {
-		return
-	}
-
-	clusterCfg.Spec.Provider.Hetzner.AllowedCIDRs = cidrs
-}
-
-// applyClusterMutationFlags merges the non-Viper CLI flag overrides
-// (--oidc-extra-scope and --allowed-cidrs) into the cluster config. Centralizing
-// the set keeps every mutation command (create, update, init) applying the same
-// flags; a new manually-merged flag is added here once rather than at each call site.
-func applyClusterMutationFlags(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
-	applyOIDCExtraScopeFlag(cmd, clusterCfg)
-	applyAllowedCIDRsFlag(cmd, clusterCfg)
-}
-
 // validatePostMutationFlags re-validates the configuration fields that
-// applyClusterMutationFlags can change: OIDC extra scopes and Hetzner allowed
+// clusterflags.ApplyClusterMutationFlags can change: OIDC extra scopes and Hetzner allowed
 // CIDRs. Shared by create and update so the two commands cannot drift.
 func validatePostMutationFlags(ctx *localregistry.Context) error {
 	// Re-validate OIDC after merging CLI scope flags which can change ExtraScopes
@@ -167,10 +90,10 @@ func setupMutationCmdFlags(cmd *cobra.Command) *ksailconfigmanager.ConfigManager
 		defaultClusterMutationFieldSelectors(),
 	)
 
-	registerMirrorRegistryFlag(cmd)
-	registerNameFlag(cmd, cfgManager)
-	registerOIDCExtraScopeFlag(cmd)
-	registerAllowedCIDRsFlag(cmd)
+	clusterflags.RegisterMirrorRegistryFlag(cmd)
+	clusterflags.RegisterNameFlag(cmd, cfgManager)
+	clusterflags.RegisterOIDCExtraScopeFlag(cmd)
+	clusterflags.RegisterAllowedCIDRsFlag(cmd)
 
 	return cfgManager
 }

--- a/pkg/cli/cmd/cluster/update.go
+++ b/pkg/cli/cmd/cluster/update.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/annotations"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/flags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
@@ -141,7 +142,7 @@ func handleUpdateRunE(
 		return err
 	}
 
-	applyClusterMutationFlags(cmd, ctx.ClusterCfg)
+	clusterflags.ApplyClusterMutationFlags(cmd, ctx.ClusterCfg)
 
 	err = validatePostMutationFlags(ctx)
 	if err != nil {

--- a/pkg/cli/cmd/clusterflags/clusterflags.go
+++ b/pkg/cli/cmd/clusterflags/clusterflags.go
@@ -1,0 +1,96 @@
+// Package clusterflags provides the shared cluster-configuration flag helpers
+// used by every command that takes cluster-spec input on the CLI — the cluster
+// lifecycle commands (create, update, diff) and the project-scaffolding command
+// (init). It registers the flags that populate a [v1alpha1.Cluster] and merges the
+// non-Viper flag overrides back into a loaded config.
+//
+// The helpers live in their own neutral package (rather than in the `cluster`
+// command package) so both the `cluster` and `project` command groups can use them
+// without an import cycle: `cluster` imports `project` to expose the moved
+// file-only commands as hidden deprecated aliases, so `project` cannot import
+// `cluster` back — a shared, group-neutral home is the only cycle-free option.
+package clusterflags
+
+import (
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	"github.com/spf13/cobra"
+)
+
+// RegisterMirrorRegistryFlag adds the --mirror-registry flag to a command.
+// The flag is intentionally NOT bound to Viper to allow custom merge logic
+// via getMirrorRegistriesWithDefaults() in setup/mirrorregistry.
+func RegisterMirrorRegistryFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSlice("mirror-registry", []string{},
+		"Configure mirror registries with optional authentication. Format: [user:pass@]host[=upstream]. "+
+			"Credentials support environment variables using ${VAR} syntax (quote placeholders so KSail can expand them). "+
+			"Examples: docker.io=https://registry-1.docker.io, '${USER}:${TOKEN}@ghcr.io=https://ghcr.io'")
+}
+
+// RegisterNameFlag adds the --name flag to a command and binds it to Viper.
+func RegisterNameFlag(cmd *cobra.Command, cfgManager *ksailconfigmanager.ConfigManager) {
+	cmd.Flags().StringP("name", "n", "",
+		"Cluster name used for container names, registry names, and kubeconfig context")
+	_ = cfgManager.Viper.BindPFlag("name", cmd.Flags().Lookup("name"))
+}
+
+// RegisterOIDCExtraScopeFlag adds the --oidc-extra-scope flag to a command.
+// Like --mirror-registry, this is a string slice flag that is NOT bound to Viper
+// and instead merged manually after config loading.
+func RegisterOIDCExtraScopeFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSlice("oidc-extra-scope", []string{},
+		"Additional OIDC scopes beyond openid (repeatable)")
+}
+
+// applyOIDCExtraScopeFlag merges --oidc-extra-scope flag values into the cluster config.
+// CLI flag values take precedence over config file values when explicitly set.
+func applyOIDCExtraScopeFlag(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
+	scopeFlag := cmd.Flags().Lookup("oidc-extra-scope")
+	if scopeFlag == nil || !scopeFlag.Changed {
+		return
+	}
+
+	scopes, err := cmd.Flags().GetStringSlice("oidc-extra-scope")
+	if err != nil {
+		return
+	}
+
+	// When the flag is explicitly set, always assign — even if empty — so the
+	// user can clear extraScopes from a config file via CLI.
+	clusterCfg.Spec.Cluster.OIDC.ExtraScopes = scopes
+}
+
+// RegisterAllowedCIDRsFlag adds the --allowed-cidrs flag to a command.
+// Like --mirror-registry, this is a string slice flag NOT bound to Viper
+// and merged manually via applyAllowedCIDRsFlag.
+func RegisterAllowedCIDRsFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSlice("allowed-cidrs", []string{},
+		"CIDR blocks allowed to access the Kubernetes API and Talos API on control-plane nodes. "+
+			"When empty, both APIs are open to 0.0.0.0/0 and ::/0 (all IPv4 and IPv6). "+
+			"Example: --allowed-cidrs 203.0.113.0/24 --allowed-cidrs 198.51.100.0/24")
+}
+
+// applyAllowedCIDRsFlag merges --allowed-cidrs flag values into the cluster config.
+// CLI flag values take precedence over config file values when explicitly set.
+func applyAllowedCIDRsFlag(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
+	cidrFlag := cmd.Flags().Lookup("allowed-cidrs")
+	if cidrFlag == nil || !cidrFlag.Changed {
+		return
+	}
+
+	cidrs, err := cmd.Flags().GetStringSlice("allowed-cidrs")
+	if err != nil {
+		return
+	}
+
+	clusterCfg.Spec.Provider.Hetzner.AllowedCIDRs = cidrs
+}
+
+// ApplyClusterMutationFlags merges the non-Viper CLI flag overrides
+// (--oidc-extra-scope and --allowed-cidrs) into the cluster config. Centralizing
+// the set keeps every mutation command (create, update, init) applying the same
+// flags; a new manually-merged flag is added here once rather than at each call site.
+func ApplyClusterMutationFlags(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster) {
+	applyOIDCExtraScopeFlag(cmd, clusterCfg)
+	applyAllowedCIDRsFlag(cmd, clusterCfg)
+}

--- a/pkg/cli/cmd/clusterflags/clusterflags_test.go
+++ b/pkg/cli/cmd/clusterflags/clusterflags_test.go
@@ -1,0 +1,94 @@
+package clusterflags_test
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
+	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterMirrorRegistryFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	clusterflags.RegisterMirrorRegistryFlag(cmd)
+
+	flag := cmd.Flags().Lookup("mirror-registry")
+	require.NotNil(t, flag, "mirror-registry flag should be registered")
+	assert.Equal(t, "stringSlice", flag.Value.Type())
+}
+
+func TestRegisterNameFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cfgManager := ksailconfigmanager.NewCommandConfigManager(cmd, nil)
+	clusterflags.RegisterNameFlag(cmd, cfgManager)
+
+	flag := cmd.Flags().Lookup("name")
+	require.NotNil(t, flag, "name flag should be registered")
+	assert.Equal(t, "n", flag.Shorthand, "name flag exposes the -n shorthand")
+
+	// The flag is bound to Viper, so a set value is readable through the manager.
+	require.NoError(t, cmd.Flags().Set("name", "prod"))
+	assert.Equal(t, "prod", cfgManager.Viper.GetString("name"))
+}
+
+func TestRegisterOIDCExtraScopeFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	clusterflags.RegisterOIDCExtraScopeFlag(cmd)
+
+	flag := cmd.Flags().Lookup("oidc-extra-scope")
+	require.NotNil(t, flag, "oidc-extra-scope flag should be registered")
+	assert.Equal(t, "stringSlice", flag.Value.Type())
+}
+
+func TestRegisterAllowedCIDRsFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	clusterflags.RegisterAllowedCIDRsFlag(cmd)
+
+	flag := cmd.Flags().Lookup("allowed-cidrs")
+	require.NotNil(t, flag, "allowed-cidrs flag should be registered")
+	assert.Equal(t, "stringSlice", flag.Value.Type())
+}
+
+func TestApplyClusterMutationFlags_MergesChangedFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	clusterflags.RegisterOIDCExtraScopeFlag(cmd)
+	clusterflags.RegisterAllowedCIDRsFlag(cmd)
+
+	require.NoError(t, cmd.Flags().Set("oidc-extra-scope", "groups,email"))
+	require.NoError(t, cmd.Flags().Set("allowed-cidrs", "203.0.113.0/24"))
+
+	cfg := &v1alpha1.Cluster{}
+	clusterflags.ApplyClusterMutationFlags(cmd, cfg)
+
+	assert.Equal(t, []string{"groups", "email"}, cfg.Spec.Cluster.OIDC.ExtraScopes)
+	assert.Equal(t, []string{"203.0.113.0/24"}, cfg.Spec.Provider.Hetzner.AllowedCIDRs)
+}
+
+func TestApplyClusterMutationFlags_LeavesUnsetFlagsUntouched(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	clusterflags.RegisterOIDCExtraScopeFlag(cmd)
+	clusterflags.RegisterAllowedCIDRsFlag(cmd)
+
+	cfg := &v1alpha1.Cluster{}
+	cfg.Spec.Cluster.OIDC.ExtraScopes = []string{"preexisting"}
+	clusterflags.ApplyClusterMutationFlags(cmd, cfg)
+
+	// Flags were never set (.Changed is false), so the config is left as-is.
+	assert.Equal(t, []string{"preexisting"}, cfg.Spec.Cluster.OIDC.ExtraScopes)
+	assert.Empty(t, cfg.Spec.Provider.Hetzner.AllowedCIDRs)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5637 · Part of #5626

## What

Extracts the shared cluster-config **flag helpers** out of the `cluster` command package into a new, group-neutral `pkg/cli/cmd/clusterflags` package:

- `RegisterMirrorRegistryFlag`, `RegisterNameFlag`, `RegisterOIDCExtraScopeFlag`, `RegisterAllowedCIDRsFlag`, `ApplyClusterMutationFlags` (+ the internal `applyOIDCExtraScopeFlag`/`applyAllowedCIDRsFlag`).
- `cluster`'s `create` / `update` / `diff` / `init` and `mutation.go` now call the new package.
- The cluster **lifecycle workflow** (`setupMutationCmdFlags`, `loadAndValidateClusterConfig`, `runClusterCreationWorkflow`, `resolveCreatedContextName`, `validatePostMutationFlags`, `defaultClusterMutationFieldSelectors`, `hideConfigOnlyFlags`) stays in the `cluster` package.

## Why

The #5626 taxonomy work moves `init` → `ksail project init`. Unlike `add-environment` (#5634), `init` shares these cluster-config flag helpers with the cluster lifecycle commands. Since `cluster` imports `project` (for the hidden deprecated aliases), `project` can't import `cluster` back — so the shared helpers must live in a neutral package for `init` to move without an import cycle. This is the cycle-breaking prerequisite; the `init` move follows as the next increment.

## Behaviour

Pure, behaviour-preserving refactor — **no command, flag, or generated-surface change**. The moved functions are byte-identical (only relocated + exported); the generators (`go generate ./docs/... ./pkg/svc/chat/...`) produce zero drift.

## Validation

- `go build ./pkg/cli/...` ✓
- `go test ./pkg/cli/cmd/cluster/... ./pkg/cli/cmd/clusterflags/... ./pkg/cli/cmd/project/...` → all pass (incl. 6 new `clusterflags` tests, 90.5% package coverage)
- `gofmt -l` clean · `golangci-lint run` → 0 issues
- Generated docs / MCP+chat tool surface / help + tool-surface snapshots: no drift