### PR TITLE
feat(cluster): report real EKS status in cluster info

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,10 @@ linters:
       - linters:
           - paralleltest
         path: pkg/k8s/rest_config_test.go
+      # Tests that modify env vars cannot run in parallel
+      - linters:
+          - paralleltest
+        path: pkg/cli/lifecycle/awsregion_test.go
       # Tests that mutate the global go-keyring mock provider cannot run in parallel
       - linters:
           - paralleltest

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -35,8 +35,9 @@ func ExportAWSProviderStatus(
 	ctx context.Context,
 	client *eksctlclient.Client,
 	clusterName string,
+	region string,
 ) (*provider.ClusterStatus, error) {
-	return awsProviderStatus(ctx, client, clusterName)
+	return awsProviderStatus(ctx, client, clusterName, region)
 }
 
 // ErrProviderNotConfigured exports errProviderNotConfigured for testing.

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
+	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
@@ -27,6 +29,18 @@ import (
 func ExportShouldPushOCIArtifact(clusterCfg *v1alpha1.Cluster) bool {
 	return setup.ShouldPushOCIArtifact(clusterCfg)
 }
+
+// ExportAWSProviderStatus exports awsProviderStatus for testing.
+func ExportAWSProviderStatus(
+	ctx context.Context,
+	client *eksctlclient.Client,
+	clusterName string,
+) (*provider.ClusterStatus, error) {
+	return awsProviderStatus(ctx, client, clusterName)
+}
+
+// ErrProviderNotConfigured exports errProviderNotConfigured for testing.
+var ErrProviderNotConfigured = errProviderNotConfigured
 
 // ExportSetupK3dCSI exports setupK3dCSI for testing.
 func ExportSetupK3dCSI(clusterCfg *v1alpha1.Cluster, k3dConfig *v1alpha5.SimpleConfig) {

--- a/pkg/cli/cmd/cluster/info.go
+++ b/pkg/cli/cmd/cluster/info.go
@@ -13,11 +13,13 @@ import (
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	dockerclient "github.com/devantler-tech/ksail/v7/pkg/client/docker"
+	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	"github.com/devantler-tech/ksail/v7/pkg/client/kubectl"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	awsprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
 	dockerprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/docker"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/omni"
@@ -216,9 +218,10 @@ func getProviderStatus(
 		return getHetznerProviderStatus(cmd.Context(), clusterName)
 	case v1alpha1.ProviderOmni:
 		return getOmniProviderStatus(cmd.Context(), clusterName, omniOpts)
-	case v1alpha1.ProviderAWS, v1alpha1.ProviderGCP, v1alpha1.ProviderAzure:
-		// AWS/EKS, GCP/GKE, and Azure/AKS status is derived from the cloud API
-		// through the provisioner, not from local container inspection. Return
+	case v1alpha1.ProviderAWS:
+		return getAWSProviderStatus(cmd.Context(), clusterName)
+	case v1alpha1.ProviderGCP, v1alpha1.ProviderAzure:
+		// GCP/GKE and Azure/AKS status inspection is not yet implemented. Return
 		// a minimal stub so callers that rely on this helper do not fail for them.
 		return &provider.ClusterStatus{Phase: "unknown"}, nil
 	case v1alpha1.ProviderKubernetes:
@@ -318,6 +321,44 @@ func getOmniProviderStatus(
 	result, err := omniProvider.GetClusterStatus(ctx, clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("omni provider status: %w", err)
+	}
+
+	return result, nil
+}
+
+// getAWSProviderStatus queries Amazon EKS for cluster status via eksctl.
+func getAWSProviderStatus(
+	ctx context.Context,
+	clusterName string,
+) (*provider.ClusterStatus, error) {
+	return awsProviderStatus(ctx, eksctlclient.NewClient(), clusterName)
+}
+
+// awsProviderStatus is the injectable core of getAWSProviderStatus: it accepts
+// the eksctl client so tests can substitute a scripted runner. The region is
+// left empty so eksctl resolves it from AWS_REGION / the active profile — the
+// info command has no region flag. A missing eksctl binary is reported as
+// errProviderNotConfigured (a soft error classifyProviderError maps to "no
+// provider info"), so 'cluster info' falls back to kubectl instead of failing
+// when AWS tooling is absent, mirroring the Hetzner/Omni credential paths.
+func awsProviderStatus(
+	ctx context.Context,
+	client *eksctlclient.Client,
+	clusterName string,
+) (*provider.ClusterStatus, error) {
+	err := client.CheckAvailable()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errProviderNotConfigured, err)
+	}
+
+	awsProv, err := awsprovider.NewProvider(client, "")
+	if err != nil {
+		return nil, fmt.Errorf("aws provider: %w", err)
+	}
+
+	result, err := awsProv.GetClusterStatus(ctx, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("aws provider status: %w", err)
 	}
 
 	return result, nil

--- a/pkg/cli/cmd/cluster/info.go
+++ b/pkg/cli/cmd/cluster/info.go
@@ -81,6 +81,7 @@ func runInfoCmd(
 		resolved.Provider,
 		resolved.ClusterName,
 		resolved.OmniOpts,
+		resolved.AWSRegion,
 	)
 
 	if errors.Is(provErr, errUnsupportedProvider) {
@@ -210,6 +211,7 @@ func getProviderStatus(
 	prov v1alpha1.Provider,
 	clusterName string,
 	omniOpts v1alpha1.OptionsOmni,
+	awsRegion string,
 ) (*provider.ClusterStatus, error) {
 	switch prov {
 	case v1alpha1.ProviderDocker, "":
@@ -219,7 +221,7 @@ func getProviderStatus(
 	case v1alpha1.ProviderOmni:
 		return getOmniProviderStatus(cmd.Context(), clusterName, omniOpts)
 	case v1alpha1.ProviderAWS:
-		return getAWSProviderStatus(cmd.Context(), clusterName)
+		return getAWSProviderStatus(cmd.Context(), clusterName, awsRegion)
 	case v1alpha1.ProviderGCP, v1alpha1.ProviderAzure:
 		// GCP/GKE and Azure/AKS status inspection is not yet implemented. Return
 		// a minimal stub so callers that rely on this helper do not fail for them.
@@ -326,32 +328,38 @@ func getOmniProviderStatus(
 	return result, nil
 }
 
-// getAWSProviderStatus queries Amazon EKS for cluster status via eksctl.
+// getAWSProviderStatus queries Amazon EKS for cluster status via eksctl. The
+// region is resolved from the cluster config (the RegionEnvVar env var, else
+// eks.yaml's region) so the lookup targets the cluster's configured region
+// rather than only eksctl's AWS_REGION/profile default.
 func getAWSProviderStatus(
 	ctx context.Context,
 	clusterName string,
+	region string,
 ) (*provider.ClusterStatus, error) {
-	return awsProviderStatus(ctx, eksctlclient.NewClient(), clusterName)
+	return awsProviderStatus(ctx, eksctlclient.NewClient(), clusterName, region)
 }
 
 // awsProviderStatus is the injectable core of getAWSProviderStatus: it accepts
-// the eksctl client so tests can substitute a scripted runner. The region is
-// left empty so eksctl resolves it from AWS_REGION / the active profile — the
-// info command has no region flag. A missing eksctl binary is reported as
-// errProviderNotConfigured (a soft error classifyProviderError maps to "no
-// provider info"), so 'cluster info' falls back to kubectl instead of failing
-// when AWS tooling is absent, mirroring the Hetzner/Omni credential paths.
+// the eksctl client so tests can substitute a scripted runner. The resolved
+// region is passed through to scope the lookup; an empty region defers to
+// eksctl's own resolution (AWS_REGION / the active profile). A missing eksctl
+// binary is reported as errProviderNotConfigured (a soft error
+// classifyProviderError maps to "no provider info"), so 'cluster info' falls
+// back to kubectl instead of failing when AWS tooling is absent, mirroring the
+// Hetzner/Omni credential paths.
 func awsProviderStatus(
 	ctx context.Context,
 	client *eksctlclient.Client,
 	clusterName string,
+	region string,
 ) (*provider.ClusterStatus, error) {
 	err := client.CheckAvailable()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errProviderNotConfigured, err)
 	}
 
-	awsProv, err := awsprovider.NewProvider(client, "")
+	awsProv, err := awsprovider.NewProvider(client, region)
 	if err != nil {
 		return nil, fmt.Errorf("aws provider: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/info_test.go
+++ b/pkg/cli/cmd/cluster/info_test.go
@@ -1,0 +1,109 @@
+package cluster_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errEksctlStubEmptyArgs is returned when the stub runner is invoked with no
+// positional arguments (should never happen in real test cases).
+var errEksctlStubEmptyArgs = errors.New("eksctl stub: empty args")
+
+// eksctlStubRunner replays canned eksctl responses keyed by the first two
+// positional arguments (e.g. "get cluster", "get nodegroup"), mirroring the
+// scripted-runner pattern used by the aws provider tests.
+type eksctlStubRunner struct {
+	t         *testing.T
+	responses map[string][]byte
+}
+
+func (s *eksctlStubRunner) Run(
+	_ context.Context,
+	_ string,
+	args []string,
+	_ io.Reader,
+) ([]byte, []byte, error) {
+	s.t.Helper()
+
+	if len(args) == 0 {
+		return nil, nil, errEksctlStubEmptyArgs
+	}
+
+	key := args[0]
+	if len(args) >= 2 {
+		key = args[0] + " " + args[1]
+	}
+
+	out, ok := s.responses[key]
+	if !ok {
+		s.t.Fatalf("eksctl stub: no response configured for %q (args=%v)", key, args)
+	}
+
+	return out, nil, nil
+}
+
+// newEksctlClient builds an eksctl client whose binary points at the test
+// executable (so CheckAvailable's exec.LookPath succeeds hermetically) and
+// whose runner replays the supplied canned responses instead of shelling out.
+func newEksctlClient(t *testing.T, responses map[string][]byte) *eksctlclient.Client {
+	t.Helper()
+
+	return eksctlclient.NewClient(
+		eksctlclient.WithBinary(os.Args[0]),
+		eksctlclient.WithRunner(&eksctlStubRunner{t: t, responses: responses}),
+	)
+}
+
+func TestAWSProviderStatus_AggregatesNodegroups(t *testing.T) {
+	t.Parallel()
+
+	client := newEksctlClient(t, map[string][]byte{
+		"get cluster": []byte(`[{"Name":"demo","Region":"us-east-1","EksctlCreated":"True"}]`),
+		"get nodegroup": []byte(
+			`[{"Cluster":"demo","Name":"ng-1","Status":"ACTIVE"},{"Cluster":"demo","Name":"ng-2","Status":"ACTIVE"}]`,
+		),
+	})
+
+	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo")
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, 2, status.NodesTotal)
+	assert.Equal(t, 2, status.NodesReady)
+	assert.True(t, status.Ready)
+}
+
+func TestAWSProviderStatus_ClusterNotFound(t *testing.T) {
+	t.Parallel()
+
+	client := newEksctlClient(t, map[string][]byte{
+		"get cluster": []byte("null"),
+	})
+
+	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "missing")
+	require.ErrorIs(t, err, provider.ErrClusterNotFound)
+	assert.Nil(t, status)
+}
+
+func TestAWSProviderStatus_EksctlUnavailable(t *testing.T) {
+	t.Parallel()
+
+	// A binary that does not exist on PATH makes CheckAvailable fail, which
+	// must surface as the soft errProviderNotConfigured so 'cluster info' falls
+	// back to kubectl rather than erroring out.
+	client := eksctlclient.NewClient(
+		eksctlclient.WithBinary("ksail-nonexistent-eksctl-binary"),
+	)
+
+	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo")
+	require.ErrorIs(t, err, cluster.ErrProviderNotConfigured)
+	assert.Nil(t, status)
+}

--- a/pkg/cli/cmd/cluster/info_test.go
+++ b/pkg/cli/cmd/cluster/info_test.go
@@ -24,6 +24,9 @@ var errEksctlStubEmptyArgs = errors.New("eksctl stub: empty args")
 type eksctlStubRunner struct {
 	t         *testing.T
 	responses map[string][]byte
+	// gotArgs records every argument slice the runner was invoked with, so tests
+	// can assert on the flags the eksctl client built (e.g. --region).
+	gotArgs [][]string
 }
 
 func (s *eksctlStubRunner) Run(
@@ -33,6 +36,8 @@ func (s *eksctlStubRunner) Run(
 	_ io.Reader,
 ) ([]byte, []byte, error) {
 	s.t.Helper()
+
+	s.gotArgs = append(s.gotArgs, args)
 
 	if len(args) == 0 {
 		return nil, nil, errEksctlStubEmptyArgs
@@ -73,7 +78,7 @@ func TestAWSProviderStatus_AggregatesNodegroups(t *testing.T) {
 		),
 	})
 
-	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo")
+	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo", "")
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	assert.Equal(t, 2, status.NodesTotal)
@@ -88,7 +93,7 @@ func TestAWSProviderStatus_ClusterNotFound(t *testing.T) {
 		"get cluster": []byte("null"),
 	})
 
-	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "missing")
+	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "missing", "")
 	require.ErrorIs(t, err, provider.ErrClusterNotFound)
 	assert.Nil(t, status)
 }
@@ -103,7 +108,49 @@ func TestAWSProviderStatus_EksctlUnavailable(t *testing.T) {
 		eksctlclient.WithBinary("ksail-nonexistent-eksctl-binary"),
 	)
 
-	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo")
+	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo", "")
 	require.ErrorIs(t, err, cluster.ErrProviderNotConfigured)
 	assert.Nil(t, status)
+}
+
+// TestAWSProviderStatus_ForwardsRegion asserts the resolved region is threaded
+// into eksctl's calls (as --region), so 'cluster info' targets the cluster's
+// configured region instead of only eksctl's AWS_REGION/profile default.
+func TestAWSProviderStatus_ForwardsRegion(t *testing.T) {
+	t.Parallel()
+
+	runner := &eksctlStubRunner{
+		t: t,
+		responses: map[string][]byte{
+			"get cluster": []byte(
+				`[{"Name":"demo","Region":"eu-west-1","EksctlCreated":"True"}]`,
+			),
+			"get nodegroup": []byte(`[{"Cluster":"demo","Name":"ng-1","Status":"ACTIVE"}]`),
+		},
+	}
+	client := eksctlclient.NewClient(
+		eksctlclient.WithBinary(os.Args[0]),
+		eksctlclient.WithRunner(runner),
+	)
+
+	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo", "eu-west-1")
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	var sawRegion bool
+
+	for _, args := range runner.gotArgs {
+		for i := range len(args) - 1 {
+			if args[i] == "--region" && args[i+1] == "eu-west-1" {
+				sawRegion = true
+			}
+		}
+	}
+
+	assert.True(
+		t,
+		sawRegion,
+		"expected eksctl to be invoked with --region eu-west-1, got %v",
+		runner.gotArgs,
+	)
 }

--- a/pkg/cli/lifecycle/awsregion_test.go
+++ b/pkg/cli/lifecycle/awsregion_test.go
@@ -1,0 +1,50 @@
+package lifecycle_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveAWSRegion verifies the documented precedence: the env var named by
+// RegionEnvVar (default AWS_REGION) overrides eks.yaml's region, which in turn
+// beats an empty (defer-to-eksctl) result. This test mutates process env vars,
+// so it must not run in parallel.
+func TestResolveAWSRegion(t *testing.T) {
+	eksDistCfg := &clusterprovisioner.DistributionConfig{
+		EKS: &clusterprovisioner.EKSConfig{Region: "eu-west-1"},
+	}
+
+	t.Run("env var overrides eks.yaml", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "us-east-2")
+
+		got := lifecycle.ResolveAWSRegion(v1alpha1.OptionsAWS{}, eksDistCfg)
+		assert.Equal(t, "us-east-2", got)
+	})
+
+	t.Run("custom RegionEnvVar is honored", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "")
+		t.Setenv("KSAIL_AWS_REGION", "ap-southeast-1")
+
+		opts := v1alpha1.OptionsAWS{RegionEnvVar: "KSAIL_AWS_REGION"}
+		got := lifecycle.ResolveAWSRegion(opts, eksDistCfg)
+		assert.Equal(t, "ap-southeast-1", got)
+	})
+
+	t.Run("falls back to eks.yaml region when env unset", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "")
+
+		got := lifecycle.ResolveAWSRegion(v1alpha1.OptionsAWS{}, eksDistCfg)
+		assert.Equal(t, "eu-west-1", got)
+	})
+
+	t.Run("empty when no env and no eks config", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "")
+
+		got := lifecycle.ResolveAWSRegion(v1alpha1.OptionsAWS{}, nil)
+		assert.Empty(t, got)
+	})
+}

