### PR TITLE
feat(mirror): add the Phase 2 intercept tunnel frame codec

### DIFF
--- a/pkg/svc/mirror/doc.go
+++ b/pkg/svc/mirror/doc.go
@@ -59,7 +59,15 @@
 //     cluster.
 //
 //   - Phase 2 — intercept: steer a subset (or all) of the Deployment's traffic to
-//     the local process and return its responses.
+//     the local process and return its responses. Unlike mirror mode, responses
+//     must flow back into the cluster, so intercept needs a reverse tunnel: the
+//     one bidirectional exec byte stream (SPDY stdin+stdout) must carry many
+//     concurrent intercepted connections at once. The foundation increment is
+//     the multiplexing wire format — [Frame], [WriteFrame], and [ReadFrame] —
+//     a self-framing, length-prefixed codec that tags each chunk with a
+//     StreamID so the mux/demux (a later increment) can present each
+//     intercepted connection as its own stream. Steering (iptables/NET_ADMIN in
+//     the tap container) and the in-cluster intercept agent follow.
 //
 //   - Phase 3 — environment & volume projection: run the local process with the
 //     target pod's env vars and mounted volumes/secrets for cluster-equivalent

--- a/pkg/svc/mirror/tunnel.go
+++ b/pkg/svc/mirror/tunnel.go
@@ -95,9 +95,13 @@ func checkFrameLength(frameType FrameType, length uint32) error {
 // (unknown type, oversized Data payload, or a control frame with a payload) is
 // rejected before anything is written.
 func WriteFrame(writer io.Writer, frame Frame) error {
-	// len is non-negative and, for a valid Data frame, well under 2^32;
-	// checkFrameLength rejects anything over MaxTunnelPayload next.
-	length := uint32(len(frame.Payload)) //nolint:gosec // G115: len fits uint32.
+	// Bound the payload on the un-narrowed int first: narrowing an oversized
+	// length to uint32 could wrap into range and desync header from payload.
+	if len(frame.Payload) > MaxTunnelPayload {
+		return fmt.Errorf("%w: %d bytes", ErrTunnelFrameTooLarge, len(frame.Payload))
+	}
+
+	length := uint32(len(frame.Payload)) //nolint:gosec // G115: bounded above.
 
 	err := checkFrameLength(frame.Type, length)
 	if err != nil {

--- a/pkg/svc/mirror/tunnel.go
+++ b/pkg/svc/mirror/tunnel.go
@@ -1,0 +1,176 @@
+package mirror
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// FrameType identifies what a tunnel frame carries: the lifecycle of one
+// multiplexed connection (Open/Close) or a chunk of its bytes (Data).
+type FrameType uint8
+
+const (
+	// FrameOpen announces a new multiplexed connection on a StreamID. It
+	// carries no payload.
+	FrameOpen FrameType = 1
+	// FrameData carries a chunk of bytes for an already-open StreamID.
+	FrameData FrameType = 2
+	// FrameClose ends a multiplexed connection on a StreamID. It carries no
+	// payload; any buffered Data for the stream was sent in earlier frames.
+	FrameClose FrameType = 3
+)
+
+// tunnelHeaderSize is the fixed on-wire header: StreamID (uint32) + Type
+// (uint8) + Length (uint32), big-endian.
+const tunnelHeaderSize = 4 + 1 + 4
+
+// MaxTunnelPayload bounds a single FrameData payload. A frame declaring a
+// larger length is rejected before any allocation, so a malformed or hostile
+// stream cannot make the reader allocate unbounded memory — the same
+// defensive stance the replay parser takes with maxPendingSegments. 64 KiB
+// matches a comfortable chunk for the exec transport without over-fragmenting.
+const MaxTunnelPayload = 64 * 1024
+
+// ErrTunnelFrameTooLarge is returned when a frame's declared payload length
+// exceeds MaxTunnelPayload.
+var ErrTunnelFrameTooLarge = errors.New("tunnel frame payload exceeds the maximum size")
+
+// ErrTunnelUnknownFrameType is returned when a frame carries a type that is
+// not one of FrameOpen/FrameData/FrameClose.
+var ErrTunnelUnknownFrameType = errors.New("tunnel frame has an unknown type")
+
+// ErrTunnelControlFramePayload is returned when a control frame (FrameOpen or
+// FrameClose) carries a non-empty payload — control frames must be empty so a
+// peer never has to guess whether their bytes are meaningful.
+var ErrTunnelControlFramePayload = errors.New("tunnel control frame must not carry a payload")
+
+// Frame is one unit on the multiplexing tunnel that will carry intercepted
+// connections back and forth over the single bidirectional exec byte stream
+// (SPDY stdin+stdout). Each frame belongs to a StreamID — one intercepted
+// connection — so many connections share the one channel. It is the wire
+// format the Phase 2 intercept mux/demux is built on; see [doc.go] and
+// ksail#4521.
+type Frame struct {
+	// StreamID identifies the multiplexed connection this frame belongs to.
+	StreamID uint32
+	// Type is the frame's role in that connection's lifecycle.
+	Type FrameType
+	// Payload is the byte chunk for a FrameData frame; it must be empty for
+	// FrameOpen and FrameClose.
+	Payload []byte
+}
+
+// checkFrameLength validates a frame type against its declared payload length.
+// It is shared by the writer (before encoding) and the reader (after decoding
+// the header, before allocating the payload), so both sides enforce the same
+// invariants: only FrameData may carry bytes, FrameData is capped at
+// MaxTunnelPayload, and control frames must be empty.
+func checkFrameLength(frameType FrameType, length uint32) error {
+	switch frameType {
+	case FrameData:
+		if length > MaxTunnelPayload {
+			return fmt.Errorf("%w: %d bytes", ErrTunnelFrameTooLarge, length)
+		}
+	case FrameOpen, FrameClose:
+		if length > 0 {
+			return fmt.Errorf(
+				"%w: type %d has %d bytes",
+				ErrTunnelControlFramePayload,
+				frameType,
+				length,
+			)
+		}
+	default:
+		return fmt.Errorf("%w: %d", ErrTunnelUnknownFrameType, frameType)
+	}
+
+	return nil
+}
+
+// WriteFrame encodes frame to writer as a length-prefixed, self-framing record
+// so a peer can read exactly one frame back with [ReadFrame] over a byte
+// stream that carries no message boundaries of its own. A malformed frame
+// (unknown type, oversized Data payload, or a control frame with a payload) is
+// rejected before anything is written.
+func WriteFrame(writer io.Writer, frame Frame) error {
+	// len is non-negative and, for a valid Data frame, well under 2^32;
+	// checkFrameLength rejects anything over MaxTunnelPayload next.
+	length := uint32(len(frame.Payload)) //nolint:gosec // G115: len fits uint32.
+
+	err := checkFrameLength(frame.Type, length)
+	if err != nil {
+		return err
+	}
+
+	var header [tunnelHeaderSize]byte
+	binary.BigEndian.PutUint32(header[0:4], frame.StreamID)
+	header[4] = byte(frame.Type)
+	binary.BigEndian.PutUint32(header[5:9], length)
+
+	_, err = writer.Write(header[:])
+	if err != nil {
+		return fmt.Errorf("writing tunnel frame header: %w", err)
+	}
+
+	if length > 0 {
+		_, err = writer.Write(frame.Payload)
+		if err != nil {
+			return fmt.Errorf("writing tunnel frame payload: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ReadFrame decodes exactly one frame from reader. A clean end of stream at a
+// frame boundary is reported as io.EOF; a stream that ends part-way through a
+// header or payload is reported as io.ErrUnexpectedEOF (the tunnel was cut off
+// mid-frame). A frame whose header declares an oversized payload or an unknown
+// type is rejected without reading the payload, so a hostile length can never
+// drive an allocation.
+func ReadFrame(reader io.Reader) (Frame, error) {
+	var header [tunnelHeaderSize]byte
+
+	_, err := io.ReadFull(reader, header[:])
+	if err != nil {
+		// io.ReadFull maps a clean boundary EOF to io.EOF and a partial read
+		// to io.ErrUnexpectedEOF; pass the sentinel through so callers can
+		// distinguish a graceful close from a truncated tunnel.
+		if errors.Is(err, io.EOF) {
+			return Frame{}, io.EOF
+		}
+
+		return Frame{}, fmt.Errorf("reading tunnel frame header: %w", err)
+	}
+
+	frame := Frame{
+		StreamID: binary.BigEndian.Uint32(header[0:4]),
+		Type:     FrameType(header[4]),
+		Payload:  nil,
+	}
+	length := binary.BigEndian.Uint32(header[5:9])
+
+	err = checkFrameLength(frame.Type, length)
+	if err != nil {
+		return Frame{}, err
+	}
+
+	if length > 0 {
+		frame.Payload = make([]byte, length)
+
+		_, err = io.ReadFull(reader, frame.Payload)
+		if err != nil {
+			// Any EOF here is mid-frame — the header promised bytes that never
+			// arrived — so report it as a truncation, not a clean close.
+			if errors.Is(err, io.EOF) {
+				return Frame{}, io.ErrUnexpectedEOF
+			}
+
+			return Frame{}, fmt.Errorf("reading tunnel frame payload: %w", err)
+		}
+	}
+
+	return frame, nil
+}

--- a/pkg/svc/mirror/tunnel_test.go
+++ b/pkg/svc/mirror/tunnel_test.go
@@ -1,0 +1,205 @@
+package mirror_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReadFrame_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	frames := []mirror.Frame{
+		{StreamID: 1, Type: mirror.FrameOpen},
+		{StreamID: 1, Type: mirror.FrameData, Payload: []byte("GET / HTTP/1.1\r\n\r\n")},
+		{StreamID: 1, Type: mirror.FrameData, Payload: []byte{}},
+		{StreamID: 4294967295, Type: mirror.FrameClose},
+	}
+
+	for _, frame := range frames {
+		var buf bytes.Buffer
+
+		require.NoError(t, mirror.WriteFrame(&buf, frame))
+
+		got, err := mirror.ReadFrame(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, frame.StreamID, got.StreamID)
+		assert.Equal(t, frame.Type, got.Type)
+		// An empty payload round-trips to nil (ReadFrame allocates only for a
+		// non-zero length); compare content so nil and empty count as equal.
+		assert.Equal(t, string(frame.Payload), string(got.Payload))
+	}
+}
+
+func TestReadFrame_DecodesInterleavedStreams(t *testing.T) {
+	t.Parallel()
+
+	// Two multiplexed connections interleave their frames on the one stream;
+	// each frame must decode back to its own StreamID in order.
+	written := []mirror.Frame{
+		{StreamID: 1, Type: mirror.FrameOpen},
+		{StreamID: 2, Type: mirror.FrameOpen},
+		{StreamID: 1, Type: mirror.FrameData, Payload: []byte("one-a")},
+		{StreamID: 2, Type: mirror.FrameData, Payload: []byte("two-a")},
+		{StreamID: 1, Type: mirror.FrameData, Payload: []byte("one-b")},
+		{StreamID: 1, Type: mirror.FrameClose},
+		{StreamID: 2, Type: mirror.FrameClose},
+	}
+
+	var buf bytes.Buffer
+	for _, frame := range written {
+		require.NoError(t, mirror.WriteFrame(&buf, frame))
+	}
+
+	for _, want := range written {
+		got, err := mirror.ReadFrame(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, want.StreamID, got.StreamID)
+		assert.Equal(t, want.Type, got.Type)
+		assert.Equal(t, string(want.Payload), string(got.Payload))
+	}
+
+	// The buffer is exhausted at a clean frame boundary.
+	_, err := mirror.ReadFrame(&buf)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestReadFrame_EmptyStreamReturnsEOF(t *testing.T) {
+	t.Parallel()
+
+	_, err := mirror.ReadFrame(bytes.NewReader(nil))
+
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestReadFrame_TruncatedHeaderIsUnexpectedEOF(t *testing.T) {
+	t.Parallel()
+
+	var full bytes.Buffer
+	require.NoError(t, mirror.WriteFrame(&full, mirror.Frame{StreamID: 7, Type: mirror.FrameOpen}))
+
+	// Cut the encoded frame short inside its 9-byte header.
+	truncated := full.Bytes()[:4]
+
+	_, err := mirror.ReadFrame(bytes.NewReader(truncated))
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadFrame_TruncatedPayloadIsUnexpectedEOF(t *testing.T) {
+	t.Parallel()
+
+	var full bytes.Buffer
+	require.NoError(t, mirror.WriteFrame(&full, mirror.Frame{
+		StreamID: 3,
+		Type:     mirror.FrameData,
+		Payload:  []byte("the full payload"),
+	}))
+
+	// Keep the whole header but drop the last few payload bytes.
+	encoded := full.Bytes()
+	truncated := encoded[:len(encoded)-3]
+
+	_, err := mirror.ReadFrame(bytes.NewReader(truncated))
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestWriteFrame_RejectsOversizedPayload(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	err := mirror.WriteFrame(&buf, mirror.Frame{
+		StreamID: 1,
+		Type:     mirror.FrameData,
+		Payload:  make([]byte, mirror.MaxTunnelPayload+1),
+	})
+
+	require.ErrorIs(t, err, mirror.ErrTunnelFrameTooLarge)
+	assert.Zero(t, buf.Len(), "no bytes should be written when the frame is rejected")
+}
+
+func TestWriteFrame_AcceptsMaxPayload(t *testing.T) {
+	t.Parallel()
+
+	payload := bytes.Repeat([]byte{0xAB}, mirror.MaxTunnelPayload)
+
+	var buf bytes.Buffer
+	require.NoError(t, mirror.WriteFrame(&buf, mirror.Frame{
+		StreamID: 1,
+		Type:     mirror.FrameData,
+		Payload:  payload,
+	}))
+
+	got, err := mirror.ReadFrame(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got.Payload)
+}
+
+func TestReadFrame_RejectsOversizedDeclaredLength(t *testing.T) {
+	t.Parallel()
+
+	// Hand-craft a header that declares more than MaxTunnelPayload without
+	// ever supplying the bytes — the reader must reject it before allocating.
+	header := make([]byte, 9)
+	header[4] = byte(mirror.FrameData)
+	// Length field (bytes 5..9), big-endian, one over the cap.
+	binary.BigEndian.PutUint32(header[5:9], uint32(mirror.MaxTunnelPayload+1))
+
+	_, err := mirror.ReadFrame(bytes.NewReader(header))
+	require.ErrorIs(t, err, mirror.ErrTunnelFrameTooLarge)
+}
+
+func TestWriteFrame_RejectsUnknownType(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	err := mirror.WriteFrame(&buf, mirror.Frame{StreamID: 1, Type: mirror.FrameType(99)})
+
+	require.ErrorIs(t, err, mirror.ErrTunnelUnknownFrameType)
+	assert.Zero(t, buf.Len())
+}
+
+func TestReadFrame_RejectsUnknownType(t *testing.T) {
+	t.Parallel()
+
+	header := make([]byte, 9)
+	header[4] = 99 // unknown type, zero length
+
+	_, err := mirror.ReadFrame(bytes.NewReader(header))
+	require.ErrorIs(t, err, mirror.ErrTunnelUnknownFrameType)
+}
+
+func TestWriteFrame_RejectsPayloadOnControlFrame(t *testing.T) {
+	t.Parallel()
+
+	for _, frameType := range []mirror.FrameType{mirror.FrameOpen, mirror.FrameClose} {
+		var buf bytes.Buffer
+
+		err := mirror.WriteFrame(&buf, mirror.Frame{
+			StreamID: 1,
+			Type:     frameType,
+			Payload:  []byte("unexpected"),
+		})
+
+		require.ErrorIs(t, err, mirror.ErrTunnelControlFramePayload)
+		assert.Zero(t, buf.Len())
+	}
+}
+
+func TestReadFrame_RejectsPayloadOnControlFrame(t *testing.T) {
+	t.Parallel()
+
+	// A control frame header that dishonestly declares a payload length.
+	header := make([]byte, 9)
+	header[4] = byte(mirror.FrameOpen)
+	header[8] = 5 // length = 5
+
+	_, err := mirror.ReadFrame(bytes.NewReader(header))
+	require.ErrorIs(t, err, mirror.ErrTunnelControlFramePayload)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The `workload mirror` intercept phase (#4521 Phase 2) needs to send the local process's replies back into the cluster — something the read-only mirror path deliberately can't do. Doing that means carrying many intercepted connections at once over the single bidirectional channel KSail already has (the exec stream), which requires a multiplexing wire format before any traffic-steering work can start.

## What
Adds that foundation: a small, self-contained frame codec (open/data/close frames tagged by connection) with encode/decode and hardening against malformed input. Pure Go, fully unit-tested, no cluster or elevated privileges — the same increment shape as the earlier mirror pieces. No user-facing behaviour or flags change yet; later increments (the connection multiplexer, traffic steering, the in-cluster agent) build on it.

Fixes #5808
Part of #4521