### PR TITLE
fix(eks): report control-plane endpoint in EKS provider status

### DIFF
--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	awsprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
@@ -36,8 +37,9 @@ func ExportAWSProviderStatus(
 	client *eksctlclient.Client,
 	clusterName string,
 	region string,
+	opts ...awsprovider.Option,
 ) (*provider.ClusterStatus, error) {
-	return awsProviderStatus(ctx, client, clusterName, region)
+	return awsProviderStatus(ctx, client, clusterName, region, opts...)
 }
 
 // ErrProviderNotConfigured exports errProviderNotConfigured for testing.

--- a/pkg/cli/cmd/cluster/info.go
+++ b/pkg/cli/cmd/cluster/info.go
@@ -353,13 +353,14 @@ func awsProviderStatus(
 	client *eksctlclient.Client,
 	clusterName string,
 	region string,
+	opts ...awsprovider.Option,
 ) (*provider.ClusterStatus, error) {
 	err := client.CheckAvailable()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errProviderNotConfigured, err)
 	}
 
-	awsProv, err := awsprovider.NewProvider(client, region)
+	awsProv, err := awsprovider.NewProvider(client, region, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("aws provider: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/info_test.go
+++ b/pkg/cli/cmd/cluster/info_test.go
@@ -7,9 +7,12 @@ import (
 	"os"
 	"testing"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	awsprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +20,21 @@ import (
 // errEksctlStubEmptyArgs is returned when the stub runner is invoked with no
 // positional arguments (should never happen in real test cases).
 var errEksctlStubEmptyArgs = errors.New("eksctl stub: empty args")
+
+// stubEndpoint is the EKS control-plane endpoint the stub describer returns so
+// the AWS status tests never resolve real AWS credentials.
+const stubEndpoint = "https://ABCDEF.gr7.us-east-1.eks.amazonaws.com"
+
+// stubDescriber is a credential-free stand-in for the EKS DescribeCluster
+// seam, returning a cluster carrying stubEndpoint.
+type stubDescriber struct{}
+
+func (stubDescriber) DescribeCluster(
+	_ context.Context,
+	_ string,
+) (*ekstypes.Cluster, error) {
+	return &ekstypes.Cluster{Endpoint: awssdk.String(stubEndpoint)}, nil
+}
 
 // eksctlStubRunner replays canned eksctl responses keyed by the first two
 // positional arguments (e.g. "get cluster", "get nodegroup"), mirroring the
@@ -78,12 +96,16 @@ func TestAWSProviderStatus_AggregatesNodegroups(t *testing.T) {
 		),
 	})
 
-	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo", "")
+	status, err := cluster.ExportAWSProviderStatus(
+		t.Context(), client, "demo", "",
+		awsprovider.WithClusterDescriber(stubDescriber{}),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	assert.Equal(t, 2, status.NodesTotal)
 	assert.Equal(t, 2, status.NodesReady)
 	assert.True(t, status.Ready)
+	assert.Equal(t, stubEndpoint, status.Endpoint)
 }
 
 func TestAWSProviderStatus_ClusterNotFound(t *testing.T) {
@@ -133,7 +155,10 @@ func TestAWSProviderStatus_ForwardsRegion(t *testing.T) {
 		eksctlclient.WithRunner(runner),
 	)
 
-	status, err := cluster.ExportAWSProviderStatus(t.Context(), client, "demo", "eu-west-1")
+	status, err := cluster.ExportAWSProviderStatus(
+		t.Context(), client, "demo", "eu-west-1",
+		awsprovider.WithClusterDescriber(stubDescriber{}),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 

--- a/pkg/svc/provider/aws/provider.go
+++ b/pkg/svc/provider/aws/provider.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"strings"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 )
@@ -14,22 +17,49 @@ import (
 // nodegroup is healthy and reconciling its desired capacity.
 const NodegroupStatusActive = "ACTIVE"
 
+// clusterDescriber is the narrow seam over the AWS-SDK EKS DescribeCluster
+// operation the provider uses to read a cluster's control-plane endpoint —
+// data eksctl's cluster summary does not carry. *pkg/client/eks.Client
+// satisfies it, and tests inject a fake so no AWS credentials are needed.
+type clusterDescriber interface {
+	DescribeCluster(ctx context.Context, name string) (*ekstypes.Cluster, error)
+}
+
 // Provider implements provider.Provider for Amazon EKS via eksctl.
 type Provider struct {
-	client *eksctlclient.Client
-	region string
+	client    *eksctlclient.Client
+	region    string
+	describer clusterDescriber
+}
+
+// Option customises a Provider.
+type Option func(*Provider)
+
+// WithClusterDescriber injects the EKS DescribeCluster implementation, letting
+// tests substitute a fake for the AWS-SDK-backed client the provider would
+// otherwise construct lazily on the first GetClusterStatus call.
+func WithClusterDescriber(describer clusterDescriber) Option {
+	return func(p *Provider) {
+		p.describer = describer
+	}
 }
 
 // NewProvider returns a Provider using the given eksctl client and AWS region.
 // Pass region="" to defer to eksctl's own region resolution (AWS_REGION env,
 // active AWS profile, etc.). A nil client returns ErrClientRequired so callers
 // can fail fast rather than getting ErrProviderUnavailable at the first call.
-func NewProvider(client *eksctlclient.Client, region string) (*Provider, error) {
+func NewProvider(client *eksctlclient.Client, region string, opts ...Option) (*Provider, error) {
 	if client == nil {
 		return nil, ErrClientRequired
 	}
 
-	return &Provider{client: client, region: region}, nil
+	prov := &Provider{client: client, region: region, describer: nil}
+
+	for _, opt := range opts {
+		opt(prov)
+	}
+
+	return prov, nil
 }
 
 // StartNodes scales all managed nodegroups for the cluster back to their
@@ -191,12 +221,56 @@ func (p *Provider) GetClusterStatus(
 		status = &provider.ClusterStatus{Phase: provider.PhaseStopped, Nodes: nodes}
 	}
 
+	endpoint, err := p.clusterEndpoint(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	status.Endpoint = endpoint
+
 	return status, nil
 }
 
 // Region returns the AWS region this provider was configured with.
 func (p *Provider) Region() string {
 	return p.region
+}
+
+// clusterEndpoint reads the cluster's control-plane endpoint from the AWS SDK,
+// which eksctl's cluster summary omits — bringing EKS to parity with the GKE
+// and Azure providers, which both surface the endpoint on their status. The
+// SDK-backed describer is resolved lazily so the eksctl-only lifecycle paths
+// never resolve AWS credentials.
+func (p *Provider) clusterEndpoint(ctx context.Context, clusterName string) (string, error) {
+	describer, err := p.resolveDescriber(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get cluster status: %w", err)
+	}
+
+	cluster, err := describer.DescribeCluster(ctx, clusterName)
+	if err != nil {
+		return "", fmt.Errorf("get cluster status: describe eks cluster: %w", err)
+	}
+
+	return awssdk.ToString(cluster.Endpoint), nil
+}
+
+// resolveDescriber returns the injected describer, or lazily constructs the
+// AWS-SDK-backed EKS client when none was injected. Construction is deferred
+// to first use because the eksctl lifecycle paths never need AWS credentials
+// resolved; GetClusterStatus is called once per `cluster info`, so no caching
+// of the constructed client is warranted.
+func (p *Provider) resolveDescriber(ctx context.Context) (clusterDescriber, error) {
+	if p.describer != nil {
+		return p.describer, nil
+	}
+
+	client, err := eksclient.NewClient(ctx, p.region)
+	if err != nil {
+		return nil, fmt.Errorf("creating aws eks client: %w", err)
+	}
+
+	return client, nil
 }
 
 // fetchNodegroups guards against a nil client and fetches this cluster's nodegroups — the

--- a/pkg/svc/provider/aws/provider_test.go
+++ b/pkg/svc/provider/aws/provider_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
@@ -14,9 +16,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testEndpoint is the control-plane endpoint the default fake describer
+// returns so GetClusterStatus success paths never resolve real AWS
+// credentials.
+const testEndpoint = "https://ABCDEF0123456789.gr7.us-east-1.eks.amazonaws.com"
+
+// fakeDescriber is a credential-free stand-in for the AWS-SDK EKS
+// DescribeCluster seam. It records the requested name and returns the
+// configured cluster/err.
+type fakeDescriber struct {
+	cluster *ekstypes.Cluster
+	err     error
+	gotName string
+}
+
+func (f *fakeDescriber) DescribeCluster(
+	_ context.Context,
+	name string,
+) (*ekstypes.Cluster, error) {
+	f.gotName = name
+
+	return f.cluster, f.err
+}
+
 // errScriptedRunnerEmptyArgs is returned when the scripted runner is invoked
 // with no positional arguments (should never happen in real test cases).
 var errScriptedRunnerEmptyArgs = errors.New("scripted runner: empty args")
+
+// errDescribeDenied is a static describer error used to assert that
+// GetClusterStatus surfaces a DescribeCluster failure.
+var errDescribeDenied = errors.New("access denied")
 
 // scriptedRunner replays canned responses keyed by the first argument
 // (`create`, `delete`, `get`, `scale`, `upgrade`). It records every call for
@@ -73,7 +102,12 @@ func newProvider(t *testing.T, responses map[string][]response) (*aws.Provider, 
 		eksctlclient.WithRunner(runner),
 	)
 
-	prov, err := aws.NewProvider(client, "us-east-1")
+	// Inject a happy describer so GetClusterStatus success paths populate the
+	// endpoint without resolving real AWS credentials. Tests that exercise the
+	// endpoint itself construct the provider with their own describer inline.
+	prov, err := aws.NewProvider(client, "us-east-1", aws.WithClusterDescriber(
+		&fakeDescriber{cluster: &ekstypes.Cluster{Endpoint: awssdk.String(testEndpoint)}},
+	))
 	require.NoError(t, err)
 
 	return prov, runner
@@ -289,6 +323,74 @@ func TestGetClusterStatus_AggregatesNodegroupStatus(t *testing.T) {
 	assert.Equal(t, 1, status.NodesReady)
 	assert.False(t, status.Ready)
 	assert.Equal(t, "degraded", status.Phase)
+}
+
+// newProviderWithDescriber builds a provider whose eksctl client reports a
+// single running cluster, paired with the given describer, so the endpoint
+// branch of GetClusterStatus can be exercised in isolation.
+func newProviderWithDescriber(
+	t *testing.T,
+	describer aws.Option,
+) *aws.Provider {
+	t.Helper()
+
+	runner := &scriptedRunner{t: t, responses: map[string][]response{
+		"get cluster": {
+			{stdout: []byte(`[{"Name":"demo","Region":"us-east-1","EksctlCreated":"True"}]`)},
+		},
+		"get nodegroup": {{stdout: []byte(`[]`)}},
+	}}
+
+	client := eksctlclient.NewClient(
+		eksctlclient.WithBinary("eksctl-under-test"),
+		eksctlclient.WithRunner(runner),
+	)
+
+	prov, err := aws.NewProvider(client, "us-east-1", describer)
+	require.NoError(t, err)
+
+	return prov
+}
+
+func TestGetClusterStatus_PopulatesEndpoint(t *testing.T) {
+	t.Parallel()
+
+	describer := &fakeDescriber{
+		cluster: &ekstypes.Cluster{Endpoint: awssdk.String(testEndpoint)},
+	}
+	prov := newProviderWithDescriber(t, aws.WithClusterDescriber(describer))
+
+	status, err := prov.GetClusterStatus(t.Context(), "demo")
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, testEndpoint, status.Endpoint)
+	assert.Equal(t, "demo", describer.gotName, "endpoint must be read for the requested cluster")
+}
+
+func TestGetClusterStatus_EmptyEndpointWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	// A described cluster with a nil Endpoint (still provisioning) yields an
+	// empty endpoint string, not a failure — cluster info omits the line.
+	prov := newProviderWithDescriber(t, aws.WithClusterDescriber(
+		&fakeDescriber{cluster: &ekstypes.Cluster{}},
+	))
+
+	status, err := prov.GetClusterStatus(t.Context(), "demo")
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Empty(t, status.Endpoint)
+}
+
+func TestGetClusterStatus_DescribeError(t *testing.T) {
+	t.Parallel()
+
+	prov := newProviderWithDescriber(t, aws.WithClusterDescriber(
+		&fakeDescriber{err: errDescribeDenied},
+	))
+
+	_, err := prov.GetClusterStatus(t.Context(), "demo")
+	require.ErrorIs(t, err, errDescribeDenied)
 }
 
 // sanity check that provider.Provider interface is implemented.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

**Why:** `ksail cluster info` shows the cluster API endpoint, but EKS clusters silently showed nothing there while GKE and Azure clusters did — the EKS provider never populated the endpoint field. It's a small parity gap in a shipped command.

**What:** The EKS provider now reads the control-plane endpoint from the AWS SDK (eksctl's summary omits it) via a narrow, credential-free describer seam that resolves lazily — so the eksctl-only create/delete/scale paths still never touch AWS credentials. Behaviour is unchanged for every other provider. Unit-tested end-to-end through the `cluster info` path with a fake describer; no live AWS credentials needed.

Part of #4328 (completes the endpoint half of "cluster info reports EKS status").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster status now includes the AWS EKS control-plane endpoint when available.
  * Endpoint details are retrieved for the selected cluster and region.

* **Bug Fixes**
  * Improved handling when endpoint information is unavailable.
  * Clearer error reporting when cluster endpoint details cannot be retrieved.
  * Region selection is consistently applied when checking AWS provider status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->