### PR TITLE
feat(operator): implement Connector for EKS (AWS SDK-built kubeconfig)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -178,6 +178,14 @@ linters:
             # armcontainerservice for the management plane, azcore/azidentity for
             # transport and the DefaultAzureCredential chain.
             - github.com/Azure/azure-sdk-for-go
+            # github.com/aws/aws-sdk-go-v2 is the official native AWS SDK backing
+            # pkg/client/eks (EKS control-plane reads + bearer-token minting for the
+            # operator Connector, #5825): service/eks for DescribeCluster, service/sts
+            # for the presigned GetCallerIdentity token, smithy-go for the signed
+            # headers that bind it to a cluster. Already linked transitively via the
+            # go-containerregistry ECR credential stack.
+            - github.com/aws/aws-sdk-go-v2
+            - github.com/aws/smithy-go
             - filippo.io/age
             - golang.design/x
             # x/crypto/ssh backs pkg/svc/bootstrap/ssh — the post-provision

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,12 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/apricote/hcloud-upload-image/hcloudimages v1.4.0
 	github.com/atotto/clipboard v0.1.4
+	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2/config v1.32.17
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
+	github.com/aws/aws-sdk-go-v2/service/eks v1.48.5
+	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
+	github.com/aws/smithy-go v1.25.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
@@ -235,10 +241,7 @@ require (
 	github.com/ashanbrown/forbidigo/v2 v2.3.0 // indirect
 	github.com/ashanbrown/makezero/v2 v2.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.17 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.18 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
@@ -246,7 +249,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.10 // indirect
-	github.com/aws/aws-sdk-go-v2/service/eks v1.48.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
@@ -257,8 +259,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -1,0 +1,160 @@
+package eks
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+const (
+	// v1SchemePrefix is the scheme aws-iam-authenticator defined for EKS
+	// bearer tokens: the prefix followed by the base64url-encoded presigned
+	// STS GetCallerIdentity URL.
+	v1SchemePrefix = "k8s-aws-v1."
+	// clusterIDHeader is the signed header that binds a presigned
+	// GetCallerIdentity URL to one EKS cluster, so a token minted for this
+	// cluster cannot authenticate against another.
+	clusterIDHeader = "x-k8s-aws-id"
+	// expiresHeader caps the presigned URL's validity; EKS rejects tokens
+	// whose X-Amz-Expires exceeds 15 minutes.
+	expiresHeader = "X-Amz-Expires"
+	// presignExpirySeconds mirrors aws-iam-authenticator's 60-second default —
+	// the operator consumes the token immediately, so the shortest standard
+	// window is enough.
+	presignExpirySeconds = "60"
+)
+
+// clusterDescriber is the narrow seam over the EKS SDK operation this
+// package uses, so tests can inject a fake without AWS credentials.
+// *awseks.Client satisfies it.
+type clusterDescriber interface {
+	DescribeCluster(
+		ctx context.Context,
+		params *awseks.DescribeClusterInput,
+		optFns ...func(*awseks.Options),
+	) (*awseks.DescribeClusterOutput, error)
+}
+
+// callerIdentityPresigner is the seam over the STS presign client that mints
+// the signed URL inside an EKS bearer token. *sts.PresignClient satisfies it.
+type callerIdentityPresigner interface {
+	PresignGetCallerIdentity(
+		ctx context.Context,
+		params *sts.GetCallerIdentityInput,
+		optFns ...func(*sts.PresignOptions),
+	) (*v4.PresignedHTTPRequest, error)
+}
+
+// Client reads EKS cluster connection details and mints bearer tokens for
+// them, hiding the SDK's request shapes and the token encoding scheme.
+type Client struct {
+	describer clusterDescriber
+	presigner callerIdentityPresigner
+}
+
+// Option customises a Client.
+type Option func(*Client)
+
+// WithClusterDescriber injects the DescribeCluster implementation, letting
+// tests substitute a fake for the real SDK client.
+func WithClusterDescriber(describer clusterDescriber) Option {
+	return func(client *Client) {
+		client.describer = describer
+	}
+}
+
+// WithCallerIdentityPresigner injects the STS presigner, letting tests
+// substitute a fake or a statically-credentialed presign client.
+func WithCallerIdentityPresigner(presigner callerIdentityPresigner) Option {
+	return func(client *Client) {
+		client.presigner = presigner
+	}
+}
+
+// NewClient constructs a Client. Unless both seams are injected, it resolves
+// the AWS default configuration (env, shared config, IRSA / instance
+// role) once and builds the real SDK clients from it.
+func NewClient(ctx context.Context, region string, opts ...Option) (*Client, error) {
+	client := &Client{
+		describer: nil,
+		presigner: nil,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	if client.describer == nil || client.presigner == nil {
+		cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+		if err != nil {
+			return nil, fmt.Errorf("loading aws configuration: %w", err)
+		}
+
+		if client.describer == nil {
+			client.describer = awseks.NewFromConfig(cfg)
+		}
+
+		if client.presigner == nil {
+			client.presigner = sts.NewPresignClient(sts.NewFromConfig(cfg))
+		}
+	}
+
+	return client, nil
+}
+
+// DescribeCluster returns the named EKS cluster's control-plane details.
+func (c *Client) DescribeCluster(ctx context.Context, name string) (*ekstypes.Cluster, error) {
+	out, err := c.describer.DescribeCluster(
+		ctx,
+		&awseks.DescribeClusterInput{Name: aws.String(name)},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("describing eks cluster %s: %w", name, err)
+	}
+
+	if out == nil || out.Cluster == nil {
+		return nil, fmt.Errorf("%w: %s", ErrClusterNotFound, name)
+	}
+
+	return out.Cluster, nil
+}
+
+// MintToken mints the standard EKS bearer token for the named cluster: a
+// presigned STS GetCallerIdentity URL carrying the cluster-binding header,
+// base64url-encoded under the k8s-aws-v1 prefix. The token inherits the
+// presigner's credentials and is valid for tokenExpirySeconds.
+func (c *Client) MintToken(ctx context.Context, clusterName string) (string, error) {
+	request, err := c.presigner.PresignGetCallerIdentity(
+		ctx,
+		&sts.GetCallerIdentityInput{},
+		func(options *sts.PresignOptions) {
+			options.ClientOptions = append(options.ClientOptions, withTokenHeaders(clusterName))
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("presigning sts get-caller-identity: %w", err)
+	}
+
+	return v1SchemePrefix + base64.RawURLEncoding.EncodeToString([]byte(request.URL)), nil
+}
+
+// withTokenHeaders adds the signed headers that turn a plain presigned
+// GetCallerIdentity URL into an EKS token: the cluster binding and the
+// expiry cap.
+func withTokenHeaders(clusterName string) func(*sts.Options) {
+	return func(options *sts.Options) {
+		options.APIOptions = append(
+			options.APIOptions,
+			smithyhttp.SetHeaderValue(clusterIDHeader, clusterName),
+			smithyhttp.SetHeaderValue(expiresHeader, presignExpirySeconds),
+		)
+	}
+}

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -130,7 +130,7 @@ func (c *Client) DescribeCluster(ctx context.Context, name string) (*ekstypes.Cl
 // MintToken mints the standard EKS bearer token for the named cluster: a
 // presigned STS GetCallerIdentity URL carrying the cluster-binding header,
 // base64url-encoded under the k8s-aws-v1 prefix. The token inherits the
-// presigner's credentials and is valid for tokenExpirySeconds.
+// presigner's credentials and is valid for presignExpirySeconds.
 func (c *Client) MintToken(ctx context.Context, clusterName string) (string, error) {
 	request, err := c.presigner.PresignGetCallerIdentity(
 		ctx,

--- a/pkg/client/eks/client_test.go
+++ b/pkg/client/eks/client_test.go
@@ -1,0 +1,177 @@
+package eks_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errBoom = errors.New("boom")
+
+// fakeDescriber scripts the DescribeCluster seam.
+type fakeDescriber struct {
+	out *awseks.DescribeClusterOutput
+	err error
+}
+
+func (f fakeDescriber) DescribeCluster(
+	_ context.Context,
+	_ *awseks.DescribeClusterInput,
+	_ ...func(*awseks.Options),
+) (*awseks.DescribeClusterOutput, error) {
+	return f.out, f.err
+}
+
+// fakePresigner scripts the STS presign seam.
+type fakePresigner struct {
+	request *v4.PresignedHTTPRequest
+	err     error
+}
+
+func (f fakePresigner) PresignGetCallerIdentity(
+	_ context.Context,
+	_ *sts.GetCallerIdentityInput,
+	_ ...func(*sts.PresignOptions),
+) (*v4.PresignedHTTPRequest, error) {
+	return f.request, f.err
+}
+
+// newTestClient wires a Client from injected seams so no AWS configuration
+// is resolved.
+func newTestClient(
+	t *testing.T,
+	describer fakeDescriber,
+	presigner fakePresigner,
+) *eksclient.Client {
+	t.Helper()
+
+	client, err := eksclient.NewClient(
+		t.Context(),
+		"eu-central-1",
+		eksclient.WithClusterDescriber(describer),
+		eksclient.WithCallerIdentityPresigner(presigner),
+	)
+	require.NoError(t, err)
+
+	return client
+}
+
+func TestDescribeClusterReturnsPayload(t *testing.T) {
+	t.Parallel()
+
+	cluster := &ekstypes.Cluster{Status: ekstypes.ClusterStatusActive}
+	client := newTestClient(
+		t,
+		fakeDescriber{out: &awseks.DescribeClusterOutput{Cluster: cluster}, err: nil},
+		fakePresigner{request: nil, err: nil},
+	)
+
+	got, err := client.DescribeCluster(t.Context(), "eks-default")
+	require.NoError(t, err)
+	assert.Same(t, cluster, got)
+}
+
+func TestDescribeClusterWrapsError(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(
+		t,
+		fakeDescriber{out: nil, err: errBoom},
+		fakePresigner{request: nil, err: nil},
+	)
+
+	_, err := client.DescribeCluster(t.Context(), "eks-default")
+	require.ErrorIs(t, err, errBoom)
+	require.ErrorContains(t, err, "describing eks cluster eks-default")
+}
+
+func TestDescribeClusterRejectsEmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(
+		t,
+		fakeDescriber{out: &awseks.DescribeClusterOutput{Cluster: nil}, err: nil},
+		fakePresigner{request: nil, err: nil},
+	)
+
+	_, err := client.DescribeCluster(t.Context(), "eks-default")
+	require.ErrorIs(t, err, eksclient.ErrClusterNotFound)
+}
+
+func TestMintTokenEncodesPresignedURL(t *testing.T) {
+	t.Parallel()
+
+	presignedURL := "https://sts.eu-central-1.amazonaws.com/?Action=GetCallerIdentity"
+	client := newTestClient(
+		t,
+		fakeDescriber{out: nil, err: nil},
+		fakePresigner{request: &v4.PresignedHTTPRequest{URL: presignedURL}, err: nil},
+	)
+
+	token, err := client.MintToken(t.Context(), "eks-default")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(token, "k8s-aws-v1."))
+
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, "k8s-aws-v1."))
+	require.NoError(t, err)
+	assert.Equal(t, presignedURL, string(decoded))
+}
+
+func TestMintTokenPropagatesPresignError(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(
+		t,
+		fakeDescriber{out: nil, err: nil},
+		fakePresigner{request: nil, err: errBoom},
+	)
+
+	_, err := client.MintToken(t.Context(), "eks-default")
+	require.ErrorIs(t, err, errBoom)
+}
+
+// TestMintTokenSignsClusterBindingHeaders runs the real STS presigner with
+// static credentials (signing is offline — no network) and pins the token
+// contract EKS validates: the cluster-binding header is signed and the
+// expiry cap is present.
+func TestMintTokenSignsClusterBindingHeaders(t *testing.T) {
+	t.Parallel()
+
+	stsClient := sts.New(sts.Options{
+		Region:      "eu-central-1",
+		Credentials: credentials.NewStaticCredentialsProvider("AKIDEXAMPLE", "test-secret", ""),
+	})
+	client, err := eksclient.NewClient(
+		t.Context(),
+		"eu-central-1",
+		eksclient.WithClusterDescriber(fakeDescriber{out: nil, err: nil}),
+		eksclient.WithCallerIdentityPresigner(sts.NewPresignClient(stsClient)),
+	)
+	require.NoError(t, err)
+
+	token, err := client.MintToken(t.Context(), "eks-default")
+	require.NoError(t, err)
+
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, "k8s-aws-v1."))
+	require.NoError(t, err)
+
+	signedURL, err := url.Parse(string(decoded))
+	require.NoError(t, err)
+
+	query := signedURL.Query()
+	assert.Equal(t, "GetCallerIdentity", query.Get("Action"))
+	assert.Equal(t, "60", query.Get("X-Amz-Expires"))
+	assert.Contains(t, query.Get("X-Amz-SignedHeaders"), "x-k8s-aws-id")
+}

