### PR TITLE
refactor(cluster): converge unmanaged synthesis onto a shared clusterdiscovery seam

### DIFF
--- a/pkg/cli/clusterapi/resources.go
+++ b/pkg/cli/clusterapi/resources.go
@@ -3,7 +3,6 @@ package clusterapi
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
@@ -175,30 +174,17 @@ func unmanagedClusters(
 	config *clientcmdapi.Config,
 	managed map[string]listEntry,
 ) []v1alpha1.Cluster {
-	if config == nil {
-		return nil
-	}
+	// The enumerate-and-dedup skeleton (sorted context names, minus any whose raw or ksail-detected
+	// name is in the managed set) is shared with the CLI's cluster list via
+	// clusterdiscovery.UnmanagedContextNames, so both surfaces stay aligned and cannot drift.
+	contextNames := clusterdiscovery.UnmanagedContextNames(config, func(name string) bool {
+		_, ok := managed[name]
 
-	contextNames := make([]string, 0, len(config.Contexts))
-	for contextName := range config.Contexts {
-		contextNames = append(contextNames, contextName)
-	}
-
-	sort.Strings(contextNames)
+		return ok
+	})
 
 	items := make([]v1alpha1.Cluster, 0, len(contextNames))
-
 	for _, contextName := range contextNames {
-		// The dedup rule (raw context name OR ksail-detected name in the managed set) is shared with
-		// the CLI's cluster list via clusterdiscovery.ContextIsManaged, so both surfaces stay aligned.
-		if clusterdiscovery.ContextIsManaged(contextName, func(name string) bool {
-			_, ok := managed[name]
-
-			return ok
-		}) {
-			continue
-		}
-
 		endpoint := endpointForContext(config, contextName)
 		items = append(items, newUnmanagedCluster(contextName, endpoint))
 	}

--- a/pkg/svc/clusterdiscovery/unmanaged.go
+++ b/pkg/svc/clusterdiscovery/unmanaged.go
@@ -22,14 +22,36 @@ import (
 // unreadable kubeconfig yields none. Results are sorted by context name so the list stays stable.
 func DiscoverUnmanaged(kubeconfigPath string, managed map[string]struct{}) []Cluster {
 	config := LoadKubeconfig(kubeconfigPath)
-	if config == nil {
-		return nil
-	}
 
 	isManaged := func(name string) bool {
 		_, ok := managed[name]
 
 		return ok
+	}
+
+	contextNames := UnmanagedContextNames(config, isManaged)
+
+	unmanaged := make([]Cluster, 0, len(contextNames))
+	for _, contextName := range contextNames {
+		unmanaged = append(unmanaged, Cluster{
+			Name:     contextName,
+			RunState: RunStateUnmanaged,
+		})
+	}
+
+	return unmanaged
+}
+
+// UnmanagedContextNames returns, sorted and deduped, the names of every kubeconfig context in config
+// that does NOT correspond to an already-managed cluster — the enumerate-and-dedup rule shared by the
+// CLI's DiscoverUnmanaged and the web-UI model (pkg/cli/clusterapi), so the skeleton lives in exactly
+// one place and cannot drift. isManaged reports whether a name is in the caller's managed set (each
+// surface keys its own map); a context is skipped when ContextIsManaged accepts it under isManaged. A
+// nil config (missing or unreadable kubeconfig) yields none. Results are sorted by context name so the
+// list stays stable across surfaces.
+func UnmanagedContextNames(config *clientcmdapi.Config, isManaged func(name string) bool) []string {
+	if config == nil {
+		return nil
 	}
 
 	contextNames := make([]string, 0, len(config.Contexts))
@@ -39,17 +61,14 @@ func DiscoverUnmanaged(kubeconfigPath string, managed map[string]struct{}) []Clu
 
 	sort.Strings(contextNames)
 
-	unmanaged := make([]Cluster, 0, len(contextNames))
+	unmanaged := make([]string, 0, len(contextNames))
 
 	for _, contextName := range contextNames {
 		if ContextIsManaged(contextName, isManaged) {
 			continue
 		}
 
-		unmanaged = append(unmanaged, Cluster{
-			Name:     contextName,
-			RunState: RunStateUnmanaged,
-		})
+		unmanaged = append(unmanaged, contextName)
 	}
 
 	return unmanaged

--- a/pkg/svc/clusterdiscovery/unmanaged_test.go
+++ b/pkg/svc/clusterdiscovery/unmanaged_test.go
@@ -110,3 +110,37 @@ func TestDiscoverUnmanaged_UnreadableKubeconfigYieldsNoneNoError(t *testing.T) {
 
 	assert.Empty(t, got)
 }
+
+// alwaysUnmanaged is an isManaged predicate that treats every context as unmanaged.
+func alwaysUnmanaged(string) bool { return false }
+
+func TestUnmanagedContextNames_NilConfigYieldsNone(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, clusterdiscovery.UnmanagedContextNames(nil, alwaysUnmanaged))
+}
+
+func TestUnmanagedContextNames_SortedAndDeduped(t *testing.T) {
+	t.Parallel()
+
+	config := clusterdiscovery.LoadKubeconfig(
+		writeKubeconfig(t, "zeta-external", "alpha-external", "beta-external"))
+	require.NotNil(t, config)
+
+	got := clusterdiscovery.UnmanagedContextNames(config, alwaysUnmanaged)
+
+	assert.Equal(t, []string{"alpha-external", "beta-external", "zeta-external"}, got)
+}
+
+func TestUnmanagedContextNames_SkipsManagedByRawName(t *testing.T) {
+	t.Parallel()
+
+	config := clusterdiscovery.LoadKubeconfig(writeKubeconfig(t, "managed-ctx", "external-ctx"))
+	require.NotNil(t, config)
+
+	got := clusterdiscovery.UnmanagedContextNames(config, func(name string) bool {
+		return name == "managed-ctx"
+	})
+
+	assert.Equal(t, []string{"external-ctx"}, got)
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The CLI's `cluster list` and the web-UI/desktop model each carried their own copy of the same "list unmanaged kubeconfig clusters" rule. Two copies can silently drift — a fix to one surface (e.g. context detection) can miss the other, so the two views disagree about which clusters are unmanaged.

## What

Extracts the shared enumerate-and-dedup step into one place so both surfaces stay aligned by construction. Behaviour is unchanged (existing tests pass; the shared step is unit-tested).

Fixes #5876