### PR TITLE
feat(provider): add the Azure provider service for AKS (pkg/svc/provider/azure)

### DIFF
--- a/pkg/client/aks/client.go
+++ b/pkg/client/aks/client.go
@@ -219,7 +219,9 @@ func collectPages[T any](
 // SetAgentPoolCount resizes the named agent pool to count nodes and blocks
 // until the operation completes. It re-submits the pool's current definition
 // with only the count changed, per ARM create-or-update semantics — the
-// primitive Stop (count 0) and Start (restore count) build on. ARM has no
+// primitive an exact-size restore builds on (whole-cluster stop/start uses
+// [Client.StopCluster]/[Client.StartCluster] instead: system agent pools
+// cannot be resized to zero). ARM has no
 // partial PATCH for agent pools, so this get-then-resubmit flow is
 // last-writer-wins on the whole pool object: concurrent edits to other pool
 // fields between the Get and the resubmit are silently overwritten.
@@ -252,6 +254,40 @@ func (c *Client) SetAgentPoolCount(
 		return fmt.Errorf(
 			"%w: wait for agent pool %q resize: %w", ErrOperationFailed, poolName, err,
 		)
+	}
+
+	return nil
+}
+
+// StartCluster starts a stopped managed cluster (control plane and agent
+// pools) and blocks until the operation completes.
+func (c *Client) StartCluster(ctx context.Context, resourceGroup, name string) error {
+	poller, err := c.managedClusters.BeginStart(ctx, resourceGroup, name, nil)
+	if err != nil {
+		return fmt.Errorf("start cluster %q: %w", name, err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, c.pollOptions())
+	if err != nil {
+		return fmt.Errorf("%w: wait for cluster %q start: %w", ErrOperationFailed, name, err)
+	}
+
+	return nil
+}
+
+// StopCluster stops the managed cluster — Azure's supported way to halt AKS
+// node costs: the control plane and every agent pool deallocate while the
+// cluster's state and configuration are kept (a GKE-style resize-to-zero is
+// rejected for system agent pools). Blocks until the operation completes.
+func (c *Client) StopCluster(ctx context.Context, resourceGroup, name string) error {
+	poller, err := c.managedClusters.BeginStop(ctx, resourceGroup, name, nil)
+	if err != nil {
+		return fmt.Errorf("stop cluster %q: %w", name, err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, c.pollOptions())
+	if err != nil {
+		return fmt.Errorf("%w: wait for cluster %q stop: %w", ErrOperationFailed, name, err)
 	}
 
 	return nil

--- a/pkg/client/aks/client_test.go
+++ b/pkg/client/aks/client_test.go
@@ -689,3 +689,37 @@ func TestStopClusterSurfacesOperationError(t *testing.T) {
 	require.ErrorContains(t, err, "StopInProgress")
 	require.ErrorContains(t, err, testClusterName)
 }
+
+// TestStartClusterSurfacesOperationError pins the ErrOperationFailed wrap on
+// the start wrapper's PollUntilDone path, mirroring the stop-side test.
+func TestStartClusterSurfacesOperationError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginStart: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientBeginStartOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientStartResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientStartResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.AddNonTerminalResponse(http.StatusAccepted, nil)
+			resp.SetTerminalError(http.StatusConflict, "StartInProgress")
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).StartCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.ErrorIs(t, err, aks.ErrOperationFailed)
+	require.ErrorContains(t, err, "StartInProgress")
+	require.ErrorContains(t, err, testClusterName)
+}

--- a/pkg/client/aks/client_test.go
+++ b/pkg/client/aks/client_test.go
@@ -587,3 +587,105 @@ func TestSetAgentPoolCountWrapsGetError(t *testing.T) {
 	require.ErrorContains(t, err, "get agent pool")
 	require.ErrorContains(t, err, "AgentPoolNotFound")
 }
+
+// TestStartClusterWaitsForOperation pins the start wrapper's LRO handling:
+// BeginStart is polled to completion before the call returns.
+func TestStartClusterWaitsForOperation(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginStart: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientBeginStartOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientStartResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientStartResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.AddNonTerminalResponse(http.StatusAccepted, nil)
+			resp.SetTerminalResponse(
+				http.StatusOK, armcontainerservice.ManagedClustersClientStartResponse{}, nil,
+			)
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).StartCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.NoError(t, err)
+}
+
+// TestStopClusterWaitsForOperation pins the stop wrapper's LRO handling.
+func TestStopClusterWaitsForOperation(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginStop: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientBeginStopOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientStopResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientStopResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.AddNonTerminalResponse(http.StatusAccepted, nil)
+			resp.SetTerminalResponse(
+				http.StatusOK, armcontainerservice.ManagedClustersClientStopResponse{}, nil,
+			)
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).StopCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.NoError(t, err)
+}
+
+// TestStopClusterSurfacesOperationError pins the ErrOperationFailed wrap on
+// the stop wrapper's PollUntilDone path (a non-terminal page first, so the
+// failure surfaces during the wait rather than at BeginStop).
+func TestStopClusterSurfacesOperationError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		BeginStop: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientBeginStopOptions,
+		) (
+			azfake.PollerResponder[armcontainerservice.ManagedClustersClientStopResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.PollerResponder[armcontainerservice.ManagedClustersClientStopResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.AddNonTerminalResponse(http.StatusAccepted, nil)
+			resp.SetTerminalError(http.StatusConflict, "StopInProgress")
+
+			return resp, errResp
+		},
+	}}
+
+	err := newTestClient(t, factory).StopCluster(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.ErrorIs(t, err, aks.ErrOperationFailed)
+	require.ErrorContains(t, err, "StopInProgress")
+	require.ErrorContains(t, err, testClusterName)
+}

--- a/pkg/svc/provider/azure/doc.go
+++ b/pkg/svc/provider/azure/doc.go
@@ -1,8 +1,9 @@
 // Package azure implements provider.Provider for Azure Kubernetes Service over
 // the pkg/client/aks cluster-lifecycle client. AKS agent pools are not
 // individual nodes — like GKE node pools and EKS nodegroups they are managed
-// groups — so the provider collapses each pool to a single NodeInfo, and node
-// start/stop is implemented as pool resizes (the control plane is
-// Azure-managed and keeps running either way). It is the AKS sibling of the
-// gcp provider and mirrors its lifecycle semantics.
+// groups — so the provider collapses each pool to a single NodeInfo. Node
+// start/stop uses AKS's native cluster stop/start (system agent pools cannot
+// be resized to zero, so the gcp provider's pool-resize stop does not
+// translate): the whole cluster — control plane included — deallocates and
+// resumes with its state kept. It is the AKS sibling of the gcp provider.
 package azure

