### PR TITLE
feat(talos): nested-cluster Connector — publish the kubeconfig as an in-cluster Secret

### DIFF
--- a/pkg/svc/provisioner/cluster/factory_talos.go
+++ b/pkg/svc/provisioner/cluster/factory_talos.go
@@ -118,7 +118,7 @@ func (f DefaultFactory) createTalosKubernetesProvisioner(
 		clusterName = cluster.Name
 	}
 
-	_, restConfig, dynClient, k8sProvider, err := buildKubernetesInfra(opts)
+	hostClient, restConfig, dynClient, k8sProvider, err := buildKubernetesInfra(opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -148,6 +148,7 @@ func (f DefaultFactory) createTalosKubernetesProvisioner(
 			KubeconfigPath:   cluster.Spec.Cluster.Connection.Kubeconfig,
 			K8sProvider:      k8sProvider,
 			DynamicClient:    dynClient,
+			HostClientset:    hostClient,
 			RestConfig:       restConfig,
 			ClusterName:      clusterName,
 			Distribution:     string(cluster.Spec.Cluster.Distribution),

--- a/pkg/svc/provisioner/cluster/internal/nested/secret.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/secret.go
@@ -6,10 +6,12 @@ import (
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 )
 
 // FetchKubeconfigSecret reads the kubeconfig bytes published under key in the named Secret once
@@ -34,6 +36,72 @@ func FetchKubeconfigSecret(
 	}
 
 	return raw, nil
+}
+
+// ConnectorKubeconfig is the shared Connector read path: it validates the
+// resolved cluster name and host clientset, then fetches the published
+// kubeconfig Secret. Callers resolve the per-distribution connection
+// coordinates (namespace/secret/key) and wrap errors with their
+// distribution label.
+func ConnectorKubeconfig(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	clusterName, namespace, secretName, key string,
+) ([]byte, error) {
+	if clusterName == "" {
+		return nil, fmt.Errorf("%w: cluster name not set", clustererr.ErrConfigNil)
+	}
+
+	if clientset == nil {
+		return nil, fmt.Errorf("%w: host clientset not set", clustererr.ErrConfigNil)
+	}
+
+	return FetchKubeconfigSecret(ctx, clientset, namespace, secretName, key)
+}
+
+// UpsertSecret creates secret, or — when it already exists — re-reads the live
+// object and updates that in place so the write carries the current
+// resourceVersion (an Update built from a fresh object would be rejected by
+// the API server's optimistic-concurrency check). Get/Update conflicts with
+// concurrent writers are retried.
+func UpsertSecret(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	secret *corev1.Secret,
+) error {
+	_, err := clientset.CoreV1().Secrets(secret.Namespace).
+		Create(ctx, secret, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, getErr := clientset.CoreV1().Secrets(secret.Namespace).
+			Get(ctx, secret.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("get secret %s/%s: %w", secret.Namespace, secret.Name, getErr)
+		}
+
+		existing.Labels = secret.Labels
+		existing.Data = secret.Data
+
+		_, updateErr := clientset.CoreV1().Secrets(secret.Namespace).
+			Update(ctx, existing, metav1.UpdateOptions{})
+		if updateErr != nil {
+			return fmt.Errorf("update secret %s/%s: %w", secret.Namespace, secret.Name, updateErr)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("upsert secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	}
+
+	return nil
 }
 
 // fetchSecretData is the single Get+NotFound+Data[key] step shared by

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -322,18 +322,11 @@ func (p *K3kProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, e
 		clusterName = name
 	}
 
-	if clusterName == "" {
-		return nil, fmt.Errorf("%w: k3k cluster name not set", clustererr.ErrConfigNil)
-	}
-
-	if p.hostClientset == nil {
-		return nil, fmt.Errorf("%w: host clientset not set", clustererr.ErrConfigNil)
-	}
-
 	conn := ConnectionFor(clusterName)
 
-	raw, err := nested.FetchKubeconfigSecret(
-		ctx, p.hostClientset, conn.Namespace, conn.SecretName, k3kKubeconfigKey,
+	raw, err := nested.ConnectorKubeconfig(
+		ctx, p.hostClientset, clusterName,
+		conn.Namespace, conn.SecretName, k3kKubeconfigKey,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("k3k: %w", err)

--- a/pkg/svc/provisioner/cluster/talos/connection.go
+++ b/pkg/svc/provisioner/cluster/talos/connection.go
@@ -1,0 +1,65 @@
+package talosprovisioner
+
+import (
+	"fmt"
+
+	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
+)
+
+// Connection coordinates for a nested Talos cluster on a host Kubernetes cluster. These are the
+// single source of truth for the naming contract between the DinD exposure resources ksail
+// creates (namespace + apiserver Service) and the kubeconfig Secret it publishes at create time.
+// The operator imports these (rather than re-deriving them) so a naming change here can never
+// silently break operator component installs or status observation.
+const (
+	// talosKubeconfigSecretSuffix is appended to the prefixed cluster name for the kubeconfig
+	// Secret ("talos-<name>-kubeconfig", mirroring k3k's "k3k-<name>-kubeconfig").
+	talosKubeconfigSecretSuffix = "kubeconfig"
+	// talosKubeconfigKey is the Secret data key holding the kubeconfig ("kubeconfig.yaml",
+	// the same key the k3k operator publishes under).
+	talosKubeconfigKey = "kubeconfig.yaml"
+)
+
+// Connection holds the in-hub coordinates for a named nested Talos cluster: the namespace and
+// kubeconfig Secret ksail publishes and the in-cluster API endpoint reachable from where the
+// ksail operator runs.
+type Connection struct {
+	// Namespace is the host-cluster namespace holding the DinD pod, the apiserver Service, and
+	// the published kubeconfig Secret ("ksail-<name>" — the shared DinD exposure namespace, so
+	// the Secret's lifecycle is tied to the cluster's and namespace deletion cleans it up).
+	Namespace string
+	// SecretName is the kubeconfig Secret name in Namespace ("talos-<name>-kubeconfig").
+	SecretName string
+	// Endpoint is the in-cluster API server URL ("https://apiserver.ksail-<name>:6443").
+	// The bare "<service>.<namespace>" form (no ".svc" suffix) mirrors the k3k Connection
+	// contract; CertSANs() covers both forms so either resolves and verifies.
+	Endpoint string
+}
+
+// ConnectionFor returns the in-hub connection coordinates for the named nested Talos cluster. It
+// is the single source of truth shared by prepareExposure (cert SANs), the create-time Secret
+// publish, the provisioner's Kubeconfig(), and any operator-side consumer, so the
+// namespace/secret/endpoint contract is derived in exactly one place.
+func ConnectionFor(name string) Connection {
+	namespace := kubernetesprovider.NamespaceName(name)
+
+	return Connection{
+		Namespace:  namespace,
+		SecretName: fmt.Sprintf("talos-%s-%s", name, talosKubeconfigSecretSuffix),
+		Endpoint: fmt.Sprintf(
+			"https://%s.%s:%d",
+			kubernetesprovider.APIServiceName, namespace, kubernetesprovider.DinDAPIServerPort,
+		),
+	}
+}
+
+// CertSANs returns the in-cluster DNS names the nested API server certificate must cover so the
+// published kubeconfig's Endpoint verifies against the served cert with the kubeconfig's own CA
+// (no tls-server-name override needed). Unlike k3k — whose operator inserts the Service DNS SAN
+// itself — the Talos exposure flow only bakes in the host-reachable address, so ksail adds these
+// during prepareExposure before the cluster PKI is generated.
+func (c Connection) CertSANs() []string {
+	host := kubernetesprovider.APIServiceName + "." + c.Namespace
+
+	return []string{host, host + ".svc"}
+}

--- a/pkg/svc/provisioner/cluster/talos/connector_test.go
+++ b/pkg/svc/provisioner/cluster/talos/connector_test.go
@@ -1,0 +1,204 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// The nested Talos provisioner must satisfy the operator's Connector capability.
+var _ clusterprovisioner.Connector = (*talosprovisioner.KubernetesProvisioner)(nil)
+
+const talosConnectorTestCluster = "nested-talos"
+
+// talosFetchedKubeconfig is a minimal valid kubeconfig as fetched from the Talos API during
+// create — the server points at a DinD-internal loopback endpoint, unreachable from an
+// operator pod, so the publish step must rewrite it.
+const talosFetchedKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:56443
+  name: nested-talos
+contexts:
+- context:
+    cluster: nested-talos
+    user: admin@nested-talos
+  name: admin@nested-talos
+current-context: admin@nested-talos
+users:
+- name: admin@nested-talos
+  user: {}
+`
+
+func TestConnectionFor(t *testing.T) {
+	t.Parallel()
+
+	conn := talosprovisioner.ConnectionFor(talosConnectorTestCluster)
+
+	assert.Equal(t, "ksail-nested-talos", conn.Namespace)
+	assert.Equal(t, "talos-nested-talos-kubeconfig", conn.SecretName)
+	assert.Equal(t, "https://apiserver.ksail-nested-talos:6443", conn.Endpoint)
+}
+
+func TestConnectionCertSANs(t *testing.T) {
+	t.Parallel()
+
+	conn := talosprovisioner.ConnectionFor(talosConnectorTestCluster)
+
+	assert.Equal(
+		t,
+		[]string{"apiserver.ksail-nested-talos", "apiserver.ksail-nested-talos.svc"},
+		conn.CertSANs(),
+	)
+}
+
+func newTalosKubernetesProvisionerWithClientset(
+	t *testing.T, clientset *k8sfake.Clientset,
+) *talosprovisioner.KubernetesProvisioner {
+	t.Helper()
+
+	provisioner, err := talosprovisioner.NewKubernetesProvisioner(
+		talosprovisioner.KubernetesProvisionerConfig{
+			HostClientset:  clientset,
+			ClusterName:    talosConnectorTestCluster,
+			KubeconfigPath: filepath.Join(t.TempDir(), "kubeconfig"),
+		},
+	)
+	require.NoError(t, err)
+
+	return provisioner
+}
+
+func TestKubeconfig_NotReadyWhileSecretUnpublished(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newTalosKubernetesProvisionerWithClientset(t, k8sfake.NewClientset())
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_NotReadyWhileSecretKeyEmpty(t *testing.T) {
+	t.Parallel()
+
+	conn := talosprovisioner.ConnectionFor(talosConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+	})
+	provisioner := newTalosKubernetesProvisionerWithClientset(t, clientset)
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_ReturnsSecretAsPublished(t *testing.T) {
+	t.Parallel()
+
+	published := []byte("apiVersion: v1\nkind: Config\n")
+	conn := talosprovisioner.ConnectionFor(talosConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": published},
+	})
+	provisioner := newTalosKubernetesProvisionerWithClientset(t, clientset)
+
+	out, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.NoError(t, err)
+	assert.Equal(t, published, out)
+}
+
+func TestKubeconfig_ErrorsWhenClientsetNil(t *testing.T) {
+	t.Parallel()
+
+	provisioner, err := talosprovisioner.NewKubernetesProvisioner(
+		talosprovisioner.KubernetesProvisionerConfig{
+			ClusterName:    talosConnectorTestCluster,
+			KubeconfigPath: filepath.Join(t.TempDir(), "kubeconfig"),
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrConfigNil)
+}
+
+func TestPublishConnectorKubeconfig_RewritesServerToInClusterEndpoint(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	provisioner := newTalosKubernetesProvisionerWithClientset(t, clientset)
+	conn := talosprovisioner.ConnectionFor(talosConnectorTestCluster)
+
+	err := provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), talosConnectorTestCluster, []byte(talosFetchedKubeconfig),
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().
+		Secrets(conn.Namespace).
+		Get(context.Background(), conn.SecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(secret.Data["kubeconfig.yaml"])
+	require.NoError(t, err)
+	require.NotEmpty(t, config.Clusters)
+
+	for _, cluster := range config.Clusters {
+		assert.Equal(t, conn.Endpoint, cluster.Server)
+	}
+}
+
+func TestPublishConnectorKubeconfig_UpdatesExistingSecret(t *testing.T) {
+	t.Parallel()
+
+	conn := talosprovisioner.ConnectionFor(talosConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": []byte("stale")},
+	})
+	provisioner := newTalosKubernetesProvisionerWithClientset(t, clientset)
+
+	err := provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), talosConnectorTestCluster, []byte(talosFetchedKubeconfig),
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().
+		Secrets(conn.Namespace).
+		Get(context.Background(), conn.SecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotEqual(t, []byte("stale"), secret.Data["kubeconfig.yaml"])
+}
+
+func TestPublishConnectorKubeconfig_ErrorsWhenClientsetNil(t *testing.T) {
+	t.Parallel()
+
+	provisioner, err := talosprovisioner.NewKubernetesProvisioner(
+		talosprovisioner.KubernetesProvisionerConfig{
+			ClusterName:    talosConnectorTestCluster,
+			KubeconfigPath: filepath.Join(t.TempDir(), "kubeconfig"),
+		},
+	)
+	require.NoError(t, err)
+
+	err = provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), talosConnectorTestCluster, []byte(talosFetchedKubeconfig),
+	)
+
+	require.ErrorIs(t, err, clustererr.ErrConfigNil)
+}

--- a/pkg/svc/provisioner/cluster/talos/connector_test.go
+++ b/pkg/svc/provisioner/cluster/talos/connector_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -183,6 +185,49 @@ func TestPublishConnectorKubeconfig_UpdatesExistingSecret(t *testing.T) {
 		Get(context.Background(), conn.SecretName, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.NotEqual(t, []byte("stale"), secret.Data["kubeconfig.yaml"])
+}
+
+// The update path must write through the LIVE object so the API server's
+// optimistic-concurrency check sees the current resourceVersion — an Update
+// built from a freshly constructed Secret would carry none and be rejected
+// (the fake clientset tolerates that, so assert on the submitted object).
+func TestPublishConnectorKubeconfig_UpdateCarriesLiveResourceVersion(t *testing.T) {
+	t.Parallel()
+
+	conn := talosprovisioner.ConnectionFor(talosConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            conn.SecretName,
+			Namespace:       conn.Namespace,
+			ResourceVersion: "42",
+		},
+		Data: map[string][]byte{"kubeconfig.yaml": []byte("stale")},
+	})
+
+	var submittedResourceVersion string
+
+	clientset.PrependReactor(
+		"update", "secrets",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			update, ok := action.(k8stesting.UpdateAction)
+			require.True(t, ok)
+
+			updated, ok := update.GetObject().(*corev1.Secret)
+			require.True(t, ok)
+
+			submittedResourceVersion = updated.ResourceVersion
+
+			return false, nil, nil
+		},
+	)
+
+	provisioner := newTalosKubernetesProvisionerWithClientset(t, clientset)
+
+	err := provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), talosConnectorTestCluster, []byte(talosFetchedKubeconfig),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "42", submittedResourceVersion)
 }
 
 func TestPublishConnectorKubeconfig_ErrorsWhenClientsetNil(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -929,3 +929,13 @@ func (p *Provisioner) BuildStorageHealthProberOrWarnForTest(
 ) bool {
 	return p.buildStorageHealthProberOrWarn(ctx, clientset, clusterName) != nil
 }
+
+// PublishConnectorKubeconfigForTest exercises the create-time Connector Secret publish with
+// caller-supplied kubeconfig bytes (the seam replaces the live Talos clusterAccess fetch).
+func (p *KubernetesProvisioner) PublishConnectorKubeconfigForTest(
+	ctx context.Context,
+	clusterName string,
+	raw []byte,
+) error {
+	return p.publishConnectorKubeconfig(ctx, clusterName, raw)
+}

--- a/pkg/svc/provisioner/cluster/talos/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/kubernetes_provisioner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/access"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -345,18 +344,11 @@ func (p *KubernetesProvisioner) Kubeconfig(ctx context.Context, name string) ([]
 		clusterName = p.clusterName
 	}
 
-	if clusterName == "" {
-		return nil, fmt.Errorf("%w: talos cluster name not set", clustererr.ErrConfigNil)
-	}
-
-	if p.hostClientset == nil {
-		return nil, fmt.Errorf("%w: host clientset not set", clustererr.ErrConfigNil)
-	}
-
 	conn := ConnectionFor(clusterName)
 
-	raw, err := nested.FetchKubeconfigSecret(
-		ctx, p.hostClientset, conn.Namespace, conn.SecretName, talosKubeconfigKey,
+	raw, err := nested.ConnectorKubeconfig(
+		ctx, p.hostClientset, clusterName,
+		conn.Namespace, conn.SecretName, talosKubeconfigKey,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("talos: %w", err)
@@ -494,17 +486,9 @@ func (p *KubernetesProvisioner) publishConnectorKubeconfig(
 		Data: map[string][]byte{talosKubeconfigKey: rewritten},
 	}
 
-	_, err = p.hostClientset.CoreV1().
-		Secrets(conn.Namespace).
-		Create(ctx, secret, metav1.CreateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		_, err = p.hostClientset.CoreV1().
-			Secrets(conn.Namespace).
-			Update(ctx, secret, metav1.UpdateOptions{})
-	}
-
+	err = nested.UpsertSecret(ctx, p.hostClientset, secret)
 	if err != nil {
-		return fmt.Errorf("write kubeconfig secret %s/%s: %w", conn.Namespace, conn.SecretName, err)
+		return fmt.Errorf("write kubeconfig secret: %w", err)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/talos/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/kubernetes_provisioner.go
@@ -14,6 +14,7 @@ import (
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/registry"
 	"github.com/docker/docker/api/types/container"
@@ -21,7 +22,11 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/access"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -37,6 +42,7 @@ type KubernetesProvisioner struct {
 	inner            *Provisioner
 	k8sProvider      *kubernetesprovider.Provider
 	dynamicClient    dynamic.Interface
+	hostClientset    kubernetes.Interface
 	restConfig       *rest.Config
 	clusterName      string
 	distribution     string
@@ -58,6 +64,9 @@ type KubernetesProvisionerConfig struct {
 	K8sProvider *kubernetesprovider.Provider
 	// DynamicClient is the dynamic client for Gateway API resources.
 	DynamicClient dynamic.Interface
+	// HostClientset is the typed client for the host cluster, used to publish the nested
+	// cluster's kubeconfig Secret for the Connector contract.
+	HostClientset kubernetes.Interface
 	// RestConfig is the REST config for port-forwarding to the DinD pod.
 	RestConfig *rest.Config
 	// ClusterName is the nested cluster name.
@@ -92,6 +101,7 @@ func NewKubernetesProvisioner(cfg KubernetesProvisionerConfig) (*KubernetesProvi
 		inner:            cfg.InnerProvisioner,
 		k8sProvider:      cfg.K8sProvider,
 		dynamicClient:    cfg.DynamicClient,
+		hostClientset:    cfg.HostClientset,
 		restConfig:       cfg.RestConfig,
 		clusterName:      cfg.ClusterName,
 		distribution:     cfg.Distribution,
@@ -308,7 +318,51 @@ func (p *KubernetesProvisioner) Create(ctx context.Context, name string) error {
 		return fmt.Errorf("repoint kubeconfig at exposure address: %w", err)
 	}
 
+	// Publish the kubeconfig as an in-cluster Secret so the operator (Connector contract) can
+	// reach the nested cluster without a DinD-internal or host-only address.
+	raw, err := clusterAccess.Kubeconfig(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch kubeconfig for connector publish: %w", err)
+	}
+
+	err = p.publishConnectorKubeconfig(ctx, clusterName, raw)
+	if err != nil {
+		return fmt.Errorf("publish connector kubeconfig: %w", err)
+	}
+
 	return nil
+}
+
+// Kubeconfig returns a kubeconfig for the named nested Talos cluster reachable from inside the
+// host cluster (where the operator runs). Create publishes it with the API server already
+// rewritten to the in-cluster apiserver Service endpoint (see publishConnectorKubeconfig), so it
+// is served as-published. It satisfies the clusterprovisioner.Connector capability and returns
+// clustererr.ErrKubeconfigNotReady while the talos-<name>-kubeconfig Secret has not been
+// published yet.
+func (p *KubernetesProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	clusterName := name
+	if clusterName == "" {
+		clusterName = p.clusterName
+	}
+
+	if clusterName == "" {
+		return nil, fmt.Errorf("%w: talos cluster name not set", clustererr.ErrConfigNil)
+	}
+
+	if p.hostClientset == nil {
+		return nil, fmt.Errorf("%w: host clientset not set", clustererr.ErrConfigNil)
+	}
+
+	conn := ConnectionFor(clusterName)
+
+	raw, err := nested.FetchKubeconfigSecret(
+		ctx, p.hostClientset, conn.Namespace, conn.SecretName, talosKubeconfigKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("talos: %w", err)
+	}
+
+	return raw, nil
 }
 
 // Delete deletes the Talos cluster inside DinD and cleans up host cluster resources.
@@ -394,8 +448,13 @@ func (p *KubernetesProvisioner) prepareExposure(
 		return nil, fmt.Errorf("expose API server: %w", err)
 	}
 
+	// The in-cluster Service DNS names (Connection.CertSANs) are included so the kubeconfig
+	// published for the Connector contract verifies against the served certificate.
 	newConfigs, err := p.inner.talosConfigs.WithCertSANs(
-		[]string{"127.0.0.1", "localhost", exposure.Address},
+		append(
+			[]string{"127.0.0.1", "localhost", exposure.Address},
+			ConnectionFor(clusterName).CertSANs()...,
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("add exposure address to cert SANs: %w", err)
@@ -404,6 +463,51 @@ func (p *KubernetesProvisioner) prepareExposure(
 	p.inner.talosConfigs = newConfigs
 
 	return exposure, nil
+}
+
+// publishConnectorKubeconfig publishes the nested cluster's kubeconfig in the exposure namespace
+// under the Connection naming contract, with every server rewritten to the in-cluster apiserver
+// Service endpoint (a cert SAN since prepareExposure — never a DinD-internal address). Kubeconfig()
+// serves this Secret back to the operator as-published.
+func (p *KubernetesProvisioner) publishConnectorKubeconfig(
+	ctx context.Context,
+	clusterName string,
+	raw []byte,
+) error {
+	if p.hostClientset == nil {
+		return fmt.Errorf("%w: host clientset not set", clustererr.ErrConfigNil)
+	}
+
+	conn := ConnectionFor(clusterName)
+
+	rewritten, err := rewriteKubeconfigEndpoint(raw, conn.Endpoint)
+	if err != nil {
+		return fmt.Errorf("rewrite kubeconfig to in-cluster endpoint: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      conn.SecretName,
+			Namespace: conn.Namespace,
+			Labels:    kubernetesprovider.CommonLabels(clusterName),
+		},
+		Data: map[string][]byte{talosKubeconfigKey: rewritten},
+	}
+
+	_, err = p.hostClientset.CoreV1().
+		Secrets(conn.Namespace).
+		Create(ctx, secret, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		_, err = p.hostClientset.CoreV1().
+			Secrets(conn.Namespace).
+			Update(ctx, secret, metav1.UpdateOptions{})
+	}
+
+	if err != nil {
+		return fmt.Errorf("write kubeconfig secret %s/%s: %w", conn.Namespace, conn.SecretName, err)
+	}
+
+	return nil
 }
 
 // discoverMappedPorts returns the host ports the Talos API and Kubernetes API are published on


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The operator inside a management cluster can only run component installs against a nested cluster when it can fetch that cluster's kubeconfig from an in-cluster Secret. Nested Talos publishes nothing the operator can reach — its kubeconfig points at DinD-internal addresses.

## What
Talos now follows the k3k pattern: at create time it publishes the kubeconfig as a Secret with the API server rewritten to the in-cluster Service endpoint (added to the cert SANs so it verifies cleanly), and the provisioner serves it back through the shared Connector contract. Kind and KWOK follow as separate children.

Fixes #5743 · Part of #4899