### PR TITLE
feat(workload): add intercept traffic-steering seams (rule builder + ksail-steer container)

### DIFF
--- a/pkg/svc/mirror/doc.go
+++ b/pkg/svc/mirror/doc.go
@@ -62,12 +62,17 @@
 //     the local process and return its responses. Unlike mirror mode, responses
 //     must flow back into the cluster, so intercept needs a reverse tunnel: the
 //     one bidirectional exec byte stream (SPDY stdin+stdout) must carry many
-//     concurrent intercepted connections at once. The foundation increment is
-//     the multiplexing wire format — [Frame], [WriteFrame], and [ReadFrame] —
-//     a self-framing, length-prefixed codec that tags each chunk with a
-//     StreamID so the mux/demux (a later increment) can present each
-//     intercepted connection as its own stream. Steering (iptables/NET_ADMIN in
-//     the tap container) and the in-cluster intercept agent follow.
+//     concurrent intercepted connections at once. Increments so far: the
+//     multiplexing wire format ([Frame], [WriteFrame], [ReadFrame]) — a
+//     self-framing, length-prefixed codec tagging each chunk with a StreamID;
+//     the mux itself ([NewTunnelSession], presenting each intercepted
+//     connection as its own [TunnelStream]); and the steering seams per the
+//     #5839 design — the iptables NAT REDIRECT rule builder
+//     ([SteeringRedirect]) and the separately-injected steering agent
+//     container ([InjectSteer]/[WaitForSteer], NET_ADMIN-only — deliberately a
+//     SECOND container, never an upgrade of the NET_RAW tap, so mirror and
+//     intercept stay independently runnable). The conn↔stream pump and the
+//     CLI wiring follow.
 //
 //   - Phase 3 — environment & volume projection: run the local process with the
 //     target pod's env vars and mounted volumes/secrets for cluster-equivalent

