### PR TITLE
fix(intercept): fail loud on a corrupted steering tunnel and silence the agent banner

### DIFF
--- a/Dockerfile.steer
+++ b/Dockerfile.steer
@@ -26,4 +26,14 @@ ARG TARGETPLATFORM
 # command exec'd over the tunnel is simply `ksail steer-agent …`.
 COPY ${TARGETPLATFORM}/ksail /usr/local/bin/ksail
 
+# Point the XDG state dir at a writable tmpfs. ksail links k9s's cmd package,
+# whose init() prints "Fail to init k9s logs location …" to STDOUT when it cannot
+# create its state dir (the default ~/.local/state is unwritable under this
+# read-only-rootfs steer container). For `ksail steer-agent` STDOUT *is* the
+# tunnel channel, so that banner would inject non-frame bytes and corrupt the
+# steering tunnel — the intercept client rejects it as an unknown frame type.
+# /dev/shm is a writable tmpfs present in every pod, so InitLogLoc succeeds and
+# emits nothing.
+ENV XDG_STATE_HOME=/dev/shm
+
 ENTRYPOINT ["/usr/local/bin/ksail"]

--- a/pkg/svc/mirror/pump.go
+++ b/pkg/svc/mirror/pump.go
@@ -152,10 +152,11 @@ func pumpUntilDone(ctx context.Context, left, right io.ReadWriteCloser) {
 // stream the steering agent opened, dials the developer's local process, and
 // pumps the two together. A failed dial closes the stream — the tunnel's
 // "connection refused", which makes the agent close the redirected cluster
-// connection. It blocks until the context is cancelled or the session closes
-// (both return nil — inspect [TunnelSession.Err] for why a session ended);
-// cancellation also tears down every active pump, and all pumps are drained
-// before it returns.
+// connection. It blocks until the context is cancelled or the session ends: a
+// clean end (context cancelled or the caller closed the session) returns nil,
+// while a session the demux loop tore down on a protocol/codec error returns
+// that error. Cancellation also tears down every active pump, and all pumps are
+// drained before it returns.
 func ServeIntercepted(ctx context.Context, session *TunnelSession, dial LocalDialer) error {
 	pumps := &sync.WaitGroup{}
 	defer pumps.Wait()
@@ -163,15 +164,37 @@ func ServeIntercepted(ctx context.Context, session *TunnelSession, dial LocalDia
 	for {
 		stream, err := session.AcceptStream(ctx)
 		if err != nil {
-			// AcceptStream only fails when the session closed or the context
-			// ended — both are a deliberate end of serving, not a failure.
-			return nil
+			// AcceptStream fails both on a deliberate end of serving (the context
+			// ended or the caller closed the session — nil) and when the demux
+			// loop tore the session down on a protocol/codec error (e.g. non-frame
+			// bytes on the steering channel from a noisy agent image). Surface the
+			// latter so a corrupted tunnel is a diagnosable failure, never a silent
+			// success.
+			return sessionTeardownErr(session)
 		}
 
 		pumps.Go(func() {
 			serveOneStream(ctx, stream, dial)
 		})
 	}
+}
+
+// sessionTeardownErr reports the demux loop's terminal error when the session
+// has already torn itself down — its Done channel is closed and Err is non-nil.
+// teardown records Err before closing Done, so a closed Done means Err is final.
+// A caller-initiated Close or a context cancellation leaves Err nil (Done may
+// still be open), both of which are a clean stop and yield nil here.
+func sessionTeardownErr(session *TunnelSession) error {
+	select {
+	case <-session.Done():
+		loopErr := session.Err()
+		if loopErr != nil {
+			return fmt.Errorf("steering tunnel torn down: %w", loopErr)
+		}
+	default:
+	}
+
+	return nil
 }
 
 // serveOneStream dials the local process for one intercepted stream and pumps

--- a/pkg/svc/mirror/pump_test.go
+++ b/pkg/svc/mirror/pump_test.go
@@ -340,14 +340,15 @@ func TestServeIntercepted_ReturnsNilWhenTheSessionCloses(t *testing.T) {
 	}
 }
 
+// TestServeIntercepted_SurfacesAProtocolErrorThatTearsTheTunnelDown pins that a
+// steering channel yielding non-frame bytes (e.g. a stray banner the agent
+// image printed onto its stdout, the tunnel channel) corrupts the demux, tears
+// the session down with a codec error, and ServeIntercepted surfaces that error
+// rather than returning nil — a corrupted tunnel is a diagnosable failure,
+// never a silent success.
 func TestServeIntercepted_SurfacesAProtocolErrorThatTearsTheTunnelDown(t *testing.T) {
 	t.Parallel()
 
-	// A steering channel that yields non-frame bytes (e.g. a stray banner the
-	// agent image printed onto its stdout, the tunnel channel) corrupts the
-	// demux and tears the session down with a codec error. ServeIntercepted must
-	// surface it rather than returning nil — a corrupted tunnel is a diagnosable
-	// failure, never a silent success.
 	garbage := io.NopCloser(strings.NewReader("Fail to init k9s logs location\n"))
 	session := mirror.NewTunnelSession(garbage, io.Discard, mirror.TunnelRoleClient)
 

--- a/pkg/svc/mirror/pump_test.go
+++ b/pkg/svc/mirror/pump_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -336,6 +337,35 @@ func TestServeIntercepted_ReturnsNilWhenTheSessionCloses(t *testing.T) {
 		require.NoError(t, serveErr)
 	case <-time.After(testTimeout):
 		t.Fatal("serve loop did not stop after the session closed")
+	}
+}
+
+func TestServeIntercepted_SurfacesAProtocolErrorThatTearsTheTunnelDown(t *testing.T) {
+	t.Parallel()
+
+	// A steering channel that yields non-frame bytes (e.g. a stray banner the
+	// agent image printed onto its stdout, the tunnel channel) corrupts the
+	// demux and tears the session down with a codec error. ServeIntercepted must
+	// surface it rather than returning nil — a corrupted tunnel is a diagnosable
+	// failure, never a silent success.
+	garbage := io.NopCloser(strings.NewReader("Fail to init k9s logs location\n"))
+	session := mirror.NewTunnelSession(garbage, io.Discard, mirror.TunnelRoleClient)
+
+	dial := func(_ context.Context) (io.ReadWriteCloser, error) {
+		return nil, errTransportTorn
+	}
+
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- mirror.ServeIntercepted(context.Background(), session, dial)
+	}()
+
+	select {
+	case serveErr := <-serveDone:
+		require.Error(t, serveErr)
+		require.ErrorIs(t, serveErr, mirror.ErrTunnelUnknownFrameType)
+	case <-time.After(testTimeout):
+		t.Fatal("serve loop did not return after the tunnel was corrupted")
 	}
 }
 

