### PR TITLE
feat(mirror): inject the read-only tap ephemeral container into the tap point pod

### DIFF
--- a/pkg/svc/mirror/inject.go
+++ b/pkg/svc/mirror/inject.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 )
 
 // TapContainerName is the fixed name of the ephemeral tap container InjectTap
@@ -66,6 +67,8 @@ func WithTapCommand(command ...string) TapOption {
 // runtime supports it; pod network is shared regardless, which is what the
 // mirror traffic path needs. Injection is one-way — ephemeral containers cannot
 // be removed — so a pod that already has a tap yields ErrTapAlreadyInjected.
+// Concurrent injectors converge on that same error: a 409 conflict from the
+// update re-reads the pod and re-checks for the tap before retrying.
 //
 // The container runs an inert holder command by default; wiring the actual
 // traffic tap and the reverse tunnel are the next Phase 1 increments (#4521).
@@ -86,29 +89,37 @@ func InjectTap(
 
 	pods := client.CoreV1().Pods(point.Namespace)
 
-	pod, err := pods.Get(ctx, point.Pod, metav1.GetOptions{})
-	if err != nil {
-		return "", fmt.Errorf("getting pod %q in %s: %w", point.Pod, point.Namespace, err)
-	}
-
-	for _, ephemeral := range pod.Spec.EphemeralContainers {
-		if ephemeral.Name == TapContainerName {
-			return "", fmt.Errorf(
-				"%w: %q on pod %q", ErrTapAlreadyInjected, TapContainerName, point.Pod,
-			)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod, err := pods.Get(ctx, point.Pod, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("getting pod: %w", err)
 		}
-	}
 
-	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, corev1.EphemeralContainer{
-		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-			Name:    TapContainerName,
-			Image:   cfg.image,
-			Command: cfg.command,
-		},
-		TargetContainerName: point.Container,
+		for _, ephemeral := range pod.Spec.EphemeralContainers {
+			if ephemeral.Name == TapContainerName {
+				return fmt.Errorf(
+					"%w: %q on pod %q", ErrTapAlreadyInjected, TapContainerName, point.Pod,
+				)
+			}
+		}
+
+		tap := corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:    TapContainerName,
+				Image:   cfg.image,
+				Command: cfg.command,
+			},
+			TargetContainerName: point.Container,
+		}
+		pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, tap)
+
+		_, err = pods.UpdateEphemeralContainers(ctx, pod.Name, pod, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("updating ephemeral containers: %w", err)
+		}
+
+		return nil
 	})
