### PR TITLE
fix(reconcile): gate argocd app-sync on control-plane readiness

### DIFF
--- a/pkg/cli/cmd/workload/reconcile.go
+++ b/pkg/cli/cmd/workload/reconcile.go
@@ -791,19 +791,17 @@ func gateArgoCDControlPlaneReady(
 	}
 }
 
-// buildArgoCDApplicationTasks builds one progress task per ArgoCD Application,
-// capturing the name per iteration to avoid the loop-variable closure bug.
+// buildArgoCDApplicationTasks builds one progress task per ArgoCD Application.
 func buildArgoCDApplicationTasks(
 	apps []argocd.ApplicationInfo,
 	argoReconciler *argocd.Reconciler,
 ) []notify.ProgressTask {
 	tasks := make([]notify.ProgressTask, 0, len(apps))
 	for _, app := range apps {
-		name := app.Name
 		tasks = append(tasks, notify.ProgressTask{
-			Name: name,
+			Name: app.Name,
 			Fn: func(ctx context.Context) error {
-				return pollUntilApplicationReady(ctx, argoReconciler, name)
+				return pollUntilApplicationReady(ctx, argoReconciler, app.Name)
 			},
 		})
 	}

--- a/pkg/cli/cmd/workload/reconcile.go
+++ b/pkg/cli/cmd/workload/reconcile.go
@@ -716,10 +716,16 @@ func reconcileArgoCD(
 
 	writer := cmd.OutOrStdout()
 
+	// Gate the control-plane readiness on the command's own context, self-bounded
+	// by the gate's internal budget, BEFORE opening the reconcile deadline. If the
+	// gate shared the reconcile deadline, a slow control-plane could consume the
+	// whole timeout budget, leaving TriggerRefresh and the app poll to run on an
+	// already-expired context. Opening deadlineCtx afterwards reserves the full
+	// timeout for the reconcile itself.
+	gateArgoCDControlPlaneReady(cmd.Context(), argoReconciler, timeout, writer)
+
 	deadlineCtx, deadlineCancel := context.WithTimeout(cmd.Context(), timeout)
 	defer deadlineCancel()
-
-	gateArgoCDControlPlaneReady(deadlineCtx, argoReconciler, timeout, writer)
 
 	writeActivityNotification("triggering argocd refresh...", writer)
 

--- a/pkg/cli/cmd/workload/reconcile.go
+++ b/pkg/cli/cmd/workload/reconcile.go
@@ -719,6 +719,8 @@ func reconcileArgoCD(
 	deadlineCtx, deadlineCancel := context.WithTimeout(cmd.Context(), timeout)
 	defer deadlineCancel()
 
+	gateArgoCDControlPlaneReady(deadlineCtx, argoReconciler, timeout, writer)
+
 	writeActivityNotification("triggering argocd refresh...", writer)
 
 	err = argoReconciler.TriggerRefresh(deadlineCtx, true)
@@ -737,16 +739,7 @@ func reconcileArgoCD(
 		return nil
 	}
 
-	tasks := make([]notify.ProgressTask, 0, len(apps))
-	for _, app := range apps {
-		name := app.Name
-		tasks = append(tasks, notify.ProgressTask{
-			Name: name,
-			Fn: func(ctx context.Context) error {
-				return pollUntilApplicationReady(ctx, argoReconciler, name)
-			},
-		})
-	}
+	tasks := buildArgoCDApplicationTasks(apps, argoReconciler)
 
 	appGroup := notify.NewProgressGroup(
 		"", "", writer,
@@ -764,6 +757,52 @@ func reconcileArgoCD(
 	}
 
 	return nil
+}
+
+// gateArgoCDControlPlaneReady waits for the ArgoCD control-plane (repo-server /
+// redis / server) to be Ready before the first app-sync poll (issue #5948), so a
+// just-starting control-plane's transient errors ("connection refused", "unable to
+// resolve") are not misclassified as a permanent source-unavailable failure.
+//
+// It is best-effort (fail-open): a control-plane that never becomes ready is not
+// terminal here — reconcile proceeds and any genuine problem surfaces through the
+// unchanged poll path — so the gate can only reduce the cold-start race, never add
+// a failure mode.
+func gateArgoCDControlPlaneReady(
+	ctx context.Context,
+	argoReconciler *argocd.Reconciler,
+	timeout time.Duration,
+	writer io.Writer,
+) {
+	writeActivityNotification("waiting for argocd control-plane...", writer)
+
+	err := argoReconciler.WaitForControlPlaneReady(ctx, timeout)
+	if err != nil {
+		writeActivityNotification(
+			fmt.Sprintf("warning: argocd control-plane not fully ready, proceeding: %v", err),
+			writer,
+		)
+	}
+}
+
+// buildArgoCDApplicationTasks builds one progress task per ArgoCD Application,
+// capturing the name per iteration to avoid the loop-variable closure bug.
+func buildArgoCDApplicationTasks(
+	apps []argocd.ApplicationInfo,
+	argoReconciler *argocd.Reconciler,
+) []notify.ProgressTask {
+	tasks := make([]notify.ProgressTask, 0, len(apps))
+	for _, app := range apps {
+		name := app.Name
+		tasks = append(tasks, notify.ProgressTask{
+			Name: name,
+			Fn: func(ctx context.Context) error {
+				return pollUntilApplicationReady(ctx, argoReconciler, name)
+			},
+		})
+	}
+
+	return tasks
 }
 
 // pollUntilApplicationReady polls a named ArgoCD Application until it is

--- a/pkg/client/argocd/controlplane.go
+++ b/pkg/client/argocd/controlplane.go
@@ -1,0 +1,110 @@
+package argocd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s"
+	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
+	"k8s.io/client-go/kubernetes"
+)
+
+// maxControlPlaneReadyWait bounds how long the pre-reconcile readiness gate will
+// wait for the ArgoCD control-plane, so a genuinely-stuck component cannot starve
+// the app-sync poll of its own window. The reconcile --timeout caps it further
+// when it is smaller.
+const maxControlPlaneReadyWait = 3 * time.Minute
+
+// errControlPlaneReadyBudgetExhausted is returned when the gate's time budget is
+// spent before a component could even be checked. It is handled fail-open by the
+// caller (a warning, then reconcile proceeds), so it never aborts a reconcile.
+var errControlPlaneReadyBudgetExhausted = errors.New(
+	"timeout budget exhausted before checking argocd control-plane readiness",
+)
+
+// newControlPlaneClientset builds a typed clientset for the readiness gate.
+//
+//nolint:gochecknoglobals // Allows mocking for tests.
+var newControlPlaneClientset = func(kubeconfigPath string) (kubernetes.Interface, error) {
+	restConfig, err := k8s.BuildRESTConfig(kubeconfigPath, "")
+	if err != nil {
+		return nil, fmt.Errorf("build rest config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	return clientset, nil
+}
+
+// controlPlaneComponents returns the ArgoCD control-plane Deployments whose
+// cold-start (not-yet-Ready) state produces the transient signals — "connection
+// refused" (redis), "unable to resolve"/"failed to fetch" (repo-server) — that the
+// app-sync poll would otherwise misclassify as a permanent source-unavailable
+// failure. The gate waits for them before the first poll so the cold-start window
+// is closed at the root. Absent components (custom or renamed installs, e.g. HA
+// redis) are tolerated and skipped.
+func controlPlaneComponents() []string {
+	return []string{"argocd-repo-server", "argocd-redis", "argocd-server"}
+}
+
+// WaitForControlPlaneReady waits (bounded) for the ArgoCD control-plane Deployments
+// to be Ready before app-sync polling begins, so a just-started repo-server/redis
+// does not emit transient errors that ksail's poll loop treats as a permanent
+// source-unavailable failure (issue #5948).
+//
+// It is intended to be used fail-open: the caller treats a returned error as a
+// warning and proceeds with reconcile, so the gate can only reduce the cold-start
+// race, never add a failure mode. Genuine source errors are still surfaced by the
+// unchanged app-sync poll once the control-plane is ready.
+func (r *Reconciler) WaitForControlPlaneReady(ctx context.Context, timeout time.Duration) error {
+	clientset, err := newControlPlaneClientset(r.KubeconfigPath)
+	if err != nil {
+		return err
+	}
+
+	return waitForControlPlaneReady(ctx, clientset, timeout)
+}
+
+// waitForControlPlaneReady checks each control-plane component in sequence, sharing
+// a single bounded time budget. Absent components are tolerated. It returns the
+// first readiness error (for precise unit testing); the caller applies the
+// fail-open policy.
+func waitForControlPlaneReady(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	timeout time.Duration,
+) error {
+	budget := timeout
+	if budget <= 0 || budget > maxControlPlaneReadyWait {
+		budget = maxControlPlaneReadyWait
+	}
+
+	deadline := time.Now().Add(budget)
+
+	for _, name := range controlPlaneComponents() {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf(
+				"%w (last: %s/%s)",
+				errControlPlaneReadyBudgetExhausted, DefaultNamespace, name,
+			)
+		}
+
+		err := readiness.WaitForDeploymentReadyIfExists(
+			ctx, clientset, DefaultNamespace, name, remaining,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"argocd control-plane component %s/%s not ready: %w",
+				DefaultNamespace, name, err,
+			)
+		}
+	}
+
+	return nil
+}

--- a/pkg/client/argocd/controlplane_test.go
+++ b/pkg/client/argocd/controlplane_test.go
@@ -1,0 +1,157 @@
+package argocd_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const argoCDNamespace = "argocd"
+
+func readyDeployment(name string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: argoCDNamespace},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          1,
+			UpdatedReplicas:   1,
+			AvailableReplicas: 1,
+		},
+	}
+}
+
+func notReadyDeployment(name string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: argoCDNamespace},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          1,
+			UpdatedReplicas:   0,
+			AvailableReplicas: 0,
+		},
+	}
+}
+
+func TestWaitForControlPlaneReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AllComponentsReady", testControlPlaneAllReady)
+	t.Run("AbsentComponentsTolerated", testControlPlaneAbsentTolerated)
+	t.Run("PresentButNotReadyReturnsError", testControlPlaneNotReady)
+}
+
+// testControlPlaneAllReady covers the healthy case: every control-plane component
+// exists and is Ready, so the gate returns nil (poll may proceed immediately).
+func testControlPlaneAllReady(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	client := fake.NewClientset(
+		readyDeployment("argocd-repo-server"),
+		readyDeployment("argocd-redis"),
+		readyDeployment("argocd-server"),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := argocd.WaitForControlPlaneReady(ctx, client, 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected nil for all-ready control-plane, got: %v", err)
+	}
+}
+
+// testControlPlaneAbsentTolerated covers custom/renamed installs: a component that
+// is not present (e.g. HA redis under a different name) is skipped, not waited on.
+func testControlPlaneAbsentTolerated(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	// Only repo-server exists; redis and server are absent.
+	client := fake.NewClientset(readyDeployment("argocd-repo-server"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := argocd.WaitForControlPlaneReady(ctx, client, 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected nil when components are absent (tolerated), got: %v", err)
+	}
+}
+
+// testControlPlaneNotReady covers the transient window: a component exists but is
+// not yet Ready, so the gate reports it (the caller applies the fail-open policy).
+func testControlPlaneNotReady(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	client := fake.NewClientset(
+		notReadyDeployment("argocd-repo-server"),
+		readyDeployment("argocd-redis"),
+		readyDeployment("argocd-server"),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := argocd.WaitForControlPlaneReady(ctx, client, 150*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for a not-ready control-plane component")
+	}
+
+	if !strings.Contains(err.Error(), "argocd-repo-server") {
+		t.Fatalf("expected error to name argocd-repo-server, got: %v", err)
+	}
+}
+
+var errStubClientset = errors.New("clientset construction failed")
+
+// TestReconcilerWaitForControlPlaneReady exercises the exported method wrapper and
+// its clientset-construction seam. It mutates a package seam, so it is not run in
+// parallel.
+//
+//nolint:paralleltest // Mutates the newControlPlaneClientset seam via export_test.go.
+func TestReconcilerWaitForControlPlaneReady(t *testing.T) {
+	t.Run("UsesInjectedClientset", func(t *testing.T) {
+		client := fake.NewClientset(
+			readyDeployment("argocd-repo-server"),
+			readyDeployment("argocd-redis"),
+			readyDeployment("argocd-server"),
+		)
+
+		restore := argocd.SetNewControlPlaneClientset(
+			func(string) (kubernetes.Interface, error) { return client, nil },
+		)
+		defer restore()
+
+		rec := argocd.NewReconcilerWithClientForTest()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := rec.WaitForControlPlaneReady(ctx, 2*time.Second)
+		if err != nil {
+			t.Fatalf("expected nil with injected all-ready clientset, got: %v", err)
+		}
+	})
+
+	t.Run("PropagatesClientsetError", func(t *testing.T) {
+		restore := argocd.SetNewControlPlaneClientset(
+			func(string) (kubernetes.Interface, error) { return nil, errStubClientset },
+		)
+		defer restore()
+
+		rec := argocd.NewReconcilerWithClientForTest()
+
+		err := rec.WaitForControlPlaneReady(context.Background(), time.Second)
+		if !errors.Is(err, errStubClientset) {
+			t.Fatalf("expected clientset-construction error to propagate, got: %v", err)
+		}
+	})
+}

--- a/pkg/client/argocd/export_test.go
+++ b/pkg/client/argocd/export_test.go
@@ -1,0 +1,37 @@
+package argocd
+
+import (
+	"context"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
+	"k8s.io/client-go/kubernetes"
+)
+
+// NewReconcilerWithClientForTest builds a Reconciler with a dummy base so the
+// WaitForControlPlaneReady method can be exercised with an injected clientset seam.
+func NewReconcilerWithClientForTest() *Reconciler {
+	return &Reconciler{Base: &reconciler.Base{KubeconfigPath: "unused"}}
+}
+
+// WaitForControlPlaneReady exports waitForControlPlaneReady for testing.
+func WaitForControlPlaneReady(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	timeout time.Duration,
+) error {
+	return waitForControlPlaneReady(ctx, clientset, timeout)
+}
+
+// SetNewControlPlaneClientset replaces newControlPlaneClientset with a stub and
+// returns a restore func.
+func SetNewControlPlaneClientset(
+	fn func(string) (kubernetes.Interface, error),
+) func() {
+	original := newControlPlaneClientset
+	newControlPlaneClientset = fn
+
+	return func() {
+		newControlPlaneClientset = original
+	}
+}

--- a/pkg/k8s/readiness/deployment.go
+++ b/pkg/k8s/readiness/deployment.go
@@ -29,6 +29,13 @@ func deploymentReadyCheck(
 			return false, fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
 		}
 
+		// The controller must have observed the current spec before its status
+		// replica counters can be trusted: right after a spec change or upgrade the
+		// Status still reflects the previous generation's (possibly ready) counts.
+		if deployment.Status.ObservedGeneration < deployment.Generation {
+			return false, nil
+		}
+
 		if deployment.Status.Replicas == 0 {
 			return false, nil
 		}

--- a/pkg/k8s/readiness/deployment_test.go
+++ b/pkg/k8s/readiness/deployment_test.go
@@ -1,0 +1,71 @@
+package readiness_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestWaitForDeploymentReadyIfExists_StaleObservedGeneration verifies that a
+// Deployment whose Status still reflects a previous generation (ObservedGeneration
+// < Generation) is NOT treated as ready even when its replica counters look
+// healthy — the controller has not yet observed the current spec (e.g. right after
+// an upgrade), so those counters describe the old rollout.
+func TestWaitForDeploymentReadyIfExists_StaleObservedGeneration(t *testing.T) {
+	t.Parallel()
+
+	const namespace, name = "argocd", "argocd-repo-server"
+
+	client := fake.NewClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Generation: 2},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1, // controller has not observed generation 2 yet
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	err := readiness.WaitForDeploymentReadyIfExists(
+		ctx, client, namespace, name, 150*time.Millisecond,
+	)
+
+	require.Error(t, err, "stale observedGeneration must not read as ready")
+}
+
+// TestWaitForDeploymentReadyIfExists_ObservedGenerationCaughtUp verifies the same
+// Deployment reads as ready once the controller has observed the current
+// generation and the replica counters are healthy.
+func TestWaitForDeploymentReadyIfExists_ObservedGenerationCaughtUp(t *testing.T) {
+	t.Parallel()
+
+	const namespace, name = "argocd", "argocd-repo-server"
+
+	client := fake.NewClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Generation: 2},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := readiness.WaitForDeploymentReadyIfExists(
+		ctx, client, namespace, name, time.Second,
+	)
+
+	require.NoError(t, err, "current-generation ready deployment must read as ready")
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
The E2E System-Test matrix flakes intermittently on ArgoCD `ComparisonError`s during control-plane cold-start (redis/repo-server not yet Ready). ArgoCD self-heals seconds later, but ksail's reconcile wait has already given up and misclassified the transient as a permanent source-unavailable failure — stalling own PRs *and* the dependabot lane on the required System-Test gate portfolio-wide (#5948).

## What
Before the first app-sync poll, wait (bounded, fail-open) for the ArgoCD control-plane Deployments to be Ready — closing the cold-start window at the root. The error classification path is unchanged, so a genuinely bad source still fails fast once the control-plane is up. Absent components (custom/HA installs) are tolerated.

This is the first, lowest-risk slice of the fix. The parent bug stays open for the remaining slices and the real acceptance signal: the `--cni Calico`/`--cni Cilium` System-Test legs passing reliably across repeated CI runs.

Part of #5948