### PR TITLE
feat(bootstrap): SSH remote-exec primitive for Hetzner live bring-up

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -173,6 +173,11 @@ linters:
             - github.com/googleapis/gax-go
             - filippo.io/age
             - golang.design/x
+            # x/crypto/ssh backs pkg/svc/bootstrap/ssh — the post-provision
+            # remote-exec transport for Hetzner live bring-up (#5696): kubeconfig
+            # fetch + join sequencing, native Go instead of a shelled ssh binary.
+            # Already linked transitively (containerd/helm stack).
+            - golang.org/x/crypto/ssh
             - golang.org/x/oauth2
             - golang.org/x/sync
             - golang.org/x/term

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/sigstore/sigstore v1.10.8
 	github.com/sigstore/sigstore-go v1.2.1
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.38.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa
@@ -925,7 +926,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/image v0.43.0 // indirect

--- a/pkg/svc/bootstrap/ssh/client.go
+++ b/pkg/svc/bootstrap/ssh/client.go
@@ -1,0 +1,250 @@
+package sshbootstrap
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	// DefaultDialTimeout bounds a single TCP+handshake attempt when
+	// Options.DialTimeout is zero.
+	DefaultDialTimeout = 10 * time.Second
+
+	// DefaultRetryInterval is the pause between [DialWithRetry] attempts when the
+	// caller passes a non-positive interval. First boot of a cloud server takes
+	// tens of seconds, so a few seconds between probes is plenty.
+	DefaultRetryInterval = 3 * time.Second
+)
+
+// Options configures [Dial]. Addr, User, Signer, and HostKeyCallback are
+// required; see the matching Err* sentinels.
+type Options struct {
+	// Addr is the server's host:port SSH endpoint.
+	Addr string
+	// User is the login to authenticate as (root on Hetzner stock images).
+	User string
+	// Signer is the client identity, typically [KeyPair.Signer].
+	Signer ssh.Signer
+	// HostKeyCallback is the host-key trust policy. There is no default: pick
+	// ssh.FixedHostKey when the host key is known, or an explicit
+	// trust-on-first-use policy at the call site.
+	HostKeyCallback ssh.HostKeyCallback
+	// DialTimeout bounds each connection attempt; zero means
+	// [DefaultDialTimeout].
+	DialTimeout time.Duration
+}
+
+func (o Options) validate() error {
+	switch {
+	case o.Addr == "":
+		return ErrMissingAddr
+	case o.User == "":
+		return ErrMissingUser
+	case o.Signer == nil:
+		return ErrMissingSigner
+	case o.HostKeyCallback == nil:
+		return ErrMissingHostKeyCallback
+	default:
+		return nil
+	}
+}
+
+// Client is an established SSH connection to a bootstrapped server. It is safe
+// for sequential use; close it when done.
+type Client struct {
+	conn *ssh.Client
+}
+
+// RunResult carries a remote command's captured output. ExitCode is only
+// meaningful when the returned error wraps [ErrCommandFailed] (non-zero exit)
+// or is nil (zero exit).
+type RunResult struct {
+	Stdout   []byte
+	Stderr   []byte
+	ExitCode int
+}
+
+// Dial opens a single SSH connection attempt to the server, bounded by ctx and
+// Options.DialTimeout.
+func Dial(ctx context.Context, opts Options) (*Client, error) {
+	err := opts.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := opts.DialTimeout
+	if timeout <= 0 {
+		timeout = DefaultDialTimeout
+	}
+
+	dialer := net.Dialer{Timeout: timeout}
+
+	netConn, err := dialer.DialContext(ctx, "tcp", opts.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", opts.Addr, err)
+	}
+
+	config := &ssh.ClientConfig{
+		User:            opts.User,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(opts.Signer)},
+		HostKeyCallback: opts.HostKeyCallback,
+		Timeout:         timeout,
+	}
+
+	// The handshake API is not context-aware; closing the net.Conn on
+	// cancellation unblocks it.
+	stop := closeOnDone(ctx, netConn)
+
+	sshConn, channels, requests, err := ssh.NewClientConn(netConn, opts.Addr, config)
+
+	stop()
+
+	if err != nil {
+		_ = netConn.Close()
+
+		return nil, fmt.Errorf("ssh handshake with %s: %w", opts.Addr, err)
+	}
+
+	return &Client{conn: ssh.NewClient(sshConn, channels, requests)}, nil
+}
+
+// DialWithRetry dials until the server's SSH endpoint accepts the connection
+// or ctx expires — the "wait for first boot" primitive. A non-positive
+// interval means [DefaultRetryInterval]. The last attempt's error is wrapped
+// into the context error so the caller sees why the wait was still failing
+// when time ran out.
+func DialWithRetry(
+	ctx context.Context,
+	opts Options,
+	interval time.Duration,
+) (*Client, error) {
+	if interval <= 0 {
+		interval = DefaultRetryInterval
+	}
+
+	var lastErr error
+
+	for {
+		client, err := Dial(ctx, opts)
+		if err == nil {
+			return client, nil
+		}
+
+		// Option errors never heal; retrying them would just burn the deadline.
+		if errors.Is(err, ErrMissingAddr) || errors.Is(err, ErrMissingUser) ||
+			errors.Is(err, ErrMissingSigner) || errors.Is(err, ErrMissingHostKeyCallback) {
+			return nil, err
+		}
+
+		lastErr = err
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf(
+				"ssh endpoint %s did not come up: %w (last attempt: %w)",
+				opts.Addr, ctx.Err(), lastErr,
+			)
+		case <-time.After(interval):
+		}
+	}
+}
+
+// Run executes a single command on the server and captures its output. A
+// non-zero exit returns [RunResult] alongside an error wrapping
+// [ErrCommandFailed]; transport failures return only the error.
+func (c *Client) Run(ctx context.Context, command string) (RunResult, error) {
+	session, err := c.conn.NewSession()
+	if err != nil {
+		return RunResult{}, fmt.Errorf("open session: %w", err)
+	}
+
+	defer func() { _ = session.Close() }()
+
+	var stdout, stderr bytes.Buffer
+
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+
+	// Session.Run is not context-aware; closing the session on cancellation
+	// unblocks it.
+	stop := closeOnDone(ctx, session)
+
+	err = session.Run(command)
+
+	stop()
+
+	result := RunResult{Stdout: stdout.Bytes(), Stderr: stderr.Bytes(), ExitCode: 0}
+
+	var exitErr *ssh.ExitError
+	if errors.As(err, &exitErr) {
+		result.ExitCode = exitErr.ExitStatus()
+
+		return result, fmt.Errorf(
+			"%w: %q exited %d: %s",
+			ErrCommandFailed, command, result.ExitCode,
+			strings.TrimSpace(stderr.String()),
+		)
+	}
+
+	if err != nil {
+		if ctx.Err() != nil {
+			return result, fmt.Errorf("run %q: %w", command, ctx.Err())
+		}
+
+		return result, fmt.Errorf("run %q: %w", command, err)
+	}
+
+	return result, nil
+}
+
+// ReadFile streams a remote file's contents over the exec channel (`cat`), so
+// fetching the kubeconfig needs no SFTP subsystem. The path is single-quoted
+// against shell interpretation.
+func (c *Client) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	result, err := c.Run(ctx, "cat -- "+shellQuote(path))
+	if err != nil {
+		return nil, fmt.Errorf("read remote file %s: %w", path, err)
+	}
+
+	return result.Stdout, nil
+}
+
+// Close tears down the underlying SSH connection.
+func (c *Client) Close() error {
+	err := c.conn.Close()
+	if err != nil {
+		return fmt.Errorf("close ssh connection: %w", err)
+	}
+
+	return nil
+}
+
+// closeOnDone closes closer when ctx is cancelled, and returns a stop func
+// that ends the watch (idempotent with respect to the ctx firing afterwards —
+// the closer is only closed while the watch is active).
+func closeOnDone(ctx context.Context, closer interface{ Close() error }) func() {
+	done := make(chan struct{})
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = closer.Close()
+		case <-done:
+		}
+	}()
+
+	return func() { close(done) }
+}
+
+// shellQuote single-quotes s for POSIX shells, escaping embedded single
+// quotes, so remote paths survive word splitting and globbing.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/pkg/svc/bootstrap/ssh/client_test.go
+++ b/pkg/svc/bootstrap/ssh/client_test.go
@@ -1,0 +1,529 @@
+package sshbootstrap_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	testUser          = "root"
+	testDialTimeout   = 5 * time.Second
+	testRetryInterval = 30 * time.Millisecond
+	testCancelBudget  = 250 * time.Millisecond
+	testRunBudget     = 5 * time.Second
+)
+
+var errUnknownClientKey = errors.New("unknown client key")
+
+// execHandler scripts the in-process server's response to one exec request.
+type execHandler func(command string) (stdout string, stderr string, exitCode uint32)
+
+// exitStatusPayload is the SSH exit-status request payload (RFC 4254 §6.10).
+type exitStatusPayload struct {
+	Status uint32
+}
+
+// startServer runs a minimal in-process SSH server that authenticates
+// clientKey, answers exec requests via handler, and rejects the first
+// rejectFirst TCP connections outright (to exercise retry). It returns the
+// listen address and the server's host key.
+func startServer(
+	t *testing.T,
+	clientKey ssh.PublicKey,
+	handler execHandler,
+	rejectFirst int,
+) (string, ssh.PublicKey) {
+	t.Helper()
+
+	hostPair, err := sshbootstrap.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+
+	config := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if !bytes.Equal(key.Marshal(), clientKey.Marshal()) {
+				return nil, errUnknownClientKey
+			}
+
+			return &ssh.Permissions{}, nil
+		},
+	}
+	config.AddHostKey(hostPair.Signer)
+
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go acceptLoop(listener, config, handler, rejectFirst)
+
+	return listener.Addr().String(), hostPair.Signer.PublicKey()
+}
+
+// acceptLoop serves connections until the listener closes.
+func acceptLoop(
+	listener net.Listener,
+	config *ssh.ServerConfig,
+	handler execHandler,
+	rejectFirst int,
+) {
+	rejected := 0
+
+	for {
+		netConn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+
+		if rejected < rejectFirst {
+			rejected++
+
+			_ = netConn.Close()
+
+			continue
+		}
+
+		go serveConn(netConn, config, handler)
+	}
+}
+
+// serveConn handles one SSH connection: session channels with exec requests.
+func serveConn(netConn net.Conn, config *ssh.ServerConfig, handler execHandler) {
+	_, channels, requests, err := ssh.NewServerConn(netConn, config)
+	if err != nil {
+		return
+	}
+
+	go ssh.DiscardRequests(requests)
+
+	for newChannel := range channels {
+		if newChannel.ChannelType() != "session" {
+			_ = newChannel.Reject(ssh.UnknownChannelType, "only sessions are supported")
+
+			continue
+		}
+
+		channel, channelRequests, err := newChannel.Accept()
+		if err != nil {
+			continue
+		}
+
+		go serveSession(channel, channelRequests, handler)
+	}
+}
+
+// execRequestPayload is the SSH exec request payload (RFC 4254 §6.5).
+type execRequestPayload struct {
+	Command string
+}
+
+// serveSession answers exec requests on one session channel.
+func serveSession(channel ssh.Channel, requests <-chan *ssh.Request, handler execHandler) {
+	defer func() { _ = channel.Close() }()
+
+	for request := range requests {
+		if request.Type != "exec" {
+			_ = request.Reply(false, nil)
+
+			continue
+		}
+
+		var payload execRequestPayload
+
+		err := ssh.Unmarshal(request.Payload, &payload)
+		if err != nil {
+			_ = request.Reply(false, nil)
+
+			continue
+		}
+
+		_ = request.Reply(true, nil)
+
+		stdout, stderr, exitCode := handler(payload.Command)
+
+		_, _ = channel.Write([]byte(stdout))
+		_, _ = channel.Stderr().Write([]byte(stderr))
+		_, _ = channel.SendRequest(
+			"exit-status", false, ssh.Marshal(exitStatusPayload{Status: exitCode}),
+		)
+
+		return
+	}
+}
+
+// dialOptions builds client options against the test server.
+func dialOptions(
+	addr string,
+	pair sshbootstrap.KeyPair,
+	hostKey ssh.PublicKey,
+) sshbootstrap.Options {
+	return sshbootstrap.Options{
+		Addr:            addr,
+		User:            testUser,
+		Signer:          pair.Signer,
+		HostKeyCallback: ssh.FixedHostKey(hostKey),
+		DialTimeout:     testDialTimeout,
+	}
+}
+
+// mustDial connects to the test server or fails the test.
+func mustDial(
+	t *testing.T,
+	addr string,
+	pair sshbootstrap.KeyPair,
+	hostKey ssh.PublicKey,
+) *sshbootstrap.Client {
+	t.Helper()
+
+	client, err := sshbootstrap.Dial(t.Context(), dialOptions(addr, pair, hostKey))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// mustGenerateKeyPair mints a client keypair or fails the test.
+func mustGenerateKeyPair(t *testing.T) sshbootstrap.KeyPair {
+	t.Helper()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+
+	return pair
+}
+
+func TestGenerateKeyPairRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+
+	parsedPub, _, _, rest, err := ssh.ParseAuthorizedKey([]byte(pair.AuthorizedKey + "\n"))
+	if err != nil {
+		t.Fatalf("authorized key does not parse: %v", err)
+	}
+
+	if len(rest) != 0 {
+		t.Fatalf("authorized key has trailing data: %q", rest)
+	}
+
+	if !bytes.Equal(parsedPub.Marshal(), pair.Signer.PublicKey().Marshal()) {
+		t.Fatal("authorized key does not match the signer's public key")
+	}
+
+	restored, err := sshbootstrap.ParsePrivateKey(pair.PrivateKeyPEM)
+	if err != nil {
+		t.Fatalf("PEM round-trip failed: %v", err)
+	}
+
+	if restored.AuthorizedKey != pair.AuthorizedKey {
+		t.Fatalf(
+			"round-tripped public key mismatch: got %q, want %q",
+			restored.AuthorizedKey, pair.AuthorizedKey,
+		)
+	}
+}
+
+func TestParsePrivateKeyRejectsGarbage(t *testing.T) {
+	t.Parallel()
+
+	_, err := sshbootstrap.ParsePrivateKey([]byte("not a key"))
+	if err == nil {
+		t.Fatal("expected an error for garbage input")
+	}
+}
+
+func TestDialValidatesOptions(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+	hostKeyCallback := ssh.FixedHostKey(pair.Signer.PublicKey())
+
+	tests := []struct {
+		name    string
+		opts    sshbootstrap.Options
+		wantErr error
+	}{
+		{
+			name: "missing addr",
+			opts: sshbootstrap.Options{
+				User:            testUser,
+				Signer:          pair.Signer,
+				HostKeyCallback: hostKeyCallback,
+			},
+			wantErr: sshbootstrap.ErrMissingAddr,
+		},
+		{
+			name: "missing user",
+			opts: sshbootstrap.Options{
+				Addr:            "127.0.0.1:22",
+				Signer:          pair.Signer,
+				HostKeyCallback: hostKeyCallback,
+			},
+			wantErr: sshbootstrap.ErrMissingUser,
+		},
+		{
+			name: "missing signer",
+			opts: sshbootstrap.Options{
+				Addr:            "127.0.0.1:22",
+				User:            testUser,
+				HostKeyCallback: hostKeyCallback,
+			},
+			wantErr: sshbootstrap.ErrMissingSigner,
+		},
+		{
+			name: "missing host key callback",
+			opts: sshbootstrap.Options{
+				Addr:   "127.0.0.1:22",
+				User:   testUser,
+				Signer: pair.Signer,
+			},
+			wantErr: sshbootstrap.ErrMissingHostKeyCallback,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := sshbootstrap.Dial(t.Context(), testCase.opts)
+			if !errors.Is(err, testCase.wantErr) {
+				t.Fatalf("got %v, want %v", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunCapturesOutputAndZeroExit(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(command string) (string, string, uint32) {
+			if command != "uname -r" {
+				return "", "unexpected command: " + command, 1
+			}
+
+			return "6.8.0-generic\n", "", 0
+		},
+		0,
+	)
+
+	client := mustDial(t, addr, pair, hostKey)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testRunBudget)
+	defer cancel()
+
+	result, err := client.Run(ctx, "uname -r")
+	if err != nil {
+		t.Fatalf("run: %v (stderr: %s)", err, result.Stderr)
+	}
+
+	if got, want := string(result.Stdout), "6.8.0-generic\n"; got != want {
+		t.Fatalf("stdout: got %q, want %q", got, want)
+	}
+
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code: got %d, want 0", result.ExitCode)
+	}
+}
+
+func TestRunSurfacesNonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(t, pair.Signer.PublicKey(), func(string) (string, string, uint32) {
+		return "", "boom\n", 7
+	}, 0)
+
+	client := mustDial(t, addr, pair, hostKey)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testRunBudget)
+	defer cancel()
+
+	result, err := client.Run(ctx, "false")
+	if !errors.Is(err, sshbootstrap.ErrCommandFailed) {
+		t.Fatalf("got %v, want ErrCommandFailed", err)
+	}
+
+	if result.ExitCode != 7 {
+		t.Fatalf("exit code: got %d, want 7", result.ExitCode)
+	}
+
+	if got, want := string(result.Stderr), "boom\n"; got != want {
+		t.Fatalf("stderr: got %q, want %q", got, want)
+	}
+}
+
+func TestReadFileFetchesQuotedPath(t *testing.T) {
+	t.Parallel()
+
+	const kubeconfig = "apiVersion: v1\nkind: Config\n"
+
+	var sawCommand string
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(command string) (string, string, uint32) {
+			sawCommand = command
+
+			return kubeconfig, "", 0
+		},
+		0,
+	)
+
+	client := mustDial(t, addr, pair, hostKey)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testRunBudget)
+	defer cancel()
+
+	got, err := client.ReadFile(ctx, "/etc/rancher/k3s/k3s.yaml")
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	if string(got) != kubeconfig {
+		t.Fatalf("content: got %q, want %q", got, kubeconfig)
+	}
+
+	if want := "cat -- '/etc/rancher/k3s/k3s.yaml'"; sawCommand != want {
+		t.Fatalf("command: got %q, want %q", sawCommand, want)
+	}
+}
+
+func TestReadFileEscapesSingleQuotes(t *testing.T) {
+	t.Parallel()
+
+	var sawCommand string
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(command string) (string, string, uint32) {
+			sawCommand = command
+
+			return "", "", 0
+		},
+		0,
+	)
+
+	client := mustDial(t, addr, pair, hostKey)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testRunBudget)
+	defer cancel()
+
+	_, err := client.ReadFile(ctx, "/tmp/o'clock")
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	if want := `cat -- '/tmp/o'\''clock'`; sawCommand != want {
+		t.Fatalf("command: got %q, want %q", sawCommand, want)
+	}
+}
+
+func TestDialRejectsUnknownHostKey(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+	otherPair := mustGenerateKeyPair(t)
+
+	addr, _ := startServer(t, pair.Signer.PublicKey(), func(string) (string, string, uint32) {
+		return "", "", 0
+	}, 0)
+
+	// Pin the WRONG host key: the handshake must fail.
+	_, err := sshbootstrap.Dial(
+		t.Context(),
+		dialOptions(addr, pair, otherPair.Signer.PublicKey()),
+	)
+	if err == nil {
+		t.Fatal("expected a host-key verification error")
+	}
+}
+
+func TestDialWithRetryRecoversFromEarlyRefusals(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(t, pair.Signer.PublicKey(), func(string) (string, string, uint32) {
+		return "up\n", "", 0
+	}, 2)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testRunBudget)
+	defer cancel()
+
+	client, err := sshbootstrap.DialWithRetry(
+		ctx, dialOptions(addr, pair, hostKey), testRetryInterval,
+	)
+	if err != nil {
+		t.Fatalf("dial with retry: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+}
+
+func TestDialWithRetryHonoursContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+
+	// Reserve a port, then close it so every attempt is refused.
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	addr := listener.Addr().String()
+	_ = listener.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), testCancelBudget)
+	defer cancel()
+
+	_, err = sshbootstrap.DialWithRetry(
+		ctx,
+		dialOptions(addr, pair, pair.Signer.PublicKey()),
+		testRetryInterval,
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("got %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestDialWithRetryStopsOnOptionError(t *testing.T) {
+	t.Parallel()
+
+	started := time.Now()
+
+	_, err := sshbootstrap.DialWithRetry(
+		t.Context(),
+		sshbootstrap.Options{Addr: "127.0.0.1:22", User: testUser},
+		testRetryInterval,
+	)
+	if !errors.Is(err, sshbootstrap.ErrMissingSigner) {
+		t.Fatalf("got %v, want ErrMissingSigner", err)
+	}
+
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("option error should fail fast, took %s", elapsed)
+	}
+}

