### PR TITLE
fix(system-test): bound reserved pod sandbox recovery

### DIFF
--- a/.github/actions/ksail-cluster/action.yml
+++ b/.github/actions/ksail-cluster/action.yml
@@ -363,18 +363,38 @@ runs:
           fi
         }
 
-        # Talos+Docker clusters may experience transient bootstrap failures
-        # (node-join timeouts, CNI/CSI initialization races on shared CI runners).
-        # Retry up to 3 times with cleanup between attempts.
-        # See: https://github.com/devantler-tech/ksail/issues/4289
+        should_retry_create() {
+          local log_file="$1"
+
+          # Talos+Docker has a broader set of known transient bootstrap races.
+          if [ "$DISTRIBUTION" = "Talos" ] && [ "$PROVIDER" = "Docker" ]; then
+            return 0
+          fi
+
+          # K3s+Docker gets one recovery attempt, but only for the typed event
+          # signature emitted by KSail's reserved-pod-sandbox monitor.
+          if [ "$DISTRIBUTION" = "K3s" ] && [ "$PROVIDER" = "Docker" ] && \
+            grep -Fq "repeated reserved pod sandbox failures" "$log_file"; then
+            return 0
+          fi
+
+          return 1
+        }
+
+        # Keep Talos' existing broad retry policy. K3s retries only the
+        # repeated-reservation signature so unrelated failures remain fail-fast.
         if [ "$DISTRIBUTION" = "Talos" ] && [ "$PROVIDER" = "Docker" ]; then
           MAX_ATTEMPTS=3
+        elif [ "$DISTRIBUTION" = "K3s" ] && [ "$PROVIDER" = "Docker" ]; then
+          MAX_ATTEMPTS=2
         else
           MAX_ATTEMPTS=1
         fi
 
         create_succeeded=false
+        LAST_ATTEMPT=1
         for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+          LAST_ATTEMPT="$attempt"
           LOG_FILE="/tmp/ksail-system-test-logs/cluster-create-attempt-${attempt}.log"
           if create_cluster 2>&1 | tee "$LOG_FILE"; then
             create_succeeded=true
@@ -382,25 +402,43 @@ runs:
             cp "$LOG_FILE" /tmp/ksail-system-test-logs/cluster-create.log
             break
           fi
-          if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-            echo "⚠️ cluster create attempt $attempt failed, cleaning up before retry…"
-            CLEANUP_LOG="/tmp/ksail-system-test-logs/cluster-create-cleanup-${attempt}.log"
-            # Remove the partially-created cluster so the next attempt starts clean
-            {
-            ksail ${CONFIG:+--config "$CONFIG"} cluster delete --force || true
-            # Remove any lingering Talos cluster node containers.
-            # ksail cluster delete --force may leave Talos Docker containers behind,
-            # keeping the cluster Docker network alive. The next create attempt then
-            # fails with "cluster already exists" or "network '<cluster>' already exists".
-            docker ps -aq --filter "label=talos.owned=true" \
-              | xargs -r docker rm -f 2>/dev/null || true
-            # Remove any lingering Talos cluster state directories.
-            # ksail cluster delete --force may not clean up ~/.talos/clusters/<name>/.
-            # On the next attempt, the Talos provisioner checks for this directory and
-            # refuses to create with "state directory already exists, is the cluster
-            # already running?". Since this retry loop is only for Talos+Docker on a
-            # single-use CI runner, it is safe to remove all leftover Talos state.
-            rm -rf ~/.talos/clusters/ || true
+          if [ "$attempt" -ge "$MAX_ATTEMPTS" ] || ! should_retry_create "$LOG_FILE"; then
+            break
+          fi
+
+          echo "⚠️ cluster create attempt $attempt hit a recoverable failure; cleaning up…"
+          CLEANUP_LOG="/tmp/ksail-system-test-logs/cluster-create-cleanup-${attempt}.log"
+          # Every external cleanup operation is bounded. A wedged runtime must
+          # not consume the remainder of the six-hour system-test job.
+          {
+            timeout --kill-after=10s 2m \
+              ksail ${CONFIG:+--config "$CONFIG"} cluster delete --force || true
+
+            if [ "$DISTRIBUTION" = "K3s" ] && [ "$PROVIDER" = "Docker" ]; then
+              # A timed-out delete can leave k3d node containers running. This
+              # job owns its runner, so removing k3d-named containers is scoped
+              # to the cluster under test.
+              timeout --kill-after=10s 30s bash -c \
+                'docker ps -aq --filter "name=k3d-" | xargs -r docker rm -f' || true
+            fi
+
+            if [ "$DISTRIBUTION" = "Talos" ] && [ "$PROVIDER" = "Docker" ]; then
+              # Remove any lingering Talos cluster node containers.
+              # ksail cluster delete --force may leave Talos Docker containers behind,
+              # keeping the cluster Docker network alive. The next create attempt then
+              # fails with "cluster already exists" or "network '<cluster>' already exists".
+              timeout --kill-after=10s 30s bash -c \
+                'docker ps -aq --filter "label=talos.owned=true" | xargs -r docker rm -f' \
+                || true
+              # Remove any lingering Talos cluster state directories.
+              # ksail cluster delete --force may not clean up ~/.talos/clusters/<name>/.
+              # On the next attempt, the Talos provisioner checks for this directory and
+              # refuses to create with "state directory already exists, is the cluster
+              # already running?". Since this retry loop is only for Talos+Docker on a
+              # single-use CI runner, it is safe to remove all leftover Talos state.
+              rm -rf ~/.talos/clusters/ || true
+            fi
+
             # Remove any lingering KSail-managed mirror registry containers.
             # ksail cluster delete may not remove registry containers, leaving their
             # Docker network endpoints alive. The next create attempt then fails with
@@ -408,26 +446,28 @@ runs:
             # Filter by the KSail ownership label first, and keep the suffix match to
             # limit cleanup to the known registry container naming scheme.
             for _reg_suffix in docker.io ghcr.io quay.io registry.k8s.io; do
-              docker ps -aq \
-                --filter "label=io.ksail.registry" \
-                --filter "name=-${_reg_suffix}" \
-                | xargs -r docker rm -f 2>/dev/null || true
+              # shellcheck disable=SC2016 # $1 is expanded by the bounded child shell.
+              timeout --kill-after=10s 30s bash -c '
+                docker ps -aq \
+                  --filter "label=io.ksail.registry" \
+                  --filter "name=-$1" \
+                  | xargs -r docker rm -f
+              ' _ "$_reg_suffix" || true
             done
             # Prune unused Docker resources (networks, stopped containers, dangling images).
             # This will also remove any cluster Docker networks left behind after the
             # container cleanup above.
-            docker system prune -f || true
-            } 2>&1 | tee "$CLEANUP_LOG"
-            echo "⚠️ waiting 30s before retry…"
-            sleep 30
-          fi
+            timeout --kill-after=10s 1m docker system prune -f || true
+          } 2>&1 | tee "$CLEANUP_LOG"
+          echo "⚠️ waiting 30s before the final retry…"
+          sleep 30
         done
 
         if [ "$create_succeeded" != "true" ]; then
           # Copy the last attempt log to the canonical name for diagnostic uploads
-          cp "/tmp/ksail-system-test-logs/cluster-create-attempt-${MAX_ATTEMPTS}.log" \
+          cp "/tmp/ksail-system-test-logs/cluster-create-attempt-${LAST_ATTEMPT}.log" \
             /tmp/ksail-system-test-logs/cluster-create.log 2>/dev/null || true
-          echo "❌ cluster create failed after $MAX_ATTEMPTS attempts"
+          echo "❌ cluster create failed after $LAST_ATTEMPT attempt(s)"
           exit 1
         fi
 

--- a/.github/actions/ksail-system-test-cleanup/action.yaml
+++ b/.github/actions/ksail-system-test-cleanup/action.yaml
@@ -1,0 +1,48 @@
+name: KSail System Test Cleanup
+description: Deletes a KSail system-test cluster with provider-aware failure handling.
+
+inputs:
+  distribution:
+    description: Kubernetes distribution used by the system test.
+    required: true
+  provider:
+    description: Infrastructure provider used by the system test.
+    required: false
+    default: "Docker"
+  args:
+    description: Original system-test arguments, used to recover an explicit cluster name.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: 🧪 ksail cluster delete
+      shell: bash
+      env:
+        DISTRIBUTION: ${{ inputs.distribution }}
+        PROVIDER: ${{ inputs.provider }}
+        ARGS: ${{ inputs.args }}
+      run: |
+        {
+        mkdir -p /tmp/ksail-system-test-logs
+        # Extract --name for reliable cleanup even when no kubeconfig exists.
+        CLUSTER_NAME=$(echo "$ARGS" | grep -oP '(?<=--name\s)\S+' || true)
+        DELETE_COMMAND=(ksail cluster delete)
+        if [ -n "$CLUSTER_NAME" ]; then
+          DELETE_COMMAND+=(--provider "$PROVIDER" --name "$CLUSTER_NAME" --force)
+        fi
+
+        # Only the local K3s recovery path needs a short bound. All Docker
+        # cleanup remains best-effort; cloud teardown is unbounded and visible
+        # because it may wait on provider APIs or lifecycle finalizers.
+        if [ "$PROVIDER" = "Docker" ] && [ "$DISTRIBUTION" = "K3s" ]; then
+          timeout --kill-after=10s 2m "${DELETE_COMMAND[@]}" \
+            || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
+        elif [ "$PROVIDER" = "Docker" ]; then
+          "${DELETE_COMMAND[@]}" \
+            || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
+        else
+          "${DELETE_COMMAND[@]}"
+        fi
+        } 2>&1 | tee /tmp/ksail-system-test-logs/cluster-delete.log

