### PR TITLE
feat(cluster): reject start/stop on unmanaged clusters with a clear error

### DIFF
--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -74,6 +74,22 @@ func ExportResolveKubeContext(ctx *localregistry.Context) string {
 	return resolveKubeContext(ctx)
 }
 
+// ExportEnsureClusterManaged exports ensureClusterManaged for testing, driving it from a fixed
+// managed-set + completeness pair (instead of the live cross-provider discoverer) so the
+// unmanaged-cluster guard can be exercised fully offline.
+func ExportEnsureClusterManaged(
+	ctx context.Context,
+	resolved *lifecycle.ResolvedClusterInfo,
+	managed map[string]struct{},
+	complete bool,
+) error {
+	return ensureClusterManaged(
+		ctx,
+		resolved,
+		func(context.Context) (map[string]struct{}, bool) { return managed, complete },
+	)
+}
+
 // ExportResolveCreatedContextName exports resolveCreatedContextName for testing.
 func ExportResolveCreatedContextName(
 	distribution v1alpha1.Distribution,

--- a/pkg/cli/cmd/cluster/startstop.go
+++ b/pkg/cli/cmd/cluster/startstop.go
@@ -40,6 +40,7 @@ func NewStartCmd() *cobra.Command {
 		) error {
 			return provisioner.Start(ctx, clusterName)
 		},
+		Guard: unmanagedClusterGuard,
 	})
 
 	cmd.Annotations = map[string]string{
@@ -80,6 +81,7 @@ func NewStopCmd() *cobra.Command {
 		) error {
 			return provisioner.Stop(ctx, clusterName)
 		},
+		Guard: unmanagedClusterGuard,
 	})
 
 	cmd.Annotations = map[string]string{

--- a/pkg/cli/cmd/cluster/unmanaged_guard.go
+++ b/pkg/cli/cmd/cluster/unmanaged_guard.go
@@ -1,0 +1,103 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
+)
+
+// ErrUnmanagedCluster indicates a ksail-only lifecycle action (start/stop/…) was attempted against a
+// kubeconfig context ksail did not provision — an unmanaged cluster (a managed cloud cluster, a
+// kubeadm cluster, a colleague's cluster). Read-only operations still work; only ksail-only
+// lifecycle actions are refused (ksail#5885, part of the unmanaged-cluster surface epic #5654).
+var ErrUnmanagedCluster = errors.New("cluster is not managed by ksail")
+
+// managedClusterLister enumerates the names of clusters ksail manages across every provider and
+// reports whether discovery was complete (no provider failed). The guard fails open when discovery
+// is incomplete so a transient provider error (e.g. a stopped Docker daemon) never wrongly refuses a
+// genuine managed cluster. Overridable in tests.
+type managedClusterLister func(ctx context.Context) (managed map[string]struct{}, complete bool)
+
+// discoverManagedClusters is the production managedClusterLister: it queries every provider via the
+// shared clusterdiscovery.Discoverer — the same enumeration `ksail cluster list` uses — and keys the
+// result by cluster name. complete is false when any provider failed to list, so the guard can fail
+// open rather than refuse a cluster the failed provider might actually manage.
+func discoverManagedClusters(ctx context.Context) (map[string]struct{}, bool) {
+	clusters, failures := (&clusterdiscovery.Discoverer{}).
+		Discover(ctx, clusterdiscovery.DefaultProviders())
+
+	managed := make(map[string]struct{}, len(clusters))
+	for _, cluster := range clusters {
+		managed[cluster.Name] = struct{}{}
+	}
+
+	return managed, len(failures) == 0
+}
+
+// ensureClusterManaged rejects a ksail-only lifecycle action when the target cluster is NOT among
+// ksail's managed clusters but a matching kubeconfig context DOES exist — i.e. the user is pointing
+// ksail at a cluster it did not provision. It is best-effort and FAILS OPEN so a genuine managed
+// cluster is never wrongly refused: it returns nil when discovery could not fully enumerate every
+// provider (complete=false), or when the kubeconfig has no matching context (a nonexistent cluster,
+// left to the normal not-found path). Only a resolved cluster that is unmanaged AND present in the
+// kubeconfig is refused.
+func ensureClusterManaged(
+	ctx context.Context,
+	resolved *lifecycle.ResolvedClusterInfo,
+	lister managedClusterLister,
+) error {
+	managed, complete := lister(ctx)
+	if !complete {
+		return nil
+	}
+
+	isManaged := func(name string) bool {
+		_, ok := managed[name]
+
+		return ok
+	}
+
+	if clusterdiscovery.ContextIsManaged(resolved.ClusterName, isManaged) {
+		return nil
+	}
+
+	if !kubeconfigHasClusterContext(resolved.KubeconfigPath, resolved.ClusterName) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%q is an unmanaged cluster: %w; read-only operations (list, resource browsing, logs, exec) still work",
+		resolved.ClusterName,
+		ErrUnmanagedCluster,
+	)
+}
+
+// kubeconfigHasClusterContext reports whether the kubeconfig at kubeconfigPath contains a context
+// that maps to clusterName — directly, or via ksail's context→name detection so a Docker cluster's
+// "kind-dev" context matches the ksail name "dev". It reuses clusterdiscovery.ContextIsManaged so the
+// context↔name mapping stays defined in exactly one place. Best-effort: a missing/unreadable
+// kubeconfig yields false (treated as "not an unmanaged cluster, just absent").
+func kubeconfigHasClusterContext(kubeconfigPath, clusterName string) bool {
+	config := clusterdiscovery.LoadKubeconfig(kubeconfigPath)
+	if config == nil {
+		return false
+	}
+
+	matchesClusterName := func(name string) bool { return name == clusterName }
+	for contextName := range config.Contexts {
+		if clusterdiscovery.ContextIsManaged(contextName, matchesClusterName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// unmanagedClusterGuard is the SimpleLifecycleConfig.Guard shared by the start and stop commands: it
+// rejects an action on a cluster ksail did not provision, using the real cross-provider discoverer.
+func unmanagedClusterGuard(ctx context.Context, resolved *lifecycle.ResolvedClusterInfo) error {
+	return ensureClusterManaged(ctx, resolved, discoverManagedClusters)
+}

--- a/pkg/cli/cmd/cluster/unmanaged_guard_test.go
+++ b/pkg/cli/cmd/cluster/unmanaged_guard_test.go
@@ -1,0 +1,132 @@
+package cluster_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureClusterManaged_ManagedAllows verifies that a cluster present in the managed set passes
+// the guard without inspecting the kubeconfig — ksail provisioned it, so the action proceeds.
+func TestEnsureClusterManaged_ManagedAllows(t *testing.T) {
+	t.Parallel()
+
+	resolved := &lifecycle.ResolvedClusterInfo{
+		ClusterName:    "dev",
+		KubeconfigPath: "/does/not/exist",
+	}
+	managed := map[string]struct{}{"dev": {}}
+
+	require.NoError(
+		t,
+		cluster.ExportEnsureClusterManaged(context.Background(), resolved, managed, true),
+	)
+}
+
+// TestEnsureClusterManaged_DiscoveryIncompleteFailsOpen verifies that when discovery could not fully
+// enumerate every provider (complete=false), the guard fails open — a transient provider failure
+// (e.g. a stopped Docker daemon) must never wrongly refuse a genuine managed cluster.
+func TestEnsureClusterManaged_DiscoveryIncompleteFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	resolved := &lifecycle.ResolvedClusterInfo{
+		ClusterName:    "external",
+		KubeconfigPath: writeKubeconfigWithContext(t, t.TempDir(), "external"),
+	}
+
+	require.NoError(
+		t,
+		cluster.ExportEnsureClusterManaged(
+			context.Background(),
+			resolved,
+			map[string]struct{}{},
+			false,
+		),
+	)
+}
+
+// TestEnsureClusterManaged_UnmanagedContextRejected verifies the core behaviour (ksail#5885): a
+// cluster that is NOT managed by ksail but DOES exist as a kubeconfig context is refused with a
+// clear ErrUnmanagedCluster naming the cluster.
+func TestEnsureClusterManaged_UnmanagedContextRejected(t *testing.T) {
+	t.Parallel()
+
+	resolved := &lifecycle.ResolvedClusterInfo{
+		ClusterName:    "external-cluster",
+		KubeconfigPath: writeKubeconfigWithContext(t, t.TempDir(), "external-cluster"),
+	}
+
+	err := cluster.ExportEnsureClusterManaged(
+		context.Background(), resolved, map[string]struct{}{}, true,
+	)
+
+	require.ErrorIs(t, err, cluster.ErrUnmanagedCluster)
+	assert.Contains(t, err.Error(), "external-cluster")
+}
+
+// TestEnsureClusterManaged_UnmanagedContextRejectedViaDetection verifies the guard maps a context to
+// its ksail cluster name via detection (a Docker cluster's "kind-dev" context maps to the ksail name
+// "dev"), so an unmanaged cluster is caught even when the context carries a distribution prefix.
+func TestEnsureClusterManaged_UnmanagedContextRejectedViaDetection(t *testing.T) {
+	t.Parallel()
+
+	resolved := &lifecycle.ResolvedClusterInfo{
+		ClusterName:    "dev",
+		KubeconfigPath: writeKubeconfigWithContext(t, t.TempDir(), "kind-dev"),
+	}
+
+	err := cluster.ExportEnsureClusterManaged(
+		context.Background(), resolved, map[string]struct{}{}, true,
+	)
+
+	require.ErrorIs(t, err, cluster.ErrUnmanagedCluster)
+}
+
+// TestEnsureClusterManaged_NonexistentClusterAllows verifies that a cluster absent from BOTH the
+// managed set and the kubeconfig is left to the normal not-found path (guard returns nil) rather
+// than being mislabelled unmanaged.
+func TestEnsureClusterManaged_NonexistentClusterAllows(t *testing.T) {
+	t.Parallel()
+
+	resolved := &lifecycle.ResolvedClusterInfo{
+		ClusterName:    "ghost",
+		KubeconfigPath: writeKubeconfigWithContext(t, t.TempDir(), "external-cluster"),
+	}
+
+	require.NoError(
+		t,
+		cluster.ExportEnsureClusterManaged(
+			context.Background(),
+			resolved,
+			map[string]struct{}{},
+			true,
+		),
+	)
+}
+
+// TestEnsureClusterManaged_MissingKubeconfigAllows verifies that an unreadable/missing kubeconfig
+// yields no rejection — with no context to prove the cluster exists, the guard cannot conclude it is
+// an unmanaged cluster and so stays silent.
+func TestEnsureClusterManaged_MissingKubeconfigAllows(t *testing.T) {
+	t.Parallel()
+
+	resolved := &lifecycle.ResolvedClusterInfo{
+		ClusterName:    "whatever",
+		KubeconfigPath: filepath.Join(t.TempDir(), "absent"),
+	}
+
+	require.NoError(
+		t,
+		cluster.ExportEnsureClusterManaged(
+			context.Background(),
+			resolved,
+			map[string]struct{}{},
+			true,
+		),
+	)
+}

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -56,6 +56,10 @@ type SimpleLifecycleConfig struct {
 		provisioner clusterprovisioner.Provisioner,
 		clusterName string,
 	) error
+	// Guard, when non-nil, runs after cluster resolution and before the provisioner is created. It
+	// lets a caller refuse the action for a resolved cluster — e.g. an unmanaged, ksail-unprovisioned
+	// cluster — with a clear error. A nil Guard is a no-op.
+	Guard func(ctx context.Context, resolved *ResolvedClusterInfo) error
 }
 
 // NewSimpleLifecycleCmd creates a simple lifecycle command (start/stop) with --name and --provider flags.
@@ -270,6 +274,13 @@ func runSimpleLifecycleAction(
 	resolved, err := ResolveClusterInfo(cmd, nameFlag, providerFlag, "")
 	if err != nil {
 		return err
+	}
+
+	if config.Guard != nil {
+		err = config.Guard(cmd.Context(), resolved)
+		if err != nil {
+			return err
+		}
 	}
 
 	notify.WriteMessage(notify.Message{

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -301,6 +301,16 @@ func runSimpleLifecycleAction(
 		Writer: cmd.OutOrStdout(),
 	})
 
+	return provisionAndAct(cmd, config, resolved)
+}
+
+// provisionAndAct creates a minimal provisioner for the resolved cluster, runs the
+// configured lifecycle action, and emits the success message on completion.
+func provisionAndAct(
+	cmd *cobra.Command,
+	config SimpleLifecycleConfig,
+	resolved *ResolvedClusterInfo,
+) error {
 	// Create cluster info for provisioner creation
 	clusterInfo := &clusterdetector.Info{
 		ClusterName:    resolved.ClusterName,


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Running `ksail cluster start`/`stop` against a cluster ksail did not provision (a managed cloud cluster, a kubeadm cluster, a colleague's context) fails confusingly today — it falls through to the default Docker provider and reports "cluster not found", instead of telling the user plainly that ksail does not manage this cluster. Epic #5654 requires unmanaged clusters to never silently or confusingly fail a ksail-only action.

## What

Adds a guard that rejects a start/stop on an unmanaged cluster with a clear, actionable error, while leaving read-only operations (list, resource browsing, logs, exec) untouched. It is deliberately conservative: it only fires when ksail is confident the cluster is unmanaged, and never refuses a genuine ksail-managed cluster.

First increment of #5885 — covers `start` and `stop`; the `delete` and `update`/`reconcile` guards follow as separate PRs (higher-stakes, worth landing independently).

Part of #5885
Part of #5654