### PR TITLE
fix(flux): gate source-API poll on flux-operator availability

### DIFF
--- a/pkg/svc/installer/flux/export_test.go
+++ b/pkg/svc/installer/flux/export_test.go
@@ -11,6 +11,7 @@ import (
 	fluxclient "github.com/devantler-tech/ksail/v7/pkg/client/flux"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer/internal/sopsutil"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -138,6 +139,27 @@ func SetLoadRESTConfig(fn func(string, string) (*rest.Config, error)) func() {
 
 	return func() {
 		loadRESTConfig = original
+	}
+}
+
+// WaitForOperatorAvailable exports waitForOperatorAvailable for testing.
+func WaitForOperatorAvailable(
+	ctx context.Context,
+	restConfig *rest.Config,
+	timeout, interval time.Duration,
+) error {
+	return waitForOperatorAvailable(ctx, restConfig, timeout, interval)
+}
+
+// SetNewKubernetesClient allows tests to replace newKubernetesClient with a mock.
+func SetNewKubernetesClient(
+	fn func(*rest.Config) (kubernetes.Interface, error),
+) func() {
+	original := newKubernetesClient
+	newKubernetesClient = fn
+
+	return func() {
+		newKubernetesClient = original
 	}
 }
 

--- a/pkg/svc/installer/flux/operatorwaiter.go
+++ b/pkg/svc/installer/flux/operatorwaiter.go
@@ -1,0 +1,100 @@
+package fluxinstaller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	fluxclient "github.com/devantler-tech/ksail/v7/pkg/client/flux"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// fluxOperatorDeploymentName is the Deployment the flux-operator Helm chart
+// installs; it is the reconciler that turns the FluxInstance into the Flux
+// controllers and their CRDs (source.toolkit.fluxcd.io etc.).
+const fluxOperatorDeploymentName = "flux-operator"
+
+var errOperatorNotAvailable = errors.New(
+	"flux-operator deployment is not yet available",
+)
+
+// newKubernetesClient creates a typed clientset for reading the operator
+// Deployment.
+//
+//nolint:gochecknoglobals // Allows mocking for tests
+var newKubernetesClient = func(restConfig *rest.Config) (kubernetes.Interface, error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return clientset, nil
+}
+
+// waitForOperatorAvailable waits for the flux-operator Deployment to report
+// Available=True before callers start polling for the APIs the operator
+// installs. The source.toolkit.fluxcd.io group only appears after the
+// operator reconciles the FluxInstance, so without this gate a slow or
+// crash-looping operator start silently consumes the whole API availability
+// budget and the eventual timeout blames the wrong phase (issue #5597).
+// On timeout the error names this phase and appends pod diagnostics from the
+// flux-system namespace so the starved stage is attributable from the error
+// alone.
+func waitForOperatorAvailable(
+	ctx context.Context,
+	restConfig *rest.Config,
+	timeout, interval time.Duration,
+) error {
+	err := pollUntilReady(
+		ctx,
+		timeout,
+		interval,
+		"Deployment "+fluxclient.DefaultNamespace+"/"+fluxOperatorDeploymentName+
+			" to be Available",
+		func() (bool, error) {
+			return checkOperatorAvailable(ctx, restConfig)
+		},
+	)
+	if err != nil {
+		diag := diagnoseFluxPodFailures(ctx, restConfig)
+
+		return fmt.Errorf(
+			"flux-operator did not become available (Flux CRDs are installed by"+
+				" the operator, so its APIs cannot appear until it runs): %w%s",
+			err, diag,
+		)
+	}
+
+	return nil
+}
+
+// checkOperatorAvailable performs one availability probe of the operator
+// Deployment. Get errors (incl. not-found while the Helm release is still
+// settling) are reported for timeout attribution but treated as retryable.
+func checkOperatorAvailable(ctx context.Context, restConfig *rest.Config) (bool, error) {
+	clientset, err := newKubernetesClient(restConfig)
+	if err != nil {
+		return false, err
+	}
+
+	deployment, err := clientset.AppsV1().
+		Deployments(fluxclient.DefaultNamespace).
+		Get(ctx, fluxOperatorDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get flux-operator deployment: %w", err)
+	}
+
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentAvailable &&
+			condition.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+	}
+
+	return false, errOperatorNotAvailable
+}