--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -650,19 +650,24 @@ runs:
       if: always()
       shell: bash
       env:
+        DISTRIBUTION: ${{ inputs.distribution }}
         PROVIDER: ${{ inputs.provider }}
         ARGS: ${{ steps.resolve-args.outputs.args }}
       run: |
         {
         # Extract --name value from args for reliable cleanup even when no kubeconfig exists
         CLUSTER_NAME=$(echo "$ARGS" | grep -oP '(?<=--name\s)\S+' || true)
+        DELETE_COMMAND=(ksail cluster delete)
         if [ -n "$CLUSTER_NAME" ]; then
-          timeout --kill-after=10s 2m \
-            ksail cluster delete --provider "$PROVIDER" --name "$CLUSTER_NAME" --force \
+          DELETE_COMMAND+=(--provider "$PROVIDER" --name "$CLUSTER_NAME" --force)
+        fi
+        # Only the local K3s recovery path needs a short best-effort bound. Cloud
+        # teardown may wait on provider APIs/finalizers and must fail visibly.
+        if [ "$PROVIDER" = "Docker" ] && [ "$DISTRIBUTION" = "K3s" ]; then
+          timeout --kill-after=10s 2m "${DELETE_COMMAND[@]}" \
             || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
         else
-          timeout --kill-after=10s 2m ksail cluster delete \
-            || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
+          "${DELETE_COMMAND[@]}"
         fi
         } 2>&1 | tee /tmp/ksail-system-test-logs/cluster-delete.log
 

--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -111,6 +111,25 @@ inputs:
       Leave empty to skip.
     required: false
     default: ""
+  upload-artifacts:
+    description: |
+      Upload diagnostics and logs from inside this composite action. Callers
+      that need hard upload timeouts can disable these and upload the exposed
+      paths from workflow-level steps instead.
+    required: false
+    default: "true"
+  comprehensive-debug:
+    description: |
+      Run the comprehensive Kubernetes debug action after a failure. Disable
+      for failure modes where the Kubernetes API itself may be wedged; the
+      bounded core diagnostics still run.
+    required: false
+    default: "true"
+
+outputs:
+  artifact-tag:
+    description: Unique suffix for this matrix entry's diagnostic artifacts
+    value: ${{ steps.generate-tag.outputs.tag }}
 
 runs:
   using: composite
@@ -544,7 +563,18 @@ runs:
     # ── Phase 5 — Debug ──────────────────────────────────────────────
 
     - name: 🐞 Debug Kubernetes failure
-      if: failure() && (steps.cluster-create.outcome == 'failure' || steps.workload-mirror-tests.outcome == 'failure' || steps.image-export-import-tests.outcome == 'failure' || steps.workload-watch-tests.outcome == 'failure' || steps.online-gen.outcome == 'failure' || steps.cluster-update-dry-run.outcome == 'failure' || steps.cluster-update.outcome == 'failure' || steps.cluster-update-rolling-resize.outcome == 'failure' || steps.kubernetes-provider-tests.outcome == 'failure')
+      if: >-
+        inputs.comprehensive-debug == 'true'
+        && failure()
+        && (steps.cluster-create.outcome == 'failure'
+        || steps.workload-mirror-tests.outcome == 'failure'
+        || steps.image-export-import-tests.outcome == 'failure'
+        || steps.workload-watch-tests.outcome == 'failure'
+        || steps.online-gen.outcome == 'failure'
+        || steps.cluster-update-dry-run.outcome == 'failure'
+        || steps.cluster-update.outcome == 'failure'
+        || steps.cluster-update-rolling-resize.outcome == 'failure'
+        || steps.kubernetes-provider-tests.outcome == 'failure')
       uses: ./.github/actions/debug-kubernetes-failure
       with:
         kubectl-command: "ksail workload"
@@ -589,23 +619,24 @@ runs:
           echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo ""
           echo "=== Docker Containers ==="
-          docker ps -a 2>&1 || true
+          timeout --kill-after=10s 30s docker ps -a 2>&1 || true
           echo ""
           echo "=== Cluster Info ==="
-          ksail cluster info 2>&1 || true
+          timeout --kill-after=10s 1m ksail cluster info 2>&1 || true
           echo ""
           echo "=== Pod Status (all namespaces) ==="
-          ksail workload get pods -A 2>&1 || true
+          timeout --kill-after=10s 1m ksail workload get pods -A 2>&1 || true
           echo ""
           echo "=== Recent Events ==="
-          ksail workload get events -A --sort-by=.lastTimestamp 2>&1 || true
+          timeout --kill-after=10s 1m \
+            ksail workload get events -A --sort-by=.lastTimestamp 2>&1 || true
           echo ""
           echo "=== Node Status ==="
-          ksail workload get nodes -o wide 2>&1 || true
+          timeout --kill-after=10s 1m ksail workload get nodes -o wide 2>&1 || true
         } > /tmp/system-test-diagnostics/diagnostics.log 2>&1
 
     - name: 📤 Upload system test diagnostics
-      if: failure()
+      if: failure() && inputs.upload-artifacts == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: system-test-diagnostics-${{ steps.generate-tag.outputs.tag }}
@@ -626,10 +657,11 @@ runs:
         # Extract --name value from args for reliable cleanup even when no kubeconfig exists
         CLUSTER_NAME=$(echo "$ARGS" | grep -oP '(?<=--name\s)\S+' || true)
         if [ -n "$CLUSTER_NAME" ]; then
-          ksail cluster delete --provider "$PROVIDER" --name "$CLUSTER_NAME" --force \
+          timeout --kill-after=10s 2m \
+            ksail cluster delete --provider "$PROVIDER" --name "$CLUSTER_NAME" --force \
             || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
         else
-          ksail cluster delete \
+          timeout --kill-after=10s 2m ksail cluster delete \
             || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
         fi
         } 2>&1 | tee /tmp/ksail-system-test-logs/cluster-delete.log
@@ -641,7 +673,7 @@ runs:
         echo "System test completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/ksail-system-test-logs/test-timeline.log
 
     - name: 📤 Upload system test logs
-      if: always()
+      if: always() && inputs.upload-artifacts == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: system-test-logs-${{ steps.generate-tag.outputs.tag }}

--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -9,7 +9,7 @@ description: |
     Phase 4 — Online tests (workload CRUD, image export/import, online gen, backup/restore, update)
     Phase 5 — Debug (on failure)
     Phase 6 — Lifecycle tests (stop, start, switch)
-    Phase 7 — Cleanup (cluster delete, always)
+    Phase 7 — Cleanup (cluster delete, always unless the caller defers it)
 
   Cloud provider credentials are read from environment variables, not action
   inputs. Set these in the calling job before invoking this action:
@@ -116,6 +116,13 @@ inputs:
       Upload diagnostics and logs from inside this composite action. Callers
       that need hard upload timeouts can disable these and upload the exposed
       paths from workflow-level steps instead.
+    required: false
+    default: "true"
+  cleanup:
+    description: |
+      Delete the cluster inside this composite action. Workflow callers that
+      must upload diagnostics before cleanup can disable this and invoke the
+      dedicated cleanup action afterward.
     required: false
     default: "true"
   comprehensive-debug:
@@ -646,30 +653,15 @@ runs:
 
     # ── Phase 7 — Cleanup ────────────────────────────────────────────
 
