### PR TITLE
fix(desktop): add gopacket go.sum entry for pkg/svc/mirror

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -382,6 +382,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gookit/color v1.6.0 // indirect
+	github.com/gopacket/gopacket v1.5.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -1164,6 +1164,8 @@ github.com/gookit/assert v0.1.1/go.mod h1:jS5bmIVQZTIwk42uXl4lyj4iaaxx32tqH16CFj
 github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gookit/color v1.6.0 h1:JjJXBTk1ETNyqyilJhkTXJYYigHG24TM9Xa2M1xAhRA=
 github.com/gookit/color v1.6.0/go.mod h1:9ACFc7/1IpHGBW8RwuDm/0YEnhg3dwwXpoMsmtyHfjs=
+github.com/gopacket/gopacket v1.5.0 h1:9s9fcSUVKFlRV97B77Bq9XNV3ly2gvvsneFMQUGjc+M=
+github.com/gopacket/gopacket v1.5.0/go.mod h1:i3NaGaqfoWKAr1+g7qxEdWsmfT+MXuWkAe9+THv8LME=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why:** The desktop app / GoReleaser snapshot build is broken. The desktop module compiles the parent's packages through `replace ksail/v7 => ../`, so its `go.sum` must carry the parent's transitive checksums. `pkg/svc/mirror` now imports gopacket, but `desktop/go.sum` was never tidied to add it — so the build fails with "missing go.sum entry for gopacket". It's latent on `main` (the Desktop App workflow is path-filtered and hasn't re-run since the import landed) and it blocks releases and any PR that runs the desktop build.

**What:** `go mod tidy` in the desktop module adds the one missing indirect entry (`desktop/go.mod` +1, `desktop/go.sum` +2). Desktop build now succeeds locally.