--- a/pkg/svc/bootstrap/ssh/doc.go
+++ b/pkg/svc/bootstrap/ssh/doc.go
@@ -1,0 +1,26 @@
+// Package sshbootstrap is the post-provision half of the server bootstrap
+// transport: a minimal, provider-agnostic SSH client for talking to a server
+// that cloud-init (pkg/svc/bootstrap/cloudinit) has already brought up.
+//
+// The provision-time seam delivers install commands as user_data at server
+// creation; it is fire-and-forget and cannot observe the server afterwards.
+// The K3s × Hetzner (devantler-tech/ksail#5512) and kubeadm × Hetzner
+// (devantler-tech/ksail#5513) live bring-up paths additionally need to reach
+// the first server after boot — to retrieve the kubeconfig
+// (/etc/rancher/k3s/k3s.yaml, /etc/kubernetes/admin.conf) and to observe join
+// sequencing — which is exactly the seam this package provides
+// (devantler-tech/ksail#5696):
+//
+//   - [GenerateKeyPair] mints the per-cluster ed25519 identity: the public half
+//     is registered at server creation, the private half authenticates the
+//     client.
+//   - [DialWithRetry] waits for the server's SSH endpoint to come up after
+//     first boot, bounded by the caller's context.
+//   - [Client.Run] executes a single command; [Client.ReadFile] streams a
+//     remote file (the kubeconfig) over the same exec channel, so no SFTP
+//     subsystem or extra dependency is needed.
+//
+// Everything is native Go (golang.org/x/crypto/ssh) — no shelled-out ssh
+// binary — and unit-testable against an in-process SSH server, so the package
+// carries no Hetzner coupling and no cloud cost.
+package sshbootstrap

