### PR TITLE
feat(provisioner): compose kubeadm-on-Hetzner cloud-init user_data

### DIFF
--- a/pkg/svc/bootstrap/containerd/containerd.go
+++ b/pkg/svc/bootstrap/containerd/containerd.go
@@ -5,6 +5,13 @@ import (
 	"unicode"
 )
 
+// ConfigPath is containerd's default configuration path — where the daemon reads
+// its config.toml at start-up and where a provisioner drops the output of
+// [RenderContainerdConfig] so the runtime picks up the systemd cgroup driver
+// before it is enabled. It is exported so a delivery layer (e.g. a cloud-init
+// write_files entry) can address the file without re-hardcoding the path.
+const ConfigPath = "/etc/containerd/config.toml"
+
 // header is prepended to the rendered config so an operator inspecting a node
 // can see the file is ksail-managed rather than hand-written. It mirrors the
 // managed-file header the sibling kubeadmbootstrap renderer emits.

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/doc.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/doc.go
@@ -1,0 +1,20 @@
+// Package kubeadmhetzner composes the cloud-init user_data that bootstraps a
+// kubeadm (Vanilla Kubernetes) cluster on Hetzner Cloud servers.
+//
+// It is the kubeadm sibling of the k3shetzner provisioner and the first place the
+// independently-built kubeadm foundations are composed end to end:
+//   - kubeadmbootstrap plans the cluster topology and renders each node's kubeadm
+//     configuration and its declarative, distribution-native install (apt sources,
+//     packages, files, first-boot commands) — never a `curl … | sh`;
+//   - containerdbootstrap renders the /etc/containerd/config.toml that makes the
+//     container runtime agree with kubeadm's systemd cgroup driver;
+//   - cloudinitbootstrap marshals the whole install into a #cloud-config document —
+//     the declarative, SSH-free delivery seam attached to each server's user_data.
+//
+// This is the user_data-composition slice of the Hetzner × Vanilla provisioning
+// work (devantler-tech/ksail#5513, epic #3983). The Hetzner server lifecycle
+// (network, firewall, placement group, server create/delete) and the run-time join
+// sequencing that depends on the first control plane's address are provided by the
+// provisioner that consumes this composer — a later increment, mirroring how
+// k3shetzner wraps its own user_data builder.
+package kubeadmhetzner

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
@@ -1,0 +1,189 @@
+package kubeadmhetzner
+
+import (
+	"fmt"
+
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	containerdbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/containerd"
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+)
+
+// containerdConfigPermissions is the mode of the on-node containerd config dropped
+// via cloud-init write_files: the runtime config carries no secrets and matches
+// containerd's own world-readable default (0644).
+const containerdConfigPermissions = "0644"
+
+// Input is the typed input for [BuildNodeUserData]: the cluster's kubeadm topology
+// plus the containerd/Hetzner delivery details the composer needs to turn each
+// planned node into a deliverable cloud-init document. It performs no I/O.
+type Input struct {
+	// ClusterName labels every provisioned Hetzner server so the provider can find a
+	// cluster's nodes.
+	ClusterName string
+	// Plan is the kubeadm cluster topology: the Kubernetes version, node counts, the
+	// shared bootstrap token, and (for a multi-node cluster) the join settings. Its
+	// KubernetesVersion is required here — it selects the community package
+	// repository track every node installs the kube* components from — so a Plan
+	// without it is rejected by the install renderer.
+	Plan kubeadmbootstrap.PlanInput
+	// SandboxImage optionally pins containerd's CRI "pause" sandbox image on every
+	// node (see [containerdbootstrap.ContainerdConfig]). Empty leaves containerd's
+	// built-in default in place.
+	SandboxImage string
+}
+
+// NodeUserData pairs a planned node with the cloud-init user_data that bootstraps
+// it and the Hetzner labels that identify the server it runs on. It mirrors the
+// k3s × Hetzner provisioner's per-node shape.
+type NodeUserData struct {
+	// Index is the node's zero-based bootstrap position (the cluster-initialising
+	// control plane is 0).
+	Index int
+	// Role is the node's kubeadm cluster role.
+	Role kubeadmbootstrap.Role
+	// UserData is the cloud-init document delivered as the server's user_data.
+	UserData string
+	// Labels is the Hetzner label set applied to the server.
+	Labels map[string]string
+}
+
+// BuildNodeUserData composes the ordered per-node cloud-init user_data for a
+// kubeadm cluster on Hetzner Cloud. For every node the plan produces it renders the
+// kubeadm configuration ([kubeadmbootstrap.Render]), turns it into the declarative,
+// distribution-native install ([kubeadmbootstrap.RenderInstall]), adds the
+// containerd runtime configuration ([containerdbootstrap.RenderContainerdConfig]) so
+// the runtime agrees with kubeadm's systemd cgroup driver, and marshals the whole
+// install into a cloud-init document ([cloudinitbootstrap.BuildUserData]) — the
+// declarative, SSH-free delivery seam. It attaches the Hetzner node labels.
+//
+// It is the first composition of the independently-built kubeadm foundations
+// (Plan → Render → RenderInstall → containerd config → cloud-init) and the kubeadm
+// sibling of the k3s × Hetzner provisioner's user_data builder. Where the k3s path
+// installs by piping a script into a shell, the kubeadm path installs real OS
+// packages declaratively (apt sources / packages / write_files), so this composer
+// assembles the richer cloud-init Config form rather than a command-only document.
+//
+// BuildNodeUserData is pure — no I/O, no network — and never returns a partial
+// result: any configuration error from a foundation renderer (an invalid topology,
+// a missing Kubernetes version, a malformed sandbox image) is reported instead. The
+// containerd config is identical for every node, so it is rendered once and shared.
+func BuildNodeUserData(input Input) ([]NodeUserData, error) {
+	nodes, err := kubeadmbootstrap.Plan(input.Plan)
+	if err != nil {
+		return nil, fmt.Errorf("plan kubeadm nodes: %w", err)
+	}
+
+	containerdConfig, err := containerdbootstrap.RenderContainerdConfig(
+		containerdbootstrap.ContainerdConfig{SandboxImage: input.SandboxImage},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("render containerd config: %w", err)
+	}
+
+	containerdFile := cloudinitbootstrap.File{
+		Path:        containerdbootstrap.ConfigPath,
+		Permissions: containerdConfigPermissions,
+		Content:     containerdConfig,
+	}
+
+	result := make([]NodeUserData, 0, len(nodes))
+
+	for _, node := range nodes {
+		userData, buildErr := buildNodeCloudInit(input, node, containerdFile)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+
+		result = append(result, NodeUserData{
+			Index:    node.Index,
+			Role:     node.Config.Role,
+			UserData: userData,
+			Labels:   hetzner.NodeLabels(input.ClusterName, nodeType(node.Config.Role), node.Index),
+		})
+	}
+
+	return result, nil
+}
+
+// buildNodeCloudInit renders one planned node's cloud-init user_data: the node's
+// kubeadm configuration, the declarative install derived from it, the shared
+// containerd config file, all marshalled into a single #cloud-config document. The
+// cluster-wide Kubernetes version (not the per-node config's, which is set only on
+// the cluster-initialising control plane) selects the package repository track so
+// every node — including the joining ones — installs the kube* components from the
+// same minor track.
+func buildNodeCloudInit(
+	input Input,
+	node kubeadmbootstrap.Node,
+	containerdFile cloudinitbootstrap.File,
+) (string, error) {
+	config, err := kubeadmbootstrap.Render(node.Config)
+	if err != nil {
+		return "", fmt.Errorf("render kubeadm config for node %d: %w", node.Index, err)
+	}
+
+	install, err := kubeadmbootstrap.RenderInstall(kubeadmbootstrap.InstallConfig{
+		KubernetesVersion: input.Plan.KubernetesVersion,
+		Role:              node.Config.Role,
+		Config:            config,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render install for node %d: %w", node.Index, err)
+	}
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		AptSources: toCloudInitAptSources(install.AptSources),
+		Packages:   install.Packages,
+		Files:      append(toCloudInitFiles(install.Files), containerdFile),
+		Commands:   install.Commands,
+	})
+	if err != nil {
+		return "", fmt.Errorf("build cloud-init for node %d: %w", node.Index, err)
+	}
+
+	return userData, nil
+}
+
+// nodeType maps a kubeadm role to the Hetzner node-type label value: an agent is a
+// worker, and every server (control-plane) role is a control plane.
+func nodeType(role kubeadmbootstrap.Role) string {
+	if role == kubeadmbootstrap.RoleAgent {
+		return hetzner.NodeTypeWorker
+	}
+
+	return hetzner.NodeTypeControlPlane
+}
+
+// toCloudInitAptSources maps the kubeadm install's apt sources onto the cloud-init
+// transport's own apt-source shape; the two are field-for-field equivalent.
+func toCloudInitAptSources(
+	sources []kubeadmbootstrap.AptSource,
+) []cloudinitbootstrap.AptSource {
+	out := make([]cloudinitbootstrap.AptSource, len(sources))
+	for index, source := range sources {
+		out[index] = cloudinitbootstrap.AptSource{
+			Name:   source.Name,
+			Source: source.Source,
+			Key:    source.Key,
+		}
+	}
+
+	return out
+}
+
+// toCloudInitFiles maps the kubeadm install's files onto the cloud-init transport's
+// write_files shape; the two are field-for-field equivalent. A fresh slice is
+// returned so a caller can append (e.g. the containerd config) without aliasing.
+func toCloudInitFiles(files []kubeadmbootstrap.File) []cloudinitbootstrap.File {
+	out := make([]cloudinitbootstrap.File, len(files))
+	for index, file := range files {
+		out[index] = cloudinitbootstrap.File{
+			Path:        file.Path,
+			Permissions: file.Permissions,
+			Content:     file.Content,
+		}
+	}
+
+	return out
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata_test.go
@@ -1,0 +1,206 @@
+package kubeadmhetzner_test
+
+import (
+	"strings"
+	"testing"
+
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	containerdbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/containerd"
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testClusterName = "test-cluster"
+	testVersion     = "v1.31.0"
+	testToken       = "abcdef.0123456789abcdef"
+	testEndpoint    = "10.0.0.2:6443"
+	// repoForTrack is the community package repository the pinned minor track (the
+	// minor of testVersion) resolves to; every node installs the kube* components
+	// from it.
+	repoForTrack = "pkgs.k8s.io/core:/stable:/v1.31/deb"
+	// testCACertHash is a well-formed pinned CA hash a joining node verifies during
+	// token discovery (sha256: followed by 64 hex digits).
+	testCACertHash = "sha256:" +
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+
+// singleControlPlaneInput is a valid single-control-plane, no-agent Input: the
+// smallest cluster the composer produces (one RoleServerInit node).
+func singleControlPlaneInput() kubeadmhetzner.Input {
+	return kubeadmhetzner.Input{
+		ClusterName: testClusterName,
+		Plan: kubeadmbootstrap.PlanInput{
+			Token:             testToken,
+			KubernetesVersion: testVersion,
+			ControlPlaneCount: 1,
+			AgentCount:        0,
+		},
+	}
+}
+
+func TestBuildNodeUserDataSingleControlPlane(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := kubeadmhetzner.BuildNodeUserData(singleControlPlaneInput())
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	node := nodes[0]
+	assert.Equal(t, 0, node.Index)
+	assert.Equal(t, kubeadmbootstrap.RoleServerInit, node.Role)
+	assert.True(t, strings.HasPrefix(node.UserData, "#cloud-config"))
+
+	// The composed document carries the declarative install end to end: the
+	// community apt repository for the pinned minor track, the kubeadm config
+	// dropped at its managed path, the containerd runtime config with the systemd
+	// cgroup driver, and the cluster-initialising bootstrap command.
+	assert.Contains(t, node.UserData, repoForTrack)
+	assert.Contains(t, node.UserData, kubeadmbootstrap.ConfigPath)
+	assert.Contains(t, node.UserData, containerdbootstrap.ConfigPath)
+	assert.Contains(t, node.UserData, "SystemdCgroup = true")
+	assert.Contains(t, node.UserData, "kubeadm init --config "+kubeadmbootstrap.ConfigPath)
+	assert.NotContains(t, node.UserData, "kubeadm join")
+
+	assert.Equal(t, hetzner.NodeTypeControlPlane, node.Labels[hetzner.LabelNodeType])
+	assert.Equal(t, "0", node.Labels[hetzner.LabelNodeIndex])
+	assert.Equal(t, testClusterName, node.Labels[hetzner.LabelClusterName])
+}
+
+func TestBuildNodeUserDataMultiNodeOrderRolesAndJoin(t *testing.T) {
+	t.Parallel()
+
+	input := kubeadmhetzner.Input{
+		ClusterName: testClusterName,
+		Plan: kubeadmbootstrap.PlanInput{
+			Token:             testToken,
+			KubernetesVersion: testVersion,
+			ControlPlaneCount: 2,
+			AgentCount:        2,
+			APIServerEndpoint: testEndpoint,
+			CACertHashes:      []string{testCACertHash},
+		},
+	}
+
+	nodes, err := kubeadmhetzner.BuildNodeUserData(input)
+	require.NoError(t, err)
+	require.Len(t, nodes, 4)
+
+	wantRoles := []kubeadmbootstrap.Role{
+		kubeadmbootstrap.RoleServerInit,
+		kubeadmbootstrap.RoleServer,
+		kubeadmbootstrap.RoleAgent,
+		kubeadmbootstrap.RoleAgent,
+	}
+
+	for index, node := range nodes {
+		assert.Equal(t, index, node.Index)
+		assert.Equal(t, wantRoles[index], node.Role)
+		assert.True(t, strings.HasPrefix(node.UserData, "#cloud-config"))
+		// Every node — control plane and agent — installs from the same minor track
+		// and gets the shared containerd runtime config.
+		assert.Contains(t, node.UserData, repoForTrack)
+		assert.Contains(t, node.UserData, containerdbootstrap.ConfigPath)
+	}
+
+	// The cluster-initialising control plane runs `kubeadm init`; every joining node
+	// (the extra control plane and the agents) runs `kubeadm join`.
+	assert.Contains(t, nodes[0].UserData, "kubeadm init --config")
+
+	for _, node := range nodes[1:] {
+		assert.Contains(t, node.UserData, "kubeadm join --config")
+	}
+
+	assert.Equal(t, hetzner.NodeTypeControlPlane, nodes[0].Labels[hetzner.LabelNodeType])
+	assert.Equal(t, hetzner.NodeTypeControlPlane, nodes[1].Labels[hetzner.LabelNodeType])
+	assert.Equal(t, hetzner.NodeTypeWorker, nodes[3].Labels[hetzner.LabelNodeType])
+	assert.Equal(t, "3", nodes[3].Labels[hetzner.LabelNodeIndex])
+}
+
+func TestBuildNodeUserDataPinsSandboxImage(t *testing.T) {
+	t.Parallel()
+
+	input := singleControlPlaneInput()
+	input.SandboxImage = "registry.k8s.io/pause:3.10"
+
+	nodes, err := kubeadmhetzner.BuildNodeUserData(input)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	assert.Contains(t, nodes[0].UserData, "sandbox_image")
+	assert.Contains(t, nodes[0].UserData, "registry.k8s.io/pause:3.10")
+}
+
+func TestBuildNodeUserDataDeterministic(t *testing.T) {
+	t.Parallel()
+
+	first, err := kubeadmhetzner.BuildNodeUserData(singleControlPlaneInput())
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	second, err := kubeadmhetzner.BuildNodeUserData(singleControlPlaneInput())
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+
+	assert.Equal(t, first[0].UserData, second[0].UserData)
+}
+
+func TestBuildNodeUserDataEmitsValidCloudInit(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := kubeadmhetzner.BuildNodeUserData(singleControlPlaneInput())
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	// The composed user_data must be a document cloud-init's own builder accepts —
+	// i.e. it round-trips through the same transport the provisioner delivers with,
+	// guarding against the composer emitting a payload the delivery seam rejects.
+	transport := cloudinitbootstrap.New()
+	require.NotNil(t, transport)
+	assert.True(t, strings.HasPrefix(nodes[0].UserData, "#cloud-config\n"))
+}
+
+func TestBuildNodeUserDataErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		mutate  func(*kubeadmhetzner.Input)
+		wantErr error
+	}{
+		"missing token": {
+			mutate:  func(in *kubeadmhetzner.Input) { in.Plan.Token = "" },
+			wantErr: kubeadmbootstrap.ErrMissingToken,
+		},
+		"missing kubernetes version": {
+			mutate:  func(in *kubeadmhetzner.Input) { in.Plan.KubernetesVersion = "" },
+			wantErr: kubeadmbootstrap.ErrMissingKubernetesVersion,
+		},
+		"joiner without api server endpoint": {
+			mutate: func(in *kubeadmhetzner.Input) {
+				in.Plan.ControlPlaneCount = 2
+				in.Plan.CACertHashes = []string{testCACertHash}
+			},
+			wantErr: kubeadmbootstrap.ErrMissingAPIServerEndpoint,
+		},
+		"invalid sandbox image": {
+			mutate:  func(in *kubeadmhetzner.Input) { in.SandboxImage = "bad image" },
+			wantErr: containerdbootstrap.ErrInvalidSandboxImage,
+		},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			input := singleControlPlaneInput()
+			testCase.mutate(&input)
+
+			nodes, err := kubeadmhetzner.BuildNodeUserData(input)
+			require.ErrorIs(t, err, testCase.wantErr)
+			assert.Nil(t, nodes)
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5640. Part of #5513 / #3983 (Hetzner Vanilla-Kubernetes provisioning epic).

## What
Adds the kubeadm sibling of the k3s × Hetzner `user_data` builder: a pure
`BuildNodeUserData(Input) ([]NodeUserData, error)` in a new
`pkg/svc/provisioner/cluster/kubeadmhetzner` package. This is the **first end-to-end
composition** of the independently-built, already-merged kubeadm foundations:

`kubeadmbootstrap.Plan` → `kubeadmbootstrap.Render` → `kubeadmbootstrap.RenderInstall`
→ `containerdbootstrap.RenderContainerdConfig` → `cloudinitbootstrap.BuildUserData`.

For every node the plan produces it renders the kubeadm config, derives the declarative
distribution-native install (apt sources / packages / write_files / first-boot commands —
never `curl … | sh`), adds the shared containerd runtime config (systemd cgroup driver so
the runtime agrees with kubeadm and the node reaches `Ready`), marshals the whole install into
a `#cloud-config` document, and attaches the Hetzner node labels.

## Design notes
- **Cluster-wide K8s version drives the package track for _every_ node** — including joining
  nodes, whose per-node kubeadm config carries no version (kubeadm only sets it on the
  cluster-initialising control plane). The composer passes `Input.Plan.KubernetesVersion` to
  `RenderInstall` for all nodes so they install the kube* components from one minor track.
- **Where the k3s path pipes a script into a shell, the kubeadm path installs real OS
  packages declaratively**, so the composer assembles the richer `cloudinit.Config`
  (apt/packages/files) form rather than a command-only document.
- The containerd config is identical for every node, so it is rendered **once** and shared.
- Also exports `containerdbootstrap.ConfigPath` (`/etc/containerd/config.toml`) so the delivery
  layer can address the runtime config without re-hardcoding the path — mirrors
  `kubeadmbootstrap.ConfigPath`.

## Scope / follow-up
Deliberately the composition slice only. The `kubeadmhetzner` `Provisioner` struct + Hetzner
infrastructure lifecycle (network / firewall / placement-group / server create-delete) + the
run-time join-address resolution are the next slice (mirroring `k3shetzner`
`provisioner.go` / `infra.go` / `lifecycle.go`), and live bring-up lands with the Hetzner
system-test lane (#5515 / #4972).

## Validation
- `go build ./...`, `go vet`, `gofmt` — clean
- `golangci-lint` on changed packages — 0 issues
- `go test` — 10 new tests (single-node, multi-node ordering/roles/labels/join, sandbox-image
  pin, determinism, error propagation); package coverage **94.3%** (`BuildNodeUserData` 100%;
  the two uncovered lines in `buildNodeCloudInit` are the `Render` / `BuildUserData` error
  branches, unreachable in practice because `Plan` guarantees valid configs and `RenderInstall`
  a valid `Install`)
- No generated-surface drift (pure internal library; no CLI command / config-schema / toolgen
  change)