### PR TITLE
feat: add GKE cluster provisioner

### DIFF
--- a/pkg/svc/provisioner/cluster/gke/doc.go
+++ b/pkg/svc/provisioner/cluster/gke/doc.go
@@ -1,0 +1,8 @@
+// Package gkeprovisioner manages Google Kubernetes Engine clusters through
+// the native Go SDK (pkg/client/gke), mirroring the EKS provisioner's shape:
+// cluster lifecycle (Create/Delete/List/Exists) delegates to the GKE client,
+// while Start/Stop delegate node scaling to the GCP infrastructure provider
+// (pkg/svc/provider/gcp). GKE control planes are Google-managed and cannot be
+// stopped, so Stop scales every node pool to zero and Start restores the
+// pools' configured initial sizes.
+package gkeprovisioner

--- a/pkg/svc/provisioner/cluster/gke/errors.go
+++ b/pkg/svc/provisioner/cluster/gke/errors.go
@@ -1,0 +1,25 @@
+package gkeprovisioner
+
+import "errors"
+
+// ErrClientRequired is returned when a GKE client is not supplied.
+var ErrClientRequired = errors.New("gke client is required")
+
+// ErrProjectRequired is returned when no Google Cloud project ID is supplied —
+// every GKE API call is project-scoped, so an empty project can never succeed.
+var ErrProjectRequired = errors.New("google cloud project is required")
+
+// ErrClusterSpecRequired is returned by Create when no declarative cluster
+// spec is supplied. Create is driven from the same declarative source of
+// truth as the rest of ksail; there is no imperative flag fallback.
+var ErrClusterSpecRequired = errors.New("gke cluster spec is required")
+
+// ErrLocationRequired is returned by Create when no concrete GKE location is
+// configured. Reads can resolve a cluster's location via the all-locations
+// list, but a create has nothing to resolve from — the caller must say where
+// the cluster goes.
+var ErrLocationRequired = errors.New("gke location is required")
+
+// ErrClusterNotFound is returned when a cluster's location cannot be resolved
+// because no cluster with that name exists in the project.
+var ErrClusterNotFound = errors.New("gke cluster not found")

