### PR TITLE
feat(hetzner): pre-seeded kubeadm cluster CA for multi-node join

### DIFF
--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/ca.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/ca.go
@@ -1,0 +1,131 @@
+package kubeadmhetzner
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+const (
+	// caCommonName is the subject common name kubeadm gives its cluster CA; the
+	// pre-seeded CA mirrors it so an operator inspecting the certificate sees the
+	// same identity kubeadm would have minted itself.
+	caCommonName = "kubernetes"
+	// caKeyBits is the RSA modulus size of the pre-seeded cluster CA. kubeadm's own
+	// default CA is RSA-2048, so matching it keeps the pre-seeded CA
+	// indistinguishable from a kubeadm-minted one.
+	caKeyBits = 2048
+	// caValidityYears is how long the cluster CA stays valid. kubeadm mints its CA
+	// with a ten-year lifetime, matched here.
+	caValidityYears = 10
+	// caSerialBits is the bit length of the CA certificate's random serial number.
+	caSerialBits = 128
+	// caCertHashPrefix is the algorithm prefix of a kubeadm token-discovery hash;
+	// kubeadm accepts only SHA-256 pins. It mirrors the kubeadmbootstrap renderer's
+	// own prefix so the hash this package computes passes that renderer's
+	// validation.
+	caCertHashPrefix = "sha256:"
+	// caBackdate offsets the CA's NotBefore into the past to tolerate minor clock
+	// skew between where the CA is generated and where a node validates it.
+	caBackdate = time.Minute
+)
+
+// ClusterCA is a self-signed kubeadm cluster certificate authority the multi-node
+// Hetzner bring-up pre-seeds onto the cluster-initialising control plane, together
+// with the token-discovery hash the joining nodes pin.
+//
+// # Why pre-seed a CA
+//
+// kubeadm normally mints the cluster CA itself during `kubeadm init`, so its
+// identity — and therefore the `--discovery-token-ca-cert-hash` a joining node
+// pins — is not known until the first control plane is already up. The two-phase
+// Hetzner bring-up composes every node's cloud-init before any server boots and
+// derives the join endpoint only at run time, so it cannot read a kubeadm-minted
+// hash back in time to pin it. Pre-seeding a CA the provisioner generated fixes
+// the CA identity up front: [GenerateClusterCA] returns the cert and key to write
+// into the init node's PKI directory (so kubeadm reuses them instead of minting
+// its own) and the discovery hash to thread into the joining nodes'
+// JoinConfiguration. This keeps the safe, pinned discovery path working under the
+// run-time two-phase model — kubeadmbootstrap requires it, the alternative being
+// the insecure unsafeSkipCAVerification mode.
+type ClusterCA struct {
+	// CertPEM is the CA certificate in PEM form, written to
+	// /etc/kubernetes/pki/ca.crt on the cluster-initialising control plane.
+	CertPEM []byte
+	// KeyPEM is the CA private key in PEM (PKCS#1) form, written to
+	// /etc/kubernetes/pki/ca.key on the cluster-initialising control plane so
+	// kubeadm can sign the cluster's leaf certificates with it.
+	KeyPEM []byte
+	// DiscoveryHash is the "sha256:<hex>" hash of the CA's public key, in the form
+	// kubeadm's token discovery pins (--discovery-token-ca-cert-hash). It is
+	// computed over the certificate's DER SubjectPublicKeyInfo, exactly as
+	// kubeadm's own pubkeypin does, so a joining node verifies the served CA
+	// against it.
+	DiscoveryHash string
+}
+
+// GenerateClusterCA generates a fresh self-signed RSA cluster CA and the kubeadm
+// token-discovery hash of its public key. The returned material is pre-seeded onto
+// the cluster-initialising control plane (cert and key) and pinned by the joining
+// nodes (hash), so the two-phase bring-up can fix the CA identity before any node
+// boots. It reaches no network and touches no filesystem; its only external
+// dependency is the cryptographic random source.
+func GenerateClusterCA() (ClusterCA, error) {
+	caKey, err := rsa.GenerateKey(rand.Reader, caKeyBits)
+	if err != nil {
+		return ClusterCA{}, fmt.Errorf("generate kubeadm cluster CA key: %w", err)
+	}
+
+	serialCeiling := new(big.Int).Lsh(big.NewInt(1), caSerialBits)
+
+	serialNumber, err := rand.Int(rand.Reader, serialCeiling)
+	if err != nil {
+		return ClusterCA{}, fmt.Errorf("generate kubeadm cluster CA serial: %w", err)
+	}
+
+	now := time.Now()
+	certTemplate := x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: caCommonName},
+		NotBefore:             now.Add(-caBackdate),
+		NotAfter:              now.AddDate(caValidityYears, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(
+		rand.Reader, &certTemplate, &certTemplate, &caKey.PublicKey, caKey,
+	)
+	if err != nil {
+		return ClusterCA{}, fmt.Errorf("create kubeadm cluster CA certificate: %w", err)
+	}
+
+	caCert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		// Unreachable in practice: CreateCertificate emits a well-formed certificate
+		// ParseCertificate can always read back. Surfaced rather than dropped so a
+		// future change that breaks this is not silently ignored.
+		return ClusterCA{}, fmt.Errorf("parse kubeadm cluster CA certificate: %w", err)
+	}
+
+	// kubeadm pins SHA-256 over the certificate's DER SubjectPublicKeyInfo (its
+	// pubkeypin algorithm), so hashing the parsed cert's RawSubjectPublicKeyInfo
+	// yields exactly the value a joining node computes and compares.
+	spkiDigest := sha256.Sum256(caCert.RawSubjectPublicKeyInfo)
+
+	return ClusterCA{
+		CertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		KeyPEM: pem.EncodeToMemory(
+			&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caKey)},
+		),
+		DiscoveryHash: caCertHashPrefix + hex.EncodeToString(spkiDigest[:]),
+	}, nil
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
@@ -1,0 +1,118 @@
+package kubeadmhetzner_test
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"testing"
+
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseCACertificate decodes and parses the PEM CA certificate, failing the test
+// on any malformed output so each case can assert against a real *x509.Certificate.
+func parseCACertificate(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	require.Equal(t, "CERTIFICATE", block.Type)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	return cert
+}
+
+func TestGenerateClusterCAReturnsACASigningCertificate(t *testing.T) {
+	t.Parallel()
+
+	clusterCA, err := kubeadmhetzner.GenerateClusterCA()
+	require.NoError(t, err)
+
+	cert := parseCACertificate(t, clusterCA.CertPEM)
+
+	// kubeadm reuses a pre-seeded CA only if it is a valid signing CA, so the
+	// certificate must carry the CA basic constraint and the cert-sign key usage.
+	assert.True(t, cert.IsCA)
+	assert.True(t, cert.BasicConstraintsValid)
+	assert.Equal(t, "kubernetes", cert.Subject.CommonName)
+	assert.NotZero(t, cert.KeyUsage&x509.KeyUsageCertSign)
+}
+
+func TestGenerateClusterCAKeyBelongsToTheCertificate(t *testing.T) {
+	t.Parallel()
+
+	clusterCA, err := kubeadmhetzner.GenerateClusterCA()
+	require.NoError(t, err)
+
+	keyBlock, _ := pem.Decode(clusterCA.KeyPEM)
+	require.NotNil(t, keyBlock)
+	require.Equal(t, "RSA PRIVATE KEY", keyBlock.Type)
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+
+	certPubKey, ok := parseCACertificate(t, clusterCA.CertPEM).PublicKey.(*rsa.PublicKey)
+	require.True(t, ok)
+
+	// The seeded key must be the one that signs from the seeded certificate, or
+	// kubeadm could not use the pair to sign the cluster's leaf certificates.
+	assert.True(t, key.PublicKey.Equal(certPubKey))
+}
+
+func TestGenerateClusterCADiscoveryHashPinsThePublicKey(t *testing.T) {
+	t.Parallel()
+
+	clusterCA, err := kubeadmhetzner.GenerateClusterCA()
+	require.NoError(t, err)
+
+	cert := parseCACertificate(t, clusterCA.CertPEM)
+
+	// The hash kubeadm pins is SHA-256 over the certificate's DER
+	// SubjectPublicKeyInfo (its pubkeypin algorithm); recomputing it here proves
+	// the provisioner pins the very key it seeds.
+	digest := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	want := "sha256:" + hex.EncodeToString(digest[:])
+
+	assert.Equal(t, want, clusterCA.DiscoveryHash)
+}
+
+func TestGenerateClusterCADiscoveryHashIsAcceptedByTheJoinRenderer(t *testing.T) {
+	t.Parallel()
+
+	clusterCA, err := kubeadmhetzner.GenerateClusterCA()
+	require.NoError(t, err)
+
+	// The computed hash must satisfy the kubeadmbootstrap join renderer, which
+	// rejects any pin that is not a full "sha256:<64-hex>" digest — the contract
+	// the two-phase bring-up relies on when it threads this hash into the joining
+	// nodes' JoinConfiguration.
+	_, err = kubeadmbootstrap.Render(kubeadmbootstrap.NodeConfig{
+		Role:              kubeadmbootstrap.RoleAgent,
+		Token:             "abcdef.0123456789abcdef",
+		APIServerEndpoint: "10.0.0.2:6443",
+		CACertHashes:      []string{clusterCA.DiscoveryHash},
+	})
+	require.NoError(t, err)
+}
+
+func TestGenerateClusterCAProducesADistinctCAEachTime(t *testing.T) {
+	t.Parallel()
+
+	first, err := kubeadmhetzner.GenerateClusterCA()
+	require.NoError(t, err)
+
+	second, err := kubeadmhetzner.GenerateClusterCA()
+	require.NoError(t, err)
+
+	// Each cluster gets its own CA identity, so two generations never collide.
+	assert.NotEqual(t, first.DiscoveryHash, second.DiscoveryHash)
+	assert.NotEqual(t, first.CertPEM, second.CertPEM)
+	assert.NotEqual(t, first.KeyPEM, second.KeyPEM)
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"testing"
+	"time"
 
 	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
@@ -43,6 +44,13 @@ func TestGenerateClusterCAReturnsACASigningCertificate(t *testing.T) {
 	assert.True(t, cert.BasicConstraintsValid)
 	assert.Equal(t, "kubernetes", cert.Subject.CommonName)
 	assert.NotZero(t, cert.KeyUsage&x509.KeyUsageCertSign)
+
+	// The CA is long-lived (kubeadm mints its own with a ten-year lifetime); pin
+	// the window so an accidental short expiry — which would silently break joins
+	// once the CA lapses — is caught here.
+	window := cert.NotAfter.Sub(cert.NotBefore)
+	assert.Greater(t, window, 9*365*24*time.Hour)
+	assert.Less(t, window, 11*365*24*time.Hour)
 }
 
 func TestGenerateClusterCAKeyBelongsToTheCertificate(t *testing.T) {
@@ -57,6 +65,10 @@ func TestGenerateClusterCAKeyBelongsToTheCertificate(t *testing.T) {
 
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 	require.NoError(t, err)
+
+	// Pin the modulus size (kubeadm's own CA is RSA-2048) so a key-size downgrade
+	// in ca.go is caught rather than silently weakening the cluster CA.
+	assert.Equal(t, 2048, key.N.BitLen())
 
 	certPubKey, ok := parseCACertificate(t, clusterCA.CertPEM).PublicKey.(*rsa.PublicKey)
 	require.True(t, ok)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Multi-node Vanilla (kubeadm) × Hetzner clusters need each joining worker to trust the control plane it registers against. kubeadm normally creates that trust anchor only *after* the first node is already running — but our Hetzner bring-up has to prepare every node before any server boots, so it never gets to read that anchor back in time to hand it to the joiners.

## What
Adds the missing building block: the provisioner now generates the cluster’s certificate authority up front, so the trust anchor is fixed before boot and the joining nodes can be told exactly what to trust. This is the first, self-contained piece of kubeadm multi-node support (fully unit-tested; no live cluster required).

Part of #5755 (multi-node bring-up) · epic #3983. The remaining wiring — and a shared design decision about the join address — are noted on #5755 for the next increment.