### PR TITLE
feat(environment): write a derived multi-cluster layout to disk

### DIFF
--- a/pkg/svc/environment/layout_write.go
+++ b/pkg/svc/environment/layout_write.go
@@ -1,0 +1,58 @@
+package environment
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil/generator"
+	yamlgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/yaml"
+	ktypes "sigs.k8s.io/kustomize/api/types"
+)
+
+// KustomizationGenerator renders a kustomization model to a file. It is the
+// scaffolder's kustomization generator interface
+// ([generator.Generator[*ktypes.Kustomization, yamlgenerator.Options]]), named
+// here so the multi-cluster writer takes exactly the dependency the single-cluster
+// scaffolder already holds — the two render the same way, keeping their output
+// byte-consistent.
+type KustomizationGenerator = generator.Generator[*ktypes.Kustomization, yamlgenerator.Options]
+
+// WriteMultiClusterLayout renders each file of a derived multi-cluster layout
+// under sourceDir and returns the resolved output paths in layout order. It is the
+// filesystem counterpart to [DeriveMultiClusterLayout]: derive is pure so the
+// layout can be asserted in isolation, and write threads that layout through the
+// scaffolder's kustomization generator so a multi-cluster scaffold stays
+// byte-consistent with a single-cluster one.
+//
+// gen is the scaffolder's kustomization generator; sourceDir is the resolved
+// GitOps source directory each [LayoutFile.RelPath] is joined onto. The generator
+// creates any missing parent directories (the nested clusters/<env>/ path), so no
+// directory is pre-created here. When force is false an existing file is left
+// untouched — the scaffolder's idempotent behaviour — and its path is still
+// reported; when force is true it is overwritten. A render error is wrapped with
+// the failing file's relative path and aborts before a partial layout is
+// reported.
+func WriteMultiClusterLayout(
+	gen KustomizationGenerator,
+	sourceDir string,
+	files []LayoutFile,
+	force bool,
+) ([]string, error) {
+	written := make([]string, 0, len(files))
+
+	for _, file := range files {
+		output := filepath.Join(sourceDir, filepath.FromSlash(file.RelPath))
+
+		_, err := gen.Generate(file.Kustomization, yamlgenerator.Options{
+			Output: output,
+			Force:  force,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("write multi-cluster layout file %q: %w", file.RelPath, err)
+		}
+
+		written = append(written, output)
+	}
+
+	return written, nil
+}

--- a/pkg/svc/environment/layout_write_test.go
+++ b/pkg/svc/environment/layout_write_test.go
@@ -1,0 +1,172 @@
+package environment_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil/generator"
+	kustomizationgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/kustomization"
+	yamlgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/yaml"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	ktypes "sigs.k8s.io/kustomize/api/types"
+)
+
+// layoutRelPaths returns the two files DeriveMultiClusterLayout("prod") seeds, in
+// layout order: the shared base, then the per-environment overlay.
+func layoutRelPaths() (string, string) {
+	return filepath.Join("clusters", "base", "kustomization.yaml"),
+		filepath.Join("clusters", "prod", "kustomization.yaml")
+}
+
+// TestWriteMultiClusterLayout_WritesBaseAndOverlay asserts the writer renders the
+// derived layout under the source dir with the real generator, creating the nested
+// per-environment directory and returning the resolved paths in layout order.
+func TestWriteMultiClusterLayout_WritesBaseAndOverlay(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+
+	files, err := environment.DeriveMultiClusterLayout("prod")
+	require.NoError(t, err)
+
+	written, err := environment.WriteMultiClusterLayout(
+		kustomizationgenerator.NewGenerator(), sourceDir, files, false,
+	)
+	require.NoError(t, err)
+
+	baseRel, overlayRel := layoutRelPaths()
+	basePath := filepath.Join(sourceDir, baseRel)
+	overlayPath := filepath.Join(sourceDir, overlayRel)
+	assert.Equal(t, []string{basePath, overlayPath}, written)
+
+	baseContent := readFile(t, basePath)
+	assert.Contains(t, baseContent, "kind: Kustomization")
+	assert.Contains(t, baseContent, "apiVersion: kustomize.config.k8s.io/v1beta1")
+	assert.NotContains(t, baseContent, "../base")
+
+	// The environment overlay references the shared base via its sibling path, so
+	// the two files together form a working multi-cluster tree.
+	overlayContent := readFile(t, overlayPath)
+	assert.Contains(t, overlayContent, "kind: Kustomization")
+	assert.Contains(t, overlayContent, "../base")
+}
+
+// TestWriteMultiClusterLayout_ByteConsistentWithGenerator asserts the written
+// bytes are exactly what the scaffolder's kustomization generator produces for the
+// same model — the byte-consistency guarantee the LayoutFile doc promises.
+func TestWriteMultiClusterLayout_ByteConsistentWithGenerator(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+
+	files, err := environment.DeriveMultiClusterLayout("prod")
+	require.NoError(t, err)
+
+	_, err = environment.WriteMultiClusterLayout(
+		kustomizationgenerator.NewGenerator(), sourceDir, files, false,
+	)
+	require.NoError(t, err)
+
+	// Re-render each model directly (Output empty → returns the YAML) and compare.
+	for _, file := range files {
+		want, genErr := kustomizationgenerator.NewGenerator().
+			Generate(file.Kustomization, yamlgenerator.Options{})
+		require.NoError(t, genErr)
+
+		got := readFile(t, filepath.Join(sourceDir, filepath.FromSlash(file.RelPath)))
+		assert.Equal(t, want, got, "written %s must match the generator output", file.RelPath)
+	}
+}
+
+// TestWriteMultiClusterLayout_IdempotentWhenNotForcing asserts an already-present
+// file is left untouched when force is false, while a missing sibling is still
+// written — the scaffolder's skip-existing behaviour.
+func TestWriteMultiClusterLayout_IdempotentWhenNotForcing(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	baseRel, overlayRel := layoutRelPaths()
+	basePath := filepath.Join(sourceDir, baseRel)
+	seedFile(t, basePath, "# hand-edited base\n")
+
+	files, err := environment.DeriveMultiClusterLayout("prod")
+	require.NoError(t, err)
+
+	_, err = environment.WriteMultiClusterLayout(
+		kustomizationgenerator.NewGenerator(), sourceDir, files, false,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "# hand-edited base\n", readFile(t, basePath),
+		"an existing file must be preserved when force is false")
+	assert.Contains(t, readFile(t, filepath.Join(sourceDir, overlayRel)), "../base",
+		"a missing overlay must still be written")
+}
+
+// TestWriteMultiClusterLayout_ForceOverwrites asserts force replaces an existing
+// file with the generated content.
+func TestWriteMultiClusterLayout_ForceOverwrites(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	baseRel, _ := layoutRelPaths()
+	basePath := filepath.Join(sourceDir, baseRel)
+	seedFile(t, basePath, "# stale\n")
+
+	files, err := environment.DeriveMultiClusterLayout("prod")
+	require.NoError(t, err)
+
+	_, err = environment.WriteMultiClusterLayout(
+		kustomizationgenerator.NewGenerator(), sourceDir, files, true,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, readFile(t, basePath), "kind: Kustomization",
+		"force must overwrite the existing file with the generated content")
+}
+
+// errGenerate is a sentinel the mock generator returns to assert error wrapping.
+var errGenerate = errors.New("boom")
+
+// TestWriteMultiClusterLayout_WrapsGeneratorError asserts a render failure is
+// wrapped with the failing file's relative path and aborts with no partial result.
+func TestWriteMultiClusterLayout_WrapsGeneratorError(t *testing.T) {
+	t.Parallel()
+
+	gen := generator.NewMockGenerator[*ktypes.Kustomization, yamlgenerator.Options](t)
+	gen.EXPECT().Generate(mock.Anything, mock.Anything).Return("", errGenerate).Once()
+
+	baseRel, _ := layoutRelPaths()
+	files := []environment.LayoutFile{
+		{RelPath: baseRel, Kustomization: &ktypes.Kustomization{}},
+	}
+
+	written, err := environment.WriteMultiClusterLayout(gen, t.TempDir(), files, false)
+	require.ErrorIs(t, err, errGenerate)
+	assert.Contains(t, err.Error(), baseRel)
+	assert.Nil(t, written)
+}
+
+// readFile reads path and fails the test on error.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path) //nolint:gosec // path is a test-owned temp dir.
+	require.NoError(t, err)
+
+	return string(content)
+}
+
+// seedFile writes content at path, creating parent directories, and fails the test
+// on error.
+func seedFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5669. Part of #5441 (item 2: multi-cluster mode for `cluster init`); follows #5615
(`DeriveMultiClusterLayout`).

