### PR TITLE
feat(client): add a typed AKS API client wrapper

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -173,6 +173,11 @@ linters:
             # Google Cloud dependency graph.
             - cloud.google.com/go/container
             - github.com/googleapis/gax-go
+            # github.com/Azure/azure-sdk-for-go is the official native AKS SDK backing
+            # pkg/client/aks (cluster lifecycle for the AKS provider, #4510):
+            # armcontainerservice for the management plane, azcore/azidentity for
+            # transport and the DefaultAzureCredential chain.
+            - github.com/Azure/azure-sdk-for-go
             - filippo.io/age
             - golang.design/x
             # x/crypto/ssh backs pkg/svc/bootstrap/ssh — the post-provision

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,9 @@ require (
 
 require (
 	cloud.google.com/go/container v1.53.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7 v7.3.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/apricote/hcloud-upload-image/hcloudimages v1.4.0
@@ -133,8 +136,6 @@ require (
 	github.com/Antonboom/nilnil v1.1.1 // indirect
 	github.com/Antonboom/testifylint v1.6.4 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,10 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthoriza
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1/go.mod h1:WqyxV5S0VtXD2+2d6oPqOvyhGubCvzLCKSAKgQ004Uk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 h1:1u/K2BFv0MwkG6he8RYuUcbbeK22rkoZbg4lKa/msZU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0/go.mod h1:U5gpsREQZE6SLk1t/cFfc1eMhYAlYpEzvaYXuDfefy8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0 h1:5n7dPVqsWfVKw+ZiEKSd3Kzu7gwBkbEBkeXb8rgaE9Q=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0/go.mod h1:HcZY0PHPo/7d75p99lB6lK0qYOP4vLRJUBpiehYXtLQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7 v7.3.0 h1:owjZtM7eVTSYIh4XAdUvWig9rV+BEra4bEnOnpXOAco=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7 v7.3.0/go.mod h1:bzstes8qsGAonl7WqKwIvWhGlfMCywgk1nons7nuNmw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=

--- a/pkg/client/aks/client.go
+++ b/pkg/client/aks/client.go
@@ -126,7 +126,7 @@ func (c *Client) CreateCluster(
 	response, err := poller.PollUntilDone(ctx, c.pollOptions())
 	if err != nil {
 		return armcontainerservice.ManagedCluster{},
-			fmt.Errorf("wait for cluster %q creation: %w", name, err)
+			fmt.Errorf("%w: wait for cluster %q creation: %w", ErrOperationFailed, name, err)
 	}
 
 	return response.ManagedCluster, nil
@@ -142,7 +142,7 @@ func (c *Client) DeleteCluster(ctx context.Context, resourceGroup, name string) 
 
 	_, err = poller.PollUntilDone(ctx, c.pollOptions())
 	if err != nil {
-		return fmt.Errorf("wait for cluster %q deletion: %w", name, err)
+		return fmt.Errorf("%w: wait for cluster %q deletion: %w", ErrOperationFailed, name, err)
 	}
 
 	return nil
@@ -219,7 +219,10 @@ func collectPages[T any](
 // SetAgentPoolCount resizes the named agent pool to count nodes and blocks
 // until the operation completes. It re-submits the pool's current definition
 // with only the count changed, per ARM create-or-update semantics — the
-// primitive Stop (count 0) and Start (restore count) build on.
+// primitive Stop (count 0) and Start (restore count) build on. ARM has no
+// partial PATCH for agent pools, so this get-then-resubmit flow is
+// last-writer-wins on the whole pool object: concurrent edits to other pool
+// fields between the Get and the resubmit are silently overwritten.
 func (c *Client) SetAgentPoolCount(
 	ctx context.Context,
 	resourceGroup, clusterName, poolName string,
@@ -246,7 +249,9 @@ func (c *Client) SetAgentPoolCount(
 
 	_, err = poller.PollUntilDone(ctx, c.pollOptions())
 	if err != nil {
-		return fmt.Errorf("wait for agent pool %q resize: %w", poolName, err)
+		return fmt.Errorf(
+			"%w: wait for agent pool %q resize: %w", ErrOperationFailed, poolName, err,
+		)
 	}
 
 	return nil

--- a/pkg/client/aks/client.go
+++ b/pkg/client/aks/client.go
@@ -1,0 +1,259 @@
+package aks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+)
+
+// defaultPollInterval is how often long-running operations are polled. Cluster
+// and agent-pool mutations take minutes, so a few seconds between polls keeps
+// the request volume negligible without adding meaningful latency.
+const defaultPollInterval = 5 * time.Second
+
+// Client performs AKS cluster lifecycle operations against one Azure
+// subscription, hiding the SDK's poller mechanics behind synchronous calls.
+type Client struct {
+	managedClusters *armcontainerservice.ManagedClustersClient
+	agentPools      *armcontainerservice.AgentPoolsClient
+	pollInterval    time.Duration
+}
+
+// config collects the constructor inputs Options mutate before the SDK
+// sub-clients are built (the SDK clients themselves are immutable once
+// constructed, so options cannot act on Client directly like gke's do).
+type config struct {
+	credential    azcore.TokenCredential
+	clientOptions *arm.ClientOptions
+	pollInterval  time.Duration
+}
+
+// Option customises a Client at construction time.
+type Option func(*config)
+
+// WithCredential injects the token credential, replacing the default
+// DefaultAzureCredential chain (e.g. a fake credential in tests, or a
+// workload-specific credential in callers that must not touch the ambient
+// environment).
+func WithCredential(credential azcore.TokenCredential) Option {
+	return func(cfg *config) {
+		cfg.credential = credential
+	}
+}
+
+// WithClientOptions sets the ARM client options for both SDK sub-clients.
+// Tests use this to route requests to the SDK's in-process fake servers via a
+// custom transport.
+func WithClientOptions(options *arm.ClientOptions) Option {
+	return func(cfg *config) {
+		cfg.clientOptions = options
+	}
+}
+
+// WithPollInterval overrides how often long-running operations are polled.
+// Values below one millisecond are ignored so a misconfigured caller cannot
+// turn the poll loop into a busy-wait against the API.
+func WithPollInterval(interval time.Duration) Option {
+	return func(cfg *config) {
+		if interval >= time.Millisecond {
+			cfg.pollInterval = interval
+		}
+	}
+}
+
+// NewClient builds an AKS client for the given subscription. Without
+// WithCredential it authenticates via DefaultAzureCredential, the SDK's
+// standard chain (environment, workload identity, managed identity, CLI).
+func NewClient(subscriptionID string, opts ...Option) (*Client, error) {
+	if subscriptionID == "" {
+		return nil, ErrMissingSubscriptionID
+	}
+
+	cfg := config{pollInterval: defaultPollInterval}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.credential == nil {
+		credential, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, fmt.Errorf("build default azure credential: %w", err)
+		}
+
+		cfg.credential = credential
+	}
+
+	managedClusters, err := armcontainerservice.NewManagedClustersClient(
+		subscriptionID, cfg.credential, cfg.clientOptions,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build managed-clusters client: %w", err)
+	}
+
+	agentPools, err := armcontainerservice.NewAgentPoolsClient(
+		subscriptionID, cfg.credential, cfg.clientOptions,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build agent-pools client: %w", err)
+	}
+
+	return &Client{
+		managedClusters: managedClusters,
+		agentPools:      agentPools,
+		pollInterval:    cfg.pollInterval,
+	}, nil
+}
+
+// CreateCluster creates (or updates, per ARM create-or-update semantics) the
+// named managed cluster and blocks until the operation completes, returning
+// the cluster as the API recorded it.
+func (c *Client) CreateCluster(
+	ctx context.Context,
+	resourceGroup, name string,
+	cluster armcontainerservice.ManagedCluster,
+) (armcontainerservice.ManagedCluster, error) {
+	poller, err := c.managedClusters.BeginCreateOrUpdate(ctx, resourceGroup, name, cluster, nil)
+	if err != nil {
+		return armcontainerservice.ManagedCluster{}, fmt.Errorf("create cluster %q: %w", name, err)
+	}
+
+	response, err := poller.PollUntilDone(ctx, c.pollOptions())
+	if err != nil {
+		return armcontainerservice.ManagedCluster{},
+			fmt.Errorf("wait for cluster %q creation: %w", name, err)
+	}
+
+	return response.ManagedCluster, nil
+}
+
+// DeleteCluster deletes the named managed cluster and blocks until the
+// operation completes.
+func (c *Client) DeleteCluster(ctx context.Context, resourceGroup, name string) error {
+	poller, err := c.managedClusters.BeginDelete(ctx, resourceGroup, name, nil)
+	if err != nil {
+		return fmt.Errorf("delete cluster %q: %w", name, err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, c.pollOptions())
+	if err != nil {
+		return fmt.Errorf("wait for cluster %q deletion: %w", name, err)
+	}
+
+	return nil
+}
+
+// GetCluster fetches the named managed cluster's definition.
+func (c *Client) GetCluster(
+	ctx context.Context,
+	resourceGroup, name string,
+) (armcontainerservice.ManagedCluster, error) {
+	response, err := c.managedClusters.Get(ctx, resourceGroup, name, nil)
+	if err != nil {
+		return armcontainerservice.ManagedCluster{}, fmt.Errorf("get cluster %q: %w", name, err)
+	}
+
+	return response.ManagedCluster, nil
+}
+
+// ListClusters lists the managed clusters in the given resource group, or —
+// when resourceGroup is empty — across the whole subscription (the AKS
+// counterpart to gke's all-locations wildcard).
+func (c *Client) ListClusters(
+	ctx context.Context,
+	resourceGroup string,
+) ([]*armcontainerservice.ManagedCluster, error) {
+	if resourceGroup == "" {
+		return collectPages(ctx, c.managedClusters.NewListPager(nil), listValue)
+	}
+
+	return collectPages(
+		ctx,
+		c.managedClusters.NewListByResourceGroupPager(resourceGroup, nil),
+		listByResourceGroupValue,
+	)
+}
+
+// listValue and listByResourceGroupValue unwrap the two list-response
+// envelopes to their shared payload shape for collectPages.
+func listValue(
+	response armcontainerservice.ManagedClustersClientListResponse,
+) []*armcontainerservice.ManagedCluster {
+	return response.Value
+}
+
+func listByResourceGroupValue(
+	response armcontainerservice.ManagedClustersClientListByResourceGroupResponse,
+) []*armcontainerservice.ManagedCluster {
+	return response.Value
+}
+
+// collectPages drains a pager, unwrapping each page's cluster slice with
+// value. The two subscription/resource-group pagers share pagination
+// mechanics but not a response type, so the envelope accessor is the one
+// generic seam.
+func collectPages[T any](
+	ctx context.Context,
+	pager *runtime.Pager[T],
+	value func(T) []*armcontainerservice.ManagedCluster,
+) ([]*armcontainerservice.ManagedCluster, error) {
+	var clusters []*armcontainerservice.ManagedCluster
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list clusters: %w", err)
+		}
+
+		clusters = append(clusters, value(page)...)
+	}
+
+	return clusters, nil
+}
+
+// SetAgentPoolCount resizes the named agent pool to count nodes and blocks
+// until the operation completes. It re-submits the pool's current definition
+// with only the count changed, per ARM create-or-update semantics — the
+// primitive Stop (count 0) and Start (restore count) build on.
+func (c *Client) SetAgentPoolCount(
+	ctx context.Context,
+	resourceGroup, clusterName, poolName string,
+	count int32,
+) error {
+	current, err := c.agentPools.Get(ctx, resourceGroup, clusterName, poolName, nil)
+	if err != nil {
+		return fmt.Errorf("get agent pool %q: %w", poolName, err)
+	}
+
+	pool := current.AgentPool
+	if pool.Properties == nil {
+		return fmt.Errorf("resize agent pool %q: %w", poolName, ErrAgentPoolPropertiesMissing)
+	}
+
+	pool.Properties.Count = &count
+
+	poller, err := c.agentPools.BeginCreateOrUpdate(
+		ctx, resourceGroup, clusterName, poolName, pool, nil,
+	)
+	if err != nil {
+		return fmt.Errorf("resize agent pool %q: %w", poolName, err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, c.pollOptions())
+	if err != nil {
+		return fmt.Errorf("wait for agent pool %q resize: %w", poolName, err)
+	}
+
+	return nil
+}
+
+// pollOptions returns the shared poll frequency for every long-running
+// operation this client waits on.
+func (c *Client) pollOptions() *runtime.PollUntilDoneOptions {
+	return &runtime.PollUntilDoneOptions{Frequency: c.pollInterval}
+}

--- a/pkg/client/aks/client_test.go
+++ b/pkg/client/aks/client_test.go
@@ -131,6 +131,7 @@ func TestCreateClusterSurfacesOperationError(t *testing.T) {
 				errResp azfake.ErrorResponder
 			)
 
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
 			resp.SetTerminalError(http.StatusConflict, "QuotaExceeded")
 
 			return resp, errResp
@@ -141,6 +142,7 @@ func TestCreateClusterSurfacesOperationError(t *testing.T) {
 		t.Context(), testResourceGroup, testClusterName, armcontainerservice.ManagedCluster{},
 	)
 
+	require.ErrorIs(t, err, aks.ErrOperationFailed)
 	require.ErrorContains(t, err, "QuotaExceeded")
 	require.ErrorContains(t, err, testClusterName)
 }
@@ -521,6 +523,39 @@ func TestSetAgentPoolCountRejectsPoolWithoutProperties(t *testing.T) {
 	)
 
 	require.ErrorIs(t, err, aks.ErrAgentPoolPropertiesMissing)
+}
+
+func TestSetAgentPoolCountSurfacesOperationError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{AgentPoolsServer: fake.AgentPoolsServer{
+		Get: threeNodePoolGet,
+		BeginCreateOrUpdate: func(
+			_ context.Context, _, _, _ string,
+			_ armcontainerservice.AgentPool,
+			_ *armcontainerservice.AgentPoolsClientBeginCreateOrUpdateOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
+			resp.SetTerminalError(http.StatusConflict, "OperationNotAllowed")
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).SetAgentPoolCount(
+		t.Context(), testResourceGroup, testClusterName, testPoolName, 5,
+	)
+
+	require.ErrorIs(t, err, aks.ErrOperationFailed)
+	require.ErrorContains(t, err, testPoolName)
 }
 
 func TestSetAgentPoolCountWrapsGetError(t *testing.T) {

--- a/pkg/client/aks/client_test.go
+++ b/pkg/client/aks/client_test.go
@@ -1,0 +1,554 @@
+package aks_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7/fake"
+	"github.com/devantler-tech/ksail/v7/pkg/client/aks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testSubscription  = "00000000-0000-0000-0000-000000000000"
+	testResourceGroup = "test-rg"
+	testClusterName   = "test-cluster"
+	testPoolName      = "default"
+)
+
+// newTestClient wires an aks.Client to the SDK's in-process fake servers, so
+// every request — including long-running-operation polling — is served by the
+// injected fakes without credentials or network access.
+func newTestClient(t *testing.T, factory *fake.ServerFactory) *aks.Client {
+	t.Helper()
+
+	return newTestClientPolling(t, factory, time.Millisecond)
+}
+
+// newTestClientPolling is newTestClient with an explicit poll interval, for
+// tests that need a wide inter-poll sleep window (e.g. cancellation).
+func newTestClientPolling(
+	t *testing.T, factory *fake.ServerFactory, pollInterval time.Duration,
+) *aks.Client {
+	t.Helper()
+
+	client, err := aks.NewClient(
+		testSubscription,
+		aks.WithCredential(&azfake.TokenCredential{}),
+		aks.WithClientOptions(&arm.ClientOptions{
+			ClientOptions: azcore.ClientOptions{
+				Transport: fake.NewServerFactoryTransport(factory),
+			},
+		}),
+		aks.WithPollInterval(pollInterval),
+	)
+	require.NoError(t, err)
+
+	return client
+}
+
+func namedCluster(name string) armcontainerservice.ManagedCluster {
+	return armcontainerservice.ManagedCluster{Name: new(name)}
+}
+
+func TestNewClientRejectsEmptySubscriptionID(t *testing.T) {
+	t.Parallel()
+
+	_, err := aks.NewClient("")
+
+	require.ErrorIs(t, err, aks.ErrMissingSubscriptionID)
+}
+
+func TestCreateClusterWaitsForOperation(t *testing.T) {
+	t.Parallel()
+
+	polled := false
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginCreateOrUpdate: func(
+			_ context.Context, resourceGroup, name string,
+			_ armcontainerservice.ManagedCluster,
+			_ *armcontainerservice.ManagedClustersClientBeginCreateOrUpdateOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientCreateOrUpdateResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientCreateOrUpdateResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			assert.Equal(t, testResourceGroup, resourceGroup)
+
+			// A non-terminal page first forces at least one poll round-trip
+			// before the terminal response, pinning the wait-for-completion
+			// contract rather than a fire-and-forget.
+			polled = true
+
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
+			resp.SetTerminalResponse(
+				http.StatusOK,
+				armcontainerservice.ManagedClustersClientCreateOrUpdateResponse{
+					ManagedCluster: namedCluster(name),
+				},
+				nil,
+			)
+
+			return resp, errResp
+		},
+	}}
+
+	created, err := newTestClient(t, factory).CreateCluster(
+		t.Context(), testResourceGroup, testClusterName, armcontainerservice.ManagedCluster{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, created.Name)
+	assert.Equal(t, testClusterName, *created.Name)
+	assert.True(t, polled)
+}
+
+func TestCreateClusterSurfacesOperationError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginCreateOrUpdate: func(
+			_ context.Context, _, _ string,
+			_ armcontainerservice.ManagedCluster,
+			_ *armcontainerservice.ManagedClustersClientBeginCreateOrUpdateOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientCreateOrUpdateResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientCreateOrUpdateResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.SetTerminalError(http.StatusConflict, "QuotaExceeded")
+
+			return resp, errResp
+		},
+	}}
+
+	_, err := newTestClient(t, factory).CreateCluster(
+		t.Context(), testResourceGroup, testClusterName, armcontainerservice.ManagedCluster{},
+	)
+
+	require.ErrorContains(t, err, "QuotaExceeded")
+	require.ErrorContains(t, err, testClusterName)
+}
+
+func TestCreateClusterHonoursContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginCreateOrUpdate: func(
+			_ context.Context, _, _ string,
+			_ armcontainerservice.ManagedCluster,
+			_ *armcontainerservice.ManagedClustersClientBeginCreateOrUpdateOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientCreateOrUpdateResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientCreateOrUpdateResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			// Enough non-terminal pages that the operation cannot finish
+			// before the context deadline strikes mid-sleep between polls.
+			for range 20 {
+				resp.AddNonTerminalResponse(http.StatusOK, nil)
+			}
+
+			resp.SetTerminalResponse(
+				http.StatusOK,
+				armcontainerservice.ManagedClustersClientCreateOrUpdateResponse{},
+				nil,
+			)
+
+			return resp, errResp
+		},
+	}}
+
+	// Deadline (40ms) lands inside the second inter-poll sleep (25–50ms), so
+	// the poll loop must notice the dead context and stop early.
+	expiring, cancel := context.WithTimeout(t.Context(), 40*time.Millisecond)
+	defer cancel()
+
+	_, err := newTestClientPolling(t, factory, 25*time.Millisecond).CreateCluster(
+		expiring, testResourceGroup, testClusterName, armcontainerservice.ManagedCluster{},
+	)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestDeleteClusterWaitsForOperation(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginDelete: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientBeginDeleteOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientDeleteResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientDeleteResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.AddNonTerminalResponse(http.StatusAccepted, nil)
+			resp.SetTerminalResponse(
+				http.StatusOK, armcontainerservice.ManagedClustersClientDeleteResponse{}, nil,
+			)
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).DeleteCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.NoError(t, err)
+}
+
+func TestDeleteClusterWrapsRequestError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginDelete: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientBeginDeleteOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientDeleteResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientDeleteResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).DeleteCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.ErrorContains(t, err, "ResourceNotFound")
+	require.ErrorContains(t, err, "delete cluster")
+}
+
+func TestGetClusterReturnsCluster(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		Get: func(
+			_ context.Context, _, name string,
+			_ *armcontainerservice.ManagedClustersClientGetOptions,
+		) (
+			azfake.Responder[armcontainerservice.ManagedClustersClientGetResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.Responder[armcontainerservice.ManagedClustersClientGetResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.SetResponse(
+				http.StatusOK,
+				armcontainerservice.ManagedClustersClientGetResponse{
+					ManagedCluster: namedCluster(name),
+				},
+				nil,
+			)
+
+			return resp, errResp
+		},
+	}}
+
+	cluster, err := newTestClient(t, factory).GetCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, cluster.Name)
+	assert.Equal(t, testClusterName, *cluster.Name)
+}
+
+func TestGetClusterWrapsError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		Get: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientGetOptions,
+		) (
+			azfake.Responder[armcontainerservice.ManagedClustersClientGetResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.Responder[armcontainerservice.ManagedClustersClientGetResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+
+			return resp, errResp
+		},
+	}}
+
+	_, err := newTestClient(t, factory).GetCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.ErrorContains(t, err, "get cluster")
+	require.ErrorContains(t, err, "ResourceNotFound")
+}
+
+func TestListClustersAcrossSubscriptionDrainsAllPages(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		NewListPager: func(
+			_ *armcontainerservice.ManagedClustersClientListOptions,
+		) azfake.PagerResponder[armcontainerservice.ManagedClustersClientListResponse] {
+			var resp azfake.PagerResponder[armcontainerservice.ManagedClustersClientListResponse]
+
+			first := namedCluster("cluster-a")
+			second := namedCluster("cluster-b")
+
+			resp.AddPage(http.StatusOK, armcontainerservice.ManagedClustersClientListResponse{
+				ManagedClusterListResult: armcontainerservice.ManagedClusterListResult{
+					Value: []*armcontainerservice.ManagedCluster{&first},
+				},
+			}, nil)
+			resp.AddPage(http.StatusOK, armcontainerservice.ManagedClustersClientListResponse{
+				ManagedClusterListResult: armcontainerservice.ManagedClusterListResult{
+					Value: []*armcontainerservice.ManagedCluster{&second},
+				},
+			}, nil)
+
+			return resp
+		},
+	}}
+
+	clusters, err := newTestClient(t, factory).ListClusters(t.Context(), "")
+
+	require.NoError(t, err)
+	require.Len(t, clusters, 2)
+	assert.Equal(t, "cluster-a", *clusters[0].Name)
+	assert.Equal(t, "cluster-b", *clusters[1].Name)
+}
+
+func TestListClustersInResourceGroupScopesTheRequest(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		NewListByResourceGroupPager: func(
+			resourceGroup string,
+			_ *armcontainerservice.ManagedClustersClientListByResourceGroupOptions,
+		) azfake.PagerResponder[armcontainerservice.ManagedClustersClientListByResourceGroupResponse] {
+			var resp azfake.PagerResponder[armcontainerservice.ManagedClustersClientListByResourceGroupResponse]
+
+			assert.Equal(t, testResourceGroup, resourceGroup)
+
+			scoped := namedCluster("scoped-cluster")
+
+			resp.AddPage(
+				http.StatusOK,
+				armcontainerservice.ManagedClustersClientListByResourceGroupResponse{
+					ManagedClusterListResult: armcontainerservice.ManagedClusterListResult{
+						Value: []*armcontainerservice.ManagedCluster{&scoped},
+					},
+				},
+				nil,
+			)
+
+			return resp
+		},
+	}}
+
+	clusters, err := newTestClient(t, factory).ListClusters(t.Context(), testResourceGroup)
+
+	require.NoError(t, err)
+	require.Len(t, clusters, 1)
+	assert.Equal(t, "scoped-cluster", *clusters[0].Name)
+}
+
+func TestListClustersWrapsPageError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		NewListPager: func(
+			_ *armcontainerservice.ManagedClustersClientListOptions,
+		) azfake.PagerResponder[armcontainerservice.ManagedClustersClientListResponse] {
+			var resp azfake.PagerResponder[armcontainerservice.ManagedClustersClientListResponse]
+
+			resp.AddResponseError(http.StatusInternalServerError, "InternalError")
+
+			return resp
+		},
+	}}
+
+	_, err := newTestClient(t, factory).ListClusters(t.Context(), "")
+
+	require.ErrorContains(t, err, "list clusters")
+	require.ErrorContains(t, err, "InternalError")
+}
+
+// threeNodePoolGet fakes fetching an existing three-node agent pool.
+func threeNodePoolGet(
+	_ context.Context, _, _, poolName string,
+	_ *armcontainerservice.AgentPoolsClientGetOptions,
+) (
+	azfake.Responder[armcontainerservice.AgentPoolsClientGetResponse],
+	azfake.ErrorResponder,
+) {
+	var (
+		resp    azfake.Responder[armcontainerservice.AgentPoolsClientGetResponse]
+		errResp azfake.ErrorResponder
+	)
+
+	resp.SetResponse(http.StatusOK, armcontainerservice.AgentPoolsClientGetResponse{
+		AgentPool: armcontainerservice.AgentPool{
+			Name: new(poolName),
+			Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
+				Count: new(int32(3)),
+			},
+		},
+	}, nil)
+
+	return resp, errResp
+}
+
+// capturingPoolUpdate fakes the resize submission, recording the submitted
+// count into captured.
+func capturingPoolUpdate(t *testing.T, captured **int32) func(
+	context.Context, string, string, string,
+	armcontainerservice.AgentPool,
+	*armcontainerservice.AgentPoolsClientBeginCreateOrUpdateOptions,
+) (
+	azfake.PollerResponder[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse],
+	azfake.ErrorResponder,
+) {
+	t.Helper()
+
+	return func(
+		_ context.Context, _, _, _ string,
+		parameters armcontainerservice.AgentPool,
+		_ *armcontainerservice.AgentPoolsClientBeginCreateOrUpdateOptions,
+	) (
+		azfake.PollerResponder[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse],
+		azfake.ErrorResponder,
+	) {
+		var (
+			resp    azfake.PollerResponder[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]
+			errResp azfake.ErrorResponder
+		)
+
+		require.NotNil(t, parameters.Properties)
+		*captured = parameters.Properties.Count
+
+		resp.SetTerminalResponse(
+			http.StatusOK,
+			armcontainerservice.AgentPoolsClientCreateOrUpdateResponse{AgentPool: parameters},
+			nil,
+		)
+
+		return resp, errResp
+	}
+}
+
+func TestSetAgentPoolCountResizesPool(t *testing.T) {
+	t.Parallel()
+
+	var submittedCount *int32
+
+	factory := &fake.ServerFactory{AgentPoolsServer: fake.AgentPoolsServer{
+		Get:                 threeNodePoolGet,
+		BeginCreateOrUpdate: capturingPoolUpdate(t, &submittedCount),
+	}}
+
+	err := newTestClient(t, factory).SetAgentPoolCount(
+		t.Context(), testResourceGroup, testClusterName, testPoolName, 5,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, submittedCount)
+	assert.Equal(t, int32(5), *submittedCount)
+}
+
+func TestSetAgentPoolCountRejectsPoolWithoutProperties(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{AgentPoolsServer: fake.AgentPoolsServer{
+		Get: func(
+			_ context.Context, _, _, poolName string,
+			_ *armcontainerservice.AgentPoolsClientGetOptions,
+		) (
+			azfake.Responder[armcontainerservice.AgentPoolsClientGetResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.Responder[armcontainerservice.AgentPoolsClientGetResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.SetResponse(http.StatusOK, armcontainerservice.AgentPoolsClientGetResponse{
+				AgentPool: armcontainerservice.AgentPool{Name: new(poolName)},
+			}, nil)
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).SetAgentPoolCount(
+		t.Context(), testResourceGroup, testClusterName, testPoolName, 5,
+	)
+
+	require.ErrorIs(t, err, aks.ErrAgentPoolPropertiesMissing)
+}
+
+func TestSetAgentPoolCountWrapsGetError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{AgentPoolsServer: fake.AgentPoolsServer{
+		Get: func(
+			_ context.Context, _, _, _ string,
+			_ *armcontainerservice.AgentPoolsClientGetOptions,
+		) (
+			azfake.Responder[armcontainerservice.AgentPoolsClientGetResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.Responder[armcontainerservice.AgentPoolsClientGetResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			errResp.SetResponseError(http.StatusNotFound, "AgentPoolNotFound")
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).SetAgentPoolCount(
+		t.Context(), testResourceGroup, testClusterName, testPoolName, 5,
+	)
+
+	require.ErrorContains(t, err, "get agent pool")
+	require.ErrorContains(t, err, "AgentPoolNotFound")
+}

--- a/pkg/client/aks/doc.go
+++ b/pkg/client/aks/doc.go
@@ -1,0 +1,18 @@
+// Package aks provides a thin, test-injectable client for Azure Kubernetes
+// Service cluster lifecycle operations, wrapping the official native Go SDK
+// (github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/
+// armcontainerservice). It is the AKS counterpart to the gke and eksctl
+// clients: everything above it (infra provider, provisioner, factory routing)
+// talks to AKS exclusively through this package.
+//
+// AKS cluster and agent-pool mutations are asynchronous: the API returns a
+// long-running operation the SDK exposes as a poller. CreateCluster,
+// DeleteCluster and SetAgentPoolCount hide that mechanic — they block until
+// the operation completes (honouring context cancellation) and surface any
+// operation error.
+//
+// Authentication uses DefaultAzureCredential (the SDK's standard environment /
+// workload-identity / CLI chain) unless a credential is injected; tests drive
+// the client against the SDK's in-process fake servers via WithClientOptions,
+// so no bespoke poller mocks are needed.
+package aks

--- a/pkg/client/aks/errors.go
+++ b/pkg/client/aks/errors.go
@@ -7,6 +7,12 @@ import "errors"
 // subscription, so a client without one could never issue a valid call.
 var ErrMissingSubscriptionID = errors.New("azure subscription ID must not be empty")
 
+// ErrOperationFailed is returned when a long-running AKS operation (cluster
+// create/delete, agent-pool resize) completes unsuccessfully, so callers can
+// detect the failure path with errors.Is regardless of which operation it
+// came from — mirroring the gke client's sentinel.
+var ErrOperationFailed = errors.New("aks: cluster operation failed")
+
 // ErrAgentPoolPropertiesMissing is returned by SetAgentPoolCount when the
 // fetched agent pool carries no properties object to update. The management
 // API always populates properties on a live pool, so this signals a malformed

--- a/pkg/client/aks/errors.go
+++ b/pkg/client/aks/errors.go
@@ -1,0 +1,14 @@
+package aks
+
+import "errors"
+
+// ErrMissingSubscriptionID is returned by NewClient when the Azure
+// subscription ID is empty: every management-plane request is scoped to a
+// subscription, so a client without one could never issue a valid call.
+var ErrMissingSubscriptionID = errors.New("azure subscription ID must not be empty")
+
+// ErrAgentPoolPropertiesMissing is returned by SetAgentPoolCount when the
+// fetched agent pool carries no properties object to update. The management
+// API always populates properties on a live pool, so this signals a malformed
+// or partial API response rather than a caller mistake.
+var ErrAgentPoolPropertiesMissing = errors.New("agent pool has no properties to update")


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The AKS half of the cloud-provider expansion has no Azure client layer yet, so nothing above it (provider service, factory, config) can be built.

## What
Adds `pkg/client/aks` — the AKS counterpart to the GKE client: synchronous create/delete/get/list/resize operations that hide the SDK's long-running-operation polling, authenticated via Azure's standard credential chain. Slice 2 (the provider service) builds on it.

**New dependency:** `armcontainerservice` v7 (official Azure SDK; was already an indirect dependency at v2).

Fixes #5800. Part of #4510.