### PR TITLE
feat(render): honor valuesFrom.targetPath in offline HelmRelease rendering

### DIFF
--- a/pkg/svc/gitops/render/coverage_test.go
+++ b/pkg/svc/gitops/render/coverage_test.go
@@ -155,26 +155,28 @@ func TestBuildChartSpecDeepMergesValues(t *testing.T) {
 	assert.Contains(t, spec.ValuesYaml, "type: LoadBalancer")
 }
 
-// TestBuildChartSpecValuesFromTargetPathSkipped verifies targetPath references
-// are skipped (not merged) until support is added.
-func TestBuildChartSpecValuesFromTargetPathSkipped(t *testing.T) {
+// TestBuildChartSpecValuesFromTargetPathMergesWithInline verifies a targetPath
+// reference is injected at its path without clobbering inline spec.values.
+func TestBuildChartSpecValuesFromTargetPathMergesWithInline(t *testing.T) {
 	t.Parallel()
 
 	helmRelease := chartRefRelease()
 	helmRelease.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(`{"keep":true}`)}
 	helmRelease.Spec.ValuesFrom = []fluxmeta.ValuesReference{
-		{Kind: "ConfigMap", Name: "extra", TargetPath: "some.path"},
+		{Kind: "ConfigMap", Name: "extra", ValuesKey: "env", TargetPath: "some.path"},
 	}
 
 	sources := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
 	sources.ConfigMaps = map[string]map[string]string{
-		"flux-system/extra": {"values.yaml": "ignored: true"},
+		"flux-system/extra": {"env": "prod"},
 	}
 
 	spec := resolveSpec(t, helmRelease, sources)
 
-	assert.Contains(t, spec.ValuesYaml, "keep: true")
-	assert.NotContains(t, spec.ValuesYaml, "ignored")
+	values := unmarshalValues(t, spec.ValuesYaml)
+	assert.Equal(t, true, values["keep"])
+	some, _ := values["some"].(map[string]any)
+	assert.Equal(t, "prod", some["path"])
 }
 
 // TestApplyOCIRepositoryNoReference covers an OCIRepository without a ref.

--- a/pkg/svc/gitops/render/resolver.go
+++ b/pkg/svc/gitops/render/resolver.go
@@ -11,6 +11,7 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	meta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	helmv4strvals "helm.sh/helm/v4/pkg/strvals"
 	"sigs.k8s.io/yaml"
 )
 
