### PR TITLE
feat(mirror): read-only capture tap spec (NET_RAW-hardened context + pinned capture image + CaptureCommand)

### DIFF
--- a/pkg/svc/mirror/capture.go
+++ b/pkg/svc/mirror/capture.go
@@ -1,0 +1,33 @@
+package mirror
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// maxPort is the highest valid TCP port number.
+const maxPort = 65535
+
+// ErrInvalidCapturePort is returned by CaptureCommand for a port outside
+// 1–65535.
+var ErrInvalidCapturePort = errors.New("capture port must be between 1 and 65535")
+
+// CaptureCommand returns the tcpdump invocation the mirror execs inside the
+// tap container to produce the read-only capture stream: pcap for TCP traffic
+// on the given service port, written packet-buffered ("-U") to stdout ("-w -")
+// so the exec channel carries it to the local process with no intermediate
+// file (the tap's root filesystem is read-only). "-p" keeps the interface out
+// of promiscuous mode — mirror mode only observes the pod's own traffic — and
+// "-i any" covers every pod interface. Capture needs CAP_NET_RAW, which is the
+// one capability the injected tap retains (see InjectTap).
+func CaptureCommand(port int) ([]string, error) {
+	if port < 1 || port > maxPort {
+		return nil, fmt.Errorf("%w: %d", ErrInvalidCapturePort, port)
+	}
+
+	return []string{
+		"tcpdump", "-p", "-i", "any", "-U", "-w", "-",
+		"tcp", "port", strconv.Itoa(port),
+	}, nil
+}

--- a/pkg/svc/mirror/capture_test.go
+++ b/pkg/svc/mirror/capture_test.go
@@ -1,0 +1,43 @@
+package mirror_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureCommand_BuildsTcpdumpInvocation(t *testing.T) {
+	t.Parallel()
+
+	command, err := mirror.CaptureCommand(8080)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"tcpdump", "-p", "-i", "any", "-U", "-w", "-",
+		"tcp", "port", "8080",
+	}, command)
+}
+
+func TestCaptureCommand_AcceptsPortBounds(t *testing.T) {
+	t.Parallel()
+
+	for _, port := range []int{1, 65535} {
+		command, err := mirror.CaptureCommand(port)
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, command)
+	}
+}
+
+func TestCaptureCommand_RejectsInvalidPorts(t *testing.T) {
+	t.Parallel()
+
+	for _, port := range []int{0, -1, 65536} {
+		command, err := mirror.CaptureCommand(port)
+
+		require.ErrorIs(t, err, mirror.ErrInvalidCapturePort)
+		assert.Nil(t, command)
+	}
+}

--- a/pkg/svc/mirror/doc.go
+++ b/pkg/svc/mirror/doc.go
@@ -33,17 +33,29 @@
 //     pods and containers a tap would attach to ([ResolveTarget]). Pure
 //     client-go, fully unit-testable, needed by every later phase regardless of
 //     the eventual tap mechanism.
+//
 //   - Phase 1 — mirror-only: inject a read-only "tap" sidecar (reusing the
-//     ephemeral-container mechanism behind `workload debug`) that copies inbound
-//     connections and forwards a copy to the local process over a reverse tunnel
-//     built from the embedded port-forward primitive. Read-only: the local
-//     process receives mirrored traffic but does not answer back into the
-//     cluster — the lowest-risk first mode the issue itself suggests. Its first
-//     increment is [SelectTapPoint]: pick the concrete pod and container the tap
-//     attaches to (honouring an optional container selector), pure logic shared
-//     by the injection and tunnel steps that follow.
+//     ephemeral-container mechanism behind `workload debug`) that captures the
+//     target's inbound traffic and streams it to the local process. Read-only:
+//     the local process receives mirrored traffic but does not answer back into
+//     the cluster — the lowest-risk first mode the issue itself suggests.
+//     Increments so far: [SelectTapPoint] (pick the concrete pod and container),
+//     [InjectTap]/[WaitForTap] (the ephemeral tap container), and the capture
+//     spec ([CaptureCommand] + the hardened NET_RAW-only security context).
+//
+//     Capture design (#4521): passive pcap via CAP_NET_RAW — tcpdump execed in
+//     the tap container, pcap on stdout over the already-embedded exec channel.
+//     A userspace proxy (socat or Go) in the pod netns cannot passively observe
+//     traffic addressed to the app container; being in-path needs
+//     NET_ADMIN/iptables, which is Phase 2 intercept by definition, and eBPF
+//     costs node-level privilege for no Phase 1 gain. Because the exec channel
+//     itself carries the stream, mirror mode needs NO reverse tunnel — the
+//     tunnel returns in Phase 2, where responses must flow back into the
+//     cluster.
+//
 //   - Phase 2 — intercept: steer a subset (or all) of the Deployment's traffic to
 //     the local process and return its responses.
+//
 //   - Phase 3 — environment & volume projection: run the local process with the
 //     target pod's env vars and mounted volumes/secrets for cluster-equivalent
 //     context.

