### PR TITLE
fix(config): reserve a Hetzner server slot for the Talos snapshot build

### DIFF
--- a/pkg/apis/cluster/v1alpha1/autoscaler_test.go
+++ b/pkg/apis/cluster/v1alpha1/autoscaler_test.go
@@ -827,9 +827,14 @@ func TestValidateAutoscalerConfig(t *testing.T) {
 			// the baseline. With baseline 6 + poolCapacity 10, the old logic computed
 			// 6 + min(10,10) = 16 and wrongly rejected, even though MaxNodesTotal(10)
 			// equals serverLimit(10). reachableTotal = min(16, 10) = 10 → valid.
-			name: "capacity guard: maxNodesTotal equal to serverLimit is valid despite large pools",
+			//
+			// Distribution is deliberately NOT Talos: only the Talos Hetzner path builds
+			// a snapshot, so only it reserves a slot (#6171). Every other distribution is
+			// entitled to the full serverLimit, which is what this case pins.
+			name: "capacity guard: maxNodesTotal equal to serverLimit is valid for a non-Talos distribution",
 			cluster: &v1alpha1.ClusterSpec{
 				Provider:      v1alpha1.ProviderHetzner,
+				Distribution:  v1alpha1.DistributionK3s,
 				ControlPlanes: 3,
 				Workers:       3,
 				Autoscaler: v1alpha1.AutoscalerConfig{
@@ -845,6 +850,89 @@ func TestValidateAutoscalerConfig(t *testing.T) {
 								Max:        10,
 							},
 						},
+					},
+				},
+			},
+			provider: &v1alpha1.ProviderSpec{
+				Hetzner: v1alpha1.OptionsHetzner{ServerLimit: 10},
+			},
+			wantErr: nil,
+		},
+		{
+			// #6171: the Talos Hetzner path builds the autoscaler's node image by booting
+			// ONE temporary server, so a cluster that can reach serverLimit leaves that
+			// server nowhere to go. It fails LATE — fine while the pinned version's
+			// snapshot exists, then every deploy dies on resource_limit_exceeded after a
+			// Talos bump. Reject it as a config error instead.
+			name: "snapshot slot: Talos reachableTotal equal to serverLimit is rejected",
+			cluster: &v1alpha1.ClusterSpec{
+				Provider:      v1alpha1.ProviderHetzner,
+				Distribution:  v1alpha1.DistributionTalos,
+				ControlPlanes: 3,
+				Workers:       3,
+				Autoscaler: v1alpha1.AutoscalerConfig{
+					Node: v1alpha1.NodeAutoscalerConfig{
+						Enabled:       v1alpha1.NodeAutoscalerEnabledEnabled,
+						MaxNodesTotal: 10,
+						Pools: []v1alpha1.NodePool{
+							{
+								Name:       "workers",
+								ServerType: "cx23",
+								Location:   "fsn1",
+								Min:        1,
+								Max:        10,
+							},
+						},
+					},
+				},
+			},
+			provider: &v1alpha1.ProviderSpec{
+				Hetzner: v1alpha1.OptionsHetzner{ServerLimit: 10},
+			},
+			wantErr: v1alpha1.ErrAutoscalerLeavesNoSnapshotSlot,
+		},
+		{
+			// One below the limit leaves exactly the reserved slot free → valid. Pins the
+			// boundary so the reserve can't silently grow or vanish.
+			name: "snapshot slot: Talos reachableTotal one below serverLimit is valid",
+			cluster: &v1alpha1.ClusterSpec{
+				Provider:      v1alpha1.ProviderHetzner,
+				Distribution:  v1alpha1.DistributionTalos,
+				ControlPlanes: 3,
+				Workers:       3,
+				Autoscaler: v1alpha1.AutoscalerConfig{
+					Node: v1alpha1.NodeAutoscalerConfig{
+						Enabled:       v1alpha1.NodeAutoscalerEnabledEnabled,
+						MaxNodesTotal: 9,
+						Pools: []v1alpha1.NodePool{
+							{
+								Name:       "workers",
+								ServerType: "cx23",
+								Location:   "fsn1",
+								Min:        1,
+								Max:        10,
+							},
+						},
+					},
+				},
+			},
+			provider: &v1alpha1.ProviderSpec{
+				Hetzner: v1alpha1.OptionsHetzner{ServerLimit: 10},
+			},
+			wantErr: nil,
+		},
+		{
+			// The reserve must not fire when the autoscaler is off: no autoscaler secret
+			// means no snapshot build, so there is no temporary server to make room for.
+			name: "snapshot slot: Talos at serverLimit with autoscaler disabled is valid",
+			cluster: &v1alpha1.ClusterSpec{
+				Provider:      v1alpha1.ProviderHetzner,
+				Distribution:  v1alpha1.DistributionTalos,
+				ControlPlanes: 3,
+				Workers:       7,
+				Autoscaler: v1alpha1.AutoscalerConfig{
+					Node: v1alpha1.NodeAutoscalerConfig{
+						Enabled: v1alpha1.NodeAutoscalerEnabledDisabled,
 					},
 				},
 			},

--- a/pkg/apis/cluster/v1alpha1/errors.go
+++ b/pkg/apis/cluster/v1alpha1/errors.go
@@ -144,6 +144,13 @@ var ErrAutoscalerExceedsServerLimit = errors.New(
 	"autoscaler configuration exceeds Hetzner server limit",
 )
 
+// ErrAutoscalerLeavesNoSnapshotSlot is returned when a Talos + Hetzner cluster can grow to
+// occupy every server the account allows, leaving no slot for the temporary server KSail
+// boots to build the Talos snapshot the autoscaler needs.
+var ErrAutoscalerLeavesNoSnapshotSlot = errors.New(
+	"autoscaler configuration leaves no Hetzner server slot for the Talos snapshot build",
+)
+
 // ErrExpanderNotSupportedForProvider is returned when the selected autoscaler
 // expander strategy is not supported by the infrastructure provider's cloud
 // provider implementation (e.g., Hetzner does not implement the pricing API

--- a/pkg/apis/cluster/v1alpha1/validation.go
+++ b/pkg/apis/cluster/v1alpha1/validation.go
@@ -476,7 +476,73 @@ func validateHetznerCapacity(
 		)
 	}
 