@@ -302,18 +303,15 @@ func buildValues(helmRelease *helmv2.HelmRelease, sources SourceIndex) (string, 
 
 // applyValuesFrom merges one valuesFrom reference into values, resolving it from
 // the in-repo ConfigMap/Secret index. References to objects not present in the
-// stream (typically cluster-managed) are skipped. Nested targetPath references
-// are not yet supported and are skipped rather than merged incorrectly.
+// stream (typically cluster-managed) are skipped. A reference with a targetPath
+// injects its single flat value at that path (see applyTargetPathValue);
+// otherwise the referenced value is YAML-merged at the root.
 func applyValuesFrom(
 	values map[string]any,
 	ref meta.ValuesReference,
 	namespace string,
 	sources SourceIndex,
 ) {
-	if ref.TargetPath != "" {
-		return
-	}
-
 	var data map[string]string
 
 	switch ref.Kind {
@@ -330,6 +328,12 @@ func applyValuesFrom(
 		return
 	}
 
+	if ref.TargetPath != "" {
+		applyTargetPathValue(values, ref, raw)
+
+		return
+	}
+
 	var parsed map[string]any
 
 	if yaml.Unmarshal([]byte(raw), &parsed) != nil {
@@ -337,6 +341,25 @@ func applyValuesFrom(
 	}
 
 	mergeValues(values, parsed)
+}
+
+// applyTargetPathValue merges a single flat value at ref.TargetPath, mirroring
+// helm-controller's valuesFrom targetPath handling so the offline render matches
+// what Flux applies. A non-literal reference uses Helm's --set-string semantics
+// (the target path is interpreted but the value stays a string); a literal
+// reference uses --set-literal semantics (the value is injected verbatim, with
+// no comma/bracket/dot/equals interpretation — the safe path for config files,
+// JSON blobs and multi-line strings). A malformed assignment is skipped rather
+// than failing the whole offline render, matching the root-merge branch.
+func applyTargetPathValue(values map[string]any, ref meta.ValuesReference, raw string) {
+	assignment := fmt.Sprintf("%s=%s", ref.TargetPath, raw)
+
+	parse := helmv4strvals.ParseIntoString
+	if ref.Literal {
+		parse = helmv4strvals.ParseLiteralInto
+	}
+
+	_ = parse(assignment, values)
 }
 
 // sourceKey builds the "namespace/name" lookup key, defaulting an empty

--- a/pkg/svc/gitops/render/resolver_test.go
+++ b/pkg/svc/gitops/render/resolver_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // captureClient embeds helm.Interface and records the ChartSpec passed to
@@ -55,6 +56,19 @@ func resolveSpec(
 	require.NotNil(t, capture.spec)
 
 	return capture.spec
+}
+
+// unmarshalValues parses a resolved ChartSpec.ValuesYaml back into a map so a
+// test can assert the value type and nesting (e.g. string-vs-number coercion),
+// which the raw YAML text alone leaves ambiguous.
+func unmarshalValues(t *testing.T, valuesYaml string) map[string]any {
+	t.Helper()
+
+	var values map[string]any
+
+	require.NoError(t, yaml.Unmarshal([]byte(valuesYaml), &values))
+
+	return values
 }
 
 func ociIndex(ref *sourcev1.OCIRepositoryRef) render.SourceIndex {
@@ -207,6 +221,56 @@ func TestBuildChartSpecValuesFromConfigMap(t *testing.T) {
 	spec := resolveSpec(t, helmRelease, sources)
 
 	assert.Contains(t, spec.ValuesYaml, "port: 9999")
+}
+
+func TestBuildChartSpecValuesFromTargetPath(t *testing.T) {
+	t.Parallel()
+
+	helmRelease := chartRefRelease()
+	helmRelease.Spec.ValuesFrom = []fluxmeta.ValuesReference{
+		{Kind: "ConfigMap", Name: "image-tag", ValuesKey: "tag", TargetPath: "image.tag"},
+	}
+
+	sources := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
+	sources.ConfigMaps = map[string]map[string]string{
+		"flux-system/image-tag": {"tag": "123"},
+	}
+
+	spec := resolveSpec(t, helmRelease, sources)
+
+	values := unmarshalValues(t, spec.ValuesYaml)
+	image, ok := values["image"].(map[string]any)
+	require.True(t, ok, "the value should be set at the nested targetPath")
+	// --set-string semantics: the flat value stays a string, never coerced to a number.
+	assert.Equal(t, "123", image["tag"])
+}
+
+func TestBuildChartSpecValuesFromTargetPathLiteral(t *testing.T) {
+	t.Parallel()
+
+	helmRelease := chartRefRelease()
+	helmRelease.Spec.ValuesFrom = []fluxmeta.ValuesReference{
+		{
+			Kind:       "Secret",
+			Name:       "config-blob",
+			ValuesKey:  "blob",
+			TargetPath: "config.raw",
+			Literal:    true,
+		},
+	}
+
+	sources := ociIndex(&sourcev1.OCIRepositoryRef{Tag: "6.5.0"})
+	sources.Secrets = map[string]map[string]string{
+		"flux-system/config-blob": {"blob": "a,b=c[0]"},
+	}
+
+	spec := resolveSpec(t, helmRelease, sources)
+
+	values := unmarshalValues(t, spec.ValuesYaml)
+	config, ok := values["config"].(map[string]any)
+	require.True(t, ok, "the literal value should be set at the nested targetPath")
+	// --set-literal semantics: commas, brackets and equals are NOT interpreted.
+	assert.Equal(t, "a,b=c[0]", config["raw"])
 }
 
 func TestRenderUnsupportedSourceKindDegrades(t *testing.T) {


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why:** `ksail workload validate`/`scan` render HelmRelease charts offline so they can catch problems shift-left. But any `valuesFrom` entry that sets a value at a nested path (`targetPath` — a common pattern like `image.tag`) was silently ignored, so the offline render diverged from what Flux actually applies. That's a fidelity hole in exactly the feature that's meant to give full-fidelity coverage.

**What:** Renders `targetPath` references the same way Flux's helm-controller does, so the offline output now matches production. No new dependencies; graceful handling of unresolvable sources is unchanged.

Fixes #5872
Part of #5344