### PR TITLE
feat(provisioner): compose RoleServer control-plane joins with a stable controlPlaneEndpoint (HA increment 2)

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -44,11 +44,14 @@ var (
 	)
 
 	// ErrHAControlPlaneNotImplemented is returned by [Base.Create] for a topology with
-	// more than one control-plane node. Additional control planes join the cluster's
-	// etcd, which needs quorum-aware ordering beyond the single-control-plane +
-	// agents path; it is a later increment of devantler-tech/ksail#5755.
+	// more than one control-plane node when the distribution's strategy does not
+	// implement the [HAControlPlaneComposer] capability: additional control planes
+	// join the cluster's etcd, whose distribution-specific mechanics (kubeadm's
+	// manual certificate distribution vs k3s' embedded etcd) each distribution
+	// lifts in its own increment of devantler-tech/ksail#5796 (epic #3983).
 	ErrHAControlPlaneNotImplemented = errors.New(
-		"hetzner: high-availability (multi-control-plane) bring-up is not yet implemented (tracked by #5755)",
+		"hetzner: high-availability (multi-control-plane) bring-up is not yet implemented" +
+			" for this distribution (tracked by #5796)",
 	)
 )
 
@@ -390,10 +393,12 @@ func (b *Base) RunCreate(
 // Create runs the whole create flow shared by both provisioners, so neither
 // re-writes it. It routes by topology: the single-control-plane, no-agent path
 // wires the embedded [CreateStrategy]'s per-node composition into the shared plan
-// composition ([PlanComposer]) and runs [Base.RunCreate]; a topology with agents
-// runs the two-phase multi-node bring-up ([Base.RunCreateMultiNode]) when the
-// strategy implements [MultiNodeComposer] (k3s and kubeadm both do), and is
-// rejected otherwise. High-availability (multiple control planes) is a later increment.
+// composition ([PlanComposer]) and runs [Base.RunCreate]; a topology with joining
+// nodes runs the two-phase multi-node bring-up ([Base.RunCreateMultiNode]) when
+// the strategy implements [MultiNodeComposer] (k3s and kubeadm both do), and is
+// rejected otherwise. A multi-control-plane (high-availability) topology
+// additionally requires the [HAControlPlaneComposer] capability (kubeadm only)
+// and is rejected per-distribution otherwise.
 // Each provisioner gets this method by embedding *Base; the distro-specific
 // pieces come from the Strategy it sets at construction.
 func (b *Base) Create(ctx context.Context, name string) error {
@@ -409,10 +414,12 @@ func (b *Base) Create(ctx context.Context, name string) error {
 // error is wrapped with the distribution label by [Base.Create].
 func (b *Base) create(ctx context.Context, name string) error {
 	if b.ControlPlanes > 1 {
-		return ErrHAControlPlaneNotImplemented
+		if _, ok := b.Strategy.(HAControlPlaneComposer); !ok {
+			return ErrHAControlPlaneNotImplemented
+		}
 	}
 
-	if b.Agents > 0 {
+	if b.ControlPlanes > 1 || b.Agents > 0 {
 		composer, ok := b.Strategy.(MultiNodeComposer)
 		if !ok {
 			return ErrMultiNodeNotImplemented

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
@@ -31,13 +31,14 @@ type MultiNodeComposer interface {
 	// (bootstrap index 0). It carries no join endpoint — it initialises the
 	// cluster the joining nodes later register against.
 	ComposeInitNode(clusterName, token string, material BootstrapMaterial) (NodeSpec, error)
-	// ComposeJoiningNodes composes the joining nodes (agents; additional control
-	// planes are a later increment) that register against the control plane
-	// reachable at joinAddress — the init node's private-network IPv4. The
-	// distribution forms its own registration URL from joinAddress (both k3s and
-	// kubeadm serve the API on the standard secure port). The returned specs carry
-	// their global bootstrap indices (>= 1) so their server names stay distinct
-	// from the init node's.
+	// ComposeJoiningNodes composes the joining nodes that register against the
+	// control plane reachable at joinAddress — the init node's private-network
+	// IPv4. For every distribution that means the agents; a distribution that
+	// also implements [HAControlPlaneComposer] composes its additional control
+	// planes here too. The distribution forms its own registration URL from joinAddress
+	// (both k3s and kubeadm serve the API on the standard secure port). The
+	// returned specs carry their global bootstrap indices (>= 1) so their server
+	// names stay distinct from the init node's.
 	ComposeJoiningNodes(
 		clusterName, token string,
 		joinAddress net.IP,
@@ -45,8 +46,28 @@ type MultiNodeComposer interface {
 	) ([]NodeSpec, error)
 }
 
-// RunCreateMultiNode runs the two-phase Hetzner create flow for a single
-// control-plane cluster with joining nodes (agents): guard against an existing
+// HAControlPlaneComposer is the optional capability a distribution's
+// [MultiNodeComposer] additionally implements once its compose halves handle a
+// multi-control-plane (high-availability) topology: the init node advertises a
+// stable control-plane endpoint and [MultiNodeComposer.ComposeJoiningNodes]
+// composes the additional control planes as control-plane joiners alongside the
+// agents. [Base.Create] rejects controlPlanes > 1 with
+// [ErrHAControlPlaneNotImplemented] for any strategy that does not implement
+// this — the guard is per-distribution because the join mechanics differ:
+// kubeadm's manual certificate distribution supports it, while k3s needs its own
+// embedded-etcd increment (see devantler-tech/ksail#5796).
+type HAControlPlaneComposer interface {
+	MultiNodeComposer
+
+	// SupportsHAControlPlanes marks the capability; it performs no work. A
+	// distribution declares — by implementing this — that its ComposeJoiningNodes
+	// output is correct for additional control planes, not only agents.
+	SupportsHAControlPlanes()
+}
+
+// RunCreateMultiNode runs the two-phase Hetzner create flow for a cluster with
+// joining nodes (agents and — for an [HAControlPlaneComposer] strategy —
+// additional control planes): guard against an existing
 // cluster, ensure the shared infrastructure, then (1) bring up the
 // cluster-initialising control plane and read its admin kubeconfig, and (2)
 // compose the joining nodes against the control plane's private-network address
@@ -64,6 +85,9 @@ type MultiNodeComposer interface {
 // usable once the control plane serves the API and its kubeconfig is retrieved;
 // end-to-end join success is validated by the live smoke tests
 // (devantler-tech/ksail#5515) once the Hetzner CI lane (#4972) is restored.
+// Additional control planes currently register concurrently like agents, which
+// can race etcd member addition; serialising their joins is the final HA
+// increment (devantler-tech/ksail#5796).
 func (b *Base) RunCreateMultiNode(
 	ctx context.Context,
 	name string,

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
@@ -42,8 +42,20 @@ const (
 // staticMultiNodeComposerCheck asserts at compile time that *Provisioner
 // implements the optional [hetznerbase.MultiNodeComposer] capability, so the
 // shared create flow routes a kubeadm topology with agents to the two-phase
-// bring-up instead of rejecting it.
-var _ hetznerbase.MultiNodeComposer = (*Provisioner)(nil)
+// bring-up instead of rejecting it — and the [hetznerbase.HAControlPlaneComposer]
+// capability, so a multi-control-plane topology routes there too.
+var (
+	_ hetznerbase.MultiNodeComposer      = (*Provisioner)(nil)
+	_ hetznerbase.HAControlPlaneComposer = (*Provisioner)(nil)
+)
+
+// SupportsHAControlPlanes marks the kubeadm strategy as able to compose a
+// multi-control-plane topology, satisfying [hetznerbase.HAControlPlaneComposer]:
+// [Provisioner.ComposeInitNode] advertises the stable join name as the cluster's
+// controlPlaneEndpoint and [Provisioner.ComposeJoiningNodes] composes the
+// additional control planes as control-plane joiners carrying the shared PKI
+// (kubeadm's manual certificate distribution).
+func (p *Provisioner) SupportsHAControlPlanes() {}
 
 // JoinName returns the cluster's stable join name: the DNS name the joining
 // nodes dial the cluster-initialising control plane by, and the extra SAN its
@@ -88,21 +100,43 @@ func (p *Provisioner) ComposeInitNode(
 
 	p.clusterPKI = &clusterPKI
 
+	joinName := JoinName(clusterName)
+
+	// A multi-control-plane cluster needs a stable controlPlaneEndpoint at init —
+	// kubeadm refuses control-plane joins without one — and the natural endpoint
+	// is the stable join name the joiners already dial. kubeadm writes the
+	// endpoint into the init node's own kubeconfigs (admin.conf, kubelet.conf),
+	// so the name must resolve locally before `kubeadm init` runs: it is pinned
+	// to loopback, which the API server serves (it binds all interfaces) and TLS
+	// accepts (verification is against the name, a SAN, not the address).
+	// Single-control-plane topologies keep no endpoint so their flow is unchanged.
+	var (
+		controlPlaneEndpoint string
+		serverInitPrelude    []string
+	)
+
+	if p.ControlPlanes > 1 {
+		controlPlaneEndpoint = net.JoinHostPort(joinName, kubeadmAPIPort)
+		serverInitPrelude = []string{hostsPinCommand(net.ParseIP("127.0.0.1"), joinName)}
+	}
+
 	// A reduced single-node plan: the init node's own configuration is identical
 	// in every topology (the join settings apply only to joining nodes), and the
 	// full plan cannot be expanded yet — its join endpoint resolves at run time.
 	nodes, err := BuildNodeUserData(Input{
 		ClusterName: clusterName,
 		Plan: kubeadmbootstrap.PlanInput{
-			Token:             token,
-			KubernetesVersion: p.kubernetesVersion,
-			CertSANs:          []string{JoinName(clusterName)},
-			ControlPlaneCount: 1,
-			AgentCount:        0,
+			Token:                token,
+			KubernetesVersion:    p.kubernetesVersion,
+			ControlPlaneEndpoint: controlPlaneEndpoint,
+			CertSANs:             []string{joinName},
+			ControlPlaneCount:    1,
+			AgentCount:           0,
 		},
 		SSHAuthorizedKeys: []string{material.AuthorizedKey},
 		HostKeys:          material.HostKeys,
 		ServerInitFiles:   pkiSeedFiles(clusterPKI),
+		ServerInitPrelude: serverInitPrelude,
 	})
 	if err != nil {
 		return hetznerbase.NodeSpec{}, fmt.Errorf("compose init control-plane node: %w", err)
@@ -152,12 +186,15 @@ func pkiSeedFiles(clusterPKI ClusterPKI) []cloudinitbootstrap.File {
 	}
 }
 
-// ComposeJoiningNodes composes the kubeadm agents that register against the
-// init control plane reachable at joinAddress (its private-network IPv4),
-// satisfying [hetznerbase.MultiNodeComposer]. It plans the full topology so the
-// joining nodes keep their global bootstrap indices, threads the stable join
-// name (pinned to joinAddress in each node's /etc/hosts) and the pre-seeded
-// CA's discovery hash into their JoinConfigurations, and returns only the
+// ComposeJoiningNodes composes the kubeadm joining nodes — additional control
+// planes first, then agents — that register against the init control plane
+// reachable at joinAddress (its private-network IPv4), satisfying
+// [hetznerbase.MultiNodeComposer]. It plans the full topology so the joining
+// nodes keep their global bootstrap indices, threads the stable join name
+// (pinned to joinAddress in each node's /etc/hosts) and the pre-seeded CA's
+// discovery hash into their JoinConfigurations, seeds the shared PKI onto the
+// control-plane joiners only (kubeadm's manual certificate distribution — an
+// agent never carries private cluster-identity material), and returns only the
 // joining nodes — the init node at index 0 is already up.
 func (p *Provisioner) ComposeJoiningNodes(
 	clusterName, token string,
@@ -183,6 +220,7 @@ func (p *Provisioner) ComposeJoiningNodes(
 		},
 		SSHAuthorizedKeys: []string{material.AuthorizedKey},
 		HostKeys:          material.HostKeys,
+		ServerJoinFiles:   pkiSeedFiles(*p.clusterPKI),
 		JoinPrelude:       []string{hostsPinCommand(joinAddress, joinName)},
 	})
 	if err != nil {

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
@@ -145,6 +145,96 @@ func TestComposeJoiningNodesPinsJoinNameAndCA(t *testing.T) {
 	}
 }
 
+// TestComposeInitNodeAdvertisesControlPlaneEndpointForHA pins the HA half of
+// the init compose contract: a multi-control-plane topology advertises the
+// stable join name as the cluster's controlPlaneEndpoint — which kubeadm
+// requires before any control-plane join — and pins that name to loopback in
+// /etc/hosts BEFORE `kubeadm init` writes it into the node's own kubeconfigs.
+// A single-control-plane topology keeps no endpoint and no local pin, so the
+// existing flow is unchanged.
+func TestComposeInitNodeAdvertisesControlPlaneEndpointForHA(t *testing.T) {
+	t.Parallel()
+
+	haProv := newProvisioner(&fakeInfra{}, 3, 1)
+
+	haSpec, err := haProv.ComposeInitNode(
+		testClusterName, "abcdef.0123456789abcdef", composeBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+
+	localPin := "echo '127.0.0.1 " + testJoinName + "' >> /etc/hosts"
+
+	assert.Contains(t, haSpec.UserData, "controlPlaneEndpoint")
+	assert.Contains(t, haSpec.UserData, testJoinName+":6443")
+	assert.Contains(t, haSpec.UserData, localPin)
+
+	pinAt := strings.Index(haSpec.UserData, localPin)
+	initAt := strings.Index(haSpec.UserData, "kubeadm init")
+	require.NotEqual(t, -1, initAt)
+	assert.Less(t, pinAt, initAt, "the local /etc/hosts pin must precede `kubeadm init`")
+
+	singleProv := newProvisioner(&fakeInfra{}, 1, 2)
+
+	singleSpec, err := singleProv.ComposeInitNode(
+		testClusterName, "abcdef.0123456789abcdef", composeBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+
+	assert.NotContains(t, singleSpec.UserData, "controlPlaneEndpoint")
+	assert.NotContains(t, singleSpec.UserData, localPin)
+}
+
+// TestComposeJoiningNodesComposesAdditionalControlPlanes pins the HA join
+// compose contract: with controlPlanes > 1 the joiners are the additional
+// control planes first (control-plane joins carrying the full pre-seeded
+// shared PKI — kubeadm's manual certificate distribution), then the agents,
+// which must never receive private cluster-identity material.
+func TestComposeJoiningNodesComposesAdditionalControlPlanes(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 3, 1)
+
+	_, err := prov.ComposeInitNode(
+		testClusterName, "abcdef.0123456789abcdef", composeBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+
+	specs, err := prov.ComposeJoiningNodes(
+		testClusterName, "abcdef.0123456789abcdef",
+		net.ParseIP("10.0.1.5"), composeBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+	require.Len(t, specs, 3)
+
+	privatePKIPaths := []string{
+		"/etc/kubernetes/pki/ca.key",
+		"/etc/kubernetes/pki/front-proxy-ca.key",
+		"/etc/kubernetes/pki/etcd/ca.key",
+		"/etc/kubernetes/pki/sa.key",
+	}
+
+	for index, spec := range specs[:2] {
+		assert.Equal(t, index+1, spec.Index)
+		assert.Equal(t, hetzner.NodeTypeControlPlane, spec.NodeType)
+		assert.Contains(t, spec.UserData, "controlPlane", "a control-plane joiner must join as one")
+		assert.Contains(t, spec.UserData, "kubeadm join")
+
+		for _, path := range privatePKIPaths {
+			assert.Contains(t, spec.UserData, path,
+				"a control-plane joiner needs the shared PKI before `kubeadm join --control-plane`")
+		}
+	}
+
+	agent := specs[2]
+	assert.Equal(t, 3, agent.Index)
+	assert.Equal(t, hetzner.NodeTypeWorker, agent.NodeType)
+
+	for _, path := range privatePKIPaths {
+		assert.NotContains(t, agent.UserData, path,
+			"agents must never receive private PKI material")
+	}
+}
+
 // TestComposeJoiningNodesRequiresInitFirst pins that composing joining nodes
 // without a prior init compose is refused: the joiners pin the CA minted during
 // the init compose, so out-of-order composition has no identity to pin.

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner_test.go
@@ -283,15 +283,31 @@ func TestCreateAlreadyExists(t *testing.T) {
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 }
 
-func TestCreateHAControlPlaneNotImplemented(t *testing.T) {
+// TestCreateHATopologyRoutesToMultiNodeBringUp pins that a multi-control-plane
+// kubeadm topology is no longer rejected wholesale: the strategy implements
+// [hetznerbase.HAControlPlaneComposer], so Create routes it to the shared
+// two-phase multi-node engine. The engine is exercised up to the first server
+// creation (the init control plane), whose composed spec proves the HA compose
+// ran; the erroring seam then surfaces, keeping the test hermetic.
+func TestCreateHATopologyRoutesToMultiNodeBringUp(t *testing.T) {
 	t.Parallel()
 
 	infra := &fakeInfra{}
+	servers := &fakeServers{createErr: errBoom}
 	prov := newProvisioner(infra, 3, 0)
+	prov.Servers = servers
 
 	err := prov.Create(context.Background(), "")
-	require.ErrorIs(t, err, kubeadmhetzner.ErrHAControlPlaneNotImplemented)
-	assert.Equal(t, 0, infra.ensureNetworkCalls)
+	require.ErrorIs(t, err, errBoom)
+	require.NotErrorIs(t, err, kubeadmhetzner.ErrHAControlPlaneNotImplemented)
+
+	// The guard no longer fires before the shared preamble: the infrastructure
+	// was ensured and the init control plane's fully-composed spec reached the
+	// server-creation seam carrying the stable controlPlaneEndpoint.
+	assert.Equal(t, 1, infra.ensureNetworkCalls)
+	assert.Equal(t, 1, servers.calls)
+	assert.Equal(t, "test-cluster-controlplane-0", servers.lastOpts.Name)
+	assert.Contains(t, servers.lastOpts.UserData, "controlPlaneEndpoint: "+testJoinName+":6443")
 }
 
 // The provisioner now satisfies hetznerbase.MultiNodeComposer (multinode.go's

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata.go
@@ -47,6 +47,18 @@ type Input struct {
 	// control plane — e.g. the pre-seeded cluster CA ([ClusterCA]) the two-phase
 	// multi-node flow fixes the cluster identity with. Optional.
 	ServerInitFiles []cloudinitbootstrap.File
+	// ServerInitPrelude are commands run on the cluster-initialising control
+	// plane before its install commands — e.g. pinning the cluster's stable join
+	// name locally so a ClusterConfiguration.controlPlaneEndpoint carrying that
+	// name resolves before `kubeadm init` writes it into the node's kubeconfigs.
+	// Optional; ignored on joining nodes.
+	ServerInitPrelude []string
+	// ServerJoinFiles are extra files delivered only to the additional
+	// control-plane joiners (RoleServer) — the pre-seeded shared PKI kubeadm's
+	// manual certificate distribution requires on every control plane before
+	// `kubeadm join --control-plane`. Optional; never delivered to agents, which
+	// must not carry private cluster-identity material.
+	ServerJoinFiles []cloudinitbootstrap.File
 	// JoinPrelude are commands run on every joining node before its install
 	// commands — e.g. pinning the stable join name to the init control plane's
 	// resolved private address in /etc/hosts, which must happen before `kubeadm
@@ -157,12 +169,26 @@ func buildNodeCloudInit(
 	commands := install.Commands
 
 	// The per-role extras: the init control plane receives the pre-seeded cluster
-	// identity files; a joining node runs the join prelude (e.g. the /etc/hosts
-	// pin of the stable join name) before its install commands reach `kubeadm join`.
-	if node.Config.Role == kubeadmbootstrap.RoleServerInit {
+	// identity files (and any init prelude, e.g. the local join-name pin its
+	// controlPlaneEndpoint needs); an additional control-plane joiner additionally
+	// receives the shared PKI (kubeadm's manual certificate distribution); every
+	// joining node runs the join prelude (e.g. the /etc/hosts pin of the stable
+	// join name) before its install commands reach `kubeadm join`.
+	switch node.Config.Role {
+	case kubeadmbootstrap.RoleServerInit:
 		files = append(files, input.ServerInitFiles...)
-	} else if len(input.JoinPrelude) > 0 {
-		commands = append(slices.Clone(input.JoinPrelude), commands...)
+		if len(input.ServerInitPrelude) > 0 {
+			commands = append(slices.Clone(input.ServerInitPrelude), commands...)
+		}
+	case kubeadmbootstrap.RoleServer:
+		files = append(files, input.ServerJoinFiles...)
+		if len(input.JoinPrelude) > 0 {
+			commands = append(slices.Clone(input.JoinPrelude), commands...)
+		}
+	case kubeadmbootstrap.RoleAgent:
+		if len(input.JoinPrelude) > 0 {
+			commands = append(slices.Clone(input.JoinPrelude), commands...)
+		}
 	}
 
 	userData, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

A Vanilla (kubeadm) × Hetzner cluster with more than one control plane is still rejected outright, even though the shared PKI foundation for it already landed — so high availability, the main reason to run multiple control planes, remains unreachable.

## What

Multi-control-plane topologies now compose end to end for kubeadm: the cluster advertises a stable API endpoint, additional control planes join as real control planes carrying the shared cluster identity, and the rejection becomes per-distribution (K3s keeps rejecting until its own HA increment). Serial join sequencing is the final increment of the design (#5796).

Fixes #5803 · Part of #5796 / #3983