### PR TITLE
feat(hetzner): multi-node bring-up for K3s × Hetzner (control plane + agents)

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
@@ -33,13 +34,21 @@ var (
 		"hetzner: no kubeconfig destination path is configured",
 	)
 
-	// ErrMultiNodeNotImplemented is returned by [Base.RunCreate] for a topology with
-	// joining nodes (more than one control-plane node, or any agent). Joining nodes
-	// register against the first node's address, which is only known once that node
-	// is running, so multi-node bring-up requires the runtime sequencing tracked by
-	// devantler-tech/ksail#5515.
+	// ErrMultiNodeNotImplemented is returned by [Base.Create] for a topology with
+	// agents when the distribution's strategy does not yet implement the joining-node
+	// bring-up ([MultiNodeComposer]) — currently the kubeadm × Hetzner provisioner,
+	// whose bootstrap has no API-server-endpoint threading yet. The two-phase join
+	// sequencing is tracked by devantler-tech/ksail#5755.
 	ErrMultiNodeNotImplemented = errors.New(
-		"hetzner: multi-node bring-up is not yet implemented (tracked by #5515)",
+		"hetzner: multi-node bring-up is not yet implemented for this distribution (tracked by #5755)",
+	)
+
+	// ErrHAControlPlaneNotImplemented is returned by [Base.Create] for a topology with
+	// more than one control-plane node. Additional control planes join the cluster's
+	// etcd, which needs quorum-aware ordering beyond the single-control-plane +
+	// agents path; it is a later increment of devantler-tech/ksail#5755.
+	ErrHAControlPlaneNotImplemented = errors.New(
+		"hetzner: high-availability (multi-control-plane) bring-up is not yet implemented (tracked by #5755)",
 	)
 )
 
@@ -129,6 +138,15 @@ type Base struct {
 	// and the node-token generator. Each provisioner sets itself here at
 	// construction so it inherits [Create] by embedding *Base.
 	Strategy CreateStrategy
+	// BringUpPort is the SSH port the multi-node bring-up dials on a created node;
+	// empty means the standard port 22 (the production default — stock OS images
+	// run sshd there). The single-node path threads its port through the composed
+	// [BringUpPlan] instead; this field lets the multi-node engine, which composes
+	// internally, be exercised against a non-standard port.
+	BringUpPort string
+	// BringUpPollInterval is the delay between the multi-node bring-up's probes for
+	// a node's admin kubeconfig; zero means [DefaultKubeconfigPollInterval].
+	BringUpPollInterval time.Duration
 }
 
 // CreateStrategy is the distribution-specific seam [Base.Create] composes with
@@ -349,7 +367,14 @@ func (b *Base) RunCreate(
 		return fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
 	}
 
