### PR TITLE
fix(release): quit KSail.app on ksail-desktop cask upgrade/uninstall

### DIFF
--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -89,15 +89,20 @@ homebrew_casks:
         # (the cask download URL would 404 for `brew install`). The cd.yaml `homebrew` job marks the
         # PR ready after `publish-release` flips the release public, letting the tap merge it then.
         draft: true
-    # The cask schema has no first-class `app` or `depends_on` field; emit both via a custom stanza.
-    # `depends_on macos` satisfies `brew style` (Homebrew/OSDependsOn) for this macOS-only GUI cask;
-    # the bare `:big_sur` symbol means "Big Sur or newer" (matching the Go toolchain's minimum
-    # supported macOS) and is the canonical form — the old `">= :big_sur"` string-comparison syntax
-    # is deprecated by Homebrew. The cd.yaml `homebrew` job runs `brew style --fix`, which reorders
-    # these stanzas into canonical position before the cask lands in the tap.
+    # The cask schema has no first-class `app`, `depends_on` or `uninstall` field; emit them via a
+    # custom stanza. `depends_on macos` satisfies `brew style` (Homebrew/OSDependsOn) for this
+    # macOS-only GUI cask; the bare `:big_sur` symbol means "Big Sur or newer" (matching the Go
+    # toolchain's minimum supported macOS) and is the canonical form — the old `">= :big_sur"`
+    # string-comparison syntax is deprecated by Homebrew. `uninstall quit:` names the app's bundle id
+    # so Homebrew quits a running KSail.app before it replaces the bundle on upgrade/uninstall; without
+    # it, upgrading while the app is open interrupts the transaction and leaves a stale
+    # `<version>.upgrading` staging dir that blocks every subsequent `brew upgrade` (a real cascade
+    # observed in the field). The cd.yaml `homebrew` job runs `brew style --fix`, which reorders these
+    # stanzas into canonical position before the cask lands in the tap.
     custom_block: |
       depends_on macos: :big_sur
       app "KSail.app"
+      uninstall quit: "tech.devantler.ksail.desktop"
     # Symlink the CLI from inside the installed app (the canonical GUI-app-with-CLI cask pattern),
     # so `ksail-desktop` is on PATH and `ksail open desktop` finds it. Without this, GoReleaser would
     # default the symlink to the bare basename, which does not exist at the archive root.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why:** Upgrading the `ksail-desktop` cask fails when KSail.app is running — Homebrew can't cleanly replace the running bundle, so the upgrade is interrupted and leaves a stale `<version>.upgrading` staging dir that then blocks *every* later `brew upgrade`. Reported from the field with the casks wedged across dozens of releases (`Directory not empty` / `No such file or directory` rename errors).

**What:** The cask declared its app bundle but no `uninstall quit:` stanza, so it never quit the running app before an upgrade. Adds `uninstall quit:` (keyed on the app's bundle id) to the GoReleaser cask config so Homebrew quits KSail.app first. Cask files are GoReleaser-generated, so the fix lives in the config, not the tap. Standard best practice for GUI `.app` casks; no effect when the app isn't running.

Fixes the recurring `ksail-desktop` cask upgrade failure.