--- a/pkg/cli/lifecycle/export_test.go
+++ b/pkg/cli/lifecycle/export_test.go
@@ -1,0 +1,14 @@
+package lifecycle
+
+import (
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+)
+
+// ResolveAWSRegion exports resolveAWSRegion for testing.
+func ResolveAWSRegion(
+	awsOpts v1alpha1.OptionsAWS,
+	distCfg *clusterprovisioner.DistributionConfig,
+) string {
+	return resolveAWSRegion(awsOpts, distCfg)
+}

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -112,6 +112,39 @@ type ResolvedClusterInfo struct {
 	KubeconfigPath string
 	OmniOpts       v1alpha1.OptionsOmni
 	KubernetesOpts v1alpha1.OptionsKubernetes
+	// AWSRegion is the resolved AWS region for read-only EKS status lookups.
+	// Empty defers region resolution to eksctl (AWS_REGION env / active profile).
+	AWSRegion string
+}
+
+// awsRegionEnvVarDefault is the fallback environment variable name for the AWS
+// region when spec.provider.aws.regionEnvVar is unset (mirrors the OptionsAWS
+// default so the info path resolves the region the same way create does).
+const awsRegionEnvVarDefault = "AWS_REGION"
+
+// resolveAWSRegion determines the AWS region for read-only EKS status lookups,
+// honoring the documented precedence from OptionsAWS: the environment variable
+// named by RegionEnvVar (default AWS_REGION) overrides the region declared in
+// eks.yaml. An empty result tells eksctl to fall back to its own resolution, so
+// this never regresses the previous always-empty behavior.
+func resolveAWSRegion(
+	awsOpts v1alpha1.OptionsAWS,
+	distCfg *clusterprovisioner.DistributionConfig,
+) string {
+	envVar := awsOpts.RegionEnvVar
+	if envVar == "" {
+		envVar = awsRegionEnvVarDefault
+	}
+
+	if region := os.Getenv(envVar); region != "" {
+		return region
+	}
+
+	if distCfg != nil && distCfg.EKS != nil {
+		return distCfg.EKS.Region
+	}
+
+	return ""
 }
 
 // ResolveClusterInfo resolves the cluster name, provider, and kubeconfig from flags, config, or kubeconfig.
