### PR TITLE
ci(intercept): add a steering-agent container image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -87,6 +87,28 @@ dockers_v2:
       "org.opencontainers.image.version": "{{.Version}}"
       "org.opencontainers.image.source": "{{.GitURL}}"
       "org.opencontainers.image.licenses": "PolyForm-Shield-1.0.0"
+  # Steering-agent image for `ksail workload intercept` (#5882). Same ksail
+  # binary as the CLI image, on an Alpine base that carries the iptables
+  # userspace + `sleep` holder the injected steering container needs. It ships
+  # latent — `mirror.DefaultSteerImage` is not yet repointed at it (a follow-up
+  # flips the default once this image publishes), so no runtime behaviour
+  # changes here. Built + signed by the same release pipeline (docker_signs
+  # `artifacts: all` below covers it).
+  - id: ksail-steer
+    images:
+      - "ghcr.io/devantler-tech/ksail-steer"
+    dockerfile: Dockerfile.steer
+    tags:
+      - "{{ .Tag }}"
+      - "latest"
+    labels:
+      "org.opencontainers.image.description": "KSail traffic-steering agent image for `ksail workload intercept`."
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.name": "{{.ProjectName}}-steer"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Version}}"
+      "org.opencontainers.image.source": "{{.GitURL}}"
+      "org.opencontainers.image.licenses": "PolyForm-Shield-1.0.0"
 
 # Keyless cosign signature for the published container image (the same
 # `ghcr.io/devantler-tech/ksail` image the ksail-operator runs). Signing it

--- a/Dockerfile.steer
+++ b/Dockerfile.steer
@@ -1,0 +1,29 @@
+# Steering-agent image for `ksail workload intercept` (#5882): a minimal Alpine
+# base carrying the iptables userspace the in-cluster agent drives, plus the
+# ksail binary so the injected ephemeral container can `exec ksail steer-agent`
+# over the tunnel — no operator-supplied --steer-image/--steer-command needed.
+#
+# Alpine (not the distroless CLI base) because the steering path needs two
+# runtime tools distroless lacks: `iptables` — the agent installs a NAT REDIRECT
+# rule in the pod's own network namespace (see pkg/svc/mirror/steering.go) — and
+# a `sleep` holder, since InjectSteer runs `sleep infinity` as the container
+# command while the real agent is exec'd over the exec channel.
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+
+# iptables userspace, including the `comment` match the steering rule tags itself
+# with (SteeringRuleComment). It is the only extra package the agent needs —
+# busybox already provides the `sleep` holder command. The apk version is left
+# unpinned (hadolint DL3018): the base is already digest-pinned above, and
+# pinning a package build against Alpine's rolling repository would rot on every
+# 3.21 point refresh for no supply-chain gain over the pinned base.
+# hadolint ignore=DL3018
+RUN apk add --no-cache iptables
+
+# GoReleaser v2 (buildx) provides TARGETPLATFORM, e.g. linux/amd64, linux/arm64.
+ARG TARGETPLATFORM
+
+# The same ksail binary the CLI image ships, placed on PATH so the steering
+# command exec'd over the tunnel is simply `ksail steer-agent …`.
+COPY ${TARGETPLATFORM}/ksail /usr/local/bin/ksail
+
+ENTRYPOINT ["/usr/local/bin/ksail"]


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
`ksail workload intercept` (the reverse dev-bridge, epic #4521) can't work out of the box: it needs an in-cluster agent that speaks the tunnel protocol, but today the operator must supply their own `--steer-image` and `--steer-command`. KSail should ship its own agent image so intercept works with zero extra setup.

## What
Adds a small, signed steering-agent image (`ghcr.io/devantler-tech/ksail-steer`) built by the release pipeline — the ksail binary plus the iptables tooling the agent drives. It lands **latent**: nothing points at it yet, so there is **no behaviour change** on merge or promotion. Activation (repointing the default + deriving the agent command) is the follow-up, #5945.

This picks the "reuse one ksail binary" direction the issue asked a decision on. Locally validated (build + image smoke test); the live in-pod steering behaviour stays integration-only, as the issue scopes it.

Part of #5882 / epic #4521.