--- a/pkg/svc/provider/azure/doc.go
+++ b/pkg/svc/provider/azure/doc.go
@@ -1,0 +1,8 @@
+// Package azure implements provider.Provider for Azure Kubernetes Service over
+// the pkg/client/aks cluster-lifecycle client. AKS agent pools are not
+// individual nodes — like GKE node pools and EKS nodegroups they are managed
+// groups — so the provider collapses each pool to a single NodeInfo, and node
+// start/stop is implemented as pool resizes (the control plane is
+// Azure-managed and keeps running either way). It is the AKS sibling of the
+// gcp provider and mirrors its lifecycle semantics.
+package azure

--- a/pkg/svc/provider/azure/errors.go
+++ b/pkg/svc/provider/azure/errors.go
@@ -1,0 +1,11 @@
+package azure
+
+import "errors"
+
+// ErrClientRequired is returned when NewProvider is called without an AKS
+// client, so callers fail fast instead of getting
+// provider.ErrProviderUnavailable at the first call. The resource group, by
+// contrast, may be empty: cluster-scoped calls then resolve it from the
+// cluster's own ARM ID via a subscription-wide list (the AKS counterpart to
+// the gcp provider's all-locations resolution).
+var ErrClientRequired = errors.New("azure provider: aks client is required")

--- a/pkg/svc/provider/azure/provider.go
+++ b/pkg/svc/provider/azure/provider.go
@@ -134,12 +134,9 @@ func (p *Provider) ListNodes(
 	ctx context.Context,
 	clusterName string,
 ) ([]provider.NodeInfo, error) {
-	cluster, err := p.getCluster(ctx, clusterName)
-	if err != nil {
-		return nil, err
-	}
+	_, nodes, err := p.clusterNodes(ctx, clusterName)
 
-	return agentPoolInfos(cluster, clusterName), nil
+	return nodes, err
 }
 
 // ListAllClusters returns the names of all AKS clusters in the configured
