### PR TITLE
feat(clusterdiscovery): wire GCP cluster discovery and web-UI availability

### DIFF
--- a/pkg/svc/clusterdiscovery/availability.go
+++ b/pkg/svc/clusterdiscovery/availability.go
@@ -59,13 +59,7 @@ func (d *Discoverer) providerAvailability(
 	case v1alpha1.ProviderAWS:
 		return d.awsAvailability()
 	case v1alpha1.ProviderGCP:
-		// GCP discovery (credential probing + cluster listing) lands with
-		// ksail#5728 part 3; until then GCP is not offered for discovery.
-		return Availability{
-			Provider:  prov,
-			Available: false,
-			Reason:    "GCP discovery is not wired yet",
-		}
+		return d.gcpAvailability()
 	case v1alpha1.ProviderAzure:
 		// Azure discovery (credential probing + cluster listing) lands with
 		// the AKS discovery follow-up; until then Azure is not offered for
@@ -170,6 +164,25 @@ func (d *Discoverer) awsAvailability() Availability {
 	}
 
 	return Availability{Provider: v1alpha1.ProviderAWS, Available: true}
+}
+
+// gcpAvailability requires a Google Cloud project (every GKE API call is project-scoped) and
+// Application Default Credentials for the SDK to authenticate with.
+func (d *Discoverer) gcpAvailability() Availability {
+	projectAvailability := d.requireCredentials(v1alpha1.ProviderGCP, credentials.GCPProject)
+	if !projectAvailability.Available {
+		return projectAvailability
+	}
+
+	if !gcpADCPresent() {
+		return Availability{
+			Provider:  v1alpha1.ProviderGCP,
+			Available: false,
+			Reason:    "Google Cloud Application Default Credentials are not configured",
+		}
+	}
+
+	return Availability{Provider: v1alpha1.ProviderGCP, Available: true}
 }
 
 // kubernetesAvailability reports the nested-Kubernetes provider as available when a host kubeconfig

--- a/pkg/svc/clusterdiscovery/availability_test.go
+++ b/pkg/svc/clusterdiscovery/availability_test.go
@@ -161,6 +161,67 @@ func TestAvailability_AWSRequiresBothStaticKeys(t *testing.T) {
 	assert.True(t, bothKeys.Available, "a complete static key pair must enable AWS")
 }
 
