### PR TITLE
feat(kind): implement operator Connector to install components into Kind children

### DIFF
--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -41,9 +41,9 @@ var installOrder = []string{
 // the same installer factory the CLI uses. It satisfies controller.ComponentInstaller.
 //
 // Child access is obtained through the provisioner's optional clusterprovisioner.Connector
-// capability: provisioners that can hand back an operator-reachable kubeconfig (today: VCluster on
-// the Kubernetes provider) get their components installed; others are a no-op until they implement
-// Connector (see design/operator-component-lifecycle.md).
+// capability: provisioners that can hand back an operator-reachable kubeconfig (the nested
+// Kubernetes-provider distributions — vCluster, k3k, Talos, and Kind — publish one) get their
+// components installed; others are a no-op until they implement Connector.
 //
 // The returned applied is false when installation was skipped (no Connector), so the reconciler can
 // report ComponentsReady=Unknown rather than a misleading True. It is true once a Connector exists,

--- a/pkg/svc/provisioner/cluster/clustererr/errors.go
+++ b/pkg/svc/provisioner/cluster/clustererr/errors.go
@@ -74,3 +74,11 @@ var ErrOperationNotSupported = errors.New("operation not supported")
 // ErrKubeconfigNotReady is returned by a Connector when the provisioned cluster's kubeconfig has
 // not been published yet, signalling the caller to retry later.
 var ErrKubeconfigNotReady = errors.New("provisioned cluster kubeconfig not ready")
+
+// ErrKubeconfigContextMissing is returned when a named context (or the cluster it references) is
+// absent from a kubeconfig being minified for publication.
+var ErrKubeconfigContextMissing = errors.New("kubeconfig context not found")
+
+// ErrKubeconfigPublishInvalid is returned when a kubeconfig Secret publish is asked to run without a
+// host clientset or with empty kubeconfig data.
+var ErrKubeconfigPublishInvalid = errors.New("invalid kubeconfig publish request")

--- a/pkg/svc/provisioner/cluster/factory_kind.go
+++ b/pkg/svc/provisioner/cluster/factory_kind.go
@@ -148,7 +148,7 @@ func (f DefaultFactory) createKindKubernetesProvisioner(
 	// while cluster.Name may be empty with --name flag.
 	clusterName := kindConfig.Name
 
-	_, restConfig, dynClient, k8sProvider, err := buildKubernetesInfra(opts)
+	hostClient, restConfig, dynClient, k8sProvider, err := buildKubernetesInfra(opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -161,6 +161,7 @@ func (f DefaultFactory) createKindKubernetesProvisioner(
 		kindprovisioner.KubernetesProvisionerConfig{
 			KindConfig:       kindConfig,
 			KubeconfigPath:   cluster.Spec.Cluster.Connection.Kubeconfig,
+			HostClientset:    hostClient,
 			K8sProvider:      k8sProvider,
 			DynamicClient:    dynClient,
 			RestConfig:       restConfig,

--- a/pkg/svc/provisioner/cluster/internal/nested/kubeconfig.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/kubeconfig.go
@@ -46,7 +46,15 @@ func ExtractContextKubeconfig(path, contextName string) ([]byte, error) {
 	minified := clientcmdapi.NewConfig()
 	minified.Clusters[kubeContext.Cluster] = cluster
 
-	if authInfo, ok := config.AuthInfos[kubeContext.AuthInfo]; ok {
+	if kubeContext.AuthInfo != "" {
+		authInfo, hasAuthInfo := config.AuthInfos[kubeContext.AuthInfo]
+		if !hasAuthInfo {
+			return nil, fmt.Errorf(
+				"%w: auth info %q for context %q not found in %s",
+				clustererr.ErrKubeconfigContextMissing, kubeContext.AuthInfo, contextName, path,
+			)
+		}
+
 		minified.AuthInfos[kubeContext.AuthInfo] = authInfo
 	}
 

--- a/pkg/svc/provisioner/cluster/internal/nested/kubeconfig.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/kubeconfig.go
@@ -1,0 +1,96 @@
+package nested
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// ExtractContextKubeconfig reads the kubeconfig at path and returns a minified
+// single-context kubeconfig for contextName: only that context and the cluster
+// and auth-info it references, with CurrentContext set to it. The DinD-based
+// provisioners (Kind, KWOK) write their nested cluster's entry into the shared
+// host kubeconfig alongside the host context, so publishing the file as-is would
+// hand the operator a config whose current-context points at the host. The
+// operator builds its child-cluster client with an empty context (it relies on
+// current-context), so the published Secret must carry exactly one, nested,
+// context.
+func ExtractContextKubeconfig(path, contextName string) ([]byte, error) {
+	config, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load kubeconfig %s: %w", path, err)
+	}
+
+	kubeContext, hasContext := config.Contexts[contextName]
+	if !hasContext {
+		return nil, fmt.Errorf(
+			"%w: context %q not found in %s",
+			clustererr.ErrKubeconfigContextMissing, contextName, path,
+		)
+	}
+
+	cluster, hasCluster := config.Clusters[kubeContext.Cluster]
+	if !hasCluster {
+		return nil, fmt.Errorf(
+			"%w: cluster %q for context %q not found in %s",
+			clustererr.ErrKubeconfigContextMissing, kubeContext.Cluster, contextName, path,
+		)
+	}
+
+	minified := clientcmdapi.NewConfig()
+	minified.Clusters[kubeContext.Cluster] = cluster
+
+	if authInfo, ok := config.AuthInfos[kubeContext.AuthInfo]; ok {
+		minified.AuthInfos[kubeContext.AuthInfo] = authInfo
+	}
+
+	minified.Contexts[contextName] = kubeContext
+	minified.CurrentContext = contextName
+
+	raw, err := clientcmd.Write(*minified)
+	if err != nil {
+		return nil, fmt.Errorf("serialize minified kubeconfig for context %q: %w", contextName, err)
+	}
+
+	return raw, nil
+}
+
+// PublishKubeconfigSecret upserts a Secret named secretName in namespace holding
+// data under key. It is the write half of the Connector contract for DinD-based
+// distributions (Kind, KWOK): the nested cluster's kubeconfig is written to a
+// file in the DinD flow rather than published by a nested controller, so the
+// provisioner publishes it to the host cluster itself so the operator can read
+// it back through the Connector. The write is idempotent (see UpsertSecret) so a
+// re-provision or re-reconcile refreshes the credentials in place.
+func PublishKubeconfigSecret(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, secretName, key string,
+	data []byte,
+	labels map[string]string,
+) error {
+	if clientset == nil {
+		return fmt.Errorf("%w: host clientset not set", clustererr.ErrKubeconfigPublishInvalid)
+	}
+
+	if len(data) == 0 {
+		return fmt.Errorf("%w: kubeconfig data is empty", clustererr.ErrKubeconfigPublishInvalid)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Data: map[string][]byte{key: data},
+	}
+
+	return UpsertSecret(ctx, clientset, secret)
+}

--- a/pkg/svc/provisioner/cluster/internal/nested/kubeconfig_test.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/kubeconfig_test.go
@@ -1,0 +1,178 @@
+package nested_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const twoContextKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://host.example:6443
+  name: host
+- cluster:
+    server: https://10.0.0.5:31234
+  name: nested
+contexts:
+- context:
+    cluster: host
+    user: host
+  name: host
+- context:
+    cluster: nested
+    user: nested
+  name: nested
+current-context: host
+users:
+- name: host
+  user: {}
+- name: nested
+  user:
+    token: nested-token
+`
+
+func writeKubeconfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+
+	return path
+}
+
+func TestExtractContextKubeconfig_MinifiesToSingleContext(t *testing.T) {
+	t.Parallel()
+
+	path := writeKubeconfig(t, twoContextKubeconfig)
+
+	raw, err := nested.ExtractContextKubeconfig(path, "nested")
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, "nested", config.CurrentContext)
+	assert.Contains(t, config.Contexts, "nested")
+	assert.NotContains(t, config.Contexts, "host")
+	assert.Contains(t, config.Clusters, "nested")
+	assert.NotContains(t, config.Clusters, "host")
+	assert.Contains(t, config.AuthInfos, "nested")
+	assert.NotContains(t, config.AuthInfos, "host")
+}
+
+func TestExtractContextKubeconfig_MissingContext(t *testing.T) {
+	t.Parallel()
+
+	path := writeKubeconfig(t, twoContextKubeconfig)
+
+	_, err := nested.ExtractContextKubeconfig(path, "absent")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigContextMissing)
+}
+
+func TestExtractContextKubeconfig_MissingCluster(t *testing.T) {
+	t.Parallel()
+
+	// The context references a cluster that is not defined.
+	path := writeKubeconfig(t, `apiVersion: v1
+kind: Config
+contexts:
+- context:
+    cluster: gone
+    user: nested
+  name: nested
+current-context: nested
+users:
+- name: nested
+  user: {}
+`)
+
+	_, err := nested.ExtractContextKubeconfig(path, "nested")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigContextMissing)
+}
+
+func TestExtractContextKubeconfig_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := nested.ExtractContextKubeconfig(
+		filepath.Join(t.TempDir(), "does-not-exist"), "nested",
+	)
+
+	require.Error(t, err)
+}
+
+func TestPublishKubeconfigSecret_CreatesSecret(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	labels := map[string]string{"app": "ksail"}
+
+	err := nested.PublishKubeconfigSecret(
+		context.Background(), clientset,
+		"ksail-x", "kind-x-kubeconfig", "kubeconfig.yaml",
+		[]byte("data"), labels,
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().
+		Secrets("ksail-x").
+		Get(context.Background(), "kind-x-kubeconfig", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), secret.Data["kubeconfig.yaml"])
+	assert.Equal(t, labels, secret.Labels)
+}
+
+func TestPublishKubeconfigSecret_UpdatesInPlace(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+
+	require.NoError(t, nested.PublishKubeconfigSecret(
+		context.Background(), clientset,
+		"ksail-x", "kind-x-kubeconfig", "kubeconfig.yaml", []byte("v1"), nil,
+	))
+	require.NoError(t, nested.PublishKubeconfigSecret(
+		context.Background(), clientset,
+		"ksail-x", "kind-x-kubeconfig", "kubeconfig.yaml", []byte("v2"), nil,
+	))
+
+	secret, err := clientset.CoreV1().
+		Secrets("ksail-x").
+		Get(context.Background(), "kind-x-kubeconfig", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v2"), secret.Data["kubeconfig.yaml"])
+}
+
+func TestPublishKubeconfigSecret_NilClientset(t *testing.T) {
+	t.Parallel()
+
+	err := nested.PublishKubeconfigSecret(
+		context.Background(), nil,
+		"ksail-x", "kind-x-kubeconfig", "kubeconfig.yaml", []byte("data"), nil,
+	)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigPublishInvalid)
+}
+
+func TestPublishKubeconfigSecret_EmptyData(t *testing.T) {
+	t.Parallel()
+
+	err := nested.PublishKubeconfigSecret(
+		context.Background(), k8sfake.NewClientset(),
+		"ksail-x", "kind-x-kubeconfig", "kubeconfig.yaml", nil, nil,
+	)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigPublishInvalid)
+}

--- a/pkg/svc/provisioner/cluster/internal/nested/kubeconfig_test.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/kubeconfig_test.go
@@ -103,6 +103,31 @@ users:
 	require.ErrorIs(t, err, clustererr.ErrKubeconfigContextMissing)
 }
 
+func TestExtractContextKubeconfig_MissingAuthInfo(t *testing.T) {
+	t.Parallel()
+
+	// The context references a user that is not defined; the minified kubeconfig
+	// would otherwise silently omit it and fail later with a generic auth error.
+	path := writeKubeconfig(t, `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: nested
+contexts:
+- context:
+    cluster: nested
+    user: gone
+  name: nested
+current-context: nested
+users: []
+`)
+
+	_, err := nested.ExtractContextKubeconfig(path, "nested")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigContextMissing)
+}
+
 func TestExtractContextKubeconfig_MissingFile(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/kind/connection.go
+++ b/pkg/svc/provisioner/cluster/kind/connection.go
@@ -1,0 +1,56 @@
+package kindprovisioner
+
+import (
+	"fmt"
+
+	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
+)
+
+// Connection coordinates for a nested Kind cluster on a host Kubernetes cluster. These are the
+// single source of truth for the naming contract between the DinD exposure resources ksail creates
+// (namespace + API-server exposure) and the kubeconfig Secret it publishes at create time. The
+// operator imports these (rather than re-deriving them) so a naming change here can never silently
+// break operator component installs or status observation.
+//
+// Unlike the operator-published distributions (k3k, vCluster), a Kind cluster runs inside a DinD pod
+// and writes its kubeconfig to a file; no nested controller publishes a Secret. So ksail publishes
+// it itself at create time (see KubernetesProvisioner.publishConnectorKubeconfig) and Kubeconfig()
+// serves it back to the operator as-published — mirroring the nested-Talos Connector.
+const (
+	// kindKubeconfigSecretSuffix is appended to the cluster name for the kubeconfig Secret
+	// ("kind-<name>-kubeconfig", mirroring talos/k3k's "<distribution>-<name>-kubeconfig").
+	kindKubeconfigSecretSuffix = "kubeconfig"
+	// kindKubeconfigKey is the Secret data key holding the kubeconfig ("kubeconfig.yaml", the same
+	// key the other nested Connectors publish under).
+	kindKubeconfigKey = "kubeconfig.yaml"
+	// kindContextPrefix is the kubeconfig context (and cluster) name the Kind SDK writes for a
+	// created cluster ("kind-<name>"). The create-time publish minifies the shared host kubeconfig
+	// down to this single context before storing it in the Secret.
+	kindContextPrefix = "kind-"
+)
+
+// Connection holds the in-hub coordinates for a named nested Kind cluster: the namespace and
+// kubeconfig Secret ksail publishes, and the context name to minify the published kubeconfig to.
+type Connection struct {
+	// Namespace is the host-cluster namespace holding the DinD pod and the published kubeconfig
+	// Secret ("ksail-<name>" — the shared DinD exposure namespace, so the Secret's lifecycle is
+	// tied to the cluster's and namespace deletion cleans it up).
+	Namespace string
+	// SecretName is the kubeconfig Secret name in Namespace ("kind-<name>-kubeconfig").
+	SecretName string
+	// ContextName is the kubeconfig context the Kind SDK writes ("kind-<name>"); the create-time
+	// publish minifies the shared host kubeconfig to exactly this context so the operator's
+	// current-context points at the nested cluster.
+	ContextName string
+}
+
+// ConnectionFor returns the in-hub connection coordinates for the named nested Kind cluster. It is
+// the single source of truth shared by the provisioner's publishConnectorKubeconfig() and
+// Kubeconfig(), so the namespace/secret/context contract is derived in exactly one place.
+func ConnectionFor(name string) Connection {
+	return Connection{
+		Namespace:   kubernetesprovider.NamespaceName(name),
+		SecretName:  fmt.Sprintf("%s%s-%s", kindContextPrefix, name, kindKubeconfigSecretSuffix),
+		ContextName: kindContextPrefix + name,
+	}
+}

--- a/pkg/svc/provisioner/cluster/kind/connector.go
+++ b/pkg/svc/provisioner/cluster/kind/connector.go
@@ -1,0 +1,29 @@
+package kindprovisioner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
+)
+
+// Kubeconfig implements the clusterprovisioner.Connector capability for a nested Kind cluster: it
+// returns the kubeconfig published at create time (see publishConnectorKubeconfig), with the API
+// server already pointed at the operator-reachable exposure address, so the ksail operator can
+// install components into the child cluster. It returns clustererr.ErrKubeconfigNotReady (via
+// nested.ConnectorKubeconfig) when the Secret has not been published yet, so the caller requeues.
+func (p *KubernetesProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	target := setName(name, p.kindConfig.Name)
+
+	conn := ConnectionFor(target)
+
+	raw, err := nested.ConnectorKubeconfig(
+		ctx, p.hostClientset, target,
+		conn.Namespace, conn.SecretName, kindKubeconfigKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("kind: %w", err)
+	}
+
+	return raw, nil
+}

--- a/pkg/svc/provisioner/cluster/kind/connector_test.go
+++ b/pkg/svc/provisioner/cluster/kind/connector_test.go
@@ -1,0 +1,222 @@
+package kindprovisioner_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	kindprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kind"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// The nested Kind provisioner must satisfy the operator's Connector capability so InstallComponents
+// installs components into the child cluster instead of skipping it.
+var _ clusterprovisioner.Connector = (*kindprovisioner.KubernetesProvisioner)(nil)
+
+const kindConnectorTestCluster = "nested-kind"
+
+// kindHostKubeconfig is a shared host kubeconfig carrying both the host context and the nested
+// "kind-<name>" context the Kind SDK writes on create. The publish step must minify it down to the
+// nested context so the operator's current-context points at the child, not the host.
+const kindHostKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://host.example:6443
+  name: host
+- cluster:
+    server: https://10.0.0.5:31234
+  name: kind-nested-kind
+contexts:
+- context:
+    cluster: host
+    user: host
+  name: host
+- context:
+    cluster: kind-nested-kind
+    user: kind-nested-kind
+  name: kind-nested-kind
+current-context: host
+users:
+- name: host
+  user: {}
+- name: kind-nested-kind
+  user:
+    token: nested-token
+`
+
+func TestConnectionFor(t *testing.T) {
+	t.Parallel()
+
+	conn := kindprovisioner.ConnectionFor(kindConnectorTestCluster)
+
+	assert.Equal(t, "ksail-nested-kind", conn.Namespace)
+	assert.Equal(t, "kind-nested-kind-kubeconfig", conn.SecretName)
+	assert.Equal(t, "kind-nested-kind", conn.ContextName)
+}
+
+func TestKubeconfig_NotReadyWhileSecretUnpublished(t *testing.T) {
+	t.Parallel()
+
+	provisioner := kindprovisioner.NewKubernetesProvisionerForConnectorTest(
+		k8sfake.NewClientset(), kindConnectorTestCluster, "",
+	)
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_NotReadyWhileSecretKeyEmpty(t *testing.T) {
+	t.Parallel()
+
+	conn := kindprovisioner.ConnectionFor(kindConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": {}},
+	})
+	provisioner := kindprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kindConnectorTestCluster, "",
+	)
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_ReturnsPublishedSecret(t *testing.T) {
+	t.Parallel()
+
+	conn := kindprovisioner.ConnectionFor(kindConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": []byte(kindHostKubeconfig)},
+	})
+	provisioner := kindprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kindConnectorTestCluster, "",
+	)
+
+	out, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte(kindHostKubeconfig), out)
+}
+
+func TestKubeconfig_ResolvesNameFromArgument(t *testing.T) {
+	t.Parallel()
+
+	conn := kindprovisioner.ConnectionFor(kindConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": []byte("kubeconfig-bytes")},
+	})
+	// Empty kindConfig name — the Kubeconfig(name) argument must resolve the cluster.
+	provisioner := kindprovisioner.NewKubernetesProvisionerForConnectorTest(clientset, "", "")
+
+	out, err := provisioner.Kubeconfig(context.Background(), kindConnectorTestCluster)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte("kubeconfig-bytes"), out)
+}
+
+func TestPublishConnectorKubeconfig_PublishesMinifiedSecret(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kindHostKubeconfig), 0o600))
+
+	clientset := k8sfake.NewClientset()
+	provisioner := kindprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kindConnectorTestCluster, kubeconfigPath,
+	)
+
+	err := provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kindConnectorTestCluster,
+	)
+	require.NoError(t, err)
+
+	conn := kindprovisioner.ConnectionFor(kindConnectorTestCluster)
+	secret, err := clientset.CoreV1().
+		Secrets(conn.Namespace).
+		Get(context.Background(), conn.SecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// The published kubeconfig is minified to the single nested context, with the host context
+	// dropped and current-context pointing at the child cluster.
+	published, err := clientcmd.Load(secret.Data["kubeconfig.yaml"])
+	require.NoError(t, err)
+	assert.Equal(t, "kind-nested-kind", published.CurrentContext)
+	assert.Contains(t, published.Clusters, "kind-nested-kind")
+	assert.NotContains(t, published.Clusters, "host")
+	assert.Contains(t, published.Contexts, "kind-nested-kind")
+	assert.NotContains(t, published.Contexts, "host")
+
+	// The read side serves exactly what was published.
+	out, err := provisioner.Kubeconfig(context.Background(), kindConnectorTestCluster)
+	require.NoError(t, err)
+	assert.Equal(t, secret.Data["kubeconfig.yaml"], out)
+}
+
+func TestPublishConnectorKubeconfig_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kindHostKubeconfig), 0o600))
+
+	clientset := k8sfake.NewClientset()
+	provisioner := kindprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kindConnectorTestCluster, kubeconfigPath,
+	)
+
+	require.NoError(t, provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kindConnectorTestCluster,
+	))
+	require.NoError(t, provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kindConnectorTestCluster,
+	))
+
+	out, err := provisioner.Kubeconfig(context.Background(), kindConnectorTestCluster)
+	require.NoError(t, err)
+	assert.NotEmpty(t, out)
+}
+
+func TestPublishConnectorKubeconfig_ErrorsWhenContextMissing(t *testing.T) {
+	t.Parallel()
+
+	// A kubeconfig without the expected "kind-<name>" context — extraction must fail loudly.
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://host.example:6443
+  name: host
+contexts:
+- context:
+    cluster: host
+    user: host
+  name: host
+current-context: host
+users:
+- name: host
+  user: {}
+`), 0o600))
+
+	provisioner := kindprovisioner.NewKubernetesProvisionerForConnectorTest(
+		k8sfake.NewClientset(), kindConnectorTestCluster, kubeconfigPath,
+	)
+
+	err := provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kindConnectorTestCluster,
+	)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigContextMissing)
+}

--- a/pkg/svc/provisioner/cluster/kind/export_test.go
+++ b/pkg/svc/provisioner/cluster/kind/export_test.go
@@ -3,8 +3,31 @@ package kindprovisioner
 import (
 	"context"
 
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/log"
 )
+
+// NewKubernetesProvisionerForConnectorTest builds a minimal KubernetesProvisioner exercising only
+// the operator Connector paths (publish + read): the host clientset, the nested cluster name
+// (resolved through the embedded kindConfig), and the on-disk kubeconfig path. It skips the DinD
+// infra the full NewKubernetesProvisioner wires, which a Connector unit test does not need.
+func NewKubernetesProvisionerForConnectorTest(
+	clientset kubernetes.Interface, clusterName, kubeconfigPath string,
+) *KubernetesProvisioner {
+	return &KubernetesProvisioner{
+		Provisioner:    &Provisioner{kindConfig: &v1alpha4.Cluster{Name: clusterName}},
+		hostClientset:  clientset,
+		kubeconfigPath: kubeconfigPath,
+	}
+}
+
+// PublishConnectorKubeconfigForTest exposes publishConnectorKubeconfig for unit testing.
+func (k *KubernetesProvisioner) PublishConnectorKubeconfigForTest(
+	ctx context.Context, target string,
+) error {
+	return k.publishConnectorKubeconfig(ctx, target)
+}
 
 // KubeConfigForTest returns the kubeConfig field for testing purposes.
 func (k *Provisioner) KubeConfigForTest() string {

--- a/pkg/svc/provisioner/cluster/kind/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kind/kubernetes_provisioner.go
@@ -10,6 +10,7 @@ import (
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 )
@@ -21,6 +22,7 @@ import (
 type KubernetesProvisioner struct {
 	*Provisioner
 
+	hostClientset    kubernetes.Interface
 	k8sProvider      *kubernetesprovider.Provider
 	dynamicClient    dynamic.Interface
 	restConfig       *rest.Config
@@ -38,6 +40,9 @@ type KubernetesProvisionerConfig struct {
 	KindConfig *v1alpha4.Cluster
 	// KubeconfigPath is the path to the nested cluster's kubeconfig.
 	KubeconfigPath string
+	// HostClientset is the Kubernetes clientset for the host cluster, used to publish and read the
+	// nested cluster's kubeconfig Secret for the operator Connector contract.
+	HostClientset kubernetes.Interface
 	// K8sProvider is the Kubernetes infrastructure provider.
 	K8sProvider *kubernetesprovider.Provider
 	// DynamicClient is the dynamic client for Gateway API resources.
@@ -78,6 +83,7 @@ func NewKubernetesProvisioner(cfg KubernetesProvisionerConfig) (*KubernetesProvi
 
 	return &KubernetesProvisioner{
 		Provisioner:      innerProvisioner,
+		hostClientset:    cfg.HostClientset,
 		k8sProvider:      cfg.K8sProvider,
 		dynamicClient:    cfg.DynamicClient,
 		restConfig:       cfg.RestConfig,
@@ -163,10 +169,11 @@ func (p *KubernetesProvisioner) Create(
 		return fmt.Errorf("kind create via SDK: %w", err)
 	}
 
-	// Step 6: Point the kubeconfig at the stable exposure address.
-	err = p.rewriteKindKubeconfig(target, exposure.ServerURL())
+	// Step 6: Point the kubeconfig at the stable exposure address and publish it as a host-cluster
+	// Secret so the operator's Connector can install components into the child cluster.
+	err = p.finalizeKubeconfig(ctx, target, exposure.ServerURL())
 	if err != nil {
-		return fmt.Errorf("rewrite kubeconfig: %w", err)
+		return err
 	}
 
 	return nil
@@ -214,6 +221,54 @@ func (p *KubernetesProvisioner) dindLifecycle() nested.DinDLifecycle {
 		KubeconfigPath: p.kubeconfigPath,
 		LogWriter:      os.Stdout,
 	}
+}
+
+// finalizeKubeconfig points the on-disk kubeconfig at the stable exposure address and then publishes
+// the nested cluster's kubeconfig as a host-cluster Secret for the operator Connector (see
+// connector.go). It groups the two kubeconfig-finalization steps that close out Create.
+func (p *KubernetesProvisioner) finalizeKubeconfig(
+	ctx context.Context,
+	target, serverURL string,
+) error {
+	err := p.rewriteKindKubeconfig(target, serverURL)
+	if err != nil {
+		return fmt.Errorf("rewrite kubeconfig: %w", err)
+	}
+
+	err = p.publishConnectorKubeconfig(ctx, target)
+	if err != nil {
+		return fmt.Errorf("publish connector kubeconfig: %w", err)
+	}
+
+	return nil
+}
+
+// publishConnectorKubeconfig minifies the shared host kubeconfig down to the nested Kind cluster's
+// context and publishes it as a Secret in the DinD namespace under the Connection naming contract,
+// so Kubeconfig() can serve it back to the operator. The on-disk kubeconfig is already pointed at the
+// operator-reachable exposure address (a cert SAN), so it is published as-is after minifying. The
+// write is idempotent, so re-creating a cluster of the same name refreshes the credentials in place.
+func (p *KubernetesProvisioner) publishConnectorKubeconfig(
+	ctx context.Context,
+	target string,
+) error {
+	conn := ConnectionFor(target)
+
+	raw, err := nested.ExtractContextKubeconfig(p.kubeconfigPath, conn.ContextName)
+	if err != nil {
+		return fmt.Errorf("extract nested kubeconfig: %w", err)
+	}
+
+	err = nested.PublishKubeconfigSecret(
+		ctx, p.hostClientset,
+		conn.Namespace, conn.SecretName, kindKubeconfigKey,
+		raw, kubernetesprovider.CommonLabels(target),
+	)
+	if err != nil {
+		return fmt.Errorf("publish kubeconfig secret: %w", err)
+	}
+
+	return nil
 }
 
 // rewriteKindKubeconfig rewrites the Kind kubeconfig server URL to the stable exposure address.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The operator can install a cluster's components (CNI, CSI, GitOps, …) into nested vCluster, k3k and Talos children, but **silently skips Kind** — Kind never handed the operator a reachable kubeconfig, so Kind users get no operator-driven component install. This is the next step of the operator component-install lifecycle (#4899).

## What

Kind now publishes its child cluster's kubeconfig as a host-cluster Secret when it comes up, and serves it back to the operator on request — the same pattern the other nested distributions already use. The operator stops skipping Kind and installs its components like any other nested cluster.

The read path is unit-tested now; the live end-to-end path becomes testable once the in-cluster dev hub has the required networking wired, so this lands the code ahead of that. KWOK is the identical next step and reuses the shared helpers this adds.

Part of #5778 · Part of #4899