--- a/pkg/svc/mirror/ephemeral.go
+++ b/pkg/svc/mirror/ephemeral.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -112,7 +113,9 @@ func injectEphemeralContainer(
 // point's pod reports Running, the container terminates (the kind's terminated
 // error, with its exit code), or timeout elapses. A pod without a matching
 // container status yet is simply polled again — the kubelet adds the status
-// asynchronously after injection.
+// asynchronously after injection. A transient pod read (a momentary apiserver
+// timeout, throttle, or 5xx) keeps polling rather than aborting the wait; a
+// persistent read failure surfaces its own cause once the deadline elapses.
 func waitForEphemeralContainer(
 	ctx context.Context,
 	client kubernetes.Interface,
@@ -131,6 +134,11 @@ func waitForEphemeralContainer(
 				Pods(point.Namespace).
 				Get(ctx, point.Pod, metav1.GetOptions{})
 			if err != nil {
+				if isTransientGetError(err) {
+					// Keep polling — the outer timeout bounds the wait.
+					return false, nil
+				}
+
 				return false, fmt.Errorf(
 					"getting pod %q in %s: %w",
 					point.Pod,
@@ -150,6 +158,20 @@ func waitForEphemeralContainer(
 	}
 
 	return nil
+}
+
+// isTransientGetError reports whether a pod Get error is a momentary
+// server-side condition worth retrying (an apiserver timeout, a throttle, an
+// internal 5xx, or the service being briefly unavailable) rather than a
+// terminal one. Terminal errors — a genuinely absent pod, an RBAC denial, a
+// malformed request — propagate so the wait fails fast with its real cause
+// instead of masquerading as a timeout.
+func isTransientGetError(err error) bool {
+	return apierrors.IsServerTimeout(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsServiceUnavailable(err)
 }
 
 // ephemeralContainerRunning reports whether the pod's kind container is

--- a/pkg/svc/mirror/ephemeral.go
+++ b/pkg/svc/mirror/ephemeral.go
@@ -1,0 +1,197 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+// ephemeralPollInterval is how often the wait helpers re-read the pod while
+// waiting for an injected ephemeral container to reach Running.
+const ephemeralPollInterval = 250 * time.Millisecond
+
+// ErrTapPointNil is returned when an inject or wait helper is called with a
+// nil TapPoint.
+var ErrTapPointNil = errors.New("tap point is nil")
+
+// ephemeralKind describes one ksail-managed ephemeral container flavour (the
+// read-only tap, the steering agent) so the injection and wait mechanics can
+// be shared while each flavour keeps its own name, privileges, and sentinel
+// errors.
+type ephemeralKind struct {
+	// containerName is the flavour's fixed container name — one per pod.
+	containerName string
+	// label names the flavour in wrapped error messages.
+	label string
+	// securityContext is the flavour's hardened security context.
+	securityContext *corev1.SecurityContext
+	// alreadyInjected is returned when the pod already carries the container.
+	alreadyInjected error
+	// terminated is returned when the container terminated instead of running.
+	terminated error
+}
+
+// ephemeralConfig holds the caller-configurable parts of an injected
+// container's spec.
+type ephemeralConfig struct {
+	image   string
+	command []string
+}
+
+// injectEphemeralContainer appends the kind's ephemeral container to the tap
+// point's pod and returns the container's name. The container targets the tap
+// point's container (TargetContainerName), sharing its process namespace where
+// the runtime supports it; pod network is shared regardless. Injection is
+// one-way — ephemeral containers cannot be removed — so a pod that already has
+// the kind's container yields its alreadyInjected error. Concurrent injectors
+// converge on that same error: a 409 conflict from the update re-reads the pod
+// and re-checks before retrying.
+func injectEphemeralContainer(
+	ctx context.Context,
+	client kubernetes.Interface,
+	point *TapPoint,
+	kind ephemeralKind,
+	cfg ephemeralConfig,
+) (string, error) {
+	if point == nil {
+		return "", ErrTapPointNil
+	}
+
+	pods := client.CoreV1().Pods(point.Namespace)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod, err := pods.Get(ctx, point.Pod, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("getting pod: %w", err)
+		}
+
+		for _, ephemeral := range pod.Spec.EphemeralContainers {
+			if ephemeral.Name == kind.containerName {
+				return fmt.Errorf(
+					"%w: %q on pod %q", kind.alreadyInjected, kind.containerName, point.Pod,
+				)
+			}
+		}
+
+		container := corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:            kind.containerName,
+				Image:           cfg.image,
+				Command:         cfg.command,
+				SecurityContext: kind.securityContext,
+			},
+			TargetContainerName: point.Container,
+		}
+		pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, container)
+
+		_, err = pods.UpdateEphemeralContainers(ctx, pod.Name, pod, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("updating ephemeral containers: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf(
+			"injecting %s container into pod %q in %s: %w",
+			kind.label, point.Pod, point.Namespace, err,
+		)
+	}
+
+	return kind.containerName, nil
+}
+
+// waitForEphemeralContainer blocks until the kind's container on the tap
+// point's pod reports Running, the container terminates (the kind's terminated
+// error, with its exit code), or timeout elapses. A pod without a matching
+// container status yet is simply polled again — the kubelet adds the status
+// asynchronously after injection.
+func waitForEphemeralContainer(
+	ctx context.Context,
+	client kubernetes.Interface,
+	point *TapPoint,
+	kind ephemeralKind,
+	timeout time.Duration,
+) error {
+	if point == nil {
+		return ErrTapPointNil
+	}
+
+	err := wait.PollUntilContextTimeout(
+		ctx, ephemeralPollInterval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := client.CoreV1().
+				Pods(point.Namespace).
+				Get(ctx, point.Pod, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf(
+					"getting pod %q in %s: %w",
+					point.Pod,
+					point.Namespace,
+					err,
+				)
+			}
+
+			return ephemeralContainerRunning(pod, kind)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"waiting for %s container %q on pod %q: %w",
+			kind.label, kind.containerName, point.Pod, err,
+		)
+	}
+
+	return nil
+}
+
+// ephemeralContainerRunning reports whether the pod's kind container is
+// Running. A terminated container is terminal (the kubelet never restarts
+// ephemeral containers), so it aborts the poll with the kind's terminated
+// error; a missing status keeps polling.
+func ephemeralContainerRunning(pod *corev1.Pod, kind ephemeralKind) (bool, error) {
+	for _, status := range pod.Status.EphemeralContainerStatuses {
+		if status.Name != kind.containerName {
+			continue
+		}
+
+		if status.State.Terminated != nil {
+			return false, fmt.Errorf(
+				"%w: exit code %d", kind.terminated, status.State.Terminated.ExitCode,
+			)
+		}
+
+		return status.State.Running != nil, nil
+	}
+
+	return false, nil
+}
+
+// hardenedSecurityContext returns the security context every ksail-managed
+// ephemeral container runs with: everything dropped except the single given
+// capability, no privilege escalation, a read-only root filesystem, and the
+// runtime's default seccomp profile. Callers are intentionally not allowed to
+// widen it: each flavour's guarantee rests on holding exactly one capability.
+func hardenedSecurityContext(capability corev1.Capability) *corev1.SecurityContext {
+	allowPrivilegeEscalation := false
+	readOnlyRootFilesystem := true
+
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+			Add:  []corev1.Capability{capability},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}

--- a/pkg/svc/mirror/inject.go
+++ b/pkg/svc/mirror/inject.go
@@ -3,14 +3,10 @@ package mirror
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
 )
 
 // TapContainerName is the fixed name of the ephemeral tap container InjectTap
@@ -25,14 +21,6 @@ const TapContainerName = "ksail-tap"
 // to a release tag so tap behaviour doesn't drift under a floating latest.
 const DefaultTapImage = "docker.io/nicolaka/netshoot:v0.16"
 
-// tapPollInterval is how often WaitForTap re-reads the pod while waiting for
-// the tap container to reach Running.
-const tapPollInterval = 250 * time.Millisecond
-
-// ErrTapPointNil is returned when InjectTap or WaitForTap is called with a nil
-// TapPoint.
-var ErrTapPointNil = errors.New("tap point is nil")
-
 // ErrTapAlreadyInjected is returned when the tap point's pod already carries a
 // tap container. Ephemeral containers cannot be removed or restarted, so the
 // existing tap is the one to use (or the pod must be replaced).
@@ -43,34 +31,36 @@ var ErrTapAlreadyInjected = errors.New("tap container already injected")
 var ErrTapTerminated = errors.New("tap container terminated")
 
 // TapOption customises the ephemeral tap container InjectTap builds.
