### PR TITLE
ci: use the canonical CodeRabbit schema URL

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   pre_merge_checks:
     docstrings:
@@ -10,3 +10,4 @@ reviews:
       # 80% threshold and permanently blocks draft promotion. Keep the signal
       # visible but non-blocking rather than wedging the review gate.
       mode: warning
+

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,4 +10,3 @@ reviews:
       # 80% threshold and permanently blocks draft promotion. Keep the signal
       # visible but non-blocking rather than wedging the review gate.
       mode: warning
-


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
The `.coderabbit.yaml` $schema modeline points at a legacy `storage.googleapis.com` endpoint, which can degrade editor schema validation and autocompletion.

## What
One-line switch to the canonical `https://coderabbit.ai/integrations/schema.v2.json` — the same fix CodeRabbit itself requested on platform#2567.