### PR TITLE
feat(cluster): derive a declared-environments reconcile plan

### DIFF
--- a/pkg/svc/environment/reconcile.go
+++ b/pkg/svc/environment/reconcile.go
@@ -58,17 +58,38 @@ type Plan struct {
 	Orphans []string
 }
 
+// baseConfigFileName is the workspace's base root config — not itself an
+// environment (DeriveEnvironments excludes it), but its kustomizationFile may
+// sync a clusters/<env> overlay that DerivePlan must not misread as orphaned.
+const baseConfigFileName = "ksail.yaml"
+
 // DerivePlan diffs the environments declared by ksail.<env>.yaml root configs in
-// repoRoot against the overlay tree at <repoRoot>/<sourceDir>/clusters/. A
-// missing clusters/ directory is a valid pre-scaffold state: every declared
-// environment is then OverlayMissing and there are no orphans.
+// repoRoot against the overlay tree at <sourceDir>/clusters/ (sourceDir is taken
+// relative to repoRoot unless already absolute — the ksail config manager hands
+// downstream consumers an absolutized source directory). A missing clusters/
+// directory is a valid pre-scaffold state: every declared environment is then
+// OverlayMissing and there are no orphans.
+//
+// A declared environment named after the reserved shared base overlay
+// (ksail.base.yaml) is rejected with ErrReservedEnvironmentName: clusters/base
+// is the shared base every overlay builds on, so treating it as that
+// environment's overlay would mask the name collision DeriveMultiClusterLayout
+// already refuses. The overlay synced by the base ksail.yaml's
+// kustomizationFile (the initial environment `project init --multi-cluster`
+// scaffolds without a ksail.<env>.yaml) is recognised and never reported as an
+// orphan.
 func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 	declared, err := DeriveEnvironments(repoRoot, load)
 	if err != nil {
 		return Plan{}, err
 	}
 
-	overlays, err := listOverlayDirs(filepath.Join(repoRoot, sourceDir, ClustersDir))
+	clustersDir := filepath.Join(repoRoot, sourceDir, ClustersDir)
+	if filepath.IsAbs(sourceDir) {
+		clustersDir = filepath.Join(sourceDir, ClustersDir)
+	}
+
+	overlays, err := listOverlayDirs(clustersDir)
 	if err != nil {
 		return Plan{}, err
 	}
@@ -77,6 +98,13 @@ func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 	declaredNames := make(map[string]struct{}, len(declared))
 
 	for _, env := range declared {
+		if env.Name == BaseEnvName {
+			return Plan{}, fmt.Errorf(
+				"%w: %s declares environment %q, which is the shared clusters/%s overlay",
+				ErrReservedEnvironmentName, env.ConfigFile, env.Name, BaseEnvName,
+			)
+		}
+
 		declaredNames[env.Name] = struct{}{}
 
 		state := OverlayMissing
@@ -91,10 +119,11 @@ func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 		})
 	}
 
