### PR TITLE
fix(provider/hetzner): reconcile subnet when network already exists

### DIFF
--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -58,6 +58,43 @@ func (p *Provider) EnsureNetwork(
 	return network, nil
 }
 
+// defaultServerSubnetCIDR is the historical server subnet carved out of the
+// default network range; kept so existing default-CIDR clusters reconcile
+// unchanged.
+const defaultServerSubnetCIDR = "10.0.1.0/24"
+
+// subnetMaskBits is the prefix length of the server subnet derived from a
+// custom network range.
+const subnetMaskBits = 24
+
+// ipv4Bits is the bit length of an IPv4 mask, used to recognise IPv4 ranges.
+const ipv4Bits = 32
+
+// serverSubnetCIDR derives the server subnet from the network CIDR. The
+// default network keeps its historical 10.0.1.0/24 subnet; a custom network
+// uses its first /24 (a Hetzner subnet must sit inside the network range, and
+// the full range would leave no room for further subnets). A custom range
+// that is already /24 or smaller — or not IPv4 — is used whole.
+func serverSubnetCIDR(cidr string) (string, error) {
+	if cidr == v1alpha1.DefaultHetznerNetworkCIDR {
+		return defaultServerSubnetCIDR, nil
+	}
+
+	_, ipRange, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("invalid network CIDR %s: %w", cidr, err)
+	}
+
+	ones, bits := ipRange.Mask.Size()
+	if bits != ipv4Bits || ones >= subnetMaskBits {
+		return ipRange.String(), nil
+	}
+
+	firstSlash24 := net.IPNet{IP: ipRange.IP, Mask: net.CIDRMask(subnetMaskBits, bits)}
+
+	return firstSlash24.String(), nil
+}
+
 // ensureSubnet adds the server subnet to the network when it is not already present.
 // It reconciles a partial-failure state (network created but AddSubnet failed) on a
 // retry and is idempotent: a subnet that already exists on the network is left as-is.
