### PR TITLE
feat(validate): attribute rendered validation failures to their HelmRelease layer

### DIFF
--- a/pkg/cli/cmd/workload/export_test.go
+++ b/pkg/cli/cmd/workload/export_test.go
@@ -30,6 +30,11 @@ var (
 	ExportTypedPlaceholderValue   = fluxsubst.TypedPlaceholderValue   //nolint:gochecknoglobals // test export
 )
 
+// ExportAttributionFromDocuments exposes attributionFromDocuments so external-package
+// tests can assert the render-provenance→failure-attribution mapping (layer tagging,
+// stream-origin skipping, and ambiguous-identity dropping) without a full render run.
+var ExportAttributionFromDocuments = attributionFromDocuments //nolint:gochecknoglobals // test export
+
 // ExportDebounceState is an exported type alias for the workloadwatch debounce
 // state. The debounce/poll machinery moved to pkg/svc/workloadwatch; the shims
 // below delegate to its exported API so existing command-package tests keep

--- a/pkg/cli/cmd/workload/validate.go
+++ b/pkg/cli/cmd/workload/validate.go
@@ -19,6 +19,7 @@ import (
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/fluxsubst"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/gitops/render"
 	"github.com/spf13/cobra"
 	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
 )
@@ -646,12 +647,28 @@ func (v *kustomizationValidator) validate(ctx context.Context, kustDir string) e
 // it without output (for parallel execution). The kustomize build error is
 // returned unwrapped so simplifyBuildError can strip its verbose prefix.
 func (v *kustomizationValidator) validateSilent(ctx context.Context, kustDir string) error {
-	data, err := v.manifests(ctx, kustDir)
+	data, attribution, err := v.manifests(ctx, kustDir)
 	if err != nil {
 		return err
 	}
 
-	err = v.kubeconform.ValidateBytes(ctx, kustDir, data, v.opts)
+	// Attach per-call attribution without mutating the shared v.opts, which
+	// validate fans out concurrently across kustomizations (see the -race guard
+	// TestValidateRendersConcurrentlyNoRace). A shallow copy is enough: the other
+	// fields are read-only during validation.
+	opts := v.opts
+
+	if attribution != nil {
+		clone := kubeconform.ValidationOptions{}
+		if v.opts != nil {
+			clone = *v.opts
+		}
+
+		clone.Attribution = attribution
+		opts = &clone
+	}
+
+	err = v.kubeconform.ValidateBytes(ctx, kustDir, data, opts)
 	if err != nil {
 		return fmt.Errorf("validate manifests: %w", err)
 	}
@@ -659,26 +676,91 @@ func (v *kustomizationValidator) validateSilent(ctx context.Context, kustDir str
 	return nil
 }
 
-// manifests returns the validation input: the Helm-rendered output when
-// rendering is enabled, otherwise the Flux-substituted kustomize build output.
-func (v *kustomizationValidator) manifests(ctx context.Context, kustDir string) ([]byte, error) {
+// manifests returns the validation input — the Helm-rendered output when rendering
+// is enabled, otherwise the Flux-substituted kustomize build output — together with
+// a resource-identity→source attribution map derived from the render provenance
+// (nil when rendering is disabled or nothing is attributable).
+func (v *kustomizationValidator) manifests(
+	ctx context.Context,
+	kustDir string,
+) ([]byte, map[string]string, error) {
 	if v.renderer != nil {
 		result, err := v.renderer.expand(ctx, kustDir)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		v.sink.add(result.Degradations)
 
-		return result.Bytes(), nil
+		return result.Bytes(), attributionFromDocuments(result.Documents), nil
 	}
 
 	output, err := v.kustomize.Build(ctx, kustDir)
 	if err != nil {
-		return nil, err //nolint:wrapcheck // unwrapped so simplifyBuildError strips the kustomize prefix
+		return nil, nil, err //nolint:wrapcheck // unwrapped so simplifyBuildError strips the kustomize prefix
 	}
 
-	return fluxsubst.ExpandFluxSubstitutions(output.Bytes()), nil
+	return fluxsubst.ExpandFluxSubstitutions(output.Bytes()), nil, nil
+}
+
+// attributionFromDocuments maps each rendered document's identity to a source
+// descriptor ("HelmRelease <namespace>/<name>") so kubeconform validation failures
+// can be traced to the originating HelmRelease layer. Documents that came verbatim
+// from the input stream (OriginStream) carry no source and are omitted. When two
+// distinct sources render the same identity the attribution is ambiguous, so that
+// identity is dropped rather than mis-attributed. Returns nil when nothing is
+// attributable, which leaves failure messages unchanged downstream.
+func attributionFromDocuments(docs []render.Document) map[string]string {
+	sources := make(map[string]string, len(docs))
+	ambiguous := make(map[string]struct{})
+
+	for _, doc := range docs {
+		if doc.Provenance.Origin != render.OriginRendered ||
+			doc.Provenance.SourceHelmRelease == "" {
+			continue
+		}
+
+		identity := documentIdentity(doc)
+		if identity == "" {
+			continue
+		}
+
+		source := "HelmRelease " + doc.Provenance.SourceHelmRelease
+		if existing, ok := sources[identity]; ok && existing != source {
+			ambiguous[identity] = struct{}{}
+
+			continue
+		}
+
+		sources[identity] = source
+	}
+
+	for identity := range ambiguous {
+		delete(sources, identity)
+	}
+
+	if len(sources) == 0 {
+		return nil
+	}
+
+	return sources
+}
+
+// documentIdentity builds the "Kind/Namespace/Name" (or "Kind/Name" for cluster-scoped
+// resources) key used to match a rendered document against the resource identity
+// kubeconform reports for a validation failure. It returns "" when the document lacks a
+// Kind or Name, mirroring the kubeconform formatter's fallback so unkeyable documents
+// are simply left unattributed.
+func documentIdentity(doc render.Document) string {
+	if doc.Kind == "" || doc.Name == "" {
+		return ""
+	}
+
+	if doc.Namespace != "" {
+		return doc.Kind + "/" + doc.Namespace + "/" + doc.Name
+	}
+
+	return doc.Kind + "/" + doc.Name
 }
 
 // validateFileSilent validates a single YAML file without output (for parallel execution).

--- a/pkg/cli/cmd/workload/validate_attribution_test.go
+++ b/pkg/cli/cmd/workload/validate_attribution_test.go
@@ -1,0 +1,132 @@
+package workload_test
+
+import (
+	"testing"
+
+	workload "github.com/devantler-tech/ksail/v7/pkg/cli/cmd/workload"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/gitops/render"
+	"github.com/stretchr/testify/assert"
+)
+
+// attributionCase is a single attributionFromDocuments table entry.
+type attributionCase struct {
+	name string
+	docs []render.Document
+	want map[string]string
+}
+
+// renderedDoc builds a rendered (OriginRendered) document attributed to the given
+// HelmRelease source ("namespace/name"), the case attributionFromDocuments maps.
+func renderedDoc(kind, namespace, name, source string) render.Document {
+	return render.Document{
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+		Provenance: render.Provenance{
+			Origin:            render.OriginRendered,
+			SourceHelmRelease: source,
+		},
+	}
+}
+
+// runAttributionCases asserts attributionFromDocuments over a table of cases.
+func runAttributionCases(t *testing.T, tests []attributionCase) {
+	t.Helper()
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := workload.ExportAttributionFromDocuments(testCase.docs)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+// TestAttributionFromDocumentsMapping covers how documents are keyed and tagged:
+// rendered docs get a Kind/Namespace/Name (or Kind/Name) key with their HelmRelease
+// source, stream-origin and source-less docs are skipped, and identity-less docs are
+// dropped.
+func TestAttributionFromDocumentsMapping(t *testing.T) {
+	t.Parallel()
+
+	runAttributionCases(t, []attributionCase{
+		{
+			name: "namespaced rendered doc is tagged with its HelmRelease",
+			docs: []render.Document{
+				renderedDoc("ConfigMap", "default", "app-bad", "flux-system/app"),
+			},
+			want: map[string]string{"ConfigMap/default/app-bad": "HelmRelease flux-system/app"},
+		},
+		{
+			name: "cluster-scoped rendered doc keys on Kind/Name",
+			docs: []render.Document{
+				renderedDoc("ClusterRole", "", "viewer", "flux-system/rbac"),
+			},
+			want: map[string]string{"ClusterRole/viewer": "HelmRelease flux-system/rbac"},
+		},
+		{
+			name: "stream-origin docs are not attributed",
+			docs: []render.Document{
+				{Kind: "OCIRepository", Namespace: "flux-system", Name: "chart"},
+			},
+			want: nil,
+		},
+		{
+			name: "rendered doc without a HelmRelease source is skipped",
+			docs: []render.Document{
+				{
+					Kind:       "ConfigMap",
+					Namespace:  "default",
+					Name:       "loose",
+					Provenance: render.Provenance{Origin: render.OriginRendered},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "docs missing a kind or name are dropped",
+			docs: []render.Document{
+				renderedDoc("", "default", "noKind", "flux-system/app"),
+				renderedDoc("ConfigMap", "default", "", "flux-system/app"),
+			},
+			want: nil,
+		},
+	})
+}
+
+// TestAttributionFromDocumentsAmbiguity covers duplicate-identity handling: the same
+// identity from one source is kept once, but an identity produced by two different
+// sources is dropped as ambiguous rather than mis-attributed (while distinct identities
+// survive).
+func TestAttributionFromDocumentsAmbiguity(t *testing.T) {
+	t.Parallel()
+
+	runAttributionCases(t, []attributionCase{
+		{
+			name: "same identity from one source is kept once",
+			docs: []render.Document{
+				renderedDoc("ConfigMap", "default", "dup", "flux-system/app"),
+				renderedDoc("ConfigMap", "default", "dup", "flux-system/app"),
+			},
+			want: map[string]string{"ConfigMap/default/dup": "HelmRelease flux-system/app"},
+		},
+		{
+			name: "same identity from two sources is dropped as ambiguous",
+			docs: []render.Document{
+				renderedDoc("ConfigMap", "default", "clash", "flux-system/app-a"),
+				renderedDoc("ConfigMap", "default", "clash", "flux-system/app-b"),
+			},
+			want: nil,
+		},
+		{
+			name: "ambiguous identity is dropped while distinct ones are kept",
+			docs: []render.Document{
+				renderedDoc("ConfigMap", "default", "clash", "flux-system/app-a"),
+				renderedDoc("ConfigMap", "default", "clash", "flux-system/app-b"),
+				renderedDoc("Deployment", "web", "site", "flux-system/site"),
+			},
+			want: map[string]string{"Deployment/web/site": "HelmRelease flux-system/site"},
+		},
+	})
+}

--- a/pkg/cli/cmd/workload/validate_render_test.go
+++ b/pkg/cli/cmd/workload/validate_render_test.go
@@ -106,7 +106,8 @@ func TestValidateRendersHelmReleaseFromLocalChart(t *testing.T) {
 
 // TestValidateCatchesInvalidRenderedManifest verifies that a HelmRelease whose
 // chart renders a schema-invalid manifest fails validation — the headline of
-// #5344. The HelmRelease CR itself is valid; only the rendered output is not.
+// #5344 — and that the failure is attributed back to the originating HelmRelease
+// layer (from the render provenance) so a multi-layer render points at the source.
 func TestValidateCatchesInvalidRenderedManifest(t *testing.T) {
 	t.Parallel()
 
@@ -114,6 +115,14 @@ func TestValidateCatchesInvalidRenderedManifest(t *testing.T) {
 
 	_, err := runValidate(t, dir, "--skip-kinds", "OCIRepository")
 	require.Error(t, err, "rendered invalid chart output should fail validation")
+	// The invalid ConfigMap is rendered from the HelmRelease flux-system/app, so the
+	// failure carries its source layer (SourceHelmRelease is "namespace/name").
+	assert.ErrorContains(
+		t,
+		err,
+		"(from HelmRelease flux-system/app)",
+		"a rendered failure should be attributed to its HelmRelease layer",
+	)
 }
 
 // TestValidateSkipHelmRenderValidatesCRAsIs verifies --skip-helm-render disables

--- a/pkg/client/kubeconform/client.go
+++ b/pkg/client/kubeconform/client.go
@@ -126,7 +126,7 @@ func (c *Client) validateData(
 	return c.validateWithRetry(ctx, func() error {
 		results := kubeValidator.Validate(sourceName, io.NopCloser(bytes.NewReader(data)))
 
-		return c.processResults(results)
+		return c.processResults(results, opts.Attribution)
 	})
 }
 
@@ -157,12 +157,14 @@ func (c *Client) validateWithRetry(ctx context.Context, validate func() error) e
 // that, when validating a stream of many manifests (e.g. a whole Kustomize + Helm render),
 // the message points at the offending resource instead of surfacing a bare schema error.
 // The caller is responsible for including any file/source context in the wrapping error.
-func (c *Client) processResults(results []validator.Result) error {
+// attribution optionally maps a resource identity to a source descriptor so a failure
+// can be traced to the layer that produced it (see formatFailure); a nil map is fine.
+func (c *Client) processResults(results []validator.Result, attribution map[string]string) error {
 	var errDetails []string
 
 	for _, res := range results {
 		if res.Status == validator.Invalid || res.Status == validator.Error {
-			errDetails = append(errDetails, formatFailure(res))
+			errDetails = append(errDetails, formatFailure(res, attribution))
 		}
 	}
 
@@ -175,16 +177,25 @@ func (c *Client) processResults(results []validator.Result) error {
 
 // formatFailure renders a single failing result as "<identity>: <detail>", falling
 // back to just the detail when the resource signature is unavailable (e.g. a document
-// missing apiVersion/kind). Preserving the original detail keeps existing error
-// substrings intact for callers that match on them.
-func formatFailure(res validator.Result) string {
+// missing apiVersion/kind). When attribution carries an entry for the resource's
+// identity, its source descriptor is appended as " (from <source>)" so a failure in a
+// multi-layer render is traced to the layer that produced it. Preserving the original
+// detail keeps existing error substrings intact for callers that match on them.
+func formatFailure(res validator.Result, attribution map[string]string) string {
 	detail := fmt.Sprintf("%v", res.Err)
 
-	if identity := resourceIdentity(res); identity != "" {
-		return identity + ": " + detail
+	identity := resourceIdentity(res)
+	if identity == "" {
+		return detail
 	}
 
-	return detail
+	message := identity + ": " + detail
+
+	if source := attribution[identity]; source != "" {
+		message += " (from " + source + ")"
+	}
+
+	return message
 }
 
 // resourceIdentity returns a "<Kind>/<Namespace>/<Name>" (or "<Kind>/<Name>" for
@@ -216,6 +227,13 @@ type ValidationOptions struct {
 	Strict bool
 	// IgnoreMissingSchemas ignores resources with missing schemas.
 	IgnoreMissingSchemas bool
+	// Attribution optionally maps a resource identity ("Kind/Namespace/Name", or
+	// "Kind/Name" for cluster-scoped resources) to a human-readable source descriptor
+	// (e.g. "HelmRelease flux-system/app"). When a failing resource's identity is
+	// present, its source is appended to the failure message so a validation error in
+	// a multi-layer render points at the originating layer. A nil map (the default)
+	// disables attribution and leaves failure messages unchanged.
+	Attribution map[string]string
 }
 
 // createValidator creates a kubeconform validator with the given options.

--- a/pkg/client/kubeconform/format_test.go
+++ b/pkg/client/kubeconform/format_test.go
@@ -15,14 +15,17 @@ var errBoom = errors.New("boom")
 
 // TestFormatFailure exercises each identity branch of the failure formatter:
 // a namespaced resource (Kind/Namespace/Name), a cluster-scoped resource
-// (Kind/Name), and a document with no usable signature (detail only).
+// (Kind/Name), and a document with no usable signature (detail only); plus the
+// attribution branches that append " (from <source>)" when the resource's identity
+// is present in the attribution map (and leave the message unchanged otherwise).
 func TestFormatFailure(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		bytes string
-		want  string
+		name        string
+		bytes       string
+		attribution map[string]string
+		want        string
 	}{
 		{
 			name: "namespaced resource is prefixed with Kind/Namespace/Name",
@@ -51,6 +54,39 @@ metadata:
 `,
 			want: "boom",
 		},
+		{
+			name: "matching attribution appends the source layer",
+			bytes: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web
+  namespace: apps
+`,
+			attribution: map[string]string{"ConfigMap/apps/web": "HelmRelease flux-system/app"},
+			want:        "ConfigMap/apps/web: boom (from HelmRelease flux-system/app)",
+		},
+		{
+			name: "attribution for a different resource is not applied",
+			bytes: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web
+  namespace: apps
+`,
+			attribution: map[string]string{
+				"ConfigMap/other/thing": "HelmRelease flux-system/other",
+			},
+			want: "ConfigMap/apps/web: boom",
+		},
+		{
+			name: "attribution is not applied to a resource without a usable signature",
+			bytes: `apiVersion: v1
+metadata:
+  name: orphan
+`,
+			attribution: map[string]string{"ConfigMap/apps/web": "HelmRelease flux-system/app"},
+			want:        "boom",
+		},
 	}
 
 	for _, testCase := range tests {
@@ -63,7 +99,7 @@ metadata:
 				Status:   validator.Error,
 			}
 
-			got := kubeconform.FormatFailure(res)
+			got := kubeconform.FormatFailure(res, testCase.attribution)
 			if got != testCase.want {
 				t.Fatalf("FormatFailure() = %q, want %q", got, testCase.want)
 			}

--- a/pkg/client/kubeconform/format_test.go
+++ b/pkg/client/kubeconform/format_test.go
@@ -13,20 +13,43 @@ import (
 // (err113 requires a static error value rather than an inline errors.New).
 var errBoom = errors.New("boom")
 
-// TestFormatFailure exercises each identity branch of the failure formatter:
-// a namespaced resource (Kind/Namespace/Name), a cluster-scoped resource
-// (Kind/Name), and a document with no usable signature (detail only); plus the
-// attribution branches that append " (from <source>)" when the resource's identity
-// is present in the attribution map (and leave the message unchanged otherwise).
-func TestFormatFailure(t *testing.T) {
+// formatCase is a single FormatFailure table entry.
+type formatCase struct {
+	name        string
+	bytes       string
+	attribution map[string]string
+	want        string
+}
+
+// runFormatCases asserts FormatFailure over a table of cases.
+func runFormatCases(t *testing.T, tests []formatCase) {
+	t.Helper()
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := validator.Result{
+				Resource: resource.Resource{Bytes: []byte(testCase.bytes)},
+				Err:      errBoom,
+				Status:   validator.Error,
+			}
+
+			got := kubeconform.FormatFailure(res, testCase.attribution)
+			if got != testCase.want {
+				t.Fatalf("FormatFailure() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestFormatFailureIdentity exercises each identity branch of the failure formatter
+// with no attribution: a namespaced resource (Kind/Namespace/Name), a cluster-scoped
+// resource (Kind/Name), and a document with no usable signature (detail only).
+func TestFormatFailureIdentity(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		bytes       string
-		attribution map[string]string
-		want        string
-	}{
+	runFormatCases(t, []formatCase{
 		{
 			name: "namespaced resource is prefixed with Kind/Namespace/Name",
 			bytes: `apiVersion: v1
@@ -54,6 +77,17 @@ metadata:
 `,
 			want: "boom",
 		},
+	})
+}
+
+// TestFormatFailureAttribution exercises the attribution branch that appends
+// " (from <source>)" when the resource's identity is present in the attribution map,
+// and leaves the message unchanged when the map targets a different resource or the
+// resource carries no usable signature.
+func TestFormatFailureAttribution(t *testing.T) {
+	t.Parallel()
+
+	runFormatCases(t, []formatCase{
 		{
 			name: "matching attribution appends the source layer",
 			bytes: `apiVersion: v1
@@ -87,22 +121,5 @@ metadata:
 			attribution: map[string]string{"ConfigMap/apps/web": "HelmRelease flux-system/app"},
 			want:        "boom",
 		},
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			res := validator.Result{
-				Resource: resource.Resource{Bytes: []byte(testCase.bytes)},
-				Err:      errBoom,
-				Status:   validator.Error,
-			}
-
-			got := kubeconform.FormatFailure(res, testCase.attribution)
-			if got != testCase.want {
-				t.Fatalf("FormatFailure() = %q, want %q", got, testCase.want)
-			}
-		})
-	}
+	})
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5663, Part of #5344.

## What

When `ksail workload validate`/`workload scan` renders GitOps layers in-process and a rendered resource fails kubeconform, the failure now names the **HelmRelease that produced it**:

```
ConfigMap/default/app-bad: ... (from HelmRelease flux-system/app)
```

This builds on #5619 (which named the failing *resource*) by adding the missing *layer* attribution — the next per-layer-attribution increment under roadmap #5344.

## How

The render pipeline already attaches `Provenance{Origin, SourceHelmRelease, ReleaseName}` to every `render.Document`, but `Result.Bytes()` flattens it away before kubeconform runs. This PR reconnects the two:

- **`pkg/cli/cmd/workload/validate.go`** — `attributionFromDocuments` builds an identity→source map (`Kind/Namespace/Name`, or `Kind/Name` for cluster-scoped → `HelmRelease <ns>/<name>`) from the `OriginRendered` documents. `manifests()` returns it alongside the bytes; `validateSilent` attaches it via a **per-call clone** of the validation options, so the concurrent per-kustomization fan-out never mutates shared state (guarded by the existing `-race` test).
- **`pkg/client/kubeconform/client.go`** — a new optional `ValidationOptions.Attribution map[string]string` threads into `processResults`/`formatFailure`, which appends ` (from <source>)` when the failing resource's identity is present. The client stays **decoupled from `render`** (plain string map, no new import). A nil map (single-file validation, non-render path) leaves #5619's message format byte-for-byte unchanged.

**Ambiguity is handled, not papered over:** if two HelmReleases render the same `Kind/Namespace/Name`, that identity is dropped from the map so a failure is never mis-attributed. Documents missing a Kind/Name are left unattributed, mirroring the formatter's existing fallback.

## Tests

- `TestFormatFailure` — extended with attribution branches (matching source appended; non-matching/absent source unchanged; no-signature resource never tagged).
- `TestAttributionFromDocumentsMapping` / `…Ambiguity` — the map builder: tagging, stream-origin skip, source-less/identity-less drop, dedup, and ambiguous-drop-while-distinct-kept.
- `TestValidateCatchesInvalidRenderedManifest` — end-to-end render→validate now asserts the error carries `(from HelmRelease flux-system/app)`.

## Validation

`go build`, `go vet`, `gofmt`, full `pkg/client/kubeconform` + `pkg/cli/cmd/workload` tests under `-race`, and `golangci-lint run --new-from-rev=origin/main` (**0 new issues**) all pass. No CLI/flag/help surface change → no generated-file regeneration needed.