### PR TITLE
feat(operator): install components into Hetzner clusters via a published kubeconfig Connector

### DIFF
--- a/pkg/k8s/namespace.go
+++ b/pkg/k8s/namespace.go
@@ -3,12 +3,42 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+const (
+	// podNamespaceEnvVar is the downward-API environment variable deployments set
+	// with the pod's own namespace.
+	podNamespaceEnvVar = "POD_NAMESPACE"
+	// serviceAccountNamespaceFile is the projected file holding the pod's
+	// namespace; the fallback when the downward-API env var is not set.
+	serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+// InClusterNamespace resolves the namespace the current process's pod runs in:
+// the POD_NAMESPACE downward-API env var, falling back to the projected
+// ServiceAccount namespace file. It returns "" when neither is available
+// (running outside a cluster); callers pick their own default.
+func InClusterNamespace() string {
+	if namespace := os.Getenv(podNamespaceEnvVar); namespace != "" {
+		return namespace
+	}
+
+	data, err := os.ReadFile(serviceAccountNamespaceFile)
+	if err == nil {
+		if namespace := strings.TrimSpace(string(data)); namespace != "" {
+			return namespace
+		}
+	}
+
+	return ""
+}
 
 // PSSLabels returns the Pod Security Standards admission labels
 // (pod-security.kubernetes.io/{enforce,audit,warn}) for the given level.

--- a/pkg/operator/hostcluster.go
+++ b/pkg/operator/hostcluster.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/internal/controller"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,17 +27,9 @@ import (
 // destination, Headlamp's "main" context).
 const HostClusterName = "host"
 
-const (
-	// podNamespaceEnvVar is the downward-API environment variable the Helm chart sets with the
-	// operator pod's namespace.
-	podNamespaceEnvVar = "POD_NAMESPACE"
-	// serviceAccountNamespaceFile is the projected file holding the pod's namespace; the fallback
-	// when the downward-API env var is not set.
-	serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-	// defaultHostClusterNamespace is the last-resort namespace for the host registration, used when
-	// the operator runs outside a cluster (e.g. local development against a kubeconfig).
-	defaultHostClusterNamespace = "default"
-)
+// defaultHostClusterNamespace is the last-resort namespace for the host registration, used when
+// the operator runs outside a cluster (e.g. local development against a kubeconfig).
+const defaultHostClusterNamespace = "default"
 
 // Bounded retry for the startup registration: the API server may briefly refuse writes right after
 // the operator starts (e.g. webhook or cache warm-up), so transient failures are retried.
@@ -56,18 +47,11 @@ var ErrHostClusterNameTaken = errors.New(
 )
 
 // HostClusterNamespace resolves the namespace the host Cluster resource is registered in: the
-// operator's own namespace from the POD_NAMESPACE downward-API env var, falling back to the
-// projected ServiceAccount namespace file, then "default" (running outside a cluster).
+// operator's own namespace (POD_NAMESPACE downward-API env var, then the projected ServiceAccount
+// namespace file — see k8s.InClusterNamespace), then "default" (running outside a cluster).
 func HostClusterNamespace() string {
-	if namespace := os.Getenv(podNamespaceEnvVar); namespace != "" {
+	if namespace := k8s.InClusterNamespace(); namespace != "" {
 		return namespace
-	}
-
-	data, err := os.ReadFile(serviceAccountNamespaceFile)
-	if err == nil {
-		if namespace := strings.TrimSpace(string(data)); namespace != "" {
-			return namespace
-		}
 	}
 
 	return defaultHostClusterNamespace

--- a/pkg/svc/provisioner/cluster/factory_k3d.go
+++ b/pkg/svc/provisioner/cluster/factory_k3d.go
@@ -130,6 +130,10 @@ func createK3sHetznerProvisioner(cluster *v1alpha1.Cluster) (Provisioner, any, e
 		return nil, nil, fmt.Errorf("create K3s Hetzner provisioner: %w", err)
 	}
 
+	// Wire the hub for the operator's Connector capability (nil outside a pod —
+	// the CLI flow publishes nothing).
+	provisioner.Hub, provisioner.HubNamespace = connectorHub()
+
 	return provisioner, nil, nil
 }
 

--- a/pkg/svc/provisioner/cluster/factory_kind.go
+++ b/pkg/svc/provisioner/cluster/factory_kind.go
@@ -110,6 +110,10 @@ func createKubeadmHetznerProvisioner(cluster *v1alpha1.Cluster) (Provisioner, an
 		return nil, nil, fmt.Errorf("create kubeadm Hetzner provisioner: %w", err)
 	}
 
+	// Wire the hub for the operator's Connector capability (nil outside a pod —
+	// the CLI flow publishes nothing).
+	provisioner.Hub, provisioner.HubNamespace = connectorHub()
+
 	return provisioner, nil, nil
 }
 

--- a/pkg/svc/provisioner/cluster/factory_shared.go
+++ b/pkg/svc/provisioner/cluster/factory_shared.go
@@ -145,3 +145,30 @@ func buildDinDProvisionerConfig(
 		Persistence:      opts.Persistence,
 	}
 }