-type TapOption func(*tapConfig)
-
-// tapConfig holds the configurable parts of the tap container spec.
-type tapConfig struct {
-	image   string
-	command []string
-}
+type TapOption func(*ephemeralConfig)
 
 // WithTapImage overrides the tap container's image (default DefaultTapImage).
 func WithTapImage(image string) TapOption {
-	return func(cfg *tapConfig) { cfg.image = image }
+	return func(cfg *ephemeralConfig) { cfg.image = image }
 }
 
 // WithTapCommand overrides the tap container's command. The default is an inert
 // holder (`sleep infinity`) until the later traffic increment supplies the real
 // tap process.
 func WithTapCommand(command ...string) TapOption {
-	return func(cfg *tapConfig) { cfg.command = command }
+	return func(cfg *ephemeralConfig) { cfg.command = command }
+}
+
+// tapKind describes the read-only tap container for the shared ephemeral
+// injection mechanics ([injectEphemeralContainer]/[waitForEphemeralContainer]).
+func tapKind() ephemeralKind {
+	return ephemeralKind{
+		containerName:   TapContainerName,
+		label:           "tap",
+		securityContext: tapSecurityContext(),
+		alreadyInjected: ErrTapAlreadyInjected,
+		terminated:      ErrTapTerminated,
+	}
 }
 
 // InjectTap appends the read-only tap ephemeral container to the tap point's
-// pod and returns the container's name. The container targets the tap point's
-// container (TargetContainerName), sharing its process namespace where the
-// runtime supports it; pod network is shared regardless, which is what the
-// mirror traffic path needs. Injection is one-way — ephemeral containers cannot
-// be removed — so a pod that already has a tap yields ErrTapAlreadyInjected.
-// Concurrent injectors converge on that same error: a 409 conflict from the
-// update re-reads the pod and re-checks for the tap before retrying.
+// pod and returns the container's name. See [injectEphemeralContainer] for the
+// injection semantics (idempotency, conflict convergence, process-namespace
+// targeting).
 //
 // The container runs an inert holder command by default; wiring the actual
 // traffic tap and the reverse tunnel are the next Phase 1 increments (#4521).
@@ -80,140 +70,31 @@ func InjectTap(
 	point *TapPoint,
 	opts ...TapOption,
 ) (string, error) {
-	if point == nil {
-		return "", ErrTapPointNil
-	}
-
-	cfg := tapConfig{image: DefaultTapImage, command: []string{"sleep", "infinity"}}
+	cfg := ephemeralConfig{image: DefaultTapImage, command: []string{"sleep", "infinity"}}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
-	pods := client.CoreV1().Pods(point.Namespace)
-
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		pod, err := pods.Get(ctx, point.Pod, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("getting pod: %w", err)
-		}
-
-		for _, ephemeral := range pod.Spec.EphemeralContainers {
-			if ephemeral.Name == TapContainerName {
-				return fmt.Errorf(
-					"%w: %q on pod %q", ErrTapAlreadyInjected, TapContainerName, point.Pod,
-				)
-			}
-		}
-
-		tap := corev1.EphemeralContainer{
-			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-				Name:            TapContainerName,
-				Image:           cfg.image,
-				Command:         cfg.command,
-				SecurityContext: tapSecurityContext(),
-			},
-			TargetContainerName: point.Container,
-		}
-		pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, tap)
-
-		_, err = pods.UpdateEphemeralContainers(ctx, pod.Name, pod, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("updating ephemeral containers: %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return "", fmt.Errorf(
-			"injecting tap container into pod %q in %s: %w", point.Pod, point.Namespace, err,
-		)
-	}
-
-	return TapContainerName, nil
+	return injectEphemeralContainer(ctx, client, point, tapKind(), cfg)
 }
 
 // tapSecurityContext returns the hardened security context every tap container
 // runs with: everything dropped except NET_RAW — the one capability passive
