### PR TITLE
feat(environment): surface declared environments as a read model

### DIFF
--- a/pkg/cli/cmd/project/add_environment.go
+++ b/pkg/cli/cmd/project/add_environment.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/annotations"
@@ -164,7 +165,7 @@ func resolveAddEnvironmentParams(
 
 	srcCfg, err := loadSourceConfig(cmd, srcName)
 	if err != nil {
-		return addEnvironmentParams{}, err
+		return addEnvironmentParams{}, enrichSourceConfigError(cmd, repoRoot, err)
 	}
 
 	distribution := srcCfg.Spec.Cluster.Distribution
@@ -226,8 +227,14 @@ func repoRelativeSourceDir(repoRoot, sourceDir string) (string, error) {
 // distribution-specific config (e.g. Talos PKI) are skipped because the clone only
 // needs the structured identity, not a provisioning-ready config.
 func loadSourceConfig(cmd *cobra.Command, srcName string) (*v1alpha1.Cluster, error) {
-	configFile := "ksail." + srcName + ".yaml"
+	return loadEnvironmentConfig(cmd, "ksail."+srcName+".yaml")
+}
 
+// loadEnvironmentConfig loads a single ksail.<name>.yaml root config by file name.
+// It is the shared loader behind loadSourceConfig and the environment.ConfigLoader
+// that enrichSourceConfigError feeds to DeriveEnvironments, so both resolve a config
+// the same silent, validation-skipping way.
+func loadEnvironmentConfig(cmd *cobra.Command, configFile string) (*v1alpha1.Cluster, error) {
 	manager := ksailconfigmanager.NewConfigManager(cmd.OutOrStdout(), configFile)
 
 	cfg, err := manager.Load(configmanager.LoadOptions{
@@ -240,6 +247,29 @@ func loadSourceConfig(cmd *cobra.Command, srcName string) (*v1alpha1.Cluster, er
 	}
 
 	return cfg, nil
+}
+
+// enrichSourceConfigError augments a --from load failure with the environments
+// actually declared in the workspace, so a mistyped source reports what is
+// available instead of only that its config file was missing. It preserves the
+// cause's error chain (ErrSourceConfigLoad) and returns it unchanged when discovery
+// fails or finds no other environments.
+func enrichSourceConfigError(cmd *cobra.Command, repoRoot string, cause error) error {
+	loader := func(configFile string) (*v1alpha1.Cluster, error) {
+		return loadEnvironmentConfig(cmd, configFile)
+	}
+
+	envs, err := environment.DeriveEnvironments(repoRoot, loader)
+	if err != nil || len(envs) == 0 {
+		return cause
+	}
+
+	names := make([]string, 0, len(envs))
+	for _, env := range envs {
+		names = append(names, env.Name)
+	}
+
+	return fmt.Errorf("%w (available environments: %s)", cause, strings.Join(names, ", "))
 }
 
 // cloneEnvironment derives the structured rewrites and clones the source overlay

--- a/pkg/svc/environment/discover.go
+++ b/pkg/svc/environment/discover.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strings"
@@ -74,6 +75,15 @@ func DeriveEnvironments(repoRoot string, load ConfigLoader) ([]Environment, erro
 
 		cfg, loadErr := load(entry.Name())
 		if loadErr != nil {
+			// A malformed config is not a usable environment and must not hide the
+			// rest, but leave a debug trace so a missing environment entry is
+			// troubleshootable rather than silently absent.
+			slog.Default().Debug(
+				"skipping unloadable environment config",
+				"file", entry.Name(),
+				"error", loadErr,
+			)
+
 			continue
 		}
 

--- a/pkg/svc/environment/discover.go
+++ b/pkg/svc/environment/discover.go
@@ -1,0 +1,120 @@
+package environment
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+)
+
+const (
+	// configFilePrefix and configFileSuffix bracket a per-environment root config
+	// file name: ksail.<name>.yaml (the same convention cluster add-environment's
+	// --from resolves against).
+	configFilePrefix = "ksail."
+	configFileSuffix = ".yaml"
+)
+
+// ErrDiscoverEnvironments is returned by DeriveEnvironments when the workspace
+// directory itself cannot be read (a per-environment config that fails to load is
+// skipped, not surfaced as this error).
+var ErrDiscoverEnvironments = errors.New("failed to discover environments")
+
+// Environment is the read-side model of a cluster environment declared in a ksail
+// workspace by a ksail.<name>.yaml root config. It is the enumeration foundation
+// for the multi-cluster layout: higher layers list, validate a --from against, or
+// (later) reconcile the clusters/ tree from the declared set (issue #5441 item 3).
+type Environment struct {
+	// Name is the environment identifier — the <name> in ksail.<name>.yaml, a
+	// DNS-1123 label. It is also the clusters/<name>/ overlay directory segment.
+	Name string
+	// ConfigFile is the root config file name (ksail.<name>.yaml), relative to the
+	// workspace root.
+	ConfigFile string
+	// Distribution is the cluster distribution declared by the config (Vanilla,
+	// K3s, Talos, …).
+	Distribution v1alpha1.Distribution
+	// Provider is the cluster provider declared by the config (Docker, Hetzner, …).
+	Provider v1alpha1.Provider
+}
+
+// ConfigLoader loads the ksail config declared by the given workspace-relative
+// configFile (e.g. "ksail.prod.yaml"). It is injected so this package stays free of
+// a config-manager dependency and DeriveEnvironments is unit-testable without the
+// filesystem; the CLI wires the real ksail config manager.
+type ConfigLoader func(configFile string) (*v1alpha1.Cluster, error)
+
+// DeriveEnvironments enumerates the environments declared in repoRoot by their
+// ksail.<name>.yaml root configs, loading each through load to read its declared
+// distribution and provider. The base ksail.yaml (no <name> segment) is not an
+// environment and is excluded, as is any file whose <name> is not a DNS-1123 label.
+// A config that fails to load is skipped — a single malformed file must not hide the
+// environments that do load — so the result lists every usable declared environment,
+// sorted by name. Only an unreadable repoRoot yields an error (ErrDiscoverEnvironments).
+func DeriveEnvironments(repoRoot string, load ConfigLoader) ([]Environment, error) {
+	entries, err := os.ReadDir(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDiscoverEnvironments, err)
+	}
+
+	environments := make([]Environment, 0, len(entries))
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name, ok := environmentNameFromConfigFile(entry.Name())
+		if !ok {
+			continue
+		}
+
+		cfg, loadErr := load(entry.Name())
+		if loadErr != nil {
+			continue
+		}
+
+		environments = append(environments, Environment{
+			Name:         name,
+			ConfigFile:   entry.Name(),
+			Distribution: cfg.Spec.Cluster.Distribution,
+			Provider:     cfg.Spec.Cluster.Provider,
+		})
+	}
+
+	slices.SortFunc(environments, func(left, right Environment) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+
+	return environments, nil
+}
+
+// environmentNameFromConfigFile extracts the environment <name> from a
+// ksail.<name>.yaml file name. It returns ok=false for the base ksail.yaml (empty
+// <name>), any file not matching the prefix/suffix, and any <name> that is not a
+// DNS-1123 label (e.g. ksail.prod.backup.yaml, whose "prod.backup" contains a dot),
+// mirroring the naming rule add-environment enforces on --from.
+func environmentNameFromConfigFile(fileName string) (string, bool) {
+	if !strings.HasPrefix(fileName, configFilePrefix) ||
+		!strings.HasSuffix(fileName, configFileSuffix) {
+		return "", false
+	}
+
+	// The prefix and suffix must not overlap: the base ksail.yaml satisfies both
+	// but leaves no <name> between them (len 10 <= len("ksail.")+len(".yaml")=11),
+	// so slicing it out excludes the base config rather than reading it as "yaml".
+	if len(fileName) <= len(configFilePrefix)+len(configFileSuffix) {
+		return "", false
+	}
+
+	name := fileName[len(configFilePrefix) : len(fileName)-len(configFileSuffix)]
+
+	if v1alpha1.ValidateClusterName(name) != nil {
+		return "", false
+	}
+
+	return name, true
+}

--- a/pkg/svc/environment/discover_test.go
+++ b/pkg/svc/environment/discover_test.go
@@ -1,0 +1,115 @@
+package environment_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errStubLoad is returned by stubLoader for a file it has no config for, exercising
+// DeriveEnvironments' skip-on-load-error path.
+var errStubLoad = errors.New("stub load failed")
+
+// stubLoader builds a ConfigLoader from a map of file name to the config it should
+// return; a file name mapped to nil (or absent) yields errStubLoad, exercising the
+// skip-on-error path.
+func stubLoader(configs map[string]*v1alpha1.Cluster) environment.ConfigLoader {
+	return func(configFile string) (*v1alpha1.Cluster, error) {
+		cfg, ok := configs[configFile]
+		if !ok || cfg == nil {
+			return nil, errStubLoad
+		}
+
+		return cfg, nil
+	}
+}
+
+func clusterConfig(dist v1alpha1.Distribution, prov v1alpha1.Provider) *v1alpha1.Cluster {
+	cfg := &v1alpha1.Cluster{}
+	cfg.Spec.Cluster.Distribution = dist
+	cfg.Spec.Cluster.Provider = prov
+
+	return cfg
+}
+
+func writeFiles(t *testing.T, dir string, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		filePath := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(filePath, []byte("apiVersion: ksail.io/v1alpha1\n"), 0o600))
+	}
+}
+
+func TestDeriveEnvironmentsEnumeratesDeclaredEnvironments(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.yaml", "ksail.prod.yaml", "ksail.local.yaml", "README.md")
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "clusters"), 0o750))
+
+	loader := stubLoader(map[string]*v1alpha1.Cluster{
+		"ksail.prod.yaml":  clusterConfig(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner),
+		"ksail.local.yaml": clusterConfig(v1alpha1.DistributionTalos, v1alpha1.ProviderDocker),
+	})
+
+	envs, err := environment.DeriveEnvironments(dir, loader)
+	require.NoError(t, err)
+	require.Len(t, envs, 2)
+
+	// Sorted by name: local before prod.
+	assert.Equal(t, "local", envs[0].Name)
+	assert.Equal(t, "ksail.local.yaml", envs[0].ConfigFile)
+	assert.Equal(t, v1alpha1.ProviderDocker, envs[0].Provider)
+	assert.Equal(t, "prod", envs[1].Name)
+	assert.Equal(t, v1alpha1.ProviderHetzner, envs[1].Provider)
+	assert.Equal(t, v1alpha1.DistributionTalos, envs[1].Distribution)
+}
+
+func TestDeriveEnvironmentsExcludesBaseAndNonEnvironmentFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// ksail.yaml is the base (no name); ksail.prod.backup.yaml has a non-label name;
+	// notksail.dev.yaml lacks the prefix; ksail.dev.yml has the wrong suffix.
+	writeFiles(t, dir, "ksail.yaml", "ksail.prod.backup.yaml", "notksail.dev.yaml", "ksail.dev.yml")
+
+	// Every file is excluded by name before the loader runs, so a nil-config loader
+	// (which errors for any file) proves none of them is read as an environment.
+	envs, err := environment.DeriveEnvironments(dir, stubLoader(nil))
+	require.NoError(t, err)
+	assert.Empty(t, envs)
+}
+
+func TestDeriveEnvironmentsSkipsUnloadableConfigs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.prod.yaml", "ksail.broken.yaml")
+
+	// Only prod loads; broken returns an error and must be skipped, not surfaced.
+	loader := stubLoader(map[string]*v1alpha1.Cluster{
+		"ksail.prod.yaml": clusterConfig(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner),
+	})
+
+	envs, err := environment.DeriveEnvironments(dir, loader)
+	require.NoError(t, err)
+	require.Len(t, envs, 1)
+	assert.Equal(t, "prod", envs[0].Name)
+}
+
+func TestDeriveEnvironmentsErrorsOnUnreadableRoot(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	envs, err := environment.DeriveEnvironments(missing, stubLoader(nil))
+	require.ErrorIs(t, err, environment.ErrDiscoverEnvironments)
+	assert.Nil(t, envs)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

A real platform is multi-cluster/multi-environment, and #5441 tracks giving ksail a first-class way to scaffold and grow that shape. Its declarative step (item 3) must reconcile the `clusters/` tree from the environments a workspace declares — but nothing yet *enumerates* that declared set. This is the read-side foundation it needs.

## What

Adds a discovery model that lists the environments a workspace declares (via its `ksail.<name>.yaml` root configs — the existing convention, no new config field), reporting each one's distribution and provider. Uses it so a mistyped `cluster add-environment --from` now tells you which environments are actually available.

First, small increment of the #5441 item-3 epic; the `list-environments` command and the declarative reconcile follow as separate children.

Fixes #5862
Part of #5441