--- a/pkg/svc/bootstrap/ssh/errors.go
+++ b/pkg/svc/bootstrap/ssh/errors.go
@@ -1,0 +1,33 @@
+package sshbootstrap
+
+import "errors"
+
+var (
+	// ErrMissingAddr is returned when Options.Addr is empty. The dialer needs the
+	// server's host:port endpoint; for Hetzner nodes this is the server's public
+	// IPv4 with the SSH port.
+	ErrMissingAddr = errors.New("ssh bootstrap: server address is required")
+
+	// ErrMissingUser is returned when Options.User is empty. Cloud images boot
+	// with a distribution-specific login (root on Hetzner's stock images), so the
+	// caller must always name one — there is no safe default.
+	ErrMissingUser = errors.New("ssh bootstrap: user is required")
+
+	// ErrMissingSigner is returned when Options.Signer is nil. The client
+	// authenticates exclusively with the per-cluster keypair
+	// ([GenerateKeyPair]); password authentication is deliberately unsupported.
+	ErrMissingSigner = errors.New("ssh bootstrap: signer is required")
+
+	// ErrMissingHostKeyCallback is returned when Options.HostKeyCallback is nil.
+	// Requiring an explicit callback forces the caller to choose a host-key
+	// policy; silently defaulting to accept-anything would invite
+	// man-in-the-middle attacks on the kubeconfig fetch.
+	ErrMissingHostKeyCallback = errors.New(
+		"ssh bootstrap: host key callback is required",
+	)
+
+	// ErrCommandFailed is returned (wrapped, with the command, exit code, and
+	// stderr) when a remote command runs but exits non-zero. Callers branch on it
+	// with errors.Is and read the exit code from [RunResult.ExitCode].
+	ErrCommandFailed = errors.New("ssh bootstrap: remote command failed")
+)

