### PR TITLE
ci: ignore flaky goreportcard.com badge links in lychee

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -32,6 +32,11 @@ https://www.siderolabs.com/
 # Intermittent Network Errors (codecov badge returns 502 occasionally)
 https://codecov.io/gh/devantler-tech/ksail/graph/badge.svg
 
+# Intermittent Network Errors (goreportcard.com badge/report time out in CI even
+# with lychee's 3 retries + 30s timeout; glob matches the README badge and its
+# report link)
+https://goreportcard.com/
+
 # Intermittent Network Errors (star-history API returns 500/timeouts in CI)
 https://api.star-history.com/
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What
The mega-linter **lychee** link-check went red on `main` (the [#5649](https://github.com/devantler-tech/ksail/pull/5649) merge-commit run) with two `[TIMEOUT]` errors on the README's Go Report Card badge and report links:

```
[TIMEOUT] https://goreportcard.com/badge/github.com/devantler-tech/ksail/v7 | Request timed out
[TIMEOUT] https://goreportcard.com/report/github.com/devantler-tech/ksail/v7 | Request timed out
```

lychee's summary shows `🚫 Errors 0, ⏳ Timeouts 2` — the "errors" are timeouts, not broken links. This happened **despite** lychee's existing `max_retries = 3` + `timeout = 30`; goreportcard.com is a perennially slow external badge service (unreachable at check time — confirmed timing out from a second network too). The failure is a false positive, unrelated to the merged code.

## Fix
Add `https://goreportcard.com/` to `.lycheeignore`, mirroring the existing entries for the same class of flaky external badges already ignored there (codecov `502`, star-history `500/timeouts`, siderolabs `500`). The glob matches both the badge and report URLs on README.md line 4.

## Validation
`lychee --config lychee.toml README.md` locally → **0 errors**, goreportcard now among the excluded links (README passed: 27 OK, 0 Errors, 11 Excluded).

## Note
This is a flaky-link CI hotfix following the repo's established `.lycheeignore` precedent — the decorative badge's target availability shouldn't gate CI. Once merged, the next `main` run's lychee check goes green.