### PR TITLE
fix(cluster): resolve the actual eksctl context before GitOps bootstrap

### DIFF
--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -81,6 +81,19 @@ func ExportResolveClusterContext(kubeconfigPath, clusterName string) (string, er
 	return resolveClusterContext(kubeconfigPath, clusterName)
 }
 
+// ExportResolveCreatedContext exports resolveCreatedContext for testing.
+func ExportResolveCreatedContext(
+	ctx *localregistry.Context,
+	clusterName string,
+) (string, error) {
+	return resolveCreatedContext(ctx, clusterName)
+}
+
+// ExportResolveEKSCreatedContext exports resolveEKSCreatedContext for testing.
+func ExportResolveEKSCreatedContext(kubeconfigSpec, name, region string) (string, error) {
+	return resolveEKSCreatedContext(kubeconfigSpec, name, region)
+}
+
 // ExportEnsureConfiguredContextResolvable exports ensureConfiguredContextResolvable for testing.
 func ExportEnsureConfiguredContextResolvable(clusterCfg *v1alpha1.Cluster) error {
 	return ensureConfiguredContextResolvable(clusterCfg)

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -1,14 +1,19 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // defaultClusterMutationFieldSelectors returns the full set of field selectors
@@ -242,14 +247,12 @@ func runClusterCreationWorkflow(
 	// For Omni clusters, the kubeconfig context is now renamed during saveOmniKubeconfig
 	// to match the configured context or the Talos convention (admin@<name>).
 	// If an explicit context is already configured, preserve it.
-	if ctx.ClusterCfg.Spec.Cluster.Connection.Context == "" {
-		clusterName := resolveClusterNameFromContext(ctx)
-		ctx.ClusterCfg.Spec.Cluster.Connection.Context = resolveCreatedContextName(
-			ctx.ClusterCfg.Spec.Cluster.Distribution,
-			ctx.ClusterCfg.Spec.Cluster.Provider,
-			clusterName,
-		)
+	createdContext, err := resolveCreatedContext(ctx, resolveClusterNameFromContext(ctx))
+	if err != nil {
+		return err
 	}
+
+	ctx.ClusterCfg.Spec.Cluster.Connection.Context = createdContext
 
 	maybeImportCachedImages(cmd, ctx, deps.Timer)
 
@@ -275,4 +278,119 @@ func resolveCreatedContextName(
 	}
 
 	return distribution.ContextName(clusterName)
+}
+
+// ErrEKSContextNotFound is returned when no kubeconfig context matches the
+// freshly created EKS cluster, so post-create GitOps bootstrapping would
+// target a context that does not exist.
+var ErrEKSContextNotFound = errors.New(
+	"no kubeconfig context matches the created EKS cluster; " +
+		"set spec.cluster.connection.context to the context eksctl wrote",
+)
+
+// ErrEKSContextAmbiguous is returned when more than one kubeconfig context
+// matches the freshly created EKS cluster and none of them is current-context.
+var ErrEKSContextAmbiguous = errors.New(
+	"multiple kubeconfig contexts match the created EKS cluster; " +
+		"set spec.cluster.connection.context to the context eksctl wrote",
+)
+
+// resolveCreatedContext returns the kubeconfig context post-creation setup
+// (CNI install, helm, Flux/ArgoCD bootstrap) should target. An explicitly
+// configured context is always preserved unchanged. Most distributions write
+// a deterministic context name (resolveCreatedContextName); EKS is the
+// exception — eksctl qualifies the context with the caller's IAM identity as
+// "<identity>@<name>.<region>.eksctl.io", and the identity is unknown until
+// eksctl has written the kubeconfig, so the actual context is read back from
+// the configured kubeconfig after creation.
+func resolveCreatedContext(
+	ctx *localregistry.Context,
+	clusterName string,
+) (string, error) {
+	cluster := &ctx.ClusterCfg.Spec.Cluster
+	if cluster.Connection.Context != "" {
+		return cluster.Connection.Context, nil
+	}
+
+	if cluster.Distribution == v1alpha1.DistributionEKS {
+		region := ""
+		if ctx.EKSConfig != nil {
+			region = ctx.EKSConfig.Region
+		}
+
+		return resolveEKSCreatedContext(cluster.Connection.Kubeconfig, clusterName, region)
+	}
+
+	return resolveCreatedContextName(cluster.Distribution, cluster.Provider, clusterName), nil
+}
+
+// resolveEKSCreatedContext reads the kubeconfig eksctl just wrote and resolves
+// the identity-qualified context ("<identity>@<name>.<region>.eksctl.io") for
+// the created cluster. A matching current-context wins; otherwise exactly one
+// matching context is accepted. Zero or multiple ambiguous matches fail closed
+// with a hint to configure the context explicitly, rather than letting the
+// GitOps bootstrap target a context that does not exist.
+func resolveEKSCreatedContext(kubeconfigSpec, name, region string) (string, error) {
+	path, err := k8s.ResolveKubeconfigPath(kubeconfigSpec)
+	if err != nil {
+		return "", fmt.Errorf("resolve kubeconfig path: %w", err)
+	}
+
+	config, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read kubeconfig after EKS creation: %w", err)
+	}
+
+	if config.CurrentContext != "" && eksContextMatches(config.CurrentContext, name, region) {
+		return config.CurrentContext, nil
+	}
+
+	matches := make([]string, 0, 1)
+
+	for contextName := range config.Contexts {
+		if eksContextMatches(contextName, name, region) {
+			matches = append(matches, contextName)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf(
+			"%w: no context matching %q in %q",
+			ErrEKSContextNotFound, "@"+name+"."+region+".eksctl.io", path,
+		)
+	default:
+		sort.Strings(matches)
+
+		return "", fmt.Errorf(
+			"%w: candidates %s in %q",
+			ErrEKSContextAmbiguous, strings.Join(matches, ", "), path,
+		)
+	}
+}
+
+// eksContextMatches reports whether an existing kubeconfig context name is the
+// eksctl-written context for the given cluster name and region. eksctl writes
+// "<iam-identity>@<name>.<region>.eksctl.io"; the identity part is arbitrary.
+// When the region is unknown (no parsed eks.yaml metadata), any region segment
+// is accepted.
+func eksContextMatches(contextName, name, region string) bool {
+	atIdx := strings.LastIndex(contextName, "@")
+	if atIdx < 0 || atIdx+1 >= len(contextName) {
+		return false
+	}
+
+	qualifier := contextName[atIdx+1:]
+	if region != "" {
+		return qualifier == name+"."+region+".eksctl.io"
+	}
+
+	rest, found := strings.CutSuffix(qualifier, ".eksctl.io")
+	if !found {
+		return false
+	}
+
+	return strings.HasPrefix(rest, name+".")
 }

--- a/pkg/cli/cmd/cluster/mutation_test.go
+++ b/pkg/cli/cmd/cluster/mutation_test.go
@@ -1,10 +1,17 @@
 package cluster_test
 
 import (
+	"path/filepath"
 	"testing"
 
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestAllDistributions(t *testing.T) {
@@ -21,4 +28,231 @@ func TestAllProviders(t *testing.T) {
 	providers := cluster.ExportAllProviders()
 	assert.NotEmpty(t, providers)
 	assert.GreaterOrEqual(t, len(providers), 3)
+}
+
+// writeTestKubeconfig writes a kubeconfig with the given contexts to a temp
+// dir and returns its path.
+func writeTestKubeconfig(t *testing.T, currentContext string, contexts ...string) string {
+	t.Helper()
+
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = currentContext
+
+	for _, name := range contexts {
+		config.Contexts[name] = clientcmdapi.NewContext()
+	}
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, clientcmd.WriteToFile(*config, path))
+
+	return path
+}
+
+// newEKSContext builds a localregistry.Context for an EKS cluster whose
+// kubeconfig is the given path.
+func newEKSContext(kubeconfigPath, explicitContext, region string) *localregistry.Context {
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	clusterCfg.Spec.Cluster.Connection.Kubeconfig = kubeconfigPath
+	clusterCfg.Spec.Cluster.Connection.Context = explicitContext
+
+	return &localregistry.Context{
+		ClusterCfg: clusterCfg,
+		EKSConfig:  &clusterprovisioner.EKSConfig{Name: "my-cluster", Region: region},
+	}
+}
+
+func TestResolveCreatedContextPreservesExplicitContext(t *testing.T) {
+	t.Parallel()
+
+	// No kubeconfig exists at this path; an explicit context must be returned
+	// unchanged without any kubeconfig read.
+	ctx := newEKSContext(
+		filepath.Join(t.TempDir(), "missing"),
+		"admin@my-cluster.eu-north-1.eksctl.io",
+		"eu-north-1",
+	)
+
+	resolved, err := cluster.ExportResolveCreatedContext(ctx, "my-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "admin@my-cluster.eu-north-1.eksctl.io", resolved)
+}
+
+func TestResolveCreatedContextNonEKSUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		distribution v1alpha1.Distribution
+		provider     v1alpha1.Provider
+		want         string
+	}{
+		{
+			name:         "vanilla kind context",
+			distribution: v1alpha1.DistributionVanilla,
+			provider:     v1alpha1.ProviderDocker,
+			want:         "kind-my-cluster",
+		},
+		{
+			name:         "k3s on kubernetes provider uses k3k prefix",
+			distribution: v1alpha1.DistributionK3s,
+			provider:     v1alpha1.ProviderKubernetes,
+			want:         "k3k-my-cluster",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterCfg := &v1alpha1.Cluster{}
+			clusterCfg.Spec.Cluster.Distribution = testCase.distribution
+			clusterCfg.Spec.Cluster.Provider = testCase.provider
+
+			resolved, err := cluster.ExportResolveCreatedContext(
+				&localregistry.Context{ClusterCfg: clusterCfg},
+				"my-cluster",
+			)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, resolved)
+		})
+	}
+}
+
+func TestResolveCreatedContextEKSReadsKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	kubeconfigPath := writeTestKubeconfig(
+		t,
+		"admin@my-cluster.eu-north-1.eksctl.io",
+		"admin@my-cluster.eu-north-1.eksctl.io",
+	)
+	ctx := newEKSContext(kubeconfigPath, "", "eu-north-1")
+
+	resolved, err := cluster.ExportResolveCreatedContext(ctx, "my-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "admin@my-cluster.eu-north-1.eksctl.io", resolved)
+}
+
+// eksContextCase is one TestResolveEKSCreatedContext table entry.
+type eksContextCase struct {
+	name           string
+	currentContext string
+	contexts       []string
+	region         string
+	want           string
+	wantErr        error
+}
+
+// runEKSContextCase asserts resolveEKSCreatedContext's outcome for one case.
+func runEKSContextCase(t *testing.T, testCase eksContextCase) {
+	t.Helper()
+
+	kubeconfigPath := writeTestKubeconfig(
+		t,
+		testCase.currentContext,
+		testCase.contexts...,
+	)
+
+	resolved, err := cluster.ExportResolveEKSCreatedContext(
+		kubeconfigPath,
+		"my-cluster",
+		testCase.region,
+	)
+
+	if testCase.wantErr != nil {
+		require.ErrorIs(t, err, testCase.wantErr)
+
+		return
+	}
+
+	require.NoError(t, err)
+	assert.Equal(t, testCase.want, resolved)
+}
+
+func TestResolveEKSCreatedContextSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []eksContextCase{
+		{
+			name:           "prefers matching current context over other matches",
+			currentContext: "role-b@my-cluster.eu-north-1.eksctl.io",
+			contexts: []string{
+				"role-a@my-cluster.eu-north-1.eksctl.io",
+				"role-b@my-cluster.eu-north-1.eksctl.io",
+			},
+			region: "eu-north-1",
+			want:   "role-b@my-cluster.eu-north-1.eksctl.io",
+		},
+		{
+			name:           "accepts unique match when current context is unrelated",
+			currentContext: "kind-other",
+			contexts: []string{
+				"kind-other",
+				"admin@my-cluster.eu-north-1.eksctl.io",
+			},
+			region: "eu-north-1",
+			want:   "admin@my-cluster.eu-north-1.eksctl.io",
+		},
+		{
+			name:           "unknown region matches any region segment",
+			currentContext: "",
+			contexts:       []string{"admin@my-cluster.us-east-1.eksctl.io"},
+			region:         "",
+			want:           "admin@my-cluster.us-east-1.eksctl.io",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			runEKSContextCase(t, testCase)
+		})
+	}
+}
+
+func TestResolveEKSCreatedContextFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []eksContextCase{
+		{
+			name:           "synthetic suffix-only context does not match",
+			currentContext: "my-cluster.eksctl.io",
+			contexts:       []string{"my-cluster.eksctl.io"},
+			region:         "eu-north-1",
+			wantErr:        cluster.ErrEKSContextNotFound,
+		},
+		{
+			name:           "wrong region does not match",
+			currentContext: "",
+			contexts:       []string{"admin@my-cluster.us-east-1.eksctl.io"},
+			region:         "eu-north-1",
+			wantErr:        cluster.ErrEKSContextNotFound,
+		},
+		{
+			name:           "no contexts fails closed",
+			currentContext: "",
+			contexts:       nil,
+			region:         "eu-north-1",
+			wantErr:        cluster.ErrEKSContextNotFound,
+		},
+		{
+			name:           "ambiguous matches without matching current context fail closed",
+			currentContext: "kind-other",
+			contexts: []string{
+				"kind-other",
+				"role-a@my-cluster.eu-north-1.eksctl.io",
+				"role-b@my-cluster.eu-north-1.eksctl.io",
+			},
+			region:  "eu-north-1",
+			wantErr: cluster.ErrEKSContextAmbiguous,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			runEKSContextCase(t, testCase)
+		})
+	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

EKS cluster creation could fail right before Flux/ArgoCD bootstrapping: KSail assumed a synthetic kubeconfig context name while eksctl writes an identity- and region-qualified one, so the post-create install targeted a context that doesn't exist.

## What

After EKS creation, KSail now reads the context eksctl actually wrote from the kubeconfig (preferring current-context, accepting a unique match, and failing closed with a clear hint when none or several match). Explicitly configured contexts and all non-EKS distributions behave exactly as before.

Fixes #6077. Part of #4328 (AC4).