### PR TITLE
refactor(provisioner): extract shared Hetzner base wiring into Base.Wire

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/hetznerbase.go
@@ -211,6 +211,16 @@ func NewBase(
 	}, nil
 }
 
+// Wire finalises a freshly built Base for a distribution provisioner: it records the
+// distro-specific create [CreateStrategy] and the Connector Secret prefix. Call it
+// once, immediately after [NewBase], passing the constructed provisioner as strategy —
+// the wiring step both distributions' NewProvisioner constructors delegate to instead
+// of open-coding it (which jscpd flagged as a near-identical clone).
+func (b *Base) Wire(strategy CreateStrategy, connectorSecretPrefix string) {
+	b.Strategy = strategy
+	b.ConnectorSecretPrefix = connectorSecretPrefix
+}
+
 // ResolveName returns name when non-empty, otherwise the Base's configured default
 // cluster name, matching the Provisioner interface's "empty name means use config
 // default" contract.

--- a/pkg/svc/provisioner/cluster/k3shetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3shetzner/provisioner.go
@@ -50,8 +50,7 @@ func NewProvisioner(
 	}
 
 	provisioner.Base = base
-	base.Strategy = provisioner
-	base.ConnectorSecretPrefix = connectorSecretPrefix
+	base.Wire(provisioner, connectorSecretPrefix)
 
 	return provisioner, nil
 }

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/provisioner.go
@@ -63,8 +63,7 @@ func NewProvisioner(
 	}
 
 	provisioner.Base = base
-	base.Strategy = provisioner
-	base.ConnectorSecretPrefix = connectorSecretPrefix
+	base.Wire(provisioner, connectorSecretPrefix)
 
 	return provisioner, nil
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why.** The two Hetzner provisioner constructors (k3s and kubeadm) repeated the same base-wiring block, which the duplicate-code linter flagged as a clone sitting right on the pass/fail edge — so unrelated changes intermittently red the main lint check.

**What.** Moves the shared wiring behind one small `Base.Wire(...)` helper both constructors call. Pure internal refactor — no behaviour change, existing tests unchanged and green.

Fixes #5748