### PR TITLE
feat(clusterapi): surface unmanaged kubeconfig clusters in the local cluster model

### DIFF
--- a/pkg/apis/cluster/v1alpha1/labels.go
+++ b/pkg/apis/cluster/v1alpha1/labels.go
@@ -36,6 +36,21 @@ const LastAppliedSpecAnnotation = "ksail.io/last-applied-spec"
 // user cannot forge it.
 const LastAppliedComponentsAnnotation = "ksail.io/last-applied-components"
 
+// UnmanagedAnnotation marks a Cluster that ksail surfaces from the user's kubeconfig but does not
+// manage: it was found as a kubeconfig context that no ksail infrastructure provider discovered, so
+// ksail never provisioned it and has no spec to drive it. Its value is the string "true". It lets
+// every surface (CLI, web UI, desktop app) show such clusters clearly marked as unmanaged and refuse
+// ksail-only operations (lifecycle, component install, GitOps, reprovision) on them, rather than
+// hiding them or presenting them as normal managed clusters. It lives here, beside the other reserved
+// ksail.io/* identifiers, so every consumer keys off one definition.
+const UnmanagedAnnotation = "ksail.io/unmanaged"
+
+// IsUnmanaged reports whether this Cluster was surfaced from the kubeconfig without being managed by
+// ksail (see UnmanagedAnnotation). ksail-only operations are unavailable for such clusters.
+func (c *Cluster) IsUnmanaged() bool {
+	return c.Annotations[UnmanagedAnnotation] == "true"
+}
+
 // IsHostCluster reports whether this Cluster resource is the operator's self-registration of the
 // cluster it runs on (see HostClusterLabel).
 func (c *Cluster) IsHostCluster() bool {

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -266,6 +266,11 @@ func (s *Service) List(ctx context.Context) (*v1alpha1.ClusterList, error) {
 		items = append(items, cluster)
 	}
 
+	// Surface kubeconfig contexts ksail did not provision as unmanaged clusters (marked, never hidden
+	// and never shown as a normal managed cluster), so read/operate surfaces can see them within limits
+	// while ksail-only operations are refused.
+	items = append(items, s.unmanagedClusters(merged)...)
+
 	return &v1alpha1.ClusterList{Items: items}, nil
 }
 

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -248,11 +248,40 @@ func (s *Service) List(ctx context.Context) (*v1alpha1.ClusterList, error) {
 
 	sort.Strings(names)
 
+	// Load the kubeconfig once and share it: both the endpoint map and the unmanaged-cluster synthesis
+	// read the same contexts, and List is polled frequently by the UI — a single read avoids parsing
+	// the file twice per request and any TOCTOU skew between the two views.
+	kubeconfig := s.loadKubeconfig()
+
 	// Endpoints come from the kubeconfig's contexts (no cluster round-trips), so the UI can show a
 	// real API server URL for clusters that have one instead of an empty status field.
-	endpoints := s.clusterEndpoints()
+	endpoints := clusterEndpoints(kubeconfig)
 
+	items := managedClusterItems(names, merged, endpoints)
+
+	// Surface kubeconfig contexts ksail did not provision as unmanaged clusters (marked, never hidden
+	// and never shown as a normal managed cluster), so read/operate surfaces can see them within limits
+	// while ksail-only operations are refused.
+	items = append(items, unmanagedClusters(kubeconfig, merged)...)
+
+	// Sort the merged managed+unmanaged list globally by name so the surface order stays alphabetically
+	// stable (the managed block and the unmanaged block are each sorted, but appending one after the
+	// other would otherwise leave the combined list unsorted). Names are unique across the two groups —
+	// contextIsManaged excludes any context that matches a managed cluster — so the sort never collides.
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+
+	return &v1alpha1.ClusterList{Items: items}, nil
+}
+
+// managedClusterItems builds the Cluster list for the ksail-managed clusters, in the given name order,
+// attaching each cluster's kubeconfig endpoint and its status condition.
+func managedClusterItems(
+	names []string,
+	merged map[string]listEntry,
+	endpoints map[string]string,
+) []v1alpha1.Cluster {
 	items := make([]v1alpha1.Cluster, 0, len(names))
+
 	for _, name := range names {
 		entry := merged[name]
 		cluster := newCluster(name, entry.distribution, entry.provider, entry.phase)
@@ -266,12 +295,7 @@ func (s *Service) List(ctx context.Context) (*v1alpha1.ClusterList, error) {
 		items = append(items, cluster)
 	}
 
-	// Surface kubeconfig contexts ksail did not provision as unmanaged clusters (marked, never hidden
-	// and never shown as a normal managed cluster), so read/operate surfaces can see them within limits
-	// while ksail-only operations are refused.
-	items = append(items, s.unmanagedClusters(merged)...)
-
-	return &v1alpha1.ClusterList{Items: items}, nil
+	return items
 }
 
 // Get returns a single local cluster. The namespace is ignored (clusters are keyed by name).

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -931,6 +931,68 @@ users:
 	assert.Equal(t, "Unmanaged", condition.Reason)
 }
 
