### PR TITLE
fix(release): hand off generated cask drafts safely

### DIFF
--- a/.github/fixtures/cask-pr-handoff/fake-bin/gh
+++ b/.github/fixtures/cask-pr-handoff/fake-bin/gh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scenario="${FAKE_GH_SCENARIO:-valid}"
+command_line="$*"
+
+if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls/42" ]]; then
+  [[ "${scenario}" == pr-failure ]] && exit 1
+  printf '%s\n' '{
+    "state":"open",
+    "draft":true,
+    "user":{"login":"devantler"},
+    "head":{"ref":"goreleaser/ksail-v7.166.1","sha":"1111111111111111111111111111111111111111","repo":{"full_name":"devantler-tech/homebrew-tap"}},
+    "base":{"ref":"main"},
+    "title":"chore(cask): update ksail to v7.166.1",
+    "labels":[{"name":"automation"},{"name":"dependencies"}]
+  }'
+elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/pulls/42/files?per_page=100" ]]; then
+  [[ "${scenario}" == files-failure ]] && exit 1
+  if [[ "${scenario}" == malformed-files ]]; then
+    printf '%s\n' '{}'
+  elif [[ "${scenario}" == paginated-files ]]; then
+    printf '%s\n' '[[{"filename":"Casks/ksail.rb"}],[{"filename":"README.md"}]]'
+  else
+    printf '%s\n' '[[{"filename":"Casks/ksail.rb"}]]'
+  fi
+elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/labels?per_page=100" ]]; then
+  [[ "${scenario}" == labels-failure ]] && exit 1
+  if [[ "${scenario}" == malformed-labels ]]; then
+    printf '%s\n' '[[{}]]'
+  else
+    printf '%s\n' '[[{"name":"automation"}],[{"name":"dependencies"}]]'
+  fi
+else
+  printf 'unexpected fake gh invocation: %s\n' "${command_line}" >&2
+  exit 2
+fi

--- a/.github/fixtures/cask-pr-handoff/fake-bin/gh
+++ b/.github/fixtures/cask-pr-handoff/fake-bin/gh
@@ -6,8 +6,8 @@ scenario="${FAKE_GH_SCENARIO:-valid}"
 command_line="$*"
 
 if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls/42" ]]; then
-  [[ "${scenario}" == pr-failure ]] && exit 1
-  printf '%s\n' '{
+	[[ "${scenario}" == pr-failure ]] && exit 1
+	printf '%s\n' '{
     "state":"open",
     "draft":true,
     "user":{"login":"devantler"},
@@ -17,22 +17,22 @@ if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls/42" ]]; 
     "labels":[{"name":"automation"},{"name":"dependencies"}]
   }'
 elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/pulls/42/files?per_page=100" ]]; then
-  [[ "${scenario}" == files-failure ]] && exit 1
-  if [[ "${scenario}" == malformed-files ]]; then
-    printf '%s\n' '{}'
-  elif [[ "${scenario}" == paginated-files ]]; then
-    printf '%s\n' '[[{"filename":"Casks/ksail.rb"}],[{"filename":"README.md"}]]'
-  else
-    printf '%s\n' '[[{"filename":"Casks/ksail.rb"}]]'
-  fi
+	[[ "${scenario}" == files-failure ]] && exit 1
+	if [[ "${scenario}" == malformed-files ]]; then
+		printf '%s\n' '{}'
+	elif [[ "${scenario}" == paginated-files ]]; then
+		printf '%s\n' '[[{"filename":"Casks/ksail.rb"}],[{"filename":"README.md"}]]'
+	else
+		printf '%s\n' '[[{"filename":"Casks/ksail.rb"}]]'
+	fi
 elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/labels?per_page=100" ]]; then
-  [[ "${scenario}" == labels-failure ]] && exit 1
-  if [[ "${scenario}" == malformed-labels ]]; then
-    printf '%s\n' '[[{}]]'
-  else
-    printf '%s\n' '[[{"name":"automation"}],[{"name":"dependencies"}]]'
-  fi
+	[[ "${scenario}" == labels-failure ]] && exit 1
+	if [[ "${scenario}" == malformed-labels ]]; then
+		printf '%s\n' '[[{}]]'
+	else
+		printf '%s\n' '[[{"name":"automation"}],[{"name":"dependencies"}]]'
+	fi
 else
-  printf 'unexpected fake gh invocation: %s\n' "${command_line}" >&2
-  exit 2
+	printf 'unexpected fake gh invocation: %s\n' "${command_line}" >&2
+	exit 2
 fi

--- a/.github/fixtures/cask-pr-handoff/valid.json
+++ b/.github/fixtures/cask-pr-handoff/valid.json
@@ -1,0 +1,44 @@
+{
+  "pr": {
+    "state": "open",
+    "draft": true,
+    "user": {
+      "login": "devantler"
+    },
+    "head": {
+      "ref": "goreleaser/ksail-v7.166.1",
+      "sha": "1111111111111111111111111111111111111111",
+      "repo": {
+        "full_name": "devantler-tech/homebrew-tap"
+      }
+    },
+    "base": {
+      "ref": "main"
+    },
+    "title": "chore(cask): update ksail to v7.166.1",
+    "labels": [
+      {
+        "name": "automation"
+      },
+      {
+        "name": "dependencies"
+      }
+    ]
+  },
+  "files": [
+    {
+      "filename": "Casks/ksail.rb"
+    }
+  ],
+  "availableLabels": [
+    {
+      "name": "automation"
+    },
+    {
+      "name": "dependencies"
+    },
+    {
+      "name": "documentation"
+    }
+  ]
+}

--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -19,63 +19,63 @@ awk '
 ' "${cd_workflow}" >"${homebrew_block}"
 
 awk '1' \
-  "${homebrew_block}" \
-  "${repo_root}/.github/scripts/collect-cask-pr-handoff.sh" \
-  "${repo_root}/.github/scripts/validate-cask-pr-handoff.sh" \
-  >"${execution_surface}"
+	"${homebrew_block}" \
+	"${repo_root}/.github/scripts/collect-cask-pr-handoff.sh" \
+	"${repo_root}/.github/scripts/validate-cask-pr-handoff.sh" \
+	>"${execution_surface}"
 
 fail() {
-  printf 'FAIL: %s\n' "$1" >&2
-  exit 1
+	printf 'FAIL: %s\n' "$1" >&2
+	exit 1
 }
 
 assert_contains() {
-  local pattern="$1" file="$2" message="$3"
-  grep -Fq -- "${pattern}" "${file}" || fail "${message}"
+	local pattern="$1" file="$2" message="$3"
+	grep -Fq -- "${pattern}" "${file}" || fail "${message}"
 }
 
 assert_not_contains() {
-  local pattern="$1" file="$2" message="$3"
-  if grep -Fq -- "${pattern}" "${file}"; then
-    fail "${message}"
-  fi
+	local pattern="$1" file="$2" message="$3"
+	if grep -Fq -- "${pattern}" "${file}"; then
+		fail "${message}"
+	fi
 }
 
 assert_contains 'name: 🍺 Prepare Homebrew cask PRs' "${homebrew_block}" \
-  'release job must be a prepare-and-handoff step'
+	'release job must be a prepare-and-handoff step'
 assert_contains 'validate-cask-pr-handoff.sh' "${homebrew_block}" \
-  'release job must validate generated PR identity and file scope'
+	'release job must validate generated PR identity and file scope'
 assert_contains 'collect-cask-pr-handoff.sh' "${homebrew_block}" \
-  'release job must use the behavior-tested paginated collector'
+	'release job must use the behavior-tested paginated collector'
 assert_contains 'title="chore(cask): update ${name} to ${TAG}"' "${homebrew_block}" \