+	baseSynced := baseConfigOverlayName(load)
 	orphans := make([]string, 0, len(overlays))
 
 	for name := range overlays {
-		if name == BaseEnvName {
+		if name == BaseEnvName || name == baseSynced {
 			continue
 		}
 
@@ -106,6 +135,28 @@ func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 	slices.SortFunc(orphans, strings.Compare)
 
 	return Plan{Entries: entries, Orphans: orphans}, nil
+}
+
+// baseConfigOverlayName reports the clusters/<name> overlay the workspace's
+// base ksail.yaml syncs via its workload kustomizationFile, or "" when there is
+// no loadable base config or its sync path is not exactly one directory under
+// clusters/. `project init --multi-cluster <env>` scaffolds this initial
+// environment without a ksail.<env>.yaml, so DerivePlan must learn it from the
+// base config to avoid misclassifying its valid overlay as an orphan.
+func baseConfigOverlayName(load ConfigLoader) string {
+	cfg, err := load(baseConfigFileName)
+	if err != nil || cfg == nil {
+		return ""
+	}
+
+	sync := path.Clean(filepath.ToSlash(cfg.Spec.Workload.KustomizationFile))
+
+	dir, name := path.Split(sync)
+	if path.Clean(dir) != ClustersDir || name == "" {
+		return ""
+	}
+
+	return name
 }
 
 // listOverlayDirs enumerates the overlay directory names under clustersAbs. A

--- a/pkg/svc/environment/reconcile.go
+++ b/pkg/svc/environment/reconcile.go
@@ -1,0 +1,133 @@
+package environment
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// ErrDerivePlan is returned by DerivePlan when the clusters/ overlay tree exists
+// but cannot be read (a missing clusters/ directory is a valid pre-scaffold state,
+// not an error, and an environment-discovery failure surfaces as
+// ErrDiscoverEnvironments).
+var ErrDerivePlan = errors.New("failed to derive environment reconcile plan")
+
+// OverlayState classifies a declared environment's clusters/<env>/ overlay in a
+// reconcile plan.
+type OverlayState string
+
+const (
+	// OverlayPresent means the environment's clusters/<env>/ overlay directory
+	// exists. This increment only checks existence; content drift against the
+	// declared config is a later reconcile increment.
+	OverlayPresent OverlayState = "Present"
+	// OverlayMissing means the environment declares a ksail.<env>.yaml root config
+	// but has no clusters/<env>/ overlay directory — the state a reconcile would
+	// resolve by generating the overlay (via the DeriveMultiClusterLayout /
+	// CloneOverlay seams).
+	OverlayMissing OverlayState = "Missing"
+)
+
+// PlanEntry pairs one declared environment with the state of its cluster overlay.
+type PlanEntry struct {
+	// Environment is the declared environment (from DeriveEnvironments).
+	Environment Environment
+	// OverlayDir is the environment's overlay directory relative to the GitOps
+	// source directory, slash-delimited (clusters/<env>).
+	OverlayDir string
+	// State reports whether that overlay directory exists.
+	State OverlayState
+}
+
+// Plan is the read-side reconcile plan for a workspace's declared environments
+// (issue #5441 item 3): which declared environments have their clusters/<env>/
+// overlay and which are missing it, plus the overlay directories nothing
+// declares. It derives purely from the filesystem — no mutation; generation and
+// CLI surfacing are follow-up increments that consume this model.
+type Plan struct {
+	// Entries holds one entry per declared environment, sorted by name.
+	Entries []PlanEntry
+	// Orphans lists overlay directories (relative to the source directory,
+	// slash-delimited) that no ksail.<env>.yaml declares, sorted; the shared
+	// clusters/base/ overlay is not an orphan. Orphans are surfaced for the
+	// operator to resolve — a reconcile must never delete them silently.
+	Orphans []string
+}
+
+// DerivePlan diffs the environments declared by ksail.<env>.yaml root configs in
+// repoRoot against the overlay tree at <repoRoot>/<sourceDir>/clusters/. A
+// missing clusters/ directory is a valid pre-scaffold state: every declared
+// environment is then OverlayMissing and there are no orphans.
+func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
+	declared, err := DeriveEnvironments(repoRoot, load)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	overlays, err := listOverlayDirs(filepath.Join(repoRoot, sourceDir, ClustersDir))
+	if err != nil {
+		return Plan{}, err
+	}
+
+	entries := make([]PlanEntry, 0, len(declared))
+	declaredNames := make(map[string]struct{}, len(declared))
+
+	for _, env := range declared {
+		declaredNames[env.Name] = struct{}{}
+
+		state := OverlayMissing
+		if _, ok := overlays[env.Name]; ok {
+			state = OverlayPresent
+		}
+
+		entries = append(entries, PlanEntry{
+			Environment: env,
+			OverlayDir:  path.Join(ClustersDir, env.Name),
+			State:       state,
+		})
+	}
+
+	orphans := make([]string, 0, len(overlays))
+
+	for name := range overlays {
+		if name == BaseEnvName {
+			continue
+		}
+
+		if _, ok := declaredNames[name]; !ok {
+			orphans = append(orphans, path.Join(ClustersDir, name))
+		}
+	}
+
+	slices.SortFunc(orphans, strings.Compare)
+
+	return Plan{Entries: entries, Orphans: orphans}, nil
+}
+
+// listOverlayDirs enumerates the overlay directory names under clustersAbs. A
+// non-existent clusters/ tree yields an empty set (the pre-scaffold state); any
+// other read failure is surfaced as ErrDerivePlan.
+func listOverlayDirs(clustersAbs string) (map[string]struct{}, error) {
+	entries, err := os.ReadDir(clustersAbs)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]struct{}{}, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDerivePlan, err)
+	}
+
+	overlays := make(map[string]struct{}, len(entries))
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			overlays[entry.Name()] = struct{}{}
+		}
+	}
+
+	return overlays, nil
+}

