### PR TITLE
fix(release): hand cask PRs off to the tap instead of leaving them draft

### DIFF
--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -56,6 +56,11 @@ assert_contains 'pulls?state=open&head=' "${homebrew_block}" \
 	'release job must enumerate cask PRs with the server-side head filter (no client-side page cap)'
 assert_contains 'head.repo.full_name == $full' "${homebrew_block}" \
 	'release job must scope matches to the tap-owned devantler PR (full head-repo name)'
+# A partial two-cask release leaves the job red with the first cask already promoted; a rerun must be
+# idempotent — an already-ready, correctly-titled cask PR for this tag is treated as done, not
+# re-validated against the draft requirement (which would fail the rerun forever). See #6134.
+assert_contains 'already handed off for ${TAG} (ready and titled)' "${homebrew_block}" \
+	'release job must treat an already-promoted cask PR for this tag as an idempotent retry, not a failure'
 assert_contains '--source-repo "$GITHUB_REPOSITORY"' "${homebrew_block}" \
 	'release job must collect release-asset digest evidence for the sha256 handoff check'
 # Cask PRs are a trusted programmed release path (maintainer direction ksail#6095): after full

--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -57,10 +57,24 @@ assert_contains 'pulls?state=open&head=' "${homebrew_block}" \
 assert_contains 'head.repo.full_name == $full' "${homebrew_block}" \
 	'release job must scope matches to the tap-owned devantler PR (full head-repo name)'
 # A partial two-cask release leaves the job red with the first cask already promoted; a rerun must be
-# idempotent — an already-ready, correctly-titled cask PR for this tag is treated as done, not
-# re-validated against the draft requirement (which would fail the rerun forever). See #6134.
-assert_contains 'already handed off for ${TAG} (ready and titled)' "${homebrew_block}" \
-	'release job must treat an already-promoted cask PR for this tag as an idempotent retry, not a failure'
+# idempotent — an already-ready, correctly-titled cask PR for this tag is treated as done rather than
+# re-validated against the DRAFT requirement (which would fail the rerun forever). But "ready + right
+# title" is not proof the tap will merge the correct cask, so the rerun re-runs the non-draft
+# (`prepared`) validator first; only a revalidated ready PR is skipped. See #6134.
+assert_contains 'already handed off for ${TAG} (ready, titled, and revalidated)' "${homebrew_block}" \
+	'release job must treat a REVALIDATED already-promoted cask PR for this tag as an idempotent retry, not a failure'
+assert_contains 'failed prepared revalidation' "${homebrew_block}" \
+	'release job must fail the rerun red when an already-ready cask PR no longer passes prepared revalidation'
+# A partial rerun may find the first cask ALREADY MERGED by the tap auto-merge; the open-only query
+# then returns zero, so the job must check for a merged, this-tag cask before failing red (#6134).
+assert_contains 'pulls?state=closed&head=' "${homebrew_block}" \
+	'release job must check for an already-merged cask PR on a rerun (open-only query misses it)'
+assert_contains 'merged_at != null' "${homebrew_block}" \
+	'release job must count only MERGED closed cask PRs when treating a rerun as already handed off'
+# A generated cask the runner could not style-clean (clone/tempdir/push failure) would be rejected by
+# the tap's brew-style gate, silently blocking auto-merge — the job must go red, not promote it (#6134).
+assert_contains 'could not ensure it is brew-style-clean' "${homebrew_block}" \
+	'release job must fail red (not promote) when it cannot ensure the cask is brew-style-clean'
 assert_contains '--source-repo "$GITHUB_REPOSITORY"' "${homebrew_block}" \
 	'release job must collect release-asset digest evidence for the sha256 handoff check'
 # Cask PRs are a trusted programmed release path (maintainer direction ksail#6095): after full
@@ -87,9 +101,12 @@ if [ "${validator_calls}" -lt 3 ]; then
 	fail "expected pre-style, post-style, and prepared validation; found ${validator_calls} calls"
 fi
 ready_line="$(grep -Fn -- 'markPullRequestReadyForReview' "${homebrew_block}" | head -1 | cut -d: -f1)"
-prepared_line="$(grep -Fn -- '"$evidence" prepared' "${homebrew_block}" | head -1 | cut -d: -f1)"
+# There are now two `prepared` calls — the idempotency-rerun revalidation and the final pre-promotion
+# validation. The invariant guards the LATTER: the ready mutation must come after the FINAL prepared
+# validation, so key on the last match.
+prepared_line="$(grep -Fn -- '"$evidence" prepared' "${homebrew_block}" | tail -1 | cut -d: -f1)"
 if [ -z "${ready_line}" ] || [ -z "${prepared_line}" ] || [ "${ready_line}" -le "${prepared_line}" ]; then
-	fail 'the ready-for-auto-merge handoff must come after the prepared validation'
+	fail 'the ready-for-auto-merge handoff must come after the final prepared validation'
 fi
 
 # The pre-release checkpoint: a reused, still-promoted evergreen PR is demoted BEFORE GoReleaser

