### PR TITLE
fix(kustomize): pre-warm openapi schema to fix concurrent-build data race

### DIFF
--- a/pkg/client/kustomize/client.go
+++ b/pkg/client/kustomize/client.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // Client provides kustomize build functionality.
@@ -18,8 +21,37 @@ func NewClient() *Client {
 	return &Client{}
 }
 
+// schemaWarmOnce serializes the first kyaml openapi builtin-schema
+// initialization across concurrent builds. See warmSchema and
+// https://github.com/devantler-tech/ksail/issues/5858.
+var schemaWarmOnce sync.Once //nolint:gochecknoglobals
+
+// warmSchema forces kustomize's kyaml openapi builtin-schema package globals to
+// initialize once, serially, before any concurrent build reads them.
+//
+// The first kustomize build lazily initializes those globals (schema parse plus
+// the namespaceability map). That init is not goroutine-safe: kyaml writes the
+// namespaceability map under a lock inside findNamespaceability, but
+// IsNamespaceScoped reads the same map without the lock — so a second concurrent
+// build racing the first's init trips the race detector (and can read a
+// half-populated map). Running one SchemaForResourceType call under a sync.Once
+// forces the full init (findNamespaceability included) exactly once; after it
+// every concurrent build only ever reads a settled, no-longer-mutated global.
+// This covers the default built-in schema that ksail always uses.
+func warmSchema() {
+	schemaWarmOnce.Do(func() {
+		_ = openapi.SchemaForResourceType(
+			kyaml.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		)
+	})
+}
+
 // Build runs kustomize build on the specified directory and returns the output.
 func (c *Client) Build(_ context.Context, path string) (*bytes.Buffer, error) {
+	// Initialize the shared kyaml openapi schema once before building, so
+	// concurrent Build calls never race its lazy first-init (#5858).
+	warmSchema()
+
 	// Create a file system abstraction
 	fSys := filesys.MakeFsOnDisk()
 

--- a/pkg/client/kustomize/client_test.go
+++ b/pkg/client/kustomize/client_test.go
@@ -3,8 +3,10 @@ package kustomize_test
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -325,41 +327,104 @@ data:
 	}
 }
 