@@ -189,12 +186,10 @@ func (p *Provider) GetClusterStatus(
 	ctx context.Context,
 	clusterName string,
 ) (*provider.ClusterStatus, error) {
-	cluster, err := p.getCluster(ctx, clusterName)
+	cluster, nodes, err := p.clusterNodes(ctx, clusterName)
 	if err != nil {
 		return nil, err
 	}
-
-	nodes := agentPoolInfos(cluster, clusterName)
 
 	status := provider.BuildClusterStatus(nodes, agentPoolReadyState)
 	if status == nil {
@@ -212,6 +207,22 @@ func (p *Provider) GetClusterStatus(
 // with (empty when operating subscription-wide).
 func (p *Provider) ResourceGroup() string {
 	return p.resourceGroup
+}
+
+// clusterNodes is the shared fetch-and-collapse behind ListNodes and
+// GetClusterStatus: it fetches the cluster once and maps its agent pools to
+// NodeInfo entries, returning the cluster too for callers that need more of
+// it (e.g. the API-server FQDN).
+func (p *Provider) clusterNodes(
+	ctx context.Context,
+	clusterName string,
+) (armcontainerservice.ManagedCluster, []provider.NodeInfo, error) {
+	cluster, err := p.getCluster(ctx, clusterName)
+	if err != nil {
+		return armcontainerservice.ManagedCluster{}, nil, err
+	}
+
+	return cluster, agentPoolInfos(cluster, clusterName), nil
 }
 
 // getCluster is the shared cluster fetch that guards against nil clients and

--- a/pkg/svc/provider/azure/provider.go
+++ b/pkg/svc/provider/azure/provider.go
@@ -25,7 +25,7 @@ const agentPoolReadyState = "Succeeded"
 // ClusterClient is the slice of the pkg/client/aks surface the provider
 // drives. It is the provider's test seam: the aks client has no injectable
 // manager (its own tests fake the ARM transport), so the provider narrows the
-// dependency to the three calls it makes instead.
+// dependency to the calls it makes instead.
 type ClusterClient interface {
 	// GetCluster fetches one managed cluster in a resource group.
 	GetCluster(
@@ -38,12 +38,10 @@ type ClusterClient interface {
 		ctx context.Context,
 		resourceGroup string,
 	) ([]*armcontainerservice.ManagedCluster, error)
-	// SetAgentPoolCount resizes one agent pool of a cluster.
-	SetAgentPoolCount(
-		ctx context.Context,
-		resourceGroup, clusterName, poolName string,
-		count int32,
-	) error
+	// StartCluster starts a stopped managed cluster.
+	StartCluster(ctx context.Context, resourceGroup, name string) error
+	// StopCluster stops a running managed cluster.
+	StopCluster(ctx context.Context, resourceGroup, name string) error
 }
 
 // staticClusterClientCheck asserts at compile time that the production aks
@@ -70,55 +68,47 @@ func NewProvider(client ClusterClient, resourceGroup string) (*Provider, error) 
 	return &Provider{client: client, resourceGroup: resourceGroup}, nil
 }
 
-// StartNodes resizes every agent pool of the cluster back to at least one
-// node: the pool's current count when it still has one, its autoscaler
-// minimum when one is configured, and one node otherwise.
-//
-// AKS does not preserve a creation-time count on the agent-pool profile (the
-// profile's Count is the live size, zero after StopNodes), so unlike GKE
-// there is no initial count to restore — the resize is re-asserted for every
-// pool, which the API treats as a no-op when the pool is already at that
-// size. The provisioner — which has the ksail.yaml spec — is responsible for
-// restoring an exact desired size when needed.
+// StartNodes starts a stopped cluster via AKS's native start, the
+// counterpart of [Provider.StopNodes]. A cluster already running is left
+// alone, keeping the call idempotent (ARM rejects starting a running
+// cluster).
 func (p *Provider) StartNodes(ctx context.Context, clusterName string) error {
-	pools, resourceGroup, err := p.agentPoolsForScale(ctx, clusterName)
+	resourceGroup, cluster, err := p.clusterWithGroup(ctx, clusterName)
 	if err != nil {
 		return err
 	}
 
-	for _, pool := range pools {
-		target := max(derefInt32(pool.Count), derefInt32(pool.MinCount), 1)
+	if powerCode(cluster) == armcontainerservice.CodeRunning {
+		return nil
+	}
 
-		err = p.client.SetAgentPoolCount(
-			ctx, resourceGroup, clusterName, derefString(pool.Name), target,
-		)
-		if err != nil {
-			return fmt.Errorf(
-				"start nodes: resize agent pool %s: %w", derefString(pool.Name), err,
-			)
-		}
+	err = p.client.StartCluster(ctx, resourceGroup, clusterName)
+	if err != nil {
+		return fmt.Errorf("start cluster %s: %w", clusterName, err)
 	}
 
 	return nil
 }
 
-// StopNodes resizes every agent pool of the cluster to zero nodes. The AKS
-// control plane keeps running (and billing) but all node costs stop.
+// StopNodes stops the cluster via AKS's native stop — Azure's supported way
+// to halt node costs. Unlike the gcp provider's pool-resize stop, agent pools
+// cannot be resized to zero on AKS (system pools require at least one node),
+// so the whole cluster — control plane included — deallocates while its state
+// and configuration are kept. A cluster already stopped is left alone,
+// keeping the call idempotent (ARM rejects stopping a stopped cluster).
 func (p *Provider) StopNodes(ctx context.Context, clusterName string) error {
-	pools, resourceGroup, err := p.agentPoolsForScale(ctx, clusterName)
+	resourceGroup, cluster, err := p.clusterWithGroup(ctx, clusterName)
 	if err != nil {
 		return err
 	}
 
-	for _, pool := range pools {
-		err = p.client.SetAgentPoolCount(
-			ctx, resourceGroup, clusterName, derefString(pool.Name), 0,
-		)
-		if err != nil {
-			return fmt.Errorf(
-				"stop nodes: resize agent pool %s: %w", derefString(pool.Name), err,
-			)
-		}
+	if powerCode(cluster) == armcontainerservice.CodeStopped {
+		return nil
+	}
+
+	err = p.client.StopCluster(ctx, resourceGroup, clusterName)
+	if err != nil {
+		return fmt.Errorf("stop cluster %s: %w", clusterName, err)
 	}
 
 	return nil
@@ -217,7 +207,7 @@ func (p *Provider) clusterNodes(
 	ctx context.Context,
 	clusterName string,
 ) (armcontainerservice.ManagedCluster, []provider.NodeInfo, error) {
-	cluster, err := p.getCluster(ctx, clusterName)
+	_, cluster, err := p.clusterWithGroup(ctx, clusterName)
 	if err != nil {
 		return armcontainerservice.ManagedCluster{}, nil, err
 	}
@@ -225,56 +215,29 @@ func (p *Provider) clusterNodes(
 	return cluster, agentPoolInfos(cluster, clusterName), nil
 }
 
-// getCluster is the shared cluster fetch that guards against nil clients and
-// translates client errors into the provider sentinels.
-func (p *Provider) getCluster(
+// clusterWithGroup is the shared cluster fetch that guards against nil
+// clients, resolves the resource group the cluster lives in, and translates
+// client errors into the provider sentinels — the prelude of every
+// cluster-scoped operation.
+func (p *Provider) clusterWithGroup(
 	ctx context.Context,
 	clusterName string,
-) (armcontainerservice.ManagedCluster, error) {
+) (string, armcontainerservice.ManagedCluster, error) {
 	if p.client == nil {
-		return armcontainerservice.ManagedCluster{}, provider.ErrProviderUnavailable
+		return "", armcontainerservice.ManagedCluster{}, provider.ErrProviderUnavailable
 	}
 
 	resourceGroup, err := p.clusterResourceGroup(ctx, clusterName)
 	if err != nil {
-		return armcontainerservice.ManagedCluster{}, err
+		return "", armcontainerservice.ManagedCluster{}, err
 	}
 
 	cluster, err := p.client.GetCluster(ctx, resourceGroup, clusterName)
 	if err != nil {
-		return armcontainerservice.ManagedCluster{}, translateClientErr(err)
+		return "", armcontainerservice.ManagedCluster{}, translateClientErr(err)
 	}
 
-	return cluster, nil
-}
-
-// agentPoolsForScale is the shared prelude for StartNodes and StopNodes that
-// fetches the cluster's agent pools (and the resource group they live in) and
-// classifies an empty result as provider.ErrNoNodes.
-func (p *Provider) agentPoolsForScale(
-	ctx context.Context,
-	clusterName string,
-) ([]*armcontainerservice.ManagedClusterAgentPoolProfile, string, error) {
-	if p.client == nil {
-		return nil, "", provider.ErrProviderUnavailable
-	}
-
-	resourceGroup, err := p.clusterResourceGroup(ctx, clusterName)
-	if err != nil {
-		return nil, "", err
-	}
-
-	cluster, err := p.client.GetCluster(ctx, resourceGroup, clusterName)
-	if err != nil {
-		return nil, "", translateClientErr(err)
-	}
-
-	pools := agentPools(cluster)
-	if len(pools) == 0 {
-		return nil, "", provider.ErrNoNodes
-	}
-
-	return pools, resourceGroup, nil
+	return resourceGroup, cluster, nil
 }
 
 // clusterResourceGroup resolves the resource group a cluster-scoped call
@@ -364,19 +327,22 @@ func translateClientErr(err error) error {
 	return err
 }
 
+// powerCode unwraps a cluster's power state, mapping any missing level of
+// the optional chain to the empty code (neither running nor stopped, so the
+// idempotence short-circuits never fire on it and the native call decides).
+func powerCode(cluster armcontainerservice.ManagedCluster) armcontainerservice.Code {
+	if cluster.Properties == nil || cluster.Properties.PowerState == nil ||
+		cluster.Properties.PowerState.Code == nil {
+		return ""
+	}
+
+	return *cluster.Properties.PowerState.Code
+}
+
 // derefString unwraps the SDK's optional string fields, mapping nil to "".
 func derefString(value *string) string {
 	if value == nil {
 		return ""
-	}
-
-	return *value
-}
-
-// derefInt32 unwraps the SDK's optional int32 fields, mapping nil to zero.
-func derefInt32(value *int32) int32 {
-	if value == nil {
-		return 0
 	}
 
 	return *value

--- a/pkg/svc/provider/azure/provider.go
+++ b/pkg/svc/provider/azure/provider.go
@@ -1,0 +1,372 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/devantler-tech/ksail/v7/pkg/client/aks"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+)
+
+// nodeRoleWorker is the role every AKS agent pool maps to: the control plane
+// is Azure-managed and never surfaces as a pool.
+const nodeRoleWorker = "worker"
+
+// agentPoolReadyState is the ARM provisioning state of a healthy agent pool —
+// the AKS counterpart to a RUNNING GKE node pool.
+const agentPoolReadyState = "Succeeded"
+
+// ClusterClient is the slice of the pkg/client/aks surface the provider
+// drives. It is the provider's test seam: the aks client has no injectable
+// manager (its own tests fake the ARM transport), so the provider narrows the
+// dependency to the three calls it makes instead.
+type ClusterClient interface {
+	// GetCluster fetches one managed cluster in a resource group.
+	GetCluster(
+		ctx context.Context,
+		resourceGroup, name string,
+	) (armcontainerservice.ManagedCluster, error)
+	// ListClusters lists the clusters in a resource group, or across the whole
+	// subscription when resourceGroup is empty.
+	ListClusters(
+		ctx context.Context,
+		resourceGroup string,
+	) ([]*armcontainerservice.ManagedCluster, error)
+	// SetAgentPoolCount resizes one agent pool of a cluster.
+	SetAgentPoolCount(
+		ctx context.Context,
+		resourceGroup, clusterName, poolName string,
+		count int32,
+	) error
+}
+
+// staticClusterClientCheck asserts at compile time that the production aks
+// client satisfies the provider's seam.
+var _ ClusterClient = (*aks.Client)(nil)
+
+// Provider implements provider.Provider for Azure Kubernetes Service.
+type Provider struct {
+	client        ClusterClient
+	resourceGroup string
+}
+
+// NewProvider returns a Provider for the given resource group using the given
+// AKS client. Pass resourceGroup="" to operate across the whole subscription
+// where the API allows it (cluster listing); cluster-scoped calls then resolve
+// the cluster's own resource group from its ARM ID via a subscription-wide
+// list. A nil client returns ErrClientRequired so callers fail fast rather
+// than at the first API call.
+func NewProvider(client ClusterClient, resourceGroup string) (*Provider, error) {
+	if client == nil {
+		return nil, ErrClientRequired
+	}
+
+	return &Provider{client: client, resourceGroup: resourceGroup}, nil
+}
+
+// StartNodes resizes every agent pool of the cluster back to at least one
+// node: the pool's current count when it still has one, its autoscaler
+// minimum when one is configured, and one node otherwise.
+//
+// AKS does not preserve a creation-time count on the agent-pool profile (the
+// profile's Count is the live size, zero after StopNodes), so unlike GKE
+// there is no initial count to restore — the resize is re-asserted for every
+// pool, which the API treats as a no-op when the pool is already at that
+// size. The provisioner — which has the ksail.yaml spec — is responsible for
+// restoring an exact desired size when needed.
+func (p *Provider) StartNodes(ctx context.Context, clusterName string) error {
+	pools, resourceGroup, err := p.agentPoolsForScale(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	for _, pool := range pools {
+		target := max(derefInt32(pool.Count), derefInt32(pool.MinCount), 1)
+
+		err = p.client.SetAgentPoolCount(
+			ctx, resourceGroup, clusterName, derefString(pool.Name), target,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"start nodes: resize agent pool %s: %w", derefString(pool.Name), err,
+			)
+		}
+	}
+
+	return nil
+}
+
+// StopNodes resizes every agent pool of the cluster to zero nodes. The AKS
+// control plane keeps running (and billing) but all node costs stop.
+func (p *Provider) StopNodes(ctx context.Context, clusterName string) error {
+	pools, resourceGroup, err := p.agentPoolsForScale(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	for _, pool := range pools {
+		err = p.client.SetAgentPoolCount(
+			ctx, resourceGroup, clusterName, derefString(pool.Name), 0,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"stop nodes: resize agent pool %s: %w", derefString(pool.Name), err,
+			)
+		}
+	}
+
+	return nil
+}
+
+// ListNodes returns one NodeInfo per agent pool of the cluster.
+//
+// AKS agent pools are managed scale sets, not individual machines, so KSail
+// collapses the distinction and represents each pool as a single NodeInfo
+// whose Name is the pool name — mirroring how the gcp provider represents GKE
+// node pools and the AWS provider represents EKS nodegroups.
+func (p *Provider) ListNodes(
+	ctx context.Context,
+	clusterName string,
+) ([]provider.NodeInfo, error) {
+	cluster, err := p.getCluster(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	return agentPoolInfos(cluster, clusterName), nil
+}
+
+// ListAllClusters returns the names of all AKS clusters in the configured
+// resource group (the whole subscription when the provider was built with an
+// empty resource group).
+func (p *Provider) ListAllClusters(ctx context.Context) ([]string, error) {
+	if p.client == nil {
+		return nil, provider.ErrProviderUnavailable
+	}
+
+	clusters, err := p.client.ListClusters(ctx, p.resourceGroup)
+	if err != nil {
+		return nil, translateClientErr(err)
+	}
+
+	names := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		names = append(names, derefString(cluster.Name))
+	}
+
+	return names, nil
+}
+
+// NodesExist returns true if the cluster has at least one agent pool.
+func (p *Provider) NodesExist(ctx context.Context, clusterName string) (bool, error) {
+	exists, err := provider.CheckNodesExist(ctx, p, clusterName)
+	if err != nil {
+		return false, fmt.Errorf("check aks agent pools: %w", err)
+	}
+
+	return exists, nil
+}
+
+// DeleteNodes is a no-op for AKS: deleting the cluster deletes its agent
+// pools atomically, so pool deletion is owned by the provisioner's cluster
+// deletion — mirroring the gcp and AWS providers' contract.
+func (p *Provider) DeleteNodes(_ context.Context, _ string) error {
+	return nil
+}
+
+// GetClusterStatus aggregates agent-pool statuses into a
+// provider.ClusterStatus. Returns provider.ErrClusterNotFound when the
+// cluster does not exist. A cluster that exists but has no agent pools yields
+// a zero-node "stopped" status rather than a nil status, keeping the
+// (status, err) contract: status is non-nil whenever err is nil.
+func (p *Provider) GetClusterStatus(
+	ctx context.Context,
+	clusterName string,
+) (*provider.ClusterStatus, error) {
+	cluster, err := p.getCluster(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := agentPoolInfos(cluster, clusterName)
+
+	status := provider.BuildClusterStatus(nodes, agentPoolReadyState)
+	if status == nil {
+		status = &provider.ClusterStatus{Phase: provider.PhaseStopped, Nodes: nodes}
+	}
+
+	if cluster.Properties != nil {
+		status.Endpoint = derefString(cluster.Properties.Fqdn)
+	}
+
+	return status, nil
+}
+
+// ResourceGroup returns the Azure resource group this provider was configured
+// with (empty when operating subscription-wide).
+func (p *Provider) ResourceGroup() string {
+	return p.resourceGroup
+}
+
+// getCluster is the shared cluster fetch that guards against nil clients and
+// translates client errors into the provider sentinels.
+func (p *Provider) getCluster(
+	ctx context.Context,
+	clusterName string,
+) (armcontainerservice.ManagedCluster, error) {
+	if p.client == nil {
+		return armcontainerservice.ManagedCluster{}, provider.ErrProviderUnavailable
+	}
+
+	resourceGroup, err := p.clusterResourceGroup(ctx, clusterName)
+	if err != nil {
+		return armcontainerservice.ManagedCluster{}, err
+	}
+
+	cluster, err := p.client.GetCluster(ctx, resourceGroup, clusterName)
+	if err != nil {
+		return armcontainerservice.ManagedCluster{}, translateClientErr(err)
+	}
+
+	return cluster, nil
+}
+
+// agentPoolsForScale is the shared prelude for StartNodes and StopNodes that
+// fetches the cluster's agent pools (and the resource group they live in) and
+// classifies an empty result as provider.ErrNoNodes.
+func (p *Provider) agentPoolsForScale(
+	ctx context.Context,
+	clusterName string,
+) ([]*armcontainerservice.ManagedClusterAgentPoolProfile, string, error) {
+	if p.client == nil {
+		return nil, "", provider.ErrProviderUnavailable
+	}
+
+	resourceGroup, err := p.clusterResourceGroup(ctx, clusterName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	cluster, err := p.client.GetCluster(ctx, resourceGroup, clusterName)
+	if err != nil {
+		return nil, "", translateClientErr(err)
+	}
+
+	pools := agentPools(cluster)
+	if len(pools) == 0 {
+		return nil, "", provider.ErrNoNodes
+	}
+
+	return pools, resourceGroup, nil
+}
+
+// clusterResourceGroup resolves the resource group a cluster-scoped call
+// should target. With a configured resource group it is used directly; with
+// an empty one the cluster's own resource group is parsed from its ARM ID via
+// a subscription-wide list, since cluster-scoped AKS calls require one.
+func (p *Provider) clusterResourceGroup(
+	ctx context.Context,
+	clusterName string,
+) (string, error) {
+	if p.resourceGroup != "" {
+		return p.resourceGroup, nil
+	}
+
+	clusters, err := p.client.ListClusters(ctx, "")
+	if err != nil {
+		return "", translateClientErr(err)
+	}
+
+	for _, cluster := range clusters {
+		if cluster == nil || derefString(cluster.Name) != clusterName {
+			continue
+		}
+
+		resourceID, parseErr := arm.ParseResourceID(derefString(cluster.ID))
+		if parseErr != nil {
+			return "", fmt.Errorf(
+				"parse ARM ID of cluster %s: %w", clusterName, parseErr,
+			)
+		}
+
+		return resourceID.ResourceGroupName, nil
+	}
+
+	return "", fmt.Errorf("%w: %s", provider.ErrClusterNotFound, clusterName)
+}
+
+// agentPools unwraps a cluster's agent-pool profiles, tolerating the
+// zero-value cluster (nil Properties) the API never returns but tests may.
+func agentPools(
+	cluster armcontainerservice.ManagedCluster,
+) []*armcontainerservice.ManagedClusterAgentPoolProfile {
+	if cluster.Properties == nil {
+		return nil
+	}
+
+	return cluster.Properties.AgentPoolProfiles
+}
+
+// agentPoolInfos maps a cluster's agent pools to NodeInfo entries.
+func agentPoolInfos(
+	cluster armcontainerservice.ManagedCluster,
+	clusterName string,
+) []provider.NodeInfo {
+	pools := agentPools(cluster)
+	nodes := make([]provider.NodeInfo, 0, len(pools))
+
+	for _, pool := range pools {
+		if pool == nil {
+			continue
+		}
+
+		nodes = append(nodes, provider.NodeInfo{
+			Name:        derefString(pool.Name),
+			ClusterName: clusterName,
+			Role:        nodeRoleWorker,
+			State:       derefString(pool.ProvisioningState),
+			ServerType:  derefString(pool.VMSize),
+		})
+	}
+
+	return nodes
+}
+
+// translateClientErr maps AKS client errors onto the provider sentinels: an
+// ARM 404 anywhere in the chain becomes provider.ErrClusterNotFound.
+func translateClientErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) && responseErr.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%w: %s", provider.ErrClusterNotFound, strings.TrimSpace(err.Error()))
+	}
+
+	return err
+}
+
+// derefString unwraps the SDK's optional string fields, mapping nil to "".
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
+}
+
+// derefInt32 unwraps the SDK's optional int32 fields, mapping nil to zero.
+func derefInt32(value *int32) int32 {
+	if value == nil {
+		return 0
+	}
+
+	return *value
+}

--- a/pkg/svc/provider/azure/provider_test.go
+++ b/pkg/svc/provider/azure/provider_test.go
@@ -2,6 +2,7 @@ package azure_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -19,26 +20,29 @@ const (
 	testResourceGroup = "rg-dev"
 )
 
-// resizeCall records one SetAgentPoolCount invocation the provider made.
-type resizeCall struct {
+// errBoom is a sentinel used to assert error propagation from the client seam.
+var errBoom = errors.New("boom")
+
+// powerCall records one StartCluster/StopCluster invocation the provider made.
+type powerCall struct {
 	resourceGroup string
 	cluster       string
-	pool          string
-	count         int32
 }
 
 // fakeClusterClient scripts the azure.ClusterClient seam: it serves the
-// configured clusters for Get/List and records resizes, mirroring the gcp
-// provider's fakeClusterManager.
+// configured clusters for Get/List and records the native stop/start calls,
+// mirroring the gcp provider's fakeClusterManager.
 type fakeClusterClient struct {
 	clusters []*armcontainerservice.ManagedCluster
 
-	getErr  error
-	listErr error
-	sizeErr error
+	getErr   error
+	listErr  error
+	startErr error
+	stopErr  error
 
 	lastGetResourceGroup string
-	resizes              []resizeCall
+	starts               []powerCall
+	stops                []powerCall
 }
 
 func (f *fakeClusterClient) GetCluster(
@@ -74,21 +78,28 @@ func (f *fakeClusterClient) ListClusters(
 	return f.clusters, nil
 }
 
-func (f *fakeClusterClient) SetAgentPoolCount(
+func (f *fakeClusterClient) StartCluster(
 	_ context.Context,
-	resourceGroup, clusterName, poolName string,
-	count int32,
+	resourceGroup, name string,
 ) error {
-	if f.sizeErr != nil {
-		return f.sizeErr
+	if f.startErr != nil {
+		return f.startErr
 	}
 
-	f.resizes = append(f.resizes, resizeCall{
-		resourceGroup: resourceGroup,
-		cluster:       clusterName,
-		pool:          poolName,
-		count:         count,
-	})
+	f.starts = append(f.starts, powerCall{resourceGroup: resourceGroup, cluster: name})
+
+	return nil
+}
+
+func (f *fakeClusterClient) StopCluster(
+	_ context.Context,
+	resourceGroup, name string,
+) error {
+	if f.stopErr != nil {
+		return f.stopErr
+	}
+
+	f.stops = append(f.stops, powerCall{resourceGroup: resourceGroup, cluster: name})
 
 	return nil
 }
@@ -122,8 +133,22 @@ func managedCluster(
 		Properties: &armcontainerservice.ManagedClusterProperties{
 			Fqdn:              new(name + ".hcp.westeurope.azmk8s.io"),
 			AgentPoolProfiles: pools,
+			PowerState: &armcontainerservice.PowerState{
+				Code: new(armcontainerservice.CodeRunning),
+			},
 		},
 	}
+}
+
+// stoppedCluster returns a managedCluster whose power state reads Stopped.
+func stoppedCluster(
+	name string,
+	pools ...*armcontainerservice.ManagedClusterAgentPoolProfile,
+) *armcontainerservice.ManagedCluster {
+	cluster := managedCluster(name, pools...)
+	cluster.Properties.PowerState.Code = new(armcontainerservice.CodeStopped)
+
+	return cluster
 }
 
 // agentPool assembles an agent-pool profile in the given provisioning state.
@@ -206,73 +231,123 @@ func TestListNodesUnknownClusterWithoutResourceGroupIsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, provider.ErrClusterNotFound)
 }
 
-// TestStartNodesRestoresAtLeastOneNode pins the start targets: a stopped pool
-// (count zero) is restored to one node, a pool with an autoscaler minimum to
-// that minimum, and a running pool has its current size re-asserted — the
-// idempotent re-assert the design locked (AKS preserves no creation-time
-// count on the profile).
-func TestStartNodesRestoresAtLeastOneNode(t *testing.T) {
-	t.Parallel()
-
-	autoscaled := agentPool("autoscaled", 0, "Succeeded")
-	autoscaled.MinCount = new(int32(3))
-
-	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
-		managedCluster(
-			testCluster,
-			agentPool("stopped", 0, "Succeeded"),
-			autoscaled,
-			agentPool("running", 5, "Succeeded"),
-		),
-	}}
-	prov := newProvider(t, fake, testResourceGroup)
-
-	err := prov.StartNodes(context.Background(), testCluster)
-	require.NoError(t, err)
-
-	require.Len(t, fake.resizes, 3)
-	assert.Equal(t, resizeCall{testResourceGroup, testCluster, "stopped", 1}, fake.resizes[0])
-	assert.Equal(t, resizeCall{testResourceGroup, testCluster, "autoscaled", 3}, fake.resizes[1])
-	assert.Equal(t, resizeCall{testResourceGroup, testCluster, "running", 5}, fake.resizes[2])
-}
-
-// TestStopNodesResizesPoolsToZero pins the stop semantics: every pool is
-// resized to zero nodes (the control plane stays up; node costs stop).
-func TestStopNodesResizesPoolsToZero(t *testing.T) {
+// TestStopNodesStopsARunningCluster pins the stop semantics: a running
+// cluster is stopped via AKS's native whole-cluster stop (system agent pools
+// cannot be resized to zero, so there is no pool-resize path), targeting the
+// resolved resource group.
+func TestStopNodesStopsARunningCluster(t *testing.T) {
 	t.Parallel()
 
 	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
-		managedCluster(
-			testCluster,
-			agentPool("system", 1, "Succeeded"),
-			agentPool("user", 3, "Succeeded"),
-		),
+		managedCluster(testCluster, agentPool("system", 1, "Succeeded")),
 	}}
 	prov := newProvider(t, fake, testResourceGroup)
 
 	err := prov.StopNodes(context.Background(), testCluster)
 	require.NoError(t, err)
 
-	require.Len(t, fake.resizes, 2)
-
-	for _, resize := range fake.resizes {
-		assert.Equal(t, int32(0), resize.count)
-	}
+	assert.Equal(t, []powerCall{{testResourceGroup, testCluster}}, fake.stops)
+	assert.Empty(t, fake.starts)
 }
 
-// TestStartStopNodesRequirePools pins that scaling a cluster without agent
-// pools is classified as provider.ErrNoNodes rather than silently succeeding.
-func TestStartStopNodesRequirePools(t *testing.T) {
+// TestStopNodesAlreadyStoppedIsNoOp pins the idempotence: ARM rejects
+// stopping a stopped cluster, so the provider short-circuits on the power
+// state instead of surfacing that conflict.
+func TestStopNodesAlreadyStoppedIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
-		managedCluster(testCluster),
+		stoppedCluster(testCluster, agentPool("system", 1, "Succeeded")),
 	}}
 	prov := newProvider(t, fake, testResourceGroup)
 
-	require.ErrorIs(t, prov.StartNodes(context.Background(), testCluster), provider.ErrNoNodes)
-	require.ErrorIs(t, prov.StopNodes(context.Background(), testCluster), provider.ErrNoNodes)
-	assert.Empty(t, fake.resizes)
+	err := prov.StopNodes(context.Background(), testCluster)
+	require.NoError(t, err)
+	assert.Empty(t, fake.stops)
+}
+
+// TestStartNodesStartsAStoppedCluster pins the start semantics: a stopped
+// cluster is started via AKS's native whole-cluster start.
+func TestStartNodesStartsAStoppedCluster(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		stoppedCluster(testCluster, agentPool("system", 1, "Succeeded")),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	err := prov.StartNodes(context.Background(), testCluster)
+	require.NoError(t, err)
+
+	assert.Equal(t, []powerCall{{testResourceGroup, testCluster}}, fake.starts)
+	assert.Empty(t, fake.stops)
+}
+
+// TestStartNodesAlreadyRunningIsNoOp pins the idempotence on the start side.
+func TestStartNodesAlreadyRunningIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(testCluster, agentPool("system", 1, "Succeeded")),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	err := prov.StartNodes(context.Background(), testCluster)
+	require.NoError(t, err)
+	assert.Empty(t, fake.starts)
+}
+
+// TestStopNodesPropagatesStopError pins the negative path: a failing native
+// stop surfaces to the caller instead of being swallowed.
+func TestStopNodesPropagatesStopError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{
+		clusters: []*armcontainerservice.ManagedCluster{
+			managedCluster(testCluster, agentPool("system", 1, "Succeeded")),
+		},
+		stopErr: errBoom,
+	}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	err := prov.StopNodes(context.Background(), testCluster)
+	require.ErrorIs(t, err, errBoom)
+}
+
+// TestStartNodesPropagatesStartError pins the start-side negative path.
+func TestStartNodesPropagatesStartError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{
+		clusters: []*armcontainerservice.ManagedCluster{
+			stoppedCluster(testCluster, agentPool("system", 1, "Succeeded")),
+		},
+		startErr: errBoom,
+	}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	err := prov.StartNodes(context.Background(), testCluster)
+	require.ErrorIs(t, err, errBoom)
+}
+
+// TestListAllClustersPropagatesListError pins the listing negative path.
+func TestListAllClustersPropagatesListError(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterClient{listErr: errBoom}, testResourceGroup)
+
+	_, err := prov.ListAllClusters(context.Background())
+	require.ErrorIs(t, err, errBoom)
+}
+
+// TestListNodesPropagatesGetError pins the cluster-fetch negative path.
+func TestListNodesPropagatesGetError(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterClient{getErr: errBoom}, testResourceGroup)
+
+	_, err := prov.ListNodes(context.Background(), testCluster)
+	require.ErrorIs(t, err, errBoom)
 }
 
 // TestGetClusterStatusAggregatesPools pins the status aggregation: a cluster