+// TestListSortsManagedAndUnmanagedGlobally checks that the merged managed+unmanaged list is sorted by
+// name as a whole, not just within each block — an unmanaged kubeconfig context alphabetically before
+// the managed cluster appears before it, and one after appears after it. Without the global sort the
+// unmanaged block is simply appended after the managed block, so an earlier-sorting unmanaged cluster
+// would wrongly trail a later-sorting managed one.
+func TestListSortsManagedAndUnmanagedGlobally(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionVanilla: {clusters: []string{devClusterName}},
+	})
+
+	// The managed cluster is "dev"; add unmanaged contexts on either alphabetical side of it.
+	kubeconfig := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: kind-dev
+  cluster:
+    server: https://127.0.0.1:6443
+- name: aaa
+  cluster:
+    server: https://aaa.example.com:6443
+- name: zzz
+  cluster:
+    server: https://zzz.example.com:6443
+contexts:
+- name: kind-dev
+  context:
+    cluster: kind-dev
+    user: kind-dev
+- name: aaa-cluster
+  context:
+    cluster: aaa
+    user: aaa
+- name: zzz-cluster
+  context:
+    cluster: zzz
+    user: zzz
+users:
+- name: kind-dev
+  user: {}
+- name: aaa
+  user: {}
+- name: zzz
+  user: {}
+`), 0o600))
+	service.SetKubeconfigPathForTest(kubeconfig)
+
+	list, err := service.List(context.Background())
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(list.Items))
+	for _, item := range list.Items {
+		names = append(names, item.Name)
+	}
+
+	// "aaa-cluster" (unmanaged) < "dev" (managed) < "zzz-cluster" (unmanaged): the combined list is
+	// globally alphabetical, not the managed block followed by the unmanaged block.
+	assert.Equal(t, []string{"aaa-cluster", devClusterName, "zzz-cluster"}, names)
+}
+
 // TestListWithoutKubeconfigSurfacesNoUnmanaged checks that when no kubeconfig is readable, List
 // synthesizes no unmanaged clusters (newTestService points the kubeconfig at nowhere).
 func TestListWithoutKubeconfigSurfacesNoUnmanaged(t *testing.T) {

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -857,3 +857,91 @@ func TestCreateDefaultsEKSProviderToAWS(t *testing.T) {
 		t.Fatal("factory was never asked to build the EKS cluster with a defaulted AWS provider")
 	}
 }
+
+// clusterNamed returns a pointer to the cluster with the given name in the list, or nil if absent.
+func clusterNamed(list *v1alpha1.ClusterList, name string) *v1alpha1.Cluster {
+	for i := range list.Items {
+		if list.Items[i].Name == name {
+			return &list.Items[i]
+		}
+	}
+
+	return nil
+}
+
+// TestListSurfacesUnmanagedKubeconfigContexts checks that List surfaces a kubeconfig context ksail did
+// not provision as an unmanaged cluster (marked, with its endpoint), while a context that maps to a
+// discovered cluster is listed once and never re-surfaced as unmanaged.
+func TestListSurfacesUnmanagedKubeconfigContexts(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionVanilla: {clusters: []string{devClusterName}},
+	})
+
+	kubeconfig := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: kind-dev
+  cluster:
+    server: https://127.0.0.1:6443
+- name: colleague
+  cluster:
+    server: https://cluster.example.com:6443
+contexts:
+- name: kind-dev
+  context:
+    cluster: kind-dev
+    user: kind-dev
+- name: colleague-cluster
+  context:
+    cluster: colleague
+    user: colleague
+users:
+- name: kind-dev
+  user: {}
+- name: colleague
+  user: {}
+`), 0o600))
+	service.SetKubeconfigPathForTest(kubeconfig)
+
+	list, err := service.List(context.Background())
+	require.NoError(t, err)
+
+	// The managed cluster (context kind-dev detects to the discovered "dev") is listed once and is not
+	// re-surfaced as unmanaged.
+	managed := clusterNamed(list, devClusterName)
+	require.NotNil(t, managed, "the discovered cluster must still be listed")
+	assert.False(t, managed.IsUnmanaged(), "a discovered cluster must not be flagged unmanaged")
+
+	// The kubeconfig-only context is surfaced, clearly marked unmanaged, with its endpoint.
+	unmanaged := clusterNamed(list, "colleague-cluster")
+	require.NotNil(t, unmanaged, "an unmanaged kubeconfig context must be surfaced")
+	assert.True(t, unmanaged.IsUnmanaged())
+	assert.Equal(t, "true", unmanaged.Annotations[v1alpha1.UnmanagedAnnotation])
+	assert.Equal(t, "https://cluster.example.com:6443", unmanaged.Status.Endpoint)
+	assert.Empty(t, unmanaged.Spec.Cluster.Distribution,
+		"an unmanaged cluster has no ksail-known distribution")
+
+	require.Len(t, unmanaged.Status.Conditions, 1)
+	condition := unmanaged.Status.Conditions[0]
+	assert.Equal(t, "Ready", condition.Type)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, "Unmanaged", condition.Reason)
+}
+
+// TestListWithoutKubeconfigSurfacesNoUnmanaged checks that when no kubeconfig is readable, List
+// synthesizes no unmanaged clusters (newTestService points the kubeconfig at nowhere).
+func TestListWithoutKubeconfigSurfacesNoUnmanaged(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionVanilla: {clusters: []string{devClusterName}},
+	})
+
+	list, err := service.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+	assert.False(t, list.Items[0].IsUnmanaged())
+}

