### PR TITLE
docs(guides): document unmanaged (kubeconfig-only) cluster tracking

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -126,6 +126,7 @@ export default defineConfig({
                 { label: "Day-2 Operations", link: "/guides/day-2-operations/" },
                 { label: "Ephemeral Clusters (--ttl)", link: "/guides/ephemeral-clusters/" },
                 { label: "Backup & Restore", link: "/guides/backup-restore/" },
+                { label: "Unmanaged Clusters", link: "/guides/unmanaged-clusters/" },
                 { label: "Multi-Environment Workflows", link: "/guides/multi-environment/" },
               ],
             },

--- a/docs/src/content/docs/guides/unmanaged-clusters.mdx
+++ b/docs/src/content/docs/guides/unmanaged-clusters.mdx
@@ -30,15 +30,20 @@ ksail cluster switch my-eks-prod           # switch the active kubeconfig contex
 ksail cluster connect                      # open k9s against the selected context
 ksail cluster info --name my-eks-prod      # endpoint + kubeconfig access for a named cluster
 ksail cluster diagnose --name my-eks-prod  # diagnoses the ACTIVE context; --name only labels the report
+ksail cluster backup ./snapshot            # snapshot Kubernetes resources over the API server
+ksail cluster restore ./snapshot           # restore them
 ```
+
+> [!IMPORTANT]
+> **The context must live in the kubeconfig KSail reads.** Only `cluster switch` consults the `KUBECONFIG` environment variable — `cluster connect` and the `ksail workload` wrappers resolve their kubeconfig from `spec.cluster.connection.kubeconfig` in `ksail.yaml`, falling back to the **default** `~/.kube/config`, and never read `KUBECONFIG`. So if your unmanaged context exists only in a non-default `KUBECONFIG` file, `cluster switch` will select it while `apply`, `logs` or `connect` quietly target a *different* kubeconfig. Merge the context into `~/.kube/config`, or point `spec.cluster.connection.kubeconfig` at the file, before operating.
 
 > [!IMPORTANT]
 > `cluster diagnose --name <name>` does **not** select the named context — it builds its Kubernetes client from your kubeconfig's **current context** and uses `--name` only to label the report. Always `ksail cluster switch <name>` first, or you will diagnose the wrong cluster. Tracked in [#6117](https://github.com/devantler-tech/ksail/issues/6117).
 
-Within the `ksail workload` group, the commands that work against any selected unmanaged context are the **API-backed** ones: the kubectl-style wrappers (`get`, `logs`, `apply`, `exec`, `describe`, `wait`, `port-forward`, …) plus `watch`, `edit`, `validate`, `scan`, and `debug`. Helm-based `workload install` works too, as do **`backup` and `restore`**, which snapshot and restore Kubernetes resources over the API server — all resolve the kubeconfig and need no KSail metadata.
+Within the `ksail workload` group, the commands that work against any selected unmanaged context are the **API-backed** ones: the kubectl-style wrappers (`get`, `logs`, `apply`, `exec`, `describe`, `wait`, `forward`, …) plus `watch`, `edit`, `validate`, `scan`, and `debug`. Helm-based `workload install` works too — all resolve the kubeconfig and need no KSail metadata. (Backup and restore are **`ksail cluster`** subcommands, shown above, not `workload` ones.)
 
 > [!NOTE]
-> Three `workload` commands are **not** purely kubeconfig-backed and need a local `ksail.yaml` even against an unmanaged cluster: `network` refuses unless `spec.cluster.cni` is Cilium; `images` derives its image list from the local KSail config rather than the live cluster; and `push` resolves its registry, source directory and tag from that config.
+> Some `workload` commands are **not** purely kubeconfig-backed and do not work on an arbitrary unmanaged context. Three need a local `ksail.yaml`: `network` refuses unless `spec.cluster.cni` is Cilium; `images` derives its image list from the local KSail config rather than the live cluster; and `push` resolves its registry, source directory and tag from that config. Two more are **Docker-only**: `export` and `import` detect the cluster's distribution/provider and operate on Docker node containers, so they reject a non-Docker provider — an unmanaged EKS/GKE/`kubeadm` context is out of scope for them.
 
 ## What is refused (ksail-only actions)
 
@@ -66,9 +71,10 @@ The refusal covers the lifecycle operations KSail cannot drive without a provide
 | List / switch / connect | ✅ | ✅ (marked unmanaged) |
 | Info | ✅ | ✅ with a resolvable `--name` |
 | Diagnose | ✅ | ⚠️ diagnoses the **active** context — `switch` first ([#6117](https://github.com/devantler-tech/ksail/issues/6117)) |
-| `workload` API-backed (get, logs, exec, apply, watch, install, …) | ✅ | ✅ |
+| `workload` API-backed (get, logs, exec, apply, watch, forward, install, …) | ✅ | ✅ |
 | `workload network` / `images` / `push` | ✅ | ⚠️ also need a local `ksail.yaml` |
-| Backup / restore | ✅ | ✅ |
+| `workload export` / `import` | ✅ (Docker) | ⛔ Docker-backed nodes only |
+| `cluster backup` / `cluster restore` | ✅ | ✅ |
 | Web UI / desktop resource browsing | ✅ | ⛔ listed only; operations are CLI-only ([#6116](https://github.com/devantler-tech/ksail/issues/6116)) |
 | Delete / update / start / stop | ✅ | ⛔ refused with a documented message |
 | Component install (CNI, CSI, GitOps, policy) | ✅ | ⛔ requires `spec.cluster.*` |

--- a/docs/src/content/docs/guides/unmanaged-clusters.mdx
+++ b/docs/src/content/docs/guides/unmanaged-clusters.mdx
@@ -16,20 +16,23 @@ KSail can **see and operate on any cluster in your kubeconfig**, even one it did
 ksail cluster list
 ```
 
