### PR TITLE
test(mirror): smoke traffic capture across Docker distributions

### DIFF
--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -82,6 +82,12 @@ inputs:
       per host type to avoid redundant testing.
     required: false
     default: "false"
+  test-workload-mirror:
+    description: |
+      When 'true', smoke-tests workload mirror against a live HTTP deployment.
+      Enable on one Docker matrix entry per supported distribution.
+    required: false
+    default: "false"
   kubernetes-provider-distributions:
     description: |
       Comma-separated list of distributions to test on the Kubernetes provider.
@@ -285,6 +291,14 @@ runs:
         ghcr-user: ${{ inputs.ghcr-user }}
         ghcr-token: ${{ inputs.ghcr-token }}
         gitops-path: ${{ inputs.gitops-path }}
+
+    - name: 🧪 Workload Mirror Tests
+      id: workload-mirror-tests
+      if: inputs.provider == 'Docker' && inputs.test-workload-mirror == 'true'
+      uses: ./.github/actions/ksail-test-workload-mirror
+      with:
+        distribution: ${{ inputs.distribution }}
+        workload-timeout: ${{ inputs.workload-timeout }}
 
     - name: 🧪 Image Export/Import Tests
       id: image-export-import-tests
@@ -530,7 +544,7 @@ runs:
     # ── Phase 5 — Debug ──────────────────────────────────────────────
 
     - name: 🐞 Debug Kubernetes failure
-      if: failure() && (steps.cluster-create.outcome == 'failure' || steps.image-export-import-tests.outcome == 'failure' || steps.workload-watch-tests.outcome == 'failure' || steps.online-gen.outcome == 'failure' || steps.cluster-update-dry-run.outcome == 'failure' || steps.cluster-update.outcome == 'failure' || steps.cluster-update-rolling-resize.outcome == 'failure' || steps.kubernetes-provider-tests.outcome == 'failure')
+      if: failure() && (steps.cluster-create.outcome == 'failure' || steps.workload-mirror-tests.outcome == 'failure' || steps.image-export-import-tests.outcome == 'failure' || steps.workload-watch-tests.outcome == 'failure' || steps.online-gen.outcome == 'failure' || steps.cluster-update-dry-run.outcome == 'failure' || steps.cluster-update.outcome == 'failure' || steps.cluster-update-rolling-resize.outcome == 'failure' || steps.kubernetes-provider-tests.outcome == 'failure')
       uses: ./.github/actions/debug-kubernetes-failure
       with:
         kubectl-command: "ksail workload"