+
+// connectorHub resolves the hub clientset and namespace for provisioners whose Connector
+// capability publishes the child kubeconfig as a hub Secret (the Hetzner server distributions).
+// It is best-effort by design: inside a pod (the KSail operator) the in-cluster ServiceAccount
+// is the hub; outside one (the CLI flow) there is no hub, so it returns nil and those
+// provisioners skip the publish.
+func connectorHub() (kubernetes.Interface, string) {
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, ""
+	}
+
+	clientset, _, _, err := clientsFromRESTConfig(restConfig)
+	if err != nil {
+		return nil, ""
+	}
+
+	namespace := k8s.InClusterNamespace()
+	if namespace == "" {
+		// In-cluster config resolved, so the ServiceAccount namespace file exists in
+		// practice; "default" is a defensive fallback, mirroring the operator's own
+		// host-cluster registration.
+		namespace = "default"
+	}
+
+	return clientset, namespace
+}

--- a/pkg/svc/provisioner/cluster/factory_shared.go
+++ b/pkg/svc/provisioner/cluster/factory_shared.go
@@ -2,6 +2,7 @@ package clusterprovisioner
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -159,6 +160,15 @@ func connectorHub() (kubernetes.Interface, string) {
 
 	clientset, _, _, err := clientsFromRESTConfig(restConfig)
 	if err != nil {
+		// In-cluster config resolved, so this is NOT the expected outside-a-pod
+		// case: the hub wiring itself broke. Say so — a silent nil here disables
+		// the Connector publish with no diagnostic trail.
+		slog.Warn(
+			"connector hub: in-cluster config resolved but building the hub clientset failed; "+
+				"connector kubeconfig publishing is disabled",
+			"error", err,
+		)
+
 		return nil, ""
 	}
 

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/connector.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/connector.go
@@ -1,0 +1,101 @@
+package hetznerbase
+
+import (
+	"context"
+	"fmt"
+
+	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// connectorKubeconfigKey is the Secret data key holding the kubeconfig
+	// ("kubeconfig.yaml", the same key the nested Connectors publish under).
+	connectorKubeconfigKey = "kubeconfig.yaml"
+	// connectorSecretSuffix is appended to the cluster name for the kubeconfig
+	// Secret ("<prefix>-<name>-kubeconfig", mirroring the nested distributions'
+	// "<distribution>-<name>-kubeconfig" convention).
+	connectorSecretSuffix = "kubeconfig"
+)
+
+// connectorSecretName is the single source of truth for the Connector kubeconfig
+// Secret's name, shared by the create-time publish, the Connector read, and the
+// delete-time cleanup.
+func (b *Base) connectorSecretName(clusterName string) string {
+	return fmt.Sprintf("%s-%s-%s", b.ConnectorSecretPrefix, clusterName, connectorSecretSuffix)
+}
+
+// Kubeconfig implements the clusterprovisioner.Connector capability for a Hetzner
+// cluster: it returns the kubeconfig published at create time (see
+// publishConnectorKubeconfig), whose API server already points at the node's
+// public IPv4 — reachable from where the operator runs. It returns
+// clustererr.ErrKubeconfigNotReady (via nested.ConnectorKubeconfig) while the
+// Secret is not yet published, so the caller requeues. Hetzner is not a managed
+// service and the bootstrap SSH keypair is discarded after create, so the
+// published Secret is the only operator-reachable credential source.
+func (b *Base) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
+	target := b.ResolveName(name)
+
+	raw, err := nested.ConnectorKubeconfig(
+		ctx, b.Hub, target,
+		b.HubNamespace, b.connectorSecretName(target), connectorKubeconfigKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", b.ConnectorSecretPrefix, err)
+	}
+
+	return raw, nil
+}
+
+// publishConnectorKubeconfig upserts the endpoint-rewritten admin kubeconfig as a
+// hub Secret under the Connector naming contract so Kubeconfig() can serve it back
+// to the operator. Without a configured hub clientset (the CLI flow) it is a
+// no-op — there is no hub to publish to and nothing consumes the Connector.
+func (b *Base) publishConnectorKubeconfig(
+	ctx context.Context,
+	clusterName string,
+	kubeconfig []byte,
+) error {
+	if b.Hub == nil {
+		return nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.connectorSecretName(clusterName),
+			Namespace: b.HubNamespace,
+			Labels:    kubernetesprovider.CommonLabels(clusterName),
+		},
+		Data: map[string][]byte{connectorKubeconfigKey: kubeconfig},
+	}
+
+	err := nested.UpsertSecret(ctx, b.Hub, secret)
+	if err != nil {
+		return fmt.Errorf("publish connector kubeconfig: %w", err)
+	}
+
+	return nil
+}
+
+// deleteConnectorKubeconfig removes the published Connector kubeconfig Secret when
+// the cluster is deleted. Unlike the nested distributions — whose Secret lives in a
+// per-cluster hub namespace that is deleted with the cluster — the Hetzner Secret
+// lives in the operator's namespace, so it must be cleaned up explicitly. An
+// absent Secret (never published, or already cleaned) is not an error.
+func (b *Base) deleteConnectorKubeconfig(ctx context.Context, clusterName string) error {
+	if b.Hub == nil {
+		return nil
+	}
+
+	name := b.connectorSecretName(clusterName)
+
+	err := b.Hub.CoreV1().Secrets(b.HubNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete connector kubeconfig secret %s/%s: %w", b.HubNamespace, name, err)
+	}
+
+	return nil
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/connector.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/connector.go
@@ -3,12 +3,15 @@ package hetznerbase
 import (
 	"context"
 	"fmt"
+	"time"
 
 	kubernetesprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/kubernetes"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/nested"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -19,6 +22,14 @@ const (
 	// Secret ("<prefix>-<name>-kubeconfig", mirroring the nested distributions'
 	// "<distribution>-<name>-kubeconfig" convention).
 	connectorSecretSuffix = "kubeconfig"
+	// connectorPublishSteps / connectorPublishBaseDelay / connectorPublishFactor
+	// bound the retry around the hub Secret upsert. The publish runs at the very
+	// end of a paid bring-up whose failure path tears the cluster down, so a
+	// transient hub API blip must be absorbed here; only a persistent failure —
+	// the operator could never reach the child anyway — is worth the teardown.
+	connectorPublishSteps     = 4
+	connectorPublishBaseDelay = 250 * time.Millisecond
+	connectorPublishFactor    = 2.0
 )
 
 // connectorSecretName is the single source of truth for the Connector kubeconfig
@@ -72,7 +83,18 @@ func (b *Base) publishConnectorKubeconfig(
 		Data: map[string][]byte{connectorKubeconfigKey: kubeconfig},
 	}
 
-	err := nested.UpsertSecret(ctx, b.Hub, secret)
+	// Retry any error with backoff: UpsertSecret itself only retries update
+	// conflicts, and the caller's failure path destroys the just-provisioned
+	// servers — too drastic for a transient hub API failure.
+	backoff := wait.Backoff{
+		Steps:    connectorPublishSteps,
+		Duration: connectorPublishBaseDelay,
+		Factor:   connectorPublishFactor,
+	}
+
+	err := retry.OnError(backoff, func(error) bool { return true }, func() error {
+		return nested.UpsertSecret(ctx, b.Hub, secret)
+	})
 	if err != nil {
 		return fmt.Errorf("publish connector kubeconfig: %w", err)
 	}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/connector_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/connector_test.go
@@ -1,0 +1,193 @@
+package hetznerbase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	connectorTestCluster   = "test-cluster"
+	connectorTestNamespace = "ksail-system"
+	connectorTestPrefix    = "k3s-hetzner"
+	connectorTestSecret    = connectorTestPrefix + "-" + connectorTestCluster + "-kubeconfig"
+	connectorTestKey       = "kubeconfig.yaml"
+)
+
+// newConnectorBase builds a Base wired for the Connector paths only — the hub
+// clientset, namespace, secret prefix, and default cluster name; the Hetzner
+// infra seams stay nil because publish/read/delete never touch them.
+func newConnectorBase(hub kubernetes.Interface) *hetznerbase.Base {
+	return &hetznerbase.Base{
+		ClusterName:           connectorTestCluster,
+		Hub:                   hub,
+		HubNamespace:          connectorTestNamespace,
+		ConnectorSecretPrefix: connectorTestPrefix,
+	}
+}
+
+func publishedSecret(data []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      connectorTestSecret,
+			Namespace: connectorTestNamespace,
+		},
+		Data: map[string][]byte{connectorTestKey: data},
+	}
+}
+
+func TestConnectorSecretName(t *testing.T) {
+	t.Parallel()
+
+	base := newConnectorBase(nil)
+
+	assert.Equal(t, connectorTestSecret, base.ConnectorSecretNameForTest(connectorTestCluster))
+}
+
+func TestKubeconfig_NotReadyWhileSecretUnpublished(t *testing.T) {
+	t.Parallel()
+
+	base := newConnectorBase(k8sfake.NewClientset())
+
+	_, err := base.Kubeconfig(context.Background(), connectorTestCluster)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_NotReadyWhileSecretKeyEmpty(t *testing.T) {
+	t.Parallel()
+
+	base := newConnectorBase(k8sfake.NewClientset(publishedSecret(nil)))
+
+	_, err := base.Kubeconfig(context.Background(), connectorTestCluster)
+
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestKubeconfig_ReturnsPublishedSecret(t *testing.T) {
+	t.Parallel()
+
+	kubeconfig := []byte("apiVersion: v1\nkind: Config\n")
+	base := newConnectorBase(k8sfake.NewClientset(publishedSecret(kubeconfig)))
+
+	raw, err := base.Kubeconfig(context.Background(), connectorTestCluster)
+
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig, raw)
+}
+
+func TestKubeconfig_ResolvesNameFromConfigDefault(t *testing.T) {
+	t.Parallel()
+
+	kubeconfig := []byte("apiVersion: v1\nkind: Config\n")
+	base := newConnectorBase(k8sfake.NewClientset(publishedSecret(kubeconfig)))
+
+	raw, err := base.Kubeconfig(context.Background(), "")
+
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig, raw)
+}
+
+func TestKubeconfig_ErrorsWithoutHub(t *testing.T) {
+	t.Parallel()
+
+	base := newConnectorBase(nil)
+
+	_, err := base.Kubeconfig(context.Background(), connectorTestCluster)
+
+	require.ErrorIs(t, err, clustererr.ErrConfigNil)
+}
+
+func TestPublishConnectorKubeconfig_SkipsWithoutHub(t *testing.T) {
+	t.Parallel()
+
+	base := newConnectorBase(nil)
+
+	err := base.PublishConnectorKubeconfigForTest(
+		context.Background(), connectorTestCluster, []byte("ignored"),
+	)
+
+	require.NoError(t, err)
+}
+
+func TestPublishConnectorKubeconfig_PublishesSecret(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	base := newConnectorBase(clientset)
+	kubeconfig := []byte("apiVersion: v1\nkind: Config\n")
+
+	err := base.PublishConnectorKubeconfigForTest(
+		context.Background(), connectorTestCluster, kubeconfig,
+	)
+	require.NoError(t, err)
+
+	secret, err := clientset.CoreV1().Secrets(connectorTestNamespace).
+		Get(context.Background(), connectorTestSecret, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig, secret.Data[connectorTestKey])
+	assert.Equal(t, "ksail", secret.Labels["ksail.io/managed-by"])
+	assert.Equal(t, connectorTestCluster, secret.Labels["ksail.io/cluster"])
+}
+
+func TestPublishConnectorKubeconfig_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	base := newConnectorBase(clientset)
+
+	err := base.PublishConnectorKubeconfigForTest(
+		context.Background(), connectorTestCluster, []byte("first"),
+	)
+	require.NoError(t, err)
+
+	err = base.PublishConnectorKubeconfigForTest(
+		context.Background(), connectorTestCluster, []byte("second"),
+	)
+	require.NoError(t, err)
+
+	raw, err := base.Kubeconfig(context.Background(), connectorTestCluster)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("second"), raw)
+}
+
+func TestDeleteConnectorKubeconfig_RemovesPublishedSecret(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(publishedSecret([]byte("kubeconfig")))
+	base := newConnectorBase(clientset)
+
+	err := base.DeleteConnectorKubeconfigForTest(context.Background(), connectorTestCluster)
+	require.NoError(t, err)
+
+	_, err = base.Kubeconfig(context.Background(), connectorTestCluster)
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
+}
+
+func TestDeleteConnectorKubeconfig_ToleratesAbsentSecret(t *testing.T) {
+	t.Parallel()
+
+	base := newConnectorBase(k8sfake.NewClientset())
+
+	err := base.DeleteConnectorKubeconfigForTest(context.Background(), connectorTestCluster)
+
+	require.NoError(t, err)
+}
+
+func TestDeleteConnectorKubeconfig_SkipsWithoutHub(t *testing.T) {
+	t.Parallel()
+
+	base := newConnectorBase(nil)
+
+	err := base.DeleteConnectorKubeconfigForTest(context.Background(), connectorTestCluster)
+
+	require.NoError(t, err)
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/connector_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/connector_test.go
@@ -2,6 +2,7 @@ package hetznerbase_test
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
@@ -190,4 +191,20 @@ func TestDeleteConnectorKubeconfig_SkipsWithoutHub(t *testing.T) {
 	err := base.DeleteConnectorKubeconfigForTest(context.Background(), connectorTestCluster)
 
 	require.NoError(t, err)
+}
+
+func TestDelete_CleansConnectorSecretWhenNetworkAlreadyGone(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset(publishedSecret([]byte("kubeconfig")))
+	base := newConnectorBase(clientset)
+	base.Infra = &fakeInfra{networkExists: false}
+	base.LogWriter = io.Discard
+
+	err := base.Delete(context.Background(), connectorTestCluster)
+	require.NoError(t, err)
+
+	// The retry-after-teardown path must not orphan the credential Secret.
+	_, err = base.Kubeconfig(context.Background(), connectorTestCluster)
+	require.ErrorIs(t, err, clustererr.ErrKubeconfigNotReady)
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/export_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/export_test.go
@@ -1,0 +1,20 @@
+package hetznerbase
+
+import "context"
+
+// PublishConnectorKubeconfigForTest exposes publishConnectorKubeconfig for unit testing.
+func (b *Base) PublishConnectorKubeconfigForTest(
+	ctx context.Context, clusterName string, kubeconfig []byte,
+) error {
+	return b.publishConnectorKubeconfig(ctx, clusterName, kubeconfig)
+}
+
+// DeleteConnectorKubeconfigForTest exposes deleteConnectorKubeconfig for unit testing.
+func (b *Base) DeleteConnectorKubeconfigForTest(ctx context.Context, clusterName string) error {
+	return b.deleteConnectorKubeconfig(ctx, clusterName)
+}
+
+// ConnectorSecretNameForTest exposes connectorSecretName for unit testing.
+func (b *Base) ConnectorSecretNameForTest(clusterName string) string {
+	return b.connectorSecretName(clusterName)
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -150,6 +151,19 @@ type Base struct {
 	// BringUpPollInterval is the delay between the multi-node bring-up's probes for
 	// a node's admin kubeconfig; zero means [DefaultKubeconfigPollInterval].
 	BringUpPollInterval time.Duration
+	// Hub is the hub-cluster clientset the Connector capability publishes the child
+	// kubeconfig Secret through (the cluster the KSail operator runs on). Nil outside
+	// a pod (the CLI flow), which skips the publish and leaves the Connector read
+	// unavailable — a CLI-created Hetzner cluster has no hub to publish to.
+	Hub kubernetes.Interface
+	// HubNamespace is the hub namespace the Connector kubeconfig Secret lives in
+	// (the operator's own namespace). Read only when Hub is set.
+	HubNamespace string
+	// ConnectorSecretPrefix is the distribution-specific prefix of the Connector
+	// kubeconfig Secret name ("<prefix>-<name>-kubeconfig"). Each provisioner sets
+	// its own (e.g. "k3s-hetzner") so distributions never collide in the shared hub
+	// namespace.
+	ConnectorSecretPrefix string
 }
 
 // CreateStrategy is the distribution-specific seam [Base.Create] composes with
@@ -296,6 +310,13 @@ func (b *Base) Delete(ctx context.Context, name string) error {
 	err = b.Infra.DeleteNodes(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("delete nodes: %w", err)
+	}
+
+	err = b.deleteConnectorKubeconfig(ctx, clusterName)
+	if err != nil {
+		// The cluster itself is gone; a leftover Secret must not fail the delete.
+		// Surface it on the progress output instead.
+		_, _ = fmt.Fprintf(b.LogWriter, "warning: %v\n", err)
 	}
 
 	return nil
@@ -484,6 +505,15 @@ func (b *Base) rewriteAndPersistKubeconfig(
 	}
 
 	persistedPath, err := b.persistKubeconfig(kubeconfig)
+	if err != nil {
+		return "", "", b.cleanUpFailedBringUp(ctx, clusterName, err)
+	}
+
+	// Publish the rewritten kubeconfig for the operator's Connector read (a no-op
+	// without a hub clientset). Failure tears the cluster down like the other
+	// post-bring-up steps: a cluster the operator can never reach would otherwise
+	// wedge behind ErrClusterAlreadyExists on the retry.
+	err = b.publishConnectorKubeconfig(ctx, clusterName, kubeconfig)
 	if err != nil {
 		return "", "", b.cleanUpFailedBringUp(ctx, clusterName, err)
 	}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -303,15 +303,15 @@ func (b *Base) Delete(ctx context.Context, name string) error {
 		return fmt.Errorf("check network: %w", err)
 	}
 
-	if !networkExists {
-		return nil
+	if networkExists {
+		err = b.Infra.DeleteNodes(ctx, clusterName)
+		if err != nil {
+			return fmt.Errorf("delete nodes: %w", err)
+		}
 	}
 
-	err = b.Infra.DeleteNodes(ctx, clusterName)
-	if err != nil {
-		return fmt.Errorf("delete nodes: %w", err)
-	}
-
+	// Clean the published Connector Secret on BOTH paths — a retry after the infra
+	// is already gone must not orphan the credential in the hub namespace.
 	err = b.deleteConnectorKubeconfig(ctx, clusterName)
 	if err != nil {
 		// The cluster itself is gone; a leftover Secret must not fail the delete.

--- a/pkg/svc/provisioner/cluster/k3shetzner/connector_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/connector_test.go
@@ -1,0 +1,32 @@
+package k3shetzner_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3shetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The K3s × Hetzner provisioner must satisfy the operator's Connector capability so
+// InstallComponents installs components into the provisioned cluster instead of skipping it.
+var _ clusterprovisioner.Connector = (*k3shetzner.Provisioner)(nil)
+
+func TestNewProvisionerWiresConnectorSecretPrefix(t *testing.T) {
+	t.Setenv("KSAIL_K3SHETZNER_CONNECTOR_TEST_TOKEN", "dummy-token")
+
+	prov, err := k3shetzner.NewProvisioner(
+		"test-cluster",
+		"test-kubeconfig",
+		"v1.36.1+k3s1",
+		1,
+		0,
+		//nolint:gosec // G101 false positive: this is an env-var NAME, not a credential.
+		v1alpha1.OptionsHetzner{TokenEnvVar: "KSAIL_K3SHETZNER_CONNECTOR_TEST_TOKEN"},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "k3s-hetzner", prov.ConnectorSecretPrefix)
+}

--- a/pkg/svc/provisioner/cluster/k3shetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/provisioner.go
@@ -8,6 +8,13 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
 )
 
+// connectorSecretPrefix names this distribution's Connector kubeconfig Secret
+// ("k3s-hetzner-<name>-kubeconfig") in the shared hub namespace; "k3s" alone would
+// collide with the k3k (K3s-on-Kubernetes) naming space.
+//
+//nolint:gosec // G101 false positive: this is a Secret NAME prefix, not a credential.
+const connectorSecretPrefix = "k3s-hetzner"
+
 // Provisioner provisions a K3s cluster on Hetzner Cloud servers by composing the
 // native k3s install renderer, the cloud-init delivery transport, and the shared
 // Hetzner infrastructure lifecycle ([hetznerbase.Base]). See the package
@@ -44,6 +51,7 @@ func NewProvisioner(
 
 	provisioner.Base = base
 	base.Strategy = provisioner
+	base.ConnectorSecretPrefix = connectorSecretPrefix
 
 	return provisioner, nil
 }

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/connector_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/connector_test.go
@@ -1,0 +1,32 @@
+package kubeadmhetzner_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kubeadmhetzner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The Vanilla (kubeadm) × Hetzner provisioner must satisfy the operator's Connector capability so
+// InstallComponents installs components into the provisioned cluster instead of skipping it.
+var _ clusterprovisioner.Connector = (*kubeadmhetzner.Provisioner)(nil)
+
+func TestNewProvisionerWiresConnectorSecretPrefix(t *testing.T) {
+	t.Setenv("KSAIL_KUBEADMHETZNER_CONNECTOR_TEST_TOKEN", "dummy-token")
+
+	prov, err := kubeadmhetzner.NewProvisioner(
+		"test-cluster",
+		"test-kubeconfig",
+		"v1.34.0",
+		1,
+		0,
+		//nolint:gosec // G101 false positive: this is an env-var NAME, not a credential.
+		v1alpha1.OptionsHetzner{TokenEnvVar: "KSAIL_KUBEADMHETZNER_CONNECTOR_TEST_TOKEN"},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "vanilla-hetzner", prov.ConnectorSecretPrefix)
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
@@ -7,6 +7,13 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
 )
 
+// connectorSecretPrefix names this distribution's Connector kubeconfig Secret
+// ("vanilla-hetzner-<name>-kubeconfig") in the shared hub namespace, using the
+// distribution's API name (Vanilla) rather than the implementation (kubeadm).
+//
+//nolint:gosec // G101 false positive: this is a Secret NAME prefix, not a credential.
+const connectorSecretPrefix = "vanilla-hetzner"
+
 // Provisioner provisions a Vanilla (kubeadm) cluster on Hetzner Cloud servers by
 // composing the declarative kubeadm install (via [BuildNodeUserData]), the
 // cloud-init delivery transport, and the shared Hetzner infrastructure lifecycle
@@ -57,6 +64,7 @@ func NewProvisioner(
 
 	provisioner.Base = base
 	base.Strategy = provisioner
+	base.ConnectorSecretPrefix = connectorSecretPrefix
 
 	return provisioner, nil
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

A Hetzner cluster created through the operator never gets its declared components (CNI, GitOps engine, …) installed — the operator has no way to reach the child cluster's credentials, so it silently skips component install and the cluster reconciles incomplete.

## What

The create flow now hands the operator the cluster's kubeconfig the same way the Kind/KWOK tranche did (published as a hub Secret, already pointed at the node's public IP), both Hetzner distributions gain the operator's Connector capability on their shared base, and deleting the cluster cleans the Secret up. CLI-created clusters are unaffected. Unit-tested; live operator-on-Hetzner validation stays gated on the cloud-credentials lane, as recorded on the parent epic.

Fixes #5848 · Part of #4899