--- a/pkg/svc/bootstrap/ssh/keys.go
+++ b/pkg/svc/bootstrap/ssh/keys.go
@@ -1,0 +1,79 @@
+package sshbootstrap
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// KeyPair is the per-cluster SSH identity: the public half is registered with
+// the provider at server-creation time (e.g. hcloud SSH keys / cloud-init
+// authorized_keys), the private half authenticates [Dial]. ed25519 keeps it
+// small, modern, and universally supported by current cloud images.
+type KeyPair struct {
+	// Signer authenticates the client side of the connection; pass it to
+	// [Options.Signer].
+	Signer ssh.Signer
+	// AuthorizedKey is the single-line authorized_keys / provider representation
+	// of the public key (no trailing newline).
+	AuthorizedKey string
+	// PrivateKeyPEM is the OpenSSH PEM encoding of the private key, for
+	// persisting the identity so later invocations (start/stop/delete flows) can
+	// reconnect to the same cluster.
+	PrivateKeyPEM []byte
+}
+
+// GenerateKeyPair mints a fresh ed25519 SSH keypair for a cluster's live
+// bring-up. Generation is local and instant; nothing is registered anywhere.
+func GenerateKeyPair() (KeyPair, error) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return KeyPair{}, fmt.Errorf("generate ed25519 key: %w", err)
+	}
+
+	pemBlock, err := ssh.MarshalPrivateKey(privateKey, "")
+	if err != nil {
+		return KeyPair{}, fmt.Errorf("marshal private key: %w", err)
+	}
+
+	signer, err := ssh.NewSignerFromSigner(privateKey)
+	if err != nil {
+		return KeyPair{}, fmt.Errorf("build signer: %w", err)
+	}
+
+	return KeyPair{
+		Signer:        signer,
+		AuthorizedKey: authorizedKeyLine(signer),
+		PrivateKeyPEM: pem.EncodeToMemory(pemBlock),
+	}, nil
+}
+
+// ParsePrivateKey reconstructs a [KeyPair] from a previously persisted
+// [KeyPair.PrivateKeyPEM], so a later invocation can reconnect to servers
+// created with the same identity.
+func ParsePrivateKey(pemBytes []byte) (KeyPair, error) {
+	signer, err := ssh.ParsePrivateKey(pemBytes)
+	if err != nil {
+		return KeyPair{}, fmt.Errorf("parse private key: %w", err)
+	}
+
+	return KeyPair{
+		Signer:        signer,
+		AuthorizedKey: authorizedKeyLine(signer),
+		PrivateKeyPEM: pemBytes,
+	}, nil
+}
+
+// authorizedKeyLine renders the signer's public key as a single
+// authorized_keys line without the trailing newline ssh.MarshalAuthorizedKey
+// appends.
+func authorizedKeyLine(signer ssh.Signer) string {
+	return strings.TrimSuffix(
+		string(ssh.MarshalAuthorizedKey(signer.PublicKey())),
+		"\n",
+	)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5696. Part of #5512 / #5513 (epic #3983).

## What
`pkg/svc/bootstrap/ssh` (`sshbootstrap`) — the **post-provision** half of the bootstrap transport that the cloud-init seam (`pkg/svc/bootstrap/cloudinit`) explicitly scopes out. Both remaining #3983 lanes need it to get past `hetznerbase.RunCreate`'s `ErrLiveBringUpNotImplemented`: cloud-init delivers the install at server create, but nothing can *reach the server afterwards* to fetch the kubeconfig (`/etc/rancher/k3s/k3s.yaml` / `/etc/kubernetes/admin.conf`) or observe join sequencing.

- `GenerateKeyPair` / `ParsePrivateKey` — per-cluster ed25519 identity (authorized_keys line for `CreateServerOpts`, OpenSSH PEM for persistence).
- `Dial` / `DialWithRetry` — context-bounded connect; retry variant is the "wait for first boot" primitive (option errors fail fast, transport errors retry until deadline; last attempt's error joined into the deadline error).
- `Client.Run` — single command, captured stdout/stderr, non-zero exit surfaced as `ErrCommandFailed` + `RunResult.ExitCode`.
- `Client.ReadFile` — kubeconfig fetch over the exec channel (`cat` with single-quote shell escaping) — no SFTP subsystem, no extra dependency.
- **Host-key policy is mandatory** (`ErrMissingHostKeyCallback`): no silent accept-anything default.

## Tests
15 new tests against an **in-process `x/crypto/ssh` server** (offline, hermetic — no Hetzner coupling, so the env-blocked #4972 lane does not gate this slice): keypair round-trip, option validation sentinels, output/exit-code capture, quoted-path fetch, wrong-host-key rejection, retry-through-refusals, deadline handling, fail-fast on option errors.

## Flags for review
- **Dependency:** `golang.org/x/crypto` promoted indirect → direct (same version v0.53.0, already linked transitively) + a `depguard` allow-list entry for `golang.org/x/crypto/ssh` with justification comment (same pattern as the GKE `cloud.google.com/go/container` entry).
- Foundation only — no behaviour change to existing provisioners. Next child composes it into `RunCreate` (server create → wait → fetch kubeconfig, with cleanup-on-failure so no leaked servers).

## Validation
`golangci-lint run` clean on the package; `go build .` OK; `go test ./pkg/svc/bootstrap/...` 168 passed (15 new); desktop module tidy (no-op — same dep version).