### PR TITLE
fix(update): never persist an unreachable floating-IP endpoint

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/endpoint_probe.go
+++ b/pkg/svc/provisioner/cluster/talos/endpoint_probe.go
@@ -1,0 +1,62 @@
+package talosprovisioner
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	// kubernetesAPIPort is the port the Kubernetes API server listens on for
+	// every KSail-managed Talos cluster.
+	kubernetesAPIPort = 6443
+
+	// secretsSyncEndpointProbeTimeout bounds the reachability probe of the
+	// endpoint read from a running cluster's config during secret sync. A live
+	// endpoint answers within one dial round-trip; the window only has to
+	// absorb transient network jitter, and a short window keeps updates from
+	// stalling when the recorded endpoint is dead (a floating IP that was
+	// attached but never claimed on the node — ksail#6070).
+	secretsSyncEndpointProbeTimeout = 10 * time.Second
+
+	// floatingIPEndpointProbeTimeout bounds the reachability probe of a
+	// freshly reconciled floating IP before it is persisted as the kubeconfig
+	// endpoint. The Talos hcloud VIP controller claims the address
+	// asynchronously after the machine config lands, so this window allows
+	// the claim to settle without letting a never-claimed IP stall the update
+	// indefinitely.
+	floatingIPEndpointProbeTimeout = 30 * time.Second
+)
+
+// verifiedEndpointIP returns candidateIP when the Kubernetes API accepts TCP
+// connections on candidateIP:6443 within timeout, and fallbackIP (with a
+// logged warning) otherwise. A Hetzner floating IP is attached via the cloud
+// API but only becomes reachable once the node claims it, so persisting an
+// unverified endpoint into cluster secrets or a kubeconfig can record an
+// address nothing answers on (ksail#6070). fallbackIP must be an address that
+// is already known reachable (a control-plane node IP kept in the cert SANs).
+func (p *Provisioner) verifiedEndpointIP(
+	ctx context.Context,
+	candidateIP, fallbackIP string,
+	timeout time.Duration,
+) string {
+	if candidateIP == fallbackIP {
+		return candidateIP
+	}
+
+	err := p.apiEndpointReachabilityCheck(ctx, candidateIP, timeout)
+	if err == nil {
+		return candidateIP
+	}
+
+	_, _ = fmt.Fprintf(
+		p.logWriter,
+		"  ⚠️ Cluster endpoint %s does not answer on port %d; using %s instead"+
+			" (the floating IP may not be claimed on the node — see ksail#6070)\n",
+		candidateIP,
+		kubernetesAPIPort,
+		fallbackIP,
+	)
+
+	return fallbackIP
+}

--- a/pkg/svc/provisioner/cluster/talos/endpoint_probe_test.go
+++ b/pkg/svc/provisioner/cluster/talos/endpoint_probe_test.go
@@ -1,0 +1,79 @@
+package talosprovisioner_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVerifiedEndpointIP_SameAddressSkipsProbe pins the short-circuit: when
+// candidate and fallback already agree there is nothing to verify, so plain
+// node-endpoint clusters never pay for a probe.
+func TestVerifiedEndpointIP_SameAddressSkipsProbe(t *testing.T) {
+	t.Parallel()
+
+	probes := 0
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithAPIEndpointReachabilityCheckForTest(
+			func(context.Context, string, time.Duration) error {
+				probes++
+
+				return nil
+			},
+		)
+
+	got := provisioner.VerifiedEndpointIPForTest(
+		t.Context(), "203.0.113.5", "203.0.113.5", time.Second,
+	)
+
+	assert.Equal(t, "203.0.113.5", got)
+	assert.Equal(t, 0, probes, "identical candidate and fallback must not probe")
+}
+
+// TestVerifiedEndpointIP_ReachableCandidateAdopted verifies a candidate the
+// probe confirms reachable is adopted unchanged.
+func TestVerifiedEndpointIP_ReachableCandidateAdopted(t *testing.T) {
+	t.Parallel()
+
+	logs := &bytes.Buffer{}
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(logs).
+		WithAPIEndpointReachabilityCheckForTest(
+			func(context.Context, string, time.Duration) error { return nil },
+		)
+
+	got := provisioner.VerifiedEndpointIPForTest(
+		t.Context(), "192.0.2.10", "203.0.113.5", time.Second,
+	)
+
+	assert.Equal(t, "192.0.2.10", got)
+	assert.Empty(t, logs.String(), "a reachable endpoint must not warn")
+}
+
+// TestVerifiedEndpointIP_UnreachableCandidateFallsBackWithWarning pins the
+// ksail#6070 guard at the unit level: a dead candidate yields the fallback and
+// a warning naming both addresses so the operator can see the substitution.
+func TestVerifiedEndpointIP_UnreachableCandidateFallsBackWithWarning(t *testing.T) {
+	t.Parallel()
+
+	logs := &bytes.Buffer{}
+	provisioner := talosprovisioner.NewProvisioner(nil, nil).
+		WithLogWriter(logs).
+		WithAPIEndpointReachabilityCheckForTest(
+			func(context.Context, string, time.Duration) error {
+				return errEndpointProbeFailed
+			},
+		)
+
+	got := provisioner.VerifiedEndpointIPForTest(
+		t.Context(), "192.0.2.10", "203.0.113.5", time.Second,
+	)
+
+	assert.Equal(t, "203.0.113.5", got)
+	assert.Contains(t, logs.String(), "192.0.2.10")
+	assert.Contains(t, logs.String(), "203.0.113.5")
+}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -86,6 +86,26 @@ func (p *Provisioner) WithNodeReachabilityCheckForTest(
 	return p
 }
 
