### PR TITLE
feat(gke): implement the operator Connector capability

### DIFF
--- a/pkg/svc/provisioner/cluster/gke/connector.go
+++ b/pkg/svc/provisioner/cluster/gke/connector.go
@@ -7,6 +7,7 @@ import (
 
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -70,17 +71,14 @@ func (p *Provisioner) Kubeconfig(ctx context.Context, name string) ([]byte, erro
 
 // accessToken mints a bearer token from the injected token source, falling
 // back to Google application default credentials (workload identity or a
-// mounted service-account key in the operator pod).
+// mounted service-account key in the operator pod). The resolved default
+// source is cached so credential discovery (env/file checks, metadata-server
+// probing) runs once, not on every reconcile; a failed discovery is not
+// cached, so a transient ADC error is retried on the next call.
 func (p *Provisioner) accessToken(ctx context.Context) (string, error) {
-	source := p.tokenSource
-
-	if source == nil {
-		var err error
-
-		source, err = google.DefaultTokenSource(ctx, cloudPlatformScope)
-		if err != nil {
-			return "", fmt.Errorf("resolving google default credentials: %w", err)
-		}
+	source, err := p.resolveTokenSource(ctx)
+	if err != nil {
+		return "", err
 	}
 
 	token, err := source.Token()
@@ -89,6 +87,26 @@ func (p *Provisioner) accessToken(ctx context.Context) (string, error) {
 	}
 
 	return token.AccessToken, nil
+}
+
+// resolveTokenSource returns the injected token source, lazily resolving and
+// caching Google application default credentials when none was injected.
+func (p *Provisioner) resolveTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	p.tokenMu.Lock()
+	defer p.tokenMu.Unlock()
+
+	if p.tokenSource != nil {
+		return p.tokenSource, nil
+	}
+
+	source, err := google.DefaultTokenSource(ctx, cloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("resolving google default credentials: %w", err)
+	}
+
+	p.tokenSource = source
+
+	return source, nil
 }
 
 // writeKubeconfig serializes a single-context kubeconfig for the given

--- a/pkg/svc/provisioner/cluster/gke/connector.go
+++ b/pkg/svc/provisioner/cluster/gke/connector.go
@@ -1,0 +1,115 @@
+package gkeprovisioner
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"golang.org/x/oauth2/google"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// cloudPlatformScope is the OAuth scope GKE accepts for cluster API access;
+// the default token source mints tokens with it when none is injected.
+const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+// Kubeconfig implements the clusterprovisioner.Connector capability for a GKE
+// cluster: it builds a kubeconfig from the cluster's own control-plane
+// endpoint and CA (public to the operator, no address rewrite needed) with a
+// bearer token minted from the provisioner's token source (Google application
+// default credentials unless one was injected). Tokens are short-lived by
+// design — the operator calls Kubeconfig on each reconcile and the installers
+// consume it immediately. It returns clustererr.ErrKubeconfigNotReady while
+// the cluster is still provisioning so the caller requeues.
+func (p *Provisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	target := p.resolveName(name)
+	if target == "" {
+		return nil, fmt.Errorf("%w: no cluster name configured", ErrClusterNotFound)
+	}
+
+	location, err := p.resolveLocation(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := p.client.GetCluster(ctx, p.project, location, target)
+	if err != nil {
+		return nil, fmt.Errorf("gke get cluster: %w", err)
+	}
+
+	endpoint := cluster.GetEndpoint()
+	caCertificate := cluster.GetMasterAuth().GetClusterCaCertificate()
+
+	if cluster.GetStatus() != containerpb.Cluster_RUNNING || endpoint == "" || caCertificate == "" {
+		return nil, fmt.Errorf(
+			"%w: gke cluster %q is %s",
+			clustererr.ErrKubeconfigNotReady, target, cluster.GetStatus(),
+		)
+	}
+
+	certificateAuthority, err := base64.StdEncoding.DecodeString(caCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("decoding gke cluster CA certificate: %w", err)
+	}
+
+	token, err := p.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return writeKubeconfig(
+		fmt.Sprintf("gke_%s_%s_%s", p.project, location, target),
+		"https://"+endpoint,
+		certificateAuthority,
+		token,
+	)
+}
+
+// accessToken mints a bearer token from the injected token source, falling
+// back to Google application default credentials (workload identity or a
+// mounted service-account key in the operator pod).
+func (p *Provisioner) accessToken(ctx context.Context) (string, error) {
+	source := p.tokenSource
+
+	if source == nil {
+		var err error
+
+		source, err = google.DefaultTokenSource(ctx, cloudPlatformScope)
+		if err != nil {
+			return "", fmt.Errorf("resolving google default credentials: %w", err)
+		}
+	}
+
+	token, err := source.Token()
+	if err != nil {
+		return "", fmt.Errorf("minting gke access token: %w", err)
+	}
+
+	return token.AccessToken, nil
+}
+
+// writeKubeconfig serializes a single-context kubeconfig for the given
+// server, CA, and bearer token.
+func writeKubeconfig(contextName, server string, caData []byte, token string) ([]byte, error) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters[contextName] = &clientcmdapi.Cluster{
+		Server:                   server,
+		CertificateAuthorityData: caData,
+	}
+	config.AuthInfos[contextName] = &clientcmdapi.AuthInfo{Token: token}
+	config.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  contextName,
+		AuthInfo: contextName,
+	}
+	config.CurrentContext = contextName
+
+	raw, err := clientcmd.Write(*config)
+	if err != nil {
+		return nil, fmt.Errorf("serializing gke kubeconfig: %w", err)
+	}
+
+	return raw, nil
+}

--- a/pkg/svc/provisioner/cluster/gke/connector_test.go
+++ b/pkg/svc/provisioner/cluster/gke/connector_test.go
@@ -1,0 +1,202 @@
+package gkeprovisioner_test
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/devantler-tech/ksail/v7/pkg/client/gke"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	gkeprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/gke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// failingTokenSource pins token-mint error propagation.
+type failingTokenSource struct{}
+
+func (failingTokenSource) Token() (*oauth2.Token, error) { return nil, errBoom }
+
+// caPEM is the raw CA material tests round-trip through the base64 field the
+// GKE API serves.
+func caPEM() []byte { return []byte("test-ca-pem") }
+
+func runningCluster(endpoint, caBase64 string) *containerpb.Cluster {
+	return &containerpb.Cluster{
+		Name:     "gke-default",
+		Location: "europe-west1",
+		Status:   containerpb.Cluster_RUNNING,
+		Endpoint: endpoint,
+		MasterAuth: &containerpb.MasterAuth{
+			ClusterCaCertificate: caBase64,
+		},
+	}
+}
+
+// newConnectorProvisioner wires a Provisioner around the fake manager and
+// token source, mirroring newProvisioner but exercising the Option seam.
+func newConnectorProvisioner(
+	t *testing.T,
+	fake *fakeClusterManager,
+	location string,
+	source oauth2.TokenSource,
+) *gkeprovisioner.Provisioner {
+	t.Helper()
+
+	client, err := gke.NewClient(
+		t.Context(),
+		gke.WithClusterManager(fake),
+		gke.WithPollInterval(time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	provisioner, err := gkeprovisioner.NewProvisioner(
+		"gke-default", "test-project", location, nil, client, nil,
+		gkeprovisioner.WithTokenSource(source),
+	)
+	require.NoError(t, err)
+
+	return provisioner
+}
+
+func TestKubeconfigBuildsOperatorUsableConfig(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		getFunc: func(_ *containerpb.GetClusterRequest) (*containerpb.Cluster, error) {
+			return runningCluster(
+				"203.0.113.10", base64.StdEncoding.EncodeToString(caPEM()),
+			), nil
+		},
+	}
+	source := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"})
+	provisioner := newConnectorProvisioner(t, fake, "europe-west1", source)
+
+	raw, err := provisioner.Kubeconfig(t.Context(), "")
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(raw)
+	require.NoError(t, err)
+
+	contextName := "gke_test-project_europe-west1_gke-default"
+	assert.Equal(t, contextName, config.CurrentContext)
+	require.Contains(t, config.Clusters, contextName)
+	assert.Equal(t, "https://203.0.113.10", config.Clusters[contextName].Server)
+	assert.Equal(t, caPEM(), config.Clusters[contextName].CertificateAuthorityData)
+	require.Contains(t, config.AuthInfos, contextName)
+	assert.Equal(t, "test-token", config.AuthInfos[contextName].Token)
+}
+
+func TestKubeconfigNotReadyWhileProvisioning(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		cluster *containerpb.Cluster
+	}{
+		{
+			name: "provisioning status",
+			cluster: &containerpb.Cluster{
+				Name:     "gke-default",
+				Status:   containerpb.Cluster_PROVISIONING,
+				Endpoint: "203.0.113.10",
+				MasterAuth: &containerpb.MasterAuth{
+					ClusterCaCertificate: base64.StdEncoding.EncodeToString(caPEM()),
+				},
+			},
+		},
+		{
+			name:    "running without endpoint",
+			cluster: runningCluster("", base64.StdEncoding.EncodeToString(caPEM())),
+		},
+		{
+			name:    "running without cluster CA",
+			cluster: runningCluster("203.0.113.10", ""),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeClusterManager{
+				getFunc: func(_ *containerpb.GetClusterRequest) (*containerpb.Cluster, error) {
+					return testCase.cluster, nil
+				},
+			}
+			provisioner := newConnectorProvisioner(
+				t, fake, "europe-west1",
+				oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			)
+
+			_, err := provisioner.Kubeconfig(t.Context(), "")
+			require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+		})
+	}
+}
+
+func TestKubeconfigClusterNotFoundAcrossLocations(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		listFunc: func(_ *containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error) {
+			return listResponse(), nil
+		},
+	}
+	provisioner := newConnectorProvisioner(
+		t, fake, "",
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+	)
+
+	_, err := provisioner.Kubeconfig(t.Context(), "gke-default")
+	require.ErrorIs(t, err, gkeprovisioner.ErrClusterNotFound)
+}
+
+func TestKubeconfigPropagatesGetClusterError(t *testing.T) {
+	t.Parallel()
+
+	// getFunc left nil: the fake's GetCluster fails with errBoom.
+	provisioner := newConnectorProvisioner(
+		t, &fakeClusterManager{}, "europe-west1",
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+	)
+
+	_, err := provisioner.Kubeconfig(t.Context(), "")
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestKubeconfigPropagatesTokenSourceError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		getFunc: func(_ *containerpb.GetClusterRequest) (*containerpb.Cluster, error) {
+			return runningCluster(
+				"203.0.113.10", base64.StdEncoding.EncodeToString(caPEM()),
+			), nil
+		},
+	}
+	provisioner := newConnectorProvisioner(t, fake, "europe-west1", failingTokenSource{})
+
+	_, err := provisioner.Kubeconfig(t.Context(), "")
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestKubeconfigRejectsMalformedClusterCA(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterManager{
+		getFunc: func(_ *containerpb.GetClusterRequest) (*containerpb.Cluster, error) {
+			return runningCluster("203.0.113.10", "not-base64!"), nil
+		},
+	}
+	provisioner := newConnectorProvisioner(
+		t, fake, "europe-west1",
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+	)
+
+	_, err := provisioner.Kubeconfig(t.Context(), "")
+	require.ErrorContains(t, err, "decoding gke cluster CA certificate")
+}