-// writeConfigMapKustomization writes a minimal ConfigMap kustomization into dir.
-func writeConfigMapKustomization(t *testing.T, dir, name string) {
+// writeSchemaExercisingKustomization writes a kustomization whose build races the
+// kyaml openapi builtin-schema global on both sides: a strategic-merge patch on a
+// Deployment forces SchemaForResourceType → the lazy init that WRITES the
+// namespaceability map (findNamespaceability), and a custom-kind (non-precomputed)
+// resource forces resWrangler.Append → IsNamespaceScoped → the UNLOCKED read of
+// that same map. A plain resource passthrough (e.g. a ConfigMap, all precomputed)
+// exercises neither, so the concurrent race test needs this shape to be meaningful.
+func writeSchemaExercisingKustomization(t *testing.T, dir, name string) {
 	t.Helper()
 
-	configMapYAML := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + name +
-		"\n  namespace: default\ndata:\n  key: value\n"
-
-	err := os.WriteFile(filepath.Join(dir, "configmap.yaml"), []byte(configMapYAML), 0o600)
-	if err != nil {
-		t.Fatalf("failed to write configmap: %v", err)
+	// A strategic-merge patch on a Deployment forces SchemaForResourceType → the
+	// one-time builtin-schema init that WRITES the namespaceability map
+	// (findNamespaceability, under a lock it releases per-caller).
+	files := map[string]string{
+		"deployment.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: " + name +
+			"\n  namespace: default\nspec:\n  selector:\n    matchLabels:\n      app: " + name +
+			"\n  template:\n    metadata:\n      labels:\n        app: " + name +
+			"\n    spec:\n      containers:\n        - name: app\n          image: nginx:latest\n",
+		"patch.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: " + name +
+			"\n  namespace: default\nspec:\n  replicas: 2\n",
 	}
 
-	err = os.WriteFile(
-		filepath.Join(dir, "kustomization.yaml"),
-		[]byte(simpleConfigMapKustomization),
-		0o600,
-	)
-	if err != nil {
-		t.Fatalf("failed to write kustomization: %v", err)
+	var resources strings.Builder
+
+	resources.WriteString("resources:\n  - deployment.yaml\n")
+
+	// Many custom, non-precomputed kinds: each is looked up via the UNLOCKED map
+	// read (IsNamespaceScoped) that races the init write above. A high count keeps
+	// reads flowing across the init window, so the race reproduces reliably (a
+	// single custom resource almost never overlaps the brief one-time init).
+	const widgets = 120
+	for i := range widgets {
+		fname := "widget-" + strconv.Itoa(i) + ".yaml"
+		files[fname] = "apiVersion: example.com/v1\nkind: Widget" + strconv.Itoa(i) +
+			"\nmetadata:\n  name: " + name + "-" + strconv.Itoa(i) + "\n"
+
+		resources.WriteString("  - " + fname + "\n")
+	}
+
+	files["kustomization.yaml"] = "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n" +
+		resources.String() + "patches:\n  - path: patch.yaml\n"
+
+	for filename, content := range files {
+		err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o600)
+		if err != nil {
+			t.Fatalf("failed to write %s: %v", filename, err)
+		}
 	}
 }
 
-// TestBuild_ConcurrentBuildsNoRace runs many builds concurrently to guard the
-// kyaml openapi builtin-schema global against a lazy-first-init data race. It
-// fails under `go test -race` if concurrent builds race that global (they did
-// before the warmSchema pre-init). See #5858.
+// raceChildEnv marks the re-exec'd child process of
+// TestBuild_ConcurrentBuildsNoRace.
+const raceChildEnv = "KSAIL_KUSTOMIZE_RACE_CHILD"
+
+// TestBuild_ConcurrentBuildsNoRace guards the kyaml openapi builtin-schema global
+// against a lazy-first-init data race across concurrent builds (#5858).
+//
+// It re-execs itself in a fresh subprocess so the global starts *unwarmed*.
+// Another Build test in this package could otherwise warm the process-global
+// schema before this test runs, which would let the test pass even if
+// Client.Build stopped pre-warming — masking a regression. The child runs the
+// concurrent builds from a clean process; under `go test -race` it fails (and the
+// parent surfaces the report) if those builds race.
 func TestBuild_ConcurrentBuildsNoRace(t *testing.T) {
+	if os.Getenv(raceChildEnv) == "1" {
+		runConcurrentBuilds(t)
+
+		return
+	}
+
 	t.Parallel()
+
+	args := []string{"-test.run=^TestBuild_ConcurrentBuildsNoRace$", "-test.v"}
+
+	// #nosec G204 G702 -- re-exec of this test binary (os.Args[0]) with a static
+	// argv slice; no shell is invoked, so there is no command-injection surface.
+	cmd := exec.CommandContext(t.Context(), os.Args[0], args...)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, raceChildEnv+"=1")
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("concurrent-build race subprocess failed: %v\n%s", err, out)
+	}
+}
+
+// runConcurrentBuilds builds several kustomizations concurrently and reports any
+// error. It is the body executed by the re-exec'd child of
+// TestBuild_ConcurrentBuildsNoRace.
+func runConcurrentBuilds(t *testing.T) {
+	t.Helper()
 
 	const builders = 16
 
 	dirs := make([]string, builders)
 	for i := range dirs {
 		dir := t.TempDir()
-		writeConfigMapKustomization(t, dir, "cm-"+strconv.Itoa(i))
+		writeSchemaExercisingKustomization(t, dir, "app-"+strconv.Itoa(i))
 		dirs[i] = dir
 	}
 

--- a/pkg/client/kustomize/client_test.go
+++ b/pkg/client/kustomize/client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 
 	snapshottest "github.com/devantler-tech/ksail/v7/internal/testutil/snapshottest"
@@ -320,5 +322,71 @@ data:
 	// Verify it has the correct type
 	if output.Len() == 0 {
 		t.Fatal("expected non-empty buffer")
+	}
+}
+
+// writeConfigMapKustomization writes a minimal ConfigMap kustomization into dir.
+func writeConfigMapKustomization(t *testing.T, dir, name string) {
+	t.Helper()
+
+	configMapYAML := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + name +
+		"\n  namespace: default\ndata:\n  key: value\n"
+
+	err := os.WriteFile(filepath.Join(dir, "configmap.yaml"), []byte(configMapYAML), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write configmap: %v", err)
+	}
+
+	err = os.WriteFile(
+		filepath.Join(dir, "kustomization.yaml"),
+		[]byte(simpleConfigMapKustomization),
+		0o600,
+	)
+	if err != nil {
+		t.Fatalf("failed to write kustomization: %v", err)
+	}
+}
+
+// TestBuild_ConcurrentBuildsNoRace runs many builds concurrently to guard the
+// kyaml openapi builtin-schema global against a lazy-first-init data race. It
+// fails under `go test -race` if concurrent builds race that global (they did
+// before the warmSchema pre-init). See #5858.
+func TestBuild_ConcurrentBuildsNoRace(t *testing.T) {
+	t.Parallel()
+
+	const builders = 16
+
+	dirs := make([]string, builders)
+	for i := range dirs {
+		dir := t.TempDir()
+		writeConfigMapKustomization(t, dir, "cm-"+strconv.Itoa(i))
+		dirs[i] = dir
+	}
+
+	client := kustomize.NewClient()
+	ctx := context.Background()
+
+	errCh := make(chan error, builders)
+
+	var waitGroup sync.WaitGroup
+
+	waitGroup.Add(builders)
+
+	for _, dir := range dirs {
+		go func() {
+			defer waitGroup.Done()
+
+			_, err := client.Build(ctx, dir)
+			if err != nil {
+				errCh <- err
+			}
+		}()
+	}
+
+	waitGroup.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent build failed: %v", err)
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Concurrent kustomize builds — which `ksail workload validate` runs when it fans out one validator per manifest — intermittently trip the race detector, reddening the `📊 Code Coverage` job on unrelated PRs. It's a genuine correctness hazard, not just a test artifact: two builds racing kustomize's one-time internal schema init can read a half-populated global.

## What
Initializes that shared schema **once, serially, before** any parallel build runs, so every concurrent build only ever reads a settled global. Full parallelism is preserved after the one-time warm-up. Adds a concurrent-build regression test that runs under `-race`.

Fixes #5858