### PR TITLE
ci(eks): enforce smoke-test role boundaries

### DIFF
--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -141,12 +141,15 @@ jobs:
           set -euo pipefail
           account_id="$(aws sts get-caller-identity --query Account --output text)"
           caller_arn="$(aws sts get-caller-identity --query Arn --output text)"
-          IFS=: read -r arn_prefix partition service _ arn_account_id _ <<< "$caller_arn"
+          IFS=: read -r arn_prefix partition service arn_region arn_account_id arn_resource \
+            <<< "$caller_arn"
           if [[ ! "$account_id" =~ ^[0-9]{12}$ ]] ||
              [[ "$arn_prefix" != "arn" ]] ||
              [[ ! "$partition" =~ ^aws(-[a-z0-9-]+)?$ ]] ||
              [[ "$service" != "sts" ]] ||
-             [[ "$arn_account_id" != "$account_id" ]]; then
+             [[ -n "$arn_region" ]] ||
+             [[ "$arn_account_id" != "$account_id" ]] ||
+             [[ ! "$arn_resource" =~ ^assumed-role/[A-Za-z0-9+=,.@_-]+/[A-Za-z0-9+=,.@_-]+$ ]]; then
             echo "::error::AWS identity returned an invalid account ID or caller ARN."
             exit 1
           fi

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -16,7 +16,9 @@ name: "System Test - EKS"
 #   3. Attach a least-privilege permission policy: only what `eksctl create/delete
 #      cluster` needs (CloudFormation, EC2, EKS, and the scoped IAM actions from
 #      eksctl's documented minimum policies —
-#      https://eksctl.io/usage/minimum-iam-policies/). Never AdministratorAccess.
+#      https://eksctl.io/usage/minimum-iam-policies/). Require every role created
+#      by that identity to carry the `eks-ci-smoke-boundary` permissions boundary.
+#      Never grant AdministratorAccess.
 #   4. Set the role's MaxSessionDuration to 7200 seconds — the smoke test job
 #      may run up to 120 minutes and must keep credentials through cleanup.
 #   5. Store the role ARN as the `AWS_OIDC_ROLE_ARN` secret on the `ci`
@@ -132,6 +134,26 @@ jobs:
           # clusters. Requires MaxSessionDuration=7200 on the role.
           role-duration-seconds: 7200
 
+      - name: 🔐 Resolve EKS permissions boundary
+        id: permissions-boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+          caller_arn="$(aws sts get-caller-identity --query Arn --output text)"
+          IFS=: read -r arn_prefix partition service _ arn_account_id _ <<< "$caller_arn"
+          if [[ ! "$account_id" =~ ^[0-9]{12}$ ]] ||
+             [[ "$arn_prefix" != "arn" ]] ||
+             [[ ! "$partition" =~ ^aws(-[a-z0-9-]+)?$ ]] ||
+             [[ "$service" != "sts" ]] ||
+             [[ "$arn_account_id" != "$account_id" ]]; then
+            echo "::error::AWS identity returned an invalid account ID or caller ARN."
+            exit 1
+          fi
+
+          printf 'arn=arn:%s:iam::%s:policy/eks-ci-smoke-boundary\n' \
+            "$partition" "$account_id" >> "$GITHUB_OUTPUT"
+
       - name: ⚙️ Setup Go
         id: setup-go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -171,6 +193,7 @@ jobs:
         id: init
         shell: bash
         env:
+          AWS_PERMISSIONS_BOUNDARY_ARN: ${{ steps.permissions-boundary.outputs.arn }}
           GITOPS_ENGINE: ${{ inputs.gitops_engine }}
         run: |
           set -euo pipefail
@@ -192,11 +215,24 @@ jobs:
           ruby -ryaml -e '
             path = "eks.yaml"
             data = YAML.load_file(path)
+            boundary = ENV.fetch("AWS_PERMISSIONS_BOUNDARY_ARN")
+            raise "AWS permissions boundary ARN is empty" if boundary.empty?
+
             data.fetch("metadata")["region"] = ENV.fetch("AWS_REGION")