--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -61,8 +61,13 @@ assert_contains '--source-repo "$GITHUB_REPOSITORY"' "${homebrew_block}" \
 # Cask PRs are a trusted programmed release path (maintainer direction ksail#6095): after full
 # validation the job marks the PR ready so the tap's checks gate its auto-merge — but ONLY after
 # the prepared validation, and never by merging or bypassing anything itself.
-assert_contains 'gh pr ready "$pr" --repo "$TAP"' "${homebrew_block}" \
+# The handoff drives `markPullRequestReadyForReview` directly rather than `gh pr ready`: that
+# subcommand resolves the viewer's `login`, a scope the tap token does not have, so it failed on every
+# release and stranded each cask PR as a draft (#6134). Assert the mechanism that actually promotes.
+assert_contains 'markPullRequestReadyForReview' "${homebrew_block}" \
 	'release job must hand the validated cask PR to the tap check-gated auto-merge path'
+assert_not_contains 'gh pr ready' "${homebrew_block}" \
+	'release job must not promote via `gh pr ready` (needs a login scope the tap token lacks; see #6134)'
 assert_contains 'marked ready for check-gated auto-merge' "${homebrew_block}" \
 	'release job must record the ready-for-auto-merge handoff'
 assert_not_contains 'gh pr merge' "${execution_surface}" \
@@ -76,7 +81,7 @@ validator_calls="$(grep -Fc -- 'validate_handoff "$pr"' "${homebrew_block}" || t
 if [ "${validator_calls}" -lt 3 ]; then
 	fail "expected pre-style, post-style, and prepared validation; found ${validator_calls} calls"
 fi
-ready_line="$(grep -Fn -- 'gh pr ready "$pr" --repo "$TAP"' "${homebrew_block}" | head -1 | cut -d: -f1)"
+ready_line="$(grep -Fn -- 'markPullRequestReadyForReview' "${homebrew_block}" | head -1 | cut -d: -f1)"
 prepared_line="$(grep -Fn -- '"$evidence" prepared' "${homebrew_block}" | head -1 | cut -d: -f1)"
 if [ -z "${ready_line}" ] || [ -z "${prepared_line}" ] || [ "${ready_line}" -le "${prepared_line}" ]; then
 	fail 'the ready-for-auto-merge handoff must come after the prepared validation'

--- a/.github/scripts/validate-cask-pr-handoff.sh
+++ b/.github/scripts/validate-cask-pr-handoff.sh
@@ -6,12 +6,14 @@ usage() {
 	cat <<'EOF'
 Usage:
   validate-cask-pr-handoff.sh --evidence FILE --tap OWNER/REPO
-                              --cask-name NAME --tag TAG [--prepared]
+                              --cask-name NAME --tag TAG [--prepared] [--ready]
 
 Fail closed unless a GoReleaser cask PR is the expected trusted draft, from the
 tap itself, into main, with exactly its matching cask file. With --prepared,
 also require the normalized title and every requested label that exists in the
-repository's available-label inventory.
+repository's available-label inventory. With --ready, require the PR to already
+be marked ready for review instead of a draft — used to revalidate an
+already-handed-off PR on an idempotent rerun.
 EOF
 }
 
@@ -20,6 +22,7 @@ tap=""
 cask_name=""
 tag=""
 prepared=false