--- a/pkg/svc/provisioner/cluster/gke/connector_test.go
+++ b/pkg/svc/provisioner/cluster/gke/connector_test.go
@@ -20,6 +20,11 @@ type failingTokenSource struct{}
 
 func (failingTokenSource) Token() (*oauth2.Token, error) { return nil, errBoom }
 
+// staticTokenSource is the happy-path token source tests inject.
+func staticTokenSource() oauth2.TokenSource {
+	return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"})
+}
+
 // caPEM is the raw CA material tests round-trip through the base64 field the
 // GKE API serves.
 func caPEM() []byte { return []byte("test-ca-pem") }
@@ -72,8 +77,7 @@ func TestKubeconfigBuildsOperatorUsableConfig(t *testing.T) {
 			), nil
 		},
 	}
-	source := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"})
-	provisioner := newConnectorProvisioner(t, fake, "europe-west1", source)
+	provisioner := newConnectorProvisioner(t, fake, "europe-west1", staticTokenSource())
 
 	raw, err := provisioner.Kubeconfig(t.Context(), "")
 	require.NoError(t, err)
@@ -127,10 +131,7 @@ func TestKubeconfigNotReadyWhileProvisioning(t *testing.T) {
 					return testCase.cluster, nil
 				},
 			}
-			provisioner := newConnectorProvisioner(
-				t, fake, "europe-west1",
-				oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
-			)
+			provisioner := newConnectorProvisioner(t, fake, "europe-west1", staticTokenSource())
 
 			_, err := provisioner.Kubeconfig(t.Context(), "")
 			require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
