### PR TITLE
feat(hetzner): ksail-owned floating IP primitives for a stable control-plane endpoint

### DIFF
--- a/pkg/svc/provider/hetzner/errors.go
+++ b/pkg/svc/provider/hetzner/errors.go
@@ -28,6 +28,9 @@ var (
 	ErrServerTypeUnavailable = errors.New("server type unavailable in all configured locations")
 	// ErrNoLocationsConfigured indicates that no valid locations were provided for server creation.
 	ErrNoLocationsConfigured = errors.New("no locations configured for server creation")
+	// ErrFloatingIPNotOwned indicates a floating IP with the cluster's conventional name exists
+	// but is not ksail-owned, so the cluster must not adopt (or ever release) it.
+	ErrFloatingIPNotOwned = errors.New("floating IP exists but is not ksail-owned")
 )
 
 // retryableErrorCodes are Hetzner API error codes that warrant a retry.

--- a/pkg/svc/provider/hetzner/export_test.go
+++ b/pkg/svc/provider/hetzner/export_test.go
@@ -82,6 +82,11 @@ func (p *Provider) CheckServerAvailabilityWithRetryForTest(
 	)
 }
 
+// DeleteFloatingIPForTest exports deleteFloatingIP for testing.
+func (p *Provider) DeleteFloatingIPForTest(ctx context.Context, clusterName string) error {
+	return p.deleteFloatingIP(ctx, clusterName)
+}
+
 // NewSnapshotManagerWithUploaderForTest creates a SnapshotManager with a custom uploader,
 // allowing tests to inject a mock without hitting real Hetzner upload infrastructure.
 // A nil logWriter is replaced with io.Discard, matching NewSnapshotManager behavior.

--- a/pkg/svc/provider/hetzner/floating_ip.go
+++ b/pkg/svc/provider/hetzner/floating_ip.go
@@ -1,0 +1,136 @@
+package hetzner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// EnsureFloatingIP ensures an IPv4 floating IP exists for the cluster's
+// control-plane endpoint, creating it if absent (get-by-name, create-if-absent,
+// like EnsureNetwork/EnsureFirewall). The floating IP gives the Kubernetes API
+// an address that survives any individual control-plane server being deleted
+// and recreated; Talos reassigns it to the elected leader (VIP). homeLocation
+// is the Hetzner location the IP is homed in (the cluster's configured
+// location) — homing only affects routing latency, not which servers the IP
+// can be assigned to.
+func (p *Provider) EnsureFloatingIP(
+	ctx context.Context,
+	clusterName string,
+	homeLocation string,
+) (*hcloud.FloatingIP, error) {
+	if p.client == nil {
+		return nil, provider.ErrProviderUnavailable
+	}
+
+	floatingIPName := clusterName + FloatingIPSuffix
+
+	// Check if the floating IP already exists
+	floatingIP, _, err := p.client.FloatingIP.GetByName(ctx, floatingIPName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get floating IP %s: %w", floatingIPName, err)
+	}
+
+	if floatingIP != nil {
+		return floatingIP, nil
+	}
+
+	result, _, err := p.client.FloatingIP.Create(ctx, hcloud.FloatingIPCreateOpts{
+		Type:         hcloud.FloatingIPTypeIPv4,
+		Name:         new(floatingIPName),
+		HomeLocation: &hcloud.Location{Name: homeLocation},
+		Labels:       ResourceLabels(clusterName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create floating IP %s: %w", floatingIPName, err)
+	}
+
+	return result.FloatingIP, nil
+}
+
+// AttachFloatingIPToServer assigns the floating IP to the given server. It is
+// idempotent: when the IP is already assigned to that server the call is a
+// no-op, so a Create retry after a partial failure re-asserts the assignment
+// without an API roundtrip.
+func (p *Provider) AttachFloatingIPToServer(
+	ctx context.Context,
+	floatingIP *hcloud.FloatingIP,
+	server *hcloud.Server,
+) error {
+	if p.client == nil {
+		return provider.ErrProviderUnavailable
+	}
+
+	if floatingIP.Server != nil && floatingIP.Server.ID == server.ID {
+		return nil
+	}
+
+	_, _, err := p.client.FloatingIP.Assign(ctx, floatingIP, server)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to assign floating IP %s to server %s: %w",
+			floatingIP.Name, server.Name, err,
+		)
+	}
+
+	return nil
+}
+
+// DetachFloatingIP unassigns the floating IP from whatever server it is
+// assigned to. Unassigned IPs are a no-op, so the call is idempotent.
+func (p *Provider) DetachFloatingIP(ctx context.Context, floatingIP *hcloud.FloatingIP) error {
+	if p.client == nil {
+		return provider.ErrProviderUnavailable
+	}
+
+	if floatingIP.Server == nil {
+		return nil
+	}
+
+	_, _, err := p.client.FloatingIP.Unassign(ctx, floatingIP)
+	if err != nil {
+		return fmt.Errorf("failed to unassign floating IP %s: %w", floatingIP.Name, err)
+	}
+
+	return nil
+}
+
+// deleteFloatingIP deletes the cluster's floating IP when it exists and is
+// ksail-owned. A floating IP that merely shares the name but lacks the
+// ksail.owned label is left alone — reserved addresses the user manages
+// themselves must never be released by cluster deletion (a released floating
+// IP cannot be recovered).
+func (p *Provider) deleteFloatingIP(ctx context.Context, clusterName string) error {
+	floatingIPName := clusterName + FloatingIPSuffix
+
+	floatingIP, err := retryTransientHetznerOperation(
+		ctx,
+		DefaultTransientRetryCount,
+		p.calculateRetryDelay,
+		func() (*hcloud.FloatingIP, error) {
+			floatingIP, _, getErr := p.client.FloatingIP.GetByName(ctx, floatingIPName)
+			if getErr != nil {
+				return nil, fmt.Errorf("failed to get floating IP %s: %w", floatingIPName, getErr)
+			}
+
+			return floatingIP, nil
+		},
+	)
+	if err != nil {
+		// Log error but don't fail - resource may not exist
+		return nil //nolint:nilerr // Ignoring lookup error - resource may not exist
+	}
+
+	if floatingIP == nil || floatingIP.Labels[LabelOwned] != "true" {
+		return nil
+	}
+
+	_, deleteErr := p.client.FloatingIP.Delete(ctx, floatingIP)
+	if deleteErr != nil {
+		return fmt.Errorf("failed to delete floating IP %s: %w", floatingIPName, deleteErr)
+	}
+
+	return nil
+}