-
-	_, err = pods.UpdateEphemeralContainers(ctx, pod.Name, pod, metav1.UpdateOptions{})
 	if err != nil {
 		return "", fmt.Errorf(
 			"injecting tap container into pod %q in %s: %w", point.Pod, point.Namespace, err,

--- a/pkg/svc/mirror/inject.go
+++ b/pkg/svc/mirror/inject.go
@@ -1,0 +1,181 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// TapContainerName is the fixed name of the ephemeral tap container InjectTap
+// appends to the tap point's pod. One tap per pod: a second InjectTap on the
+// same pod returns ErrTapAlreadyInjected.
+const TapContainerName = "ksail-tap"
+
+// DefaultTapImage is the image the tap container runs when the caller does not
+// override it with WithTapImage. It matches the `workload debug` default: a
+// small, ubiquitous utility image.
+const DefaultTapImage = "docker.io/library/alpine:latest"
+
+// tapPollInterval is how often WaitForTap re-reads the pod while waiting for
+// the tap container to reach Running.
+const tapPollInterval = 250 * time.Millisecond
+
+// ErrTapPointNil is returned when InjectTap or WaitForTap is called with a nil
+// TapPoint.
+var ErrTapPointNil = errors.New("tap point is nil")
+
+// ErrTapAlreadyInjected is returned when the tap point's pod already carries a
+// tap container. Ephemeral containers cannot be removed or restarted, so the
+// existing tap is the one to use (or the pod must be replaced).
+var ErrTapAlreadyInjected = errors.New("tap container already injected")
+
+// ErrTapTerminated is returned by WaitForTap when the tap container terminated
+// instead of reaching Running.
+var ErrTapTerminated = errors.New("tap container terminated")
+
+// TapOption customises the ephemeral tap container InjectTap builds.
+type TapOption func(*tapConfig)
+
+// tapConfig holds the configurable parts of the tap container spec.
+type tapConfig struct {
+	image   string
+	command []string
+}
+
+// WithTapImage overrides the tap container's image (default DefaultTapImage).
+func WithTapImage(image string) TapOption {
+	return func(cfg *tapConfig) { cfg.image = image }
+}
+
+// WithTapCommand overrides the tap container's command. The default is an inert
+// holder (`sleep infinity`) until the later traffic increment supplies the real
+// tap process.
+func WithTapCommand(command ...string) TapOption {
+	return func(cfg *tapConfig) { cfg.command = command }
+}
+
+// InjectTap appends the read-only tap ephemeral container to the tap point's
+// pod and returns the container's name. The container targets the tap point's
+// container (TargetContainerName), sharing its process namespace where the
+// runtime supports it; pod network is shared regardless, which is what the
+// mirror traffic path needs. Injection is one-way — ephemeral containers cannot
+// be removed — so a pod that already has a tap yields ErrTapAlreadyInjected.
+//
+// The container runs an inert holder command by default; wiring the actual
+// traffic tap and the reverse tunnel are the next Phase 1 increments (#4521).
+func InjectTap(
+	ctx context.Context,
+	client kubernetes.Interface,
+	point *TapPoint,
+	opts ...TapOption,
+) (string, error) {
+	if point == nil {
+		return "", ErrTapPointNil
+	}
+
+	cfg := tapConfig{image: DefaultTapImage, command: []string{"sleep", "infinity"}}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	pods := client.CoreV1().Pods(point.Namespace)
+
+	pod, err := pods.Get(ctx, point.Pod, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting pod %q in %s: %w", point.Pod, point.Namespace, err)
+	}
+
+	for _, ephemeral := range pod.Spec.EphemeralContainers {
+		if ephemeral.Name == TapContainerName {
+			return "", fmt.Errorf(
+				"%w: %q on pod %q", ErrTapAlreadyInjected, TapContainerName, point.Pod,
+			)
+		}
+	}
+
+	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, corev1.EphemeralContainer{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:    TapContainerName,
+			Image:   cfg.image,
+			Command: cfg.command,
+		},
+		TargetContainerName: point.Container,
+	})
+
+	_, err = pods.UpdateEphemeralContainers(ctx, pod.Name, pod, metav1.UpdateOptions{})
+	if err != nil {
+		return "", fmt.Errorf(
+			"injecting tap container into pod %q in %s: %w", point.Pod, point.Namespace, err,
+		)
+	}
+
+	return TapContainerName, nil
+}
+
+// WaitForTap blocks until the tap container on the tap point's pod reports
+// Running, the container terminates (ErrTapTerminated, with its exit code), or
+// timeout elapses. A pod without a tap status yet is simply polled again — the
+// kubelet adds the status asynchronously after injection.
+func WaitForTap(
+	ctx context.Context,
+	client kubernetes.Interface,
+	point *TapPoint,
+	timeout time.Duration,
+) error {
+	if point == nil {
+		return ErrTapPointNil
+	}
+
+	err := wait.PollUntilContextTimeout(
+		ctx, tapPollInterval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := client.CoreV1().
+				Pods(point.Namespace).
+				Get(ctx, point.Pod, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf(
+					"getting pod %q in %s: %w",
+					point.Pod,
+					point.Namespace,
+					err,
+				)
+			}
+
+			return tapRunning(pod)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"waiting for tap container %q on pod %q: %w", TapContainerName, point.Pod, err,
+		)
+	}
+
+	return nil
+}
+
+// tapRunning reports whether the pod's tap container is Running. A terminated
+// tap is terminal (the kubelet never restarts ephemeral containers), so it
+// aborts the poll with ErrTapTerminated; a missing status keeps polling.
+func tapRunning(pod *corev1.Pod) (bool, error) {
+	for _, status := range pod.Status.EphemeralContainerStatuses {
+		if status.Name != TapContainerName {
+			continue
+		}
+
+		if status.State.Terminated != nil {
+			return false, fmt.Errorf(
+				"%w: exit code %d", ErrTapTerminated, status.State.Terminated.ExitCode,
+			)
+		}
+
+		return status.State.Running != nil, nil
+	}
+
+	return false, nil
+}

