### PR TITLE
feat(hetzner): run the live bring-up from RunCreate and persist the kubeconfig

### DIFF
--- a/pkg/svc/provisioner/cluster/factory_k3d.go
+++ b/pkg/svc/provisioner/cluster/factory_k3d.go
@@ -120,6 +120,7 @@ func createK3sHetznerProvisioner(cluster *v1alpha1.Cluster) (Provisioner, any, e
 
 	provisioner, err := k3shetznerprovisioner.NewProvisioner(
 		cluster.Name,
+		cluster.Spec.Cluster.Connection.Kubeconfig,
 		k3sInstallVersion(),
 		controlPlanes,
 		int(cluster.Spec.Cluster.Workers),

--- a/pkg/svc/provisioner/cluster/factory_kind.go
+++ b/pkg/svc/provisioner/cluster/factory_kind.go
@@ -102,6 +102,7 @@ func createKubeadmHetznerProvisioner(cluster *v1alpha1.Cluster) (Provisioner, an
 
 	provisioner, err := kubeadmhetznerprovisioner.NewProvisioner(
 		cluster.Name,
+		cluster.Spec.Cluster.Connection.Kubeconfig,
 		kubeadmInstallVersion(),
 		controlPlanes,
 		int(cluster.Spec.Cluster.Workers),

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup.go
@@ -40,6 +40,33 @@ var (
 	ErrMissingKubeconfigPath = errors.New("hetzner: bring-up spec is missing the kubeconfig path")
 )
 
+// BringUpPlan is what a provisioner's composePlan callback returns to
+// [Base.RunCreate]: the ordered composed server specs plus the bootstrap
+// material the live bring-up authenticates with and the remote location the
+// node's first boot writes the admin kubeconfig to. The current increment
+// carries exactly one spec (multi-node topologies are rejected before
+// composition); the ordered slice is the multi-node join sequencing's seam.
+type BringUpPlan struct {
+	// Specs is the ordered composed server specs (index 0 is the
+	// cluster-initialising control plane). Each spec's UserData must deliver
+	// the public half of the bootstrap keypair (see [BringUpSpec.Server]).
+	Specs []hetzner.CreateServerOpts
+	// Signer is the private half of the bootstrap keypair (see
+	// [BringUpSpec.Signer]).
+	Signer gossh.Signer
+	// HostKeyCallback is the host-key trust policy (see
+	// [BringUpSpec.HostKeyCallback]).
+	HostKeyCallback gossh.HostKeyCallback
+	// RemoteKubeconfigPath is the remote path of the admin kubeconfig the
+	// node's bootstrap writes (see [BringUpSpec.KubeconfigPath]).
+	RemoteKubeconfigPath string
+	// PollInterval is the delay between kubeconfig probes; zero means
+	// [DefaultKubeconfigPollInterval].
+	PollInterval time.Duration
+	// Port is the SSH port dialed on the node; empty means the standard port.
+	Port string
+}
+
 // BringUpSpec carries everything [Base.BringUpNode] needs to take one composed
 // server spec to a running node and its admin kubeconfig.
 type BringUpSpec struct {
@@ -174,16 +201,27 @@ func (b *Base) cleanUpFailedBringUp(ctx context.Context, clusterName string, cau
 // none (IPv4 disabled or not yet assigned). An empty port means the standard
 // SSH port.
 func publicSSHAddr(server *hcloud.Server, port string) (string, error) {
-	if server == nil || server.PublicNet.IPv4.IP == nil ||
-		server.PublicNet.IPv4.IP.IsUnspecified() {
-		return "", ErrNoPublicIPv4
+	address, err := publicIPv4(server)
+	if err != nil {
+		return "", err
 	}
 
 	if port == "" {
 		port = sshPort
 	}
 
-	return net.JoinHostPort(server.PublicNet.IPv4.IP.String(), port), nil
+	return net.JoinHostPort(address.String(), port), nil
+}
+
+// publicIPv4 returns the created server's public IPv4, or [ErrNoPublicIPv4]
+// when the server has none (IPv4 disabled or not yet assigned).
+func publicIPv4(server *hcloud.Server) (net.IP, error) {
+	if server == nil || server.PublicNet.IPv4.IP == nil ||
+		server.PublicNet.IPv4.IP.IsUnspecified() {
+		return nil, ErrNoPublicIPv4
+	}
+
+	return server.PublicNet.IPv4.IP, nil
 }
 
 // waitForRemoteFile polls the remote node until path exists

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup.go
@@ -38,6 +38,13 @@ var (
 	// ErrMissingKubeconfigPath is returned by [Base.BringUpNode] when the spec
 	// names no remote kubeconfig path to wait for.
 	ErrMissingKubeconfigPath = errors.New("hetzner: bring-up spec is missing the kubeconfig path")
+
+	// ErrKubeconfigNoClusters is returned when the kubeconfig retrieved from
+	// the node parses but carries no cluster entries (e.g. read mid-write), so
+	// there is nothing to rewrite and it must not be persisted.
+	ErrKubeconfigNoClusters = errors.New(
+		"hetzner: retrieved kubeconfig contains no cluster entries",
+	)
 )
 
 // BringUpPlan is what a provisioner's composePlan callback returns to

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/bringup_test.go
@@ -172,8 +172,8 @@ func serverWithPublicIPv4(host string) *hcloud.Server {
 }
 
 // kubeconfigHandler scripts a node whose kubeconfig appears after notReadyProbes
-// probes and then serves its content.
-func kubeconfigHandler(notReadyProbes int32) bringUpExecHandler {
+// probes and then serves content.
+func kubeconfigHandler(notReadyProbes int32, content string) bringUpExecHandler {
 	var probes atomic.Int32
 
 	return func(command string) (string, uint32) {
@@ -185,7 +185,7 @@ func kubeconfigHandler(notReadyProbes int32) bringUpExecHandler {
 
 			return "", 0
 		case testReadCommand:
-			return testKubeconfig, 0
+			return content, 0
 		default:
 			return "", errExitUnknownProbe
 		}
@@ -214,7 +214,7 @@ func TestBringUpNodeRetrievesKubeconfig(t *testing.T) {
 	require.NoError(t, err)
 
 	host, port, hostKey := startBringUpSSHServer(
-		t, pair.Signer.PublicKey(), kubeconfigHandler(2),
+		t, pair.Signer.PublicKey(), kubeconfigHandler(2, testKubeconfig),
 	)
 
 	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host)}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -17,14 +17,30 @@ var (
 	// target cluster already exist, so creation would collide with a running cluster.
 	ErrClusterAlreadyExists = errors.New("hetzner: cluster already exists")
 
-	// ErrLiveBringUpNotImplemented is returned by [Base.RunCreate] after the shared
-	// infrastructure is ensured and the per-node cloud-init user_data is composed.
-	// The remaining steps — creating the servers (which needs boot-image resolution),
-	// the runtime join sequencing that depends on the first node's address, and
-	// retrieving the generated kubeconfig — are integration paths that land with the
-	// Hetzner system-test lane (devantler-tech/ksail#5515).
+	// ErrLiveBringUpNotImplemented is returned by the provisioners' composePlan
+	// callbacks (see [Base.RunCreate]) after the per-node cloud-init user_data is
+	// composed: deriving the live server specs still needs boot-image resolution
+	// and the bootstrap-material threading tracked by devantler-tech/ksail#5726.
+	// Once a caller returns a complete [BringUpPlan] instead, RunCreate carries the
+	// cluster all the way to a merged kubeconfig.
 	ErrLiveBringUpNotImplemented = errors.New(
-		"hetzner: live cluster bring-up is not yet implemented (tracked by #5515)",
+		"hetzner: live cluster bring-up is not yet implemented (tracked by #5726)",
+	)
+
+	// ErrSingleNodePlanExpected is returned by [Base.RunCreate] when a composed
+	// [BringUpPlan] does not carry exactly one server spec. Multi-node topologies
+	// are rejected before composition ([ErrMultiNodeNotImplemented]), so a plan
+	// with any other count is a composition bug, not a user error.
+	ErrSingleNodePlanExpected = errors.New(
+		"hetzner: bring-up plan must carry exactly one server spec",
+	)
+
+	// ErrMissingKubeconfigDestination is returned by [Base.RunCreate] when the
+	// Base has no kubeconfig destination path to merge the retrieved admin
+	// kubeconfig into. It is checked before any server is created so a
+	// misconfiguration cannot leak paid resources.
+	ErrMissingKubeconfigDestination = errors.New(
+		"hetzner: no kubeconfig destination path is configured",
 	)
 
 	// ErrMultiNodeNotImplemented is returned by [Base.RunCreate] for a topology with
@@ -112,6 +128,10 @@ type Base struct {
 	ControlPlanes int
 	// Agents is the requested agent (worker) node count.
 	Agents int
+	// KubeconfigPath is the local kubeconfig file the retrieved admin kubeconfig
+	// is merged into after a successful bring-up (the cluster spec's
+	// connection.kubeconfig, e.g. "~/.kube/config").
+	KubeconfigPath string
 	// LogWriter receives the provisioner's progress output.
 	LogWriter io.Writer
 }
@@ -119,9 +139,10 @@ type Base struct {
 // NewBase constructs a Base, building the Hetzner provider from opts (resolving the
 // API token from the configured environment variable). It is the shared provider
 // construction both provisioners' NewProvisioner constructors delegate to;
-// LogWriter defaults to os.Stdout.
+// kubeconfigPath is the local kubeconfig file a successful bring-up merges the
+// admin kubeconfig into; LogWriter defaults to os.Stdout.
 func NewBase(
-	clusterName string,
+	clusterName, kubeconfigPath string,
 	controlPlanes, agents int,
 	opts v1alpha1.OptionsHetzner,
 ) (*Base, error) {
@@ -131,13 +152,14 @@ func NewBase(
 	}
 
 	return &Base{
-		Infra:         provider,
-		Servers:       provider,
-		Opts:          opts,
-		ClusterName:   clusterName,
-		ControlPlanes: controlPlanes,
-		Agents:        agents,
-		LogWriter:     os.Stdout,
+		Infra:          provider,
+		Servers:        provider,
+		Opts:           opts,
+		ClusterName:    clusterName,
+		ControlPlanes:  controlPlanes,
+		Agents:         agents,
+		KubeconfigPath: kubeconfigPath,
+		LogWriter:      os.Stdout,
 	}, nil
 }
 
@@ -288,15 +310,19 @@ func (b *Base) Exists(ctx context.Context, name string) (bool, error) {
 // RunCreate runs the Hetzner create flow shared by the k3s and kubeadm provisioners:
 // guard against an existing cluster ([ErrClusterAlreadyExists]), reject multi-node
 // topologies ([ErrMultiNodeNotImplemented]), ensure the shared infrastructure,
-// generate the node token, compose the per-node cloud-init user_data, and stop at
-// the live-bring-up boundary ([ErrLiveBringUpNotImplemented], see
-// devantler-tech/ksail#5515). The two steps that differ between the provisioners are
-// supplied as callbacks: generateToken produces the node token, and composeNodes
-// composes the per-node user_data and returns the node count.
+// generate the node token, compose the bring-up plan, and — when the caller returns
+// a complete [BringUpPlan] — run the live bring-up: create the server, wait for the
+// distribution's admin kubeconfig ([Base.BringUpNode]), rewrite its endpoint to the
+// node's public IPv4, and merge it into the Base's kubeconfig destination. The two
+// steps that differ between the provisioners are supplied as callbacks:
+// generateToken produces the node token, and composePlan composes the per-node
+// cloud-init user_data into server specs plus the bootstrap material (a caller
+// whose spec derivation has not landed yet returns
+// [ErrLiveBringUpNotImplemented] there instead — see devantler-tech/ksail#5726).
 func (b *Base) RunCreate(
 	ctx context.Context,
 	name string,
-	composeNodes func(clusterName, token string) (int, error),
+	composePlan func(clusterName, token string, infra ResolvedInfra) (BringUpPlan, error),
 	generateToken func() (string, error),
 ) error {
 	clusterName := b.ResolveName(name)
@@ -314,7 +340,13 @@ func (b *Base) RunCreate(
 		return ErrMultiNodeNotImplemented
 	}
 
-	_, err = b.EnsureInfrastructure(ctx, clusterName)
+	// Fail before any paid resource exists when the retrieved kubeconfig would
+	// have nowhere to go.
+	if b.KubeconfigPath == "" {
+		return ErrMissingKubeconfigDestination
+	}
+
+	infra, err := b.EnsureInfrastructure(ctx, clusterName)
 	if err != nil {
 		return err
 	}
@@ -324,19 +356,64 @@ func (b *Base) RunCreate(
 		return err
 	}
 
-	count, err := composeNodes(clusterName, token)
+	plan, err := composePlan(clusterName, token, infra)
 	if err != nil {
 		return err
 	}
 
+	return b.bringUpFromPlan(ctx, clusterName, plan)
+}
+
+// bringUpFromPlan runs the live half of the create flow from a composed plan:
+// bring the single node up, rewrite the retrieved kubeconfig's endpoint to the
+// node's public IPv4, and merge it into the Base's kubeconfig destination. The
+// post-bring-up steps share [Base.BringUpNode]'s cleanup-on-failure semantics —
+// a cluster whose kubeconfig cannot be rewritten or persisted is torn down again
+// rather than left running without credentials (re-running create would only hit
+// [ErrClusterAlreadyExists]).
+func (b *Base) bringUpFromPlan(
+	ctx context.Context,
+	clusterName string,
+	plan BringUpPlan,
+) error {
+	if len(plan.Specs) != 1 {
+		return fmt.Errorf("%w: got %d", ErrSingleNodePlanExpected, len(plan.Specs))
+	}
+
+	result, err := b.BringUpNode(ctx, clusterName, BringUpSpec{
+		Server:          plan.Specs[0],
+		Signer:          plan.Signer,
+		HostKeyCallback: plan.HostKeyCallback,
+		KubeconfigPath:  plan.RemoteKubeconfigPath,
+		PollInterval:    plan.PollInterval,
+		Port:            plan.Port,
+	})
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := apiServerEndpoint(result.Server)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	kubeconfig, err := rewriteKubeconfigEndpoint(result.Kubeconfig, endpoint)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	persistedPath, err := b.persistKubeconfig(kubeconfig)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
 	_, _ = fmt.Fprintf(
 		b.LogWriter,
-		"Prepared cloud-init bootstrap for %d node(s); server creation and "+
-			"kubeconfig retrieval are tracked by #5515\n",
-		count,
+		"Cluster %q is up at %s; kubeconfig merged into %q\n",
+		clusterName, endpoint, persistedPath,
 	)
 
-	return ErrLiveBringUpNotImplemented
+	return nil
 }
 
 // resolveSSHKeyID resolves the configured Hetzner SSH key name to its ID, or

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/kubeconfig.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/kubeconfig.go
@@ -40,6 +40,13 @@ func rewriteKubeconfigEndpoint(kubeconfigBytes []byte, endpoint string) ([]byte,
 		return nil, fmt.Errorf("parse retrieved kubeconfig: %w", err)
 	}
 
+	// clientcmd.Load tolerates empty/partial input (e.g. a file read mid-write
+	// on the node), so guard explicitly — a clusterless kubeconfig would
+	// otherwise be persisted with no endpoint rewritten and no error surfaced.
+	if len(kubeConfig.Clusters) == 0 {
+		return nil, ErrKubeconfigNoClusters
+	}
+
 	for name := range kubeConfig.Clusters {
 		kubeConfig.Clusters[name].Server = endpoint
 	}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/kubeconfig.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/kubeconfig.go
@@ -1,0 +1,71 @@
+package hetznerbase
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// kubeAPIPort is the port the distributions' API server listens on (both k3s
+// and kubeadm default to the standard secure port).
+const kubeAPIPort = "6443"
+
+// apiServerEndpoint derives the externally reachable API-server URL from the
+// created server's public IPv4 — the endpoint the retrieved kubeconfig is
+// rewritten to. Both k3s and kubeadm include the node's own addresses in the
+// API server's serving-certificate SANs, so the node's public IPv4 verifies
+// without threading extra SANs through the user_data; a stable floating-IP
+// endpoint (which does need that threading) is the follow-up increment
+// (devantler-tech/ksail#5725).
+func apiServerEndpoint(server *hcloud.Server) (string, error) {
+	address, err := publicIPv4(server)
+	if err != nil {
+		return "", err
+	}
+
+	return "https://" + net.JoinHostPort(address.String(), kubeAPIPort), nil
+}
+
+// rewriteKubeconfigEndpoint rewrites every cluster's server URL in the raw
+// kubeconfig to endpoint. The distribution writes the kubeconfig for use on
+// the node itself (a loopback or private address); external access goes to
+// the node's public address instead.
+func rewriteKubeconfigEndpoint(kubeconfigBytes []byte, endpoint string) ([]byte, error) {
+	kubeConfig, err := clientcmd.Load(kubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse retrieved kubeconfig: %w", err)
+	}
+
+	for name := range kubeConfig.Clusters {
+		kubeConfig.Clusters[name].Server = endpoint
+	}
+
+	result, err := clientcmd.Write(*kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("serialize rewritten kubeconfig: %w", err)
+	}
+
+	return result, nil
+}
+
+// persistKubeconfig merges the raw kubeconfig into the Base's kubeconfig
+// destination (expanding a leading tilde) and returns the expanded path, the
+// same house pattern the other distributions use (k8s.MergeKubeconfig creates
+// the file and its directory when missing and preserves unrelated entries).
+func (b *Base) persistKubeconfig(kubeconfig []byte) (string, error) {
+	destPath, err := fsutil.ExpandHomePath(b.KubeconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("expand kubeconfig path: %w", err)
+	}
+
+	err = k8s.MergeKubeconfig(destPath, kubeconfig)
+	if err != nil {
+		return "", fmt.Errorf("merge kubeconfig into %q: %w", destPath, err)
+	}
+
+	return destPath, nil
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/runcreate_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/runcreate_test.go
@@ -1,0 +1,271 @@
+package hetznerbase_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// remoteAdminKubeconfig is what the node's bootstrap wrote: a kubeconfig whose
+// endpoint is only reachable on the node itself, which RunCreate must rewrite
+// to the node's public address.
+const remoteAdminKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.9.9.9:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+users:
+- name: default
+  user: {}
+`
+
+// staticToken is the composePlan-visible node token the tests' generateToken
+// returns.
+const staticToken = "test-token"
+
+func staticTokenGenerator() (string, error) { return staticToken, nil }
+
+// runCreatePlan composes a single-spec BringUpPlan against the in-process SSH
+// server, mirroring what a provisioner's composePlan returns once its spec
+// derivation lands.
+func runCreatePlan(
+	pair sshbootstrap.KeyPair,
+	hostKey gossh.PublicKey,
+	port string,
+) hetznerbase.BringUpPlan {
+	return hetznerbase.BringUpPlan{
+		Specs:                []hetzner.CreateServerOpts{{Name: "node-0"}},
+		Signer:               pair.Signer,
+		HostKeyCallback:      gossh.FixedHostKey(hostKey),
+		RemoteKubeconfigPath: testKubeconfigPath,
+		PollInterval:         testPollInterval,
+		Port:                 port,
+	}
+}
+
+func TestRunCreateBringsUpNodeAndPersistsKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(), kubeconfigHandler(1, remoteAdminKubeconfig),
+	)
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host), networkID: 11}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+
+	var composedInfra hetznerbase.ResolvedInfra
+
+	var composedToken string
+
+	composePlan := func(
+		_, token string,
+		resolved hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		composedInfra = resolved
+		composedToken = token
+
+		return runCreatePlan(pair, hostKey, port), nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	require.NoError(t, base.RunCreate(ctx, "", composePlan, staticTokenGenerator))
+
+	// The compose callback received the resolved infrastructure and the token.
+	assert.Equal(t, int64(11), composedInfra.NetworkID)
+	assert.Equal(t, staticToken, composedToken)
+	assert.Equal(t, 1, infra.createServerCalls)
+	assert.Equal(t, 0, infra.deleteNodesCalls)
+
+	// The kubeconfig is persisted with its endpoint rewritten to the node's
+	// public IPv4 (the in-process SSH server's loopback address).
+	merged, err := os.ReadFile(base.KubeconfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(merged), "https://"+host+":6443")
+	assert.NotContains(t, string(merged), "10.9.9.9")
+}
+
+func TestRunCreateMissingKubeconfigDestinationFailsFast(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		t.Fatal("composePlan must not be reached without a kubeconfig destination")
+
+		return hetznerbase.BringUpPlan{}, nil
+	}
+
+	err := base.RunCreate(t.Context(), "", composePlan, staticTokenGenerator)
+	require.ErrorIs(t, err, hetznerbase.ErrMissingKubeconfigDestination)
+	assert.Equal(t, 0, infra.ensureNetworkCalls)
+	assert.Equal(t, 0, infra.createServerCalls)
+}
+
+func TestRunCreateComposePlanErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		return hetznerbase.BringUpPlan{}, hetznerbase.ErrLiveBringUpNotImplemented
+	}
+
+	err := base.RunCreate(t.Context(), "", composePlan, staticTokenGenerator)
+	require.ErrorIs(t, err, hetznerbase.ErrLiveBringUpNotImplemented)
+	assert.Equal(t, 0, infra.createServerCalls)
+}
+
+func TestRunCreateRejectsNonSingleNodePlan(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		return hetznerbase.BringUpPlan{}, nil
+	}
+
+	err := base.RunCreate(t.Context(), "", composePlan, staticTokenGenerator)
+	require.ErrorIs(t, err, hetznerbase.ErrSingleNodePlanExpected)
+	assert.Equal(t, 0, infra.createServerCalls)
+}
+
+func TestRunCreateExistingClusterRejected(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{nodesExist: true}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		t.Fatal("composePlan must not be reached for an existing cluster")
+
+		return hetznerbase.BringUpPlan{}, nil
+	}
+
+	err := base.RunCreate(t.Context(), "", composePlan, staticTokenGenerator)
+	require.ErrorIs(t, err, hetznerbase.ErrClusterAlreadyExists)
+}
+
+func TestRunCreateMultiNodeRejected(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeInfra{}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+	base.Agents = 1
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		t.Fatal("composePlan must not be reached for a multi-node topology")
+
+		return hetznerbase.BringUpPlan{}, nil
+	}
+
+	err := base.RunCreate(t.Context(), "", composePlan, staticTokenGenerator)
+	require.ErrorIs(t, err, hetznerbase.ErrMultiNodeNotImplemented)
+}
+
+func TestRunCreateUnparsableKubeconfigCleansUp(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(), kubeconfigHandler(0, "\tnot a kubeconfig"),
+	)
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host)}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		return runCreatePlan(pair, hostKey, port), nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	err = base.RunCreate(ctx, "", composePlan, staticTokenGenerator)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse retrieved kubeconfig")
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestRunCreatePersistFailureCleansUp(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(), kubeconfigHandler(0, remoteAdminKubeconfig),
+	)
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host)}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+
+	// A destination whose parent is a regular file cannot be created.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	base.KubeconfigPath = filepath.Join(blocker, "kubeconfig")
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		return runCreatePlan(pair, hostKey, port), nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	err = base.RunCreate(ctx, "", composePlan, staticTokenGenerator)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge kubeconfig")
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/runcreate_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/runcreate_test.go
@@ -269,3 +269,95 @@ func TestRunCreatePersistFailureCleansUp(t *testing.T) {
 	assert.Contains(t, err.Error(), "merge kubeconfig")
 	assert.Equal(t, 1, infra.deleteNodesCalls)
 }
+
+// preexistingKubeconfig seeds the destination before RunCreate to pin the
+// merge behaviour: existing unrelated entries must survive the persist.
+const preexistingKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://other.example:6443
+  name: other
+contexts:
+- context:
+    cluster: other
+    user: other
+  name: other
+current-context: other
+users:
+- name: other
+  user: {}
+`
+
+func TestRunCreateMergesIntoExistingKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(), kubeconfigHandler(1, remoteAdminKubeconfig),
+	)
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host), networkID: 11}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(base.KubeconfigPath, []byte(preexistingKubeconfig), 0o600))
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		return runCreatePlan(pair, hostKey, port), nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	require.NoError(t, base.RunCreate(ctx, "", composePlan, staticTokenGenerator))
+
+	// Both the preexisting unrelated cluster and the new rewritten entry
+	// coexist after the merge.
+	merged, err := os.ReadFile(base.KubeconfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(merged), "https://other.example:6443")
+	assert.Contains(t, string(merged), "https://"+host+":6443")
+}
+
+// clusterlessKubeconfig parses fine but has no cluster entries — the guard
+// against persisting a kubeconfig read mid-write on the node.
+const clusterlessKubeconfig = `apiVersion: v1
+kind: Config
+`
+
+func TestRunCreateClusterlessKubeconfigFails(t *testing.T) {
+	t.Parallel()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(), kubeconfigHandler(1, clusterlessKubeconfig),
+	)
+
+	infra := &fakeInfra{createdServer: serverWithPublicIPv4(host), networkID: 11}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+
+	composePlan := func(
+		_, _ string,
+		_ hetznerbase.ResolvedInfra,
+	) (hetznerbase.BringUpPlan, error) {
+		return runCreatePlan(pair, hostKey, port), nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	err = base.RunCreate(ctx, "", composePlan, staticTokenGenerator)
+	require.ErrorIs(t, err, hetznerbase.ErrKubeconfigNoClusters)
+
+	// Nothing was persisted for the clusterless kubeconfig.
+	_, statErr := os.Stat(base.KubeconfigPath)
+	require.True(t, os.IsNotExist(statErr))
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/runcreate_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/runcreate_test.go
@@ -357,6 +357,10 @@ func TestRunCreateClusterlessKubeconfigFails(t *testing.T) {
 	err = base.RunCreate(ctx, "", composePlan, staticTokenGenerator)
 	require.ErrorIs(t, err, hetznerbase.ErrKubeconfigNoClusters)
 
+	// Cleanup-on-failure applies to this post-bring-up guard too: the created
+	// node is torn down like in the parse- and persist-failure cases.
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+
 	// Nothing was persisted for the clusterless kubeconfig.
 	_, statErr := os.Stat(base.KubeconfigPath)
 	require.True(t, os.IsNotExist(statErr))

--- a/pkg/svc/provisioner/cluster/k3shetzner/doc.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/doc.go
@@ -16,10 +16,12 @@
 // This package is the K3s × Hetzner provisioner tracked by
 // devantler-tech/ksail#5512 (epic #3983). The K3s × Hetzner distribution/provider
 // combination stays unselectable until the validation flip (#5514), so the
-// factory wiring exists but the path is gated. Live bring-up — actual server
-// creation (which needs the boot-image resolution), the runtime join sequencing
-// that depends on the first server's private address, and pulling the generated
-// kubeconfig off a node — lands with the Hetzner system-test lane (#5515 / #4972);
-// [Provisioner.Create] composes the per-node user_data and prepares the
-// infrastructure up to that boundary.
+// factory wiring exists but the path is gated. The shared create flow
+// ([Provisioner.Create] via hetznerbase) runs the live bring-up — server
+// creation, kubeconfig retrieval, endpoint rewrite, and persistence — once
+// composePlan returns a complete bring-up plan; deriving that plan (boot-image
+// resolution, the bootstrap keypair, pinned host keys) is tracked by #5726, and
+// the live E2E validation stays with the Hetzner system-test lane (#5515 /
+// #4972). Until then [Provisioner.Create] composes the per-node user_data and
+// prepares the infrastructure up to that boundary.
 package k3shetzner

--- a/pkg/svc/provisioner/cluster/k3shetzner/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/export_test.go
@@ -37,7 +37,10 @@ func NewProvisionerForTest(
 			ClusterName:   clusterName,
 			ControlPlanes: controlPlanes,
 			Agents:        agents,
-			LogWriter:     logWriter,
+			// A non-empty destination satisfies RunCreate's fail-fast guard; the
+			// gated composePlan stops before anything is persisted there.
+			KubeconfigPath: "test-kubeconfig",
+			LogWriter:      logWriter,
 		},
 		transport: transport,
 		version:   version,

--- a/pkg/svc/provisioner/cluster/k3shetzner/lifecycle.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/lifecycle.go
@@ -3,21 +3,51 @@ package k3shetzner
 import (
 	"context"
 	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
 )
 
 // Create provisions a K3s cluster on Hetzner Cloud. It runs the shared Hetzner
 // create flow ([hetznerbase.Base.RunCreate]) — guard against an existing cluster,
 // reject multi-node topologies, ensure the shared infrastructure, and compose the
-// per-node cloud-init user_data — stopping at the live-bring-up boundary
-// ([ErrLiveBringUpNotImplemented], devantler-tech/ksail#5515). Only the node token
-// (generateNodeToken) and the user_data composition (composeNodes) are k3s-specific;
-// they are handed to the shared flow. The K3s × Hetzner combination is unselectable
-// until the validation flip (#5514), so this path is gated.
+// bring-up plan. Only the node token (generateNodeToken) and the plan composition
+// (composePlan) are k3s-specific; they are handed to the shared flow. Deriving the
+// live server specs still needs boot-image resolution and bootstrap-material
+// threading (devantler-tech/ksail#5726), so composePlan stops at the
+// live-bring-up boundary ([ErrLiveBringUpNotImplemented]); the K3s × Hetzner
+// combination is unselectable until the validation flip (#5514), so this path is
+// gated either way.
 func (p *Provisioner) Create(ctx context.Context, name string) error {
-	err := p.RunCreate(ctx, name, p.composeNodes, generateNodeToken)
+	err := p.RunCreate(ctx, name, p.composePlan, generateNodeToken)
 	if err != nil {
 		return fmt.Errorf("provision K3s × Hetzner cluster: %w", err)
 	}
 
 	return nil
+}
+
+// composePlan composes the K3s per-node cloud-init user_data toward the shared
+// create flow's bring-up plan ([hetznerbase.Base.RunCreate]). The single-
+// control-plane path carries no join server URL and no SSH authorized key yet;
+// deriving the composed user_data into live server specs — boot-image
+// resolution, the bootstrap keypair, and the pinned host keys — is tracked by
+// devantler-tech/ksail#5726, so the composition stops at the live-bring-up
+// boundary.
+func (p *Provisioner) composePlan(
+	clusterName, token string,
+	_ hetznerbase.ResolvedInfra,
+) (hetznerbase.BringUpPlan, error) {
+	nodes, err := p.buildNodeUserData(clusterName, token, "", nil)
+	if err != nil {
+		return hetznerbase.BringUpPlan{}, err
+	}
+
+	_, _ = fmt.Fprintf(
+		p.LogWriter,
+		"Prepared cloud-init bootstrap for %d node(s); deriving live server "+
+			"specs is tracked by #5726\n",
+		len(nodes),
+	)
+
+	return hetznerbase.BringUpPlan{}, hetznerbase.ErrLiveBringUpNotImplemented
 }

--- a/pkg/svc/provisioner/cluster/k3shetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/provisioner.go
@@ -25,13 +25,14 @@ type Provisioner struct {
 // Hetzner factory constructs its provider. version is the k3s release the nodes
 // install (INSTALL_K3S_VERSION form, e.g. "v1.36.1+k3s1"); controlPlanes and agents
 // are the node counts; clusterName is the default cluster name used when an
-// operation is called with an empty name.
+// operation is called with an empty name; kubeconfigPath is the local kubeconfig
+// file a successful bring-up merges the admin kubeconfig into.
 func NewProvisioner(
-	clusterName, version string,
+	clusterName, kubeconfigPath, version string,
 	controlPlanes, agents int,
 	opts v1alpha1.OptionsHetzner,
 ) (*Provisioner, error) {
-	base, err := hetznerbase.NewBase(clusterName, controlPlanes, agents, opts)
+	base, err := hetznerbase.NewBase(clusterName, kubeconfigPath, controlPlanes, agents, opts)
 	if err != nil {
 		return nil, fmt.Errorf("create K3s × Hetzner base: %w", err)
 	}

--- a/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
@@ -425,6 +425,7 @@ func TestNewProvisionerMissingToken(t *testing.T) {
 
 	_, err := k3shetzner.NewProvisioner(
 		testClusterName,
+		"test-kubeconfig",
 		testVersion,
 		1,
 		0,
@@ -439,6 +440,7 @@ func TestNewProvisionerSucceeds(t *testing.T) {
 
 	prov, err := k3shetzner.NewProvisioner(
 		testClusterName,
+		"test-kubeconfig",
 		testVersion,
 		1,
 		0,

--- a/pkg/svc/provisioner/cluster/k3shetzner/userdata.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/userdata.go
@@ -75,20 +75,6 @@ func (p *Provisioner) buildNodeUserData(
 	return result, nil
 }
 
-// composeNodes composes the K3s per-node cloud-init user_data and returns the node
-// count, adapting buildNodeUserData to the shared create flow's composeNodes
-// callback ([hetznerbase.Base.RunCreate]). The single-control-plane path carries no
-// join server URL, and no SSH authorized key yet — the live bring-up composition
-// (#5515) generates the bootstrap keypair and threads its public half through here.
-func (p *Provisioner) composeNodes(clusterName, token string) (int, error) {
-	nodes, err := p.buildNodeUserData(clusterName, token, "", nil)
-	if err != nil {
-		return 0, err
-	}
-
-	return len(nodes), nil
-}
-
 // nodeType maps a k3s role to the Hetzner node-type label value: agents are
 // workers, every server role is a control plane.
 func nodeType(role k3sbootstrap.Role) string {

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/export_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/export_test.go
@@ -27,7 +27,10 @@ func NewProvisionerForTest(
 			ClusterName:   clusterName,
 			ControlPlanes: controlPlanes,
 			Agents:        agents,
-			LogWriter:     logWriter,
+			// A non-empty destination satisfies RunCreate's fail-fast guard; the
+			// gated composePlan stops before anything is persisted there.
+			KubeconfigPath: "test-kubeconfig",
+			LogWriter:      logWriter,
 		},
 		kubernetesVersion: kubernetesVersion,
 	}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
@@ -5,19 +5,21 @@ import (
 	"fmt"
 
 	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
 )
 
 // Create provisions a kubeadm cluster on Hetzner Cloud. It runs the shared Hetzner
 // create flow ([hetznerbase.Base.RunCreate]) — guard against an existing cluster,
 // reject multi-node topologies, ensure the shared infrastructure, and compose the
-// per-node cloud-init user_data — stopping at the live-bring-up boundary
-// ([ErrLiveBringUpNotImplemented], devantler-tech/ksail#5515). Only the node token
-// (generateNodeToken) and the user_data composition (composeNodes) are
-// kubeadm-specific; they are handed to the shared flow. The Vanilla × Hetzner
+// bring-up plan. Only the node token (generateNodeToken) and the plan composition
+// (composePlan) are kubeadm-specific; they are handed to the shared flow. Deriving
+// the live server specs still needs boot-image resolution and bootstrap-material
+// threading (devantler-tech/ksail#5726), so composePlan stops at the
+// live-bring-up boundary ([ErrLiveBringUpNotImplemented]); the Vanilla × Hetzner
 // combination is unselectable until the validation flip (#5514), so this path is
-// gated.
+// gated either way.
 func (p *Provisioner) Create(ctx context.Context, name string) error {
-	err := p.RunCreate(ctx, name, p.composeNodes, generateNodeToken)
+	err := p.RunCreate(ctx, name, p.composePlan, generateNodeToken)
 	if err != nil {
 		return fmt.Errorf("provision Vanilla × Hetzner cluster: %w", err)
 	}
@@ -48,14 +50,27 @@ func (p *Provisioner) buildNodes(clusterName, token string) ([]NodeUserData, err
 	return nodes, nil
 }
 
-// composeNodes composes the kubeadm per-node cloud-init user_data and returns the
-// node count, adapting buildNodes to the shared create flow's composeNodes callback
-// ([hetznerbase.Base.RunCreate]).
-func (p *Provisioner) composeNodes(clusterName, token string) (int, error) {
+// composePlan composes the kubeadm per-node cloud-init user_data toward the
+// shared create flow's bring-up plan ([hetznerbase.Base.RunCreate]). Deriving
+// the composed user_data into live server specs — boot-image resolution, the
+// bootstrap keypair, and the pinned host keys — is tracked by
+// devantler-tech/ksail#5726, so the composition stops at the live-bring-up
+// boundary.
+func (p *Provisioner) composePlan(
+	clusterName, token string,
+	_ hetznerbase.ResolvedInfra,
+) (hetznerbase.BringUpPlan, error) {
 	nodes, err := p.buildNodes(clusterName, token)
 	if err != nil {
-		return 0, err
+		return hetznerbase.BringUpPlan{}, err
 	}
 
-	return len(nodes), nil
+	_, _ = fmt.Fprintf(
+		p.LogWriter,
+		"Prepared cloud-init bootstrap for %d node(s); deriving live server "+
+			"specs is tracked by #5726\n",
+		len(nodes),
+	)
+
+	return hetznerbase.BringUpPlan{}, hetznerbase.ErrLiveBringUpNotImplemented
 }

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
@@ -30,13 +30,15 @@ type Provisioner struct {
 // Hetzner factory constructs its provider. kubernetesVersion is the Kubernetes
 // release the nodes install (e.g. "v1.31.0"), which selects the community package
 // repository track; controlPlanes and agents are the node counts; clusterName is
-// the default cluster name used when an operation is called with an empty name.
+// the default cluster name used when an operation is called with an empty name;
+// kubeconfigPath is the local kubeconfig file a successful bring-up merges the
+// admin kubeconfig into.
 func NewProvisioner(
-	clusterName, kubernetesVersion string,
+	clusterName, kubeconfigPath, kubernetesVersion string,
 	controlPlanes, agents int,
 	opts v1alpha1.OptionsHetzner,
 ) (*Provisioner, error) {
-	base, err := hetznerbase.NewBase(clusterName, controlPlanes, agents, opts)
+	base, err := hetznerbase.NewBase(clusterName, kubeconfigPath, controlPlanes, agents, opts)
 	if err != nil {
 		return nil, fmt.Errorf("create kubeadm × Hetzner base: %w", err)
 	}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
@@ -385,6 +385,7 @@ func TestNewProvisionerMissingToken(t *testing.T) {
 
 	_, err := kubeadmhetzner.NewProvisioner(
 		testClusterName,
+		"test-kubeconfig",
 		testVersion,
 		1,
 		0,
@@ -399,6 +400,7 @@ func TestNewProvisionerSucceeds(t *testing.T) {
 
 	prov, err := kubeadmhetzner.NewProvisioner(
 		testClusterName,
+		"test-kubeconfig",
 		testVersion,
 		1,
 		0,


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The Hetzner cloud-provisioning epic (#3983): KSail could already build the cloud servers, but 'create cluster' didn't finish the job — it stopped before making the new cluster reachable from the user's machine, so there was no usable end-to-end path.

## What

Completes the create flow's backbone: bring the node up, wait for the cluster to be ready, and install a working connection (kubeconfig) pointing at the cluster's public address — with cleanup if anything fails midway. The final user-visible switch-on ships in the follow-up (#5726), which adds the remaining server-configuration pieces.

First increment of #5725.