### PR TITLE
ci: add EKS smoke test workflow

### DIFF
--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -1,0 +1,215 @@
+name: "System Test - EKS"
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitops_engine:
+        description: "GitOps engine to bootstrap and reconcile"
+        required: false
+        type: choice
+        options: [None, Flux, ArgoCD]
+        default: Flux
+      region:
+        description: "AWS region for the smoke-test cluster"
+        required: false
+        type: string
+        default: us-east-1
+  # No schedule yet: this smoke test creates billable AWS resources. Keep it
+  # manual until AWS test credentials and the expected spend envelope exist.
+
+env:
+  GOPROXY: "https://proxy.golang.org|direct"
+  GOMEMLIMIT: "6GiB"
+  EKSCTL_VERSION: "v0.229.0"
+
+concurrency:
+  group: system-test-eks
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  preflight:
+    name: 🔎 Check AWS Credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    environment: ci
+    outputs:
+      aws-credentials: ${{ steps.aws.outputs.available }}
+    steps:
+      - name: 🔎 Check required AWS secrets
+        id: aws
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "::notice::Skipping EKS smoke test because AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY is not configured."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
+
+  build-artifact:
+    name: 🏗️ Build KSail Binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [preflight]
+    if: needs.preflight.outputs.aws-credentials == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        id: setup-go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: 📦 Cache KSail Binary
+        uses: ./.github/actions/cache-ksail-binary
+        with:
+          go-version: ${{ steps.setup-go.outputs.go-version }}
+          source-hash: ${{ hashFiles('go.mod', 'go.sum', '**/*.go') }}
+          output-path: /usr/local/bin/ksail
+
+  smoke-test:
+    name: 🧪 EKS Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: [preflight, build-artifact]
+    if: needs.preflight.outputs.aws-credentials == 'true'
+    environment: ci
+    permissions:
+      contents: read
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+      AWS_REGION: ${{ inputs.region }}
+      AWS_DEFAULT_REGION: ${{ inputs.region }}
+      KSAIL_EKS_WORKDIR: /tmp/ksail-eks-smoke-${{ github.run_id }}
+      KSAIL_EKS_CLUSTER_NAME: st-eks-${{ github.run_id }}
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        id: setup-go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: 📦 Cache KSail Binary
+        uses: ./.github/actions/cache-ksail-binary
+        with:
+          go-version: ${{ steps.setup-go.outputs.go-version }}
+          source-hash: ${{ hashFiles('go.mod', 'go.sum', '**/*.go') }}
+          output-path: /usr/local/bin/ksail
+          save: "false"
+
+      - name: 📥 Install eksctl
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/eksctl"
+          gh release download "$EKSCTL_VERSION" \
+            --repo eksctl-io/eksctl \
+            --pattern eksctl_Linux_amd64.tar.gz \
+            --dir "$RUNNER_TEMP/eksctl"
+          tar -xzf "$RUNNER_TEMP/eksctl/eksctl_Linux_amd64.tar.gz" -C "$RUNNER_TEMP/eksctl"
+          sudo install "$RUNNER_TEMP/eksctl/eksctl" /usr/local/bin/eksctl
+          eksctl version
+
+      - name: 🔧 Initialize EKS project
+        id: init
+        shell: bash
+        env:
+          GITOPS_ENGINE: ${{ inputs.gitops_engine }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$KSAIL_EKS_WORKDIR"
+          cd "$KSAIL_EKS_WORKDIR"
+
+          args=(
+            project init
+            --name "$KSAIL_EKS_CLUSTER_NAME"
+            --distribution EKS
+            --provider AWS
+          )
+          if [ "$GITOPS_ENGINE" != "None" ]; then
+            args+=(--gitops-engine "$GITOPS_ENGINE")
+          fi
+
+          ksail "${args[@]}"
+
+          ruby -ryaml -e '
+            path = "eks.yaml"
+            data = YAML.load_file(path)
+            data.fetch("metadata")["region"] = ENV.fetch("AWS_REGION")
+            Array(data["managedNodeGroups"]).each do |nodegroup|
+              nodegroup["desiredCapacity"] = 1
+              nodegroup["minSize"] = 1
+              nodegroup["maxSize"] = 1
+            end
+            File.write(path, data.to_yaml)
+          '
+
+      - name: 🧪 ksail cluster create
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$KSAIL_EKS_WORKDIR"
+          ksail cluster create
+
+      - name: 🧪 ksail cluster info
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$KSAIL_EKS_WORKDIR"
+          ksail cluster info
+
+      - name: 🧪 ksail workload reconcile
+        if: inputs.gitops_engine != 'None'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$KSAIL_EKS_WORKDIR"
+          ksail workload reconcile --timeout 10m
+
+      - name: 🧹 Delete EKS smoke cluster
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [ ! -d "$KSAIL_EKS_WORKDIR" ]; then
+            echo "No EKS smoke workdir exists; nothing to clean up."
+            exit 0
+          fi
+
+          cd "$KSAIL_EKS_WORKDIR"
+          ksail cluster delete --provider AWS --name "$KSAIL_EKS_CLUSTER_NAME" --force
+          delete_status=$?
+          if [ "$delete_status" -ne 0 ]; then
+            echo "::warning::ksail cluster delete failed; falling back to eksctl delete cluster."
+            eksctl delete cluster \
+              --name "$KSAIL_EKS_CLUSTER_NAME" \
+              --region "$AWS_REGION" \
+              --wait
+            delete_status=$?
+          fi
+
+          if [ "$delete_status" -ne 0 ]; then
+            echo "::warning::EKS cleanup did not complete. Check AWS for cluster '$KSAIL_EKS_CLUSTER_NAME' in region '$AWS_REGION'."
+          fi

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -94,8 +94,8 @@ jobs:
       AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
       AWS_REGION: ${{ inputs.region }}
       AWS_DEFAULT_REGION: ${{ inputs.region }}
-      KSAIL_EKS_WORKDIR: /tmp/ksail-eks-smoke-${{ github.run_id }}
-      KSAIL_EKS_CLUSTER_NAME: st-eks-${{ github.run_id }}
+      KSAIL_EKS_WORKDIR: /tmp/ksail-eks-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+      KSAIL_EKS_CLUSTER_NAME: st-eks-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -127,7 +127,12 @@ jobs:
           gh release download "$EKSCTL_VERSION" \
             --repo eksctl-io/eksctl \
             --pattern eksctl_Linux_amd64.tar.gz \
+            --pattern eksctl_checksums.txt \
             --dir "$RUNNER_TEMP/eksctl"
+          (
+            cd "$RUNNER_TEMP/eksctl"
+            grep 'Linux_amd64' eksctl_checksums.txt | sha256sum --check
+          )
           tar -xzf "$RUNNER_TEMP/eksctl/eksctl_Linux_amd64.tar.gz" -C "$RUNNER_TEMP/eksctl"
           sudo install "$RUNNER_TEMP/eksctl/eksctl" /usr/local/bin/eksctl
           eksctl version
@@ -167,6 +172,7 @@ jobs:
           '
 
       - name: 🧪 ksail cluster create
+        timeout-minutes: 30
         shell: bash
         run: |
           set -euo pipefail
@@ -174,6 +180,7 @@ jobs:
           ksail cluster create
 
       - name: 🧪 ksail cluster info
+        timeout-minutes: 5
         shell: bash
         run: |
           set -euo pipefail
@@ -182,6 +189,7 @@ jobs:
 
       - name: 🧪 ksail workload reconcile
         if: inputs.gitops_engine != 'None'
+        timeout-minutes: 15
         shell: bash
         run: |
           set -euo pipefail
@@ -190,6 +198,7 @@ jobs:
 
       - name: 🧹 Delete EKS smoke cluster
         if: always()
+        timeout-minutes: 45
         shell: bash
         run: |
           set +e

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -221,4 +221,5 @@ jobs:
 
           if [ "$delete_status" -ne 0 ]; then
             echo "::warning::EKS cleanup did not complete. Check AWS for cluster '$KSAIL_EKS_CLUSTER_NAME' in region '$AWS_REGION'."
+            exit "$delete_status"
           fi


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The EKS provider epic has code-complete lifecycle pieces, but no CI entry point that can validate a real AWS/EKS create/info/delete path once AWS test credentials exist. A scheduled lane would be noisy until credentials and a spend envelope are configured, so this adds a manual, secret-gated smoke workflow first.

Fixes #5996
Part of #4328

## What

- Add `System Test - EKS` as a `workflow_dispatch` workflow.
- Check for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` up front and skip cleanly when they are absent.
- Build/cache the current KSail binary, install pinned `eksctl` v0.229.0, initialize a one-node EKS project, and run `ksail cluster create` + `ksail cluster info`.
- Optionally run `ksail workload reconcile` for Flux/ArgoCD smoke coverage.
- Always attempt cleanup with `ksail cluster delete`, falling back to `eksctl delete cluster`.

## Validation

- Red check first: `test -f .github/workflows/system-test-eks.yaml` failed before adding the workflow.
- `test -f .github/workflows/system-test-eks.yaml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/system-test-eks.yaml")'`\n- `yamllint .github/workflows/system-test-eks.yaml`\n- `actionlint .github/workflows/system-test-eks.yaml`\n- `git diff --check`\n\n## Notes\n\nThis intentionally does not add a schedule. Enabling recurring EKS runs should wait until AWS credentials and an expected spend envelope are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an on-demand “System Test - EKS” GitHub Actions workflow.
  * Provisions an EKS smoke test cluster, verifies connectivity/info, and performs optional GitOps reconciliation (Flux or ArgoCD).
  * Supports configurable AWS region and runs in an isolated run workspace.
  * Automatically cleans up clusters after the run, and safely skips AWS provisioning when required credentials aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->