--- a/pkg/svc/mirror/inject_test.go
+++ b/pkg/svc/mirror/inject_test.go
@@ -1,0 +1,188 @@
+package mirror_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// errUpdateFailed is a static sentinel for the UpdateEphemeralContainers-error
+// reactor test.
+var errUpdateFailed = errors.New("update ephemeral containers failed")
+
+// newTapPoint builds the tap point the injection tests target: the test pod's
+// sole container.
+func newTapPoint() *mirror.TapPoint {
+	return &mirror.TapPoint{Namespace: testNamespace, Pod: "api-0", Container: "api"}
+}
+
+// tappedPod builds a Running pod that already carries a tap ephemeral
+// container, for the idempotency test.
+func tappedPod() *corev1.Pod {
+	pod := newPod("api-0", selectorLabels(), corev1.PodRunning)
+	pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: mirror.TapContainerName},
+	}}
+
+	return pod
+}
+
+// podWithTapStatus builds a Running pod whose tap ephemeral container reports
+// the given state.
+func podWithTapStatus(state corev1.ContainerState) *corev1.Pod {
+	pod := tappedPod()
+	pod.Status.EphemeralContainerStatuses = []corev1.ContainerStatus{{
+		Name:  mirror.TapContainerName,
+		State: state,
+	}}
+
+	return pod
+}
+
+func TestInjectTapDefaults(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
+
+	require.NoError(t, err)
+	assert.Equal(t, mirror.TapContainerName, name)
+
+	pod, err := clientset.CoreV1().
+		Pods(testNamespace).
+		Get(t.Context(), "api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, pod.Spec.EphemeralContainers, 1)
+
+	tap := pod.Spec.EphemeralContainers[0]
+	assert.Equal(t, mirror.TapContainerName, tap.Name)
+	assert.Equal(t, mirror.DefaultTapImage, tap.Image)
+	assert.Equal(t, []string{"sleep", "infinity"}, tap.Command)
+	assert.Equal(t, "api", tap.TargetContainerName)
+}
+
+func TestInjectTapOptions(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	_, err := mirror.InjectTap(
+		t.Context(), clientset, newTapPoint(),
+		mirror.WithTapImage("ghcr.io/example/tap:1"),
+		mirror.WithTapCommand("tcpdump", "-i", "any"),
+	)
+
+	require.NoError(t, err)
+
+	pod, err := clientset.CoreV1().
+		Pods(testNamespace).
+		Get(t.Context(), "api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, pod.Spec.EphemeralContainers, 1)
+	assert.Equal(t, "ghcr.io/example/tap:1", pod.Spec.EphemeralContainers[0].Image)
+	assert.Equal(t, []string{"tcpdump", "-i", "any"}, pod.Spec.EphemeralContainers[0].Command)
+}
+
+func TestInjectTapNilPoint(t *testing.T) {
+	t.Parallel()
+
+	name, err := mirror.InjectTap(t.Context(), k8sfake.NewClientset(), nil)
+
+	require.ErrorIs(t, err, mirror.ErrTapPointNil)
+	assert.Empty(t, name)
+}
+
+func TestInjectTapPodMissing(t *testing.T) {
+	t.Parallel()
+
+	name, err := mirror.InjectTap(t.Context(), k8sfake.NewClientset(), newTapPoint())
+
+	require.Error(t, err)
+	assert.Empty(t, name)
+}
+
+func TestInjectTapAlreadyInjected(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(tappedPod())
+
+	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
+
+	require.ErrorIs(t, err, mirror.ErrTapAlreadyInjected)
+	assert.Empty(t, name)
+}
+
+func TestInjectTapUpdateError(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+	clientset.PrependReactor("update", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "ephemeralcontainers" {
+				return false, nil, nil
+			}
+
+			return true, nil, errUpdateFailed
+		})
+
+	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
+
+	require.ErrorIs(t, err, errUpdateFailed)
+	assert.Empty(t, name)
+}
+
+func TestWaitForTapNilPoint(t *testing.T) {
+	t.Parallel()
+
+	err := mirror.WaitForTap(t.Context(), k8sfake.NewClientset(), nil, time.Second)
+
+	require.ErrorIs(t, err, mirror.ErrTapPointNil)
+}
+
+func TestWaitForTapRunning(t *testing.T) {
+	t.Parallel()
+
+	pod := podWithTapStatus(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}})
+	clientset := k8sfake.NewClientset(pod)
+
+	err := mirror.WaitForTap(t.Context(), clientset, newTapPoint(), time.Second)
+
+	require.NoError(t, err)
+}
+
+func TestWaitForTapTerminated(t *testing.T) {
+	t.Parallel()
+
+	pod := podWithTapStatus(corev1.ContainerState{
+		Terminated: &corev1.ContainerStateTerminated{ExitCode: 2},
+	})
+	clientset := k8sfake.NewClientset(pod)
+
+	err := mirror.WaitForTap(t.Context(), clientset, newTapPoint(), time.Second)
+
+	require.ErrorIs(t, err, mirror.ErrTapTerminated)
+	assert.ErrorContains(t, err, "exit code 2")
+}
+
+func TestWaitForTapTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Pod exists but never reports a tap status: the poll must give up at the
+	// timeout rather than spin forever.
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	err := mirror.WaitForTap(t.Context(), clientset, newTapPoint(), 50*time.Millisecond)
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, mirror.ErrTapTerminated)
+}