-// pcap capture ([CaptureCommand]) needs — no privilege escalation, a read-only
-// root filesystem (the capture writes only to stdout), and the runtime's
-// default seccomp profile. The context is intentionally not caller-configurable:
-// the read-only guarantee of mirror mode rests on the tap never holding more
-// than capture privileges.
+// pcap capture ([CaptureCommand]) needs. The context is intentionally not
+// caller-configurable: the read-only guarantee of mirror mode rests on the tap
+// never holding more than capture privileges.
 func tapSecurityContext() *corev1.SecurityContext {
-	allowPrivilegeEscalation := false
-	readOnlyRootFilesystem := true
-
-	return &corev1.SecurityContext{
-		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-		ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-			Add:  []corev1.Capability{"NET_RAW"},
-		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
+	return hardenedSecurityContext("NET_RAW")
 }
 
 // WaitForTap blocks until the tap container on the tap point's pod reports
 // Running, the container terminates (ErrTapTerminated, with its exit code), or
-// timeout elapses. A pod without a tap status yet is simply polled again — the
-// kubelet adds the status asynchronously after injection.
+// timeout elapses.
 func WaitForTap(
 	ctx context.Context,
 	client kubernetes.Interface,
 	point *TapPoint,
 	timeout time.Duration,
 ) error {
-	if point == nil {
-		return ErrTapPointNil
-	}
-
-	err := wait.PollUntilContextTimeout(
-		ctx, tapPollInterval, timeout, true,
-		func(ctx context.Context) (bool, error) {
-			pod, err := client.CoreV1().
-				Pods(point.Namespace).
-				Get(ctx, point.Pod, metav1.GetOptions{})
-			if err != nil {
-				return false, fmt.Errorf(
-					"getting pod %q in %s: %w",
-					point.Pod,
-					point.Namespace,
-					err,
-				)
-			}
-
-			return tapRunning(pod)
-		},
-	)
-	if err != nil {
-		return fmt.Errorf(
-			"waiting for tap container %q on pod %q: %w", TapContainerName, point.Pod, err,
-		)
-	}
-
-	return nil
-}
-
-// tapRunning reports whether the pod's tap container is Running. A terminated
-// tap is terminal (the kubelet never restarts ephemeral containers), so it
-// aborts the poll with ErrTapTerminated; a missing status keeps polling.
-func tapRunning(pod *corev1.Pod) (bool, error) {
-	for _, status := range pod.Status.EphemeralContainerStatuses {
-		if status.Name != TapContainerName {
-			continue
-		}
-
-		if status.State.Terminated != nil {
-			return false, fmt.Errorf(
-				"%w: exit code %d", ErrTapTerminated, status.State.Terminated.ExitCode,
-			)
-		}
-
-		return status.State.Running != nil, nil
-	}
-
-	return false, nil
+	return waitForEphemeralContainer(ctx, client, point, tapKind(), timeout)
 }

--- a/pkg/svc/mirror/inject_test.go
+++ b/pkg/svc/mirror/inject_test.go
@@ -58,20 +58,11 @@ func podWithTapStatus(state corev1.ContainerState) *corev1.Pod {
 func TestInjectTapDefaults(t *testing.T) {
 	t.Parallel()
 
-	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+	name, tap := injectIntoFreshPod(t, func(clientset *k8sfake.Clientset) (string, error) {
+		return mirror.InjectTap(t.Context(), clientset, newTapPoint())
+	})
 
-	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
-
-	require.NoError(t, err)
 	assert.Equal(t, mirror.TapContainerName, name)
-
-	pod, err := clientset.CoreV1().
-		Pods(testNamespace).
-		Get(t.Context(), "api-0", metav1.GetOptions{})
-	require.NoError(t, err)
-	require.Len(t, pod.Spec.EphemeralContainers, 1)
-
-	tap := pod.Spec.EphemeralContainers[0]
 	assert.Equal(t, mirror.TapContainerName, tap.Name)
 	assert.Equal(t, mirror.DefaultTapImage, tap.Image)
 	assert.Equal(t, []string{"sleep", "infinity"}, tap.Command)

--- a/pkg/svc/mirror/steer.go
+++ b/pkg/svc/mirror/steer.go
@@ -1,0 +1,107 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// SteerContainerName is the fixed name of the ephemeral steering container
+// InjectSteer appends to the tap point's pod. One steering agent per pod: a
+// second InjectSteer on the same pod returns ErrSteerAlreadyInjected.
+//
+// Steering is deliberately a SECOND container, never an upgrade of the tap:
+// the tap's NET_RAW-only context is the security posture of mirror-only mode,
+// so mirror and intercept stay independently runnable (#5839).
+const SteerContainerName = "ksail-steer"
+
+// DefaultSteerImage is the image the steering container runs when the caller
+// does not override it with WithSteerImage. The same pinned netshoot release
+// as the tap ([DefaultTapImage]) — it carries the iptables userspace tooling
+// the steering agent drives.
+const DefaultSteerImage = DefaultTapImage
+
+// ErrSteerAlreadyInjected is returned when the tap point's pod already carries
+// a steering container. Ephemeral containers cannot be removed or restarted,
+// so the existing agent is the one to use (or the pod must be replaced).
+var ErrSteerAlreadyInjected = errors.New("steering container already injected")
+
+// ErrSteerTerminated is returned by WaitForSteer when the steering container
+// terminated instead of reaching Running.
+var ErrSteerTerminated = errors.New("steering container terminated")
+
+// SteerOption customises the ephemeral steering container InjectSteer builds.
+type SteerOption func(*ephemeralConfig)
+
+// WithSteerImage overrides the steering container's image (default
+// DefaultSteerImage).
+func WithSteerImage(image string) SteerOption {
+	return func(cfg *ephemeralConfig) { cfg.image = image }
+}
+
+// WithSteerCommand overrides the steering container's command. The default is
+// an inert holder (`sleep infinity`) until the conn↔stream pump increment
+// supplies the real steering agent process (#5839 increment 2).
+func WithSteerCommand(command ...string) SteerOption {
+	return func(cfg *ephemeralConfig) { cfg.command = command }
+}
+
+// steerKind describes the steering container for the shared ephemeral
+// injection mechanics ([injectEphemeralContainer]/[waitForEphemeralContainer]).
+func steerKind() ephemeralKind {
+	return ephemeralKind{
+		containerName:   SteerContainerName,
+		label:           "steering",
+		securityContext: steerSecurityContext(),
+		alreadyInjected: ErrSteerAlreadyInjected,
+		terminated:      ErrSteerTerminated,
+	}
+}
+
+// InjectSteer appends the steering ephemeral container to the tap point's pod
+// and returns the container's name. See [injectEphemeralContainer] for the
+// injection semantics (idempotency, conflict convergence, process-namespace
+// targeting). A pod already carrying a tap can still receive a steering agent
+// and vice versa — the two flavours are independent by design.
+//
+// The container runs an inert holder command by default; the iptables rule
+// application and the conn↔stream pump are the next intercept increments
+// (#5839).
+func InjectSteer(
+	ctx context.Context,
+	client kubernetes.Interface,
+	point *TapPoint,
+	opts ...SteerOption,
+) (string, error) {
+	cfg := ephemeralConfig{image: DefaultSteerImage, command: []string{"sleep", "infinity"}}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return injectEphemeralContainer(ctx, client, point, steerKind(), cfg)
+}
+
+// steerSecurityContext returns the hardened security context every steering
+// container runs with: everything dropped except NET_ADMIN — the one
+// capability writing iptables NAT rules in the pod's network namespace needs.
+// The context is intentionally not caller-configurable: intercept's blast
+// radius rests on the agent holding exactly the rule-writing privilege and
+// nothing else (notably NOT the tap's NET_RAW).
+func steerSecurityContext() *corev1.SecurityContext {
+	return hardenedSecurityContext("NET_ADMIN")
+}
+
+// WaitForSteer blocks until the steering container on the tap point's pod
+// reports Running, the container terminates (ErrSteerTerminated, with its exit
+// code), or timeout elapses.
+func WaitForSteer(
+	ctx context.Context,
+	client kubernetes.Interface,
+	point *TapPoint,
+	timeout time.Duration,
+) error {
+	return waitForEphemeralContainer(ctx, client, point, steerKind(), timeout)
+}

--- a/pkg/svc/mirror/steer_test.go
+++ b/pkg/svc/mirror/steer_test.go
@@ -1,0 +1,285 @@
+package mirror_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// steeredPod builds a Running pod that already carries a steering ephemeral
+// container, for the idempotency test.
+func steeredPod() *corev1.Pod {
+	pod := newPod("api-0", selectorLabels(), corev1.PodRunning)
+	pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name: mirror.SteerContainerName,
+		},
+	}}
+
+	return pod
+}
+
+// podWithSteerStatus builds a Running pod whose steering ephemeral container
+// reports the given state.
+func podWithSteerStatus(state corev1.ContainerState) *corev1.Pod {
+	pod := steeredPod()
+	pod.Status.EphemeralContainerStatuses = []corev1.ContainerStatus{{
+		Name:  mirror.SteerContainerName,
+		State: state,
+	}}
+
+	return pod
+}
+
+// injectIntoFreshPod runs the given inject call against a fresh Running pod
+// and returns the returned container name plus the single ephemeral container
+// it appended — the shared skeleton of the tap and steer defaults tests.
+func injectIntoFreshPod(
+	t *testing.T,
+	inject func(clientset *k8sfake.Clientset) (string, error),
+) (string, corev1.EphemeralContainer) {
+	t.Helper()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	name, err := inject(clientset)
+	require.NoError(t, err)
+
+	pod, err := clientset.CoreV1().
+		Pods(testNamespace).
+		Get(t.Context(), "api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, pod.Spec.EphemeralContainers, 1)
+
+	return name, pod.Spec.EphemeralContainers[0]
+}
+
+func TestInjectSteerDefaults(t *testing.T) {
+	t.Parallel()
+
+	name, steer := injectIntoFreshPod(t, func(clientset *k8sfake.Clientset) (string, error) {
+		return mirror.InjectSteer(t.Context(), clientset, newTapPoint())
+	})
+
+	assert.Equal(t, mirror.SteerContainerName, name)
+	assert.Equal(t, mirror.SteerContainerName, steer.Name)
+	assert.Equal(t, mirror.DefaultSteerImage, steer.Image)
+	assert.Equal(t, []string{"sleep", "infinity"}, steer.Command)
+	assert.Equal(t, "api", steer.TargetContainerName)
+	assertHardenedSteerSecurityContext(t, steer.SecurityContext)
+}
+
+// assertHardenedSteerSecurityContext pins the intercept blast radius: the
+// steering agent holds NET_ADMIN (for iptables NAT rules in the pod netns) and
+// nothing else — notably NOT the tap's NET_RAW.
+func assertHardenedSteerSecurityContext(t *testing.T, secCtx *corev1.SecurityContext) {
+	t.Helper()
+
+	require.NotNil(t, secCtx)
+	require.NotNil(t, secCtx.AllowPrivilegeEscalation)
+	assert.False(t, *secCtx.AllowPrivilegeEscalation)
+	require.NotNil(t, secCtx.ReadOnlyRootFilesystem)
+	assert.True(t, *secCtx.ReadOnlyRootFilesystem)
+	require.NotNil(t, secCtx.Capabilities)
+	assert.Equal(t, []corev1.Capability{"ALL"}, secCtx.Capabilities.Drop)
+	assert.Equal(t, []corev1.Capability{"NET_ADMIN"}, secCtx.Capabilities.Add)
+	require.NotNil(t, secCtx.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, secCtx.SeccompProfile.Type)
+}
+
+func TestInjectSteerOptions(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	_, err := mirror.InjectSteer(
+		t.Context(), clientset, newTapPoint(),
+		mirror.WithSteerImage("ghcr.io/example/steer:1"),
+		mirror.WithSteerCommand("ksail-steer-agent", "--port", "9090"),
+	)
+
+	require.NoError(t, err)
+
+	pod, err := clientset.CoreV1().
+		Pods(testNamespace).
+		Get(t.Context(), "api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, pod.Spec.EphemeralContainers, 1)
+	assert.Equal(t, "ghcr.io/example/steer:1", pod.Spec.EphemeralContainers[0].Image)
+	assert.Equal(
+		t,
+		[]string{"ksail-steer-agent", "--port", "9090"},
+		pod.Spec.EphemeralContainers[0].Command,
+	)
+}
+
+func TestInjectSteerNilPoint(t *testing.T) {
+	t.Parallel()
+
+	name, err := mirror.InjectSteer(t.Context(), k8sfake.NewClientset(), nil)
+
+	require.ErrorIs(t, err, mirror.ErrTapPointNil)
+	assert.Empty(t, name)
+}
+
+func TestInjectSteerAlreadyInjected(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(steeredPod())
+
+	name, err := mirror.InjectSteer(t.Context(), clientset, newTapPoint())
+
+	require.ErrorIs(t, err, mirror.ErrSteerAlreadyInjected)
+	assert.Empty(t, name)
+}
+
+func TestInjectSteerCoexistsWithTap(t *testing.T) {
+	t.Parallel()
+
+	// Mirror and intercept are independently runnable by design (#5839): a pod
+	// already carrying the tap must accept the steering agent, and the two
+	// containers must keep their distinct privilege sets.
+	clientset := k8sfake.NewClientset(tappedPod())
+
+	name, err := mirror.InjectSteer(t.Context(), clientset, newTapPoint())
+
+	require.NoError(t, err)
+	assert.Equal(t, mirror.SteerContainerName, name)
+
+	pod, err := clientset.CoreV1().
+		Pods(testNamespace).
+		Get(t.Context(), "api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, pod.Spec.EphemeralContainers, 2)
+	assert.Equal(t, mirror.TapContainerName, pod.Spec.EphemeralContainers[0].Name)
+	assert.Equal(t, mirror.SteerContainerName, pod.Spec.EphemeralContainers[1].Name)
+}
+
+func TestInjectTapCoexistsWithSteer(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(steeredPod())
+
+	name, err := mirror.InjectTap(t.Context(), clientset, newTapPoint())
+
+	require.NoError(t, err)
+	assert.Equal(t, mirror.TapContainerName, name)
+
+	pod, err := clientset.CoreV1().
+		Pods(testNamespace).
+		Get(t.Context(), "api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, pod.Spec.EphemeralContainers, 2)
+}
+
+func TestInjectSteerUpdateError(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+	clientset.PrependReactor("update", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != ephemeralContainersSubresource {
+				return false, nil, nil
+			}
+
+			return true, nil, errUpdateFailed
+		})
+
+	name, err := mirror.InjectSteer(t.Context(), clientset, newTapPoint())
+
+	require.ErrorIs(t, err, errUpdateFailed)
+	assert.Empty(t, name)
+}
+
+func TestInjectSteerConflictRetriesAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	conflicted := false
+
+	clientset.PrependReactor("update", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != ephemeralContainersSubresource || conflicted {
+				return false, nil, nil
+			}
+
+			conflicted = true
+
+			return true, nil, conflictError()
+		})
+
+	name, err := mirror.InjectSteer(t.Context(), clientset, newTapPoint())
+
+	require.NoError(t, err)
+	assert.Equal(t, mirror.SteerContainerName, name)
+	assert.True(t, conflicted)
+}
+
+func TestWaitForSteerNilPoint(t *testing.T) {
+	t.Parallel()
+
+	err := mirror.WaitForSteer(t.Context(), k8sfake.NewClientset(), nil, time.Second)
+
+	require.ErrorIs(t, err, mirror.ErrTapPointNil)
+}
+
+func TestWaitForSteerRunning(t *testing.T) {
+	t.Parallel()
+
+	pod := podWithSteerStatus(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}})
+	clientset := k8sfake.NewClientset(pod)
+
+	err := mirror.WaitForSteer(t.Context(), clientset, newTapPoint(), time.Second)
+
+	require.NoError(t, err)
+}
+
+func TestWaitForSteerTerminated(t *testing.T) {
+	t.Parallel()
+
+	pod := podWithSteerStatus(corev1.ContainerState{
+		Terminated: &corev1.ContainerStateTerminated{ExitCode: 3},
+	})
+	clientset := k8sfake.NewClientset(pod)
+
+	err := mirror.WaitForSteer(t.Context(), clientset, newTapPoint(), time.Second)
+
+	require.ErrorIs(t, err, mirror.ErrSteerTerminated)
+	assert.ErrorContains(t, err, "exit code 3")
+}
+
+func TestWaitForSteerTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Pod exists but never reports a steering status: the poll must give up at
+	// the timeout rather than spin forever.
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	err := mirror.WaitForSteer(t.Context(), clientset, newTapPoint(), 50*time.Millisecond)
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, mirror.ErrSteerTerminated)
+}
+
+func TestWaitForSteerIgnoresTapStatus(t *testing.T) {
+	t.Parallel()
+
+	// A pod whose TAP is running but whose steering agent has no status yet
+	// must keep polling — the two flavours' statuses are independent.
+	pod := podWithTapStatus(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}})
+	clientset := k8sfake.NewClientset(pod)
+
+	err := mirror.WaitForSteer(t.Context(), clientset, newTapPoint(), 50*time.Millisecond)
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, mirror.ErrSteerTerminated)
+}