+ready=false
 
 while (($# > 0)); do
 	case "$1" in
@@ -41,6 +44,10 @@ while (($# > 0)); do
 		;;
 	--prepared)
 		prepared=true
+		shift
+		;;
+	--ready)
+		ready=true
 		shift
 		;;
 	--help | -h)
@@ -88,8 +95,15 @@ json_string() {
 if [[ "$(json_string '.pr.state | ascii_downcase')" != "open" ]]; then
 	block 'PR state must be open'
 fi
-if ! jq -e '.pr.draft == true' "${evidence_file}" >/dev/null 2>&1; then
-	block 'PR must remain a draft for maintainer promotion'
+if [[ "${ready}" == true ]]; then
+	# Revalidating an already-handed-off PR: it has been promoted, so it must NOT be a draft.
+	if ! jq -e '.pr.draft == false' "${evidence_file}" >/dev/null 2>&1; then
+		block 'already-handed-off PR must be marked ready for review'
+	fi
+else
+	if ! jq -e '.pr.draft == true' "${evidence_file}" >/dev/null 2>&1; then
+		block 'PR must remain a draft for maintainer promotion'
+	fi
 fi
 if [[ "$(json_string '.pr.user.login')" != "devantler" ]]; then
 	block 'PR author must be devantler'

--- a/.github/scripts/validate-cask-pr-handoff.test.sh
+++ b/.github/scripts/validate-cask-pr-handoff.test.sh
@@ -12,13 +12,16 @@ pass_count=0
 
 run_case() {
 	local name="$1" expected_status="$2" expected_output="$3"
-	local filter="${4:-.}" prepared="${5:-false}"
+	local filter="${4:-.}" prepared="${5:-false}" ready="${6:-false}"
 	local evidence="${tmp_dir}/${name}.json" output status
 	local args=(--evidence "${evidence}" --tap devantler-tech/homebrew-tap --cask-name ksail --tag v7.166.1)
 
 	jq "${filter}" "${fixture}" >"${evidence}"
 	if [[ "${prepared}" == true ]]; then
 		args+=(--prepared)
+	fi
+	if [[ "${ready}" == true ]]; then
+		args+=(--ready)
 	fi
 
 	set +e
@@ -72,5 +75,10 @@ run_case missing-label-inventory 1 'available-label inventory is missing' 'del(.
 run_case malformed-label-inventory 1 'available-label inventory is malformed' '.availableLabels = [{}] | .pr.labels = []' true
 run_case missing-label 1 'available label is missing from PR: dependencies' '.pr.labels = [{"name":"automation"}]' true
 run_case unavailable-label 0 'PASS: generated cask PR identity, scope, and metadata are valid' '.availableLabels = [{"name":"automation"}] | .pr.labels = [{"name":"automation"}]' true
+
+# --ready revalidates an already-handed-off (promoted, non-draft) PR on an idempotent rerun: it must
+# pass on a non-draft PR and fail on one still in draft, the inverse of the default draft requirement.
+run_case ready-nondraft 0 'PASS: generated cask PR identity, scope, and metadata are valid' '.pr.draft = false' true true
+run_case ready-still-draft 1 'already-handed-off PR must be marked ready for review' '.' true true
 
 printf 'All %d cask PR handoff cases passed.\n' "${pass_count}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -860,13 +860,25 @@ jobs:
             fi
             metadata_ok=true
             for label in automation dependencies; do
-              if jq -e --arg label "$label" \
-                  '.availableLabels | any(.name == $label)' "$evidence" >/dev/null; then
-                if ! gh api -X POST "repos/${TAP}/issues/${pr}/labels" -f "labels[]=$label" >/dev/null; then
-                  echo "::warning::Could not add available label ${label} to ${TAP}#${pr}"
+              # Capture jq's result instead of testing it inside `if`: an external command in an `if`
+              # condition is exempt from `set -e`, so a jq crash would read as "label not available" and
+              # silently skip the label while leaving metadata_ok=true — a fail-open on the very check
+              # that gates the promote. Treat a non-boolean answer as a hard failure.
+              label_available="$(jq -r --arg label "$label" \
+                '.availableLabels | any(.name == $label)' "$evidence" 2>/dev/null || true)"
+              case "$label_available" in
+                true)
+                  if ! gh api -X POST "repos/${TAP}/issues/${pr}/labels" -f "labels[]=$label" >/dev/null; then
+                    echo "::warning::Could not add available label ${label} to ${TAP}#${pr}"
+                    metadata_ok=false
+                  fi
+                  ;;
+                false) : ;; # the tap does not define this label — nothing to add
+                *)
+                  echo "::warning::Could not determine whether ${TAP} defines the ${label} label"
                   metadata_ok=false
-                fi
-              fi
+                  ;;
+              esac
             done
             if [ "$metadata_ok" != true ]; then
               echo "::warning::${TAP}#${pr} metadata is incomplete; leaving it draft/open"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -695,9 +695,12 @@ jobs:
   # each release updates the ONE open cask PR in place instead of superseding it, tap#1172). See #6067.
   homebrew:
     name: 🍺 Prepare Homebrew cask PRs
-    runs-on: ubuntu-latest
-    # `brew style` can bootstrap rubocop on a cold Linuxbrew runner. Keep enough room for two clones
-    # and style passes; every GitHub mutation below is fail-soft because the release is already public.
+    # Homebrew is preinstalled on the macOS images and NOT on ubuntu — on ubuntu every `brew style`
+    # here failed with `brew: command not found`, so the casks were never style-cleaned. The tap audits
+    # casks on macOS for the same reason (devantler-tech/homebrew-tap `ci.yaml`).
+    runs-on: macos-latest
+    # `brew style` can bootstrap rubocop on a cold runner. Keep enough room for two clones and style
+    # passes; every GitHub mutation below is fail-soft because the release is already public.
     timeout-minutes: 20
     needs: [publish-release]
     permissions:
@@ -746,6 +749,13 @@ jobs:
           fi
           trap 'rm -rf "$evidence_dir"' EXIT
 
+          # A cask PR left as a draft means the tap silently stops tracking releases — which is exactly
+          # how it drifted six versions behind while every CD run stayed green. Track it and fail the
+          # step at the end so the breakage is visible. The release itself is already published and
+          # immutable, and `cleanup-failed-release` keys off `publish-release`, not this job, so failing
+          # here never deletes a good release.
+          handoff_failed=0
+
           for name in ksail ksail-desktop; do
             branch="goreleaser/${name}"
             # `|| true` keeps the job fail-soft: a transient API failure (5xx, rate limit,
