### PR TITLE
feat(gitops): CEL rule engine foundation for manifest validation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -191,6 +191,10 @@ linters:
             # transitively via the Kubernetes client stack.
             - google.golang.org/grpc
             - google.golang.org/protobuf
+            # cel-go powers the native CEL rule validation of rendered GitOps
+            # manifests in pkg/svc/gitops/celrules (#5693, epic #5344). Already
+            # linked transitively via the Kubernetes apiserver stack.
+            - github.com/google/cel-go
             - gopkg.in/yaml.v3
             - helm.sh/helm
             - k8s.io

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/github/copilot-sdk/go v1.0.4
 	github.com/go-jose/go-jose/v4 v4.1.4
+	github.com/google/cel-go v0.28.0
 	github.com/google/go-github/v72 v72.0.0
 	github.com/googleapis/gax-go/v2 v2.22.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
@@ -476,7 +477,6 @@ require (
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/goodhosts/hostsfile v0.1.7 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/cel-go v0.28.0 // indirect
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/pkg/svc/gitops/celrules/celrules.go
+++ b/pkg/svc/gitops/celrules/celrules.go
@@ -1,0 +1,241 @@
+// Package celrules provides the CEL rule engine backing native semantic
+// validation of rendered GitOps manifests (issue #5693, epic #5344): a YAML
+// rules-file schema, per-rule expression compilation, and an evaluation loop
+// producing attributable violations. It is deliberately decoupled from the
+// render pipeline and CLI — callers hand it decoded documents — so the engine
+// stays unit-testable and the validate wiring can evolve independently.
+package celrules
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/ext"
+	"sigs.k8s.io/yaml"
+)
+
+// Severity classifies how a violated rule is reported.
+type Severity string
+
+const (
+	// SeverityError marks a violation that should fail validation.
+	SeverityError Severity = "error"
+	// SeverityWarning marks a violation that should be reported without
+	// failing validation.
+	SeverityWarning Severity = "warning"
+)
+
+// objectVarName is the CEL variable each rendered document is bound to,
+// matching the convention users know from Kubernetes ValidatingAdmissionPolicy.
+const objectVarName = "object"
+
+var (
+	errNoRules            = errors.New("rules file declares no rules")
+	errRuleNameEmpty      = errors.New("rule has no name")
+	errRuleNameDuplicate  = errors.New("duplicate rule name")
+	errRuleExpressionOnly = errors.New("rule has no expression")
+	errRuleSeverity       = errors.New("rule has invalid severity (want error or warning)")
+	errRuleNotBool        = errors.New("rule expression must evaluate to a boolean")
+)
+
+// Rule is one semantic check evaluated against every rendered document.
+type Rule struct {
+	// Name uniquely identifies the rule in reports.
+	Name string `json:"name"`
+	// Expression is a CEL expression over `object` that must evaluate to
+	// true for a document to pass.
+	Expression string `json:"expression"`
+	// Message optionally overrides the violation text.
+	Message string `json:"message,omitempty"`
+	// Severity is error (default) or warning.
+	Severity Severity `json:"severity,omitempty"`
+}
+
+// RulesFile is the on-disk YAML schema of a rules file.
+type RulesFile struct {
+	Rules []Rule `json:"rules"`
+}
+
+// Violation reports one rule failing against one document.
+type Violation struct {
+	// Rule is the violated rule's name.
+	Rule string
+	// Message is the rule's message, or a synthesized description when the
+	// rule declares none or its evaluation errored.
+	Message string
+	// Severity mirrors the rule's severity.
+	Severity Severity
+}
+
+// LoadRules reads and validates a YAML rules file. The severity of rules that
+// omit one defaults to error.
+func LoadRules(path string) ([]Rule, error) {
+	//nolint:gosec // the rules file is user-project input by design
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read rules file: %w", err)
+	}
+
+	var file RulesFile
+
+	err = yaml.UnmarshalStrict(content, &file)
+	if err != nil {
+		return nil, fmt.Errorf("parse rules file %s: %w", path, err)
+	}
+
+	err = validateRules(file.Rules)
+	if err != nil {
+		return nil, fmt.Errorf("invalid rules file %s: %w", path, err)
+	}
+
+	for index := range file.Rules {
+		if file.Rules[index].Severity == "" {
+			file.Rules[index].Severity = SeverityError
+		}
+	}
+
+	return file.Rules, nil
+}
+
+// validateRules enforces the rules-file invariants: at least one rule, unique
+// non-empty names, non-empty expressions, and a known severity.
+func validateRules(rules []Rule) error {
+	if len(rules) == 0 {
+		return errNoRules
+	}
+
+	seen := make(map[string]struct{}, len(rules))
+
+	for index, rule := range rules {
+		name := strings.TrimSpace(rule.Name)
+		if name == "" {
+			return fmt.Errorf("%w (index %d)", errRuleNameEmpty, index)
+		}
+
+		_, duplicate := seen[name]
+		if duplicate {
+			return fmt.Errorf("%w: %s", errRuleNameDuplicate, name)
+		}
+
+		seen[name] = struct{}{}
+
+		if strings.TrimSpace(rule.Expression) == "" {
+			return fmt.Errorf("%w: %s", errRuleExpressionOnly, name)
+		}
+
+		switch rule.Severity {
+		case "", SeverityError, SeverityWarning:
+		default:
+			return fmt.Errorf("%w: %s has %q", errRuleSeverity, name, rule.Severity)
+		}
+	}
+
+	return nil
+}
+
+// compiledRule pairs a rule with its compiled CEL program.
+type compiledRule struct {
+	rule    Rule
+	program cel.Program
+}
+
+// Engine evaluates a compiled rule set against rendered documents.
+type Engine struct {
+	rules []compiledRule
+}
+
+// NewEngine compiles every rule's expression against a CEL environment that
+// binds each document as `object` (dynamic type, ValidatingAdmissionPolicy
+// style) with the strings extension library. Compilation errors name the
+// offending rule so a broken rules file is diagnosable from the error alone.
+func NewEngine(rules []Rule) (*Engine, error) {
+	env, err := cel.NewEnv(
+		cel.Variable(objectVarName, cel.DynType),
+		ext.Strings(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create CEL environment: %w", err)
+	}
+
+	compiled := make([]compiledRule, 0, len(rules))
+
+	for _, rule := range rules {
+		program, err := compileRule(env, rule)
+		if err != nil {
+			return nil, err
+		}
+
+		compiled = append(compiled, compiledRule{rule: rule, program: program})
+	}
+
+	return &Engine{rules: compiled}, nil
+}
+
+// compileRule compiles one rule and enforces a boolean output type.
+func compileRule(env *cel.Env, rule Rule) (cel.Program, error) {
+	ast, issues := env.Compile(rule.Expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("compile rule %s: %w", rule.Name, issues.Err())
+	}
+
+	if ast.OutputType() != cel.BoolType {
+		return nil, fmt.Errorf(
+			"%w: %s returns %s", errRuleNotBool, rule.Name, ast.OutputType(),
+		)
+	}
+
+	program, err := env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("build program for rule %s: %w", rule.Name, err)
+	}
+
+	return program, nil
+}
+
+// Evaluate runs every rule against one decoded document and returns the
+// violations. An expression evaluating to false violates its rule; an
+// evaluation error (e.g. selecting a missing field without has()) also
+// violates it — fail-closed, matching ValidatingAdmissionPolicy semantics —
+// with the evaluation error carried in the message.
+func (e *Engine) Evaluate(doc map[string]any) []Violation {
+	violations := make([]Violation, 0)
+
+	for _, compiled := range e.rules {
+		result, _, err := compiled.program.Eval(map[string]any{objectVarName: doc})
+		if err != nil {
+			violations = append(violations, Violation{
+				Rule:     compiled.rule.Name,
+				Message:  fmt.Sprintf("rule evaluation failed: %v", err),
+				Severity: compiled.rule.Severity,
+			})
+
+			continue
+		}
+
+		if result == types.True {
+			continue
+		}
+
+		violations = append(violations, newViolation(compiled.rule))
+	}
+
+	return violations
+}
+
+// newViolation builds the violation for a rule whose expression returned false.
+func newViolation(rule Rule) Violation {
+	message := rule.Message
+	if message == "" {
+		message = "expression evaluated to false: " + rule.Expression
+	}
+
+	return Violation{
+		Rule:     rule.Name,
+		Message:  message,
+		Severity: rule.Severity,
+	}
+}

