### PR TITLE
ci: bump TODO workflow actions pin

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@fec61388ed0c4ec4d6d93e3f1a8b8d17e7d40a72 # v9.0.4
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@23a6d6ad0152839e3012a885b3029931628f1b9b # v9.0.5
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary
- bump the TODO workflow reusable-workflow pin from `devantler-tech/actions` v9.0.4 to v9.0.5
- pick up the upstream retry hardening for `alstr/todo-to-issue-action` raw.githubusercontent.com language/syntax fetches
- addresses the red `TODOs` run on `main` after the shared action fetch failed upstream

## Validation
- `actionlint .github/workflows/todos.yaml`
- verified `devantler-tech/actions` tag `v9.0.5` resolves to `23a6d6ad0152839e3012a885b3029931628f1b9b`

## Notes
- no product code changed; this is workflow-health only