--- a/pkg/cli/clusterapi/resources.go
+++ b/pkg/cli/clusterapi/resources.go
@@ -3,10 +3,13 @@ package clusterapi
 import (
 	"context"
 	"fmt"
+	"sort"
 
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/webui/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -128,4 +131,93 @@ func (s *Service) clusterEndpoints() map[string]string {
 	}
 
 	return endpoints
+}
+
+// unmanagedClusters synthesizes a Cluster for every kubeconfig context that does NOT correspond to a
+// cluster ksail already lists (discovered via an infrastructure provider or tracked as an in-flight
+// job — the keys of managed), flagged unmanaged via the ksail.io/unmanaged annotation. It lets ksail
+// see clusters that exist in the user's kubeconfig but were not provisioned by ksail (a managed
+// EKS/GKE/AKS cluster, a kubeadm cluster, a colleague's cluster) so read/operate surfaces can work
+// against them within limits while ksail-only operations are refused. Best-effort and offline, exactly
+// like clusterEndpoints: one file read, no cluster round-trips, and an unreadable kubeconfig yields
+// none. Contexts are emitted in sorted order so the list is stable.
+func (s *Service) unmanagedClusters(managed map[string]listEntry) []v1alpha1.Cluster {
+	config, err := clientcmd.LoadFromFile(s.kubeconfigPath())
+	if err != nil {
+		return nil
+	}
+
+	contextNames := make([]string, 0, len(config.Contexts))
+	for contextName := range config.Contexts {
+		contextNames = append(contextNames, contextName)
+	}
+
+	sort.Strings(contextNames)
+
+	items := make([]v1alpha1.Cluster, 0, len(contextNames))
+
+	for _, contextName := range contextNames {
+		if contextIsManaged(contextName, managed) {
+			continue
+		}
+
+		endpoint := ""
+
+		if kubeContext, ok := config.Contexts[contextName]; ok {
+			if cluster, ok := config.Clusters[kubeContext.Cluster]; ok {
+				endpoint = cluster.Server
+			}
+		}
+
+		items = append(items, newUnmanagedCluster(contextName, endpoint))
+	}
+
+	return items
+}
+
+// contextIsManaged reports whether a kubeconfig context corresponds to a cluster ksail already lists,
+// so unmanagedClusters does not re-surface it. A context maps to a managed cluster when its
+// ksail-detected name — or, when detection fails, the raw context name — is a key in the managed set.
+// Detection is what List uses to key discovered clusters (via clusterEndpoints), so matching on it
+// keeps a managed cluster from appearing twice (once managed, once as an unmanaged context).
+func contextIsManaged(contextName string, managed map[string]listEntry) bool {
+	if _, ok := managed[contextName]; ok {
+		return true
+	}
+
+	_, name, err := clusterdetector.DetectDistributionFromContext(contextName)
+	if err == nil {
+		if _, ok := managed[name]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// newUnmanagedCluster builds the Cluster ksail surfaces for a kubeconfig context it does not manage.
+// It is keyed by the context name, carries the ksail.io/unmanaged=true annotation (the stable marker
+// every surface reads), and reports a Ready=False/reason=Unmanaged condition — reusing the same
+// "Ready" condition the web UI already renders for stopped clusters, so an unmanaged cluster is never
+// shown green/normal even before a surface adds a dedicated badge. Distribution and provider are left
+// empty: without a ksail spec they are unknown.
+func newUnmanagedCluster(contextName, endpoint string) v1alpha1.Cluster {
+	cluster := v1alpha1.Cluster{}
+	cluster.Name = contextName
+	cluster.Namespace = localNamespace
+	cluster.Annotations = map[string]string{v1alpha1.UnmanagedAnnotation: "true"}
+	cluster.Status.Endpoint = endpoint
+	cluster.Status.Conditions = []metav1.Condition{unmanagedCondition()}
+
+	return cluster
+}
+
+// unmanagedCondition is the Ready=False condition attached to an unmanaged (kubeconfig-only) cluster.
+func unmanagedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    "Ready",
+		Status:  metav1.ConditionFalse,
+		Reason:  "Unmanaged",
+		Message: "Cluster is present in the kubeconfig but not managed by ksail",
+	}
 }

