### PR TITLE
feat(provisioner): derive Hetzner server specs from kubeadm cloud-init nodes

### DIFF
--- a/pkg/svc/provider/hetzner/node_name.go
+++ b/pkg/svc/provider/hetzner/node_name.go
@@ -1,0 +1,33 @@
+package hetzner
+
+import (
+	"errors"
+	"fmt"
+)
+
+// MaxNodeNameLength is the maximum length of a Hetzner server name. A server name
+// doubles as the Kubernetes node name, so it must be a valid 63-character DNS-1123
+// label. ValidateClusterName caps the cluster name at 63, but the composed
+// "-<node-type>-<index>" suffix can push the full name past the limit.
+const MaxNodeNameLength = 63
+
+// ErrNodeNameTooLong indicates a composed Hetzner server name exceeds
+// [MaxNodeNameLength].
+var ErrNodeNameTooLong = errors.New("hetzner node name too long")
+
+// NodeName composes the deterministic Hetzner server name for a cluster node from
+// its cluster name, node type ([NodeTypeControlPlane] or [NodeTypeWorker]) and
+// index, and validates it against the 63-character DNS-1123 label limit. The name
+// encodes the same identity as [NodeLabels] (built from the same three values), so
+// a server can be found by either its name or its labels.
+func NodeName(clusterName, nodeType string, index int) (string, error) {
+	name := fmt.Sprintf("%s-%s-%d", clusterName, nodeType, index)
+	if len(name) > MaxNodeNameLength {
+		return name, fmt.Errorf(
+			"%w: %q is %d characters (max %d); shorten the cluster name",
+			ErrNodeNameTooLong, name, len(name), MaxNodeNameLength,
+		)
+	}
+
+	return name, nil
+}

