### PR TITLE
fix(autoscaler): wire ignoreDaemonsetsUtilization & skipNodesWith* into detect and diff

### DIFF
--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -642,6 +642,23 @@ func parseAutoscalerExtraArgs(cfg *v1alpha1.NodeAutoscalerConfig, args map[strin
 	if capacityBuffers, ok := args["capacity-buffer-controller-enabled"].(bool); ok {
 		cfg.CapacityBuffers = capacityBuffers
 	}
+
+	// ignoreDaemonsetsUtilization is a plain bool (off by default); the installer
+	// omits the flag when false, so an absent key leaves cfg's zero value (false).
+	if ignoreDaemonsets, ok := args["ignore-daemonsets-utilization"].(bool); ok {
+		cfg.IgnoreDaemonsetsUtilization = ignoreDaemonsets
+	}
+
+	// skipNodesWith* are *bool: the installer omits the flag when unset, so an
+	// absent key leaves cfg's nil pointer (inherits the upstream default true).
+	// A present key is an explicit true/false and is preserved as a non-nil value.
+	if skipLocalStorage, ok := args["skip-nodes-with-local-storage"].(bool); ok {
+		cfg.SkipNodesWithLocalStorage = &skipLocalStorage
+	}
+
+	if skipSystemPods, ok := args["skip-nodes-with-system-pods"].(bool); ok {
+		cfg.SkipNodesWithSystemPods = &skipSystemPods
+	}
 }
 
 // helmExpandersToEnum reverses the Helm chart's expander value — a single

--- a/pkg/svc/detector/component_test.go
+++ b/pkg/svc/detector/component_test.go
@@ -1109,6 +1109,72 @@ func TestDetectNodeAutoscaler_CapacityBuffers(t *testing.T) {
 		"capacity-buffer-controller-enabled extraArg should round-trip to CapacityBuffers")
 }
 
+func TestDetectNodeAutoscaler_SkipNodesAndDaemonsets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ReleaseExists", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(true, nil)
+
+	helmClient.On("GetReleaseValues", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(map[string]any{
+		"extraArgs": map[string]any{
+			"ignore-daemonsets-utilization": true,
+			"skip-nodes-with-local-storage": false,
+			"skip-nodes-with-system-pods":   true,
+		},
+	}, nil)
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	cfg, err := d.ExportDetectNodeAutoscaler(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, cfg.IgnoreDaemonsetsUtilization,
+		"ignore-daemonsets-utilization extraArg should round-trip to IgnoreDaemonsetsUtilization")
+	require.NotNil(t, cfg.SkipNodesWithLocalStorage,
+		"an explicit skip-nodes-with-local-storage should round-trip to a non-nil pointer")
+	assert.False(t, *cfg.SkipNodesWithLocalStorage,
+		"skip-nodes-with-local-storage=false should round-trip to a *false pointer")
+	require.NotNil(t, cfg.SkipNodesWithSystemPods,
+		"an explicit skip-nodes-with-system-pods should round-trip to a non-nil pointer")
+	assert.True(t, *cfg.SkipNodesWithSystemPods,
+		"skip-nodes-with-system-pods=true should round-trip to a *true pointer")
+}
+
+func TestDetectNodeAutoscaler_SkipNodesUnsetStayNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ReleaseExists", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(true, nil)
+
+	helmClient.On("GetReleaseValues", ctx,
+		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
+	).Return(map[string]any{
+		"extraArgs": map[string]any{},
+	}, nil)
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	cfg, err := d.ExportDetectNodeAutoscaler(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, cfg.IgnoreDaemonsetsUtilization,
+		"an absent ignore-daemonsets-utilization should leave the zero value (false)")
+	assert.Nil(t, cfg.SkipNodesWithLocalStorage,
+		"an absent skip-nodes-with-local-storage should leave a nil pointer (upstream default)")
+	assert.Nil(t, cfg.SkipNodesWithSystemPods,
+		"an absent skip-nodes-with-system-pods should leave a nil pointer (upstream default)")
+}
+
 func TestDetectNodeAutoscaler_NotInstalled(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -790,6 +790,41 @@ func (e *Engine) checkAutoscalerNodeScalarsChange(
 		"false",
 		"capacity buffers can be toggled via Helm chart upgrade",
 		clusterupdate.ChangeCategoryInPlace)
+
+	appendChange(result, "cluster.autoscaler.node.ignoreDaemonsetsUtilization",
+		strconv.FormatBool(oldNode.IgnoreDaemonsetsUtilization),
+		strconv.FormatBool(newNode.IgnoreDaemonsetsUtilization),
+		"false",
+		"ignoreDaemonsetsUtilization can be toggled via Helm chart upgrade",
+		clusterupdate.ChangeCategoryInPlace)
+
+	// skipNodesWith* are *bool with an upstream default of true; a nil pointer
+	// (unset) compares as "true" so nil→false surfaces as a change and nil↔true
+	// does not.
+	appendChange(result, "cluster.autoscaler.node.skipNodesWithLocalStorage",
+		formatBoolPtr(oldNode.SkipNodesWithLocalStorage),
+		formatBoolPtr(newNode.SkipNodesWithLocalStorage),
+		"true",
+		"skipNodesWithLocalStorage can be toggled via Helm chart upgrade",
+		clusterupdate.ChangeCategoryInPlace)
+
+	appendChange(result, "cluster.autoscaler.node.skipNodesWithSystemPods",
+		formatBoolPtr(oldNode.SkipNodesWithSystemPods),
+		formatBoolPtr(newNode.SkipNodesWithSystemPods),
+		"true",
+		"skipNodesWithSystemPods can be toggled via Helm chart upgrade",
+		clusterupdate.ChangeCategoryInPlace)
+}
+
+// formatBoolPtr renders a *bool for diffing: a nil pointer yields the empty
+// string so appendChange's default substitution supplies the field's upstream
+// default, while a non-nil pointer renders its explicit true/false.
+func formatBoolPtr(b *bool) string {
+	if b == nil {
+		return ""
+	}
+
+	return strconv.FormatBool(*b)
 }
 
 // checkAutoscalerPodScalarsChange emits in-place changes for scalar pod-autoscaler fields.

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -1332,6 +1332,86 @@ func TestEngine_AutoscalerNodeCapacityBuffersChange(t *testing.T) {
 		"false", "true", clusterupdate.ChangeCategoryInPlace)
 }
 