-  'release job must normalize the Conventional title'
+	'release job must normalize the Conventional title'
 assert_contains 'for label in automation dependencies' "${homebrew_block}" \
-  'release job must add available automation/dependencies labels'
+	'release job must add available automation/dependencies labels'
 assert_contains 'remains draft/open for maintainer promotion' "${homebrew_block}" \
-  'release job must record the draft PR handoff'
+	'release job must record the draft PR handoff'
 assert_not_contains 'gh pr ready' "${execution_surface}" \
-  'release job and its helpers must never self-promote a generated draft'
+	'release job and its helpers must never self-promote a generated draft'
 assert_not_contains 'gh pr merge' "${execution_surface}" \
-  'release job and its helpers must never merge a generated cask PR'
+	'release job and its helpers must never merge a generated cask PR'
 assert_not_contains '--auto' "${execution_surface}" \
-  'release job and its helpers must never arm auto-merge'
+	'release job and its helpers must never arm auto-merge'
 assert_not_contains '--admin' "${execution_surface}" \
-  'release job and its helpers must never bypass branch protections'
+	'release job and its helpers must never bypass branch protections'
 
 validator_calls="$(grep -Fc -- 'validate_handoff "$pr"' "${homebrew_block}" || true)"
 if [ "${validator_calls}" -lt 3 ]; then
-  fail "expected pre-style, post-style, and prepared validation; found ${validator_calls} calls"
+	fail "expected pre-style, post-style, and prepared validation; found ${validator_calls} calls"
 fi
 
 assert_contains 'if: always() && needs.publish-release.result != '\''success'\''' "${cd_workflow}" \
-  'a pending cask handoff must not delete a published release'
+	'a pending cask handoff must not delete a published release'
 assert_contains 'cask-pr-handoff:' "${ci_workflow}" \
-  'CI must include the cask PR handoff fixture job'
+	'CI must include the cask PR handoff fixture job'
 assert_contains '.github/scripts/validate-cask-pr-handoff.test.sh' "${ci_workflow}" \
-  'CI must execute the handoff fixture suite'
+	'CI must execute the handoff fixture suite'
 assert_contains '.github/scripts/collect-cask-pr-handoff.test.sh' "${ci_workflow}" \
-  'CI must execute the handoff collector suite'
+	'CI must execute the handoff collector suite'
 assert_contains '.github/scripts/cask-pr-handoff-workflow.test.sh' "${ci_workflow}" \
-  'CI must execute the handoff workflow contract suite'
+	'CI must execute the handoff workflow contract suite'
 
 printf 'Cask PR handoff workflow contract passed.\n'

--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # Assertions intentionally match literal workflow shell variables.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+cd_workflow="${repo_root}/.github/workflows/cd.yaml"
+ci_workflow="${repo_root}/.github/workflows/ci.yaml"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+homebrew_block="${tmp_dir}/homebrew.yaml"
+execution_surface="${tmp_dir}/execution-surface.sh"
+
+awk '
+  /^  homebrew:/ { in_homebrew = 1 }
+  /^  cleanup-failed-release:/ { in_homebrew = 0 }
+  in_homebrew { print }
+' "${cd_workflow}" >"${homebrew_block}"
+
+awk '1' \
+  "${homebrew_block}" \
+  "${repo_root}/.github/scripts/collect-cask-pr-handoff.sh" \
+  "${repo_root}/.github/scripts/validate-cask-pr-handoff.sh" \
+  >"${execution_surface}"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local pattern="$1" file="$2" message="$3"
+  grep -Fq -- "${pattern}" "${file}" || fail "${message}"
+}
+
+assert_not_contains() {
+  local pattern="$1" file="$2" message="$3"
+  if grep -Fq -- "${pattern}" "${file}"; then
+    fail "${message}"
+  fi
+}
+
+assert_contains 'name: 🍺 Prepare Homebrew cask PRs' "${homebrew_block}" \
+  'release job must be a prepare-and-handoff step'
+assert_contains 'validate-cask-pr-handoff.sh' "${homebrew_block}" \
+  'release job must validate generated PR identity and file scope'
+assert_contains 'collect-cask-pr-handoff.sh' "${homebrew_block}" \
+  'release job must use the behavior-tested paginated collector'
+assert_contains 'title="chore(cask): update ${name} to ${TAG}"' "${homebrew_block}" \
+  'release job must normalize the Conventional title'
+assert_contains 'for label in automation dependencies' "${homebrew_block}" \
+  'release job must add available automation/dependencies labels'
+assert_contains 'remains draft/open for maintainer promotion' "${homebrew_block}" \
+  'release job must record the draft PR handoff'
+assert_not_contains 'gh pr ready' "${execution_surface}" \
+  'release job and its helpers must never self-promote a generated draft'
+assert_not_contains 'gh pr merge' "${execution_surface}" \
+  'release job and its helpers must never merge a generated cask PR'
+assert_not_contains '--auto' "${execution_surface}" \
+  'release job and its helpers must never arm auto-merge'
+assert_not_contains '--admin' "${execution_surface}" \
+  'release job and its helpers must never bypass branch protections'
+
+validator_calls="$(grep -Fc -- 'validate_handoff "$pr"' "${homebrew_block}" || true)"
+if [ "${validator_calls}" -lt 3 ]; then
+  fail "expected pre-style, post-style, and prepared validation; found ${validator_calls} calls"
+fi
+
+assert_contains 'if: always() && needs.publish-release.result != '\''success'\''' "${cd_workflow}" \
+  'a pending cask handoff must not delete a published release'
+assert_contains 'cask-pr-handoff:' "${ci_workflow}" \
+  'CI must include the cask PR handoff fixture job'
+assert_contains '.github/scripts/validate-cask-pr-handoff.test.sh' "${ci_workflow}" \
+  'CI must execute the handoff fixture suite'
+assert_contains '.github/scripts/collect-cask-pr-handoff.test.sh' "${ci_workflow}" \
+  'CI must execute the handoff collector suite'
+assert_contains '.github/scripts/cask-pr-handoff-workflow.test.sh' "${ci_workflow}" \
+  'CI must execute the handoff workflow contract suite'
+
+printf 'Cask PR handoff workflow contract passed.\n'

--- a/.github/scripts/collect-cask-pr-handoff.sh
+++ b/.github/scripts/collect-cask-pr-handoff.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage:
   collect-cask-pr-handoff.sh --tap OWNER/REPO --pr NUMBER --output FILE
 
@@ -18,35 +18,35 @@ pr=""
 output=""
 
 while (($# > 0)); do
-  case "$1" in
-    --tap)
-      tap="${2:-}"
-      shift 2
-      ;;
-    --pr)
-      pr="${2:-}"
-      shift 2
-      ;;
-    --output)
-      output="${2:-}"
-      shift 2
-      ;;
-    --help|-h)
-      usage
-      exit 0
-      ;;
-    *)
-      printf 'ERROR: unknown argument: %s\n' "$1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
+	case "$1" in
+	--tap)
+		tap="${2:-}"
+		shift 2
+		;;
+	--pr)
+		pr="${2:-}"
+		shift 2
+		;;
+	--output)
+		output="${2:-}"
+		shift 2
+		;;
+	--help | -h)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'ERROR: unknown argument: %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
 done
 
 if [[ ! "${tap}" =~ ^[^/]+/[^/]+$ || ! "${pr}" =~ ^[1-9][0-9]*$ || -z "${output}" ]]; then
-  printf 'ERROR: --tap OWNER/REPO, --pr NUMBER, and --output FILE are required\n' >&2
-  usage >&2
-  exit 2
+	printf 'ERROR: --tap OWNER/REPO, --pr NUMBER, and --output FILE are required\n' >&2
+	usage >&2
+	exit 2
 fi
 
 work="$(mktemp -d)"
