### PR TITLE
feat(mirror): bridge redirected connections with tunnel streams for intercept

### DIFF
--- a/pkg/svc/mirror/doc.go
+++ b/pkg/svc/mirror/doc.go
@@ -71,8 +71,10 @@
 //     ([SteeringRedirect]) and the separately-injected steering agent
 //     container ([InjectSteer]/[WaitForSteer], NET_ADMIN-only — deliberately a
 //     SECOND container, never an upgrade of the NET_RAW tap, so mirror and
-//     intercept stay independently runnable). The conn↔stream pump and the
-//     CLI wiring follow.
+//     intercept stay independently runnable); and the conn↔stream pump
+//     bridging the two ([Pump], with [ForwardRedirected] accepting redirected
+//     connections agent-side and [ServeIntercepted] dialing the local process
+//     ksail-side). The CLI wiring follows.
 //
 //   - Phase 3 — environment & volume projection: run the local process with the
 //     target pod's env vars and mounted volumes/secrets for cluster-equivalent

--- a/pkg/svc/mirror/pump.go
+++ b/pkg/svc/mirror/pump.go
@@ -52,14 +52,15 @@ func copyDirection(results chan<- error, dst io.Writer, src io.Reader) {
 // ForwardRedirected is the steering agent's side of intercept: it accepts each
 // connection the iptables REDIRECT delivers to the listener, opens one tunnel
 // stream for it, and pumps the two together. It blocks until the context is
-// cancelled (returns nil — the deliberate stop closes the listener), the
-// session closes (returns nil — the tunnel ending is the session owner's event
-// to inspect via [TunnelSession.Err]), or the listener fails (returns the
-// error). Cancellation also tears down every active pump, and all pumps are
-// drained before it returns.
+// cancelled (returns nil), the session ends (returns nil — the tunnel ending
+// is the session owner's event to inspect via [TunnelSession.Err]), or the
+// listener fails (returns the error). Both stop signals close the listener so
+// a parked Accept notices them without another connection having to arrive.
+// Cancellation also tears down every active pump, and all pumps are drained
+// before it returns.
 func ForwardRedirected(ctx context.Context, listener net.Listener, session *TunnelSession) error {
-	stopClosing := context.AfterFunc(ctx, func() { _ = listener.Close() })
-	defer stopClosing()
+	stopWatch := unblockAcceptOnStop(ctx, session, listener)
+	defer stopWatch()
 
 	pumps := &sync.WaitGroup{}
 	defer pumps.Wait()
@@ -67,7 +68,7 @@ func ForwardRedirected(ctx context.Context, listener net.Listener, session *Tunn
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			if ctx.Err() != nil {
+			if stopRequested(ctx, session, err) {
 				return nil
 			}
 
@@ -78,7 +79,7 @@ func ForwardRedirected(ctx context.Context, listener net.Listener, session *Tunn
 		if err != nil {
 			_ = conn.Close()
 
-			if ctx.Err() != nil || errors.Is(err, ErrTunnelSessionClosed) {
+			if stopRequested(ctx, session, err) {
 				return nil
 			}
 
@@ -88,6 +89,49 @@ func ForwardRedirected(ctx context.Context, listener net.Listener, session *Tunn
 		pumps.Go(func() {
 			pumpUntilDone(ctx, conn, stream)
 		})
+	}
+}
+
+// unblockAcceptOnStop closes the listener when either stop signal fires — the
+// context ending or the tunnel session ending — so a parked Accept notices a
+// stop without another connection having to arrive. The returned stop
+// function releases the watcher once the accept loop has returned.
+func unblockAcceptOnStop(
+	ctx context.Context,
+	session *TunnelSession,
+	listener net.Listener,
+) func() {
+	watchDone := make(chan struct{})
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = listener.Close()
+		case <-session.Done():
+			_ = listener.Close()
+		case <-watchDone:
+		}
+	}()
+
+	return func() { close(watchDone) }
+}
+
+// stopRequested reports whether an accept-loop failure was caused by a stop
+// signal — the context ending or the session ending — rather than being a
+// genuine failure.
+func stopRequested(ctx context.Context, session *TunnelSession, err error) bool {
+	return ctx.Err() != nil || sessionEnded(session) || errors.Is(err, ErrTunnelSessionClosed)
+}
+
+// sessionEnded reports whether the session's demux loop has exited — the
+// signal the listener watcher acts on, so an Accept it unblocked can tell a
+// session end from a genuine listener failure.
+func sessionEnded(session *TunnelSession) bool {
+	select {
+	case <-session.Done():
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/svc/mirror/pump.go
+++ b/pkg/svc/mirror/pump.go
@@ -1,0 +1,144 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// pumpDirections sizes the result channel so both copy goroutines can finish
+// without a receiver.
+const pumpDirections = 2
+
+// LocalDialer opens one connection to the developer's local process for one
+// intercepted stream. It is a seam so the serve loop is testable against
+// in-memory pipes and the CLI wiring can plug in a real TCP dial.
+type LocalDialer func(ctx context.Context) (io.ReadWriteCloser, error)
+
+// Pump bridges one intercepted connection with its tunnel stream: bytes are
+// copied in both directions until either side ends, then BOTH halves are
+// closed — a dropped local process must never leave the redirected cluster
+// connection half-open (#5839's reversibility posture applied to data flow).
+// It returns the error that ended the first direction (nil for a clean EOF);
+// whatever the closes provoke in the other direction is teardown noise and is
+// discarded.
+func Pump(left, right io.ReadWriteCloser) error {
+	results := make(chan error, pumpDirections)
+
+	go copyDirection(results, left, right)
+	go copyDirection(results, right, left)
+
+	firstErr := <-results
+
+	_ = left.Close()
+	_ = right.Close()
+
+	// Wait for the second direction to unwind against the closed halves so
+	// Pump never leaks a copy goroutine.
+	<-results
+
+	return firstErr
+}
+
+// copyDirection copies one direction of a pump and reports how it ended.
+func copyDirection(results chan<- error, dst io.Writer, src io.Reader) {
+	_, err := io.Copy(dst, src)
+	results <- err
+}
+
+// ForwardRedirected is the steering agent's side of intercept: it accepts each
+// connection the iptables REDIRECT delivers to the listener, opens one tunnel
+// stream for it, and pumps the two together. It blocks until the context is
+// cancelled (returns nil — the deliberate stop closes the listener), the
+// session closes (returns nil — the tunnel ending is the session owner's event
+// to inspect via [TunnelSession.Err]), or the listener fails (returns the
+// error). Cancellation also tears down every active pump, and all pumps are
+// drained before it returns.
+func ForwardRedirected(ctx context.Context, listener net.Listener, session *TunnelSession) error {
+	stopClosing := context.AfterFunc(ctx, func() { _ = listener.Close() })
+	defer stopClosing()
+
+	pumps := &sync.WaitGroup{}
+	defer pumps.Wait()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+
+			return fmt.Errorf("accepting a redirected connection: %w", err)
+		}
+
+		stream, err := session.OpenStream()
+		if err != nil {
+			_ = conn.Close()
+
+			if ctx.Err() != nil || errors.Is(err, ErrTunnelSessionClosed) {
+				return nil
+			}
+
+			return fmt.Errorf("opening a tunnel stream for a redirected connection: %w", err)
+		}
+
+		pumps.Go(func() {
+			pumpUntilDone(ctx, conn, stream)
+		})
+	}
+}
+
+// pumpUntilDone runs one pump and tears both halves down early when the
+// context ends, so a cancelled intercept session never leaves a pump — and
+// the loop draining it — blocked on a still-open connection.
+func pumpUntilDone(ctx context.Context, left, right io.ReadWriteCloser) {
+	stopTeardown := context.AfterFunc(ctx, func() {
+		_ = left.Close()
+		_ = right.Close()
+	})
+	defer stopTeardown()
+
+	_ = Pump(left, right)
+}
+
+// ServeIntercepted is the local ksail side of intercept: it accepts each
+// stream the steering agent opened, dials the developer's local process, and
+// pumps the two together. A failed dial closes the stream — the tunnel's
+// "connection refused", which makes the agent close the redirected cluster
+// connection. It blocks until the context is cancelled or the session closes
+// (both return nil — inspect [TunnelSession.Err] for why a session ended);
+// cancellation also tears down every active pump, and all pumps are drained
+// before it returns.
+func ServeIntercepted(ctx context.Context, session *TunnelSession, dial LocalDialer) error {
+	pumps := &sync.WaitGroup{}
+	defer pumps.Wait()
+
+	for {
+		stream, err := session.AcceptStream(ctx)
+		if err != nil {
+			// AcceptStream only fails when the session closed or the context
+			// ended — both are a deliberate end of serving, not a failure.
+			return nil
+		}
+
+		pumps.Go(func() {
+			serveOneStream(ctx, stream, dial)
+		})
+	}
+}
+
+// serveOneStream dials the local process for one intercepted stream and pumps
+// until either side ends.
+func serveOneStream(ctx context.Context, stream *TunnelStream, dial LocalDialer) {
+	conn, err := dial(ctx)
+	if err != nil {
+		_ = stream.Close()
+
+		return
+	}
+
+	pumpUntilDone(ctx, stream, conn)
+}

--- a/pkg/svc/mirror/pump_test.go
+++ b/pkg/svc/mirror/pump_test.go
@@ -69,15 +69,24 @@ func deadlined(t *testing.T, conn net.Conn) {
 	require.NoError(t, conn.SetDeadline(time.Now().Add(testTimeout)))
 }
 
-// failingHalf is a ReadWriteCloser whose reads fail immediately, simulating a
-// torn transport under one pumped half.
+// failingHalf is a ReadWriteCloser whose reads (and, when writeErr is set,
+// writes) fail immediately, simulating a torn transport.
 type failingHalf struct {
-	readErr error
+	readErr  error
+	writeErr error
 }
 
-func (f *failingHalf) Read([]byte) (int, error)    { return 0, f.readErr }
-func (f *failingHalf) Write(p []byte) (int, error) { return len(p), nil }
-func (f *failingHalf) Close() error                { return nil }
+func (f *failingHalf) Read([]byte) (int, error) { return 0, f.readErr }
+
+func (f *failingHalf) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+
+	return len(p), nil
+}
+
+func (f *failingHalf) Close() error { return nil }
 
 func TestPump_CopiesBothDirectionsAndTearsDownOnEOF(t *testing.T) {
 	t.Parallel()
@@ -185,8 +194,40 @@ func TestForwardRedirected_ReturnsNilWhenTheSessionIsClosed(t *testing.T) {
 		forwardDone <- mirror.ForwardRedirected(context.Background(), listener, server)
 	}()
 
+	// No connection ever arrives: ending the session must unblock the parked
+	// Accept by itself.
 	require.NoError(t, client.Close())
 	require.NoError(t, server.Close())
+
+	select {
+	case forwardErr := <-forwardDone:
+		require.NoError(t, forwardErr)
+	case <-time.After(testTimeout):
+		t.Fatal("forward loop did not stop after the session closed")
+	}
+}
+
+func TestForwardRedirected_AFailedStreamOpenClosesTheConnection(t *testing.T) {
+	t.Parallel()
+
+	// A session whose transport reads block (the session stays alive) while
+	// every write fails, so opening a stream fails without the session ending.
+	blockedReader, _ := io.Pipe()
+
+	t.Cleanup(func() { _ = blockedReader.Close() })
+
+	session := mirror.NewTunnelSession(
+		blockedReader, &failingHalf{writeErr: errTransportTorn}, mirror.TunnelRoleServer,
+	)
+
+	t.Cleanup(func() { _ = session.Close() })
+
+	listener := newPipeListener()
+	forwardDone := make(chan error, 1)
+
+	go func() {
+		forwardDone <- mirror.ForwardRedirected(context.Background(), listener, session)
+	}()
 
 	clusterSide, redirected := net.Pipe()
 	deadlined(t, clusterSide)
@@ -194,9 +235,9 @@ func TestForwardRedirected_ReturnsNilWhenTheSessionIsClosed(t *testing.T) {
 
 	select {
 	case forwardErr := <-forwardDone:
-		require.NoError(t, forwardErr)
+		require.ErrorIs(t, forwardErr, errTransportTorn)
 	case <-time.After(testTimeout):
-		t.Fatal("forward loop did not stop after the session closed")
+		t.Fatal("forward loop did not stop after a failed stream open")
 	}
 
 	// The connection that could not become a stream is closed, not leaked.

--- a/pkg/svc/mirror/pump_test.go
+++ b/pkg/svc/mirror/pump_test.go
@@ -1,0 +1,331 @@
+package mirror_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pipeListener is an in-memory net.Listener the tests feed connections into,
+// standing in for the steering agent's redirected-traffic listener.
+type pipeListener struct {
+	conns     chan net.Conn
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func newPipeListener() *pipeListener {
+	return &pipeListener{
+		conns:     make(chan net.Conn),
+		closeOnce: sync.Once{},
+		closed:    make(chan struct{}),
+	}
+}
+
+func (l *pipeListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.conns:
+		return conn, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *pipeListener) Close() error {
+	l.closeOnce.Do(func() { close(l.closed) })
+
+	return nil
+}
+
+func (l *pipeListener) Addr() net.Addr {
+	return &net.UnixAddr{Name: "ksail-steer-test", Net: "unix"}
+}
+
+// deliver hands one redirected connection to the listener's Accept loop.
+func (l *pipeListener) deliver(t *testing.T, conn net.Conn) {
+	t.Helper()
+
+	select {
+	case l.conns <- conn:
+	case <-l.closed:
+		t.Fatal("delivering to a closed listener")
+	case <-time.After(testTimeout):
+		t.Fatal("timed out delivering a connection")
+	}
+}
+
+// deadlined bounds every read/write on a pipe connection so a pump bug fails
+// fast instead of hanging the suite.
+func deadlined(t *testing.T, conn net.Conn) {
+	t.Helper()
+
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testTimeout)))
+}
+
+// failingHalf is a ReadWriteCloser whose reads fail immediately, simulating a
+// torn transport under one pumped half.
+type failingHalf struct {
+	readErr error
+}
+
+func (f *failingHalf) Read([]byte) (int, error)    { return 0, f.readErr }
+func (f *failingHalf) Write(p []byte) (int, error) { return len(p), nil }
+func (f *failingHalf) Close() error                { return nil }
+
+func TestPump_CopiesBothDirectionsAndTearsDownOnEOF(t *testing.T) {
+	t.Parallel()
+
+	outerLeft, innerLeft := net.Pipe()
+	innerRight, outerRight := net.Pipe()
+
+	deadlined(t, outerLeft)
+	deadlined(t, outerRight)
+
+	pumpDone := make(chan error, 1)
+
+	go func() { pumpDone <- mirror.Pump(innerLeft, innerRight) }()
+
+	go func() { _, _ = outerLeft.Write([]byte("ping")) }()
+
+	buffer := make([]byte, 4)
+	_, err := io.ReadFull(outerRight, buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "ping", string(buffer))
+
+	go func() { _, _ = outerRight.Write([]byte("pong")) }()
+
+	_, err = io.ReadFull(outerLeft, buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "pong", string(buffer))
+
+	// Ending one side ends the pump and closes BOTH halves, so the other
+	// side's peer sees EOF instead of a half-open connection.
+	require.NoError(t, outerLeft.Close())
+
+	select {
+	case pumpErr := <-pumpDone:
+		require.NoError(t, pumpErr)
+	case <-time.After(testTimeout):
+		t.Fatal("pump did not end after one side closed")
+	}
+
+	_, err = outerRight.Read(buffer)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestPump_ReturnsTheErrorThatEndedTheFirstDirection(t *testing.T) {
+	t.Parallel()
+
+	_, inner := net.Pipe()
+	failing := &failingHalf{readErr: errTransportTorn}
+
+	err := mirror.Pump(failing, inner)
+	require.ErrorIs(t, err, errTransportTorn)
+}
+
+func TestForwardRedirected_BridgesARedirectedConnectionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+	listener := newPipeListener()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	forwardDone := make(chan error, 1)
+
+	go func() { forwardDone <- mirror.ForwardRedirected(ctx, listener, server) }()
+
+	clusterSide, redirected := net.Pipe()
+	deadlined(t, clusterSide)
+	listener.deliver(t, redirected)
+
+	stream, err := client.AcceptStream(acceptContext(t))
+	require.NoError(t, err)
+
+	go func() { _, _ = clusterSide.Write([]byte("request")) }()
+
+	buffer := make([]byte, 7)
+	_, err = io.ReadFull(stream, buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "request", string(buffer))
+
+	_, err = stream.Write([]byte("reply!!"))
+	require.NoError(t, err)
+
+	_, err = io.ReadFull(clusterSide, buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "reply!!", string(buffer))
+
+	cancel()
+
+	select {
+	case forwardErr := <-forwardDone:
+		require.NoError(t, forwardErr)
+	case <-time.After(testTimeout):
+		t.Fatal("forward loop did not stop on context cancellation")
+	}
+}
+
+func TestForwardRedirected_ReturnsNilWhenTheSessionIsClosed(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+	listener := newPipeListener()
+
+	forwardDone := make(chan error, 1)
+
+	go func() {
+		forwardDone <- mirror.ForwardRedirected(context.Background(), listener, server)
+	}()
+
+	require.NoError(t, client.Close())
+	require.NoError(t, server.Close())
+
+	clusterSide, redirected := net.Pipe()
+	deadlined(t, clusterSide)
+	listener.deliver(t, redirected)
+
+	select {
+	case forwardErr := <-forwardDone:
+		require.NoError(t, forwardErr)
+	case <-time.After(testTimeout):
+		t.Fatal("forward loop did not stop after the session closed")
+	}
+
+	// The connection that could not become a stream is closed, not leaked.
+	buffer := make([]byte, 1)
+	_, err := clusterSide.Read(buffer)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestServeIntercepted_DialsTheLocalProcessAndPumps(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	localApp, dialSide := net.Pipe()
+	deadlined(t, localApp)
+
+	serveDone := make(chan error, 1)
+
+	go func() {
+		serveDone <- mirror.ServeIntercepted(ctx, client,
+			func(_ context.Context) (io.ReadWriteCloser, error) { return dialSide, nil })
+	}()
+
+	stream, err := server.OpenStream()
+	require.NoError(t, err)
+
+	_, err = stream.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	buffer := make([]byte, 5)
+	_, err = io.ReadFull(localApp, buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(buffer))
+
+	go func() { _, _ = localApp.Write([]byte("world")) }()
+
+	_, err = io.ReadFull(stream, buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(buffer))
+
+	cancel()
+
+	select {
+	case serveErr := <-serveDone:
+		require.NoError(t, serveErr)
+	case <-time.After(testTimeout):
+		t.Fatal("serve loop did not stop on context cancellation")
+	}
+}
+
+func TestServeIntercepted_AFailedDialClosesTheStream(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	dial := func(_ context.Context) (io.ReadWriteCloser, error) {
+		return nil, errTransportTorn
+	}
+
+	go func() { _ = mirror.ServeIntercepted(ctx, client, dial) }()
+
+	stream, err := server.OpenStream()
+	require.NoError(t, err)
+
+	// The refused stream is closed by the serving side: the agent's reads end
+	// with EOF, which is what makes it close the redirected connection.
+	buffer := make([]byte, 1)
+	_, err = stream.Read(buffer)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestServeIntercepted_ReturnsNilWhenTheSessionCloses(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+
+	dial := func(_ context.Context) (io.ReadWriteCloser, error) {
+		return nil, errTransportTorn
+	}
+
+	serveDone := make(chan error, 1)
+
+	go func() {
+		serveDone <- mirror.ServeIntercepted(context.Background(), client, dial)
+	}()
+
+	require.NoError(t, client.Close())
+	require.NoError(t, server.Close())
+
+	select {
+	case serveErr := <-serveDone:
+		require.NoError(t, serveErr)
+	case <-time.After(testTimeout):
+		t.Fatal("serve loop did not stop after the session closed")
+	}
+}
+
+func TestInterceptPump_EndToEndEchoThroughTheTunnel(t *testing.T) {
+	t.Parallel()
+
+	client, server := newSessionPair(t)
+	listener := newPipeListener()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Local "developer process": an echo server behind the dialer seam.
+	dial := func(_ context.Context) (io.ReadWriteCloser, error) {
+		localApp, dialSide := net.Pipe()
+
+		go func() { _, _ = io.Copy(localApp, localApp) }()
+
+		return dialSide, nil
+	}
+
+	go func() { _ = mirror.ForwardRedirected(ctx, listener, server) }()
+	go func() { _ = mirror.ServeIntercepted(ctx, client, dial) }()
+
+	clusterSide, redirected := net.Pipe()
+	deadlined(t, clusterSide)
+	listener.deliver(t, redirected)
+
+	go func() { _, _ = clusterSide.Write([]byte("echo-me")) }()
+
+	buffer := make([]byte, 7)
+	_, err := io.ReadFull(clusterSide, buffer)
+	require.NoError(t, err)
+	assert.Equal(t, "echo-me", string(buffer))
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Intercept mode has both ends merged — the steering agent that redirects a workload's traffic, and the tunnel that multiplexes connections over the exec channel — but no bytes flow between them yet, so an intercepted connection still goes nowhere.

## What

Adds the pump layer that bridges the two: each redirected connection becomes one tunnel stream, the local ksail side dials the developer's process per stream, and ending either side (or cancelling the session) tears the pair down so no connection is ever left half-open. Fully unit-tested in-memory; the `workload intercept` CLI wiring is the next increment.

Fixes #5846. Part of #5839 / #4521.