### PR TITLE
feat(provisioner): wire Vanilla × Hetzner into the cluster factory

### DIFF
--- a/pkg/svc/provisioner/cluster/export_test.go
+++ b/pkg/svc/provisioner/cluster/export_test.go
@@ -16,3 +16,8 @@ func ExportApplyK3dNodeCounts(config *k3dv1alpha5.SimpleConfig, controlPlanes, w
 func ExportWriteK3dConfigToTempFile(config *k3dv1alpha5.SimpleConfig) (string, error) {
 	return writeK3dConfigToTempFile(config)
 }
+
+// ExportKubeadmInstallVersion exposes kubeadmInstallVersion for testing.
+func ExportKubeadmInstallVersion() string {
+	return kubeadmInstallVersion()
+}

--- a/pkg/svc/provisioner/cluster/factory_kind.go
+++ b/pkg/svc/provisioner/cluster/factory_kind.go
@@ -2,17 +2,29 @@ package clusterprovisioner
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	kindconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/kind"
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
 	kindprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kind"
+	kubeadmhetznerprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 )
 
 func (f DefaultFactory) createKindProvisioner(
 	cluster *v1alpha1.Cluster,
 ) (Provisioner, any, error) {
+	// Hetzner provider: native kubeadm (upstream Kubernetes) on Hetzner Cloud
+	// servers — the Vanilla distribution's server implementation, mirroring the
+	// k3s × Hetzner path. The Vanilla × Hetzner combination stays unselectable
+	// until the validation flip (#5514), so this path is gated; see the
+	// kubeadmhetzner package. It needs no Kind config, so it dispatches before the
+	// Kind-config requirement below.
+	if cluster.Spec.Cluster.Provider == v1alpha1.ProviderHetzner {
+		return createKubeadmHetznerProvisioner(cluster)
+	}
+
 	if f.DistributionConfig.Kind == nil {
 		return nil, nil, fmt.Errorf(
 			"kind config is required for Vanilla distribution: %w",
@@ -74,6 +86,53 @@ func (f DefaultFactory) createKindProvisioner(
 	}
 
 	return provisioner, kindConfig, nil
+}
+
+// createKubeadmHetznerProvisioner creates a native-kubeadm-on-Hetzner provisioner —
+// the Vanilla distribution's Hetzner (server) implementation. It resolves the node
+// counts from the cluster spec and the Kubernetes release from the Vanilla default
+// (see kubeadmInstallVersion), then builds the provisioner, which constructs the
+// Hetzner provider from the cluster's Hetzner options. It is the kubeadm sibling of
+// createK3sHetznerProvisioner.
+func createKubeadmHetznerProvisioner(cluster *v1alpha1.Cluster) (Provisioner, any, error) {
+	controlPlanes := int(cluster.Spec.Cluster.ControlPlanes)
+	if controlPlanes <= 0 {
+		controlPlanes = 1
+	}
+
+	provisioner, err := kubeadmhetznerprovisioner.NewProvisioner(
+		cluster.Name,
+		kubeadmInstallVersion(),
+		controlPlanes,
+		int(cluster.Spec.Cluster.Workers),
+		cluster.Spec.Provider.Hetzner,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create kubeadm Hetzner provisioner: %w", err)
+	}
+
+	return provisioner, nil, nil
+}
+
+// kubeadmInstallVersion returns the default Kubernetes release the kubeadm × Hetzner
+// nodes install, in the "vMAJOR.MINOR.PATCH" form kubeadm's package-repository
+// selection requires. The Vanilla distribution's Kubernetes version is defined by the
+// Dependabot-tracked Kind node image (kindconfigmanager.DefaultKindNodeImage, e.g.
+// "kindest/node:v1.36.1@sha256:..."); the kubeadm × Hetzner path installs the same
+// release so a Vanilla cluster runs the same Kubernetes version whether it lands on
+// Docker (Kind) or Hetzner (kubeadm). It is the kubeadm sibling of k3sInstallVersion.
+func kubeadmInstallVersion() string {
+	image := kindconfigmanager.DefaultKindNodeImage
+	// Strip an optional "@sha256:..." digest, then take the tag after the final ":".
+	if at := strings.IndexByte(image, '@'); at != -1 {
+		image = image[:at]
+	}
+
+	if colon := strings.LastIndexByte(image, ':'); colon != -1 {
+		return image[colon+1:]
+	}
+
+	return image
 }
 
 // createKindKubernetesProvisioner creates a Kind provisioner that runs inside

--- a/pkg/svc/provisioner/cluster/factory_kind_test.go
+++ b/pkg/svc/provisioner/cluster/factory_kind_test.go
@@ -1,0 +1,62 @@
+package clusterprovisioner_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	kindconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/kind"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	kubeadmhetznerprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateProvisioner_VanillaHetzner verifies the factory dispatches the Vanilla ×
+// Hetzner combination to the kubeadm-on-Hetzner provisioner without a Kind config:
+// the DistributionConfig struct is present (Create requires it) but its Kind field is
+// nil, so the Hetzner dispatch must resolve before the Kind-config requirement — the
+// same shape the k3s × Hetzner path relies on. Cannot run in parallel: it sets
+// HCLOUD_TOKEN so the provisioner's Hetzner provider construction succeeds.
+func TestCreateProvisioner_VanillaHetzner(t *testing.T) {
+	t.Setenv("HCLOUD_TOKEN", "dummy-token")
+
+	factory := clusterprovisioner.DefaultFactory{
+		DistributionConfig: &clusterprovisioner.DistributionConfig{},
+	}
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution:  v1alpha1.DistributionVanilla,
+				Provider:      v1alpha1.ProviderHetzner,
+				ControlPlanes: 1,
+			},
+		},
+	}
+
+	provisioner, distributionConfig, err := factory.Create(context.Background(), cluster)
+
+	require.NoError(t, err)
+	require.NotNil(t, provisioner)
+	assert.IsType(t, &kubeadmhetznerprovisioner.Provisioner{}, provisioner)
+	// The Hetzner path returns no distribution config (unlike the Docker/Kind path).
+	assert.Nil(t, distributionConfig)
+}
+
+// TestKubeadmInstallVersion verifies the kubeadm install version is derived from the
+// Vanilla distribution's Kind node image: a bare "vMAJOR.MINOR[.PATCH]" tag with the
+// image digest and repository path stripped, matching the tag kubeadm requires to
+// select the community package repository.
+func TestKubeadmInstallVersion(t *testing.T) {
+	t.Parallel()
+
+	version := clusterprovisioner.ExportKubeadmInstallVersion()
+
+	require.NotEmpty(t, version)
+	assert.Regexp(t, `^v[0-9]+\.[0-9]+(\.[0-9]+)?$`, version,
+		"want a bare v-prefixed version with the digest stripped, got %q", version)
+	// The version tracks the Kind node image tag exactly, so a Vanilla cluster runs
+	// the same Kubernetes release on Docker (Kind) and Hetzner (kubeadm).
+	assert.Contains(t, kindconfigmanager.DefaultKindNodeImage, version,
+		"version must be a substring of the Kind node image")
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5658. Part of #5513, epic #3983 / #4627.

## What
Wires the merged kubeadm-on-Hetzner provisioner (#5649) + `DeriveServerSpecs` (#5647) into the cluster-provisioner factory so `--distribution Vanilla --provider Hetzner` selects it — the last piece before the Vanilla × Hetzner path is end-to-end functional. This mirrors the existing **K3s × Hetzner** wiring (`createK3sHetznerProvisioner` in `factory_k3d.go`).

## How
- **Dispatch** (`factory_kind.go`): `createKindProvisioner` now routes `Provider == ProviderHetzner` to a new package-level `createKubeadmHetznerProvisioner`, **before** the Kind-config requirement — the Hetzner (server) path needs no `kind.yaml`, exactly as the K3d factory dispatches Hetzner before its `k3d.yaml` check.
- **Version source** (`kubeadmInstallVersion`): the Kubernetes release is derived from the Vanilla distribution's Dependabot-tracked Kind node image (`kindconfigmanager.DefaultKindNodeImage`, e.g. `kindest/node:v1.36.1@sha256:…`), digest stripped to the bare `vMAJOR.MINOR.PATCH` tag kubeadm's package-repository selection requires. So a Vanilla cluster runs the **same Kubernetes version** whether it lands on Docker (Kind) or Hetzner (kubeadm) — the kubeadm sibling of `k3sInstallVersion`.
- **Gating unchanged**: no `supportedProviders` change. Vanilla × Hetzner stays **unselectable via validation** until the flip (#5514, "lands last"); the code path is reachable but gated, exactly as K3s × Hetzner is today.

## Tests
- `TestCreateProvisioner_VanillaHetzner`: the factory dispatches Vanilla × Hetzner to `*kubeadmhetzner.Provisioner` with no Kind config (a non-nil `DistributionConfig` with a nil `Kind`, the shape the Hetzner path relies on).
- `TestKubeadmInstallVersion`: the version is a bare `vMAJOR.MINOR[.PATCH]` tag (digest/path stripped) and a substring of the Kind node image.

## Validation
`gofmt` clean · `go build`/`go vet` clean · `go test ./pkg/svc/provisioner/cluster/` = 56 pass · `golangci-lint run --new-from-rev=origin/main` = 0 new issues · no generated-surface drift (pure factory wiring; no apis/CLI/schema changes).

## Note
Draft for your review before promotion. Once the K3s and/or Vanilla × Hetzner paths are validated end-to-end (and the live-bring-up boundary #5515 lands), #5514 flips `supportedProviders` to make the combos selectable.