### PR TITLE
feat(operator): implement Connector for AKS (ARM-fetched kubeconfig)

### DIFF
--- a/pkg/client/aks/client.go
+++ b/pkg/client/aks/client.go
@@ -161,6 +161,31 @@ func (c *Client) GetCluster(
 	return response.ManagedCluster, nil
 }
 
+// GetClusterUserCredentials fetches the named managed cluster's user
+// kubeconfig via the ARM ListClusterUserCredentials API, returning the first
+// kubeconfig payload the response carries. For clusters with local accounts
+// the payload embeds a client certificate and is usable as-is; for AAD-only
+// clusters (local accounts disabled) ARM instead returns an exec-plugin
+// (kubelogin) kubeconfig, which only authenticates where that plugin is
+// installed.
+func (c *Client) GetClusterUserCredentials(
+	ctx context.Context,
+	resourceGroup, name string,
+) ([]byte, error) {
+	response, err := c.managedClusters.ListClusterUserCredentials(ctx, resourceGroup, name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list cluster %q user credentials: %w", name, err)
+	}
+
+	for _, kubeconfig := range response.Kubeconfigs {
+		if kubeconfig != nil && len(kubeconfig.Value) > 0 {
+			return kubeconfig.Value, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: cluster %q", ErrNoKubeconfig, name)
+}
+
 // ListClusters lists the managed clusters in the given resource group, or —
 // when resourceGroup is empty — across the whole subscription (the AKS
 // counterpart to gke's all-locations wildcard).

--- a/pkg/client/aks/client_test.go
+++ b/pkg/client/aks/client_test.go
@@ -321,6 +321,100 @@ func TestGetClusterWrapsError(t *testing.T) {
 	require.ErrorContains(t, err, "ResourceNotFound")
 }
 
+// userCredentialsFactory wires the fake ListClusterUserCredentials endpoint to
+// serve the given credential entries.
+func userCredentialsFactory(
+	kubeconfigs []*armcontainerservice.CredentialResult,
+) *fake.ServerFactory {
+	return &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		ListClusterUserCredentials: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientListClusterUserCredentialsOptions,
+		) (
+			azfake.Responder[armcontainerservice.ManagedClustersClientListClusterUserCredentialsResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.Responder[armcontainerservice.ManagedClustersClientListClusterUserCredentialsResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			resp.SetResponse(
+				http.StatusOK,
+				armcontainerservice.ManagedClustersClientListClusterUserCredentialsResponse{
+					CredentialResults: armcontainerservice.CredentialResults{
+						Kubeconfigs: kubeconfigs,
+					},
+				},
+				nil,
+			)
+
+			return resp, errResp
+		},
+	}}
+}
+
+func TestGetClusterUserCredentialsReturnsFirstKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	kubeconfig := []byte("apiVersion: v1\nkind: Config\n")
+	name := "clusterUser"
+	factory := userCredentialsFactory([]*armcontainerservice.CredentialResult{
+		nil,
+		{Name: &name, Value: nil},
+		{Name: &name, Value: kubeconfig},
+	})
+
+	raw, err := newTestClient(t, factory).GetClusterUserCredentials(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig, raw)
+}
+
+func TestGetClusterUserCredentialsRejectsEmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	factory := userCredentialsFactory(nil)
+
+	_, err := newTestClient(t, factory).GetClusterUserCredentials(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.ErrorIs(t, err, aks.ErrNoKubeconfig)
+}
+
+func TestGetClusterUserCredentialsWrapsError(t *testing.T) {
+	t.Parallel()
+
+	factory := &fake.ServerFactory{ManagedClustersServer: fake.ManagedClustersServer{
+		ListClusterUserCredentials: func(
+			_ context.Context, _, _ string,
+			_ *armcontainerservice.ManagedClustersClientListClusterUserCredentialsOptions,
+		) (
+			azfake.Responder[armcontainerservice.ManagedClustersClientListClusterUserCredentialsResponse],
+			azfake.ErrorResponder,
+		) {
+			var (
+				resp    azfake.Responder[armcontainerservice.ManagedClustersClientListClusterUserCredentialsResponse]
+				errResp azfake.ErrorResponder
+			)
+
+			errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+
+			return resp, errResp
+		},
+	}}
+
+	_, err := newTestClient(t, factory).GetClusterUserCredentials(
+		t.Context(), testResourceGroup, testClusterName,
+	)
+
+	require.ErrorContains(t, err, "user credentials")
+	require.ErrorContains(t, err, "ResourceNotFound")
+}
+
 func TestListClustersAcrossSubscriptionDrainsAllPages(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/client/aks/errors.go
+++ b/pkg/client/aks/errors.go
@@ -18,3 +18,9 @@ var ErrOperationFailed = errors.New("aks: cluster operation failed")
 // API always populates properties on a live pool, so this signals a malformed
 // or partial API response rather than a caller mistake.
 var ErrAgentPoolPropertiesMissing = errors.New("agent pool has no properties to update")
+
+// ErrNoKubeconfig is returned by GetClusterUserCredentials when the
+// credentials response carries no kubeconfig payload. ARM always returns at
+// least one kubeconfig for a provisioned cluster, so this signals a malformed
+// or partial API response rather than a caller mistake.
+var ErrNoKubeconfig = errors.New("aks cluster credentials carry no kubeconfig")

--- a/pkg/svc/provisioner/cluster/aks/connector.go
+++ b/pkg/svc/provisioner/cluster/aks/connector.go
@@ -1,0 +1,68 @@
+package aksprovisioner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+)
+
+// provisioningStateSucceeded is the ARM provisioning state of a managed
+// cluster whose control plane is fully provisioned — the AKS counterpart to
+// the GKE connector's RUNNING gate and the EKS connector's ACTIVE gate.
+const provisioningStateSucceeded = "Succeeded"
+
+// Kubeconfig implements the clusterprovisioner.Connector capability for an
+// AKS cluster. Unlike GKE/EKS — where the connector assembles a kubeconfig
+// from the control-plane endpoint, CA, and a freshly minted bearer token —
+// ARM serves a ready-made kubeconfig via ListClusterUserCredentials, with the
+// server set to the cluster's FQDN (reachable from wherever the operator
+// runs, no address rewrite needed) and, for clusters with local accounts, an
+// embedded client certificate that authenticates without ambient Azure
+// credentials. AAD-only clusters (local accounts disabled) instead get an
+// exec-plugin kubeconfig that needs kubelogin, which the operator image does
+// not carry — a documented limitation of this increment. It returns
+// clustererr.ErrKubeconfigNotReady until the cluster's provisioning state is
+// Succeeded so the caller requeues.
+func (p *Provisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	target := p.resolveName(name)
+	if target == "" {
+		return nil, fmt.Errorf("%w: no cluster name configured", ErrClusterNotFound)
+	}
+
+	resourceGroup, err := p.resolveResourceGroup(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := p.client.GetCluster(ctx, resourceGroup, target)
+	if err != nil {
+		return nil, fmt.Errorf("aks get cluster: %w", err)
+	}
+
+	if state := provisioningState(cluster); state != provisioningStateSucceeded {
+		return nil, fmt.Errorf(
+			"%w: aks cluster %q is %s",
+			clustererr.ErrKubeconfigNotReady, target, state,
+		)
+	}
+
+	raw, err := p.client.GetClusterUserCredentials(ctx, resourceGroup, target)
+	if err != nil {
+		return nil, fmt.Errorf("aks cluster user credentials: %w", err)
+	}
+
+	return raw, nil
+}
+
+// provisioningState extracts the cluster's ARM provisioning state, reading
+// through the nullable properties chain; an absent state reads as "unknown"
+// so the not-ready error names something actionable.
+func provisioningState(cluster armcontainerservice.ManagedCluster) string {
+	if cluster.Properties == nil || cluster.Properties.ProvisioningState == nil {
+		return "unknown"
+	}
+
+	return *cluster.Properties.ProvisioningState
+}

--- a/pkg/svc/provisioner/cluster/aks/connector_test.go
+++ b/pkg/svc/provisioner/cluster/aks/connector_test.go
@@ -1,0 +1,133 @@
+package aksprovisioner_test
+
+import (
+	"testing"
+
+	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	aksprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/aks"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The AKS provisioner exposes the operator's Connector capability.
+var _ clusterprovisioner.Connector = (*aksprovisioner.Provisioner)(nil)
+
+// provisionedCluster assembles a ManagedCluster in the given ARM provisioning
+// state.
+func provisionedCluster(state string) armcontainerservice.ManagedCluster {
+	return armcontainerservice.ManagedCluster{
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			ProvisioningState: new(state),
+		},
+	}
+}
+
+func TestKubeconfig_ReturnsARMServedKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	kubeconfig := []byte("apiVersion: v1\nkind: Config\n")
+	fake := &fakeClusterClient{
+		cluster:    provisionedCluster("Succeeded"),
+		kubeconfig: kubeconfig,
+	}
+	provisioner := newProvisioner(t, fake, testGroup, nil, nil)
+
+	raw, err := provisioner.Kubeconfig(t.Context(), testClusterName)
+
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig, raw)
+	require.Len(t, fake.gets, 1)
+	assert.Equal(t, clusterCall{resourceGroup: testGroup, name: testClusterName}, fake.gets[0])
+	require.Len(t, fake.credentials, 1)
+	assert.Equal(
+		t, clusterCall{resourceGroup: testGroup, name: testClusterName}, fake.credentials[0],
+	)
+}
+
+func TestKubeconfig_ResolvesResourceGroupWhenUnpinned(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{
+		clusters: []*armcontainerservice.ManagedCluster{
+			managedCluster(testClusterName, testGroup),
+		},
+		cluster:    provisionedCluster("Succeeded"),
+		kubeconfig: []byte("kubeconfig"),
+	}
+	provisioner := newProvisioner(t, fake, "", nil, nil)
+
+	_, err := provisioner.Kubeconfig(t.Context(), testClusterName)
+
+	require.NoError(t, err)
+	require.Len(t, fake.credentials, 1)
+	assert.Equal(t, testGroup, fake.credentials[0].resourceGroup)
+}
+
+func TestKubeconfig_NotReadyWhileProvisioning(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{cluster: provisionedCluster("Creating")}
+	provisioner := newProvisioner(t, fake, testGroup, nil, nil)
+
+	_, err := provisioner.Kubeconfig(t.Context(), testClusterName)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+	require.ErrorContains(t, err, "Creating")
+	assert.Empty(t, fake.credentials)
+}
+
+func TestKubeconfig_NotReadyWithoutProvisioningState(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{cluster: armcontainerservice.ManagedCluster{}}
+	provisioner := newProvisioner(t, fake, testGroup, nil, nil)
+
+	_, err := provisioner.Kubeconfig(t.Context(), testClusterName)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+	require.ErrorContains(t, err, "unknown")
+	assert.Empty(t, fake.credentials)
+}
+
+func TestKubeconfig_RequiresClusterName(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{}
+	provisioner, err := aksprovisioner.NewProvisioner("", testGroup, nil, fake, nil)
+	require.NoError(t, err)
+
+	_, err = provisioner.Kubeconfig(t.Context(), "")
+
+	require.ErrorIs(t, err, aksprovisioner.ErrClusterNotFound)
+	assert.Empty(t, fake.gets)
+}
+
+func TestKubeconfig_WrapsGetClusterError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{getErr: errBoom}
+	provisioner := newProvisioner(t, fake, testGroup, nil, nil)
+
+	_, err := provisioner.Kubeconfig(t.Context(), testClusterName)
+
+	require.ErrorIs(t, err, errBoom)
+	require.ErrorContains(t, err, "aks get cluster")
+	assert.Empty(t, fake.credentials)
+}
+
+func TestKubeconfig_WrapsCredentialsError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeClusterClient{
+		cluster:        provisionedCluster("Succeeded"),
+		credentialsErr: errBoom,
+	}
+	provisioner := newProvisioner(t, fake, testGroup, nil, nil)
+
+	_, err := provisioner.Kubeconfig(t.Context(), testClusterName)
+
+	require.ErrorIs(t, err, errBoom)
+	require.ErrorContains(t, err, "aks cluster user credentials")
+}