--- a/pkg/svc/environment/reconcile.go
+++ b/pkg/svc/environment/reconcile.go
@@ -94,12 +94,30 @@ func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 		return Plan{}, err
 	}
 
+	entries, declaredNames, err := planEntries(declared, overlays)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	return Plan{
+		Entries: entries,
+		Orphans: orphanOverlays(overlays, declaredNames, baseConfigOverlayName(load)),
+	}, nil
+}
+
+// planEntries pairs each declared environment with its overlay state, rejecting
+// the reserved base name (see DerivePlan), and returns the declared-name set the
+// orphan scan filters against.
+func planEntries(
+	declared []Environment,
+	overlays map[string]struct{},
+) ([]PlanEntry, map[string]struct{}, error) {
 	entries := make([]PlanEntry, 0, len(declared))
 	declaredNames := make(map[string]struct{}, len(declared))
 
 	for _, env := range declared {
 		if env.Name == BaseEnvName {
-			return Plan{}, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"%w: %s declares environment %q, which is the shared clusters/%s overlay",
 				ErrReservedEnvironmentName, env.ConfigFile, env.Name, BaseEnvName,
 			)
@@ -119,7 +137,17 @@ func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 		})
 	}
 
-	baseSynced := baseConfigOverlayName(load)
+	return entries, declaredNames, nil
+}
+
+// orphanOverlays lists the overlay directories nothing declares, sorted —
+// excluding the shared base overlay and the overlay the base ksail.yaml syncs
+// (baseSynced, "" when there is none).
+func orphanOverlays(
+	overlays map[string]struct{},
+	declaredNames map[string]struct{},
+	baseSynced string,
+) []string {
 	orphans := make([]string, 0, len(overlays))
 
 	for name := range overlays {
@@ -134,7 +162,7 @@ func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 
 	slices.SortFunc(orphans, strings.Compare)
 
-	return Plan{Entries: entries, Orphans: orphans}, nil
+	return orphans
 }
 
 // baseConfigOverlayName reports the clusters/<name> overlay the workspace's

--- a/pkg/svc/environment/reconcile.go
+++ b/pkg/svc/environment/reconcile.go
@@ -49,7 +49,9 @@ type PlanEntry struct {
 // declares. It derives purely from the filesystem — no mutation; generation and
 // CLI surfacing are follow-up increments that consume this model.
 type Plan struct {
-	// Entries holds one entry per declared environment, sorted by name.
+	// Entries holds one entry per declared environment, sorted by name —
+	// including the initial environment the base ksail.yaml declares through
+	// its kustomizationFile (which has no ksail.<env>.yaml of its own).
 	Entries []PlanEntry
 	// Orphans lists overlay directories (relative to the source directory,
 	// slash-delimited) that no ksail.<env>.yaml declares, sorted; the shared
@@ -99,10 +101,55 @@ func DerivePlan(repoRoot, sourceDir string, load ConfigLoader) (Plan, error) {
 		return Plan{}, err
 	}
 
+	entries, declaredNames = appendBaseSyncedEntry(entries, declaredNames, overlays, load)
+
 	return Plan{
 		Entries: entries,
-		Orphans: orphanOverlays(overlays, declaredNames, baseConfigOverlayName(load)),
+		Orphans: orphanOverlays(overlays, declaredNames),
 	}, nil
+}
+
+// appendBaseSyncedEntry adds the environment declared by the base ksail.yaml's
+// kustomizationFile (the initial environment `project init --multi-cluster`
+// scaffolds without a ksail.<env>.yaml) as a first-class plan entry, so a
+// deleted clusters/<env> overlay is reported as Missing — and reconciled — like
+// any other declared environment, rather than only being kept out of the
+// orphan list. A name also declared by its own ksail.<env>.yaml keeps that
+// entry (no duplicate), and a base config syncing the shared clusters/base
+// overlay declares nothing.
+func appendBaseSyncedEntry(
+	entries []PlanEntry,
+	declaredNames map[string]struct{},
+	overlays map[string]struct{},
+	load ConfigLoader,
+) ([]PlanEntry, map[string]struct{}) {
+	baseEnv, ok := baseConfigEnvironment(load)
+	if !ok || baseEnv.Name == BaseEnvName {
+		return entries, declaredNames
+	}
+
+	if _, dup := declaredNames[baseEnv.Name]; dup {
+		return entries, declaredNames
+	}
+
+	declaredNames[baseEnv.Name] = struct{}{}
+
+	state := OverlayMissing
+	if _, exists := overlays[baseEnv.Name]; exists {
+		state = OverlayPresent
+	}
+
+	entries = append(entries, PlanEntry{
+		Environment: baseEnv,
+		OverlayDir:  path.Join(ClustersDir, baseEnv.Name),
+		State:       state,
+	})
+
+	slices.SortFunc(entries, func(left, right PlanEntry) int {
+		return strings.Compare(left.Environment.Name, right.Environment.Name)
+	})
+
+	return entries, declaredNames
 }
 
 // planEntries pairs each declared environment with its overlay state, rejecting
@@ -141,17 +188,16 @@ func planEntries(
 }
 
 // orphanOverlays lists the overlay directories nothing declares, sorted —
-// excluding the shared base overlay and the overlay the base ksail.yaml syncs
-// (baseSynced, "" when there is none).
+// excluding the shared base overlay (declaredNames already includes the
+// overlay the base ksail.yaml syncs, via appendBaseSyncedEntry).
 func orphanOverlays(
 	overlays map[string]struct{},
 	declaredNames map[string]struct{},
-	baseSynced string,
 ) []string {
 	orphans := make([]string, 0, len(overlays))
 
 	for name := range overlays {
-		if name == BaseEnvName || name == baseSynced {
+		if name == BaseEnvName {
 			continue
 		}
 
@@ -165,26 +211,32 @@ func orphanOverlays(
 	return orphans
 }
 
-// baseConfigOverlayName reports the clusters/<name> overlay the workspace's
-// base ksail.yaml syncs via its workload kustomizationFile, or "" when there is
-// no loadable base config or its sync path is not exactly one directory under
-// clusters/. `project init --multi-cluster <env>` scaffolds this initial
-// environment without a ksail.<env>.yaml, so DerivePlan must learn it from the
-// base config to avoid misclassifying its valid overlay as an orphan.
-func baseConfigOverlayName(load ConfigLoader) string {
+// baseConfigEnvironment derives the environment the workspace's base
+// ksail.yaml declares through its workload kustomizationFile (clusters/<name>),
+// reporting ok=false when there is no loadable base config or its sync path is
+// not exactly one directory under clusters/. `project init --multi-cluster
+// <env>` scaffolds this initial environment without a ksail.<env>.yaml, so
+// DerivePlan must learn it from the base config: its overlay is a real plan
+// entry (reported Missing when deleted), never an orphan.
+func baseConfigEnvironment(load ConfigLoader) (Environment, bool) {
 	cfg, err := load(baseConfigFileName)
 	if err != nil || cfg == nil {
-		return ""
+		return Environment{}, false
 	}
 
 	sync := path.Clean(filepath.ToSlash(cfg.Spec.Workload.KustomizationFile))
 
 	dir, name := path.Split(sync)
 	if path.Clean(dir) != ClustersDir || name == "" {
-		return ""
+		return Environment{}, false
 	}
 
-	return name
+	return Environment{
+		Name:         name,
+		ConfigFile:   baseConfigFileName,
+		Distribution: cfg.Spec.Cluster.Distribution,
+		Provider:     cfg.Spec.Cluster.Provider,
+	}, true
 }
 
 // listOverlayDirs enumerates the overlay directory names under clustersAbs. A

--- a/pkg/svc/environment/reconcile_test.go
+++ b/pkg/svc/environment/reconcile_test.go
@@ -205,9 +205,64 @@ func TestDerivePlanKeepsBaseConfigSyncedOverlayOutOfOrphans(t *testing.T) {
 	plan, err := environment.DerivePlan(dir, sourceDir, loader)
 
 	require.NoError(t, err)
-	require.Len(t, plan.Entries, 1)
-	assert.Equal(t, "prod", plan.Entries[0].Environment.Name)
+	// The base-synced environment is a first-class entry (ConfigFile
+	// ksail.yaml), not merely excluded from the orphans.
+	require.Len(t, plan.Entries, 2)
+	assert.Equal(t, "local", plan.Entries[0].Environment.Name)
+	assert.Equal(t, "ksail.yaml", plan.Entries[0].Environment.ConfigFile)
+	assert.Equal(t, environment.OverlayPresent, plan.Entries[0].State)
+	assert.Equal(t, "prod", plan.Entries[1].Environment.Name)
 	assert.Equal(t, []string{"clusters/attic"}, plan.Orphans)
+}
+
+func TestDerivePlanReportsBaseSyncedOverlayMissing(t *testing.T) {
+	t.Parallel()
+
+	// The init-scaffolded initial environment has no ksail.<env>.yaml; when its
+	// clusters/<env> overlay was deleted, the plan must report it Missing so a
+	// reconcile can regenerate it — not silently omit it.
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.yaml")
+	mkOverlays(t, dir, "attic")
+
+	base := clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+	base.Spec.Workload.KustomizationFile = "clusters/local"
+
+	loader := stubLoader(map[string]*v1alpha1.Cluster{"ksail.yaml": base})
+
+	plan, err := environment.DerivePlan(dir, sourceDir, loader)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, "local", plan.Entries[0].Environment.Name)
+	assert.Equal(t, "ksail.yaml", plan.Entries[0].Environment.ConfigFile)
+	assert.Equal(t, environment.OverlayMissing, plan.Entries[0].State)
+	assert.Equal(t, []string{"clusters/attic"}, plan.Orphans)
+}
+
+func TestDerivePlanPrefersDeclaredConfigOverBaseSync(t *testing.T) {
+	t.Parallel()
+
+	// When ksail.local.yaml exists AND the base config syncs clusters/local,
+	// the dedicated config's entry wins — no duplicate.
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.yaml", "ksail.local.yaml")
+	mkOverlays(t, dir, "local")
+
+	base := clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+	base.Spec.Workload.KustomizationFile = "clusters/local"
+
+	loader := stubLoader(map[string]*v1alpha1.Cluster{
+		"ksail.yaml":       base,
+		"ksail.local.yaml": clusterConfig(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner),
+	})
+
+	plan, err := environment.DerivePlan(dir, sourceDir, loader)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, "ksail.local.yaml", plan.Entries[0].Environment.ConfigFile)
+	assert.Empty(t, plan.Orphans)
 }
 
 func TestDerivePlanIgnoresBaseConfigSyncPathsOutsideClusters(t *testing.T) {

--- a/pkg/svc/environment/reconcile_test.go
+++ b/pkg/svc/environment/reconcile_test.go
@@ -1,0 +1,147 @@
+package environment_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sourceDir mirrors the conventional GitOps source directory the plan diffs
+// against in these tests.
+const sourceDir = "k8s"
+
+// mkOverlays creates <dir>/<sourceDir>/clusters/<name> directories.
+func mkOverlays(t *testing.T, dir string, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		require.NoError(
+			t,
+			os.MkdirAll(filepath.Join(dir, sourceDir, environment.ClustersDir, name), 0o750),
+		)
+	}
+}
+
+func planLoader() environment.ConfigLoader {
+	return stubLoader(map[string]*v1alpha1.Cluster{
+		"ksail.local.yaml": clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker),
+		"ksail.prod.yaml":  clusterConfig(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner),
+	})
+}
+
+func TestDerivePlanReportsPresentAndMissingOverlays(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.yaml", "ksail.local.yaml", "ksail.prod.yaml")
+	mkOverlays(t, dir, "prod")
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+
+	require.NoError(t, err)
+	require.Len(t, plan.Entries, 2)
+	assert.Equal(t, "local", plan.Entries[0].Environment.Name)
+	assert.Equal(t, "clusters/local", plan.Entries[0].OverlayDir)
+	assert.Equal(t, environment.OverlayMissing, plan.Entries[0].State)
+	assert.Equal(t, "prod", plan.Entries[1].Environment.Name)
+	assert.Equal(t, "clusters/prod", plan.Entries[1].OverlayDir)
+	assert.Equal(t, environment.OverlayPresent, plan.Entries[1].State)
+	assert.Empty(t, plan.Orphans)
+}
+
+func TestDerivePlanReportsOrphanOverlaysExcludingBase(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.prod.yaml")
+	mkOverlays(t, dir, "prod", "base", "staging", "attic")
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+
+	require.NoError(t, err)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, environment.OverlayPresent, plan.Entries[0].State)
+	assert.Equal(t, []string{"clusters/attic", "clusters/staging"}, plan.Orphans)
+}
+
+func TestDerivePlanTreatsMissingClustersTreeAsPreScaffold(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+
+	require.NoError(t, err)
+	require.Len(t, plan.Entries, 2)
+
+	for _, entry := range plan.Entries {
+		assert.Equal(t, environment.OverlayMissing, entry.State)
+	}
+
+	assert.Empty(t, plan.Orphans)
+}
+
+func TestDerivePlanIgnoresFilesInClustersTree(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.prod.yaml")
+	mkOverlays(t, dir, "prod")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, sourceDir, environment.ClustersDir, "README.md"),
+		[]byte("not an overlay\n"),
+		0o600,
+	))
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+
+	require.NoError(t, err)
+	assert.Empty(t, plan.Orphans)
+}
+
+func TestDerivePlanEmptyWorkspaceYieldsEmptyPlan(t *testing.T) {
+	t.Parallel()
+
+	plan, err := environment.DerivePlan(t.TempDir(), sourceDir, planLoader())
+
+	require.NoError(t, err)
+	assert.Empty(t, plan.Entries)
+	assert.Empty(t, plan.Orphans)
+}
+
+func TestDerivePlanErrorsOnUnreadableWorkspace(t *testing.T) {
+	t.Parallel()
+
+	_, err := environment.DerivePlan(
+		filepath.Join(t.TempDir(), "does-not-exist"),
+		sourceDir,
+		planLoader(),
+	)
+
+	require.ErrorIs(t, err, environment.ErrDiscoverEnvironments)
+}
+
+func TestDerivePlanErrorsOnUnreadableClustersTree(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.prod.yaml")
+	// A regular FILE at the clusters/ path makes ReadDir fail with ENOTDIR —
+	// distinct from the valid missing-directory pre-scaffold state.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, sourceDir), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, sourceDir, environment.ClustersDir),
+		[]byte("a file, not a directory\n"),
+		0o600,
+	))
+
+	_, err := environment.DerivePlan(dir, sourceDir, planLoader())
+
+	require.ErrorIs(t, err, environment.ErrDerivePlan)
+}