--- a/pkg/cli/clusterapi/resources.go
+++ b/pkg/cli/clusterapi/resources.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // Ensure the local backend exposes the read-only resource browser and the safe write actions via the
@@ -101,14 +102,28 @@ func contextForCluster(kubeconfigPath, clusterName string) (string, error) {
 	return "", fmt.Errorf("%w: no kubeconfig context for cluster %q", api.ErrNotFound, clusterName)
 }
 
-// clusterEndpoints maps every cluster name detectable from the kubeconfig's contexts to its API
-// server URL, so List can report a real endpoint for local/discovered clusters (the operator surface
-// observes it during reconciliation instead). Best-effort and offline (one file read, no cluster
-// round-trips): an unreadable kubeconfig yields no endpoints. The first context detected for a name
-// wins, matching contextForCluster.
-func (s *Service) clusterEndpoints() map[string]string {
+// loadKubeconfig reads the user's kubeconfig once, best-effort and offline. List calls it a single
+// time and shares the parsed config with both clusterEndpoints and unmanagedClusters, so the file is
+// read and YAML-parsed once per List (not once per helper) and both helpers observe the SAME snapshot
+// — closing the TOCTOU window where two independent reads could otherwise mix contexts from a
+// kubeconfig that changed between them. An unreadable kubeconfig yields nil, which both helpers treat
+// as "no contexts".
+func (s *Service) loadKubeconfig() *clientcmdapi.Config {
 	config, err := clientcmd.LoadFromFile(s.kubeconfigPath())
 	if err != nil {
+		return nil
+	}
+
+	return config
+}
+
+// clusterEndpoints maps every cluster name detectable from the kubeconfig's contexts to its API
+// server URL, so List can report a real endpoint for local/discovered clusters (the operator surface
+// observes it during reconciliation instead). Best-effort and offline (no cluster round-trips): a nil
+// config (unreadable kubeconfig) yields no endpoints. The first context detected for a name wins,
+// matching contextForCluster.
+func clusterEndpoints(config *clientcmdapi.Config) map[string]string {
+	if config == nil {
 		return nil
 	}
 
@@ -139,11 +154,13 @@ func (s *Service) clusterEndpoints() map[string]string {
 // see clusters that exist in the user's kubeconfig but were not provisioned by ksail (a managed
 // EKS/GKE/AKS cluster, a kubeadm cluster, a colleague's cluster) so read/operate surfaces can work
 // against them within limits while ksail-only operations are refused. Best-effort and offline, exactly
-// like clusterEndpoints: one file read, no cluster round-trips, and an unreadable kubeconfig yields
-// none. Contexts are emitted in sorted order so the list is stable.
-func (s *Service) unmanagedClusters(managed map[string]listEntry) []v1alpha1.Cluster {
-	config, err := clientcmd.LoadFromFile(s.kubeconfigPath())
-	if err != nil {
+// like clusterEndpoints: no cluster round-trips, and a nil config (unreadable kubeconfig) yields none.
+// Contexts are emitted in sorted order so the list is stable.
+func unmanagedClusters(
+	config *clientcmdapi.Config,
+	managed map[string]listEntry,
+) []v1alpha1.Cluster {
+	if config == nil {
 		return nil
 	}
 

--- a/pkg/cli/clusterapi/resources.go
+++ b/pkg/cli/clusterapi/resources.go
@@ -3,6 +3,7 @@ package clusterapi
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -111,10 +112,33 @@ func contextForCluster(kubeconfigPath, clusterName string) (string, error) {
 func (s *Service) loadKubeconfig() *clientcmdapi.Config {
 	config, err := clientcmd.LoadFromFile(s.kubeconfigPath())
 	if err != nil {
+		// Best-effort: a missing kubeconfig is normal, but a malformed one would otherwise silently
+		// yield zero endpoints and zero unmanaged clusters with no trail — log at debug so the cause is
+		// discoverable without changing the nil return contract.
+		slog.Debug("load kubeconfig for cluster list",
+			"path", s.kubeconfigPath(), "error", err)
+
 		return nil
 	}
 
 	return config
+}
+
+// endpointForContext resolves the API server URL for a kubeconfig context, or "" when the context or
+// its cluster is absent. Shared by clusterEndpoints and unmanagedClusters so the two-step
+// context -> cluster -> server lookup and its nil checks live in one place.
+func endpointForContext(config *clientcmdapi.Config, contextName string) string {
+	kubeContext, contextExists := config.Contexts[contextName]
+	if !contextExists {
+		return ""
+	}
+
+	cluster, clusterExists := config.Clusters[kubeContext.Cluster]
+	if !clusterExists {
+		return ""
+	}
+
+	return cluster.Server
 }
 
 // clusterEndpoints maps every cluster name detectable from the kubeconfig's contexts to its API
@@ -129,19 +153,19 @@ func clusterEndpoints(config *clientcmdapi.Config) map[string]string {
 
 	endpoints := make(map[string]string, len(config.Contexts))
 
-	for contextName, kubeContext := range config.Contexts {
+	for contextName := range config.Contexts {
 		_, name, detectErr := clusterdetector.DetectDistributionFromContext(contextName)
 		if detectErr != nil {
 			continue
 		}
 
-		cluster, ok := config.Clusters[kubeContext.Cluster]
-		if !ok || cluster.Server == "" {
+		server := endpointForContext(config, contextName)
+		if server == "" {
 			continue
 		}
 
 		if _, exists := endpoints[name]; !exists {
-			endpoints[name] = cluster.Server
+			endpoints[name] = server
 		}
 	}
 
@@ -178,14 +202,7 @@ func unmanagedClusters(
 			continue
 		}
 
-		endpoint := ""
-
-		if kubeContext, ok := config.Contexts[contextName]; ok {
-			if cluster, ok := config.Clusters[kubeContext.Cluster]; ok {
-				endpoint = cluster.Server
-			}
-		}
-
+		endpoint := endpointForContext(config, contextName)
 		items = append(items, newUnmanagedCluster(contextName, endpoint))
 	}
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
ksail only "sees" clusters it provisioned itself, so a cluster that already lives in the user's kubeconfig — a managed EKS/GKE/AKS cluster, a kubeadm cluster, a colleague's cluster — is invisible in the web UI / desktop app, even though most read/operate features already work against any context. This is the first, model-layer slice of that gap.

## What
The local cluster model now also reads the kubeconfig and lists those unmanaged contexts, each **clearly marked unmanaged** (a stable annotation plus a not-ready status marker) so they are never hidden and never shown as a normal managed cluster. A context that maps to a cluster ksail already manages is not duplicated. Nothing changes for managed-only setups.

Model-only for now: surfacing unmanaged clusters in the `ksail cluster list` CLI and adding a UI badge / import affordance are tracked as follow-up children of the epic.

Part of #5654
Fixes #5856