### PR TITLE
feat(provisioner): K3s × Hetzner HA control-plane joins (embedded etcd)

### DIFF
--- a/pkg/svc/bootstrap/k3s/install.go
+++ b/pkg/svc/bootstrap/k3s/install.go
@@ -15,6 +15,30 @@ const installScriptURL = "https://get.k3s.io"
 // (RoleServerInit and RoleServer); agents use the literal "agent".
 const subcommandServer = "server"
 
+// sentinelDir is the ksail-managed directory the join-complete sentinel lands
+// in; it is created by the same first-boot command that writes the sentinel. It
+// matches the kubeadm path's directory so an operator finds ksail's bootstrap
+// markers in one place regardless of distribution.
+const sentinelDir = "/var/lib/ksail"
+
+// ServerJoinCompleteSentinelPath is the file an additional control-plane server
+// (RoleServer) writes once it has joined the cluster's embedded etcd and its
+// local API server reports ready — the reliable "control-plane join finished"
+// signal the shared Hetzner bring-up polls over SSH to serialise HA joins.
+//
+// Unlike kubeadm's synchronous `kubeadm join`, the k3s install script starts
+// k3s asynchronously and returns before etcd membership is established, so the
+// sentinel is gated behind a readiness poll (see [serverJoinCompleteTail]) and
+// never written by the install command alone — a file written part-way would
+// report completion while etcd membership is still changing, exactly what
+// [Render] must avoid for a joining server.
+const ServerJoinCompleteSentinelPath = sentinelDir + "/k3s-server-join-complete"
+
+// readinessPollSeconds is how long the joining server's readiness gate sleeps
+// between local /readyz probes. Five seconds keeps the etcd-join serialisation
+// responsive without hammering the freshly-joined API server.
+const readinessPollSeconds = "5"
+
 // Role identifies how a node joins the cluster. The first control-plane node
 // initialises the cluster (RoleServerInit); further control-plane nodes
 // (RoleServer) and workers (RoleAgent) join an existing one via its ServerURL.
@@ -81,8 +105,36 @@ func Render(cfg InstallConfig) (string, error) {
 	}
 
 	env, subcommand, args := cfg.invocation()
+	command := assembleCommand(env, subcommand, args)
 
-	return assembleCommand(env, subcommand, args), nil
+	// An additional control-plane server joins the cluster's embedded etcd; the
+	// shared Hetzner create flow serialises those joins by polling a completion
+	// sentinel over SSH before creating the next joiner (concurrent joins race
+	// etcd member addition). The install command above starts k3s asynchronously
+	// and returns before the join settles, so this server's first boot must
+	// publish the sentinel only after a readiness gate confirms it is a healthy
+	// member — never right after the install returns. The init server and agents
+	// are never polled (init readiness is confirmed by the kubeconfig fetch;
+	// agents register asynchronously), so their command is unchanged.
+	if cfg.Role == RoleServer {
+		command += " && " + serverJoinCompleteTail()
+	}
+
+	return command, nil
+}
+
+// serverJoinCompleteTail renders the shell tail a joining control-plane server
+// appends after its install command: block until the node's local API server
+// reports ready — `/readyz` fails until this node's etcd member is added and in
+// quorum, so it is a truthful "joined and healthy" gate — then publish the
+// completion sentinel. The whole tail is chained with && so a failed install or
+// a readiness gate that never succeeds never writes a false completion marker.
+// `k3s kubectl` resolves the node's own admin kubeconfig, so the probe needs no
+// external configuration.
+func serverJoinCompleteTail() string {
+	return "until k3s kubectl get --raw='/readyz' >/dev/null 2>&1; do sleep " +
+		readinessPollSeconds + "; done && mkdir -p " + sentinelDir +
+		" && touch " + ServerJoinCompleteSentinelPath
 }
 
 // invocation maps a validated cfg to the environment assignments, k3s

