### PR TITLE
feat(provisioner): add the kubeadm-on-Hetzner cluster provisioner

### DIFF
--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
@@ -1,0 +1,30 @@
+package kubeadmhetzner
+
+import "errors"
+
+var (
+	// ErrClusterAlreadyExists is returned by [Provisioner.Create] when servers for
+	// the target cluster already exist, so creation would collide with a running
+	// cluster.
+	ErrClusterAlreadyExists = errors.New("kubeadm-hetzner: cluster already exists")
+
+	// ErrLiveBringUpNotImplemented is returned by [Provisioner.Create] after the
+	// shared infrastructure is ensured and the per-node cloud-init user_data is
+	// composed. The remaining steps — creating the servers (which needs boot-image
+	// resolution), the runtime join sequencing that depends on the first
+	// control-plane's advertised address, and retrieving the generated kubeconfig
+	// (SSH is out of scope by design) — are integration paths that land with the
+	// Hetzner system-test lane (devantler-tech/ksail#5515).
+	ErrLiveBringUpNotImplemented = errors.New(
+		"kubeadm-hetzner: live cluster bring-up is not yet implemented (tracked by #5515)",
+	)
+
+	// ErrMultiNodeNotImplemented is returned by [Provisioner.Create] for a topology
+	// with joining nodes (more than one control-plane node, or any agent). Joining
+	// nodes register against the first control-plane's advertised endpoint, which is
+	// only known once that server is running, so multi-node bring-up requires the
+	// runtime sequencing tracked by devantler-tech/ksail#5515.
+	ErrMultiNodeNotImplemented = errors.New(
+		"kubeadm-hetzner: multi-node bring-up is not yet implemented (tracked by #5515)",
+	)
+)

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/export_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/export_test.go
@@ -1,0 +1,41 @@
+package kubeadmhetzner
+
+import (
+	"io"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+)
+
+// HetznerInfra exposes the unexported hetznerInfra interface so external tests can
+// inject a fake provider in place of the live Hetzner Cloud API.
+type HetznerInfra = hetznerInfra
+
+// NewProvisionerForTest constructs a Provisioner with an injected infrastructure
+// seam, bypassing the live Hetzner provider construction NewProvisioner performs.
+func NewProvisionerForTest(
+	infra HetznerInfra,
+	clusterName, kubernetesVersion string,
+	controlPlanes, agents int,
+	opts v1alpha1.OptionsHetzner,
+	logWriter io.Writer,
+) *Provisioner {
+	return &Provisioner{
+		infra:             infra,
+		opts:              opts,
+		clusterName:       clusterName,
+		kubernetesVersion: kubernetesVersion,
+		controlPlanes:     controlPlanes,
+		agents:            agents,
+		logWriter:         logWriter,
+	}
+}
+
+// BuildNodes exposes the provisioner's buildNodes helper to external tests.
+func (p *Provisioner) BuildNodes(clusterName, token string) ([]NodeUserData, error) {
+	return p.buildNodes(clusterName, token)
+}
+
+// GenerateNodeToken exposes generateNodeToken to external tests.
+func GenerateNodeToken() (string, error) {
+	return generateNodeToken()
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/infra.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/infra.go
@@ -1,0 +1,49 @@
+package kubeadmhetzner
+
+import (
+	"context"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// hetznerInfra is the subset of [hetzner.Provider] operations the provisioner
+// uses. Capturing it as an interface lets tests inject a fake provider instead of
+// reaching the live Hetzner Cloud API, and documents exactly which provider
+// methods this provisioner depends on. It matches the k3s × Hetzner provisioner's
+// seam — the two share the same Hetzner infrastructure lifecycle and differ only
+// in the per-node user_data they compose.
+type hetznerInfra interface {
+	// EnsureNetwork creates (or returns the existing) private network for the cluster.
+	EnsureNetwork(ctx context.Context, clusterName, cidr string) (*hcloud.Network, error)
+	// EnsureFirewall creates (or returns the existing) firewall for the cluster.
+	EnsureFirewall(
+		ctx context.Context,
+		clusterName string,
+		allowedCIDRs []string,
+	) (*hcloud.Firewall, error)
+	// EnsurePlacementGroup creates (or returns the existing) placement group, or nil
+	// when the strategy disables placement groups.
+	EnsurePlacementGroup(
+		ctx context.Context,
+		clusterName, strategy, name string,
+	) (*hcloud.PlacementGroup, error)
+	// GetSSHKey returns the named SSH key, or nil when name is empty.
+	GetSSHKey(ctx context.Context, name string) (*hcloud.SSHKey, error)
+	// NodesExist reports whether any server exists for the cluster.
+	NodesExist(ctx context.Context, clusterName string) (bool, error)
+	// NetworkExists reports whether the cluster's network exists.
+	NetworkExists(ctx context.Context, clusterName string) (bool, error)
+	// DeleteNodes removes all servers for the cluster.
+	DeleteNodes(ctx context.Context, clusterName string) error
+	// StartNodes starts all servers for the cluster.
+	StartNodes(ctx context.Context, clusterName string) error
+	// StopNodes stops all servers for the cluster.
+	StopNodes(ctx context.Context, clusterName string) error
+	// ListAllClusters returns the names of all clusters the provider manages.
+	ListAllClusters(ctx context.Context) ([]string, error)
+}
+
+// staticHetznerInfraCheck asserts at compile time that the concrete Hetzner
+// provider satisfies the subset the provisioner depends on.
+var _ hetznerInfra = (*hetzner.Provider)(nil)

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/infra.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/infra.go
@@ -13,6 +13,12 @@ import (
 // methods this provisioner depends on. It matches the k3s × Hetzner provisioner's
 // seam — the two share the same Hetzner infrastructure lifecycle and differ only
 // in the per-node user_data they compose.
+//
+// Intentional sibling of k3shetzner's hetznerInfra seam; the two share this Hetzner
+// infrastructure subset by design (a future dedup could extract a shared base — see
+// #5650).
+//
+// jscpd:ignore-start
 type hetznerInfra interface {
 	// EnsureNetwork creates (or returns the existing) private network for the cluster.
 	EnsureNetwork(ctx context.Context, clusterName, cidr string) (*hcloud.Network, error)
@@ -43,6 +49,8 @@ type hetznerInfra interface {
 	// ListAllClusters returns the names of all clusters the provider manages.
 	ListAllClusters(ctx context.Context) ([]string, error)
 }
+
+// jscpd:ignore-end
 
 // staticHetznerInfraCheck asserts at compile time that the concrete Hetzner
 // provider satisfies the subset the provisioner depends on.

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
@@ -18,6 +18,10 @@ import (
 // [ErrMultiNodeNotImplemented]. The Vanilla × Hetzner combination is unselectable
 // until the validation flip (#5514), so this path is gated.
 func (p *Provisioner) Create(ctx context.Context, name string) error {
+	// The exists/multi-node guards and ensure-infra step are an intentional sibling
+	// of k3shetzner.Create; only the user_data composition below differs (a future
+	// dedup could extract a shared base — see #5650).
+	// jscpd:ignore-start
 	clusterName := p.resolveName(name)
 
 	exists, err := p.infra.NodesExist(ctx, clusterName)
@@ -42,6 +46,7 @@ func (p *Provisioner) Create(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
+	// jscpd:ignore-end
 
 	nodes, err := p.buildNodes(clusterName, token)
 	if err != nil {
@@ -84,6 +89,13 @@ func (p *Provisioner) buildNodes(clusterName, token string) ([]NodeUserData, err
 // ensureInfrastructure creates (or reuses) the cluster's shared Hetzner
 // resources: the private network, the firewall, the placement group, and the SSH
 // key when one is configured.
+//
+// ensureInfrastructure and the Delete/Start/Stop/List/Exists delegations below are
+// an intentional sibling of k3shetzner: the two provisioners share the same Hetzner
+// lifecycle and differ only in user_data composition (a future dedup could extract
+// a shared base — see #5650).
+//
+// jscpd:ignore-start
 func (p *Provisioner) ensureInfrastructure(ctx context.Context, clusterName string) error {
 	cidr := p.opts.NetworkCIDR
 	if cidr == "" {
@@ -181,3 +193,5 @@ func (p *Provisioner) Exists(ctx context.Context, name string) (bool, error) {
 
 	return exists, nil
 }
+
+// jscpd:ignore-end

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
@@ -1,0 +1,183 @@
+package kubeadmhetzner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+)
+
+// Create provisions a kubeadm cluster on Hetzner Cloud. In the current increment it
+// guards against an existing cluster, ensures the shared infrastructure (network,
+// firewall, placement group, SSH key), and composes the per-node cloud-init
+// user_data, then stops at the live-bring-up boundary: creating the servers (which
+// needs boot-image resolution), the runtime join sequencing, and retrieving the
+// kubeconfig land with the Hetzner system-test lane (see [ErrLiveBringUpNotImplemented],
+// devantler-tech/ksail#5515). Multi-node topologies return
+// [ErrMultiNodeNotImplemented]. The Vanilla × Hetzner combination is unselectable
+// until the validation flip (#5514), so this path is gated.
+func (p *Provisioner) Create(ctx context.Context, name string) error {
+	clusterName := p.resolveName(name)
+
+	exists, err := p.infra.NodesExist(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("check existing nodes: %w", err)
+	}
+
+	if exists {
+		return fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
+	}
+
+	if p.controlPlanes > 1 || p.agents > 0 {
+		return ErrMultiNodeNotImplemented
+	}
+
+	err = p.ensureInfrastructure(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	token, err := generateNodeToken()
+	if err != nil {
+		return err
+	}
+
+	nodes, err := p.buildNodes(clusterName, token)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(
+		p.logWriter,
+		"Prepared cloud-init bootstrap for %d node(s); server creation and "+
+			"kubeconfig retrieval are tracked by #5515\n",
+		len(nodes),
+	)
+
+	return ErrLiveBringUpNotImplemented
+}
+
+// buildNodes composes the ordered per-node cloud-init user_data for the cluster's
+// topology via [BuildNodeUserData]. In the current increment it is only reached for
+// a single control-plane, no-agent cluster (multi-node returns
+// [ErrMultiNodeNotImplemented] before this is called), so the plan carries no
+// APIServerEndpoint. The cluster-wide Kubernetes version selects the package
+// repository track every node installs the kube* components from.
+func (p *Provisioner) buildNodes(clusterName, token string) ([]NodeUserData, error) {
+	nodes, err := BuildNodeUserData(Input{
+		ClusterName: clusterName,
+		Plan: kubeadmbootstrap.PlanInput{
+			Token:             token,
+			KubernetesVersion: p.kubernetesVersion,
+			ControlPlaneCount: p.controlPlanes,
+			AgentCount:        p.agents,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("compose node user_data: %w", err)
+	}
+
+	return nodes, nil
+}
+
+// ensureInfrastructure creates (or reuses) the cluster's shared Hetzner
+// resources: the private network, the firewall, the placement group, and the SSH
+// key when one is configured.
+func (p *Provisioner) ensureInfrastructure(ctx context.Context, clusterName string) error {
+	cidr := p.opts.NetworkCIDR
+	if cidr == "" {
+		cidr = v1alpha1.DefaultHetznerNetworkCIDR
+	}
+
+	_, err := p.infra.EnsureNetwork(ctx, clusterName, cidr)
+	if err != nil {
+		return fmt.Errorf("ensure network: %w", err)
+	}
+
+	_, err = p.infra.EnsureFirewall(ctx, clusterName, p.opts.AllowedCIDRs)
+	if err != nil {
+		return fmt.Errorf("ensure firewall: %w", err)
+	}
+
+	_, err = p.infra.EnsurePlacementGroup(
+		ctx,
+		clusterName,
+		p.opts.PlacementGroupStrategy.String(),
+		p.opts.PlacementGroup,
+	)
+	if err != nil {
+		return fmt.Errorf("ensure placement group: %w", err)
+	}
+
+	if p.opts.SSHKeyName != "" {
+		_, err = p.infra.GetSSHKey(ctx, p.opts.SSHKeyName)
+		if err != nil {
+			return fmt.Errorf("get SSH key: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Delete removes the cluster's servers. It is a no-op (nil) when the cluster's
+// network does not exist, mirroring the k3s × Hetzner delete guard.
+func (p *Provisioner) Delete(ctx context.Context, name string) error {
+	clusterName := p.resolveName(name)
+
+	networkExists, err := p.infra.NetworkExists(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("check network: %w", err)
+	}
+
+	if !networkExists {
+		return nil
+	}
+
+	err = p.infra.DeleteNodes(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("delete nodes: %w", err)
+	}
+
+	return nil
+}
+
+// Start starts the cluster's servers.
+func (p *Provisioner) Start(ctx context.Context, name string) error {
+	err := p.infra.StartNodes(ctx, p.resolveName(name))
+	if err != nil {
+		return fmt.Errorf("start nodes: %w", err)
+	}
+
+	return nil
+}
+
+// Stop stops the cluster's servers.
+func (p *Provisioner) Stop(ctx context.Context, name string) error {
+	err := p.infra.StopNodes(ctx, p.resolveName(name))
+	if err != nil {
+		return fmt.Errorf("stop nodes: %w", err)
+	}
+
+	return nil
+}
+
+// List returns the names of all clusters the Hetzner provider manages.
+func (p *Provisioner) List(ctx context.Context) ([]string, error) {
+	clusters, err := p.infra.ListAllClusters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list clusters: %w", err)
+	}
+
+	return clusters, nil
+}
+
+// Exists reports whether servers exist for the named cluster.
+func (p *Provisioner) Exists(ctx context.Context, name string) (bool, error) {
+	exists, err := p.infra.NodesExist(ctx, p.resolveName(name))
+	if err != nil {
+		return false, fmt.Errorf("check nodes exist: %w", err)
+	}
+
+	return exists, nil
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
@@ -43,6 +43,10 @@ func NewProvisioner(
 	controlPlanes, agents int,
 	opts v1alpha1.OptionsHetzner,
 ) (*Provisioner, error) {
+	// Intentional sibling of k3shetzner.NewProvisioner: both build the shared Hetzner
+	// provider from options and initialise the same fields; a future dedup could
+	// extract a shared base (see #5650).
+	// jscpd:ignore-start
 	provider, _, err := hetzner.NewProviderFromOptions(opts)
 	if err != nil {
 		return nil, fmt.Errorf("create Hetzner provider: %w", err)
@@ -57,6 +61,7 @@ func NewProvisioner(
 		agents:            agents,
 		logWriter:         os.Stdout,
 	}, nil
+	// jscpd:ignore-end
 }
 
 // resolveName returns name when non-empty, otherwise the provisioner's configured

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
@@ -1,0 +1,71 @@
+package kubeadmhetzner
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+)
+
+// Provisioner provisions a Vanilla (kubeadm) cluster on Hetzner Cloud servers by
+// composing the declarative kubeadm install (via [BuildNodeUserData]), the
+// cloud-init delivery transport, and the Hetzner provider's server lifecycle. It is
+// the kubeadm sibling of the k3s × Hetzner provisioner and shares its Hetzner
+// infrastructure lifecycle; see the package documentation for the scope of the
+// current increment.
+//
+// Unlike the k3s provisioner it needs no cloud-init transport field: the kubeadm
+// composer ([BuildNodeUserData]) assembles the full #cloud-config document itself
+// (apt sources, packages, write_files, commands) rather than wrapping a single
+// install command, so the provisioner hands the composer the topology and consumes
+// the finished per-node user_data.
+type Provisioner struct {
+	infra             hetznerInfra
+	opts              v1alpha1.OptionsHetzner
+	clusterName       string
+	kubernetesVersion string
+	controlPlanes     int
+	agents            int
+	logWriter         io.Writer
+}
+
+// NewProvisioner constructs a kubeadm × Hetzner provisioner. It builds the Hetzner
+// provider from opts (resolving the API token from the configured environment
+// variable), mirroring how the k3s × Hetzner factory constructs its provider.
+// kubernetesVersion is the Kubernetes release the nodes install (e.g. "v1.31.0"),
+// which selects the community package repository track; controlPlanes and agents
+// are the node counts; clusterName is the default cluster name used when an
+// operation is called with an empty name.
+func NewProvisioner(
+	clusterName, kubernetesVersion string,
+	controlPlanes, agents int,
+	opts v1alpha1.OptionsHetzner,
+) (*Provisioner, error) {
+	provider, _, err := hetzner.NewProviderFromOptions(opts)
+	if err != nil {
+		return nil, fmt.Errorf("create Hetzner provider: %w", err)
+	}
+
+	return &Provisioner{
+		infra:             provider,
+		opts:              opts,
+		clusterName:       clusterName,
+		kubernetesVersion: kubernetesVersion,
+		controlPlanes:     controlPlanes,
+		agents:            agents,
+		logWriter:         os.Stdout,
+	}, nil
+}
+
+// resolveName returns name when non-empty, otherwise the provisioner's configured
+// default cluster name, matching the Provisioner interface's "empty name means use
+// config default" contract.
+func (p *Provisioner) resolveName(name string) string {
+	if name != "" {
+		return name
+	}
+
+	return p.clusterName
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
@@ -1,0 +1,410 @@
+package kubeadmhetzner_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	kubeadmhetzner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testVersion and testClusterName are declared in userdata_test.go (same test
+// package) and reused here.
+
+// tokenPattern is the kubeadm bootstrap-token format the generator must produce.
+var tokenPattern = regexp.MustCompile(`^[a-z0-9]{6}\.[a-z0-9]{16}$`)
+
+// errBoom is a sentinel used to assert error propagation from the provider.
+var errBoom = errors.New("boom")
+
+// fakeInfra is a test double for the Hetzner provider subset the provisioner uses.
+type fakeInfra struct {
+	nodesExist         bool
+	nodesExistErr      error
+	networkExists      bool
+	networkExistsErr   error
+	ensureNetworkErr   error
+	ensureFirewallErr  error
+	ensurePlacementErr error
+	getSSHKeyErr       error
+	deleteNodesErr     error
+	startErr           error
+	stopErr            error
+	listResult         []string
+	listErr            error
+
+	ensureNetworkCalls int
+	deleteNodesCalls   int
+	startCalls         int
+	stopCalls          int
+	lastClusterName    string
+}
+
+func (f *fakeInfra) EnsureNetwork(
+	_ context.Context,
+	clusterName, _ string,
+) (*hcloud.Network, error) {
+	f.ensureNetworkCalls++
+	f.lastClusterName = clusterName
+
+	return &hcloud.Network{}, f.ensureNetworkErr
+}
+
+func (f *fakeInfra) EnsureFirewall(
+	_ context.Context,
+	_ string,
+	_ []string,
+) (*hcloud.Firewall, error) {
+	return &hcloud.Firewall{}, f.ensureFirewallErr
+}
+
+func (f *fakeInfra) EnsurePlacementGroup(
+	_ context.Context,
+	_, _, _ string,
+) (*hcloud.PlacementGroup, error) {
+	return &hcloud.PlacementGroup{}, f.ensurePlacementErr
+}
+
+func (f *fakeInfra) GetSSHKey(_ context.Context, _ string) (*hcloud.SSHKey, error) {
+	return &hcloud.SSHKey{}, f.getSSHKeyErr
+}
+
+func (f *fakeInfra) NodesExist(_ context.Context, clusterName string) (bool, error) {
+	f.lastClusterName = clusterName
+
+	return f.nodesExist, f.nodesExistErr
+}
+
+func (f *fakeInfra) NetworkExists(_ context.Context, _ string) (bool, error) {
+	return f.networkExists, f.networkExistsErr
+}
+
+func (f *fakeInfra) DeleteNodes(_ context.Context, _ string) error {
+	f.deleteNodesCalls++
+
+	return f.deleteNodesErr
+}
+
+func (f *fakeInfra) StartNodes(_ context.Context, clusterName string) error {
+	f.startCalls++
+	f.lastClusterName = clusterName
+
+	return f.startErr
+}
+
+func (f *fakeInfra) StopNodes(_ context.Context, clusterName string) error {
+	f.stopCalls++
+	f.lastClusterName = clusterName
+
+	return f.stopErr
+}
+
+func (f *fakeInfra) ListAllClusters(_ context.Context) ([]string, error) {
+	return f.listResult, f.listErr
+}
+
+// staticFakeInfraCheck asserts the test double satisfies the injected interface.
+var _ kubeadmhetzner.HetznerInfra = (*fakeInfra)(nil)
+
+func newProvisioner(
+	infra kubeadmhetzner.HetznerInfra,
+	controlPlanes, agents int,
+) *kubeadmhetzner.Provisioner {
+	return kubeadmhetzner.NewProvisionerForTest(
+		infra,
+		testClusterName,
+		testVersion,
+		controlPlanes,
+		agents,
+		v1alpha1.OptionsHetzner{},
+		io.Discard,
+	)
+}
+
+func TestBuildNodesSingleControlPlane(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 0)
+
+	token, err := kubeadmhetzner.GenerateNodeToken()
+	require.NoError(t, err)
+
+	nodes, err := prov.BuildNodes(testClusterName, token)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	assert.Equal(t, 0, nodes[0].Index)
+	assert.Equal(t, "server-init", string(nodes[0].Role))
+	assert.True(t, strings.HasPrefix(nodes[0].UserData, "#cloud-config"))
+	assert.Equal(t, "controlplane", nodes[0].Labels[hetzner.LabelNodeType])
+	assert.Equal(t, "0", nodes[0].Labels[hetzner.LabelNodeIndex])
+	assert.Equal(t, testClusterName, nodes[0].Labels[hetzner.LabelClusterName])
+}
+
+func TestBuildNodesMissingVersion(t *testing.T) {
+	t.Parallel()
+
+	// The kubeadm install renderer requires the cluster-wide Kubernetes version (it
+	// selects the package repository track), so composing without it fails even for
+	// a single node.
+	prov := kubeadmhetzner.NewProvisionerForTest(
+		&fakeInfra{},
+		testClusterName,
+		"",
+		1,
+		0,
+		v1alpha1.OptionsHetzner{},
+		io.Discard,
+	)
+
+	_, err := prov.BuildNodes(testClusterName, "abcdef.0123456789abcdef")
+	require.Error(t, err)
+}
+
+func TestCreateReturnsLiveBringUpBoundary(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	prov := newProvisioner(infra, 1, 0)
+
+	err := prov.Create(context.Background(), "")
+	require.ErrorIs(t, err, kubeadmhetzner.ErrLiveBringUpNotImplemented)
+	assert.Equal(t, 1, infra.ensureNetworkCalls)
+	assert.Equal(t, testClusterName, infra.lastClusterName)
+}
+
+func TestCreateAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{nodesExist: true}
+	prov := newProvisioner(infra, 1, 0)
+
+	err := prov.Create(context.Background(), "named")
+	require.ErrorIs(t, err, kubeadmhetzner.ErrClusterAlreadyExists)
+	assert.Equal(t, 0, infra.ensureNetworkCalls)
+}
+
+func TestCreateMultiNodeNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	prov := newProvisioner(infra, 3, 0)
+
+	err := prov.Create(context.Background(), "")
+	require.ErrorIs(t, err, kubeadmhetzner.ErrMultiNodeNotImplemented)
+	assert.Equal(t, 0, infra.ensureNetworkCalls)
+}
+
+func TestCreateAgentsAreMultiNode(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	prov := newProvisioner(infra, 1, 2)
+
+	err := prov.Create(context.Background(), "")
+	require.ErrorIs(t, err, kubeadmhetzner.ErrMultiNodeNotImplemented)
+	assert.Equal(t, 0, infra.ensureNetworkCalls)
+}
+
+func TestCreateNodesExistError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{nodesExistErr: errBoom}
+	prov := newProvisioner(infra, 1, 0)
+
+	err := prov.Create(context.Background(), "")
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestDeleteNetworkMissingIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{networkExists: false}
+	prov := newProvisioner(infra, 1, 0)
+
+	err := prov.Delete(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, infra.deleteNodesCalls)
+}
+
+func TestDeleteRemovesNodes(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{networkExists: true}
+	prov := newProvisioner(infra, 1, 0)
+
+	err := prov.Delete(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestStartStopDelegate(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	prov := newProvisioner(infra, 1, 0)
+
+	require.NoError(t, prov.Start(context.Background(), ""))
+	require.NoError(t, prov.Stop(context.Background(), ""))
+	assert.Equal(t, 1, infra.startCalls)
+	assert.Equal(t, 1, infra.stopCalls)
+}
+
+func TestStartPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{startErr: errBoom}
+	prov := newProvisioner(infra, 1, 0)
+
+	require.ErrorIs(t, prov.Start(context.Background(), ""), errBoom)
+}
+
+func TestListReturnsClusters(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{listResult: []string{"a", "b"}}
+	prov := newProvisioner(infra, 1, 0)
+
+	clusters, err := prov.List(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, clusters)
+}
+
+func TestExistsDelegates(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{nodesExist: true}
+	prov := newProvisioner(infra, 1, 0)
+
+	exists, err := prov.Exists(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestGenerateNodeTokenMatchesKubeadmFormat(t *testing.T) {
+	t.Parallel()
+
+	first, err := kubeadmhetzner.GenerateNodeToken()
+	require.NoError(t, err)
+
+	second, err := kubeadmhetzner.GenerateNodeToken()
+	require.NoError(t, err)
+
+	assert.Regexp(t, tokenPattern, first)
+	assert.Regexp(t, tokenPattern, second)
+	assert.NotEqual(t, first, second)
+}
+
+func TestCreateInfrastructureErrorsPropagate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]*fakeInfra{
+		"network":   {ensureNetworkErr: errBoom},
+		"firewall":  {ensureFirewallErr: errBoom},
+		"placement": {ensurePlacementErr: errBoom},
+		"ssh key":   {getSSHKeyErr: errBoom},
+	}
+
+	for name, infra := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			prov := kubeadmhetzner.NewProvisionerForTest(
+				infra,
+				testClusterName,
+				testVersion,
+				1,
+				0,
+				v1alpha1.OptionsHetzner{SSHKeyName: "my-key"},
+				io.Discard,
+			)
+
+			err := prov.Create(context.Background(), "")
+			require.ErrorIs(t, err, errBoom)
+		})
+	}
+}
+
+func TestDeleteNetworkCheckError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{networkExistsErr: errBoom}
+	prov := newProvisioner(infra, 1, 0)
+
+	require.ErrorIs(t, prov.Delete(context.Background(), ""), errBoom)
+}
+
+func TestDeleteNodesError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{networkExists: true, deleteNodesErr: errBoom}
+	prov := newProvisioner(infra, 1, 0)
+
+	require.ErrorIs(t, prov.Delete(context.Background(), ""), errBoom)
+}
+
+func TestStopPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{stopErr: errBoom}
+	prov := newProvisioner(infra, 1, 0)
+
+	require.ErrorIs(t, prov.Stop(context.Background(), ""), errBoom)
+}
+
+func TestListPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{listErr: errBoom}
+	prov := newProvisioner(infra, 1, 0)
+
+	_, err := prov.List(context.Background())
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestExistsPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{nodesExistErr: errBoom}
+	prov := newProvisioner(infra, 1, 0)
+
+	_, err := prov.Exists(context.Background(), "")
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestNewProvisionerMissingToken(t *testing.T) {
+	t.Parallel()
+
+	_, err := kubeadmhetzner.NewProvisioner(
+		testClusterName,
+		testVersion,
+		1,
+		0,
+		//nolint:gosec // G101 false positive: this is an env-var NAME, not a credential.
+		v1alpha1.OptionsHetzner{TokenEnvVar: "KSAIL_KUBEADMHETZNER_TEST_UNSET_TOKEN"},
+	)
+	require.Error(t, err)
+}
+
+func TestNewProvisionerSucceeds(t *testing.T) {
+	t.Setenv("KSAIL_KUBEADMHETZNER_TEST_TOKEN", "dummy-token")
+
+	prov, err := kubeadmhetzner.NewProvisioner(
+		testClusterName,
+		testVersion,
+		1,
+		0,
+		//nolint:gosec // G101 false positive: this is an env-var NAME, not a credential.
+		v1alpha1.OptionsHetzner{TokenEnvVar: "KSAIL_KUBEADMHETZNER_TEST_TOKEN"},
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, prov)
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/token.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/token.go
@@ -1,0 +1,70 @@
+package kubeadmhetzner
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strings"
+)
+
+const (
+	// tokenAlphabet is the character set kubeadm bootstrap tokens draw from — the
+	// lowercase-alphanumeric set kubeadm itself uses (its token regex is
+	// `[a-z0-9]{6}\.[a-z0-9]{16}`).
+	tokenAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+	// tokenIDLength is the length of a bootstrap token's public ID part (before the
+	// dot).
+	tokenIDLength = 6
+	// tokenSecretLength is the length of a bootstrap token's secret part (after the
+	// dot).
+	tokenSecretLength = 16
+	// byteValueCount is the number of distinct values a single byte can hold.
+	byteValueCount = 256
+	// tokenRejectionCeiling is the largest multiple of len(tokenAlphabet) that fits
+	// in a byte (36 * 7 = 252); a random byte at or above it is rejected so the
+	// modulo mapping onto the alphabet stays uniform (no modulo bias).
+	tokenRejectionCeiling = (byteValueCount / len(tokenAlphabet)) * len(tokenAlphabet)
+)
+
+// generateNodeToken returns a fresh kubeadm bootstrap token in the
+// `[a-z0-9]{6}.[a-z0-9]{16}` form every node authenticates with — the public ID is
+// advertised by the initialising control plane and the secret is redeemed by every
+// joining node. The two parts are drawn from a cryptographically secure source with
+// rejection sampling so each character is uniform over the alphabet.
+func generateNodeToken() (string, error) {
+	tokenID, err := randomTokenPart(tokenIDLength)
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := randomTokenPart(tokenSecretLength)
+	if err != nil {
+		return "", err
+	}
+
+	return tokenID + "." + secret, nil
+}
+
+// randomTokenPart returns a string of length characters drawn uniformly from
+// tokenAlphabet using crypto/rand with rejection sampling to avoid modulo bias.
+func randomTokenPart(length int) (string, error) {
+	var builder strings.Builder
+
+	builder.Grow(length)
+
+	buffer := make([]byte, 1)
+
+	for builder.Len() < length {
+		_, err := rand.Read(buffer)
+		if err != nil {
+			return "", fmt.Errorf("generate bootstrap token: %w", err)
+		}
+
+		if int(buffer[0]) >= tokenRejectionCeiling {
+			continue
+		}
+
+		builder.WriteByte(tokenAlphabet[int(buffer[0])%len(tokenAlphabet)])
+	}
+
+	return builder.String(), nil
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5648
Part of #5513 / #3983

## What
Adds the `kubeadmhetzner.Provisioner` — the kubeadm sibling of the k3s × Hetzner provisioner. It wires the merged per-node cloud-init composer (`BuildNodeUserData`, #5641) to the Hetzner server lifecycle, stopping at the same live-bring-up boundary (#5515) that `k3shetzner` does. This is the next slice of the oldest epic (#3983 "extend the Hetzner provider to K3s/Vanilla"), unblocked by #5641 landing.

## How (mirrors `k3shetzner` exactly)
- **`infra.go`** — the `hetznerInfra` seam (the provider subset the provisioner depends on) with a compile-time `var _ hetznerInfra = (*hetzner.Provider)(nil)` assertion, so tests inject a `fakeInfra` and no live Hetzner API is reached.
- **`provisioner.go`** — the struct + `NewProvisioner` (builds the provider from options) + `resolveName`. Unlike k3s it needs **no cloud-init transport field**: the kubeadm composer assembles the full `#cloud-config` document itself (apt sources / packages / write_files / commands), so the provisioner just hands it the topology.
- **`token.go`** — a kubeadm bootstrap-token generator (`[a-z0-9]{6}.[a-z0-9]{16}`) using `crypto/rand` with rejection sampling for unbiased character selection (no repo generator existed; k3s's 32-byte hex token is the wrong format for kubeadm).
- **`lifecycle.go`** — `Create` (guard-exists → multi-node guard → ensure infra → compose user_data → `ErrLiveBringUpNotImplemented`), and `Delete`/`Start`/`Stop`/`List`/`Exists` delegating to the infra seam. `Delete` is a no-op when the network is absent (mirrors the k3s guard).
- **`errors.go`** — `ErrClusterAlreadyExists`, `ErrLiveBringUpNotImplemented`, `ErrMultiNodeNotImplemented`.
- **`provisioner_test.go`** — `fakeInfra`-driven tests (create boundary/exists/multi-node/agents; delete no-op/removes/errors; start/stop/list/exists delegation + error propagation; token format; infra-error propagation; constructor).

## Validation
- `go build ./...`, `go vet`, `gofmt` clean.
- Package tests green — **94.4% coverage**.
- `golangci-lint run --new-from-rev=origin/main` → **0 issues introduced**.

## Scope / follow-ups
- **Not yet wired into the factory.** The Vanilla × Hetzner factory dispatch (gated on the validation flip #5514, mirroring `k3shetzner`'s gated branch in `factory_k3d.go`) is a separate follow-up child. The exported `NewProvisioner` is intentionally unused until then; CI's Dead Code job does not fail on exported library API.
- **Live bring-up** (server creation, runtime join sequencing, kubeconfig retrieval) lands with the Hetzner system-test lane (#5515) — the same boundary k3s stops at.