@@ -54,24 +54,24 @@ trap 'rm -rf "${work}"' EXIT
 
 gh api "repos/${tap}/pulls/${pr}" >"${work}/pr.json"
 gh api --paginate --slurp \
-  "repos/${tap}/pulls/${pr}/files?per_page=100" >"${work}/file-pages.json"
+	"repos/${tap}/pulls/${pr}/files?per_page=100" >"${work}/file-pages.json"
 gh api --paginate --slurp \
-  "repos/${tap}/labels?per_page=100" >"${work}/label-pages.json"
+	"repos/${tap}/labels?per_page=100" >"${work}/label-pages.json"
 
 jq -e 'type == "object"' "${work}/pr.json" >/dev/null
 jq -e 'type == "array" and all(.[]; type == "array")' \
-  "${work}/file-pages.json" >/dev/null
+	"${work}/file-pages.json" >/dev/null
 jq -e '
   type == "array"
   and all(.[]; type == "array")
   and all(.[][]; (.name | type == "string" and length > 0))
 ' \
-  "${work}/label-pages.json" >/dev/null
+	"${work}/label-pages.json" >/dev/null
 
 jq -n \
-  --slurpfile pr "${work}/pr.json" \
-  --slurpfile pages "${work}/file-pages.json" \
-  --slurpfile label_pages "${work}/label-pages.json" '
+	--slurpfile pr "${work}/pr.json" \
+	--slurpfile pages "${work}/file-pages.json" \
+	--slurpfile label_pages "${work}/label-pages.json" '
     {
       pr: $pr[0],
       files: [$pages[0][][]],

--- a/.github/scripts/collect-cask-pr-handoff.sh
+++ b/.github/scripts/collect-cask-pr-handoff.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  collect-cask-pr-handoff.sh --tap OWNER/REPO --pr NUMBER --output FILE
+
+Collect a stable normalized snapshot of a generated Homebrew cask pull request:
+REST PR identity, every paginated changed file, and the repository label inventory.
+Any API or response-shape failure exits non-zero without publishing partial output.
+EOF
+}
+
+tap=""
+pr=""
+output=""
+
+while (($# > 0)); do
+  case "$1" in
+    --tap)
+      tap="${2:-}"
+      shift 2
+      ;;
+    --pr)
+      pr="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'ERROR: unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! "${tap}" =~ ^[^/]+/[^/]+$ || ! "${pr}" =~ ^[1-9][0-9]*$ || -z "${output}" ]]; then
+  printf 'ERROR: --tap OWNER/REPO, --pr NUMBER, and --output FILE are required\n' >&2
+  usage >&2
+  exit 2
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+gh api "repos/${tap}/pulls/${pr}" >"${work}/pr.json"
+gh api --paginate --slurp \
+  "repos/${tap}/pulls/${pr}/files?per_page=100" >"${work}/file-pages.json"
+gh api --paginate --slurp \
+  "repos/${tap}/labels?per_page=100" >"${work}/label-pages.json"
+
+jq -e 'type == "object"' "${work}/pr.json" >/dev/null
+jq -e 'type == "array" and all(.[]; type == "array")' \
+  "${work}/file-pages.json" >/dev/null
+jq -e '
+  type == "array"
+  and all(.[]; type == "array")
+  and all(.[][]; (.name | type == "string" and length > 0))
+' \
+  "${work}/label-pages.json" >/dev/null
+
+jq -n \
+  --slurpfile pr "${work}/pr.json" \
+  --slurpfile pages "${work}/file-pages.json" \
+  --slurpfile label_pages "${work}/label-pages.json" '
+    {
+      pr: $pr[0],
+      files: [$pages[0][][]],
+      availableLabels: [$label_pages[0][][]]
+    }
+  ' >"${work}/evidence.json"
+
+mv "${work}/evidence.json" "${output}"

--- a/.github/scripts/collect-cask-pr-handoff.test.sh
+++ b/.github/scripts/collect-cask-pr-handoff.test.sh
@@ -11,17 +11,17 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 
 if [[ ! -x "${fake_bin}/gh" ]]; then
-  printf 'FAIL: tracked fake gh executable is missing: %s\n' "${fake_bin}/gh" >&2
-  exit 1
+	printf 'FAIL: tracked fake gh executable is missing: %s\n' "${fake_bin}/gh" >&2
+	exit 1
 fi
 
 run_collector() {
-  local scenario="$1" output="$2"
-  PATH="${fake_bin}:${PATH}" FAKE_GH_SCENARIO="${scenario}" \
-    "${collector}" \
-      --tap devantler-tech/homebrew-tap \
-      --pr 42 \
-      --output "${output}"
+	local scenario="$1" output="$2"
+	PATH="${fake_bin}:${PATH}" FAKE_GH_SCENARIO="${scenario}" \
+		"${collector}" \
+		--tap devantler-tech/homebrew-tap \
+		--pr 42 \
+		--output "${output}"
 }
 
 valid="${tmp_dir}/valid.json"
@@ -32,33 +32,33 @@ jq -e '
   and (.availableLabels | map(.name)) == ["automation", "dependencies"]
 ' "${valid}" >/dev/null
 "${validator}" \
-  --evidence "${valid}" \
-  --tap devantler-tech/homebrew-tap \
-  --cask-name ksail \
-  --tag v7.166.1 \
-  --prepared >/dev/null
+	--evidence "${valid}" \
+	--tap devantler-tech/homebrew-tap \
+	--cask-name ksail \
+	--tag v7.166.1 \
+	--prepared >/dev/null
 printf 'PASS: collector-to-validator round trip\n'
 
 paginated="${tmp_dir}/paginated.json"
 run_collector paginated-files "${paginated}"
 jq -e '(.files | map(.filename)) == ["Casks/ksail.rb", "README.md"]' \
-  "${paginated}" >/dev/null
+	"${paginated}" >/dev/null
 if "${validator}" \
-    --evidence "${paginated}" \
-    --tap devantler-tech/homebrew-tap \
-    --cask-name ksail \
-    --tag v7.166.1 >/dev/null 2>&1; then
-  printf 'FAIL: validator accepted an extra file from a later API page\n' >&2
-  exit 1
+	--evidence "${paginated}" \
+	--tap devantler-tech/homebrew-tap \
+	--cask-name ksail \
+	--tag v7.166.1 >/dev/null 2>&1; then
+	printf 'FAIL: validator accepted an extra file from a later API page\n' >&2
+	exit 1
 fi
 printf 'PASS: paginated extra file remains visible and blocks\n'
 
 for scenario in pr-failure files-failure labels-failure malformed-files malformed-labels; do
-  if run_collector "${scenario}" "${tmp_dir}/${scenario}.json" >/dev/null 2>&1; then
-    printf 'FAIL: collector accepted %s\n' "${scenario}" >&2
-    exit 1
-  fi
-  printf 'PASS: collector fails closed on %s\n' "${scenario}"
+	if run_collector "${scenario}" "${tmp_dir}/${scenario}.json" >/dev/null 2>&1; then
+		printf 'FAIL: collector accepted %s\n' "${scenario}" >&2
+		exit 1
+	fi
+	printf 'PASS: collector fails closed on %s\n' "${scenario}"
 done
 
 printf 'All cask PR handoff collector cases passed.\n'