--- a/pkg/svc/mirror/steer_test.go
+++ b/pkg/svc/mirror/steer_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -268,6 +270,55 @@ func TestWaitForSteerTimeout(t *testing.T) {
 
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, mirror.ErrSteerTerminated)
+}
+
+func TestWaitForEphemeralContainerRetriesTransientGetError(t *testing.T) {
+	t.Parallel()
+
+	// A momentary apiserver error must not abort the wait: the poll keeps
+	// going and succeeds once a later Get returns the Running pod.
+	pod := podWithSteerStatus(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}})
+	clientset := k8sfake.NewClientset(pod)
+
+	failed := false
+
+	clientset.PrependReactor("get", "pods",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			if failed {
+				return false, nil, nil
+			}
+
+			failed = true
+
+			return true, nil, apierrors.NewServerTimeout(
+				schema.GroupResource{Resource: "pods"}, "get", 1,
+			)
+		})
+
+	err := mirror.WaitForSteer(t.Context(), clientset, newTapPoint(), time.Second)
+
+	require.NoError(t, err)
+	assert.True(t, failed, "expected the transient Get error to have fired")
+}
+
+func TestWaitForEphemeralContainerPropagatesTerminalGetError(t *testing.T) {
+	t.Parallel()
+
+	// A terminal error (here forbidden) must surface its own cause, not be
+	// swallowed into a timeout.
+	clientset := k8sfake.NewClientset(newPod("api-0", selectorLabels(), corev1.PodRunning))
+
+	clientset.PrependReactor("get", "pods",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: "pods"}, "api-0", errUpdateFailed,
+			)
+		})
+
+	err := mirror.WaitForSteer(t.Context(), clientset, newTapPoint(), time.Second)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "forbidden")
 }
 
 func TestWaitForSteerIgnoresTapStatus(t *testing.T) {

--- a/pkg/svc/mirror/steering.go
+++ b/pkg/svc/mirror/steering.go
@@ -1,0 +1,110 @@
+package mirror
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// Steering rule placement: intercept steers inbound TCP in the pod's OWN
+// network namespace, so the rules live in the nat table's PREROUTING chain —
+// the earliest hook inbound packets traverse, and the only place a REDIRECT
+// can retarget them before the app container's socket accepts them.
+const (
+	steeringTable = "nat"
+	steeringChain = "PREROUTING"
+)
+
+// SteeringRuleComment tags every rule the steering agent writes, so cleanup
+// (and the idle-watchdog increment) can identify ksail's rules — and only
+// ksail's — inside a chain that may carry unrelated entries.
+const SteeringRuleComment = "ksail-steer"
+
+// Valid TCP port bounds for a steering redirect.
+const (
+	steeringPortMin = 1
+	steeringPortMax = 65535
+)
+
+// ErrSteeringPortInvalid is returned when a redirect names a port outside the
+// valid TCP range.
+var ErrSteeringPortInvalid = errors.New("steering port out of range")
+
+// SteeringRedirect describes one traffic-steering rule: inbound TCP to the
+// workload's ServicePort is redirected — same network namespace, via iptables
+// NAT REDIRECT — to the InterceptPort the steering agent listens on. The
+// original destination stays recoverable via SO_ORIGINAL_DST. TPROXY is
+// deliberately not used: it needs policy routing and more privileges for no
+// benefit inside a single pod netns (#5839).
+type SteeringRedirect struct {
+	// ServicePort is the workload port whose inbound TCP is steered.
+	ServicePort int
+	// InterceptPort is the steering agent's listener the traffic is
+	// redirected to.
+	InterceptPort int
+}
+
+// Validate reports whether both ports are inside the valid TCP range.
+func (r SteeringRedirect) Validate() error {
+	ports := []struct {
+		name  string
+		value int
+	}{
+		{"service", r.ServicePort},
+		{"intercept", r.InterceptPort},
+	}
+	for _, port := range ports {
+		if port.value < steeringPortMin || port.value > steeringPortMax {
+			return fmt.Errorf("%w: %s port %d", ErrSteeringPortInvalid, port.name, port.value)
+		}
+	}
+
+	return nil
+}
+
+// InsertArgs returns the iptables argument vector that installs the redirect
+// at the head of the nat PREROUTING chain (`-I`, so it wins over any later
+// rules for the same port).
+func (r SteeringRedirect) InsertArgs() ([]string, error) {
+	return r.args("-I")
+}
+
+// DeleteArgs returns the iptables argument vector that removes the redirect.
+// It is the exact inverse of [SteeringRedirect.InsertArgs] (`-D` with an
+// otherwise identical rule specification), which is what makes cleanup
+// verifiable: reversibility is a hard requirement because ephemeral containers
+// cannot be removed — only the rules can be (#5839).
+func (r SteeringRedirect) DeleteArgs() ([]string, error) {
+	return r.args("-D")
+}
+
+// args builds the full iptables argument vector for the given chain action,
+// validating the redirect first so no malformed rule ever reaches a chain.
+func (r SteeringRedirect) args(action string) ([]string, error) {
+	err := r.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	prefix := []string{"-t", steeringTable, action, steeringChain}
+	spec := r.ruleSpec()
+
+	args := make([]string, 0, len(prefix)+len(spec))
+	args = append(args, prefix...)
+	args = append(args, spec...)
+
+	return args, nil
+}
+
+// ruleSpec is the rule specification shared verbatim by insertion and
+// deletion — iptables `-D` only matches a rule whose specification is
+// byte-identical to the one `-I` installed.
+func (r SteeringRedirect) ruleSpec() []string {
+	return []string{
+		"-p", "tcp",
+		"--dport", strconv.Itoa(r.ServicePort),
+		"-m", "comment", "--comment", SteeringRuleComment,
+		"-j", "REDIRECT",
+		"--to-ports", strconv.Itoa(r.InterceptPort),
+	}
+}

--- a/pkg/svc/mirror/steering_test.go
+++ b/pkg/svc/mirror/steering_test.go
@@ -1,0 +1,144 @@
+package mirror_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSteeringRedirectValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		redirect mirror.SteeringRedirect
+		wantErr  bool
+	}{
+		{
+			name:     "valid ports",
+			redirect: mirror.SteeringRedirect{ServicePort: 8080, InterceptPort: 9090},
+		},
+		{
+			name:     "port bounds",
+			redirect: mirror.SteeringRedirect{ServicePort: 1, InterceptPort: 65535},
+		},
+		{
+			name:     "zero service port",
+			redirect: mirror.SteeringRedirect{ServicePort: 0, InterceptPort: 9090},
+			wantErr:  true,
+		},
+		{
+			name:     "negative service port",
+			redirect: mirror.SteeringRedirect{ServicePort: -1, InterceptPort: 9090},
+			wantErr:  true,
+		},
+		{
+			name:     "service port too high",
+			redirect: mirror.SteeringRedirect{ServicePort: 65536, InterceptPort: 9090},
+			wantErr:  true,
+		},
+		{
+			name:     "zero intercept port",
+			redirect: mirror.SteeringRedirect{ServicePort: 8080, InterceptPort: 0},
+			wantErr:  true,
+		},
+		{
+			name:     "intercept port too high",
+			redirect: mirror.SteeringRedirect{ServicePort: 8080, InterceptPort: 70000},
+			wantErr:  true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.redirect.Validate()
+
+			if testCase.wantErr {
+				require.ErrorIs(t, err, mirror.ErrSteeringPortInvalid)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSteeringRedirectInsertArgs(t *testing.T) {
+	t.Parallel()
+
+	redirect := mirror.SteeringRedirect{ServicePort: 8080, InterceptPort: 9090}
+
+	args, err := redirect.InsertArgs()
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"-t", "nat", "-I", "PREROUTING",
+		"-p", "tcp",
+		"--dport", "8080",
+		"-m", "comment", "--comment", mirror.SteeringRuleComment,
+		"-j", "REDIRECT",
+		"--to-ports", "9090",
+	}, args)
+}
+
+func TestSteeringRedirectDeleteArgs(t *testing.T) {
+	t.Parallel()
+
+	redirect := mirror.SteeringRedirect{ServicePort: 8080, InterceptPort: 9090}
+
+	args, err := redirect.DeleteArgs()
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"-t", "nat", "-D", "PREROUTING",
+		"-p", "tcp",
+		"--dport", "8080",
+		"-m", "comment", "--comment", mirror.SteeringRuleComment,
+		"-j", "REDIRECT",
+		"--to-ports", "9090",
+	}, args)
+}
+
+func TestSteeringRedirectDeleteIsExactInverseOfInsert(t *testing.T) {
+	t.Parallel()
+
+	// Reversibility is a hard requirement (#5839): iptables -D only matches a
+	// byte-identical rule specification, so the delete vector must differ from
+	// the insert vector in exactly the chain action and nothing else.
+	redirect := mirror.SteeringRedirect{ServicePort: 443, InterceptPort: 18443}
+
+	insert, err := redirect.InsertArgs()
+	require.NoError(t, err)
+
+	deleteArgs, err := redirect.DeleteArgs()
+	require.NoError(t, err)
+
+	require.Len(t, deleteArgs, len(insert))
+
+	for index := range insert {
+		if insert[index] == "-I" {
+			assert.Equal(t, "-D", deleteArgs[index], "index %d", index)
+
+			continue
+		}
+
+		assert.Equal(t, insert[index], deleteArgs[index], "index %d", index)
+	}
+}
+
+func TestSteeringRedirectArgsInvalid(t *testing.T) {
+	t.Parallel()
+
+	redirect := mirror.SteeringRedirect{ServicePort: 0, InterceptPort: 9090}
+
+	insert, err := redirect.InsertArgs()
+	require.ErrorIs(t, err, mirror.ErrSteeringPortInvalid)
+	assert.Nil(t, insert)
+
+	deleteArgs, err := redirect.DeleteArgs()
+	require.ErrorIs(t, err, mirror.ErrSteeringPortInvalid)
+	assert.Nil(t, deleteArgs)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Intercept mode (#4521) has its tunnel foundations merged, but nothing steers a workload's inbound traffic into that tunnel yet — the accepted #5839 design's first increment is the steering seams everything else builds on.

## What
Adds the pure iptables REDIRECT rule builder (deletion is the exact inverse of insertion, so cleanup of a dropped session is verifiable), the hardened NET_ADMIN-only `ksail-steer` ephemeral container with inject/wait seams, and extracts the tap's injection mechanics for shared use. Mirror-only mode is unchanged; no CLI surface yet (that is increment 3).

Fixes #5840. Part of #5839 / #4521.