### PR TITLE
feat(hetzner): single-node bring-up engine — create server, SSH-bootstrap, retrieve kubeconfig

### DIFF
--- a/pkg/svc/bootstrap/ssh/client.go
+++ b/pkg/svc/bootstrap/ssh/client.go
@@ -216,6 +216,23 @@ func (c *Client) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	return result.Stdout, nil
 }
 
+// FileExists reports whether a regular file exists at path on the remote node
+// (`test -f`, with the path single-quoted against shell interpretation). A
+// false exit (code 1) means the file does not exist; any other failure — a
+// transport error or an unexpected exit code — is returned as an error.
+func (c *Client) FileExists(ctx context.Context, path string) (bool, error) {
+	result, err := c.Run(ctx, "test -f "+shellQuote(path))
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.Is(err, ErrCommandFailed) && result.ExitCode == 1 {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("probe remote file %s: %w", path, err)
+}
+
 // Close tears down the underlying SSH connection.
 func (c *Client) Close() error {
 	err := c.conn.Close()

--- a/pkg/svc/bootstrap/ssh/client_test.go
+++ b/pkg/svc/bootstrap/ssh/client_test.go
@@ -207,6 +207,44 @@ func mustGenerateKeyPair(t *testing.T) sshbootstrap.KeyPair {
 	return pair
 }
 
+func TestFileExists(t *testing.T) {
+	t.Parallel()
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(command string) (string, string, uint32) {
+			switch command {
+			case "test -f '/present'":
+				return "", "", 0
+			case "test -f '/absent'":
+				return "", "", 1
+			default:
+				return "", "", 2
+			}
+		},
+		0,
+	)
+
+	client := mustDial(t, addr, pair, hostKey)
+
+	exists, err := client.FileExists(t.Context(), "/present")
+	if err != nil || !exists {
+		t.Fatalf("present file: got exists=%v err=%v, want true, nil", exists, err)
+	}
+
+	exists, err = client.FileExists(t.Context(), "/absent")
+	if err != nil || exists {
+		t.Fatalf("absent file: got exists=%v err=%v, want false, nil", exists, err)
+	}
+
+	_, err = client.FileExists(t.Context(), "/probe-error")
+	if err == nil {
+		t.Fatal("unexpected exit code: want an error, got nil")
+	}
+}
+
 func TestGenerateKeyPairRoundTrips(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provider/hetzner/errors.go
+++ b/pkg/svc/provider/hetzner/errors.go
@@ -18,10 +18,14 @@ var (
 	ErrAllRetriesExhausted = errors.New("all retry attempts failed")
 	// ErrSnapshotBuildFailed indicates that the Talos snapshot build process failed.
 	ErrSnapshotBuildFailed = errors.New("talos snapshot build failed")
-	// ErrImageAndISOBothSet indicates that both ImageID and ISOID were provided, which is invalid.
-	ErrImageAndISOBothSet = errors.New("ImageID and ISOID are mutually exclusive; set only one")
-	// ErrImageOrISORequired indicates that neither ImageID nor ISOID was provided, but one is required.
-	ErrImageOrISORequired = errors.New("either ImageID or ISOID must be provided")
+	// ErrImageAndISOBothSet indicates that more than one boot-image source
+	// (ImageName, ImageID, ISOID) was provided, which is invalid.
+	ErrImageAndISOBothSet = errors.New(
+		"ImageName, ImageID and ISOID are mutually exclusive; set exactly one",
+	)
+	// ErrImageOrISORequired indicates that no boot-image source (ImageName,
+	// ImageID, ISOID) was provided, but exactly one is required.
+	ErrImageOrISORequired = errors.New("one of ImageName, ImageID or ISOID must be provided")
 	// ErrServerTypeNotFound indicates that the requested server type does not exist.
 	ErrServerTypeNotFound = errors.New("server type not found")
 	// ErrServerTypeUnavailable indicates that the server type is not available in any configured location.

--- a/pkg/svc/provider/hetzner/server_opts.go
+++ b/pkg/svc/provider/hetzner/server_opts.go
@@ -4,10 +4,15 @@ import "github.com/hetznercloud/hcloud-go/v2/hcloud"
 
 // CreateServerOpts contains options for creating a Hetzner server.
 type CreateServerOpts struct {
-	Name             string
-	ServerType       string
-	ImageID          int64 // Image ID (for snapshots) - mutually exclusive with ISOID
-	ISOID            int64 // ISO ID (for Talos public ISOs) - mutually exclusive with ImageID
+	Name       string
+	ServerType string
+	// ImageName is a base OS image referenced by name (e.g. "ubuntu-24.04"), for
+	// distributions that install onto a stock image via cloud-init (k3s, kubeadm).
+	// The hcloud API resolves the name server-side, so no lookup call is needed.
+	// Exactly one of ImageName, ImageID, or ISOID must be set.
+	ImageName        string
+	ImageID          int64 // Image ID (for snapshots) - exactly one of ImageName/ImageID/ISOID
+	ISOID            int64 // ISO ID (for Talos public ISOs) - exactly one of ImageName/ImageID/ISOID
 	Location         string
 	Labels           map[string]string
 	UserData         string
@@ -30,15 +35,36 @@ func publicNetEnabled(ptr *bool) bool {
 	return ptr == nil || *ptr
 }
 
-// buildServerCreateOpts builds the hcloud.ServerCreateOpts from CreateServerOpts.
-// Exactly one of ImageID or ISOID must be set; both or neither is an error.
-func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) (hcloud.ServerCreateOpts, error) {
-	if opts.ImageID > 0 && opts.ISOID > 0 {
-		return hcloud.ServerCreateOpts{}, ErrImageAndISOBothSet
+// imageSourceCount returns how many of the mutually exclusive boot-image sources
+// (ImageName, ImageID, ISOID) are set on opts.
+func imageSourceCount(opts CreateServerOpts) int {
+	count := 0
+
+	if opts.ImageName != "" {
+		count++
 	}
 
-	if opts.ImageID == 0 && opts.ISOID == 0 {
+	if opts.ImageID > 0 {
+		count++
+	}
+
+	if opts.ISOID > 0 {
+		count++
+	}
+
+	return count
+}
+
+// buildServerCreateOpts builds the hcloud.ServerCreateOpts from CreateServerOpts.
+// Exactly one of ImageName, ImageID, or ISOID must be set; more or none is an error.
+func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) (hcloud.ServerCreateOpts, error) {
+	switch imageSourceCount(opts) {
+	case 0:
 		return hcloud.ServerCreateOpts{}, ErrImageOrISORequired
+	case 1:
+		// exactly one boot-image source — valid
+	default:
+		return hcloud.ServerCreateOpts{}, ErrImageAndISOBothSet
 	}
 
 	createOpts := hcloud.ServerCreateOpts{
@@ -59,8 +85,10 @@ func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) (hcloud.ServerCr
 		},
 	}
 
-	// Use either Image or ISO - ISOs are used for Talos public ISOs
-	if opts.ISOID > 0 {
+	// Boot from the single configured source: an ISO (Talos public ISOs), a
+	// snapshot image by ID, or a stock OS image by name (k3s/kubeadm cloud-init).
+	switch {
+	case opts.ISOID > 0:
 		// When using ISO, we need a placeholder image for the server disk.
 		// The server must NOT start automatically so the ISO can be attached
 		// before the first boot — otherwise the server boots from the Debian
@@ -69,7 +97,11 @@ func (p *Provider) buildServerCreateOpts(opts CreateServerOpts) (hcloud.ServerCr
 			Name: "debian-13",
 		}
 		createOpts.StartAfterCreate = new(false)
-	} else {
+	case opts.ImageName != "":
+		createOpts.Image = &hcloud.Image{
+			Name: opts.ImageName,
+		}
+	default:
 		createOpts.Image = &hcloud.Image{
 			ID: opts.ImageID,
 		}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup.go
@@ -1,0 +1,220 @@
+package hetznerbase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// DefaultKubeconfigPollInterval is the default delay between probes for the
+// remote kubeconfig while the node's first-boot bootstrap (cloud-init running
+// the k3s or kubeadm install) is still writing it.
+const DefaultKubeconfigPollInterval = 3 * time.Second
+
+// sshPort is the port the bootstrap SSH dial connects to on a freshly created
+// server (stock OS images run sshd on the standard port).
+const sshPort = "22"
+
+// bootstrapUser is the user the bootstrap SSH dial authenticates as. Hetzner
+// stock OS images deliver cloud-init ssh_authorized_keys to root.
+const bootstrapUser = "root"
+
+var (
+	// ErrNoPublicIPv4 is returned by [Base.BringUpNode] when the created server
+	// carries no public IPv4 address to dial the bootstrap SSH connection to.
+	// IPv4-less topologies need a private-network dial path, which the bring-up
+	// engine does not implement yet.
+	ErrNoPublicIPv4 = errors.New(
+		"hetzner: created server has no public IPv4 address for the SSH bootstrap",
+	)
+
+	// ErrMissingKubeconfigPath is returned by [Base.BringUpNode] when the spec
+	// names no remote kubeconfig path to wait for.
+	ErrMissingKubeconfigPath = errors.New("hetzner: bring-up spec is missing the kubeconfig path")
+)
+
+// BringUpSpec carries everything [Base.BringUpNode] needs to take one composed
+// server spec to a running node and its admin kubeconfig.
+type BringUpSpec struct {
+	// Server is the composed server spec. Its UserData must deliver the public
+	// half of the bootstrap keypair into the node's authorized_keys (the
+	// cloud-init ssh_authorized_keys module) — otherwise the SSH dial below can
+	// never authenticate.
+	Server hetzner.CreateServerOpts
+	// Signer is the private half of the bootstrap keypair, authenticating the
+	// SSH dial.
+	Signer gossh.Signer
+	// HostKeyCallback verifies the server's SSH host key. The trust policy is
+	// the caller's decision (mirroring [sshbootstrap.Options]): a caller that
+	// delivers pre-generated host keys via user_data can pin them with
+	// [gossh.FixedHostKey]; a caller accepting first-boot trust supplies its own
+	// accept policy.
+	HostKeyCallback gossh.HostKeyCallback
+	// KubeconfigPath is the remote path of the admin kubeconfig the node's
+	// bootstrap writes (k3s: /etc/rancher/k3s/k3s.yaml, kubeadm:
+	// /etc/kubernetes/admin.conf).
+	KubeconfigPath string
+	// PollInterval is the delay between probes for KubeconfigPath; zero means
+	// [DefaultKubeconfigPollInterval].
+	PollInterval time.Duration
+	// Port is the SSH port dialed on the node; empty means the standard port 22
+	// (stock OS images run sshd there).
+	Port string
+}
+
+// BringUpResult is the outcome of a successful [Base.BringUpNode]: the created
+// server and the admin kubeconfig read off it.
+type BringUpResult struct {
+	// Server is the created Hetzner server.
+	Server *hcloud.Server
+	// Kubeconfig is the raw admin kubeconfig read from the node. Its API-server
+	// endpoint is whatever the distribution wrote (typically a loopback or
+	// private address) — rewriting it for external access is the caller's
+	// concern.
+	Kubeconfig []byte
+}
+
+// BringUpNode is the single-node live bring-up engine: it creates the server
+// from the composed spec, dials SSH on the server's public IPv4 with the
+// bootstrap keypair (retrying until the first boot brings sshd up), waits for
+// the distribution's kubeconfig to exist, and reads it back. When any step
+// after server creation fails, the cluster's servers are deleted again
+// (cleanup-on-failure) so a failed bring-up does not leak paid resources, and
+// both the cause and any cleanup failure are surfaced.
+//
+// The engine is deliberately policy-free: the spec's UserData, host-key trust,
+// and the kubeconfig's onward handling (endpoint rewrite, persistence) belong
+// to the caller. Wiring it into [Base.RunCreate] lands with the API-endpoint
+// design increment (devantler-tech/ksail#5720 scopes this boundary).
+func (b *Base) BringUpNode(
+	ctx context.Context,
+	clusterName string,
+	spec BringUpSpec,
+) (BringUpResult, error) {
+	if spec.KubeconfigPath == "" {
+		return BringUpResult{}, ErrMissingKubeconfigPath
+	}
+
+	server, err := b.Servers.CreateServer(ctx, spec.Server)
+	if err != nil {
+		return BringUpResult{}, fmt.Errorf("create server: %w", err)
+	}
+
+	kubeconfig, err := b.bootstrapAndReadKubeconfig(ctx, server, spec)
+	if err != nil {
+		return BringUpResult{}, b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	return BringUpResult{Server: server, Kubeconfig: kubeconfig}, nil
+}
+
+// bootstrapAndReadKubeconfig runs the post-create half of the bring-up: dial
+// SSH on the server's public IPv4, wait for the kubeconfig, read it.
+func (b *Base) bootstrapAndReadKubeconfig(
+	ctx context.Context,
+	server *hcloud.Server,
+	spec BringUpSpec,
+) ([]byte, error) {
+	addr, err := publicSSHAddr(server, spec.Port)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := sshbootstrap.DialWithRetry(ctx, sshbootstrap.Options{
+		Addr:            addr,
+		User:            bootstrapUser,
+		Signer:          spec.Signer,
+		HostKeyCallback: spec.HostKeyCallback,
+	}, 0)
+	if err != nil {
+		return nil, fmt.Errorf("dial bootstrap SSH at %s: %w", addr, err)
+	}
+
+	defer func() { _ = client.Close() }()
+
+	err = waitForRemoteFile(ctx, client, spec.KubeconfigPath, spec.PollInterval)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfig, err := client.ReadFile(ctx, spec.KubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read kubeconfig %q: %w", spec.KubeconfigPath, err)
+	}
+
+	return kubeconfig, nil
+}
+
+// cleanUpFailedBringUp deletes the cluster's servers after a failed bring-up so
+// a half-provisioned node does not keep accruing cost, and joins any cleanup
+// failure onto the original cause. It deletes with a cancel-free context: the
+// bring-up often fails *because* ctx was cancelled, and the cleanup must still
+// run then.
+func (b *Base) cleanUpFailedBringUp(ctx context.Context, clusterName string, cause error) error {
+	deleteErr := b.Infra.DeleteNodes(context.WithoutCancel(ctx), clusterName)
+	if deleteErr != nil {
+		return errors.Join(
+			cause,
+			fmt.Errorf("clean up servers after failed bring-up: %w", deleteErr),
+		)
+	}
+
+	return cause
+}
+
+// publicSSHAddr derives the "host:port" the bootstrap SSH dial connects to from
+// the created server's public IPv4, or [ErrNoPublicIPv4] when the server has
+// none (IPv4 disabled or not yet assigned). An empty port means the standard
+// SSH port.
+func publicSSHAddr(server *hcloud.Server, port string) (string, error) {
+	if server == nil || server.PublicNet.IPv4.IP == nil ||
+		server.PublicNet.IPv4.IP.IsUnspecified() {
+		return "", ErrNoPublicIPv4
+	}
+
+	if port == "" {
+		port = sshPort
+	}
+
+	return net.JoinHostPort(server.PublicNet.IPv4.IP.String(), port), nil
+}
+
+// waitForRemoteFile polls the remote node until path exists
+// ([sshbootstrap.Client.FileExists]), sleeping interval between probes and
+// giving up when ctx ends. "Does not exist yet" retries; a probe error is
+// surfaced immediately — the connection is already established, so transport
+// errors are real failures, not boot-time races.
+func waitForRemoteFile(
+	ctx context.Context,
+	client *sshbootstrap.Client,
+	path string,
+	interval time.Duration,
+) error {
+	if interval <= 0 {
+		interval = DefaultKubeconfigPollInterval
+	}
+
+	for {
+		exists, err := client.FileExists(ctx, path)
+		if err != nil {
+			return fmt.Errorf("wait for remote file: %w", err)
+		}
+
+		if exists {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for remote file %q: %w", path, ctx.Err())
+		case <-time.After(interval):
+		}
+	}
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup_test.go
@@ -1,0 +1,348 @@
+package hetznerbase_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+const (
+	testKubeconfigPath  = "/etc/rancher/k3s/k3s.yaml"
+	testKubeconfig      = "apiVersion: v1\nkind: Config\n"
+	testProbeCommand    = "test -f '/etc/rancher/k3s/k3s.yaml'"
+	testReadCommand     = "cat -- '/etc/rancher/k3s/k3s.yaml'"
+	testBringUpBudget   = 10 * time.Second
+	testFailFastBudget  = 400 * time.Millisecond
+	testPollInterval    = 5 * time.Millisecond
+	errExitNotFound     = 1
+	errExitUnknownProbe = 2
+)
+
+var errUnknownTestClientKey = errors.New("unknown client key")
+
+// bringUpExecHandler scripts the in-process SSH server's response to one exec
+// request during a bring-up test.
+type bringUpExecHandler func(command string) (stdout string, exitCode uint32)
+
+// sshExitStatusPayload is the SSH exit-status request payload (RFC 4254 §6.10).
+type sshExitStatusPayload struct {
+	Status uint32
+}
+
+// sshExecRequestPayload is the SSH exec request payload (RFC 4254 §6.5).
+type sshExecRequestPayload struct {
+	Command string
+}
+
+// startBringUpSSHServer runs a minimal in-process SSH server that authenticates
+// clientKey and answers exec requests via handler, returning the listener's
+// host and port and the server's host key.
+func startBringUpSSHServer(
+	t *testing.T,
+	clientKey gossh.PublicKey,
+	handler bringUpExecHandler,
+) (string, string, gossh.PublicKey) {
+	t.Helper()
+
+	hostPair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	config := &gossh.ServerConfig{
+		PublicKeyCallback: func(
+			_ gossh.ConnMetadata,
+			key gossh.PublicKey,
+		) (*gossh.Permissions, error) {
+			if !bytes.Equal(key.Marshal(), clientKey.Marshal()) {
+				return nil, errUnknownTestClientKey
+			}
+
+			return &gossh.Permissions{}, nil
+		},
+	}
+	config.AddHostKey(hostPair.Signer)
+
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			netConn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+
+			go serveBringUpConn(netConn, config, handler)
+		}
+	}()
+
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+
+	return host, port, hostPair.Signer.PublicKey()
+}
+
+// serveBringUpConn handles one SSH connection: session channels carrying exec
+// requests.
+func serveBringUpConn(
+	netConn net.Conn,
+	config *gossh.ServerConfig,
+	handler bringUpExecHandler,
+) {
+	_, channels, requests, err := gossh.NewServerConn(netConn, config)
+	if err != nil {
+		return
+	}
+
+	go gossh.DiscardRequests(requests)
+
+	for newChannel := range channels {
+		if newChannel.ChannelType() != "session" {
+			_ = newChannel.Reject(gossh.UnknownChannelType, "only sessions are supported")
+
+			continue
+		}
+
+		channel, channelRequests, acceptErr := newChannel.Accept()
+		if acceptErr != nil {
+			continue
+		}
+
+		go serveBringUpSession(channel, channelRequests, handler)
+	}
+}
+
+// serveBringUpSession answers the first exec request on one session channel.
+func serveBringUpSession(
+	channel gossh.Channel,
+	requests <-chan *gossh.Request,
+	handler bringUpExecHandler,
+) {
+	defer func() { _ = channel.Close() }()
+
+	for request := range requests {
+		if request.Type != "exec" {
+			_ = request.Reply(false, nil)
+
+			continue
+		}
+
+		var payload sshExecRequestPayload
+
+		err := gossh.Unmarshal(request.Payload, &payload)
+		if err != nil {
+			_ = request.Reply(false, nil)
+
+			continue
+		}
+
+		_ = request.Reply(true, nil)
+
+		stdout, exitCode := handler(payload.Command)
+
+		_, _ = channel.Write([]byte(stdout))
+		_, _ = channel.SendRequest(
+			"exit-status", false, gossh.Marshal(sshExitStatusPayload{Status: exitCode}),
+		)
+
+		return
+	}
+}
+
+// serverWithPublicIPv4 builds the hcloud server the fake Infra hands back: one
+// with the test SSH server's loopback address as its public IPv4.
+func serverWithPublicIPv4(host string) *hcloud.Server {
+	server := &hcloud.Server{}
+	server.PublicNet.IPv4.IP = net.ParseIP(host)
+
+	return server
+}
+
+// kubeconfigHandler scripts a node whose kubeconfig appears after notReadyProbes
+// probes and then serves its content.
+func kubeconfigHandler(notReadyProbes int32) bringUpExecHandler {
+	var probes atomic.Int32
+
+	return func(command string) (string, uint32) {
+		switch command {
+		case testProbeCommand:
+			if probes.Add(1) <= notReadyProbes {
+				return "", errExitNotFound
+			}
+
+			return "", 0
+		case testReadCommand:
+			return testKubeconfig, 0
+		default:
+			return "", errExitUnknownProbe
+		}
+	}
+}
+
+// bringUpSpec composes a valid BringUpSpec against the in-process SSH server.
+func bringUpSpec(
+	pair sshbootstrap.KeyPair,
+	hostKey gossh.PublicKey,
+	port string,
+) hetznerbase.BringUpSpec {
+	return hetznerbase.BringUpSpec{
+		Signer:          pair.Signer,
+		HostKeyCallback: gossh.FixedHostKey(hostKey),
+		KubeconfigPath:  testKubeconfigPath,
+		PollInterval:    testPollInterval,
+		Port:            port,
+	}
+}
+
+func TestBringUpNodeRetrievesKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(), kubeconfigHandler(2),
+	)
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host)}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	result, err := base.BringUpNode(ctx, testClusterName, bringUpSpec(pair, hostKey, port))
+	require.NoError(t, err)
+	assert.Equal(t, []byte(testKubeconfig), result.Kubeconfig)
+	assert.Same(t, infra.createdServer, result.Server)
+	assert.Equal(t, 1, infra.createServerCalls)
+	assert.Equal(t, 0, infra.deleteNodesCalls)
+}
+
+func TestBringUpNodeMissingKubeconfigPath(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	spec := hetznerbase.BringUpSpec{}
+
+	_, err := base.BringUpNode(t.Context(), testClusterName, spec)
+	require.ErrorIs(t, err, hetznerbase.ErrMissingKubeconfigPath)
+	assert.Equal(t, 0, infra.createServerCalls)
+}
+
+func TestBringUpNodeCreateServerErrorSkipsCleanup(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{createServerErr: errBoom}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	spec := hetznerbase.BringUpSpec{KubeconfigPath: testKubeconfigPath}
+
+	_, err := base.BringUpNode(t.Context(), testClusterName, spec)
+	require.ErrorIs(t, err, errBoom)
+	assert.Equal(t, 0, infra.deleteNodesCalls)
+}
+
+func TestBringUpNodeWithoutPublicIPv4CleansUp(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{createdServer: &hcloud.Server{}}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	spec := hetznerbase.BringUpSpec{KubeconfigPath: testKubeconfigPath}
+
+	_, err := base.BringUpNode(t.Context(), testClusterName, spec)
+	require.ErrorIs(t, err, hetznerbase.ErrNoPublicIPv4)
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestBringUpNodeCleanupFailureJoinsBothErrors(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{createdServer: &hcloud.Server{}, deleteNodesErr: errBoom}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	spec := hetznerbase.BringUpSpec{KubeconfigPath: testKubeconfigPath}
+
+	_, err := base.BringUpNode(t.Context(), testClusterName, spec)
+	require.ErrorIs(t, err, hetznerbase.ErrNoPublicIPv4)
+	require.ErrorIs(t, err, errBoom)
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestBringUpNodeDialFailureCleansUp(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	// A listener that is closed immediately: the dial gets connection-refused
+	// until the short ctx budget ends.
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host)}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	// The dial never completes, so host-key verification is never reached; any
+	// pinned key satisfies the required callback.
+	spec := hetznerbase.BringUpSpec{
+		Signer:          pair.Signer,
+		HostKeyCallback: gossh.FixedHostKey(pair.Signer.PublicKey()),
+		KubeconfigPath:  testKubeconfigPath,
+		Port:            port,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testFailFastBudget)
+	defer cancel()
+
+	_, err = base.BringUpNode(ctx, testClusterName, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dial bootstrap SSH")
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestBringUpNodeKubeconfigNeverAppearsCleansUp(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	neverReady := func(command string) (string, uint32) {
+		if command == testProbeCommand {
+			return "", errExitNotFound
+		}
+
+		return "", errExitUnknownProbe
+	}
+
+	host, port, hostKey := startBringUpSSHServer(t, pair.Signer.PublicKey(), neverReady)
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host)}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	ctx, cancel := context.WithTimeout(t.Context(), testFailFastBudget)
+	defer cancel()
+
+	_, err = base.BringUpNode(ctx, testClusterName, bringUpSpec(pair, hostKey, port))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -74,9 +74,22 @@ type Infra interface {
 	ListAllClusters(ctx context.Context) ([]string, error)
 }
 
+// ServerCreator is the server-creation half of the provider seam, kept separate
+// from [Infra] (interface segregation): only the bring-up engine creates
+// servers, while every lifecycle operation uses [Infra]. Test doubles for the
+// lifecycle never have to fake server creation.
+type ServerCreator interface {
+	// CreateServer creates a single server from the composed options and waits
+	// for the creation to complete.
+	CreateServer(ctx context.Context, opts hetzner.CreateServerOpts) (*hcloud.Server, error)
+}
+
 // staticInfraCheck asserts at compile time that the concrete Hetzner provider
-// satisfies the subset the provisioners depend on.
-var _ Infra = (*hetzner.Provider)(nil)
+// satisfies the subsets the provisioners depend on.
+var (
+	_ Infra         = (*hetzner.Provider)(nil)
+	_ ServerCreator = (*hetzner.Provider)(nil)
+)
 
 // Base carries the Hetzner infrastructure lifecycle shared by the k3s and kubeadm ×
 // Hetzner provisioners: the common configuration and the ResolveName /
@@ -86,6 +99,9 @@ var _ Infra = (*hetzner.Provider)(nil)
 type Base struct {
 	// Infra is the Hetzner provider seam the lifecycle operations delegate to.
 	Infra Infra
+	// Servers is the server-creation seam the bring-up engine delegates to
+	// (backed by the same provider as Infra in production).
+	Servers ServerCreator
 	// Opts is the resolved Hetzner options (network CIDR, firewall CIDRs, placement
 	// group, SSH key) the infrastructure step reads.
 	Opts v1alpha1.OptionsHetzner
@@ -116,6 +132,7 @@ func NewBase(
 
 	return &Base{
 		Infra:         provider,
+		Servers:       provider,
 		Opts:          opts,
 		ClusterName:   clusterName,
 		ControlPlanes: controlPlanes,
@@ -135,43 +152,75 @@ func (b *Base) ResolveName(name string) string {
 	return b.ClusterName
 }
 
+// ResolvedInfra carries the IDs of the cluster's shared Hetzner resources after
+// [Base.EnsureInfrastructure] created (or reused) them — the placement a composed
+// server spec needs. A zero ID means the resource is not in play (no placement
+// group for the configured strategy, no SSH key configured, or a provider that
+// returned no ID).
+type ResolvedInfra struct {
+	// NetworkID is the private network every node joins.
+	NetworkID int64
+	// FirewallID is the firewall applied to every node; zero attaches none.
+	FirewallID int64
+	// PlacementGroupID is the placement group every node is created in; zero when
+	// the strategy disables placement groups.
+	PlacementGroupID int64
+	// SSHKeyID is the pre-registered Hetzner SSH key installed on every node; zero
+	// when no key name is configured. This is Hetzner's account-level key, distinct
+	// from the per-cluster bootstrap keypair delivered via cloud-init.
+	SSHKeyID int64
+}
+
 // EnsureInfrastructure creates (or reuses) the cluster's shared Hetzner resources:
 // the private network, the firewall, the placement group, and the SSH key when one
-// is configured.
-func (b *Base) EnsureInfrastructure(ctx context.Context, clusterName string) error {
+// is configured. It returns their resolved IDs so the server-spec composition can
+// place nodes into them.
+func (b *Base) EnsureInfrastructure(
+	ctx context.Context,
+	clusterName string,
+) (ResolvedInfra, error) {
 	cidr := b.Opts.NetworkCIDR
 	if cidr == "" {
 		cidr = v1alpha1.DefaultHetznerNetworkCIDR
 	}
 
-	_, err := b.Infra.EnsureNetwork(ctx, clusterName, cidr)
+	resolved := ResolvedInfra{}
+
+	network, err := b.Infra.EnsureNetwork(ctx, clusterName, cidr)
 	if err != nil {
-		return fmt.Errorf("ensure network: %w", err)
+		return ResolvedInfra{}, fmt.Errorf("ensure network: %w", err)
 	}
 
-	_, err = b.Infra.EnsureFirewall(ctx, clusterName, b.Opts.AllowedCIDRs)
+	resolved.NetworkID = idOrZero(network, func(n *hcloud.Network) int64 { return n.ID })
+
+	firewall, err := b.Infra.EnsureFirewall(ctx, clusterName, b.Opts.AllowedCIDRs)
 	if err != nil {
-		return fmt.Errorf("ensure firewall: %w", err)
+		return ResolvedInfra{}, fmt.Errorf("ensure firewall: %w", err)
 	}
 
-	_, err = b.Infra.EnsurePlacementGroup(
+	resolved.FirewallID = idOrZero(firewall, func(f *hcloud.Firewall) int64 { return f.ID })
+
+	placementGroup, err := b.Infra.EnsurePlacementGroup(
 		ctx,
 		clusterName,
 		b.Opts.PlacementGroupStrategy.String(),
 		b.Opts.PlacementGroup,
 	)
 	if err != nil {
-		return fmt.Errorf("ensure placement group: %w", err)
+		return ResolvedInfra{}, fmt.Errorf("ensure placement group: %w", err)
 	}
 
-	if b.Opts.SSHKeyName != "" {
-		_, err = b.Infra.GetSSHKey(ctx, b.Opts.SSHKeyName)
-		if err != nil {
-			return fmt.Errorf("get SSH key: %w", err)
-		}
+	resolved.PlacementGroupID = idOrZero(
+		placementGroup,
+		func(g *hcloud.PlacementGroup) int64 { return g.ID },
+	)
+
+	resolved.SSHKeyID, err = b.resolveSSHKeyID(ctx)
+	if err != nil {
+		return ResolvedInfra{}, err
 	}
 
-	return nil
+	return resolved, nil
 }
 
 // Delete removes the cluster's servers. It is a no-op (nil) when the cluster's
@@ -265,7 +314,7 @@ func (b *Base) RunCreate(
 		return ErrMultiNodeNotImplemented
 	}
 
-	err = b.EnsureInfrastructure(ctx, clusterName)
+	_, err = b.EnsureInfrastructure(ctx, clusterName)
 	if err != nil {
 		return err
 	}
@@ -288,4 +337,29 @@ func (b *Base) RunCreate(
 	)
 
 	return ErrLiveBringUpNotImplemented
+}
+
+// resolveSSHKeyID resolves the configured Hetzner SSH key name to its ID, or
+// zero when no key name is configured.
+func (b *Base) resolveSSHKeyID(ctx context.Context) (int64, error) {
+	if b.Opts.SSHKeyName == "" {
+		return 0, nil
+	}
+
+	sshKey, err := b.Infra.GetSSHKey(ctx, b.Opts.SSHKeyName)
+	if err != nil {
+		return 0, fmt.Errorf("get SSH key: %w", err)
+	}
+
+	return idOrZero(sshKey, func(k *hcloud.SSHKey) int64 { return k.ID }), nil
+}
+
+// idOrZero returns id(resource), or zero when the provider returned no
+// resource (e.g. a placement-group strategy that disables placement groups).
+func idOrZero[T any](resource *T, id func(*T) int64) int64 {
+	if resource == nil {
+		return 0
+	}
+
+	return id(resource)
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
@@ -33,11 +34,20 @@ type fakeInfra struct {
 	stopErr            error
 	listResult         []string
 	listErr            error
+	createServerErr    error
+	createdServer      *hcloud.Server
+
+	networkID        int64
+	firewallID       int64
+	placementGroupID int64
+	sshKeyID         int64
 
 	ensureNetworkCalls int
 	deleteNodesCalls   int
 	startCalls         int
 	stopCalls          int
+	createServerCalls  int
+	lastServerOpts     hetzner.CreateServerOpts
 	lastClusterName    string
 }
 
@@ -48,7 +58,7 @@ func (f *fakeInfra) EnsureNetwork(
 	f.ensureNetworkCalls++
 	f.lastClusterName = clusterName
 
-	return &hcloud.Network{}, f.ensureNetworkErr
+	return &hcloud.Network{ID: f.networkID}, f.ensureNetworkErr
 }
 
 func (f *fakeInfra) EnsureFirewall(
@@ -56,18 +66,18 @@ func (f *fakeInfra) EnsureFirewall(
 	_ string,
 	_ []string,
 ) (*hcloud.Firewall, error) {
-	return &hcloud.Firewall{}, f.ensureFirewallErr
+	return &hcloud.Firewall{ID: f.firewallID}, f.ensureFirewallErr
 }
 
 func (f *fakeInfra) EnsurePlacementGroup(
 	_ context.Context,
 	_, _, _ string,
 ) (*hcloud.PlacementGroup, error) {
-	return &hcloud.PlacementGroup{}, f.ensurePlacementErr
+	return &hcloud.PlacementGroup{ID: f.placementGroupID}, f.ensurePlacementErr
 }
 
 func (f *fakeInfra) GetSSHKey(_ context.Context, _ string) (*hcloud.SSHKey, error) {
-	return &hcloud.SSHKey{}, f.getSSHKeyErr
+	return &hcloud.SSHKey{ID: f.sshKeyID}, f.getSSHKeyErr
 }
 
 func (f *fakeInfra) NodesExist(_ context.Context, clusterName string) (bool, error) {
@@ -104,12 +114,26 @@ func (f *fakeInfra) ListAllClusters(_ context.Context) ([]string, error) {
 	return f.listResult, f.listErr
 }
 
-// staticFakeInfraCheck asserts the test double satisfies the shared seam.
-var _ hetznerbase.Infra = (*fakeInfra)(nil)
+func (f *fakeInfra) CreateServer(
+	_ context.Context,
+	opts hetzner.CreateServerOpts,
+) (*hcloud.Server, error) {
+	f.createServerCalls++
+	f.lastServerOpts = opts
 
-func newBase(infra hetznerbase.Infra, opts v1alpha1.OptionsHetzner) *hetznerbase.Base {
+	return f.createdServer, f.createServerErr
+}
+
+// staticFakeInfraCheck asserts the test double satisfies the shared seams.
+var (
+	_ hetznerbase.Infra         = (*fakeInfra)(nil)
+	_ hetznerbase.ServerCreator = (*fakeInfra)(nil)
+)
+
+func newBase(infra *fakeInfra, opts v1alpha1.OptionsHetzner) *hetznerbase.Base {
 	return &hetznerbase.Base{
 		Infra:         infra,
+		Servers:       infra,
 		Opts:          opts,
 		ClusterName:   testClusterName,
 		ControlPlanes: 1,
@@ -133,10 +157,42 @@ func TestEnsureInfrastructureUsesResolvedNameAndSSHKey(t *testing.T) {
 	infra := &fakeInfra{}
 	base := newBase(infra, v1alpha1.OptionsHetzner{SSHKeyName: "my-key"})
 
-	err := base.EnsureInfrastructure(context.Background(), testClusterName)
+	_, err := base.EnsureInfrastructure(context.Background(), testClusterName)
 	require.NoError(t, err)
 	assert.Equal(t, 1, infra.ensureNetworkCalls)
 	assert.Equal(t, testClusterName, infra.lastClusterName)
+}
+
+func TestEnsureInfrastructureReturnsResolvedIDs(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{
+		networkID:        11,
+		firewallID:       22,
+		placementGroupID: 33,
+		sshKeyID:         44,
+	}
+	base := newBase(infra, v1alpha1.OptionsHetzner{SSHKeyName: "my-key"})
+
+	resolved, err := base.EnsureInfrastructure(context.Background(), testClusterName)
+	require.NoError(t, err)
+	assert.Equal(t, hetznerbase.ResolvedInfra{
+		NetworkID:        11,
+		FirewallID:       22,
+		PlacementGroupID: 33,
+		SSHKeyID:         44,
+	}, resolved)
+}
+
+func TestEnsureInfrastructureSkipsUnconfiguredSSHKey(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{sshKeyID: 44}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	resolved, err := base.EnsureInfrastructure(context.Background(), testClusterName)
+	require.NoError(t, err)
+	assert.Zero(t, resolved.SSHKeyID)
 }
 
 func TestEnsureInfrastructureErrorsPropagate(t *testing.T) {
@@ -155,7 +211,7 @@ func TestEnsureInfrastructureErrorsPropagate(t *testing.T) {
 
 			base := newBase(infra, v1alpha1.OptionsHetzner{SSHKeyName: "my-key"})
 
-			err := base.EnsureInfrastructure(context.Background(), testClusterName)
+			_, err := base.EnsureInfrastructure(context.Background(), testClusterName)
 			require.ErrorIs(t, err, errBoom)
 		})
 	}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #5720 — part of #3983 (K3s/Vanilla × Hetzner), the next child after #5697 (SSH bootstrap client) and #5713 (cloud-init key delivery).

**What.** `hetznerbase.BringUpNode`, the unit-testable single-node live bring-up engine: create the server from a composed spec → require its public IPv4 → `ssh.DialWithRetry` as root with the bootstrap keypair (retries until first boot brings sshd up) → poll for the distribution's kubeconfig (`ssh.Client.FileExists`, new) → `ReadFile` it → **cleanup-on-failure** (any post-create failure deletes the cluster's servers with a cancel-free context and joins both errors, so a failed bring-up leaks no paid resources).

Supporting seams:
- `hetzner.CreateServerOpts.ImageName` — boot a stock OS image by name (k3s/kubeadm install onto e.g. `ubuntu-24.04`; the hcloud API resolves names server-side, mirroring the existing ISO-placeholder-by-name path), with exactly-one-of `ImageName`/`ImageID`/`ISOID` validation.
- `hetznerbase.EnsureInfrastructure` now returns `ResolvedInfra` (network/firewall/placement-group/SSH-key IDs) — what the server-spec composition places nodes into.
- `hetznerbase.ServerCreator` — a segregated seam next to `Infra` so lifecycle test doubles never fake server creation.

**Deliberately policy-free:** user_data composition, host-key trust, and the kubeconfig's onward handling stay the caller's. `RunCreate` still stops at `ErrLiveBringUpNotImplemented` — wiring the engine in needs the API-endpoint/TLS-SAN design decision (user_data is composed before the server's IP exists), which is the follow-up child; #5515 remains the live smoke-test lane.

**Validation.** New tests: engine happy-path against an in-process SSH server (kubeconfig appears after 2 probes), missing-path/create-error/no-IPv4/dial-failure/never-appears/cleanup-failure-joins paths, `FileExists` semantics, `ResolvedInfra` IDs. `golangci-lint`: 0 issues on the touched trees. Full suite: 1523+ passed; only the known `pkg/cli/cmd/open/chat` copilot-CLI parallel flake failed and passes alone (127/127-equivalent re-run green).