--- a/.github/scripts/collect-cask-pr-handoff.test.sh
+++ b/.github/scripts/collect-cask-pr-handoff.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+collector="${script_dir}/collect-cask-pr-handoff.sh"
+validator="${script_dir}/validate-cask-pr-handoff.sh"
+fake_bin="${repo_root}/.github/fixtures/cask-pr-handoff/fake-bin"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+if [[ ! -x "${fake_bin}/gh" ]]; then
+  printf 'FAIL: tracked fake gh executable is missing: %s\n' "${fake_bin}/gh" >&2
+  exit 1
+fi
+
+run_collector() {
+  local scenario="$1" output="$2"
+  PATH="${fake_bin}:${PATH}" FAKE_GH_SCENARIO="${scenario}" \
+    "${collector}" \
+      --tap devantler-tech/homebrew-tap \
+      --pr 42 \
+      --output "${output}"
+}
+
+valid="${tmp_dir}/valid.json"
+run_collector valid "${valid}"
+jq -e '
+  .pr.head.repo.full_name == "devantler-tech/homebrew-tap"
+  and (.files | map(.filename)) == ["Casks/ksail.rb"]
+  and (.availableLabels | map(.name)) == ["automation", "dependencies"]
+' "${valid}" >/dev/null
+"${validator}" \
+  --evidence "${valid}" \
+  --tap devantler-tech/homebrew-tap \
+  --cask-name ksail \
+  --tag v7.166.1 \
+  --prepared >/dev/null
+printf 'PASS: collector-to-validator round trip\n'
+
+paginated="${tmp_dir}/paginated.json"
+run_collector paginated-files "${paginated}"
+jq -e '(.files | map(.filename)) == ["Casks/ksail.rb", "README.md"]' \
+  "${paginated}" >/dev/null
+if "${validator}" \
+    --evidence "${paginated}" \
+    --tap devantler-tech/homebrew-tap \
+    --cask-name ksail \
+    --tag v7.166.1 >/dev/null 2>&1; then
+  printf 'FAIL: validator accepted an extra file from a later API page\n' >&2
+  exit 1
+fi
+printf 'PASS: paginated extra file remains visible and blocks\n'
+
+for scenario in pr-failure files-failure labels-failure malformed-files malformed-labels; do
+  if run_collector "${scenario}" "${tmp_dir}/${scenario}.json" >/dev/null 2>&1; then
+    printf 'FAIL: collector accepted %s\n' "${scenario}" >&2
+    exit 1
+  fi
+  printf 'PASS: collector fails closed on %s\n' "${scenario}"
+done
+
+printf 'All cask PR handoff collector cases passed.\n'

--- a/.github/scripts/validate-cask-pr-handoff.sh
+++ b/.github/scripts/validate-cask-pr-handoff.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage:
   validate-cask-pr-handoff.sh --evidence FILE --tap OWNER/REPO
                               --cask-name NAME --tag TAG [--prepared]
@@ -22,51 +22,51 @@ tag=""
 prepared=false
 
 while (($# > 0)); do
-  case "$1" in
-    --evidence)
-      evidence_file="${2:-}"
-      shift 2
-      ;;
-    --tap)
-      tap="${2:-}"
-      shift 2
-      ;;
-    --cask-name)
-      cask_name="${2:-}"
-      shift 2
-      ;;
-    --tag)
-      tag="${2:-}"
-      shift 2
-      ;;
-    --prepared)
-      prepared=true
-      shift
-      ;;
-    --help|-h)
-      usage
-      exit 0
-      ;;
-    *)
-      printf 'ERROR: unknown argument: %s\n' "$1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
+	case "$1" in
+	--evidence)
+		evidence_file="${2:-}"
+		shift 2
+		;;
+	--tap)
+		tap="${2:-}"
+		shift 2
+		;;
+	--cask-name)
+		cask_name="${2:-}"
+		shift 2
+		;;
+	--tag)
+		tag="${2:-}"
+		shift 2
+		;;
+	--prepared)
+		prepared=true
+		shift
+		;;
+	--help | -h)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'ERROR: unknown argument: %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
 done
 
 if [[ -z "${evidence_file}" || -z "${tap}" || -z "${cask_name}" || -z "${tag}" ]]; then
-  printf 'ERROR: --evidence, --tap, --cask-name, and --tag are required\n' >&2
-  usage >&2
-  exit 2
+	printf 'ERROR: --evidence, --tap, --cask-name, and --tag are required\n' >&2
+	usage >&2
+	exit 2
 fi
 if [[ ! -f "${evidence_file}" ]]; then
-  printf 'ERROR: evidence file does not exist: %s\n' "${evidence_file}" >&2
-  exit 2
+	printf 'ERROR: evidence file does not exist: %s\n' "${evidence_file}" >&2
+	exit 2
 fi
 if ! jq -e . "${evidence_file}" >/dev/null 2>&1; then
-  printf 'BLOCKED: evidence is not valid JSON\n' >&2
-  exit 1
+	printf 'BLOCKED: evidence is not valid JSON\n' >&2
+	exit 1
 fi
 
 expected_head="goreleaser/${cask_name}-${tag}"
@@ -75,81 +75,81 @@ expected_title="chore(cask): update ${cask_name} to ${tag}"
 failures=()
 
 block() {
-  failures+=("$1")
+	failures+=("$1")
 }
 
 json_string() {
-  local expression="$1"
-  jq -r "${expression} // empty" "${evidence_file}" 2>/dev/null || true
+	local expression="$1"
+	jq -r "${expression} // empty" "${evidence_file}" 2>/dev/null || true
 }
 
 if [[ "$(json_string '.pr.state | ascii_downcase')" != "open" ]]; then
-  block 'PR state must be open'
+	block 'PR state must be open'
 fi
 if ! jq -e '.pr.draft == true' "${evidence_file}" >/dev/null 2>&1; then
-  block 'PR must remain a draft for maintainer promotion'
+	block 'PR must remain a draft for maintainer promotion'
 fi
 if [[ "$(json_string '.pr.user.login')" != "devantler" ]]; then
-  block 'PR author must be devantler'
+	block 'PR author must be devantler'
 fi
 if [[ "$(json_string '.pr.head.repo.full_name')" != "${tap}" ]]; then
-  block "head repository must exactly equal ${tap}"
+	block "head repository must exactly equal ${tap}"
 fi
 if [[ "$(json_string '.pr.head.ref')" != "${expected_head}" ]]; then
-  block "head branch must exactly equal ${expected_head}"
+	block "head branch must exactly equal ${expected_head}"
 fi
 if [[ "$(json_string '.pr.base.ref')" != "main" ]]; then
-  block 'base branch must exactly equal main'
+	block 'base branch must exactly equal main'
 fi
 head_sha="$(json_string '.pr.head.sha')"
 if [[ ! "${head_sha}" =~ ^[[:xdigit:]]{40}$ ]]; then
-  block 'head SHA is missing or invalid'
+	block 'head SHA is missing or invalid'
 fi
 
 if ! jq -e '.files | type == "array"' "${evidence_file}" >/dev/null 2>&1; then
-  block 'changed-file evidence is missing'
+	block 'changed-file evidence is missing'
 elif ! jq -e --arg path "${expected_path}" \
-    '.files | length == 1 and .[0].filename == $path' \
-    "${evidence_file}" >/dev/null 2>&1; then
-  block "only ${expected_path} may change"
+	'.files | length == 1 and .[0].filename == $path' \
+	"${evidence_file}" >/dev/null 2>&1; then
+	block "only ${expected_path} may change"
 fi
 
 if [[ "${prepared}" == true ]]; then
-  if [[ "$(json_string '.pr.title')" != "${expected_title}" ]]; then
-    block "title must exactly equal ${expected_title}"
-  fi
-  if ! jq -e '.availableLabels | type == "array"' \
-      "${evidence_file}" >/dev/null 2>&1; then
-    block 'available-label inventory is missing'
-  elif ! jq -e '
+	if [[ "$(json_string '.pr.title')" != "${expected_title}" ]]; then
+		block "title must exactly equal ${expected_title}"
+	fi
+	if ! jq -e '.availableLabels | type == "array"' \
+		"${evidence_file}" >/dev/null 2>&1; then
+		block 'available-label inventory is missing'
+	elif ! jq -e '
       .availableLabels
       | all(.[]; (.name | type == "string" and length > 0))
     ' "${evidence_file}" >/dev/null 2>&1; then