+// WithAPIEndpointReachabilityCheckForTest overrides the Kubernetes API
+// endpoint reachability probe so unit tests can pin the verified-endpoint
+// fallback (ksail#6070) without real network I/O.
+func (p *Provisioner) WithAPIEndpointReachabilityCheckForTest(
+	fn func(ctx context.Context, ip string, timeout time.Duration) error,
+) *Provisioner {
+	p.apiEndpointReachabilityCheck = fn
+
+	return p
+}
+
+// VerifiedEndpointIPForTest exposes verifiedEndpointIP for unit testing.
+func (p *Provisioner) VerifiedEndpointIPForTest(
+	ctx context.Context,
+	candidateIP, fallbackIP string,
+	timeout time.Duration,
+) string {
+	return p.verifiedEndpointIP(ctx, candidateIP, fallbackIP, timeout)
+}
+
 // WaitForNewDockerNodesReachableForTest exposes waitForNewDockerNodesReachable
 // for unit testing. Each IP in nodeIPs is turned into a node spec (the IP doubles
 // as the node name in log/error output).

--- a/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
+++ b/pkg/svc/provisioner/cluster/talos/hetzner_nodes.go
@@ -441,7 +441,9 @@ func (p *Provisioner) waitForServerReachable(
 		return addrErr
 	}
 