--- a/.github/actions/ksail-test-workload-mirror/action.yaml
+++ b/.github/actions/ksail-test-workload-mirror/action.yaml
@@ -1,0 +1,237 @@
+name: KSail Workload Mirror Test
+description: |
+  Smoke-tests workload mirror against a live HTTP deployment and verifies
+  that the capture contains the request payload.
+
+inputs:
+  distribution:
+    description: Kubernetes distribution under test
+    required: true
+  workload-timeout:
+    description: Timeout for the mirror test workload to become available
+    required: false
+    default: "600s"
+
+runs:
+  using: composite
+  steps:
+    - name: 🧪 ksail workload mirror
+      id: mirror-smoke
+      shell: bash
+      env:
+        DISTRIBUTION: ${{ inputs.distribution }}
+        TIMEOUT: ${{ inputs.workload-timeout }}
+        WORKLOAD_IMAGE: docker.io/traefik/whoami:v1.10
+        WORKLOAD_NAME: ksail-mirror-smoke
+      run: |
+        set -euo pipefail
+
+        LOG_DIR=/tmp/ksail-system-test-logs
+        DIST_LOWER=$(printf '%s' "$DISTRIBUTION" | tr '[:upper:]' '[:lower:]')
+        CAPTURE_FILE="$LOG_DIR/mirror-${DIST_LOWER}.pcap"
+        MIRROR_LOG="$LOG_DIR/mirror-${DIST_LOWER}.log"
+        FORWARD_LOG="$LOG_DIR/mirror-forward-${DIST_LOWER}.log"
+        PCAP_VERIFY_LOG="$LOG_DIR/mirror-pcap-verify-${DIST_LOWER}.log"
+        RESPONSE_LOG="$LOG_DIR/mirror-response-${DIST_LOWER}.log"
+        LOCAL_PORT=18080
+        TOKEN="mirror-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-${DIST_LOWER}"
+        mirror_pid=""
+        forward_pid=""
+
+        mkdir -p "$LOG_DIR"
+
+        stop_process() {
+          local pid="$1"
+          local signal="$2"
+
+          if [ -z "$pid" ]; then
+            return
+          fi
+
+          if kill -0 "$pid" 2>/dev/null; then
+            kill "-$signal" "$pid" 2>/dev/null || true
+            for _ in $(seq 1 20); do
+              if ! kill -0 "$pid" 2>/dev/null; then
+                break
+              fi
+              sleep 1
+            done
+            if kill -0 "$pid" 2>/dev/null; then
+              kill -KILL "$pid" 2>/dev/null || true
+            fi
+          fi
+          wait "$pid" 2>/dev/null || true
+        }
+
+        cleanup() {
+          local status=$?
+          local cleanup_failed=0
+          local resources_gone=false
+          trap - EXIT INT TERM
+          set +e
+
+          stop_process "$forward_pid" TERM
+          stop_process "$mirror_pid" INT
+
+          timeout 35 ksail workload delete deployment/"$WORKLOAD_NAME" \
+            --ignore-not-found --wait=false --request-timeout=30s \
+            >> "$MIRROR_LOG" 2>&1 || cleanup_failed=1
+
+          cleanup_deadline=$((SECONDS + 90))
+          while [ "$SECONDS" -lt "$cleanup_deadline" ]; do
+            deployment_output=$(timeout 5 ksail workload get \
+              deployment/"$WORKLOAD_NAME" --ignore-not-found \
+              --request-timeout=3s -o name 2>> "$MIRROR_LOG")
+            deployment_status=$?
+            pods_output=$(timeout 5 ksail workload get pods \
+              -l "app=$WORKLOAD_NAME" --request-timeout=3s \
+              -o name 2>> "$MIRROR_LOG")
+            pods_status=$?
+            if [ "$deployment_status" -eq 0 ] && [ -z "$deployment_output" ] && \
+              [ "$pods_status" -eq 0 ] && [ -z "$pods_output" ]; then
+              resources_gone=true
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$resources_gone" != "true" ]; then
+            echo "❌ mirror smoke workload cleanup did not complete" >&2
+            cleanup_failed=1
+          else
+            echo "✅ mirror smoke workload cleanup complete"
+          fi
+
+          if [ "$status" -eq 0 ] && [ "$cleanup_failed" -ne 0 ]; then
+            status=1
+          fi
+          exit "$status"
+        }
+        trap cleanup EXIT
+        trap 'exit 130' INT
+        trap 'exit 143' TERM
+
+        ksail workload create deployment "$WORKLOAD_NAME" --image="$WORKLOAD_IMAGE"
+        ksail workload wait --for=condition=Available deployment/"$WORKLOAD_NAME" \
+          --timeout="$TIMEOUT"
+
+        ksail workload mirror "$WORKLOAD_NAME" --port 80 --output "$CAPTURE_FILE" \
+          > "$MIRROR_LOG" 2>&1 &
+        mirror_pid=$!
+
+        mirror_ready=false
+        for _ in $(seq 1 120); do
+          if grep -Fq "capturing TCP traffic on port 80" "$MIRROR_LOG"; then
+            mirror_ready=true
+            break
+          fi
+          if ! kill -0 "$mirror_pid" 2>/dev/null; then
+            echo "❌ workload mirror exited before becoming ready" >&2
+            cat "$MIRROR_LOG" >&2
+            exit 1
+          fi
+          sleep 1
+        done
+        if [ "$mirror_ready" != "true" ]; then
+          echo "❌ workload mirror did not become ready within 120 seconds" >&2
+          cat "$MIRROR_LOG" >&2
+          exit 1
+        fi
+
+        capture_stream_ready=false
+        for _ in $(seq 1 60); do
+          if [ -f "$CAPTURE_FILE" ] && [ "$(wc -c < "$CAPTURE_FILE")" -ge 24 ]; then
+            capture_stream_ready=true
+            break
+          fi
+          if ! kill -0 "$mirror_pid" 2>/dev/null; then
+            echo "❌ workload mirror exited before writing the pcap header" >&2
+            cat "$MIRROR_LOG" >&2
+            exit 1
+          fi
+          sleep 1
+        done
+        if [ "$capture_stream_ready" != "true" ]; then
+          echo "❌ workload mirror did not start its capture stream within 60 seconds" >&2
+          cat "$MIRROR_LOG" >&2
+          exit 1
+        fi
+
+        pod_name=$(ksail workload get pods -l "app=$WORKLOAD_NAME" \
+          -o jsonpath='{.items[0].metadata.name}')
+        tap_name=$(ksail workload get pod "$pod_name" \
+          -o jsonpath='{.spec.ephemeralContainers[?(@.name=="ksail-tap")].name}')
+        if [ "$tap_name" != "ksail-tap" ]; then
+          echo "❌ expected ephemeral container ksail-tap on pod $pod_name" >&2
+          exit 1
+        fi
+
+        ksail workload forward deployment/"$WORKLOAD_NAME" "$LOCAL_PORT:80" \
+          > "$FORWARD_LOG" 2>&1 &
+        forward_pid=$!
+
+        forward_ready=false
+        for _ in $(seq 1 60); do
+          if curl --fail --silent --show-error --max-time 2 --noproxy '*' \
+            "http://127.0.0.1:${LOCAL_PORT}/${TOKEN}" > "$RESPONSE_LOG" 2>/dev/null; then
+            forward_ready=true
+            break
+          fi
+          if ! kill -0 "$forward_pid" 2>/dev/null; then
+            echo "❌ workload forward exited before becoming ready" >&2
+            cat "$FORWARD_LOG" >&2
+            exit 1
+          fi
+          sleep 1
+        done
+        if [ "$forward_ready" != "true" ]; then
+          echo "❌ workload forward did not become ready within 60 seconds" >&2
+          cat "$FORWARD_LOG" >&2
+          exit 1
+        fi
+
+        for attempt in $(seq 1 5); do
+          curl --fail --silent --show-error --max-time 5 --noproxy '*' \
+            "http://127.0.0.1:${LOCAL_PORT}/${TOKEN}?attempt=${attempt}" \
+            >> "$RESPONSE_LOG"
+          sleep 1
+        done
+
+        capture_ready=false
+        for _ in $(seq 1 30); do
+          if [ -f "$CAPTURE_FILE" ] && [ "$(wc -c < "$CAPTURE_FILE")" -gt 24 ] && \
+            grep -aFq "$TOKEN" "$CAPTURE_FILE"; then
+            capture_ready=true
+            break
+          fi
+          sleep 1
+        done
+        if [ "$capture_ready" != "true" ]; then
+          echo "❌ mirror capture did not contain the expected request token" >&2
+          cat "$MIRROR_LOG" >&2
+          exit 1
+        fi
+
+        # The root process currently exits 130 on SIGINT before printing the
+        # documented packet summary (#6005). Assert the continuously-flushed
+        # pcap above, then treat process termination as cleanup for this smoke.
+        stop_process "$forward_pid" TERM
+        forward_pid=""
+        stop_process "$mirror_pid" INT
+        mirror_pid=""
+
+        if [ ! -f "$CAPTURE_FILE" ] || [ "$(wc -c < "$CAPTURE_FILE")" -le 24 ] || \
+          ! grep -aFq "$TOKEN" "$CAPTURE_FILE"; then
+          echo "❌ finalized mirror capture is empty or missing the request token" >&2
+          exit 1
+        fi
+
+        if ! timeout 30 ksail workload exec "$pod_name" -c ksail-tap -i \
+          --request-timeout=10s -- tcpdump -nn -r - \
+          < "$CAPTURE_FILE" > "$PCAP_VERIFY_LOG" 2>&1; then
+          echo "❌ tcpdump could not parse the finalized mirror capture" >&2
+          cat "$PCAP_VERIFY_LOG" >&2
+          exit 1
+        fi
+
+        echo "✅ workload mirror captured HTTP traffic for $DISTRIBUTION"