@@ -793,6 +803,14 @@ jobs:
             if work="$(mktemp -d)"; then
               if git clone --depth 1 --branch "$branch" \
                   "https://x-access-token:${GH_TOKEN}@github.com/${TAP}.git" "$work" 2>/dev/null; then
+                # Never claim a cask is style-clean without having actually run the linter: on ubuntu
+                # `brew` was absent, `brew style --fix` failed, the diff was empty for that reason, and
+                # the job reported "already brew-style-clean" — a fail-open that hid the breakage.
+                if ! command -v brew >/dev/null 2>&1; then
+                  echo "::error::brew is not available on this runner; cannot style-check ${name}"
+                  rm -rf "$work"
+                  continue
+                fi
                 # `brew style --fix` can apply partial autocorrections yet still exit non-zero when
                 # offenses remain. Run it fail-soft and commit whatever diff it produced regardless of
                 # exit status, so partial cleanups are never discarded (and a failure never blocks the
@@ -800,7 +818,7 @@ jobs:
                 brew style --fix "$work/Casks/${name}.rb" \
                   || echo "::warning::brew style --fix exited non-zero for ${name}; committing any partial autocorrections"
                 if git -C "$work" diff --quiet; then
-                  echo "${name} cask already brew-style-clean; nothing to autocorrect"
+                  echo "${name} cask is brew-style-clean; nothing to autocorrect"
                 else
                   git -C "$work" \
                       -c user.name='github-actions[bot]' \
@@ -828,8 +846,15 @@ jobs:
               continue
             fi
 
+            # Use the REST/GraphQL endpoints directly rather than `gh pr edit` / `gh pr ready`: those
+            # subcommands resolve the viewer's `login` over GraphQL, which the tap token is not scoped
+            # for ("The 'login' field requires one of the following scopes"). That failure landed on the
+            # step right before the promote, so every release left its cask PR a draft forever and the
+            # tap silently fell six versions behind. Talking to the endpoints directly needs only the
+            # PR-write scope the token already has — and keeps the token least-privilege instead of
+            # widening it.
             title="chore(cask): update ${name} to ${TAG}"
-            if ! gh pr edit "$pr" --repo "$TAP" --title "$title"; then
+            if ! gh api -X PATCH "repos/${TAP}/pulls/${pr}" -f title="$title" >/dev/null; then
               echo "::warning::Could not normalize the title on ${TAP}#${pr}; leaving it draft/open"
               continue
             fi
@@ -837,7 +862,7 @@ jobs:
             for label in automation dependencies; do
               if jq -e --arg label "$label" \
                   '.availableLabels | any(.name == $label)' "$evidence" >/dev/null; then
-                if ! gh pr edit "$pr" --repo "$TAP" --add-label "$label"; then
+                if ! gh api -X POST "repos/${TAP}/issues/${pr}/labels" -f "labels[]=$label" >/dev/null; then
                   echo "::warning::Could not add available label ${label} to ${TAP}#${pr}"
                   metadata_ok=false
                 fi
@@ -861,16 +886,31 @@ jobs:
             # current-version content, title, and labels all validated above — and the release
             # assets now public — mark it ready so the tap's own automation arms auto-merge and its
             # checks gate the merge. Fail-soft: a draft left behind is handed to the maintainer.
-            if gh pr ready "$pr" --repo "$TAP"; then
+            # Same reason as the title/label calls above: `gh pr ready` needs a scope the tap token does
+            # not have, so drive the mutation directly off the PR's node id.
+            pr_node="$(gh api "repos/${TAP}/pulls/${pr}" --jq .node_id 2>/dev/null || true)"
+            # `\$id` is escaped so the shell leaves it literal: it is a GraphQL variable, not a shell one.
+            ready_mutation="mutation(\$id: ID!) { markPullRequestReadyForReview(input: { pullRequestId: \$id }) { pullRequest { isDraft } } }"
+            if [ -n "$pr_node" ] && gh api graphql \
+                -f query="$ready_mutation" \
+                -F id="$pr_node" >/dev/null; then
               echo "::notice::${TAP}#${pr} validated and marked ready — the tap's checks gate its auto-merge"
               printf -- '- %s#%s validated and marked ready for check-gated auto-merge\n' \
                 "$TAP" "$pr" >>"$GITHUB_STEP_SUMMARY"
             else
-              echo "::warning::Could not mark ${TAP}#${pr} ready; it remains draft/open for the maintainer"
+              # A cask PR that never leaves draft means the tap silently stops tracking releases, so this
+              # must be loud rather than a buried warning on an otherwise-green release.
+              echo "::error::Could not mark ${TAP}#${pr} ready; it remains draft and the tap will NOT pick up ${TAG}"
               printf -- '- %s#%s remains draft/open: could not mark it ready after validation\n' \
                 "$TAP" "$pr" >>"$GITHUB_STEP_SUMMARY"