-Unmanaged clusters report an empty distribution/provider (shown as `—`) because there is no KSail spec to read, and a `Ready=False` status with reason `Unmanaged`. The same marked model backs the CLI and the web UI / desktop app, so a cluster behaves identically wherever you look at it.
+Unmanaged clusters appear with **blank distribution and provider columns** (there is no KSail spec to read) and a `STATUS` of `Unmanaged`. Discovery reads your **default kubeconfig** (`~/.kube/config`), so a context kept only in a non-default `KUBECONFIG` path may not be listed. The same marked model backs the CLI and the web UI / desktop app, so a cluster behaves identically wherever you look at it.
 
 ## Operating within limits
 
 Because most of KSail's read/operate surface is client-go-backed, it works against any selected context — managed or not. Select an unmanaged cluster and use it like any other:
 
 ```sh
-ksail cluster switch my-eks-prod       # switch the active kubeconfig context
-ksail cluster info                     # endpoint + kubeconfig access (unknown ksail-only fields shown as —)
-ksail cluster connect                  # open k9s against the context
-ksail cluster diagnose                 # run diagnostics against the selected context
+ksail cluster switch my-eks-prod           # switch the active kubeconfig context
+ksail cluster connect                      # open k9s against the selected context
+ksail cluster info --name my-eks-prod      # endpoint + kubeconfig access for a named cluster
+ksail cluster diagnose --name my-eks-prod  # diagnostics for a named cluster
 ```
 