--- a/pkg/svc/environment/reconcile_test.go
+++ b/pkg/svc/environment/reconcile_test.go
@@ -15,6 +15,10 @@ import (
 // against in these tests.
 const sourceDir = "k8s"
 
+// localOverlayDir is the overlay directory the base config's kustomizationFile
+// points at in the base-sync test cases.
+const localOverlayDir = "clusters/local"
+
 // mkOverlays creates <dir>/<sourceDir>/clusters/<name> directories.
 func mkOverlays(t *testing.T, dir string, names ...string) {
 	t.Helper()
@@ -46,7 +50,7 @@ func TestDerivePlanReportsPresentAndMissingOverlays(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, plan.Entries, 2)
 	assert.Equal(t, "local", plan.Entries[0].Environment.Name)
-	assert.Equal(t, "clusters/local", plan.Entries[0].OverlayDir)
+	assert.Equal(t, localOverlayDir, plan.Entries[0].OverlayDir)
 	assert.Equal(t, environment.OverlayMissing, plan.Entries[0].State)
 	assert.Equal(t, "prod", plan.Entries[1].Environment.Name)
 	assert.Equal(t, "clusters/prod", plan.Entries[1].OverlayDir)
@@ -195,7 +199,7 @@ func TestDerivePlanKeepsBaseConfigSyncedOverlayOutOfOrphans(t *testing.T) {
 	mkOverlays(t, dir, "local", "prod", "attic")
 
 	base := clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
-	base.Spec.Workload.KustomizationFile = "clusters/local"
+	base.Spec.Workload.KustomizationFile = localOverlayDir
 
 	loader := stubLoader(map[string]*v1alpha1.Cluster{
 		"ksail.yaml":      base,
@@ -226,7 +230,7 @@ func TestDerivePlanReportsBaseSyncedOverlayMissing(t *testing.T) {
 	mkOverlays(t, dir, "attic")
 
 	base := clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
-	base.Spec.Workload.KustomizationFile = "clusters/local"
+	base.Spec.Workload.KustomizationFile = localOverlayDir
 
 	loader := stubLoader(map[string]*v1alpha1.Cluster{"ksail.yaml": base})
 
@@ -250,7 +254,7 @@ func TestDerivePlanPrefersDeclaredConfigOverBaseSync(t *testing.T) {
 	mkOverlays(t, dir, "local")
 
 	base := clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
-	base.Spec.Workload.KustomizationFile = "clusters/local"
+	base.Spec.Workload.KustomizationFile = localOverlayDir
 
 	loader := stubLoader(map[string]*v1alpha1.Cluster{
 		"ksail.yaml":       base,

--- a/pkg/svc/environment/reconcile_test.go
+++ b/pkg/svc/environment/reconcile_test.go
@@ -145,3 +145,88 @@ func TestDerivePlanErrorsOnUnreadableClustersTree(t *testing.T) {
 
 	require.ErrorIs(t, err, environment.ErrDerivePlan)
 }
+
+func TestDerivePlanAcceptsAbsoluteSourceDirectory(t *testing.T) {
+	t.Parallel()
+
+	// The ksail config manager absolutizes Spec.Workload.SourceDirectory before
+	// handing it downstream; joining that against repoRoot again would probe
+	// <repo>/<repo>/k8s/clusters and misread every overlay as Missing.
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.prod.yaml")
+	mkOverlays(t, dir, "prod", "attic")
+
+	plan, err := environment.DerivePlan(dir, filepath.Join(dir, sourceDir), planLoader())
+
+	require.NoError(t, err)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, environment.OverlayPresent, plan.Entries[0].State)
+	assert.Equal(t, []string{"clusters/attic"}, plan.Orphans)
+}
+
+func TestDerivePlanRejectsReservedBaseEnvironment(t *testing.T) {
+	t.Parallel()
+
+	// ksail.base.yaml would map onto the SHARED clusters/base overlay; the plan
+	// must surface the name collision DeriveMultiClusterLayout reserves instead
+	// of reporting the shared base as that environment's Present overlay.
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.base.yaml", "ksail.prod.yaml")
+	mkOverlays(t, dir, "base", "prod")
+
+	loader := stubLoader(map[string]*v1alpha1.Cluster{
+		"ksail.base.yaml": clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker),
+		"ksail.prod.yaml": clusterConfig(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner),
+	})
+
+	_, err := environment.DerivePlan(dir, sourceDir, loader)
+
+	require.ErrorIs(t, err, environment.ErrReservedEnvironmentName)
+}
+
+func TestDerivePlanKeepsBaseConfigSyncedOverlayOutOfOrphans(t *testing.T) {
+	t.Parallel()
+
+	// `project init --multi-cluster local` scaffolds ksail.yaml with
+	// kustomizationFile clusters/local and NO ksail.local.yaml: that initial
+	// overlay is declared by the base config, not an orphan.
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.yaml", "ksail.prod.yaml")
+	mkOverlays(t, dir, "local", "prod", "attic")
+
+	base := clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+	base.Spec.Workload.KustomizationFile = "clusters/local"
+
+	loader := stubLoader(map[string]*v1alpha1.Cluster{
+		"ksail.yaml":      base,
+		"ksail.prod.yaml": clusterConfig(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner),
+	})
+
+	plan, err := environment.DerivePlan(dir, sourceDir, loader)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, "prod", plan.Entries[0].Environment.Name)
+	assert.Equal(t, []string{"clusters/attic"}, plan.Orphans)
+}
+
+func TestDerivePlanIgnoresBaseConfigSyncPathsOutsideClusters(t *testing.T) {
+	t.Parallel()
+
+	// A base config syncing something that is not exactly clusters/<name>
+	// (deeper path, empty, or elsewhere) declares no initial environment.
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.yaml")
+	mkOverlays(t, dir, "attic")
+
+	base := clusterConfig(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+	base.Spec.Workload.KustomizationFile = "clusters/local/deeper"
+
+	loader := stubLoader(map[string]*v1alpha1.Cluster{"ksail.yaml": base})
+
+	plan, err := environment.DerivePlan(dir, sourceDir, loader)
+
+	require.NoError(t, err)
+	assert.Empty(t, plan.Entries)
+	assert.Equal(t, []string{"clusters/attic"}, plan.Orphans)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Item 3 of the multi-cluster epic (declarative environments) needs a foundation that can say what the workspace's declared environments actually require: which `ksail.<env>.yaml` configs are missing their cluster overlay, and which overlays nothing declares.

## What

Adds the pure read-side reconcile plan — per declared environment its overlay Present/Missing state plus the orphan overlay list (never deleted, only surfaced). Overlay generation and CLI surfacing are the follow-up increments that consume this model.

Fixes #6053. Part of #5441.
