### PR TITLE
feat(chart): support imagePullSecrets on the ksail-operator chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -933,6 +933,22 @@ jobs:
             --set auth.oidc.clientID=ksail \
             --set auth.oidc.clientSecret=dummy \
             --set auth.oidc.redirectURL=https://ksail.local/api/v1/auth/callback >/dev/null
+          echo "=== imagePullSecrets unset (default) -> nothing rendered ==="
+          if helm template ksail-operator charts/ksail-operator | grep -q 'imagePullSecrets'; then
+            echo "::error::imagePullSecrets rendered even though the value is empty"
+            exit 1
+          fi
+          echo "=== imagePullSecrets set -> on the Deployment and the ServiceAccount ==="
+          rendered=$(helm template ksail-operator charts/ksail-operator \
+            --set 'imagePullSecrets[0].name=ghcr-auth')
+          deployment=$(echo "$rendered" \
+            | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[0].name')
+          serviceaccount=$(echo "$rendered" \
+            | yq 'select(.kind == "ServiceAccount") | .imagePullSecrets[0].name')
+          if [ "$deployment" != "ghcr-auth" ] || [ "$serviceaccount" != "ghcr-auth" ]; then
+            echo "::error::imagePullSecrets not applied (deployment=$deployment serviceaccount=$serviceaccount)"
+            exit 1
+          fi
           echo "✅ All chart template permutations rendered"
 
   operator-chart-e2e:

--- a/charts/ksail-operator/README.md
+++ b/charts/ksail-operator/README.md
@@ -174,8 +174,8 @@ The UI is embedded in the operator binary and served on `api.bindPort` — it ha
 
 ### Image pull secrets
 
-| Key                | Description                                                                                                                | Default |
-|--------------------|----------------------------------------------------------------------------------------------------------------------------|---------|
+| Key                | Description                                                                                                                          | Default |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `imagePullSecrets` | Existing `kubernetes.io/dockerconfigjson` Secrets used to pull the operator image. Applied to the Deployment and the ServiceAccount. | `[]`    |
 
 The published operator image is public, so the default is empty and pulls fall back to the node's

--- a/charts/ksail-operator/README.md
+++ b/charts/ksail-operator/README.md
@@ -172,6 +172,25 @@ The UI is embedded in the operator binary and served on `api.bindPort` — it ha
 | `rbac.create`                | Create RBAC resources.                                                                                                                                                              | `true`  |
 | `rbac.clusterAdmin`          | Grant a full wildcard ClusterRole (cluster-admin) instead of the least-privilege default. Opt in only when a distribution/component set needs resources the default does not cover. | `false` |
 
+### Image pull secrets
+
+| Key                | Description                                                                                                                | Default |
+|--------------------|----------------------------------------------------------------------------------------------------------------------------|---------|
+| `imagePullSecrets` | Existing `kubernetes.io/dockerconfigjson` Secrets used to pull the operator image. Applied to the Deployment and the ServiceAccount. | `[]`    |
+
+The published operator image is public, so the default is empty and pulls fall back to the node's
+registry credentials. Set this when the image lives in a private registry — or when you would rather
+the pull not depend on node-level auth at all, since a stale node credential leaves new pods unable to
+pull and silently blocks upgrades:
+
+```yaml
+imagePullSecrets:
+  - name: ghcr-auth
+```
+
+The secrets are attached to the operator Deployment's pod spec **and** to the chart's ServiceAccount,
+so pods that run under that ServiceAccount inherit them.
+
 ### Scheduling
 
 | Key              | Description                | Default |

--- a/charts/ksail-operator/templates/deployment.yaml
+++ b/charts/ksail-operator/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "ksail-operator.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: operator
           image: {{ include "ksail-operator.operatorImage" . | quote }}

--- a/charts/ksail-operator/templates/serviceaccount.yaml
+++ b/charts/ksail-operator/templates/serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/ksail-operator/values.yaml
+++ b/charts/ksail-operator/values.yaml
@@ -4,6 +4,17 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# imagePullSecrets are references to existing Secrets (type kubernetes.io/dockerconfigjson) used to
+# pull the operator image. Leave empty to rely on the node's registry credentials (the default: the
+# published image is public). Set it when the image lives in a private registry, or when you would
+# rather not depend on node-level auth — a stale node credential otherwise leaves new pods unable to
+# pull, which blocks upgrades. The secrets are attached to both the operator Deployment's pod spec
+# and the chart's ServiceAccount, so pods that use the ServiceAccount inherit them too.
+#
+#   imagePullSecrets:
+#     - name: ghcr-auth
+imagePullSecrets: []
+
 operator:
   enabled: true
   image:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Pulling the operator image depends **entirely on node-level registry credentials** today — the chart has no way to point a pull at a Secret. When that node credential goes stale, every new operator pod fails to pull, the Helm upgrade times out and rolls back, and the operator stays pinned to the last tag that pulled. Production is stuck four releases behind right now for exactly this reason, and it also keeps evicting unrelated platform PRs from the merge queue.

This gives operators a way off that single point of failure.

## What

Adds a top-level `imagePullSecrets` list to the chart, attached to both the operator Deployment and the ServiceAccount, so the pull can use an existing registry Secret instead of node auth.

Default is empty, which renders exactly what the chart renders today — nothing changes for existing installs. CI asserts both states.

Fixes #6120