-	err := dialTCPUntilReachable(ctx, serverIP, clusterReadinessTimeout, longRetryInterval)
+	err := dialTCPUntilReachable(
+		ctx, serverIP, talosAPIPort, clusterReadinessTimeout, longRetryInterval,
+	)
 	if err != nil {
 		return diagnoseUnreachableNode(server, fmt.Errorf(
 			"timeout waiting for %s to become reachable after install: %w",
@@ -453,29 +455,30 @@ func (p *Provisioner) waitForServerReachable(
 	return nil
 }
 
-// dialTCPUntilReachable polls ip:talosAPIPort until a TCP connection succeeds or
-// the context is done, retrying every interval up to timeout. A successful dial
-// means the Talos apid service is accepting connections on the node. This is
+// dialTCPUntilReachable polls ip:port until a TCP connection succeeds or
+// the context is done, retrying every interval up to timeout. A successful
+// dial means the service is accepting connections at the address. This is
 // shared by the Hetzner install/reboot wait (waitForServerReachable) and the
-// Docker scale-up wait (waitForNewDockerNodesReachable); each caller wraps the
+// Docker scale-up wait (waitForNewDockerNodesReachable) — both dialing the
+// Talos API at talosAPIPort — and by the cluster-endpoint reachability probe
+// dialing the Kubernetes API at kubernetesAPIPort; each caller wraps the
 // returned error with its own server/node context.
 func dialTCPUntilReachable(
 	ctx context.Context,
 	nodeIP string,
+	port int,
 	timeout, interval time.Duration,
 ) error {
+	address := net.JoinHostPort(nodeIP, strconv.Itoa(port))
+
 	err := retry.Constant(timeout, retry.WithUnits(interval)).
 		RetryWithContext(ctx, func(ctx context.Context) error {
 			dialer := &net.Dialer{Timeout: retryInterval}
 
-			conn, dialErr := dialer.DialContext(
-				ctx,
-				"tcp",
-				net.JoinHostPort(nodeIP, strconv.Itoa(talosAPIPort)),
-			)
+			conn, dialErr := dialer.DialContext(ctx, "tcp", address)
 			if dialErr != nil {
 				return retry.ExpectedError(
-					fmt.Errorf("waiting for Talos API to become reachable: %w", dialErr),
+					fmt.Errorf("waiting for %s to accept connections: %w", address, dialErr),
 				)
 			}
 
@@ -484,7 +487,7 @@ func dialTCPUntilReachable(
 			return nil
 		})
 	if err != nil {
-		return fmt.Errorf("dialing Talos API at %s: %w", nodeIP, err)
+		return fmt.Errorf("dialing %s: %w", address, err)
 	}
 
 	return nil

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -167,6 +167,14 @@ type Provisioner struct {
 	// reconciliation must wait for it. Defaults to a TCP dial loop; tests override
 	// it via export_test.go to avoid real network I/O.
 	nodeReachabilityCheck func(ctx context.Context, ip string) error
+	// apiEndpointReachabilityCheck reports when the Kubernetes API is accepting
+	// connections at ip:kubernetesAPIPort within timeout. It gates the endpoint
+	// adopted by cluster-secret sync and the endpoint persisted into the
+	// kubeconfig: a Hetzner floating IP is attached via the cloud API but only
+	// becomes reachable once the node claims it, so an unverified endpoint can
+	// be a dead address (ksail#6070). Defaults to a bounded TCP dial loop;
+	// tests override it via export_test.go to avoid real network I/O.
+	apiEndpointReachabilityCheck func(ctx context.Context, ip string, timeout time.Duration) error
 	// nodeConfigFetcher returns the running Talos machine config for a node by IP.
 	// Defaults to fetchNodeConfig; tests override it via export_test.go to inject a
 	// known running config without real Talos API connectivity (used by the per-node
@@ -224,7 +232,13 @@ func NewProvisioner(
 	}
 
 	prov.nodeReachabilityCheck = func(ctx context.Context, ip string) error {
-		return dialTCPUntilReachable(ctx, ip, talosAPIWaitTimeout, retryInterval)
+		return dialTCPUntilReachable(ctx, ip, talosAPIPort, talosAPIWaitTimeout, retryInterval)
+	}
+
+	prov.apiEndpointReachabilityCheck = func(
+		ctx context.Context, ip string, timeout time.Duration,
+	) error {
+		return dialTCPUntilReachable(ctx, ip, kubernetesAPIPort, timeout, retryInterval)
 	}
 
 	prov.nodeConfigFetcher = prov.fetchNodeConfig

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -570,7 +570,15 @@ func (p *Provisioner) refreshFloatingIPKubeconfig(ctx context.Context, clusterNa
 		return err
 	}
 
-	kubernetesEndpoint := "https://" + net.JoinHostPort(endpointIP, "6443")
+	// The floating IP is attached via the cloud API, but only the Talos hcloud
+	// VIP controller makes it answer — persisting it unverified can bake a
+	// dead endpoint into the kubeconfig (ksail#6070). The node address stays
+	// in the cert SANs, so falling back to it keeps the kubeconfig working.
+	verifiedIP := p.verifiedEndpointIP(
+		ctx, endpointIP, talosEndpoint, floatingIPEndpointProbeTimeout,
+	)
+
+	kubernetesEndpoint := "https://" + net.JoinHostPort(verifiedIP, "6443")
 
 	return p.fetchAndWriteKubeconfigForCP(ctx, talosEndpoint, kubernetesEndpoint)
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
@@ -1,12 +1,14 @@
 package talosprovisioner_test
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	configmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
@@ -127,9 +129,16 @@ func newFloatingIPTestProvisionerWithOptions(
 	require.NoError(t, err)
 	require.NotNil(t, configs)
 
+	// The floating-IP fixtures use TEST-NET addresses nothing answers on, so
+	// pin the endpoint reachability probe to success here; the verified-
+	// endpoint fallback itself is covered by the dedicated endpoint_probe and
+	// fallback tests.
 	return talosprovisioner.NewProvisioner(nil, options).
 		WithHetznerOptions(hetznerOpts).
 		WithTalosConfigsForTest(configs).
+		WithAPIEndpointReachabilityCheckForTest(
+			func(context.Context, string, time.Duration) error { return nil },
+		).
 		WithLogWriter(io.Discard)
 }
 

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -1193,5 +1193,12 @@ func (p *Provisioner) fetchClusterSecretsAndEndpoint(
 		endpointIP = cpIP
 	}
 
+	// The running config can carry a dead endpoint — a floating IP that was
+	// attached but never claimed on the node (ksail#6070) — and adopting it
+	// verbatim would re-record the dead address into the rebuilt bundle. cpIP
+	// is the node this sync just fetched the config from, so it is known
+	// reachable.
+	endpointIP = p.verifiedEndpointIP(ctx, endpointIP, cpIP, secretsSyncEndpointProbeTimeout)
+
 	return existingSecrets, endpointIP, nil
 }

--- a/pkg/svc/provisioner/cluster/talos/update_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_floating_ip_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,6 +28,21 @@ import (
 // floatingIPEnabledField mirrors the diff field name mergeFloatingIPChanges
 // emits, asserted literally so a rename shows up in this test.
 const floatingIPEnabledField = "provider.hetzner.floatingIPEnabled"
+
+// errEndpointProbeFailed is the canned probe failure the ksail#6070 fallback
+// tests inject for an unreachable Kubernetes API endpoint.
+var errEndpointProbeFailed = errors.New("kubernetes api endpoint unreachable")
+
+// withUnreachableEndpointProbe overrides the endpoint reachability probe to
+// always fail, simulating a floating IP that was attached but never claimed
+// on the node (ksail#6070).
+func withUnreachableEndpointProbe(p *talosprovisioner.Provisioner) {
+	p.WithAPIEndpointReachabilityCheckForTest(
+		func(context.Context, string, time.Duration) error {
+			return errEndpointProbeFailed
+		},
+	)
+}
 
 // fipUpdateCalls counts the hcloud API calls the update-reconcile tests care
 // about.
@@ -805,11 +821,16 @@ func TestRefreshFloatingIPEndpointAfterNodeChanges_RefreshesControlPlaneInventor
 	assert.Equal(t, int32(1), calls.assign.Load())
 }
 
-// TestUpdateApplyStep_PreparesFloatingIPBeforeControlPlaneRoll verifies a
-// topology-only update refreshes the generated VIP bundle before replacement,
-// even when live drift detection was clean and emitted no floating-IP change.
-func TestUpdateApplyStep_PreparesFloatingIPBeforeControlPlaneRoll(t *testing.T) {
-	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+// newFloatingIPRunningClusterProvisioner builds a provisioner backed by the
+// fake hcloud fixtures whose node-config fetcher serves a running control-
+// plane config that already carries the floating-IP endpoint — the state a
+// live cluster is in when an update's sync/reconcile steps run. Runtime
+// options are optional (kubeconfig persistence tests pass a kubeconfig path).
+func newFloatingIPRunningClusterProvisioner(
+	t *testing.T,
+	runtimeOptions *talosprovisioner.Options,
+) *talosprovisioner.Provisioner {
+	t.Helper()
 
 	calls := &fipUpdateCalls{}
 	server := fipUpdateTestServer(t, true, calls)
@@ -826,16 +847,30 @@ func TestUpdateApplyStep_PreparesFloatingIPBeforeControlPlaneRoll(t *testing.T) 
 		[]*hcloud.Server{controlPlaneServer(11, "fip-cluster-cp-0", "203.0.113.5")},
 	))
 	runningControlPlane := configuredProvisioner.TalosConfigsForTest().ControlPlane()
-	kubeconfigPath := t.TempDir() + "/kubeconfig"
-	provisioner := newFloatingIPTestProvisionerWithOptions(
-		t, options, talosprovisioner.NewOptions().WithKubeconfigPath(kubeconfigPath),
-	).
+
+	return newFloatingIPTestProvisionerWithOptions(t, options, runtimeOptions).
 		WithInfraProvider(hzProvider).
 		WithNodeConfigFetcherForTest(
 			func(context.Context, string) (talosconfig.Provider, error) {
 				return runningControlPlane, nil
 			},
 		)
+}
+
+// runFloatingIPEndpointReconcileStep drives the "reconcile floating IP
+// endpoint" update step against the running-cluster fixtures, optionally
+// mutating the provisioner first (e.g. overriding the reachability probe),
+// and returns the kubeconfig capture plus the written kubeconfig path.
+func runFloatingIPEndpointReconcileStep(
+	t *testing.T,
+	mutate func(*talosprovisioner.Provisioner),
+) (*floatingIPKubeconfigCapture, string) {
+	t.Helper()
+
+	kubeconfigPath := t.TempDir() + "/kubeconfig"
+	provisioner := newFloatingIPRunningClusterProvisioner(
+		t, talosprovisioner.NewOptions().WithKubeconfigPath(kubeconfigPath),
+	)
 	capture := &floatingIPKubeconfigCapture{}
 
 	provisioner.WithTalosClientFactoryForTest(
@@ -846,6 +881,10 @@ func TestUpdateApplyStep_PreparesFloatingIPBeforeControlPlaneRoll(t *testing.T) 
 			return &mockKubeconfigFetcher{kubeconfig: minimalKubeconfigBytes()}, nil
 		},
 	)
+
+	if mutate != nil {
+		mutate(provisioner)
+	}
 
 	diff := clusterupdate.NewEmptyUpdateResult()
 	result := clusterupdate.NewEmptyUpdateResult()
@@ -862,12 +901,40 @@ func TestUpdateApplyStep_PreparesFloatingIPBeforeControlPlaneRoll(t *testing.T) 
 	))
 	assert.True(t, provisioner.HasDesiredHetznerFloatingIPEndpointForTest(),
 		"replacement control planes must receive the VIP config before the roll starts")
+
+	return capture, kubeconfigPath
+}
+
+// TestUpdateApplyStep_PreparesFloatingIPBeforeControlPlaneRoll verifies a
+// topology-only update refreshes the generated VIP bundle before replacement,
+// even when live drift detection was clean and emitted no floating-IP change.
+func TestUpdateApplyStep_PreparesFloatingIPBeforeControlPlaneRoll(t *testing.T) {
+	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+
+	capture, kubeconfigPath := runFloatingIPEndpointReconcileStep(t, nil)
+
 	assert.Equal(t, 1, capture.calls)
 	assert.Equal(t, "203.0.113.5", capture.talosEndpoint)
 
 	written, err := os.ReadFile(kubeconfigPath) //nolint:gosec // test-owned path
 	require.NoError(t, err)
 	assert.Contains(t, string(written), "https://192.0.2.10:6443")
+}
+
+// TestUpdateApplyStep_KubeconfigFallsBackWhenFloatingIPUnreachable pins the
+// ksail#6070 guard: a floating IP that never becomes reachable must not be
+// persisted as the kubeconfig endpoint — the directly reachable control-plane
+// address (already in the cert SANs) is written instead.
+func TestUpdateApplyStep_KubeconfigFallsBackWhenFloatingIPUnreachable(t *testing.T) {
+	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+
+	_, kubeconfigPath := runFloatingIPEndpointReconcileStep(t, withUnreachableEndpointProbe)
+
+	written, err := os.ReadFile(kubeconfigPath) //nolint:gosec // test-owned path
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "https://203.0.113.5:6443",
+		"an unreachable floating IP must fall back to the control-plane address")
+	assert.NotContains(t, string(written), "192.0.2.10")
 }
 
 // TestUpdateApplyStep_DoesNotPrepareFloatingIPForWorkerRoll keeps the pre-roll