--- a/pkg/svc/provider/hetzner/node_name_test.go
+++ b/pkg/svc/provider/hetzner/node_name_test.go
@@ -1,0 +1,72 @@
+package hetzner_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		clusterName string
+		nodeType    string
+		index       int
+		want        string
+	}{
+		{
+			name:        "control-plane node zero",
+			clusterName: "my-cluster",
+			nodeType:    hetzner.NodeTypeControlPlane,
+			index:       0,
+			want:        "my-cluster-controlplane-0",
+		},
+		{
+			name:        "worker node",
+			clusterName: "my-cluster",
+			nodeType:    hetzner.NodeTypeWorker,
+			index:       2,
+			want:        "my-cluster-worker-2",
+		},
+		{
+			name:        "name exactly at the limit is accepted",
+			clusterName: strings.Repeat("a", hetzner.MaxNodeNameLength-len("-worker-0")),
+			nodeType:    hetzner.NodeTypeWorker,
+			index:       0,
+			want: strings.Repeat("a", hetzner.MaxNodeNameLength-len("-worker-0")) +
+				"-worker-0",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := hetzner.NodeName(testCase.clusterName, testCase.nodeType, testCase.index)
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
+			assert.LessOrEqual(t, len(got), hetzner.MaxNodeNameLength)
+		})
+	}
+}
+
+func TestNodeNameTooLong(t *testing.T) {
+	t.Parallel()
+
+	// A cluster name at the 63-char cap plus the "-controlplane-0" suffix exceeds
+	// the DNS-1123 label limit, so the composed name is rejected.
+	clusterName := strings.Repeat("a", hetzner.MaxNodeNameLength)
+
+	name, err := hetzner.NodeName(clusterName, hetzner.NodeTypeControlPlane, 0)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, hetzner.ErrNodeNameTooLong)
+	// The over-long name is still returned alongside the error for the message.
+	assert.Greater(t, len(name), hetzner.MaxNodeNameLength)
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/serverspecs.go
@@ -1,0 +1,98 @@
+package kubeadmhetzner
+
+import (
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+)
+
+// Infra carries the resolved Hetzner infrastructure the server specs are placed
+// into. The provisioner fills it after ensuring the network, firewall, placement
+// group and SSH key exist and after resolving the base OS image and server type;
+// [DeriveServerSpecs] performs no I/O and treats these as given.
+//
+// This increment provisions a homogeneous cluster: every node shares the same
+// server type, location and base image. Per-role sizing (a larger control plane, a
+// cheaper worker type) is an additive later increment.
+type Infra struct {
+	// ServerType is the Hetzner server type every node is created as (e.g. "cx22").
+	ServerType string
+	// Location is the Hetzner location every node is created in (e.g. "fsn1").
+	Location string
+	// ImageID is the base OS image every node boots (the provisioner resolves an
+	// image such as Ubuntu to its ID). kubeadm installs onto a stock OS image, so —
+	// unlike the Talos path's ISO — a kubeadm server always boots an ImageID, never
+	// an ISO.
+	ImageID int64
+	// NetworkID is the private network every node joins.
+	NetworkID int64
+	// FirewallID is the firewall applied to every node. A zero value attaches no
+	// firewall.
+	FirewallID int64
+	// PlacementGroupID is the placement group every node is created in.
+	PlacementGroupID int64
+	// SSHKeyID is the SSH key installed on every node.
+	SSHKeyID int64
+	// EnableIPv4 controls the servers' public IPv4 (nil = the Hetzner default, a
+	// public IPv4 is assigned). See [hetzner.CreateServerOpts].
+	EnableIPv4 *bool
+	// EnableIPv6 controls the servers' public IPv6 (nil = the Hetzner default, a
+	// public IPv6 is assigned). See [hetzner.CreateServerOpts].
+	EnableIPv6 *bool
+}
+
+// DeriveServerSpecs turns the per-node cloud-init user_data produced by
+// [BuildNodeUserData] into the ordered [hetzner.CreateServerOpts] the provisioner
+// feeds to the Hetzner server-creation API — the composition step between "what to
+// run on each node" and "which server runs it". For every node it derives the
+// validated server name ([hetzner.NodeName], sharing the identity encoded in the
+// node's labels), attaches the node's cloud-init document and Hetzner labels, and
+// places the server into the resolved infrastructure.
+//
+// The index carried by each [NodeUserData] (the zero-based bootstrap position, 0
+// being the cluster-initialising control plane) is reused verbatim for the server
+// name and matches the node's ksail.node.index label, so a node's name and labels
+// always agree. DeriveServerSpecs is pure — no I/O, no network — and never returns
+// a partial result: a name that exceeds the DNS-1123 label limit fails the whole
+// derivation rather than provisioning a mis-named subset.
+func DeriveServerSpecs(
+	clusterName string,
+	nodes []NodeUserData,
+	infra Infra,
+) ([]hetzner.CreateServerOpts, error) {
+	specs := make([]hetzner.CreateServerOpts, 0, len(nodes))
+
+	for _, node := range nodes {
+		name, err := hetzner.NodeName(clusterName, nodeType(node.Role), node.Index)
+		if err != nil {
+			return nil, fmt.Errorf("derive server name for node %d: %w", node.Index, err)
+		}
+
+		specs = append(specs, hetzner.CreateServerOpts{
+			Name:             name,
+			ServerType:       infra.ServerType,
+			ImageID:          infra.ImageID,
+			Location:         infra.Location,
+			Labels:           node.Labels,
+			UserData:         node.UserData,
+			NetworkID:        infra.NetworkID,
+			PlacementGroupID: infra.PlacementGroupID,
+			SSHKeyID:         infra.SSHKeyID,
+			FirewallIDs:      firewallIDs(infra.FirewallID),
+			EnableIPv4:       infra.EnableIPv4,
+			EnableIPv6:       infra.EnableIPv6,
+		})
+	}
+
+	return specs, nil
+}
+
+// firewallIDs wraps a resolved firewall ID as the single-element slice
+// [hetzner.CreateServerOpts] expects, or nil when no firewall (a zero ID) is set.
+func firewallIDs(firewallID int64) []int64 {
+	if firewallID == 0 {
+		return nil
+	}
+
+	return []int64{firewallID}
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/serverspecs_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/serverspecs_test.go
@@ -1,0 +1,152 @@
+package kubeadmhetzner_test
+
+import (
+	"strings"
+	"testing"
+
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// twoNodeUserData is a control-plane-plus-worker pair mirroring what
+// BuildNodeUserData emits: a cluster-initialising control plane at index 0 and a
+// worker at index 1, each carrying its cloud-init document and Hetzner labels.
+func twoNodeUserData() []kubeadmhetzner.NodeUserData {
+	return []kubeadmhetzner.NodeUserData{
+		{
+			Index:    0,
+			Role:     kubeadmbootstrap.RoleServerInit,
+			UserData: "#cloud-config\n# control plane",
+			Labels: hetzner.NodeLabels(
+				testClusterName, hetzner.NodeTypeControlPlane, 0,
+			),
+		},
+		{
+			Index:    1,
+			Role:     kubeadmbootstrap.RoleAgent,
+			UserData: "#cloud-config\n# worker",
+			Labels: hetzner.NodeLabels(
+				testClusterName, hetzner.NodeTypeWorker, 1,
+			),
+		},
+	}
+}
+
+func testInfra() kubeadmhetzner.Infra {
+	enableIPv4, enableIPv6 := true, false
+
+	return kubeadmhetzner.Infra{
+		ServerType:       "cx22",
+		Location:         "fsn1",
+		ImageID:          114690387,
+		NetworkID:        100,
+		FirewallID:       200,
+		PlacementGroupID: 300,
+		SSHKeyID:         400,
+		EnableIPv4:       &enableIPv4,
+		EnableIPv6:       &enableIPv6,
+	}
+}
+
+func TestDeriveServerSpecs(t *testing.T) {
+	t.Parallel()
+
+	nodes := twoNodeUserData()
+	infra := testInfra()
+
+	specs, err := kubeadmhetzner.DeriveServerSpecs(testClusterName, nodes, infra)
+
+	require.NoError(t, err)
+	require.Len(t, specs, len(nodes))
+
+	// Control plane (index 0): name and labels agree; cloud-init and infra placement
+	// carried through verbatim.
+	controlPlane := specs[0]
+	assert.Equal(t, "test-cluster-controlplane-0", controlPlane.Name)
+	assert.Equal(t, nodes[0].UserData, controlPlane.UserData)
+	assert.Equal(t, nodes[0].Labels, controlPlane.Labels)
+	assert.Equal(t, "cx22", controlPlane.ServerType)
+	assert.Equal(t, "fsn1", controlPlane.Location)
+	assert.Equal(t, int64(114690387), controlPlane.ImageID)
+	assert.Equal(t, int64(100), controlPlane.NetworkID)
+	assert.Equal(t, int64(300), controlPlane.PlacementGroupID)
+	assert.Equal(t, int64(400), controlPlane.SSHKeyID)
+	assert.Equal(t, []int64{200}, controlPlane.FirewallIDs)
+	require.NotNil(t, controlPlane.EnableIPv4)
+	assert.True(t, *controlPlane.EnableIPv4)
+	require.NotNil(t, controlPlane.EnableIPv6)
+	assert.False(t, *controlPlane.EnableIPv6)
+
+	// Worker (index 1): the global bootstrap index is reused for the name, matching
+	// the ksail.node.index label.
+	worker := specs[1]
+	assert.Equal(t, "test-cluster-worker-1", worker.Name)
+	assert.Equal(t, nodes[1].UserData, worker.UserData)
+	assert.Equal(t, nodes[1].Labels, worker.Labels)
+	assert.Equal(t, "1", worker.Labels[hetzner.LabelNodeIndex])
+}
+
+func TestDeriveServerSpecsNoFirewall(t *testing.T) {
+	t.Parallel()
+
+	infra := testInfra()
+	infra.FirewallID = 0
+
+	specs, err := kubeadmhetzner.DeriveServerSpecs(testClusterName, twoNodeUserData(), infra)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, specs)
+	// A zero firewall ID attaches no firewall rather than a bogus firewall 0.
+	assert.Nil(t, specs[0].FirewallIDs)
+}
+
+func TestDeriveServerSpecsEmpty(t *testing.T) {
+	t.Parallel()
+
+	specs, err := kubeadmhetzner.DeriveServerSpecs(
+		testClusterName, []kubeadmhetzner.NodeUserData{}, testInfra(),
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, specs)
+}
+
+func TestDeriveServerSpecsNameTooLong(t *testing.T) {
+	t.Parallel()
+
+	// A cluster name at the 63-char cap plus the "-controlplane-0" suffix exceeds
+	// the DNS-1123 label limit, so the whole derivation fails (no partial result).
+	longName := strings.Repeat("a", hetzner.MaxNodeNameLength)
+	nodes := []kubeadmhetzner.NodeUserData{
+		{Index: 0, Role: kubeadmbootstrap.RoleServerInit},
+	}
+
+	specs, err := kubeadmhetzner.DeriveServerSpecs(longName, nodes, testInfra())
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, hetzner.ErrNodeNameTooLong)
+	assert.Nil(t, specs)
+}
+
+// TestDeriveServerSpecsFromBuildNodeUserData wires the two composers end to end:
+// BuildNodeUserData produces the nodes, DeriveServerSpecs turns them into server
+// specs — the real path the provisioner will follow.
+func TestDeriveServerSpecsFromBuildNodeUserData(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := kubeadmhetzner.BuildNodeUserData(singleControlPlaneInput())
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	specs, err := kubeadmhetzner.DeriveServerSpecs(testClusterName, nodes, testInfra())
+
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+	assert.Equal(t, "test-cluster-controlplane-0", specs[0].Name)
+	// The composed cloud-init document flows through unchanged onto the server.
+	assert.Equal(t, nodes[0].UserData, specs[0].UserData)
+	assert.True(t, strings.HasPrefix(specs[0].UserData, "#cloud-config"))
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5646. Part of #5513 / #3983 (Vanilla-kubeadm × Hetzner provisioning epic).

## What
The next pure composition slice after #5641's `BuildNodeUserData`. Adds:

- **`kubeadmhetzner.DeriveServerSpecs(clusterName, nodes, infra)`** — turns the ordered
  per-node cloud-init `user_data` + labels from `BuildNodeUserData` into the
  `[]hetzner.CreateServerOpts` the provider's server-creation API consumes. It is the
  composition step between *what to run on each node* and *which server runs it*: for
  every node it derives the validated server name, attaches the node's cloud-init
  document and Hetzner labels, and places the server into the resolved infrastructure.
- **`hetzner.NodeName(clusterName, nodeType, index)`** + `ErrNodeNameTooLong` /
  `MaxNodeNameLength` — a shared helper (sibling of the existing `hetzner.NodeLabels`)
  composing the deterministic server name with the 63-char DNS-1123 validation.

## Why here
- **Pure + unit-tested, no I/O** — mirrors every prior Hetzner foundation slice
  (`Plan`, `RenderInstall`, `RenderContainerdConfig`, `BuildUserData`, `BuildNodeUserData`)
  built before the server lifecycle. `DeriveServerSpecs` / `NodeName` / `firewallIDs` are
  all 100% covered.
- **Name and labels agree by construction** — the server name reuses each node's
  zero-based bootstrap index (0 = the cluster-initialising control plane), which is the
  same value `BuildNodeUserData` writes into the `ksail.node.index` label, so a node can
  be found by either its name or its labels.
- **`NodeName` lives with `NodeLabels`** rather than as a third private copy — the Talos
  path keeps its own `hetznerNodeName` for now; converging it is a filed follow-up so this
  PR stays a clean additive slice (no behaviour change to Talos).

## Scope / decisions
- **Homogeneous cluster**: one server type / location / base image for all nodes. Per-role
  sizing (a larger control plane, a cheaper worker) is an additive later increment — noted
  on the `Infra` doc.
- kubeadm boots a **stock OS image** (`ImageID`), never the Talos path's ISO.
- A **zero `FirewallID`** attaches no firewall (rather than a bogus firewall `0`).
- **No CLI / config / schema / docs surface** touched — pure library slice, so no
  generated-file regeneration is involved.

## Validation
`go build` · `go vet` · `gofmt` clean; package tests green; `golangci-lint --new-from-rev=origin/main`
reports **0 issues**; new symbols `NodeName` / `DeriveServerSpecs` / `firewallIDs` at **100%**
statement coverage.

## Next increment (anti-stack, after this promotes)
The `kubeadmhetzner.Provisioner` struct + lifecycle (`Create`/`Delete`/`Start`/`Stop`) that
consumes `DeriveServerSpecs`, ensures the Hetzner infra, and resolves the run-time
control-plane / join addresses — mirroring how `talos` wraps its own builder.