--- a/.github/actions/ksail-test-workload-mirror/action.yaml
+++ b/.github/actions/ksail-test-workload-mirror/action.yaml
@@ -119,25 +119,9 @@ runs:
           > "$MIRROR_LOG" 2>&1 &
         mirror_pid=$!
 
-        mirror_ready=false
-        for _ in $(seq 1 120); do
-          if grep -Fq "capturing TCP traffic on port 80" "$MIRROR_LOG"; then
-            mirror_ready=true
-            break
-          fi
-          if ! kill -0 "$mirror_pid" 2>/dev/null; then
-            echo "❌ workload mirror exited before becoming ready" >&2
-            cat "$MIRROR_LOG" >&2
-            exit 1
-          fi
-          sleep 1
-        done
-        if [ "$mirror_ready" != "true" ]; then
-          echo "❌ workload mirror did not become ready within 120 seconds" >&2
-          cat "$MIRROR_LOG" >&2
-          exit 1
-        fi
-
+        # Activity notifications are not stable in non-interactive logs. The
+        # pcap global header is the first byte-level proof that the remote
+        # tcpdump stream is live, so use it as the readiness signal.
         capture_stream_ready=false
         for _ in $(seq 1 60); do
           if [ -f "$CAPTURE_FILE" ] && [ "$(wc -c < "$CAPTURE_FILE")" -ge 24 ]; then