-The `ksail workload` group — `kubectl`, `watch`, `network`, `edit`, `images`, `push`, `render`, `validate`, `scan`, `debug` — also works against the selected unmanaged context, as do **`backup` and `restore`**, which snapshot and restore Kubernetes resources over the API server (they resolve the kubeconfig like the other cluster commands and need no KSail metadata).
+> [!NOTE]
+> `cluster info` and `cluster diagnose` resolve a cluster identity before they run. For an arbitrary unmanaged context (a typical EKS/AKS or `kubeadm` context) pass `--name` so the command targets it; without a resolvable name they report that a name is required rather than guessing.
+
+The `ksail workload` group also works against the selected unmanaged context: the kubectl-style wrappers (`get`, `logs`, `apply`, `exec`, `describe`, `wait`, `port-forward`, …) plus `watch`, `network`, `edit`, `images`, `push`, `validate`, `scan`, and `debug`. Helm-based `workload install` works too, as do **`backup` and `restore`**, which snapshot and restore Kubernetes resources over the API server — all resolve the kubeconfig like the other cluster commands and need no KSail metadata.
 
 ## What is refused (ksail-only actions)
 
@@ -43,9 +46,9 @@ ksail cluster delete --name my-eks-prod
 
 The refusal covers the lifecycle operations KSail cannot drive without a provider:
 
-- **Lifecycle** — `create`, `delete`, `update`, `start`, `stop` (no provider/distribution to act on).
+- **Lifecycle** — `delete`, `update`, `start`, `stop` are refused with the unmanaged message (no provider/distribution to act on). `create` is not a selected-context action — it provisions from `ksail.yaml`, so it is unaffected by this guard.
 - **Component installation** — CNI, CSI, metrics-server, GitOps/Flux, policy engine (all driven from `spec.cluster.*`).
-- **GitOps operations** — `workload reconcile` / `workload install` need a KSail/GitOps configuration, not just a kubeconfig.
+- **GitOps reconciliation** — `workload reconcile` targets GitOps-managed workloads and needs a Flux/GitOps-configured cluster, not just a kubeconfig.
 
 > [!NOTE]
 > The unmanaged guard **fails open on incomplete discovery**: if KSail cannot fully enumerate every provider (for example a stopped Docker daemon), it does not wrongly refuse a cluster it might actually manage — it only refuses a cluster that is confirmed unmanaged and present in the kubeconfig.
@@ -54,10 +57,11 @@ The refusal covers the lifecycle operations KSail cannot drive without a provide
 
 | Capability | Managed cluster | Unmanaged (kubeconfig-only) cluster |
 | --- | --- | --- |
-| List / switch / info / connect / diagnose | ✅ | ✅ (marked unmanaged) |
-| `workload` (kubectl, logs, exec, apply, watch, …) | ✅ | ✅ |
+| List / switch / connect | ✅ | ✅ (marked unmanaged) |
+| Info / diagnose | ✅ | ✅ with a resolvable `--name` |
+| `workload` (get, logs, exec, apply, watch, install, …) | ✅ | ✅ |
 | Backup / restore | ✅ | ✅ |
-| Create / delete / start / stop / update | ✅ | ⛔ refused with a documented message |
+| Delete / update / start / stop | ✅ | ⛔ refused with a documented message |
 | Component install (CNI, CSI, GitOps, policy) | ✅ | ⛔ requires `spec.cluster.*` |
-| GitOps reconcile / install | ✅ | ⛔ requires a GitOps-configured cluster |
-| Distribution / provider | reported | `—` (no KSail spec) |
+| GitOps reconcile | ✅ | ⛔ requires a GitOps-configured cluster |
+| Distribution / provider | reported | blank (no KSail spec) |

--- a/docs/src/content/docs/guides/unmanaged-clusters.mdx
+++ b/docs/src/content/docs/guides/unmanaged-clusters.mdx
@@ -6,7 +6,7 @@ description: How KSail sees and operates on clusters that exist in your kubeconf
 KSail can **see and operate on any cluster in your kubeconfig**, even one it did not provision — a managed cloud cluster (EKS/GKE/AKS), a `kubeadm` cluster, or a colleague's cluster shared with you. These appear as **unmanaged** clusters: KSail surfaces them clearly marked, never hidden and never shown as a normal managed cluster, and refuses ksail-only lifecycle actions on them with a documented message instead of failing silently.
 
 > [!NOTE]