-    block 'available-label inventory is malformed'
-  else
-    for label in automation dependencies; do
-      if jq -e --arg label "${label}" \
-          '.availableLabels | any(.name == $label)' \
-          "${evidence_file}" >/dev/null 2>&1 &&
-        ! jq -e --arg label "${label}" \
-          '.pr.labels | type == "array" and any(.name == $label)' \
-          "${evidence_file}" >/dev/null 2>&1; then
-        block "available label is missing from PR: ${label}"
-      fi
-    done
-  fi
+		block 'available-label inventory is malformed'
+	else
+		for label in automation dependencies; do
+			if jq -e --arg label "${label}" \
+				'.availableLabels | any(.name == $label)' \
+				"${evidence_file}" >/dev/null 2>&1 &&
+				! jq -e --arg label "${label}" \
+					'.pr.labels | type == "array" and any(.name == $label)' \
+					"${evidence_file}" >/dev/null 2>&1; then
+				block "available label is missing from PR: ${label}"
+			fi
+		done
+	fi
 fi
 
 if ((${#failures[@]} > 0)); then
-  printf 'BLOCKED: %d cask PR handoff validation(s) failed\n' "${#failures[@]}" >&2
-  for failure in "${failures[@]}"; do
-    printf -- '- %s\n' "${failure}" >&2
-  done
-  exit 1
+	printf 'BLOCKED: %d cask PR handoff validation(s) failed\n' "${#failures[@]}" >&2
+	for failure in "${failures[@]}"; do
+		printf -- '- %s\n' "${failure}" >&2
+	done
+	exit 1
 fi
 
 if [[ "${prepared}" == true ]]; then
-  printf 'PASS: generated cask PR identity, scope, and metadata are valid at %s\n' "${head_sha}"
+	printf 'PASS: generated cask PR identity, scope, and metadata are valid at %s\n' "${head_sha}"
 else
-  printf 'PASS: generated cask PR identity and scope are valid at %s\n' "${head_sha}"
+	printf 'PASS: generated cask PR identity and scope are valid at %s\n' "${head_sha}"
 fi

--- a/.github/scripts/validate-cask-pr-handoff.sh
+++ b/.github/scripts/validate-cask-pr-handoff.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  validate-cask-pr-handoff.sh --evidence FILE --tap OWNER/REPO
+                              --cask-name NAME --tag TAG [--prepared]
+
+Fail closed unless a GoReleaser cask PR is the expected trusted draft, from the
+tap itself, into main, with exactly its matching cask file. With --prepared,
+also require the normalized title and every requested label that exists in the
+repository's available-label inventory.
+EOF
+}
+
+evidence_file=""
+tap=""
+cask_name=""
+tag=""
+prepared=false
+
+while (($# > 0)); do
+  case "$1" in
+    --evidence)
+      evidence_file="${2:-}"
+      shift 2
+      ;;
+    --tap)
+      tap="${2:-}"
+      shift 2
+      ;;
+    --cask-name)
+      cask_name="${2:-}"
+      shift 2
+      ;;
+    --tag)
+      tag="${2:-}"
+      shift 2
+      ;;
+    --prepared)
+      prepared=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'ERROR: unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${evidence_file}" || -z "${tap}" || -z "${cask_name}" || -z "${tag}" ]]; then
+  printf 'ERROR: --evidence, --tap, --cask-name, and --tag are required\n' >&2
+  usage >&2
+  exit 2
+fi
+if [[ ! -f "${evidence_file}" ]]; then
+  printf 'ERROR: evidence file does not exist: %s\n' "${evidence_file}" >&2
+  exit 2
+fi
+if ! jq -e . "${evidence_file}" >/dev/null 2>&1; then
+  printf 'BLOCKED: evidence is not valid JSON\n' >&2
+  exit 1
+fi
+
+expected_head="goreleaser/${cask_name}-${tag}"
+expected_path="Casks/${cask_name}.rb"
+expected_title="chore(cask): update ${cask_name} to ${tag}"
+failures=()
+
+block() {
+  failures+=("$1")
+}
+
+json_string() {
+  local expression="$1"
+  jq -r "${expression} // empty" "${evidence_file}" 2>/dev/null || true
+}
+
+if [[ "$(json_string '.pr.state | ascii_downcase')" != "open" ]]; then
+  block 'PR state must be open'
+fi
+if ! jq -e '.pr.draft == true' "${evidence_file}" >/dev/null 2>&1; then
+  block 'PR must remain a draft for maintainer promotion'
+fi
+if [[ "$(json_string '.pr.user.login')" != "devantler" ]]; then
+  block 'PR author must be devantler'
+fi
+if [[ "$(json_string '.pr.head.repo.full_name')" != "${tap}" ]]; then
+  block "head repository must exactly equal ${tap}"
+fi
+if [[ "$(json_string '.pr.head.ref')" != "${expected_head}" ]]; then
+  block "head branch must exactly equal ${expected_head}"
+fi
+if [[ "$(json_string '.pr.base.ref')" != "main" ]]; then
+  block 'base branch must exactly equal main'
+fi
+head_sha="$(json_string '.pr.head.sha')"
+if [[ ! "${head_sha}" =~ ^[[:xdigit:]]{40}$ ]]; then
+  block 'head SHA is missing or invalid'
+fi
+
+if ! jq -e '.files | type == "array"' "${evidence_file}" >/dev/null 2>&1; then
+  block 'changed-file evidence is missing'
+elif ! jq -e --arg path "${expected_path}" \
+    '.files | length == 1 and .[0].filename == $path' \
+    "${evidence_file}" >/dev/null 2>&1; then
+  block "only ${expected_path} may change"
+fi
+
+if [[ "${prepared}" == true ]]; then
+  if [[ "$(json_string '.pr.title')" != "${expected_title}" ]]; then
+    block "title must exactly equal ${expected_title}"
+  fi
+  if ! jq -e '.availableLabels | type == "array"' \
+      "${evidence_file}" >/dev/null 2>&1; then
+    block 'available-label inventory is missing'
+  elif ! jq -e '
+      .availableLabels
+      | all(.[]; (.name | type == "string" and length > 0))
+    ' "${evidence_file}" >/dev/null 2>&1; then
+    block 'available-label inventory is malformed'
+  else
+    for label in automation dependencies; do
+      if jq -e --arg label "${label}" \
+          '.availableLabels | any(.name == $label)' \
+          "${evidence_file}" >/dev/null 2>&1 &&
+        ! jq -e --arg label "${label}" \
+          '.pr.labels | type == "array" and any(.name == $label)' \
+          "${evidence_file}" >/dev/null 2>&1; then
+        block "available label is missing from PR: ${label}"
+      fi
+    done
+  fi
+fi
+
+if ((${#failures[@]} > 0)); then
+  printf 'BLOCKED: %d cask PR handoff validation(s) failed\n' "${#failures[@]}" >&2
+  for failure in "${failures[@]}"; do
+    printf -- '- %s\n' "${failure}" >&2
+  done
+  exit 1
+fi
+
+if [[ "${prepared}" == true ]]; then
+  printf 'PASS: generated cask PR identity, scope, and metadata are valid at %s\n' "${head_sha}"
+else
+  printf 'PASS: generated cask PR identity and scope are valid at %s\n' "${head_sha}"
+fi

--- a/.github/scripts/validate-cask-pr-handoff.test.sh
+++ b/.github/scripts/validate-cask-pr-handoff.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+validator="${script_dir}/validate-cask-pr-handoff.sh"
+fixture="${repo_root}/.github/fixtures/cask-pr-handoff/valid.json"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+pass_count=0
+
+run_case() {
+  local name="$1" expected_status="$2" expected_output="$3"
+  local filter="${4:-.}" prepared="${5:-false}"
+  local evidence="${tmp_dir}/${name}.json" output status
+  local args=(--evidence "${evidence}" --tap devantler-tech/homebrew-tap --cask-name ksail --tag v7.166.1)
+
+  jq "${filter}" "${fixture}" >"${evidence}"
+  if [[ "${prepared}" == true ]]; then
+    args+=(--prepared)
+  fi
+
+  set +e
+  output="$(${validator} "${args[@]}" 2>&1)"
+  status=$?
+  set -e
+
+  if [[ "${status}" -ne "${expected_status}" ]]; then
+    printf 'FAIL: %s: expected status %s, got %s\n%s\n' \
+      "${name}" "${expected_status}" "${status}" "${output}" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"${expected_output}"* ]]; then
+    printf 'FAIL: %s: expected output containing %q, got:\n%s\n' \
+      "${name}" "${expected_output}" "${output}" >&2
+    return 1
+  fi
+
+  pass_count=$((pass_count + 1))
+  printf 'PASS: %s\n' "${name}"
+}
+
+run_case valid-draft 0 'PASS: generated cask PR identity and scope are valid'
+run_case prepared 0 'PASS: generated cask PR identity, scope, and metadata are valid' '.' true
+run_case closed 1 'PR state must be open' '.pr.state = "closed"'
+run_case promoted 1 'PR must remain a draft for maintainer promotion' '.pr.draft = false'
+run_case wrong-author 1 'PR author must be devantler' '.pr.user.login = "someone-else"'
+run_case cross-repository 1 'head repository must exactly equal devantler-tech/homebrew-tap' '.pr.head.repo.full_name = "someone-else/homebrew-tap"'
+run_case missing-head-repository 1 'head repository must exactly equal devantler-tech/homebrew-tap' 'del(.pr.head.repo)'
+run_case wrong-branch 1 'head branch must exactly equal goreleaser/ksail-v7.166.1' '.pr.head.ref = "feature/untrusted"'
+run_case wrong-base 1 'base branch must exactly equal main' '.pr.base.ref = "release"'
+run_case invalid-head 1 'head SHA is missing or invalid' '.pr.head.sha = "short"'
+run_case missing-files 1 'changed-file evidence is missing' 'del(.files)'
+run_case extra-file 1 'only Casks/ksail.rb may change' '.files += [{"filename":"README.md"}]'
+run_case wrong-file 1 'only Casks/ksail.rb may change' '.files = [{"filename":"Casks/other.rb"}]'
+run_case missing-title 1 'title must exactly equal chore(cask): update ksail to v7.166.1' '.pr.title = "Brew cask update"' true
+run_case missing-label-inventory 1 'available-label inventory is missing' 'del(.availableLabels)' true
+run_case malformed-label-inventory 1 'available-label inventory is malformed' '.availableLabels = [{}] | .pr.labels = []' true
+run_case missing-label 1 'available label is missing from PR: dependencies' '.pr.labels = [{"name":"automation"}]' true
+run_case unavailable-label 0 'PASS: generated cask PR identity, scope, and metadata are valid' '.availableLabels = [{"name":"automation"}] | .pr.labels = [{"name":"automation"}]' true
+
+printf 'All %d cask PR handoff cases passed.\n' "${pass_count}"

--- a/.github/scripts/validate-cask-pr-handoff.test.sh
+++ b/.github/scripts/validate-cask-pr-handoff.test.sh
@@ -11,34 +11,34 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 pass_count=0
 
 run_case() {
-  local name="$1" expected_status="$2" expected_output="$3"
-  local filter="${4:-.}" prepared="${5:-false}"
-  local evidence="${tmp_dir}/${name}.json" output status
-  local args=(--evidence "${evidence}" --tap devantler-tech/homebrew-tap --cask-name ksail --tag v7.166.1)
+	local name="$1" expected_status="$2" expected_output="$3"
+	local filter="${4:-.}" prepared="${5:-false}"
+	local evidence="${tmp_dir}/${name}.json" output status
+	local args=(--evidence "${evidence}" --tap devantler-tech/homebrew-tap --cask-name ksail --tag v7.166.1)
 
-  jq "${filter}" "${fixture}" >"${evidence}"
-  if [[ "${prepared}" == true ]]; then
-    args+=(--prepared)
-  fi
+	jq "${filter}" "${fixture}" >"${evidence}"
+	if [[ "${prepared}" == true ]]; then
+		args+=(--prepared)
+	fi
 
-  set +e
-  output="$(${validator} "${args[@]}" 2>&1)"
-  status=$?
-  set -e
+	set +e
+	output="$(${validator} "${args[@]}" 2>&1)"
+	status=$?
+	set -e
 
-  if [[ "${status}" -ne "${expected_status}" ]]; then
-    printf 'FAIL: %s: expected status %s, got %s\n%s\n' \
-      "${name}" "${expected_status}" "${status}" "${output}" >&2
-    return 1
-  fi
-  if [[ "${output}" != *"${expected_output}"* ]]; then
-    printf 'FAIL: %s: expected output containing %q, got:\n%s\n' \
-      "${name}" "${expected_output}" "${output}" >&2
-    return 1
-  fi
+	if [[ "${status}" -ne "${expected_status}" ]]; then
+		printf 'FAIL: %s: expected status %s, got %s\n%s\n' \
+			"${name}" "${expected_status}" "${status}" "${output}" >&2
+		return 1
+	fi
+	if [[ "${output}" != *"${expected_output}"* ]]; then
+		printf 'FAIL: %s: expected output containing %q, got:\n%s\n' \
+			"${name}" "${expected_output}" "${output}" >&2
+		return 1
+	fi
 
-  pass_count=$((pass_count + 1))
-  printf 'PASS: %s\n' "${name}"
+	pass_count=$((pass_count + 1))
+	printf 'PASS: %s\n' "${name}"
 }
 
 run_case valid-draft 0 'PASS: generated cask PR identity and scope are valid'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -658,36 +658,31 @@ jobs:
   # GoReleaser opens the Homebrew cask PRs during the build (CLI in `goreleaser`, macOS in
   # `desktop-macos`) as DRAFTS, so the tap cannot merge them while the cask still points at a draft
   # (not-yet-public, 404) release. Now that `publish-release` has made the release public, this job
-  # promotes both PRs and drives them to merge — the final action of a release.
+  # style-cleans and normalizes both PRs, then leaves them as drafts for the maintainer checkpoint.
   #
-  # We do NOT rely on the tap to merge them. The tap's `enable-auto-merge.yaml` is a ruleset-injected
-  # REQUIRED workflow, and GitHub does not re-dispatch required workflows on the `ready_for_review`
-  # activity — only its draft-open run fires, and that run `if: !draft`-skips — so the tap never arms
-  # auto-merge for these PRs (they sat open until merged by hand). Instead we mark each PR ready (so
-  # the tap's Cask audit re-runs against the now-public asset; a draft also can't be merged), wait for
-  # the fresh required checks to pass, then squash-merge from here. Waiting for the post-ready status
-  # (rather than arming auto-merge right after `gh pr ready`) avoids racing the stale draft-time green
-  # status (see #5080). All gates are satisfiable: 0 required approvals, the audit passes against the
-  # public asset, and the required-workflow gate is satisfied by the draft-open skipped run. Keeps the
-  # tap bump strictly after the GitHub release exists. Branches mirror `.goreleaser*.yaml`
-  # (goreleaser/<project>-<tag>).
+  # Promotion and merge are intentionally outside this privileged release job. Review threads,
+  # reviewer verdicts, and editable pre-merge summaries cannot be atomically bound to a client-side
+  # `gh pr merge` call, so even a final poll can race a new negative review without changing the head
+  # SHA. The standard maintainer lane promotes and merges only after its live pentad is green. This job
+  # validates the trusted same-repository draft and exact cask-only scope before and after its style
+  # mutation, normalizes metadata, and records the pending handoff without failing an already-published
+  # release. Branches mirror `.goreleaser*.yaml` (`goreleaser/<project>-<tag>`). See #6067.
   homebrew:
-    name: 🍺 Promote and merge Homebrew cask PRs
+    name: 🍺 Prepare Homebrew cask PRs
     runs-on: ubuntu-latest
-    # Backstop only — the script self-bounds its runtime: brew-style prep (2 clones + `brew style`,
-    # which can bootstrap rubocop on a cold Linuxbrew runner) + `sleep 30` + two sequential
-    # `merge_cask_pr` polls that are additive (each computes `SECONDS + 600`, and bash `SECONDS` is
-    # whole-job elapsed time, never reset) for up to 600s apiece = ~1230s of polling. Worst case is
-    # ~prep + 30s + 1200s, which crowds a 25-min budget; a kill mid-poll would skip the second cask's
-    # fail-soft `--auto` fallback and exit non-zero, failing an already-published release. Keep this
-    # comfortably above the script's own ceiling so its fail-soft logic — not this timeout — is the
-    # binding limit.
-    timeout-minutes: 35
+    # `brew style` can bootstrap rubocop on a cold Linuxbrew runner. Keep enough room for two clones
+    # and style passes; every GitHub mutation below is fail-soft because the release is already public.
+    timeout-minutes: 20
     needs: [publish-release]
     permissions:
       contents: read
     steps:
-      - name: 🍺 Style-clean cask PRs, then drive them to merge
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🍺 Style-clean and prepare cask PR handoffs
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           TAP: devantler-tech/homebrew-tap
@@ -695,61 +690,67 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Poll a ready cask PR until its required checks pass (mergeStateStatus CLEAN), then
-          # squash-merge it. Fail-soft: a stuck cask must never fail an already-published release, so
-          # on timeout we arm auto-merge as a fallback (safe here — we have already waited past the
-          # stale draft-time window) and warn rather than exit non-zero.
-          merge_cask_pr() {
-            local pr="$1" deadline=$((SECONDS + 600)) info state status
-            while [ "$SECONDS" -lt "$deadline" ]; do
-              info="$(gh pr view "$pr" --repo "$TAP" \
-                --json state,mergeStateStatus --jq '.state, .mergeStateStatus' 2>/dev/null || true)"
-              state="$(printf '%s\n' "$info" | sed -n 1p)"
-              status="$(printf '%s\n' "$info" | sed -n 2p)"
-              case "$state" in
-                MERGED) echo "Merged ${TAP}#${pr}"; return 0 ;;
-                CLOSED) echo "::warning::${TAP}#${pr} was closed without merging"; return 0 ;;
-              esac
-              case "$status" in
-                CLEAN)
-                  if gh pr merge "$pr" --repo "$TAP" --squash; then
-                    echo "Merged ${TAP}#${pr}"
-                    return 0
-                  fi
-                  ;;
-                DIRTY)
-                  echo "::warning::${TAP}#${pr} has merge conflicts; merge it manually"
-                  return 0
-                  ;;
-              esac
-              sleep 20
-            done
-            echo "::warning::Timed out waiting for ${TAP}#${pr} to become mergeable; arming auto-merge as a fallback"
-            gh pr merge "$pr" --repo "$TAP" --auto --squash \
-              || echo "::warning::Could not arm auto-merge for ${TAP}#${pr}; merge it manually"
+          collect_handoff_evidence() {
+            .github/scripts/collect-cask-pr-handoff.sh \
+              --tap "$TAP" \
+              --pr "$1" \
+              --output "$2"
           }
 
