### PR TITLE
feat(clusterdiscovery): wire Azure AKS cluster discovery and web-UI availability

### DIFF
--- a/pkg/svc/clusterdiscovery/availability.go
+++ b/pkg/svc/clusterdiscovery/availability.go
@@ -61,14 +61,7 @@ func (d *Discoverer) providerAvailability(
 	case v1alpha1.ProviderGCP:
 		return d.gcpAvailability()
 	case v1alpha1.ProviderAzure:
-		// Azure discovery (credential probing + cluster listing) lands with
-		// the AKS discovery follow-up; until then Azure is not offered for
-		// discovery.
-		return Availability{
-			Provider:  prov,
-			Available: false,
-			Reason:    "Azure discovery is not wired yet",
-		}
+		return d.azureAvailability()
 	case v1alpha1.ProviderKubernetes:
 		return kubernetesAvailability()
 	default:
@@ -183,6 +176,28 @@ func (d *Discoverer) gcpAvailability() Availability {
 	}
 
 	return Availability{Provider: v1alpha1.ProviderGCP, Available: true}
+}
+
+// azureAvailability requires an Azure subscription (every ARM call is subscription-scoped) and a
+// credential source the SDK's DefaultAzureCredential chain can resolve.
+func (d *Discoverer) azureAvailability() Availability {
+	subscriptionAvailability := d.requireCredentials(
+		v1alpha1.ProviderAzure,
+		credentials.AzureSubscriptionID,
+	)
+	if !subscriptionAvailability.Available {
+		return subscriptionAvailability
+	}
+
+	if !azureCredentialPresent() {
+		return Availability{
+			Provider:  v1alpha1.ProviderAzure,
+			Available: false,
+			Reason:    "Azure credentials are not configured (az login or AZURE_* variables)",
+		}
+	}
+
+	return Availability{Provider: v1alpha1.ProviderAzure, Available: true}
 }
 
 // kubernetesAvailability reports the nested-Kubernetes provider as available when a host kubeconfig

--- a/pkg/svc/clusterdiscovery/availability_test.go
+++ b/pkg/svc/clusterdiscovery/availability_test.go
@@ -222,6 +222,77 @@ func TestAvailability_GCPWellKnownADCFile(t *testing.T) {
 	assert.True(t, got.Available, "the gcloud well-known ADC file must enable GCP")
 }
 