--- a/pkg/svc/mirror/inject.go
+++ b/pkg/svc/mirror/inject.go
@@ -19,9 +19,11 @@ import (
 const TapContainerName = "ksail-tap"
 
 // DefaultTapImage is the image the tap container runs when the caller does not
-// override it with WithTapImage. It matches the `workload debug` default: a
-// small, ubiquitous utility image.
-const DefaultTapImage = "docker.io/library/alpine:latest"
+// override it with WithTapImage. netshoot is the de-facto standard network
+// debugging image and carries tcpdump, which the read-only capture increment
+// execs to produce the mirror's pcap stream ([CaptureCommand]); it is pinned
+// to a release tag so tap behaviour doesn't drift under a floating latest.
+const DefaultTapImage = "docker.io/nicolaka/netshoot:v0.16"
 
 // tapPollInterval is how often WaitForTap re-reads the pod while waiting for
 // the tap container to reach Running.
@@ -105,9 +107,10 @@ func InjectTap(
 
 		tap := corev1.EphemeralContainer{
 			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-				Name:    TapContainerName,
-				Image:   cfg.image,
-				Command: cfg.command,
+				Name:            TapContainerName,
+				Image:           cfg.image,
+				Command:         cfg.command,
+				SecurityContext: tapSecurityContext(),
 			},
 			TargetContainerName: point.Container,
 		}
@@ -127,6 +130,30 @@ func InjectTap(
 	}
 
 	return TapContainerName, nil
+}
+
+// tapSecurityContext returns the hardened security context every tap container
+// runs with: everything dropped except NET_RAW — the one capability passive
+// pcap capture ([CaptureCommand]) needs — no privilege escalation, a read-only
+// root filesystem (the capture writes only to stdout), and the runtime's
+// default seccomp profile. The context is intentionally not caller-configurable:
+// the read-only guarantee of mirror mode rests on the tap never holding more
+// than capture privileges.
+func tapSecurityContext() *corev1.SecurityContext {
+	allowPrivilegeEscalation := false
+	readOnlyRootFilesystem := true
+
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+			Add:  []corev1.Capability{"NET_RAW"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
 }
 
 // WaitForTap blocks until the tap container on the tap point's pod reports

--- a/pkg/svc/mirror/inject_test.go
+++ b/pkg/svc/mirror/inject_test.go
@@ -76,6 +76,24 @@ func TestInjectTapDefaults(t *testing.T) {
 	assert.Equal(t, mirror.DefaultTapImage, tap.Image)
 	assert.Equal(t, []string{"sleep", "infinity"}, tap.Command)
 	assert.Equal(t, "api", tap.TargetContainerName)
+	assertHardenedTapSecurityContext(t, tap.SecurityContext)
+}
+
+// assertHardenedTapSecurityContext pins the read-only guarantee: the tap holds
+// NET_RAW (for passive pcap capture) and nothing else.
+func assertHardenedTapSecurityContext(t *testing.T, secCtx *corev1.SecurityContext) {
+	t.Helper()
+
+	require.NotNil(t, secCtx)
+	require.NotNil(t, secCtx.AllowPrivilegeEscalation)
+	assert.False(t, *secCtx.AllowPrivilegeEscalation)
+	require.NotNil(t, secCtx.ReadOnlyRootFilesystem)
+	assert.True(t, *secCtx.ReadOnlyRootFilesystem)
+	require.NotNil(t, secCtx.Capabilities)
+	assert.Equal(t, []corev1.Capability{"ALL"}, secCtx.Capabilities.Drop)
+	assert.Equal(t, []corev1.Capability{"NET_RAW"}, secCtx.Capabilities.Add)
+	require.NotNil(t, secCtx.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, secCtx.SeccompProfile.Type)
 }
 
 func TestInjectTapOptions(t *testing.T) {


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5702. Part of #4521 (P1 mirror-only); follows #5685's `InjectTap`/`WaitForTap`.

## What

- **Hardened tap security context (non-configurable):** the injected ephemeral tap now runs with `capabilities: {drop: [ALL], add: [NET_RAW]}`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and `seccompProfile: RuntimeDefault`. NET_RAW is the one capability passive pcap capture needs; the read-only guarantee of mirror mode rests on the tap never holding more.
- **Pinned capture-capable default image:** `DefaultTapImage` moves from `alpine:latest` (inert placeholder, no capture tooling, floating tag) to `docker.io/nicolaka/netshoot:v0.16` — the de-facto standard network-debug image, carries tcpdump, pinned to a release tag. `WithTapImage` still overrides. **⚠️ New external runtime dependency (a third-party image) — flagged for steering; alternatives were a ksail-published tap image (a whole new release artifact, disproportionate for P1) or runtime `apk add tcpdump` (network-dependent, mutates the container, defeats the read-only root fs).**
- **`CaptureCommand(port)`:** builds the validated tcpdump invocation the upcoming exec-stream increment runs inside the tap — `tcpdump -p -i any -U -w - tcp port <n>` (unbuffered pcap to stdout, non-promiscuous, scoped to the target TCP port).
- **doc.go** records the capture design decision (also commented on #4521): passive pcap via CAP_NET_RAW, delivered over the already-embedded exec channel — a userspace proxy cannot passively observe the app container's inbound traffic, and being in-path needs NET_ADMIN (= Phase 2 intercept). Consequence: **mirror-only mode needs no reverse tunnel**; the tunnel returns in Phase 2.

## Notes

- No CLI surface change; `sleep infinity` stays the inert injection command, so `WaitForTap` semantics are untouched. Capture runs as a later exec, not as the container command — injection and capture lifecycles stay independent.
- PSS note: NET_RAW is rejected under the `restricted` Pod Security profile; mirror is a dev-cluster inner-loop tool, and the failure mode is an explicit admission error, not silent breakage.

## Validation

- `go build ./...` green; `go test ./pkg/svc/...` 4459 passed / 78 packages; `golangci-lint run ./pkg/svc/mirror/...` 0 issues.
- New tests: `TestCaptureCommand_*` (invocation shape, port bounds, rejection) and `assertHardenedTapSecurityContext` pinning the security context in `TestInjectTapDefaults`.

## Next increments (per #5702)

1. Exec-based capture session streaming pcap to the local process (pure-Go `pcapgo` reader — new Go dep, will be flagged).
2. `workload mirror` CLI wiring.
3. Phase 2 intercept (in-path, NET_ADMIN, reverse tunnel).