+              handoff_failed=1
             fi
           done
+
+          if [ "$handoff_failed" -ne 0 ]; then
+            echo "::error::One or more cask PRs could not be handed off; the Homebrew tap will not pick up ${TAG}"
+            exit 1
+          fi
 
   # Backstop for the immutable-release model: if the release did NOT publish — any asset job failed,
   # or the publish step bailed (so `publish-release` is skipped or failed) — delete the orphaned draft

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -785,6 +785,26 @@ jobs:
             fi
             pr="$(jq -r '.[0].number' <<<"$matches")"
 
+            # Idempotent retry after a PARTIAL success. A two-cask release can promote the first cask
+            # and then fail on the second (transient API/label/style hiccup) — leaving the job red. On
+            # a normal rerun the loop re-enters, but the first cask is now READY (non-draft) and the
+            # draft-requiring validation below would reject it, re-setting handoff_failed and failing
+            # the job forever: the rerun could never go green. So before validating, treat a cask PR
+            # that is ALREADY non-draft AND already carries this tag's handoff title as completed —
+            # the handoff finished on the earlier run; record it and move on. Capture the state into a
+            # variable (an external command inside `if` is exempt from `set -e`, so a crash there would
+            # read as "not handed off" and re-drive it); a non-draft PR with a DIFFERENT title is NOT
+            # ours — it falls through to the draft-requiring validation, preserving race detection.
+            pr_state="$(gh api "repos/${TAP}/pulls/${pr}" --jq '[(.draft|tostring), .title] | @tsv' 2>/dev/null || true)"
+            pr_is_draft="${pr_state%%$'\t'*}"
+            pr_title="${pr_state#*$'\t'}"
+            if [ "$pr_is_draft" = "false" ] && [ "$pr_title" = "chore(cask): update ${name} to ${TAG}" ]; then
+              echo "${TAP}#${pr} already handed off for ${TAG} (ready and titled); nothing to do"
+              printf -- '- %s#%s already handed off for %s (idempotent retry)\n' \
+                "$TAP" "$pr" "$TAG" >>"$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
             # The cask-checkpoint job re-drafted any reused promoted PR before GoReleaser rewrote
             # the branch, so a non-draft here means someone raced this run — validation below
             # requires draft state and fails soft, leaving the PR untouched.

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -736,16 +736,22 @@ jobs:
               --cask-name "$name"
               --tag "$TAG"
             )
-            if [ "$mode" = prepared ]; then
-              args+=(--prepared)
-            fi
+            case "$mode" in
+              prepared) args+=(--prepared) ;;
+              # An already-handed-off PR revalidated on an idempotent rerun has been promoted, so it is
+              # no longer a draft: check it against the ready state, not the draft one.
+              prepared-ready) args+=(--prepared --ready) ;;
+            esac
             collect_handoff_evidence "$pr" "$evidence" \
               && .github/scripts/validate-cask-pr-handoff.sh "${args[@]}"
           }
 
           if ! evidence_dir="$(mktemp -d)"; then
-            echo "::warning::Could not create cask handoff evidence directory; leaving generated PRs untouched"
-            exit 0
+            # A missing evidence dir means no cask can be validated or handed off. Exiting 0 here would
+            # leave both cask PRs untouched behind a green release — the exact silent drift this job
+            # exists to surface — so fail loudly instead.
+            echo "::error::Could not create cask handoff evidence directory; failing so the un-handed-off cask is not hidden behind a green release"
+            exit 1
           fi
           trap 'rm -rf "$evidence_dir"' EXIT
 
@@ -827,7 +833,7 @@ jobs:
               # before skipping — it re-verifies identity, scope, base, current-version content, and
               # title. Only a validated ready PR is treated as done; otherwise it is left for the
               # maintainer and the rerun stays red.
-              if validation="$(validate_handoff "$pr" "$name" "$evidence" prepared 2>&1)"; then
+              if validation="$(validate_handoff "$pr" "$name" "$evidence" prepared-ready 2>&1)"; then
                 echo "${TAP}#${pr} already handed off for ${TAG} (ready, titled, and revalidated); nothing to do"
                 printf -- '- %s#%s already handed off for %s (idempotent retry, revalidated)\n' \
                   "$TAP" "$pr" "$TAG" >>"$GITHUB_STEP_SUMMARY"
@@ -887,18 +893,29 @@ jobs:
                 # release).
                 brew style --fix "$work/Casks/${name}.rb" \
                   || echo "::warning::brew style --fix exited non-zero for ${name}; committing any partial autocorrections"
+                pushed_ok=true
                 if git -C "$work" diff --quiet; then
-                  echo "${name} cask is brew-style-clean; nothing to autocorrect"
-                  style_clean=1
+                  echo "${name} cask has no autocorrectable diff to push"
                 elif git -C "$work" \
                       -c user.name='github-actions[bot]' \
                       -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
                       commit -am 'style: brew style --fix generated cask' \
                     && git -C "$work" push; then
                   echo "Pushed brew style --fix autocorrections to ${branch}"
