### PR TITLE
feat(operator): k3k Connector — publish the K3s child kubeconfig to the operator

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/nested/nested_test.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/nested_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,4 +93,44 @@ func TestSetDockerHost_SetsAndRestores(t *testing.T) {
 
 	restore()
 	assert.Equal(t, sentinel, os.Getenv("DOCKER_HOST"))
+}
+
+func TestFetchKubeconfigSecret_NotFoundIsNotReady(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+
+	_, err := nested.FetchKubeconfigSecret(
+		context.Background(), clientset, "k3k-demo", "k3k-demo-kubeconfig", "kubeconfig.yaml",
+	)
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestFetchKubeconfigSecret_EmptyKeyIsNotReady(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "k3k-demo-kubeconfig", Namespace: "k3k-demo"},
+		Data:       map[string][]byte{"other": []byte("x")},
+	})
+
+	_, err := nested.FetchKubeconfigSecret(
+		context.Background(), clientset, "k3k-demo", "k3k-demo-kubeconfig", "kubeconfig.yaml",
+	)
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestFetchKubeconfigSecret_ReturnsData(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "vc-demo", Namespace: "vcluster-demo"},
+		Data:       map[string][]byte{"config": []byte("kubeconfig-bytes")},
+	})
+
+	raw, err := nested.FetchKubeconfigSecret(
+		context.Background(), clientset, "vcluster-demo", "vc-demo", "config",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("kubeconfig-bytes"), raw)
 }

--- a/pkg/svc/provisioner/cluster/internal/nested/secret.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/secret.go
@@ -24,21 +24,38 @@ func FetchKubeconfigSecret(
 	clientset kubernetes.Interface,
 	namespace, secretName, key string,
 ) ([]byte, error) {
+	raw, err := fetchSecretData(ctx, clientset, namespace, secretName, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(raw) == 0 {
+		return nil, clustererr.ErrKubeconfigNotReady
+	}
+
+	return raw, nil
+}
+
+// fetchSecretData is the single Get+NotFound+Data[key] step shared by
+// FetchKubeconfigSecret and WaitForKubeconfigSecret. A missing Secret or an
+// absent key yields (nil, nil) — the callers decide whether that means
+// "not ready" or "keep waiting"; any other API error is wrapped with the
+// Secret's coordinates.
+func fetchSecretData(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, secretName, key string,
+) ([]byte, error) {
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		return nil, clustererr.ErrKubeconfigNotReady
+		return nil, nil
 	}
 
 	if err != nil {
 		return nil, fmt.Errorf("get kubeconfig secret %s/%s: %w", namespace, secretName, err)
 	}
 
-	raw := secret.Data[key]
-	if len(raw) == 0 {
-		return nil, clustererr.ErrKubeconfigNotReady
-	}
-
-	return raw, nil
+	return secret.Data[key], nil
 }
 
 // NamespaceExists reports whether namespace exists on the host cluster. A