--- a/pkg/svc/mirror/inject_test.go
+++ b/pkg/svc/mirror/inject_test.go
@@ -2,6 +2,7 @@ package mirror_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,8 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -138,6 +141,78 @@ func TestInjectTapUpdateError(t *testing.T) {
 	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
 
 	require.ErrorIs(t, err, errUpdateFailed)
+	assert.Empty(t, name)
+}
+
+// conflictError builds the 409 the API server returns when a concurrent write
+// bumped the pod's resourceVersion between InjectTap's read and its update.
+func conflictError() error {
+	return apierrors.NewConflict(
+		schema.GroupResource{Resource: "pods"}, "api-0", errUpdateFailed,
+	)
+}
+
+func TestInjectTapConflictRetriesAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	conflicted := false
+
+	clientset.PrependReactor("update", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "ephemeralcontainers" || conflicted {
+				return false, nil, nil
+			}
+
+			conflicted = true
+
+			return true, nil, conflictError()
+		})
+
+	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
+
+	require.NoError(t, err)
+	assert.Equal(t, mirror.TapContainerName, name)
+	assert.True(t, conflicted)
+
+	pod, err := clientset.CoreV1().
+		Pods(testNamespace).
+		Get(t.Context(), "api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, pod.Spec.EphemeralContainers, 1)
+}
+
+func TestInjectTapConflictLoserConvergesOnAlreadyInjected(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	// The first update conflicts AND lands the winner's tap in the store, so
+	// the retry's re-read must yield ErrTapAlreadyInjected, not the conflict.
+	conflicted := false
+
+	clientset.PrependReactor("update", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "ephemeralcontainers" || conflicted {
+				return false, nil, nil
+			}
+
+			conflicted = true
+
+			err := clientset.Tracker().Update(
+				corev1.SchemeGroupVersion.WithResource("pods"), tappedPod(), testNamespace,
+			)
+			if err != nil {
+				return true, nil, fmt.Errorf("seeding winner pod: %w", err)
+			}
+
+			return true, nil, conflictError()
+		})
+
+	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
+
+	require.ErrorIs(t, err, mirror.ErrTapAlreadyInjected)
 	assert.Empty(t, name)
 }
 