-                  style_clean=1
                 else
                   echo "::warning::Could not push brew style --fix autocorrections to ${branch}; the tap's style gate would block auto-merge"
+                  pushed_ok=false
+                fi
+                # A successful push (or an empty diff) does not prove the cask is style-clean:
+                # `brew style --fix` exits non-zero when offenses remain after only partial
+                # autocorrection, and an unpushed fix leaves the tap's branch still dirty. Only mark
+                # clean when the pushed state passes a read-only `brew style`, so a cask the tap's
+                # style gate would reject is never promoted (recreating the stranded-cask failure).
+                if [ "$pushed_ok" = true ] && brew style "$work/Casks/${name}.rb"; then
+                  echo "${name} cask is brew-style-clean"
+                  style_clean=1
+                else
+                  echo "::warning::${name} cask is not confirmed brew-style-clean (unpushed autocorrections or remaining offenses); leaving it for the maintainer lane"
                 fi
               else
                 echo "::warning::Could not clone ${TAP} branch ${branch} for brew style --fix"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -750,10 +750,13 @@ jobs:
           trap 'rm -rf "$evidence_dir"' EXIT
 
           # A cask PR left as a draft means the tap silently stops tracking releases — which is exactly
-          # how it drifted six versions behind while every CD run stayed green. Track it and fail the
-          # step at the end so the breakage is visible. The release itself is already published and
-          # immutable, and `cleanup-failed-release` keys off `publish-release`, not this job, so failing
-          # here never deletes a good release.
+          # how it drifted six versions behind while every CD run stayed green. So EVERY path that
+          # leaves a cask unpromoted sets this, not just the final mutation: an enumeration failure, a
+          # validation failure, a missing `brew`, a title/label failure — in all of them the tap does not
+          # pick up the published release, and a green run would preserve the silent drift this job now
+          # exists to surface. The release itself is already published and immutable, and
+          # `cleanup-failed-release` keys off `publish-release` rather than this job, so failing here
+          # never deletes a good release.
           handoff_failed=0
 
           for name in ksail ksail-desktop; do
@@ -772,10 +775,12 @@ jobs:
               2>/dev/null || true)"
             if ! count="$(jq -er 'length' <<<"$matches" 2>/dev/null)"; then
               echo "::warning::Could not enumerate cask PRs on $TAP for branch ${branch}; leaving it pending"
+              handoff_failed=1
               continue
             fi
             if [ "$count" -ne 1 ]; then
               echo "::warning::Expected exactly one open tap-owned cask PR on $TAP for branch ${branch}, found ${count}; leaving it pending"
+              handoff_failed=1
               continue
             fi
             pr="$(jq -r '.[0].number' <<<"$matches")"
@@ -788,6 +793,7 @@ jobs:
               validation="${validation//$'\n'/; }"
               echo "::warning::Refusing to mutate ${TAP}#${pr}: ${validation}"
               printf -- '- %s#%s left untouched: %s\n' "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
+              handoff_failed=1
               continue
             fi
             echo "Preparing ${TAP}#${pr} (${branch})"
@@ -809,6 +815,7 @@ jobs:
                 if ! command -v brew >/dev/null 2>&1; then
                   echo "::error::brew is not available on this runner; cannot style-check ${name}"
                   rm -rf "$work"
+                  handoff_failed=1
                   continue
                 fi
                 # `brew style --fix` can apply partial autocorrections yet still exit non-zero when
@@ -843,6 +850,7 @@ jobs:
               echo "::warning::Post-style validation failed for ${TAP}#${pr}: ${validation}"
               printf -- '- %s#%s remains open after style validation failed: %s\n' \
                 "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
+              handoff_failed=1
               continue
             fi
 
@@ -856,6 +864,7 @@ jobs:
             title="chore(cask): update ${name} to ${TAG}"
             if ! gh api -X PATCH "repos/${TAP}/pulls/${pr}" -f title="$title" >/dev/null; then
               echo "::warning::Could not normalize the title on ${TAP}#${pr}; leaving it draft/open"
+              handoff_failed=1
               continue
             fi
             metadata_ok=true
@@ -882,6 +891,7 @@ jobs:
             done
             if [ "$metadata_ok" != true ]; then
               echo "::warning::${TAP}#${pr} metadata is incomplete; leaving it draft/open"
+              handoff_failed=1
               continue
             fi
 
@@ -890,6 +900,7 @@ jobs:
               echo "::warning::Prepared handoff validation failed for ${TAP}#${pr}: ${validation}"
               printf -- '- %s#%s remains open with incomplete handoff metadata: %s\n' \
                 "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
+              handoff_failed=1
               continue
             fi
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -778,6 +778,27 @@ jobs:
               handoff_failed=1
               continue
             fi