--- a/pkg/svc/provider/hetzner/floating_ip.go
+++ b/pkg/svc/provider/hetzner/floating_ip.go
@@ -34,6 +34,18 @@ func (p *Provider) EnsureFloatingIP(
 	}
 
 	if floatingIP != nil {
+		// Only adopt a ksail-owned IP. A user-managed reserved address that
+		// merely shares the conventional name must never be claimed for the
+		// cluster (deleteFloatingIP applies the same ownership guard), and
+		// creating a second IP under the same name would fail Hetzner's name
+		// uniqueness anyway — so surface the collision instead.
+		if floatingIP.Labels[LabelOwned] != LabelOwnedValue {
+			return nil, fmt.Errorf(
+				"%w: %s (release or rename it, or choose a different cluster name)",
+				ErrFloatingIPNotOwned, floatingIPName,
+			)
+		}
+
 		return floatingIP, nil
 	}
 
@@ -101,7 +113,10 @@ func (p *Provider) DetachFloatingIP(ctx context.Context, floatingIP *hcloud.Floa
 // ksail-owned. A floating IP that merely shares the name but lacks the
 // ksail.owned label is left alone — reserved addresses the user manages
 // themselves must never be released by cluster deletion (a released floating
-// IP cannot be recovered).
+// IP cannot be recovered). Lookup failures propagate after the transient
+// retries: GetByName reports "not found" as a nil IP with a nil error, so a
+// non-nil error is a real API failure, and swallowing it would silently leak
+// a billed reserved address.
 func (p *Provider) deleteFloatingIP(ctx context.Context, clusterName string) error {
 	floatingIPName := clusterName + FloatingIPSuffix
 
@@ -119,11 +134,10 @@ func (p *Provider) deleteFloatingIP(ctx context.Context, clusterName string) err
 		},
 	)
 	if err != nil {
-		// Log error but don't fail - resource may not exist
-		return nil //nolint:nilerr // Ignoring lookup error - resource may not exist
+		return err
 	}
 