@@ -82,19 +99,12 @@ func WaitForKubeconfigSecret(
 	err := wait.PollUntilContextTimeout(
 		ctx, interval, timeout, true,
 		func(ctx context.Context) (bool, error) {
-			secret, err := clientset.CoreV1().Secrets(namespace).Get(
-				ctx, secretName, metav1.GetOptions{},
-			)
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
-
+			data, err := fetchSecretData(ctx, clientset, namespace, secretName, key)
 			if err != nil {
-				return false, fmt.Errorf("get kubeconfig secret: %w", err)
+				return false, err
 			}
 
-			data, ok := secret.Data[key]
-			if !ok || len(data) == 0 {
+			if len(data) == 0 {
 				return false, nil
 			}
 

--- a/pkg/svc/provisioner/cluster/internal/nested/secret.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/secret.go
@@ -5,11 +5,41 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
+
+// FetchKubeconfigSecret reads the kubeconfig bytes published under key in the named Secret once
+// (no polling — the Connector capability's read path). A not-yet-created Secret (NotFound) and an
+// empty/absent key value are reported as clustererr.ErrKubeconfigNotReady so operator callers can
+// retry; any other API error is wrapped with the Secret's coordinates.
+//
+// This is the shared fetch the K3d (k3k operator) and VCluster (vc-<name>) Connector
+// implementations use; the per-distribution secret name and data key are passed in by the caller.
+func FetchKubeconfigSecret(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, secretName, key string,
+) ([]byte, error) {
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, clustererr.ErrKubeconfigNotReady
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("get kubeconfig secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	raw := secret.Data[key]
+	if len(raw) == 0 {
+		return nil, clustererr.ErrKubeconfigNotReady
+	}
+
+	return raw, nil
+}
 
 // NamespaceExists reports whether namespace exists on the host cluster. A
 // NotFound result is reported as (false, nil); any other API error is wrapped and

--- a/pkg/svc/provisioner/cluster/k3d/connection.go
+++ b/pkg/svc/provisioner/cluster/k3d/connection.go
@@ -1,0 +1,49 @@
+package k3dprovisioner
+
+import "fmt"
+
+// Connection coordinates for a k3k-provisioned K3s cluster on a host Kubernetes cluster. These are
+// the single source of truth for the naming contract between ksail and the rancher/k3k operator —
+// the namespace ksail creates, the kubeconfig Secret k3k publishes, and the in-cluster API endpoint
+// the k3k server Service exposes. The operator imports these (rather than re-deriving them) so a
+// naming change here can never silently break operator component installs or status observation.
+const (
+	// k3kServiceSuffix is appended to the prefixed cluster name for the k3k server Service
+	// ("k3k-<name>-service", rancher/k3k's server.ServiceName contract).
+	k3kServiceSuffix = "service"
+	// k3kServiceAPIPort is the port the k3k server Service exposes the nested K3s API on inside
+	// the host cluster (targeting the k3s server pods' 6443).
+	k3kServiceAPIPort = 443
+)
+
+// Connection holds the in-hub coordinates for a named k3k cluster: the namespace and kubeconfig
+// Secret the k3k operator publishes and the in-cluster API endpoint reachable from where the ksail
+// operator runs.
+type Connection struct {
+	// Namespace is the host-cluster namespace holding the k3k cluster ("k3k-<name>").
+	Namespace string
+	// SecretName is the kubeconfig Secret name in Namespace ("k3k-<name>-kubeconfig").
+	SecretName string
+	// Endpoint is the in-cluster API server URL ("https://k3k-<name>-service.<namespace>:443").
+	// The bare "<service>.<namespace>" form (no ".svc" suffix) is deliberate: it is the exact DNS
+	// SAN k3k inserts into the nested k3s server certificate (rancher/k3k
+	// pkg/controller/cluster/server/config.go Config()), so the endpoint verifies against the
+	// served cert with the kubeconfig's own CA and needs no tls-server-name override.
+	Endpoint string
+}
+
+// ConnectionFor returns the in-hub connection coordinates for the named k3k cluster. It is the
+// single source of truth shared by the provisioner's Kubeconfig() and any operator-side consumer,
+// so the namespace/secret/endpoint contract is derived in exactly one place.
+func ConnectionFor(name string) Connection {
+	namespace := k3kNamespacePrefix + name
+
+	return Connection{
+		Namespace:  namespace,
+		SecretName: fmt.Sprintf("k3k-%s-%s", name, k3kKubeconfigSecretSuffix),
+		Endpoint: fmt.Sprintf(
+			"https://k3k-%s-%s.%s:%d",
+			name, k3kServiceSuffix, namespace, k3kServiceAPIPort,
+		),
+	}
+}

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -332,25 +332,11 @@ func (p *K3kProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, e
 
 	conn := ConnectionFor(clusterName)
 
-	secret, err := p.hostClientset.CoreV1().
-		Secrets(conn.Namespace).
-		Get(ctx, conn.SecretName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil, clustererr.ErrKubeconfigNotReady
-	}
-
+	raw, err := nested.FetchKubeconfigSecret(
+		ctx, p.hostClientset, conn.Namespace, conn.SecretName, k3kKubeconfigKey,
+	)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"get k3k kubeconfig secret %s/%s: %w",
-			conn.Namespace,
-			conn.SecretName,
-			err,
-		)
-	}
-
-	raw := secret.Data[k3kKubeconfigKey]
-	if len(raw) == 0 {
-		return nil, clustererr.ErrKubeconfigNotReady
+		return nil, fmt.Errorf("k3k: %w", err)
 	}
 
 	config, err := clientcmd.Load(raw)

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -305,6 +306,68 @@ func (p *K3kProvisioner) List(ctx context.Context) ([]string, error) {
 	}
 
 	return names, nil
+}
+
+// Kubeconfig returns a kubeconfig for the named k3k cluster reachable from inside the host
+// cluster (where the operator runs), with the API server rewritten to the in-cluster k3k server
+// Service endpoint (https://k3k-<name>-service.k3k-<name>:443 — a DNS SAN on the served
+// certificate, see ConnectionFor). The rewrite is required because k3k substitutes the CR's first
+// TLS SAN (127.0.0.1 here) into the published kubeconfig's server URL, which is unreachable from
+// an operator pod. It satisfies the clusterprovisioner.Connector capability and returns
+// clustererr.ErrKubeconfigNotReady while the k3k-<name>-kubeconfig Secret has not been published
+// yet.
+func (p *K3kProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	clusterName := p.clusterName
+	if clusterName == "" {
+		clusterName = name
+	}
+
+	if clusterName == "" {
+		return nil, fmt.Errorf("%w: k3k cluster name not set", clustererr.ErrConfigNil)
+	}
+
+	if p.hostClientset == nil {
+		return nil, fmt.Errorf("%w: host clientset not set", clustererr.ErrConfigNil)
+	}
+
+	conn := ConnectionFor(clusterName)
+
+	secret, err := p.hostClientset.CoreV1().
+		Secrets(conn.Namespace).
+		Get(ctx, conn.SecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, clustererr.ErrKubeconfigNotReady
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get k3k kubeconfig secret %s/%s: %w",
+			conn.Namespace,
+			conn.SecretName,
+			err,
+		)
+	}
+
+	raw := secret.Data[k3kKubeconfigKey]
+	if len(raw) == 0 {
+		return nil, clustererr.ErrKubeconfigNotReady
+	}
+
+	config, err := clientcmd.Load(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse k3k kubeconfig: %w", err)
+	}
+
+	for _, cluster := range config.Clusters {
+		cluster.Server = conn.Endpoint
+	}
+
+	out, err := clientcmd.Write(*config)
+	if err != nil {
+		return nil, fmt.Errorf("serialize k3k kubeconfig: %w", err)
+	}
+
+	return out, nil
 }
 
 // connectAndMergeKubeconfig waits for the k3k kubeconfig Secret, rewrites the kubeconfig to
@@ -806,7 +869,7 @@ func (p *K3kProvisioner) waitForKubeconfigSecret(
 	clusterName, namespace string,
 ) ([]byte, error) {
 	// k3k names the kubeconfig secret as k3k-<clusterName>-kubeconfig
-	secretName := fmt.Sprintf("k3k-%s-%s", clusterName, k3kKubeconfigSecretSuffix)
+	secretName := ConnectionFor(clusterName).SecretName
 
 	//nolint:wrapcheck // helper already wraps with "wait for kubeconfig secret" context
 	return nested.WaitForKubeconfigSecret(

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -7,13 +7,20 @@ import (
 	"time"
 
 	k3dconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/k3d"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	k3dprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3d"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
 )
+
+// The k3k provisioner must satisfy the operator's Connector capability so component installs
+// run against k3k-provisioned K3s children (#5732).
+var _ clusterprovisioner.Connector = (*k3dprovisioner.K3kProvisioner)(nil)
 
 func TestBuildClusterCR_ServerArgs(t *testing.T) {
 	t.Parallel()
@@ -109,6 +116,146 @@ func TestBuildClusterCR_Version(t *testing.T) {
 
 		assert.Empty(t, cluster.Spec.Version)
 	})
+}
+
+func TestConnectionFor(t *testing.T) {
+	t.Parallel()
+
+	conn := k3dprovisioner.ConnectionFor("nested-k3s")
+
+	assert.Equal(t, "k3k-nested-k3s", conn.Namespace)
+	assert.Equal(t, "k3k-nested-k3s-kubeconfig", conn.SecretName)
+	assert.Equal(t, "https://k3k-nested-k3s-service.k3k-nested-k3s:443", conn.Endpoint)
+}
+
+// k3kPublishedKubeconfig is a minimal valid kubeconfig as the k3k operator publishes it — the
+// server points at the CR's first TLS SAN (127.0.0.1), unreachable from an operator pod.
+const k3kPublishedKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+users:
+- name: default
+  user: {}
+`
+
+func newK3kProvisionerWithClientset(
+	t *testing.T, clientset *k8sfake.Clientset,
+) *k3dprovisioner.K3kProvisioner {
+	t.Helper()
+
+	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
+		HostClientset: clientset,
+		ClusterName:   "nested-k3s",
+	})
+	require.NoError(t, err)
+
+	return provisioner
+}
+
+func TestKubeconfig_NotReadyWhileSecretUnpublished(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newK3kProvisionerWithClientset(t, k8sfake.NewClientset())
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_NotReadyWhileSecretKeyEmpty(t *testing.T) {
+	t.Parallel()
+
+	conn := k3dprovisioner.ConnectionFor("nested-k3s")
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+	})
+	provisioner := newK3kProvisionerWithClientset(t, clientset)
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_RewritesServerToInClusterServiceEndpoint(t *testing.T) {
+	t.Parallel()
+
+	conn := k3dprovisioner.ConnectionFor("nested-k3s")
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
+	})
+	provisioner := newK3kProvisionerWithClientset(t, clientset)
+
+	out, err := provisioner.Kubeconfig(context.Background(), "")
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(out)
+	require.NoError(t, err)
+	require.NotEmpty(t, config.Clusters)
+
+	for _, cluster := range config.Clusters {
+		assert.Equal(t, conn.Endpoint, cluster.Server)
+	}
+}
+
+func TestKubeconfig_FallsBackToNameArgument(t *testing.T) {
+	t.Parallel()
+
+	conn := k3dprovisioner.ConnectionFor("from-arg")
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
+	})
+
+	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
+		HostClientset: clientset,
+	})
+	require.NoError(t, err)
+
+	out, err := provisioner.Kubeconfig(context.Background(), "from-arg")
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(out)
+	require.NoError(t, err)
+
+	for _, cluster := range config.Clusters {
+		assert.Equal(t, conn.Endpoint, cluster.Server)
+	}
+}
+
+func TestKubeconfig_ErrorsWithoutAnyName(t *testing.T) {
+	t.Parallel()
+
+	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
+		HostClientset: k8sfake.NewClientset(),
+	})
+	require.NoError(t, err)
+
+	_, err = provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrConfigNil)
+}
+
+func TestKubeconfig_ErrorsWithoutHostClientset(t *testing.T) {
+	t.Parallel()
+
+	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
+		ClusterName: "nested-k3s",
+	})
+	require.NoError(t, err)
+
+	_, err = provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrConfigNil)
 }
 
 func TestFirstRunningPodName(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/vcluster/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/vcluster/kubernetes_provisioner.go
@@ -330,25 +330,11 @@ func (p *KubernetesProvisioner) Kubeconfig(ctx context.Context, name string) ([]
 
 	conn := ConnectionFor(clusterName)
 
-	secret, err := p.hostClientset.CoreV1().
-		Secrets(conn.Namespace).
-		Get(ctx, conn.SecretName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil, clustererr.ErrKubeconfigNotReady
-	}
-
+	raw, err := nested.FetchKubeconfigSecret(
+		ctx, p.hostClientset, conn.Namespace, conn.SecretName, KubeconfigSecretKey,
+	)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"get vcluster kubeconfig secret %s/%s: %w",
-			conn.Namespace,
-			conn.SecretName,
-			err,
-		)
-	}
-
-	raw := secret.Data[KubeconfigSecretKey]
-	if len(raw) == 0 {
-		return nil, clustererr.ErrKubeconfigNotReady
+		return nil, fmt.Errorf("vcluster: %w", err)
 	}
 
 	config, err := clientcmd.Load(raw)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The operator-lifecycle epic (#4899): KSail's operator manages clusters-inside-clusters, but couldn't actually connect to the ones created via k3k — the published connection details point at an address only valid inside the child itself, so the operator was locked out of clusters it had just created.

## What

Gives the operator a working connection path to k3k child clusters (with a clean 'not ready yet, retry' signal while a cluster is still coming up). Same pattern as the existing vCluster support; the remaining child-cluster flavors follow in later increments.

Fixes #5732.