--- a/pkg/client/eks/doc.go
+++ b/pkg/client/eks/doc.go
@@ -1,0 +1,7 @@
+// Package eks wraps the AWS SDK operations the EKS connector needs:
+// describing a cluster (endpoint, CA, status) and minting the standard EKS
+// bearer token (a presigned STS GetCallerIdentity URL). It complements
+// pkg/client/eksctl, which drives cluster lifecycle through the eksctl
+// binary — this package is for the operator-side read/auth path, where
+// shelling out is not an option.
+package eks

--- a/pkg/client/eks/errors.go
+++ b/pkg/client/eks/errors.go
@@ -1,0 +1,7 @@
+package eks
+
+import "errors"
+
+// ErrClusterNotFound is returned when DescribeCluster succeeds but the
+// response carries no cluster payload.
+var ErrClusterNotFound = errors.New("eks cluster not found")

--- a/pkg/svc/provisioner/cluster/eks/connector.go
+++ b/pkg/svc/provisioner/cluster/eks/connector.go
@@ -74,6 +74,13 @@ func (p *Provisioner) Kubeconfig(ctx context.Context, name string) ([]byte, erro
 // from a described cluster, returning clustererr.ErrKubeconfigNotReady until
 // an ACTIVE cluster serves both.
 func clusterConnection(name string, cluster *ekstypes.Cluster) (string, []byte, error) {
+	if cluster == nil {
+		return "", nil, fmt.Errorf(
+			"%w: eks cluster %q has no payload",
+			clustererr.ErrKubeconfigNotReady, name,
+		)
+	}
+
 	endpoint := aws.ToString(cluster.Endpoint)
 
 	var caCertificate string

--- a/pkg/svc/provisioner/cluster/eks/connector.go
+++ b/pkg/svc/provisioner/cluster/eks/connector.go
@@ -1,0 +1,120 @@
+package eksprovisioner
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeconfigwriter"
+)
+
+// AWSClusterAPI is the narrow seam over the AWS-SDK-backed EKS client the
+// connector uses, so tests can inject a fake without AWS credentials.
+// *pkg/client/eks.Client satisfies it.
+type AWSClusterAPI interface {
+	// DescribeCluster returns the named cluster's control-plane details.
+	DescribeCluster(ctx context.Context, name string) (*ekstypes.Cluster, error)
+	// MintToken mints an EKS bearer token bound to the named cluster.
+	MintToken(ctx context.Context, clusterName string) (string, error)
+}
+
+// Kubeconfig implements the clusterprovisioner.Connector capability for an
+// EKS cluster: it builds a kubeconfig from the cluster's own control-plane
+// endpoint and CA (public to the operator, no address rewrite needed) with a
+// bearer token minted from the AWS credentials the operator runs under (IRSA
+// or an instance role unless a client was injected). Tokens are short-lived
+// by design — the operator calls Kubeconfig on each reconcile and the
+// installers consume it immediately. It returns
+// clustererr.ErrKubeconfigNotReady while the cluster is still provisioning
+// so the caller requeues.
+func (p *Provisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	target := p.resolveName(name)
+	if target == "" {
+		return nil, fmt.Errorf("%w: no cluster name configured", ErrClusterNameRequired)
+	}
+
+	api, err := p.resolveAWSClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := api.DescribeCluster(ctx, target)
+	if err != nil {
+		return nil, fmt.Errorf("eks describe cluster: %w", err)
+	}
+
+	endpoint, certificateAuthority, err := clusterConnection(target, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := api.MintToken(ctx, target)
+	if err != nil {
+		return nil, fmt.Errorf("minting eks bearer token: %w", err)
+	}
+
+	raw, err := kubeconfigwriter.Write(
+		fmt.Sprintf("eks_%s_%s", p.region, target),
+		endpoint,
+		certificateAuthority,
+		token,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("eks kubeconfig: %w", err)
+	}
+
+	return raw, nil
+}
+
+// clusterConnection extracts the operator-reachable endpoint and decoded CA
+// from a described cluster, returning clustererr.ErrKubeconfigNotReady until
+// an ACTIVE cluster serves both.
+func clusterConnection(name string, cluster *ekstypes.Cluster) (string, []byte, error) {
+	endpoint := aws.ToString(cluster.Endpoint)
+
+	var caCertificate string
+	if cluster.CertificateAuthority != nil {
+		caCertificate = aws.ToString(cluster.CertificateAuthority.Data)
+	}
+
+	if cluster.Status != ekstypes.ClusterStatusActive || endpoint == "" || caCertificate == "" {
+		return "", nil, fmt.Errorf(
+			"%w: eks cluster %q is %s",
+			clustererr.ErrKubeconfigNotReady, name, cluster.Status,
+		)
+	}
+
+	certificateAuthority, err := base64.StdEncoding.DecodeString(caCertificate)
+	if err != nil {
+		return "", nil, fmt.Errorf("decoding eks cluster CA certificate: %w", err)
+	}
+
+	return endpoint, certificateAuthority, nil
+}
+
+// resolveAWSClient returns the injected AWS client, lazily constructing and
+// caching the real SDK-backed one when none was injected. Construction is
+// deferred to first connector use (and a failed construction is not cached)
+// because the CLI lifecycle paths drive eksctl and never need AWS
+// credentials resolved.
+func (p *Provisioner) resolveAWSClient(ctx context.Context) (AWSClusterAPI, error) {
+	p.awsMu.Lock()
+	defer p.awsMu.Unlock()
+
+	if p.awsClient != nil {
+		return p.awsClient, nil
+	}
+
+	client, err := eksclient.NewClient(ctx, p.region)
+	if err != nil {
+		return nil, fmt.Errorf("creating aws eks client: %w", err)
+	}
+
+	p.awsClient = client
+
+	return client, nil
+}

--- a/pkg/svc/provisioner/cluster/eks/connector_test.go
+++ b/pkg/svc/provisioner/cluster/eks/connector_test.go
@@ -130,6 +130,10 @@ func TestKubeconfigNotReadyWhileProvisioning(t *testing.T) {
 			},
 		},
 		{
+			name:    "nil cluster payload",
+			cluster: nil,
+		},
+		{
 			name:    "active without endpoint",
 			cluster: activeCluster("", caBase64),
 		},

--- a/pkg/svc/provisioner/cluster/eks/connector_test.go
+++ b/pkg/svc/provisioner/cluster/eks/connector_test.go
@@ -1,0 +1,219 @@
+package eksprovisioner_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	eksprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var errConnectorBoom = errors.New("connector boom")
+
+// fakeAWSClusterAPI scripts the connector's AWS seam per test. A nil
+// describeFunc fails with errConnectorBoom; a nil mintFunc returns a static
+// happy-path token.
+type fakeAWSClusterAPI struct {
+	describeFunc func(name string) (*ekstypes.Cluster, error)
+	mintFunc     func(clusterName string) (string, error)
+}
+
+func (f *fakeAWSClusterAPI) DescribeCluster(
+	_ context.Context,
+	name string,
+) (*ekstypes.Cluster, error) {
+	if f.describeFunc == nil {
+		return nil, errConnectorBoom
+	}
+
+	return f.describeFunc(name)
+}
+
+func (f *fakeAWSClusterAPI) MintToken(_ context.Context, clusterName string) (string, error) {
+	if f.mintFunc == nil {
+		return "test-token", nil
+	}
+
+	return f.mintFunc(clusterName)
+}
+
+// connectorCAPEM is the raw CA material tests round-trip through the base64
+// field the EKS API serves.
+func connectorCAPEM() []byte { return []byte("test-ca-pem") }
+
+func activeCluster(endpoint, caBase64 string) *ekstypes.Cluster {
+	return &ekstypes.Cluster{
+		Name:     aws.String("eks-default"),
+		Status:   ekstypes.ClusterStatusActive,
+		Endpoint: aws.String(endpoint),
+		CertificateAuthority: &ekstypes.Certificate{
+			Data: aws.String(caBase64),
+		},
+	}
+}
+
+// newConnectorProvisioner wires a Provisioner around the fake AWS seam. The
+// eksctl client is a default one — the connector path never shells out.
+func newConnectorProvisioner(
+	t *testing.T,
+	name string,
+	fake *fakeAWSClusterAPI,
+) *eksprovisioner.Provisioner {
+	t.Helper()
+
+	provisioner, err := eksprovisioner.NewProvisioner(
+		name, "eu-central-1", "",
+		eksctlclient.NewClient(),
+		nil,
+		eksprovisioner.WithAWSClusterAPI(fake),
+	)
+	require.NoError(t, err)
+
+	return provisioner
+}
+
+func TestKubeconfigBuildsOperatorUsableConfig(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAWSClusterAPI{
+		describeFunc: func(_ string) (*ekstypes.Cluster, error) {
+			return activeCluster(
+				"https://203.0.113.10",
+				base64.StdEncoding.EncodeToString(connectorCAPEM()),
+			), nil
+		},
+		mintFunc: nil,
+	}
+	provisioner := newConnectorProvisioner(t, "eks-default", fake)
+
+	raw, err := provisioner.Kubeconfig(t.Context(), "")
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(raw)
+	require.NoError(t, err)
+
+	contextName := "eks_eu-central-1_eks-default"
+	assert.Equal(t, contextName, config.CurrentContext)
+	require.Contains(t, config.Clusters, contextName)
+	assert.Equal(t, "https://203.0.113.10", config.Clusters[contextName].Server)
+	assert.Equal(t, connectorCAPEM(), config.Clusters[contextName].CertificateAuthorityData)
+	require.Contains(t, config.AuthInfos, contextName)
+	assert.Equal(t, "test-token", config.AuthInfos[contextName].Token)
+}
+
+func TestKubeconfigNotReadyWhileProvisioning(t *testing.T) {
+	t.Parallel()
+
+	caBase64 := base64.StdEncoding.EncodeToString(connectorCAPEM())
+
+	testCases := []struct {
+		name    string
+		cluster *ekstypes.Cluster
+	}{
+		{
+			name: "creating status",
+			cluster: &ekstypes.Cluster{
+				Name:     aws.String("eks-default"),
+				Status:   ekstypes.ClusterStatusCreating,
+				Endpoint: aws.String("https://203.0.113.10"),
+				CertificateAuthority: &ekstypes.Certificate{
+					Data: aws.String(caBase64),
+				},
+			},
+		},
+		{
+			name:    "active without endpoint",
+			cluster: activeCluster("", caBase64),
+		},
+		{
+			name:    "active without cluster CA",
+			cluster: activeCluster("https://203.0.113.10", ""),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeAWSClusterAPI{
+				describeFunc: func(_ string) (*ekstypes.Cluster, error) {
+					return testCase.cluster, nil
+				},
+				mintFunc: nil,
+			}
+			provisioner := newConnectorProvisioner(t, "eks-default", fake)
+
+			_, err := provisioner.Kubeconfig(t.Context(), "")
+			require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+		})
+	}
+}
+
+func TestKubeconfigRequiresClusterName(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newConnectorProvisioner(t, "", &fakeAWSClusterAPI{
+		describeFunc: nil,
+		mintFunc:     nil,
+	})
+
+	_, err := provisioner.Kubeconfig(t.Context(), "")
+	require.ErrorIs(t, err, eksprovisioner.ErrClusterNameRequired)
+}
+
+func TestKubeconfigPropagatesDescribeClusterError(t *testing.T) {
+	t.Parallel()
+
+	// describeFunc left nil: the fake's DescribeCluster fails with
+	// errConnectorBoom.
+	provisioner := newConnectorProvisioner(t, "eks-default", &fakeAWSClusterAPI{
+		describeFunc: nil,
+		mintFunc:     nil,
+	})
+
+	_, err := provisioner.Kubeconfig(t.Context(), "")
+	require.ErrorIs(t, err, errConnectorBoom)
+}
+
+func TestKubeconfigPropagatesTokenMintError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAWSClusterAPI{
+		describeFunc: func(_ string) (*ekstypes.Cluster, error) {
+			return activeCluster(
+				"https://203.0.113.10",
+				base64.StdEncoding.EncodeToString(connectorCAPEM()),
+			), nil
+		},
+		mintFunc: func(_ string) (string, error) {
+			return "", errConnectorBoom
+		},
+	}
+	provisioner := newConnectorProvisioner(t, "eks-default", fake)
+
+	_, err := provisioner.Kubeconfig(t.Context(), "")
+	require.ErrorIs(t, err, errConnectorBoom)
+}
+
+func TestKubeconfigRejectsMalformedClusterCA(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAWSClusterAPI{
+		describeFunc: func(_ string) (*ekstypes.Cluster, error) {
+			return activeCluster("https://203.0.113.10", "not-base64!"), nil
+		},
+		mintFunc: nil,
+	}
+	provisioner := newConnectorProvisioner(t, "eks-default", fake)
+
+	_, err := provisioner.Kubeconfig(t.Context(), "")
+	require.ErrorContains(t, err, "decoding eks cluster CA certificate")
+}