--- a/pkg/svc/installer/flux/operatorwaiter_test.go
+++ b/pkg/svc/installer/flux/operatorwaiter_test.go
@@ -1,0 +1,171 @@
+//nolint:err113 // Tests use dynamic errors to simulate transport failures
+package fluxinstaller_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	operatorWaitTestTimeout  = 200 * time.Millisecond
+	operatorWaitTestInterval = 20 * time.Millisecond
+)
+
+// newOperatorDeployment builds a flux-system/flux-operator Deployment with the
+// given Available condition status.
+func newOperatorDeployment(available corev1.ConditionStatus) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flux-operator",
+			Namespace: "flux-system",
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: available,
+				},
+			},
+		},
+	}
+}
+
+// stubKubernetesClient routes newKubernetesClient to a fake clientset for the
+// duration of a test.
+func stubKubernetesClient(t *testing.T, clientset kubernetes.Interface, err error) {
+	t.Helper()
+
+	restore := fluxinstaller.SetNewKubernetesClient(
+		func(_ *rest.Config) (kubernetes.Interface, error) {
+			if err != nil {
+				return nil, err
+			}
+
+			return clientset, nil
+		},
+	)
+	t.Cleanup(restore)
+}
+
+// stubQuietDiagnostics silences the pod-failure diagnostics appended on
+// timeout so assertions target the wait error itself.
+func stubQuietDiagnostics(t *testing.T) {
+	t.Helper()
+
+	restore := fluxinstaller.SetDiagnoseFluxPodFailures(
+		func(_ context.Context, _ *rest.Config) string { return "" },
+	)
+	t.Cleanup(restore)
+}
+
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestWaitForOperatorAvailable_Available(t *testing.T) {
+	clientset := k8sfake.NewClientset(newOperatorDeployment(corev1.ConditionTrue))
+	stubKubernetesClient(t, clientset, nil)
+
+	err := fluxinstaller.WaitForOperatorAvailable(
+		context.Background(), &rest.Config{},
+		operatorWaitTestTimeout, operatorWaitTestInterval,
+	)
+	if err != nil {
+		t.Fatalf("expected nil error for an Available deployment, got: %v", err)
+	}
+}
+
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestWaitForOperatorAvailable_NotAvailableTimesOut(t *testing.T) {
+	stubQuietDiagnostics(t)
+
+	clientset := k8sfake.NewClientset(newOperatorDeployment(corev1.ConditionFalse))
+	stubKubernetesClient(t, clientset, nil)
+
+	err := fluxinstaller.WaitForOperatorAvailable(
+		context.Background(), &rest.Config{},
+		operatorWaitTestTimeout, operatorWaitTestInterval,
+	)
+	if err == nil {
+		t.Fatal("expected timeout error for a not-Available deployment")
+	}
+
+	if !strings.Contains(err.Error(), "flux-operator") {
+		t.Fatalf("expected error to attribute the flux-operator phase, got: %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "not yet available") {
+		t.Fatalf("expected error to carry the last probe error, got: %v", err)
+	}
+}
+
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestWaitForOperatorAvailable_DeploymentMissingTimesOut(t *testing.T) {
+	stubQuietDiagnostics(t)
+
+	stubKubernetesClient(t, k8sfake.NewClientset(), nil)
+
+	err := fluxinstaller.WaitForOperatorAvailable(
+		context.Background(), &rest.Config{},
+		operatorWaitTestTimeout, operatorWaitTestInterval,
+	)
+	if err == nil {
+		t.Fatal("expected timeout error when the deployment does not exist")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected error to carry the not-found probe error, got: %v", err)
+	}
+}
+
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestWaitForOperatorAvailable_ClientErrorTimesOut(t *testing.T) {
+	stubQuietDiagnostics(t)
+
+	clientErr := errors.New("no route to host")
+	stubKubernetesClient(t, nil, clientErr)
+
+	err := fluxinstaller.WaitForOperatorAvailable(
+		context.Background(), &rest.Config{},
+		operatorWaitTestTimeout, operatorWaitTestInterval,
+	)
+	if err == nil {
+		t.Fatal("expected timeout error when the client cannot be created")
+	}
+
+	if !strings.Contains(err.Error(), "no route to host") {
+		t.Fatalf("expected error to carry the client error, got: %v", err)
+	}
+}
+
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestWaitForOperatorAvailable_AppendsPodDiagnostics(t *testing.T) {
+	restore := fluxinstaller.SetDiagnoseFluxPodFailures(
+		func(_ context.Context, _ *rest.Config) string {
+			return "\nPod flux-operator-abc: CrashLoopBackOff"
+		},
+	)
+	t.Cleanup(restore)
+
+	stubKubernetesClient(t, k8sfake.NewClientset(), nil)
+
+	err := fluxinstaller.WaitForOperatorAvailable(
+		context.Background(), &rest.Config{},
+		operatorWaitTestTimeout, operatorWaitTestInterval,
+	)
+	if err == nil {
+		t.Fatal("expected timeout error when the deployment does not exist")
+	}
+
+	if !strings.Contains(err.Error(), "CrashLoopBackOff") {
+		t.Fatalf("expected error to append pod diagnostics, got: %v", err)
+	}
+}

--- a/pkg/svc/installer/flux/resources.go
+++ b/pkg/svc/installer/flux/resources.go
@@ -107,6 +107,22 @@ func setupFluxCore(ctx context.Context, params setupParams) error {
 		return err
 	}
 
+	// The source.toolkit.fluxcd.io APIs only exist after the flux-operator
+	// reconciles the FluxInstance, so confirm the operator Deployment is
+	// Available before spending the API availability budget polling for them.
+	// Under CI saturation the operator's own startup (image pulls, scheduling)
+	// can otherwise consume the whole poll budget while discovery keeps
+	// returning group-not-found (issue #5597).
+	err = waitForOperatorAvailable(
+		ctx,
+		params.restConfig,
+		fluxAPIAvailabilityTimeout,
+		fluxAPIAvailabilityPollInterval,
+	)
+	if err != nil {
+		return err
+	}
+
 	// Wait for OCIRepository API to be available before patching
 	ociPatcher := newOCIRepositoryPatcher(
 		params.restConfig,
@@ -116,7 +132,13 @@ func setupFluxCore(ctx context.Context, params setupParams) error {
 
 	err = ociPatcher.waitForAPI(ctx)
 	if err != nil {
-		return err
+		diag := diagnoseFluxPodFailures(ctx, params.restConfig)
+
+		return fmt.Errorf(
+			"waiting for Flux source APIs (flux-operator is available but has"+
+				" not served source.toolkit.fluxcd.io yet): %w%s",
+			err, diag,
+		)
 	}
 
 	// For local Docker registries (not external like GHCR), patch OCIRepository to use insecure HTTP


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5597

## Problem

`cluster create` polls discovery for `source.toolkit.fluxcd.io` with a flat 12m budget (`fluxAPIAvailabilityTimeout`). That group only appears after the **flux-operator reconciles the FluxInstance** — so under CI saturation (slow image pulls, scheduling delays, a crash-looping operator) the operator's own startup silently consumes the whole budget while discovery keeps returning group-not-found, and the E2E leg dies with the unattributable `timed out waiting for resource to be ready: API source.toolkit.fluxcd.io/v1` flake.

## Fix (root cause: observability, not a timeout bump)

- **New gate:** after the FluxInstance is upserted and before the source-API poll starts, wait for the `flux-system/flux-operator` Deployment to report `Available=True` (`operatorwaiter.go`). A failing operator start now fails fast **with pod diagnostics** (`diagnoseFluxPodFailures`) instead of starving the API poll.
- **Phase attribution:** a source-API timeout after the gate now says the operator *was* available but hasn't served the group yet, and appends pod diagnostics — so the starved phase is identifiable from the error alone.
- Deliberately **no timeout increase** — a bare bump would mask the root cause (per the scoping comment on #5597).

## Validation

- `go build ./...` clean
- `go test ./pkg/svc/installer/flux/` — 207 passed (5 new tests: Available, not-Available timeout, missing deployment, client error, diagnostics append)
- `golangci-lint run ./pkg/svc/installer/flux/...` — 0 issues
- Full `go test ./pkg/...` — 5860 passed; only failures were the known `pkg/cli/cmd/open/chat` copilot-CLI parallel-run flake (passes alone, 127/127, unrelated)

## Notes

- The gate uses the existing package seam pattern (mockable `newKubernetesClient` var + `export_test.go` setters), consistent with `SetNewFluxResourcesClient`/`SetDiagnoseFluxPodFailures`.
- The E2E effect is only fully observable on saturated runners; the flake signature to watch for post-merge is the one in #5597 (distinct from the mirror-cache-tar corruption flake noted there).