### PR TITLE
feat(provisioner): serialise HA control-plane joins

### DIFF
--- a/pkg/svc/bootstrap/kubeadm/install.go
+++ b/pkg/svc/bootstrap/kubeadm/install.go
@@ -15,6 +15,19 @@ const ConfigPath = "/etc/kubernetes/ksail/kubeadm-config.yaml"
 // the shared bootstrap token, so it is root read/write only.
 const configPermissions = "0600"
 
+// sentinelDir is the ksail-managed directory the bootstrap-completion sentinel
+// lands in; it is created by the same first-boot command that writes the
+// sentinel.
+const sentinelDir = "/var/lib/ksail"
+
+// BootstrapSentinelPath is the file the node's first-boot bootstrap writes after
+// its kubeadm command succeeded — the reliable "bootstrap finished" signal a
+// live bring-up polls for over SSH. For a joining control plane this marks
+// `kubeadm join --control-plane` complete, including etcd member addition; none
+// of kubeadm's own files can stand in for it (admin.conf, for one, is written
+// during the control-plane-prepare phase, before the etcd member is added).
+const BootstrapSentinelPath = sentinelDir + "/bootstrap-complete"
+
 // packageRepoBaseURL is the base of the Kubernetes community (pkgs.k8s.io) package
 // repository. A node installs the kube* components from the stable channel of its
 // pinned minor track, e.g. .../core:/stable:/v1.31/deb/.