@@ -68,10 +105,9 @@ func (p *Provider) ensureSubnet(
 	cidr string,
 ) error {
 	// Add a subnet for the servers
-	subnetCIDR := "10.0.1.0/24"
-	if cidr != v1alpha1.DefaultHetznerNetworkCIDR {
-		// Use first /24 of the provided range
-		subnetCIDR = cidr
+	subnetCIDR, err := serverSubnetCIDR(cidr)
+	if err != nil {
+		return err
 	}
 
 	_, subnetIPRange, err := net.ParseCIDR(subnetCIDR)

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -13,6 +13,9 @@ import (
 )
 
 // EnsureNetwork ensures a network exists for the cluster, creating it if needed.
+// The server subnet is reconciled on every call, so a Create retry after a partial
+// failure (network created but AddSubnet not yet applied) heals the network instead
+// of returning it without a subnet.
 func (p *Provider) EnsureNetwork(
 	ctx context.Context,
 	clusterName string,
@@ -30,25 +33,40 @@ func (p *Provider) EnsureNetwork(
 		return nil, fmt.Errorf("failed to get network %s: %w", networkName, err)
 	}
 
-	if network != nil {
-		return network, nil
+	if network == nil {
+		// Parse the network CIDR
+		_, ipRange, parseErr := net.ParseCIDR(cidr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid network CIDR %s: %w", cidr, parseErr)
+		}
+
+		network, _, err = p.client.Network.Create(ctx, hcloud.NetworkCreateOpts{
+			Name:    networkName,
+			IPRange: ipRange,
+			Labels:  ResourceLabels(clusterName),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create network %s: %w", networkName, err)
+		}
 	}
 
-	// Parse the network CIDR
-	_, ipRange, err := net.ParseCIDR(cidr)
+	err = p.ensureSubnet(ctx, network, networkName, cidr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid network CIDR %s: %w", cidr, err)
+		return nil, err
 	}
 
-	network, _, err = p.client.Network.Create(ctx, hcloud.NetworkCreateOpts{
-		Name:    networkName,
-		IPRange: ipRange,
-		Labels:  ResourceLabels(clusterName),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create network %s: %w", networkName, err)
-	}
+	return network, nil
+}
 
+// ensureSubnet adds the server subnet to the network when it is not already present.
+// It reconciles a partial-failure state (network created but AddSubnet failed) on a
+// retry and is idempotent: a subnet that already exists on the network is left as-is.
+func (p *Provider) ensureSubnet(
+	ctx context.Context,
+	network *hcloud.Network,
+	networkName string,
+	cidr string,
+) error {
 	// Add a subnet for the servers
 	subnetCIDR := "10.0.1.0/24"
 	if cidr != v1alpha1.DefaultHetznerNetworkCIDR {
@@ -58,7 +76,14 @@ func (p *Provider) EnsureNetwork(
 
 	_, subnetIPRange, err := net.ParseCIDR(subnetCIDR)
 	if err != nil {
-		return nil, fmt.Errorf("invalid subnet CIDR %s: %w", subnetCIDR, err)
+		return fmt.Errorf("invalid subnet CIDR %s: %w", subnetCIDR, err)
+	}
+
+	// Skip when the network already carries the subnet (idempotent reconcile).
+	for _, subnet := range network.Subnets {
+		if subnet.IPRange != nil && subnet.IPRange.String() == subnetIPRange.String() {
+			return nil
+		}
 	}
 
 	_, _, err = p.client.Network.AddSubnet(ctx, network, hcloud.NetworkAddSubnetOpts{
@@ -69,10 +94,10 @@ func (p *Provider) EnsureNetwork(
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to add subnet to network %s: %w", networkName, err)
+		return fmt.Errorf("failed to add subnet to network %s: %w", networkName, err)
 	}
 
-	return network, nil
+	return nil
 }
 
 // EnsureFirewall ensures a firewall exists for the cluster, creating it if needed.

--- a/pkg/svc/provider/hetzner/infrastructure_reconcile_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_reconcile_test.go
@@ -1,0 +1,88 @@
+package hetzner_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newNetworkReconcileServer returns an httptest server that answers the network
+// GetByName lookup with a single existing network carrying the given subnets, and
+// records how many times AddSubnet is invoked. It lets the reconcile tests assert
+// whether EnsureNetwork adds the server subnet when adopting an existing network.
+func newNetworkReconcileServer(
+	t *testing.T,
+	subnetsJSON string,
+	addSubnetCalls *int32,
+) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	// GetByName lists networks filtered by name -> return one existing network.
+	mux.HandleFunc("/networks", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"networks":[{"id":42,"name":"test-cluster-network",` +
+			`"ip_range":"10.0.0.0/16","subnets":` + subnetsJSON + `,"servers":[],"labels":{}}]}`))
+	})
+
+	// AddSubnet posts an action against the network id.
+	mux.HandleFunc("/networks/42/actions/add_subnet",
+		func(responseWriter http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(addSubnetCalls, 1)
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(
+				`{"action":{"id":1,"command":"add_subnet","status":"success","progress":100}}`))
+		})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// TestEnsureNetwork_ReconcilesMissingSubnetOnExisting proves that when a prior
+// Create left the network created but subnet-less (AddSubnet failed), a later
+// EnsureNetwork call adopts the existing network AND adds the missing subnet,
+// healing the partial state instead of returning a subnet-less network.
+func TestEnsureNetwork_ReconcilesMissingSubnetOnExisting(t *testing.T) {
+	t.Parallel()
+
+	var addSubnetCalls int32
+
+	srv := newNetworkReconcileServer(t, `[]`, &addSubnetCalls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", defaultNetworkCIDR)
+
+	require.NoError(t, err)
+	require.NotNil(t, network)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&addSubnetCalls),
+		"EnsureNetwork should add the missing subnet when adopting an existing subnet-less network")
+}
+
+// TestEnsureNetwork_SkipsSubnetWhenPresent proves the reconcile is idempotent:
+// when the existing network already carries the expected server subnet, no
+// duplicate AddSubnet call is made.
+func TestEnsureNetwork_SkipsSubnetWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	var addSubnetCalls int32
+
+	existingSubnet := `[{"type":"cloud","ip_range":"10.0.1.0/24","network_zone":"eu-central","gateway":"10.0.0.1"}]`
+	srv := newNetworkReconcileServer(t, existingSubnet, &addSubnetCalls)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", defaultNetworkCIDR)
+
+	require.NoError(t, err)
+	require.NotNil(t, network)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&addSubnetCalls),
+		"EnsureNetwork should not re-add a subnet the network already carries")
+}

--- a/pkg/svc/provider/hetzner/infrastructure_reconcile_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_reconcile_test.go
@@ -2,6 +2,7 @@ package hetzner_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -13,13 +14,16 @@ import (
 )
 
 // newNetworkReconcileServer returns an httptest server that answers the network
-// GetByName lookup with a single existing network carrying the given subnets, and
-// records how many times AddSubnet is invoked. It lets the reconcile tests assert
-// whether EnsureNetwork adds the server subnet when adopting an existing network.
+// GetByName lookup with a single existing network carrying the given ip_range and
+// subnets, records how many times AddSubnet is invoked, and stores the last
+// AddSubnet request body. It lets the reconcile tests assert whether EnsureNetwork
+// adds the server subnet — and which subnet — when adopting an existing network.
 func newNetworkReconcileServer(
 	t *testing.T,
+	networkCIDR string,
 	subnetsJSON string,
 	addSubnetCalls *int32,
+	lastAddSubnetBody *atomic.Value,
 ) *httptest.Server {
 	t.Helper()
 
@@ -29,13 +33,17 @@ func newNetworkReconcileServer(
 	mux.HandleFunc("/networks", func(responseWriter http.ResponseWriter, _ *http.Request) {
 		responseWriter.Header().Set("Content-Type", "application/json")
 		_, _ = responseWriter.Write([]byte(`{"networks":[{"id":42,"name":"test-cluster-network",` +
-			`"ip_range":"10.0.0.0/16","subnets":` + subnetsJSON + `,"servers":[],"labels":{}}]}`))
+			`"ip_range":"` + networkCIDR + `","subnets":` + subnetsJSON + `,"servers":[],"labels":{}}]}`))
 	})
 
 	// AddSubnet posts an action against the network id.
 	mux.HandleFunc("/networks/42/actions/add_subnet",
-		func(responseWriter http.ResponseWriter, _ *http.Request) {
+		func(responseWriter http.ResponseWriter, request *http.Request) {
 			atomic.AddInt32(addSubnetCalls, 1)
+
+			body, _ := io.ReadAll(request.Body)
+			lastAddSubnetBody.Store(string(body))
+
 			responseWriter.Header().Set("Content-Type", "application/json")
 			_, _ = responseWriter.Write([]byte(
 				`{"action":{"id":1,"command":"add_subnet","status":"success","progress":100}}`))
@@ -54,9 +62,18 @@ func newNetworkReconcileServer(
 func TestEnsureNetwork_ReconcilesMissingSubnetOnExisting(t *testing.T) {
 	t.Parallel()
 
-	var addSubnetCalls int32
+	var (
+		addSubnetCalls    int32
+		lastAddSubnetBody atomic.Value
+	)
 
-	srv := newNetworkReconcileServer(t, `[]`, &addSubnetCalls)
+	srv := newNetworkReconcileServer(
+		t,
+		defaultNetworkCIDR,
+		`[]`,
+		&addSubnetCalls,
+		&lastAddSubnetBody,
+	)
 	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
 
 	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", defaultNetworkCIDR)
@@ -65,6 +82,8 @@ func TestEnsureNetwork_ReconcilesMissingSubnetOnExisting(t *testing.T) {
 	require.NotNil(t, network)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&addSubnetCalls),
 		"EnsureNetwork should add the missing subnet when adopting an existing subnet-less network")
+	assert.Contains(t, lastAddSubnetBody.Load(), `"ip_range":"10.0.1.0/24"`,
+		"the default network keeps its historical 10.0.1.0/24 server subnet")
 }
 
 // TestEnsureNetwork_SkipsSubnetWhenPresent proves the reconcile is idempotent:
@@ -73,10 +92,15 @@ func TestEnsureNetwork_ReconcilesMissingSubnetOnExisting(t *testing.T) {
 func TestEnsureNetwork_SkipsSubnetWhenPresent(t *testing.T) {
 	t.Parallel()
 
-	var addSubnetCalls int32
+	var (
+		addSubnetCalls    int32
+		lastAddSubnetBody atomic.Value
+	)
 
 	existingSubnet := `[{"type":"cloud","ip_range":"10.0.1.0/24","network_zone":"eu-central","gateway":"10.0.0.1"}]`
-	srv := newNetworkReconcileServer(t, existingSubnet, &addSubnetCalls)
+	srv := newNetworkReconcileServer(
+		t, defaultNetworkCIDR, existingSubnet, &addSubnetCalls, &lastAddSubnetBody,
+	)
 	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
 
 	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", defaultNetworkCIDR)
@@ -85,4 +109,76 @@ func TestEnsureNetwork_SkipsSubnetWhenPresent(t *testing.T) {
 	require.NotNil(t, network)
 	assert.Equal(t, int32(0), atomic.LoadInt32(&addSubnetCalls),
 		"EnsureNetwork should not re-add a subnet the network already carries")
+}
+
+// TestEnsureNetwork_CustomCIDRAddsFirstSlash24 proves a custom network range gets
+// the FIRST /24 of that range as its server subnet — not the whole range, which
+// would break the reconcile (a subnet equal to the network leaves no room and
+// mismatches what the comment and provisioners expect).
+func TestEnsureNetwork_CustomCIDRAddsFirstSlash24(t *testing.T) {
+	t.Parallel()
+
+	var (
+		addSubnetCalls    int32
+		lastAddSubnetBody atomic.Value
+	)
+
+	srv := newNetworkReconcileServer(t, "10.100.0.0/16", `[]`, &addSubnetCalls, &lastAddSubnetBody)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", "10.100.0.0/16")
+
+	require.NoError(t, err)
+	require.NotNil(t, network)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&addSubnetCalls))
+	assert.Contains(t, lastAddSubnetBody.Load(), `"ip_range":"10.100.0.0/24"`,
+		"a custom /16 network must get its first /24 as the server subnet, not the full range")
+}
+
+// TestEnsureNetwork_CustomCIDRSkipsWhenFirstSlash24Present proves the idempotency
+// check compares against the DERIVED /24 for custom ranges, so a network already
+// carrying its first /24 is left as-is.
+func TestEnsureNetwork_CustomCIDRSkipsWhenFirstSlash24Present(t *testing.T) {
+	t.Parallel()
+
+	var (
+		addSubnetCalls    int32
+		lastAddSubnetBody atomic.Value
+	)
+
+	existingSubnet := `[{"type":"cloud","ip_range":"10.100.0.0/24","network_zone":"eu-central","gateway":"10.100.0.1"}]`
+	srv := newNetworkReconcileServer(
+		t, "10.100.0.0/16", existingSubnet, &addSubnetCalls, &lastAddSubnetBody,
+	)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", "10.100.0.0/16")
+
+	require.NoError(t, err)
+	require.NotNil(t, network)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&addSubnetCalls),
+		"the idempotency check must match the derived first /24, not the full range")
+}
+
+// TestEnsureNetwork_CustomSlash24UsesWholeRange proves a custom range that is
+// already /24 (no room for a smaller carve-out) is used whole as the server
+// subnet.
+func TestEnsureNetwork_CustomSlash24UsesWholeRange(t *testing.T) {
+	t.Parallel()
+
+	var (
+		addSubnetCalls    int32
+		lastAddSubnetBody atomic.Value
+	)
+
+	srv := newNetworkReconcileServer(t, "10.200.5.0/24", `[]`, &addSubnetCalls, &lastAddSubnetBody)
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", "10.200.5.0/24")
+
+	require.NoError(t, err)
+	require.NotNil(t, network)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&addSubnetCalls))
+	assert.Contains(t, lastAddSubnetBody.Load(), `"ip_range":"10.200.5.0/24"`,
+		"a /24 network uses its whole range as the server subnet")
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5651

## Problem

`Provider.EnsureNetwork` returned an existing network **early** without ensuring its server subnet:

```go
if network != nil {
    return network, nil   // subnet never checked
}
// ...only the create path added the subnet
```

If a first `Create` created the network but then `AddSubnet` failed (transient hcloud error, rate limit, context cancel), a later `Create` **retry** found the existing network and returned it **subnet-less** — a partial-provisioned state that never healed (servers attach to a network with no subnet). This is shared Hetzner provider infra, so it affected **every** Hetzner provisioner (k3s, Talos, and the new kubeadm). Surfaced by CodeRabbit on #5649.

## Change

- Extract subnet handling into an idempotent `ensureSubnet` helper called by **both** the fresh-create and adopt-existing paths.
- `ensureSubnet` skips when the network already carries the expected subnet and adds it otherwise, so a retry reconciles a missing subnet.
- No behaviour change to the fresh-create path (a freshly-created network has no subnets, so the helper adds it exactly as before).

## Tests

New `infrastructure_reconcile_test.go` (httptest mock of the Hetzner API, reusing the existing `newTestHcloudClient` pattern):

- **`ReconcilesMissingSubnetOnExisting`** — network exists with `subnets: []`, so `EnsureNetwork` issues one `AddSubnet` (heals the partial state). Mutation-checked: neutering `ensureSubnet` fails this test.
- **`SkipsSubnetWhenPresent`** — network already has `10.0.1.0/24`, so **no** `AddSubnet` call (idempotent).

## Validation

`go build` / `go vet` / `gofmt` clean; full `pkg/svc/provider/hetzner` test package green; `golangci-lint run --new-from-rev=origin/main ./pkg/svc/provider/hetzner/...` reports 0 issues. Pure library change — no CLI/schema/apis/generated-surface drift.