@@ -146,10 +147,7 @@ func TestKubeconfigClusterNotFoundAcrossLocations(t *testing.T) {
 			return listResponse(), nil
 		},
 	}
-	provisioner := newConnectorProvisioner(
-		t, fake, "",
-		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
-	)
+	provisioner := newConnectorProvisioner(t, fake, "", staticTokenSource())
 
 	_, err := provisioner.Kubeconfig(t.Context(), "gke-default")
 	require.ErrorIs(t, err, gkeprovisioner.ErrClusterNotFound)
@@ -160,8 +158,10 @@ func TestKubeconfigPropagatesGetClusterError(t *testing.T) {
 
 	// getFunc left nil: the fake's GetCluster fails with errBoom.
 	provisioner := newConnectorProvisioner(
-		t, &fakeClusterManager{}, "europe-west1",
-		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+		t,
+		&fakeClusterManager{},
+		"europe-west1",
+		staticTokenSource(),
 	)
 
 	_, err := provisioner.Kubeconfig(t.Context(), "")
@@ -192,10 +192,7 @@ func TestKubeconfigRejectsMalformedClusterCA(t *testing.T) {
 			return runningCluster("203.0.113.10", "not-base64!"), nil
 		},
 	}
-	provisioner := newConnectorProvisioner(
-		t, fake, "europe-west1",
-		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
-	)
+	provisioner := newConnectorProvisioner(t, fake, "europe-west1", staticTokenSource())
 
 	_, err := provisioner.Kubeconfig(t.Context(), "")
 	require.ErrorContains(t, err, "decoding gke cluster CA certificate")