@@ -895,35 +962,21 @@ func TestUpdateApplyStep_DoesNotPrepareFloatingIPForWorkerRoll(t *testing.T) {
 	assert.False(t, provisioner.HasDesiredHetznerFloatingIPEndpointForTest())
 }
 
-// TestUpdateApplyStep_SyncsFloatingIPEndpointBeforeWorkerRoll verifies the
-// secrets-sync step that precedes topology changes copies the live stable
-// endpoint into the worker config used for first boot.
-func TestUpdateApplyStep_SyncsFloatingIPEndpointBeforeWorkerRoll(t *testing.T) {
-	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+// runFloatingIPWorkerRollSecretsSync drives the "sync cluster secrets" update
+// step against the running-cluster fixtures, optionally mutating the
+// provisioner first, and returns it for endpoint assertions.
+func runFloatingIPWorkerRollSecretsSync(
+	t *testing.T,
+	mutate func(*talosprovisioner.Provisioner),
+) *talosprovisioner.Provisioner {
+	t.Helper()
 
-	calls := &fipUpdateCalls{}
-	server := fipUpdateTestServer(t, true, calls)
-	hzProvider := newFipUpdateProvider(server.URL)
-	options := v1alpha1.OptionsHetzner{
-		FloatingIPEnabled:  true,
-		FloatingIPLocation: "fsn1",
-		TokenEnvVar:        testFloatingIPTokenEnvVar,
+	provisioner := newFloatingIPRunningClusterProvisioner(t, nil)
+
+	if mutate != nil {
+		mutate(provisioner)
 	}
-	configuredProvisioner := newFloatingIPTestProvisioner(t, options).
-		WithInfraProvider(hzProvider)
-	require.NoError(t, configuredProvisioner.UpdateConfigsWithEndpointForTest(
-		t.Context(), hzProvider, "fip-cluster",
-		[]*hcloud.Server{controlPlaneServer(11, "fip-cluster-cp-0", "203.0.113.5")},
-	))
-	runningControlPlane := configuredProvisioner.TalosConfigsForTest().ControlPlane()
 
-	provisioner := newFloatingIPTestProvisioner(t, options).
-		WithInfraProvider(hzProvider).
-		WithNodeConfigFetcherForTest(
-			func(context.Context, string) (talosconfig.Provider, error) {
-				return runningControlPlane, nil
-			},
-		)
 	result := clusterupdate.NewEmptyUpdateResult()
 	result.RollingRecreate = append(result.RollingRecreate, clusterupdate.Change{
 		Field:    "provider.hetzner.workerServerType",
@@ -935,7 +988,32 @@ func TestUpdateApplyStep_SyncsFloatingIPEndpointBeforeWorkerRoll(t *testing.T) {
 		t.Context(), "sync cluster secrets", "fip-cluster",
 		spec, spec, clusterupdate.NewEmptyUpdateResult(), result,
 	))
+
+	return provisioner
+}
+
+// TestUpdateApplyStep_SyncsFloatingIPEndpointBeforeWorkerRoll verifies the
+// secrets-sync step that precedes topology changes copies the live stable
+// endpoint into the worker config used for first boot.
+func TestUpdateApplyStep_SyncsFloatingIPEndpointBeforeWorkerRoll(t *testing.T) {
+	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+
+	provisioner := runFloatingIPWorkerRollSecretsSync(t, nil)
+
 	assert.Equal(t, "192.0.2.10",
+		provisioner.TalosConfigsForTest().Worker().Cluster().Endpoint().Hostname())
+}
+
+// TestUpdateApplyStep_SecretsSyncFallsBackWhenEndpointUnreachable pins the
+// ksail#6070 guard on the secrets-sync side: a dead endpoint read from the
+// running config must not be re-recorded into the rebuilt bundle — the sync
+// falls back to the control-plane node it fetched the config from.
+func TestUpdateApplyStep_SecretsSyncFallsBackWhenEndpointUnreachable(t *testing.T) {
+	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+
+	provisioner := runFloatingIPWorkerRollSecretsSync(t, withUnreachableEndpointProbe)
+
+	assert.Equal(t, "203.0.113.5",
 		provisioner.TalosConfigsForTest().Worker().Cluster().Endpoint().Hostname())
 }
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The first live floating-IP reconcile on the prod platform cluster recorded a dead API endpoint into the synced cluster secrets and the kubeconfig — the IP was attached in the cloud but never became reachable, so kubeconfig exports and new-node joins would target an address nothing answers on (#6070).

## What

Cluster updates now verify an endpoint actually answers before persisting it: an unreachable floating IP is no longer written into synced secrets or the kubeconfig — the directly reachable control-plane address is used instead, with a visible warning. Once released and picked up by the platform, the next deploy self-heals the dead endpoint currently recorded on prod.

Part of #6070 (the unclaimed-VIP root cause and duplicate floating-IP surfacing remain on the issue).