### PR TITLE
perf(render): cache resolved chart renders across kustomizations

### DIFF
--- a/pkg/cli/cmd/workload/render.go
+++ b/pkg/cli/cmd/workload/render.go
@@ -23,14 +23,21 @@ const renderedManifestPerm = 0o600
 // actually applies: Kustomize build, Flux variable substitution, then in-process
 // Helm rendering of HelmReleases. It is shared by the validate and scan commands.
 type gitopsRenderer struct {
-	kustomize *kustomize.Client
+	kustomize  *kustomize.Client
+	chartCache *render.ChartCache
 }
 
 // newGitOpsRenderer constructs a renderer. The kustomize client is stateless and
 // safe to share across goroutines; the Helm template client is created per
-// kustomization in expand (see below).
+// kustomization in expand (see below). The chart cache is created once here so a
+// chart referenced by several kustomizations in this run is templated once; it
+// is scoped to this renderer (one run) so a floating chart version can't go
+// stale across runs.
 func newGitOpsRenderer() *gitopsRenderer {
-	return &gitopsRenderer{kustomize: kustomize.NewClient()}
+	return &gitopsRenderer{
+		kustomize:  kustomize.NewClient(),
+		chartCache: render.NewChartCache(),
+	}
 }
 
 // expand builds, substitutes, and Helm-renders one kustomization directory. The
@@ -55,7 +62,10 @@ func (g *gitopsRenderer) expand(ctx context.Context, kustDir string) (render.Res
 	expanded := fluxsubst.ExpandFluxSubstitutions(output.Bytes())
 
 	result, err := render.Expand(ctx, expanded, render.Options{
-		Resolver: render.NewHelmChartResolver(helmClient),
+		Resolver: render.NewHelmChartResolver(
+			helmClient,
+			render.WithChartCache(g.chartCache),
+		),
 	})
 	if err != nil {
 		return render.Result{}, fmt.Errorf("expand HelmReleases: %w", err)

--- a/pkg/svc/gitops/render/cache.go
+++ b/pkg/svc/gitops/render/cache.go
@@ -1,0 +1,60 @@
+package render
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+)
+
+// ChartCache memoizes rendered Helm chart manifests by their resolved chart
+// spec, so a chart referenced by multiple kustomizations in one validate/scan
+// run is templated only once. It is safe for concurrent use.
+//
+// Scope it to a single run (create one per gitopsRenderer): the render output
+// is fully determined by the spec key, but a HelmRelease pinned to a floating
+// chart version could resolve to a different chart between runs, so a cache
+// must not outlive the run it was populated in.
+type ChartCache struct {
+	mu      sync.Mutex
+	entries map[string]string
+}
+
+// NewChartCache returns an empty, ready-to-use ChartCache.
+func NewChartCache() *ChartCache {
+	return &ChartCache{entries: make(map[string]string)}
+}
+
+// get returns the cached manifest for spec, if present.
+func (c *ChartCache) get(spec *helm.ChartSpec) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	manifest, ok := c.entries[chartCacheKey(spec)]
+
+	return manifest, ok
+}
+
+// put stores the rendered manifest for spec.
+func (c *ChartCache) put(spec *helm.ChartSpec, manifest string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[chartCacheKey(spec)] = manifest
+}
+
+// chartCacheKey builds a deterministic, collision-free key from the only fields
+// buildChartSpec populates that affect the rendered output. The NUL separator
+// cannot appear in a chart reference, release name, namespace, or valid YAML,
+// so the join is unambiguous. Keep this in sync with buildChartSpec: a new
+// output-affecting field there must be added here.
+func chartCacheKey(spec *helm.ChartSpec) string {
+	return strings.Join([]string{
+		spec.ChartName,
+		spec.RepoURL,
+		spec.Version,
+		spec.ReleaseName,
+		spec.Namespace,
+		spec.ValuesYaml,
+	}, "\x00")
+}