-          prs=()
+          validate_handoff() {
+            local pr="$1" name="$2" evidence="$3" mode="${4:-draft}"
+            local args=(
+              --evidence "$evidence"
+              --tap "$TAP"
+              --cask-name "$name"
+              --tag "$TAG"
+            )
+            if [ "$mode" = prepared ]; then
+              args+=(--prepared)
+            fi
+            collect_handoff_evidence "$pr" "$evidence" \
+              && .github/scripts/validate-cask-pr-handoff.sh "${args[@]}"
+          }
+
+          if ! evidence_dir="$(mktemp -d)"; then
+            echo "::warning::Could not create cask handoff evidence directory; leaving generated PRs untouched"
+            exit 0
+          fi
+          trap 'rm -rf "$evidence_dir"' EXIT
+
           for name in ksail ksail-desktop; do
             branch="goreleaser/${name}-${TAG}"
             # `|| true` keeps the job fail-soft: a transient `gh pr list` failure (5xx, rate limit,
             # network blip) must not abort the step under `set -e` after the release is already public —
-            # the `-z "$pr"` guard below then warns and skips, same as the no-PR-found case.
-            pr="$(gh pr list --repo "$TAP" --head "$branch" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
-            if [ -z "$pr" ]; then
-              echo "::warning::No open cask PR found on $TAP for branch ${branch}; skipping"
+            # invalid evidence below then warns and skips, same as the no-PR-found case.
+            matches="$(gh pr list --repo "$TAP" --head "$branch" --state open \
+              --limit 2 --json number 2>/dev/null || true)"
+            if ! count="$(jq -er 'length' <<<"$matches" 2>/dev/null)"; then
+              echo "::warning::Could not enumerate cask PRs on $TAP for branch ${branch}; leaving it pending"
               continue
             fi
