### PR TITLE
feat(gke): add native GKE cluster-lifecycle client foundation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -165,6 +165,12 @@ linters:
             - github.com/loft-sh/vcluster
             - github.com/yannh
             - github.com/zalando/go-keyring
+            # cloud.google.com/go/container is the official native GKE SDK backing
+            # pkg/client/gke (cluster lifecycle for the GKE provider, #4510); gax-go
+            # carries its per-call options. Already linked transitively via the
+            # Google Cloud dependency graph.
+            - cloud.google.com/go/container
+            - github.com/googleapis/gax-go
             - filippo.io/age
             - golang.design/x
             - golang.org/x/oauth2

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -30,7 +30,7 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/container v1.52.0 // indirect
+	cloud.google.com/go/container v1.53.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/kms v1.31.0 // indirect
 	cloud.google.com/go/longrunning v1.0.0 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -49,8 +49,8 @@ cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4g
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-cloud.google.com/go/container v1.52.0 h1:oAkZciqdQ+xpP29pa5UJfsBBvcWrNNgKsWvraoz9Ajk=
-cloud.google.com/go/container v1.52.0/go.mod h1:EvqoT2eXfxLweXXUlhAMGR0sOAB00XPzEjoL01esSDs=
+cloud.google.com/go/container v1.53.0 h1:3zUySblDfZI9c+5gUWVOacKrdsQwiEerK4HM8eS/Ud8=
+cloud.google.com/go/container v1.53.0/go.mod h1:SBOylKhlKYCBFs/8kz2yqRdUW5ctVNHs82JKOTjrB9s=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.6.1/go.mod h1:asNXNOzBdyVQmEU+ggO8UPodTkEVFW5Qx+rwHnAz+EY=

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/container v1.53.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/apricote/hcloud-upload-image/hcloudimages v1.4.0
@@ -68,6 +69,7 @@ require (
 	github.com/github/copilot-sdk/go v1.0.4
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-github/v72 v72.0.0
+	github.com/googleapis/gax-go/v2 v2.22.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hetznercloud/hcloud-go/v2 v2.44.0
 	github.com/invopop/jsonschema v0.14.0
@@ -89,6 +91,7 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.38.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
@@ -105,7 +108,6 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/container v1.52.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/kms v1.31.0 // indirect
 	cloud.google.com/go/longrunning v1.0.0 // indirect
@@ -488,7 +490,6 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
-	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gookit/color v1.6.0 // indirect
 	github.com/gordonklaus/ineffassign v0.2.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
@@ -941,7 +942,6 @@ require (
 	google.golang.org/api v0.280.0 // indirect
 	google.golang.org/genproto v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4g
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-cloud.google.com/go/container v1.52.0 h1:oAkZciqdQ+xpP29pa5UJfsBBvcWrNNgKsWvraoz9Ajk=
-cloud.google.com/go/container v1.52.0/go.mod h1:EvqoT2eXfxLweXXUlhAMGR0sOAB00XPzEjoL01esSDs=
+cloud.google.com/go/container v1.53.0 h1:3zUySblDfZI9c+5gUWVOacKrdsQwiEerK4HM8eS/Ud8=
+cloud.google.com/go/container v1.53.0/go.mod h1:SBOylKhlKYCBFs/8kz2yqRdUW5ctVNHs82JKOTjrB9s=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.6.1/go.mod h1:asNXNOzBdyVQmEU+ggO8UPodTkEVFW5Qx+rwHnAz+EY=

--- a/pkg/client/gke/client.go
+++ b/pkg/client/gke/client.go
@@ -1,0 +1,256 @@
+package gke
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	container "cloud.google.com/go/container/apiv1"
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+// defaultPollInterval is how often Create/Delete poll their long-running
+// operation. Cluster mutations take minutes, so a few seconds between polls
+// keeps the request volume negligible without adding meaningful latency.
+const defaultPollInterval = 5 * time.Second
+
+// clusterManager is the narrow seam over the GKE ClusterManagerClient
+// operations this package uses, so tests can inject a fake without GCP
+// credentials. *container.ClusterManagerClient satisfies it.
+type clusterManager interface {
+	CreateCluster(
+		ctx context.Context,
+		req *containerpb.CreateClusterRequest,
+		opts ...gax.CallOption,
+	) (*containerpb.Operation, error)
+	DeleteCluster(
+		ctx context.Context,
+		req *containerpb.DeleteClusterRequest,
+		opts ...gax.CallOption,
+	) (*containerpb.Operation, error)
+	GetCluster(
+		ctx context.Context,
+		req *containerpb.GetClusterRequest,
+		opts ...gax.CallOption,
+	) (*containerpb.Cluster, error)
+	ListClusters(
+		ctx context.Context,
+		req *containerpb.ListClustersRequest,
+		opts ...gax.CallOption,
+	) (*containerpb.ListClustersResponse, error)
+	GetOperation(
+		ctx context.Context,
+		req *containerpb.GetOperationRequest,
+		opts ...gax.CallOption,
+	) (*containerpb.Operation, error)
+	Close() error
+}
+
+// Client performs GKE cluster lifecycle operations against one Google Cloud
+// project, hiding the SDK's request shapes and long-running-operation polling.
+type Client struct {
+	manager      clusterManager
+	pollInterval time.Duration
+}
+
+// Option customises a Client.
+type Option func(*Client)
+
+// WithClusterManager injects the cluster-manager implementation, letting tests
+// substitute a fake for the real SDK client.
+func WithClusterManager(manager clusterManager) Option {
+	return func(client *Client) {
+		client.manager = manager
+	}
+}
+
+// WithPollInterval overrides how often long-running operations are polled.
+// Values below one millisecond are ignored so a misconfigured caller cannot
+// turn the poll loop into a busy-wait against the API.
+func WithPollInterval(interval time.Duration) Option {
+	return func(client *Client) {
+		if interval >= time.Millisecond {
+			client.pollInterval = interval
+		}
+	}
+}
+
+// NewClient constructs a Client. Unless a cluster manager is injected, it
+// creates the real SDK client using Application Default Credentials.
+func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
+	client := &Client{
+		manager:      nil,
+		pollInterval: defaultPollInterval,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	if client.manager == nil {
+		manager, err := container.NewClusterManagerClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("creating GKE cluster manager client: %w", err)
+		}
+
+		client.manager = manager
+	}
+
+	return client, nil
+}
+
+// Close releases the underlying SDK client's connections.
+func (c *Client) Close() error {
+	err := c.manager.Close()
+	if err != nil {
+		return fmt.Errorf("closing GKE cluster manager client: %w", err)
+	}
+
+	return nil
+}
+
+// CreateCluster creates the given cluster in the project and location and
+// blocks until the create operation completes.
+func (c *Client) CreateCluster(
+	ctx context.Context,
+	project string,
+	location string,
+	cluster *containerpb.Cluster,
+) error {
+	if cluster == nil {
+		return ErrNilCluster
+	}
+
+	request := &containerpb.CreateClusterRequest{
+		Parent:  locationName(project, location),
+		Cluster: cluster,
+	}
+
+	operation, err := c.manager.CreateCluster(ctx, request)
+	if err != nil {
+		return fmt.Errorf("creating GKE cluster %q: %w", cluster.GetName(), err)
+	}
+
+	return c.waitForOperation(ctx, project, location, operation)
+}
+
+// DeleteCluster deletes the named cluster in the project and location and
+// blocks until the delete operation completes.
+func (c *Client) DeleteCluster(
+	ctx context.Context,
+	project string,
+	location string,
+	name string,
+) error {
+	request := &containerpb.DeleteClusterRequest{
+		Name: clusterName(project, location, name),
+	}
+
+	operation, err := c.manager.DeleteCluster(ctx, request)
+	if err != nil {
+		return fmt.Errorf("deleting GKE cluster %q: %w", name, err)
+	}
+
+	return c.waitForOperation(ctx, project, location, operation)
+}
+
+// GetCluster returns the named cluster in the project and location.
+func (c *Client) GetCluster(
+	ctx context.Context,
+	project string,
+	location string,
+	name string,
+) (*containerpb.Cluster, error) {
+	request := &containerpb.GetClusterRequest{
+		Name: clusterName(project, location, name),
+	}
+
+	cluster, err := c.manager.GetCluster(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("getting GKE cluster %q: %w", name, err)
+	}
+
+	return cluster, nil
+}
+
+// ListClusters returns the clusters in the project and location. Location "-"
+// lists across all locations, per the GKE API convention.
+func (c *Client) ListClusters(
+	ctx context.Context,
+	project string,
+	location string,
+) ([]*containerpb.Cluster, error) {
+	request := &containerpb.ListClustersRequest{
+		Parent: locationName(project, location),
+	}
+
+	response, err := c.manager.ListClusters(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("listing GKE clusters in %q: %w", location, err)
+	}
+
+	return response.GetClusters(), nil
+}
+
+// waitForOperation polls the long-running operation until it reaches DONE,
+// honouring context cancellation. A DONE operation that carries an error is
+// surfaced as ErrOperationFailed.
+func (c *Client) waitForOperation(
+	ctx context.Context,
+	project string,
+	location string,
+	operation *containerpb.Operation,
+) error {
+	for {
+		if operation.GetStatus() == containerpb.Operation_DONE {
+			return operationResult(operation)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for GKE operation %q: %w", operation.GetName(), ctx.Err())
+		case <-time.After(c.pollInterval):
+		}
+
+		request := &containerpb.GetOperationRequest{
+			Name: operationName(project, location, operation.GetName()),
+		}
+
+		refreshed, err := c.manager.GetOperation(ctx, request)
+		if err != nil {
+			return fmt.Errorf("polling GKE operation %q: %w", operation.GetName(), err)
+		}
+
+		operation = refreshed
+	}
+}
+
+// operationResult maps a DONE operation to its outcome. The API reports
+// failures via the operation's structured error field.
+func operationResult(operation *containerpb.Operation) error {
+	opErr := operation.GetError()
+	if opErr != nil {
+		return fmt.Errorf(
+			"%w: operation %q: %s", ErrOperationFailed, operation.GetName(), opErr.GetMessage(),
+		)
+	}
+
+	return nil
+}
+
+// locationName renders the "projects/*/locations/*" resource name that
+// parents cluster requests.
+func locationName(project string, location string) string {
+	return fmt.Sprintf("projects/%s/locations/%s", project, location)
+}
+
+// clusterName renders the fully-qualified cluster resource name.
+func clusterName(project string, location string, name string) string {
+	return fmt.Sprintf("%s/clusters/%s", locationName(project, location), name)
+}
+
+// operationName renders the fully-qualified operation resource name.
+func operationName(project string, location string, name string) string {
+	return fmt.Sprintf("%s/operations/%s", locationName(project, location), name)
+}

--- a/pkg/client/gke/client_test.go
+++ b/pkg/client/gke/client_test.go
@@ -1,0 +1,356 @@
+package gke_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/devantler-tech/ksail/v7/pkg/client/gke"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/status"
+)
+
+// errBoom is the sentinel the fakes fail with.
+var errBoom = errors.New("boom")
+
+// fakeClusterManager implements the client's cluster-manager seam with
+// injectable behaviour per operation.
+type fakeClusterManager struct {
+	createFunc func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error)
+	deleteFunc func(*containerpb.DeleteClusterRequest) (*containerpb.Operation, error)
+	getFunc    func(*containerpb.GetClusterRequest) (*containerpb.Cluster, error)
+	listFunc   func(*containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error)
+	opFunc     func(*containerpb.GetOperationRequest) (*containerpb.Operation, error)
+	closeErr   error
+}
+
+func (f *fakeClusterManager) CreateCluster(
+	_ context.Context,
+	req *containerpb.CreateClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return f.createFunc(req)
+}
+
+func (f *fakeClusterManager) DeleteCluster(
+	_ context.Context,
+	req *containerpb.DeleteClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return f.deleteFunc(req)
+}
+
+func (f *fakeClusterManager) GetCluster(
+	_ context.Context,
+	req *containerpb.GetClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Cluster, error) {
+	return f.getFunc(req)
+}
+
+func (f *fakeClusterManager) ListClusters(
+	_ context.Context,
+	req *containerpb.ListClustersRequest,
+	_ ...gax.CallOption,
+) (*containerpb.ListClustersResponse, error) {
+	return f.listFunc(req)
+}
+
+func (f *fakeClusterManager) GetOperation(
+	_ context.Context,
+	req *containerpb.GetOperationRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return f.opFunc(req)
+}
+
+func (f *fakeClusterManager) Close() error {
+	return f.closeErr
+}
+
+// newTestClient builds a Client around the fake with a fast poll interval.
+func newTestClient(t *testing.T, fake *fakeClusterManager) *gke.Client {
+	t.Helper()
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(fake),
+		gke.WithPollInterval(time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	return client
+}
+
+func doneOperation(name string) *containerpb.Operation {
+	return &containerpb.Operation{
+		Name:   name,
+		Status: containerpb.Operation_DONE,
+	}
+}
+
+func runningOperation() *containerpb.Operation {
+	return &containerpb.Operation{
+		Name:   "op-create",
+		Status: containerpb.Operation_RUNNING,
+	}
+}
+
+func TestCreateClusterWaitsForOperation(t *testing.T) {
+	t.Parallel()
+
+	polls := 0
+	fake := &fakeClusterManager{
+		createFunc: func(req *containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+			assert.Equal(t, "projects/proj/locations/europe-north1", req.GetParent())
+			assert.Equal(t, "demo", req.GetCluster().GetName())
+
+			return runningOperation(), nil
+		},
+		opFunc: func(req *containerpb.GetOperationRequest) (*containerpb.Operation, error) {
+			assert.Equal(
+				t,
+				"projects/proj/locations/europe-north1/operations/op-create",
+				req.GetName(),
+			)
+
+			polls++
+			if polls < 2 {
+				return runningOperation(), nil
+			}
+
+			return doneOperation("op-create"), nil
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.CreateCluster(
+		t.Context(), "proj", "europe-north1", &containerpb.Cluster{Name: "demo"},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, polls)
+}
+
+func TestCreateClusterNilClusterIsRejected(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, &fakeClusterManager{})
+
+	err := client.CreateCluster(t.Context(), "proj", "loc", nil)
+
+	require.ErrorIs(t, err, gke.ErrNilCluster)
+}
+
+func TestCreateClusterWrapsRequestError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		createFunc: func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+			return nil, errBoom
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.CreateCluster(t.Context(), "proj", "loc", &containerpb.Cluster{Name: "demo"})
+
+	require.ErrorIs(t, err, errBoom)
+	assert.Contains(t, err.Error(), `creating GKE cluster "demo"`)
+}
+
+func TestCreateClusterSurfacesOperationError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		createFunc: func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+			operation := doneOperation("op-create")
+			operation.Error = &status.Status{Message: "quota exceeded"}
+
+			return operation, nil
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.CreateCluster(t.Context(), "proj", "loc", &containerpb.Cluster{Name: "demo"})
+
+	require.ErrorIs(t, err, gke.ErrOperationFailed)
+	assert.Contains(t, err.Error(), "quota exceeded")
+}
+
+func TestCreateClusterHonoursContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		createFunc: func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+			return runningOperation(), nil
+		},
+	}
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(fake),
+		gke.WithPollInterval(time.Hour),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = client.CreateCluster(ctx, "proj", "loc", &containerpb.Cluster{Name: "demo"})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCreateClusterWrapsPollError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		createFunc: func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+			return runningOperation(), nil
+		},
+		opFunc: func(*containerpb.GetOperationRequest) (*containerpb.Operation, error) {
+			return nil, errBoom
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.CreateCluster(t.Context(), "proj", "loc", &containerpb.Cluster{Name: "demo"})
+
+	require.ErrorIs(t, err, errBoom)
+	assert.Contains(t, err.Error(), `polling GKE operation "op-create"`)
+}
+
+func TestDeleteClusterWaitsForOperation(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		deleteFunc: func(req *containerpb.DeleteClusterRequest) (*containerpb.Operation, error) {
+			assert.Equal(t, "projects/proj/locations/loc/clusters/demo", req.GetName())
+
+			return doneOperation("op-delete"), nil
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.DeleteCluster(t.Context(), "proj", "loc", "demo")
+
+	require.NoError(t, err)
+}
+
+func TestDeleteClusterWrapsRequestError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		deleteFunc: func(*containerpb.DeleteClusterRequest) (*containerpb.Operation, error) {
+			return nil, errBoom
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.DeleteCluster(t.Context(), "proj", "loc", "demo")
+
+	require.ErrorIs(t, err, errBoom)
+	assert.Contains(t, err.Error(), `deleting GKE cluster "demo"`)
+}
+
+func TestGetClusterReturnsCluster(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		getFunc: func(req *containerpb.GetClusterRequest) (*containerpb.Cluster, error) {
+			assert.Equal(t, "projects/proj/locations/loc/clusters/demo", req.GetName())
+
+			return &containerpb.Cluster{Name: "demo"}, nil
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	cluster, err := client.GetCluster(t.Context(), "proj", "loc", "demo")
+
+	require.NoError(t, err)
+	assert.Equal(t, "demo", cluster.GetName())
+}
+
+func TestGetClusterWrapsError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		getFunc: func(*containerpb.GetClusterRequest) (*containerpb.Cluster, error) {
+			return nil, errBoom
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	_, err := client.GetCluster(t.Context(), "proj", "loc", "demo")
+
+	require.ErrorIs(t, err, errBoom)
+	assert.Contains(t, err.Error(), `getting GKE cluster "demo"`)
+}
+
+func TestListClustersReturnsClusters(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		listFunc: func(req *containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error) {
+			assert.Equal(t, "projects/proj/locations/-", req.GetParent())
+
+			return &containerpb.ListClustersResponse{
+				Clusters: []*containerpb.Cluster{{Name: "one"}, {Name: "two"}},
+			}, nil
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	clusters, err := client.ListClusters(t.Context(), "proj", "-")
+
+	require.NoError(t, err)
+	require.Len(t, clusters, 2)
+	assert.Equal(t, "one", clusters[0].GetName())
+}
+
+func TestListClustersWrapsError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		listFunc: func(*containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error) {
+			return nil, errBoom
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	_, err := client.ListClusters(t.Context(), "proj", "loc")
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestCloseWrapsError(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, &fakeClusterManager{closeErr: errBoom})
+
+	err := client.Close()
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestCloseSucceeds(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, &fakeClusterManager{})
+
+	require.NoError(t, client.Close())
+}

--- a/pkg/client/gke/doc.go
+++ b/pkg/client/gke/doc.go
@@ -1,0 +1,14 @@
+// Package gke provides a thin, mockable client for Google Kubernetes Engine
+// cluster lifecycle operations, wrapping the official native Go SDK
+// (cloud.google.com/go/container). It is the GKE counterpart to the eksctl
+// client: everything above it (infra provider, provisioner, factory routing)
+// talks to GKE exclusively through this package.
+//
+// GKE's cluster mutations are asynchronous: the API returns a long-running
+// operation that must be polled to completion. CreateCluster and DeleteCluster
+// hide that mechanic — they block until the operation reaches DONE (honouring
+// context cancellation) and surface any operation error.
+//
+// Authentication uses the SDK's Application Default Credentials chain; this
+// package adds no credential handling of its own.
+package gke

--- a/pkg/client/gke/errors.go
+++ b/pkg/client/gke/errors.go
@@ -1,0 +1,15 @@
+package gke
+
+import "errors"
+
+var (
+	// ErrNilCluster is returned when CreateCluster is called without a cluster
+	// specification. The GKE API requires one, so the misconfiguration is caught
+	// before any request is made.
+	ErrNilCluster = errors.New("gke: a cluster specification is required")
+
+	// ErrOperationFailed is returned when a long-running GKE operation completes
+	// unsuccessfully. The wrapped message carries the operation's own error
+	// detail so the caller sees what GKE reported.
+	ErrOperationFailed = errors.New("gke: cluster operation failed")
+)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5676 — Part of #4510 (GKE + AKS cloud providers)

First increment of the GKE lane, foundations-first per the #3983/#5513 precedent: the pure client layer lands before any user-facing surface (provider/distribution enums, schema, and factory routing follow in later slices, validation-gated until an E2E path exists).

## What

- **`pkg/client/gke`** — a thin, mockable client over the official **native Go SDK** (`cloud.google.com/go/container/apiv1` `ClusterManagerClient`), the GKE counterpart to `pkg/client/eksctl`, per the settled native-SDK provisioning direction (no shelled `gcloud`):
  - `CreateCluster` / `DeleteCluster` hide GKE's **long-running-operation** mechanic — they block until the operation reaches `DONE` (poll interval configurable, context-cancellation honoured) and surface operation errors as `ErrOperationFailed`.
  - `GetCluster` / `ListClusters` map the SDK types; `projects/*/locations/*` resource names are rendered internally.
  - Narrow unexported `clusterManager` seam → tests inject a fake, **no GCP credentials needed**; auth is the SDK's Application Default Credentials chain.
- **`.golangci.yml`** — allowlist `cloud.google.com/go/container` + `github.com/googleapis/gax-go` in depguard (comment explains why).

## Dependency note (flagging prominently)

`cloud.google.com/go/container` becomes a **direct** dependency — it was already in the module graph transitively (v1.52.0), now pinned v1.53.0 (Apache-2.0, official Google Cloud SDK). `google.golang.org/genproto` (rpc status) is test-only.

## Validation

`go build ./...` (root + desktop tidied), 14 unit tests green (happy paths, nil-cluster, request/poll/operation errors, context cancel, name formats), `golangci-lint run` on the package: 0 issues, `golangci-lint fmt` applied.

## Next slices (#4510)

1. `pkg/svc/provider/gcp` infra provider over this client
2. GKE provisioner + factory routing (validation-gated)
3. Provider/distribution enums + schema surface
4. AKS mirror of the same lane