--- a/pkg/svc/provisioner/cluster/aks/provisioner.go
+++ b/pkg/svc/provisioner/cluster/aks/provisioner.go
@@ -33,6 +33,17 @@ type ClusterClient interface {
 		ctx context.Context,
 		resourceGroup string,
 	) ([]*armcontainerservice.ManagedCluster, error)
+	// GetCluster fetches the named managed cluster's definition.
+	GetCluster(
+		ctx context.Context,
+		resourceGroup, name string,
+	) (armcontainerservice.ManagedCluster, error)
+	// GetClusterUserCredentials fetches the named managed cluster's user
+	// kubeconfig as served by ARM.
+	GetClusterUserCredentials(
+		ctx context.Context,
+		resourceGroup, name string,
+	) ([]byte, error)
 }
 
 // staticClusterClientCheck asserts at compile time that the production aks

--- a/pkg/svc/provisioner/cluster/aks/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/aks/provisioner_test.go
@@ -36,18 +36,31 @@ type deleteCall struct {
 	name          string
 }
 
+// clusterCall records one cluster-scoped read (GetCluster /
+// GetClusterUserCredentials) the provisioner made.
+type clusterCall struct {
+	resourceGroup string
+	name          string
+}
+
 // fakeClusterClient implements the provisioner's ClusterClient seam with
 // injectable behaviour per operation, recording every call it receives.
 type fakeClusterClient struct {
-	creates []createCall
-	deletes []deleteCall
-	lists   []string
+	creates     []createCall
+	deletes     []deleteCall
+	lists       []string
+	gets        []clusterCall
+	credentials []clusterCall
 
-	createErr error
-	deleteErr error
-	listErr   error
+	createErr      error
+	deleteErr      error
+	listErr        error
+	getErr         error
+	credentialsErr error
 
-	clusters []*armcontainerservice.ManagedCluster
+	clusters   []*armcontainerservice.ManagedCluster
+	cluster    armcontainerservice.ManagedCluster
+	kubeconfig []byte
 }
 
 func (f *fakeClusterClient) CreateCluster(
@@ -80,6 +93,24 @@ func (f *fakeClusterClient) ListClusters(
 	f.lists = append(f.lists, resourceGroup)
 
 	return f.clusters, f.listErr
+}
+
+func (f *fakeClusterClient) GetCluster(
+	_ context.Context,
+	resourceGroup, name string,
+) (armcontainerservice.ManagedCluster, error) {
+	f.gets = append(f.gets, clusterCall{resourceGroup: resourceGroup, name: name})
+
+	return f.cluster, f.getErr
+}
+
+func (f *fakeClusterClient) GetClusterUserCredentials(
+	_ context.Context,
+	resourceGroup, name string,
+) ([]byte, error) {
+	f.credentials = append(f.credentials, clusterCall{resourceGroup: resourceGroup, name: name})
+
+	return f.kubeconfig, f.credentialsErr
 }
 
 // fakeProvider records Start/Stop delegation without touching real


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The operator can install components into GKE and EKS children but not AKS ones — the AKS provisioner landed without the Connector capability, leaving the cloud lifecycle asymmetric.

## What
Adds the AKS Connector mirroring the merged GKE/EKS pattern: ARM serves a ready-made kubeconfig, gated on the cluster being fully provisioned so the operator requeues instead of failing. AAD-only clusters (which need a client-side auth plugin) are a documented limitation for a follow-up.

Fixes #5829 · Part of #4899