-> A cluster is **unmanaged** when it is present in your kubeconfig as a context that KSail did not create through one of its infrastructure providers (Docker, Hetzner, Omni, AWS-EKS, nested Kubernetes). KSail still has no provider or distribution spec for it, so anything that requires provisioning is unavailable — but everything that works over the Kubernetes API works normally.
+> A cluster is marked **unmanaged** when it is a kubeconfig context that KSail did not find among the providers it discovered. By default `ksail cluster list` discovers only **Docker, Hetzner and Omni**, so the marker means "not discovered", not "definitely not created by KSail": a KSail-created **EKS** or **nested-Kubernetes** cluster is not queried by default and therefore also shows up as `Unmanaged`. Pass `--provider` to widen discovery. In every case KSail has no provider or distribution spec to read for the context, so anything requiring provisioning is unavailable — while the Kubernetes-API surface works normally.
 
 ## Seeing unmanaged clusters
 
@@ -16,23 +16,29 @@ KSail can **see and operate on any cluster in your kubeconfig**, even one it did
 ksail cluster list
 ```
 
-Unmanaged clusters appear with **blank distribution and provider columns** (there is no KSail spec to read) and a `STATUS` of `Unmanaged`. Discovery reads your **default kubeconfig** (`~/.kube/config`), so a context kept only in a non-default `KUBECONFIG` path may not be listed. The same marked model backs the CLI and the web UI / desktop app, so a cluster behaves identically wherever you look at it.
+Unmanaged clusters appear with **blank distribution and provider columns** (there is no KSail spec to read) and a `STATUS` of `Unmanaged`. Discovery reads your **default kubeconfig** (`~/.kube/config`), so a context kept only in a non-default `KUBECONFIG` path may not be listed.
+
+> [!NOTE]
+> The web UI / desktop app **lists** unmanaged contexts, but selecting one for resource browsing or actions currently reports *not found*: the UI resolves a row back to a context by KSail-detected cluster name, which an arbitrary unmanaged context (an EKS/`kubeadm` context) has none of. **Operating on an unmanaged cluster is CLI-only for now** — tracked in [#6116](https://github.com/devantler-tech/ksail/issues/6116).
 
 ## Operating within limits
 
-Because most of KSail's read/operate surface is client-go-backed, it works against any selected context — managed or not. Select an unmanaged cluster and use it like any other:
+Much of KSail's read/operate surface is client-go-backed, so it works against the **selected kubeconfig context** — managed or not. Switch to the unmanaged cluster first, then use it like any other:
 
 ```sh
 ksail cluster switch my-eks-prod           # switch the active kubeconfig context
 ksail cluster connect                      # open k9s against the selected context
 ksail cluster info --name my-eks-prod      # endpoint + kubeconfig access for a named cluster
