### PR TITLE
feat(hetzner): kubeadm multi-node join via pre-seeded CA and a stable join name

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -35,10 +35,10 @@ var (
 	)
 
 	// ErrMultiNodeNotImplemented is returned by [Base.Create] for a topology with
-	// agents when the distribution's strategy does not yet implement the joining-node
-	// bring-up ([MultiNodeComposer]) — currently the kubeadm × Hetzner provisioner,
-	// whose bootstrap has no API-server-endpoint threading yet. The two-phase join
-	// sequencing is tracked by devantler-tech/ksail#5755.
+	// agents when the distribution's strategy does not yet implement the
+	// joining-node bring-up ([MultiNodeComposer]). Both current Hetzner
+	// distributions (k3s and kubeadm) implement it, so this guards any future
+	// strategy added without join sequencing (see devantler-tech/ksail#5755).
 	ErrMultiNodeNotImplemented = errors.New(
 		"hetzner: multi-node bring-up is not yet implemented for this distribution (tracked by #5755)",
 	)
@@ -392,8 +392,8 @@ func (b *Base) RunCreate(
 // wires the embedded [CreateStrategy]'s per-node composition into the shared plan
 // composition ([PlanComposer]) and runs [Base.RunCreate]; a topology with agents
 // runs the two-phase multi-node bring-up ([Base.RunCreateMultiNode]) when the
-// strategy implements [MultiNodeComposer] (currently k3s), and is rejected
-// otherwise. High-availability (multiple control planes) is a later increment.
+// strategy implements [MultiNodeComposer] (k3s and kubeadm both do), and is
+// rejected otherwise. High-availability (multiple control planes) is a later increment.
 // Each provisioner gets this method by embedding *Base; the distro-specific
 // pieces come from the Strategy it sets at construction.
 func (b *Base) Create(ctx context.Context, name string) error {

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
@@ -23,7 +23,7 @@ var ErrNoPrivateIPv4 = errors.New(
 // flow ([Base.RunCreateMultiNode]) needs the init control plane composed on its
 // own (before any address is known) and the joining nodes composed afterwards
 // against the init control plane's resolved private address — a distribution
-// whose bootstrap cannot yet thread that join endpoint (kubeadm) simply does not
+// whose bootstrap cannot yet thread that join endpoint simply does not
 // implement this, and a topology with agents is rejected before any resource is
 // created. See devantler-tech/ksail#5755.
 type MultiNodeComposer interface {

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/doc.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/doc.go
@@ -11,10 +11,12 @@
 //   - cloudinitbootstrap marshals the whole install into a #cloud-config document —
 //     the declarative, SSH-free delivery seam attached to each server's user_data.
 //
-// This is the user_data-composition slice of the Hetzner × Vanilla provisioning
-// work (devantler-tech/ksail#5513, epic #3983). The Hetzner server lifecycle
-// (network, firewall, placement group, server create/delete) and the run-time join
-// sequencing that depends on the first control plane's address are provided by the
-// provisioner that consumes this composer — a later increment, mirroring how
-// k3shetzner wraps its own user_data builder.
+// This is the Hetzner × Vanilla provisioning work of devantler-tech/ksail#5513
+// (epic #3983). The Hetzner server lifecycle (network, firewall, placement group,
+// server create/delete) comes from the shared hetznerbase engine, and the run-time
+// two-phase join sequencing (devantler-tech/ksail#5755) is implemented in
+// multinode.go: the cluster identity is a pre-seeded CA (ca.go) fixed at compose
+// time, and the joining nodes dial a compose-time-stable join name whose
+// resolution each node pins to the init control plane's private address at first
+// boot — see [JoinName] for why a name rather than the IP.
 package kubeadmhetzner

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
@@ -1,6 +1,10 @@
 package kubeadmhetzner
 
-import "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+import (
+	"errors"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+)
 
 // The kubeadm × Hetzner provisioner reports the sentinels of the shared Hetzner
 // create flow; these aliases keep the package's public API stable while the
@@ -10,13 +14,17 @@ var (
 	// the target kubeadm cluster already exist; see [hetznerbase.ErrClusterAlreadyExists].
 	ErrClusterAlreadyExists = hetznerbase.ErrClusterAlreadyExists
 
-	// ErrMultiNodeNotImplemented is returned by [Provisioner.Create] for a kubeadm
-	// topology with agents — kubeadm does not yet implement joining-node bring-up;
-	// see [hetznerbase.ErrMultiNodeNotImplemented].
-	ErrMultiNodeNotImplemented = hetznerbase.ErrMultiNodeNotImplemented
-
 	// ErrHAControlPlaneNotImplemented is returned by [Provisioner.Create] for a
 	// kubeadm topology with more than one control plane; see
 	// [hetznerbase.ErrHAControlPlaneNotImplemented].
 	ErrHAControlPlaneNotImplemented = hetznerbase.ErrHAControlPlaneNotImplemented
+)
+
+// ErrJoiningNodesComposedFirst is returned by
+// [Provisioner.ComposeJoiningNodes] when it is called before
+// [Provisioner.ComposeInitNode] has minted the cluster CA — the two-phase flow
+// guarantees the init compose runs first, so hitting this means the composer
+// was driven outside that flow.
+var ErrJoiningNodesComposedFirst = errors.New(
+	"kubeadm × Hetzner: joining nodes composed before the init control plane",
 )

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/lifecycle.go
@@ -19,11 +19,11 @@ const remoteKubeconfigPath = "/etc/kubernetes/admin.conf"
 // pieces below.
 
 // buildNodes composes the ordered per-node cloud-init user_data for the cluster's
-// topology via [BuildNodeUserData]. In the current increment it is only reached for
-// a single control-plane, no-agent cluster (multi-node returns
-// [ErrMultiNodeNotImplemented] before this is called), so the plan carries no
-// APIServerEndpoint. The cluster-wide Kubernetes version selects the package
-// repository track every node installs the kube* components from;
+// topology via [BuildNodeUserData]. It is only reached on the single-node create
+// path (a topology with agents is routed to the two-phase multi-node flow via
+// [Provisioner.ComposeInitNode] / [Provisioner.ComposeJoiningNodes]), so the plan
+// carries no APIServerEndpoint. The cluster-wide Kubernetes version selects the
+// package repository track every node installs the kube* components from;
 // sshAuthorizedKeys and hostKeys deliver the bring-up's bootstrap material
 // (the bootstrap public key and the pinned host identity) into every node.
 func (p *Provisioner) buildNodes(
@@ -64,6 +64,12 @@ func (p *Provisioner) ComposeNodes(
 		return nil, err
 	}
 
+	return nodeSpecsFrom(nodes), nil
+}
+
+// nodeSpecsFrom projects the kubeadm composer's per-node user_data onto the
+// shared [hetznerbase.NodeSpec]s both create engines derive server specs from.
+func nodeSpecsFrom(nodes []NodeUserData) []hetznerbase.NodeSpec {
 	return hetznerbase.NodeSpecsFrom(nodes, func(node NodeUserData) hetznerbase.NodeSpec {
 		return hetznerbase.NodeSpec{
 			Index:    node.Index,
@@ -71,7 +77,7 @@ func (p *Provisioner) ComposeNodes(
 			UserData: node.UserData,
 			Labels:   node.Labels,
 		}
-	}), nil
+	})
 }
 
 // RemoteKubeconfigPath reports where kubeadm writes the admin kubeconfig,

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
@@ -3,6 +3,7 @@ package kubeadmhetzner
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
 	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
@@ -147,10 +148,15 @@ func (p *Provisioner) ComposeJoiningNodes(
 // hostsPinCommand renders the first-boot command that pins the cluster's stable
 // join name to the init control plane's private address in /etc/hosts, making
 // the name the joining node's kubeadm configuration dials resolvable — durably,
-// so the kubelet's post-join API connections keep resolving it too. Both
-// interpolated values are provisioner-controlled: the address is a formatted
-// [net.IP] and the name is the cluster's Hetzner-accepted (RFC-1123) server
-// name plus a fixed suffix, so neither can carry shell metacharacters.
+// so the kubelet's post-join API connections keep resolving it too. The payload
+// is single-quoted with embedded quotes escaped, so shell safety holds here
+// regardless of what the name-composition path upstream accepted.
 func hostsPinCommand(joinAddress net.IP, joinName string) string {
-	return "echo '" + joinAddress.String() + " " + joinName + "' >> /etc/hosts"
+	return "echo " + shellSingleQuote(joinAddress.String()+" "+joinName) + " >> /etc/hosts"
+}
+
+// shellSingleQuote wraps s in single quotes, escaping any embedded single
+// quote, so the result splices into a shell command as one literal word.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
@@ -1,0 +1,156 @@
+package kubeadmhetzner
+
+import (
+	"fmt"
+	"net"
+
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+)
+
+// kubeadmAPIPort is the port the kubeadm API server serves on — the standard
+// Kubernetes secure port a joining node's discovery dials.
+const kubeadmAPIPort = "6443"
+
+// joinNameSuffix completes the cluster's stable join name (see [JoinName]). The
+// reserved-for-internal-use ".internal" TLD guarantees the name never collides
+// with a public DNS zone.
+const joinNameSuffix = "-api.ksail.internal"
+
+// Where the pre-seeded cluster CA lands on the cluster-initialising control
+// plane. kubeadm reuses an existing CA at its canonical PKI paths instead of
+// minting its own, which is what fixes the cluster identity to the material
+// [GenerateClusterCA] produced at compose time. The certificate is public
+// (world-readable, like kubeadm's own); the key is owner-only.
+const (
+	caCertPath        = "/etc/kubernetes/pki/ca.crt"
+	caCertPermissions = "0644"
+	caKeyPath         = "/etc/kubernetes/pki/ca.key"
+	caKeyPermissions  = "0600"
+)
+
+// staticMultiNodeComposerCheck asserts at compile time that *Provisioner
+// implements the optional [hetznerbase.MultiNodeComposer] capability, so the
+// shared create flow routes a kubeadm topology with agents to the two-phase
+// bring-up instead of rejecting it.
+var _ hetznerbase.MultiNodeComposer = (*Provisioner)(nil)
+
+// JoinName returns the cluster's stable join name: the DNS name the joining
+// nodes dial the cluster-initialising control plane by, and the extra SAN its
+// API-server serving certificate carries.
+//
+// # Why a name and not the IP
+//
+// A joining node registers against the init control plane's *private-network*
+// IPv4, which Hetzner assigns only when that server is created — after every
+// node's kubeadm configuration (and thus the init node's certificate SAN list)
+// has been composed. The IP therefore cannot appear in the serving certificate,
+// and a joiner dialing it raw would fail TLS hostname verification after token
+// discovery. A compose-time-stable NAME closes the gap from both sides: the
+// init node's certificate carries it up front (kubeadm renders CertSANs into
+// the serving cert), and each joining node pins it to the resolved private
+// address in /etc/hosts (see [hostsPinCommand]) before `kubeadm join` dials it.
+// No extra cloud resource (pre-allocated/floating IP) and no boot-time
+// certificate mutation is needed, and the same name is the natural
+// ControlPlaneEndpoint for the later HA increment.
+func JoinName(clusterName string) string {
+	return clusterName + joinNameSuffix
+}
+
+// ComposeInitNode composes the single cluster-initialising kubeadm control
+// plane (bootstrap index 0), satisfying [hetznerbase.MultiNodeComposer]. It
+// mints the cluster's CA ([GenerateClusterCA]) and seeds it into the node's
+// PKI directory so the cluster identity — and the discovery hash the joining
+// nodes pin — is fixed before any server boots; the node's API-server
+// certificate additionally carries the cluster's stable join name as a SAN
+// (see [JoinName]). The generated CA is retained on the Provisioner for
+// [Provisioner.ComposeJoiningNodes], which the shared flow always calls after
+// this within one create.
+func (p *Provisioner) ComposeInitNode(
+	clusterName, token string,
+	material hetznerbase.BootstrapMaterial,
+) (hetznerbase.NodeSpec, error) {
+	clusterCA, err := GenerateClusterCA()
+	if err != nil {
+		return hetznerbase.NodeSpec{}, err
+	}
+
+	p.clusterCA = &clusterCA
+
+	// A reduced single-node plan: the init node's own configuration is identical
+	// in every topology (the join settings apply only to joining nodes), and the
+	// full plan cannot be expanded yet — its join endpoint resolves at run time.
+	nodes, err := BuildNodeUserData(Input{
+		ClusterName: clusterName,
+		Plan: kubeadmbootstrap.PlanInput{
+			Token:             token,
+			KubernetesVersion: p.kubernetesVersion,
+			CertSANs:          []string{JoinName(clusterName)},
+			ControlPlaneCount: 1,
+			AgentCount:        0,
+		},
+		SSHAuthorizedKeys: []string{material.AuthorizedKey},
+		HostKeys:          material.HostKeys,
+		ServerInitFiles: []cloudinitbootstrap.File{
+			{Path: caCertPath, Permissions: caCertPermissions, Content: string(clusterCA.CertPEM)},
+			{Path: caKeyPath, Permissions: caKeyPermissions, Content: string(clusterCA.KeyPEM)},
+		},
+	})
+	if err != nil {
+		return hetznerbase.NodeSpec{}, fmt.Errorf("compose init control-plane node: %w", err)
+	}
+
+	return nodeSpecsFrom(nodes)[0], nil
+}
+
+// ComposeJoiningNodes composes the kubeadm agents that register against the
+// init control plane reachable at joinAddress (its private-network IPv4),
+// satisfying [hetznerbase.MultiNodeComposer]. It plans the full topology so the
+// joining nodes keep their global bootstrap indices, threads the stable join
+// name (pinned to joinAddress in each node's /etc/hosts) and the pre-seeded
+// CA's discovery hash into their JoinConfigurations, and returns only the
+// joining nodes — the init node at index 0 is already up.
+func (p *Provisioner) ComposeJoiningNodes(
+	clusterName, token string,
+	joinAddress net.IP,
+	material hetznerbase.BootstrapMaterial,
+) ([]hetznerbase.NodeSpec, error) {
+	if p.clusterCA == nil {
+		return nil, ErrJoiningNodesComposedFirst
+	}
+
+	joinName := JoinName(clusterName)
+
+	nodes, err := BuildNodeUserData(Input{
+		ClusterName: clusterName,
+		Plan: kubeadmbootstrap.PlanInput{
+			Token:             token,
+			KubernetesVersion: p.kubernetesVersion,
+			CertSANs:          []string{joinName},
+			ControlPlaneCount: p.ControlPlanes,
+			AgentCount:        p.Agents,
+			APIServerEndpoint: net.JoinHostPort(joinName, kubeadmAPIPort),
+			CACertHashes:      []string{p.clusterCA.DiscoveryHash},
+		},
+		SSHAuthorizedKeys: []string{material.AuthorizedKey},
+		HostKeys:          material.HostKeys,
+		JoinPrelude:       []string{hostsPinCommand(joinAddress, joinName)},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("compose joining nodes: %w", err)
+	}
+
+	return nodeSpecsFrom(nodes)[1:], nil
+}
+
+// hostsPinCommand renders the first-boot command that pins the cluster's stable
+// join name to the init control plane's private address in /etc/hosts, making
+// the name the joining node's kubeadm configuration dials resolvable — durably,
+// so the kubelet's post-join API connections keep resolving it too. Both
+// interpolated values are provisioner-controlled: the address is a formatted
+// [net.IP] and the name is the cluster's Hetzner-accepted (RFC-1123) server
+// name plus a fixed suffix, so neither can carry shell metacharacters.
+func hostsPinCommand(joinAddress net.IP, joinName string) string {
+	return "echo '" + joinAddress.String() + " " + joinName + "' >> /etc/hosts"
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
@@ -89,6 +89,12 @@ func TestComposeJoiningNodesPinsJoinNameAndCA(t *testing.T) {
 		joinAt := strings.Index(spec.UserData, "kubeadm join")
 		require.NotEqual(t, -1, joinAt)
 		assert.Less(t, pinAt, joinAt, "the /etc/hosts pin must precede `kubeadm join`")
+
+		// The CA private key is seeded onto the init control plane only; a
+		// joiner carrying it (or its PKI path) would leak the cluster identity
+		// to every worker.
+		assert.NotContains(t, spec.UserData, "/etc/kubernetes/pki/ca.key",
+			"joining nodes must never receive the cluster CA private key")
 	}
 }
 

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
@@ -1,0 +1,108 @@
+package kubeadmhetzner_test
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	kubeadmhetzner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// composeBootstrapMaterial is minimal composition-only bootstrap material — the
+// SSH signer and host-key callback feed only the live bring-up, which these
+// composition tests never reach.
+func composeBootstrapMaterial() hetznerbase.BootstrapMaterial {
+	return hetznerbase.BootstrapMaterial{
+		AuthorizedKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA ksail-bootstrap",
+	}
+}
+
+// testJoinName is the stable join name derived from testClusterName; the init
+// node's certificate carries it as a SAN and the joining nodes dial it.
+const testJoinName = "test-cluster-api.ksail.internal"
+
+// TestComposeInitNodeSeedsClusterIdentity pins the init compose contract of the
+// kubeadm two-phase flow: exactly the cluster-initialising control plane
+// (bootstrap index 0) is composed regardless of the agent count, its cloud-init
+// seeds the pre-generated cluster CA at kubeadm's canonical PKI paths (fixing
+// the cluster identity before boot), its certificate SAN list carries the
+// stable join name, and it runs `kubeadm init` — never a join.
+func TestComposeInitNodeSeedsClusterIdentity(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 2)
+
+	spec, err := prov.ComposeInitNode(
+		testClusterName, "abcdef.0123456789abcdef", composeBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, spec.Index)
+	assert.Equal(t, hetzner.NodeTypeControlPlane, spec.NodeType)
+	assert.True(t, strings.HasPrefix(spec.UserData, "#cloud-config"))
+	assert.Contains(t, spec.UserData, "/etc/kubernetes/pki/ca.crt")
+	assert.Contains(t, spec.UserData, "/etc/kubernetes/pki/ca.key")
+	assert.Contains(t, spec.UserData, "BEGIN CERTIFICATE")
+	assert.Contains(t, spec.UserData, "BEGIN RSA PRIVATE KEY")
+	assert.Contains(t, spec.UserData, testJoinName)
+	assert.Contains(t, spec.UserData, "kubeadm init")
+	assert.NotContains(t, spec.UserData, "kubeadm join")
+}
+
+// TestComposeJoiningNodesPinsJoinNameAndCA pins the join compose contract:
+// only the joining nodes come back (global bootstrap indices preserved, the
+// init node at 0 dropped), each dials the stable join name — pinned to the
+// resolved private address in /etc/hosts BEFORE `kubeadm join` runs — and each
+// pins the pre-seeded CA's sha256 discovery hash instead of skipping CA
+// verification.
+func TestComposeJoiningNodesPinsJoinNameAndCA(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 2)
+
+	_, err := prov.ComposeInitNode(
+		testClusterName, "abcdef.0123456789abcdef", composeBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+
+	specs, err := prov.ComposeJoiningNodes(
+		testClusterName, "abcdef.0123456789abcdef",
+		net.ParseIP("10.0.1.5"), composeBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+	require.Len(t, specs, 2)
+
+	hostsPin := "echo '10.0.1.5 " + testJoinName + "' >> /etc/hosts"
+
+	for index, spec := range specs {
+		assert.Equal(t, index+1, spec.Index)
+		assert.Equal(t, hetzner.NodeTypeWorker, spec.NodeType)
+		assert.Contains(t, spec.UserData, testJoinName+":6443")
+		assert.Contains(t, spec.UserData, "sha256:")
+		assert.Contains(t, spec.UserData, hostsPin)
+
+		pinAt := strings.Index(spec.UserData, hostsPin)
+		joinAt := strings.Index(spec.UserData, "kubeadm join")
+		require.NotEqual(t, -1, joinAt)
+		assert.Less(t, pinAt, joinAt, "the /etc/hosts pin must precede `kubeadm join`")
+	}
+}
+
+// TestComposeJoiningNodesRequiresInitFirst pins that composing joining nodes
+// without a prior init compose is refused: the joiners pin the CA minted during
+// the init compose, so out-of-order composition has no identity to pin.
+func TestComposeJoiningNodesRequiresInitFirst(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 2)
+
+	_, err := prov.ComposeJoiningNodes(
+		testClusterName, "abcdef.0123456789abcdef",
+		net.ParseIP("10.0.1.5"), composeBootstrapMaterial(),
+	)
+	require.ErrorIs(t, err, kubeadmhetzner.ErrJoiningNodesComposedFirst)
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
@@ -22,6 +22,14 @@ type Provisioner struct {
 	*hetznerbase.Base
 
 	kubernetesVersion string
+
+	// clusterCA is the pre-seeded cluster CA minted by
+	// [Provisioner.ComposeInitNode] and consumed by
+	// [Provisioner.ComposeJoiningNodes] within one two-phase create — the only
+	// state the multi-node flow threads between its two compose calls. Nil until
+	// an init node has been composed; a provisioner instance drives at most one
+	// create, matching the shared flow's ordering guarantee.
+	clusterCA *ClusterCA
 }
 
 // NewProvisioner constructs a kubeadm × Hetzner provisioner. It builds the shared

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
@@ -294,21 +294,10 @@ func TestCreateHAControlPlaneNotImplemented(t *testing.T) {
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 }
 
-// TestCreateAgentsAreMultiNode pins that the kubeadm × Hetzner provisioner does
-// not yet implement joining-node bring-up: it does not satisfy
-// hetznerbase.MultiNodeComposer, so a topology with agents is rejected before
-// any infrastructure is created (kubeadm's join-endpoint threading is a later
-// increment of #5755).
-func TestCreateAgentsAreMultiNode(t *testing.T) {
-	t.Parallel()
-
-	infra := &fakeInfra{}
-	prov := newProvisioner(infra, 1, 2)
-
-	err := prov.Create(context.Background(), "")
-	require.ErrorIs(t, err, kubeadmhetzner.ErrMultiNodeNotImplemented)
-	assert.Equal(t, 0, infra.ensureNetworkCalls)
-}
+// The provisioner now satisfies hetznerbase.MultiNodeComposer (multinode.go's
+// compile-time check), so a topology with agents routes to the shared two-phase
+// bring-up instead of being rejected; the compose halves of that flow are pinned
+// by multinode_test.go and the engine by the hetznerbase package's own tests.
 
 func TestCreateNodesExistError(t *testing.T) {
 	t.Parallel()

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
@@ -2,6 +2,7 @@ package kubeadmhetzner
 
 import (
 	"fmt"
+	"slices"
 
 	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
 	containerdbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/containerd"
@@ -42,6 +43,15 @@ type Input struct {
 	// the bootstrap SSH dial can pin the host key instead of trusting first use.
 	// Optional; nil lets the node generate its own host keys at first boot.
 	HostKeys *cloudinitbootstrap.HostKeys
+	// ServerInitFiles are extra files delivered only to the cluster-initialising
+	// control plane — e.g. the pre-seeded cluster CA ([ClusterCA]) the two-phase
+	// multi-node flow fixes the cluster identity with. Optional.
+	ServerInitFiles []cloudinitbootstrap.File
+	// JoinPrelude are commands run on every joining node before its install
+	// commands — e.g. pinning the stable join name to the init control plane's
+	// resolved private address in /etc/hosts, which must happen before `kubeadm
+	// join` dials it. Optional; ignored on the cluster-initialising control plane.
+	JoinPrelude []string
 }
 
 // NodeUserData pairs a planned node with the cloud-init user_data that bootstraps
@@ -143,11 +153,23 @@ func buildNodeCloudInit(
 		return "", fmt.Errorf("render install for node %d: %w", node.Index, err)
 	}
 
+	files := append(toCloudInitFiles(install.Files), containerdFile)
+	commands := install.Commands
+
+	// The per-role extras: the init control plane receives the pre-seeded cluster
+	// identity files; a joining node runs the join prelude (e.g. the /etc/hosts
+	// pin of the stable join name) before its install commands reach `kubeadm join`.
+	if node.Config.Role == kubeadmbootstrap.RoleServerInit {
+		files = append(files, input.ServerInitFiles...)
+	} else if len(input.JoinPrelude) > 0 {
+		commands = append(slices.Clone(input.JoinPrelude), commands...)
+	}
+
 	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
 		AptSources:        toCloudInitAptSources(install.AptSources),
 		Packages:          install.Packages,
-		Files:             append(toCloudInitFiles(install.Files), containerdFile),
-		Commands:          install.Commands,
+		Files:             files,
+		Commands:          commands,
 		SSHAuthorizedKeys: input.SSHAuthorizedKeys,
 		HostKeys:          input.HostKeys,
 	})


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Vanilla (kubeadm) × Hetzner clusters could only be single-node: a joining node must dial the first control plane's private address over verified TLS, but that address only exists once the server is created — after every node's certificate configuration is already composed. This was the open "endpoint before the IP exists" design decision blocking the lane.

## What
Resolves it without extra cloud resources or boot-time certificate hacks: the init control plane's certificate carries a stable join name composed up front, each joining node pins that name to the resolved private address at first boot, and the cluster identity is the pre-seeded CA so joiners verify against a pinned hash. `ksail cluster create --distribution Vanilla --provider Hetzner` topologies with agents now bring up end to end (live join validation stays with the smoke-test lane, #5515).

Fixes #5755. Part of #5513 / #3983.