### PR TITLE
feat(workload): resolve and verify the ephemeral cluster connection (#5919 3b-2)

### DIFF
--- a/pkg/cli/cmd/workload/ephemeral.go
+++ b/pkg/cli/cmd/workload/ephemeral.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	kwokprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/kwok"
@@ -34,12 +36,59 @@ var newEphemeralProvisioner = func(name string) clusterprovisioner.Provisioner {
 	return kwokprovisioner.NewProvisioner(name, "", nil)
 }
 
-// withEphemeralCluster provisions a throwaway cluster, runs runFn while it is
-// live, and guarantees the cluster is deleted afterwards — on success, on an
-// error from runFn, and on SIGINT/SIGTERM. It is scaffold-only: runFn runs
-// unchanged today (validate/scan still operate on local files); wiring the
-// ephemeral cluster's kubeconfig into the installer/apply/scan pipeline is a
-// follow-up (ksail#5919 Phase 3b-2/3b-3).
+// waitForEphemeralCluster verifies a freshly provisioned --ephemeral cluster
+// is genuinely usable — the API server answers /readyz AND a basic authorized
+// read succeeds — before runFn is invoked, so downstream steps never race the
+// control plane's warm-up window. A package var so tests can substitute a
+// fake without a live Docker/KWOK dependency.
+//
+//nolint:gochecknoglobals // test seam, mirrors newEphemeralProvisioner above
+var waitForEphemeralCluster = k8s.WaitForClusterReady
+
+// ephemeralCluster describes how a --ephemeral run reaches its throwaway
+// cluster once provisioned: the kubeconfig file the embedded kwokctl merged
+// the new context into, and that context's name. Phase 3b-2 of ksail#5919
+// consumes this handle to install the workload's declared operators into the
+// cluster; Phase 3b-3 applies the rendered manifests and scans their children.
+type ephemeralCluster struct {
+	// Name is the throwaway cluster's own name (ksail-ephemeral-<nanos>).
+	Name string
+	// KubeconfigPath is the kubeconfig file holding the cluster's context —
+	// the same file kwokctl writes to ($KUBECONFIG, or ~/.kube/config).
+	KubeconfigPath string
+	// Context is the kubeconfig context kwokctl created ("kwok-<name>").
+	Context string
+}
+
+// resolveEphemeralCluster derives the connection handle for a provisioned
+// --ephemeral cluster. The KWOK provisioner does not hand back a kubeconfig;
+// the embedded kwokctl merges the cluster's context into the kubeconfig at
+// $KUBECONFIG (or ~/.kube/config) under the distribution's context naming
+// convention, so the handle is derived from the cluster name.
+func resolveEphemeralCluster(name string) (ephemeralCluster, error) {
+	kubeconfigPath, err := k8s.ResolveKubeconfigPath("")
+	if err != nil {
+		return ephemeralCluster{}, fmt.Errorf(
+			"resolve kubeconfig path for ephemeral cluster %q: %w", name, err,
+		)
+	}
+
+	distribution := v1alpha1.DistributionKWOK
+
+	return ephemeralCluster{
+		Name:           name,
+		KubeconfigPath: kubeconfigPath,
+		Context:        distribution.ContextName(name),
+	}, nil
+}
+
+// withEphemeralCluster provisions a throwaway cluster, waits until it is
+// genuinely ready, runs runFn with the cluster's connection handle while it
+// is live, and guarantees the cluster is deleted afterwards — on success, on
+// an error from any step, and on SIGINT/SIGTERM. runFn receives a verified
+// ephemeralCluster (kubeconfig path + context); wiring it into the
+// installer/apply/scan pipeline is the remainder of ksail#5919 Phase
+// 3b-2/3b-3.
 //
 // ctx should be the caller's own context (typically cmd.Context()); cmd is
 // used only for output (notify) and is not read for its context here, so the
@@ -55,7 +104,7 @@ var newEphemeralProvisioner = func(name string) clusterprovisioner.Provisioner {
 func withEphemeralCluster(
 	ctx context.Context,
 	cmd *cobra.Command,
-	runFn func(ctx context.Context) error,
+	runFn func(ctx context.Context, cluster ephemeralCluster) error,
 ) (err error) {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -97,7 +146,19 @@ func withEphemeralCluster(
 		err = errors.Join(err, deleteCluster())
 	}()
 
-	return runFn(ctx)
+	cluster, resolveErr := resolveEphemeralCluster(name)
+	if resolveErr != nil {
+		return resolveErr
+	}
+
+	notify.Infof(cmd.OutOrStdout(), "waiting for ephemeral cluster %q to become ready...", name)
+
+	waitErr := waitForEphemeralCluster(ctx, cluster.KubeconfigPath, cluster.Context)
+	if waitErr != nil {
+		return fmt.Errorf("ephemeral cluster %q never became ready: %w", name, waitErr)
+	}
+
+	return runFn(ctx, cluster)
 }
 
 // ephemeralClusterName generates a unique, DNS-1123-safe name for a throwaway

--- a/pkg/cli/cmd/workload/ephemeral_test.go
+++ b/pkg/cli/cmd/workload/ephemeral_test.go
@@ -19,6 +19,7 @@ var (
 	errEphemeralFnFailed     = errors.New("fn failed")
 	errEphemeralCreateFailed = errors.New("create failed")
 	errEphemeralDeleteFailed = errors.New("delete failed")
+	errEphemeralWaitFailed   = errors.New("wait failed")
 )
 
 // fakeEphemeralProvisioner is a clusterprovisioner.Provisioner test double
@@ -54,6 +55,34 @@ func (f *fakeEphemeralProvisioner) Exists(_ context.Context, _ string) (bool, er
 	return false, nil
 }
 
+// fakeEphemeralWaiter records the readiness-wait calls withEphemeralCluster
+// makes and can be configured to fail, standing in for the real
+// k8s.WaitForClusterReady (which would poll a cluster that does not exist
+// under the fake provisioner).
+type fakeEphemeralWaiter struct {
+	waitErr error
+
+	kubeconfigPaths []string
+	contexts        []string
+}
+
+func (f *fakeEphemeralWaiter) wait(_ context.Context, kubeconfigPath, contextName string) error {
+	f.kubeconfigPaths = append(f.kubeconfigPaths, kubeconfigPath)
+	f.contexts = append(f.contexts, contextName)
+
+	return f.waitErr
+}
+
+func installEphemeralWaiter(t *testing.T, fake *fakeEphemeralWaiter) {
+	t.Helper()
+
+	restore := workload.ExportSetEphemeralClusterWaiter(fake.wait)
+	t.Cleanup(restore)
+}
+
+// installEphemeralProvisioner wires the fake provisioner AND a no-op
+// readiness waiter: with a fake provisioner there is never a real cluster to
+// poll, so the real waiter would always time out.
 func installEphemeralProvisioner(t *testing.T, fake *fakeEphemeralProvisioner) {
 	t.Helper()
 
@@ -61,6 +90,8 @@ func installEphemeralProvisioner(t *testing.T, fake *fakeEphemeralProvisioner) {
 		func(_ string) clusterprovisioner.Provisioner { return fake },
 	)
 	t.Cleanup(restore)
+
+	installEphemeralWaiter(t, &fakeEphemeralWaiter{})
 }
 
 // newTestCommand returns a minimal *cobra.Command with a background context,
@@ -88,14 +119,22 @@ func TestWithEphemeralClusterProvisionsAndTearsDownOnSuccess(t *testing.T) {
 	ran := false
 	cmd := newEphemeralTestCommand(t, fake)
 
-	err := workload.ExportWithEphemeralCluster(cmd.Context(), cmd, func(_ context.Context) error {
-		ran = true
-		// The cluster must be created before fn runs, and not yet deleted.
-		assert.Len(t, fake.created, 1)
-		assert.Empty(t, fake.deleted)
+	err := workload.ExportWithEphemeralCluster(
+		cmd.Context(), cmd,
+		func(_ context.Context, cluster workload.EphemeralCluster) error {
+			ran = true
+			// The cluster must be created before fn runs, and not yet deleted.
+			assert.Len(t, fake.created, 1)
+			assert.Empty(t, fake.deleted)
+			// The connection handle must describe the created cluster per the
+			// KWOK context naming convention.
+			assert.Equal(t, fake.created[0], cluster.Name)
+			assert.Equal(t, "kwok-"+fake.created[0], cluster.Context)
+			assert.NotEmpty(t, cluster.KubeconfigPath)
 
-		return nil
-	})
+			return nil
+		},
+	)
 
 	require.NoError(t, err)
 	assert.True(t, ran)
@@ -109,14 +148,63 @@ func TestWithEphemeralClusterProvisionsAndTearsDownOnSuccess(t *testing.T) {
 	)
 }
 
+// TestWithEphemeralClusterWaitsForReadinessBeforeFn pins that the readiness
+// waiter is called with the same kubeconfig path and context handed to runFn,
+// so the handle runFn receives is the one that was actually verified.
+//
+//nolint:paralleltest // swaps the shared package-level provisioner seam; cannot run in parallel.
+func TestWithEphemeralClusterWaitsForReadinessBeforeFn(t *testing.T) {
+	fake := &fakeEphemeralProvisioner{}
+	cmd := newEphemeralTestCommand(t, fake)
+	waiter := &fakeEphemeralWaiter{}
+	installEphemeralWaiter(t, waiter)
+
+	err := workload.ExportWithEphemeralCluster(
+		cmd.Context(), cmd,
+		func(_ context.Context, cluster workload.EphemeralCluster) error {
+			require.Len(t, waiter.contexts, 1, "readiness must be verified before fn runs")
+			assert.Equal(t, cluster.Context, waiter.contexts[0])
+			assert.Equal(t, cluster.KubeconfigPath, waiter.kubeconfigPaths[0])
+
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+}
+
+//nolint:paralleltest // swaps the shared package-level provisioner seam; cannot run in parallel.
+func TestWithEphemeralClusterSkipsFnAndTearsDownWhenWaitFails(t *testing.T) {
+	fake := &fakeEphemeralProvisioner{}
+	ran := false
+	cmd := newEphemeralTestCommand(t, fake)
+	installEphemeralWaiter(t, &fakeEphemeralWaiter{waitErr: errEphemeralWaitFailed})
+
+	err := workload.ExportWithEphemeralCluster(
+		cmd.Context(), cmd,
+		func(_ context.Context, _ workload.EphemeralCluster) error {
+			ran = true
+
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, errEphemeralWaitFailed)
+	assert.False(t, ran, "fn must not run when the ephemeral cluster never becomes ready")
+	assert.Len(t, fake.deleted, 1, "teardown must run when the readiness wait fails")
+}
+
 //nolint:paralleltest // swaps the shared package-level provisioner seam; cannot run in parallel.
 func TestWithEphemeralClusterTearsDownEvenWhenFnFails(t *testing.T) {
 	fake := &fakeEphemeralProvisioner{}
 	cmd := newEphemeralTestCommand(t, fake)
 
-	err := workload.ExportWithEphemeralCluster(cmd.Context(), cmd, func(_ context.Context) error {
-		return errEphemeralFnFailed
-	})
+	err := workload.ExportWithEphemeralCluster(
+		cmd.Context(), cmd,
+		func(_ context.Context, _ workload.EphemeralCluster) error {
+			return errEphemeralFnFailed
+		},
+	)
 
 	require.ErrorIs(t, err, errEphemeralFnFailed)
 	assert.Len(t, fake.created, 1)
@@ -129,11 +217,14 @@ func TestWithEphemeralClusterSkipsFnAndTearsDownWhenCreateFails(t *testing.T) {
 	ran := false
 	cmd := newEphemeralTestCommand(t, fake)
 
-	err := workload.ExportWithEphemeralCluster(cmd.Context(), cmd, func(_ context.Context) error {
-		ran = true
+	err := workload.ExportWithEphemeralCluster(
+		cmd.Context(), cmd,
+		func(_ context.Context, _ workload.EphemeralCluster) error {
+			ran = true
 
-		return nil
-	})
+			return nil
+		},
+	)
 
 	require.ErrorIs(t, err, errEphemeralCreateFailed)
 	assert.False(t, ran, "fn must not run when the ephemeral cluster fails to provision")
@@ -156,9 +247,12 @@ func TestWithEphemeralClusterJoinsFnAndDeleteErrors(t *testing.T) {
 	fake := &fakeEphemeralProvisioner{deleteErr: errEphemeralDeleteFailed}
 	cmd := newEphemeralTestCommand(t, fake)
 
-	err := workload.ExportWithEphemeralCluster(cmd.Context(), cmd, func(_ context.Context) error {
-		return errEphemeralFnFailed
-	})
+	err := workload.ExportWithEphemeralCluster(
+		cmd.Context(), cmd,
+		func(_ context.Context, _ workload.EphemeralCluster) error {
+			return errEphemeralFnFailed
+		},
+	)
 
 	require.Error(t, err)
 	require.ErrorIs(
@@ -174,9 +268,12 @@ func TestWithEphemeralClusterReturnsDeleteErrorWhenFnSucceeds(t *testing.T) {
 	fake := &fakeEphemeralProvisioner{deleteErr: errEphemeralDeleteFailed}
 	cmd := newEphemeralTestCommand(t, fake)
 
-	err := workload.ExportWithEphemeralCluster(cmd.Context(), cmd, func(_ context.Context) error {
-		return nil
-	})
+	err := workload.ExportWithEphemeralCluster(
+		cmd.Context(), cmd,
+		func(_ context.Context, _ workload.EphemeralCluster) error {
+			return nil
+		},
+	)
 
 	require.ErrorIs(t, err, errEphemeralDeleteFailed)
 }

--- a/pkg/cli/cmd/workload/export_test.go
+++ b/pkg/cli/cmd/workload/export_test.go
@@ -472,12 +472,28 @@ func ExportSetEphemeralProvisioner(
 	return func() { newEphemeralProvisioner = original }
 }
 
+// EphemeralCluster re-exports the internal --ephemeral connection handle so
+// external-package tests can assert on what runFn receives.
+type EphemeralCluster = ephemeralCluster
+
+// ExportSetEphemeralClusterWaiter swaps the --ephemeral cluster readiness
+// waiter so tests can substitute a fake without a live cluster to poll. It
+// returns a restore function that reinstates the original.
+func ExportSetEphemeralClusterWaiter(
+	wait func(ctx context.Context, kubeconfigPath, contextName string) error,
+) func() {
+	original := waitForEphemeralCluster
+	waitForEphemeralCluster = wait
+
+	return func() { waitForEphemeralCluster = original }
+}
+
 // ExportWithEphemeralCluster exposes withEphemeralCluster for external-package
-// tests exercising the provision/guaranteed-teardown seam directly.
+// tests exercising the provision/readiness/guaranteed-teardown seam directly.
 func ExportWithEphemeralCluster(
 	ctx context.Context,
 	cmd *cobra.Command,
-	runFn func(ctx context.Context) error,
+	runFn func(ctx context.Context, cluster EphemeralCluster) error,
 ) error {
 	return withEphemeralCluster(ctx, cmd, runFn)
 }

--- a/pkg/cli/cmd/workload/scan.go
+++ b/pkg/cli/cmd/workload/scan.go
@@ -149,8 +149,10 @@ func addScanFlags(
 // runScanCmd dispatches to runScanCmdInner directly, or — when --ephemeral is
 // set — wraps it in a throwaway KWOK cluster that is guaranteed to be torn
 // down afterwards (see withEphemeralCluster, shared with the validate
-// command). The ephemeral cluster does not yet change what is scanned; wiring
-// it into the pipeline is a follow-up (ksail#5919 Phase 3b-2/3b-3).
+// command). The cluster's connection handle is resolved and readiness-verified
+// but not yet consumed here: installing the declared operators and scanning
+// their rendered children against it is the remainder of ksail#5919 Phase
+// 3b-2/3b-3.
 func runScanCmd(
 	ctx context.Context,
 	cmd *cobra.Command,
@@ -158,7 +160,7 @@ func runScanCmd(
 	flags scanFlags,
 ) error {
 	if flags.ephemeral {
-		return withEphemeralCluster(ctx, cmd, func(ctx context.Context) error {
+		return withEphemeralCluster(ctx, cmd, func(ctx context.Context, _ ephemeralCluster) error {
 			return runScanCmdInner(ctx, cmd, args, flags)
 		})
 	}

--- a/pkg/cli/cmd/workload/validate.go
+++ b/pkg/cli/cmd/workload/validate.go
@@ -166,8 +166,10 @@ func addValidateFlags(cmd *cobra.Command, flags *validateFlags) {
 // runValidateCmd dispatches to runValidateCmdInner directly, or — when
 // --ephemeral is set — wraps it in a throwaway KWOK cluster that is
 // guaranteed to be torn down afterwards (see withEphemeralCluster). The
-// ephemeral cluster does not yet change what validatePath validates; wiring
-// it into the pipeline is a follow-up (ksail#5919 Phase 3b-2/3b-3).
+// cluster's connection handle is resolved and readiness-verified but not yet
+// consumed here: installing the declared operators and validating their
+// rendered children against it is the remainder of ksail#5919 Phase
+// 3b-2/3b-3.
 func runValidateCmd(
 	ctx context.Context,
 	cmd *cobra.Command,
@@ -175,7 +177,7 @@ func runValidateCmd(
 	flags validateFlags,
 ) error {
 	if flags.ephemeral {
-		return withEphemeralCluster(ctx, cmd, func(ctx context.Context) error {
+		return withEphemeralCluster(ctx, cmd, func(ctx context.Context, _ ephemeralCluster) error {
 			return runValidateCmdInner(ctx, cmd, args, flags)
 		})
 	}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The `--ephemeral` scaffold (#5976) provisions a throwaway KWOK cluster that nothing can reach — no kubeconfig or context is resolved, and the wrapped validate/scan run can race the control plane's startup. Every further Phase 3b step (installing declared operators, scanning their children) needs a verified way to talk to that cluster.

## What

`--ephemeral` runs now derive the cluster's connection handle (kubeconfig path + `kwok-<name>` context), wait until the API server is genuinely ready before proceeding, and hand the verified handle to the wrapped run — with teardown still guaranteed on every path. Behaviour of what is validated/scanned is unchanged; verified end-to-end against a real local KWOK cluster (provision → ready → teardown, zero residue).

Part of #5919 (Phase 3b-2 — the operator-install step consumes this handle next).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ephemeral clusters are now verified as ready and connected before workload scanning or validation proceeds.
  * Workload operations receive a confirmed cluster connection handle for downstream execution.

* **Bug Fixes**
  * Prevented workload callbacks from running when ephemeral cluster readiness or creation fails.
  * Improved cleanup and error reporting when callbacks or cluster teardown encounter failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->