### PR TITLE
ci(mega-linter): disable betterleaks secret scanner

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -12,6 +12,12 @@ DISABLE_LINTERS:
   - ACTION_ZIZMOR
   - GO_GOLANGCI_LINT # Disabled: MegaLinter container has Go 1.24.7, but project requires Go 1.26.0. CI runs golangci-lint separately with correct Go version.
   - GO_REVIVE
+  - REPOSITORY_BETTERLEAKS
+  # Disabled: a gitleaks fork newly default-activated by MegaLinter v9.6.0.
+  # Consistent with GITLEAKS/SECRETLINT below — this repo does not gate on an
+  # in-MegaLinter secret scanner; its only findings are deterministic test
+  # fixtures/snapshots (e.g. cipher_test.go age key, cloudinit_test.go SSH/PGP
+  # keys, gen testdata/snapshots), not real credentials.
   - REPOSITORY_CHECKOV
   - REPOSITORY_GITLEAKS
   - REPOSITORY_GRYPE


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why:** MegaLinter v9.6.0 newly default-activated **betterleaks** (a gitleaks fork), which fails the mega-linter job on every full-codebase run — a secret scanner that only fires on false positives trains everyone to ignore it.

**What:** Adds `REPOSITORY_BETTERLEAKS` to `DISABLE_LINTERS`, consistent with the already-disabled sibling secret scanners (GITLEAKS/SECRETLINT). All 6 of its findings are deterministic test fixtures/snapshots, not real credentials — verified. Removes betterleaks from the `main` red.

Note: this clears the *betterleaks* half of the `main` mega-linter failure. The other half — jscpd reporting residual clones on full-codebase runs — is a distinct, larger concern tracked in #5908 and is out of scope here.