### PR TITLE
ci: repoint reusable workflows to actions v8.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,7 +270,7 @@ jobs:
   ci-go:
     name: ✅ Validate Go Project
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/validate-go-project.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,6 @@ permissions:
 jobs:
   release:
     name: 🎉 Create Release
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/create-release.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     with:
       dir: .agents/skills
       # Open the PR with a GitHub App token so the caller's `on: pull_request`


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

We merged our reusable CI workflows into `devantler-tech/actions` a week ago, but this repo still runs them from the old `reusable-workflows` repo. Until every repo moves over, the old repo can't be archived — and its leftover automation has now started failing every night (reusable-workflows#350).

## What

Points this repo's CI at the workflows' new home. Same workflows, new address — no behavior change.

Part of devantler-tech/actions#425.

**Note:** needs a direct merge after promotion — the auto-merge bot can't merge workflow-file changes.