-	if floatingIP == nil || floatingIP.Labels[LabelOwned] != "true" {
+	if floatingIP == nil || floatingIP.Labels[LabelOwned] != LabelOwnedValue {
 		return nil
 	}
 

--- a/pkg/svc/provider/hetzner/floating_ip_test.go
+++ b/pkg/svc/provider/hetzner/floating_ip_test.go
@@ -25,6 +25,15 @@ const ownedFloatingIPJSON = `{"id":7,"name":"test-cluster-floating-ip","descript
 	`"labels":{"ksail.owned":"true","ksail.cluster.name":"test-cluster"},` +
 	`"created":"2026-07-02T00:00:00+00:00"}`
 
+// unownedFloatingIPJSON is the same address without the ksail.owned label — a
+// user-managed reserved address that ksail must neither adopt nor release.
+const unownedFloatingIPJSON = `{"id":7,"name":"test-cluster-floating-ip","description":"",` +
+	`"ip":"192.0.2.10","type":"ipv4","server":null,"dns_ptr":[],` +
+	`"home_location":{"id":1,"name":"fsn1","description":"","country":"DE","city":"",` +
+	`"latitude":0,"longitude":0,"network_zone":"eu-central"},` +
+	`"blocked":false,"protection":{"delete":false},"labels":{},` +
+	`"created":"2026-07-02T00:00:00+00:00"}`
+
 // newFloatingIPServer returns an httptest server answering the floating IP
 // list (GetByName) with listJSON, counting Create/Delete/Assign/Unassign
 // calls, and storing the last Create request body.
@@ -163,6 +172,21 @@ func TestEnsureFloatingIP_ReturnsExistingWithoutCreate(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.create))
 }
 
+func TestEnsureFloatingIP_RejectsUnownedNameCollision(t *testing.T) {
+	t.Parallel()
+
+	// A user-managed reserved address sharing the conventional name must not
+	// be silently adopted for the cluster (and a same-name create would fail
+	// Hetzner's name uniqueness) — surface the collision as an error instead.
+	prov, counters := newFloatingIPProvider(t, unownedFloatingIPJSON)
+
+	floatingIP, err := prov.EnsureFloatingIP(t.Context(), "test-cluster", "fsn1")
+
+	require.ErrorIs(t, err, hetzner.ErrFloatingIPNotOwned)
+	assert.Nil(t, floatingIP)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.create))
+}
+
 func TestEnsureFloatingIP_NilClient(t *testing.T) {
 	t.Parallel()
 
@@ -258,16 +282,7 @@ func TestDeleteFloatingIP_DeletesOwned(t *testing.T) {
 func TestDeleteFloatingIP_SkipsUnowned(t *testing.T) {
 	t.Parallel()
 
-	// Same name, but no ksail.owned label — a user-managed reserved address
-	// that cluster deletion must never release.
-	unowned := `{"id":7,"name":"test-cluster-floating-ip","description":"",` +
-		`"ip":"192.0.2.10","type":"ipv4","server":null,"dns_ptr":[],` +
-		`"home_location":{"id":1,"name":"fsn1","description":"","country":"DE","city":"",` +
-		`"latitude":0,"longitude":0,"network_zone":"eu-central"},` +
-		`"blocked":false,"protection":{"delete":false},"labels":{},` +
-		`"created":"2026-07-02T00:00:00+00:00"}`
-
-	prov, counters := newFloatingIPProvider(t, unowned)
+	prov, counters := newFloatingIPProvider(t, unownedFloatingIPJSON)
 
 	err := prov.DeleteFloatingIPForTest(t.Context(), "test-cluster")
 
@@ -284,4 +299,39 @@ func TestDeleteFloatingIP_NoopWhenAbsent(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.del))
+}
+
+func TestDeleteFloatingIP_PropagatesLookupError(t *testing.T) {
+	t.Parallel()
+
+	// A real API failure (here a non-retryable 401) must propagate — treating
+	// it as "not found" would silently skip the release and leak a billed
+	// reserved address. GetByName reports absence as nil/nil, never an error.
+	var deleteCalls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/floating_ips",
+		func(responseWriter http.ResponseWriter, request *http.Request) {
+			if request.Method == http.MethodDelete {
+				deleteCalls.Add(1)
+			}
+
+			responseWriter.Header().Set("Content-Type", "application/json")
+			responseWriter.WriteHeader(http.StatusUnauthorized)
+			_, _ = responseWriter.Write([]byte(
+				`{"error":{"code":"unauthorized","message":"unable to authenticate"}}`))
+		},
+	)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+
+	err := prov.DeleteFloatingIPForTest(t.Context(), "test-cluster")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get floating IP test-cluster-floating-ip")
+	assert.Equal(t, int32(0), deleteCalls.Load())
 }

--- a/pkg/svc/provider/hetzner/floating_ip_test.go
+++ b/pkg/svc/provider/hetzner/floating_ip_test.go
@@ -1,0 +1,287 @@
+package hetzner_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	hcloudtest "github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ownedFloatingIPJSON is the canned API representation of the cluster's
+// ksail-owned floating IP (id 7, name "test-cluster-floating-ip").
+const ownedFloatingIPJSON = `{"id":7,"name":"test-cluster-floating-ip","description":"",` +
+	`"ip":"192.0.2.10","type":"ipv4","server":null,"dns_ptr":[],` +
+	`"home_location":{"id":1,"name":"fsn1","description":"","country":"DE","city":"",` +
+	`"latitude":0,"longitude":0,"network_zone":"eu-central"},` +
+	`"blocked":false,"protection":{"delete":false},` +
+	`"labels":{"ksail.owned":"true","ksail.cluster.name":"test-cluster"},` +
+	`"created":"2026-07-02T00:00:00+00:00"}`
+
+// newFloatingIPServer returns an httptest server answering the floating IP
+// list (GetByName) with listJSON, counting Create/Delete/Assign/Unassign
+// calls, and storing the last Create request body.
+func newFloatingIPServer(
+	t *testing.T,
+	listJSON string,
+	createCalls, deleteCalls, assignCalls, unassignCalls *int32,
+	lastCreateBody *atomic.Value,
+) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(
+		"/floating_ips",
+		func(responseWriter http.ResponseWriter, request *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+
+			if request.Method == http.MethodPost {
+				atomic.AddInt32(createCalls, 1)
+
+				body, _ := io.ReadAll(request.Body)
+				lastCreateBody.Store(string(body))
+
+				_, _ = responseWriter.Write([]byte(
+					`{"floating_ip":` + ownedFloatingIPJSON + `,"action":null}`))
+
+				return
+			}
+
+			_, _ = responseWriter.Write([]byte(`{"floating_ips":[` + listJSON + `]}`))
+		},
+	)
+
+	mux.HandleFunc(
+		"/floating_ips/7",
+		func(responseWriter http.ResponseWriter, request *http.Request) {
+			if request.Method == http.MethodDelete {
+				atomic.AddInt32(deleteCalls, 1)
+				responseWriter.WriteHeader(http.StatusNoContent)
+			}
+		},
+	)
+
+	registerFloatingIPActionHandlers(mux, assignCalls, unassignCalls)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// registerFloatingIPActionHandlers wires the assign/unassign action endpoints
+// onto the fake floating IP server, counting each invocation.
+func registerFloatingIPActionHandlers(mux *http.ServeMux, assignCalls, unassignCalls *int32) {
+	actionResponse := func(responseWriter http.ResponseWriter, command string) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(
+			`{"action":{"id":1,"command":"` + command + `","status":"success","progress":100}}`))
+	}
+
+	mux.HandleFunc("/floating_ips/7/actions/assign",
+		func(responseWriter http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(assignCalls, 1)
+			actionResponse(responseWriter, "assign_floating_ip")
+		})
+
+	mux.HandleFunc("/floating_ips/7/actions/unassign",
+		func(responseWriter http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(unassignCalls, 1)
+			actionResponse(responseWriter, "unassign_floating_ip")
+		})
+}
+
+// floatingIPCounters bundles the per-test call counters.
+type floatingIPCounters struct {
+	create, del, assign, unassign int32
+	lastCreateBody                atomic.Value
+}
+
+func newFloatingIPProvider(
+	t *testing.T,
+	listJSON string,
+) (*hetzner.Provider, *floatingIPCounters) {
+	t.Helper()
+
+	counters := &floatingIPCounters{}
+	srv := newFloatingIPServer(
+		t, listJSON,
+		&counters.create, &counters.del, &counters.assign, &counters.unassign,
+		&counters.lastCreateBody,
+	)
+
+	return hetzner.NewProvider(newTestHcloudClient(srv.URL)), counters
+}
+
+func TestEnsureFloatingIP_CreatesWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, "")
+
+	floatingIP, err := prov.EnsureFloatingIP(t.Context(), "test-cluster", "fsn1")
+
+	require.NoError(t, err)
+	require.NotNil(t, floatingIP)
+	assert.Equal(t, int64(7), floatingIP.ID)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&counters.create))
+
+	// The create request carries the conventional name, IPv4 type, home
+	// location, and ksail ownership labels. Decoded as a map because the
+	// request body follows the Hetzner API's snake_case schema.
+	var createBody map[string]any
+
+	body, _ := counters.lastCreateBody.Load().(string)
+	require.NoError(t, json.Unmarshal([]byte(body), &createBody))
+	assert.Equal(t, "test-cluster-floating-ip", createBody["name"])
+	assert.Equal(t, "ipv4", createBody["type"])
+	assert.Equal(t, "fsn1", createBody["home_location"])
+
+	labels, ok := createBody["labels"].(map[string]any)
+	require.True(t, ok, "create body labels should be an object")
+	assert.Equal(t, "true", labels["ksail.owned"])
+	assert.Equal(t, "test-cluster", labels["ksail.cluster.name"])
+}
+
+func TestEnsureFloatingIP_ReturnsExistingWithoutCreate(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, ownedFloatingIPJSON)
+
+	floatingIP, err := prov.EnsureFloatingIP(t.Context(), "test-cluster", "fsn1")
+
+	require.NoError(t, err)
+	require.NotNil(t, floatingIP)
+	assert.Equal(t, int64(7), floatingIP.ID)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.create))
+}
+
+func TestEnsureFloatingIP_NilClient(t *testing.T) {
+	t.Parallel()
+
+	prov := hetzner.NewProvider(nil)
+
+	_, err := prov.EnsureFloatingIP(t.Context(), "test-cluster", "fsn1")
+
+	require.ErrorIs(t, err, provider.ErrProviderUnavailable)
+}
+
+func TestAttachFloatingIPToServer_NoopWhenAlreadyAssigned(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, "")
+	floatingIP := &hcloudtest.FloatingIP{
+		ID:     7,
+		Server: &hcloudtest.Server{ID: 9},
+	}
+
+	err := prov.AttachFloatingIPToServer(t.Context(), floatingIP, &hcloudtest.Server{ID: 9})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.assign))
+}
+
+func TestAttachFloatingIPToServer_AssignsWhenUnassigned(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, "")
+
+	err := prov.AttachFloatingIPToServer(
+		t.Context(),
+		&hcloudtest.FloatingIP{ID: 7},
+		&hcloudtest.Server{ID: 9},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&counters.assign))
+}
+
+func TestAttachFloatingIPToServer_ReassignsWhenAssignedElsewhere(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, "")
+	floatingIP := &hcloudtest.FloatingIP{
+		ID:     7,
+		Server: &hcloudtest.Server{ID: 3},
+	}
+
+	err := prov.AttachFloatingIPToServer(t.Context(), floatingIP, &hcloudtest.Server{ID: 9})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&counters.assign))
+}
+
+func TestDetachFloatingIP_NoopWhenUnassigned(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, "")
+
+	err := prov.DetachFloatingIP(t.Context(), &hcloudtest.FloatingIP{ID: 7})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.unassign))
+}
+
+func TestDetachFloatingIP_UnassignsWhenAssigned(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, "")
+	floatingIP := &hcloudtest.FloatingIP{
+		ID:     7,
+		Server: &hcloudtest.Server{ID: 9},
+	}
+
+	err := prov.DetachFloatingIP(t.Context(), floatingIP)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&counters.unassign))
+}
+
+func TestDeleteFloatingIP_DeletesOwned(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, ownedFloatingIPJSON)
+
+	err := prov.DeleteFloatingIPForTest(t.Context(), "test-cluster")
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&counters.del))
+}
+
+func TestDeleteFloatingIP_SkipsUnowned(t *testing.T) {
+	t.Parallel()
+
+	// Same name, but no ksail.owned label — a user-managed reserved address
+	// that cluster deletion must never release.
+	unowned := `{"id":7,"name":"test-cluster-floating-ip","description":"",` +
+		`"ip":"192.0.2.10","type":"ipv4","server":null,"dns_ptr":[],` +
+		`"home_location":{"id":1,"name":"fsn1","description":"","country":"DE","city":"",` +
+		`"latitude":0,"longitude":0,"network_zone":"eu-central"},` +
+		`"blocked":false,"protection":{"delete":false},"labels":{},` +
+		`"created":"2026-07-02T00:00:00+00:00"}`
+
+	prov, counters := newFloatingIPProvider(t, unowned)
+
+	err := prov.DeleteFloatingIPForTest(t.Context(), "test-cluster")
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.del))
+}
+
+func TestDeleteFloatingIP_NoopWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	prov, counters := newFloatingIPProvider(t, "")
+
+	err := prov.DeleteFloatingIPForTest(t.Context(), "test-cluster")
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&counters.del))
+}

--- a/pkg/svc/provider/hetzner/infrastructure.go
+++ b/pkg/svc/provider/hetzner/infrastructure.go
@@ -473,6 +473,13 @@ func (p *Provider) deleteInfrastructure(ctx context.Context, clusterName string)
 		return err
 	}
 
+	// Release the cluster's ksail-owned floating IP so `cluster delete` never
+	// leaks a billed reserved address (server deletion only unassigns it).
+	err = p.deleteFloatingIP(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
 	// Delete load balancers before the network — LBs attached to the network
 	// must be removed first, otherwise network deletion will fail.
 	err = p.deleteLoadBalancers(ctx, clusterName)

--- a/pkg/svc/provider/hetzner/labels.go
+++ b/pkg/svc/provider/hetzner/labels.go
@@ -72,6 +72,9 @@ const (
 	FirewallSuffix = "-firewall"
 	// PlacementGroupSuffix is appended to cluster name for placement group naming.
 	PlacementGroupSuffix = "-placement"
+	// FloatingIPSuffix is appended to cluster name for the control-plane
+	// floating IP naming.
+	FloatingIPSuffix = "-floating-ip"
 )
 
 // ResourceLabels creates the standard label set for a KSail-managed resource.

--- a/pkg/svc/provider/hetzner/labels.go
+++ b/pkg/svc/provider/hetzner/labels.go
@@ -8,8 +8,11 @@ import (
 // These labels are applied to servers, networks, firewalls, and placement groups.
 const (
 	// LabelOwned indicates the resource is managed by KSail.
-	// Value is always "true" for KSail-managed resources.
+	// Value is always [LabelOwnedValue] for KSail-managed resources.
 	LabelOwned = "ksail.owned"
+
+	// LabelOwnedValue is the value LabelOwned carries on KSail-managed resources.
+	LabelOwnedValue = "true"
 
 	// LabelClusterName identifies which cluster the resource belongs to.
 	LabelClusterName = "ksail.cluster.name"
@@ -80,7 +83,7 @@ const (
 // ResourceLabels creates the standard label set for a KSail-managed resource.
 func ResourceLabels(clusterName string) map[string]string {
 	return map[string]string{
-		LabelOwned:       "true",
+		LabelOwned:       LabelOwnedValue,
 		LabelClusterName: clusterName,
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5698. Foundation for devantler-tech/platform#2120 (Option A — Talos-managed hcloud floating-IP VIP, per the maintainer's on-issue choice).

## What

Slice 1 of the stable control-plane endpoint work — the floating-IP primitives, following the provider's existing idempotent ensure pattern (`EnsureNetwork`/`EnsureFirewall`):

- **`EnsureFloatingIP`** — get-by-name (`<cluster>-floating-ip`), create-if-absent (IPv4, homed in the cluster's location, `ksail.owned` labels).
- **`AttachFloatingIPToServer` / `DetachFloatingIP`** — idempotent assign/unassign (no-op when already in the desired state), so create-retries re-assert instead of erroring.
- **`deleteInfrastructure` now releases the cluster's floating IP** — but **only when it carries the `ksail.owned` label**: a user-managed reserved address that merely shares the name is never released (a released floating IP is unrecoverable). Server deletion only unassigns, so without this `cluster delete` would leak a billed address once slice 2 starts creating them.

**No create-path behavior change yet:** nothing calls `EnsureFloatingIP` in this slice. Slice 2 (follow-up child of #5698's plan) adds the `spec.provider.hetzner` config surface, endpoint computation from the floating IP, and the Talos VIP machine-config/cert-SAN rendering.

## Design decision expressed here (platform#2120)

platform#2120's open question — *where is the floating IP reserved declaratively?* — is decided as **(A) the KSail provisioner**: KSail already owns the Hetzner servers/network/firewall via native hcloud-go (the standing native-Go-SDK provisioning direction), so the floating IP is a sibling resource; a whole Crossplane hcloud provider for one resource would be disproportionate. If you'd rather have (B), redirect here before promotion.

## Validation

- `go test ./pkg/svc/provider/hetzner/` — 11 new tests (httptest-backed hcloud API fake, same pattern as the network-reconcile tests): ensure create/adopt/nil-client, attach no-op/assign/reassign, detach no-op/unassign, delete owned/unowned-skip/absent.
- `golangci-lint run ./pkg/svc/provider/hetzner/...` — clean (after `cache clean`; the repo-wide local run only reports the known stale-worktree cache + local-version drift, CI is authoritative).
- `go build` + full `go test ./...` — green except the known `pkg/cli/cmd/open/chat` parallel-run flake (127/127 pass alone).