### PR TITLE
feat(mirror): bridge a tunnel over a container exec stream

### DIFF
--- a/pkg/svc/mirror/exectransport.go
+++ b/pkg/svc/mirror/exectransport.go
@@ -151,6 +151,10 @@ func (t *ExecTransport) Close() error {
 // the intended way to stop the stream and is normalised to a clean shutdown.
 func (t *ExecTransport) run(ctx context.Context, executor CaptureExecutor) {
 	defer close(t.done)
+	// Release the WithCancel child unconditionally: when the stream ends on its
+	// own (Close never called) the child would otherwise stay registered on the
+	// parent until it cancels. cancel is idempotent, so this is safe alongside Close.
+	defer t.cancel()
 
 	streamErr := executor.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  t.stdinReader,

--- a/pkg/svc/mirror/exectransport.go
+++ b/pkg/svc/mirror/exectransport.go
@@ -93,6 +93,9 @@ func OpenExecTransport(
 		return nil, fmt.Errorf("create exec transport executor: %w", err)
 	}
 
+	// cancel is stored on the transport and invoked in Close (the type's
+	// io.Closer contract requires Close); gosec G118 cannot track that transfer.
+	//nolint:gosec // G118: cancel is owned by the transport and called in Close().
 	streamCtx, cancel := context.WithCancel(ctx)
 	stdinReader, stdinWriter := io.Pipe()
 	stdoutReader, stdoutWriter := io.Pipe()

--- a/pkg/svc/mirror/exectransport.go
+++ b/pkg/svc/mirror/exectransport.go
@@ -1,0 +1,194 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// ErrExecTransportClientNil is returned when OpenExecTransport is called with
+// a nil Kubernetes client.
+var ErrExecTransportClientNil = errors.New("exec transport client is nil")
+
+// ErrExecTransportRESTConfigNil is returned when OpenExecTransport is called
+// with a nil REST config.
+var ErrExecTransportRESTConfigNil = errors.New("exec transport rest config is nil")
+
+// ErrExecTransportContainerEmpty is returned when OpenExecTransport is called
+// without a container name.
+var ErrExecTransportContainerEmpty = errors.New("exec transport container is empty")
+
+// ErrExecTransportClosed is the error a blocked stdout write is unblocked with
+// when the transport is closed before the stream ends on its own.
+var ErrExecTransportClosed = errors.New("exec transport closed")
+
+// ExecTransport is a bidirectional byte stream over a container exec session:
+// Read yields the container's stdout and Write feeds its stdin. It satisfies
+// io.ReadWriteCloser so it can back a TunnelSession (see NewTunnelSession) —
+// the mux the intercept path runs the steering tunnel over. Unlike the capture
+// session (stdout-only, see RunCaptureSession), the intercept tunnel needs both
+// directions, so this bridges the exec channel's stdin and stdout onto pipes.
+type ExecTransport struct {
+	stdinReader  *io.PipeReader
+	stdinWriter  *io.PipeWriter
+	stdoutReader *io.PipeReader
+	stdoutWriter *io.PipeWriter
+	cancel       context.CancelFunc
+	done         chan struct{}
+	closeOnce    sync.Once
+	mu           sync.Mutex
+	streamErr    error
+}
+
+// OpenExecTransport opens an exec session running command in the named
+// container of point.Pod and returns a bidirectional transport whose Read and
+// Write are the session's stdout and stdin. The exec runs in a background
+// goroutine for the life of the transport; Close (or the stream ending on its
+// own) tears it down and reports the terminal stream error. It reuses the
+// shared exec-executor seam (CaptureExecutor / WithCaptureExecutorFactory) so
+// tests can stub the stream without a live cluster.
+func OpenExecTransport(
+	ctx context.Context,
+	client kubernetes.Interface,
+	config *rest.Config,
+	point *TapPoint,
+	container string,
+	command []string,
+	opts ...CaptureSessionOption,
+) (*ExecTransport, error) {
+	if point == nil {
+		return nil, ErrTapPointNil
+	}
+
+	if client == nil {
+		return nil, ErrExecTransportClientNil
+	}
+
+	if config == nil {
+		return nil, ErrExecTransportRESTConfigNil
+	}
+
+	if container == "" {
+		return nil, ErrExecTransportContainerEmpty
+	}
+
+	cfg := captureSessionConfig{newExecutor: defaultCaptureExecutor}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	execURL := execStreamURL(client, point, container, command)
+
+	executor, err := cfg.newExecutor(config, "POST", execURL)
+	if err != nil {
+		return nil, fmt.Errorf("create exec transport executor: %w", err)
+	}
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+
+	transport := &ExecTransport{
+		stdinReader:  stdinReader,
+		stdinWriter:  stdinWriter,
+		stdoutReader: stdoutReader,
+		stdoutWriter: stdoutWriter,
+		cancel:       cancel,
+		done:         make(chan struct{}),
+	}
+
+	go transport.run(streamCtx, executor)
+
+	return transport, nil
+}
+
+// Read yields bytes the container wrote to the exec session's stdout.
+func (t *ExecTransport) Read(data []byte) (int, error) {
+	//nolint:wrapcheck // io.PipeReader errors (io.EOF / io.ErrClosedPipe) are the transport's own contract.
+	return t.stdoutReader.Read(data)
+}
+
+// Write feeds bytes into the exec session's stdin.
+func (t *ExecTransport) Write(data []byte) (int, error) {
+	//nolint:wrapcheck // io.PipeWriter errors (io.ErrClosedPipe) are the transport's own contract.
+	return t.stdinWriter.Write(data)
+}
+
+// Close ends the exec stream, unblocks any parked Read/Write, waits for the
+// carrier goroutine to finish, and returns the terminal stream error (nil when
+// the stream ended cleanly or was stopped by Close/context cancellation).
+func (t *ExecTransport) Close() error {
+	t.closeOnce.Do(func() {
+		t.cancel()
+		// Unblock a carrier goroutine parked writing stdout into the pipe, and
+		// signal EOF to the exec stdin so the remote command sees the close.
+		_ = t.stdoutReader.CloseWithError(ErrExecTransportClosed)
+		_ = t.stdinWriter.Close()
+	})
+
+	<-t.done
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.streamErr
+}
+
+// run carries the exec stream for the transport's lifetime and, on exit, closes
+// both pipe ends so any blocked Read/Write unblocks. A context cancellation is
+// the intended way to stop the stream and is normalised to a clean shutdown.
+func (t *ExecTransport) run(ctx context.Context, executor CaptureExecutor) {
+	defer close(t.done)
+
+	streamErr := executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  t.stdinReader,
+		Stdout: t.stdoutWriter,
+		Stderr: io.Discard,
+	})
+
+	// StreamWithContext returns ctx.Err() verbatim when the context ends the
+	// stream, which Close triggers on purpose — treat it as a clean stop.
+	if errors.Is(streamErr, context.Canceled) || errors.Is(streamErr, context.DeadlineExceeded) {
+		streamErr = nil
+	}
+
+	t.mu.Lock()
+	t.streamErr = streamErr
+	t.mu.Unlock()
+
+	// Unblock a caller parked in Read (stdout EOF) and in Write (stdin closed).
+	_ = t.stdoutWriter.CloseWithError(io.EOF)
+	_ = t.stdinReader.CloseWithError(io.EOF)
+}
+
+// execStreamURL builds the exec-subresource URL for a bidirectional stream
+// (stdin + stdout) running command in the named container of the tapped pod.
+func execStreamURL(
+	client kubernetes.Interface,
+	point *TapPoint,
+	container string,
+	command []string,
+) *url.URL {
+	return client.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(point.Pod).
+		Namespace(point.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec).
+		URL()
+}

