### PR TITLE
feat(operator): implement Connector for nested KWOK clusters

### DIFF
--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -42,7 +42,7 @@ var installOrder = []string{
 //
 // Child access is obtained through the provisioner's optional clusterprovisioner.Connector
 // capability: provisioners that can hand back an operator-reachable kubeconfig (the nested
-// Kubernetes-provider distributions — vCluster, k3k, Talos, and Kind — publish one) get their
+// Kubernetes-provider distributions — vCluster, k3k, Talos, Kind, and KWOK — publish one) get their
 // components installed; others are a no-op until they implement Connector.
 //
 // The returned applied is false when installation was skipped (no Connector), so the reconciler can

--- a/pkg/svc/provider/kubernetes/provisioner_config.go
+++ b/pkg/svc/provider/kubernetes/provisioner_config.go
@@ -1,0 +1,35 @@
+package kubernetes
+
+import (
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// DinDProvisionerConfig holds the host-cluster wiring shared by the DinD-based nested provisioners
+// (Kind, KWOK): both run their nested cluster inside a Docker-in-Docker pod on the same host
+// cluster, so they take the same host clients, Kubernetes provider, and nested-cluster identity.
+// It is built once (see the factory's buildDinDProvisionerConfig) and embedded in each
+// distribution's provisioner config so the two never drift and the assembly lives in one place.
+type DinDProvisionerConfig struct {
+	// KubeconfigPath is the path to the nested cluster's kubeconfig.
+	KubeconfigPath string
+	// HostClientset is the Kubernetes clientset for the host cluster, used to publish and read the
+	// nested cluster's kubeconfig Secret for the operator Connector contract.
+	HostClientset kubernetes.Interface
+	// K8sProvider is the Kubernetes infrastructure provider.
+	K8sProvider *Provider
+	// DynamicClient is the dynamic client for Gateway API resources.
+	DynamicClient dynamic.Interface
+	// RestConfig is the REST config for port-forwarding to the DinD pod.
+	RestConfig *rest.Config
+	// ClusterName is the nested cluster name (used for namespace, labels).
+	ClusterName string
+	// Distribution is the distribution name (for labels).
+	Distribution string
+	// GatewayClassName is the Gateway class for API exposure (empty = no gateway).
+	GatewayClassName string
+	// Persistence holds PVC configuration for the DinD Docker data directory.
+	Persistence v1alpha1.KubernetesPersistence
+}

--- a/pkg/svc/provisioner/cluster/factory_kind.go
+++ b/pkg/svc/provisioner/cluster/factory_kind.go
@@ -159,18 +159,12 @@ func (f DefaultFactory) createKindKubernetesProvisioner(
 
 	provisioner, err := kindprovisioner.NewKubernetesProvisioner(
 		kindprovisioner.KubernetesProvisionerConfig{
-			KindConfig:       kindConfig,
-			KubeconfigPath:   cluster.Spec.Cluster.Connection.Kubeconfig,
-			HostClientset:    hostClient,
-			K8sProvider:      k8sProvider,
-			DynamicClient:    dynClient,
-			RestConfig:       restConfig,
-			ClusterName:      clusterName,
-			Distribution:     string(cluster.Spec.Cluster.Distribution),
-			GatewayClassName: opts.GatewayClassName,
-			HostContext:      resolveKubernetesOption(opts.Context, opts.ContextEnvVar),
-			APIServerPort:    kubernetesprovider.DinDAPIServerPort,
-			Persistence:      opts.Persistence,
+			DinDProvisionerConfig: buildDinDProvisionerConfig(
+				cluster, opts, hostClient, restConfig, dynClient, k8sProvider, clusterName,
+			),
+			KindConfig:    kindConfig,
+			HostContext:   resolveKubernetesOption(opts.Context, opts.ContextEnvVar),
+			APIServerPort: kubernetesprovider.DinDAPIServerPort,
 		},
 	)
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/factory_kwok.go
+++ b/pkg/svc/provisioner/cluster/factory_kwok.go
@@ -53,17 +53,11 @@ func (f DefaultFactory) createKWOKKubernetesProvisioner(
 
 	provisioner, err := kwokprovisioner.NewKubernetesProvisioner(
 		kwokprovisioner.KubernetesProvisionerConfig{
-			Name:             kwokConfig.Name,
-			ConfigPath:       kwokConfig.ConfigPath,
-			KubeconfigPath:   cluster.Spec.Cluster.Connection.Kubeconfig,
-			HostClientset:    hostClient,
-			K8sProvider:      k8sProvider,
-			DynamicClient:    dynClient,
-			RestConfig:       restConfig,
-			ClusterName:      clusterName,
-			Distribution:     string(cluster.Spec.Cluster.Distribution),
-			GatewayClassName: opts.GatewayClassName,
-			Persistence:      opts.Persistence,
+			DinDProvisionerConfig: buildDinDProvisionerConfig(
+				cluster, opts, hostClient, restConfig, dynClient, k8sProvider, clusterName,
+			),
+			Name:       kwokConfig.Name,
+			ConfigPath: kwokConfig.ConfigPath,
 		},
 	)
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/factory_kwok.go
+++ b/pkg/svc/provisioner/cluster/factory_kwok.go
@@ -41,7 +41,7 @@ func (f DefaultFactory) createKWOKKubernetesProvisioner(
 ) (Provisioner, any, error) {
 	opts := cluster.Spec.Provider.Kubernetes
 
-	_, restConfig, dynClient, k8sProvider, err := buildKubernetesInfra(opts)
+	hostClient, restConfig, dynClient, k8sProvider, err := buildKubernetesInfra(opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -56,6 +56,7 @@ func (f DefaultFactory) createKWOKKubernetesProvisioner(
 			Name:             kwokConfig.Name,
 			ConfigPath:       kwokConfig.ConfigPath,
 			KubeconfigPath:   cluster.Spec.Cluster.Connection.Kubeconfig,
+			HostClientset:    hostClient,
 			K8sProvider:      k8sProvider,
 			DynamicClient:    dynClient,
 			RestConfig:       restConfig,

--- a/pkg/svc/provisioner/cluster/factory_shared.go
+++ b/pkg/svc/provisioner/cluster/factory_shared.go
@@ -119,3 +119,29 @@ func buildKubernetesInfra(
 
 	return hostClient, restConfig, dynClient, k8sProvider, nil
 }
+
+// buildDinDProvisionerConfig assembles the host-cluster wiring shared by the DinD-based nested
+// provisioners (Kind, KWOK) from the resolved cluster, options, clients and provider. Both
+// distributions embed the result in their provisioner config, so building it here keeps the two
+// factories from drifting.
+func buildDinDProvisionerConfig(
+	cluster *v1alpha1.Cluster,
+	opts v1alpha1.OptionsKubernetes,
+	hostClient kubernetes.Interface,
+	restConfig *rest.Config,
+	dynClient dynamic.Interface,
+	k8sProvider *kubernetesprovider.Provider,
+	clusterName string,
+) kubernetesprovider.DinDProvisionerConfig {
+	return kubernetesprovider.DinDProvisionerConfig{
+		KubeconfigPath:   cluster.Spec.Cluster.Connection.Kubeconfig,
+		HostClientset:    hostClient,
+		K8sProvider:      k8sProvider,
+		DynamicClient:    dynClient,
+		RestConfig:       restConfig,
+		ClusterName:      clusterName,
+		Distribution:     string(cluster.Spec.Cluster.Distribution),
+		GatewayClassName: opts.GatewayClassName,
+		Persistence:      opts.Persistence,
+	}
+}

--- a/pkg/svc/provisioner/cluster/internal/nested/kubeconfig.go
+++ b/pkg/svc/provisioner/cluster/internal/nested/kubeconfig.go
@@ -69,6 +69,31 @@ func ExtractContextKubeconfig(path, contextName string) ([]byte, error) {
 	return raw, nil
 }
 
+// PublishConnectorKubeconfig extracts the nested cluster's single-context kubeconfig from the
+// shared host kubeconfig at kubeconfigPath and publishes it as a Secret under the Connection
+// naming contract (namespace/secretName/key), so the operator's Connector can read it back. It is
+// the shared publish flow for the DinD-based distributions (Kind, KWOK), whose on-disk kubeconfig
+// is already pointed at the operator-reachable exposure address; it is published as-is after
+// minifying. Idempotent: re-provisioning a cluster of the same name refreshes the credentials.
+func PublishConnectorKubeconfig(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	key, kubeconfigPath, contextName, namespace, secretName string,
+	labels map[string]string,
+) error {
+	raw, err := ExtractContextKubeconfig(kubeconfigPath, contextName)
+	if err != nil {
+		return fmt.Errorf("extract nested kubeconfig: %w", err)
+	}
+
+	err = PublishKubeconfigSecret(ctx, clientset, namespace, secretName, key, raw, labels)
+	if err != nil {
+		return fmt.Errorf("publish kubeconfig secret: %w", err)
+	}
+
+	return nil
+}
+
 // PublishKubeconfigSecret upserts a Secret named secretName in namespace holding
 // data under key. It is the write half of the Connector contract for DinD-based
 // distributions (Kind, KWOK): the nested cluster's kubeconfig is written to a

--- a/pkg/svc/provisioner/cluster/kind/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kind/kubernetes_provisioner.go
@@ -36,32 +36,16 @@ type KubernetesProvisioner struct {
 
 // KubernetesProvisionerConfig holds configuration for creating a KubernetesProvisioner.
 type KubernetesProvisionerConfig struct {
+	// DinDProvisionerConfig holds the host-cluster wiring shared with the KWOK DinD provisioner.
+	kubernetesprovider.DinDProvisionerConfig
+
 	// KindConfig is the Kind cluster configuration.
 	KindConfig *v1alpha4.Cluster
-	// KubeconfigPath is the path to the nested cluster's kubeconfig.
-	KubeconfigPath string
-	// HostClientset is the Kubernetes clientset for the host cluster, used to publish and read the
-	// nested cluster's kubeconfig Secret for the operator Connector contract.
-	HostClientset kubernetes.Interface
-	// K8sProvider is the Kubernetes infrastructure provider.
-	K8sProvider *kubernetesprovider.Provider
-	// DynamicClient is the dynamic client for Gateway API resources.
-	DynamicClient dynamic.Interface
-	// RestConfig is the REST config for port-forwarding to the DinD pod.
-	RestConfig *rest.Config
-	// ClusterName is the nested cluster name.
-	ClusterName string
-	// Distribution is the distribution name (for labels).
-	Distribution string
-	// GatewayClassName is the Gateway class for API exposure (empty = no gateway).
-	GatewayClassName string
 	// HostContext is the explicitly-configured host kubeconfig context (empty = resolved from
 	// the kubeconfig's current-context).
 	HostContext string
 	// APIServerPort is the port the nested API server listens on.
 	APIServerPort int32
-	// Persistence holds PVC configuration for the DinD Docker data directory.
-	Persistence v1alpha1.KubernetesPersistence
 }
 
 // NewKubernetesProvisioner creates a KubernetesProvisioner that wraps Kind with DinD lifecycle.
@@ -243,29 +227,22 @@ func (p *KubernetesProvisioner) finalizeKubeconfig(
 	return nil
 }
 
-// publishConnectorKubeconfig minifies the shared host kubeconfig down to the nested Kind cluster's
-// context and publishes it as a Secret in the DinD namespace under the Connection naming contract,
-// so Kubeconfig() can serve it back to the operator. The on-disk kubeconfig is already pointed at the
-// operator-reachable exposure address (a cert SAN), so it is published as-is after minifying. The
-// write is idempotent, so re-creating a cluster of the same name refreshes the credentials in place.
+// publishConnectorKubeconfig publishes the nested Kind cluster's kubeconfig under its Connection
+// naming contract so Kubeconfig() can serve it back to the operator (see
+// nested.PublishConnectorKubeconfig for the shared DinD publish flow).
 func (p *KubernetesProvisioner) publishConnectorKubeconfig(
 	ctx context.Context,
 	target string,
 ) error {
 	conn := ConnectionFor(target)
 
-	raw, err := nested.ExtractContextKubeconfig(p.kubeconfigPath, conn.ContextName)
-	if err != nil {
-		return fmt.Errorf("extract nested kubeconfig: %w", err)
-	}
-
-	err = nested.PublishKubeconfigSecret(
-		ctx, p.hostClientset,
-		conn.Namespace, conn.SecretName, kindKubeconfigKey,
-		raw, kubernetesprovider.CommonLabels(target),
+	err := nested.PublishConnectorKubeconfig(
+		ctx, p.hostClientset, kindKubeconfigKey, p.kubeconfigPath,
+		conn.ContextName, conn.Namespace, conn.SecretName,
+		kubernetesprovider.CommonLabels(target),
 	)
 	if err != nil {
-		return fmt.Errorf("publish kubeconfig secret: %w", err)
+		return fmt.Errorf("kind: %w", err)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/kwok/connection.go
+++ b/pkg/svc/provisioner/cluster/kwok/connection.go
@@ -28,6 +28,12 @@ const (
 	// cluster ("kwok-<name>"). The create-time publish minifies the shared host kubeconfig down to
 	// this single context before storing it in the Secret.
 	kwokContextPrefix = "kwok-"
+	// kwokDistributionPrefix is the distribution prefix in the kubeconfig Secret name
+	// ("kwok-<name>-kubeconfig", mirroring kind/talos/k3k's "<distribution>-<name>-kubeconfig"). It
+	// is kept distinct from kwokContextPrefix — the two happen to share a value today but name
+	// separate concepts (kwokctl's context prefix vs. the Secret naming scheme), so one can change
+	// without silently shifting the other.
+	kwokDistributionPrefix = "kwok-"
 )
 
 // Connection holds the in-hub coordinates for a named nested KWOK cluster: the namespace and
@@ -50,8 +56,13 @@ type Connection struct {
 // Kubeconfig(), so the namespace/secret/context contract is derived in exactly one place.
 func ConnectionFor(name string) Connection {
 	return Connection{
-		Namespace:   kubernetesprovider.NamespaceName(name),
-		SecretName:  fmt.Sprintf("%s%s-%s", kwokContextPrefix, name, kwokKubeconfigSecretSuffix),
+		Namespace: kubernetesprovider.NamespaceName(name),
+		SecretName: fmt.Sprintf(
+			"%s%s-%s",
+			kwokDistributionPrefix,
+			name,
+			kwokKubeconfigSecretSuffix,
+		),
 		ContextName: kwokContextPrefix + name,
 	}
 }

--- a/pkg/svc/provisioner/cluster/kwok/connection.go
+++ b/pkg/svc/provisioner/cluster/kwok/connection.go
@@ -1,0 +1,57 @@
+package kwokprovisioner
+
+import (
+	"fmt"
+
+	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
+)
+
+// Connection coordinates for a nested KWOK cluster on a host Kubernetes cluster. These are the
+// single source of truth for the naming contract between the DinD exposure resources ksail creates
+// (namespace + API-server exposure) and the kubeconfig Secret it publishes at create time. The
+// operator imports these (rather than re-deriving them) so a naming change here can never silently
+// break operator component installs or status observation.
+//
+// Unlike the operator-published distributions (k3k, vCluster), a KWOK cluster runs inside a DinD pod
+// and writes its kubeconfig to a file; no nested controller publishes a Secret. So ksail publishes
+// it itself at create time (see KubernetesProvisioner.publishConnectorKubeconfig) and Kubeconfig()
+// serves it back to the operator as-published — mirroring the nested-Kind and nested-Talos
+// Connectors.
+const (
+	// kwokKubeconfigSecretSuffix is appended to the cluster name for the kubeconfig Secret
+	// ("kwok-<name>-kubeconfig", mirroring kind/talos/k3k's "<distribution>-<name>-kubeconfig").
+	kwokKubeconfigSecretSuffix = "kubeconfig"
+	// kwokKubeconfigKey is the Secret data key holding the kubeconfig ("kubeconfig.yaml", the same
+	// key the other nested Connectors publish under).
+	kwokKubeconfigKey = "kubeconfig.yaml"
+	// kwokContextPrefix is the kubeconfig context (and cluster) name kwokctl writes for a created
+	// cluster ("kwok-<name>"). The create-time publish minifies the shared host kubeconfig down to
+	// this single context before storing it in the Secret.
+	kwokContextPrefix = "kwok-"
+)
+
+// Connection holds the in-hub coordinates for a named nested KWOK cluster: the namespace and
+// kubeconfig Secret ksail publishes, and the context name to minify the published kubeconfig to.
+type Connection struct {
+	// Namespace is the host-cluster namespace holding the DinD pod and the published kubeconfig
+	// Secret ("ksail-<name>" — the shared DinD exposure namespace, so the Secret's lifecycle is
+	// tied to the cluster's and namespace deletion cleans it up).
+	Namespace string
+	// SecretName is the kubeconfig Secret name in Namespace ("kwok-<name>-kubeconfig").
+	SecretName string
+	// ContextName is the kubeconfig context kwokctl writes ("kwok-<name>"); the create-time publish
+	// minifies the shared host kubeconfig to exactly this context so the operator's current-context
+	// points at the nested cluster.
+	ContextName string
+}
+
+// ConnectionFor returns the in-hub connection coordinates for the named nested KWOK cluster. It is
+// the single source of truth shared by the provisioner's publishConnectorKubeconfig() and
+// Kubeconfig(), so the namespace/secret/context contract is derived in exactly one place.
+func ConnectionFor(name string) Connection {
+	return Connection{
+		Namespace:   kubernetesprovider.NamespaceName(name),
+		SecretName:  fmt.Sprintf("%s%s-%s", kwokContextPrefix, name, kwokKubeconfigSecretSuffix),
+		ContextName: kwokContextPrefix + name,
+	}
+}

--- a/pkg/svc/provisioner/cluster/kwok/connector.go
+++ b/pkg/svc/provisioner/cluster/kwok/connector.go
@@ -1,0 +1,29 @@
+package kwokprovisioner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
+)
+
+// Kubeconfig implements the clusterprovisioner.Connector capability for a nested KWOK cluster: it
+// returns the kubeconfig published at create time (see publishConnectorKubeconfig), with the API
+// server already pointed at the operator-reachable exposure address, so the ksail operator can
+// install components into the child cluster. It returns clustererr.ErrKubeconfigNotReady (via
+// nested.ConnectorKubeconfig) when the Secret has not been published yet, so the caller requeues.
+func (p *KubernetesProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	target := p.resolveName(name)
+
+	conn := ConnectionFor(target)
+
+	raw, err := nested.ConnectorKubeconfig(
+		ctx, p.hostClientset, target,
+		conn.Namespace, conn.SecretName, kwokKubeconfigKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("kwok: %w", err)
+	}
+
+	return raw, nil
+}

--- a/pkg/svc/provisioner/cluster/kwok/connector_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/connector_test.go
@@ -1,0 +1,222 @@
+package kwokprovisioner_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	kwokprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kwok"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// The nested KWOK provisioner must satisfy the operator's Connector capability so InstallComponents
+// installs components into the child cluster instead of skipping it.
+var _ clusterprovisioner.Connector = (*kwokprovisioner.KubernetesProvisioner)(nil)
+
+const kwokConnectorTestCluster = "nested-kwok"
+
+// kwokHostKubeconfig is a shared host kubeconfig carrying both the host context and the nested
+// "kwok-<name>" context kwokctl writes on create. The publish step must minify it down to the
+// nested context so the operator's current-context points at the child, not the host.
+const kwokHostKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://host.example:6443
+  name: host
+- cluster:
+    server: https://10.0.0.5:31234
+  name: kwok-nested-kwok
+contexts:
+- context:
+    cluster: host
+    user: host
+  name: host
+- context:
+    cluster: kwok-nested-kwok
+    user: kwok-nested-kwok
+  name: kwok-nested-kwok
+current-context: host
+users:
+- name: host
+  user: {}
+- name: kwok-nested-kwok
+  user:
+    token: nested-token
+`
+
+func TestConnectionFor(t *testing.T) {
+	t.Parallel()
+
+	conn := kwokprovisioner.ConnectionFor(kwokConnectorTestCluster)
+
+	assert.Equal(t, "ksail-nested-kwok", conn.Namespace)
+	assert.Equal(t, "kwok-nested-kwok-kubeconfig", conn.SecretName)
+	assert.Equal(t, "kwok-nested-kwok", conn.ContextName)
+}
+
+func TestKubeconfig_NotReadyWhileSecretUnpublished(t *testing.T) {
+	t.Parallel()
+
+	provisioner := kwokprovisioner.NewKubernetesProvisionerForConnectorTest(
+		k8sfake.NewClientset(), kwokConnectorTestCluster, "",
+	)
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_NotReadyWhileSecretKeyEmpty(t *testing.T) {
+	t.Parallel()
+
+	conn := kwokprovisioner.ConnectionFor(kwokConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": {}},
+	})
+	provisioner := kwokprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kwokConnectorTestCluster, "",
+	)
+
+	_, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_ReturnsPublishedSecret(t *testing.T) {
+	t.Parallel()
+
+	conn := kwokprovisioner.ConnectionFor(kwokConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": []byte(kwokHostKubeconfig)},
+	})
+	provisioner := kwokprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kwokConnectorTestCluster, "",
+	)
+
+	out, err := provisioner.Kubeconfig(context.Background(), "")
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte(kwokHostKubeconfig), out)
+}
+
+func TestKubeconfig_ResolvesNameFromArgument(t *testing.T) {
+	t.Parallel()
+
+	conn := kwokprovisioner.ConnectionFor(kwokConnectorTestCluster)
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: conn.SecretName, Namespace: conn.Namespace},
+		Data:       map[string][]byte{"kubeconfig.yaml": []byte("kubeconfig-bytes")},
+	})
+	// Empty provisioner name — the Kubeconfig(name) argument must resolve the cluster.
+	provisioner := kwokprovisioner.NewKubernetesProvisionerForConnectorTest(clientset, "", "")
+
+	out, err := provisioner.Kubeconfig(context.Background(), kwokConnectorTestCluster)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte("kubeconfig-bytes"), out)
+}
+
+func TestPublishConnectorKubeconfig_PublishesMinifiedSecret(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kwokHostKubeconfig), 0o600))
+
+	clientset := k8sfake.NewClientset()
+	provisioner := kwokprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kwokConnectorTestCluster, kubeconfigPath,
+	)
+
+	err := provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kwokConnectorTestCluster,
+	)
+	require.NoError(t, err)
+
+	conn := kwokprovisioner.ConnectionFor(kwokConnectorTestCluster)
+	secret, err := clientset.CoreV1().
+		Secrets(conn.Namespace).
+		Get(context.Background(), conn.SecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// The published kubeconfig is minified to the single nested context, with the host context
+	// dropped and current-context pointing at the child cluster.
+	published, err := clientcmd.Load(secret.Data["kubeconfig.yaml"])
+	require.NoError(t, err)
+	assert.Equal(t, "kwok-nested-kwok", published.CurrentContext)
+	assert.Contains(t, published.Clusters, "kwok-nested-kwok")
+	assert.NotContains(t, published.Clusters, "host")
+	assert.Contains(t, published.Contexts, "kwok-nested-kwok")
+	assert.NotContains(t, published.Contexts, "host")
+
+	// The read side serves exactly what was published.
+	out, err := provisioner.Kubeconfig(context.Background(), kwokConnectorTestCluster)
+	require.NoError(t, err)
+	assert.Equal(t, secret.Data["kubeconfig.yaml"], out)
+}
+
+func TestPublishConnectorKubeconfig_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kwokHostKubeconfig), 0o600))
+
+	clientset := k8sfake.NewClientset()
+	provisioner := kwokprovisioner.NewKubernetesProvisionerForConnectorTest(
+		clientset, kwokConnectorTestCluster, kubeconfigPath,
+	)
+
+	require.NoError(t, provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kwokConnectorTestCluster,
+	))
+	require.NoError(t, provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kwokConnectorTestCluster,
+	))
+
+	out, err := provisioner.Kubeconfig(context.Background(), kwokConnectorTestCluster)
+	require.NoError(t, err)
+	assert.NotEmpty(t, out)
+}
+
+func TestPublishConnectorKubeconfig_ErrorsWhenContextMissing(t *testing.T) {
+	t.Parallel()
+
+	// A kubeconfig without the expected "kwok-<name>" context — extraction must fail loudly.
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://host.example:6443
+  name: host
+contexts:
+- context:
+    cluster: host
+    user: host
+  name: host
+current-context: host
+users:
+- name: host
+  user: {}
+`), 0o600))
+
+	provisioner := kwokprovisioner.NewKubernetesProvisionerForConnectorTest(
+		k8sfake.NewClientset(), kwokConnectorTestCluster, kubeconfigPath,
+	)
+
+	err := provisioner.PublishConnectorKubeconfigForTest(
+		context.Background(), kwokConnectorTestCluster,
+	)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigContextMissing)
+}

--- a/pkg/svc/provisioner/cluster/kwok/export_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/export_test.go
@@ -1,8 +1,35 @@
 //nolint:gochecknoglobals // export_test.go pattern requires global variables to expose internal functions
 package kwokprovisioner
 
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+)
+
 // KwokControllerImageVersionForTest exposes kwokControllerImageVersion for unit testing.
 const KwokControllerImageVersionForTest = kwokControllerImageVersion
+
+// NewKubernetesProvisionerForConnectorTest builds a minimal KubernetesProvisioner exercising only
+// the operator Connector paths (publish + read): the host clientset, the nested cluster name
+// (resolved through the embedded Provisioner), and the on-disk kubeconfig path. It skips the DinD
+// infra the full NewKubernetesProvisioner wires, which a Connector unit test does not need.
+func NewKubernetesProvisionerForConnectorTest(
+	clientset kubernetes.Interface, clusterName, kubeconfigPath string,
+) *KubernetesProvisioner {
+	return &KubernetesProvisioner{
+		Provisioner:    &Provisioner{name: clusterName},
+		hostClientset:  clientset,
+		kubeconfigPath: kubeconfigPath,
+	}
+}
+
+// PublishConnectorKubeconfigForTest exposes publishConnectorKubeconfig for unit testing.
+func (p *KubernetesProvisioner) PublishConnectorKubeconfigForTest(
+	ctx context.Context, target string,
+) error {
+	return p.publishConnectorKubeconfig(ctx, target)
+}
 
 // IsTransientCreateErrorForTest exposes isTransientCreateError for unit testing.
 var IsTransientCreateErrorForTest = isTransientCreateError

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
@@ -46,29 +46,13 @@ type KubernetesProvisioner struct {
 
 // KubernetesProvisionerConfig holds configuration for creating a KubernetesProvisioner.
 type KubernetesProvisionerConfig struct {
+	// DinDProvisionerConfig holds the host-cluster wiring shared with the Kind DinD provisioner.
+	kubernetesprovider.DinDProvisionerConfig
+
 	// Name is the KWOK cluster name passed to kwokctl.
 	Name string
 	// ConfigPath is the optional path to a kwok.yaml configuration file.
 	ConfigPath string
-	// KubeconfigPath is the path to the nested cluster's kubeconfig.
-	KubeconfigPath string
-	// HostClientset is the Kubernetes clientset for the host cluster, used to publish and read the
-	// nested cluster's kubeconfig Secret for the operator Connector contract.
-	HostClientset kubernetes.Interface
-	// K8sProvider is the Kubernetes infrastructure provider.
-	K8sProvider *kubernetesprovider.Provider
-	// DynamicClient is the dynamic client for Gateway API resources.
-	DynamicClient dynamic.Interface
-	// RestConfig is the REST config for port-forwarding to the DinD pod.
-	RestConfig *rest.Config
-	// ClusterName is the nested cluster name (used for namespace, labels).
-	ClusterName string
-	// Distribution is the distribution name (for labels).
-	Distribution string
-	// GatewayClassName is the Gateway class for API exposure (empty = no gateway).
-	GatewayClassName string
-	// Persistence holds PVC configuration for the DinD Docker data directory.
-	Persistence v1alpha1.KubernetesPersistence
 }
 
 // NewKubernetesProvisioner creates a KubernetesProvisioner that wraps KWOK with DinD lifecycle.
@@ -607,29 +591,22 @@ func (p *KubernetesProvisioner) restartContainersInDinD(
 	return nil
 }
 
-// publishConnectorKubeconfig minifies the shared host kubeconfig down to the nested KWOK cluster's
-// context and publishes it as a Secret in the DinD namespace under the Connection naming contract,
-// so Kubeconfig() can serve it back to the operator. The on-disk kubeconfig is already pointed at the
-// operator-reachable exposure address (a cert SAN), so it is published as-is after minifying. The
-// write is idempotent, so re-creating a cluster of the same name refreshes the credentials in place.
+// publishConnectorKubeconfig publishes the nested KWOK cluster's kubeconfig under its Connection
+// naming contract so Kubeconfig() can serve it back to the operator (see
+// nested.PublishConnectorKubeconfig for the shared DinD publish flow).
 func (p *KubernetesProvisioner) publishConnectorKubeconfig(
 	ctx context.Context,
 	target string,
 ) error {
 	conn := ConnectionFor(target)
 
-	raw, err := nested.ExtractContextKubeconfig(p.kubeconfigPath, conn.ContextName)
-	if err != nil {
-		return fmt.Errorf("extract nested kubeconfig: %w", err)
-	}
-
-	err = nested.PublishKubeconfigSecret(
-		ctx, p.hostClientset,
-		conn.Namespace, conn.SecretName, kwokKubeconfigKey,
-		raw, kubernetesprovider.CommonLabels(target),
+	err := nested.PublishConnectorKubeconfig(
+		ctx, p.hostClientset, kwokKubeconfigKey, p.kubeconfigPath,
+		conn.ContextName, conn.Namespace, conn.SecretName,
+		kubernetesprovider.CommonLabels(target),
 	)
 	if err != nil {
-		return fmt.Errorf("publish kubeconfig secret: %w", err)
+		return fmt.Errorf("kwok: %w", err)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner.go
@@ -17,6 +17,7 @@ import (
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -32,6 +33,7 @@ const kwokContainerRestartDelay = 3 * time.Second
 type KubernetesProvisioner struct {
 	*Provisioner
 
+	hostClientset    kubernetes.Interface
 	k8sProvider      *kubernetesprovider.Provider
 	dynamicClient    dynamic.Interface
 	restConfig       *rest.Config
@@ -50,6 +52,9 @@ type KubernetesProvisionerConfig struct {
 	ConfigPath string
 	// KubeconfigPath is the path to the nested cluster's kubeconfig.
 	KubeconfigPath string
+	// HostClientset is the Kubernetes clientset for the host cluster, used to publish and read the
+	// nested cluster's kubeconfig Secret for the operator Connector contract.
+	HostClientset kubernetes.Interface
 	// K8sProvider is the Kubernetes infrastructure provider.
 	K8sProvider *kubernetesprovider.Provider
 	// DynamicClient is the dynamic client for Gateway API resources.
@@ -81,6 +86,7 @@ func NewKubernetesProvisioner(cfg KubernetesProvisionerConfig) (*KubernetesProvi
 
 	return &KubernetesProvisioner{
 		Provisioner:      innerProvisioner,
+		hostClientset:    cfg.HostClientset,
 		k8sProvider:      cfg.K8sProvider,
 		dynamicClient:    cfg.DynamicClient,
 		restConfig:       cfg.RestConfig,
@@ -247,6 +253,13 @@ func (p *KubernetesProvisioner) Create(ctx context.Context, name string) error {
 	err = p.rewriteKubeconfig(name, exposure.ServerURL())
 	if err != nil {
 		return fmt.Errorf("rewrite kubeconfig: %w", err)
+	}
+
+	// Step 13: Publish the nested cluster's kubeconfig as a host-cluster Secret so the operator's
+	// Connector can install components into the child cluster (see connector.go).
+	err = p.publishConnectorKubeconfig(ctx, target)
+	if err != nil {
+		return fmt.Errorf("publish connector kubeconfig: %w", err)
 	}
 
 	return nil
@@ -590,6 +603,34 @@ func (p *KubernetesProvisioner) restartContainersInDinD(
 
 	// Give the containers a moment to start up
 	time.Sleep(kwokContainerRestartDelay)
+
+	return nil
+}
+
+// publishConnectorKubeconfig minifies the shared host kubeconfig down to the nested KWOK cluster's
+// context and publishes it as a Secret in the DinD namespace under the Connection naming contract,
+// so Kubeconfig() can serve it back to the operator. The on-disk kubeconfig is already pointed at the
+// operator-reachable exposure address (a cert SAN), so it is published as-is after minifying. The
+// write is idempotent, so re-creating a cluster of the same name refreshes the credentials in place.
+func (p *KubernetesProvisioner) publishConnectorKubeconfig(
+	ctx context.Context,
+	target string,
+) error {
+	conn := ConnectionFor(target)
+
+	raw, err := nested.ExtractContextKubeconfig(p.kubeconfigPath, conn.ContextName)
+	if err != nil {
+		return fmt.Errorf("extract nested kubeconfig: %w", err)
+	}
+
+	err = nested.PublishKubeconfigSecret(
+		ctx, p.hostClientset,
+		conn.Namespace, conn.SecretName, kwokKubeconfigKey,
+		raw, kubernetesprovider.CommonLabels(target),
+	)
+	if err != nil {
+		return fmt.Errorf("publish kubeconfig secret: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kwok/kubernetes_provisioner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
 	kwokprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kwok"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,8 +24,10 @@ func newKubernetesProvisionerForTest(
 
 	prov, err := kwokprovisioner.NewKubernetesProvisioner(
 		kwokprovisioner.KubernetesProvisionerConfig{
-			Name:           name,
-			KubeconfigPath: kubeconfigPath,
+			DinDProvisionerConfig: kubernetesprovider.DinDProvisionerConfig{
+				KubeconfigPath: kubeconfigPath,
+			},
+			Name: name,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The operator installs a cluster's components into the child cluster only for distributions that can hand back an operator-reachable kubeconfig (the `Connector` capability). The nested **KWOK** (DinD) distribution didn't implement it, so KWOK-on-Kubernetes clusters silently had their component installs skipped.

## What

Adds the KWOK Connector, completing the Kind + KWOK pair started by #5779. KWOK now publishes its child kubeconfig at create time and serves it back to the operator, so the operator installs components into nested KWOK clusters like the other nested distributions. Internal change only — no new flags, config, or CRDs.

Fixes #5778
Part of #4899