### PR TITLE
ci: bump TODO workflow actions pin to v9.0.6

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@23a6d6ad0152839e3012a885b3029931628f1b9b # v9.0.5
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@8835de82ebb5450c332e963bd9ffb4a6286bdd29 # v9.0.6
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary
- Bump the TODO workflow reusable-workflow pin from `devantler-tech/actions` v9.0.5 to v9.0.6.
- Align ksail with the current actions release after recent `main` TODO runs locked down in Harden-Runner while fetching shared action code.

## Validation
- `git diff --check`
- `actionlint .github/workflows/todos.yaml`

## Context
- Recent failing `main` run: https://github.com/devantler-tech/ksail/actions/runs/28983966138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated TODO comment scanning workflow to use the latest action revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->