### PR TITLE
fix(release): stop plugin PR auto-merge

### DIFF
--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -10,6 +10,7 @@ ci_workflow="${repo_root}/.github/workflows/ci.yaml"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 homebrew_block="${tmp_dir}/homebrew.yaml"
+copilot_plugin_block="${tmp_dir}/copilot-plugin.yaml"
 execution_surface="${tmp_dir}/execution-surface.sh"
 
 awk '
@@ -18,8 +19,15 @@ awk '
   in_homebrew { print }
 ' "${cd_workflow}" >"${homebrew_block}"
 
+awk '
+  /^  copilot-plugin:/ { in_copilot_plugin = 1 }
+  /^  operator-chart:/ { in_copilot_plugin = 0 }
+  in_copilot_plugin { print }
+' "${cd_workflow}" >"${copilot_plugin_block}"
+
 awk '1' \
 	"${homebrew_block}" \
+	"${copilot_plugin_block}" \
 	"${repo_root}/.github/scripts/collect-cask-pr-handoff.sh" \
 	"${repo_root}/.github/scripts/validate-cask-pr-handoff.sh" \
 	>"${execution_surface}"
@@ -53,14 +61,20 @@ assert_contains 'for label in automation dependencies' "${homebrew_block}" \
 	'release job must add available automation/dependencies labels'
 assert_contains 'remains draft/open for maintainer promotion' "${homebrew_block}" \
 	'release job must record the draft PR handoff'
+assert_contains 'name: 🧩 Release Copilot CLI Plugin' "${copilot_plugin_block}" \
+	'workflow contract must find the Copilot plugin release job'
+assert_contains 'gh pr create' "${copilot_plugin_block}" \
+	'Copilot plugin release job must create its generated PR'
+assert_not_contains 'allow_auto_merge=true' "${execution_surface}" \
+	'release jobs must never enable repository auto-merge'
 assert_not_contains 'gh pr ready' "${execution_surface}" \
-	'release job and its helpers must never self-promote a generated draft'
+	'release jobs and helpers must never self-promote a generated draft'
 assert_not_contains 'gh pr merge' "${execution_surface}" \
-	'release job and its helpers must never merge a generated cask PR'
+	'release jobs and helpers must never merge a generated PR'
 assert_not_contains '--auto' "${execution_surface}" \
-	'release job and its helpers must never arm auto-merge'
+	'release jobs and helpers must never arm auto-merge'
 assert_not_contains '--admin' "${execution_surface}" \
-	'release job and its helpers must never bypass branch protections'
+	'release jobs and helpers must never bypass branch protections'
 
 validator_calls="$(grep -Fc -- 'validate_handoff "$pr"' "${homebrew_block}" || true)"
 if [ "${validator_calls}" -lt 3 ]; then

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -265,10 +265,10 @@ jobs:
     name: 🧩 Release Copilot CLI Plugin
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Runs in parallel with the other releases — it only opens an auto-merging version-bump
-    # PR and consumes no GoReleaser artifact, so it does not wait on `goreleaser`. The gated
-    # `publish-release` and `pages-deploy` jobs both list it in `needs`, so a failure here
-    # still blocks the GitHub release publish and the docs deploy.
+    # Runs in parallel with the other releases — it only opens a version-bump PR for CI and
+    # the standard maintainer review gates, and consumes no GoReleaser artifact, so it does
+    # not wait on `goreleaser`. The gated `publish-release` and `pages-deploy` jobs both list
+    # it in `needs`, so a failure here still blocks the GitHub release publish and docs deploy.
     environment: ci
     permissions:
       contents: write
@@ -292,8 +292,8 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       # Instead of pushing directly to main (which is blocked by the required
-      # "✅ Validate Go Project" workflow rule), open a PR so CI can run on the
-      # version bump commit and auto-merge once checks pass.
+      # "✅ Validate Go Project" workflow rule), open a PR so CI and the standard
+      # maintainer review gates can run on the version bump commit.
       - name: 📤 Create version bump PR
         env:
           VERSION: ${{ steps.get_version.outputs.version }}
@@ -356,15 +356,6 @@ jobs:
               --head "${BRANCH}" \
               --title "chore(copilot-plugin): release v${VERSION}" \
               --body "Automated version bump for copilot plugin manifests to v${VERSION}."
-          fi
-
-          # Ensure auto-merge is enabled at the repository level (idempotent).
-          if ! gh api "repos/{owner}/{repo}" --method PATCH -f allow_auto_merge=true --silent; then
-            echo "::warning::Could not enable auto-merge at the repository level (token may lack administration permissions)."
-          fi
-
-          if ! gh pr merge "${BRANCH}" --auto --squash; then
-            echo "::warning::Auto-merge could not be enabled; the PR must be merged manually or auto-merge must be enabled in repository settings."
           fi
 
   operator-chart:


### PR DESCRIPTION
> 🤖 Generated by the Codex Daily AI Engineer

## Summary

- stop the Copilot CLI plugin release job from enabling repository auto-merge
- leave the generated version-bump PR open for the standard maintainer review lane
- extend the existing release-PR handoff contract across both Homebrew and Copilot plugin PR surfaces
- preserve bot PR creation and existing release dependencies

## Why

Bot PR [#6093](https://github.com/devantler-tech/ksail/pull/6093) merged after required CI passed, but without any review and without a supported CodeRabbit pre-merge result. The release workflow had armed `gh pr merge --auto --squash`; GitHub then behaved according to the repository's currently configured requirements.

This removes the privileged local merge arm. The separate organization ruleset repair remains tracked in [devantler-tech/.github#87](https://github.com/devantler-tech/.github/issues/87).

## Validation

- RED: `.github/scripts/cask-pr-handoff-workflow.test.sh` failed on the live `allow_auto_merge=true` path
- GREEN: focused workflow contract passes after the deletion
- `bash -n .github/scripts/cask-pr-handoff-workflow.test.sh`
- `shellcheck .github/scripts/cask-pr-handoff-workflow.test.sh`
- `actionlint .github/workflows/cd.yaml`
- cask PR collector and validator fixture suites
- `git diff --check`

The repository-prescribed `mega-linter-runner` executable is not installed on this host; CI remains the full MegaLinter gate.

Fixes #6094