@@ -375,7 +450,8 @@ func TestDeleteNodesIsNoOp(t *testing.T) {
 	prov := newProvider(t, fake, testResourceGroup)
 
 	require.NoError(t, prov.DeleteNodes(context.Background(), testCluster))
-	assert.Empty(t, fake.resizes)
+	assert.Empty(t, fake.stops)
+	assert.Empty(t, fake.starts)
 }
 
 // TestResourceGroupAccessor pins the configured-resource-group accessor.

--- a/pkg/svc/provider/azure/provider_test.go
+++ b/pkg/svc/provider/azure/provider_test.go
@@ -1,0 +1,387 @@
+package azure_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/azure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCluster       = "dev"
+	testResourceGroup = "rg-dev"
+)
+
+// resizeCall records one SetAgentPoolCount invocation the provider made.
+type resizeCall struct {
+	resourceGroup string
+	cluster       string
+	pool          string
+	count         int32
+}
+
+// fakeClusterClient scripts the azure.ClusterClient seam: it serves the
+// configured clusters for Get/List and records resizes, mirroring the gcp
+// provider's fakeClusterManager.
+type fakeClusterClient struct {
+	clusters []*armcontainerservice.ManagedCluster
+
+	getErr  error
+	listErr error
+	sizeErr error
+
+	lastGetResourceGroup string
+	resizes              []resizeCall
+}
+
+func (f *fakeClusterClient) GetCluster(
+	_ context.Context,
+	resourceGroup, name string,
+) (armcontainerservice.ManagedCluster, error) {
+	f.lastGetResourceGroup = resourceGroup
+
+	if f.getErr != nil {
+		return armcontainerservice.ManagedCluster{}, f.getErr
+	}
+
+	for _, cluster := range f.clusters {
+		if cluster.Name != nil && *cluster.Name == name {
+			return *cluster, nil
+		}
+	}
+
+	return armcontainerservice.ManagedCluster{}, &azcore.ResponseError{
+		StatusCode: http.StatusNotFound,
+		ErrorCode:  "ResourceNotFound",
+	}
+}
+
+func (f *fakeClusterClient) ListClusters(
+	_ context.Context,
+	_ string,
+) ([]*armcontainerservice.ManagedCluster, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+
+	return f.clusters, nil
+}
+
+func (f *fakeClusterClient) SetAgentPoolCount(
+	_ context.Context,
+	resourceGroup, clusterName, poolName string,
+	count int32,
+) error {
+	if f.sizeErr != nil {
+		return f.sizeErr
+	}
+
+	f.resizes = append(f.resizes, resizeCall{
+		resourceGroup: resourceGroup,
+		cluster:       clusterName,
+		pool:          poolName,
+		count:         count,
+	})
+
+	return nil
+}
+
+// newProvider builds a Provider over the fake, failing the test on a
+// constructor error.
+func newProvider(t *testing.T, fake *fakeClusterClient, resourceGroup string) *azure.Provider {
+	t.Helper()
+
+	prov, err := azure.NewProvider(fake, resourceGroup)
+	require.NoError(t, err)
+
+	return prov
+}
+
+// managedCluster assembles a ManagedCluster with the given name and agent
+// pools, carrying the ARM ID the resource-group resolution parses.
+func managedCluster(
+	name string,
+	pools ...*armcontainerservice.ManagedClusterAgentPoolProfile,
+) *armcontainerservice.ManagedCluster {
+	armID := fmt.Sprintf(
+		"/subscriptions/00000000-0000-0000-0000-000000000000"+
+			"/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s",
+		testResourceGroup, name,
+	)
+
+	return &armcontainerservice.ManagedCluster{
+		ID:   new(armID),
+		Name: new(name),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			Fqdn:              new(name + ".hcp.westeurope.azmk8s.io"),
+			AgentPoolProfiles: pools,
+		},
+	}
+}
+
+// agentPool assembles an agent-pool profile in the given provisioning state.
+func agentPool(
+	name string,
+	count int32,
+	state string,
+) *armcontainerservice.ManagedClusterAgentPoolProfile {
+	return &armcontainerservice.ManagedClusterAgentPoolProfile{
+		Name:              new(name),
+		Count:             new(count),
+		VMSize:            new("Standard_D2s_v5"),
+		ProvisioningState: new(state),
+	}
+}
+
+func TestNewProviderRequiresClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := azure.NewProvider(nil, testResourceGroup)
+	require.ErrorIs(t, err, azure.ErrClientRequired)
+}
+
+// TestListNodesCollapsesAgentPools pins the pool→NodeInfo collapse: one entry
+// per agent pool carrying the pool name, worker role, provisioning state, and
+// VM size — mirroring the gcp provider's node-pool collapse.
+func TestListNodesCollapsesAgentPools(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(
+			testCluster,
+			agentPool("system", 1, "Succeeded"),
+			agentPool("user", 3, "Creating"),
+		),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	nodes, err := prov.ListNodes(context.Background(), testCluster)
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+
+	assert.Equal(t, provider.NodeInfo{
+		Name:        "system",
+		ClusterName: testCluster,
+		Role:        "worker",
+		State:       "Succeeded",
+		ServerType:  "Standard_D2s_v5",
+	}, nodes[0])
+	assert.Equal(t, "user", nodes[1].Name)
+	assert.Equal(t, "Creating", nodes[1].State)
+}
+
+// TestListNodesResolvesResourceGroupWhenUnconfigured pins the ARM-ID
+// resolution: with an empty resource group the provider finds the cluster in
+// a subscription-wide list and targets the resource group parsed from its ID.
+func TestListNodesResolvesResourceGroupWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(testCluster, agentPool("system", 1, "Succeeded")),
+	}}
+	prov := newProvider(t, fake, "")
+
+	nodes, err := prov.ListNodes(context.Background(), testCluster)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, testResourceGroup, fake.lastGetResourceGroup)
+}
+
+// TestListNodesUnknownClusterWithoutResourceGroupIsNotFound pins that the
+// resolution path classifies a cluster absent from the subscription as
+// provider.ErrClusterNotFound before any cluster-scoped call is attempted.
+func TestListNodesUnknownClusterWithoutResourceGroupIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterClient{}, "")
+
+	_, err := prov.ListNodes(context.Background(), testCluster)
+	require.ErrorIs(t, err, provider.ErrClusterNotFound)
+}
+
+// TestStartNodesRestoresAtLeastOneNode pins the start targets: a stopped pool
+// (count zero) is restored to one node, a pool with an autoscaler minimum to
+// that minimum, and a running pool has its current size re-asserted — the
+// idempotent re-assert the design locked (AKS preserves no creation-time
+// count on the profile).
+func TestStartNodesRestoresAtLeastOneNode(t *testing.T) {
+	t.Parallel()
+
+	autoscaled := agentPool("autoscaled", 0, "Succeeded")
+	autoscaled.MinCount = new(int32(3))
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(
+			testCluster,
+			agentPool("stopped", 0, "Succeeded"),
+			autoscaled,
+			agentPool("running", 5, "Succeeded"),
+		),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	err := prov.StartNodes(context.Background(), testCluster)
+	require.NoError(t, err)
+
+	require.Len(t, fake.resizes, 3)
+	assert.Equal(t, resizeCall{testResourceGroup, testCluster, "stopped", 1}, fake.resizes[0])
+	assert.Equal(t, resizeCall{testResourceGroup, testCluster, "autoscaled", 3}, fake.resizes[1])
+	assert.Equal(t, resizeCall{testResourceGroup, testCluster, "running", 5}, fake.resizes[2])
+}
+
+// TestStopNodesResizesPoolsToZero pins the stop semantics: every pool is
+// resized to zero nodes (the control plane stays up; node costs stop).
+func TestStopNodesResizesPoolsToZero(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(
+			testCluster,
+			agentPool("system", 1, "Succeeded"),
+			agentPool("user", 3, "Succeeded"),
+		),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	err := prov.StopNodes(context.Background(), testCluster)
+	require.NoError(t, err)
+
+	require.Len(t, fake.resizes, 2)
+
+	for _, resize := range fake.resizes {
+		assert.Equal(t, int32(0), resize.count)
+	}
+}
+
+// TestStartStopNodesRequirePools pins that scaling a cluster without agent
+// pools is classified as provider.ErrNoNodes rather than silently succeeding.
+func TestStartStopNodesRequirePools(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(testCluster),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	require.ErrorIs(t, prov.StartNodes(context.Background(), testCluster), provider.ErrNoNodes)
+	require.ErrorIs(t, prov.StopNodes(context.Background(), testCluster), provider.ErrNoNodes)
+	assert.Empty(t, fake.resizes)
+}
+
+// TestGetClusterStatusAggregatesPools pins the status aggregation: a cluster
+// with one ready and one provisioning pool is degraded, counts both, and
+// carries the API-server FQDN as its endpoint.
+func TestGetClusterStatusAggregatesPools(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(
+			testCluster,
+			agentPool("system", 1, "Succeeded"),
+			agentPool("user", 3, "Creating"),
+		),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	status, err := prov.GetClusterStatus(context.Background(), testCluster)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	assert.Equal(t, provider.PhaseDegraded, status.Phase)
+	assert.False(t, status.Ready)
+	assert.Equal(t, 2, status.NodesTotal)
+	assert.Equal(t, 1, status.NodesReady)
+	assert.Equal(t, testCluster+".hcp.westeurope.azmk8s.io", status.Endpoint)
+}
+
+// TestGetClusterStatusWithoutPoolsIsStopped pins the zero-pool contract: the
+// status is non-nil, stopped, and empty rather than a nil status.
+func TestGetClusterStatusWithoutPoolsIsStopped(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(testCluster),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	status, err := prov.GetClusterStatus(context.Background(), testCluster)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	assert.Equal(t, provider.PhaseStopped, status.Phase)
+	assert.False(t, status.Ready)
+	assert.Empty(t, status.Nodes)
+}
+
+// TestGetClusterStatusNotFoundTranslated pins the error translation: an ARM
+// 404 from the client surfaces as provider.ErrClusterNotFound.
+func TestGetClusterStatusNotFoundTranslated(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterClient{}, testResourceGroup)
+
+	_, err := prov.GetClusterStatus(context.Background(), testCluster)
+	require.ErrorIs(t, err, provider.ErrClusterNotFound)
+}
+
+// TestListAllClustersReturnsNames pins subscription/resource-group listing.
+func TestListAllClustersReturnsNames(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster("alpha"),
+		managedCluster("beta"),
+	}}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	names, err := prov.ListAllClusters(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "beta"}, names)
+}
+
+// TestNodesExistReflectsPools pins the NodesExist contract on both sides.
+func TestNodesExistReflectsPools(t *testing.T) {
+	t.Parallel()
+
+	withPools := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(testCluster, agentPool("system", 1, "Succeeded")),
+	}}
+	exists, err := newProvider(t, withPools, testResourceGroup).
+		NodesExist(context.Background(), testCluster)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	withoutPools := &fakeClusterClient{clusters: []*armcontainerservice.ManagedCluster{
+		managedCluster(testCluster),
+	}}
+	exists, err = newProvider(t, withoutPools, testResourceGroup).
+		NodesExist(context.Background(), testCluster)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// TestDeleteNodesIsNoOp pins that pool deletion is owned by cluster deletion.
+func TestDeleteNodesIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{}
+	prov := newProvider(t, fake, testResourceGroup)
+
+	require.NoError(t, prov.DeleteNodes(context.Background(), testCluster))
+	assert.Empty(t, fake.resizes)
+}
+
+// TestResourceGroupAccessor pins the configured-resource-group accessor.
+func TestResourceGroupAccessor(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvider(t, &fakeClusterClient{}, testResourceGroup)
+	assert.Equal(t, testResourceGroup, prov.ResourceGroup())
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The AKS client layer landed with #5801, but nothing above it can drive an AKS cluster's lifecycle yet — start/stop, node listing, and status all stop at the client, blocking the rest of the AKS provider lane.

## What

Adds the Azure provider service mirroring the GCP one: agent pools collapse to per-pool node entries, and stop/start use Azure's native whole-cluster stop/start with power-state idempotence (AKS forbids resizing system pools to zero, so the GKE-style resize does not translate). Enum/factory/config wiring follows as the next slice.

Fixes #5806 · Part of #4510