--- a/pkg/svc/provisioner/cluster/eks/errors.go
+++ b/pkg/svc/provisioner/cluster/eks/errors.go
@@ -9,3 +9,7 @@ var ErrClientRequired = errors.New("eksctl client is required")
 // supplied. The binary wrapper always accepts -f <config> rather than an
 // inline spec, so the caller must point at a config file.
 var ErrConfigPathRequired = errors.New("eksctl config path is required")
+
+// ErrClusterNameRequired is returned when a cluster-scoped call has neither
+// a caller-supplied name nor a configured default to act on.
+var ErrClusterNameRequired = errors.New("eks cluster name is required")

--- a/pkg/svc/provisioner/cluster/eks/provisioner.go
+++ b/pkg/svc/provisioner/cluster/eks/provisioner.go
@@ -3,6 +3,7 @@ package eksprovisioner
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
@@ -31,6 +32,23 @@ type Provisioner struct {
 	// infraProvider is the AWS provider used for Start/Stop semantics
 	// (nodegroup scale). Optional: if nil, Start/Stop return an error.
 	infraProvider provider.Provider
+	// awsClient serves the Connector capability (DescribeCluster + token
+	// minting via the AWS SDK). Injected in tests; lazily resolved from the
+	// operator's AWS credentials otherwise.
+	awsClient AWSClusterAPI
+	// awsMu guards the lazy awsClient resolution.
+	awsMu sync.Mutex
+}
+
+// Option customises a Provisioner beyond the required constructor arguments.
+type Option func(*Provisioner)
+
+// WithAWSClusterAPI injects the AWS-SDK-backed client the Connector
+// capability uses, letting tests substitute a fake.
+func WithAWSClusterAPI(api AWSClusterAPI) Option {
+	return func(p *Provisioner) {
+		p.awsClient = api
+	}
 }
 
 // NewProvisioner builds a Provisioner. The eksctl client must be non-nil;
