### PR TITLE
feat(hetzner): deliver bootstrap SSH public keys via cloud-init ssh_authorized_keys

### DIFF
--- a/pkg/svc/bootstrap/cloudinit/cloudinit.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit.go
@@ -60,6 +60,16 @@ type Config struct {
 	// apt/package processing and the boot script. Optional; see [File] and
 	// [ErrInvalidFile].
 	Files []File
+	// SSHAuthorizedKeys are public keys added to the default user's
+	// authorized_keys (cloud-init's `ssh_authorized_keys:` module; on Hetzner
+	// stock images the default user is root) so a post-provision client — the
+	// SSH bootstrap seam (#5696) that retrieves the generated kubeconfig — can
+	// authenticate. Optional; each must be a single line with no NUL byte (see
+	// [ErrInvalidSSHAuthorizedKey]). Blank entries are dropped. Keys alone do
+	// not make a Config renderable: a document with a key but nothing to run
+	// would create a server that never bootstraps, so a keys-only Config is
+	// still rejected with [ErrNoCommands].
+	SSHAuthorizedKeys []string
 	// ScriptPath overrides where the boot script is written. Optional; defaults to
 	// [DefaultScriptPath]. Must be absolute when set (see [ErrPathNotAbsolute]).
 	ScriptPath string
@@ -113,7 +123,9 @@ type cloudConfig struct {
 	WriteFiles []writeFile `yaml:"write_files,omitempty"`
 	Apt        *aptConfig  `yaml:"apt,omitempty"`
 	Packages   []string    `yaml:"packages,omitempty"`
-	RunCmd     [][]string  `yaml:"runcmd,omitempty"`
+	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key "ssh_authorized_keys".
+	SSHAuthorizedKeys []string   `yaml:"ssh_authorized_keys,omitempty"`
+	RunCmd            [][]string `yaml:"runcmd,omitempty"`
 }
 
 // writeFile is one entry of cloud-init's write_files module: a file dropped onto
@@ -173,10 +185,13 @@ type directives struct {
 	packages []string
 	sources  map[string]aptSource
 	files    []writeFile
+	sshKeys  []string
 }
 
 // empty reports whether there is nothing to render — no command, package, apt
-// source, or file.
+// source, or file. SSH authorized keys are deliberately excluded: a keys-only
+// document would create a server that never bootstraps, so keys alone don't
+// make a Config renderable (see [Config.SSHAuthorizedKeys]).
 func (d directives) empty() bool {
 	return len(d.commands) == 0 &&
 		len(d.packages) == 0 &&
@@ -207,12 +222,45 @@ func (cfg Config) validate() (directives, error) {
 		return directives{}, err
 	}
 
-	dirs := directives{commands: commands, packages: packages, sources: sources, files: files}
+	sshKeys, err := cfg.validatedSSHAuthorizedKeys()
+	if err != nil {
+		return directives{}, err
+	}
+
+	dirs := directives{
+		commands: commands,
+		packages: packages,
+		sources:  sources,
+		files:    files,
+		sshKeys:  sshKeys,
+	}
 	if dirs.empty() {
 		return directives{}, ErrNoCommands
 	}
 
 	return dirs, nil
+}
+
+// validatedSSHAuthorizedKeys returns the non-blank SSH public keys of cfg in
+// order, rejecting a key that is not a single line. Each key is one element of
+// cloud-init's ssh_authorized_keys: list (one authorized_keys line), so it must
+// be a single line. Blank entries are dropped.
+func (cfg Config) validatedSSHAuthorizedKeys() ([]string, error) {
+	keys := make([]string, 0, len(cfg.SSHAuthorizedKeys))
+
+	for _, key := range cfg.SSHAuthorizedKeys {
+		if strings.ContainsAny(key, "\n\x00") {
+			return nil, ErrInvalidSSHAuthorizedKey
+		}
+
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+
+		keys = append(keys, key)
+	}
+
+	return keys, nil
 }
 
 // buildDoc assembles the cloud-config from already-validated directives. Files
@@ -221,7 +269,11 @@ func (cfg Config) validate() (directives, error) {
 // cloud-init's own module order so a package a command relies on is present
 // before the command runs.
 func (cfg Config) buildDoc(dirs directives) (cloudConfig, error) {
-	doc := cloudConfig{WriteFiles: dirs.files, Packages: dirs.packages}
+	doc := cloudConfig{
+		WriteFiles:        dirs.files,
+		Packages:          dirs.packages,
+		SSHAuthorizedKeys: dirs.sshKeys,
+	}
 
 	if len(dirs.sources) > 0 {
 		doc.Apt = &aptConfig{Sources: dirs.sources}

--- a/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
@@ -24,8 +24,10 @@ type parsedConfig struct {
 			Key    string `yaml:"key"`
 		} `yaml:"sources"`
 	} `yaml:"apt"`
-	Packages []string   `yaml:"packages"`
-	RunCmd   [][]string `yaml:"runcmd"`
+	Packages []string `yaml:"packages"`
+	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key.
+	SSHAuthorizedKeys []string   `yaml:"ssh_authorized_keys"`
+	RunCmd            [][]string `yaml:"runcmd"`
 }
 
 // parse asserts the document carries the cloud-config header and is valid YAML,
@@ -182,11 +184,68 @@ func TestBuildUserDataCommandOnlyOmitsDeclarativeKeys(t *testing.T) {
 
 	assert.NotContains(t, userData, "packages:")
 	assert.NotContains(t, userData, "apt:")
+	assert.NotContains(t, userData, "ssh_authorized_keys:")
 
 	cfg := parse(t, userData)
 	assert.Empty(t, cfg.Packages)
 	assert.Empty(t, cfg.Apt.Sources)
+	assert.Empty(t, cfg.SSHAuthorizedKeys)
 	require.Len(t, cfg.WriteFiles, 1) // only the boot script
+}
+
+func TestBuildUserDataRendersSSHAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"echo hi"},
+		SSHAuthorizedKeys: []string{
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap",
+			"",
+			"   ",
+			"ssh-rsa AAAAB3NzaC1yc2E operator",
+		},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+
+	// Blank entries dropped, order preserved.
+	assert.Equal(t, []string{
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap",
+		"ssh-rsa AAAAB3NzaC1yc2E operator",
+	}, cfg.SSHAuthorizedKeys)
+}
+
+func TestBuildUserDataSSHKeysOnlyRejected(t *testing.T) {
+	t.Parallel()
+
+	// A key with nothing to run would create a server that never bootstraps, so a
+	// keys-only Config is rejected like an empty one.
+	_, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		SSHAuthorizedKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap"},
+	})
+	require.ErrorIs(t, err, cloudinitbootstrap.ErrNoCommands)
+}
+
+func TestBuildUserDataSSHKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"newline": "ssh-ed25519 AAAA\nssh-rsa BBBB",
+		"NUL":     "ssh-ed25519 AAAA\x00 key",
+	}
+
+	for name, key := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+				Commands:          []string{"echo hi"},
+				SSHAuthorizedKeys: []string{key},
+			})
+			require.ErrorIs(t, err, cloudinitbootstrap.ErrInvalidSSHAuthorizedKey)
+		})
+	}
 }
 
 func TestBuildUserDataRendersPackages(t *testing.T) {

--- a/pkg/svc/bootstrap/cloudinit/errors.go
+++ b/pkg/svc/bootstrap/cloudinit/errors.go
@@ -27,6 +27,14 @@ var (
 		"cloud-init: a package name must be a single line with no NUL byte",
 	)
 
+	// ErrInvalidSSHAuthorizedKey is returned when an SSH authorized key contains a
+	// newline or a NUL byte. Each key is one element of cloud-init's
+	// ssh_authorized_keys: list — one authorized_keys line — so it must be a single
+	// line.
+	ErrInvalidSSHAuthorizedKey = errors.New(
+		"cloud-init: an SSH authorized key must be a single line with no NUL byte",
+	)
+
 	// ErrInvalidAptSource is returned when an [AptSource] has a blank or multi-line
 	// Name or Source, a Name containing a path separator, a Key containing a NUL
 	// byte, or a Name that duplicates another source's. cloud-init keys the sources

--- a/pkg/svc/bootstrap/cloudinit/transport.go
+++ b/pkg/svc/bootstrap/cloudinit/transport.go
@@ -12,8 +12,11 @@ package cloudinitbootstrap
 // — so it is not folded into this interface.
 type UserDataProvider interface {
 	// UserData returns the cloud-init user_data that runs commands once at first
-	// boot, or an error if commands is not a valid command set.
-	UserData(commands []string) (string, error)
+	// boot and installs sshAuthorizedKeys into the default user's authorized_keys
+	// (nil for none), or an error if commands or sshAuthorizedKeys is not valid.
+	// The keys are provision-time delivery too: they let the post-provision SSH
+	// bootstrap seam authenticate, but are delivered declaratively at first boot.
+	UserData(commands []string, sshAuthorizedKeys []string) (string, error)
 }
 
 // Transport is the cloud-init implementation of [UserDataProvider]. The zero
@@ -33,15 +36,17 @@ func New() *Transport {
 	return &Transport{}
 }
 
-// UserData renders commands into a cloud-init user_data document, honouring the
-// transport's script and log paths. It is pure and reaches no network, so the
-// command-construction it performs is fully unit-testable; the document it
-// returns is consumed by the provisioner at server-creation time.
-func (t *Transport) UserData(commands []string) (string, error) {
+// UserData renders commands (and any SSH authorized keys) into a cloud-init
+// user_data document, honouring the transport's script and log paths. It is pure
+// and reaches no network, so the command-construction it performs is fully
+// unit-testable; the document it returns is consumed by the provisioner at
+// server-creation time.
+func (t *Transport) UserData(commands []string, sshAuthorizedKeys []string) (string, error) {
 	return BuildUserData(Config{
-		Commands:   commands,
-		ScriptPath: t.ScriptPath,
-		LogPath:    t.LogPath,
+		Commands:          commands,
+		SSHAuthorizedKeys: sshAuthorizedKeys,
+		ScriptPath:        t.ScriptPath,
+		LogPath:           t.LogPath,
 	})
 }
 

--- a/pkg/svc/bootstrap/cloudinit/transport_test.go
+++ b/pkg/svc/bootstrap/cloudinit/transport_test.go
@@ -13,7 +13,7 @@ func TestTransportUserDataMatchesBuilder(t *testing.T) {
 
 	commands := []string{"echo hi", "echo bye"}
 
-	got, err := cloudinitbootstrap.New().UserData(commands)
+	got, err := cloudinitbootstrap.New().UserData(commands, nil)
 	require.NoError(t, err)
 
 	want, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{Commands: commands})
@@ -31,7 +31,7 @@ func TestTransportUserDataHonoursPaths(t *testing.T) {
 		LogPath:    "/var/log/custom.log",
 	}
 
-	got, err := transport.UserData([]string{"echo hi"})
+	got, err := transport.UserData([]string{"echo hi"}, nil)
 	require.NoError(t, err)
 
 	want, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
@@ -47,9 +47,28 @@ func TestTransportUserDataHonoursPaths(t *testing.T) {
 func TestTransportUserDataPropagatesError(t *testing.T) {
 	t.Parallel()
 
-	out, err := cloudinitbootstrap.New().UserData(nil)
+	out, err := cloudinitbootstrap.New().UserData(nil, nil)
 	require.ErrorIs(t, err, cloudinitbootstrap.ErrNoCommands)
 	assert.Empty(t, out)
+}
+
+func TestTransportUserDataRendersSSHAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	got, err := cloudinitbootstrap.New().UserData(
+		[]string{"echo hi"},
+		[]string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap"},
+	)
+	require.NoError(t, err)
+
+	want, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands:          []string{"echo hi"},
+		SSHAuthorizedKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, want, got)
+	assert.Contains(t, got, "ssh_authorized_keys:")
 }
 
 func TestTransportSatisfiesUserDataProvider(t *testing.T) {
@@ -57,7 +76,7 @@ func TestTransportSatisfiesUserDataProvider(t *testing.T) {
 
 	var provider cloudinitbootstrap.UserDataProvider = cloudinitbootstrap.New()
 
-	out, err := provider.UserData([]string{"echo hi"})
+	out, err := provider.UserData([]string{"echo hi"}, nil)
 	require.NoError(t, err)
 	assert.Contains(t, out, "#cloud-config")
 }

--- a/pkg/svc/provisioner/cluster/k3shetzner/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/export_test.go
@@ -47,8 +47,9 @@ func NewProvisionerForTest(
 // BuildNodeUserData exposes buildNodeUserData to external tests as exported data.
 func (p *Provisioner) BuildNodeUserData(
 	clusterName, token, serverURL string,
+	sshAuthorizedKeys []string,
 ) ([]TestNode, error) {
-	nodes, err := p.buildNodeUserData(clusterName, token, serverURL)
+	nodes, err := p.buildNodeUserData(clusterName, token, serverURL, sshAuthorizedKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
@@ -134,7 +134,7 @@ func TestBuildNodeUserDataSingleControlPlane(t *testing.T) {
 
 	prov := newProvisioner(&fakeInfra{}, 1, 0)
 
-	nodes, err := prov.BuildNodeUserData(testClusterName, "token", "")
+	nodes, err := prov.BuildNodeUserData(testClusterName, "token", "", nil)
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)
 
@@ -151,7 +151,7 @@ func TestBuildNodeUserDataMultiNodeOrderAndLabels(t *testing.T) {
 
 	prov := newProvisioner(&fakeInfra{}, 3, 2)
 
-	nodes, err := prov.BuildNodeUserData(testClusterName, "token", "https://10.0.0.2:6443")
+	nodes, err := prov.BuildNodeUserData(testClusterName, "token", "https://10.0.0.2:6443", nil)
 	require.NoError(t, err)
 	require.Len(t, nodes, 5)
 
@@ -165,6 +165,20 @@ func TestBuildNodeUserDataMultiNodeOrderAndLabels(t *testing.T) {
 
 	assert.Equal(t, "controlplane", nodes[0].Labels[hetzner.LabelNodeType])
 	assert.Equal(t, "worker", nodes[4].Labels[hetzner.LabelNodeType])
+}
+
+func TestBuildNodeUserDataDeliversSSHAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 0)
+	key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap"
+
+	nodes, err := prov.BuildNodeUserData(testClusterName, "token", "", []string{key})
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	assert.Contains(t, nodes[0].UserData, "ssh_authorized_keys:")
+	assert.Contains(t, nodes[0].UserData, key)
 }
 
 func TestBuildNodeUserDataErrors(t *testing.T) {
@@ -200,7 +214,7 @@ func TestBuildNodeUserDataErrors(t *testing.T) {
 				io.Discard,
 			)
 
-			_, err := prov.BuildNodeUserData(testClusterName, "token", testCase.serverURL)
+			_, err := prov.BuildNodeUserData(testClusterName, "token", testCase.serverURL, nil)
 			require.Error(t, err)
 		})
 	}

--- a/pkg/svc/provisioner/cluster/k3shetzner/userdata.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/userdata.go
@@ -33,9 +33,12 @@ type nodeUserData struct {
 // (the transport), and attaches the Hetzner node labels. It is pure — it performs
 // no I/O and reaches no network — so it is fully unit-testable; serverURL is the
 // address joining nodes register against (empty for a single control-plane node
-// with no agents).
+// with no agents), and sshAuthorizedKeys are the public keys delivered into every
+// node's authorized_keys (nil for none) so the post-provision SSH bootstrap seam
+// can authenticate.
 func (p *Provisioner) buildNodeUserData(
 	clusterName, token, serverURL string,
+	sshAuthorizedKeys []string,
 ) ([]nodeUserData, error) {
 	nodes, err := k3sbootstrap.Plan(k3sbootstrap.PlanInput{
 		Version:           p.version,
@@ -56,7 +59,7 @@ func (p *Provisioner) buildNodeUserData(
 			return nil, fmt.Errorf("render k3s install for node %d: %w", node.Index, renderErr)
 		}
 
-		userData, transportErr := p.transport.UserData([]string{command})
+		userData, transportErr := p.transport.UserData([]string{command}, sshAuthorizedKeys)
 		if transportErr != nil {
 			return nil, fmt.Errorf("build cloud-init for node %d: %w", node.Index, transportErr)
 		}
@@ -75,9 +78,10 @@ func (p *Provisioner) buildNodeUserData(
 // composeNodes composes the K3s per-node cloud-init user_data and returns the node
 // count, adapting buildNodeUserData to the shared create flow's composeNodes
 // callback ([hetznerbase.Base.RunCreate]). The single-control-plane path carries no
-// join server URL.
+// join server URL, and no SSH authorized key yet — the live bring-up composition
+// (#5515) generates the bootstrap keypair and threads its public half through here.
 func (p *Provisioner) composeNodes(clusterName, token string) (int, error) {
-	nodes, err := p.buildNodeUserData(clusterName, token, "")
+	nodes, err := p.buildNodeUserData(clusterName, token, "", nil)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
@@ -31,6 +31,12 @@ type Input struct {
 	// node (see [containerdbootstrap.ContainerdConfig]). Empty leaves containerd's
 	// built-in default in place.
 	SandboxImage string
+	// SSHAuthorizedKeys are public keys delivered into every node's
+	// authorized_keys via cloud-init (see [cloudinitbootstrap.Config]) so the
+	// post-provision SSH bootstrap seam can authenticate. Optional; the live
+	// bring-up composition (#5515) generates the bootstrap keypair and threads
+	// its public half through here.
+	SSHAuthorizedKeys []string
 }
 
 // NodeUserData pairs a planned node with the cloud-init user_data that bootstraps
@@ -133,10 +139,11 @@ func buildNodeCloudInit(
 	}
 
 	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
-		AptSources: toCloudInitAptSources(install.AptSources),
-		Packages:   install.Packages,
-		Files:      append(toCloudInitFiles(install.Files), containerdFile),
-		Commands:   install.Commands,
+		AptSources:        toCloudInitAptSources(install.AptSources),
+		Packages:          install.Packages,
+		Files:             append(toCloudInitFiles(install.Files), containerdFile),
+		Commands:          install.Commands,
+		SSHAuthorizedKeys: input.SSHAuthorizedKeys,
 	})
 	if err != nil {
 		return "", fmt.Errorf("build cloud-init for node %d: %w", node.Index, err)

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata_test.go
@@ -120,6 +120,21 @@ func TestBuildNodeUserDataMultiNodeOrderRolesAndJoin(t *testing.T) {
 	assert.Equal(t, "3", nodes[3].Labels[hetzner.LabelNodeIndex])
 }
 
+func TestBuildNodeUserDataDeliversSSHAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap"
+	input := singleControlPlaneInput()
+	input.SSHAuthorizedKeys = []string{key}
+
+	nodes, err := kubeadmhetzner.BuildNodeUserData(input)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	assert.Contains(t, nodes[0].UserData, "ssh_authorized_keys:")
+	assert.Contains(t, nodes[0].UserData, key)
+}
+
 func TestBuildNodeUserDataPinsSandboxImage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5712. Part of #3983 / #5515 (Hetzner live bring-up lane).

## What

The missing key-delivery foundation under the live `RunCreate` composition: the SSH bootstrap client (#5697) can authenticate only if its generated public key is on the server, and until now nothing could put it there.

- `cloudinit.Config.SSHAuthorizedKeys` → rendered as cloud-init's `ssh_authorized_keys:` module (keys land in the default user's `authorized_keys`; `root` on Hetzner stock images, matching the bootstrap client's login). Validation mirrors the existing directives (single line, no NUL, blanks dropped; new sentinel `ErrInvalidSSHAuthorizedKey`). A keys-only Config is still rejected with `ErrNoCommands` — a server with a key but nothing to run never bootstraps.
- `UserDataProvider.UserData` gains an `sshAuthorizedKeys` parameter so the k3s command-only composition can carry keys through its transport seam.
- `kubeadmhetzner.Input.SSHAuthorizedKeys` → passed into its cloud-init Config.

## Behaviour

**Zero behaviour change**: no caller passes keys yet (both provisioners pass nil). The next increment — the actual `hetznerbase.RunCreate` composition (create server → `DialWithRetry` → kubeconfig fetch → cleanup-on-failure) — generates the keypair and threads `KeyPair.AuthorizedKey` through these fields.

## Validation

- `go build ./...` clean; `go build -o /tmp/ksail-maint-529 .` clean
- `go test` on cloudinit + k3shetzner + kubeadmhetzner + hetznerbase: **137 passed**
- `golangci-lint run` on the changed packages: 0 issues