### PR TITLE
feat(environment): generate missing cluster overlays from the reconcile plan

### DIFF
--- a/pkg/svc/environment/reconcile_generate.go
+++ b/pkg/svc/environment/reconcile_generate.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 )
 
 // ErrUnsafeOverlayPath is returned by GenerateMissingOverlays when a path it
@@ -95,11 +97,18 @@ func GenerateMissingOverlays(
 	return WriteMultiClusterLayout(gen, sourceDir, files, false)
 }
 
-// prepareSourceDir canonicalizes sourceDir's existing ancestors and then
-// fail-closes on an unsafe source root, returning the physical path every
-// guard and write below operates on.
+// prepareSourceDir expands a `~/` prefix and normalizes sourceDir (a
+// trailing separator would make Dir/Base split the leaf as duplicated),
+// canonicalizes its existing ancestors, and then fail-closes on an unsafe
+// source root — returning the physical path every guard and write below
+// operates on.
 func prepareSourceDir(sourceDir string) (string, error) {
-	resolved, err := resolveSourceDirAncestors(sourceDir)
+	expanded, err := fsutil.ExpandHomePath(sourceDir)
+	if err != nil {
+		return "", fmt.Errorf("expand source directory %q: %w", sourceDir, err)
+	}
+
+	resolved, err := resolveSourceDirAncestors(filepath.Clean(expanded))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/svc/environment/reconcile_generate.go
+++ b/pkg/svc/environment/reconcile_generate.go
@@ -10,11 +10,14 @@ import (
 )
 
 // ErrUnsafeOverlayPath is returned by GenerateMissingOverlays when a path it
-// would render through exists but is not what generation expects — a directory
-// segment that is a symlink or regular file, or a layout file that exists as a
-// symlink. DerivePlan classifies such an overlay as Missing (it only counts
-// real directories), but writing through the entry would follow the link and
-// escape the source tree, so generation refuses instead.
+// would render through exists but is not what generation expects — a source
+// directory or directory segment that is a symlink or regular file, or a
+// layout file that exists as anything but a regular file (a symlink would be
+// written through; a directory makes the force-off writer skip the file while
+// reporting it, leaving a silently broken layout). DerivePlan classifies such
+// an overlay as Missing (it only counts real directories), but writing
+// through the entry would follow the link and escape the source tree, so
+// generation refuses instead.
 var ErrUnsafeOverlayPath = errors.New(
 	"refusing to generate through a non-directory overlay path",
 )
@@ -32,11 +35,13 @@ var ErrUnsafeOverlayPath = errors.New(
 // writer's contract an existing, untouched file is still reported, so a
 // second run reports the same paths while rewriting nothing.
 //
-// Every path is containment-checked before writing: a clusters/ or
-// clusters/<env>/ segment that exists as a symlink or regular file — which
-// DerivePlan reports as Missing but a write would follow out of the source
-// tree — is rejected with [ErrUnsafeOverlayPath], as is a layout file that
-// exists as a symlink (a dangling one would otherwise be written through).
+// Every path is containment-checked before writing: sourceDir itself and any
+// clusters/ or clusters/<env>/ segment that exists as a symlink or regular
+// file — which DerivePlan reports as Missing but a write would follow out of
+// the source tree — is rejected with [ErrUnsafeOverlayPath], as is a layout
+// file that exists as anything but a regular file (a dangling symlink would
+// be written through; a directory would make the force-off writer skip the
+// file while still reporting it as resolved).
 func GenerateMissingOverlays(
 	gen KustomizationGenerator,
 	sourceDir string,
@@ -68,6 +73,13 @@ func GenerateMissingOverlays(
 		}
 	}
 
+	if len(files) > 0 {
+		err := ensureSafeSourceDir(sourceDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	for _, file := range files {
 		err := ensureSafeOverlayPath(sourceDir, file.RelPath)
 		if err != nil {
@@ -78,12 +90,35 @@ func GenerateMissingOverlays(
 	return WriteMultiClusterLayout(gen, sourceDir, files, false)
 }
 
+// ensureSafeSourceDir rejects a sourceDir that exists as anything but a real
+// directory. The per-file walk starts below sourceDir, so a symlinked source
+// root would never be inspected there while every write still goes through
+// it into the link target. A sourceDir that does not exist yet is fine — the
+// writer creates it fresh.
+func ensureSafeSourceDir(sourceDir string) error {
+	info, err := os.Lstat(sourceDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("inspect source directory %q: %w", sourceDir, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s is not a directory", ErrUnsafeOverlayPath, sourceDir)
+	}
+
+	return nil
+}
+
 // ensureSafeOverlayPath walks relPath's segments under sourceDir with Lstat:
 // every directory segment that already exists must be a real directory (not a
 // symlink or file), and the leaf — preserved by the force-off writer when
-// present — must not be a symlink (a dangling one would be written through).
-// A segment that does not exist ends the walk: everything below it is created
-// fresh by the writer.
+// present — must be a regular file (a dangling symlink would be written
+// through; a directory or other non-regular node would make the writer skip
+// the file while reporting it as resolved). A segment that does not exist
+// ends the walk: everything below it is created fresh by the writer.
 func ensureSafeOverlayPath(sourceDir, relPath string) error {
 	current := sourceDir
 	segments := strings.Split(path.Clean(relPath), "/")
@@ -101,8 +136,8 @@ func ensureSafeOverlayPath(sourceDir, relPath string) error {
 		}
 
 		if index == len(segments)-1 {
-			if info.Mode()&os.ModeSymlink != 0 {
-				return fmt.Errorf("%w: %s is a symlink", ErrUnsafeOverlayPath, current)
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("%w: %s is not a regular file", ErrUnsafeOverlayPath, current)
 			}
 
 			return nil

--- a/pkg/svc/environment/reconcile_generate.go
+++ b/pkg/svc/environment/reconcile_generate.go
@@ -1,7 +1,22 @@
 package environment
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// ErrUnsafeOverlayPath is returned by GenerateMissingOverlays when a path it
+// would render through exists but is not what generation expects — a directory
+// segment that is a symlink or regular file, or a layout file that exists as a
+// symlink. DerivePlan classifies such an overlay as Missing (it only counts
+// real directories), but writing through the entry would follow the link and
+// escape the source tree, so generation refuses instead.
+var ErrUnsafeOverlayPath = errors.New(
+	"refusing to generate through a non-directory overlay path",
 )
 
 // GenerateMissingOverlays scaffolds the clusters/<env>/ overlay for every
@@ -16,6 +31,12 @@ import (
 // delete them). It returns the resolved output paths in layout order; per the
 // writer's contract an existing, untouched file is still reported, so a
 // second run reports the same paths while rewriting nothing.
+//
+// Every path is containment-checked before writing: a clusters/ or
+// clusters/<env>/ segment that exists as a symlink or regular file — which
+// DerivePlan reports as Missing but a write would follow out of the source
+// tree — is rejected with [ErrUnsafeOverlayPath], as is a layout file that
+// exists as a symlink (a dangling one would otherwise be written through).
 func GenerateMissingOverlays(
 	gen KustomizationGenerator,
 	sourceDir string,
@@ -47,5 +68,50 @@ func GenerateMissingOverlays(
 		}
 	}
 
+	for _, file := range files {
+		err := ensureSafeOverlayPath(sourceDir, file.RelPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return WriteMultiClusterLayout(gen, sourceDir, files, false)
+}
+
+// ensureSafeOverlayPath walks relPath's segments under sourceDir with Lstat:
+// every directory segment that already exists must be a real directory (not a
+// symlink or file), and the leaf — preserved by the force-off writer when
+// present — must not be a symlink (a dangling one would be written through).
+// A segment that does not exist ends the walk: everything below it is created
+// fresh by the writer.
+func ensureSafeOverlayPath(sourceDir, relPath string) error {
+	current := sourceDir
+	segments := strings.Split(path.Clean(relPath), "/")
+
+	for index, segment := range segments {
+		current = filepath.Join(current, segment)
+
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("inspect overlay path %q: %w", current, err)
+		}
+
+		if index == len(segments)-1 {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("%w: %s is a symlink", ErrUnsafeOverlayPath, current)
+			}
+
+			return nil
+		}
+
+		if !info.IsDir() {
+			return fmt.Errorf("%w: %s is not a directory", ErrUnsafeOverlayPath, current)
+		}
+	}
+
+	return nil
 }

--- a/pkg/svc/environment/reconcile_generate.go
+++ b/pkg/svc/environment/reconcile_generate.go
@@ -1,0 +1,51 @@
+package environment
+
+import (
+	"fmt"
+)
+
+// GenerateMissingOverlays scaffolds the clusters/<env>/ overlay for every
+// [OverlayMissing] entry in plan, composing the seams the multi-cluster
+// scaffold already uses: each missing environment's files come from
+// [DeriveMultiClusterLayout] (the shared clusters/base/ plus the overlay
+// referencing it), the shared base is deduplicated across entries, and
+// rendering goes through [WriteMultiClusterLayout] with force hardwired off —
+// generation never overwrites an existing file (a populated clusters/base/ is
+// preserved by the writer's idempotent semantics) and never touches orphan
+// overlays (the plan surfaces them for the operator; a reconcile must never
+// delete them). It returns the resolved output paths in layout order; per the
+// writer's contract an existing, untouched file is still reported, so a
+// second run reports the same paths while rewriting nothing.
+func GenerateMissingOverlays(
+	gen KustomizationGenerator,
+	sourceDir string,
+	plan Plan,
+) ([]string, error) {
+	files := make([]LayoutFile, 0, len(plan.Entries)+1)
+	seen := make(map[string]struct{}, len(plan.Entries)+1)
+
+	for _, entry := range plan.Entries {
+		if entry.State != OverlayMissing {
+			continue
+		}
+
+		layout, err := DeriveMultiClusterLayout(entry.Environment.Name)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"generate overlay for environment %q: %w", entry.Environment.Name, err,
+			)
+		}
+
+		for _, file := range layout {
+			if _, dup := seen[file.RelPath]; dup {
+				continue
+			}
+
+			seen[file.RelPath] = struct{}{}
+
+			files = append(files, file)
+		}
+	}
+
+	return WriteMultiClusterLayout(gen, sourceDir, files, false)
+}

--- a/pkg/svc/environment/reconcile_generate.go
+++ b/pkg/svc/environment/reconcile_generate.go
@@ -35,7 +35,10 @@ var ErrUnsafeOverlayPath = errors.New(
 // writer's contract an existing, untouched file is still reported, so a
 // second run reports the same paths while rewriting nothing.
 //
-// Every path is containment-checked before writing: sourceDir itself and any
+// Every path is containment-checked before writing: sourceDir's existing
+// ancestors are first canonicalized (so the checks and the writes agree on
+// one physical tree — a symlinked ancestor like macOS's /var is resolved up
+// front, never followed blindly at write time), then sourceDir itself and any
 // clusters/ or clusters/<env>/ segment that exists as a symlink or regular
 // file — which DerivePlan reports as Missing but a write would follow out of
 // the source tree — is rejected with [ErrUnsafeOverlayPath], as is a layout
@@ -74,10 +77,12 @@ func GenerateMissingOverlays(
 	}
 
 	if len(files) > 0 {
-		err := ensureSafeSourceDir(sourceDir)
+		resolved, err := prepareSourceDir(sourceDir)
 		if err != nil {
 			return nil, err
 		}
+
+		sourceDir = resolved
 	}
 
 	for _, file := range files {
@@ -88,6 +93,58 @@ func GenerateMissingOverlays(
 	}
 
 	return WriteMultiClusterLayout(gen, sourceDir, files, false)
+}
+
+// prepareSourceDir canonicalizes sourceDir's existing ancestors and then
+// fail-closes on an unsafe source root, returning the physical path every
+// guard and write below operates on.
+func prepareSourceDir(sourceDir string) (string, error) {
+	resolved, err := resolveSourceDirAncestors(sourceDir)
+	if err != nil {
+		return "", err
+	}
+
+	err = ensureSafeSourceDir(resolved)
+	if err != nil {
+		return "", err
+	}
+
+	return resolved, nil
+}
+
+// resolveSourceDirAncestors canonicalizes every EXISTING ancestor of
+// sourceDir with [filepath.EvalSymlinks] (macOS `/var` → `/private/var` and
+// the like), leaving the leaf untouched so ensureSafeSourceDir still rejects
+// a symlinked source root itself. The guards and the writer then agree on
+// one physical path: an ancestor symlink is resolved to its canonical target
+// up front instead of being silently followed at write time, so every
+// Lstat-based check below the root inspects the same tree the writes land
+// in. Ancestors that do not exist yet are kept verbatim — the writer creates
+// them fresh.
+func resolveSourceDirAncestors(sourceDir string) (string, error) {
+	parent := filepath.Dir(sourceDir)
+	if parent == sourceDir {
+		// Filesystem root (or a bare "." / ".."): nothing left to resolve.
+		return sourceDir, nil
+	}
+
+	base := filepath.Base(sourceDir)
+
+	resolved, err := filepath.EvalSymlinks(parent)
+	if errors.Is(err, os.ErrNotExist) {
+		resolvedParent, parentErr := resolveSourceDirAncestors(parent)
+		if parentErr != nil {
+			return "", parentErr
+		}
+
+		return filepath.Join(resolvedParent, base), nil
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("resolve source directory ancestors of %q: %w", sourceDir, err)
+	}
+
+	return filepath.Join(resolved, base), nil
 }
 
 // ensureSafeSourceDir rejects a sourceDir that exists as anything but a real

--- a/pkg/svc/environment/reconcile_generate_test.go
+++ b/pkg/svc/environment/reconcile_generate_test.go
@@ -147,6 +147,17 @@ func TestGenerateMissingOverlaysRejectsReservedBaseName(t *testing.T) {
 	require.ErrorIs(t, err, environment.ErrReservedEnvironmentName)
 }
 
+// symlinkOrSkip creates a symlink or skips the test on platforms where
+// symlink creation is not permitted (e.g. Windows without extra privileges).
+func symlinkOrSkip(t *testing.T, target, link string) {
+	t.Helper()
+
+	err := os.Symlink(target, link)
+	if err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+}
+
 // generateExpectingUnsafePath derives the plan for dir and asserts generation
 // refuses it with ErrUnsafeOverlayPath.
 func generateExpectingUnsafePath(t *testing.T, dir string) {
@@ -173,10 +184,7 @@ func TestGenerateMissingOverlaysRejectsSymlinkedOverlayDir(t *testing.T) {
 	// directories count), but writing through it would land in the target.
 	target := filepath.Join(dir, "outside-target")
 	require.NoError(t, os.MkdirAll(target, 0o750))
-	require.NoError(
-		t,
-		os.Symlink(target, filepath.Join(dir, sourceDir, environment.ClustersDir, "local")),
-	)
+	symlinkOrSkip(t, target, filepath.Join(dir, sourceDir, environment.ClustersDir, "local"))
 
 	generateExpectingUnsafePath(t, dir)
 	assert.NoFileExists(t, filepath.Join(target, "kustomization.yaml"))
@@ -191,10 +199,7 @@ func TestGenerateMissingOverlaysRejectsSymlinkedClustersRoot(t *testing.T) {
 	target := filepath.Join(dir, "outside-clusters")
 	require.NoError(t, os.MkdirAll(target, 0o750))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, sourceDir), 0o750))
-	require.NoError(
-		t,
-		os.Symlink(target, filepath.Join(dir, sourceDir, environment.ClustersDir)),
-	)
+	symlinkOrSkip(t, target, filepath.Join(dir, sourceDir, environment.ClustersDir))
 
 	generateExpectingUnsafePath(t, dir)
 	assert.NoDirExists(t, filepath.Join(target, "base"))
@@ -210,13 +215,45 @@ func TestGenerateMissingOverlaysRejectsSymlinkedLayoutFile(t *testing.T) {
 	// A dangling symlink at clusters/base/kustomization.yaml Lstats as a
 	// symlink but Stats as absent, so a force-off write would follow it.
 	escape := filepath.Join(dir, "escape-file.yaml")
-	require.NoError(t, os.Symlink(
-		escape,
-		filepath.Join(
-			dir, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
-		),
+	symlinkOrSkip(t, escape, filepath.Join(
+		dir, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
 	))
 
 	generateExpectingUnsafePath(t, dir)
 	assert.NoFileExists(t, escape)
+}
+
+func TestGenerateMissingOverlaysRejectsSymlinkedSourceDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+
+	// The per-file walk starts below sourceDir, so a symlinked source root
+	// must be rejected up front — every write would land in the link target.
+	target := filepath.Join(dir, "outside-source")
+	require.NoError(t, os.MkdirAll(target, 0o750))
+	symlinkOrSkip(t, target, filepath.Join(dir, sourceDir))
+
+	generateExpectingUnsafePath(t, dir)
+	assert.NoDirExists(t, filepath.Join(target, environment.ClustersDir))
+}
+
+func TestGenerateMissingOverlaysRejectsDirectoryLayoutLeaf(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+
+	// A directory at clusters/base/kustomization.yaml Stats as existing, so
+	// the force-off writer would skip the file yet report it as resolved,
+	// leaving overlays that reference a base without a kustomization.
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(
+			dir, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
+		),
+		0o750,
+	))
+
+	generateExpectingUnsafePath(t, dir)
 }

--- a/pkg/svc/environment/reconcile_generate_test.go
+++ b/pkg/svc/environment/reconcile_generate_test.go
@@ -11,6 +11,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// canonicalTempDir returns t.TempDir() with symlinked ancestors resolved
+// (macOS's /var → /private/var): generation canonicalizes sourceDir
+// ancestors, so tests asserting absolute output paths need the physical path.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	return dir
+}
+
 // populatedBase is a hand-authored shared base kustomization whose bytes the
 // generation step must preserve (force is hardwired off).
 const populatedBase = "resources:\n  - podinfo.yaml\n"
@@ -48,7 +60,7 @@ func generatePlan(t *testing.T, dir string) (environment.Plan, []string) {
 func TestGenerateMissingOverlaysScaffoldsMissingEntryPreservingBase(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.yaml", "ksail.local.yaml", "ksail.prod.yaml")
 	mkOverlays(t, dir, "prod")
 	basePath := writeBaseKustomization(t, dir)
@@ -66,7 +78,7 @@ func TestGenerateMissingOverlaysScaffoldsMissingEntryPreservingBase(t *testing.T
 func TestGenerateMissingOverlaysScaffoldsPreScaffoldTreeWithSharedBaseOnce(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 
 	_, written := generatePlan(t, dir)
@@ -87,7 +99,7 @@ func TestGenerateMissingOverlaysScaffoldsPreScaffoldTreeWithSharedBaseOnce(t *te
 func TestGenerateMissingOverlaysIsANoOpForPresentEntriesAndOrphans(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 	mkOverlays(t, dir, "local", "prod", "attic")
 
@@ -102,7 +114,7 @@ func TestGenerateMissingOverlaysIsANoOpForPresentEntriesAndOrphans(t *testing.T)
 func TestGenerateMissingOverlaysIsIdempotent(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 
 	_, first := generatePlan(t, dir)
@@ -176,7 +188,7 @@ func generateExpectingUnsafePath(t *testing.T, dir string) {
 func TestGenerateMissingOverlaysRejectsSymlinkedOverlayDir(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 	mkOverlays(t, dir, "prod")
 
@@ -193,7 +205,7 @@ func TestGenerateMissingOverlaysRejectsSymlinkedOverlayDir(t *testing.T) {
 func TestGenerateMissingOverlaysRejectsSymlinkedClustersRoot(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 
 	target := filepath.Join(dir, "outside-clusters")
@@ -208,7 +220,7 @@ func TestGenerateMissingOverlaysRejectsSymlinkedClustersRoot(t *testing.T) {
 func TestGenerateMissingOverlaysRejectsSymlinkedLayoutFile(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 	mkOverlays(t, dir, environment.BaseEnvName)
 
@@ -226,7 +238,7 @@ func TestGenerateMissingOverlaysRejectsSymlinkedLayoutFile(t *testing.T) {
 func TestGenerateMissingOverlaysRejectsSymlinkedSourceDir(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 
 	// The per-file walk starts below sourceDir, so a symlinked source root
@@ -239,10 +251,40 @@ func TestGenerateMissingOverlaysRejectsSymlinkedSourceDir(t *testing.T) {
 	assert.NoDirExists(t, filepath.Join(target, environment.ClustersDir))
 }
 
+func TestGenerateMissingOverlaysResolvesSymlinkedAncestorOfSourceDir(t *testing.T) {
+	t.Parallel()
+
+	dir := canonicalTempDir(t)
+
+	// A symlinked ANCESTOR of sourceDir (macOS's /var → /private/var class) is
+	// canonicalized up front, not rejected and not blindly followed at write
+	// time: generation succeeds and the layout lands in the physical target.
+	physical := filepath.Join(dir, "physical")
+	require.NoError(t, os.MkdirAll(physical, 0o750))
+
+	link := filepath.Join(dir, "link")
+	symlinkOrSkip(t, physical, link)
+
+	writeFiles(t, dir, "ksail.local.yaml")
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+	require.NoError(t, err)
+
+	written, err := environment.GenerateMissingOverlays(
+		kustomizationgenerator.NewGenerator(), filepath.Join(link, sourceDir), plan,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, written)
+
+	assert.FileExists(t, filepath.Join(
+		physical, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
+	))
+}
+
 func TestGenerateMissingOverlaysRejectsDirectoryLayoutLeaf(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
 
 	// A directory at clusters/base/kustomization.yaml Stats as existing, so

--- a/pkg/svc/environment/reconcile_generate_test.go
+++ b/pkg/svc/environment/reconcile_generate_test.go
@@ -281,6 +281,53 @@ func TestGenerateMissingOverlaysResolvesSymlinkedAncestorOfSourceDir(t *testing.
 	))
 }
 
+func TestGenerateMissingOverlaysNormalizesTrailingSeparator(t *testing.T) {
+	t.Parallel()
+
+	dir := canonicalTempDir(t)
+	writeFiles(t, dir, "ksail.local.yaml")
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+	require.NoError(t, err)
+
+	// A trailing separator must not make Dir/Base duplicate the leaf
+	// (`/repo/k8s/` once resolved as `/repo/k8s/k8s`).
+	trailing := filepath.Join(dir, sourceDir) + string(filepath.Separator)
+	written, err := environment.GenerateMissingOverlays(
+		kustomizationgenerator.NewGenerator(), trailing, plan,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, written)
+
+	assert.FileExists(t, filepath.Join(
+		dir, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
+	))
+	assert.NoDirExists(t, filepath.Join(dir, sourceDir, sourceDir))
+}
+
+func TestGenerateMissingOverlaysExpandsHomePrefixedSourceDir(t *testing.T) {
+	home := canonicalTempDir(t)
+	t.Setenv("HOME", home)
+
+	dir := canonicalTempDir(t)
+	writeFiles(t, dir, "ksail.local.yaml")
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+	require.NoError(t, err)
+
+	// `~/` must resolve to the user's home, never to a literal `./~/` dir.
+	written, err := environment.GenerateMissingOverlays(
+		kustomizationgenerator.NewGenerator(), "~/"+sourceDir, plan,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, written)
+
+	assert.FileExists(t, filepath.Join(
+		home, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
+	))
+	assert.NoDirExists(t, "~")
+}
+
 func TestGenerateMissingOverlaysRejectsDirectoryLayoutLeaf(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/environment/reconcile_generate_test.go
+++ b/pkg/svc/environment/reconcile_generate_test.go
@@ -1,0 +1,148 @@
+package environment_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	kustomizationgenerator "github.com/devantler-tech/ksail/v7/pkg/fsutil/generator/kustomization"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// populatedBase is a hand-authored shared base kustomization whose bytes the
+// generation step must preserve (force is hardwired off).
+const populatedBase = "resources:\n  - podinfo.yaml\n"
+
+// writeBaseKustomization seeds <dir>/<sourceDir>/clusters/base/kustomization.yaml
+// with the populated base content.
+func writeBaseKustomization(t *testing.T, dir string) string {
+	t.Helper()
+
+	basePath := filepath.Join(
+		dir, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(basePath), 0o750))
+	require.NoError(t, os.WriteFile(basePath, []byte(populatedBase), 0o600))
+
+	return basePath
+}
+
+// generatePlan derives the plan for dir and runs GenerateMissingOverlays over it
+// with the real kustomization generator, returning the plan and written paths.
+func generatePlan(t *testing.T, dir string) (environment.Plan, []string) {
+	t.Helper()
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+	require.NoError(t, err)
+
+	written, err := environment.GenerateMissingOverlays(
+		kustomizationgenerator.NewGenerator(), filepath.Join(dir, sourceDir), plan,
+	)
+	require.NoError(t, err)
+
+	return plan, written
+}
+
+func TestGenerateMissingOverlaysScaffoldsMissingEntryPreservingBase(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.yaml", "ksail.local.yaml", "ksail.prod.yaml")
+	mkOverlays(t, dir, "prod")
+	basePath := writeBaseKustomization(t, dir)
+
+	_, written := generatePlan(t, dir)
+
+	overlayPath := filepath.Join(dir, sourceDir, "clusters", "local", "kustomization.yaml")
+	assert.Equal(t, []string{basePath, overlayPath}, written)
+	assert.Equal(t, populatedBase, readFile(t, basePath))
+	assert.Contains(t, readFile(t, overlayPath), "../base")
+	// The present overlay is untouched — generation only resolves Missing entries.
+	assert.NoFileExists(t, filepath.Join(dir, sourceDir, "clusters", "prod", "kustomization.yaml"))
+}
+
+func TestGenerateMissingOverlaysScaffoldsPreScaffoldTreeWithSharedBaseOnce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+
+	_, written := generatePlan(t, dir)
+
+	clusters := filepath.Join(dir, sourceDir, "clusters")
+	assert.Equal(t, []string{
+		filepath.Join(clusters, "base", "kustomization.yaml"),
+		filepath.Join(clusters, "local", "kustomization.yaml"),
+		filepath.Join(clusters, "prod", "kustomization.yaml"),
+	}, written)
+
+	for _, env := range []string{"local", "prod"} {
+		overlay := readFile(t, filepath.Join(clusters, env, "kustomization.yaml"))
+		assert.Contains(t, overlay, "../base")
+	}
+}
+
+func TestGenerateMissingOverlaysIsANoOpForPresentEntriesAndOrphans(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+	mkOverlays(t, dir, "local", "prod", "attic")
+
+	plan, written := generatePlan(t, dir)
+
+	assert.Empty(t, written)
+	assert.Equal(t, []string{"clusters/attic"}, plan.Orphans)
+	// The orphan overlay is surfaced, never scaffolded into or deleted.
+	assert.NoFileExists(t, filepath.Join(dir, sourceDir, "clusters", "attic", "kustomization.yaml"))
+}
+
+func TestGenerateMissingOverlaysIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+
+	_, first := generatePlan(t, dir)
+
+	contents := make(map[string]string, len(first))
+	for _, path := range first {
+		contents[path] = readFile(t, path)
+	}
+
+	// Re-deriving reports every overlay Present; a second generation over the
+	// original plan (all Missing) must also rewrite nothing (force is off).
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+	require.NoError(t, err)
+
+	for _, entry := range plan.Entries {
+		assert.Equal(t, environment.OverlayPresent, entry.State)
+	}
+
+	_, second := generatePlan(t, dir)
+	assert.Empty(t, second)
+
+	for path, content := range contents {
+		assert.Equal(t, content, readFile(t, path))
+	}
+}
+
+func TestGenerateMissingOverlaysRejectsReservedBaseName(t *testing.T) {
+	t.Parallel()
+
+	plan := environment.Plan{
+		Entries: []environment.PlanEntry{{
+			Environment: environment.Environment{Name: environment.BaseEnvName},
+			OverlayDir:  "clusters/base",
+			State:       environment.OverlayMissing,
+		}},
+	}
+
+	_, err := environment.GenerateMissingOverlays(
+		kustomizationgenerator.NewGenerator(), t.TempDir(), plan,
+	)
+
+	require.ErrorIs(t, err, environment.ErrReservedEnvironmentName)
+}

--- a/pkg/svc/environment/reconcile_generate_test.go
+++ b/pkg/svc/environment/reconcile_generate_test.go
@@ -146,3 +146,77 @@ func TestGenerateMissingOverlaysRejectsReservedBaseName(t *testing.T) {
 
 	require.ErrorIs(t, err, environment.ErrReservedEnvironmentName)
 }
+
+// generateExpectingUnsafePath derives the plan for dir and asserts generation
+// refuses it with ErrUnsafeOverlayPath.
+func generateExpectingUnsafePath(t *testing.T, dir string) {
+	t.Helper()
+
+	plan, err := environment.DerivePlan(dir, sourceDir, planLoader())
+	require.NoError(t, err)
+
+	_, err = environment.GenerateMissingOverlays(
+		kustomizationgenerator.NewGenerator(), filepath.Join(dir, sourceDir), plan,
+	)
+
+	require.ErrorIs(t, err, environment.ErrUnsafeOverlayPath)
+}
+
+func TestGenerateMissingOverlaysRejectsSymlinkedOverlayDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+	mkOverlays(t, dir, "prod")
+
+	// DerivePlan reports a symlinked clusters/local as Missing (only real
+	// directories count), but writing through it would land in the target.
+	target := filepath.Join(dir, "outside-target")
+	require.NoError(t, os.MkdirAll(target, 0o750))
+	require.NoError(
+		t,
+		os.Symlink(target, filepath.Join(dir, sourceDir, environment.ClustersDir, "local")),
+	)
+
+	generateExpectingUnsafePath(t, dir)
+	assert.NoFileExists(t, filepath.Join(target, "kustomization.yaml"))
+}
+
+func TestGenerateMissingOverlaysRejectsSymlinkedClustersRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+
+	target := filepath.Join(dir, "outside-clusters")
+	require.NoError(t, os.MkdirAll(target, 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, sourceDir), 0o750))
+	require.NoError(
+		t,
+		os.Symlink(target, filepath.Join(dir, sourceDir, environment.ClustersDir)),
+	)
+
+	generateExpectingUnsafePath(t, dir)
+	assert.NoDirExists(t, filepath.Join(target, "base"))
+}
+
+func TestGenerateMissingOverlaysRejectsSymlinkedLayoutFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFiles(t, dir, "ksail.local.yaml", "ksail.prod.yaml")
+	mkOverlays(t, dir, environment.BaseEnvName)
+
+	// A dangling symlink at clusters/base/kustomization.yaml Lstats as a
+	// symlink but Stats as absent, so a force-off write would follow it.
+	escape := filepath.Join(dir, "escape-file.yaml")
+	require.NoError(t, os.Symlink(
+		escape,
+		filepath.Join(
+			dir, sourceDir, environment.ClustersDir, environment.BaseEnvName, "kustomization.yaml",
+		),
+	))
+
+	generateExpectingUnsafePath(t, dir)
+	assert.NoFileExists(t, escape)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
Declared environments (`ksail.<env>.yaml`) whose `clusters/<env>/` overlay is missing are reported by the reconcile plan but still have to be scaffolded by hand — the declarative-environments lane needs the plan to be resolvable, not just readable.

## What
Adds the generation step that scaffolds every missing overlay from the plan, composing the already-merged derive/write seams. It never overwrites existing files (a populated shared base is preserved) and never touches orphan overlays. CLI surfacing is the next increment.

Fixes #6072
Part of #5441