## What

Adds `environment.WriteMultiClusterLayout(gen, sourceDir, files, force)` — the filesystem
counterpart to the pure `DeriveMultiClusterLayout` (#5615). It renders each derived
`LayoutFile` under the resolved source directory using the **scaffolder's own** kustomization
generator (`generator.Generator[*ktypes.Kustomization, yamlgenerator.Options]`, aliased as
`KustomizationGenerator`), so a multi-cluster scaffold stays **byte-consistent** with a
single-cluster one — the guarantee the `LayoutFile` doc already promises.

## Why

`DeriveMultiClusterLayout` derives the `clusters/base/` + `clusters/<env>/` tree in memory but
nothing persists it, so `cluster init` still can't scaffold the multi-cluster shape. This is the
"write" half; the next increment (item-2 b) composes derive + write behind a
`cluster init --multi-cluster` flag.

## Behaviour

- Joins each `LayoutFile.RelPath` onto `sourceDir`; the generator's `TryWriteFile` creates the
  nested `clusters/<env>/` parent dirs.
- **Idempotent** when `force` is false (an existing file is left untouched — the scaffolder's
  behaviour) and its path is still reported; overwrites when `force` is true.
- Returns the resolved output paths in layout order; a render error is wrapped with the failing
  file's `RelPath` and aborts before a partial result is reported.

Keeps derive (pure) and write (filesystem) separable and each unit-testable.

## Tests

`layout_write_test.go` (external `_test` package): end-to-end write with the real generator +
temp dir (paths + content: base has empty resources, overlay references `../base`),
**byte-consistency** vs a direct generator render, `force=false` idempotency (skip existing,
still write the missing sibling), `force=true` overwrite, and generator-error propagation via
the generator mock.

## Validation

`go build ./...`, `go vet`, `gofmt`, `go test ./pkg/svc/environment/...` (60 pass),
`golangci-lint run ./pkg/svc/environment/...` (0 issues, full-package). No CLI surface or
generated files touched — library-only addition; no generated-doc drift.