### PR TITLE
feat(cloudinit): deliver a pre-generated SSH host identity via ssh_keys

### DIFF
--- a/pkg/svc/bootstrap/cloudinit/cloudinit.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit.go
@@ -70,6 +70,14 @@ type Config struct {
 	// would create a server that never bootstraps, so a keys-only Config is
 	// still rejected with [ErrNoCommands].
 	SSHAuthorizedKeys []string
+	// HostKeys is a pre-generated SSH host identity delivered via cloud-init's
+	// `ssh_keys:` module, replacing the host keys the image would otherwise
+	// generate at first boot. Delivering the identity up front lets the SSH
+	// bootstrap client pin the host key (golang.org/x/crypto/ssh.FixedHostKey)
+	// instead of trusting first contact. Optional; when set, both halves are
+	// required (see [ErrInvalidHostKeys]). Like SSHAuthorizedKeys, a host
+	// identity alone does not make a Config renderable ([ErrNoCommands]).
+	HostKeys *HostKeys
 	// ScriptPath overrides where the boot script is written. Optional; defaults to
 	// [DefaultScriptPath]. Must be absolute when set (see [ErrPathNotAbsolute]).
 	ScriptPath string
@@ -114,6 +122,20 @@ type File struct {
 	Content string
 }
 
+// HostKeys is cloud-init's `ssh_keys:` module limited to the ed25519 host
+// identity this package delivers: the private half the node's sshd serves and
+// the matching public half a bootstrap client pins. ed25519 matches the
+// bootstrap keypair the ssh bootstrap package generates.
+type HostKeys struct {
+	// ED25519Private is the PEM-encoded ed25519 private host key. Required when
+	// HostKeys is set; spans multiple lines, no NUL byte (see
+	// [ErrInvalidHostKeys]).
+	ED25519Private string
+	// ED25519Public is the single-line (authorized_keys-style) public host key.
+	// Required when HostKeys is set (see [ErrInvalidHostKeys]).
+	ED25519Public string
+}
+
 // cloudConfig is the subset of the cloud-init schema this package emits. It is
 // marshalled to YAML and prefixed with the `#cloud-config` header. Every field
 // is omitempty so a command-only Config renders exactly as it did before the
@@ -124,8 +146,19 @@ type cloudConfig struct {
 	Apt        *aptConfig  `yaml:"apt,omitempty"`
 	Packages   []string    `yaml:"packages,omitempty"`
 	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key "ssh_authorized_keys".
-	SSHAuthorizedKeys []string   `yaml:"ssh_authorized_keys,omitempty"`
-	RunCmd            [][]string `yaml:"runcmd,omitempty"`
+	SSHAuthorizedKeys []string `yaml:"ssh_authorized_keys,omitempty"`
+	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key "ssh_keys".
+	SSHKeys *sshKeysConfig `yaml:"ssh_keys,omitempty"`
+	RunCmd  [][]string     `yaml:"runcmd,omitempty"`
+}
+
+// sshKeysConfig is cloud-init's `ssh_keys:` module, limited to the ed25519
+// host identity this package emits (see [HostKeys]).
+type sshKeysConfig struct {
+	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key "ed25519_private".
+	ED25519Private string `yaml:"ed25519_private"`
+	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key "ed25519_public".
+	ED25519Public string `yaml:"ed25519_public"`
 }
 
 // writeFile is one entry of cloud-init's write_files module: a file dropped onto
@@ -186,12 +219,14 @@ type directives struct {
 	sources  map[string]aptSource
 	files    []writeFile
 	sshKeys  []string
+	hostKeys *sshKeysConfig
 }
 
 // empty reports whether there is nothing to render — no command, package, apt
-// source, or file. SSH authorized keys are deliberately excluded: a keys-only
-// document would create a server that never bootstraps, so keys alone don't
-// make a Config renderable (see [Config.SSHAuthorizedKeys]).
+// source, or file. SSH authorized keys and the host identity are deliberately
+// excluded: a keys-only document would create a server that never bootstraps,
+// so keys alone don't make a Config renderable (see
+// [Config.SSHAuthorizedKeys]).
 func (d directives) empty() bool {
 	return len(d.commands) == 0 &&
 		len(d.packages) == 0 &&
@@ -227,12 +262,22 @@ func (cfg Config) validate() (directives, error) {
 		return directives{}, err
 	}
 
+	var hostKeys *sshKeysConfig
+
+	if cfg.HostKeys != nil {
+		hostKeys, err = cfg.validatedHostKeys()
+		if err != nil {
+			return directives{}, err
+		}
+	}
+
 	dirs := directives{
 		commands: commands,
 		packages: packages,
 		sources:  sources,
 		files:    files,
 		sshKeys:  sshKeys,
+		hostKeys: hostKeys,
 	}
 	if dirs.empty() {
 		return directives{}, ErrNoCommands
@@ -263,6 +308,24 @@ func (cfg Config) validatedSSHAuthorizedKeys() ([]string, error) {
 	return keys, nil
 }
 
+// validatedHostKeys returns cfg's (non-nil) host identity as the rendered
+// ssh_keys module. Both halves are required together; the public half must be
+// a single line; neither may contain a NUL byte.
+func (cfg Config) validatedHostKeys() (*sshKeysConfig, error) {
+	private := cfg.HostKeys.ED25519Private
+	public := cfg.HostKeys.ED25519Public
+
+	if strings.TrimSpace(private) == "" || strings.TrimSpace(public) == "" {
+		return nil, ErrInvalidHostKeys
+	}
+
+	if strings.ContainsRune(private, '\x00') || strings.ContainsAny(public, "\n\x00") {
+		return nil, ErrInvalidHostKeys
+	}
+
+	return &sshKeysConfig{ED25519Private: private, ED25519Public: public}, nil
+}
+
 // buildDoc assembles the cloud-config from already-validated directives. Files
 // are written first, then apt sources and packages, then (when there are
 // commands) the boot script and the runcmd that executes it — matching
@@ -273,6 +336,7 @@ func (cfg Config) buildDoc(dirs directives) (cloudConfig, error) {
 		WriteFiles:        dirs.files,
 		Packages:          dirs.packages,
 		SSHAuthorizedKeys: dirs.sshKeys,
+		SSHKeys:           dirs.hostKeys,
 	}
 
 	if len(dirs.sources) > 0 {

--- a/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
@@ -26,8 +26,15 @@ type parsedConfig struct {
 	} `yaml:"apt"`
 	Packages []string `yaml:"packages"`
 	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key.
-	SSHAuthorizedKeys []string   `yaml:"ssh_authorized_keys"`
-	RunCmd            [][]string `yaml:"runcmd"`
+	SSHAuthorizedKeys []string `yaml:"ssh_authorized_keys"`
+	//nolint:tagliatelle // cloud-init's schema mandates the snake_case key.
+	SSHKeys struct {
+		//nolint:tagliatelle // cloud-init's schema mandates the snake_case key.
+		ED25519Private string `yaml:"ed25519_private"`
+		//nolint:tagliatelle // cloud-init's schema mandates the snake_case key.
+		ED25519Public string `yaml:"ed25519_public"`
+	} `yaml:"ssh_keys"`
+	RunCmd [][]string `yaml:"runcmd"`
 }
 
 // parse asserts the document carries the cloud-config header and is valid YAML,
@@ -244,6 +251,81 @@ func TestBuildUserDataSSHKeyErrors(t *testing.T) {
 				SSHAuthorizedKeys: []string{key},
 			})
 			require.ErrorIs(t, err, cloudinitbootstrap.ErrInvalidSSHAuthorizedKey)
+		})
+	}
+}
+
+func TestBuildUserDataRendersHostKeys(t *testing.T) {
+	t.Parallel()
+
+	private := "-----BEGIN OPENSSH PRIVATE KEY-----\nAAAA\n-----END OPENSSH PRIVATE KEY-----\n"
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"echo hi"},
+		HostKeys: &cloudinitbootstrap.HostKeys{
+			ED25519Private: private,
+			ED25519Public:  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA host",
+		},
+	})
+	require.NoError(t, err)
+
+	cfg := parse(t, userData)
+	assert.Equal(t, private, cfg.SSHKeys.ED25519Private)
+	assert.Equal(t, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA host", cfg.SSHKeys.ED25519Public)
+}
+
+func TestBuildUserDataOmitsHostKeysWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"echo hi"},
+	})
+	require.NoError(t, err)
+
+	assert.NotContains(t, userData, "ssh_keys:")
+}
+
+func TestBuildUserDataHostKeysOnlyRejected(t *testing.T) {
+	t.Parallel()
+
+	// A host identity with nothing to run would create a server that never
+	// bootstraps, so an identity-only Config is rejected like an empty one.
+	_, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		HostKeys: &cloudinitbootstrap.HostKeys{
+			ED25519Private: "-----BEGIN OPENSSH PRIVATE KEY-----\nAAAA\n-----END OPENSSH PRIVATE KEY-----\n",
+			ED25519Public:  "ssh-ed25519 AAAA host",
+		},
+	})
+	require.ErrorIs(t, err, cloudinitbootstrap.ErrNoCommands)
+}
+
+func TestBuildUserDataHostKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	private := "-----BEGIN OPENSSH PRIVATE KEY-----\nAAAA\n-----END OPENSSH PRIVATE KEY-----\n"
+
+	tests := map[string]cloudinitbootstrap.HostKeys{
+		"missing private": {ED25519Public: "ssh-ed25519 AAAA host"},
+		"missing public":  {ED25519Private: private},
+		"multi-line public": {
+			ED25519Private: private,
+			ED25519Public:  "ssh-ed25519 AAAA\nhost",
+		},
+		"NUL in private": {
+			ED25519Private: "-----BEGIN\x00-----",
+			ED25519Public:  "ssh-ed25519 AAAA host",
+		},
+	}
+
+	for name, hostKeys := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+				Commands: []string{"echo hi"},
+				HostKeys: &hostKeys,
+			})
+			require.ErrorIs(t, err, cloudinitbootstrap.ErrInvalidHostKeys)
 		})
 	}
 }