+            data.fetch("iam")["serviceRolePermissionsBoundary"] = boundary
             Array(data["managedNodeGroups"]).each do |nodegroup|
               nodegroup["desiredCapacity"] = 1
               nodegroup["minSize"] = 1
               nodegroup["maxSize"] = 1
+              nodegroup["iam"] ||= {}
+              nodegroup["iam"]["instanceRolePermissionsBoundary"] = boundary
+            end
+
+            role_addons = %w[vpc-cni aws-ebs-csi-driver]
+            Array(data["addons"]).each do |addon|
+              next unless role_addons.include?(addon["name"])
+
+              addon["permissionsBoundary"] = boundary
             end
             File.write(path, data.to_yaml)
           '

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -301,6 +301,59 @@ func TestEKSSmokeConfigBoundaryMutationSemantics(t *testing.T) {
 	assertEKSSmokeMutation(t, config)
 }
 
+func TestEKSSmokeConfigBoundaryRejectsInvalidIdentity(t *testing.T) {
+	t.Parallel()
+	requireTestExecutable(t, "bash")
+
+	workflow := readCIWorkflow(t, ".github/workflows/system-test-eks.yaml")
+	smokeJob, ok := workflow.Jobs["smoke-test"]
+	require.True(t, ok, "smoke-test job is missing")
+	boundaryStep := findHarnessStep(t, smokeJob.Steps, "🔐 Resolve EKS permissions boundary")
+
+	testCases := map[string]struct {
+		accountID string
+		callerARN string
+	}{
+		"invalid account ID": {
+			accountID: "not-an-account",
+			callerARN: "arn:aws:sts::123456789012:assumed-role/eks-ci/smoke-test",
+		},
+		"malformed caller ARN": {
+			accountID: "123456789012",
+			callerARN: "not-an-arn",
+		},
+		"foreign ARN partition": {
+			accountID: "123456789012",
+			callerARN: "arn:azure:sts::123456789012:assumed-role/eks-ci/smoke-test",
+		},
+		"mismatched ARN account": {
+			accountID: "123456789012",
+			callerARN: "arn:aws:sts::210987654321:assumed-role/eks-ci/smoke-test",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			boundaryOutput, diagnostics, err := executePermissionsBoundaryStep(
+				t,
+				boundaryStep.Run,
+				testCase.accountID,
+				testCase.callerARN,
+			)
+
+			require.Error(t, err)
+			assert.Empty(t, boundaryOutput)
+			assert.Contains(
+				t,
+				diagnostics,
+				"AWS identity returned an invalid account ID or caller ARN",
+			)
+		})
+	}
+}
+
 func requireTestExecutable(t *testing.T, name string) {
 	t.Helper()
 
@@ -313,14 +366,33 @@ func requireTestExecutable(t *testing.T, name string) {
 func runPermissionsBoundaryStep(t *testing.T, workflowRun string) string {
 	t.Helper()
 
+	boundaryOutput, diagnostics, err := executePermissionsBoundaryStep(
+		t,
+		workflowRun,
+		"123456789012",
+		"arn:aws-us-gov:sts::123456789012:assumed-role/eks-ci/smoke-test",
+	)
+	require.NoErrorf(t, err, "permissions-boundary step failed:\n%s", diagnostics)
+
+	return boundaryOutput
+}
+
+func executePermissionsBoundaryStep(
+	t *testing.T,
+	workflowRun string,
+	accountID string,
+	callerARN string,
+) (string, string, error) {
+	t.Helper()
+
 	const awsStub = `#!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
   *"--query Account"*)
-    printf '123456789012\n'
+    printf '%s\n' "$STUB_ACCOUNT_ID"
     ;;
   *"--query Arn"*)
-    printf 'arn:aws-us-gov:sts::123456789012:assumed-role/eks-ci/smoke-test\n'
+    printf '%s\n' "$STUB_CALLER_ARN"
     ;;
   *)
     exit 64
@@ -336,6 +408,10 @@ esac
 		t,
 		os.WriteFile(awsPath, []byte(awsStub), 0o700), //nolint:gosec // Test-owned path.
 	)
+	require.NoError(
+		t,
+		os.WriteFile(outputPath, nil, 0o600),
+	)
 
 	// The executable and shell source are both repository-owned test inputs.
 	command := exec.CommandContext(t.Context(), "bash", "-c", workflowRun) //nolint:gosec
@@ -344,14 +420,15 @@ esac
 		os.Environ(),
 		"PATH="+tempDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"GITHUB_OUTPUT="+outputPath,
+		"STUB_ACCOUNT_ID="+accountID,
+		"STUB_CALLER_ARN="+callerARN,
 	)
-	output, err := command.CombinedOutput()
-	require.NoErrorf(t, err, "permissions-boundary step failed:\n%s", output)
+	diagnostics, commandErr := command.CombinedOutput()
 
 	boundaryOutput, err := os.ReadFile(outputPath) //nolint:gosec // Test-owned path.
 	require.NoError(t, err)
 
-	return string(boundaryOutput)
+	return string(boundaryOutput), string(diagnostics), commandErr
 }
 
 func assertEKSSmokeMutation(t *testing.T, config map[string]any) {

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -2,6 +2,7 @@ package ciharness_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +10,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	eksSmokeBoundaryFixture = "arn:aws-us-gov:iam::123456789012:policy/eks-ci-smoke-boundary"
+	eksSmokeConfigFixture   = `apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: fixture
+  region: us-east-1
+  tags:
+    owner: keep
+iam:
+  withOIDC: true
+managedNodeGroups:
+  - name: primary
+    desiredCapacity: 3
+    minSize: 2
+    maxSize: 4
+    labels:
+      workload: keep
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+  - name: secondary
+    desiredCapacity: 2
+    minSize: 1
+    maxSize: 3
+addons:
+  - name: vpc-cni
+    version: latest
+  - name: aws-ebs-csi-driver
+    attachPolicyARNs:
+      - arn:aws-us-gov:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+  - name: kube-proxy
+    version: v1.31.0-eksbuild.1
+`
 )
 
 //nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
@@ -193,6 +230,245 @@ func TestSystemTestHarnessOnlyBoundsDockerK3sCleanup(t *testing.T) {
 	assert.NotContains(t, cloudBranch, `timeout --kill-after=10s 2m`)
 	assert.Contains(t, cloudBranch, `"${DELETE_COMMAND[@]}"`)
 	assert.NotContains(t, cloudBranch, `|| echo`)
+}
+
+func TestEKSSmokeConfigBoundsEveryCreatedIAMRole(t *testing.T) {
+	t.Parallel()
+
+	workflow := readCIWorkflow(t, ".github/workflows/system-test-eks.yaml")
+	smokeJob, ok := workflow.Jobs["smoke-test"]
+	require.True(t, ok, "smoke-test job is missing")
+
+	boundaryStep := findHarnessStep(
+		t,
+		smokeJob.Steps,
+		"🔐 Resolve EKS permissions boundary",
+	)
+	assert.Equal(t, "permissions-boundary", boundaryStep.ID)
+	assert.Contains(t, boundaryStep.Run, `aws sts get-caller-identity`)
+	assert.Contains(t, boundaryStep.Run, `--query Arn`)
+	assert.Contains(t, boundaryStep.Run, `^[0-9]{12}$`)
+	assert.Contains(t, boundaryStep.Run, `^aws(-[a-z0-9-]+)?$`)
+	assert.Contains(t, boundaryStep.Run, `"$arn_account_id" != "$account_id"`)
+	assert.Contains(t, boundaryStep.Run, `policy/eks-ci-smoke-boundary`)
+	assert.Contains(t, boundaryStep.Run, `arn=arn:%s:iam::%s:policy`)
+	assert.Contains(t, boundaryStep.Run, `>> "$GITHUB_OUTPUT"`)
+
+	initStep := findHarnessStep(t, smokeJob.Steps, "🔧 Initialize EKS project")
+	assert.Equal(
+		t,
+		"${{ steps.permissions-boundary.outputs.arn }}",
+		initStep.Env["AWS_PERMISSIONS_BOUNDARY_ARN"],
+	)
+	assert.Contains(
+		t,
+		initStep.Run,
+		`boundary = ENV.fetch("AWS_PERMISSIONS_BOUNDARY_ARN")`,
+	)
+	assert.Contains(
+		t,
+		initStep.Run,
+		`data.fetch("iam")["serviceRolePermissionsBoundary"] = boundary`,
+	)
+	assert.Contains(t, initStep.Run, `nodegroup["iam"] ||= {}`)
+	assert.Contains(
+		t,
+		initStep.Run,
+		`nodegroup["iam"]["instanceRolePermissionsBoundary"] = boundary`,
+	)
+	assert.Contains(t, initStep.Run, `%w[vpc-cni aws-ebs-csi-driver]`)
+	assert.Contains(t, initStep.Run, `addon["permissionsBoundary"] = boundary`)
+}
+
+func TestEKSSmokeConfigBoundaryMutationSemantics(t *testing.T) {
+	t.Parallel()
+	requireTestExecutable(t, "bash")
+	requireTestExecutable(t, "ruby")
+
+	workflow := readCIWorkflow(t, ".github/workflows/system-test-eks.yaml")
+	smokeJob, ok := workflow.Jobs["smoke-test"]
+	require.True(t, ok, "smoke-test job is missing")
+
+	boundaryStep := findHarnessStep(t, smokeJob.Steps, "🔐 Resolve EKS permissions boundary")
+	assert.Equal(
+		t,
+		"arn="+eksSmokeBoundaryFixture+"\n",
+		runPermissionsBoundaryStep(t, boundaryStep.Run),
+	)
+
+	initStep := findHarnessStep(t, smokeJob.Steps, "🔧 Initialize EKS project")
+	config := runEmbeddedEKSSmokeMutation(t, initStep.Run)
+	assertEKSSmokeMutation(t, config)
+}
+
+func requireTestExecutable(t *testing.T, name string) {
+	t.Helper()
+
+	_, err := exec.LookPath(name)
+	if err != nil {
+		t.Skipf("%s is unavailable: %v", name, err)
+	}
+}
+
+func runPermissionsBoundaryStep(t *testing.T, workflowRun string) string {
+	t.Helper()
+
+	const awsStub = `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"--query Account"*)
+    printf '123456789012\n'
+    ;;
+  *"--query Arn"*)
+    printf 'arn:aws-us-gov:sts::123456789012:assumed-role/eks-ci/smoke-test\n'
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+`
+
+	tempDir := t.TempDir()
+	awsPath := filepath.Join(tempDir, "aws")
+	outputPath := filepath.Join(tempDir, "github-output")
+
+	require.NoError(
+		t,
+		os.WriteFile(awsPath, []byte(awsStub), 0o700), //nolint:gosec // Test-owned path.
+	)
+
+	// The executable and shell source are both repository-owned test inputs.
+	command := exec.CommandContext(t.Context(), "bash", "-c", workflowRun) //nolint:gosec
+
+	command.Env = append(
+		os.Environ(),
+		"PATH="+tempDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITHUB_OUTPUT="+outputPath,
+	)
+	output, err := command.CombinedOutput()
+	require.NoErrorf(t, err, "permissions-boundary step failed:\n%s", output)
+
+	boundaryOutput, err := os.ReadFile(outputPath) //nolint:gosec // Test-owned path.
+	require.NoError(t, err)
+
+	return string(boundaryOutput)
+}
+
+func assertEKSSmokeMutation(t *testing.T, config map[string]any) {
+	t.Helper()
+
+	metadata := requireStringMap(t, config["metadata"])
+	assert.Equal(t, "fixture", metadata["name"])
+	assert.Equal(t, "us-gov-west-1", metadata["region"])
+	assert.Equal(t, "keep", requireStringMap(t, metadata["tags"])["owner"])
+
+	iam := requireStringMap(t, config["iam"])
+	assert.Equal(t, true, iam["withOIDC"])
+	assert.Equal(t, eksSmokeBoundaryFixture, iam["serviceRolePermissionsBoundary"])
+
+	assertEKSSmokeNodegroups(t, config["managedNodeGroups"])
+	assertEKSSmokeAddons(t, config["addons"])
+}
+
+func assertEKSSmokeNodegroups(t *testing.T, rawNodegroups any) {
+	t.Helper()
+
+	nodegroups := requireAnySlice(t, rawNodegroups)
+	require.Len(t, nodegroups, 2)
+
+	for _, rawNodegroup := range nodegroups {
+		nodegroup := requireStringMap(t, rawNodegroup)
+		assert.Equal(t, 1, nodegroup["desiredCapacity"])
+		assert.Equal(t, 1, nodegroup["minSize"])
+		assert.Equal(t, 1, nodegroup["maxSize"])
+		assert.Equal(
+			t,
+			eksSmokeBoundaryFixture,
+			requireStringMap(t, nodegroup["iam"])["instanceRolePermissionsBoundary"],
+		)
+	}
+
+	primary := requireStringMap(t, nodegroups[0])
+	assert.Equal(t, "keep", requireStringMap(t, primary["labels"])["workload"])
+	addonPolicies := requireStringMap(
+		t,
+		requireStringMap(t, primary["iam"])["withAddonPolicies"],
+	)
+	assert.Equal(t, true, addonPolicies["autoScaler"])
+}
+
+func assertEKSSmokeAddons(t *testing.T, rawAddons any) {
+	t.Helper()
+
+	addons := requireAnySlice(t, rawAddons)
+	require.Len(t, addons, 3)
+
+	for _, rawAddon := range addons[:2] {
+		addon := requireStringMap(t, rawAddon)
+		assert.Equal(t, eksSmokeBoundaryFixture, addon["permissionsBoundary"])
+	}
+
+	kubeProxy := requireStringMap(t, addons[2])
+	assert.Equal(t, "kube-proxy", kubeProxy["name"])
+	assert.Equal(t, "v1.31.0-eksbuild.1", kubeProxy["version"])
+	assert.NotContains(t, kubeProxy, "permissionsBoundary")
+}
+
+func runEmbeddedEKSSmokeMutation(t *testing.T, workflowRun string) map[string]any {
+	t.Helper()
+
+	const rubyPrefix = "ruby -ryaml -e '\n"
+
+	start := strings.Index(workflowRun, rubyPrefix)
+	require.NotEqual(t, -1, start, "embedded Ruby mutation is missing")
+	remainder := workflowRun[start+len(rubyPrefix):]
+	end := strings.Index(remainder, "\n'")
+	require.NotEqual(t, -1, end, "embedded Ruby mutation is unterminated")
+	rubyScript := remainder[:end]
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "eks.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(eksSmokeConfigFixture), 0o600))
+
+	// The command and script both come from this repository's owned workflow.
+	command := exec.CommandContext( //nolint:gosec
+		t.Context(), "ruby", "-ryaml", "-e", rubyScript,
+	)
+	command.Dir = tempDir
+
+	command.Env = append(
+		os.Environ(),
+		"AWS_REGION=us-gov-west-1",
+		"AWS_PERMISSIONS_BOUNDARY_ARN="+eksSmokeBoundaryFixture,
+	)
+	output, err := command.CombinedOutput()
+	require.NoErrorf(t, err, "embedded Ruby mutation failed:\n%s", output)
+
+	mutated, err := os.ReadFile(configPath) //nolint:gosec // Test-owned temporary path.
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, yaml.Unmarshal(mutated, &config))
+
+	return config
+}
+
+func requireStringMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+
+	result, ok := value.(map[string]any)
+	require.True(t, ok, "expected map, got %T", value)
+
+	return result
+}
+
+func requireAnySlice(t *testing.T, value any) []any {
+	t.Helper()
+
+	result, ok := value.([]any)
+	require.True(t, ok, "expected slice, got %T", value)
+
+	return result
 }
 
 func readCompositeAction(t *testing.T, path string) compositeAction {

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -249,6 +249,12 @@ func TestEKSSmokeConfigBoundsEveryCreatedIAMRole(t *testing.T) {
 	assert.Contains(t, boundaryStep.Run, `--query Arn`)
 	assert.Contains(t, boundaryStep.Run, `^[0-9]{12}$`)
 	assert.Contains(t, boundaryStep.Run, `^aws(-[a-z0-9-]+)?$`)
+	assert.Contains(t, boundaryStep.Run, `[[ -n "$arn_region" ]]`)
+	assert.Contains(
+		t,
+		boundaryStep.Run,
+		`^assumed-role/[A-Za-z0-9+=,.@_-]+/[A-Za-z0-9+=,.@_-]+$`,
+	)
 	assert.Contains(t, boundaryStep.Run, `"$arn_account_id" != "$account_id"`)
 	assert.Contains(t, boundaryStep.Run, `policy/eks-ci-smoke-boundary`)
 	assert.Contains(t, boundaryStep.Run, `arn=arn:%s:iam::%s:policy`)
@@ -316,11 +322,19 @@ func TestEKSSmokeConfigBoundaryRejectsInvalidIdentity(t *testing.T) {
 	}{
 		"invalid account ID": {
 			accountID: "not-an-account",
-			callerARN: "arn:aws:sts::123456789012:assumed-role/eks-ci/smoke-test",
+			callerARN: "arn:aws:sts::not-an-account:assumed-role/eks-ci/smoke-test",
 		},
 		"malformed caller ARN": {
 			accountID: "123456789012",
 			callerARN: "not-an-arn",
+		},
+		"truncated caller ARN": {
+			accountID: "123456789012",
+			callerARN: "arn:aws:sts::123456789012:",
+		},
+		"regional caller ARN": {
+			accountID: "123456789012",
+			callerARN: "arn:aws:sts:us-east-1:123456789012:assumed-role/eks-ci/smoke-test",
 		},
 		"foreign ARN partition": {
 			accountID: "123456789012",


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The Platform-owned EKS CI role may create IAM roles only when they carry the `eks-ci-smoke-boundary` policy. The smoke workflow's generated `eks.yaml` omitted those boundary fields, so the first live EKS dispatch would fail while eksctl creates its cluster, node-group, and add-on roles.

## What changed

- derive the AWS partition and account from the assumed STS identity, rejecting malformed or mismatched identity data
- inject the boundary into the cluster service role and every managed node-group role
- inject it into the VPC CNI and EBS CSI add-ons, the two current add-ons that create implicit IRSA roles
- execute the exact embedded Ruby mutation against an offline fixture and verify that region/capacity changes and unrelated fields are preserved

## Safety

The generic EKS project scaffold remains account-agnostic. The workflow fails closed before provisioning when it cannot construct a trustworthy boundary ARN, and it leaves non-role-creating add-ons such as `kube-proxy` untouched.

## Validation

- `go test ./internal/ciharness -run TestEKSSmokeConfigBoundsEveryCreatedIAMRole -count=1` (red before implementation; green after)
- `go test ./internal/ciharness`
- `go test -race ./internal/ciharness`
- `go test -count=1 ./...` (the changed package and 12,458 tests passed; four existing chat subprocess cases exceeded their fixed 3–5 second deadlines under the full parallel load)
- `go test -count=1 ./pkg/cli/cmd/open/chat` (green isolated rerun)
- `golangci-lint run --timeout 5m ./internal/ciharness`
- `go build -o /tmp/ksail-maint-182e-6082 .`
- `actionlint .github/workflows/system-test-eks.yaml`
- `yamllint .github/workflows/system-test-eks.yaml`
- `zizmor --config zizmor.yml .github/workflows/system-test-eks.yaml`
- `git diff --check`

Fixes #6082

Part of #4328