+func TestAvailability_GCPRequiresProject(t *testing.T) {
+	t.Parallel()
+
+	// The project check short-circuits before any host credential-file probe, so this stays
+	// deterministic regardless of the machine's real gcloud setup.
+	got := availabilityFor(
+		(&clusterdiscovery.Discoverer{Resolver: mapResolver{}}).
+			Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderGCP}),
+		v1alpha1.ProviderGCP,
+	)
+	assert.False(t, got.Available)
+	assert.Contains(t, got.Reason, "GOOGLE_CLOUD_PROJECT")
+}
+
+// TestAvailability_GCPRequiresADC verifies a project alone (no GOOGLE_APPLICATION_CREDENTIALS, no
+// gcloud well-known ADC file) does not mark GCP available. HOME is pointed at an empty temp dir so
+// the well-known-file check is deterministic.
+func TestAvailability_GCPRequiresADC(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+	projectOnly := availabilityFor(
+		(&clusterdiscovery.Discoverer{
+			Resolver: mapResolver{credentials.GCPProject: "my-project"},
+		}).Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderGCP}),
+		v1alpha1.ProviderGCP,
+	)
+	assert.False(t, projectOnly.Available, "a project without ADC must not enable GCP")
+	assert.Contains(t, projectOnly.Reason, "Application Default Credentials")
+
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "adc.json"))
+
+	withADC := availabilityFor(
+		(&clusterdiscovery.Discoverer{
+			Resolver: mapResolver{credentials.GCPProject: "my-project"},
+		}).Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderGCP}),
+		v1alpha1.ProviderGCP,
+	)
+	assert.True(t, withADC.Available, "a project plus ADC must enable GCP")
+}
+
+// TestAvailability_GCPWellKnownADCFile verifies the gcloud well-known ADC file alone (no
+// GOOGLE_APPLICATION_CREDENTIALS variable) satisfies the credential probe.
+func TestAvailability_GCPWellKnownADCFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+	adcPath := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(adcPath), 0o750))
+	require.NoError(t, os.WriteFile(adcPath, []byte("{}"), 0o600))
+
+	got := availabilityFor(
+		(&clusterdiscovery.Discoverer{
+			Resolver: mapResolver{credentials.GCPProject: "my-project"},
+		}).Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderGCP}),
+		v1alpha1.ProviderGCP,
+	)
+	assert.True(t, got.Available, "the gcloud well-known ADC file must enable GCP")
+}
+
 func TestAvailability_KubernetesRequiresHostKubeconfig(t *testing.T) {
 	t.Setenv("KSAIL_HOST_KUBECONFIG", "/definitely/not/a/real/kubeconfig")
 

--- a/pkg/svc/clusterdiscovery/cloud.go
+++ b/pkg/svc/clusterdiscovery/cloud.go
@@ -9,10 +9,12 @@ import (
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	gkeclient "github.com/devantler-tech/ksail/v7/pkg/client/gke"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	awsprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
+	gcpprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/gcp"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/omni"
@@ -99,6 +101,43 @@ func (d *Discoverer) listAWS(ctx context.Context) ([]Cluster, error) {
 	return clustersWithDistribution(names, v1alpha1.DistributionEKS, v1alpha1.ProviderAWS), nil
 }
 
+// listGCP lists GKE clusters. It skips silently unless GCP appears configured (a project plus
+// Application Default Credentials), so the common no-GCP case costs nothing and never emits a
+// warning.
+func (d *Discoverer) listGCP(ctx context.Context) ([]Cluster, error) {
+	lister := d.GCP
+	if lister == nil {
+		if !d.gcpConfigured() {
+			return nil, nil
+		}
+
+		client, err := gkeclient.NewClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("create GKE client: %w", err)
+		}
+
+		defer func() { _ = client.Close() }()
+
+		provider, err := gcpprovider.NewProvider(
+			client,
+			d.resolver().Value(credentials.GCPProject),
+			d.resolver().Value(credentials.GCPLocation),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create GCP provider: %w", err)
+		}
+
+		lister = provider
+	}
+
+	names, err := lister.ListAllClusters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query GKE: %w", err)
+	}
+
+	return clustersWithDistribution(names, v1alpha1.DistributionGKE, v1alpha1.ProviderGCP), nil
+}
+
 // listKubernetes lists clusters nested inside a host Kubernetes cluster. With no reachable host
 // kubeconfig it skips silently.
 func (d *Discoverer) listKubernetes(ctx context.Context) ([]Cluster, error) {
@@ -173,6 +212,37 @@ func (d *Discoverer) awsConfigured() bool {
 	}
 
 	return false
+}
+
+// gcpConfigured reports whether GCP appears set up for GKE discovery: a project ID (which the GKE
+// API scopes every list call to) plus Application Default Credentials. The project check comes
+// first so an unset project skips without touching the host's credential files.
+func (d *Discoverer) gcpConfigured() bool {
+	if d.resolver().Value(credentials.GCPProject) == "" {
+		return false
+	}
+
+	return gcpADCPresent()
+}
+
+// gcpADCPresent reports whether Google Application Default Credentials appear available: the
+// GOOGLE_APPLICATION_CREDENTIALS variable is set, or gcloud's well-known ADC file exists. This is
+// a presence probe only — the SDK performs the real credential resolution when a client is built.
+func gcpADCPresent() bool {
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") != "" {
+		return true
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	_, statErr := os.Stat(
+		filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"),
+	)
+
+	return statErr == nil
 }
 
 // eksctlAvailable reports whether the eksctl binary (which the AWS provider shells out to) is on

--- a/pkg/svc/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/svc/clusterdiscovery/clusterdiscovery.go
@@ -1,6 +1,7 @@
 // Package clusterdiscovery enumerates KSail-managed clusters across every infrastructure provider
-// (Docker, Hetzner, Omni, AWS/EKS, and nested Kubernetes), reading provider credentials from the
-// environment via a credentials.Resolver and silently skipping providers that are not configured.
+// (Docker, Hetzner, Omni, AWS/EKS, GCP/GKE, and nested Kubernetes), reading provider credentials
+// from the environment via a credentials.Resolver and silently skipping providers that are not
+// configured.
 //
 // It is the single source of truth for "what clusters exist" shared by the `ksail cluster list`
 // command and the local web-UI backend (pkg/cli/clusterapi). Before this package existed the two