@@ -191,7 +204,9 @@ func RenderInstall(cfg InstallConfig) (Install, error) {
 // bootstrapCommands returns the ordered first-boot commands for role: enable the
 // container runtime, pin the kube* packages so an unattended upgrade cannot break
 // the control plane mid-cluster, then run the role's kubeadm bootstrap command
-// against the dropped config.
+// against the dropped config. The bootstrap command chains the completion
+// sentinel (`&&`, so it is written only when kubeadm succeeded) — see
+// [BootstrapSentinelPath].
 func bootstrapCommands(role Role) []string {
 	bootstrap := "kubeadm init --config " + ConfigPath
 	if role != RoleServerInit {
@@ -201,7 +216,7 @@ func bootstrapCommands(role Role) []string {
 	return []string{
 		"systemctl enable --now " + containerdPackage,
 		"apt-mark hold " + strings.Join(kubePackages(), " "),
-		bootstrap,
+		bootstrap + " && mkdir -p " + sentinelDir + " && touch " + BootstrapSentinelPath,
 	}
 }
 

--- a/pkg/svc/bootstrap/kubeadm/install_test.go
+++ b/pkg/svc/bootstrap/kubeadm/install_test.go
@@ -92,7 +92,8 @@ func TestRenderInstallServerInitBootstrapsWithInit(t *testing.T) {
 	assert.Equal(t, []string{
 		"systemctl enable --now containerd",
 		"apt-mark hold kubelet kubeadm kubectl",
-		"kubeadm init --config " + kubeadmbootstrap.ConfigPath,
+		"kubeadm init --config " + kubeadmbootstrap.ConfigPath +
+			" && mkdir -p /var/lib/ksail && touch " + kubeadmbootstrap.BootstrapSentinelPath,
 	}, install.Commands)
 }
 
@@ -112,9 +113,11 @@ func TestRenderInstallJoiningNodesBootstrapWithJoin(t *testing.T) {
 
 		require.NotEmpty(t, install.Commands)
 		assert.Equal(t,
-			"kubeadm join --config "+kubeadmbootstrap.ConfigPath,
+			"kubeadm join --config "+kubeadmbootstrap.ConfigPath+
+				" && mkdir -p /var/lib/ksail && touch "+kubeadmbootstrap.BootstrapSentinelPath,
 			install.Commands[len(install.Commands)-1],
-			"a joining node (%q) runs `kubeadm join`, not `kubeadm init`",
+			"a joining node (%q) runs `kubeadm join`, not `kubeadm init`, and chains "+
+				"the completion sentinel so it appears only on success",
 			role,
 		)
 	}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase_test.go
@@ -36,6 +36,9 @@ type fakeInfra struct {
 	listErr            error
 	createServerErr    error
 	createdServer      *hcloud.Server
+	// onCreateServer, when set, observes each CreateServer call (multi-node
+	// sequencing tests interleave it with SSH-probe observations).
+	onCreateServer func(hetzner.CreateServerOpts)
 
 	networkID        int64
 	firewallID       int64
@@ -120,6 +123,10 @@ func (f *fakeInfra) CreateServer(
 ) (*hcloud.Server, error) {
 	f.createServerCalls++
 	f.lastServerOpts = opts
+
+	if f.onCreateServer != nil {
+		f.onCreateServer(opts)
+	}
 
 	return f.createdServer, f.createServerErr
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net"
 
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
@@ -16,6 +18,13 @@ import (
 // private IP means the network placement did not take and the join would fail.
 var ErrNoPrivateIPv4 = errors.New(
 	"hetzner: cluster-initialising control plane has no private-network IPv4 for joining nodes",
+)
+
+// ErrMissingControlPlaneJoinSentinel is returned by [Base.RunCreateMultiNode]
+// when an [HAControlPlaneComposer] supplies no join-complete sentinel path for
+// its control-plane joiners — without one their joins cannot be serialised.
+var ErrMissingControlPlaneJoinSentinel = errors.New(
+	"hetzner: control-plane join-complete sentinel path is empty",
 )
 
 // MultiNodeComposer is the optional capability a distribution's [CreateStrategy]
@@ -63,6 +72,14 @@ type HAControlPlaneComposer interface {
 	// distribution declares — by implementing this — that its ComposeJoiningNodes
 	// output is correct for additional control planes, not only agents.
 	SupportsHAControlPlanes()
+
+	// ControlPlaneJoinCompletePath returns the remote file path whose existence
+	// marks a joining control plane's bootstrap complete — a file the
+	// distribution's first boot writes only after its join command succeeded
+	// (never a file the join writes part-way, which would report completion
+	// while etcd membership is still changing). [Base.RunCreateMultiNode] polls
+	// it over SSH to serialise control-plane joins.
+	ControlPlaneJoinCompletePath() string
 }
 
 // RunCreateMultiNode runs the two-phase Hetzner create flow for a cluster with
@@ -81,13 +98,15 @@ type HAControlPlaneComposer interface {
 // takes an already-composed plan) so the SSH bring-up is testable with an
 // in-process server.
 //
-// Joining nodes are created and left to register asynchronously — the cluster is
+// Agents are created and left to register asynchronously — the cluster is
 // usable once the control plane serves the API and its kubeconfig is retrieved;
 // end-to-end join success is validated by the live smoke tests
 // (devantler-tech/ksail#5515) once the Hetzner CI lane (#4972) is restored.
-// Additional control planes currently register concurrently like agents, which
-// can race etcd member addition; serialising their joins is the final HA
-// increment (devantler-tech/ksail#5796).
+// Additional control planes are serialised instead: each control-plane joiner's
+// join-complete sentinel ([HAControlPlaneComposer.ControlPlaneJoinCompletePath])
+// is awaited over SSH before the next joining node is created, because
+// concurrent control-plane joins race etcd member addition
+// (devantler-tech/ksail#5818).
 func (b *Base) RunCreateMultiNode(
 	ctx context.Context,
 	name string,
@@ -171,9 +190,11 @@ func (b *Base) bringUpInitControlPlane(
 }
 
 // createJoiningNodes composes the joining nodes against the init control plane's
-// private-network address and creates them. They bootstrap and register
-// asynchronously, so it does not wait for a kubeconfig from them; a creation
-// failure tears the whole cluster down.
+// private-network address and creates them. Agents bootstrap and register
+// asynchronously, so it does not wait for a kubeconfig from them; a
+// control-plane joiner's join-complete sentinel is awaited before the next
+// joining node is created (etcd member addition must not be raced). A creation
+// or join failure tears the whole cluster down.
 func (b *Base) createJoiningNodes(
 	ctx context.Context,
 	clusterName string,
@@ -198,8 +219,10 @@ func (b *Base) createJoiningNodes(
 		return b.cleanUpFailedBringUp(ctx, clusterName, err)
 	}
 
-	for _, spec := range joinSpecs {
-		_, createErr := b.Servers.CreateServer(ctx, spec)
+	haComposer, _ := composer.(HAControlPlaneComposer)
+
+	for index, spec := range joinSpecs {
+		server, createErr := b.Servers.CreateServer(ctx, spec)
 		if createErr != nil {
 			return b.cleanUpFailedBringUp(
 				ctx,
@@ -207,9 +230,59 @@ func (b *Base) createJoiningNodes(
 				fmt.Errorf("create joining node %q: %w", spec.Name, createErr),
 			)
 		}
+
+		// joinSpecs is derived 1:1 in order from joinNodes, so the node's role
+		// travels by index.
+		if haComposer == nil || joinNodes[index].NodeType != hetzner.NodeTypeControlPlane {
+			continue
+		}
+
+		waitErr := b.waitForControlPlaneJoin(ctx, server, material, haComposer)
+		if waitErr != nil {
+			return b.cleanUpFailedBringUp(
+				ctx,
+				clusterName,
+				fmt.Errorf("wait for control-plane joiner %q: %w", spec.Name, waitErr),
+			)
+		}
 	}
 
 	return nil
+}
+
+// waitForControlPlaneJoin dials the created control-plane joiner over SSH with
+// the cluster's bootstrap material and waits for its join-complete sentinel, so
+// the next joining node is not created while this one's etcd member addition is
+// still in flight.
+func (b *Base) waitForControlPlaneJoin(
+	ctx context.Context,
+	server *hcloud.Server,
+	material BootstrapMaterial,
+	haComposer HAControlPlaneComposer,
+) error {
+	sentinelPath := haComposer.ControlPlaneJoinCompletePath()
+	if sentinelPath == "" {
+		return ErrMissingControlPlaneJoinSentinel
+	}
+
+	addr, err := publicSSHAddr(server, b.BringUpPort)
+	if err != nil {
+		return err
+	}
+
+	client, err := sshbootstrap.DialWithRetry(ctx, sshbootstrap.Options{
+		Addr:            addr,
+		User:            bootstrapUser,
+		Signer:          material.Signer,
+		HostKeyCallback: material.HostKeyCallback,
+	}, 0)
+	if err != nil {
+		return fmt.Errorf("dial bootstrap SSH at %s: %w", addr, err)
+	}
+
+	defer func() { _ = client.Close() }()
+
+	return waitForRemoteFile(ctx, client, sentinelPath, b.BringUpPollInterval)
 }
 
 // privateIPv4 returns the created server's first private-network IPv4, or

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -236,4 +237,224 @@ func TestRunCreateMultiNodeMissingKubeconfigDestinationFailsFast(t *testing.T) {
 	require.ErrorIs(t, err, hetznerbase.ErrMissingKubeconfigDestination)
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 	assert.Equal(t, 0, infra.createServerCalls)
+}
+
+// testSentinelPath is the join-complete sentinel the fake HA strategy exposes;
+// testSentinelProbe is the FileExists command the engine's wait issues for it.
+const (
+	testSentinelPath  = "/var/lib/fake/join-complete"
+	testSentinelProbe = "test -f '/var/lib/fake/join-complete'"
+)
+
+// testHAControlPlaneJoiners is the additional-control-plane count the HA
+// multi-node engine tests bring up alongside the init control plane and the
+// [testMultiNodeAgents] agents.
+const testHAControlPlaneJoiners = 2
+
+// fakeHAMultiNodeStrategy upgrades the multi-node fake to an
+// [hetznerbase.HAControlPlaneComposer]: its joining nodes are the additional
+// control planes first, then the agents — mirroring the real composers' order.
+type fakeHAMultiNodeStrategy struct {
+	fakeMultiNodeStrategy
+
+	controlPlaneJoiners int
+	sentinelPath        string
+}
+
+func (f *fakeHAMultiNodeStrategy) SupportsHAControlPlanes() {}
+
+func (f *fakeHAMultiNodeStrategy) ControlPlaneJoinCompletePath() string { return f.sentinelPath }
+
+func (f *fakeHAMultiNodeStrategy) ComposeJoiningNodes(
+	_, _ string,
+	joinAddress net.IP,
+	_ hetznerbase.BootstrapMaterial,
+) ([]hetznerbase.NodeSpec, error) {
+	f.receivedJoinAddress = joinAddress
+
+	specs := make([]hetznerbase.NodeSpec, 0, f.controlPlaneJoiners+f.agents)
+
+	for index := 1; index <= f.controlPlaneJoiners; index++ {
+		specs = append(specs, hetznerbase.NodeSpec{
+			Index:    index,
+			NodeType: hetzner.NodeTypeControlPlane,
+			UserData: "#cloud-config\n",
+		})
+	}
+
+	for index := 1; index <= f.agents; index++ {
+		specs = append(specs, hetznerbase.NodeSpec{
+			Index:    f.controlPlaneJoiners + index,
+			NodeType: hetzner.NodeTypeWorker,
+			UserData: "#cloud-config\n",
+		})
+	}
+
+	return specs, nil
+}
+
+// eventLog records the interleaving of server creations (engine goroutine) and
+// sentinel probes (in-process SSH server goroutines) under one mutex, so the
+// serialisation assertion is race-free.
+type eventLog struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (l *eventLog) add(event string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.events = append(l.events, event)
+}
+
+func (l *eventLog) list() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return append([]string(nil), l.events...)
+}
+
+// newHAMultiNodeBase wires a Base whose strategy composes additional control
+// planes, against an SSH server that answers the init node's kubeconfig
+// protocol and reports the join-complete sentinel via sentinelHandler.
+func newHAMultiNodeBase(
+	t *testing.T,
+	log *eventLog,
+	sentinelHandler func() (string, uint32),
+) (*hetznerbase.Base, *fakeInfra, *fakeHAMultiNodeStrategy, hetznerbase.BootstrapMaterial) {
+	t.Helper()
+
+	pair, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	kubeconfig := kubeconfigHandler(0, remoteAdminKubeconfig)
+	host, port, hostKey := startBringUpSSHServer(
+		t, pair.Signer.PublicKey(),
+		func(command string) (string, uint32) {
+			if command == testSentinelProbe {
+				return sentinelHandler()
+			}
+
+			return kubeconfig(command)
+		},
+	)
+
+	server := serverWithPublicIPv4(host)
+	server.PrivateNet = []hcloud.ServerPrivateNet{{IP: net.ParseIP(testJoinPrivateIP)}}
+
+	infra := &fakeInfra{createdServer: server, networkID: 11}
+	infra.onCreateServer = func(opts hetzner.CreateServerOpts) { log.add("create:" + opts.Name) }
+
+	base := newBase(infra, v1alpha1.OptionsHetzner{})
+	base.ControlPlanes = 1 + testHAControlPlaneJoiners
+	base.Agents = testMultiNodeAgents
+	base.KubeconfigPath = filepath.Join(t.TempDir(), "kubeconfig")
+	base.BringUpPort = port
+	base.BringUpPollInterval = testPollInterval
+
+	strategy := &fakeHAMultiNodeStrategy{
+		fakeMultiNodeStrategy: fakeMultiNodeStrategy{
+			kubeconfigPath: testKubeconfigPath,
+			agents:         testMultiNodeAgents,
+		},
+		controlPlaneJoiners: testHAControlPlaneJoiners,
+		sentinelPath:        testSentinelPath,
+	}
+	base.Strategy = strategy
+
+	material := hetznerbase.BootstrapMaterial{
+		Signer:          pair.Signer,
+		AuthorizedKey:   pair.AuthorizedKey,
+		HostKeyCallback: gossh.FixedHostKey(hostKey),
+	}
+
+	return base, infra, strategy, material
+}
+
+// nodeName derives the server name the engine gives clusterName's node, so the
+// serialisation assertion matches on real creation events.
+func nodeName(t *testing.T, clusterName, nodeType string, index int) string {
+	t.Helper()
+
+	name, err := hetzner.NodeName(clusterName, nodeType, index)
+	require.NoError(t, err)
+
+	return name
+}
+
+func TestRunCreateMultiNodeSerialisesControlPlaneJoins(t *testing.T) {
+	t.Parallel()
+
+	log := &eventLog{}
+	base, infra, strategy, material := newHAMultiNodeBase(
+		t, log,
+		func() (string, uint32) {
+			log.add("join-complete-probe")
+
+			return "", 0
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	require.NoError(t, base.RunCreateMultiNode(ctx, "", strategy, material))
+
+	clusterName := base.ClusterName
+	controlPlane := hetzner.NodeTypeControlPlane
+	worker := hetzner.NodeTypeWorker
+
+	// Each control-plane joiner's join completion is observed BEFORE the next
+	// joining node is created; the agents follow without any join wait.
+	assert.Equal(t, []string{
+		"create:" + nodeName(t, clusterName, controlPlane, 0),
+		"create:" + nodeName(t, clusterName, controlPlane, 1),
+		"join-complete-probe",
+		"create:" + nodeName(t, clusterName, controlPlane, 2),
+		"join-complete-probe",
+		"create:" + nodeName(t, clusterName, worker, 3),
+		"create:" + nodeName(t, clusterName, worker, 4),
+	}, log.list())
+
+	assert.Equal(t, 0, infra.deleteNodesCalls)
+}
+
+func TestRunCreateMultiNodeControlPlaneJoinNeverCompletesCleansUp(t *testing.T) {
+	t.Parallel()
+
+	log := &eventLog{}
+	base, infra, strategy, material := newHAMultiNodeBase(
+		t, log,
+		func() (string, uint32) { return "", errExitNotFound }, // sentinel never appears
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testFailFastBudget)
+	defer cancel()
+
+	err := base.RunCreateMultiNode(ctx, "", strategy, material)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, "wait for control-plane joiner")
+	// Only the init control plane and the first (stuck) joiner were created —
+	// the wedged join blocked every later node — and cleanup-on-failure ran.
+	assert.Equal(t, 2, infra.createServerCalls)
+	assert.Equal(t, 1, infra.deleteNodesCalls)
+}
+
+func TestRunCreateMultiNodeEmptyJoinSentinelCleansUp(t *testing.T) {
+	t.Parallel()
+
+	log := &eventLog{}
+	base, infra, strategy, material := newHAMultiNodeBase(
+		t, log,
+		func() (string, uint32) { return "", 0 },
+	)
+	strategy.sentinelPath = ""
+
+	ctx, cancel := context.WithTimeout(t.Context(), testBringUpBudget)
+	defer cancel()
+
+	err := base.RunCreateMultiNode(ctx, "", strategy, material)
+	require.ErrorIs(t, err, hetznerbase.ErrMissingControlPlaneJoinSentinel)
+	assert.Equal(t, 1, infra.deleteNodesCalls)
 }

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode.go
@@ -57,6 +57,15 @@ var (
 // (kubeadm's manual certificate distribution).
 func (p *Provisioner) SupportsHAControlPlanes() {}
 
+// ControlPlaneJoinCompletePath returns the sentinel the kubeadm first-boot
+// bootstrap writes once its `kubeadm join` command succeeded, satisfying
+// [hetznerbase.HAControlPlaneComposer]: the shared flow polls it over SSH to
+// serialise control-plane joins — kubeadm's etcd member addition must not be
+// raced by a concurrently-joining control plane.
+func (p *Provisioner) ControlPlaneJoinCompletePath() string {
+	return kubeadmbootstrap.BootstrapSentinelPath
+}
+
 // JoinName returns the cluster's stable join name: the DNS name the joining
 // nodes dial the cluster-initialising control plane by, and the extra SAN its
 // API-server serving certificate carries.

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
@@ -218,6 +218,10 @@ func TestComposeJoiningNodesComposesAdditionalControlPlanes(t *testing.T) {
 		assert.Equal(t, hetzner.NodeTypeControlPlane, spec.NodeType)
 		assert.Contains(t, spec.UserData, "controlPlane", "a control-plane joiner must join as one")
 		assert.Contains(t, spec.UserData, "kubeadm join")
+		assert.Contains(t, spec.UserData,
+			"&& touch "+prov.ControlPlaneJoinCompletePath(),
+			"a control-plane joiner must chain the join-complete sentinel the "+
+				"serialised bring-up polls for")
 
 		for _, path := range privatePKIPaths {
 			assert.Contains(t, spec.UserData, path,


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Bringing up an HA cluster lets every additional control plane join at the same time, and concurrent control-plane joins race etcd member addition — a bring-up can wedge with a broken quorum. This is the last gap in the HA control-plane lane.

## What
Each additional control plane now finishes its join (proven by a completion sentinel its first boot writes only on success) before the next joining node is created; workers keep joining concurrently. A wedged join times out and tears the cluster down as before.

Fixes #5818. Part of #5796 (#3983).