-            echo "Promoting ${TAP}#${pr} (${branch})"
+            if [ "$count" -ne 1 ]; then
+              echo "::warning::Expected exactly one open cask PR on $TAP for branch ${branch}, found ${count}; leaving it pending"
+              continue
+            fi
+            pr="$(jq -r '.[0].number' <<<"$matches")"
+            evidence="${evidence_dir}/${pr}.json"
+            if ! validation="$(validate_handoff "$pr" "$name" "$evidence" 2>&1)"; then
+              validation="${validation//$'\n'/; }"
+              echo "::warning::Refusing to mutate ${TAP}#${pr}: ${validation}"
+              printf -- '- %s#%s left untouched: %s\n' "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            echo "Preparing ${TAP}#${pr} (${branch})"
 
             # GoReleaser's cask template emits a few `brew style` offenses no config knob can reach
             # (Layout/ArgumentAlignment on url/verified, Cask/StanzaOrder for the custom_block stanzas).
-            # Autocorrect them on the PR branch before promoting so the cask that lands in the tap is
+            # Autocorrect them on the draft PR branch before handoff so the eventual cask is
             # brew-style-clean — letting the tap enforce a `brew style` gate (devantler-tech/homebrew-tap#734).
-            # Fail-soft throughout: a style/clone/push hiccup must never block the release; the cask
-            # still lands (uncorrected) exactly as it does today.
+            # Fail-soft throughout: a style/clone/push hiccup must never block the published release;
+            # the draft remains open for the maintainer lane to correct.
             # `mktemp -d` under `set -e` would abort the job on a tempdir failure; guard it so a
-            # hiccup just skips the (best-effort) autocorrect and still promotes the cask below.
+            # hiccup just skips the (best-effort) autocorrect and continues to the draft handoff.
             if work="$(mktemp -d)"; then
               if git clone --depth 1 --branch "$branch" \
                   "https://x-access-token:${GH_TOKEN}@github.com/${TAP}.git" "$work" 2>/dev/null; then
@@ -768,34 +769,57 @@ jobs:
                       commit -am 'style: brew style --fix generated cask' \
                     && git -C "$work" push \
                     && echo "Pushed brew style --fix autocorrections to ${branch}" \
