### PR TITLE
chore(provisioner): drop stale #5514-gated comments on the Hetzner factory paths

### DIFF
--- a/pkg/svc/provisioner/cluster/factory_k3d.go
+++ b/pkg/svc/provisioner/cluster/factory_k3d.go
@@ -150,9 +150,8 @@ func (f DefaultFactory) createK3dProvisioner(
 		return f.createK3dKubernetesProvisioner(cluster)
 	}
 
-	// Hetzner provider: native k3s on Hetzner Cloud servers. The K3s × Hetzner
-	// combination is unselectable until the validation flip (#5514), so this path
-	// is gated; see the k3shetzner package.
+	// Hetzner provider: native k3s on Hetzner Cloud servers; see the
+	// k3shetzner package.
 	if cluster.Spec.Cluster.Provider == v1alpha1.ProviderHetzner {
 		return createK3sHetznerProvisioner(cluster)
 	}

--- a/pkg/svc/provisioner/cluster/factory_kind.go
+++ b/pkg/svc/provisioner/cluster/factory_kind.go
@@ -17,10 +17,8 @@ func (f DefaultFactory) createKindProvisioner(
 ) (Provisioner, any, error) {
 	// Hetzner provider: native kubeadm (upstream Kubernetes) on Hetzner Cloud
 	// servers — the Vanilla distribution's server implementation, mirroring the
-	// k3s × Hetzner path. The Vanilla × Hetzner combination stays unselectable
-	// until the validation flip (#5514), so this path is gated; see the
-	// kubeadmhetzner package. It needs no Kind config, so it dispatches before the
-	// Kind-config requirement below.
+	// k3s × Hetzner path; see the kubeadmhetzner package. It needs no Kind
+	// config, so it dispatches before the Kind-config requirement below.
 	if cluster.Spec.Cluster.Provider == v1alpha1.ProviderHetzner {
 		return createKubeadmHetznerProvisioner(cluster)
 	}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Two code comments still claim the K3s × Hetzner and Vanilla × Hetzner paths are "unselectable until the validation flip (#5514)" — that flip landed in #5686, so the comments now mislead anyone reading the factory code (they suggest live paths are dead).

## What
Removes the stale gating claims from the two factory comments; no behaviour change.

Part of the #5512/#5513 close-out (both closed as done-by-events).