--- a/.github/actions/ksail-test-workload-mirror/action.yaml
+++ b/.github/actions/ksail-test-workload-mirror/action.yaml
@@ -191,9 +191,12 @@ runs:
         fi
 
         for attempt in $(seq 1 5); do
-          curl --fail --silent --show-error --max-time 5 --noproxy '*' \
+          if ! curl --fail --silent --show-error --max-time 5 --noproxy '*' \
             "http://127.0.0.1:${LOCAL_PORT}/${TOKEN}?attempt=${attempt}" \
-            >> "$RESPONSE_LOG"
+            >> "$RESPONSE_LOG"; then
+            echo "⚠️ mirror request attempt $attempt failed; continuing" \
+              | tee -a "$RESPONSE_LOG" >&2
+          fi
           sleep 1
         done
 

--- a/.github/actions/restore-mirror-cache/action.yaml
+++ b/.github/actions/restore-mirror-cache/action.yaml
@@ -68,10 +68,12 @@ runs:
         grep '^FROM ' pkg/fsutil/configmanager/talos/Dockerfile | sed 's/^FROM //' >> "$IMAGES_FILE"
 
         # Append CI test workload images (must match warm-mirror-cache exactly).
-        # This also includes the API connectivity pre-flight pod image so mirror
-        # restores cover that pull path too. See issue #3822 for related context.
+        # This also includes the workload-mirror tap and API connectivity pre-flight
+        # pod images so mirror restores cover those pull paths too. See issue #3822
+        # for related context.
         echo "docker.io/traefik/whoami:v1.10" >> "$IMAGES_FILE"
         echo "docker.io/library/busybox:1.36.1" >> "$IMAGES_FILE"
+        echo "docker.io/nicolaka/netshoot:v0.16" >> "$IMAGES_FILE"
 
         # Deduplicate and sort (must match warm-mirror-cache exactly)
         sort -u "$IMAGES_FILE" > /tmp/unique-images.txt

--- a/.github/actions/warm-mirror-cache/action.yaml
+++ b/.github/actions/warm-mirror-cache/action.yaml
@@ -120,11 +120,13 @@ runs:
 
         # Append CI test workload images that are not part of any cluster component
         # but are used by ksail-test-workload, ksail-test-backup-restore,
-        # ksail-test-workload-watch, and the in-cluster API connectivity pre-flight
-        # pod. Without pre-warming, transient Docker Hub or proxy registry errors can
-        # cause ImagePullBackOff timeouts in system tests (see issue #3822).
+        # ksail-test-workload-watch, ksail-test-workload-mirror, and the in-cluster
+        # API connectivity pre-flight pod. Without pre-warming, transient Docker Hub
+        # or proxy registry errors can cause ImagePullBackOff timeouts in system tests
+        # (see issue #3822).
         echo "docker.io/traefik/whoami:v1.10" >> "$IMAGES_FILE"
         echo "docker.io/library/busybox:1.36.1" >> "$IMAGES_FILE"
