### PR TITLE
fix(hetzner): save kubeconfig against the floating-IP endpoint

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -262,6 +262,11 @@ func ApplyHetznerDefaultsForTest(opts v1alpha1.OptionsHetzner) v1alpha1.OptionsH
 	return applyHetznerDefaults(opts)
 }
 
+// KubeconfigEndpointURLForTest exposes kubeconfigEndpointURL for unit testing.
+func (p *Provisioner) KubeconfigEndpointURLForTest(nodeIP string) string {
+	return p.kubeconfigEndpointURL(nodeIP)
+}
+
 // UpdateConfigsWithEndpointForTest exposes updateConfigsWithEndpoint for unit testing.
 func (p *Provisioner) UpdateConfigsWithEndpointForTest(
 	ctx context.Context,

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -267,6 +267,16 @@ func (p *Provisioner) KubeconfigEndpointURLForTest(nodeIP string) string {
 	return p.kubeconfigEndpointURL(nodeIP)
 }
 
+// NewHetznerClusterWithEndpointForTest exposes newHetznerClusterWithEndpoint
+// for unit testing.
+func (p *Provisioner) NewHetznerClusterWithEndpointForTest(
+	clusterName string,
+	controlPlaneServers []*hcloud.Server,
+	workerServers []*hcloud.Server,
+) (*HetznerClusterResult, error) {
+	return p.newHetznerClusterWithEndpoint(clusterName, controlPlaneServers, workerServers)
+}
+
 // UpdateConfigsWithEndpointForTest exposes updateConfigsWithEndpoint for unit testing.
 func (p *Provisioner) UpdateConfigsWithEndpointForTest(
 	ctx context.Context,

--- a/pkg/svc/provisioner/cluster/talos/hetzner_bootstrap.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_bootstrap.go
@@ -231,11 +231,14 @@ func (p *Provisioner) saveHetznerKubeconfig(
 	return nil
 }
 
-// newHetznerClusterWithEndpoint constructs a HetznerClusterResult with the
-// Kubernetes API endpoint derived from the first control-plane server's reachable
-// address (its public IPv4, or its private-network IP when the control plane is
-// IPv4-less).
-func newHetznerClusterWithEndpoint(
+// newHetznerClusterWithEndpoint constructs a HetznerClusterResult whose
+// Kubernetes API endpoint is the cluster's effective endpoint — the same one
+// the saved kubeconfig is rewritten to (the floating IP when enabled), so
+// connection metadata and the kubeconfig can never disagree — falling back to
+// the first control-plane server's reachable address (its public IPv4, or its
+// private-network IP when the control plane is IPv4-less) when no effective
+// endpoint was recorded.
+func (p *Provisioner) newHetznerClusterWithEndpoint(
 	clusterName string,
 	controlPlaneServers []*hcloud.Server,
 	workerServers []*hcloud.Server,
@@ -245,7 +248,7 @@ func newHetznerClusterWithEndpoint(
 		return nil, addrErr
 	}
 
-	kubeEndpoint := "https://" + net.JoinHostPort(cpIP, "6443")
+	kubeEndpoint := p.kubeconfigEndpointURL(cpIP)
 
 	return NewHetznerClusterResult(clusterName, controlPlaneServers, workerServers, kubeEndpoint)
 }
@@ -266,7 +269,7 @@ func (p *Provisioner) waitForHetznerClusterReady(
 	workerServers []*hcloud.Server,
 	configBundle *bundle.Bundle,
 ) error {
-	hetznerCluster, err := newHetznerClusterWithEndpoint(
+	hetznerCluster, err := p.newHetznerClusterWithEndpoint(
 		clusterName,
 		controlPlaneServers,
 		workerServers,
@@ -308,7 +311,7 @@ func (p *Provisioner) waitForHetznerClusterReadyAfterStart(
 	}
 
 	// Build the cluster result from the discovered servers
-	hetznerCluster, err := newHetznerClusterWithEndpoint(
+	hetznerCluster, err := p.newHetznerClusterWithEndpoint(
 		clusterName,
 		controlPlaneServers,
 		workerServers,

--- a/pkg/svc/provisioner/cluster/talos/hetzner_bootstrap.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_bootstrap.go
@@ -208,13 +208,15 @@ func (p *Provisioner) saveHetznerKubeconfig(
 		return fmt.Errorf("failed to fetch kubeconfig: %w", err)
 	}
 
-	// The kubeconfig from Talos uses internal IPs. Rewrite the server endpoint to the
-	// node's reachable address: its public IPv4, or its private-network IP when the
-	// control plane is IPv4-less (in which case the kubeconfig only works from inside
-	// the private network).
+	// The kubeconfig from Talos uses internal IPs. Rewrite the server endpoint to
+	// the cluster's effective API endpoint: the floating IP when enabled (so the
+	// saved file survives control-plane replacement, #6043), else the fetched
+	// node's reachable address — its public IPv4, or its private-network IP when
+	// the control plane is IPv4-less (in which case the kubeconfig only works
+	// from inside the private network).
 	kubeconfig, err = rewriteKubeconfigEndpoint(
 		kubeconfig,
-		"https://"+net.JoinHostPort(nodeIP, "6443"),
+		p.kubeconfigEndpointURL(nodeIP),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to rewrite kubeconfig endpoint: %w", err)
@@ -383,4 +385,17 @@ func (p *Provisioner) discoverHetznerServers(
 	}
 
 	return controlPlaneServers, workerServers, nil
+}
+
+// kubeconfigEndpointURL returns the URL the saved kubeconfig's server entries
+// are rewritten to: the effective cluster endpoint rendered into the machine
+// configs when one exists (the floating IP when FloatingIPEnabled), else the
+// given node's reachable address.
+func (p *Provisioner) kubeconfigEndpointURL(nodeIP string) string {
+	endpointIP := p.clusterEndpointIP
+	if endpointIP == "" {
+		endpointIP = nodeIP
+	}
+
+	return "https://" + net.JoinHostPort(endpointIP, "6443")
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -144,6 +144,12 @@ type Provisioner struct {
 	talosOpts *v1alpha1.OptionsTalos
 	// hetznerOpts holds Hetzner-specific options when using the Hetzner provider.
 	hetznerOpts *v1alpha1.OptionsHetzner
+	// clusterEndpointIP is the effective Kubernetes API endpoint rendered into
+	// the machine configs by updateConfigsWithEndpoint — the cluster's floating
+	// IP when FloatingIPEnabled, else the first control-plane node's reachable
+	// address. saveHetznerKubeconfig rewrites the saved kubeconfig to it so the
+	// file survives control-plane replacement when the endpoint is stable.
+	clusterEndpointIP string
 	// omniOpts holds Omni-specific options when using the Omni provider.
 	omniOpts           *v1alpha1.OptionsOmni
 	provisionerFactory func(ctx context.Context) (provision.Provisioner, error)

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -207,8 +207,10 @@ func (p *Provisioner) updateConfigsWithEndpoint(
 		return err
 	}
 
-	// Update the stored configs
+	// Update the stored configs and remember the effective endpoint for the
+	// kubeconfig rewrite in saveHetznerKubeconfig.
 	p.talosConfigs = updatedConfigs
+	p.clusterEndpointIP = endpointIP
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
@@ -146,6 +146,27 @@ func controlPlaneServer(id int64, name, publicIPv4 string) *hcloud.Server {
 	}
 }
 
+// assertSavedKubeconfigServer runs the fetched-from-Talos kubeconfig fixture
+// (talosFetchedKubeconfig, shared with connector_test.go) through the same
+// rewrite saveHetznerKubeconfig performs and asserts the serialized file's
+// server value — pinning the final artifact, not just the endpoint-URL helper.
+func assertSavedKubeconfigServer(
+	t *testing.T,
+	provisioner *talosprovisioner.Provisioner,
+	nodeIP string,
+	wantServer string,
+) {
+	t.Helper()
+
+	rewritten, err := talosprovisioner.RewriteKubeconfigEndpointForTest(
+		[]byte(talosFetchedKubeconfig),
+		provisioner.KubeconfigEndpointURLForTest(nodeIP),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, string(rewritten), "server: "+wantServer,
+		"saved kubeconfig must target the effective cluster endpoint")
+}
+
 // TestUpdateConfigsWithEndpoint_FloatingIPDisabled verifies the default path
 // is unchanged: the endpoint is the first control-plane node's IP, no
 // exposure cert-SANs patch is added, and the Hetzner API is never called (the
@@ -173,6 +194,16 @@ func TestUpdateConfigsWithEndpoint_FloatingIPDisabled(t *testing.T) {
 	assert.Equal(t, "https://203.0.113.5:6443",
 		provisioner.KubeconfigEndpointURLForTest("203.0.113.5"),
 		"disabled path must save the kubeconfig against the node's reachable address")
+	assertSavedKubeconfigServer(t, provisioner, "203.0.113.5", "https://203.0.113.5:6443")
+
+	// Connection metadata must agree with the saved kubeconfig.
+	cluster, err := provisioner.NewHetznerClusterWithEndpointForTest(
+		"fip-cluster",
+		[]*hcloud.Server{controlPlaneServer(1, "cp-1", "203.0.113.5")},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "https://203.0.113.5:6443", cluster.Info().KubernetesEndpoint)
 }
 
 // TestKubeconfigEndpointURL_FallsBackToNodeIP pins the defensive default: a
@@ -185,6 +216,7 @@ func TestKubeconfigEndpointURL_FallsBackToNodeIP(t *testing.T) {
 
 	assert.Equal(t, "https://203.0.113.7:6443",
 		provisioner.KubeconfigEndpointURLForTest("203.0.113.7"))
+	assertSavedKubeconfigServer(t, provisioner, "203.0.113.7", "https://203.0.113.7:6443")
 }
 
 // TestUpdateConfigsWithEndpoint_FloatingIPEnabled verifies the opt-in path:
@@ -256,6 +288,22 @@ func TestUpdateConfigsWithEndpoint_FloatingIPEnabled(t *testing.T) {
 	assert.Equal(t, "https://192.0.2.10:6443",
 		provisioner.KubeconfigEndpointURLForTest("203.0.113.5"),
 		"kubeconfig endpoint must be the floating IP when the feature is enabled")
+	assertSavedKubeconfigServer(t, provisioner, "203.0.113.5", "https://192.0.2.10:6443")
+
+	// Connection metadata must expose the same effective endpoint as the saved
+	// kubeconfig — not the first control-plane node's address — so consumers of
+	// HetznerClusterResult survive control-plane replacement too.
+	cluster, err := provisioner.NewHetznerClusterWithEndpointForTest(
+		"fip-cluster",
+		[]*hcloud.Server{
+			controlPlaneServer(1, "cp-1", "203.0.113.5"),
+			controlPlaneServer(2, "cp-2", "203.0.113.6"),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "https://192.0.2.10:6443", cluster.Info().KubernetesEndpoint,
+		"connection metadata endpoint must be the floating IP when the feature is enabled")
 }
 
 // TestUpdateConfigsWithEndpoint_FloatingIPEnabledTokenUnset verifies the

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
@@ -167,6 +167,25 @@ func assertSavedKubeconfigServer(
 		"saved kubeconfig must target the effective cluster endpoint")
 }
 
+// assertClusterMetadataEndpoint pins HetznerClusterResult's connection
+// metadata to the same effective endpoint the saved kubeconfig targets, so
+// consumers of the metadata survive control-plane replacement too.
+func assertClusterMetadataEndpoint(
+	t *testing.T,
+	provisioner *talosprovisioner.Provisioner,
+	servers []*hcloud.Server,
+	want string,
+) {
+	t.Helper()
+
+	cluster, err := provisioner.NewHetznerClusterWithEndpointForTest(
+		"fip-cluster", servers, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, want, cluster.Info().KubernetesEndpoint,
+		"connection metadata must expose the effective cluster endpoint")
+}
+
 // TestUpdateConfigsWithEndpoint_FloatingIPDisabled verifies the default path
 // is unchanged: the endpoint is the first control-plane node's IP, no
 // exposure cert-SANs patch is added, and the Hetzner API is never called (the
@@ -195,15 +214,9 @@ func TestUpdateConfigsWithEndpoint_FloatingIPDisabled(t *testing.T) {
 		provisioner.KubeconfigEndpointURLForTest("203.0.113.5"),
 		"disabled path must save the kubeconfig against the node's reachable address")
 	assertSavedKubeconfigServer(t, provisioner, "203.0.113.5", "https://203.0.113.5:6443")
-
-	// Connection metadata must agree with the saved kubeconfig.
-	cluster, err := provisioner.NewHetznerClusterWithEndpointForTest(
-		"fip-cluster",
+	assertClusterMetadataEndpoint(t, provisioner,
 		[]*hcloud.Server{controlPlaneServer(1, "cp-1", "203.0.113.5")},
-		nil,
-	)
-	require.NoError(t, err)
-	assert.Equal(t, "https://203.0.113.5:6443", cluster.Info().KubernetesEndpoint)
+		"https://203.0.113.5:6443")
 }
 
 // TestKubeconfigEndpointURL_FallsBackToNodeIP pins the defensive default: a
@@ -217,6 +230,39 @@ func TestKubeconfigEndpointURL_FallsBackToNodeIP(t *testing.T) {
 	assert.Equal(t, "https://203.0.113.7:6443",
 		provisioner.KubeconfigEndpointURLForTest("203.0.113.7"))
 	assertSavedKubeconfigServer(t, provisioner, "203.0.113.7", "https://203.0.113.7:6443")
+}
+
+// assertFloatingIPRenderedConfigs pins the enabled-path rendering: the
+// floating IP as the cluster endpoint, the floating IP plus every
+// control-plane node IP in the certificate SAN set, and a Talos VIP block
+// (with hcloud API management) on the control-plane machine configs only —
+// the node-side ownership handover that makes the elected leader claim the
+// address on every leader change.
+func assertFloatingIPRenderedConfigs(t *testing.T, configs *talos.Configs) {
+	t.Helper()
+
+	endpoint := configs.ControlPlane().Cluster().Endpoint()
+	require.NotNil(t, endpoint)
+	assert.Equal(t, "192.0.2.10", endpoint.Hostname(),
+		"endpoint must be the floating IP")
+
+	sans := configs.ControlPlane().Cluster().CertSANs()
+	assert.Contains(t, sans, "192.0.2.10")
+	assert.Contains(t, sans, "203.0.113.5")
+	assert.Contains(t, sans, "203.0.113.6")
+
+	devices := configs.ControlPlane().Machine().Network().Devices()
+	require.Len(t, devices, 1)
+	assert.Equal(t, "eth0", devices[0].Interface())
+
+	vip := devices[0].VIPConfig()
+	require.NotNil(t, vip)
+	assert.Equal(t, "192.0.2.10", vip.IP())
+	require.NotNil(t, vip.HCloud())
+	assert.Equal(t, "vip-test-token", vip.HCloud().APIToken())
+
+	// Workers claim nothing: the VIP patch is control-plane-scoped.
+	assert.Empty(t, configs.Worker().Machine().Network().Devices())
 }
 
 // TestUpdateConfigsWithEndpoint_FloatingIPEnabled verifies the opt-in path:
@@ -256,31 +302,7 @@ func TestUpdateConfigsWithEndpoint_FloatingIPEnabled(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&assignCalls),
 		"floating IP must be attached to the first control-plane server")
 
-	configs := provisioner.TalosConfigsForTest()
-	endpoint := configs.ControlPlane().Cluster().Endpoint()
-	require.NotNil(t, endpoint)
-	assert.Equal(t, "192.0.2.10", endpoint.Hostname(),
-		"endpoint must be the floating IP")
-
-	sans := configs.ControlPlane().Cluster().CertSANs()
-	assert.Contains(t, sans, "192.0.2.10")
-	assert.Contains(t, sans, "203.0.113.5")
-	assert.Contains(t, sans, "203.0.113.6")
-
-	// Node-side ownership handover: the control-plane configs must carry the
-	// Talos VIP block for the floating IP, with hcloud API management.
-	devices := configs.ControlPlane().Machine().Network().Devices()
-	require.Len(t, devices, 1)
-	assert.Equal(t, "eth0", devices[0].Interface())
-
-	vip := devices[0].VIPConfig()
-	require.NotNil(t, vip)
-	assert.Equal(t, "192.0.2.10", vip.IP())
-	require.NotNil(t, vip.HCloud())
-	assert.Equal(t, "vip-test-token", vip.HCloud().APIToken())
-
-	// Workers claim nothing: the VIP patch is control-plane-scoped.
-	assert.Empty(t, configs.Worker().Machine().Network().Devices())
+	assertFloatingIPRenderedConfigs(t, provisioner.TalosConfigsForTest())
 
 	// The saved kubeconfig must target the stable floating-IP endpoint, not the
 	// first control-plane node it was fetched from (#6043) — otherwise replacing
@@ -289,21 +311,12 @@ func TestUpdateConfigsWithEndpoint_FloatingIPEnabled(t *testing.T) {
 		provisioner.KubeconfigEndpointURLForTest("203.0.113.5"),
 		"kubeconfig endpoint must be the floating IP when the feature is enabled")
 	assertSavedKubeconfigServer(t, provisioner, "203.0.113.5", "https://192.0.2.10:6443")
-
-	// Connection metadata must expose the same effective endpoint as the saved
-	// kubeconfig — not the first control-plane node's address — so consumers of
-	// HetznerClusterResult survive control-plane replacement too.
-	cluster, err := provisioner.NewHetznerClusterWithEndpointForTest(
-		"fip-cluster",
+	assertClusterMetadataEndpoint(t, provisioner,
 		[]*hcloud.Server{
 			controlPlaneServer(1, "cp-1", "203.0.113.5"),
 			controlPlaneServer(2, "cp-2", "203.0.113.6"),
 		},
-		nil,
-	)
-	require.NoError(t, err)
-	assert.Equal(t, "https://192.0.2.10:6443", cluster.Info().KubernetesEndpoint,
-		"connection metadata endpoint must be the floating IP when the feature is enabled")
+		"https://192.0.2.10:6443")
 }
 
 // TestUpdateConfigsWithEndpoint_FloatingIPEnabledTokenUnset verifies the

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
@@ -170,6 +170,21 @@ func TestUpdateConfigsWithEndpoint_FloatingIPDisabled(t *testing.T) {
 	assert.NotContains(t, configs.ControlPlane().Cluster().CertSANs(), "192.0.2.10")
 	assert.Empty(t, configs.ControlPlane().Machine().Network().Devices(),
 		"disabled floating IP must render no VIP interface block")
+	assert.Equal(t, "https://203.0.113.5:6443",
+		provisioner.KubeconfigEndpointURLForTest("203.0.113.5"),
+		"disabled path must save the kubeconfig against the node's reachable address")
+}
+
+// TestKubeconfigEndpointURL_FallsBackToNodeIP pins the defensive default: a
+// provisioner that never rendered an endpoint (updateConfigsWithEndpoint not
+// run) rewrites the kubeconfig to the dialed node's address.
+func TestKubeconfigEndpointURL_FallsBackToNodeIP(t *testing.T) {
+	t.Parallel()
+
+	provisioner := newFloatingIPTestProvisioner(t, v1alpha1.OptionsHetzner{})
+
+	assert.Equal(t, "https://203.0.113.7:6443",
+		provisioner.KubeconfigEndpointURLForTest("203.0.113.7"))
 }
 
 // TestUpdateConfigsWithEndpoint_FloatingIPEnabled verifies the opt-in path:
@@ -234,6 +249,13 @@ func TestUpdateConfigsWithEndpoint_FloatingIPEnabled(t *testing.T) {
 
 	// Workers claim nothing: the VIP patch is control-plane-scoped.
 	assert.Empty(t, configs.Worker().Machine().Network().Devices())
+
+	// The saved kubeconfig must target the stable floating-IP endpoint, not the
+	// first control-plane node it was fetched from (#6043) — otherwise replacing
+	// that cattle node still breaks every saved kubeconfig.
+	assert.Equal(t, "https://192.0.2.10:6443",
+		provisioner.KubeconfigEndpointURLForTest("203.0.113.5"),
+		"kubeconfig endpoint must be the floating IP when the feature is enabled")
 }
 
 // TestUpdateConfigsWithEndpoint_FloatingIPEnabledTokenUnset verifies the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
With `floatingIPEnabled: true` the cluster gets a stable API endpoint, but the saved kubeconfig was still rewritten to the first control-plane node's IP — so replacing that cattle node broke CI and client access anyway, defeating the feature's purpose and blocking the platform's stable-endpoint rollout (devantler-tech/platform#2120).

## What
The provisioner now remembers the effective endpoint it rendered into the machine configs and saves the kubeconfig against it: the floating IP when the feature is enabled, the node's reachable address otherwise (unchanged default). Regression tests pin both paths and the defensive fallback.

Fixes #6043