### PR TITLE
fix(ci): free disk before desktop builds

### DIFF
--- a/.github/actions/free-disk-space/action.yaml
+++ b/.github/actions/free-disk-space/action.yaml
@@ -35,31 +35,4 @@ runs:
       shell: bash
       env:
         DOCKER_PRUNE: ${{ inputs.docker-prune }}
-      run: |
-        set -euo pipefail
-        before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
-        # Largest offenders on ubuntu-latest (sizes from
-        # https://github.com/actions/runner-images). Order by descending size.
-        sudo rm -rf \
-          /usr/local/lib/android \
-          /usr/share/dotnet \
-          /opt/ghc \
-          /usr/local/share/boost \
-          /usr/share/swift \
-          /opt/hostedtoolcache/CodeQL \
-          /opt/hostedtoolcache/PyPy \
-          /opt/hostedtoolcache/Ruby \
-          /opt/hostedtoolcache/Python \
-          /usr/local/share/chromium \
-          /usr/local/share/powershell \
-          /usr/local/julia* \
-          /usr/local/aws-cli \
-          /usr/local/aws-sam-cli \
-          /usr/share/gradle* \
-          /usr/share/az* \
-          /usr/share/miniconda || true
-        if [ "$DOCKER_PRUNE" = "true" ]; then
-          docker system prune -af --volumes || true
-        fi
-        after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
-        echo "Free disk space on /: ${before}G -> ${after}G (gained $((after - before))G)"
+      run: bash "$GITHUB_ACTION_PATH/free-disk-space.sh"

--- a/.github/actions/free-disk-space/free-disk-space.sh
+++ b/.github/actions/free-disk-space/free-disk-space.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+docker_prune="${DOCKER_PRUNE:-false}"
+before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+
+# Largest offenders on ubuntu-latest (sizes from
+# https://github.com/actions/runner-images). Order by descending size.
+sudo rm -rf \
+  /usr/local/lib/android \
+  /usr/share/dotnet \
+  /opt/ghc \
+  /usr/local/share/boost \
+  /usr/share/swift \
+  /opt/hostedtoolcache/CodeQL \
+  /opt/hostedtoolcache/PyPy \
+  /opt/hostedtoolcache/Ruby \
+  /opt/hostedtoolcache/Python \
+  /usr/local/share/chromium \
+  /usr/local/share/powershell \
+  /usr/local/julia* \
+  /usr/local/aws-cli \
+  /usr/local/aws-sam-cli \
+  /usr/share/gradle* \
+  /usr/share/az* \
+  /usr/share/miniconda || true
+
+if [ "$docker_prune" = "true" ]; then
+  docker system prune -af --volumes || true
+fi
+
+after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+echo "Free disk space on /: ${before}G -> ${after}G (gained $((after - before))G)"

--- a/.github/actions/free-disk-space/free-disk-space.sh
+++ b/.github/actions/free-disk-space/free-disk-space.sh
@@ -8,26 +8,26 @@ before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
 # Largest offenders on ubuntu-latest (sizes from
 # https://github.com/actions/runner-images). Order by descending size.
 sudo rm -rf \
-  /usr/local/lib/android \
-  /usr/share/dotnet \
-  /opt/ghc \
-  /usr/local/share/boost \
-  /usr/share/swift \
-  /opt/hostedtoolcache/CodeQL \
-  /opt/hostedtoolcache/PyPy \
-  /opt/hostedtoolcache/Ruby \
-  /opt/hostedtoolcache/Python \
-  /usr/local/share/chromium \
-  /usr/local/share/powershell \
-  /usr/local/julia* \
-  /usr/local/aws-cli \
-  /usr/local/aws-sam-cli \
-  /usr/share/gradle* \
-  /usr/share/az* \
-  /usr/share/miniconda || true
+	/usr/local/lib/android \
+	/usr/share/dotnet \
+	/opt/ghc \
+	/usr/local/share/boost \
+	/usr/share/swift \
+	/opt/hostedtoolcache/CodeQL \
+	/opt/hostedtoolcache/PyPy \
+	/opt/hostedtoolcache/Ruby \
+	/opt/hostedtoolcache/Python \
+	/usr/local/share/chromium \
+	/usr/local/share/powershell \
+	/usr/local/julia* \
+	/usr/local/aws-cli \
+	/usr/local/aws-sam-cli \
+	/usr/share/gradle* \
+	/usr/share/az* \
+	/usr/share/miniconda || true
 
 if [ "$docker_prune" = "true" ]; then