-ksail cluster diagnose --name my-eks-prod  # diagnostics for a named cluster
+ksail cluster diagnose --name my-eks-prod  # diagnoses the ACTIVE context; --name only labels the report
 ```
 
-> [!NOTE]
-> `cluster info` and `cluster diagnose` resolve a cluster identity before they run. For an arbitrary unmanaged context (a typical EKS/AKS or `kubeadm` context) pass `--name` so the command targets it; without a resolvable name they report that a name is required rather than guessing.
+> [!IMPORTANT]
+> `cluster diagnose --name <name>` does **not** select the named context — it builds its Kubernetes client from your kubeconfig's **current context** and uses `--name` only to label the report. Always `ksail cluster switch <name>` first, or you will diagnose the wrong cluster. Tracked in [#6117](https://github.com/devantler-tech/ksail/issues/6117).
 
-The `ksail workload` group also works against the selected unmanaged context: the kubectl-style wrappers (`get`, `logs`, `apply`, `exec`, `describe`, `wait`, `port-forward`, …) plus `watch`, `network`, `edit`, `images`, `push`, `validate`, `scan`, and `debug`. Helm-based `workload install` works too, as do **`backup` and `restore`**, which snapshot and restore Kubernetes resources over the API server — all resolve the kubeconfig like the other cluster commands and need no KSail metadata.
+Within the `ksail workload` group, the commands that work against any selected unmanaged context are the **API-backed** ones: the kubectl-style wrappers (`get`, `logs`, `apply`, `exec`, `describe`, `wait`, `port-forward`, …) plus `watch`, `edit`, `validate`, `scan`, and `debug`. Helm-based `workload install` works too, as do **`backup` and `restore`**, which snapshot and restore Kubernetes resources over the API server — all resolve the kubeconfig and need no KSail metadata.
+
+> [!NOTE]
+> Three `workload` commands are **not** purely kubeconfig-backed and need a local `ksail.yaml` even against an unmanaged cluster: `network` refuses unless `spec.cluster.cni` is Cilium; `images` derives its image list from the local KSail config rather than the live cluster; and `push` resolves its registry, source directory and tag from that config.
 
 ## What is refused (ksail-only actions)
 
@@ -58,9 +64,12 @@ The refusal covers the lifecycle operations KSail cannot drive without a provide
 | Capability | Managed cluster | Unmanaged (kubeconfig-only) cluster |
 | --- | --- | --- |
 | List / switch / connect | ✅ | ✅ (marked unmanaged) |
-| Info / diagnose | ✅ | ✅ with a resolvable `--name` |
-| `workload` (get, logs, exec, apply, watch, install, …) | ✅ | ✅ |
+| Info | ✅ | ✅ with a resolvable `--name` |
+| Diagnose | ✅ | ⚠️ diagnoses the **active** context — `switch` first ([#6117](https://github.com/devantler-tech/ksail/issues/6117)) |
+| `workload` API-backed (get, logs, exec, apply, watch, install, …) | ✅ | ✅ |
+| `workload network` / `images` / `push` | ✅ | ⚠️ also need a local `ksail.yaml` |
 | Backup / restore | ✅ | ✅ |
+| Web UI / desktop resource browsing | ✅ | ⛔ listed only; operations are CLI-only ([#6116](https://github.com/devantler-tech/ksail/issues/6116)) |
 | Delete / update / start / stop | ✅ | ⛔ refused with a documented message |
 | Component install (CNI, CSI, GitOps, policy) | ✅ | ⛔ requires `spec.cluster.*` |
 | GitOps reconcile | ✅ | ⛔ requires a GitOps-configured cluster |

--- a/docs/src/content/docs/guides/unmanaged-clusters.mdx
+++ b/docs/src/content/docs/guides/unmanaged-clusters.mdx
@@ -1,0 +1,63 @@
+---
+title: Unmanaged (kubeconfig-only) Clusters
+description: How KSail sees and operates on clusters that exist in your kubeconfig but were not provisioned by KSail — clearly marked unmanaged, with ksail-only lifecycle actions refused rather than silently failing.
+---
+
+KSail can **see and operate on any cluster in your kubeconfig**, even one it did not provision — a managed cloud cluster (EKS/GKE/AKS), a `kubeadm` cluster, or a colleague's cluster shared with you. These appear as **unmanaged** clusters: KSail surfaces them clearly marked, never hidden and never shown as a normal managed cluster, and refuses ksail-only lifecycle actions on them with a documented message instead of failing silently.
+
+> [!NOTE]
+> A cluster is **unmanaged** when it is present in your kubeconfig as a context that KSail did not create through one of its infrastructure providers (Docker, Hetzner, Omni, AWS-EKS, nested Kubernetes). KSail still has no provider or distribution spec for it, so anything that requires provisioning is unavailable — but everything that works over the Kubernetes API works normally.
+
+## Seeing unmanaged clusters
+
+`ksail cluster list` includes kubeconfig contexts KSail did not provision, each shown with an explicit **unmanaged** marker:
+
+```sh
+ksail cluster list
+```
+
+Unmanaged clusters report an empty distribution/provider (shown as `—`) because there is no KSail spec to read, and a `Ready=False` status with reason `Unmanaged`. The same marked model backs the CLI and the web UI / desktop app, so a cluster behaves identically wherever you look at it.
+
+## Operating within limits
+
+Because most of KSail's read/operate surface is client-go-backed, it works against any selected context — managed or not. Select an unmanaged cluster and use it like any other:
+
+```sh
+ksail cluster switch my-eks-prod       # switch the active kubeconfig context
+ksail cluster info                     # endpoint + kubeconfig access (unknown ksail-only fields shown as —)
+ksail cluster connect                  # open k9s against the context
+ksail cluster diagnose                 # run diagnostics against the selected context
+```
+
+The `ksail workload` group — `kubectl`, `watch`, `network`, `edit`, `images`, `push`, `render`, `validate`, `scan`, `debug` — also works against the selected unmanaged context, as do **`backup` and `restore`**, which snapshot and restore Kubernetes resources over the API server (they resolve the kubeconfig like the other cluster commands and need no KSail metadata).
+
+## What is refused (ksail-only actions)
+
+Anything that needs KSail-managed provisioning or a `spec.cluster.*` configuration is **clearly refused** on an unmanaged cluster — never a silent no-op or a stack trace:
+
+```sh
+ksail cluster delete --name my-eks-prod
+# Error: "my-eks-prod" is an unmanaged cluster: cluster is not managed by ksail;
+#        read-only operations (list, resource browsing, logs, exec) still work
+```
+
+The refusal covers the lifecycle operations KSail cannot drive without a provider:
+
+- **Lifecycle** — `create`, `delete`, `update`, `start`, `stop` (no provider/distribution to act on).
+- **Component installation** — CNI, CSI, metrics-server, GitOps/Flux, policy engine (all driven from `spec.cluster.*`).
+- **GitOps operations** — `workload reconcile` / `workload install` need a KSail/GitOps configuration, not just a kubeconfig.
+
+> [!NOTE]
+> The unmanaged guard **fails open on incomplete discovery**: if KSail cannot fully enumerate every provider (for example a stopped Docker daemon), it does not wrongly refuse a cluster it might actually manage — it only refuses a cluster that is confirmed unmanaged and present in the kubeconfig.
+
+## Limitations summary
+
+| Capability | Managed cluster | Unmanaged (kubeconfig-only) cluster |
+| --- | --- | --- |
+| List / switch / info / connect / diagnose | ✅ | ✅ (marked unmanaged) |
+| `workload` (kubectl, logs, exec, apply, watch, …) | ✅ | ✅ |
+| Backup / restore | ✅ | ✅ |
+| Create / delete / start / stop / update | ✅ | ⛔ refused with a documented message |
+| Component install (CNI, CSI, GitOps, policy) | ✅ | ⛔ requires `spec.cluster.*` |
+| GitOps reconcile / install | ✅ | ⛔ requires a GitOps-configured cluster |
+| Distribution / provider | reported | `—` (no KSail spec) |


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

**Why**
KSail can already see and operate on clusters that exist in a user's kubeconfig but were not provisioned by KSail (managed EKS/GKE/AKS, kubeadm, a colleague's cluster) — marked unmanaged, with ksail-only lifecycle actions refused cleanly. That capability shipped in the CLI but had no user-facing documentation.

**What**
Adds a *Guides → Cluster lifecycle → Unmanaged Clusters* page documenting how unmanaged clusters are surfaced and marked, which commands operate on them (the client-go-backed set, including backup/restore), which ksail-only actions are refused with a documented message, and a capability/limitations summary. Docs-only; internal-link validation passes.

Fixes #6112
Part of #5654