### PR TITLE
docs: repoint the moved Claude Code docs links at their new homes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the [Installation Guide](https://ksail.devantler.tech/installation/) for bin
 
 ## AI Assistant Plugins
 
-Install the ksail plugin for [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) or [Claude Code](https://docs.claude.com/en/docs/claude-code/plugins) to auto-register ksail's MCP server and a ksail expertise skill.
+Install the ksail plugin for [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) or [Claude Code](https://code.claude.com/docs/en/discover-plugins) to auto-register ksail's MCP server and a ksail expertise skill.
 
 **Copilot CLI:**
 

--- a/docs/src/content/docs/integrations/ai-plugins.mdx
+++ b/docs/src/content/docs/integrations/ai-plugins.mdx
@@ -3,7 +3,7 @@ title: AI Assistant Plugins
 description: Install the ksail plugin for GitHub Copilot CLI or Claude Code to auto-register the ksail MCP server and a ksail expertise skill.
 ---
 
-KSail ships a first-party plugin distributed for both [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) and [Claude Code](https://docs.claude.com/en/docs/claude-code/plugins). The plugin:
+KSail ships a first-party plugin distributed for both [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) and [Claude Code](https://code.claude.com/docs/en/plugins). The plugin:
 
 - Registers the `ksail` [MCP server](/integrations/mcp/) (via `ksail open mcp`), giving the assistant direct access to consolidated `cluster_*`, `workload_*`, and `cipher_*` tools.
 - Adds a **ksail** skill so the assistant knows when to reach for ksail and links back to this documentation site instead of guessing at flag semantics.
@@ -35,7 +35,7 @@ See the official [installing plugins guide](https://docs.github.com/en/copilot/h
 /plugin install ksail@ksail
 ```
 
-See the official [Claude Code plugins overview](https://docs.claude.com/en/docs/claude-code/plugins) and [marketplace docs](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces).
+See the official [Claude Code plugins overview](https://code.claude.com/docs/en/plugins) and [marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces).
 
 ## Prerequisites
 
@@ -60,4 +60,4 @@ The plugin version tracks ksail releases. Each `v*` tag triggers [`cd.yaml`](htt
 ## Further reading
 
 - Copilot CLI: [about plugins](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-cli-plugins) · [creating a plugin](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-creating) · [reference](https://docs.github.com/en/copilot/reference/cli-plugin-reference)
-- Claude Code: [plugins overview](https://docs.claude.com/en/docs/claude-code/plugins) · [plugin marketplaces](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces) · [reference](https://docs.claude.com/en/docs/claude-code/plugins-reference)
+- Claude Code: [plugins overview](https://code.claude.com/docs/en/plugins) · [plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces) · [reference](https://code.claude.com/docs/en/plugins-reference)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Anthropic moved the Claude Code docs host, so the README and the AI-plugins docs page carried links that redirect and then 404 — the README one was turning unrelated PRs red via the link checker.

## What

Repoints all six links (README + docs page) at their new homes, each confirmed live via Anthropic's own 301 redirects.

Fixes #6193