--- a/pkg/svc/gitops/celrules/celrules_test.go
+++ b/pkg/svc/gitops/celrules/celrules_test.go
@@ -1,0 +1,211 @@
+package celrules_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/gitops/celrules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeRulesFile writes a temp rules file and returns its path.
+func writeRulesFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "validation-rules.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// deployment returns a minimal decoded Deployment-shaped document.
+func deployment(image string) map[string]any {
+	return map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "app"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "app", "image": image},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestLoadRules_ValidFileDefaultsSeverity(t *testing.T) {
+	t.Parallel()
+
+	path := writeRulesFile(t, `
+rules:
+  - name: no-latest-tag
+    expression: "object.kind != 'Deployment'"
+    message: images must not use :latest
+  - name: warn-rule
+    expression: "true"
+    severity: warning
+`)
+
+	rules, err := celrules.LoadRules(path)
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	assert.Equal(t, celrules.SeverityError, rules[0].Severity)
+	assert.Equal(t, celrules.SeverityWarning, rules[1].Severity)
+}
+
+func TestLoadRules_Errors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{"empty rules", "rules: []", "declares no rules"},
+		{"missing name", "rules:\n  - expression: 'true'", "has no name"},
+		{
+			"duplicate name",
+			"rules:\n  - name: a\n    expression: 'true'\n  - name: a\n    expression: 'false'",
+			"duplicate rule name",
+		},
+		{"missing expression", "rules:\n  - name: a", "has no expression"},
+		{
+			"bad severity",
+			"rules:\n  - name: a\n    expression: 'true'\n    severity: fatal",
+			"invalid severity",
+		},
+		{
+			"unknown field",
+			"rules:\n  - name: a\n    expression: 'true'\n    expr: dup",
+			"parse rules file",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := celrules.LoadRules(writeRulesFile(t, testCase.content))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), testCase.wantErr)
+		})
+	}
+}
+
+func TestLoadRules_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := celrules.LoadRules(filepath.Join(t.TempDir(), "absent.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read rules file")
+}
+
+func TestNewEngine_CompileErrorNamesRule(t *testing.T) {
+	t.Parallel()
+
+	_, err := celrules.NewEngine([]celrules.Rule{
+		{Name: "broken", Expression: "object.kind ==", Severity: celrules.SeverityError},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "compile rule broken")
+}
+
+func TestNewEngine_NonBoolExpressionNamesRule(t *testing.T) {
+	t.Parallel()
+
+	_, err := celrules.NewEngine([]celrules.Rule{
+		{Name: "stringy", Expression: "object.kind", Severity: celrules.SeverityError},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must evaluate to a boolean")
+	assert.Contains(t, err.Error(), "stringy")
+}
+
+func TestEvaluate_PassProducesNoViolation(t *testing.T) {
+	t.Parallel()
+
+	engine, err := celrules.NewEngine([]celrules.Rule{
+		{
+			Name:       "kind-known",
+			Expression: "object.kind == 'Deployment'",
+			Severity:   celrules.SeverityError,
+		},
+	})
+	require.NoError(t, err)
+
+	violations := engine.Evaluate(deployment("app:v1.2.3"))
+	assert.Empty(t, violations)
+}
+
+func TestEvaluate_FailProducesAttributedViolation(t *testing.T) {
+	t.Parallel()
+
+	engine, err := celrules.NewEngine([]celrules.Rule{
+		{
+			Name:       "no-latest-tag",
+			Expression: "object.spec.template.spec.containers.all(c, !c.image.endsWith(':latest'))",
+			Message:    "images must be pinned, not :latest",
+			Severity:   celrules.SeverityError,
+		},
+	})
+	require.NoError(t, err)
+
+	violations := engine.Evaluate(deployment("app:latest"))
+	require.Len(t, violations, 1)
+	assert.Equal(t, "no-latest-tag", violations[0].Rule)
+	assert.Equal(t, "images must be pinned, not :latest", violations[0].Message)
+	assert.Equal(t, celrules.SeverityError, violations[0].Severity)
+}
+
+func TestEvaluate_DefaultMessageIncludesExpression(t *testing.T) {
+	t.Parallel()
+
+	engine, err := celrules.NewEngine([]celrules.Rule{
+		{Name: "always-false", Expression: "false", Severity: celrules.SeverityWarning},
+	})
+	require.NoError(t, err)
+
+	violations := engine.Evaluate(deployment("app:v1"))
+	require.Len(t, violations, 1)
+	assert.Contains(t, violations[0].Message, "false")
+	assert.Equal(t, celrules.SeverityWarning, violations[0].Severity)
+}
+
+func TestEvaluate_EvalErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	engine, err := celrules.NewEngine([]celrules.Rule{
+		{
+			Name:       "needs-annotations",
+			Expression: "object.metadata.annotations.size() > 0",
+			Severity:   celrules.SeverityError,
+		},
+	})
+	require.NoError(t, err)
+
+	// The document has no metadata.annotations key, so evaluation errors —
+	// which must surface as a violation (fail-closed), not a silent pass.
+	violations := engine.Evaluate(deployment("app:v1"))
+	require.Len(t, violations, 1)
+	assert.Equal(t, "needs-annotations", violations[0].Rule)
+	assert.Contains(t, violations[0].Message, "rule evaluation failed")
+}
+
+func TestEvaluate_MultipleRulesReportIndependently(t *testing.T) {
+	t.Parallel()
+
+	engine, err := celrules.NewEngine([]celrules.Rule{
+		{Name: "pass", Expression: "object.kind == 'Deployment'", Severity: celrules.SeverityError},
+		{Name: "fail", Expression: "object.kind == 'Service'", Severity: celrules.SeverityWarning},
+	})
+	require.NoError(t, err)
+
+	violations := engine.Evaluate(deployment("app:v1"))
+	require.Len(t, violations, 1)
+	assert.Equal(t, "fail", violations[0].Rule)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5706 — first child of #5693 (native CEL rule validation; part of the #5344 epic).

## What

New package `pkg/svc/gitops/celrules`: the rule engine that will back semantic/policy validation of rendered GitOps manifests in `workload validate` — deliberately **not yet wired into any command** (zero behaviour change), so the increment is reviewable and unit-testable alone, mirroring the foundation→wiring decomposition proven on #5441 and #4521.

- **Rules file (YAML):** `rules: [{name, expression, message, severity}]`, strict-parsed; invariants validated with clear errors (missing/duplicate name, empty expression, unknown severity); severity defaults to `error`.
- **Compilation:** each expression compiles against a CEL env binding the document as `object` (dyn) + strings extensions — the convention users know from ValidatingAdmissionPolicy. Compile errors and non-boolean expressions fail **naming the rule**.
- **Evaluation:** `Engine.Evaluate(doc)` — `false` ⇒ violation (rule message or synthesized default); an evaluation error (e.g. selecting a missing field without `has()`) ⇒ **fail-closed** violation carrying the error, matching VAP semantics.

## Dependency note (flagged for steering)

⚠️ `github.com/google/cel-go` v0.28.0 is promoted **indirect → direct** (it was already linked transitively via the Kubernetes apiserver stack — no new supply-chain surface, no version change) + a commented depguard allow entry. This implements the stay-native decision recorded in #5624: in-process CEL over any external policy binary (kyverno CLI / conftest).

## Validation

- `go test ./pkg/svc/gitops/celrules/` — 16 passed (load/validate errors, compile/non-bool naming the rule, pass/fail/attribution, fail-closed eval error, multi-rule independence, severity handling)
- `golangci-lint run ./pkg/svc/gitops/celrules/...` — 0 issues
- `go build ./...` clean; `go -C desktop mod tidy` no-op (dep already in graph)

## Follow-up (next child, anti-stacked)

Wire into `workload validate`: `--rules`/config surface, per-layer attribution via #5619/#5664, docs reference page + example rules file.