+            if [ "$count" -eq 0 ]; then
+              # A partial rerun may already have MERGED this cask: the tap's auto-merge can land the
+              # first cask before this job is rerun. A merged PR is no longer `open`, so the open-only
+              # query returns nothing — treat a merged, this-tag-titled, tap-owned cask as done rather
+              # than failing the rerun red. `state=closed` returns merged AND closed-unmerged, so filter
+              # on `merged_at != null`. Fail-soft: an enumeration hiccup falls through to the pending path.
+              merged="$(gh api \
+                "repos/$TAP/pulls?state=closed&head=${TAP%%/*}:${branch}&per_page=100" 2>/dev/null \
+                | jq -er --arg full "$TAP" --arg title "chore(cask): update ${name} to ${TAG}" \
+                    '[.[] | select(.merged_at != null and .head.repo.full_name == $full and .user.login == "devantler" and .title == $title)] | length' \
+                2>/dev/null || echo 0)"
+              if [ "${merged:-0}" -ge 1 ]; then
+                echo "${TAP} cask ${name} already merged for ${TAG}; nothing to do"
+                printf -- '- %s cask %s already merged for %s (idempotent retry)\n' \
+                  "$TAP" "$name" "$TAG" >>"$GITHUB_STEP_SUMMARY"
+                continue
+              fi
+              echo "::warning::No open or merged tap-owned cask PR on $TAP for branch ${branch}; leaving it pending"
+              handoff_failed=1
+              continue
+            fi
             if [ "$count" -ne 1 ]; then
               echo "::warning::Expected exactly one open tap-owned cask PR on $TAP for branch ${branch}, found ${count}; leaving it pending"
               handoff_failed=1
@@ -798,17 +819,31 @@ jobs:
             pr_state="$(gh api "repos/${TAP}/pulls/${pr}" --jq '[(.draft|tostring), .title] | @tsv' 2>/dev/null || true)"
             pr_is_draft="${pr_state%%$'\t'*}"
             pr_title="${pr_state#*$'\t'}"
+            evidence="${evidence_dir}/${pr}.json"
             if [ "$pr_is_draft" = "false" ] && [ "$pr_title" = "chore(cask): update ${name} to ${TAG}" ]; then
-              echo "${TAP}#${pr} already handed off for ${TAG} (ready and titled); nothing to do"
-              printf -- '- %s#%s already handed off for %s (idempotent retry)\n' \
-                "$TAP" "$pr" "$TAG" >>"$GITHUB_STEP_SUMMARY"
+              # Ready + right title is not by itself proof the tap will merge the CORRECT cask: after
+              # the failed run the PR could have been retargeted off `main`, had its evidence file or
+              # head branch changed, or lost its metadata. Re-run the non-draft (`prepared`) validator
+              # before skipping — it re-verifies identity, scope, base, current-version content, and
+              # title. Only a validated ready PR is treated as done; otherwise it is left for the
+              # maintainer and the rerun stays red.
+              if validation="$(validate_handoff "$pr" "$name" "$evidence" prepared 2>&1)"; then
+                echo "${TAP}#${pr} already handed off for ${TAG} (ready, titled, and revalidated); nothing to do"
+                printf -- '- %s#%s already handed off for %s (idempotent retry, revalidated)\n' \
+                  "$TAP" "$pr" "$TAG" >>"$GITHUB_STEP_SUMMARY"
+                continue
+              fi
+              validation="${validation//$'\n'/; }"
+              echo "::warning::${TAP}#${pr} is ready and titled but failed prepared revalidation: ${validation}"
+              printf -- '- %s#%s ready but revalidation failed: %s\n' \
+                "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
+              handoff_failed=1
               continue
             fi
 
             # The cask-checkpoint job re-drafted any reused promoted PR before GoReleaser rewrote
             # the branch, so a non-draft here means someone raced this run — validation below
-            # requires draft state and fails soft, leaving the PR untouched.
-            evidence="${evidence_dir}/${pr}.json"
+            # requires draft state and fails soft, leaving the PR untouched. (`evidence` was set above.)
             if ! validation="$(validate_handoff "$pr" "$name" "$evidence" 2>&1)"; then
               validation="${validation//$'\n'/; }"
               echo "::warning::Refusing to mutate ${TAP}#${pr}: ${validation}"
@@ -826,6 +861,14 @@ jobs:
             # the draft remains open for the maintainer lane to correct.
             # `mktemp -d` under `set -e` would abort the job on a tempdir failure; guard it so a
             # hiccup just skips the (best-effort) autocorrect and continues to the draft handoff.
+            # Ensure the generated cask is brew-style-clean BEFORE promotion. GoReleaser's template
+            # emits a few `brew style` offenses no config knob can reach, and the tap enforces a
+            # `brew style` gate — so an uncorrected cask silently blocks the tap's auto-merge, exactly
+            # the "green release, stranded cask" drift this job exists to surface. `style_clean` stays
+            # 0 until we have either confirmed no offenses remain or PUSHED the autocorrections to the
+            # branch; if we cannot reach that state (clone, tempdir, or push failure), promotion is
+            # skipped and the job goes red rather than marking a cask the tap will refuse to merge.
+            style_clean=0
             if work="$(mktemp -d)"; then
               if git clone --depth 1 --branch "$branch" \
                   "https://x-access-token:${GH_TOKEN}@github.com/${TAP}.git" "$work" 2>/dev/null; then
@@ -846,21 +889,30 @@ jobs:
                   || echo "::warning::brew style --fix exited non-zero for ${name}; committing any partial autocorrections"
                 if git -C "$work" diff --quiet; then
                   echo "${name} cask is brew-style-clean; nothing to autocorrect"
-                else
-                  git -C "$work" \
+                  style_clean=1
+                elif git -C "$work" \
                       -c user.name='github-actions[bot]' \
                       -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
                       commit -am 'style: brew style --fix generated cask' \
-                    && git -C "$work" push \
-                    && echo "Pushed brew style --fix autocorrections to ${branch}" \
-                    || echo "::warning::Could not push brew style --fix autocorrections to ${branch}; leaving the draft as-is"
+                    && git -C "$work" push; then
+                  echo "Pushed brew style --fix autocorrections to ${branch}"
+                  style_clean=1
+                else
+                  echo "::warning::Could not push brew style --fix autocorrections to ${branch}; the tap's style gate would block auto-merge"
                 fi
               else
-                echo "::warning::Could not clone ${TAP} branch ${branch} for brew style --fix; leaving the draft as-is"
+                echo "::warning::Could not clone ${TAP} branch ${branch} for brew style --fix"
               fi
               rm -rf "$work"
             else
-              echo "::warning::Could not create tempdir for brew style --fix; leaving ${name} draft as-is"
+              echo "::warning::Could not create tempdir for brew style --fix"
+            fi
+            if [ "$style_clean" -ne 1 ]; then
+              echo "::error::Could not ensure ${name} cask is brew-style-clean; the tap's style gate would block auto-merge for ${TAG}"
+              printf -- '- %s cask %s left draft/open: could not ensure it is brew-style-clean\n' \
+                "$TAP" "$name" >>"$GITHUB_STEP_SUMMARY"
+              handoff_failed=1
+              continue
             fi
 
             # Recollect after the possible style push. A concurrent promotion, cross-repository head,

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -846,8 +846,8 @@ jobs:
               continue
             fi
 
-            # Use the REST/GraphQL endpoints directly rather than `gh pr edit` / `gh pr ready`: those
-            # subcommands resolve the viewer's `login` over GraphQL, which the tap token is not scoped
+            # Use the REST/GraphQL endpoints directly rather than the gh pr edit/promote subcommands:
+            # those resolve the viewer's `login` over GraphQL, which the tap token is not scoped
             # for ("The 'login' field requires one of the following scopes"). That failure landed on the
             # step right before the promote, so every release left its cask PR a draft forever and the
             # tap silently fell six versions behind. Talking to the endpoints directly needs only the
@@ -886,8 +886,8 @@ jobs:
             # current-version content, title, and labels all validated above — and the release
             # assets now public — mark it ready so the tap's own automation arms auto-merge and its
             # checks gate the merge. Fail-soft: a draft left behind is handed to the maintainer.
-            # Same reason as the title/label calls above: `gh pr ready` needs a scope the tap token does
-            # not have, so drive the mutation directly off the PR's node id.
+            # Same reason as the title/label calls above: the gh promote subcommand needs a scope the tap
+            # token does not have, so drive the mutation directly off the PR's node id.
             pr_node="$(gh api "repos/${TAP}/pulls/${pr}" --jq .node_id 2>/dev/null || true)"
             # `\$id` is escaped so the shell leaves it literal: it is a GraphQL variable, not a shell one.
             ready_mutation="mutation(\$id: ID!) { markPullRequestReadyForReview(input: { pullRequestId: \$id }) { pullRequest { isDraft } } }"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

**Anyone installing ksail with Homebrew has been getting v7.166.1 while we shipped through v7.169.2 —
six releases stale**, and nothing showed it: every release ran green.

The release job that hands the new cask to the tap was failing silently. It marks the cask PR "ready"
so the tap can merge it — but the step just before that died on a permissions error, so the job gave up
and left the PR as a draft. Forever. Every release since.

## What

- Fix the handoff so the cask PR actually gets promoted and the tap picks up each release.
- Run the job where Homebrew actually exists — it was running on a machine without it, so the cask was
  never style-checked (and the job then *claimed* it was clean, which is how this hid).
- **Make a failed handoff fail the release job.** A stranded tap must not look like a green release —
  that is the whole reason this went unnoticed for six versions.

Verified against the two real stuck PRs (homebrew-tap#1185, #1184): the new calls promoted them, and
the tap is picking up v7.169.2 / v7.169.3 now. One caveat worth knowing: I could only exercise the calls
with my own credentials, so the very next release is the true proof — and it will now go red instead of
silently green if anything is still wrong.

Fixes #6134