-    - name: 🧪 ksail cluster delete
-      if: always()
-      shell: bash
-      env:
-        DISTRIBUTION: ${{ inputs.distribution }}
-        PROVIDER: ${{ inputs.provider }}
-        ARGS: ${{ steps.resolve-args.outputs.args }}
-      run: |
-        {
-        # Extract --name value from args for reliable cleanup even when no kubeconfig exists
-        CLUSTER_NAME=$(echo "$ARGS" | grep -oP '(?<=--name\s)\S+' || true)
-        DELETE_COMMAND=(ksail cluster delete)
-        if [ -n "$CLUSTER_NAME" ]; then
-          DELETE_COMMAND+=(--provider "$PROVIDER" --name "$CLUSTER_NAME" --force)
-        fi
-        # Only the local K3s recovery path needs a short best-effort bound. Cloud
-        # teardown may wait on provider APIs/finalizers and must fail visibly.
-        if [ "$PROVIDER" = "Docker" ] && [ "$DISTRIBUTION" = "K3s" ]; then
-          timeout --kill-after=10s 2m "${DELETE_COMMAND[@]}" \
-            || echo "⚠️ ksail cluster delete failed (cluster may not have been created)"
-        else
-          "${DELETE_COMMAND[@]}"
-        fi
-        } 2>&1 | tee /tmp/ksail-system-test-logs/cluster-delete.log
+    - name: 🧪 Cleanup KSail System Test
+      if: always() && inputs.cleanup == 'true'
+      uses: ./.github/actions/ksail-system-test-cleanup
+      with:
+        distribution: ${{ inputs.distribution }}
+        provider: ${{ inputs.provider }}
+        # Keep credentials out of the nested action input. Cleanup needs only
+        # an optional --name from the caller's original arguments.
+        args: ${{ inputs.args }}
 
     - name: 📝 Finalize test timeline
       if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1203,6 +1203,7 @@ jobs:
         uses: ./.github/actions/restore-mirror-cache
 
       - name: 🧪 Run KSail System Test
+        id: system-test
         uses: ./.github/actions/ksail-system-test
         with:
           distribution: ${{ matrix.distribution }}
@@ -1219,6 +1220,34 @@ jobs:
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           dockerhub-user: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          # Composite-action steps cannot set timeout-minutes. Upload from the
+          # workflow instead so a stalled artifact service is hard-bounded.
+          upload-artifacts: "false"
+          # A reserved K3s pod sandbox can wedge every API-backed command in the
+          # rich debug action. Keep its essential diagnostics on bounded calls.
+          comprehensive-debug: ${{ matrix.distribution == 'K3s' && 'false' || 'true' }}
+
+      - name: 📤 Upload system test diagnostics
+        if: ${{ failure() && steps.system-test.outcome == 'failure' }}
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: system-test-diagnostics-${{ steps.system-test.outputs.artifact-tag }}
+          path: /tmp/system-test-diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: 📤 Upload system test logs
+        if: ${{ always() && steps.system-test.outcome != 'skipped' && steps.system-test.outcome != '' }}
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: system-test-logs-${{ steps.system-test.outputs.artifact-tag }}
+          path: /tmp/ksail-system-test-logs/
+          retention-days: 7
+          if-no-files-found: ignore
 
   verify-desktop-tidy:
     name: 🧩 Verify Desktop Module Tidy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1222,7 +1222,9 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           # Composite-action steps cannot set timeout-minutes. Upload from the
           # workflow instead so a stalled artifact service is hard-bounded.
+          # Defer cleanup until the failure diagnostics have been uploaded.
           upload-artifacts: "false"
+          cleanup: "false"
           # A reserved K3s pod sandbox can wedge every API-backed command in the
           # rich debug action. Keep its essential diagnostics on bounded calls.
           comprehensive-debug: ${{ matrix.distribution == 'K3s' && 'false' || 'true' }}