@@ -67,7 +68,8 @@ func (e ProviderError) Error() string {
 func (e ProviderError) Unwrap() error { return e.Err }
 
 // ClusterLister lists the cluster names managed by a single-distribution cloud provider (Hetzner,
-// Omni, AWS). *hetzner.Provider, *omni.Provider and *aws.Provider all satisfy it.
+// Omni, AWS, GCP). *hetzner.Provider, *omni.Provider, *aws.Provider and *gcp.Provider all satisfy
+// it.
 type ClusterLister interface {
 	ListAllClusters(ctx context.Context) ([]string, error)
 }
@@ -95,6 +97,7 @@ type Discoverer struct {
 	Hetzner       ClusterLister
 	Omni          ClusterLister
 	AWS           ClusterLister
+	GCP           ClusterLister
 	Kubernetes    KubernetesLister
 	DockerFactory DockerFactory
 
@@ -138,6 +141,7 @@ func AllProviders() []v1alpha1.Provider {
 		v1alpha1.ProviderHetzner,
 		v1alpha1.ProviderOmni,
 		v1alpha1.ProviderAWS,
+		v1alpha1.ProviderGCP,
 		v1alpha1.ProviderKubernetes,
 	}
 }
@@ -218,9 +222,7 @@ func (d *Discoverer) listProvider(
 	case v1alpha1.ProviderAWS:
 		return d.listAWS(ctx)
 	case v1alpha1.ProviderGCP:
-		// GCP cluster listing lands with ksail#5728 part 3; until then GCP
-		// clusters are not discoverable.
-		return nil, fmt.Errorf("%w: %s", clustererr.ErrUnsupportedProvider, prov)
+		return d.listGCP(ctx)
 	case v1alpha1.ProviderAzure:
 		// Azure cluster listing lands with the AKS discovery follow-up (same
 		// deliberate gating as GCP); until then Azure clusters are not

--- a/pkg/svc/clusterdiscovery/clusterdiscovery_test.go
+++ b/pkg/svc/clusterdiscovery/clusterdiscovery_test.go
@@ -138,13 +138,14 @@ func TestDiscover_DockerListErrorSkippedSilently(t *testing.T) {
 	assert.Empty(t, failures, "per-distribution list errors are swallowed, not surfaced")
 }
 
-func TestDiscover_CloudProvidersMapToTalosAndEKS(t *testing.T) {
+func TestDiscover_CloudProvidersMapToTheirDistributions(t *testing.T) {
 	t.Parallel()
 
 	discoverer := &clusterdiscovery.Discoverer{
 		Hetzner: fakeLister{names: []string{"prod"}},
 		Omni:    fakeLister{names: []string{"omni-prod"}},
 		AWS:     fakeLister{names: []string{"eks-1"}},
+		GCP:     fakeLister{names: []string{"gke-1"}},
 		Kubernetes: fakeKubeLister{
 			infos: []kubernetesprovider.ClusterInfo{{Name: "nested", Distribution: "K3s"}},
 		},
@@ -154,6 +155,7 @@ func TestDiscover_CloudProvidersMapToTalosAndEKS(t *testing.T) {
 		v1alpha1.ProviderHetzner,
 		v1alpha1.ProviderOmni,
 		v1alpha1.ProviderAWS,
+		v1alpha1.ProviderGCP,
 		v1alpha1.ProviderKubernetes,
 	})
 
@@ -170,6 +172,7 @@ func TestDiscover_CloudProvidersMapToTalosAndEKS(t *testing.T) {
 			Provider:     v1alpha1.ProviderOmni,
 		},
 		{Name: "eks-1", Distribution: v1alpha1.DistributionEKS, Provider: v1alpha1.ProviderAWS},
+		{Name: "gke-1", Distribution: v1alpha1.DistributionGKE, Provider: v1alpha1.ProviderGCP},
 		{
 			Name:         "nested",
 			Distribution: v1alpha1.DistributionK3s,
@@ -198,7 +201,8 @@ func TestDiscover_SkipsCloudProvidersWithoutCredentials(t *testing.T) {
 	t.Parallel()
 
 	// No injected listers + empty resolver + eksctl reported missing => every cloud provider skips
-	// silently regardless of the host's real environment.
+	// silently regardless of the host's real environment (GCP's project check short-circuits
+	// before its host credential-file probe).
 	discoverer := &clusterdiscovery.Discoverer{
 		Resolver: emptyResolver{},
 		LookPath: lookPathMissing,
@@ -208,6 +212,7 @@ func TestDiscover_SkipsCloudProvidersWithoutCredentials(t *testing.T) {
 		v1alpha1.ProviderHetzner,
 		v1alpha1.ProviderOmni,
 		v1alpha1.ProviderAWS,
+		v1alpha1.ProviderGCP,
 	})
 
 	assert.Empty(t, clusters)
@@ -306,6 +311,7 @@ func TestProviderSets(t *testing.T) {
 
 	assert.Subset(t, clusterdiscovery.AllProviders(), clusterdiscovery.DefaultProviders())
 	assert.Contains(t, clusterdiscovery.AllProviders(), v1alpha1.ProviderAWS)
+	assert.Contains(t, clusterdiscovery.AllProviders(), v1alpha1.ProviderGCP)
 	assert.Contains(t, clusterdiscovery.AllProviders(), v1alpha1.ProviderKubernetes)
 	assert.Len(t, clusterdiscovery.LocalDistributions(), 5)
 }

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -38,6 +38,10 @@ const (
 	AWSSecretAccessKey Key = "aws.secretAccessKey"
 	// AWSSessionToken is the AWS session token (for temporary credentials).
 	AWSSessionToken Key = "aws.sessionToken"
+	// GCPProject is the Google Cloud project ID used for GKE operations.
+	GCPProject Key = "gcp.project"
+	// GCPLocation is the GKE location (zone or region); empty means all locations.
+	GCPLocation Key = "gcp.location"
 	// CopilotToken is the GitHub Copilot token the AI assistant authenticates with. Not a cloud
 	// provider, but resolved the same way (secure store override, otherwise the environment) so it can
 	// be configured from the Settings page instead of only via the environment.
@@ -55,6 +59,8 @@ const (
 	defaultAWSAccessKeyIDEnvVar  = "AWS_ACCESS_KEY_ID"
 	defaultAWSSecretAccessEnvVar = "AWS_SECRET_ACCESS_KEY" //nolint:gosec // env var NAME, not a secret
 	defaultAWSSessionTokenEnvVar = "AWS_SESSION_TOKEN"     //nolint:gosec // env var NAME, not a secret
+	defaultGCPProjectEnvVar      = "GOOGLE_CLOUD_PROJECT"
+	defaultGCPLocationEnvVar     = "GOOGLE_CLOUD_LOCATION"
 	// defaultCopilotTokenEnvVar is the primary variable webchat.copilotToken() reads first (it also
 	// falls back to COPILOT_TOKEN); using it as the default keeps a stored token resolvable via Overlay.
 	defaultCopilotTokenEnvVar = "KSAIL_COPILOT_TOKEN" //nolint:gosec // env var NAME, not a secret
@@ -74,6 +80,8 @@ func AllKeys() []Key {
 		AWSAccessKeyID,
 		AWSSecretAccessKey,
 		AWSSessionToken,
+		GCPProject,
+		GCPLocation,
 		CopilotToken,
 	}
 }
@@ -90,6 +98,8 @@ func DefaultEnvVar(key Key) string {
 		AWSAccessKeyID:        defaultAWSAccessKeyIDEnvVar,
 		AWSSecretAccessKey:    defaultAWSSecretAccessEnvVar,
 		AWSSessionToken:       defaultAWSSessionTokenEnvVar,
+		GCPProject:            defaultGCPProjectEnvVar,
+		GCPLocation:           defaultGCPLocationEnvVar,
 		CopilotToken:          defaultCopilotTokenEnvVar,
 	}[key]
 }

--- a/pkg/svc/credentials/credentials_test.go
+++ b/pkg/svc/credentials/credentials_test.go
@@ -35,6 +35,9 @@ func TestDefaultEnvVar_MatchesCanonicalSources(t *testing.T) {
 		credentials.DefaultEnvVar(credentials.AWSSecretAccessKey),
 	)
 	assert.Equal(t, "AWS_SESSION_TOKEN", credentials.DefaultEnvVar(credentials.AWSSessionToken))
+	// GCP defaults mirror the struct-tag defaults on v1alpha1.OptionsGCP (no exported constants).
+	assert.Equal(t, "GOOGLE_CLOUD_PROJECT", credentials.DefaultEnvVar(credentials.GCPProject))
+	assert.Equal(t, "GOOGLE_CLOUD_LOCATION", credentials.DefaultEnvVar(credentials.GCPLocation))
 	// The Copilot token has no external canonical source; it mirrors webchat's primary token variable.
 	assert.Equal(t, "KSAIL_COPILOT_TOKEN", credentials.DefaultEnvVar(credentials.CopilotToken))
 }

--- a/pkg/svc/credentials/store.go
+++ b/pkg/svc/credentials/store.go
@@ -137,7 +137,7 @@ func IsSecret(key Key) bool {
 	case HetznerToken, OmniServiceAccountKey, AWSAccessKeyID, AWSSecretAccessKey, AWSSessionToken,
 		CopilotToken:
 		return true
-	case OmniEndpoint, AWSRegion, AWSProfile:
+	case OmniEndpoint, AWSRegion, AWSProfile, GCPProject, GCPLocation:
 		return false
 	default:
 		return false
@@ -158,6 +158,8 @@ func ProviderFor(key Key) string {
 		return string(v1alpha1.ProviderOmni)
 	case AWSRegion, AWSProfile, AWSAccessKeyID, AWSSecretAccessKey, AWSSessionToken:
 		return string(v1alpha1.ProviderAWS)
+	case GCPProject, GCPLocation:
+		return string(v1alpha1.ProviderGCP)
 	case CopilotToken:
 		return copilotGroup
 	default:
@@ -177,6 +179,8 @@ func Label(key Key) string {
 		AWSAccessKeyID:        "Access key ID",
 		AWSSecretAccessKey:    "Secret access key",
 		AWSSessionToken:       "Session token",
+		GCPProject:            "Project ID",
+		GCPLocation:           "Location",
 		CopilotToken:          "Token",
 	}
 

--- a/pkg/svc/credentials/store_test.go
+++ b/pkg/svc/credentials/store_test.go
@@ -102,6 +102,8 @@ func TestIsSecret_ClassifiesEveryKey(t *testing.T) {
 		credentials.OmniEndpoint:          false,
 		credentials.AWSRegion:             false,
 		credentials.AWSProfile:            false,
+		credentials.GCPProject:            false,
+		credentials.GCPLocation:           false,
 		credentials.Key("unknown.key"):    false,
 	}
 
@@ -129,6 +131,8 @@ func TestProviderFor_MapsEveryKey(t *testing.T) {
 		credentials.AWSAccessKeyID:        string(v1alpha1.ProviderAWS),
 		credentials.AWSSecretAccessKey:    string(v1alpha1.ProviderAWS),
 		credentials.AWSSessionToken:       string(v1alpha1.ProviderAWS),
+		credentials.GCPProject:            string(v1alpha1.ProviderGCP),
+		credentials.GCPLocation:           string(v1alpha1.ProviderGCP),
 		credentials.CopilotToken:          "GitHub Copilot",
 		credentials.Key("unknown.key"):    "",
 	}
@@ -150,6 +154,8 @@ func TestLabel_NamesEveryKey(t *testing.T) {
 		credentials.AWSAccessKeyID:        "Access key ID",
 		credentials.AWSSecretAccessKey:    "Secret access key",
 		credentials.AWSSessionToken:       "Session token",
+		credentials.GCPProject:            "Project ID",
+		credentials.GCPLocation:           "Location",
 		credentials.CopilotToken:          "Token",
 	}
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

GKE clusters can be provisioned and managed since the #4510 GKE slices landed, but discovery still hardcoded GCP as unavailable — GKE clusters never showed up in `ksail cluster list` or the web UI, and the create form couldn't tell users what GCP configuration was missing.

## What

Wires GCP into cluster discovery mirroring the existing AWS pattern: GKE clusters are listed when a project and Application Default Credentials are present (silent skip otherwise), the web UI's provider availability reports real readiness reasons, and the GCP project/location become configurable from the Settings page. Live-credential E2E validation stays deferred, same gating as EKS.

Fixes #5832
Part of #4510