+        echo "docker.io/nicolaka/netshoot:v0.16" >> "$IMAGES_FILE"
 
         # Deduplicate and sort
         sort -u "$IMAGES_FILE" > /tmp/unique-images.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1082,16 +1082,20 @@ jobs:
           # Enable Kubernetes provider tests on the default (init=true, args="")
           # entry for each distribution. This tests all 4 nested distributions
           # (Vanilla,K3s,VCluster,Talos) on each host type, once per matrix.
+          # The three mirror-supported distributions also opt into their smoke
+          # test here so it runs once per distribution rather than for all args.
           - distribution: Vanilla
             provider: Docker
             init: true
             args: ""
             test-kubernetes-provider: "true"
+            test-workload-mirror: "true"
           - distribution: K3s
             provider: Docker
             init: true
             args: ""
             test-kubernetes-provider: "true"
+            test-workload-mirror: "true"
           - distribution: Talos
             provider: Docker
             init: true
@@ -1102,6 +1106,7 @@ jobs:
             init: true
             args: ""
             test-kubernetes-provider: "true"
+            test-workload-mirror: "true"
           # Validate Calico on the Kubernetes (k3k) provider. Calico v3.30+'s CRD
           # chart ships MutatingAdmissionPolicy resources that need the v1beta1
           # admissionregistration API enabled on the embedded k3s server via the k3k
@@ -1167,6 +1172,7 @@ jobs:
           args: ${{ matrix.args }}
           apply-overlay-path: ".github/fixtures/podinfo-overlay"
           test-kubernetes-provider: ${{ matrix.test-kubernetes-provider || 'false' }}
+          test-workload-mirror: ${{ matrix.test-workload-mirror || 'false' }}
           kubernetes-provider-distributions: ${{ matrix.kubernetes-provider-distributions || 'Vanilla,K3s,VCluster,Talos' }}
           kubernetes-provider-cni: ${{ matrix.kubernetes-provider-cni || '' }}
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

KSail's workload mirror implementation and unit-level session coverage are already on `main`, but the parent feature's Vanilla/K3s/VCluster acceptance criterion has no live cross-distribution exercise. A command-only check would miss capture startup races, tap injection failures, invalid PCAP output, and leaked resources.

## What changed

- add a reusable mirror smoke action that deploys an owned HTTP target, waits for the remote capture stream, sends a unique request through `workload forward`, and parses the finalized PCAP with the pinned tap container's `tcpdump`
- bound mirror, forwarding, API requests, process shutdown, and Kubernetes cleanup; verify the deployment and pod are gone
- opt in exactly one default Docker matrix lane for Vanilla, K3s, and VCluster
- add the pinned netshoot tap image to both warm and restore cache-key inputs
- include mirror failures in the existing Kubernetes diagnostics path

## Validation

- `go test ./pkg/cli/cmd/workload ./pkg/svc/mirror` (690 tests)
- `go build -o /tmp/ksail-b272-6004 .`
- YAML parse + `yamllint` on all five changed files
- `shellcheck` on the extracted composite-action script
- `zizmor --config zizmor.yml` on the changed composite actions
- structural assertions for exactly three enabled matrix lanes and warm/restore image-list parity
- `git diff --check`

`actionlint .github/workflows/ci.yaml` still reports only the pre-existing unsupported `code-quality` permission scope at line 278. The pull request intentionally triggers the repository's live Docker system-test matrix for end-to-end verification.

## Notes

The current root process exits 130 on SIGINT before printing the documented capture summary. This smoke validates the continuously flushed and finalized PCAP instead; #6005 tracks graceful Ctrl-C behavior separately.

Fixes #6004

Parent: #4521


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional workload-mirroring smoke tests for Docker-based Kubernetes environments, validating end-to-end traffic capture and forwarding behavior.
  * Introduced a new composite test step that verifies mirrored packet data and expected request tokens.

* **CI Improvements**
  * Extended the system-test CI matrix to run mirror-backed workload tests once per distribution (Vanilla and K3s).
  * Updated mirror cache warm/restore image sets to improve cache alignment.

* **Bug Fixes**
  * Adjusted failure/debug gating so Kubernetes debug collection also runs when workload-mirror test steps fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->