--- a/pkg/svc/mirror/pump_test.go
+++ b/pkg/svc/mirror/pump_test.go
@@ -356,6 +356,7 @@ func TestServeIntercepted_SurfacesAProtocolErrorThatTearsTheTunnelDown(t *testin
 	}
 
 	serveDone := make(chan error, 1)
+
 	go func() {
 		serveDone <- mirror.ServeIntercepted(context.Background(), session, dial)
 	}()

--- a/pkg/svc/mirror/pump_test.go
+++ b/pkg/svc/mirror/pump_test.go
@@ -22,6 +22,7 @@ type pipeListener struct {
 	closed    chan struct{}
 }
 
+// newPipeListener builds a pipeListener ready to accept delivered connections.
 func newPipeListener() *pipeListener {
 	return &pipeListener{
 		conns:     make(chan net.Conn),
@@ -30,6 +31,7 @@ func newPipeListener() *pipeListener {
 	}
 }
 
+// Accept blocks until a test delivers a connection or the listener closes.
 func (l *pipeListener) Accept() (net.Conn, error) {
 	select {
 	case conn := <-l.conns:
@@ -39,12 +41,14 @@ func (l *pipeListener) Accept() (net.Conn, error) {
 	}
 }
 
+// Close ends the listener; pending and future Accepts return net.ErrClosed.
 func (l *pipeListener) Close() error {
 	l.closeOnce.Do(func() { close(l.closed) })
 
 	return nil
 }
 
+// Addr returns a synthetic address naming the fake listener.
 func (l *pipeListener) Addr() net.Addr {
 	return &net.UnixAddr{Name: "ksail-steer-test", Net: "unix"}
 }
@@ -77,8 +81,10 @@ type failingHalf struct {
 	writeErr error
 }
 
+// Read fails immediately with the configured read error.
 func (f *failingHalf) Read([]byte) (int, error) { return 0, f.readErr }
 
+// Write fails with the configured write error, or accepts the bytes when unset.
 func (f *failingHalf) Write(p []byte) (int, error) {
 	if f.writeErr != nil {
 		return 0, f.writeErr
@@ -87,8 +93,11 @@ func (f *failingHalf) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// Close is a no-op — the fake transport holds no resources.
 func (f *failingHalf) Close() error { return nil }
 
+// TestPump_CopiesBothDirectionsAndTearsDownOnEOF pins that Pump relays bytes
+// both ways and, when one side ends, closes both halves so the peer sees EOF.
 func TestPump_CopiesBothDirectionsAndTearsDownOnEOF(t *testing.T) {
 	t.Parallel()
 
@@ -130,6 +139,8 @@ func TestPump_CopiesBothDirectionsAndTearsDownOnEOF(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
+// TestPump_ReturnsTheErrorThatEndedTheFirstDirection pins that Pump surfaces
+// the transport error that tore the first direction down.
 func TestPump_ReturnsTheErrorThatEndedTheFirstDirection(t *testing.T) {
 	t.Parallel()
 
@@ -140,6 +151,8 @@ func TestPump_ReturnsTheErrorThatEndedTheFirstDirection(t *testing.T) {
 	require.ErrorIs(t, err, errTransportTorn)
 }
 
+// TestForwardRedirected_BridgesARedirectedConnectionRoundTrip pins that a
+// redirected connection is bridged over the tunnel and echoes end to end.
 func TestForwardRedirected_BridgesARedirectedConnectionRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -183,6 +196,8 @@ func TestForwardRedirected_BridgesARedirectedConnectionRoundTrip(t *testing.T) {
 	}
 }
 
+// TestForwardRedirected_ReturnsNilWhenTheSessionIsClosed pins that closing the
+// tunnel session ends forwarding as a clean stop, not an error.
 func TestForwardRedirected_ReturnsNilWhenTheSessionIsClosed(t *testing.T) {
 	t.Parallel()
 
@@ -208,6 +223,8 @@ func TestForwardRedirected_ReturnsNilWhenTheSessionIsClosed(t *testing.T) {
 	}
 }
 
+// TestForwardRedirected_AFailedStreamOpenClosesTheConnection pins that a
+// connection whose tunnel stream cannot open is closed instead of leaked.
 func TestForwardRedirected_AFailedStreamOpenClosesTheConnection(t *testing.T) {
 	t.Parallel()
 
@@ -247,6 +264,8 @@ func TestForwardRedirected_AFailedStreamOpenClosesTheConnection(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
+// TestServeIntercepted_DialsTheLocalProcessAndPumps pins that each intercepted
+// stream dials the developer's local process and pumps bytes both ways.
 func TestServeIntercepted_DialsTheLocalProcessAndPumps(t *testing.T) {
 	t.Parallel()
 
@@ -291,6 +310,8 @@ func TestServeIntercepted_DialsTheLocalProcessAndPumps(t *testing.T) {
 	}
 }
 
+// TestServeIntercepted_AFailedDialClosesTheStream pins that a failed local
+// dial closes the intercepted stream rather than leaving it half-open.
 func TestServeIntercepted_AFailedDialClosesTheStream(t *testing.T) {
 	t.Parallel()
 
@@ -314,6 +335,8 @@ func TestServeIntercepted_AFailedDialClosesTheStream(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
+// TestServeIntercepted_ReturnsNilWhenTheSessionCloses pins that a closed
+// session ends serving as a clean stop, not an error.
 func TestServeIntercepted_ReturnsNilWhenTheSessionCloses(t *testing.T) {
 	t.Parallel()
 
@@ -371,6 +394,8 @@ func TestServeIntercepted_SurfacesAProtocolErrorThatTearsTheTunnelDown(t *testin
 	}
 }
 
+// TestInterceptPump_EndToEndEchoThroughTheTunnel pins the whole intercept data
+// path: agent-side forwarding and client-side serving echo through the tunnel.
 func TestInterceptPump_EndToEndEchoThroughTheTunnel(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
A live-cluster validation pass for `workload intercept` (the graduation gate, #5971) found the command exiting **0 while doing nothing** — a silent no-op. The steering agent's own startup banner was corrupting the tunnel it runs over, and the client swallowed the failure as success. That is the worst kind of bug: it looks like it worked. This is the first of the three real defects that pass surfaced.

## What
Two changes so a broken tunnel can never again read as success:
- The intercept client now **fails loudly** — a tunnel torn down by a protocol/codec error becomes a diagnosable non-zero exit instead of a silent nil.
- The shipped steering image no longer emits the stray banner onto the tunnel channel, so the healthy path stays healthy.

Verified end-to-end against a real cluster (the session now stays up and installs its redirect rule) and with unit tests pinning both the fail-loud path and the noise-free image.

Two follow-on defects the same pass found are filed separately (#6039 listener/redirect mismatch, #6040 orphaned-agent leak); graduation (#5971) stays gated until those land.

Fixes #6038
Part of #4521