### PR TITLE
feat(provider): add the GCP infrastructure provider over the GKE client

### DIFF
--- a/pkg/client/gke/client.go
+++ b/pkg/client/gke/client.go
@@ -39,6 +39,11 @@ type clusterManager interface {
 		req *containerpb.ListClustersRequest,
 		opts ...gax.CallOption,
 	) (*containerpb.ListClustersResponse, error)
+	SetNodePoolSize(
+		ctx context.Context,
+		req *containerpb.SetNodePoolSizeRequest,
+		opts ...gax.CallOption,
+	) (*containerpb.Operation, error)
 	GetOperation(
 		ctx context.Context,
 		req *containerpb.GetOperationRequest,
@@ -193,6 +198,30 @@ func (c *Client) ListClusters(
 	return response.GetClusters(), nil
 }
 
+// SetNodePoolSize resizes the named node pool to the given node count and
+// blocks until the resize operation completes. Resizing to the pool's current
+// size is a server-side no-op, so callers may re-assert a size idempotently.
+func (c *Client) SetNodePoolSize(
+	ctx context.Context,
+	project string,
+	location string,
+	cluster string,
+	nodePool string,
+	nodeCount int32,
+) error {
+	request := &containerpb.SetNodePoolSizeRequest{
+		Name:      nodePoolName(project, location, cluster, nodePool),
+		NodeCount: nodeCount,
+	}
+
+	operation, err := c.manager.SetNodePoolSize(ctx, request)
+	if err != nil {
+		return fmt.Errorf("resizing GKE node pool %q to %d: %w", nodePool, nodeCount, err)
+	}
+
+	return c.waitForOperation(ctx, project, location, operation)
+}
+
 // waitForOperation polls the long-running operation until it reaches DONE,
 // honouring context cancellation. A DONE operation that carries an error is
 // surfaced as ErrOperationFailed.
@@ -248,6 +277,11 @@ func locationName(project string, location string) string {
 // clusterName renders the fully-qualified cluster resource name.
 func clusterName(project string, location string, name string) string {
 	return fmt.Sprintf("%s/clusters/%s", locationName(project, location), name)
+}
+
+// nodePoolName renders the fully-qualified node-pool resource name.
+func nodePoolName(project string, location string, cluster string, nodePool string) string {
+	return fmt.Sprintf("%s/nodePools/%s", clusterName(project, location, cluster), nodePool)
 }
 
 // operationName renders the fully-qualified operation resource name.

--- a/pkg/client/gke/client_test.go
+++ b/pkg/client/gke/client_test.go
@@ -20,12 +20,13 @@ var errBoom = errors.New("boom")
 // fakeClusterManager implements the client's cluster-manager seam with
 // injectable behaviour per operation.
 type fakeClusterManager struct {
-	createFunc func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error)
-	deleteFunc func(*containerpb.DeleteClusterRequest) (*containerpb.Operation, error)
-	getFunc    func(*containerpb.GetClusterRequest) (*containerpb.Cluster, error)
-	listFunc   func(*containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error)
-	opFunc     func(*containerpb.GetOperationRequest) (*containerpb.Operation, error)
-	closeErr   error
+	createFunc  func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error)
+	deleteFunc  func(*containerpb.DeleteClusterRequest) (*containerpb.Operation, error)
+	getFunc     func(*containerpb.GetClusterRequest) (*containerpb.Cluster, error)
+	listFunc    func(*containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error)
+	setSizeFunc func(*containerpb.SetNodePoolSizeRequest) (*containerpb.Operation, error)
+	opFunc      func(*containerpb.GetOperationRequest) (*containerpb.Operation, error)
+	closeErr    error
 }
 
 func (f *fakeClusterManager) CreateCluster(
@@ -58,6 +59,14 @@ func (f *fakeClusterManager) ListClusters(
 	_ ...gax.CallOption,
 ) (*containerpb.ListClustersResponse, error) {
 	return f.listFunc(req)
+}
+
+func (f *fakeClusterManager) SetNodePoolSize(
+	_ context.Context,
+	req *containerpb.SetNodePoolSizeRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return f.setSizeFunc(req)
 }
 
 func (f *fakeClusterManager) GetOperation(
@@ -353,4 +362,82 @@ func TestCloseSucceeds(t *testing.T) {
 	client := newTestClient(t, &fakeClusterManager{})
 
 	require.NoError(t, client.Close())
+}
+
+func TestSetNodePoolSizeWaitsForOperation(t *testing.T) {
+	t.Parallel()
+
+	polls := 0
+	fake := &fakeClusterManager{
+		setSizeFunc: func(req *containerpb.SetNodePoolSizeRequest) (*containerpb.Operation, error) {
+			assert.Equal(
+				t,
+				"projects/proj/locations/europe-north1/clusters/demo/nodePools/default-pool",
+				req.GetName(),
+			)
+			assert.Equal(t, int32(3), req.GetNodeCount())
+
+			operation := runningOperation()
+			operation.Name = "op-resize"
+
+			return operation, nil
+		},
+		opFunc: func(req *containerpb.GetOperationRequest) (*containerpb.Operation, error) {
+			assert.Equal(
+				t,
+				"projects/proj/locations/europe-north1/operations/op-resize",
+				req.GetName(),
+			)
+
+			polls++
+
+			return doneOperation("op-resize"), nil
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.SetNodePoolSize(
+		t.Context(), "proj", "europe-north1", "demo", "default-pool", 3,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, polls)
+}
+
+func TestSetNodePoolSizeWrapsRequestError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		setSizeFunc: func(*containerpb.SetNodePoolSizeRequest) (*containerpb.Operation, error) {
+			return nil, errBoom
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.SetNodePoolSize(t.Context(), "proj", "loc", "demo", "default-pool", 0)
+
+	require.ErrorIs(t, err, errBoom)
+	assert.Contains(t, err.Error(), `resizing GKE node pool "default-pool" to 0`)
+}
+
+func TestSetNodePoolSizeSurfacesOperationError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		setSizeFunc: func(*containerpb.SetNodePoolSizeRequest) (*containerpb.Operation, error) {
+			operation := doneOperation("op-resize")
+			operation.Error = &status.Status{Message: "node pool is being repaired"}
+
+			return operation, nil
+		},
+	}
+
+	client := newTestClient(t, fake)
+
+	err := client.SetNodePoolSize(t.Context(), "proj", "loc", "demo", "default-pool", 1)
+
+	require.ErrorIs(t, err, gke.ErrOperationFailed)
+	assert.Contains(t, err.Error(), "node pool is being repaired")
 }

--- a/pkg/svc/provider/gcp/doc.go
+++ b/pkg/svc/provider/gcp/doc.go
@@ -1,0 +1,7 @@
+// Package gcp implements provider.Provider for Google Kubernetes Engine over
+// the pkg/client/gke cluster-lifecycle client. GKE node pools are not
+// individual nodes — like EKS nodegroups they are managed groups — so the
+// provider collapses each pool to a single NodeInfo, and node start/stop is
+// implemented as pool resizes (the control plane is Google-managed and keeps
+// running either way).
+package gcp

--- a/pkg/svc/provider/gcp/errors.go
+++ b/pkg/svc/provider/gcp/errors.go
@@ -1,0 +1,15 @@
+package gcp
+
+import "errors"
+
+var (
+	// ErrClientRequired is returned when NewProvider is called without a GKE
+	// client, so callers fail fast instead of getting
+	// provider.ErrProviderUnavailable at the first call.
+	ErrClientRequired = errors.New("gcp provider: gke client is required")
+
+	// ErrProjectRequired is returned when NewProvider is called without a
+	// Google Cloud project ID — every GKE API call is project-scoped, so an
+	// empty project can never succeed.
+	ErrProjectRequired = errors.New("gcp provider: google cloud project is required")
+)

--- a/pkg/svc/provider/gcp/provider.go
+++ b/pkg/svc/provider/gcp/provider.go
@@ -1,0 +1,300 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/devantler-tech/ksail/v7/pkg/client/gke"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// AllLocations is the GKE API's location wildcard, listing clusters across
+// every location in a project.
+const AllLocations = "-"
+
+// nodeRoleWorker is the role every GKE node pool maps to: the control plane
+// is Google-managed and never surfaces as a pool.
+const nodeRoleWorker = "worker"
+
+// Provider implements provider.Provider for Google Kubernetes Engine.
+type Provider struct {
+	client   *gke.Client
+	project  string
+	location string
+}
+
+// NewProvider returns a Provider for the given project and location using the
+// given GKE client. Pass location="" to operate across all locations where
+// the API allows it (cluster listing); cluster-scoped calls then resolve the
+// cluster's own location via ListClusters. A nil client returns
+// ErrClientRequired and an empty project ErrProjectRequired so callers fail
+// fast rather than at the first API call.
+func NewProvider(client *gke.Client, project string, location string) (*Provider, error) {
+	if client == nil {
+		return nil, ErrClientRequired
+	}
+
+	if project == "" {
+		return nil, ErrProjectRequired
+	}
+
+	return &Provider{client: client, project: project, location: location}, nil
+}
+
+// StartNodes resizes every node pool of the cluster to its configured
+// initial node count (floored at one node).
+//
+// GKE does not expose a pool's live size on the NodePool message, so unlike
+// EKS there is no "already running, leave alone" check — the resize is
+// re-asserted for every pool, which the API treats as a no-op when the pool
+// is already at that size. The provisioner — which has the ksail.yaml spec —
+// is responsible for restoring an exact desired size when needed.
+func (p *Provider) StartNodes(ctx context.Context, clusterName string) error {
+	pools, location, err := p.nodePoolsForScale(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	for _, pool := range pools {
+		target := max(pool.GetInitialNodeCount(), 1)
+
+		err = p.client.SetNodePoolSize(
+			ctx, p.project, location, clusterName, pool.GetName(), target,
+		)
+		if err != nil {
+			return fmt.Errorf("start nodes: resize node pool %s: %w", pool.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+// StopNodes resizes every node pool of the cluster to zero nodes. The GKE
+// control plane keeps running (and billing) but all node costs stop.
+func (p *Provider) StopNodes(ctx context.Context, clusterName string) error {
+	pools, location, err := p.nodePoolsForScale(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	for _, pool := range pools {
+		err = p.client.SetNodePoolSize(
+			ctx, p.project, location, clusterName, pool.GetName(), 0,
+		)
+		if err != nil {
+			return fmt.Errorf("stop nodes: resize node pool %s: %w", pool.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+// ListNodes returns one NodeInfo per node pool of the cluster.
+//
+// GKE node pools are managed instance groups, not individual machines, so
+// KSail collapses the distinction and represents each pool as a single
+// NodeInfo whose Name is the pool name — mirroring how the AWS provider
+// represents EKS nodegroups.
+func (p *Provider) ListNodes(
+	ctx context.Context,
+	clusterName string,
+) ([]provider.NodeInfo, error) {
+	cluster, err := p.getCluster(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodePoolInfos(cluster, clusterName), nil
+}
+
+// ListAllClusters returns the names of all GKE clusters in the configured
+// project and location (all locations when the provider was built with an
+// empty location).
+func (p *Provider) ListAllClusters(ctx context.Context) ([]string, error) {
+	if p.client == nil {
+		return nil, provider.ErrProviderUnavailable
+	}
+
+	clusters, err := p.client.ListClusters(ctx, p.project, p.listLocation())
+	if err != nil {
+		return nil, translateClientErr(err)
+	}
+
+	names := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		names = append(names, cluster.GetName())
+	}
+
+	return names, nil
+}
+
+// NodesExist returns true if the cluster has at least one node pool.
+func (p *Provider) NodesExist(ctx context.Context, clusterName string) (bool, error) {
+	exists, err := provider.CheckNodesExist(ctx, p, clusterName)
+	if err != nil {
+		return false, fmt.Errorf("check gke node pools: %w", err)
+	}
+
+	return exists, nil
+}
+
+// DeleteNodes is a no-op for GKE: deleting the cluster deletes its node
+// pools atomically, so pool deletion is owned by the provisioner's cluster
+// deletion — mirroring the AWS provider's contract for EKS nodegroups.
+func (p *Provider) DeleteNodes(_ context.Context, _ string) error {
+	return nil
+}
+
+// GetClusterStatus aggregates node-pool statuses into a
+// provider.ClusterStatus. Returns provider.ErrClusterNotFound when the
+// cluster does not exist. A cluster that exists but has no node pools yields
+// a zero-node "stopped" status rather than a nil status, keeping the
+// (status, err) contract: status is non-nil whenever err is nil.
+func (p *Provider) GetClusterStatus(
+	ctx context.Context,
+	clusterName string,
+) (*provider.ClusterStatus, error) {
+	cluster, err := p.getCluster(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := nodePoolInfos(cluster, clusterName)
+
+	status := provider.BuildClusterStatus(nodes, containerpb.NodePool_RUNNING.String())
+	if status == nil {
+		status = &provider.ClusterStatus{Phase: provider.PhaseStopped, Nodes: nodes}
+	}
+
+	status.Endpoint = cluster.GetEndpoint()
+
+	return status, nil
+}
+
+// Project returns the Google Cloud project this provider was configured with.
+func (p *Provider) Project() string {
+	return p.project
+}
+
+// getCluster is the shared cluster fetch that guards against nil clients and
+// translates client errors into the provider sentinels.
+func (p *Provider) getCluster(
+	ctx context.Context,
+	clusterName string,
+) (*containerpb.Cluster, error) {
+	if p.client == nil {
+		return nil, provider.ErrProviderUnavailable
+	}
+
+	location, err := p.clusterLocation(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := p.client.GetCluster(ctx, p.project, location, clusterName)
+	if err != nil {
+		return nil, translateClientErr(err)
+	}
+
+	return cluster, nil
+}
+
+// nodePoolsForScale is the shared prelude for StartNodes and StopNodes that
+// fetches the cluster's node pools (and the location they live in) and
+// classifies an empty result as provider.ErrNoNodes.
+func (p *Provider) nodePoolsForScale(
+	ctx context.Context,
+	clusterName string,
+) ([]*containerpb.NodePool, string, error) {
+	if p.client == nil {
+		return nil, "", provider.ErrProviderUnavailable
+	}
+
+	location, err := p.clusterLocation(ctx, clusterName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	cluster, err := p.client.GetCluster(ctx, p.project, location, clusterName)
+	if err != nil {
+		return nil, "", translateClientErr(err)
+	}
+
+	pools := cluster.GetNodePools()
+	if len(pools) == 0 {
+		return nil, "", provider.ErrNoNodes
+	}
+
+	return pools, location, nil
+}
+
+// clusterLocation resolves the location a cluster-scoped call should target.
+// With a configured location it is used directly; with the all-locations
+// wildcard (or empty) the cluster's own location is looked up via
+// ListClusters, since cluster-scoped GKE calls reject the wildcard.
+func (p *Provider) clusterLocation(ctx context.Context, clusterName string) (string, error) {
+	if p.location != "" && p.location != AllLocations {
+		return p.location, nil
+	}
+
+	clusters, err := p.client.ListClusters(ctx, p.project, AllLocations)
+	if err != nil {
+		return "", translateClientErr(err)
+	}
+
+	for _, cluster := range clusters {
+		if cluster.GetName() == clusterName {
+			return cluster.GetLocation(), nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", provider.ErrClusterNotFound, clusterName)
+}
+
+// listLocation resolves the location for project-scoped listing, defaulting
+// to the all-locations wildcard when none was configured.
+func (p *Provider) listLocation() string {
+	if p.location == "" {
+		return AllLocations
+	}
+
+	return p.location
+}
+
+// nodePoolInfos maps a cluster's node pools to NodeInfo entries.
+func nodePoolInfos(cluster *containerpb.Cluster, clusterName string) []provider.NodeInfo {
+	pools := cluster.GetNodePools()
+	nodes := make([]provider.NodeInfo, 0, len(pools))
+
+	for _, pool := range pools {
+		nodes = append(nodes, provider.NodeInfo{
+			Name:        pool.GetName(),
+			ClusterName: clusterName,
+			Role:        nodeRoleWorker,
+			State:       pool.GetStatus().String(),
+			ServerType:  pool.GetConfig().GetMachineType(),
+		})
+	}
+
+	return nodes
+}
+
+// translateClientErr maps GKE client errors onto the provider sentinels:
+// a gRPC NotFound anywhere in the chain becomes provider.ErrClusterNotFound.
+func translateClientErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var grpcErr interface{ GRPCStatus() *grpcstatus.Status }
+	if errors.As(err, &grpcErr) && grpcErr.GRPCStatus().Code() == codes.NotFound {
+		return fmt.Errorf("%w: %s", provider.ErrClusterNotFound, strings.TrimSpace(err.Error()))
+	}
+
+	return err
+}

--- a/pkg/svc/provider/gcp/provider_test.go
+++ b/pkg/svc/provider/gcp/provider_test.go
@@ -1,0 +1,389 @@
+package gcp_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/devantler-tech/ksail/v7/pkg/client/gke"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/gcp"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// errBoom is the sentinel the fakes fail with.
+var errBoom = errors.New("boom")
+
+// resizeCall records one SetNodePoolSize request the fake received.
+type resizeCall struct {
+	name  string
+	count int32
+}
+
+// fakeClusterManager implements the GKE client's cluster-manager seam so the
+// provider can be exercised without GCP credentials. Only the operations the
+// provider uses are scripted; the rest fail the test if called.
+type fakeClusterManager struct {
+	t        *testing.T
+	clusters []*containerpb.Cluster
+	getErr   error
+	listErr  error
+	sizeErr  error
+	resizes  []resizeCall
+}
+
+func (f *fakeClusterManager) CreateCluster(
+	_ context.Context,
+	_ *containerpb.CreateClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	f.t.Fatal("unexpected CreateCluster call")
+
+	return nil, errBoom
+}
+
+func (f *fakeClusterManager) DeleteCluster(
+	_ context.Context,
+	_ *containerpb.DeleteClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	f.t.Fatal("unexpected DeleteCluster call")
+
+	return nil, errBoom
+}
+
+func (f *fakeClusterManager) GetCluster(
+	_ context.Context,
+	req *containerpb.GetClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Cluster, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+
+	for _, cluster := range f.clusters {
+		if req.GetName() == clusterResourceName(cluster) {
+			return cluster, nil
+		}
+	}
+
+	return nil, fmt.Errorf("get cluster: %w", grpcstatus.Error(codes.NotFound, "cluster not found"))
+}
+
+func (f *fakeClusterManager) ListClusters(
+	_ context.Context,
+	_ *containerpb.ListClustersRequest,
+	_ ...gax.CallOption,
+) (*containerpb.ListClustersResponse, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+
+	return &containerpb.ListClustersResponse{Clusters: f.clusters}, nil
+}
+
+func (f *fakeClusterManager) SetNodePoolSize(
+	_ context.Context,
+	req *containerpb.SetNodePoolSizeRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	if f.sizeErr != nil {
+		return nil, f.sizeErr
+	}
+
+	f.resizes = append(f.resizes, resizeCall{name: req.GetName(), count: req.GetNodeCount()})
+
+	return &containerpb.Operation{Name: "op-resize", Status: containerpb.Operation_DONE}, nil
+}
+
+func (f *fakeClusterManager) GetOperation(
+	_ context.Context,
+	_ *containerpb.GetOperationRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	f.t.Fatal("unexpected GetOperation call")
+
+	return nil, errBoom
+}
+
+func (f *fakeClusterManager) Close() error {
+	return nil
+}
+
+// clusterResourceName renders the fully-qualified name the provider is
+// expected to request for a scripted cluster.
+func clusterResourceName(cluster *containerpb.Cluster) string {
+	return "projects/proj/locations/" + cluster.GetLocation() + "/clusters/" + cluster.GetName()
+}
+
+// newProvider builds a Provider over a fake-backed GKE client.
+func newProvider(t *testing.T, fake *fakeClusterManager, location string) *gcp.Provider {
+	t.Helper()
+
+	fake.t = t
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(fake),
+		gke.WithPollInterval(time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	prov, err := gcp.NewProvider(client, "proj", location)
+	require.NoError(t, err)
+
+	return prov
+}
+
+// demoCluster scripts one cluster with two node pools in europe-north1.
+func demoCluster() *containerpb.Cluster {
+	return &containerpb.Cluster{
+		Name:     "demo",
+		Location: "europe-north1",
+		Endpoint: "34.88.0.1",
+		NodePools: []*containerpb.NodePool{
+			{
+				Name:             "default-pool",
+				InitialNodeCount: 3,
+				Status:           containerpb.NodePool_RUNNING,
+				Config:           &containerpb.NodeConfig{MachineType: "e2-standard-4"},
+			},
+			{
+				Name:   "burst-pool",
+				Status: containerpb.NodePool_PROVISIONING,
+			},
+		},
+	}
+}
+
+func TestNewProviderRequiresClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := gcp.NewProvider(nil, "proj", "")
+
+	require.ErrorIs(t, err, gcp.ErrClientRequired)
+}
+
+func TestNewProviderRequiresProject(t *testing.T) {
+	t.Parallel()
+
+	client, err := gke.NewClient(t.Context(), gke.WithClusterManager(&fakeClusterManager{}))
+	require.NoError(t, err)
+
+	_, err = gcp.NewProvider(client, "", "")
+
+	require.ErrorIs(t, err, gcp.ErrProjectRequired)
+}
+
+func TestListNodesCollapsesNodePools(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{demoCluster()}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	nodes, err := prov.ListNodes(t.Context(), "demo")
+
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+	assert.Equal(t, provider.NodeInfo{
+		Name:        "default-pool",
+		ClusterName: "demo",
+		Role:        "worker",
+		State:       "RUNNING",
+		ServerType:  "e2-standard-4",
+	}, nodes[0])
+	assert.Equal(t, "PROVISIONING", nodes[1].State)
+}
+
+func TestListNodesTranslatesNotFound(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{demoCluster()}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	_, err := prov.ListNodes(t.Context(), "missing")
+
+	require.ErrorIs(t, err, provider.ErrClusterNotFound)
+}
+
+func TestListNodesResolvesLocationWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{demoCluster()}}
+	prov := newProvider(t, fake, "")
+
+	nodes, err := prov.ListNodes(t.Context(), "demo")
+
+	require.NoError(t, err)
+	assert.Len(t, nodes, 2)
+}
+
+func TestListAllClustersReturnsNames(t *testing.T) {
+	t.Parallel()
+
+	other := &containerpb.Cluster{Name: "other", Location: "us-central1"}
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{demoCluster(), other}}
+	prov := newProvider(t, fake, "")
+
+	names, err := prov.ListAllClusters(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"demo", "other"}, names)
+}
+
+func TestListAllClustersPassesThroughError(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterManager{listErr: errBoom}, "")
+
+	_, err := prov.ListAllClusters(t.Context())
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestNodesExist(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{
+		demoCluster(),
+		{Name: "empty", Location: "europe-north1"},
+	}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	exists, err := prov.NodesExist(t.Context(), "demo")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = prov.NodesExist(t.Context(), "empty")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestStopNodesResizesAllPoolsToZero(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{demoCluster()}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	err := prov.StopNodes(t.Context(), "demo")
+
+	require.NoError(t, err)
+	require.Len(t, fake.resizes, 2)
+	assert.Equal(t, resizeCall{
+		name:  "projects/proj/locations/europe-north1/clusters/demo/nodePools/default-pool",
+		count: 0,
+	}, fake.resizes[0])
+	assert.Equal(t, int32(0), fake.resizes[1].count)
+}
+
+func TestStartNodesRestoresInitialCountFlooredAtOne(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{demoCluster()}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	err := prov.StartNodes(t.Context(), "demo")
+
+	require.NoError(t, err)
+	require.Len(t, fake.resizes, 2)
+	// default-pool restores its configured initial count.
+	assert.Equal(t, int32(3), fake.resizes[0].count)
+	// burst-pool has no initial count, so the floor of one node applies.
+	assert.Equal(t, int32(1), fake.resizes[1].count)
+}
+
+func TestStartStopNodesRequirePools(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{
+		{Name: "empty", Location: "europe-north1"},
+	}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	require.ErrorIs(t, prov.StartNodes(t.Context(), "empty"), provider.ErrNoNodes)
+	require.ErrorIs(t, prov.StopNodes(t.Context(), "empty"), provider.ErrNoNodes)
+}
+
+func TestStopNodesWrapsResizeError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		clusters: []*containerpb.Cluster{demoCluster()},
+		sizeErr:  errBoom,
+	}
+	prov := newProvider(t, fake, "europe-north1")
+
+	err := prov.StopNodes(t.Context(), "demo")
+
+	require.ErrorIs(t, err, errBoom)
+	assert.Contains(t, err.Error(), "stop nodes: resize node pool default-pool")
+}
+
+func TestDeleteNodesIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{}
+	prov := newProvider(t, fake, "europe-north1")
+
+	require.NoError(t, prov.DeleteNodes(t.Context(), "demo"))
+	assert.Empty(t, fake.resizes)
+}
+
+func TestGetClusterStatusAggregatesPools(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{demoCluster()}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	status, err := prov.GetClusterStatus(t.Context(), "demo")
+
+	require.NoError(t, err)
+	// One of two pools is RUNNING, so the cluster is degraded, not ready.
+	assert.Equal(t, provider.PhaseDegraded, status.Phase)
+	assert.False(t, status.Ready)
+	assert.Equal(t, 2, status.NodesTotal)
+	assert.Equal(t, 1, status.NodesReady)
+	assert.Equal(t, "34.88.0.1", status.Endpoint)
+}
+
+func TestGetClusterStatusNotFound(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterManager{}, "europe-north1")
+
+	_, err := prov.GetClusterStatus(t.Context(), "missing")
+
+	require.ErrorIs(t, err, provider.ErrClusterNotFound)
+}
+
+func TestGetClusterStatusWithoutPoolsIsStopped(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{clusters: []*containerpb.Cluster{
+		{Name: "empty", Location: "europe-north1", Endpoint: "34.88.0.2"},
+	}}
+	prov := newProvider(t, fake, "europe-north1")
+
+	status, err := prov.GetClusterStatus(t.Context(), "empty")
+
+	require.NoError(t, err)
+	assert.Equal(t, provider.PhaseStopped, status.Phase)
+	assert.False(t, status.Ready)
+	assert.Empty(t, status.Nodes)
+	assert.Equal(t, "34.88.0.2", status.Endpoint)
+}
+
+func TestProjectAccessor(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterManager{}, "")
+
+	assert.Equal(t, "proj", prov.Project())
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5681. Part of #4510 (GKE/AKS epic) — slice 2, building on the `pkg/client/gke` client from #5677.

## What

- **`pkg/svc/provider/gcp`** — a `provider.Provider` implementation for GKE, mirroring the AWS/EKS precedent (`pkg/svc/provider/aws`):
  - Node pools collapse to one `NodeInfo` each (pools are managed groups, not machines); pool machine type surfaces as `ServerType`.
  - `StopNodes` resizes every pool to zero (control plane keeps running, node costs stop); `StartNodes` restores `max(initialNodeCount, 1)` — GKE doesn't expose live per-pool size, so the resize is re-asserted idempotently (a same-size resize is a server-side no-op); the provisioner (slice 3) owns exact sizes.
  - `DeleteNodes` is a no-op (cluster deletion owns pools, like EKS).
  - `GetClusterStatus` builds from pool statuses via the shared `BuildClusterStatus`, with the EKS zero-pool `stopped` fallback, and surfaces the cluster endpoint.
  - gRPC `NotFound` anywhere in the chain translates to `provider.ErrClusterNotFound`.
  - With no configured location, cluster-scoped calls resolve the cluster's own location via the all-locations list (`-`), which cluster-scoped GKE calls otherwise reject.
- **`pkg/client/gke`** — adds the one call the provider needs: `SetNodePoolSize`, LRO-polled like Create/Delete, on the existing `clusterManager` seam.

**Out of scope (later #4510 slices):** GKE provisioner + factory routing (slice 3), `Provider` enum/schema surface (slice 4), AKS (slice 5). No CLI wiring changes, so no user-facing docs change.

## Validation

- `go build ./...` clean; `go test ./pkg/svc/provider/gcp ./pkg/client/gke` — 37 tests green (17 provider incl. `-race`, 20 client).
- `golangci-lint run` on both packages: 0 issues.
- jscpd across `provider/gcp`, `provider/aws`, `client/gke` at min-tokens 50: 0 clones.