### PR TITLE
feat(provisioner): pre-seed the full shared kubeadm PKI at compose time

### DIFF
--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/ca.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/ca.go
@@ -18,6 +18,12 @@ const (
 	// pre-seeded CA mirrors it so an operator inspecting the certificate sees the
 	// same identity kubeadm would have minted itself.
 	caCommonName = "kubernetes"
+	// frontProxyCACommonName is the subject common name kubeadm gives the CA that
+	// signs the API aggregation layer's front-proxy client certificates.
+	frontProxyCACommonName = "front-proxy-ca"
+	// etcdCACommonName is the subject common name kubeadm gives the CA that signs
+	// etcd's serving and peer certificates.
+	etcdCACommonName = "etcd-ca"
 	// caKeyBits is the RSA modulus size of the pre-seeded cluster CA. kubeadm's own
 	// default CA is RSA-2048, so matching it keeps the pre-seeded CA
 	// indistinguishable from a kubeadm-minted one.
@@ -78,22 +84,118 @@ type ClusterCA struct {
 // boots. It reaches no network and touches no filesystem; its only external
 // dependency is the cryptographic random source.
 func GenerateClusterCA() (ClusterCA, error) {
+	pair, caCert, err := mintCA(caCommonName)
+	if err != nil {
+		return ClusterCA{}, err
+	}
+
+	// kubeadm pins SHA-256 over the certificate's DER SubjectPublicKeyInfo (its
+	// pubkeypin algorithm), so hashing the parsed cert's RawSubjectPublicKeyInfo
+	// yields exactly the value a joining node computes and compares.
+	spkiDigest := sha256.Sum256(caCert.RawSubjectPublicKeyInfo)
+
+	return ClusterCA{
+		CertPEM:       pair.CertPEM,
+		KeyPEM:        pair.KeyPEM,
+		DiscoveryHash: caCertHashPrefix + hex.EncodeToString(spkiDigest[:]),
+	}, nil
+}
+
+// CertKeyPair is a PEM-encoded certificate and its private key — the form the
+// auxiliary pre-seeded CAs (front-proxy, etcd) are carried in.
+type CertKeyPair struct {
+	// CertPEM is the certificate in PEM form.
+	CertPEM []byte
+	// KeyPEM is the private key in PEM (PKCS#1) form.
+	KeyPEM []byte
+}
+
+// ServiceAccountKeys is the RSA keypair kube-controller-manager signs service
+// account tokens with (kubeadm's sa.key/sa.pub), in kubeadm's own on-disk
+// encodings: a PKCS#8 private key and a PKIX public key.
+type ServiceAccountKeys struct {
+	// KeyPEM is the private key in PEM (PKCS#8) form, written to
+	// /etc/kubernetes/pki/sa.key.
+	KeyPEM []byte
+	// PubPEM is the public key in PEM (PKIX) form, written to
+	// /etc/kubernetes/pki/sa.pub.
+	PubPEM []byte
+}
+
+// ClusterPKI is the full set of PKI material kubeadm shares between control
+// planes, pre-generated at compose time so the whole cluster identity — not
+// just the cluster CA — is fixed before any node boots. kubeadm reuses every
+// piece it finds at its canonical paths instead of minting its own, which is
+// what lets a later high-availability increment seed the same material onto
+// additional control planes (kubeadm's manual certificate distribution) with
+// no `--upload-certs` channel.
+type ClusterPKI struct {
+	// CA is the cluster CA plus the token-discovery hash the joining nodes pin.
+	CA ClusterCA
+	// FrontProxyCA signs the API aggregation layer's front-proxy client
+	// certificates (front-proxy-ca.crt/.key).
+	FrontProxyCA CertKeyPair
+	// EtcdCA signs etcd's serving and peer certificates (etcd/ca.crt/.key).
+	EtcdCA CertKeyPair
+	// ServiceAccount is the service-account token signing keypair (sa.key/sa.pub).
+	ServiceAccount ServiceAccountKeys
+}
+
+// GenerateClusterPKI generates the full shared kubeadm PKI: the cluster CA
+// (with its discovery hash, as [GenerateClusterCA]), the front-proxy CA, the
+// etcd CA, and the service-account keypair. Like [GenerateClusterCA] it
+// reaches no network and touches no filesystem.
+func GenerateClusterPKI() (ClusterPKI, error) {
+	clusterCA, err := GenerateClusterCA()
+	if err != nil {
+		return ClusterPKI{}, err
+	}
+
+	frontProxyCA, _, err := mintCA(frontProxyCACommonName)
+	if err != nil {
+		return ClusterPKI{}, err
+	}
+
+	etcdCA, _, err := mintCA(etcdCACommonName)
+	if err != nil {
+		return ClusterPKI{}, err
+	}
+
+	serviceAccount, err := generateServiceAccountKeys()
+	if err != nil {
+		return ClusterPKI{}, err
+	}
+
+	return ClusterPKI{
+		CA:             clusterCA,
+		FrontProxyCA:   frontProxyCA,
+		EtcdCA:         etcdCA,
+		ServiceAccount: serviceAccount,
+	}, nil
+}
+
+// mintCA generates a fresh self-signed RSA signing CA with the given subject
+// common name, in the same shape kubeadm mints its own CAs (RSA-2048, ten-year
+// lifetime, cert-sign key usage). The parsed certificate is returned alongside
+// the PEM pair so a caller can derive material from it (the cluster CA's
+// discovery hash) without re-parsing.
+func mintCA(commonName string) (CertKeyPair, *x509.Certificate, error) {
 	caKey, err := rsa.GenerateKey(rand.Reader, caKeyBits)
 	if err != nil {
-		return ClusterCA{}, fmt.Errorf("generate kubeadm cluster CA key: %w", err)
+		return CertKeyPair{}, nil, fmt.Errorf("generate %s CA key: %w", commonName, err)
 	}
 
 	serialCeiling := new(big.Int).Lsh(big.NewInt(1), caSerialBits)
 
 	serialNumber, err := rand.Int(rand.Reader, serialCeiling)
 	if err != nil {
-		return ClusterCA{}, fmt.Errorf("generate kubeadm cluster CA serial: %w", err)
+		return CertKeyPair{}, nil, fmt.Errorf("generate %s CA serial: %w", commonName, err)
 	}
 
 	now := time.Now()
 	certTemplate := x509.Certificate{
 		SerialNumber:          serialNumber,
-		Subject:               pkix.Name{CommonName: caCommonName},
+		Subject:               pkix.Name{CommonName: commonName},
 		NotBefore:             now.Add(-caBackdate),
 		NotAfter:              now.AddDate(caValidityYears, 0, 0),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
@@ -105,7 +207,7 @@ func GenerateClusterCA() (ClusterCA, error) {
 		rand.Reader, &certTemplate, &certTemplate, &caKey.PublicKey, caKey,
 	)
 	if err != nil {
-		return ClusterCA{}, fmt.Errorf("create kubeadm cluster CA certificate: %w", err)
+		return CertKeyPair{}, nil, fmt.Errorf("create %s CA certificate: %w", commonName, err)
 	}
 
 	caCert, err := x509.ParseCertificate(certDER)
@@ -113,19 +215,40 @@ func GenerateClusterCA() (ClusterCA, error) {
 		// Unreachable in practice: CreateCertificate emits a well-formed certificate
 		// ParseCertificate can always read back. Surfaced rather than dropped so a
 		// future change that breaks this is not silently ignored.
-		return ClusterCA{}, fmt.Errorf("parse kubeadm cluster CA certificate: %w", err)
+		return CertKeyPair{}, nil, fmt.Errorf("parse %s CA certificate: %w", commonName, err)
 	}
 
-	// kubeadm pins SHA-256 over the certificate's DER SubjectPublicKeyInfo (its
-	// pubkeypin algorithm), so hashing the parsed cert's RawSubjectPublicKeyInfo
-	// yields exactly the value a joining node computes and compares.
-	spkiDigest := sha256.Sum256(caCert.RawSubjectPublicKeyInfo)
-
-	return ClusterCA{
+	return CertKeyPair{
 		CertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
 		KeyPEM: pem.EncodeToMemory(
 			&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caKey)},
 		),
-		DiscoveryHash: caCertHashPrefix + hex.EncodeToString(spkiDigest[:]),
+	}, caCert, nil
+}
+
+// generateServiceAccountKeys generates the service-account token signing
+// keypair in kubeadm's own encodings: sa.key is a PKCS#8 private key and
+// sa.pub a PKIX public key.
+func generateServiceAccountKeys() (ServiceAccountKeys, error) {
+	key, err := rsa.GenerateKey(rand.Reader, caKeyBits)
+	if err != nil {
+		return ServiceAccountKeys{}, fmt.Errorf("generate service-account key: %w", err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		// Unreachable in practice: an RSA key always marshals to PKCS#8.
+		return ServiceAccountKeys{}, fmt.Errorf("marshal service-account key: %w", err)
+	}
+
+	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		// Unreachable in practice: an RSA public key always marshals to PKIX.
+		return ServiceAccountKeys{}, fmt.Errorf("marshal service-account public key: %w", err)
+	}
+
+	return ServiceAccountKeys{
+		KeyPEM: pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+		PubPEM: pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}),
 	}, nil
 }

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/ca.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/ca.go
@@ -227,18 +227,13 @@ func mintCA(commonName string) (CertKeyPair, *x509.Certificate, error) {
 }
 
 // generateServiceAccountKeys generates the service-account token signing