-	if b.ControlPlanes > 1 || b.Agents > 0 {
+	// RunCreate is the single-node engine; [Base.Create] routes multi-node
+	// topologies to [Base.RunCreateMultiNode] before reaching here, so these
+	// guards are a defensive backstop for a direct caller.
+	if b.ControlPlanes > 1 {
+		return ErrHAControlPlaneNotImplemented
+	}
+
+	if b.Agents > 0 {
 		return ErrMultiNodeNotImplemented
 	}
 
@@ -378,20 +403,47 @@ func (b *Base) RunCreate(
 }
 
 // Create runs the whole create flow shared by both provisioners, so neither
-// re-writes it: it wires the embedded [CreateStrategy]'s per-node composition
-// into the shared plan composition ([PlanComposer]) and runs [Base.RunCreate],
-// wrapping a failure with the strategy's distribution label. Each provisioner
-// gets this method by embedding *Base; the distro-specific pieces come from the
-// Strategy it sets at construction.
+// re-writes it. It routes by topology: the single-control-plane, no-agent path
+// wires the embedded [CreateStrategy]'s per-node composition into the shared plan
+// composition ([PlanComposer]) and runs [Base.RunCreate]; a topology with agents
+// runs the two-phase multi-node bring-up ([Base.RunCreateMultiNode]) when the
+// strategy implements [MultiNodeComposer] (currently k3s), and is rejected
+// otherwise. High-availability (multiple control planes) is a later increment.
+// Each provisioner gets this method by embedding *Base; the distro-specific
+// pieces come from the Strategy it sets at construction.
 func (b *Base) Create(ctx context.Context, name string) error {
-	composePlan := PlanComposer(b.Opts, b.Strategy.RemoteKubeconfigPath(), b.Strategy.ComposeNodes)
-
-	err := b.RunCreate(ctx, name, composePlan, b.Strategy.GenerateToken)
+	err := b.create(ctx, name)
 	if err != nil {
 		return fmt.Errorf("provision %s cluster: %w", b.Strategy.DistroLabel(), err)
 	}
 
 	return nil
+}
+
+// create dispatches to the single-node or multi-node engine by topology; its
+// error is wrapped with the distribution label by [Base.Create].
+func (b *Base) create(ctx context.Context, name string) error {
+	if b.ControlPlanes > 1 {
+		return ErrHAControlPlaneNotImplemented
+	}
+
+	if b.Agents > 0 {
+		composer, ok := b.Strategy.(MultiNodeComposer)
+		if !ok {
+			return ErrMultiNodeNotImplemented
+		}
+
+		material, err := GenerateBootstrapMaterial()
+		if err != nil {
+			return fmt.Errorf("generate bootstrap material: %w", err)
+		}
+
+		return b.RunCreateMultiNode(ctx, name, composer, material)
+	}
+
+	composePlan := PlanComposer(b.Opts, b.Strategy.RemoteKubeconfigPath(), b.Strategy.ComposeNodes)
+
+	return b.RunCreate(ctx, name, composePlan, b.Strategy.GenerateToken)
 }
 
 // bringUpFromPlan runs the live half of the create flow from a composed plan:

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -358,15 +358,6 @@ func (b *Base) RunCreate(
 ) error {
 	clusterName := b.ResolveName(name)
 
-	exists, err := b.Infra.NodesExist(ctx, clusterName)
-	if err != nil {
-		return fmt.Errorf("check existing nodes: %w", err)
-	}
-
-	if exists {
-		return fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
-	}
-
 	// RunCreate is the single-node engine; [Base.Create] routes multi-node
 	// topologies to [Base.RunCreateMultiNode] before reaching here, so these
 	// guards are a defensive backstop for a direct caller.
@@ -378,13 +369,7 @@ func (b *Base) RunCreate(
 		return ErrMultiNodeNotImplemented
 	}
 
-	// Fail before any paid resource exists when the retrieved kubeconfig would
-	// have nowhere to go.
-	if b.KubeconfigPath == "" {
-		return ErrMissingKubeconfigDestination
-	}
-
-	infra, err := b.EnsureInfrastructure(ctx, clusterName)
+	infra, err := b.guardCreate(ctx, clusterName)
 	if err != nil {
 		return err
 	}
@@ -446,6 +431,59 @@ func (b *Base) create(ctx context.Context, name string) error {
 	return b.RunCreate(ctx, name, composePlan, b.Strategy.GenerateToken)
 }
 
+// guardCreate checks a create flow's preconditions and ensures the shared
+// infrastructure, so the single-node ([Base.RunCreate]) and multi-node
+// ([Base.RunCreateMultiNode]) engines share one preamble: the cluster must not
+// already exist ([ErrClusterAlreadyExists]) and must have a kubeconfig
+// destination ([ErrMissingKubeconfigDestination], checked before any paid
+// resource exists), after which the network, firewall, placement group, and SSH
+// key are ensured ([Base.EnsureInfrastructure]).
+func (b *Base) guardCreate(ctx context.Context, clusterName string) (ResolvedInfra, error) {
+	exists, err := b.Infra.NodesExist(ctx, clusterName)
+	if err != nil {
+		return ResolvedInfra{}, fmt.Errorf("check existing nodes: %w", err)
+	}
+
+	if exists {
+		return ResolvedInfra{}, fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
+	}
+
+	if b.KubeconfigPath == "" {
+		return ResolvedInfra{}, ErrMissingKubeconfigDestination
+	}
+
+	return b.EnsureInfrastructure(ctx, clusterName)
+}
+
+// rewriteAndPersistKubeconfig rewrites the retrieved kubeconfig's endpoint to the
+// created server's public IPv4 and merges it into the Base's kubeconfig
+// destination, returning the external endpoint and the persisted path. On any
+// failure it tears the cluster down (cleanup-on-failure) so a cluster whose
+// credentials cannot be written is not left running. It is shared by the
+// single-node and multi-node create flows.
+func (b *Base) rewriteAndPersistKubeconfig(
+	ctx context.Context,
+	clusterName string,
+	result BringUpResult,
+) (string, string, error) {
+	endpoint, err := apiServerEndpoint(result.Server)
+	if err != nil {
+		return "", "", b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	kubeconfig, err := rewriteKubeconfigEndpoint(result.Kubeconfig, endpoint)
+	if err != nil {
+		return "", "", b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	persistedPath, err := b.persistKubeconfig(kubeconfig)
+	if err != nil {
+		return "", "", b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	return endpoint, persistedPath, nil
+}
+
 // bringUpFromPlan runs the live half of the create flow from a composed plan:
 // bring the single node up, rewrite the retrieved kubeconfig's endpoint to the
 // node's public IPv4, and merge it into the Base's kubeconfig destination. The
@@ -474,19 +512,9 @@ func (b *Base) bringUpFromPlan(
 		return err
 	}
 
-	endpoint, err := apiServerEndpoint(result.Server)
+	endpoint, persistedPath, err := b.rewriteAndPersistKubeconfig(ctx, clusterName, result)
 	if err != nil {
-		return b.cleanUpFailedBringUp(ctx, clusterName, err)
-	}
-
-	kubeconfig, err := rewriteKubeconfigEndpoint(result.Kubeconfig, endpoint)
-	if err != nil {
-		return b.cleanUpFailedBringUp(ctx, clusterName, err)
-	}
-
-	persistedPath, err := b.persistKubeconfig(kubeconfig)
-	if err != nil {
-		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+		return err
 	}
 
 	_, _ = fmt.Fprintf(

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
@@ -72,22 +72,7 @@ func (b *Base) RunCreateMultiNode(
 ) error {
 	clusterName := b.ResolveName(name)
 
-	exists, err := b.Infra.NodesExist(ctx, clusterName)
-	if err != nil {
-		return fmt.Errorf("check existing nodes: %w", err)
-	}
-
-	if exists {
-		return fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
-	}
-
-	// Fail before any paid resource exists when the retrieved kubeconfig would
-	// have nowhere to go.
-	if b.KubeconfigPath == "" {
-		return ErrMissingKubeconfigDestination
-	}
-
-	infra, err := b.EnsureInfrastructure(ctx, clusterName)
+	infra, err := b.guardCreate(ctx, clusterName)
 	if err != nil {
 		return err
 	}
@@ -115,7 +100,19 @@ func (b *Base) RunCreateMultiNode(
 		return err
 	}
 
-	return b.persistInitKubeconfig(ctx, clusterName, initResult)
+	endpoint, persistedPath, err := b.rewriteAndPersistKubeconfig(ctx, clusterName, initResult)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(
+		b.LogWriter,
+		"Cluster %q control plane is up at %s; joining nodes are registering; "+
+			"kubeconfig merged into %q\n",
+		clusterName, endpoint, persistedPath,
+	)
+
+	return nil
 }
 
 // bringUpInitControlPlane composes and brings up the cluster-initialising
@@ -187,39 +184,6 @@ func (b *Base) createJoiningNodes(
 			)
 		}
 	}
-
-	return nil
-}
-
-// persistInitKubeconfig rewrites the init control plane's kubeconfig endpoint to
-// its public IPv4 and merges it into the Base's kubeconfig destination, sharing
-// the single-node path's cleanup-on-failure semantics.
-func (b *Base) persistInitKubeconfig(
-	ctx context.Context,
-	clusterName string,
-	initResult BringUpResult,
-) error {
-	endpoint, err := apiServerEndpoint(initResult.Server)
-	if err != nil {
-		return b.cleanUpFailedBringUp(ctx, clusterName, err)
-	}
-
-	kubeconfig, err := rewriteKubeconfigEndpoint(initResult.Kubeconfig, endpoint)
-	if err != nil {
-		return b.cleanUpFailedBringUp(ctx, clusterName, err)
-	}
-
-	persistedPath, err := b.persistKubeconfig(kubeconfig)
-	if err != nil {
-		return b.cleanUpFailedBringUp(ctx, clusterName, err)
-	}
-
-	_, _ = fmt.Fprintf(
-		b.LogWriter,
-		"Cluster %q control plane is up at %s; joining nodes are registering; "+
-			"kubeconfig merged into %q\n",
-		clusterName, endpoint, persistedPath,
-	)
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
@@ -1,0 +1,241 @@
+package hetznerbase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// ErrNoPrivateIPv4 is returned by [Base.RunCreateMultiNode] when the created
+// cluster-initialising control plane has no private-network address for the
+// joining nodes to register against. Joining nodes reach the control plane over
+// the cluster's private network (unfiltered by the cloud firewall), so a missing
+// private IP means the network placement did not take and the join would fail.
+var ErrNoPrivateIPv4 = errors.New(
+	"hetzner: cluster-initialising control plane has no private-network IPv4 for joining nodes",
+)
+
+// MultiNodeComposer is the optional capability a distribution's [CreateStrategy]
+// implements once it can bring up joining nodes. The two-phase multi-node create
+// flow ([Base.RunCreateMultiNode]) needs the init control plane composed on its
+// own (before any address is known) and the joining nodes composed afterwards
+// against the init control plane's resolved private address — a distribution
+// whose bootstrap cannot yet thread that join endpoint (kubeadm) simply does not
+// implement this, and a topology with agents is rejected before any resource is
+// created. See devantler-tech/ksail#5755.
+type MultiNodeComposer interface {
+	// ComposeInitNode composes the single cluster-initialising control-plane node
+	// (bootstrap index 0). It carries no join endpoint — it initialises the
+	// cluster the joining nodes later register against.
+	ComposeInitNode(clusterName, token string, material BootstrapMaterial) (NodeSpec, error)
+	// ComposeJoiningNodes composes the joining nodes (agents; additional control
+	// planes are a later increment) that register against the control plane
+	// reachable at joinAddress — the init node's private-network IPv4. The
+	// distribution forms its own registration URL from joinAddress (both k3s and
+	// kubeadm serve the API on the standard secure port). The returned specs carry
+	// their global bootstrap indices (>= 1) so their server names stay distinct
+	// from the init node's.
+	ComposeJoiningNodes(
+		clusterName, token string,
+		joinAddress net.IP,
+		material BootstrapMaterial,
+	) ([]NodeSpec, error)
+}
+
+// RunCreateMultiNode runs the two-phase Hetzner create flow for a single
+// control-plane cluster with joining nodes (agents): guard against an existing
+// cluster, ensure the shared infrastructure, then (1) bring up the
+// cluster-initialising control plane and read its admin kubeconfig, and (2)
+// compose the joining nodes against the control plane's private-network address
+// and create them. The control plane's public IPv4 is the kubeconfig endpoint,
+// as in the single-node path; the joining nodes register over the private
+// network. A failure after the first server is created tears the whole cluster
+// down (cleanup-on-failure) so a partial bring-up does not leak paid resources.
+//
+// material is the per-cluster bootstrap material the live bring-up authenticates
+// with (minted by [Base.Create] and injected here, mirroring how [Base.RunCreate]
+// takes an already-composed plan) so the SSH bring-up is testable with an
+// in-process server.
+//
+// Joining nodes are created and left to register asynchronously — the cluster is
+// usable once the control plane serves the API and its kubeconfig is retrieved;
+// end-to-end join success is validated by the live smoke tests
+// (devantler-tech/ksail#5515) once the Hetzner CI lane (#4972) is restored.
+func (b *Base) RunCreateMultiNode(
+	ctx context.Context,
+	name string,
+	composer MultiNodeComposer,
+	material BootstrapMaterial,
+) error {
+	clusterName := b.ResolveName(name)
+
+	exists, err := b.Infra.NodesExist(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("check existing nodes: %w", err)
+	}
+
+	if exists {
+		return fmt.Errorf("%w: %s", ErrClusterAlreadyExists, clusterName)
+	}
+
+	// Fail before any paid resource exists when the retrieved kubeconfig would
+	// have nowhere to go.
+	if b.KubeconfigPath == "" {
+		return ErrMissingKubeconfigDestination
+	}
+
+	infra, err := b.EnsureInfrastructure(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	token, err := b.Strategy.GenerateToken()
+	if err != nil {
+		return fmt.Errorf("generate node token: %w", err)
+	}
+
+	initResult, err := b.bringUpInitControlPlane(ctx, clusterName, infra, token, material, composer)
+	if err != nil {
+		return err
+	}
+
+	err = b.createJoiningNodes(
+		ctx,
+		clusterName,
+		infra,
+		token,
+		material,
+		composer,
+		initResult.Server,
+	)
+	if err != nil {
+		return err
+	}
+
+	return b.persistInitKubeconfig(ctx, clusterName, initResult)
+}
+
+// bringUpInitControlPlane composes and brings up the cluster-initialising
+// control plane, returning its bring-up result (created server + admin
+// kubeconfig).
+func (b *Base) bringUpInitControlPlane(
+	ctx context.Context,
+	clusterName string,
+	infra ResolvedInfra,
+	token string,
+	material BootstrapMaterial,
+	composer MultiNodeComposer,
+) (BringUpResult, error) {
+	initNode, err := composer.ComposeInitNode(clusterName, token, material)
+	if err != nil {
+		return BringUpResult{}, fmt.Errorf("compose init control-plane node: %w", err)
+	}
+
+	initSpecs, err := DeriveServerSpecs(clusterName, []NodeSpec{initNode}, b.Opts, infra)
+	if err != nil {
+		return BringUpResult{}, err
+	}
+
+	return b.BringUpNode(ctx, clusterName, BringUpSpec{
+		Server:          initSpecs[0],
+		Signer:          material.Signer,
+		HostKeyCallback: material.HostKeyCallback,
+		KubeconfigPath:  b.Strategy.RemoteKubeconfigPath(),
+		PollInterval:    b.BringUpPollInterval,
+		Port:            b.BringUpPort,
+	})
+}
+
+// createJoiningNodes composes the joining nodes against the init control plane's
+// private-network address and creates them. They bootstrap and register
+// asynchronously, so it does not wait for a kubeconfig from them; a creation
+// failure tears the whole cluster down.
+func (b *Base) createJoiningNodes(
+	ctx context.Context,
+	clusterName string,
+	infra ResolvedInfra,
+	token string,
+	material BootstrapMaterial,
+	composer MultiNodeComposer,
+	initServer *hcloud.Server,
+) error {
+	joinAddress, err := privateIPv4(initServer)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	joinNodes, err := composer.ComposeJoiningNodes(clusterName, token, joinAddress, material)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	joinSpecs, err := DeriveServerSpecs(clusterName, joinNodes, b.Opts, infra)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	for _, spec := range joinSpecs {
+		_, createErr := b.Servers.CreateServer(ctx, spec)
+		if createErr != nil {
+			return b.cleanUpFailedBringUp(
+				ctx,
+				clusterName,
+				fmt.Errorf("create joining node %q: %w", spec.Name, createErr),
+			)
+		}
+	}
+
+	return nil
+}
+
+// persistInitKubeconfig rewrites the init control plane's kubeconfig endpoint to
+// its public IPv4 and merges it into the Base's kubeconfig destination, sharing
+// the single-node path's cleanup-on-failure semantics.
+func (b *Base) persistInitKubeconfig(
+	ctx context.Context,
+	clusterName string,
+	initResult BringUpResult,
+) error {
+	endpoint, err := apiServerEndpoint(initResult.Server)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	kubeconfig, err := rewriteKubeconfigEndpoint(initResult.Kubeconfig, endpoint)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	persistedPath, err := b.persistKubeconfig(kubeconfig)
+	if err != nil {
+		return b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	_, _ = fmt.Fprintf(
+		b.LogWriter,
+		"Cluster %q control plane is up at %s; joining nodes are registering; "+
+			"kubeconfig merged into %q\n",
+		clusterName, endpoint, persistedPath,
+	)
+
+	return nil
+}
+
+// privateIPv4 returns the created server's first private-network IPv4, or
+// [ErrNoPrivateIPv4] when it has none (the network placement did not take).
+func privateIPv4(server *hcloud.Server) (net.IP, error) {
+	if server == nil {
+		return nil, ErrNoPrivateIPv4
+	}
+
+	for _, private := range server.PrivateNet {
+		if private.IP != nil && !private.IP.IsUnspecified() {
+			return private.IP, nil
+		}
+	}
+
+	return nil, ErrNoPrivateIPv4
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode_test.go
@@ -194,6 +194,25 @@ func TestRunCreateMultiNodeComposeJoinErrorCleansUp(t *testing.T) {
 	assert.Equal(t, 1, infra.deleteNodesCalls)
 }
 
+func TestRunCreateMultiNodeComposeInitErrorFailsFast(t *testing.T) {
+	t.Parallel()
+
+	// Composing the init control plane fails before any server is created, so the
+	// engine fails fast: no server is provisioned and there is nothing to tear
+	// down. Cleanup-on-failure only runs once the control plane is up (as the
+	// missing-private-IP and compose-join cases above assert), so a compose-init
+	// failure must NOT trigger it.
+	base, infra, strategy, material, _ := newMultiNodeBase(t, true)
+	strategy.composeInitErr = errBoom
+
+	err := base.RunCreateMultiNode(t.Context(), "", strategy, material)
+	require.ErrorIs(t, err, errBoom)
+	// No servers were created and no cleanup ran — the failure is before any
+	// paid resource exists.
+	assert.Equal(t, 0, infra.createServerCalls)
+	assert.Equal(t, 0, infra.deleteNodesCalls)
+}
+
 func TestRunCreateMultiNodeAlreadyExists(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode_test.go
@@ -1,0 +1,220 @@
+package hetznerbase_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// fakeMultiNodeStrategy is a [hetznerbase.CreateStrategy] +
+// [hetznerbase.MultiNodeComposer] test double: it records the join address the
+// engine derives and returns a fixed number of agent specs, so the two-phase
+// engine's sequencing can be asserted without a real distribution.
+type fakeMultiNodeStrategy struct {
+	kubeconfigPath      string
+	agents              int
+	receivedJoinAddress net.IP
+	composeInitErr      error
+	composeJoinErr      error
+}
+
+func (f *fakeMultiNodeStrategy) ComposeNodes(
+	_, _ string,
+	_ hetznerbase.BootstrapMaterial,
+) ([]hetznerbase.NodeSpec, error) {
+	return nil, nil // unreached on the multi-node path
+}
+
+func (f *fakeMultiNodeStrategy) RemoteKubeconfigPath() string { return f.kubeconfigPath }
+
+func (f *fakeMultiNodeStrategy) DistroLabel() string { return "Fake × Hetzner" }
+
+func (f *fakeMultiNodeStrategy) GenerateToken() (string, error) { return "fake-token", nil }
+
+func (f *fakeMultiNodeStrategy) ComposeInitNode(
+	_, _ string,
+	_ hetznerbase.BootstrapMaterial,
+) (hetznerbase.NodeSpec, error) {
+	if f.composeInitErr != nil {
+		return hetznerbase.NodeSpec{}, f.composeInitErr
+	}
+
+	return hetznerbase.NodeSpec{
+		Index:    0,
+		NodeType: hetzner.NodeTypeControlPlane,
+		UserData: "#cloud-config\n",
+	}, nil
+}
+
+func (f *fakeMultiNodeStrategy) ComposeJoiningNodes(
+	_, _ string,
+	joinAddress net.IP,
+	_ hetznerbase.BootstrapMaterial,
+) ([]hetznerbase.NodeSpec, error) {
+	f.receivedJoinAddress = joinAddress
+
+	if f.composeJoinErr != nil {
+		return nil, f.composeJoinErr
+	}
+
+	specs := make([]hetznerbase.NodeSpec, 0, f.agents)
+	for index := 1; index <= f.agents; index++ {
+		specs = append(specs, hetznerbase.NodeSpec{
+			Index:    index,
+			NodeType: hetzner.NodeTypeWorker,
+			UserData: "#cloud-config\n",
+		})
+	}
+
+	return specs, nil
+}
+
+// testMultiNodeAgents is the agent count the multi-node engine tests bring up
+// alongside the single control plane.
+const testMultiNodeAgents = 2
+
+// testJoinPrivateIP is the control plane's private-network IPv4 the engine derives
+// the agents' join address from.
+const testJoinPrivateIP = "10.0.1.5"
+
+// newMultiNodeBase wires a Base against the in-process SSH server for the control
+// plane's bring-up and the fake strategy for composition. When withPrivateIP is
+// set the created control-plane server carries a private-network IPv4 (so the join
+// address resolves); otherwise it carries only its public IPv4. It returns the
+// Base, the fake infra, the strategy, the injected bootstrap material, and the
+// control plane's public host (the in-process SSH server's address).
+func newMultiNodeBase(
+	t *testing.T,
+	withPrivateIP bool,
+) (*hetznerbase.Base, *fakeInfra, *fakeMultiNodeStrategy, hetznerbase.BootstrapMaterial, string) {
+	t.Helper()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(), kubeconfigHandler(0, remoteAdminKubeconfig),
+	)
+
+	server := serverWithPublicIPv4(host)
+	if withPrivateIP {
+		server.PrivateNet = []hcloud.ServerPrivateNet{{IP: net.ParseIP(testJoinPrivateIP)}}
+	}
+
+	infra := &fakeInfra{createdServer: server, networkID: 11}
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.Agents = testMultiNodeAgents
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+	base.BringUpPort = port
+	base.BringUpPollInterval = testPollInterval
+
+	strategy := &fakeMultiNodeStrategy{
+		kubeconfigPath: testKubeconfigPath,
+		agents:         testMultiNodeAgents,
+	}
+	base.Strategy = strategy
+
+	material := hetznerbase.BootstrapMaterial{
+		Signer:          pair.Signer,
+		AuthorizedKey:   pair.AuthorizedKey,
+		HostKeyCallback: gossh.FixedHostKey(hostKey),
+	}
+
+	return base, infra, strategy, material, host
+}
+
+func TestRunCreateMultiNodeBringsUpControlPlaneAndCreatesAgents(t *testing.T) {
+	t.Parallel()
+
+	base, infra, strategy, material, host := newMultiNodeBase(t, true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	require.NoError(t, base.RunCreateMultiNode(ctx, "", strategy, material))
+
+	// One CreateServer for the control plane plus one per agent.
+	assert.Equal(t, 1+testMultiNodeAgents, infra.createServerCalls)
+	// The engine derived the join address from the control plane's private IPv4.
+	require.NotNil(t, strategy.receivedJoinAddress)
+	assert.Equal(t, testJoinPrivateIP, strategy.receivedJoinAddress.String())
+	// A successful bring-up leaves the cluster in place.
+	assert.Equal(t, 0, infra.deleteNodesCalls)
+
+	// The control plane's kubeconfig is persisted with its endpoint rewritten to
+	// the node's public IPv4.
+	merged, err := os.ReadFile(base.KubeconfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(merged), "https://"+host+":6443")
+	assert.NotContains(t, string(merged), "10.9.9.9")
+}
+
+func TestRunCreateMultiNodeMissingPrivateIPCleansUp(t *testing.T) {
+	t.Parallel()
+
+	// The control plane comes up but has no private-network address, so the join
+	// address cannot be derived and the cluster is torn down again.
+	base, infra, strategy, material, _ := newMultiNodeBase(t, false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	err := base.RunCreateMultiNode(ctx, "", strategy, material)
+	require.ErrorIs(t, err, hetznerbase.ErrNoPrivateIPv4)
+	// Only the control plane was created; no agents.
+	assert.Equal(t, 1, infra.createServerCalls)
+	// Cleanup-on-failure ran.
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestRunCreateMultiNodeComposeJoinErrorCleansUp(t *testing.T) {
+	t.Parallel()
+
+	base, infra, strategy, material, _ := newMultiNodeBase(t, true)
+	strategy.composeJoinErr = errBoom
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	err := base.RunCreateMultiNode(ctx, "", strategy, material)
+	require.ErrorIs(t, err, errBoom)
+	// The control plane was created before composing the joiners failed.
+	assert.Equal(t, 1, infra.createServerCalls)
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestRunCreateMultiNodeAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	base, infra, strategy, material, _ := newMultiNodeBase(t, true)
+	infra.nodesExist = true
+
+	err := base.RunCreateMultiNode(t.Context(), "named", strategy, material)
+	require.ErrorIs(t, err, hetznerbase.ErrClusterAlreadyExists)
+	// No infrastructure or servers were created.
+	assert.Equal(t, 0, infra.ensureNetworkCalls)
+	assert.Equal(t, 0, infra.createServerCalls)
+}
+
+func TestRunCreateMultiNodeMissingKubeconfigDestinationFailsFast(t *testing.T) {
+	t.Parallel()
+
+	base, infra, strategy, material, _ := newMultiNodeBase(t, true)
+	base.KubeconfigPath = ""
+
+	err := base.RunCreateMultiNode(t.Context(), "", strategy, material)
+	require.ErrorIs(t, err, hetznerbase.ErrMissingKubeconfigDestination)
+	assert.Equal(t, 0, infra.ensureNetworkCalls)
+	assert.Equal(t, 0, infra.createServerCalls)
+}

--- a/pkg/svc/provisioner/cluster/k3shetzner/errors.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/errors.go
@@ -4,13 +4,15 @@ import "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/
 
 // The K3s × Hetzner provisioner reports the sentinels of the shared Hetzner create
 // flow; these aliases keep the package's public API stable while the behaviour lives
-// on [hetznerbase.Base.RunCreate].
+// on the shared create flow.
 var (
 	// ErrClusterAlreadyExists is returned by [Provisioner.Create] when servers for
 	// the target K3s cluster already exist; see [hetznerbase.ErrClusterAlreadyExists].
 	ErrClusterAlreadyExists = hetznerbase.ErrClusterAlreadyExists
 
-	// ErrMultiNodeNotImplemented is returned by [Provisioner.Create] for a K3s
-	// topology with joining nodes; see [hetznerbase.ErrMultiNodeNotImplemented].
-	ErrMultiNodeNotImplemented = hetznerbase.ErrMultiNodeNotImplemented
+	// ErrHAControlPlaneNotImplemented is returned by [Provisioner.Create] for a K3s
+	// topology with more than one control plane. A single control plane with agents
+	// is brought up via the two-phase multi-node flow; see
+	// [hetznerbase.ErrHAControlPlaneNotImplemented].
+	ErrHAControlPlaneNotImplemented = hetznerbase.ErrHAControlPlaneNotImplemented
 )

--- a/pkg/svc/provisioner/cluster/k3shetzner/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/export_test.go
@@ -61,7 +61,11 @@ func (p *Provisioner) BuildNodeUserData(
 	sshAuthorizedKeys []string,
 	hostKeys *cloudinitbootstrap.HostKeys,
 ) ([]TestNode, error) {
-	nodes, err := p.buildNodeUserData(clusterName, token, serverURL, sshAuthorizedKeys, hostKeys)
+	nodes, err := p.buildNodeUserData(
+		clusterName, token, serverURL,
+		p.ControlPlanes, p.Agents,
+		sshAuthorizedKeys, hostKeys,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/svc/provisioner/cluster/k3shetzner/lifecycle.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/lifecycle.go
@@ -16,20 +16,29 @@ const remoteKubeconfigPath = "/etc/rancher/k3s/k3s.yaml"
 
 // ComposeNodes threads the minted bootstrap material into the K3s per-node
 // cloud-init user_data and projects it onto the shared [hetznerbase.NodeSpec]
-// the bring-up plan derives server specs from. The single-control-plane path
-// carries no join server URL (multi-node is rejected before composition).
+// the bring-up plan derives server specs from. It composes the configured
+// single-control-plane, no-agent topology with no join server URL; the
+// multi-node topology is composed in two phases via [Provisioner.ComposeInitNode]
+// and [Provisioner.ComposeJoiningNodes].
 func (p *Provisioner) ComposeNodes(
 	clusterName, token string,
 	material hetznerbase.BootstrapMaterial,
 ) ([]hetznerbase.NodeSpec, error) {
 	nodes, err := p.buildNodeUserData(
 		clusterName, token, "",
+		p.ControlPlanes, p.Agents,
 		[]string{material.AuthorizedKey}, material.HostKeys,
 	)
 	if err != nil {
 		return nil, err
 	}
 
+	return specsFromNodes(nodes), nil
+}
+
+// specsFromNodes projects composed per-node user_data onto the shared
+// [hetznerbase.NodeSpec]s the bring-up plan derives server specs from.
+func specsFromNodes(nodes []nodeUserData) []hetznerbase.NodeSpec {
 	return hetznerbase.NodeSpecsFrom(nodes, func(node nodeUserData) hetznerbase.NodeSpec {
 		return hetznerbase.NodeSpec{
 			Index:    node.index,
@@ -37,7 +46,7 @@ func (p *Provisioner) ComposeNodes(
 			UserData: node.userData,
 			Labels:   node.labels,
 		}
-	}), nil
+	})
 }
 
 // RemoteKubeconfigPath reports where k3s writes the admin kubeconfig, satisfying

--- a/pkg/svc/provisioner/cluster/k3shetzner/multinode.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/multinode.go
@@ -1,0 +1,60 @@
+package k3shetzner
+
+import (
+	"net"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+)
+
+// k3sAPIPort is the port a k3s server serves its API (and thus the registration
+// endpoint agents dial) on — the standard Kubernetes secure port.
+const k3sAPIPort = "6443"
+
+// staticMultiNodeComposerCheck asserts at compile time that *Provisioner
+// implements the optional [hetznerbase.MultiNodeComposer] capability, so the
+// shared create flow routes a K3s topology with agents to the two-phase bring-up.
+var _ hetznerbase.MultiNodeComposer = (*Provisioner)(nil)
+
+// ComposeInitNode composes the single cluster-initialising K3s server (bootstrap
+// index 0), which carries no join server URL, satisfying
+// [hetznerbase.MultiNodeComposer].
+func (p *Provisioner) ComposeInitNode(
+	clusterName, token string,
+	material hetznerbase.BootstrapMaterial,
+) (hetznerbase.NodeSpec, error) {
+	nodes, err := p.buildNodeUserData(
+		clusterName, token, "",
+		1, 0,
+		[]string{material.AuthorizedKey}, material.HostKeys,
+	)
+	if err != nil {
+		return hetznerbase.NodeSpec{}, err
+	}
+
+	return specsFromNodes(nodes)[0], nil
+}
+
+// ComposeJoiningNodes composes the K3s agents that register against the init
+// server reachable at joinAddress (its private-network IPv4), satisfying
+// [hetznerbase.MultiNodeComposer]. It plans the full topology so the agents keep
+// their global bootstrap indices, threads the derived server URL into their
+// install commands, and returns only the joining nodes (the init node at index 0
+// is already up).
+func (p *Provisioner) ComposeJoiningNodes(
+	clusterName, token string,
+	joinAddress net.IP,
+	material hetznerbase.BootstrapMaterial,
+) ([]hetznerbase.NodeSpec, error) {
+	serverURL := "https://" + net.JoinHostPort(joinAddress.String(), k3sAPIPort)
+
+	nodes, err := p.buildNodeUserData(
+		clusterName, token, serverURL,
+		p.ControlPlanes, p.Agents,
+		[]string{material.AuthorizedKey}, material.HostKeys,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return specsFromNodes(nodes)[1:], nil
+}

--- a/pkg/svc/provisioner/cluster/k3shetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/multinode_test.go
@@ -1,0 +1,64 @@
+package k3shetzner_test
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testBootstrapMaterial is minimal composition-only bootstrap material: only the
+// authorized key and host identity feed node composition (the SSH signer/host-key
+// callback matter only to the live bring-up, which these composition tests do not
+// exercise).
+func testBootstrapMaterial() hetznerbase.BootstrapMaterial {
+	return hetznerbase.BootstrapMaterial{
+		AuthorizedKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap",
+	}
+}
+
+// TestComposeInitNodeIsSingleControlPlane pins that ComposeInitNode composes
+// exactly the cluster-initialising control plane (bootstrap index 0), regardless
+// of the configured agent count — the joining nodes are composed separately once
+// the control plane's address is known.
+func TestComposeInitNodeIsSingleControlPlane(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 2)
+
+	spec, err := prov.ComposeInitNode(testClusterName, "token", testBootstrapMaterial())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, spec.Index)
+	assert.Equal(t, hetzner.NodeTypeControlPlane, spec.NodeType)
+	assert.True(t, strings.HasPrefix(spec.UserData, "#cloud-config"))
+	// The init node initialises the cluster, so it carries no registration URL.
+	assert.NotContains(t, spec.UserData, "K3S_URL")
+}
+
+// TestComposeJoiningNodesThreadsPrivateJoinURL pins that ComposeJoiningNodes
+// returns only the joining nodes (the init control plane at index 0 dropped),
+// with their global bootstrap indices preserved and the derived private-network
+// registration URL (https://<join-address>:6443) threaded into every agent's
+// cloud-init.
+func TestComposeJoiningNodesThreadsPrivateJoinURL(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 2)
+
+	specs, err := prov.ComposeJoiningNodes(
+		testClusterName, "token", net.ParseIP("10.0.1.5"), testBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+	require.Len(t, specs, 2)
+
+	for index, spec := range specs {
+		assert.Equal(t, index+1, spec.Index)
+		assert.Equal(t, hetzner.NodeTypeWorker, spec.NodeType)
+		assert.Contains(t, spec.UserData, "https://10.0.1.5:6443")
+	}
+}

--- a/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
@@ -334,14 +334,14 @@ func TestCreateAlreadyExists(t *testing.T) {
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 }
 
-func TestCreateMultiNodeNotImplemented(t *testing.T) {
+func TestCreateHAControlPlaneNotImplemented(t *testing.T) {
 	t.Parallel()
 
 	infra := &fakeInfra{}
 	prov := newProvisioner(infra, 3, 0)
 
 	err := prov.Create(context.Background(), "")
-	require.ErrorIs(t, err, k3shetzner.ErrMultiNodeNotImplemented)
+	require.ErrorIs(t, err, k3shetzner.ErrHAControlPlaneNotImplemented)
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 }
 

--- a/pkg/svc/provisioner/cluster/k3shetzner/userdata.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/userdata.go
@@ -34,21 +34,24 @@ type nodeUserData struct {
 // (the transport), and attaches the Hetzner node labels. It is pure — it performs
 // no I/O and reaches no network — so it is fully unit-testable; serverURL is the
 // address joining nodes register against (empty for a single control-plane node
-// with no agents), sshAuthorizedKeys are the public keys delivered into every
-// node's authorized_keys (nil for none) so the post-provision SSH bootstrap seam
-// can authenticate, and hostKeys is the pre-generated SSH host identity delivered
-// via the cloud-init ssh_keys module (nil to let the node generate its own) so
-// the bootstrap dial can pin the host key.
+// with no agents), controlPlanes and agents are the node counts to plan (passed
+// explicitly so the two-phase multi-node flow can compose the init node and the
+// joining nodes separately), sshAuthorizedKeys are the public keys delivered into
+// every node's authorized_keys (nil for none) so the post-provision SSH bootstrap
+// seam can authenticate, and hostKeys is the pre-generated SSH host identity
+// delivered via the cloud-init ssh_keys module (nil to let the node generate its
+// own) so the bootstrap dial can pin the host key.
 func (p *Provisioner) buildNodeUserData(
 	clusterName, token, serverURL string,
+	controlPlanes, agents int,
 	sshAuthorizedKeys []string,
 	hostKeys *cloudinitbootstrap.HostKeys,
 ) ([]nodeUserData, error) {
 	nodes, err := k3sbootstrap.Plan(k3sbootstrap.PlanInput{
 		Version:           p.version,
 		Token:             token,
-		ControlPlaneCount: p.ControlPlanes,
-		AgentCount:        p.Agents,
+		ControlPlaneCount: controlPlanes,
+		AgentCount:        agents,
 		ServerURL:         serverURL,
 	})
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
@@ -11,6 +11,12 @@ var (
 	ErrClusterAlreadyExists = hetznerbase.ErrClusterAlreadyExists
 
 	// ErrMultiNodeNotImplemented is returned by [Provisioner.Create] for a kubeadm
-	// topology with joining nodes; see [hetznerbase.ErrMultiNodeNotImplemented].
+	// topology with agents — kubeadm does not yet implement joining-node bring-up;
+	// see [hetznerbase.ErrMultiNodeNotImplemented].
 	ErrMultiNodeNotImplemented = hetznerbase.ErrMultiNodeNotImplemented
+
+	// ErrHAControlPlaneNotImplemented is returned by [Provisioner.Create] for a
+	// kubeadm topology with more than one control plane; see
+	// [hetznerbase.ErrHAControlPlaneNotImplemented].
+	ErrHAControlPlaneNotImplemented = hetznerbase.ErrHAControlPlaneNotImplemented
 )

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
@@ -283,17 +283,22 @@ func TestCreateAlreadyExists(t *testing.T) {
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 }
 
-func TestCreateMultiNodeNotImplemented(t *testing.T) {
+func TestCreateHAControlPlaneNotImplemented(t *testing.T) {
 	t.Parallel()
 
 	infra := &fakeInfra{}
 	prov := newProvisioner(infra, 3, 0)
 
 	err := prov.Create(context.Background(), "")
-	require.ErrorIs(t, err, kubeadmhetzner.ErrMultiNodeNotImplemented)
+	require.ErrorIs(t, err, kubeadmhetzner.ErrHAControlPlaneNotImplemented)
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 }
 
+// TestCreateAgentsAreMultiNode pins that the kubeadm × Hetzner provisioner does
+// not yet implement joining-node bring-up: it does not satisfy
+// hetznerbase.MultiNodeComposer, so a topology with agents is rejected before
+// any infrastructure is created (kubeadm's join-endpoint threading is a later
+// increment of #5755).
 func TestCreateAgentsAreMultiNode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
KSail can bring up a K3s cluster on Hetzner today, but only a **single node** — any agents were refused outright. Multi-node is the point of a real cloud cluster, and it was the next unblocked step in the Hetzner provider epic (#3983).

## What
A K3s × Hetzner cluster with `controlPlanes: 1` and `agents: N` now brings up the control plane and joins N agents to it over the private network. Multi-control-plane (HA) is still rejected for now (a follow-up), and the Vanilla/kubeadm path is unchanged (its multi-node lands next). The existing single-node behaviour is untouched.

First increment of #5755; end-to-end join is verified by the env-gated Hetzner smoke tests (#5515) once that CI lane is restored.

Part of #5755. Part of #3983.