+func TestEngine_AutoscalerNodeIgnoreDaemonsetsUtilizationChange(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	newer := clone(old)
+	newer.Autoscaler.Node.IgnoreDaemonsetsUtilization = true
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	if !result.HasInPlaceChanges() {
+		t.Fatal("autoscaler node ignoreDaemonsetsUtilization change should be in-place")
+	}
+
+	assertSingleChange(t, result.InPlaceChanges,
+		"cluster.autoscaler.node.ignoreDaemonsetsUtilization",
+		"false", "true", clusterupdate.ChangeCategoryInPlace)
+}
+
+func TestEngine_AutoscalerNodeSkipNodesWithLocalStorageChange(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	newer := clone(old)
+	disabled := false
+	// The unset (nil) old value inherits the upstream default true, so setting it
+	// explicitly false must surface as a true→false in-place change.
+	newer.Autoscaler.Node.SkipNodesWithLocalStorage = &disabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	if !result.HasInPlaceChanges() {
+		t.Fatal("autoscaler node skipNodesWithLocalStorage change should be in-place")
+	}
+
+	assertSingleChange(t, result.InPlaceChanges,
+		"cluster.autoscaler.node.skipNodesWithLocalStorage",
+		"true", "false", clusterupdate.ChangeCategoryInPlace)
+}
+
+func TestEngine_AutoscalerNodeSkipNodesWithSystemPodsChange(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	newer := clone(old)
+	disabled := false
+	newer.Autoscaler.Node.SkipNodesWithSystemPods = &disabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	if !result.HasInPlaceChanges() {
+		t.Fatal("autoscaler node skipNodesWithSystemPods change should be in-place")
+	}
+
+	assertSingleChange(t, result.InPlaceChanges,
+		"cluster.autoscaler.node.skipNodesWithSystemPods",
+		"true", "false", clusterupdate.ChangeCategoryInPlace)
+}
+
+func TestEngine_AutoscalerNodeSkipNodesUnsetNoChange(t *testing.T) {
+	t.Parallel()
+
+	old := newBaseSpec()
+	newer := clone(old)
+	// Both nil (unset) → both compare as the upstream default true → no change.
+	enabled := true
+	newer.Autoscaler.Node.SkipNodesWithLocalStorage = &enabled
+
+	engine := diff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+	result := engine.ComputeDiff(old, newer, nil, nil)
+
+	for _, change := range result.InPlaceChanges {
+		if change.Field == "cluster.autoscaler.node.skipNodesWithLocalStorage" {
+			t.Fatalf("nil→true skipNodesWithLocalStorage should not change, got %+v", change)
+		}
+	}
+}
+
 func TestEngine_AutoscalerExpanderChange(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -1398,7 +1398,8 @@ func TestEngine_AutoscalerNodeSkipNodesUnsetNoChange(t *testing.T) {
 
 	old := newBaseSpec()
 	newer := clone(old)
-	// Both nil (unset) → both compare as the upstream default true → no change.
+	// old nil (unset → upstream default true) vs newer explicit true → both
+	// effectively true → no change.
 	enabled := true
 	newer.Autoscaler.Node.SkipNodesWithLocalStorage = &enabled
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Three node-autoscaler settings (`ignoreDaemonsetsUtilization`, `skipNodesWithLocalStorage`, `skipNodesWithSystemPods`) were written when installing a cluster but ignored everywhere else — so `ksail cluster update` silently would not apply a change to any of them, and detecting an existing cluster dropped them. Their older siblings are wired end-to-end; these three fell through the gaps.

## What
Wires the three fields into the two missing paths: config detection now reads them back from a live release, and the update diff now reports a change when any of them changes. Behaviour-preserving for everything else; covered by table tests.

Fixes #5867