--- a/pkg/svc/gitops/render/cache_test.go
+++ b/pkg/svc/gitops/render/cache_test.go
@@ -141,13 +141,19 @@ func TestResolverChartCacheConcurrentSingleRender(t *testing.T) {
 
 	var waitGroup sync.WaitGroup
 
+	// Each goroutine writes its own slot, so no synchronization is needed to
+	// collect the results; every caller must observe the single cached manifest.
+	manifests := make([]string, goroutines)
+	errs := make([]error, goroutines)
+
 	waitGroup.Add(goroutines)
 
-	for range goroutines {
+	for index := range goroutines {
 		go func() {
 			defer waitGroup.Done()
 
-			_, _ = render.NewHelmChartResolver(client, render.WithChartCache(cache)).
+			manifests[index], errs[index] = render.
+				NewHelmChartResolver(client, render.WithChartCache(cache)).
 				Render(context.Background(), chartRefRelease(), source)
 		}()
 	}
@@ -156,16 +162,28 @@ func TestResolverChartCacheConcurrentSingleRender(t *testing.T) {
 
 	assert.Equal(t, int64(1), client.calls.Load(),
 		"concurrent identical renders must collapse to one TemplateChart call")
+
+	for index := range goroutines {
+		require.NoErrorf(t, errs[index], "goroutine %d must not error", index)
+		assert.Equalf(t, "render-1", manifests[index],
+			"goroutine %d must observe the single cached manifest", index)
+	}
 }
 
 // BenchmarkResolverChartCacheHit measures the cache-hit path (key build + map
-// lookup) that replaces a full chart template on a repeat render. The first
-// iteration primes the cache; the rest are hits.
+// lookup) that replaces a full chart template on a repeat render. The cache is
+// primed before the timer resets, so every measured iteration is a hit.
 func BenchmarkResolverChartCacheHit(b *testing.B) {
 	client := &countingClient{}
 	resolver := render.NewHelmChartResolver(client, render.WithChartCache(render.NewChartCache()))
 	source := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
 	release := chartRefRelease()
+
+	// Prime the cache so the timed loop measures only cache hits.
+	_, err := resolver.Render(context.Background(), release, source)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/svc/gitops/render/cache_test.go
+++ b/pkg/svc/gitops/render/cache_test.go
@@ -1,0 +1,179 @@
+package render_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/gitops/render"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// countingClient embeds helm.Interface and returns a distinct manifest per
+// TemplateChart call ("render-1", "render-2", …) so a test can prove a cache hit
+// returned the first render rather than re-templating. It counts calls
+// atomically so it is safe under the concurrency test.
+type countingClient struct {
+	helm.Interface
+
+	calls atomic.Int64
+}
+
+func (c *countingClient) TemplateChart(_ context.Context, _ *helm.ChartSpec) (string, error) {
+	return fmt.Sprintf("render-%d", c.calls.Add(1)), nil
+}
+
+// valuesRelease returns the chartRef podinfo release with inline values, so tests
+// can vary ValuesYaml (part of the cache key) independently of the chart source.
+func valuesRelease(rawValues string) *helmv2.HelmRelease {
+	release := chartRefRelease()
+	release.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(rawValues)}
+
+	return release
+}
+
+func TestResolverChartCacheServesRepeatRenderAcrossResolvers(t *testing.T) {
+	t.Parallel()
+
+	client := &countingClient{}
+	cache := render.NewChartCache()
+	source := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
+
+	// Two independent resolvers sharing one cache mirror how validate builds a
+	// fresh resolver per kustomization while sharing the run's chart cache.
+	first, err := render.NewHelmChartResolver(client, render.WithChartCache(cache)).
+		Render(context.Background(), chartRefRelease(), source)
+	require.NoError(t, err)
+	assert.Equal(t, "render-1", first)
+
+	second, err := render.NewHelmChartResolver(client, render.WithChartCache(cache)).
+		Render(context.Background(), chartRefRelease(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, "render-1", second, "second identical render must be served from cache")
+	assert.Equal(
+		t,
+		int64(1),
+		client.calls.Load(),
+		"TemplateChart must run once for an identical spec",
+	)
+}
+
+func TestResolverChartCacheMissesOnDistinctSpecs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		release *helmv2.HelmRelease
+		source  render.SourceIndex
+	}{
+		{
+			name:    "different chart version",
+			release: chartRefRelease(),
+			source:  ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.6.0"}),
+		},
+		{
+			name:    "different values",
+			release: valuesRelease(`{"replicaCount":3}`),
+			source:  ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"}),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &countingClient{}
+			cache := render.NewChartCache()
+			resolver := render.NewHelmChartResolver(client, render.WithChartCache(cache))
+
+			// Prime the cache with the baseline spec (tag 6.5.0, no values).
+			_, err := resolver.Render(
+				context.Background(),
+				chartRefRelease(),
+				ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"}),
+			)
+			require.NoError(t, err)
+
+			_, err = resolver.Render(context.Background(), testCase.release, testCase.source)
+			require.NoError(t, err)
+
+			assert.Equal(t, int64(2), client.calls.Load(), "a distinct spec must miss the cache")
+		})
+	}
+}
+
+func TestResolverWithoutChartCacheAlwaysRenders(t *testing.T) {
+	t.Parallel()
+
+	client := &countingClient{}
+	resolver := render.NewHelmChartResolver(client) // no cache configured
+	source := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
+
+	for range 3 {
+		_, err := resolver.Render(context.Background(), chartRefRelease(), source)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(3), client.calls.Load(), "without a cache each render must template")
+}
+
+// TestResolverChartCacheConcurrentSingleRender proves the cache collapses N
+// concurrent identical renders to a single TemplateChart call and is race-clean
+// (run under -race): the check/store live inside the render lock, so a waiter
+// finds the first result instead of re-rendering. Mirrors validate's fan-out —
+// a fresh resolver per goroutine sharing one run cache.
+func TestResolverChartCacheConcurrentSingleRender(t *testing.T) {
+	t.Parallel()
+
+	client := &countingClient{}
+	cache := render.NewChartCache()
+	source := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
+
+	const goroutines = 12
+
+	var waitGroup sync.WaitGroup
+
+	waitGroup.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer waitGroup.Done()
+
+			_, _ = render.NewHelmChartResolver(client, render.WithChartCache(cache)).
+				Render(context.Background(), chartRefRelease(), source)
+		}()
+	}
+
+	waitGroup.Wait()
+
+	assert.Equal(t, int64(1), client.calls.Load(),
+		"concurrent identical renders must collapse to one TemplateChart call")
+}
+
+// BenchmarkResolverChartCacheHit measures the cache-hit path (key build + map
+// lookup) that replaces a full chart template on a repeat render. The first
+// iteration primes the cache; the rest are hits.
+func BenchmarkResolverChartCacheHit(b *testing.B) {
+	client := &countingClient{}
+	resolver := render.NewHelmChartResolver(client, render.WithChartCache(render.NewChartCache()))
+	source := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
+	release := chartRefRelease()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		_, err := resolver.Render(context.Background(), release, source)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/svc/gitops/render/resolver.go
+++ b/pkg/svc/gitops/render/resolver.go
@@ -73,15 +73,32 @@ type SourceIndex struct {
 // HelmChartResolver is the production ChartResolver, backed by the in-process,
 // kubeconfig-free Helm template client (helm.NewTemplateOnlyClient()).
 type HelmChartResolver struct {
-	helm helm.Interface
+	helm  helm.Interface
+	cache *ChartCache
 }
 
 var _ ChartResolver = (*HelmChartResolver)(nil)
 
+// ResolverOption configures a HelmChartResolver.
+type ResolverOption func(*HelmChartResolver)
+
+// WithChartCache makes the resolver serve identical chart renders from the
+// shared cache instead of re-templating. Pass one cache per validate/scan run
+// (see ChartCache) so identical HelmReleases across kustomizations are
+// templated once.
+func WithChartCache(cache *ChartCache) ResolverOption {
+	return func(r *HelmChartResolver) { r.cache = cache }
+}
+
 // NewHelmChartResolver returns a resolver that renders charts with the given
 // Helm client. Pass a client from helm.NewTemplateOnlyClient() for offline use.
-func NewHelmChartResolver(client helm.Interface) *HelmChartResolver {
-	return &HelmChartResolver{helm: client}
+func NewHelmChartResolver(client helm.Interface, opts ...ResolverOption) *HelmChartResolver {
+	resolver := &HelmChartResolver{helm: client}
+	for _, opt := range opts {
+		opt(resolver)
+	}
+
+	return resolver
 }
 
 // Render resolves the chart source for helmRelease and templates it in-process.
@@ -91,6 +108,13 @@ func NewHelmChartResolver(client helm.Interface) *HelmChartResolver {
 // Helm's process-global on-disk caches, which concurrent renders corrupted
 // (issue #5362). The deferred Unlock holds the lock only across that call plus a
 // trivial error-wrap, and stays correct even if TemplateChart panics.
+//
+// When a ChartCache is configured (WithChartCache), the lookup and store happen
+// inside the helmRenderMu critical section: because that lock already serializes
+// every render, a second render of the same spec finds the first result and
+// skips TemplateChart entirely (no thundering herd), and cache hits release the
+// lock immediately. Only successful renders are cached — a template error is
+// returned as before, never memoized.
 func (r *HelmChartResolver) Render(
 	ctx context.Context,
 	helmRelease *helmv2.HelmRelease,
@@ -104,12 +128,22 @@ func (r *HelmChartResolver) Render(
 	helmRenderMu.Lock()
 	defer helmRenderMu.Unlock()
 
+	if r.cache != nil {
+		if manifest, ok := r.cache.get(spec); ok {
+			return manifest, nil
+		}
+	}
+
 	manifest, err := r.helm.TemplateChart(ctx, spec)
 	if err != nil {
 		return "", fmt.Errorf(
 			"template chart for HelmRelease %s/%s: %w",
 			helmRelease.Namespace, helmRelease.Name, err,
 		)
+	}
+
+	if r.cache != nil {
+		r.cache.put(spec, manifest)
 	}
 
 	return manifest, nil


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5665, Part of #5344 (cross-cutting: *"Cache resolved charts"*).

## Problem

`workload validate` (and `scan`) render each kustomization's HelmReleases
in-process, and validate fans the kustomizations out in parallel. Each
kustomization gets a **fresh** `HelmChartResolver`, and every `HelmRelease` is
templated via `helm.TemplateChart` under the process-global `helmRenderMu` lock.

In a real GitOps repo the **same chart at the same version with the same values
is referenced from many kustomizations** — one chart deployed across every
environment/cluster overlay (exactly the shape `cluster add-environment` /
multi-cluster scaffolding, #5441, produces). The render output is fully
determined by the resolved chart spec, so all but the first of those identical
renders were redundant work on the critical (locked) path.

## Change

A **run-scoped, concurrency-safe** `render.ChartCache`, shared across the
per-kustomization resolvers of a single validate/scan run:

- **`render.ChartCache`** (`cache.go`) — a mutex-guarded map keyed by the
  output-determining spec fields (`ChartName`, `RepoURL`, `Version`,
  `ReleaseName`, `Namespace`, `ValuesYaml`), NUL-joined (collision-free for
  these inputs).
- **Non-breaking wiring** — `NewHelmChartResolver` gains a variadic
  `WithChartCache(cache)` option; existing callers/tests are unchanged.
- **Check/store inside the render lock** — because `helmRenderMu` already
  serializes every render, a second render of the same spec finds the first
  result and **skips `TemplateChart` entirely** (no thundering herd), and cache
  hits release the lock immediately (less contention). Only **successful**
  renders are cached — a resolution/template error is returned as before, never
  memoized.
- **One cache per `gitopsRenderer`** (created in `newGitOpsRenderer`), so it
  lives for exactly one run and is discarded after — no cross-run staleness for
  a floating chart version.

Behaviour-preserving: identical spec → identical manifest, which Helm's offline
template already guarantees.

## Tests

- Repeat render of the same spec **across two resolvers sharing one cache** →
  one `TemplateChart` call; the cached manifest (not a re-render) is returned.
- Distinct specs (different **version**; different **values**) miss the cache.
- No cache configured → every render templates (behaviour unchanged).
- 12 goroutines, fresh resolver each, one shared cache → collapses to **one**
  `TemplateChart` call; **race-clean under `-race`**.

## Before/after

The cache-hit path replaces a full chart template with a key build + map lookup:

```
BenchmarkResolverChartCacheHit-10   4098218   285.3 ns/op   416 B/op   5 allocs/op
```

A real in-process Helm chart template is on the order of tens of milliseconds,
so a chart referenced by *K* kustomizations drops from *K* templates to **1**
(the other *K−1* become ~285 ns cache hits) — and those avoided renders no
longer serialize behind the global render lock.

## Validation

`go build ./...`, `go vet`, `gofmt`, `golangci-lint run --new-from-rev=origin/main`
(0 new issues), full `pkg/svc/gitops/render` (`-race`) and `pkg/cli/cmd/workload`
test packages green; no generated-file drift.