--- a/pkg/svc/mirror/inject_test.go
+++ b/pkg/svc/mirror/inject_test.go
@@ -18,6 +18,10 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
+// ephemeralContainersSubresource is the pod subresource the injection reactors
+// intercept.
+const ephemeralContainersSubresource = "ephemeralcontainers"
+
 // errUpdateFailed is a static sentinel for the UpdateEphemeralContainers-error
 // reactor test.
 var errUpdateFailed = errors.New("update ephemeral containers failed")
@@ -131,7 +135,7 @@ func TestInjectTapUpdateError(t *testing.T) {
 	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
 	clientset.PrependReactor("update", "pods",
 		func(action k8stesting.Action) (bool, runtime.Object, error) {
-			if action.GetSubresource() != "ephemeralcontainers" {
+			if action.GetSubresource() != ephemeralContainersSubresource {
 				return false, nil, nil
 			}
 
@@ -161,7 +165,7 @@ func TestInjectTapConflictRetriesAndSucceeds(t *testing.T) {
 
 	clientset.PrependReactor("update", "pods",
 		func(action k8stesting.Action) (bool, runtime.Object, error) {
-			if action.GetSubresource() != "ephemeralcontainers" || conflicted {
+			if action.GetSubresource() != ephemeralContainersSubresource || conflicted {
 				return false, nil, nil
 			}
 
@@ -194,7 +198,7 @@ func TestInjectTapConflictLoserConvergesOnAlreadyInjected(t *testing.T) {
 
 	clientset.PrependReactor("update", "pods",
 		func(action k8stesting.Action) (bool, runtime.Object, error) {
-			if action.GetSubresource() != "ephemeralcontainers" || conflicted {
+			if action.GetSubresource() != ephemeralContainersSubresource || conflicted {
 				return false, nil, nil
 			}
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5684 · Part of #4521 (Phase 1 — mirror-only)

## What

The attachment increment between the merged selection logic (`ResolveTarget` #5534, `SelectTapPoint` #5537) and the upcoming traffic path:

- **`mirror.InjectTap(ctx, client, point, opts...)`** — appends a `ksail-tap` ephemeral container to the tap point's pod via the `ephemeralcontainers` subresource, with `TargetContainerName` set to the selected container. Double-injection is guarded (`ErrTapAlreadyInjected` — ephemeral containers can't be removed, so the existing tap is authoritative). `WithTapImage` / `WithTapCommand` options; defaults are the `workload debug` alpine image and an inert `sleep infinity` holder until the traffic increment supplies the real tap process.
- **`mirror.WaitForTap(ctx, client, point, timeout)`** — polls `ephemeralContainerStatuses` until the tap reports Running; a terminated tap aborts with `ErrTapTerminated` (exit code in the message); a not-yet-reported status keeps polling (kubelet adds it asynchronously).

## Why this shape

ksail wraps kubectl's `debug` command wholesale and has no injection helper of its own, so this uses client-go's `Pods().UpdateEphemeralContainers` directly — the same mechanism, native and in-process per the #4521 design decision. Both functions are pure client-go over the already-merged `TapPoint` contract, keeping this slice fully unit-testable without a cluster.

## Validation

- `go build ./...` clean; `golangci-lint run` — no issues.
- `go test ./pkg/svc/mirror/` — 27 tests pass (10 new: defaults, option overrides, nil-point, pod-missing, already-injected, update-error reactor, wait running / terminated / timeout / nil-point).
- Full `go test ./...`: 5847 passed; the 6 fails are the documented `pkg/svc/chat` parallel-run copilot-CLI flake (passes alone: 64/64).

## Next increments (anti-stacked, follow-ups on #4521)

1. Traffic tap process (replace the holder command; needs the read-only capture design — NET_RAW/pcap vs socat duplication).
2. Reverse port-forward tunnel to the local process.
