### PR TITLE
feat(mirror): add tunnel mux session multiplexing frames into per-connection streams

### DIFF
--- a/pkg/svc/mirror/tunnelsession.go
+++ b/pkg/svc/mirror/tunnelsession.go
@@ -1,0 +1,564 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// ErrTunnelSessionClosed is returned when a stream is opened or accepted on a
+// session that is already closed, and is the read error surfaced on streams a
+// session close tore down.
+var ErrTunnelSessionClosed = errors.New("tunnel session is closed")
+
+// ErrTunnelStreamClosed is returned when writing to (or reading from) a stream
+// after its local side closed it.
+var ErrTunnelStreamClosed = errors.New("tunnel stream is closed")
+
+// ErrTunnelDuplicateOpen is returned when the peer announces a StreamID that
+// is already open — a protocol violation that tears the session down, because
+// frame routing for that StreamID is ambiguous from that point on.
+var ErrTunnelDuplicateOpen = errors.New("tunnel peer opened an already-open stream")
+
+// TunnelRole fixes which half of the StreamID space a session allocates from,
+// so the two ends of a tunnel can both open streams without ever colliding.
+type TunnelRole uint8
+
+const (
+	// TunnelRoleClient allocates odd StreamIDs (1, 3, 5, …) — the local ksail
+	// end of the tunnel.
+	TunnelRoleClient TunnelRole = iota
+	// TunnelRoleServer allocates even StreamIDs (2, 4, 6, …) — the in-cluster
+	// end of the tunnel.
+	TunnelRoleServer
+)
+
+// streamIDStep keeps each side on its own StreamID parity when allocating.
+const streamIDStep = 2
+
+// acceptBacklog bounds how many peer-opened streams may sit undelivered
+// before the demux loop blocks waiting for AcceptStream — deliberate
+// backpressure on the single shared channel rather than an unbounded queue.
+const acceptBacklog = 8
+
+// tunnelReceiveBudget bounds how many inbound bytes one stream may buffer
+// before the demux loop blocks (backpressure on the whole tunnel, since all
+// streams share the one channel). The slack keeps ordinary
+// write-then-close sequences deadlock-free without unbounded memory;
+// windowed flow control is a later increment if intercept needs it.
+const tunnelReceiveBudget = 4 * MaxTunnelPayload
+
+// TunnelSession multiplexes one bidirectional byte channel — in Phase 2 the
+// exec stream's stdin+stdout — into independent per-connection streams using
+// the tunnel frame codec ([Frame], [WriteFrame], [ReadFrame]). Both ends may
+// open streams; [TunnelRole] parity keeps their StreamIDs disjoint.
+//
+// Inbound data is delivered through one bounded buffer per stream; a stream
+// left unread beyond its budget blocks the shared demux loop. That
+// head-of-line blocking is the deliberate backpressure of a single shared
+// channel (windowed flow control is a later increment if intercept needs it).
+type TunnelSession struct {
+	reader io.Reader
+	writer io.Writer
+
+	writeMu sync.Mutex
+
+	acceptQueue chan *TunnelStream
+
+	stateMu sync.Mutex
+	streams map[uint32]*TunnelStream
+	nextID  uint32
+	closed  bool
+	loopErr error
+
+	closeOnce sync.Once
+	closing   chan struct{}
+	done      chan struct{}
+}
+
+// NewTunnelSession starts a session over the given channel halves and begins
+// demultiplexing immediately. For [TunnelSession.Close] to be able to unblock
+// a demux loop parked in a read, reader and writer should implement
+// [io.Closer] (both halves of an [io.Pipe] do, as do the exec stream's ends).
+func NewTunnelSession(reader io.Reader, writer io.Writer, role TunnelRole) *TunnelSession {
+	firstID := uint32(1)
+	if role == TunnelRoleServer {
+		firstID = 2
+	}
+
+	session := &TunnelSession{
+		reader:      reader,
+		writer:      writer,
+		writeMu:     sync.Mutex{},
+		acceptQueue: make(chan *TunnelStream, acceptBacklog),
+		stateMu:     sync.Mutex{},
+		streams:     map[uint32]*TunnelStream{},
+		nextID:      firstID,
+		closed:      false,
+		loopErr:     nil,
+		closeOnce:   sync.Once{},
+		closing:     make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+
+	go session.readLoop()
+
+	return session
+}
+
+// OpenStream announces a new locally-initiated stream to the peer and returns
+// it. The peer surfaces it through [TunnelSession.AcceptStream].
+func (s *TunnelSession) OpenStream() (*TunnelStream, error) {
+	s.stateMu.Lock()
+
+	if s.closed {
+		s.stateMu.Unlock()
+
+		return nil, ErrTunnelSessionClosed
+	}
+
+	streamID := s.nextID
+	s.nextID += streamIDStep
+	stream := newTunnelStream(s, streamID)
+	s.streams[streamID] = stream
+	s.stateMu.Unlock()
+
+	err := s.writeFrame(Frame{StreamID: streamID, Type: FrameOpen, Payload: nil})
+	if err != nil {
+		_ = stream.closeWith(false, ErrTunnelSessionClosed)
+
+		return nil, err
+	}
+
+	return stream, nil
+}
+
+// AcceptStream returns the next peer-initiated stream, blocking until one
+// arrives, the context is cancelled, or the session closes.
+func (s *TunnelSession) AcceptStream(ctx context.Context) (*TunnelStream, error) {
+	// Prefer an already-delivered stream over racing the done channel, so
+	// streams the peer opened before a close are still handed out.
+	select {
+	case stream := <-s.acceptQueue:
+		return stream, nil
+	default:
+	}
+
+	select {
+	case stream := <-s.acceptQueue:
+		return stream, nil
+	case <-s.done:
+		return nil, ErrTunnelSessionClosed
+	case <-ctx.Done():
+		return nil, fmt.Errorf("waiting for a tunnel stream: %w", ctx.Err())
+	}
+}
+
+// Close tears the session down: every open stream is closed (readers see
+// ErrTunnelSessionClosed), the channel halves are closed when they implement
+// [io.Closer], and the demux loop stops. Close never blocks and is safe to
+// call more than once.
+func (s *TunnelSession) Close() error {
+	s.closeOnce.Do(func() {
+		s.stateMu.Lock()
+		s.closed = true
+		s.stateMu.Unlock()
+
+		close(s.closing)
+		closeIfCloser(s.reader)
+		closeIfCloser(s.writer)
+
+		// Unblock a demux loop parked on an unread stream's pipe so it can
+		// observe the closed reader and tear down.
+		for _, stream := range s.snapshotStreams() {
+			_ = stream.closeWith(false, ErrTunnelSessionClosed)
+		}
+	})
+
+	return nil
+}
+
+// Done is closed once the demux loop has exited and every stream is torn
+// down; [TunnelSession.Err] is meaningful after that.
+func (s *TunnelSession) Done() <-chan struct{} {
+	return s.done
+}
+
+// Err reports why the demux loop exited: nil for a clean shutdown (peer EOF
+// or [TunnelSession.Close]), otherwise the codec/protocol/transport error
+// that tore the session down.
+func (s *TunnelSession) Err() error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	return s.loopErr
+}
+
+// readLoop is the demux: it reads one frame at a time off the shared channel
+// and routes it, exiting on EOF, a deliberate close, or the first error.
+func (s *TunnelSession) readLoop() {
+	var loopErr error
+
+	for {
+		frame, err := ReadFrame(s.reader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !s.isClosing() {
+				loopErr = err
+			}
+
+			break
+		}
+
+		err = s.dispatch(frame)
+		if err != nil {
+			loopErr = err
+
+			break
+		}
+	}
+
+	s.teardown(loopErr)
+}
+
+// dispatch routes one inbound frame by type. ReadFrame already rejected
+// unknown types, so the default arm is defensive only.
+func (s *TunnelSession) dispatch(frame Frame) error {
+	switch frame.Type {
+	case FrameOpen:
+		return s.handleOpen(frame.StreamID)
+	case FrameData:
+		s.handleData(frame)
+
+		return nil
+	case FrameClose:
+		s.handleClose(frame.StreamID)
+
+		return nil
+	default:
+		return fmt.Errorf("%w: %d", ErrTunnelUnknownFrameType, frame.Type)
+	}
+}
+
+// handleOpen registers a peer-initiated stream and queues it for
+// AcceptStream. A StreamID that is already open is a protocol violation that
+// tears the session down.
+func (s *TunnelSession) handleOpen(streamID uint32) error {
+	s.stateMu.Lock()
+
+	if s.closed {
+		s.stateMu.Unlock()
+
+		return ErrTunnelSessionClosed
+	}
+
+	_, exists := s.streams[streamID]
+	if exists {
+		s.stateMu.Unlock()
+
+		return fmt.Errorf("%w: stream %d", ErrTunnelDuplicateOpen, streamID)
+	}
+
+	stream := newTunnelStream(s, streamID)
+	s.streams[streamID] = stream
+	s.stateMu.Unlock()
+
+	select {
+	case s.acceptQueue <- stream:
+		return nil
+	case <-s.closing:
+		return ErrTunnelSessionClosed
+	}
+}
+
+// handleData feeds a data frame into its stream's inbound buffer. Data for
+// an unknown stream raced a close and is dropped, as is data arriving after
+// the local side closed the stream mid-flight.
+func (s *TunnelSession) handleData(frame Frame) {
+	s.stateMu.Lock()
+	stream, ok := s.streams[frame.StreamID]
+	s.stateMu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	stream.inbound.write(frame.Payload)
+}
+
+// handleClose tears down the stream the peer ended; its local reader drains
+// buffered bytes and then sees io.EOF. A close for an unknown stream raced a
+// local close and is dropped.
+func (s *TunnelSession) handleClose(streamID uint32) {
+	s.stateMu.Lock()
+	stream, ok := s.streams[streamID]
+	s.stateMu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	_ = stream.closeWith(false, nil)
+}
+
+// teardown closes every remaining stream, records why the loop exited, and
+// signals Done. Streams torn down by an error surface that error to their
+// readers; on a clean shutdown they surface ErrTunnelSessionClosed, because
+// the tunnel ended without an orderly per-stream FrameClose.
+func (s *TunnelSession) teardown(loopErr error) {
+	s.stateMu.Lock()
+	s.closed = true
+	s.loopErr = loopErr
+	s.stateMu.Unlock()
+
+	readErr := loopErr
+	if readErr == nil {
+		readErr = ErrTunnelSessionClosed
+	}
+
+	for _, stream := range s.snapshotStreams() {
+		_ = stream.closeWith(false, readErr)
+	}
+
+	close(s.done)
+}
+
+// snapshotStreams copies the live stream set out from under the lock so
+// callers can close streams without holding it.
+func (s *TunnelSession) snapshotStreams() []*TunnelStream {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	streams := make([]*TunnelStream, 0, len(s.streams))
+	for _, stream := range s.streams {
+		streams = append(streams, stream)
+	}
+
+	return streams
+}
+
+// unregister forgets a stream so later frames for its StreamID are treated as
+// having raced the close.
+func (s *TunnelSession) unregister(streamID uint32) {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	delete(s.streams, streamID)
+}
+
+// isClosing reports whether Close has been requested, so the demux loop can
+// tell a deliberate shutdown from a transport failure.
+func (s *TunnelSession) isClosing() bool {
+	select {
+	case <-s.closing:
+		return true
+	default:
+		return false
+	}
+}
+
+// writeFrame serializes frame writes from all streams onto the shared
+// channel, keeping each frame's header and payload contiguous.
+func (s *TunnelSession) writeFrame(frame Frame) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	return WriteFrame(s.writer, frame)
+}
+
+// closeIfCloser closes a channel half when it supports it; a bare io.Reader/
+// io.Writer is left alone (Close then relies on the peer ending the stream).
+func closeIfCloser(half any) {
+	closer, ok := half.(io.Closer)
+	if ok {
+		_ = closer.Close()
+	}
+}
+
+// TunnelStream is one multiplexed connection on a [TunnelSession]: an
+// io.ReadWriteCloser whose bytes travel as [FrameData] frames tagged with its
+// StreamID. There is no half-close: [TunnelStream.Close] (or the peer's)
+// ends the stream in both directions, matching the codec's FrameClose
+// semantics.
+type TunnelStream struct {
+	id      uint32
+	session *TunnelSession
+
+	inbound *inboundBuffer
+
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+// newTunnelStream wires a stream to its session with the buffer the demux
+// loop feeds inbound data through.
+func newTunnelStream(session *TunnelSession, streamID uint32) *TunnelStream {
+	return &TunnelStream{
+		id:        streamID,
+		session:   session,
+		inbound:   newInboundBuffer(),
+		closeOnce: sync.Once{},
+		closed:    make(chan struct{}),
+	}
+}
+
+// StreamID identifies this stream on the tunnel.
+func (s *TunnelStream) StreamID() uint32 {
+	return s.id
+}
+
+// Read returns bytes the peer sent on this stream. Once buffered bytes are
+// drained it reports io.EOF after the peer closed the stream,
+// ErrTunnelStreamClosed after a local close, and the session's failure
+// reason if the whole tunnel tore down.
+func (s *TunnelStream) Read(data []byte) (int, error) {
+	return s.inbound.Read(data)
+}
+
+// Write sends bytes to the peer on this stream, transparently splitting them
+// into frames of at most MaxTunnelPayload.
+func (s *TunnelStream) Write(data []byte) (int, error) {
+	select {
+	case <-s.closed:
+		return 0, ErrTunnelStreamClosed
+	default:
+	}
+
+	written := 0
+	for written < len(data) {
+		chunk := min(len(data)-written, MaxTunnelPayload)
+
+		err := s.session.writeFrame(Frame{
+			StreamID: s.id,
+			Type:     FrameData,
+			Payload:  data[written : written+chunk],
+		})
+		if err != nil {
+			return written, err
+		}
+
+		written += chunk
+	}
+
+	return written, nil
+}
+
+// Close ends the stream in both directions: the peer is told via FrameClose
+// and local reads unblock with ErrTunnelStreamClosed. Closing again is a
+// no-op.
+func (s *TunnelStream) Close() error {
+	return s.closeWith(true, ErrTunnelStreamClosed)
+}
+
+// closeWith is the single teardown path for a stream: it unregisters the
+// stream, optionally notifies the peer (local closes only), and ends the
+// inbound buffer with readErr (nil surfaces io.EOF once drained — the
+// peer-close case).
+func (s *TunnelStream) closeWith(sendClose bool, readErr error) error {
+	var frameErr error
+
+	s.closeOnce.Do(func() {
+		close(s.closed)
+		s.session.unregister(s.id)
+
+		if sendClose {
+			frameErr = s.session.writeFrame(Frame{StreamID: s.id, Type: FrameClose, Payload: nil})
+		}
+
+		s.inbound.close(readErr)
+	})
+
+	return frameErr
+}
+
+// inboundBuffer is the bounded, demux-fed receive side of one stream. It
+// exists so the shared demux loop only blocks when a stream is left unread
+// past tunnelReceiveBudget — an unbuffered handoff would deadlock ordinary
+// sequential write-then-close peers against the single shared channel.
+type inboundBuffer struct {
+	mu       sync.Mutex
+	notEmpty *sync.Cond
+	notFull  *sync.Cond
+	data     []byte
+	closed   bool
+	readErr  error
+}
+
+// newInboundBuffer returns an empty, open buffer.
+func newInboundBuffer() *inboundBuffer {
+	buffer := &inboundBuffer{
+		mu:       sync.Mutex{},
+		notEmpty: nil,
+		notFull:  nil,
+		data:     nil,
+		closed:   false,
+		readErr:  nil,
+	}
+	buffer.notEmpty = sync.NewCond(&buffer.mu)
+	buffer.notFull = sync.NewCond(&buffer.mu)
+
+	return buffer
+}
+
+// Read hands out buffered bytes, blocking while the buffer is open and
+// empty. Once the buffer is closed and drained it reports readErr, or io.EOF
+// when the stream ended cleanly.
+func (b *inboundBuffer) Read(out []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for len(b.data) == 0 && !b.closed {
+		b.notEmpty.Wait()
+	}
+
+	if len(b.data) == 0 {
+		if b.readErr != nil {
+			return 0, b.readErr
+		}
+
+		return 0, io.EOF
+	}
+
+	count := copy(out, b.data)
+	b.data = b.data[count:]
+	b.notFull.Signal()
+
+	return count, nil
+}
+
+// write appends an inbound chunk, blocking while the budget is exhausted —
+// the deliberate per-stream backpressure on the demux loop. Chunks arriving
+// after close raced a teardown and are dropped.
+func (b *inboundBuffer) write(chunk []byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for !b.closed && len(b.data)+len(chunk) > tunnelReceiveBudget {
+		b.notFull.Wait()
+	}
+
+	if b.closed {
+		return
+	}
+
+	b.data = append(b.data, chunk...)
+	b.notEmpty.Signal()
+}
+
+// close ends the buffer: blocked readers and the demux wake up, later chunks
+// are dropped, and reads surface readErr (io.EOF when nil) once the
+// remaining bytes drain.
+func (b *inboundBuffer) close(readErr error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+
+	b.closed = true
+	b.readErr = readErr
+	b.notEmpty.Broadcast()
+	b.notFull.Broadcast()
+}

--- a/pkg/svc/mirror/tunnelsession.go
+++ b/pkg/svc/mirror/tunnelsession.go
@@ -213,7 +213,12 @@ func (s *TunnelSession) readLoop() {
 
 		err = s.dispatch(frame)
 		if err != nil {
-			loopErr = err
+			// A dispatch parked on the accept queue unblocks through the
+			// closing channel during a deliberate Close; that is a clean
+			// shutdown, not a loop failure.
+			if !s.isClosing() {
+				loopErr = err
+			}
 
 			break
 		}

--- a/pkg/svc/mirror/tunnelsession_test.go
+++ b/pkg/svc/mirror/tunnelsession_test.go
@@ -340,8 +340,11 @@ func TestTunnelSession_AcceptHonoursContextCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestTunnelSession_DuplicateOpenTearsDownSession(t *testing.T) {
-	t.Parallel()
+// newFeedSession creates a server-role session whose inbound frames the test
+// hand-crafts through the returned pipe writer; outbound frames are
+// discarded. Shared by the protocol-error tests.
+func newFeedSession(t *testing.T) (*mirror.TunnelSession, *io.PipeWriter) {
+	t.Helper()
 
 	feedReader, feedWriter := io.Pipe()
 	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
@@ -349,6 +352,14 @@ func TestTunnelSession_DuplicateOpenTearsDownSession(t *testing.T) {
 	t.Cleanup(func() {
 		_ = session.Close()
 	})
+
+	return session, feedWriter
+}
+
+func TestTunnelSession_DuplicateOpenTearsDownSession(t *testing.T) {
+	t.Parallel()
+
+	session, feedWriter := newFeedSession(t)
 
 	openFrame := mirror.Frame{StreamID: 1, Type: mirror.FrameOpen, Payload: nil}
 
@@ -364,12 +375,7 @@ func TestTunnelSession_DuplicateOpenTearsDownSession(t *testing.T) {
 func TestTunnelSession_DataForUnknownStreamIsDropped(t *testing.T) {
 	t.Parallel()
 
-	feedReader, feedWriter := io.Pipe()
-	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
-
-	t.Cleanup(func() {
-		_ = session.Close()
-	})
+	session, feedWriter := newFeedSession(t)
 
 	go func() {
 		_ = mirror.WriteFrame(feedWriter, mirror.Frame{
@@ -392,12 +398,7 @@ func TestTunnelSession_DataForUnknownStreamIsDropped(t *testing.T) {
 func TestTunnelSession_PeerEOFTearsDownCleanly(t *testing.T) {
 	t.Parallel()
 
-	feedReader, feedWriter := io.Pipe()
-	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
-
-	t.Cleanup(func() {
-		_ = session.Close()
-	})
+	session, feedWriter := newFeedSession(t)
 
 	require.NoError(t, feedWriter.Close())
 
@@ -408,12 +409,7 @@ func TestTunnelSession_PeerEOFTearsDownCleanly(t *testing.T) {
 func TestTunnelSession_TransportErrorSurfacesOnErr(t *testing.T) {
 	t.Parallel()
 
-	feedReader, feedWriter := io.Pipe()
-	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
-
-	t.Cleanup(func() {
-		_ = session.Close()
-	})
+	session, feedWriter := newFeedSession(t)
 
 	require.NoError(t, feedWriter.CloseWithError(errTransportTorn))
 

--- a/pkg/svc/mirror/tunnelsession_test.go
+++ b/pkg/svc/mirror/tunnelsession_test.go
@@ -1,0 +1,434 @@
+package mirror_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testTimeout bounds every blocking wait in these tests so a mux bug fails
+// fast instead of hanging the suite.
+const testTimeout = 5 * time.Second
+
+// errUnexpectedRequest reports a server-side payload mismatch from a test
+// goroutine, where assertions must not run.
+var errUnexpectedRequest = errors.New("unexpected request payload")
+
+// errTransportTorn stands in for a transport failure under the session.
+var errTransportTorn = errors.New("transport torn")
+
+// newSessionPair joins a client and a server session with in-memory pipes,
+// exactly as the exec stream will join them in Phase 2.
+func newSessionPair(t *testing.T) (*mirror.TunnelSession, *mirror.TunnelSession) {
+	t.Helper()
+
+	clientReader, serverWriter := io.Pipe()
+	serverReader, clientWriter := io.Pipe()
+
+	client := mirror.NewTunnelSession(clientReader, clientWriter, mirror.TunnelRoleClient)
+	server := mirror.NewTunnelSession(serverReader, serverWriter, mirror.TunnelRoleServer)
+
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	return client, server
+}
+
+// acceptContext returns a context that bounds an AcceptStream wait.
+func acceptContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	t.Cleanup(cancel)
+
+	return ctx
+}
+
+func TestTunnelSession_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+
+	ctx := acceptContext(t)
+	serverDone := make(chan error, 1)
+
+	go func() {
+		accepted, err := server.AcceptStream(ctx)
+		if err != nil {
+			serverDone <- err
+
+			return
+		}
+
+		request := make([]byte, len("hello"))
+
+		_, err = io.ReadFull(accepted, request)
+		if err != nil {
+			serverDone <- err
+
+			return
+		}
+
+		if string(request) != "hello" {
+			serverDone <- fmt.Errorf("%w: %q", errUnexpectedRequest, request)
+
+			return
+		}
+
+		_, err = accepted.Write([]byte("world"))
+		serverDone <- err
+	}()
+
+	stream, err := client.OpenStream()
+	require.NoError(t, err)
+
+	_, err = stream.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	response := make([]byte, len("world"))
+
+	_, err = io.ReadFull(stream, response)
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(response))
+
+	require.NoError(t, <-serverDone)
+}
+
+func TestTunnelSession_StreamIDParityNeverCollides(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+
+	clientFirst, err := client.OpenStream()
+	require.NoError(t, err)
+
+	clientSecond, err := client.OpenStream()
+	require.NoError(t, err)
+
+	serverFirst, err := server.OpenStream()
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(1), clientFirst.StreamID())
+	assert.Equal(t, uint32(3), clientSecond.StreamID())
+	assert.Equal(t, uint32(2), serverFirst.StreamID())
+}
+
+func TestTunnelSession_ConcurrentStreamsDoNotCrossTalk(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+
+	const streamCount = 4
+
+	ctx := acceptContext(t)
+
+	// The server echoes every accepted stream back until the peer closes it.
+	for range streamCount {
+		go func() {
+			accepted, err := server.AcceptStream(ctx)
+			if err != nil {
+				return
+			}
+
+			_, _ = io.Copy(accepted, accepted)
+			_ = accepted.Close()
+		}()
+	}
+
+	var waitGroup sync.WaitGroup
+
+	results := make(chan error, streamCount)
+
+	for index := range streamCount {
+		waitGroup.Go(func() {
+			results <- echoOnce(client, fmt.Sprintf("stream-%d-payload", index))
+		})
+	}
+
+	waitGroup.Wait()
+	close(results)
+
+	for err := range results {
+		require.NoError(t, err)
+	}
+}
+
+// echoOnce opens a stream, sends message, and verifies the peer echoes it
+// back verbatim before closing the stream. It runs in test goroutines, so it
+// reports by error instead of asserting.
+func echoOnce(session *mirror.TunnelSession, message string) error {
+	stream, err := session.OpenStream()
+	if err != nil {
+		return fmt.Errorf("opening stream: %w", err)
+	}
+
+	_, err = stream.Write([]byte(message))
+	if err != nil {
+		return fmt.Errorf("writing message: %w", err)
+	}
+
+	echoed := make([]byte, len(message))
+
+	_, err = io.ReadFull(stream, echoed)
+	if err != nil {
+		return fmt.Errorf("reading echo: %w", err)
+	}
+
+	if string(echoed) != message {
+		return fmt.Errorf("%w: %q", errUnexpectedRequest, echoed)
+	}
+
+	err = stream.Close()
+	if err != nil {
+		return fmt.Errorf("closing stream: %w", err)
+	}
+
+	return nil
+}
+
+func TestTunnelStream_ChunksWritesLargerThanMaxPayload(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+
+	payload := make([]byte, mirror.MaxTunnelPayload+mirror.MaxTunnelPayload/2)
+	for index := range payload {
+		payload[index] = byte(index % 251)
+	}
+
+	ctx := acceptContext(t)
+	received := make(chan []byte, 1)
+	serverErr := make(chan error, 1)
+
+	go func() {
+		accepted, err := server.AcceptStream(ctx)
+		if err != nil {
+			serverErr <- err
+
+			return
+		}
+
+		buffer := make([]byte, len(payload))
+
+		_, err = io.ReadFull(accepted, buffer)
+		serverErr <- err
+
+		received <- buffer
+	}()
+
+	stream, err := client.OpenStream()
+	require.NoError(t, err)
+
+	count, err := stream.Write(payload)
+	require.NoError(t, err)
+	assert.Equal(t, len(payload), count)
+
+	require.NoError(t, <-serverErr)
+	assert.Equal(t, payload, <-received)
+}
+
+func TestTunnelStream_CloseUnblocksPeerReadsWithEOF(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+
+	stream, err := client.OpenStream()
+	require.NoError(t, err)
+
+	_, err = stream.Write([]byte("bye"))
+	require.NoError(t, err)
+	require.NoError(t, stream.Close())
+
+	accepted, err := server.AcceptStream(acceptContext(t))
+	require.NoError(t, err)
+
+	drained, err := io.ReadAll(accepted)
+	require.NoError(t, err)
+	assert.Equal(t, "bye", string(drained))
+}
+
+func TestTunnelStream_DoubleCloseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSessionPair(t)
+
+	stream, err := client.OpenStream()
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Close())
+	require.NoError(t, stream.Close())
+}
+
+func TestTunnelStream_WriteAfterCloseFails(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSessionPair(t)
+
+	stream, err := client.OpenStream()
+	require.NoError(t, err)
+	require.NoError(t, stream.Close())
+
+	_, err = stream.Write([]byte("late"))
+	require.ErrorIs(t, err, mirror.ErrTunnelStreamClosed)
+}
+
+func TestTunnelStream_ReadAfterLocalCloseFails(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSessionPair(t)
+
+	stream, err := client.OpenStream()
+	require.NoError(t, err)
+	require.NoError(t, stream.Close())
+
+	_, err = stream.Read(make([]byte, 1))
+	require.ErrorIs(t, err, mirror.ErrTunnelStreamClosed)
+}
+
+func TestTunnelSession_CloseUnblocksAcceptAndOpen(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSessionPair(t)
+
+	require.NoError(t, client.Close())
+
+	waitDone(t, client)
+
+	_, err := client.AcceptStream(acceptContext(t))
+	require.ErrorIs(t, err, mirror.ErrTunnelSessionClosed)
+
+	_, err = client.OpenStream()
+	require.ErrorIs(t, err, mirror.ErrTunnelSessionClosed)
+}
+
+func TestTunnelSession_CloseSurfacesOnOpenStreams(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+
+	stream, err := client.OpenStream()
+	require.NoError(t, err)
+
+	require.NoError(t, client.Close())
+
+	_, err = stream.Read(make([]byte, 1))
+	require.ErrorIs(t, err, mirror.ErrTunnelSessionClosed)
+
+	// The server's side of the tunnel lost its transport; it tears down too.
+	waitDone(t, server)
+}
+
+func TestTunnelSession_AcceptHonoursContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSessionPair(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.AcceptStream(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestTunnelSession_DuplicateOpenTearsDownSession(t *testing.T) {
+	t.Parallel()
+
+	feedReader, feedWriter := io.Pipe()
+	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
+
+	t.Cleanup(func() {
+		_ = session.Close()
+	})
+
+	openFrame := mirror.Frame{StreamID: 1, Type: mirror.FrameOpen, Payload: nil}
+
+	go func() {
+		_ = mirror.WriteFrame(feedWriter, openFrame)
+		_ = mirror.WriteFrame(feedWriter, openFrame)
+	}()
+
+	waitDone(t, session)
+	require.ErrorIs(t, session.Err(), mirror.ErrTunnelDuplicateOpen)
+}
+
+func TestTunnelSession_DataForUnknownStreamIsDropped(t *testing.T) {
+	t.Parallel()
+
+	feedReader, feedWriter := io.Pipe()
+	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
+
+	t.Cleanup(func() {
+		_ = session.Close()
+	})
+
+	go func() {
+		_ = mirror.WriteFrame(feedWriter, mirror.Frame{
+			StreamID: 9,
+			Type:     mirror.FrameData,
+			Payload:  []byte("orphan"),
+		})
+		_ = mirror.WriteFrame(
+			feedWriter,
+			mirror.Frame{StreamID: 1, Type: mirror.FrameOpen, Payload: nil},
+		)
+	}()
+
+	accepted, err := session.AcceptStream(acceptContext(t))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), accepted.StreamID())
+	require.NoError(t, session.Err())
+}
+
+func TestTunnelSession_PeerEOFTearsDownCleanly(t *testing.T) {
+	t.Parallel()
+
+	feedReader, feedWriter := io.Pipe()
+	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
+
+	t.Cleanup(func() {
+		_ = session.Close()
+	})
+
+	require.NoError(t, feedWriter.Close())
+
+	waitDone(t, session)
+	require.NoError(t, session.Err())
+}
+
+func TestTunnelSession_TransportErrorSurfacesOnErr(t *testing.T) {
+	t.Parallel()
+
+	feedReader, feedWriter := io.Pipe()
+	session := mirror.NewTunnelSession(feedReader, io.Discard, mirror.TunnelRoleServer)
+
+	t.Cleanup(func() {
+		_ = session.Close()
+	})
+
+	require.NoError(t, feedWriter.CloseWithError(errTransportTorn))
+
+	waitDone(t, session)
+	require.ErrorIs(t, session.Err(), errTransportTorn)
+}
+
+// waitDone fails the test if the session's demux loop does not exit within
+// the test timeout.
+func waitDone(t *testing.T, session *mirror.TunnelSession) {
+	t.Helper()
+
+	select {
+	case <-session.Done():
+	case <-time.After(testTimeout):
+		t.Fatal("tunnel session did not tear down in time")
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Phase 2 of service mirroring (intercept) needs many intercepted connections to share the single exec channel into the cluster. The frame codec shipped earlier defines the wire format, but nothing yet turned frames into usable per-connection streams.

## What

Adds the tunnel's session layer: each end can open and accept independent bidirectional streams that are transparently multiplexed over the one channel, with safe teardown and backpressure semantics pinned by tests. Pure in-process logic — next increments (traffic steering, in-cluster agent) build on it.

Fixes #5823 · Part of #4521