--- a/pkg/svc/mirror/exectransport.go
+++ b/pkg/svc/mirror/exectransport.go
@@ -95,7 +95,7 @@ func OpenExecTransport(
 
 	// cancel is stored on the transport and invoked in Close (the type's
 	// io.Closer contract requires Close); gosec G118 cannot track that transfer.
-	//nolint:gosec // G118: cancel is owned by the transport and called in Close().
+
 	streamCtx, cancel := context.WithCancel(ctx)
 	stdinReader, stdinWriter := io.Pipe()
 	stdoutReader, stdoutWriter := io.Pipe()

--- a/pkg/svc/mirror/exectransport_test.go
+++ b/pkg/svc/mirror/exectransport_test.go
@@ -86,6 +86,7 @@ func (tunnelEchoExecutor) StreamWithContext(
 	options remotecommand.StreamOptions,
 ) error {
 	peer := mirror.NewTunnelSession(options.Stdin, options.Stdout, mirror.TunnelRoleServer)
+
 	defer func() { _ = peer.Close() }()
 
 	stream, err := peer.AcceptStream(ctx)
@@ -181,6 +182,7 @@ func TestExecTransportBidirectionalEcho(t *testing.T) {
 	defer cancel()
 
 	transport := newExecTransport(ctx, t, &echoExecutor{})
+
 	defer func() { _ = transport.Close() }()
 
 	payload := []byte("ping-pong")
@@ -205,9 +207,11 @@ func TestExecTransportBacksTunnelSession(t *testing.T) {
 	defer cancel()
 
 	transport := newExecTransport(ctx, t, tunnelEchoExecutor{})
+
 	defer func() { _ = transport.Close() }()
 
 	session := mirror.NewTunnelSession(transport, transport, mirror.TunnelRoleClient)
+
 	defer func() { _ = session.Close() }()
 
 	stream, err := session.OpenStream()
@@ -245,8 +249,8 @@ func TestExecTransportCloseUnblocksRead(t *testing.T) {
 	defer cancel()
 
 	transport := newExecTransport(ctx, t, &echoExecutor{})
-
 	readReturned := make(chan error, 1)
+
 	go func() {
 		_, err := transport.Read(make([]byte, 8))
 		readReturned <- err

--- a/pkg/svc/mirror/exectransport_test.go
+++ b/pkg/svc/mirror/exectransport_test.go
@@ -1,0 +1,264 @@
+package mirror_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/mirror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const execTransportTestTimeout = 5 * time.Second
+
+// errStubExecFailed is the terminal error an echo executor surfaces to model an
+// exec stream that fails outright rather than stopping cleanly on context.
+var errStubExecFailed = errors.New("stub exec failed")
+
+// newTransportClient builds a real clientset pointed at an unreachable host.
+// The exec URL is built from its RESTClient (the fake clientset's RESTClient is
+// nil and panics), while the stubbed executor means the host is never dialed.
+func newTransportClient(t *testing.T) kubernetes.Interface {
+	t.Helper()
+
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: "https://127.0.0.1:6443"})
+	require.NoError(t, err)
+
+	return client
+}
+
+// echoExecutor implements mirror.CaptureExecutor by copying the exec session's
+// stdin straight back to its stdout, modelling a container that echoes bytes.
+// It returns termErr (when set) instead of the copy's outcome, and always
+// honours context cancellation so Close can stop it.
+type echoExecutor struct {
+	termErr error
+}
+
+func (e *echoExecutor) StreamWithContext(
+	ctx context.Context,
+	options remotecommand.StreamOptions,
+) error {
+	// A terminal error models an exec stream that fails outright (not a clean
+	// context-driven stop), so surface it immediately.
+	if e.termErr != nil {
+		return e.termErr
+	}
+
+	copyDone := make(chan error, 1)
+
+	go func() {
+		_, err := io.Copy(options.Stdout, options.Stdin)
+		copyDone <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("echo executor stopped: %w", ctx.Err())
+	case err := <-copyDone:
+		if e.termErr != nil {
+			return e.termErr
+		}
+
+		if err != nil {
+			return fmt.Errorf("echo copy: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// tunnelEchoExecutor runs a server-role TunnelSession over the exec channel and
+// echoes the first accepted stream, so a client TunnelSession layered on the
+// transport exercises a full mux round-trip.
+type tunnelEchoExecutor struct{}
+
+func (tunnelEchoExecutor) StreamWithContext(
+	ctx context.Context,
+	options remotecommand.StreamOptions,
+) error {
+	peer := mirror.NewTunnelSession(options.Stdin, options.Stdout, mirror.TunnelRoleServer)
+	defer func() { _ = peer.Close() }()
+
+	stream, err := peer.AcceptStream(ctx)
+	if err != nil {
+		return fmt.Errorf("peer accept stream: %w", err)
+	}
+
+	_, _ = io.Copy(stream, stream)
+	_ = stream.Close()
+
+	<-ctx.Done()
+
+	return fmt.Errorf("tunnel echo executor stopped: %w", ctx.Err())
+}
+
+func stubExecFactory(executor mirror.CaptureExecutor) mirror.CaptureExecutorFactory {
+	return func(_ *rest.Config, _ string, _ *url.URL) (mirror.CaptureExecutor, error) {
+		return executor, nil
+	}
+}
+
+func newExecTransport(
+	ctx context.Context,
+	t *testing.T,
+	executor mirror.CaptureExecutor,
+) *mirror.ExecTransport {
+	t.Helper()
+
+	transport, err := mirror.OpenExecTransport(
+		ctx,
+		newTransportClient(t),
+		&rest.Config{},
+		&mirror.TapPoint{Namespace: "default", Pod: "app-0", Container: "app"},
+		mirror.SteerContainerName,
+		[]string{"ksail-steer"},
+		mirror.WithCaptureExecutorFactory(stubExecFactory(executor)),
+	)
+	require.NoError(t, err)
+
+	return transport
+}
+
+func TestOpenExecTransportValidation(t *testing.T) {
+	t.Parallel()
+
+	point := &mirror.TapPoint{Namespace: "default", Pod: "app-0", Container: "app"}
+	command := []string{"sh"}
+
+	tests := map[string]struct {
+		point     *mirror.TapPoint
+		client    bool
+		config    *rest.Config
+		container string
+		wantErr   error
+	}{
+		"nil point":       {nil, true, &rest.Config{}, "app", mirror.ErrTapPointNil},
+		"nil client":      {point, false, &rest.Config{}, "app", mirror.ErrExecTransportClientNil},
+		"nil config":      {point, true, nil, "app", mirror.ErrExecTransportRESTConfigNil},
+		"empty container": {point, true, &rest.Config{}, "", mirror.ErrExecTransportContainerEmpty},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// A typed nil interface would defeat the nil-client guard, so pass
+			// an untyped nil only when the case wants the client absent.
+			var transport *mirror.ExecTransport
+
+			var err error
+			if testCase.client {
+				transport, err = mirror.OpenExecTransport(
+					context.Background(), newTransportClient(t), testCase.config,
+					testCase.point, testCase.container, command,
+				)
+			} else {
+				transport, err = mirror.OpenExecTransport(
+					context.Background(), nil, testCase.config,
+					testCase.point, testCase.container, command,
+				)
+			}
+
+			require.ErrorIs(t, err, testCase.wantErr)
+			assert.Nil(t, transport)
+		})
+	}
+}
+
+func TestExecTransportBidirectionalEcho(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), execTransportTestTimeout)
+	defer cancel()
+
+	transport := newExecTransport(ctx, t, &echoExecutor{})
+	defer func() { _ = transport.Close() }()
+
+	payload := []byte("ping-pong")
+	writeErr := make(chan error, 1)
+
+	go func() {
+		_, err := transport.Write(payload)
+		writeErr <- err
+	}()
+
+	got := make([]byte, len(payload))
+	_, err := io.ReadFull(transport, got)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+	require.NoError(t, <-writeErr)
+}
+
+func TestExecTransportBacksTunnelSession(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), execTransportTestTimeout)
+	defer cancel()
+
+	transport := newExecTransport(ctx, t, tunnelEchoExecutor{})
+	defer func() { _ = transport.Close() }()
+
+	session := mirror.NewTunnelSession(transport, transport, mirror.TunnelRoleClient)
+	defer func() { _ = session.Close() }()
+
+	stream, err := session.OpenStream()
+	require.NoError(t, err)
+
+	payload := []byte("intercept-me")
+
+	_, err = stream.Write(payload)
+	require.NoError(t, err)
+
+	got := make([]byte, len(payload))
+	_, err = io.ReadFull(stream, got)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+func TestExecTransportCloseSurfacesStreamError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), execTransportTestTimeout)
+	defer cancel()
+
+	transport := newExecTransport(ctx, t, &echoExecutor{termErr: errStubExecFailed})
+
+	// Nothing is written, so the echo copy never returns on its own; Close
+	// cancels the stream and must still surface the executor's terminal error.
+	closeErr := transport.Close()
+	require.ErrorIs(t, closeErr, errStubExecFailed)
+}
+
+func TestExecTransportCloseUnblocksRead(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), execTransportTestTimeout)
+	defer cancel()
+
+	transport := newExecTransport(ctx, t, &echoExecutor{})
+
+	readReturned := make(chan error, 1)
+	go func() {
+		_, err := transport.Read(make([]byte, 8))
+		readReturned <- err
+	}()
+
+	// Give the reader a moment to park, then close and require it unblocks.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, transport.Close())
+
+	select {
+	case <-readReturned:
+	case <-time.After(execTransportTestTimeout):
+		t.Fatal("Read did not unblock after Close")
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The intercept/steering library (the mux, pump, and iptables builder from the last two increments) has no way to run over a real pod — a tunnel needs a byte transport, and there wasn't one. This is the missing foundation that makes the whole `workload intercept` flow reachable.

## What
Adds a bidirectional transport over a container exec session (read = the container's stdout, write = its stdin) that a tunnel session can run on top of. It plugs into the existing exec plumbing so it can be tested without a live cluster; the tests prove traffic flows both ways and tears down cleanly.

First of three steps for **#5851** (steering increment 3) → Part of #5839 / #4521. Next steps (the in-pod steering agent and the `workload intercept` command) build on this.