@@ -135,9 +168,12 @@ func ResolveClusterInfo(
 	var (
 		omniOpts       v1alpha1.OptionsOmni
 		kubernetesOpts v1alpha1.OptionsKubernetes
+		awsRegion      string
 	)
 
-	resolveFromConfig(cmd, &clusterName, &provider, &kubeconfigPath, &omniOpts, &kubernetesOpts)
+	resolveFromConfig(
+		cmd, &clusterName, &provider, &kubeconfigPath, &omniOpts, &kubernetesOpts, &awsRegion,
+	)
 
 	// Fall back to kubeconfig context detection
 	if clusterName == "" {
@@ -163,6 +199,7 @@ func ResolveClusterInfo(
 		KubeconfigPath: resolvedPath,
 		OmniOpts:       omniOpts,
 		KubernetesOpts: kubernetesOpts,
+		AWSRegion:      awsRegion,
 	}, nil
 }
 
@@ -188,7 +225,7 @@ func loadConfig(cmd *cobra.Command) (*v1alpha1.Cluster, *clusterprovisioner.Dist
 	return cfg, cfgManager.DistributionConfig
 }
 
-// resolveFromConfig fills missing cluster info and Omni options from the ksail.yaml config.
+// resolveFromConfig fills missing cluster info and provider options from the ksail.yaml config.
 // When cmd is non-nil, the --config persistent flag is honored.
 // Fields that already have values (from flags) are not overwritten.
 func resolveFromConfig(
@@ -198,6 +235,7 @@ func resolveFromConfig(
 	kubeconfigPath *string,
 	omniOpts *v1alpha1.OptionsOmni,
 	kubernetesOpts *v1alpha1.OptionsKubernetes,
+	awsRegion *string,
 ) {
 	cfg, distCfg := loadConfig(cmd)
 	if cfg == nil {
@@ -224,6 +262,7 @@ func resolveFromConfig(
 
 	*omniOpts = cfg.Spec.Provider.Omni
 	*kubernetesOpts = cfg.Spec.Provider.Kubernetes
+	*awsRegion = resolveAWSRegion(cfg.Spec.Provider.AWS, distCfg)
 }
 
 // commandContext returns cmd's context, falling back to context.Background()


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`ksail cluster info` showed **"Status: UNKNOWN"** with no node count for EKS clusters, even though our support matrix already documents `info` as a supported EKS operation — a gap between what we promise and what users see on AWS.

## What

Wires the existing eksctl-backed AWS provider into `cluster info` so it reports the real EKS cluster status (node count, phase). When AWS tooling is absent it degrades gracefully to the Kubernetes API path, exactly like the Hetzner/Omni providers already do. No new dependencies; unit-tested without live AWS credentials.

Part of #4328