### PR TITLE
ci: bump TODO workflow actions pin to v9.0.7

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@8835de82ebb5450c332e963bd9ffb4a6286bdd29 # v9.0.6
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@84813ae61fb21741e0a6193b5c14c6941a448577 # v9.0.7
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
The scheduled TODO scan on `main` fails on the current pin — every v9.0.x release before v9.0.7 was broken one way or another (v9.0.6 wipes its own retry helper during checkout; root cause tracked in devantler-tech/actions#526), so the scan never completes.

## What
Retargets the pinned `scan-for-todo-comments` reusable workflow to v9.0.7, which preserves the retry helper. One-line pin bump.

Part of devantler-tech/actions#526.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated TODO comment scanning workflow to a newer version for improved maintenance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->