-// keypair in kubeadm's own encodings: sa.key is a PKCS#8 private key and
-// sa.pub a PKIX public key.
+// keypair in kubeadm's own encodings: sa.key is a PKCS#1 RSA private key
+// (kubeadm's pkiutil.WriteKey → keyutil.MarshalPrivateKeyToPEM emits RSA keys
+// as "RSA PRIVATE KEY" blocks) and sa.pub a PKIX public key.
 func generateServiceAccountKeys() (ServiceAccountKeys, error) {
 	key, err := rsa.GenerateKey(rand.Reader, caKeyBits)
 	if err != nil {
 		return ServiceAccountKeys{}, fmt.Errorf("generate service-account key: %w", err)
-	}
-
-	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
-	if err != nil {
-		// Unreachable in practice: an RSA key always marshals to PKCS#8.
-		return ServiceAccountKeys{}, fmt.Errorf("marshal service-account key: %w", err)
 	}
 
 	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
@@ -248,7 +243,9 @@ func generateServiceAccountKeys() (ServiceAccountKeys, error) {
 	}
 
 	return ServiceAccountKeys{
-		KeyPEM: pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+		KeyPEM: pem.EncodeToMemory(
+			&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)},
+		),
 		PubPEM: pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}),
 	}, nil
 }

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
@@ -166,17 +166,15 @@ func TestGenerateClusterPKIServiceAccountKeypairMatchesKubeadmEncodings(t *testi
 	pki, err := kubeadmhetzner.GenerateClusterPKI()
 	require.NoError(t, err)
 
-	// kubeadm writes sa.key as PKCS#8 and sa.pub as PKIX; any other encoding
-	// would make kube-controller-manager reject the pre-seeded pair.
+	// kubeadm writes RSA sa.key as PKCS#1 ("RSA PRIVATE KEY" — pkiutil.WriteKey
+	// → keyutil.MarshalPrivateKeyToPEM) and sa.pub as PKIX; any other encoding
+	// would diverge from kubeadm's on-disk format for the pre-seeded pair.
 	keyBlock, _ := pem.Decode(pki.ServiceAccount.KeyPEM)
 	require.NotNil(t, keyBlock)
-	require.Equal(t, "PRIVATE KEY", keyBlock.Type)
+	require.Equal(t, "RSA PRIVATE KEY", keyBlock.Type)
 
-	parsedKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	rsaKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 	require.NoError(t, err)
-
-	rsaKey, isRSAKey := parsedKey.(*rsa.PrivateKey)
-	require.True(t, isRSAKey)
 	assert.Equal(t, 2048, rsaKey.N.BitLen())
 
 	pubBlock, _ := pem.Decode(pki.ServiceAccount.PubPEM)

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/ca_test.go
@@ -114,6 +114,86 @@ func TestGenerateClusterCADiscoveryHashIsAcceptedByTheJoinRenderer(t *testing.T)
 	require.NoError(t, err)
 }
 