--- a/pkg/svc/provisioner/cluster/gke/provisioner.go
+++ b/pkg/svc/provisioner/cluster/gke/provisioner.go
@@ -1,0 +1,229 @@
+package gkeprovisioner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/devantler-tech/ksail/v7/pkg/client/gke"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/gcp"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+)
+
+// Provisioner manages Google Kubernetes Engine clusters via the native Go SDK.
+//
+// Cluster lifecycle operations delegate to pkg/client/gke.Client (which hides
+// the SDK's request shapes and long-running-operation polling); Start/Stop
+// delegate node-pool scaling to the GCP infrastructure provider. This mirrors
+// the EKS provisioner, but through the Go SDK instead of a shelled-out binary.
+type Provisioner struct {
+	// name is the cluster name derived from the ksail.yaml.
+	name string
+	// project is the Google Cloud project ID every GKE call is scoped to.
+	project string
+	// location is the GKE location (zone or region). Empty means "not
+	// pinned": reads resolve the cluster's own location via the
+	// all-locations list, while Create — which has nothing to resolve from —
+	// requires a concrete value.
+	location string
+	// clusterSpec is the declarative cluster specification submitted by
+	// Create. Required for Create; optional for inspection-only use.
+	clusterSpec *containerpb.Cluster
+	// client is the GKE SDK wrapper.
+	client *gke.Client
+	// infraProvider is the GCP provider used for Start/Stop semantics
+	// (node-pool scale). Optional: if nil, Start/Stop return an error.
+	infraProvider provider.Provider
+}
+
+// NewProvisioner builds a Provisioner. The GKE client must be non-nil and the
+// project non-empty; clusterSpec is required for Create but optional for
+// inspection-only use.
+func NewProvisioner(
+	name, project, location string,
+	clusterSpec *containerpb.Cluster,
+	client *gke.Client,
+	infraProvider provider.Provider,
+) (*Provisioner, error) {
+	if client == nil {
+		return nil, ErrClientRequired
+	}
+
+	if project == "" {
+		return nil, ErrProjectRequired
+	}
+
+	return &Provisioner{
+		name:          name,
+		project:       project,
+		location:      location,
+		clusterSpec:   clusterSpec,
+		client:        client,
+		infraProvider: infraProvider,
+	}, nil
+}
+
+// SetProvider sets the infrastructure provider used by Start/Stop.
+func (p *Provisioner) SetProvider(prov provider.Provider) {
+	p.infraProvider = prov
+}
+
+// Create provisions a new GKE cluster from the declarative cluster spec and
+// blocks until the create operation completes.
+func (p *Provisioner) Create(ctx context.Context, name string) error {
+	_ = name // name is encoded in the cluster spec; the CLI name flag is ignored.
+
+	if p.clusterSpec == nil {
+		return ErrClusterSpecRequired
+	}
+
+	if p.location == "" || p.location == gcp.AllLocations {
+		return ErrLocationRequired
+	}
+
+	err := p.client.CreateCluster(ctx, p.project, p.location, p.clusterSpec)
+	if err != nil {
+		return fmt.Errorf("gke create cluster: %w", err)
+	}
+
+	return nil
+}
+
+// Delete tears down the GKE cluster and blocks until the delete operation
+// completes. When no location is pinned, the cluster's own location is
+// resolved via the all-locations list first.
+func (p *Provisioner) Delete(ctx context.Context, name string) error {
+	target := p.resolveName(name)
+
+	location, err := p.resolveLocation(ctx, target)
+	if err != nil {
+		return err
+	}
+
+	err = p.client.DeleteCluster(ctx, p.project, location, target)
+	if err != nil {
+		return fmt.Errorf("gke delete cluster: %w", err)
+	}
+
+	return nil
+}
+
+// Start resumes a GKE cluster by scaling every node pool back to its
+// configured initial size. GKE control planes are Google-managed and never
+// stop, so "start" = "scale the pools back in".
+func (p *Provisioner) Start(ctx context.Context, name string) error {
+	if p.infraProvider == nil {
+		return fmt.Errorf("%w: start requires a GCP provider", clustererr.ErrUnsupportedProvider)
+	}
+
+	target := p.resolveName(name)
+
+	err := p.infraProvider.StartNodes(ctx, target)
+	if err != nil {
+		return fmt.Errorf("start nodes: %w", err)
+	}
+
+	return nil
+}
+
+// Stop scales every node pool to zero nodes. The GKE control plane continues
+// to run (and continues to bill) because Google does not expose a stop
+// operation for the managed control plane.
+func (p *Provisioner) Stop(ctx context.Context, name string) error {
+	if p.infraProvider == nil {
+		return fmt.Errorf("%w: stop requires a GCP provider", clustererr.ErrUnsupportedProvider)
+	}
+
+	target := p.resolveName(name)
+
+	err := p.infraProvider.StopNodes(ctx, target)
+	if err != nil {
+		return fmt.Errorf("stop nodes: %w", err)
+	}
+
+	return nil
+}
+
+// List returns the names of every GKE cluster in the configured location, or
+// across all locations in the project when no location is pinned.
+func (p *Provisioner) List(ctx context.Context) ([]string, error) {
+	clusters, err := p.client.ListClusters(ctx, p.project, p.listLocation())
+	if err != nil {
+		return nil, fmt.Errorf("gke list clusters: %w", err)
+	}
+
+	names := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		names = append(names, cluster.GetName())
+	}
+
+	return names, nil
+}
+
+// Exists reports whether a cluster with the given name (or the provisioner
+// default) exists. Implemented via ListClusters + membership check because
+// GetCluster reports a missing cluster as a gRPC NotFound error, which is
+// harder to classify reliably than an empty list result — the same trade the
+// EKS provisioner makes.
+func (p *Provisioner) Exists(ctx context.Context, name string) (bool, error) {
+	target := p.resolveName(name)
+	if target == "" {
+		return false, nil
+	}
+
+	clusters, err := p.client.ListClusters(ctx, p.project, p.listLocation())
+	if err != nil {
+		return false, fmt.Errorf("gke list clusters: %w", err)
+	}
+
+	for _, cluster := range clusters {
+		if cluster.GetName() == target {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// resolveName returns the caller-supplied name when set, otherwise falls
+// back to the provisioner's configured name.
+func (p *Provisioner) resolveName(name string) string {
+	if name != "" {
+		return name
+	}
+
+	return p.name
+}
+
+// listLocation returns the location used for list-shaped calls: the pinned
+// location when set, otherwise the GKE API's all-locations wildcard.
+func (p *Provisioner) listLocation() string {
+	if p.location == "" {
+		return gcp.AllLocations
+	}
+
+	return p.location
+}
+
+// resolveLocation returns the pinned location when set; otherwise it resolves
+// the named cluster's own location via the all-locations list, mirroring the
+// GCP provider's resolution for cluster-scoped calls.
+func (p *Provisioner) resolveLocation(ctx context.Context, clusterName string) (string, error) {
+	if p.location != "" && p.location != gcp.AllLocations {
+		return p.location, nil
+	}
+
+	clusters, err := p.client.ListClusters(ctx, p.project, gcp.AllLocations)
+	if err != nil {
+		return "", fmt.Errorf("resolve cluster location: %w", err)
+	}
+
+	for _, cluster := range clusters {
+		if cluster.GetName() == clusterName {
+			return cluster.GetLocation(), nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrClusterNotFound, clusterName)
+}

--- a/pkg/svc/provisioner/cluster/gke/provisioner.go
+++ b/pkg/svc/provisioner/cluster/gke/provisioner.go
@@ -95,6 +95,9 @@ func (p *Provisioner) Create(ctx context.Context, name string) error {
 // resolved via the all-locations list first.
 func (p *Provisioner) Delete(ctx context.Context, name string) error {
 	target := p.resolveName(name)
+	if target == "" {
+		return fmt.Errorf("%w: no cluster name configured", ErrClusterNotFound)
+	}
 
 	location, err := p.resolveLocation(ctx, target)
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/gke/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/gke/provisioner_test.go
@@ -310,6 +310,25 @@ func TestDelete_UnknownClusterFailsResolution(t *testing.T) {
 	require.ErrorIs(t, err, gkeprovisioner.ErrClusterNotFound)
 }
 
+func TestDelete_EmptyTargetFailsFastWithoutCalls(t *testing.T) {
+	t.Parallel()
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(&fakeClusterManager{}),
+	)
+	require.NoError(t, err)
+
+	provisioner, err := gkeprovisioner.NewProvisioner(
+		"", "test-project", "europe-north1", nil, client, nil,
+	)
+	require.NoError(t, err)
+
+	err = provisioner.Delete(t.Context(), "")
+
+	require.ErrorIs(t, err, gkeprovisioner.ErrClusterNotFound)
+}
+
 func TestStart_DelegatesToProvider(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/gke/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/gke/provisioner_test.go
@@ -1,0 +1,468 @@
+package gkeprovisioner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/devantler-tech/ksail/v7/pkg/client/gke"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	gkeprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/gke"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errBoom is the sentinel the fakes fail with.
+var errBoom = errors.New("boom")
+
+// fakeClusterManager implements the GKE client's cluster-manager seam with
+// injectable behaviour per operation, mirroring pkg/client/gke's test fake.
+type fakeClusterManager struct {
+	createFunc func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error)
+	deleteFunc func(*containerpb.DeleteClusterRequest) (*containerpb.Operation, error)
+	listFunc   func(*containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error)
+}
+
+func (f *fakeClusterManager) CreateCluster(
+	_ context.Context,
+	req *containerpb.CreateClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return f.createFunc(req)
+}
+
+func (f *fakeClusterManager) DeleteCluster(
+	_ context.Context,
+	req *containerpb.DeleteClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return f.deleteFunc(req)
+}
+
+func (f *fakeClusterManager) GetCluster(
+	_ context.Context,
+	_ *containerpb.GetClusterRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Cluster, error) {
+	return nil, errBoom
+}
+
+func (f *fakeClusterManager) ListClusters(
+	_ context.Context,
+	req *containerpb.ListClustersRequest,
+	_ ...gax.CallOption,
+) (*containerpb.ListClustersResponse, error) {
+	return f.listFunc(req)
+}
+
+func (f *fakeClusterManager) SetNodePoolSize(
+	_ context.Context,
+	_ *containerpb.SetNodePoolSizeRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return nil, errBoom
+}
+
+func (f *fakeClusterManager) GetOperation(
+	_ context.Context,
+	_ *containerpb.GetOperationRequest,
+	_ ...gax.CallOption,
+) (*containerpb.Operation, error) {
+	return nil, errBoom
+}
+
+func (f *fakeClusterManager) Close() error {
+	return nil
+}
+
+// fakeProvider records Start/Stop delegation without touching real
+// infrastructure. The embedded interface panics on anything not overridden,
+// pinning that the provisioner only uses StartNodes/StopNodes.
+type fakeProvider struct {
+	provider.Provider
+
+	started  []string
+	stopped  []string
+	startErr error
+	stopErr  error
+}
+
+func (f *fakeProvider) StartNodes(_ context.Context, clusterName string) error {
+	f.started = append(f.started, clusterName)
+
+	return f.startErr
+}
+
+func (f *fakeProvider) StopNodes(_ context.Context, clusterName string) error {
+	f.stopped = append(f.stopped, clusterName)
+
+	return f.stopErr
+}
+
+func doneOperation(name string) *containerpb.Operation {
+	return &containerpb.Operation{
+		Name:   name,
+		Status: containerpb.Operation_DONE,
+	}
+}
+
+func listResponse(clusters ...*containerpb.Cluster) *containerpb.ListClustersResponse {
+	return &containerpb.ListClustersResponse{Clusters: clusters}
+}
+
+func namedCluster(name, location string) *containerpb.Cluster {
+	return &containerpb.Cluster{Name: name, Location: location}
+}
+
+// newProvisioner wires a Provisioner around the fake manager with a fast poll
+// interval, mirroring the EKS test constructor.
+func newProvisioner(
+	t *testing.T,
+	fake *fakeClusterManager,
+	location string,
+	clusterSpec *containerpb.Cluster,
+	infra provider.Provider,
+) *gkeprovisioner.Provisioner {
+	t.Helper()
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(fake),
+		gke.WithPollInterval(time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	provisioner, err := gkeprovisioner.NewProvisioner(
+		"gke-default", "test-project", location, clusterSpec, client, infra,
+	)
+	require.NoError(t, err)
+
+	return provisioner
+}
+
+func TestNewProvisioner_RequiresClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := gkeprovisioner.NewProvisioner(
+		"gke-default", "test-project", "europe-north1", nil, nil, nil,
+	)
+
+	require.ErrorIs(t, err, gkeprovisioner.ErrClientRequired)
+}
+
+func TestNewProvisioner_RequiresProject(t *testing.T) {
+	t.Parallel()
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(&fakeClusterManager{}),
+	)
+	require.NoError(t, err)
+
+	_, err = gkeprovisioner.NewProvisioner("gke-default", "", "europe-north1", nil, client, nil)
+
+	require.ErrorIs(t, err, gkeprovisioner.ErrProjectRequired)
+}
+
+func TestCreate_RequiresClusterSpec(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newProvisioner(t, &fakeClusterManager{}, "europe-north1", nil, nil)
+
+	err := provisioner.Create(t.Context(), "")
+
+	require.ErrorIs(t, err, gkeprovisioner.ErrClusterSpecRequired)
+}
+
+func TestCreate_RequiresConcreteLocation(t *testing.T) {
+	t.Parallel()
+
+	for _, location := range []string{"", "-"} {
+		provisioner := newProvisioner(
+			t, &fakeClusterManager{}, location, namedCluster("gke-default", ""), nil,
+		)
+
+		err := provisioner.Create(t.Context(), "")
+
+		require.ErrorIs(t, err, gkeprovisioner.ErrLocationRequired)
+	}
+}
+
+func TestCreate_SubmitsDeclarativeSpec(t *testing.T) {
+	t.Parallel()
+
+	var captured *containerpb.CreateClusterRequest
+
+	fake := &fakeClusterManager{
+		createFunc: func(req *containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+			captured = req
+
+			return doneOperation("op-create"), nil
+		},
+	}
+	spec := namedCluster("gke-default", "")
+	provisioner := newProvisioner(t, fake, "europe-north1", spec, nil)
+
+	err := provisioner.Create(t.Context(), "ignored-flag-name")
+
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Equal(t, "projects/test-project/locations/europe-north1", captured.GetParent())
+	assert.Equal(t, "gke-default", captured.GetCluster().GetName())
+}
+
+func TestCreate_WrapsClientError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		createFunc: func(_ *containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+			return nil, errBoom
+		},
+	}
+	provisioner := newProvisioner(t, fake, "europe-north1", namedCluster("gke-default", ""), nil)
+
+	err := provisioner.Create(t.Context(), "")
+
+	require.ErrorIs(t, err, errBoom)
+	require.ErrorContains(t, err, "gke create cluster")
+}
+
+func TestDelete_UsesPinnedLocation(t *testing.T) {
+	t.Parallel()
+
+	var captured *containerpb.DeleteClusterRequest
+
+	fake := &fakeClusterManager{
+		deleteFunc: func(req *containerpb.DeleteClusterRequest) (*containerpb.Operation, error) {
+			captured = req
+
+			return doneOperation("op-delete"), nil
+		},
+	}
+	provisioner := newProvisioner(t, fake, "europe-north1", nil, nil)
+
+	err := provisioner.Delete(t.Context(), "")
+
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Equal(
+		t,
+		"projects/test-project/locations/europe-north1/clusters/gke-default",
+		captured.GetName(),
+	)
+}
+
+func TestDelete_ResolvesLocationWhenUnpinned(t *testing.T) {
+	t.Parallel()
+
+	var (
+		capturedList   *containerpb.ListClustersRequest
+		capturedDelete *containerpb.DeleteClusterRequest
+	)
+
+	fake := &fakeClusterManager{
+		listFunc: func(
+			req *containerpb.ListClustersRequest,
+		) (*containerpb.ListClustersResponse, error) {
+			capturedList = req
+
+			return listResponse(namedCluster("gke-default", "us-central1")), nil
+		},
+		deleteFunc: func(req *containerpb.DeleteClusterRequest) (*containerpb.Operation, error) {
+			capturedDelete = req
+
+			return doneOperation("op-delete"), nil
+		},
+	}
+	provisioner := newProvisioner(t, fake, "", nil, nil)
+
+	err := provisioner.Delete(t.Context(), "")
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedList)
+	assert.Equal(t, "projects/test-project/locations/-", capturedList.GetParent())
+	require.NotNil(t, capturedDelete)
+	assert.Equal(
+		t,
+		"projects/test-project/locations/us-central1/clusters/gke-default",
+		capturedDelete.GetName(),
+	)
+}
+
+func TestDelete_UnknownClusterFailsResolution(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		listFunc: func(
+			_ *containerpb.ListClustersRequest,
+		) (*containerpb.ListClustersResponse, error) {
+			return listResponse(), nil
+		},
+	}
+	provisioner := newProvisioner(t, fake, "", nil, nil)
+
+	err := provisioner.Delete(t.Context(), "missing")
+
+	require.ErrorIs(t, err, gkeprovisioner.ErrClusterNotFound)
+}
+
+func TestStart_DelegatesToProvider(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeProvider{}
+	provisioner := newProvisioner(t, &fakeClusterManager{}, "europe-north1", nil, infra)
+
+	err := provisioner.Start(t.Context(), "")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gke-default"}, infra.started)
+}
+
+func TestStart_RequiresProvider(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newProvisioner(t, &fakeClusterManager{}, "europe-north1", nil, nil)
+
+	err := provisioner.Start(t.Context(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrUnsupportedProvider)
+}
+
+func TestStop_DelegatesToProvider(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeProvider{}
+	provisioner := newProvisioner(t, &fakeClusterManager{}, "europe-north1", nil, infra)
+
+	err := provisioner.Stop(t.Context(), "named")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"named"}, infra.stopped)
+}
+
+func TestStop_RequiresProvider(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newProvisioner(t, &fakeClusterManager{}, "europe-north1", nil, nil)
+
+	err := provisioner.Stop(t.Context(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrUnsupportedProvider)
+}
+
+func TestStop_WrapsProviderError(t *testing.T) {
+	t.Parallel()
+
+	infra := &fakeProvider{stopErr: errBoom}
+	provisioner := newProvisioner(t, &fakeClusterManager{}, "europe-north1", nil, infra)
+
+	err := provisioner.Stop(t.Context(), "")
+
+	require.ErrorIs(t, err, errBoom)
+	require.ErrorContains(t, err, "stop nodes")
+}
+
+func TestSetProvider_Overrides(t *testing.T) {
+	t.Parallel()
+
+	original := &fakeProvider{}
+	replacement := &fakeProvider{}
+	provisioner := newProvisioner(t, &fakeClusterManager{}, "europe-north1", nil, original)
+
+	provisioner.SetProvider(replacement)
+	err := provisioner.Start(t.Context(), "")
+
+	require.NoError(t, err)
+	assert.Empty(t, original.started)
+	assert.Equal(t, []string{"gke-default"}, replacement.started)
+}
+
+func TestList_ReturnsClusterNamesAcrossAllLocations(t *testing.T) {
+	t.Parallel()
+
+	var captured *containerpb.ListClustersRequest
+
+	fake := &fakeClusterManager{
+		listFunc: func(
+			req *containerpb.ListClustersRequest,
+		) (*containerpb.ListClustersResponse, error) {
+			captured = req
+
+			return listResponse(
+				namedCluster("alpha", "us-central1"),
+				namedCluster("beta", "europe-north1"),
+			), nil
+		},
+	}
+	provisioner := newProvisioner(t, fake, "", nil, nil)
+
+	names, err := provisioner.List(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Equal(t, "projects/test-project/locations/-", captured.GetParent())
+	assert.Equal(t, []string{"alpha", "beta"}, names)
+}
+
+func TestList_WrapsClientError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		listFunc: func(
+			_ *containerpb.ListClustersRequest,
+		) (*containerpb.ListClustersResponse, error) {
+			return nil, errBoom
+		},
+	}
+	provisioner := newProvisioner(t, fake, "europe-north1", nil, nil)
+
+	_, err := provisioner.List(t.Context())
+
+	require.ErrorIs(t, err, errBoom)
+	require.ErrorContains(t, err, "gke list clusters")
+}
+
+func TestExists_ReportsMembership(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		listFunc: func(
+			_ *containerpb.ListClustersRequest,
+		) (*containerpb.ListClustersResponse, error) {
+			return listResponse(namedCluster("gke-default", "europe-north1")), nil
+		},
+	}
+	provisioner := newProvisioner(t, fake, "europe-north1", nil, nil)
+
+	found, err := provisioner.Exists(t.Context(), "")
+	require.NoError(t, err)
+	assert.True(t, found)
+
+	found, err = provisioner.Exists(t.Context(), "missing")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestExists_EmptyTargetIsFalseWithoutCalls(t *testing.T) {
+	t.Parallel()
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(&fakeClusterManager{}),
+	)
+	require.NoError(t, err)
+
+	provisioner, err := gkeprovisioner.NewProvisioner(
+		"", "test-project", "europe-north1", nil, client, nil,
+	)
+	require.NoError(t, err)
+
+	found, err := provisioner.Exists(t.Context(), "")
+
+	require.NoError(t, err)
+	assert.False(t, found)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Cloud expansion roadmap (#4510): KSail supports AWS (EKS) but not Google Cloud. GKE is the next provider users should be able to target with the same declarative workflow.

## What

First half of GKE support: the engine that creates, lists, starts/stops, and deletes GKE clusters. The second half — wiring it into the CLI so users can actually select GKE — follows as its own PR to keep review manageable.

Part 1 of #5728.