@@ -39,18 +57,27 @@ func NewProvisioner(
 	name, region, configPath string,
 	client *eksctl.Client,
 	infraProvider provider.Provider,
+	opts ...Option,
 ) (*Provisioner, error) {
 	if client == nil {
 		return nil, ErrClientRequired
 	}
 
-	return &Provisioner{
+	provisioner := &Provisioner{
 		name:          name,
 		region:        region,
 		configPath:    configPath,
 		client:        client,
 		infraProvider: infraProvider,
-	}, nil
+		awsClient:     nil,
+		awsMu:         sync.Mutex{},
+	}
+
+	for _, opt := range opts {
+		opt(provisioner)
+	}
+
+	return provisioner, nil
 }
 
 // SetProvider sets the infrastructure provider used by Start/Stop.

--- a/pkg/svc/provisioner/cluster/gke/connector.go
+++ b/pkg/svc/provisioner/cluster/gke/connector.go
@@ -7,10 +7,9 @@ import (
 
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeconfigwriter"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // cloudPlatformScope is the OAuth scope GKE accepts for cluster API access;
@@ -61,12 +60,17 @@ func (p *Provisioner) Kubeconfig(ctx context.Context, name string) ([]byte, erro
 		return nil, err
 	}
 
-	return writeKubeconfig(
+	raw, err := kubeconfigwriter.Write(
 		fmt.Sprintf("gke_%s_%s_%s", p.project, location, target),
 		"https://"+endpoint,
 		certificateAuthority,
 		token,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("gke kubeconfig: %w", err)
+	}
+
+	return raw, nil
 }
 
 // accessToken mints a bearer token from the injected token source, falling
@@ -107,27 +111,4 @@ func (p *Provisioner) resolveTokenSource(ctx context.Context) (oauth2.TokenSourc
 	p.tokenSource = source
 
 	return source, nil
-}
-
-// writeKubeconfig serializes a single-context kubeconfig for the given
-// server, CA, and bearer token.
-func writeKubeconfig(contextName, server string, caData []byte, token string) ([]byte, error) {
-	config := clientcmdapi.NewConfig()
-	config.Clusters[contextName] = &clientcmdapi.Cluster{
-		Server:                   server,
-		CertificateAuthorityData: caData,
-	}
-	config.AuthInfos[contextName] = &clientcmdapi.AuthInfo{Token: token}
-	config.Contexts[contextName] = &clientcmdapi.Context{
-		Cluster:  contextName,
-		AuthInfo: contextName,
-	}
-	config.CurrentContext = contextName
-
-	raw, err := clientcmd.Write(*config)
-	if err != nil {
-		return nil, fmt.Errorf("serializing gke kubeconfig: %w", err)
-	}
-
-	return raw, nil
 }

--- a/pkg/svc/provisioner/cluster/kubeconfigwriter/kubeconfigwriter.go
+++ b/pkg/svc/provisioner/cluster/kubeconfigwriter/kubeconfigwriter.go
@@ -1,0 +1,35 @@
+// Package kubeconfigwriter serializes the minimal single-context kubeconfig
+// cloud connectors hand to the operator: one cluster (server + CA), one
+// bearer-token auth-info, one context. Shared so every connector emits the
+// same shape instead of each cloud package growing its own copy.
+package kubeconfigwriter
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Write serializes a single-context kubeconfig for the given server, CA, and
+// bearer token.
+func Write(contextName, server string, caData []byte, token string) ([]byte, error) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters[contextName] = &clientcmdapi.Cluster{
+		Server:                   server,
+		CertificateAuthorityData: caData,
+	}
+	config.AuthInfos[contextName] = &clientcmdapi.AuthInfo{Token: token}
+	config.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  contextName,
+		AuthInfo: contextName,
+	}
+	config.CurrentContext = contextName
+
+	raw, err := clientcmd.Write(*config)
+	if err != nil {
+		return nil, fmt.Errorf("serializing kubeconfig: %w", err)
+	}
+
+	return raw, nil
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The operator only installs a cluster's declared components (CNI, GitOps engine, …) when its provisioner can hand over a kubeconfig, and EKS was the last cloud distribution that couldn't — an EKS `Cluster` resource was provisioned and then left bare.

## What

EKS now implements the same Connector capability GKE shipped with: the operator gets a kubeconfig built from the cluster's endpoint/CA plus a standard short-lived EKS bearer token, minted from whatever AWS credentials the operator runs under. Fully unit-tested with no live-AWS dependency; live E2E stays gated on the AWS credential lane (platform#2324).

Note: `aws-sdk-go-v2` moves from a transitive to a direct dependency (no new modules enter the graph).

Fixes #5825
Part of #4899