+// requireSigningCA asserts pair is a valid self-signed signing CA with the
+// given subject common name whose PEM key belongs to its certificate — the
+// contract kubeadm requires of every CA it reuses instead of minting.
+func requireSigningCA(t *testing.T, pair kubeadmhetzner.CertKeyPair, commonName string) {
+	t.Helper()
+
+	cert := parseCACertificate(t, pair.CertPEM)
+
+	assert.True(t, cert.IsCA)
+	assert.True(t, cert.BasicConstraintsValid)
+	assert.Equal(t, commonName, cert.Subject.CommonName)
+	assert.NotZero(t, cert.KeyUsage&x509.KeyUsageCertSign)
+
+	keyBlock, _ := pem.Decode(pair.KeyPEM)
+	require.NotNil(t, keyBlock)
+	require.Equal(t, "RSA PRIVATE KEY", keyBlock.Type)
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+
+	certPubKey, ok := cert.PublicKey.(*rsa.PublicKey)
+	require.True(t, ok)
+	assert.True(t, key.PublicKey.Equal(certPubKey))
+}
+
+func TestGenerateClusterPKIMintsTheAuxiliaryCAs(t *testing.T) {
+	t.Parallel()
+
+	pki, err := kubeadmhetzner.GenerateClusterPKI()
+	require.NoError(t, err)
+
+	// The cluster CA keeps the GenerateClusterCA contract (CN + pinned hash).
+	assert.Equal(t, "kubernetes", parseCACertificate(t, pki.CA.CertPEM).Subject.CommonName)
+	assert.NotEmpty(t, pki.CA.DiscoveryHash)
+
+	// kubeadm reuses front-proxy and etcd CAs only under their own CNs.
+	requireSigningCA(t, pki.FrontProxyCA, "front-proxy-ca")
+	requireSigningCA(t, pki.EtcdCA, "etcd-ca")
+
+	// Each authority must be its own identity: sharing a key between the CAs
+	// would let a certificate minted under one chain validate under another.
+	assert.NotEqual(t, pki.CA.KeyPEM, pki.FrontProxyCA.KeyPEM)
+	assert.NotEqual(t, pki.CA.KeyPEM, pki.EtcdCA.KeyPEM)
+	assert.NotEqual(t, pki.FrontProxyCA.KeyPEM, pki.EtcdCA.KeyPEM)
+}
+
+func TestGenerateClusterPKIServiceAccountKeypairMatchesKubeadmEncodings(t *testing.T) {
+	t.Parallel()
+
+	pki, err := kubeadmhetzner.GenerateClusterPKI()
+	require.NoError(t, err)
+
+	// kubeadm writes sa.key as PKCS#8 and sa.pub as PKIX; any other encoding
+	// would make kube-controller-manager reject the pre-seeded pair.
+	keyBlock, _ := pem.Decode(pki.ServiceAccount.KeyPEM)
+	require.NotNil(t, keyBlock)
+	require.Equal(t, "PRIVATE KEY", keyBlock.Type)
+
+	parsedKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+
+	rsaKey, isRSAKey := parsedKey.(*rsa.PrivateKey)
+	require.True(t, isRSAKey)
+	assert.Equal(t, 2048, rsaKey.N.BitLen())
+
+	pubBlock, _ := pem.Decode(pki.ServiceAccount.PubPEM)
+	require.NotNil(t, pubBlock)
+	require.Equal(t, "PUBLIC KEY", pubBlock.Type)
+
+	parsedPub, err := x509.ParsePKIXPublicKey(pubBlock.Bytes)
+	require.NoError(t, err)
+
+	rsaPub, isRSAPub := parsedPub.(*rsa.PublicKey)
+	require.True(t, isRSAPub)
+
+	// sa.pub must be the public half of sa.key, or token verification would
+	// reject every token the controller manager signs.
+	assert.True(t, rsaKey.PublicKey.Equal(rsaPub))
+}
+
 func TestGenerateClusterCAProducesADistinctCAEachTime(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/errors.go
@@ -22,7 +22,7 @@ var (
 
 // ErrJoiningNodesComposedFirst is returned by
 // [Provisioner.ComposeJoiningNodes] when it is called before
-// [Provisioner.ComposeInitNode] has minted the cluster CA — the two-phase flow
+// [Provisioner.ComposeInitNode] has minted the cluster PKI — the two-phase flow
 // guarantees the init compose runs first, so hitting this means the composer
 // was driven outside that flow.
 var ErrJoiningNodesComposedFirst = errors.New(

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
@@ -19,16 +19,24 @@ const kubeadmAPIPort = "6443"
 // with a public DNS zone.
 const joinNameSuffix = "-api.ksail.internal"
 
-// Where the pre-seeded cluster CA lands on the cluster-initialising control
-// plane. kubeadm reuses an existing CA at its canonical PKI paths instead of
-// minting its own, which is what fixes the cluster identity to the material
-// [GenerateClusterCA] produced at compose time. The certificate is public
-// (world-readable, like kubeadm's own); the key is owner-only.
+// Where the pre-seeded shared PKI lands on the cluster-initialising control
+// plane. kubeadm reuses existing material at its canonical PKI paths instead
+// of minting its own, which is what fixes the cluster identity to the material
+// [GenerateClusterPKI] produced at compose time. Certificates and the
+// service-account public key are public (world-readable, like kubeadm's own);
+// private keys are owner-only.
 const (
 	caCertPath        = "/etc/kubernetes/pki/ca.crt"
 	caCertPermissions = "0644"
 	caKeyPath         = "/etc/kubernetes/pki/ca.key"
 	caKeyPermissions  = "0600"
+
+	frontProxyCACertPath  = "/etc/kubernetes/pki/front-proxy-ca.crt"
+	frontProxyCAKeyPath   = "/etc/kubernetes/pki/front-proxy-ca.key"
+	etcdCACertPath        = "/etc/kubernetes/pki/etcd/ca.crt"
+	etcdCAKeyPath         = "/etc/kubernetes/pki/etcd/ca.key"
+	serviceAccountKeyPath = "/etc/kubernetes/pki/sa.key"
+	serviceAccountPubPath = "/etc/kubernetes/pki/sa.pub"
 )
 
 // staticMultiNodeComposerCheck asserts at compile time that *Provisioner
@@ -61,23 +69,24 @@ func JoinName(clusterName string) string {
 
 // ComposeInitNode composes the single cluster-initialising kubeadm control
 // plane (bootstrap index 0), satisfying [hetznerbase.MultiNodeComposer]. It
-// mints the cluster's CA ([GenerateClusterCA]) and seeds it into the node's
-// PKI directory so the cluster identity — and the discovery hash the joining
-// nodes pin — is fixed before any server boots; the node's API-server
-// certificate additionally carries the cluster's stable join name as a SAN
-// (see [JoinName]). The generated CA is retained on the Provisioner for
-// [Provisioner.ComposeJoiningNodes], which the shared flow always calls after
-// this within one create.
+// mints the cluster's full shared PKI ([GenerateClusterPKI] — cluster CA,
+// front-proxy CA, etcd CA, service-account keypair) and seeds it into the
+// node's PKI directory so the whole cluster identity — and the discovery hash
+// the joining nodes pin — is fixed before any server boots; the node's
+// API-server certificate additionally carries the cluster's stable join name
+// as a SAN (see [JoinName]). The generated PKI is retained on the Provisioner
+// for [Provisioner.ComposeJoiningNodes], which the shared flow always calls
+// after this within one create.
 func (p *Provisioner) ComposeInitNode(
 	clusterName, token string,
 	material hetznerbase.BootstrapMaterial,
 ) (hetznerbase.NodeSpec, error) {
-	clusterCA, err := GenerateClusterCA()
+	clusterPKI, err := GenerateClusterPKI()
 	if err != nil {
 		return hetznerbase.NodeSpec{}, err
 	}
 
-	p.clusterCA = &clusterCA
+	p.clusterPKI = &clusterPKI
 
 	// A reduced single-node plan: the init node's own configuration is identical
 	// in every topology (the join settings apply only to joining nodes), and the
@@ -93,16 +102,54 @@ func (p *Provisioner) ComposeInitNode(
 		},
 		SSHAuthorizedKeys: []string{material.AuthorizedKey},
 		HostKeys:          material.HostKeys,
-		ServerInitFiles: []cloudinitbootstrap.File{
-			{Path: caCertPath, Permissions: caCertPermissions, Content: string(clusterCA.CertPEM)},
-			{Path: caKeyPath, Permissions: caKeyPermissions, Content: string(clusterCA.KeyPEM)},
-		},
+		ServerInitFiles:   pkiSeedFiles(clusterPKI),
 	})
 	if err != nil {
 		return hetznerbase.NodeSpec{}, fmt.Errorf("compose init control-plane node: %w", err)
 	}
 
 	return nodeSpecsFrom(nodes)[0], nil
+}
+
+// pkiSeedFiles maps the pre-generated shared PKI onto the cloud-init files the
+// cluster-initialising control plane seeds at kubeadm's canonical paths.
+// Certificates and the service-account public key are world-readable (matching
+// kubeadm's own permissions); private keys are owner-only.
+func pkiSeedFiles(clusterPKI ClusterPKI) []cloudinitbootstrap.File {
+	return []cloudinitbootstrap.File{
+		{Path: caCertPath, Permissions: caCertPermissions, Content: string(clusterPKI.CA.CertPEM)},
+		{Path: caKeyPath, Permissions: caKeyPermissions, Content: string(clusterPKI.CA.KeyPEM)},
+		{
+			Path:        frontProxyCACertPath,
+			Permissions: caCertPermissions,
+			Content:     string(clusterPKI.FrontProxyCA.CertPEM),
+		},
+		{
+			Path:        frontProxyCAKeyPath,
+			Permissions: caKeyPermissions,
+			Content:     string(clusterPKI.FrontProxyCA.KeyPEM),
+		},
+		{
+			Path:        etcdCACertPath,
+			Permissions: caCertPermissions,
+			Content:     string(clusterPKI.EtcdCA.CertPEM),
+		},
+		{
+			Path:        etcdCAKeyPath,
+			Permissions: caKeyPermissions,
+			Content:     string(clusterPKI.EtcdCA.KeyPEM),
+		},
+		{
+			Path:        serviceAccountKeyPath,
+			Permissions: caKeyPermissions,
+			Content:     string(clusterPKI.ServiceAccount.KeyPEM),
+		},
+		{
+			Path:        serviceAccountPubPath,
+			Permissions: caCertPermissions,
+			Content:     string(clusterPKI.ServiceAccount.PubPEM),
+		},
+	}
 }
 
 // ComposeJoiningNodes composes the kubeadm agents that register against the
@@ -117,7 +164,7 @@ func (p *Provisioner) ComposeJoiningNodes(
 	joinAddress net.IP,
 	material hetznerbase.BootstrapMaterial,
 ) ([]hetznerbase.NodeSpec, error) {
-	if p.clusterCA == nil {
+	if p.clusterPKI == nil {
 		return nil, ErrJoiningNodesComposedFirst
 	}
 
@@ -132,7 +179,7 @@ func (p *Provisioner) ComposeJoiningNodes(
 			ControlPlaneCount: p.ControlPlanes,
 			AgentCount:        p.Agents,
 			APIServerEndpoint: net.JoinHostPort(joinName, kubeadmAPIPort),
-			CACertHashes:      []string{p.clusterCA.DiscoveryHash},
+			CACertHashes:      []string{p.clusterPKI.CA.DiscoveryHash},
 		},
 		SSHAuthorizedKeys: []string{material.AuthorizedKey},
 		HostKeys:          material.HostKeys,

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
@@ -44,10 +44,6 @@ func TestComposeInitNodeSeedsClusterIdentity(t *testing.T) {
 	assert.Equal(t, 0, spec.Index)
 	assert.Equal(t, hetzner.NodeTypeControlPlane, spec.NodeType)
 	assert.True(t, strings.HasPrefix(spec.UserData, "#cloud-config"))
-	assert.Contains(t, spec.UserData, "BEGIN CERTIFICATE")
-	assert.Contains(t, spec.UserData, "BEGIN RSA PRIVATE KEY")
-	assert.Contains(t, spec.UserData, "BEGIN PRIVATE KEY", "sa.key must be seeded (PKCS#8)")
-	assert.Contains(t, spec.UserData, "BEGIN PUBLIC KEY", "sa.pub must be seeded (PKIX)")
 	assert.Contains(t, spec.UserData, testJoinName)
 	assert.Contains(t, spec.UserData, "kubeadm init")
 	assert.NotContains(t, spec.UserData, "kubeadm join")
@@ -55,19 +51,47 @@ func TestComposeInitNodeSeedsClusterIdentity(t *testing.T) {
 	// The full shared PKI — not just the cluster CA — lands at kubeadm's
 	// canonical paths, so the whole cluster identity is fixed before boot and a
 	// later HA increment can seed the same material onto additional control
-	// planes (kubeadm's manual certificate distribution).
-	for _, path := range []string{
-		"/etc/kubernetes/pki/ca.crt",
-		"/etc/kubernetes/pki/ca.key",
-		"/etc/kubernetes/pki/front-proxy-ca.crt",
-		"/etc/kubernetes/pki/front-proxy-ca.key",
-		"/etc/kubernetes/pki/etcd/ca.crt",
-		"/etc/kubernetes/pki/etcd/ca.key",
-		"/etc/kubernetes/pki/sa.key",
-		"/etc/kubernetes/pki/sa.pub",
+	// planes (kubeadm's manual certificate distribution). Each path is tied to
+	// its own write_files entry's mode and PEM block type, so a field swap in
+	// pkiSeedFiles (a key under a cert path, or a world-readable private key)
+	// fails here rather than on the booted node.
+	for _, seeded := range []struct {
+		path        string
+		permissions string
+		pemHeader   string
+	}{
+		{"/etc/kubernetes/pki/ca.crt", "0644", "BEGIN CERTIFICATE"},
+		{"/etc/kubernetes/pki/ca.key", "0600", "BEGIN RSA PRIVATE KEY"},
+		{"/etc/kubernetes/pki/front-proxy-ca.crt", "0644", "BEGIN CERTIFICATE"},
+		{"/etc/kubernetes/pki/front-proxy-ca.key", "0600", "BEGIN RSA PRIVATE KEY"},
+		{"/etc/kubernetes/pki/etcd/ca.crt", "0644", "BEGIN CERTIFICATE"},
+		{"/etc/kubernetes/pki/etcd/ca.key", "0600", "BEGIN RSA PRIVATE KEY"},
+		{"/etc/kubernetes/pki/sa.key", "0600", "BEGIN RSA PRIVATE KEY"},
+		{"/etc/kubernetes/pki/sa.pub", "0644", "BEGIN PUBLIC KEY"},
 	} {
-		assert.Contains(t, spec.UserData, path)
+		entry := writeFilesEntry(t, spec.UserData, seeded.path)
+		assert.Contains(t, entry, seeded.permissions, seeded.path)
+		assert.Contains(t, entry, seeded.pemHeader, seeded.path)
 	}
+}
+
+// writeFilesEntry extracts the single write_files entry for path from the
+// rendered cloud-init user data: the slice from its `path:` line up to the
+// next entry's `path:` line (or the document end). Field order within an
+// entry is path → permissions → content, so the slice carries exactly that
+// entry's mode and content.
+func writeFilesEntry(t *testing.T, userData, path string) string {
+	t.Helper()
+
+	start := strings.Index(userData, "path: "+path)
+	require.NotEqual(t, -1, start, "write_files entry for %s not found", path)
+
+	entry := userData[start:]
+	if next := strings.Index(entry[1:], "path: /"); next != -1 {
+		entry = entry[:next+1]
+	}
+
+	return entry
 }
 
 // TestComposeJoiningNodesPinsJoinNameAndCA pins the join compose contract:

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
@@ -44,13 +44,30 @@ func TestComposeInitNodeSeedsClusterIdentity(t *testing.T) {
 	assert.Equal(t, 0, spec.Index)
 	assert.Equal(t, hetzner.NodeTypeControlPlane, spec.NodeType)
 	assert.True(t, strings.HasPrefix(spec.UserData, "#cloud-config"))
-	assert.Contains(t, spec.UserData, "/etc/kubernetes/pki/ca.crt")
-	assert.Contains(t, spec.UserData, "/etc/kubernetes/pki/ca.key")
 	assert.Contains(t, spec.UserData, "BEGIN CERTIFICATE")
 	assert.Contains(t, spec.UserData, "BEGIN RSA PRIVATE KEY")
+	assert.Contains(t, spec.UserData, "BEGIN PRIVATE KEY", "sa.key must be seeded (PKCS#8)")
+	assert.Contains(t, spec.UserData, "BEGIN PUBLIC KEY", "sa.pub must be seeded (PKIX)")
 	assert.Contains(t, spec.UserData, testJoinName)
 	assert.Contains(t, spec.UserData, "kubeadm init")
 	assert.NotContains(t, spec.UserData, "kubeadm join")
+
+	// The full shared PKI — not just the cluster CA — lands at kubeadm's
+	// canonical paths, so the whole cluster identity is fixed before boot and a
+	// later HA increment can seed the same material onto additional control
+	// planes (kubeadm's manual certificate distribution).
+	for _, path := range []string{
+		"/etc/kubernetes/pki/ca.crt",
+		"/etc/kubernetes/pki/ca.key",
+		"/etc/kubernetes/pki/front-proxy-ca.crt",
+		"/etc/kubernetes/pki/front-proxy-ca.key",
+		"/etc/kubernetes/pki/etcd/ca.crt",
+		"/etc/kubernetes/pki/etcd/ca.key",
+		"/etc/kubernetes/pki/sa.key",
+		"/etc/kubernetes/pki/sa.pub",
+	} {
+		assert.Contains(t, spec.UserData, path)
+	}
 }
 
 // TestComposeJoiningNodesPinsJoinNameAndCA pins the join compose contract:
@@ -90,11 +107,17 @@ func TestComposeJoiningNodesPinsJoinNameAndCA(t *testing.T) {
 		require.NotEqual(t, -1, joinAt)
 		assert.Less(t, pinAt, joinAt, "the /etc/hosts pin must precede `kubeadm join`")
 
-		// The CA private key is seeded onto the init control plane only; a
-		// joiner carrying it (or its PKI path) would leak the cluster identity
-		// to every worker.
-		assert.NotContains(t, spec.UserData, "/etc/kubernetes/pki/ca.key",
-			"joining nodes must never receive the cluster CA private key")
+		// The private PKI material is seeded onto the init control plane only;
+		// a worker carrying any of it would leak the cluster identity.
+		for _, path := range []string{
+			"/etc/kubernetes/pki/ca.key",
+			"/etc/kubernetes/pki/front-proxy-ca.key",
+			"/etc/kubernetes/pki/etcd/ca.key",
+			"/etc/kubernetes/pki/sa.key",
+		} {
+			assert.NotContains(t, spec.UserData, path,
+				"joining nodes must never receive private PKI material")
+		}
 	}
 }
 

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
@@ -23,13 +23,13 @@ type Provisioner struct {
 
 	kubernetesVersion string
 
-	// clusterCA is the pre-seeded cluster CA minted by
+	// clusterPKI is the pre-seeded shared cluster PKI minted by
 	// [Provisioner.ComposeInitNode] and consumed by
 	// [Provisioner.ComposeJoiningNodes] within one two-phase create — the only
 	// state the multi-node flow threads between its two compose calls. Nil until
 	// an init node has been composed; a provisioner instance drives at most one
 	// create, matching the shared flow's ordering guarantee.
-	clusterCA *ClusterCA
+	clusterPKI *ClusterPKI
 }
 
 // NewProvisioner constructs a kubeadm × Hetzner provisioner. It builds the shared


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Additional kubeadm control planes can only join a Vanilla × Hetzner cluster if they share the init node's PKI, and today only the cluster CA's identity is fixed at compose time — the rest is minted at boot, out of reach.

## What
Pre-generates the full shared PKI set (front-proxy CA, etcd CA, service-account keypair, alongside the existing cluster CA) and seeds it onto the init control plane via cloud-init, fixing the whole cluster identity before any node boots. First increment of the HA control-plane join lane; no config surface or behaviour change for existing topologies.

Fixes #5797. Part of #5796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)