-	return nil
+	return validateSnapshotBuildSlot(
+		cluster,
+		autoscaler,
+		snapshotSlotInput{
+			reachableTotal: reachableTotal,
+			serverLimit:    serverLimit,
+			poolCapacity:   poolCapacity,
+		},
+	)
+}
+
+// snapshotSlotInput carries the capacity figures validateHetznerCapacity has already
+// computed, so the snapshot-slot check reports them without recomputing.
+type snapshotSlotInput struct {
+	reachableTotal int32
+	serverLimit    int32
+	poolCapacity   int32
+}
+
+// snapshotBuildServerReserve is the number of Hetzner servers KSail must be able to create
+// for its OWN work, on top of the cluster's own nodes.
+//
+// On the Talos + Hetzner path KSail builds the Talos snapshot the autoscaler boots its nodes
+// from, and hcloud-upload-image does that by booting ONE temporary server. The deploy path
+// ensures the autoscaler config secret on every deploy and builds the snapshot whenever one
+// is absent, so a cluster whose reachable total can occupy every slot the account allows has
+// nowhere to put that server.
+//
+// It fails late and confusingly: while the pinned Talos version's snapshot exists the lookup
+// hits and nothing needs building, so the config looks fine for weeks. The next Talos version
+// bump invalidates the lookup, every deploy must build, and each one dies mid-apply with
+// hcloud's resource_limit_exceeded — recovery deploys included. Reserving the slot up front
+// turns that runtime deadlock into a config error. See ksail#6171.
+const snapshotBuildServerReserve int32 = 1
+
+// validateSnapshotBuildSlot rejects a Talos + Hetzner autoscaler config that can grow into
+// every available server slot, leaving none for the snapshot build's temporary server.
+//
+// Scoped to Talos deliberately: EnsureTalosSnapshot is called only from the Talos Hetzner
+// provisioner, so the k3s and kubeadm Hetzner paths never build a snapshot and are entitled
+// to the full limit.
+func validateSnapshotBuildSlot(
+	cluster *ClusterSpec,
+	autoscaler *NodeAutoscalerConfig,
+	capacity snapshotSlotInput,
+) error {
+	if cluster.Distribution != DistributionTalos {
+		return nil
+	}
+
+	usableLimit := capacity.serverLimit - snapshotBuildServerReserve
+	if capacity.reachableTotal <= usableLimit {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: reachableTotal(%d) leaves no slot free of serverLimit(%d); keep it at or below %d (serverLimit minus %d reserved for the snapshot build's temporary server), or raise serverLimit: controlPlanes(%d)+workers(%d)+poolCapacity(%d), maxNodesTotal(%d)", //nolint:lll
+		ErrAutoscalerLeavesNoSnapshotSlot,
+		capacity.reachableTotal,
+		capacity.serverLimit,
+		usableLimit,
+		snapshotBuildServerReserve,
+		cluster.ControlPlanes,
+		cluster.Workers,
+		capacity.poolCapacity,
+		autoscaler.MaxNodesTotal,
+	)
 }
 
 // resolveServerLimit validates and normalises the configured Hetzner server limit.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

KSail accepted a Talos + Hetzner cluster config that can grow to use **every server the account allows** — leaving no room for the temporary server **KSail itself boots** to build the Talos snapshot the autoscaler needs.

That config cannot work, but it fails late and confusingly: it looks fine for weeks (while the pinned Talos version's snapshot already exists), then the next Talos bump makes every deploy try to build one, and each dies mid-apply with an opaque `resource_limit_exceeded` — recovery deploys included. This wedged our own prod today, and it did the same thing on the previous Talos bump, so it's a recurring trap rather than a one-off.

## What

Validation now reserves one server slot on the Talos + Hetzner path, so this surfaces as a **config error that names the reserve** instead of a runtime failure with no obvious connection to node counts. Scoped to Talos on purpose — the k3s and kubeadm Hetzner paths build no snapshot and keep the full limit.

## ⚠️ Behaviour change — please weigh this before promoting

**Configs that deploy successfully today will start failing validation.** A Talos+Hetzner cluster sitting exactly at its server limit works fine for as long as its snapshot exists; after this, `ksail cluster create/update` refuses it up front and asks for one slot of headroom.

That's the intent — the config is a landmine that only detonates on the next Talos bump — but it does mean a working deploy can start erroring on a KSail upgrade, so the semver call is yours. **Our own `platform` prod config is affected** (it's exactly at the cap, which is what caused today's outage); its capacity needs fixing regardless.

Static `ksail workload validate` is **not** affected — I verified the cluster-spec validation doesn't run on that path — so consumers' manifest CI won't break.

Fixes #6171