+func TestAvailability_AzureRequiresSubscription(t *testing.T) {
+	t.Parallel()
+
+	// The subscription check short-circuits before any host credential-file probe, so this stays
+	// deterministic regardless of the machine's real Azure setup.
+	got := availabilityFor(
+		(&clusterdiscovery.Discoverer{Resolver: mapResolver{}}).
+			Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderAzure}),
+		v1alpha1.ProviderAzure,
+	)
+	assert.False(t, got.Available)
+	assert.Contains(t, got.Reason, "AZURE_SUBSCRIPTION_ID")
+}
+
+// TestAvailability_AzureRequiresCredential verifies a subscription alone (no AZURE_CLIENT_ID /
+// AZURE_TENANT_ID, no Azure CLI profile) does not mark Azure available. HOME is pointed at an empty
+// temp dir so the CLI-profile check is deterministic.
+func TestAvailability_AzureRequiresCredential(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AZURE_CLIENT_ID", "")
+	t.Setenv("AZURE_TENANT_ID", "")
+
+	subscriptionOnly := availabilityFor(
+		(&clusterdiscovery.Discoverer{
+			Resolver: mapResolver{credentials.AzureSubscriptionID: "00000000-0000-0000-0000-000000000000"},
+		}).Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderAzure}),
+		v1alpha1.ProviderAzure,
+	)
+	assert.False(
+		t,
+		subscriptionOnly.Available,
+		"a subscription without a credential must not enable Azure",
+	)
+	assert.Contains(t, subscriptionOnly.Reason, "Azure credentials")
+
+	t.Setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111")
+
+	withEnvCredential := availabilityFor(
+		(&clusterdiscovery.Discoverer{
+			Resolver: mapResolver{credentials.AzureSubscriptionID: "00000000-0000-0000-0000-000000000000"},
+		}).Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderAzure}),
+		v1alpha1.ProviderAzure,
+	)
+	assert.True(
+		t,
+		withEnvCredential.Available,
+		"a subscription plus environment credentials must enable Azure",
+	)
+}
+
+// TestAvailability_AzureCLIProfile verifies the Azure CLI profile file alone (no AZURE_*
+// environment credentials) satisfies the credential probe.
+func TestAvailability_AzureCLIProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AZURE_CLIENT_ID", "")
+	t.Setenv("AZURE_TENANT_ID", "")
+
+	profilePath := filepath.Join(home, ".azure", "azureProfile.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(profilePath), 0o750))
+	require.NoError(t, os.WriteFile(profilePath, []byte("{}"), 0o600))
+
+	got := availabilityFor(
+		(&clusterdiscovery.Discoverer{
+			Resolver: mapResolver{credentials.AzureSubscriptionID: "00000000-0000-0000-0000-000000000000"},
+		}).Availability(context.Background(), []v1alpha1.Provider{v1alpha1.ProviderAzure}),
+		v1alpha1.ProviderAzure,
+	)
+	assert.True(t, got.Available, "the Azure CLI profile must enable Azure")
+}
+
 func TestAvailability_KubernetesRequiresHostKubeconfig(t *testing.T) {
 	t.Setenv("KSAIL_HOST_KUBECONFIG", "/definitely/not/a/real/kubeconfig")
 

--- a/pkg/svc/clusterdiscovery/cloud.go
+++ b/pkg/svc/clusterdiscovery/cloud.go
@@ -8,12 +8,14 @@ import (
 	"path/filepath"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	aksclient "github.com/devantler-tech/ksail/v7/pkg/client/aks"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	gkeclient "github.com/devantler-tech/ksail/v7/pkg/client/gke"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	awsprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
+	azureprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/azure"
 	gcpprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/gcp"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
@@ -138,6 +140,40 @@ func (d *Discoverer) listGCP(ctx context.Context) ([]Cluster, error) {
 	return clustersWithDistribution(names, v1alpha1.DistributionGKE, v1alpha1.ProviderGCP), nil
 }
 
+// listAzure lists AKS clusters. It skips silently unless Azure appears configured (a subscription
+// plus a resolvable credential source), so the common no-Azure case costs nothing and never emits
+// a warning.
+func (d *Discoverer) listAzure(ctx context.Context) ([]Cluster, error) {
+	lister := d.Azure
+	if lister == nil {
+		if !d.azureConfigured() {
+			return nil, nil
+		}
+
+		client, err := aksclient.NewClient(d.resolver().Value(credentials.AzureSubscriptionID))
+		if err != nil {
+			return nil, fmt.Errorf("create AKS client: %w", err)
+		}
+
+		provider, err := azureprovider.NewProvider(
+			client,
+			d.resolver().Value(credentials.AzureResourceGroup),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create Azure provider: %w", err)
+		}
+
+		lister = provider
+	}
+
+	names, err := lister.ListAllClusters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query AKS: %w", err)
+	}
+
+	return clustersWithDistribution(names, v1alpha1.DistributionAKS, v1alpha1.ProviderAzure), nil
+}
+
 // listKubernetes lists clusters nested inside a host Kubernetes cluster. With no reachable host
 // kubeconfig it skips silently.
 func (d *Discoverer) listKubernetes(ctx context.Context) ([]Cluster, error) {
@@ -241,6 +277,37 @@ func gcpADCPresent() bool {
 	_, statErr := os.Stat(
 		filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"),
 	)
+
+	return statErr == nil
+}
+
+// azureConfigured reports whether Azure appears set up for AKS discovery: a subscription ID (which
+// every ARM list call is scoped to) plus a credential source. The subscription check comes first so
+// an unset subscription skips without touching the host's credential files.
+func (d *Discoverer) azureConfigured() bool {
+	if d.resolver().Value(credentials.AzureSubscriptionID) == "" {
+		return false
+	}
+
+	return azureCredentialPresent()
+}
+
+// azureCredentialPresent reports whether a credential source for the SDK's DefaultAzureCredential
+// chain appears available: environment credentials (AZURE_CLIENT_ID / AZURE_TENANT_ID), or an
+// Azure CLI profile under ~/.azure. This is a presence probe only — the SDK performs the real
+// credential resolution when a client is built (managed-identity-only environments can still list
+// by injecting a lister or setting the environment variables).
+func azureCredentialPresent() bool {
+	if os.Getenv("AZURE_CLIENT_ID") != "" || os.Getenv("AZURE_TENANT_ID") != "" {
+		return true
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	_, statErr := os.Stat(filepath.Join(home, ".azure", "azureProfile.json"))
 
 	return statErr == nil
 }

--- a/pkg/svc/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/svc/clusterdiscovery/clusterdiscovery.go
@@ -1,7 +1,7 @@
 // Package clusterdiscovery enumerates KSail-managed clusters across every infrastructure provider
-// (Docker, Hetzner, Omni, AWS/EKS, GCP/GKE, and nested Kubernetes), reading provider credentials
-// from the environment via a credentials.Resolver and silently skipping providers that are not
-// configured.
+// (Docker, Hetzner, Omni, AWS/EKS, GCP/GKE, Azure/AKS, and nested Kubernetes), reading provider
+// credentials from the environment via a credentials.Resolver and silently skipping providers that
+// are not configured.
 //
 // It is the single source of truth for "what clusters exist" shared by the `ksail cluster list`
 // command and the local web-UI backend (pkg/cli/clusterapi). Before this package existed the two
@@ -68,8 +68,8 @@ func (e ProviderError) Error() string {
 func (e ProviderError) Unwrap() error { return e.Err }
 
 // ClusterLister lists the cluster names managed by a single-distribution cloud provider (Hetzner,
-// Omni, AWS, GCP). *hetzner.Provider, *omni.Provider, *aws.Provider and *gcp.Provider all satisfy
-// it.
+// Omni, AWS, GCP, Azure). *hetzner.Provider, *omni.Provider, *aws.Provider, *gcp.Provider and
+// *azure.Provider all satisfy it.
 type ClusterLister interface {
 	ListAllClusters(ctx context.Context) ([]string, error)
 }
@@ -98,6 +98,7 @@ type Discoverer struct {
 	Omni          ClusterLister
 	AWS           ClusterLister
 	GCP           ClusterLister
+	Azure         ClusterLister
 	Kubernetes    KubernetesLister
 	DockerFactory DockerFactory
 
@@ -142,6 +143,7 @@ func AllProviders() []v1alpha1.Provider {
 		v1alpha1.ProviderOmni,
 		v1alpha1.ProviderAWS,
 		v1alpha1.ProviderGCP,
+		v1alpha1.ProviderAzure,
 		v1alpha1.ProviderKubernetes,
 	}
 }
@@ -224,10 +226,7 @@ func (d *Discoverer) listProvider(
 	case v1alpha1.ProviderGCP:
 		return d.listGCP(ctx)
 	case v1alpha1.ProviderAzure:
-		// Azure cluster listing lands with the AKS discovery follow-up (same
-		// deliberate gating as GCP); until then Azure clusters are not
-		// discoverable.
-		return nil, fmt.Errorf("%w: %s", clustererr.ErrUnsupportedProvider, prov)
+		return d.listAzure(ctx)
 	case v1alpha1.ProviderKubernetes:
 		return d.listKubernetes(ctx)
 	default:

--- a/pkg/svc/clusterdiscovery/clusterdiscovery_test.go
+++ b/pkg/svc/clusterdiscovery/clusterdiscovery_test.go
@@ -146,6 +146,7 @@ func TestDiscover_CloudProvidersMapToTheirDistributions(t *testing.T) {
 		Omni:    fakeLister{names: []string{"omni-prod"}},
 		AWS:     fakeLister{names: []string{"eks-1"}},
 		GCP:     fakeLister{names: []string{"gke-1"}},
+		Azure:   fakeLister{names: []string{"aks-1"}},
 		Kubernetes: fakeKubeLister{
 			infos: []kubernetesprovider.ClusterInfo{{Name: "nested", Distribution: "K3s"}},
 		},
@@ -156,6 +157,7 @@ func TestDiscover_CloudProvidersMapToTheirDistributions(t *testing.T) {
 		v1alpha1.ProviderOmni,
 		v1alpha1.ProviderAWS,
 		v1alpha1.ProviderGCP,
+		v1alpha1.ProviderAzure,
 		v1alpha1.ProviderKubernetes,
 	})
 
@@ -173,6 +175,11 @@ func TestDiscover_CloudProvidersMapToTheirDistributions(t *testing.T) {
 		},
 		{Name: "eks-1", Distribution: v1alpha1.DistributionEKS, Provider: v1alpha1.ProviderAWS},
 		{Name: "gke-1", Distribution: v1alpha1.DistributionGKE, Provider: v1alpha1.ProviderGCP},
+		{
+			Name:         "aks-1",
+			Distribution: v1alpha1.DistributionAKS,
+			Provider:     v1alpha1.ProviderAzure,
+		},
 		{
 			Name:         "nested",
 			Distribution: v1alpha1.DistributionK3s,
@@ -201,8 +208,8 @@ func TestDiscover_SkipsCloudProvidersWithoutCredentials(t *testing.T) {
 	t.Parallel()
 
 	// No injected listers + empty resolver + eksctl reported missing => every cloud provider skips
-	// silently regardless of the host's real environment (GCP's project check short-circuits
-	// before its host credential-file probe).
+	// silently regardless of the host's real environment (GCP's project check and Azure's
+	// subscription check short-circuit before their host credential-file probes).
 	discoverer := &clusterdiscovery.Discoverer{
 		Resolver: emptyResolver{},
 		LookPath: lookPathMissing,
@@ -213,6 +220,7 @@ func TestDiscover_SkipsCloudProvidersWithoutCredentials(t *testing.T) {
 		v1alpha1.ProviderOmni,
 		v1alpha1.ProviderAWS,
 		v1alpha1.ProviderGCP,
+		v1alpha1.ProviderAzure,
 	})
 
 	assert.Empty(t, clusters)
@@ -312,6 +320,7 @@ func TestProviderSets(t *testing.T) {
 	assert.Subset(t, clusterdiscovery.AllProviders(), clusterdiscovery.DefaultProviders())
 	assert.Contains(t, clusterdiscovery.AllProviders(), v1alpha1.ProviderAWS)
 	assert.Contains(t, clusterdiscovery.AllProviders(), v1alpha1.ProviderGCP)
+	assert.Contains(t, clusterdiscovery.AllProviders(), v1alpha1.ProviderAzure)
 	assert.Contains(t, clusterdiscovery.AllProviders(), v1alpha1.ProviderKubernetes)
 	assert.Len(t, clusterdiscovery.LocalDistributions(), 5)
 }

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -42,6 +42,11 @@ const (
 	GCPProject Key = "gcp.project"
 	// GCPLocation is the GKE location (zone or region); empty means all locations.
 	GCPLocation Key = "gcp.location"
+	// AzureSubscriptionID is the Azure subscription ID used for AKS operations.
+	AzureSubscriptionID Key = "azure.subscriptionId"
+	// AzureResourceGroup is the Azure resource group hosting AKS clusters; empty means the whole
+	// subscription.
+	AzureResourceGroup Key = "azure.resourceGroup"
 	// CopilotToken is the GitHub Copilot token the AI assistant authenticates with. Not a cloud
 	// provider, but resolved the same way (secure store override, otherwise the environment) so it can
 	// be configured from the Settings page instead of only via the environment.
@@ -52,15 +57,17 @@ const (
 // provider option structs (and the omni provider package); credentials_test asserts they stay in
 // sync so this package does not pull the heavyweight provider clients into every importer.
 const (
-	defaultOmniEndpointEnvVar    = "OMNI_ENDPOINT"
-	defaultOmniServiceAccountKey = "OMNI_SERVICE_ACCOUNT_KEY"
-	defaultAWSRegionEnvVar       = "AWS_REGION"
-	defaultAWSProfileEnvVar      = "AWS_PROFILE"
-	defaultAWSAccessKeyIDEnvVar  = "AWS_ACCESS_KEY_ID"
-	defaultAWSSecretAccessEnvVar = "AWS_SECRET_ACCESS_KEY" //nolint:gosec // env var NAME, not a secret
-	defaultAWSSessionTokenEnvVar = "AWS_SESSION_TOKEN"     //nolint:gosec // env var NAME, not a secret
-	defaultGCPProjectEnvVar      = "GOOGLE_CLOUD_PROJECT"
-	defaultGCPLocationEnvVar     = "GOOGLE_CLOUD_LOCATION"
+	defaultOmniEndpointEnvVar       = "OMNI_ENDPOINT"
+	defaultOmniServiceAccountKey    = "OMNI_SERVICE_ACCOUNT_KEY"
+	defaultAWSRegionEnvVar          = "AWS_REGION"
+	defaultAWSProfileEnvVar         = "AWS_PROFILE"
+	defaultAWSAccessKeyIDEnvVar     = "AWS_ACCESS_KEY_ID"
+	defaultAWSSecretAccessEnvVar    = "AWS_SECRET_ACCESS_KEY" //nolint:gosec // env var NAME, not a secret
+	defaultAWSSessionTokenEnvVar    = "AWS_SESSION_TOKEN"     //nolint:gosec // env var NAME, not a secret
+	defaultGCPProjectEnvVar         = "GOOGLE_CLOUD_PROJECT"
+	defaultGCPLocationEnvVar        = "GOOGLE_CLOUD_LOCATION"
+	defaultAzureSubscriptionEnvVar  = "AZURE_SUBSCRIPTION_ID"
+	defaultAzureResourceGroupEnvVar = "AZURE_RESOURCE_GROUP"
 	// defaultCopilotTokenEnvVar is the primary variable webchat.copilotToken() reads first (it also
 	// falls back to COPILOT_TOKEN); using it as the default keeps a stored token resolvable via Overlay.
 	defaultCopilotTokenEnvVar = "KSAIL_COPILOT_TOKEN" //nolint:gosec // env var NAME, not a secret
@@ -82,6 +89,8 @@ func AllKeys() []Key {
 		AWSSessionToken,
 		GCPProject,
 		GCPLocation,
+		AzureSubscriptionID,
+		AzureResourceGroup,
 		CopilotToken,
 	}
 }
@@ -100,6 +109,8 @@ func DefaultEnvVar(key Key) string {
 		AWSSessionToken:       defaultAWSSessionTokenEnvVar,
 		GCPProject:            defaultGCPProjectEnvVar,
 		GCPLocation:           defaultGCPLocationEnvVar,
+		AzureSubscriptionID:   defaultAzureSubscriptionEnvVar,
+		AzureResourceGroup:    defaultAzureResourceGroupEnvVar,
 		CopilotToken:          defaultCopilotTokenEnvVar,
 	}[key]
 }

--- a/pkg/svc/credentials/credentials_test.go
+++ b/pkg/svc/credentials/credentials_test.go
@@ -38,6 +38,17 @@ func TestDefaultEnvVar_MatchesCanonicalSources(t *testing.T) {
 	// GCP defaults mirror the struct-tag defaults on v1alpha1.OptionsGCP (no exported constants).
 	assert.Equal(t, "GOOGLE_CLOUD_PROJECT", credentials.DefaultEnvVar(credentials.GCPProject))
 	assert.Equal(t, "GOOGLE_CLOUD_LOCATION", credentials.DefaultEnvVar(credentials.GCPLocation))
+	// Azure defaults mirror the struct-tag defaults on v1alpha1.OptionsAzure (no exported constants).
+	assert.Equal(
+		t,
+		"AZURE_SUBSCRIPTION_ID",
+		credentials.DefaultEnvVar(credentials.AzureSubscriptionID),
+	)
+	assert.Equal(
+		t,
+		"AZURE_RESOURCE_GROUP",
+		credentials.DefaultEnvVar(credentials.AzureResourceGroup),
+	)
 	// The Copilot token has no external canonical source; it mirrors webchat's primary token variable.
 	assert.Equal(t, "KSAIL_COPILOT_TOKEN", credentials.DefaultEnvVar(credentials.CopilotToken))
 }

--- a/pkg/svc/credentials/store.go
+++ b/pkg/svc/credentials/store.go
@@ -137,7 +137,8 @@ func IsSecret(key Key) bool {
 	case HetznerToken, OmniServiceAccountKey, AWSAccessKeyID, AWSSecretAccessKey, AWSSessionToken,
 		CopilotToken:
 		return true
-	case OmniEndpoint, AWSRegion, AWSProfile, GCPProject, GCPLocation:
+	case OmniEndpoint, AWSRegion, AWSProfile, GCPProject, GCPLocation,
+		AzureSubscriptionID, AzureResourceGroup:
 		return false
 	default:
 		return false
@@ -160,6 +161,8 @@ func ProviderFor(key Key) string {
 		return string(v1alpha1.ProviderAWS)
 	case GCPProject, GCPLocation:
 		return string(v1alpha1.ProviderGCP)
+	case AzureSubscriptionID, AzureResourceGroup:
+		return string(v1alpha1.ProviderAzure)
 	case CopilotToken:
 		return copilotGroup
 	default:
@@ -181,6 +184,8 @@ func Label(key Key) string {
 		AWSSessionToken:       "Session token",
 		GCPProject:            "Project ID",
 		GCPLocation:           "Location",
+		AzureSubscriptionID:   "Subscription ID",
+		AzureResourceGroup:    "Resource group",
 		CopilotToken:          "Token",
 	}
 

--- a/pkg/svc/credentials/store_test.go
+++ b/pkg/svc/credentials/store_test.go
@@ -104,6 +104,8 @@ func TestIsSecret_ClassifiesEveryKey(t *testing.T) {
 		credentials.AWSProfile:            false,
 		credentials.GCPProject:            false,
 		credentials.GCPLocation:           false,
+		credentials.AzureSubscriptionID:   false,
+		credentials.AzureResourceGroup:    false,
 		credentials.Key("unknown.key"):    false,
 	}
 
@@ -133,6 +135,8 @@ func TestProviderFor_MapsEveryKey(t *testing.T) {
 		credentials.AWSSessionToken:       string(v1alpha1.ProviderAWS),
 		credentials.GCPProject:            string(v1alpha1.ProviderGCP),
 		credentials.GCPLocation:           string(v1alpha1.ProviderGCP),
+		credentials.AzureSubscriptionID:   string(v1alpha1.ProviderAzure),
+		credentials.AzureResourceGroup:    string(v1alpha1.ProviderAzure),
 		credentials.CopilotToken:          "GitHub Copilot",
 		credentials.Key("unknown.key"):    "",
 	}
@@ -156,6 +160,8 @@ func TestLabel_NamesEveryKey(t *testing.T) {
 		credentials.AWSSessionToken:       "Session token",
 		credentials.GCPProject:            "Project ID",
 		credentials.GCPLocation:           "Location",
+		credentials.AzureSubscriptionID:   "Subscription ID",
+		credentials.AzureResourceGroup:    "Resource group",
 		credentials.CopilotToken:          "Token",
 	}
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
AKS support is fully built (client, provider, provisioner, operator Connector), but AKS clusters are still invisible to `ksail cluster list --all` and the web UI — Azure was the last cloud provider carrying the deliberate "not wired yet" discovery gate.

## What
Wires Azure into cluster discovery exactly like the just-merged GCP wiring: AKS clusters are listed when a subscription and Azure credentials are present (silently skipped otherwise), the create-form reports real Azure availability reasons, and the Settings page auto-surfaces the subscription/resource-group fields.

Fixes #5836
Part of #4510