--- a/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
+++ b/pkg/svc/bootstrap/cloudinit/cloudinit_test.go
@@ -315,6 +315,10 @@ func TestBuildUserDataHostKeyErrors(t *testing.T) {
 			ED25519Private: "-----BEGIN\x00-----",
 			ED25519Public:  "ssh-ed25519 AAAA host",
 		},
+		"NUL in public": {
+			ED25519Private: private,
+			ED25519Public:  "ssh-ed25519 AAAA\x00host",
+		},
 	}
 
 	for name, hostKeys := range tests {

--- a/pkg/svc/bootstrap/cloudinit/errors.go
+++ b/pkg/svc/bootstrap/cloudinit/errors.go
@@ -35,6 +35,15 @@ var (
 		"cloud-init: an SSH authorized key must be a single line with no NUL byte",
 	)
 
+	// ErrInvalidHostKeys is returned when [Config.HostKeys] is set but incomplete
+	// (either half blank), the public half is not a single line, or either half
+	// contains a NUL byte. Delivering only half an identity would leave the node
+	// serving one host key while the client pins another, so both halves are
+	// required together.
+	ErrInvalidHostKeys = errors.New(
+		"cloud-init: host keys need both the PEM private half and a single-line public half",
+	)
+
 	// ErrInvalidAptSource is returned when an [AptSource] has a blank or multi-line
 	// Name or Source, a Name containing a path separator, a Key containing a NUL
 	// byte, or a Name that duplicates another source's. cloud-init keys the sources


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The Hetzner live bring-up (#5726) must not trust a node's SSH host key on first contact — the dial needs a host identity it already knows, which means delivering pre-generated host keys to the node at boot.

## What
Adds host-identity delivery to the cloud-init composer (the `ssh_keys:` module, ed25519, both halves required together, validated + tested). This is the missing primitive for #5726's host-key pinning; the composePlan wiring that consumes it follows separately.

Part of #5726