### PR TITLE
refactor(docs): dedup identical Card/LinkCard styles

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -269,6 +269,7 @@ body {
 /*  Cards & CardGrid                                                       */
 
 /* ----------------------------------------------------------------------- */
+
 /* Cards and LinkCards (feature overview) share the same surface treatment, so
    they are styled together rather than duplicated. */
 .card,

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -269,14 +269,18 @@ body {
 /*  Cards & CardGrid                                                       */
 
 /* ----------------------------------------------------------------------- */
-.card {
+/* Cards and LinkCards (feature overview) share the same surface treatment, so
+   they are styled together rather than duplicated. */
+.card,
+.sl-link-card {
   border: 1px solid var(--ksail-border);
   border-radius: 1rem;
   background: color-mix(in oklab, var(--ksail-surface) 75%, transparent);
   transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
 }
 
-.card:hover {
+.card:hover,
+.sl-link-card:hover {
   transform: translateY(-3px);
   border-color: color-mix(in oklab, var(--ksail-cyan) 55%, var(--ksail-border));
   box-shadow: var(--ksail-glow);
@@ -286,25 +290,7 @@ body {
   color: var(--ksail-cyan-bright);
 }
 
-.card .title {
-  font-family: var(--ksail-font-display);
-  letter-spacing: -0.01em;
-}
-
-/* LinkCards (feature overview) share the Card surface treatment. */
-.sl-link-card {
-  border: 1px solid var(--ksail-border);
-  border-radius: 1rem;
-  background: color-mix(in oklab, var(--ksail-surface) 75%, transparent);
-  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
-}
-
-.sl-link-card:hover {
-  transform: translateY(-3px);
-  border-color: color-mix(in oklab, var(--ksail-cyan) 55%, var(--ksail-border));
-  box-shadow: var(--ksail-glow);
-}
-
+.card .title,
 .sl-link-card .title {
   font-family: var(--ksail-font-display);
   letter-spacing: -0.01em;


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
`main`'s whole-codebase jscpd check is red, and one contributing cluster is self-duplication in the docs stylesheet: the `.card` and `.sl-link-card` rules were byte-identical copies of each other. This is exactly the "genuinely-avoidable clone" the check exists to catch.

## What
Groups the identical `.card` / `.sl-link-card` selectors (base, `:hover`, and `.title`) so the shared surface treatment is written once instead of duplicated. Pure selector grouping — rendered output is unchanged.

One increment toward greening `main`; the remaining CSS matches jscpd reports are decorative comment-banner repetition (a candidate for the issue's "scope the check" option — flagging for your steer).

Part of #5908