@@ -1237,6 +1239,14 @@ jobs:
           path: /tmp/system-test-diagnostics/
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: 🧪 Cleanup KSail System Test
+        if: ${{ always() && steps.system-test.outcome != 'skipped' && steps.system-test.outcome != '' }}
+        uses: ./.github/actions/ksail-system-test-cleanup
+        with:
+          distribution: ${{ matrix.distribution }}
+          provider: ${{ matrix.provider }}
+          args: ${{ matrix.args }}
 
       - name: 📤 Upload system test logs
         if: ${{ always() && steps.system-test.outcome != 'skipped' && steps.system-test.outcome != '' }}

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -13,14 +13,15 @@ import (
 
 //nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
 type harnessStep struct {
-	Name            string         `yaml:"name"`
-	ID              string         `yaml:"id"`
-	If              string         `yaml:"if"`
-	Uses            string         `yaml:"uses"`
-	Run             string         `yaml:"run"`
-	TimeoutMinutes  int            `yaml:"timeout-minutes"`
-	ContinueOnError bool           `yaml:"continue-on-error"`
-	With            map[string]any `yaml:"with"`
+	Name            string            `yaml:"name"`
+	ID              string            `yaml:"id"`
+	If              string            `yaml:"if"`
+	Env             map[string]string `yaml:"env"`
+	Uses            string            `yaml:"uses"`
+	Run             string            `yaml:"run"`
+	TimeoutMinutes  int               `yaml:"timeout-minutes"`
+	ContinueOnError bool              `yaml:"continue-on-error"`
+	With            map[string]any    `yaml:"with"`
 }
 
 type compositeAction struct {
@@ -105,6 +106,43 @@ func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
 		"/tmp/ksail-system-test-logs/",
 		"always()",
 	)
+}
+
+func TestSystemTestHarnessOnlyBoundsDockerK3sCleanup(t *testing.T) {
+	t.Parallel()
+
+	systemAction := readCompositeAction(t, ".github/actions/ksail-system-test/action.yaml")
+	deleteStep := findHarnessStep(t, systemAction.Runs.Steps, "🧪 ksail cluster delete")
+	assert.Equal(t, "${{ inputs.distribution }}", deleteStep.Env["DISTRIBUTION"])
+
+	providerGate := strings.Index(
+		deleteStep.Run,
+		`if [ "$PROVIDER" = "Docker" ] && [ "$DISTRIBUTION" = "K3s" ]; then`,
+	)
+	require.NotEqual(
+		t,
+		-1,
+		providerGate,
+		"only Docker/K3s cleanup may use the short recovery bound",
+	)
+
+	cloudBranchOffset := strings.Index(deleteStep.Run[providerGate:], "\nelse\n")
+	require.NotEqual(
+		t,
+		-1,
+		cloudBranchOffset,
+		"cluster cleanup must include a cloud-provider branch",
+	)
+	cloudBranch := deleteStep.Run[providerGate+cloudBranchOffset:]
+
+	assert.Contains(
+		t,
+		deleteStep.Run[providerGate:providerGate+cloudBranchOffset],
+		`timeout --kill-after=10s 2m`,
+	)
+	assert.NotContains(t, cloudBranch, `timeout --kill-after=10s 2m`)
+	assert.Contains(t, cloudBranch, `"${DELETE_COMMAND[@]}"`)
+	assert.NotContains(t, cloudBranch, `|| echo`)
 }
 
 func readCompositeAction(t *testing.T, path string) compositeAction {

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -1,0 +1,181 @@
+package ciharness_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+//nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
+type harnessStep struct {
+	Name            string         `yaml:"name"`
+	ID              string         `yaml:"id"`
+	If              string         `yaml:"if"`
+	Uses            string         `yaml:"uses"`
+	Run             string         `yaml:"run"`
+	TimeoutMinutes  int            `yaml:"timeout-minutes"`
+	ContinueOnError bool           `yaml:"continue-on-error"`
+	With            map[string]any `yaml:"with"`
+}
+
+type compositeAction struct {
+	Inputs map[string]struct {
+		Default string `yaml:"default"`
+	} `yaml:"inputs"`
+	Outputs map[string]struct {
+		Value string `yaml:"value"`
+	} `yaml:"outputs"`
+	Runs struct {
+		Steps []harnessStep `yaml:"steps"`
+	} `yaml:"runs"`
+}
+
+type ciWorkflow struct {
+	Jobs map[string]struct {
+		Steps []harnessStep `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+//nolint:funlen // One test locks the cross-file action/workflow contract end to end.
+func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
+	t.Parallel()
+
+	clusterAction := readCompositeAction(t, ".github/actions/ksail-cluster/action.yml")
+	createStep := findHarnessStep(t, clusterAction.Runs.Steps, "🚀 Create Cluster")
+
+	assert.Contains(t, createStep.Run, `MAX_ATTEMPTS=2`)
+	assert.Contains(t, createStep.Run, `repeated reserved pod sandbox failures`)
+	assert.Contains(t, createStep.Run, `should_retry_create "$LOG_FILE"`)
+	assert.Contains(t, createStep.Run, `timeout --kill-after=10s`)
+
+	systemAction := readCompositeAction(t, ".github/actions/ksail-system-test/action.yaml")
+	require.Contains(t, systemAction.Inputs, "upload-artifacts")
+	assert.Equal(t, "true", systemAction.Inputs["upload-artifacts"].Default)
+	require.Contains(t, systemAction.Inputs, "comprehensive-debug")
+	assert.Equal(t, "true", systemAction.Inputs["comprehensive-debug"].Default)
+	require.Contains(t, systemAction.Outputs, "artifact-tag")
+	assert.Equal(
+		t,
+		"${{ steps.generate-tag.outputs.tag }}",
+		systemAction.Outputs["artifact-tag"].Value,
+	)
+
+	diagnosticUpload := findHarnessStep(
+		t,
+		systemAction.Runs.Steps,
+		"📤 Upload system test diagnostics",
+	)
+	logUpload := findHarnessStep(t, systemAction.Runs.Steps, "📤 Upload system test logs")
+	assert.Contains(t, diagnosticUpload.If, "inputs.upload-artifacts == 'true'")
+	assert.Contains(t, logUpload.If, "inputs.upload-artifacts == 'true'")
+	debugStep := findHarnessStep(t, systemAction.Runs.Steps, "🐞 Debug Kubernetes failure")
+	assert.Contains(t, debugStep.If, "inputs.comprehensive-debug == 'true'")
+
+	deleteStep := findHarnessStep(t, systemAction.Runs.Steps, "🧪 ksail cluster delete")
+	assert.Contains(t, deleteStep.Run, `timeout --kill-after=10s`)
+
+	workflow := readCIWorkflow(t, ".github/workflows/ci.yaml")
+	dockerJob, ok := workflow.Jobs["system-test-docker"]
+	require.True(t, ok, "system-test-docker job is missing")
+	runStep := findHarnessStep(t, dockerJob.Steps, "🧪 Run KSail System Test")
+	assert.Equal(t, "system-test", runStep.ID)
+	assert.Equal(t, "false", stringValue(runStep.With["upload-artifacts"]))
+	assert.Contains(
+		t,
+		stringValue(runStep.With["comprehensive-debug"]),
+		"matrix.distribution == 'K3s'",
+	)
+
+	assertBoundedWorkflowUpload(
+		t,
+		dockerJob.Steps,
+		"📤 Upload system test diagnostics",
+		"/tmp/system-test-diagnostics/",
+		"failure()",
+	)
+	assertBoundedWorkflowUpload(
+		t,
+		dockerJob.Steps,
+		"📤 Upload system test logs",
+		"/tmp/ksail-system-test-logs/",
+		"always()",
+	)
+}
+
+func readCompositeAction(t *testing.T, path string) compositeAction {
+	t.Helper()
+
+	contents := readRepoFile(t, path)
+
+	var action compositeAction
+	require.NoError(t, yaml.Unmarshal(contents, &action))
+
+	return action
+}
+
+func readCIWorkflow(t *testing.T, path string) ciWorkflow {
+	t.Helper()
+
+	contents := readRepoFile(t, path)
+
+	var workflow ciWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	return workflow
+}
+
+func readRepoFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	// The caller supplies repository-owned fixture paths, never user input.
+	contents, err := os.ReadFile(filepath.Join("..", "..", path)) //nolint:gosec
+	require.NoError(t, err)
+
+	return contents
+}
+
+func findHarnessStep(t *testing.T, steps []harnessStep, name string) harnessStep {
+	t.Helper()
+
+	for _, step := range steps {
+		if step.Name == name {
+			return step
+		}
+	}
+
+	t.Fatalf("step %q is missing", name)
+
+	return harnessStep{}
+}
+
+func assertBoundedWorkflowUpload(
+	t *testing.T,
+	steps []harnessStep,
+	name string,
+	wantPath string,
+	wantCondition string,
+) {
+	t.Helper()
+
+	step := findHarnessStep(t, steps, name)
+	assert.True(t, strings.HasPrefix(step.Uses, "actions/upload-artifact@"))
+	assert.Equal(t, 5, step.TimeoutMinutes)
+	assert.True(t, step.ContinueOnError)
+	assert.Contains(t, step.If, wantCondition)
+	assert.Equal(t, wantPath, stringValue(step.With["path"]))
+	assert.Contains(t, stringValue(step.With["name"]), "steps.system-test.outputs.artifact-tag")
+}
+
+func stringValue(value any) string {
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+
+	return strings.TrimSpace(text)
+}

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -59,6 +59,8 @@ func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
 	assert.Equal(t, "true", systemAction.Inputs["upload-artifacts"].Default)
 	require.Contains(t, systemAction.Inputs, "comprehensive-debug")
 	assert.Equal(t, "true", systemAction.Inputs["comprehensive-debug"].Default)
+	require.Contains(t, systemAction.Inputs, "cleanup")
+	assert.Equal(t, "true", systemAction.Inputs["cleanup"].Default)
 	require.Contains(t, systemAction.Outputs, "artifact-tag")
 	assert.Equal(
 		t,
@@ -77,8 +79,14 @@ func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
 	debugStep := findHarnessStep(t, systemAction.Runs.Steps, "🐞 Debug Kubernetes failure")
 	assert.Contains(t, debugStep.If, "inputs.comprehensive-debug == 'true'")
 
-	deleteStep := findHarnessStep(t, systemAction.Runs.Steps, "🧪 ksail cluster delete")
-	assert.Contains(t, deleteStep.Run, `timeout --kill-after=10s`)
+	cleanupStep := findHarnessStep(
+		t,
+		systemAction.Runs.Steps,
+		"🧪 Cleanup KSail System Test",
+	)
+	assert.Equal(t, "./.github/actions/ksail-system-test-cleanup", cleanupStep.Uses)
+	assert.Contains(t, cleanupStep.If, "inputs.cleanup == 'true'")
+	assert.Equal(t, "${{ inputs.args }}", stringValue(cleanupStep.With["args"]))
 
 	workflow := readCIWorkflow(t, ".github/workflows/ci.yaml")
 	dockerJob, ok := workflow.Jobs["system-test-docker"]
@@ -86,6 +94,7 @@ func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
 	runStep := findHarnessStep(t, dockerJob.Steps, "🧪 Run KSail System Test")
 	assert.Equal(t, "system-test", runStep.ID)
 	assert.Equal(t, "false", stringValue(runStep.With["upload-artifacts"]))
+	assert.Equal(t, "false", stringValue(runStep.With["cleanup"]))
 	assert.Contains(
 		t,
 		stringValue(runStep.With["comprehensive-debug"]),
@@ -99,6 +108,26 @@ func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
 		"/tmp/system-test-diagnostics/",
 		"failure()",
 	)
+	workflowCleanup := findHarnessStep(
+		t,
+		dockerJob.Steps,
+		"🧪 Cleanup KSail System Test",
+	)
+	assert.Equal(t, "./.github/actions/ksail-system-test-cleanup", workflowCleanup.Uses)
+	assert.Contains(t, workflowCleanup.If, "always()")
+	assert.Equal(t, "${{ matrix.distribution }}", stringValue(workflowCleanup.With["distribution"]))
+	assert.Equal(t, "${{ matrix.provider }}", stringValue(workflowCleanup.With["provider"]))
+	assert.Equal(t, "${{ matrix.args }}", stringValue(workflowCleanup.With["args"]))
+
+	diagnosticUploadIndex := findHarnessStepIndex(
+		t,
+		dockerJob.Steps,
+		"📤 Upload system test diagnostics",
+	)
+	cleanupIndex := findHarnessStepIndex(t, dockerJob.Steps, "🧪 Cleanup KSail System Test")
+	logUploadIndex := findHarnessStepIndex(t, dockerJob.Steps, "📤 Upload system test logs")
+	assert.Less(t, diagnosticUploadIndex, cleanupIndex)
+	assert.Less(t, cleanupIndex, logUploadIndex)
 	assertBoundedWorkflowUpload(
 		t,
 		dockerJob.Steps,
@@ -111,8 +140,11 @@ func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
 func TestSystemTestHarnessOnlyBoundsDockerK3sCleanup(t *testing.T) {
 	t.Parallel()
 
-	systemAction := readCompositeAction(t, ".github/actions/ksail-system-test/action.yaml")
-	deleteStep := findHarnessStep(t, systemAction.Runs.Steps, "🧪 ksail cluster delete")
+	cleanupAction := readCompositeAction(
+		t,
+		".github/actions/ksail-system-test-cleanup/action.yaml",
+	)
+	deleteStep := findHarnessStep(t, cleanupAction.Runs.Steps, "🧪 ksail cluster delete")
 	assert.Equal(t, "${{ inputs.distribution }}", deleteStep.Env["DISTRIBUTION"])
 
 	providerGate := strings.Index(
@@ -126,20 +158,38 @@ func TestSystemTestHarnessOnlyBoundsDockerK3sCleanup(t *testing.T) {
 		"only Docker/K3s cleanup may use the short recovery bound",
 	)
 
-	cloudBranchOffset := strings.Index(deleteStep.Run[providerGate:], "\nelse\n")
+	dockerBranchOffset := strings.Index(
+		deleteStep.Run[providerGate:],
+		"\nelif [ \"$PROVIDER\" = \"Docker\" ]; then\n",
+	)
 	require.NotEqual(
 		t,
 		-1,
-		cloudBranchOffset,
-		"cluster cleanup must include a cloud-provider branch",
+		dockerBranchOffset,
+		"cluster cleanup must preserve a non-K3s Docker branch",
 	)
-	cloudBranch := deleteStep.Run[providerGate+cloudBranchOffset:]
+
+	cloudBranchOffset := strings.Index(
+		deleteStep.Run[providerGate+dockerBranchOffset:],
+		"\nelse\n",
+	)
+	require.NotEqual(t, -1, cloudBranchOffset, "cluster cleanup must include a cloud branch")
+
+	dockerBranchStart := providerGate + dockerBranchOffset
+	cloudBranchStart := dockerBranchStart + cloudBranchOffset
+	k3sBranch := deleteStep.Run[providerGate:dockerBranchStart]
+	dockerBranch := deleteStep.Run[dockerBranchStart:cloudBranchStart]
+	cloudBranch := deleteStep.Run[cloudBranchStart:]
 
 	assert.Contains(
 		t,
-		deleteStep.Run[providerGate:providerGate+cloudBranchOffset],
+		k3sBranch,
 		`timeout --kill-after=10s 2m`,
 	)
+	assert.Contains(t, k3sBranch, `|| echo`)
+	assert.NotContains(t, dockerBranch, `timeout --kill-after=10s 2m`)
+	assert.Contains(t, dockerBranch, `"${DELETE_COMMAND[@]}"`)
+	assert.Contains(t, dockerBranch, `|| echo`)
 	assert.NotContains(t, cloudBranch, `timeout --kill-after=10s 2m`)
 	assert.Contains(t, cloudBranch, `"${DELETE_COMMAND[@]}"`)
 	assert.NotContains(t, cloudBranch, `|| echo`)
@@ -189,6 +239,20 @@ func findHarnessStep(t *testing.T, steps []harnessStep, name string) harnessStep
 	t.Fatalf("step %q is missing", name)
 
 	return harnessStep{}
+}
+
+func findHarnessStepIndex(t *testing.T, steps []harnessStep, name string) int {
+	t.Helper()
+
+	for index, step := range steps {
+		if step.Name == name {
+			return index
+		}
+	}
+
+	t.Fatalf("step %q is missing", name)
+
+	return -1
 }
 
 func assertBoundedWorkflowUpload(

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -90,6 +90,11 @@ type InstallerFactories struct {
 	// pre-phase; the normal parallel infra path uses InstallLoadBalancerSilent
 	// directly.
 	CloudProviderInitInstall silentInstallFunc
+	// ReservedSandboxMonitor watches K3s-on-Docker Kubernetes events while
+	// GitOps setup runs and returns k8s.ErrRepeatedReservedPodSandbox when
+	// nested containerd repeatedly reserves a pod sandbox name. Set to nil to
+	// use the default typed-event monitor.
+	ReservedSandboxMonitor func(ctx context.Context, clusterCfg *v1alpha1.Cluster) error
 }
 
 // policyEngineFactory creates the policy engine factory function.

--- a/pkg/cli/setup/phases.go
+++ b/pkg/cli/setup/phases.go
@@ -162,18 +162,33 @@ func InstallPostCNIComponents(
 		}
 	}
 
-	err := installComponentsInPhases(ctx, cmd, clusterCfg, factories, tmr, reqs, cniInstalled)
-	if err != nil {
-		return err
-	}
-
-	return configureGitOpsResources(
+	return runWithReservedSandboxMonitor(
 		ctx,
-		cmd,
 		clusterCfg,
 		factories,
-		reqs,
-		gitOpsKubeconfig,
+		func(runCtx context.Context) error {
+			err := installComponentsInPhases(
+				runCtx,
+				cmd,
+				clusterCfg,
+				factories,
+				tmr,
+				reqs,
+				cniInstalled,
+			)
+			if err != nil {
+				return err
+			}
+
+			return configureGitOpsResources(
+				runCtx,
+				cmd,
+				clusterCfg,
+				factories,
+				reqs,
+				gitOpsKubeconfig,
+			)
+		},
 	)
 }
 

--- a/pkg/cli/setup/reserved_sandbox.go
+++ b/pkg/cli/setup/reserved_sandbox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -62,6 +63,29 @@ func runWithReservedSandboxMonitor(
 	factories *InstallerFactories,
 	setup func(context.Context) error,
 ) error {
+	return runWithReservedSandboxMonitorAndWarning(
+		ctx,
+		clusterCfg,
+		factories,
+		setup,
+		func(ctx context.Context, err error) {
+			slog.WarnContext(
+				ctx,
+				"reserved pod sandbox monitor stopped; cluster setup will continue",
+				"error",
+				err,
+			)
+		},
+	)
+}
+
+func runWithReservedSandboxMonitorAndWarning(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+	setup func(context.Context) error,
+	warn func(context.Context, error),
+) error {
 	if !needsReservedSandboxMonitor(clusterCfg) {
 		return setup(ctx)
 	}
@@ -88,6 +112,10 @@ func runWithReservedSandboxMonitor(
 			return monitorErr
 		}
 
+		if stopped {
+			reportReservedSandboxMonitorError(runCtx, monitorErr, warn)
+		}
+
 		return setupErr
 	case monitorErr := <-monitorResult:
 		if errors.Is(monitorErr, k8s.ErrRepeatedReservedPodSandbox) {
@@ -100,8 +128,27 @@ func runWithReservedSandboxMonitor(
 		}
 
 		// Losing the diagnostic event stream must not abort healthy setup.
+		reportReservedSandboxMonitorError(runCtx, monitorErr, warn)
+
 		return <-setupResult
 	}
+}
+
+func reportReservedSandboxMonitorError(
+	ctx context.Context,
+	err error,
+	warn func(context.Context, error),
+) {
+	if err == nil || errors.Is(err, k8s.ErrRepeatedReservedPodSandbox) {
+		return
+	}
+
+	ctxErr := ctx.Err()
+	if ctxErr != nil && errors.Is(err, ctxErr) {
+		return
+	}
+
+	warn(ctx, err)
 }
 
 func waitForReservedSandboxResult(result <-chan error) (bool, error) {

--- a/pkg/cli/setup/reserved_sandbox.go
+++ b/pkg/cli/setup/reserved_sandbox.go
@@ -17,6 +17,8 @@ const (
 	reservedSandboxShutdownGracePeriod = 5 * time.Second
 )
 
+// reservedSandboxMonitor returns the injected monitor when present and the
+// Kubernetes-backed implementation otherwise.
 func (f *InstallerFactories) reservedSandboxMonitor() func(
 	context.Context,
 	*v1alpha1.Cluster,
@@ -28,6 +30,8 @@ func (f *InstallerFactories) reservedSandboxMonitor() func(
 	return watchRepeatedReservedPodSandboxes
 }
 
+// watchRepeatedReservedPodSandboxes resolves the target cluster and monitors
+// its warning events for the repeated nested-containerd reservation failure.
 func watchRepeatedReservedPodSandboxes(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
@@ -57,6 +61,8 @@ func watchRepeatedReservedPodSandboxes(
 	return nil
 }
 
+// runWithReservedSandboxMonitor runs eligible cluster setup alongside the
+// reservation monitor and logs monitor failures that do not require recovery.
 func runWithReservedSandboxMonitor(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
@@ -79,6 +85,9 @@ func runWithReservedSandboxMonitor(
 	)
 }
 
+// runWithReservedSandboxMonitorAndWarning coordinates setup and monitoring,
+// returning the reservation error when recovery is required and otherwise
+// preserving the setup result.
 func runWithReservedSandboxMonitorAndWarning(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
@@ -134,6 +143,8 @@ func runWithReservedSandboxMonitorAndWarning(
 	}
 }
 
+// reportReservedSandboxMonitorError reports only unexpected monitor failures,
+// excluding the recovery sentinel and cancellation caused by setup shutdown.
 func reportReservedSandboxMonitorError(
 	ctx context.Context,
 	err error,
@@ -151,6 +162,8 @@ func reportReservedSandboxMonitorError(
 	warn(ctx, err)
 }
 
+// waitForReservedSandboxResult gives a cancelled setup or monitor a bounded
+// grace period to report its terminal result.
 func waitForReservedSandboxResult(result <-chan error) (bool, error) {
 	timer := time.NewTimer(reservedSandboxShutdownGracePeriod)
 	defer timer.Stop()
@@ -163,6 +176,8 @@ func waitForReservedSandboxResult(result <-chan error) (bool, error) {
 	}
 }
 
+// needsReservedSandboxMonitor limits recovery monitoring to nested K3s on
+// Docker when a GitOps engine is installed inside the cluster.
 func needsReservedSandboxMonitor(clusterCfg *v1alpha1.Cluster) bool {
 	if clusterCfg == nil ||
 		clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionK3s ||

--- a/pkg/cli/setup/reserved_sandbox.go
+++ b/pkg/cli/setup/reserved_sandbox.go
@@ -1,0 +1,130 @@
+package setup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/kubeconfig"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+)
+
+const (
+	reservedSandboxPollInterval        = 5 * time.Second
+	reservedSandboxShutdownGracePeriod = 5 * time.Second
+)
+
+func (f *InstallerFactories) reservedSandboxMonitor() func(
+	context.Context,
+	*v1alpha1.Cluster,
+) error {
+	if f != nil && f.ReservedSandboxMonitor != nil {
+		return f.ReservedSandboxMonitor
+	}
+
+	return watchRepeatedReservedPodSandboxes
+}
+
+func watchRepeatedReservedPodSandboxes(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+) error {
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(clusterCfg)
+	if err != nil {
+		return fmt.Errorf("resolve kubeconfig for pod sandbox monitor: %w", err)
+	}
+
+	clientset, err := k8s.NewClientset(
+		kubeconfigPath,
+		clusterCfg.Spec.Cluster.Connection.Context,
+	)
+	if err != nil {
+		return fmt.Errorf("create client for pod sandbox monitor: %w", err)
+	}
+
+	err = k8s.WatchRepeatedReservedPodSandboxes(
+		ctx,
+		clientset,
+		reservedSandboxPollInterval,
+	)
+	if err != nil {
+		return fmt.Errorf("watch for repeated reserved pod sandboxes: %w", err)
+	}
+
+	return nil
+}
+
+func runWithReservedSandboxMonitor(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+	setup func(context.Context) error,
+) error {
+	if !needsReservedSandboxMonitor(clusterCfg) {
+		return setup(ctx)
+	}
+
+	runCtx, stop := context.WithCancel(ctx)
+	defer stop()
+
+	setupResult := make(chan error, 1)
+	monitorResult := make(chan error, 1)
+
+	go func() {
+		setupResult <- setup(runCtx)
+	}()
+	go func() {
+		monitorResult <- factories.reservedSandboxMonitor()(runCtx, clusterCfg)
+	}()
+
+	select {
+	case setupErr := <-setupResult:
+		stop()
+
+		stopped, monitorErr := waitForReservedSandboxResult(monitorResult)
+		if stopped && errors.Is(monitorErr, k8s.ErrRepeatedReservedPodSandbox) {
+			return monitorErr
+		}
+
+		return setupErr
+	case monitorErr := <-monitorResult:
+		if errors.Is(monitorErr, k8s.ErrRepeatedReservedPodSandbox) {
+			stop()
+			// The detector error controls retry classification; the cancelled
+			// setup result is secondary and is joined only for bounded shutdown.
+			_, _ = waitForReservedSandboxResult(setupResult)
+
+			return monitorErr
+		}
+
+		// Losing the diagnostic event stream must not abort healthy setup.
+		return <-setupResult
+	}
+}
+
+func waitForReservedSandboxResult(result <-chan error) (bool, error) {
+	timer := time.NewTimer(reservedSandboxShutdownGracePeriod)
+	defer timer.Stop()
+
+	select {
+	case err := <-result:
+		return true, err
+	case <-timer.C:
+		return false, nil
+	}
+}
+
+func needsReservedSandboxMonitor(clusterCfg *v1alpha1.Cluster) bool {
+	if clusterCfg == nil ||
+		clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionK3s ||
+		clusterCfg.Spec.Cluster.Provider != v1alpha1.ProviderDocker {
+		return false
+	}
+
+	gitOpsEngine := clusterCfg.Spec.Cluster.GitOpsEngine
+
+	return gitOpsEngine == v1alpha1.GitOpsEngineArgoCD ||
+		gitOpsEngine == v1alpha1.GitOpsEngineFlux
+}

--- a/pkg/cli/setup/reserved_sandbox_test.go
+++ b/pkg/cli/setup/reserved_sandbox_test.go
@@ -122,6 +122,44 @@ func TestRunWithReservedSandboxMonitorPrioritizesConcurrentDetectorError(t *test
 	require.ErrorIs(t, err, k8s.ErrRepeatedReservedPodSandbox)
 }
 
+func TestRunWithReservedSandboxMonitorReportsNonSentinelErrorAndContinuesSetup(t *testing.T) {
+	t.Parallel()
+
+	setupStarted := make(chan struct{})
+	releaseSetup := make(chan struct{})
+	reported := make(chan error, 1)
+	monitorErr := fmt.Errorf("monitor unavailable: %w", assert.AnError)
+	setupErr := fmt.Errorf("setup failed independently: %w", assert.AnError)
+	factories := &InstallerFactories{
+		ReservedSandboxMonitor: func(context.Context, *v1alpha1.Cluster) error {
+			<-setupStarted
+
+			return monitorErr
+		},
+	}
+
+	err := runWithReservedSandboxMonitorAndWarning(
+		context.Background(),
+		k3sDockerGitOpsCluster(),
+		factories,
+		func(context.Context) error {
+			close(setupStarted)
+			<-releaseSetup
+
+			return setupErr
+		},
+		func(_ context.Context, err error) {
+			reported <- err
+
+			close(releaseSetup)
+		},
+	)
+
+	require.ErrorIs(t, err, setupErr)
+	require.NotErrorIs(t, err, monitorErr)
+	assert.ErrorIs(t, <-reported, monitorErr)
+}
+
 //nolint:funlen // The table documents every cluster-shape guard in one place.
 func TestRunWithReservedSandboxMonitorSkipsOtherClusterShapes(t *testing.T) {
 	t.Parallel()

--- a/pkg/cli/setup/reserved_sandbox_test.go
+++ b/pkg/cli/setup/reserved_sandbox_test.go
@@ -1,0 +1,216 @@
+//nolint:testpackage // White-box coverage locks cancellation of the setup phase.
+package setup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithReservedSandboxMonitorCancelsSetupAndPreservesDetectorError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	setupStarted := make(chan struct{})
+	setupCanceled := make(chan struct{})
+	detectorErr := &k8s.RepeatedReservedPodSandboxError{
+		Namespace: "argocd",
+		Pod:       "argocd-server-0",
+		Count:     4,
+		Message:   "failed to reserve sandbox name",
+	}
+	factories := &InstallerFactories{
+		ReservedSandboxMonitor: func(context.Context, *v1alpha1.Cluster) error {
+			<-setupStarted
+
+			return detectorErr
+		},
+	}
+
+	err := runWithReservedSandboxMonitor(
+		ctx,
+		k3sDockerGitOpsCluster(),
+		factories,
+		func(runCtx context.Context) error {
+			close(setupStarted)
+			<-runCtx.Done()
+			close(setupCanceled)
+
+			return fmt.Errorf("setup cancelled: %w", runCtx.Err())
+		},
+	)
+
+	require.ErrorIs(t, err, k8s.ErrRepeatedReservedPodSandbox)
+	require.ErrorIs(t, err, detectorErr)
+
+	select {
+	case <-setupCanceled:
+	default:
+		t.Fatal("setup did not observe monitor cancellation")
+	}
+}
+
+func TestRunWithReservedSandboxMonitorJoinsMonitorAfterSuccessfulSetup(t *testing.T) {
+	t.Parallel()
+
+	monitorStarted := make(chan struct{})
+	monitorStopped := make(chan struct{})
+	factories := &InstallerFactories{
+		ReservedSandboxMonitor: func(ctx context.Context, _ *v1alpha1.Cluster) error {
+			close(monitorStarted)
+			<-ctx.Done()
+			close(monitorStopped)
+
+			return nil
+		},
+	}
+
+	err := runWithReservedSandboxMonitor(
+		context.Background(),
+		k3sDockerGitOpsCluster(),
+		factories,
+		func(context.Context) error {
+			<-monitorStarted
+
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+
+	select {
+	case <-monitorStopped:
+	default:
+		t.Fatal("successful setup returned before the monitor stopped")
+	}
+}
+
+func TestRunWithReservedSandboxMonitorPrioritizesConcurrentDetectorError(t *testing.T) {
+	t.Parallel()
+
+	detectorErr := &k8s.RepeatedReservedPodSandboxError{
+		Namespace: "argocd",
+		Pod:       "argocd-server-0",
+		Count:     3,
+		Message:   "failed to reserve sandbox name",
+	}
+	factories := &InstallerFactories{
+		ReservedSandboxMonitor: func(ctx context.Context, _ *v1alpha1.Cluster) error {
+			<-ctx.Done()
+
+			return detectorErr
+		},
+	}
+
+	err := runWithReservedSandboxMonitor(
+		context.Background(),
+		k3sDockerGitOpsCluster(),
+		factories,
+		func(context.Context) error {
+			return assert.AnError
+		},
+	)
+
+	require.ErrorIs(t, err, k8s.ErrRepeatedReservedPodSandbox)
+}
+
+//nolint:funlen // The table documents every cluster-shape guard in one place.
+func TestRunWithReservedSandboxMonitorSkipsOtherClusterShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cluster *v1alpha1.Cluster
+	}{
+		{
+			name: "Vanilla Docker GitOps",
+			cluster: clusterWithShape(
+				v1alpha1.DistributionVanilla,
+				v1alpha1.ProviderDocker,
+				v1alpha1.GitOpsEngineArgoCD,
+			),
+		},
+		{
+			name: "K3s non-Docker GitOps",
+			cluster: clusterWithShape(
+				v1alpha1.DistributionK3s,
+				v1alpha1.ProviderHetzner,
+				v1alpha1.GitOpsEngineArgoCD,
+			),
+		},
+		{
+			name: "K3s Docker without GitOps",
+			cluster: clusterWithShape(
+				v1alpha1.DistributionK3s,
+				v1alpha1.ProviderDocker,
+				v1alpha1.GitOpsEngineNone,
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				monitorCalled bool
+				setupCalled   bool
+			)
+
+			factories := &InstallerFactories{
+				ReservedSandboxMonitor: func(context.Context, *v1alpha1.Cluster) error {
+					monitorCalled = true
+
+					return nil
+				},
+			}
+
+			err := runWithReservedSandboxMonitor(
+				context.Background(),
+				test.cluster,
+				factories,
+				func(context.Context) error {
+					setupCalled = true
+
+					return nil
+				},
+			)
+
+			require.NoError(t, err)
+			assert.True(t, setupCalled)
+			assert.False(t, monitorCalled)
+		})
+	}
+}
+
+func k3sDockerGitOpsCluster() *v1alpha1.Cluster {
+	return clusterWithShape(
+		v1alpha1.DistributionK3s,
+		v1alpha1.ProviderDocker,
+		v1alpha1.GitOpsEngineArgoCD,
+	)
+}
+
+func clusterWithShape(
+	distribution v1alpha1.Distribution,
+	provider v1alpha1.Provider,
+	gitOpsEngine v1alpha1.GitOpsEngine,
+) *v1alpha1.Cluster {
+	return &v1alpha1.Cluster{
+		Spec: v1alpha1.Spec{
+			Cluster: v1alpha1.ClusterSpec{
+				Distribution: distribution,
+				Provider:     provider,
+				GitOpsEngine: gitOpsEngine,
+			},
+		},
+	}
+}

--- a/pkg/k8s/podsandbox.go
+++ b/pkg/k8s/podsandbox.go
@@ -76,6 +76,8 @@ func WatchRepeatedReservedPodSandboxes(
 	)
 }
 
+// watchRepeatedReservedPodSandboxes implements the polling loop with an
+// injectable warning sink so transient list failures can be tested precisely.
 func watchRepeatedReservedPodSandboxes(
 	ctx context.Context,
 	clientset kubernetes.Interface,
@@ -132,6 +134,8 @@ func watchRepeatedReservedPodSandboxes(
 	}
 }
 
+// repeatedReservedPodSandboxFailure returns details for the first current
+// event that crosses the repeated reservation threshold.
 func repeatedReservedPodSandboxFailure(events []corev1.Event, started time.Time) error {
 	for idx := range events {
 		event := &events[idx]
@@ -150,6 +154,8 @@ func repeatedReservedPodSandboxFailure(events []corev1.Event, started time.Time)
 	return nil
 }
 
+// isRepeatedReservedPodSandboxEvent reports whether an event has the expected
+// pod warning signature, repetition count, and observation time.
 func isRepeatedReservedPodSandboxEvent(event *corev1.Event, started time.Time) bool {
 	if event.Type != corev1.EventTypeWarning ||
 		event.Reason != "FailedCreatePodSandBox" ||
@@ -164,6 +170,8 @@ func isRepeatedReservedPodSandboxEvent(event *corev1.Event, started time.Time) b
 	return !observedAt.IsZero() && !observedAt.Before(started)
 }
 
+// podSandboxEventCount returns the greatest repetition count reported by the
+// legacy event field or its newer series metadata.
 func podSandboxEventCount(event *corev1.Event) int32 {
 	count := event.Count
 	if event.Series != nil {
@@ -173,6 +181,8 @@ func podSandboxEventCount(event *corev1.Event) int32 {
 	return count
 }
 
+// podSandboxEventTime returns the latest observation timestamp available on
+// either the event or its series metadata.
 func podSandboxEventTime(event *corev1.Event) time.Time {
 	observedAt := event.CreationTimestamp.Time
 	if event.LastTimestamp.After(observedAt) {

--- a/pkg/k8s/podsandbox.go
+++ b/pkg/k8s/podsandbox.go
@@ -1,0 +1,154 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	reservedPodSandboxMessage             = "failed to reserve sandbox name"
+	reservedPodSandboxThreshold           = int32(3)
+	defaultReservedPodSandboxPollInterval = 5 * time.Second
+)
+
+// ErrRepeatedReservedPodSandbox identifies a nested-containerd pod sandbox
+// reservation that has repeated often enough to require bounded recovery.
+var ErrRepeatedReservedPodSandbox = errors.New("repeated reserved pod sandbox failures")
+
+// RepeatedReservedPodSandboxError describes the Kubernetes event that caused
+// KSail to stop waiting for a nested K3s cluster to recover by itself.
+type RepeatedReservedPodSandboxError struct {
+	Namespace string
+	Pod       string
+	Count     int32
+	Message   string
+}
+
+// Error returns a stable marker plus the original Kubernetes event details so
+// CI can classify the failure without discarding its diagnostic evidence.
+func (e *RepeatedReservedPodSandboxError) Error() string {
+	return fmt.Sprintf(
+		"%s: namespace=%q pod=%q count=%d: %s",
+		ErrRepeatedReservedPodSandbox,
+		e.Namespace,
+		e.Pod,
+		e.Count,
+		e.Message,
+	)
+}
+
+// Unwrap exposes the stable reservation sentinel for errors.Is checks.
+func (e *RepeatedReservedPodSandboxError) Unwrap() error {
+	return ErrRepeatedReservedPodSandbox
+}
+
+// WatchRepeatedReservedPodSandboxes polls Kubernetes warning events until the
+// context is cancelled or a current pod reports the reserved-sandbox signature
+// at least three times. Transient list failures are ignored so loss of the
+// diagnostic surface cannot abort an otherwise healthy cluster setup.
+func WatchRepeatedReservedPodSandboxes(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	pollInterval time.Duration,
+) error {
+	if pollInterval <= 0 {
+		pollInterval = defaultReservedPodSandboxPollInterval
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	started := time.Now()
+
+	selector := fields.AndSelectors(
+		fields.OneTermEqualSelector("reason", "FailedCreatePodSandBox"),
+		fields.OneTermEqualSelector("type", corev1.EventTypeWarning),
+	).String()
+
+	for {
+		events, err := clientset.CoreV1().Events(metav1.NamespaceAll).List(
+			ctx,
+			metav1.ListOptions{FieldSelector: selector},
+		)
+		if err == nil {
+			reservationErr := repeatedReservedPodSandboxFailure(events.Items, started)
+			if reservationErr != nil {
+				return reservationErr
+			}
+		} else if ctx.Err() != nil {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func repeatedReservedPodSandboxFailure(events []corev1.Event, started time.Time) error {
+	for idx := range events {
+		event := &events[idx]
+		if !isRepeatedReservedPodSandboxEvent(event, started) {
+			continue
+		}
+
+		return &RepeatedReservedPodSandboxError{
+			Namespace: event.InvolvedObject.Namespace,
+			Pod:       event.InvolvedObject.Name,
+			Count:     podSandboxEventCount(event),
+			Message:   event.Message,
+		}
+	}
+
+	return nil
+}
+
+func isRepeatedReservedPodSandboxEvent(event *corev1.Event, started time.Time) bool {
+	if event.Type != corev1.EventTypeWarning ||
+		event.Reason != "FailedCreatePodSandBox" ||
+		event.InvolvedObject.Kind != "Pod" ||
+		!strings.Contains(strings.ToLower(event.Message), reservedPodSandboxMessage) ||
+		podSandboxEventCount(event) < reservedPodSandboxThreshold {
+		return false
+	}
+
+	observedAt := podSandboxEventTime(event)
+
+	return !observedAt.IsZero() && !observedAt.Before(started)
+}
+
+func podSandboxEventCount(event *corev1.Event) int32 {
+	count := event.Count
+	if event.Series != nil {
+		count = max(count, event.Series.Count)
+	}
+
+	return count
+}
+
+func podSandboxEventTime(event *corev1.Event) time.Time {
+	observedAt := event.CreationTimestamp.Time
+	if event.LastTimestamp.After(observedAt) {
+		observedAt = event.LastTimestamp.Time
+	}
+
+	if event.EventTime.After(observedAt) {
+		observedAt = event.EventTime.Time
+	}
+
+	if event.Series != nil && event.Series.LastObservedTime.After(observedAt) {
+		observedAt = event.Series.LastObservedTime.Time
+	}
+
+	return observedAt
+}

--- a/pkg/k8s/podsandbox.go
+++ b/pkg/k8s/podsandbox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ const (
 	reservedPodSandboxMessage             = "failed to reserve sandbox name"
 	reservedPodSandboxThreshold           = int32(3)
 	defaultReservedPodSandboxPollInterval = 5 * time.Second
+	reservedPodSandboxListWarningInterval = 30 * time.Second
 )
 
 // ErrRepeatedReservedPodSandbox identifies a nested-containerd pod sandbox
@@ -52,12 +54,33 @@ func (e *RepeatedReservedPodSandboxError) Unwrap() error {
 
 // WatchRepeatedReservedPodSandboxes polls Kubernetes warning events until the
 // context is cancelled or a current pod reports the reserved-sandbox signature
-// at least three times. Transient list failures are ignored so loss of the
-// diagnostic surface cannot abort an otherwise healthy cluster setup.
+// at least three times. Transient list failures are reported at a bounded
+// cadence but cannot abort an otherwise healthy cluster setup.
 func WatchRepeatedReservedPodSandboxes(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	pollInterval time.Duration,
+) error {
+	return watchRepeatedReservedPodSandboxes(
+		ctx,
+		clientset,
+		pollInterval,
+		func(ctx context.Context, err error) {
+			slog.WarnContext(
+				ctx,
+				"reserved pod sandbox monitor could not list Kubernetes events",
+				"error",
+				err,
+			)
+		},
+	)
+}
+
+func watchRepeatedReservedPodSandboxes(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	pollInterval time.Duration,
+	warn func(context.Context, error),
 ) error {
 	if pollInterval <= 0 {
 		pollInterval = defaultReservedPodSandboxPollInterval
@@ -65,6 +88,8 @@ func WatchRepeatedReservedPodSandboxes(
 
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
+
+	var lastListWarning time.Time
 
 	started := time.Now()
 
@@ -83,8 +108,20 @@ func WatchRepeatedReservedPodSandboxes(
 			if reservationErr != nil {
 				return reservationErr
 			}
-		} else if ctx.Err() != nil {
-			return nil
+		} else {
+			if ctx.Err() != nil {
+				return nil
+			}
+
+			now := time.Now()
+
+			shouldWarn := lastListWarning.IsZero() ||
+				now.Sub(lastListWarning) >= reservedPodSandboxListWarningInterval
+			if shouldWarn {
+				lastListWarning = now
+
+				warn(ctx, fmt.Errorf("list Kubernetes warning events: %w", err))
+			}
 		}
 
 		select {

--- a/pkg/k8s/podsandbox_test.go
+++ b/pkg/k8s/podsandbox_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 //nolint:funlen // The table documents every event field that guards recovery.
@@ -115,6 +117,44 @@ func TestWatchRepeatedReservedPodSandboxesStopsOnCancellation(t *testing.T) {
 
 	err := WatchRepeatedReservedPodSandboxes(ctx, fake.NewSimpleClientset(), time.Millisecond)
 	require.NoError(t, err)
+}
+
+func TestWatchRepeatedReservedPodSandboxesReportsListErrorsWithoutSpamming(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientset := fake.NewSimpleClientset()
+	attempts := 0
+
+	clientset.PrependReactor(
+		"list",
+		"events",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			attempts++
+			if attempts == 3 {
+				cancel()
+			}
+
+			return true, nil, assert.AnError
+		},
+	)
+
+	reported := make([]error, 0, 1)
+	err := watchRepeatedReservedPodSandboxes(
+		ctx,
+		clientset,
+		time.Millisecond,
+		func(_ context.Context, err error) {
+			reported = append(reported, err)
+		},
+	)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, attempts, 3)
+	require.Len(t, reported, 1)
+	assert.ErrorIs(t, reported[0], assert.AnError)
 }
 
 func TestWatchRepeatedReservedPodSandboxesReturnsTypedCurrentEvent(t *testing.T) {

--- a/pkg/k8s/podsandbox_test.go
+++ b/pkg/k8s/podsandbox_test.go
@@ -1,0 +1,157 @@
+//nolint:testpackage // White-box coverage locks the event-classification boundary.
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+//nolint:funlen // The table documents every event field that guards recovery.
+func TestRepeatedReservedPodSandboxFailure(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, time.July, 14, 12, 0, 0, 0, time.UTC)
+	recent := metav1.NewTime(started.Add(time.Second))
+	stale := metav1.NewTime(started.Add(-time.Second))
+
+	tests := []struct {
+		name    string
+		event   corev1.Event
+		wantErr bool
+	}{
+		{
+			name:    "repeated count",
+			event:   reservedPodSandboxEvent(3, nil, recent),
+			wantErr: true,
+		},
+		{
+			name: "repeated series count",
+			event: reservedPodSandboxEvent(1, &corev1.EventSeries{
+				Count:            4,
+				LastObservedTime: metav1.NewMicroTime(recent.Time),
+			}, recent),
+			wantErr: true,
+		},
+		{
+			name:  "below threshold",
+			event: reservedPodSandboxEvent(2, nil, recent),
+		},
+		{
+			name:  "stale event",
+			event: reservedPodSandboxEvent(9, nil, stale),
+		},
+		{
+			name: "wrong reason",
+			event: func() corev1.Event {
+				event := reservedPodSandboxEvent(9, nil, recent)
+				event.Reason = "FailedScheduling"
+
+				return event
+			}(),
+		},
+		{
+			name: "normal event",
+			event: func() corev1.Event {
+				event := reservedPodSandboxEvent(9, nil, recent)
+				event.Type = corev1.EventTypeNormal
+
+				return event
+			}(),
+		},
+		{
+			name: "non-pod event",
+			event: func() corev1.Event {
+				event := reservedPodSandboxEvent(9, nil, recent)
+				event.InvolvedObject.Kind = "Node"
+
+				return event
+			}(),
+		},
+		{
+			name: "different pod sandbox failure",
+			event: func() corev1.Event {
+				event := reservedPodSandboxEvent(9, nil, recent)
+				event.Message = "failed to setup network for sandbox: flannel subnet.env missing"
+
+				return event
+			}(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := repeatedReservedPodSandboxFailure([]corev1.Event{test.event}, started)
+			if !test.wantErr {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorIs(t, err, ErrRepeatedReservedPodSandbox)
+
+			var reservationErr *RepeatedReservedPodSandboxError
+			require.ErrorAs(t, err, &reservationErr)
+			assert.Equal(t, "argocd", reservationErr.Namespace)
+			assert.Equal(t, "argocd-server-0", reservationErr.Pod)
+			assert.GreaterOrEqual(t, reservationErr.Count, int32(3))
+		})
+	}
+}
+
+func TestWatchRepeatedReservedPodSandboxesStopsOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := WatchRepeatedReservedPodSandboxes(ctx, fake.NewSimpleClientset(), time.Millisecond)
+	require.NoError(t, err)
+}
+
+func TestWatchRepeatedReservedPodSandboxesReturnsTypedCurrentEvent(t *testing.T) {
+	t.Parallel()
+
+	recent := metav1.NewTime(time.Now().Add(time.Minute))
+	event := reservedPodSandboxEvent(3, nil, recent)
+	clientset := fake.NewSimpleClientset(&event)
+
+	err := WatchRepeatedReservedPodSandboxes(
+		context.Background(),
+		clientset,
+		time.Millisecond,
+	)
+
+	require.ErrorIs(t, err, ErrRepeatedReservedPodSandbox)
+	assert.Contains(t, err.Error(), `namespace="argocd"`)
+	assert.Contains(t, err.Error(), `pod="argocd-server-0"`)
+}
+
+func reservedPodSandboxEvent(
+	count int32,
+	series *corev1.EventSeries,
+	lastTimestamp metav1.Time,
+) corev1.Event {
+	return corev1.Event{
+		Type:   corev1.EventTypeWarning,
+		Reason: "FailedCreatePodSandBox",
+		Message: "Failed to create pod sandbox: failed to reserve sandbox name " +
+			"k8s_argocd-server_argocd_123_0: name is reserved",
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: "argocd",
+			Name:      "argocd-server-0",
+		},
+		Count:         count,
+		Series:        series,
+		LastTimestamp: lastTimestamp,
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer (Codex) — routine-owned draft.

Fixes #6109

## Root cause

The K3s-on-Docker GitOps lane could keep waiting after nested containerd repeatedly emitted `FailedCreatePodSandBox` events with the reserved-sandbox-name signature. Once setup eventually failed, artifact uploads ran inside a composite action, where GitHub does not support `timeout-minutes`; a stalled upload consumed another 82 minutes and prevented cleanup/log upload from completing.

## What changed

- Watch typed Kubernetes warning events during K3s + Docker GitOps setup and cancel after the current reservation failure repeats three times.
- Preserve a stable error sentinel so the CI harness gives only that failure one cleanup-and-retry attempt; unrelated K3s failures remain fail-fast and the existing Talos retry policy is unchanged.
- Bound runtime cleanup, final cluster deletion, and core diagnostic commands with hard timeouts.
- Move Docker system-test uploads to workflow-level five-minute steps and keep them non-blocking.
- Skip the unbounded comprehensive debug composite only for K3s lanes, while retaining bounded pod, event, node, cluster, and Docker evidence.
- Add Go regression coverage plus a cross-file action/workflow contract test.

## Impact and trade-offs

This is a narrow reliability fix, so no feature flag is added. On K3s failures the bounded core diagnostic set replaces the richer debug composite to guarantee the job can terminate and upload evidence.

## Validation

- `go build -o /tmp/ksail-a8be-6109 .`
- `go test -p 1 ./... -count=1`
- `go test -race ./pkg/k8s ./pkg/cli/setup ./internal/ciharness -count=1`
- `golangci-lint run --timeout 5m ./pkg/k8s ./pkg/cli/setup ./internal/ciharness`
- `actionlint` on `.github/workflows/ci.yaml` (excluding the existing local-schema warning for `code-quality`)
- `shellcheck` on each changed composite-action script
- `git diff --check`

The normal K3s system-test lane remains the live acceptance gate in PR CI.