### PR TITLE
feat(workload): attribute CEL rule violations to their HelmRelease layer

### DIFF
--- a/pkg/cli/cmd/workload/celvalidate.go
+++ b/pkg/cli/cmd/workload/celvalidate.go
@@ -60,12 +60,18 @@ func buildCELEngine(rulesPath string) (*celrules.Engine, error) {
 // whose kind is in that set are skipped before CEL evaluation, so CEL honors the
 // same exclusions kubeconform does and a skipped Secret (or other kind) cannot
 // surface a CEL failure.
+//
+// attribution is the same resource-identity→source map kubeconform failures use
+// (ValidationOptions.Attribution); when the violating document's identity is
+// present, the source layer is appended to the description. A nil map (loose
+// files, --skip-helm-render) leaves descriptions unchanged.
 func evaluateCELDocuments(
 	engine *celrules.Engine,
 	data []byte,
 	source string,
 	skipKinds []string,
 	sink *celViolationSink,
+	attribution map[string]string,
 ) error {
 	if engine == nil {
 		return nil
@@ -91,7 +97,7 @@ func evaluateCELDocuments(
 		}
 
 		for _, violation := range engine.Evaluate(obj) {
-			described := describeCELViolation(violation, obj, source)
+			described := describeCELViolation(violation, obj, source, attribution)
 
 			if violation.Severity == celrules.SeverityWarning {
 				sink.add(described)
@@ -133,17 +139,36 @@ func decodeDocumentObject(docBytes []byte) (map[string]any, bool) {
 
 // describeCELViolation renders a single violation with its rule name, the
 // offending document's identity (Kind/Namespace/Name when derivable), and the
-// source manifest, so a failure points at the exact resource and layer.
-func describeCELViolation(violation celrules.Violation, obj map[string]any, source string) string {
+// source manifest, so a failure points at the exact resource and layer. When
+// attribution carries an entry for the identity, the source descriptor is
+// appended as " (from <source>)" — the same tag kubeconform failures carry — so
+// a violation in a multi-layer render is traced to the HelmRelease that
+// produced it. Appending keeps existing description substrings intact for
+// callers that match on them.
+func describeCELViolation(
+	violation celrules.Violation,
+	obj map[string]any,
+	source string,
+	attribution map[string]string,
+) string {
 	identity := documentIdentityFromObject(obj)
-	if identity != "" {
+	if identity == "" {
 		return fmt.Sprintf(
-			"rule %q violated by %s (in %s): %s",
-			violation.Rule, identity, source, violation.Message,
+			"rule %q violated (in %s): %s",
+			violation.Rule, source, violation.Message,
 		)
 	}
 
-	return fmt.Sprintf("rule %q violated (in %s): %s", violation.Rule, source, violation.Message)
+	described := fmt.Sprintf(
+		"rule %q violated by %s (in %s): %s",
+		violation.Rule, identity, source, violation.Message,
+	)
+
+	if layer := attribution[identity]; layer != "" {
+		described += " (from " + layer + ")"
+	}
+
+	return described
 }
 
 // documentIdentityFromObject builds "Kind/Namespace/Name" (or "Kind/Name" for

--- a/pkg/cli/cmd/workload/validate.go
+++ b/pkg/cli/cmd/workload/validate.go
@@ -793,9 +793,10 @@ func (v *kustomizationValidator) validateSilent(ctx context.Context, kustDir str
 	}
 
 	// Apply CEL rules to the same rendered/built manifests kubeconform validated,
-	// honoring the same kind exclusions (--skip-kinds / --skip-secrets) so a
-	// skipped kind cannot surface a CEL failure.
-	err = evaluateCELDocuments(v.engine, data, kustDir, opts.SkipKinds, v.celSink)
+	// honoring the same kind exclusions (--skip-kinds / --skip-secrets) and the
+	// same render-provenance attribution, so a skipped kind cannot surface a CEL
+	// failure and a rendered document's violation is traced to its HelmRelease.
+	err = evaluateCELDocuments(v.engine, data, kustDir, opts.SkipKinds, v.celSink, opts.Attribution)
 	if err != nil {
 		return err
 	}
@@ -920,8 +921,11 @@ func validateFileSilent(
 
 	// Apply CEL rules to the same content kubeconform validated, honoring the same
 	// kind exclusions (--skip-kinds / --skip-secrets) so a skipped kind cannot
-	// surface a CEL failure.
-	err = evaluateCELDocuments(engine, expanded, filePath, opts.SkipKinds, celSink)
+	// surface a CEL failure. Loose files carry no render provenance, so
+	// opts.Attribution is nil here and descriptions are unchanged.
+	err = evaluateCELDocuments(
+		engine, expanded, filePath, opts.SkipKinds, celSink, opts.Attribution,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/workload/validate_celrules_test.go
+++ b/pkg/cli/cmd/workload/validate_celrules_test.go
@@ -83,6 +83,10 @@ func TestValidateCELErrorViolationFails(t *testing.T) {
 		t, err, "resources must be in the prod namespace",
 		"the rule message should surface",
 	)
+	require.NotContains(
+		t, err.Error(), "(from HelmRelease",
+		"a non-rendered document carries no HelmRelease-layer attribution",
+	)
 }
 
 func TestValidateCELWarningViolationDoesNotFail(t *testing.T) {
@@ -257,6 +261,10 @@ func TestValidateCELErrorViolationOnRenderedManifest(t *testing.T) {
 	require.Error(t, err, "a CEL rule should evaluate the rendered manifests")
 	require.ErrorContains(
 		t, err, "forbid-configmaps", "the rendered-output violation should name the rule",
+	)
+	require.ErrorContains(
+		t, err, "(from HelmRelease flux-system/app)",
+		"the rendered-output violation should carry HelmRelease-layer attribution",
 	)
 }
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`workload validate` traces kubeconform failures to the HelmRelease that produced the failing resource, but CEL rule violations lack that tag — on a multi-layer render the operator has to re-derive the source layer by hand.

## What

CEL violations on rendered documents now carry the same `(from HelmRelease <ns>/<name>)` attribution as kubeconform failures; non-rendered output is unchanged.

Fixes #5812