-  docker system prune -af --volumes || true
+	docker system prune -af --volumes || true
 fi
 
 after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')

--- a/.github/actions/setup-desktop-build/action.yml
+++ b/.github/actions/setup-desktop-build/action.yml
@@ -1,10 +1,10 @@
 name: Setup Desktop Build
 description: |
-  Shared setup for building the KSail desktop app: set up Go and Node.js,
-  install the Linux webview build dependencies (Wails v3's default Linux build
-  targets GTK4 + WebKitGTK 6.0, available on ubuntu-24.04 — 22.04 only ships
-  the legacy webkit2gtk-4.0/4.1), and build + stage the web UI for embedding
-  (go:embed via pkg/webui/embed.go).
+  Shared setup for building the KSail desktop app: reclaim Linux runner disk,
+  set up Go and Node.js, install the Linux webview build dependencies (Wails
+  v3's default Linux build targets GTK4 + WebKitGTK 6.0, available on
+  ubuntu-24.04 — 22.04 only ships the legacy webkit2gtk-4.0/4.1), and build +
+  stage the web UI for embedding (go:embed via pkg/webui/embed.go).
 
   Used by the desktop CI build (.github/workflows/desktop.yaml) and the
   desktop release legs (.github/workflows/cd.yaml). Assumes the repository is
@@ -13,6 +13,16 @@ description: |
 runs:
   using: composite
   steps:
+    - name: 🧹 Free disk space
+      if: runner.os == 'Linux'
+      shell: bash
+      env:
+        DOCKER_PRUNE: "false"
+      # A nested `uses: ./...` resolves against the consumer's workspace and
+      # breaks remote callers. The action path reaches this sibling script in
+      # the fully downloaded KSail action repository at the same ref.
+      run: bash "$GITHUB_ACTION_PATH/../free-disk-space/free-disk-space.sh"
+
     - name: ⚙️ Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:

--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -15,6 +15,7 @@ on:
       - ".goreleaser.desktop.yaml"
       - ".github/workflows/desktop.yaml"
       - ".github/actions/setup-desktop-build/**"
+      - ".github/actions/free-disk-space/**"
       - "scripts/stage-webui.sh"
   push:
     branches: [main]
@@ -28,6 +29,7 @@ on:
       - ".goreleaser.desktop.yaml"
       - ".github/workflows/desktop.yaml"
       - ".github/actions/setup-desktop-build/**"
+      - ".github/actions/free-disk-space/**"
       - "scripts/stage-webui.sh"
 
 permissions:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary

- run KSail's existing disk cleanup before shared Linux desktop setup
- extract the cleanup into a sibling script addressed through `$GITHUB_ACTION_PATH`, preserving remote composite-action consumers
- trigger desktop validation when either shared desktop setup or free-disk helper changes
- retain the safe default (`docker-prune: false`) and leave Windows/macOS unchanged

## Evidence

[CD job 87281882383](https://github.com/devantler-tech/ksail/actions/runs/29393528100/job/87281882383) reached the Linux desktop build, then the hosted runner crashed with `System.IO.IOException: No space left on device` while writing its own `_diag` log. Windows and macOS passed. The repository's reusable cleanup explicitly handles this failure class, but the shared desktop setup did not call it. PR #6138 covered only the separate CLI GoReleaser job.

A superseding release's [fresh Linux desktop job 87288933444](https://github.com/devantler-tech/ksail/actions/runs/29394625283/job/87288933444) passed on a new runner, confirming the original crash was transient infrastructure pressure. This draft still removes that known failure mode from every future Linux desktop build.

## Validation

- red/green assertions for Linux-first cleanup, remote-safe script resolution, and both desktop workflow path filters
- `actionlint .github/workflows/desktop.yaml .github/workflows/cd.yaml`
- `shellcheck` and `bash -n` on the extracted cleanup script
- `zizmor` on both composite actions (no findings)
- YAML structure checks with `yq`
- stub execution covers default/false (no Docker prune) and true (exact prune command)
- `git diff --check`
- independent behavior-parity, portability, and scope review (no findings)
- exact-head [Linux desktop job 87290726772](https://github.com/devantler-tech/ksail/actions/runs/29396383021/job/87290726772): cleanup reclaimed 28 GB (`16G -> 44G`), then setup, build, and tests all passed

Fixes #6146