-                    || echo "::warning::Could not push brew style --fix autocorrections to ${branch}; promoting as-is"
+                    || echo "::warning::Could not push brew style --fix autocorrections to ${branch}; leaving the draft as-is"
                 fi
               else
-                echo "::warning::Could not clone ${TAP} branch ${branch} for brew style --fix; promoting as-is"
+                echo "::warning::Could not clone ${TAP} branch ${branch} for brew style --fix; leaving the draft as-is"
               fi
               rm -rf "$work"
             else
-              echo "::warning::Could not create tempdir for brew style --fix; promoting ${name} cask as-is"
+              echo "::warning::Could not create tempdir for brew style --fix; leaving ${name} draft as-is"
             fi
 
-            # Mark the PR ready so its Cask audit re-runs against the now-public asset and the PR
-            # becomes mergeable; the merge itself is driven below by `merge_cask_pr`. Non-fatal under
-            # `set -e`: the PR may already be ready.
-            gh pr ready "$pr" --repo "$TAP" \
-              || echo "::warning::Could not mark ${TAP}#${pr} ready; it may already be ready"
-            prs+=("$pr")
-          done
+            # Recollect after the possible style push. A concurrent promotion, cross-repository head,
+            # or extra changed file stops all further mutation and leaves the PR to the maintainer.
+            if ! validation="$(validate_handoff "$pr" "$name" "$evidence" 2>&1)"; then
+              validation="${validation//$'\n'/; }"
+              echo "::warning::Post-style validation failed for ${TAP}#${pr}: ${validation}"
+              printf -- '- %s#%s remains open after style validation failed: %s\n' \
+                "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
+              continue
+            fi
 
-          # Let the ready_for_review-triggered required checks register as pending before polling, so
-          # the first status read can't catch the stale draft-time CLEAN status (see #5080). Marking
-          # all PRs ready first lets their audits run in parallel.
-          if [ "${#prs[@]}" -gt 0 ]; then
-            sleep 30
-          fi
+            title="chore(cask): update ${name} to ${TAG}"
+            if ! gh pr edit "$pr" --repo "$TAP" --title "$title"; then
+              echo "::warning::Could not normalize the title on ${TAP}#${pr}; leaving it draft/open"
+              continue
+            fi
+            metadata_ok=true
+            for label in automation dependencies; do
+              if jq -e --arg label "$label" \
+                  '.availableLabels | any(.name == $label)' "$evidence" >/dev/null; then
+                if ! gh pr edit "$pr" --repo "$TAP" --add-label "$label"; then
+                  echo "::warning::Could not add available label ${label} to ${TAP}#${pr}"
+                  metadata_ok=false
+                fi
+              fi
+            done
+            if [ "$metadata_ok" != true ]; then
+              echo "::warning::${TAP}#${pr} metadata is incomplete; leaving it draft/open"
+              continue
+            fi
 
-          # Drive each ready PR to merge — the last thing the release does.
-          for pr in "${prs[@]}"; do
-            merge_cask_pr "$pr"
+            if ! validation="$(validate_handoff "$pr" "$name" "$evidence" prepared 2>&1)"; then
+              validation="${validation//$'\n'/; }"
+              echo "::warning::Prepared handoff validation failed for ${TAP}#${pr}: ${validation}"
+              printf -- '- %s#%s remains open with incomplete handoff metadata: %s\n' \
+                "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            echo "::notice::${TAP}#${pr} remains draft/open for maintainer promotion"
+            printf -- '- %s#%s remains draft/open for maintainer promotion after live pentad review\n' \
+              "$TAP" "$pr" >>"$GITHUB_STEP_SUMMARY"
           done
 
   # Backstop for the immutable-release model: if the release did NOT publish — any asset job failed,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,6 +133,7 @@ jobs:
       operator-chart: ${{ steps.filter.outputs.operator-chart }}
       desktop: ${{ steps.filter.outputs.desktop }}
       calico-cni: ${{ steps.filter.outputs.calico-cni }}
+      cask-pr-handoff: ${{ steps.filter.outputs.cask-pr-handoff }}
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -266,6 +267,42 @@ jobs:
               # so guard a bump to this file with validate-calico-chart.
               - 'pkg/svc/installer/cni/calico/Dockerfile'
               - '.github/workflows/ci.yaml'
+            cask-pr-handoff:
+              - '.github/fixtures/cask-pr-handoff/**'
+              - '.github/scripts/cask-pr-handoff-workflow.test.sh'
+              - '.github/scripts/collect-cask-pr-handoff.sh'
+              - '.github/scripts/collect-cask-pr-handoff.test.sh'
+              - '.github/scripts/validate-cask-pr-handoff.sh'
+              - '.github/scripts/validate-cask-pr-handoff.test.sh'
+              - '.github/workflows/cd.yaml'
+              - '.github/workflows/ci.yaml'
+
+  cask-pr-handoff:
+    name: 🔐 Validate Cask PR Handoff
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes]
+    if: needs.changes.outputs.cask-pr-handoff == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🔐 Verify fail-closed cask PR handoff
+        run: |
+          shellcheck \
+            .github/fixtures/cask-pr-handoff/fake-bin/gh \
+            .github/scripts/collect-cask-pr-handoff.sh \
+            .github/scripts/collect-cask-pr-handoff.test.sh \
+            .github/scripts/validate-cask-pr-handoff.sh \
+            .github/scripts/validate-cask-pr-handoff.test.sh \
+            .github/scripts/cask-pr-handoff-workflow.test.sh
+          .github/scripts/collect-cask-pr-handoff.test.sh
+          .github/scripts/validate-cask-pr-handoff.test.sh
+          .github/scripts/cask-pr-handoff-workflow.test.sh
 
   ci-go:
     name: ✅ Validate Go Project
@@ -1321,6 +1358,7 @@ jobs:
         operator-chart-e2e,
         verify-desktop-tidy,
         validate-calico-chart,
+        cask-pr-handoff,
       ]
     if: ${{ always() }}
     steps:
@@ -1347,3 +1385,4 @@ jobs:
             ${{ needs.operator-chart-e2e.result }}
             ${{ needs.verify-desktop-tidy.result }}
             ${{ needs.validate-calico-chart.result }}
+            ${{ needs.cask-pr-handoff.result }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary

- remove release-side promotion, direct merge, and auto-merge authority from generated Homebrew cask PRs
- validate the trusted same-repository draft, exact GoReleaser branch, `main` base, and cask-only file scope before and after the style pass
- normalize the Conventional title and available `automation` / `dependencies` labels, then leave a precise draft handoff for the maintainer lane
- add a behavior-tested paginated GitHub collector, a pure fail-closed validator, and a transitive workflow contract that forbids ready/merge/auto/admin paths

## Why this boundary

A client-side poll can bind a commit SHA, but it cannot atomically bind mutable review threads, reviewer verdicts, labels, and edited pre-merge comments to a later `gh pr merge` call. A negative review can arrive after the final read without changing the head. Leaving the generated PR draft/open makes the maintainer promotion checkpoint and the standard live pentad the only merge path.

## Validation

- collector suite: paginated files plus PR/files/labels API failures and malformed responses
- validator suite: 18 trusted identity, draft, head/base, cask-only scope, title, and label cases
- structural workflow contract: no `gh pr ready`, `gh pr merge`, `--auto`, or `--admin` in the job or invoked helpers
- ShellCheck for every added shell executable
- actionlint for `cd.yaml` and `ci.yaml` (ignoring only the repository's pre-existing local `code-quality` scope warning)
- `go build -o /private/tmp/ksail-6067 .`
- `env -u HCLOUD_TOKEN go test -p 4 ./...`
- independent adversarial review: clean after the architectural pivot and fixture/pagination fixes

Fixes #6067