--- a/pkg/svc/provisioner/cluster/gke/provisioner.go
+++ b/pkg/svc/provisioner/cluster/gke/provisioner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/gcp"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"golang.org/x/oauth2"
 )
 
 // Provisioner manages Google Kubernetes Engine clusters via the native Go SDK.
@@ -35,6 +36,21 @@ type Provisioner struct {
 	// infraProvider is the GCP provider used for Start/Stop semantics
 	// (node-pool scale). Optional: if nil, Start/Stop return an error.
 	infraProvider provider.Provider
+	// tokenSource mints bearer tokens for Kubeconfig. Nil means Google
+	// application default credentials are resolved at call time; tests
+	// inject a static source.
+	tokenSource oauth2.TokenSource
+}
+
+// Option customises a Provisioner beyond the required constructor arguments.
+type Option func(*Provisioner)
+
+// WithTokenSource injects the OAuth token source Kubeconfig mints bearer
+// tokens from, letting tests avoid Google application default credentials.
+func WithTokenSource(source oauth2.TokenSource) Option {
+	return func(p *Provisioner) {
+		p.tokenSource = source
+	}
 }
 
 // NewProvisioner builds a Provisioner. The GKE client must be non-nil and the
@@ -45,6 +61,7 @@ func NewProvisioner(
 	clusterSpec *containerpb.Cluster,
 	client *gke.Client,
 	infraProvider provider.Provider,
+	opts ...Option,
 ) (*Provisioner, error) {
 	if client == nil {
 		return nil, ErrClientRequired
@@ -54,14 +71,21 @@ func NewProvisioner(
 		return nil, ErrProjectRequired
 	}
 
-	return &Provisioner{
+	provisioner := &Provisioner{
 		name:          name,
 		project:       project,
 		location:      location,
 		clusterSpec:   clusterSpec,
 		client:        client,
 		infraProvider: infraProvider,
-	}, nil
+		tokenSource:   nil,
+	}
+
+	for _, opt := range opts {
+		opt(provisioner)
+	}
+
+	return provisioner, nil
 }
 
 // SetProvider sets the infrastructure provider used by Start/Stop.

--- a/pkg/svc/provisioner/cluster/gke/provisioner.go
+++ b/pkg/svc/provisioner/cluster/gke/provisioner.go
@@ -3,6 +3,7 @@ package gkeprovisioner
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/devantler-tech/ksail/v7/pkg/client/gke"
@@ -37,9 +38,11 @@ type Provisioner struct {
 	// (node-pool scale). Optional: if nil, Start/Stop return an error.
 	infraProvider provider.Provider
 	// tokenSource mints bearer tokens for Kubeconfig. Nil means Google
-	// application default credentials are resolved at call time; tests
-	// inject a static source.
+	// application default credentials are resolved (and cached) on first
+	// use; tests inject a static source.
 	tokenSource oauth2.TokenSource
+	// tokenMu guards the lazy tokenSource resolution.
+	tokenMu sync.Mutex
 }
 
 // Option customises a Provisioner beyond the required constructor arguments.

--- a/pkg/svc/provisioner/cluster/gke/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/gke/provisioner_test.go
@@ -25,6 +25,7 @@ type fakeClusterManager struct {
 	createFunc func(*containerpb.CreateClusterRequest) (*containerpb.Operation, error)
 	deleteFunc func(*containerpb.DeleteClusterRequest) (*containerpb.Operation, error)
 	listFunc   func(*containerpb.ListClustersRequest) (*containerpb.ListClustersResponse, error)
+	getFunc    func(*containerpb.GetClusterRequest) (*containerpb.Cluster, error)
 }
 
 func (f *fakeClusterManager) CreateCluster(
@@ -45,10 +46,14 @@ func (f *fakeClusterManager) DeleteCluster(
 
 func (f *fakeClusterManager) GetCluster(
 	_ context.Context,
-	_ *containerpb.GetClusterRequest,
+	req *containerpb.GetClusterRequest,
 	_ ...gax.CallOption,
 ) (*containerpb.Cluster, error) {
-	return nil, errBoom
+	if f.getFunc == nil {
+		return nil, errBoom
+	}
+
+	return f.getFunc(req)
 }
 
 func (f *fakeClusterManager) ListClusters(


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

A GKE cluster managed by the operator is provisioned but then silently gets no components installed (CNI, GitOps engine, …) because the GKE provisioner doesn't expose child-cluster access — the last remaining gap class in the operator lifecycle epic now that all nested distributions have Connectors.

## What

Implements the operator's Connector capability for GKE: it builds a ready-gated, operator-usable kubeconfig straight from the GKE API (cluster endpoint + CA + a short-lived Google-credentials token), so the operator can install the declared components and correctly requeues while the cluster is still provisioning. Fully unit-tested against the existing fake SDK seam; no new dependencies.

Fixes #5810 · Part of #4899