--- a/pkg/svc/bootstrap/k3s/install_test.go
+++ b/pkg/svc/bootstrap/k3s/install_test.go
@@ -46,7 +46,9 @@ func TestRenderValid(t *testing.T) {
 				"--disable 'servicelb' --disable 'traefik' --write-kubeconfig-mode '0644'",
 		},
 		{
-			name: "additional server joins via --server",
+			// A joining control-plane server appends a readiness gate and the
+			// join-complete sentinel so the shared bring-up can serialise HA joins.
+			name: "additional server joins via --server and publishes the join sentinel",
 			cfg: k3sbootstrap.InstallConfig{
 				Version:   "v1.30.2+k3s1",
 				Role:      k3sbootstrap.RoleServer,
@@ -55,7 +57,9 @@ func TestRenderValid(t *testing.T) {
 			},
 			want: "script=\"$(curl -sfL 'https://get.k3s.io')\" && printf '%s' \"$script\" | " +
 				"INSTALL_K3S_VERSION='v1.30.2+k3s1' " +
-				"K3S_TOKEN='secret' sh -s - server --server 'https://10.0.0.2:6443'",
+				"K3S_TOKEN='secret' sh -s - server --server 'https://10.0.0.2:6443'" +
+				" && until k3s kubectl get --raw='/readyz' >/dev/null 2>&1; do sleep 5; done" +
+				" && mkdir -p /var/lib/ksail && touch /var/lib/ksail/k3s-server-join-complete",
 		},
 		{
 			name: "agent joins via K3S_URL",

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/multinode.go
@@ -63,8 +63,9 @@ type MultiNodeComposer interface {
 // agents. [Base.Create] rejects controlPlanes > 1 with
 // [ErrHAControlPlaneNotImplemented] for any strategy that does not implement
 // this — the guard is per-distribution because the join mechanics differ:
-// kubeadm's manual certificate distribution supports it, while k3s needs its own
-// embedded-etcd increment (see devantler-tech/ksail#5796).
+// kubeadm's manual certificate distribution (devantler-tech/ksail#5796) and
+// k3s's embedded etcd (devantler-tech/ksail#5854) each implement it their own
+// way.
 type HAControlPlaneComposer interface {
 	MultiNodeComposer
 

--- a/pkg/svc/provisioner/cluster/k3shetzner/doc.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/doc.go
@@ -13,6 +13,13 @@
 // the joining nodes. SSH-based remote execution is intentionally out of scope —
 // cloud-init is the declarative transport — so it is not used here.
 //
+// A multi-control-plane (high-availability) topology is supported: the
+// provisioner implements [hetznerbase.HAControlPlaneComposer], so the additional
+// control-plane servers join the init server's embedded etcd (via `--server`) and
+// the shared flow serialises their joins by polling each one's readiness-gated
+// join-complete sentinel — no manual certificate distribution is needed, unlike
+// the kubeadm path (devantler-tech/ksail#5854).
+//
 // This package is the K3s × Hetzner provisioner tracked by
 // devantler-tech/ksail#5512 (epic #3983). The shared create flow
 // ([Provisioner.Create] via hetznerbase) runs the live bring-up end to end:

--- a/pkg/svc/provisioner/cluster/k3shetzner/errors.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/errors.go
@@ -3,16 +3,10 @@ package k3shetzner
 import "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
 
 // The K3s × Hetzner provisioner reports the sentinels of the shared Hetzner create
-// flow; these aliases keep the package's public API stable while the behaviour lives
+// flow; this alias keeps the package's public API stable while the behaviour lives
 // on the shared create flow.
 var (
 	// ErrClusterAlreadyExists is returned by [Provisioner.Create] when servers for
 	// the target K3s cluster already exist; see [hetznerbase.ErrClusterAlreadyExists].
 	ErrClusterAlreadyExists = hetznerbase.ErrClusterAlreadyExists
-
-	// ErrHAControlPlaneNotImplemented is returned by [Provisioner.Create] for a K3s
-	// topology with more than one control plane. A single control plane with agents
-	// is brought up via the two-phase multi-node flow; see
-	// [hetznerbase.ErrHAControlPlaneNotImplemented].
-	ErrHAControlPlaneNotImplemented = hetznerbase.ErrHAControlPlaneNotImplemented
 )

--- a/pkg/svc/provisioner/cluster/k3shetzner/multinode.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/multinode.go
@@ -3,6 +3,7 @@ package k3shetzner
 import (
 	"net"
 
+	k3sbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/k3s"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
 )
 
@@ -10,10 +11,38 @@ import (
 // endpoint agents dial) on — the standard Kubernetes secure port.
 const k3sAPIPort = "6443"
 
-// staticMultiNodeComposerCheck asserts at compile time that *Provisioner
-// implements the optional [hetznerbase.MultiNodeComposer] capability, so the
-// shared create flow routes a K3s topology with agents to the two-phase bring-up.
-var _ hetznerbase.MultiNodeComposer = (*Provisioner)(nil)
+// staticCapabilityChecks assert at compile time that *Provisioner implements the
+// optional shared-create-flow capabilities: [hetznerbase.MultiNodeComposer], so a
+// K3s topology with agents routes to the two-phase bring-up, and
+// [hetznerbase.HAControlPlaneComposer], so a multi-control-plane topology routes
+// there too instead of being rejected — K3s's embedded etcd needs no manual
+// certificate distribution (each additional server joins the cluster via the
+// shared token and its own bootstrap), so the same two-phase compose that plans
+// the agents already plans the additional control planes.
+var (
+	_ hetznerbase.MultiNodeComposer      = (*Provisioner)(nil)
+	_ hetznerbase.HAControlPlaneComposer = (*Provisioner)(nil)
+)
+
+// SupportsHAControlPlanes marks the K3s strategy as able to compose a
+// multi-control-plane topology, satisfying [hetznerbase.HAControlPlaneComposer]:
+// [Provisioner.ComposeJoiningNodes] already plans the full topology, so the
+// additional control-plane servers (RoleServer, joining the init server's
+// embedded etcd via `--server`) are composed alongside the agents. It performs
+// no work.
+func (p *Provisioner) SupportsHAControlPlanes() {}
+
+// ControlPlaneJoinCompletePath returns the sentinel an additional K3s control
+// plane writes once it has joined the embedded etcd and its local API server is
+// ready, satisfying [hetznerbase.HAControlPlaneComposer]: the shared flow polls
+// it over SSH to serialise control-plane joins, because concurrent joins race
+// etcd member addition. The joining server's first boot publishes it only behind
+// a readiness gate (see [k3sbootstrap.ServerJoinCompleteSentinelPath]) — the k3s
+// install command returns before the etcd join settles, so it can never stand in
+// for the sentinel.
+func (p *Provisioner) ControlPlaneJoinCompletePath() string {
+	return k3sbootstrap.ServerJoinCompleteSentinelPath
+}
 
 // ComposeInitNode composes the single cluster-initialising K3s server (bootstrap
 // index 0), which carries no join server URL, satisfying

--- a/pkg/svc/provisioner/cluster/k3shetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/multinode_test.go
@@ -62,3 +62,38 @@ func TestComposeJoiningNodesThreadsPrivateJoinURL(t *testing.T) {
 		assert.Contains(t, spec.UserData, "https://10.0.1.5:6443")
 	}
 }
+
+// TestComposeJoiningNodesIncludesAdditionalControlPlanes pins the HA topology:
+// with more than one control plane, ComposeJoiningNodes returns the additional
+// control-plane servers first (tagged control planes, joining the init server via
+// --server and publishing the readiness-gated join-complete sentinel), then the
+// agents (tagged workers, no sentinel) — the shape the shared flow serialises.
+func TestComposeJoiningNodesIncludesAdditionalControlPlanes(t *testing.T) {
+	t.Parallel()
+
+	// 3 control planes + 1 agent → after the init node, 2 additional control
+	// planes then 1 agent.
+	prov := newProvisioner(&fakeInfra{}, 3, 1)
+
+	specs, err := prov.ComposeJoiningNodes(
+		testClusterName, "token", net.ParseIP("10.0.1.5"), testBootstrapMaterial(),
+	)
+	require.NoError(t, err)
+	require.Len(t, specs, 3)
+
+	// The two additional control planes come first: they join the init server's
+	// embedded etcd and publish the join-complete sentinel behind the /readyz gate.
+	for _, spec := range specs[:2] {
+		assert.Equal(t, hetzner.NodeTypeControlPlane, spec.NodeType)
+		assert.Contains(t, spec.UserData, "https://10.0.1.5:6443")
+		assert.Contains(t, spec.UserData, "readyz")
+		assert.Contains(t, spec.UserData, "k3s-server-join-complete")
+	}
+
+	// The agent follows: a worker that registers via K3S_URL and never writes the
+	// control-plane join sentinel.
+	agent := specs[2]
+	assert.Equal(t, hetzner.NodeTypeWorker, agent.NodeType)
+	assert.Contains(t, agent.UserData, "K3S_URL")
+	assert.NotContains(t, agent.UserData, "k3s-server-join-complete")
+}

--- a/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/provisioner_test.go
@@ -334,15 +334,19 @@ func TestCreateAlreadyExists(t *testing.T) {
 	assert.Equal(t, 0, infra.ensureNetworkCalls)
 }
 
-func TestCreateHAControlPlaneNotImplemented(t *testing.T) {
+func TestSupportsHAControlPlanes(t *testing.T) {
 	t.Parallel()
 
-	infra := &fakeInfra{}
-	prov := newProvisioner(infra, 3, 0)
+	// The provisioner advertises the HA capability, so the shared create flow no
+	// longer rejects a multi-control-plane K3s topology. The sentinel it exposes is
+	// the readiness-gated join-complete marker the flow polls to serialise joins.
+	var haComposer hetznerbase.HAControlPlaneComposer = newProvisioner(&fakeInfra{}, 3, 0)
 
-	err := prov.Create(context.Background(), "")
-	require.ErrorIs(t, err, k3shetzner.ErrHAControlPlaneNotImplemented)
-	assert.Equal(t, 0, infra.ensureNetworkCalls)
+	haComposer.SupportsHAControlPlanes()
+	assert.Equal(t,
+		"/var/lib/ksail/k3s-server-join-complete",
+		haComposer.ControlPlaneJoinCompletePath(),
+	)
 }
 
 func TestCreateNodesExistError(t *testing.T) {


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Running K3s on Hetzner only allowed a single control plane — asking for a highly-available (multi-control-plane) K3s cluster failed outright, even though the Vanilla path already supported it. This closes the last K3s gap for the Hetzner-distribution epic.

## What
K3s clusters on Hetzner can now be created with multiple control planes. Each additional control plane joins the cluster's built-in datastore one at a time, only advancing once the previous one is confirmed healthy — so the cluster comes up reliably. Live cloud validation stays with the existing (credential-gated) Hetzner test lane, as with the rest of this epic.

Fixes #5854
Part of #3983