### PR TITLE
ci: exclude goreportcard.com badge from lychee link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -53,4 +53,8 @@ exclude_path = [
 #     from the lychee runner.
 #   - ksail.local: placeholder OIDC redirect/ingress host in chart template
 #     permutations; an unresolvable .local address, not a real link.
-exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'git\.k8s\.io', 'localhost', '127\.0\.0\.1', 'ksail\.local', 'www\.gnu\.org/licenses/gpl-3\.0']
+#   - goreportcard.com: the README Go Report Card badge/report links. The service
+#     intermittently times out for GitHub Actions runner IP ranges through all
+#     retries (took `main` CI red on 2026-07-01); the badge is decorative and the
+#     report is a stable, reachable service outside CI — not a broken link.
+exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'git\.k8s\.io', 'localhost', '127\.0\.0\.1', 'ksail\.local', 'www\.gnu\.org/licenses/gpl-3\.0', 'goreportcard\.com']


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds `goreportcard\.com` to the `lychee.toml` exclude list so the README Go Report Card badge/report links are no longer verified by the link checker.

## Why

The `main` CI went **red** on 2026-07-01 ([run 28526527477](https://github.com/devantler-tech/ksail/actions/runs/28526527477)) — the mega-linter's `lychee` step failed with:

```
[TIMEOUT] https://goreportcard.com/badge/github.com/devantler-tech/ksail/v7 | Request timed out
[TIMEOUT] https://goreportcard.com/report/github.com/devantler-tech/ksail/v7 | Request timed out
```

`goreportcard.com` intermittently times out for GitHub Actions runner IP ranges through all 3 lychee retries. The badge is **decorative** and the report is a **stable, reachable** service outside CI — the links are not broken. The transient failure was cleared by re-running the job (`main` is green again), but this prevents recurrence.

## Approach

This mirrors the **existing precedent** in the same exclude list for other stable-but-CI-flaky hosts already documented there — `siderolabs.com`, `starlight.astro.build`, and `git.k8s.io` — each excluded because it returns 500/timeout for GHA IP ranges while resolving fine outside CI. A one-line host exclude with the same documented rationale.

## Validation

- `tomllib` parse: valid TOML, 11 exclude entries.
- `lychee --config lychee.toml --dump README.md`: 27 URLs checked, **0** goreportcard (the 2 README goreportcard links are excluded); a default dump confirms the links exist in the README.
- No code / generated files touched (CI-config only).