### PR TITLE
fix(eks): bind lifecycle to immutable AWS identity

### DIFF
--- a/pkg/awsconfig/neutral.go
+++ b/pkg/awsconfig/neutral.go
@@ -1,0 +1,51 @@
+// Package awsconfig provides shared AWS SDK configuration policies.
+package awsconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+const frozenProfile = "__ksail_frozen__"
+
+// LoadNeutral loads an AWS configuration with one explicit credential provider while disabling
+// ambient shared profiles and credential files. The temporary profile prevents stale AWS_PROFILE
+// values from redirecting the load, without mutating process environment.
+func LoadNeutral(
+	ctx context.Context,
+	loader func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error),
+	region string,
+	provider aws.CredentialsProvider,
+) (aws.Config, error) {
+	file, err := os.CreateTemp("", "ksail-frozen-aws-config-*")
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("create neutral AWS config: %w", err)
+	}
+
+	path := file.Name()
+	defer func() { _ = os.Remove(path) }()
+
+	_, writeErr := fmt.Fprintf(file, "[profile %s]\n", frozenProfile)
+	closeErr := file.Close()
+
+	if writeErr != nil {
+		return aws.Config{}, fmt.Errorf("write neutral AWS config: %w", writeErr)
+	}
+
+	if closeErr != nil {
+		return aws.Config{}, fmt.Errorf("close neutral AWS config: %w", closeErr)
+	}
+
+	return loader(
+		ctx,
+		config.WithRegion(region),
+		config.WithCredentialsProvider(provider),
+		config.WithSharedConfigProfile(frozenProfile),
+		config.WithSharedConfigFiles([]string{path}),
+		config.WithSharedCredentialsFiles([]string{}),
+	)
+}

--- a/pkg/awsconfig/neutral.go
+++ b/pkg/awsconfig/neutral.go
@@ -27,6 +27,7 @@ func LoadNeutral(
 	}
 
 	path := file.Name()
+
 	defer func() { _ = os.Remove(path) }()
 
 	_, writeErr := fmt.Fprintf(file, "[profile %s]\n", frozenProfile)

--- a/pkg/cli/cmd/cluster/cluster.go
+++ b/pkg/cli/cmd/cluster/cluster.go
@@ -104,6 +104,7 @@ func NewClusterCmd() *cobra.Command {
 	cmd.AddCommand(NewRestoreCmd())
 	cmd.AddCommand(NewSwitchCmd())
 	cmd.AddCommand(NewRepairCmd(nil))
+	cmd.AddCommand(NewRebindEKSOwnershipCmd())
 	cmd.AddCommand(oidc.NewOIDCCmd())
 
 	return cmd

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -139,6 +139,8 @@ func newProvisionerFactory(ctx *localregistry.Context) clusterprovisioner.Factor
 // be populated here — omitting one breaks provisioner creation for that distribution.
 func defaultProvisionerFactory(ctx *localregistry.Context) clusterprovisioner.DefaultFactory {
 	return clusterprovisioner.DefaultFactory{
+		AWSResolution:        ctx.AWSResolution,
+		AWSOwnershipVerifier: ctx.AWSOwnershipVerifier,
 		DistributionConfig: &clusterprovisioner.DistributionConfig{
 			Kind:        ctx.KindConfig,
 			K3d:         ctx.K3dConfig,

--- a/pkg/cli/cmd/cluster/create_test.go
+++ b/pkg/cli/cmd/cluster/create_test.go
@@ -3,6 +3,7 @@ package cluster_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,7 +17,9 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	dockerpkg "github.com/devantler-tech/ksail/v7/pkg/client/docker"
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/devantler-tech/ksail/v7/pkg/timer"
 	"github.com/gkampitakis/go-snaps/snaps"
 	v1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
@@ -25,6 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var errSTSUnavailable = errors.New("STS unavailable")
 
 //nolint:paralleltest // uses t.Chdir and mutates shared test hooks
 func TestCreate_EnabledCertManager_PrintsInstallStage(t *testing.T) {
@@ -252,54 +257,20 @@ func TestCreate_EKS_GitOps_UsesEksctlContext(t *testing.T) {
 		{name: "Flux", engine: v1alpha1.GitOpsEngineFlux, arg: "Flux"},
 	}
 
-	const eksctlContext = "arn:aws:iam::123456789012:role/ci@st-eks.eu-west-1.eksctl.io"
-
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			workingDir := t.TempDir()
 			t.Chdir(workingDir)
 			setupMockRegistryBackend(t)
-
-			writeFile(t, workingDir, "ksail.yaml", `apiVersion: ksail.io/v1alpha1
-kind: Cluster
-metadata:
-  name: st-eks
-spec:
-  cluster:
-    distribution: EKS
-    provider: AWS
-    distributionConfig: eks.yaml
-    metricsServer: Disabled
-    localRegistry:
-      registry: ""
-    connection:
-      kubeconfig: ./kubeconfig
-`)
-			writeFile(t, workingDir, "eks.yaml", `apiVersion: eksctl.io/v1alpha5
-kind: ClusterConfig
-metadata:
-  name: st-eks
-  region: eu-west-1
-`)
-			writeFile(t, workingDir, "kubeconfig", `apiVersion: v1
-kind: Config
-current-context: `+eksctlContext+`
-clusters:
-  - cluster:
-      server: https://example.invalid
-    name: `+eksctlContext+`
-contexts:
-  - context:
-      cluster: `+eksctlContext+`
-      user: `+eksctlContext+`
-    name: `+eksctlContext+`
-users:
-  - name: `+eksctlContext+`
-    user:
-      token: fake
-`)
+			eksctlContext := writeEKSCreateTestFiles(t, workingDir)
 
 			setupGitOpsTestMocks(t, testCase.engine)
+			setEKSIdentityClient(t, &fakeEKSIdentityClient{
+				accountID: "123456789012",
+				cluster: immutableEKSClusterInRegion(
+					"st-eks", "eu-west-1", immutableIdentityTime(),
+				),
+			})
 
 			capturedContext := ""
 
@@ -331,8 +302,194 @@ users:
 			err := cmd.Execute()
 			require.NoError(t, err)
 			assert.Equal(t, eksctlContext, capturedContext)
+
+			ownership, loadErr := state.LoadEKSOwnershipState("st-eks", "eu-west-1")
+			require.NoError(t, loadErr)
+			assert.Equal(t, "123456789012", ownership.AccountID)
+			assert.Equal(t, immutableIdentityTime(), ownership.CreatedAt)
 		})
 	}
+}
+
+//nolint:paralleltest // uses t.Chdir and mutates shared test hooks
+func TestCreate_EKSCaptureFailureStopsPostCreateWorkflow(t *testing.T) {
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	setupMockRegistryBackend(t)
+	writeEKSCreateTestFiles(t, workingDir)
+	require.NoError(t, state.DeleteClusterState("st-eks"))
+
+	fake, ensureCalled := setupGitOpsTestMocks(t, v1alpha1.GitOpsEngineArgoCD)
+	setEKSIdentityClient(t, &fakeEKSIdentityClient{
+		accountErr: errSTSUnavailable,
+	})
+
+	cmd := cluster.NewCreateCmd()
+
+	var output bytes.Buffer
+
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--gitops-engine", "ArgoCD"})
+
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "capture immutable EKS ownership identity")
+	assert.Contains(t, output.String(), "cluster created")
+	assert.False(t, *ensureCalled)
+	assert.Nil(t, fake())
+
+	_, loadErr := state.LoadEKSOwnershipState("st-eks", "eu-west-1")
+	require.ErrorIs(t, loadErr, state.ErrEKSOwnershipStateNotFound)
+}
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestCreate_EKSProfileRegionFeedsIdentityCapture(t *testing.T) {
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	setupMockRegistryBackend(t)
+	writeEKSProfileRegionCreateTestFiles(t, workingDir)
+	configureEKSProfileRegionCredentials(t, workingDir)
+
+	setupGitOpsTestMocks(t, v1alpha1.GitOpsEngineArgoCD)
+
+	var capturedRegion string
+
+	setEKSIdentityClientWithResolutionObserver(
+		t,
+		&fakeEKSIdentityClient{
+			accountID: "123456789012",
+			cluster: immutableEKSClusterInRegion(
+				"st-eks", "eu-north-1", immutableIdentityTime(),
+			),
+		},
+		func(region string, _ credentials.AWSResolution) {
+			capturedRegion = region
+		},
+	)
+
+	cmd := cluster.NewCreateCmd()
+	cmd.SetContext(t.Context())
+	cmd.SetArgs([]string{"--gitops-engine", "ArgoCD"})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "eu-north-1", capturedRegion)
+}
+
+func writeEKSProfileRegionCreateTestFiles(t *testing.T, workingDir string) {
+	t.Helper()
+
+	writeFile(t, workingDir, "ksail.yaml", `apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  name: st-eks
+spec:
+  cluster:
+    distribution: EKS
+    provider: AWS
+    distributionConfig: eks.yaml
+    metricsServer: Disabled
+    localRegistry:
+      registry: ""
+    connection:
+      kubeconfig: ./kubeconfig
+  provider:
+    aws:
+      profileEnvVar: KSAIL_PROFILE
+`)
+	writeFile(t, workingDir, "eks.yaml", `apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: st-eks
+`)
+	writeFile(t, workingDir, "kubeconfig", `apiVersion: v1
+kind: Config
+current-context: arn:aws:iam::123456789012:role/ci@st-eks.eu-north-1.eksctl.io
+clusters:
+  - cluster:
+      server: https://example.invalid
+    name: arn:aws:iam::123456789012:role/ci@st-eks.eu-north-1.eksctl.io
+contexts:
+  - context:
+      cluster: arn:aws:iam::123456789012:role/ci@st-eks.eu-north-1.eksctl.io
+      user: arn:aws:iam::123456789012:role/ci@st-eks.eu-north-1.eksctl.io
+    name: arn:aws:iam::123456789012:role/ci@st-eks.eu-north-1.eksctl.io
+users:
+  - name: arn:aws:iam::123456789012:role/ci@st-eks.eu-north-1.eksctl.io
+    user:
+      token: fake
+`)
+}
+
+func configureEKSProfileRegionCredentials(t *testing.T, workingDir string) {
+	t.Helper()
+
+	credentialsFile := filepath.Join(workingDir, "aws-credentials")
+	configFile := filepath.Join(workingDir, "aws-config")
+	writeFile(t, workingDir, "aws-credentials", `[selected-profile]
+aws_access_key_id = profile-access
+aws_secret_access_key = profile-secret
+`)
+	writeFile(t, workingDir, "aws-config", `[profile selected-profile]
+region = eu-north-1
+`)
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("KSAIL_PROFILE", "selected-profile")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credentialsFile)
+	t.Setenv("AWS_CONFIG_FILE", configFile)
+}
+
+func writeEKSCreateTestFiles(t *testing.T, workingDir string) string {
+	t.Helper()
+
+	const eksctlContext = "arn:aws:iam::123456789012:role/ci@st-eks.eu-west-1.eksctl.io"
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "fixture-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fixture-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "fixture-session")
+
+	writeFile(t, workingDir, "ksail.yaml", `apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  name: st-eks
+spec:
+  cluster:
+    distribution: EKS
+    provider: AWS
+    distributionConfig: eks.yaml
+    metricsServer: Disabled
+    localRegistry:
+      registry: ""
+    connection:
+      kubeconfig: ./kubeconfig
+`)
+	writeFile(t, workingDir, "eks.yaml", `apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: st-eks
+  region: eu-west-1
+`)
+	writeFile(t, workingDir, "kubeconfig", `apiVersion: v1
+kind: Config
+current-context: `+eksctlContext+`
+clusters:
+  - cluster:
+      server: https://example.invalid
+    name: `+eksctlContext+`
+contexts:
+  - context:
+      cluster: `+eksctlContext+`
+      user: `+eksctlContext+`
+    name: `+eksctlContext+`
+users:
+  - name: `+eksctlContext+`
+    user:
+      token: fake
+`)
+
+	return eksctlContext
 }
 
 //nolint:paralleltest // uses t.Chdir and mutates shared test hooks

--- a/pkg/cli/cmd/cluster/delete.go
+++ b/pkg/cli/cmd/cluster/delete.go
@@ -133,12 +133,9 @@ func runDeleteAction(
 	// Pre-discover registries before deletion for Docker provider
 	preDiscovered := prepareDockerDeletion(cmd, resolved, clusterInfo)
 
-	// Show confirmation prompt unless force flag is set or non-TTY
-	if !confirm.ShouldSkipPrompt(flags.force) {
-		err := promptForDeletion(cmd, resolved, preDiscovered, isKindCluster)
-		if err != nil {
-			return err
-		}
+	err = confirmAndReverifyDeleteTarget(cmd, flags, resolved, preDiscovered, isKindCluster)
+	if err != nil {
+		return err
 	}
 
 	// Delete the cluster
@@ -161,16 +158,44 @@ func runDeleteAction(
 	return nil
 }
 
+func confirmAndReverifyDeleteTarget(
+	cmd *cobra.Command,
+	flags *deleteFlags,
+	resolved *lifecycle.ResolvedClusterInfo,
+	preDiscovered *mirrorregistry.DiscoveredRegistries,
+	isKindCluster bool,
+) error {
+	// Show confirmation prompt unless force flag is set or non-TTY.
+	if !confirm.ShouldSkipPrompt(flags.force) {
+		err := promptForDeletion(cmd, resolved, preDiscovered, isKindCluster)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := lifecycle.VerifyAWSOwnershipBeforeMutation(
+		cmd.Context(),
+		resolved.AWSOwnershipVerifier,
+	)
+	if err != nil {
+		return fmt.Errorf("reverify EKS ownership after delete confirmation: %w", err)
+	}
+
+	return nil
+}
+
 func minimalProvisionerOptions(
 	resolved *lifecycle.ResolvedClusterInfo,
 	deleteStorage bool,
 ) lifecycle.MinimalProvisionerOptions {
 	return lifecycle.MinimalProvisionerOptions{
-		OmniOpts:       resolved.OmniOpts,
-		KubernetesOpts: resolved.KubernetesOpts,
-		AWSOpts:        resolved.AWSOpts,
-		AWSRegion:      resolved.AWSRegion,
-		DeleteStorage:  deleteStorage,
+		OmniOpts:             resolved.OmniOpts,
+		KubernetesOpts:       resolved.KubernetesOpts,
+		AWSOpts:              resolved.AWSOpts,
+		AWSRegion:            resolved.AWSRegion,
+		AWSResolution:        resolved.AWSResolution,
+		AWSOwnershipVerifier: resolved.AWSOwnershipVerifier,
+		DeleteStorage:        deleteStorage,
 	}
 }
 

--- a/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
+++ b/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
@@ -1,0 +1,515 @@
+package cluster_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errEKSIdentityQuery = errors.New("EKS identity query failed")
+
+type fakeEKSIdentityClient struct {
+	accountID      string
+	accountErr     error
+	cluster        *ekstypes.Cluster
+	clusters       []*ekstypes.Cluster
+	describeErr    error
+	describeCalls  int
+	beforeDescribe func(int)
+}
+
+func (f *fakeEKSIdentityClient) CallerAccountID(_ context.Context) (string, error) {
+	return f.accountID, f.accountErr
+}
+
+func (f *fakeEKSIdentityClient) DescribeCluster(
+	_ context.Context,
+	_ string,
+) (*ekstypes.Cluster, error) {
+	if f.beforeDescribe != nil {
+		f.beforeDescribe(f.describeCalls)
+	}
+
+	if len(f.clusters) > 0 {
+		index := min(f.describeCalls, len(f.clusters)-1)
+		f.describeCalls++
+
+		return f.clusters[index], f.describeErr
+	}
+
+	f.describeCalls++
+
+	return f.cluster, f.describeErr
+}
+
+//nolint:paralleltest // subtests mutate process environment, working directory, and shared hooks.
+func TestStandaloneEKSLifecycleRejectsImmutableIdentityMismatchBeforeMutation(t *testing.T) {
+	for _, testCase := range standaloneEKSLifecycleCases() {
+		//nolint:paralleltest // each case mutates process environment, working directory, and shared hooks.
+		t.Run(testCase.name+" account mismatch", func(t *testing.T) {
+			clusterName := "ksail-eks-" + testCase.name + "-account-identity-6202"
+			markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+			configureStandaloneEKSNodegroupAction(t, testCase.name)
+			persistStandaloneEKSIdentity(t, clusterName, immutableIdentityTime())
+			setEKSIdentityClient(t, &fakeEKSIdentityClient{accountID: "210987654321"})
+
+			cmd := testCase.newCommand()
+			args := make([]string, 0, 4+len(testCase.extraArgs))
+			args = append(args, "--name", clusterName, "--provider", "AWS")
+			args = append(args, testCase.extraArgs...)
+			cmd.SetArgs(args)
+			cmd.SetContext(t.Context())
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+			assert.Equal(t, []string{fmt.Sprintf(
+				"get cluster --name %s --output json --region ap-southeast-2",
+				clusterName,
+			)}, readStandaloneEKSCalls(t, markerPath))
+			assertParentAWSEnvironmentUnchanged(t)
+		})
+	}
+}
+
+//nolint:paralleltest // subtests mutate process environment, working directory, and shared hooks.
+func TestStandaloneEKSLifecycleRechecksSameARNReplacementImmediatelyBeforeMutation(t *testing.T) {
+	for _, testCase := range standaloneEKSLifecycleCases() {
+		//nolint:paralleltest // each case mutates process environment, working directory, and shared hooks.
+		t.Run(testCase.name, func(t *testing.T) {
+			clusterName := "ksail-eks-" + testCase.name + "-replacement-identity-6202"
+			markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+			configureStandaloneEKSNodegroupAction(t, testCase.name)
+
+			replacementTime := immutableIdentityTime().Add(time.Minute)
+
+			identityClient := &fakeEKSIdentityClient{
+				accountID: "123456789012",
+				clusters: []*ekstypes.Cluster{
+					immutableEKSCluster(clusterName, immutableIdentityTime()),
+					immutableEKSCluster(clusterName, immutableIdentityTime()),
+					immutableEKSCluster(clusterName, replacementTime),
+				},
+				beforeDescribe: func(call int) {
+					if call == 2 {
+						persistStandaloneEKSIdentity(
+							t, clusterName, replacementTime,
+						)
+					}
+				},
+			}
+			setEKSIdentityClient(t, identityClient)
+
+			cmd := testCase.newCommand()
+			args := make([]string, 0, 4+len(testCase.extraArgs))
+			args = append(args, "--name", clusterName, "--provider", "AWS")
+			args = append(args, testCase.extraArgs...)
+			cmd.SetArgs(args)
+			cmd.SetContext(t.Context())
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+			require.ErrorContains(t, err, "creation time")
+
+			expectedCalls := testCase.expectedCalls(clusterName)
+			assert.Equal(
+				t,
+				expectedCalls[:len(expectedCalls)-1],
+				readStandaloneEKSCalls(t, markerPath),
+			)
+			assert.Equal(t, 3, identityClient.describeCalls)
+		})
+	}
+}
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestStandaloneEKSLifecycleFreezesCustomAWSCredentialsForEveryConsumer(t *testing.T) {
+	const clusterName = "ksail-eks-start-frozen-credentials-6202"
+
+	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+	identityClient := &fakeEKSIdentityClient{
+		accountID: "123456789012",
+		cluster: immutableEKSCluster(
+			clusterName,
+			immutableIdentityTime(),
+		),
+	}
+
+	var (
+		captured       credentials.AWSResolution
+		capturedRegion string
+		factoryCalls   int
+	)
+
+	setEKSIdentityClientWithResolutionObserver(
+		t,
+		identityClient,
+		func(region string, resolution credentials.AWSResolution) {
+			factoryCalls++
+			capturedRegion = region
+			captured = resolution
+		},
+	)
+
+	cmd := cluster.NewStartCmd()
+	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, captured.IsFrozen())
+	assert.Empty(t, captured.Profile)
+	assert.Equal(t, "fixture-access", captured.AccessKeyID)
+	assert.Equal(t, "fixture-secret", captured.SecretAccessKey)
+	assert.Equal(t, "fixture-session", captured.SessionToken)
+	assert.Equal(t, "ap-southeast-2", capturedRegion)
+	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, 3, identityClient.describeCalls)
+	assert.Equal(
+		t,
+		standaloneEKSLifecycleCases()[1].expectedCalls(clusterName),
+		readStandaloneEKSCalls(t, markerPath),
+	)
+	assert.Equal(t, "selected-profile", os.Getenv("KSAIL_PROFILE"))
+	assert.Equal(t, "fixture-access", os.Getenv("KSAIL_ACCESS"))
+	assert.Equal(t, "fixture-secret", os.Getenv("KSAIL_SECRET"))
+	assert.Equal(t, "fixture-session", os.Getenv("KSAIL_SESSION"))
+	assertParentAWSEnvironmentUnchanged(t)
+}
+
+//nolint:paralleltest // table mutates process environment, working directory, and shared hooks.
+func TestStandaloneEKSLifecycleIdentityQueryFailuresNeverReachMutation(t *testing.T) {
+	queryCases := []struct {
+		name   string
+		client func() *fakeEKSIdentityClient
+	}{
+		{
+			name: "caller account",
+			client: func() *fakeEKSIdentityClient {
+				return &fakeEKSIdentityClient{accountErr: errEKSIdentityQuery}
+			},
+		},
+		{
+			name: "cluster description",
+			client: func() *fakeEKSIdentityClient {
+				return &fakeEKSIdentityClient{
+					accountID:   "123456789012",
+					describeErr: errEKSIdentityQuery,
+				}
+			},
+		},
+	}
+
+	for _, lifecycleCase := range standaloneEKSLifecycleCases() {
+		for _, queryCase := range queryCases {
+			t.Run(lifecycleCase.name+" "+queryCase.name, func(t *testing.T) {
+				clusterName := "ksail-eks-" + lifecycleCase.name + "-query-error-6202"
+				markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+				configureStandaloneEKSNodegroupAction(t, lifecycleCase.name)
+				setEKSIdentityClient(t, queryCase.client())
+
+				cmd := lifecycleCase.newCommand()
+				args := []string{"--name", clusterName, "--provider", "AWS"}
+				args = append(args, lifecycleCase.extraArgs...)
+				cmd.SetArgs(args)
+				cmd.SetContext(t.Context())
+				cmd.SetOut(io.Discard)
+				cmd.SetErr(io.Discard)
+
+				err := cmd.Execute()
+				require.ErrorIs(t, err, errEKSIdentityQuery)
+				assert.Equal(t, []string{fmt.Sprintf(
+					"get cluster --name %s --output json --region ap-southeast-2",
+					clusterName,
+				)}, readStandaloneEKSCalls(t, markerPath))
+				assertParentAWSEnvironmentUnchanged(t)
+			})
+		}
+	}
+}
+
+//nolint:paralleltest // subtests mutate process environment, working directory, and shared hooks.
+func TestStandaloneEKSStartRejectsLegacyAndMalformedOwnershipState(t *testing.T) {
+	testCases := []struct {
+		name      string
+		slug      string
+		corrupt   func(t *testing.T, clusterName string)
+		wantCause error
+	}{
+		{
+			name: "legacy missing identity",
+			slug: "legacy-missing",
+			corrupt: func(t *testing.T, clusterName string) {
+				t.Helper()
+				require.NoError(t, state.DeleteClusterState(clusterName))
+			},
+			wantCause: state.ErrEKSOwnershipStateNotFound,
+		},
+		{
+			name: "malformed identity",
+			slug: "malformed",
+			corrupt: func(t *testing.T, clusterName string) {
+				t.Helper()
+
+				home, err := os.UserHomeDir()
+				require.NoError(t, err)
+
+				path := filepath.Join(
+					home, ".ksail", "clusters", clusterName,
+					"eks-ownership-ap-southeast-2.json",
+				)
+				require.NoError(t, os.WriteFile(path, []byte("{"), 0o600))
+			},
+			wantCause: state.ErrInvalidEKSOwnershipState,
+		},
+	}
+
+	for _, testCase := range testCases {
+		//nolint:paralleltest // each case mutates process environment, working directory, and shared hooks.
+		t.Run(testCase.name, func(t *testing.T) {
+			clusterName := "ksail-eks-start-" + testCase.slug + "-6202"
+			markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+			testCase.corrupt(t, clusterName)
+
+			cmd := cluster.NewStartCmd()
+			cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
+			cmd.SetContext(t.Context())
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.ErrorIs(t, err, testCase.wantCause)
+			require.ErrorContains(t, err, "eks-bind")
+			assert.Equal(t, []string{fmt.Sprintf(
+				"get cluster --name %s --output json --region ap-southeast-2",
+				clusterName,
+			)}, readStandaloneEKSCalls(t, markerPath))
+		})
+	}
+}
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestEKSUpdateRejectsImmutableIdentityMismatchBeforePlanning(t *testing.T) {
+	clusterName := "ksail-eks-update-account-identity-6202"
+	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+	setEKSIdentityClient(t, &fakeEKSIdentityClient{accountID: "210987654321"})
+
+	cmd := cluster.NewUpdateCmd()
+	cmd.SetArgs([]string{})
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	assert.Equal(t, []string{fmt.Sprintf(
+		"get cluster --name %s --output json --region ap-southeast-2",
+		clusterName,
+	)}, readStandaloneEKSCalls(t, markerPath))
+}
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestEKSTTLCleanupRejectsImmutableIdentityMismatchBeforeDelete(t *testing.T) {
+	clusterName := "ksail-eks-ttl-account-identity-6202"
+	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+	setEKSIdentityClient(t, &fakeEKSIdentityClient{accountID: "210987654321"})
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cluster.ExportAutoDeleteCluster(
+		cmd,
+		clusterName,
+		standaloneEKSTTLClusterConfig(),
+		&clusterprovisioner.EKSConfig{
+			Name:           clusterName,
+			Region:         "ap-southeast-2",
+			ConfigPath:     filepath.Join(".", "eks.yaml"),
+			KubeconfigPath: filepath.Join(".", "kubeconfig"),
+			NameFromConfig: true,
+		},
+	)
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	assert.Equal(t, []string{fmt.Sprintf(
+		"get cluster --name %s --output json --region ap-southeast-2",
+		clusterName,
+	)}, readStandaloneEKSCalls(t, markerPath))
+}
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestEKSTTLCleanupRechecksSameARNReplacementImmediatelyBeforeDelete(t *testing.T) {
+	clusterName := "ksail-eks-ttl-replacement-identity-6202"
+	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+	identityClient := &fakeEKSIdentityClient{
+		accountID: "123456789012",
+		clusters: []*ekstypes.Cluster{
+			immutableEKSCluster(clusterName, immutableIdentityTime()),
+			immutableEKSCluster(clusterName, immutableIdentityTime()),
+			immutableEKSCluster(
+				clusterName,
+				immutableIdentityTime().Add(time.Minute),
+			),
+		},
+	}
+	setEKSIdentityClient(t, identityClient)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cluster.ExportAutoDeleteCluster(
+		cmd,
+		clusterName,
+		standaloneEKSTTLClusterConfig(),
+		&clusterprovisioner.EKSConfig{
+			Name:           clusterName,
+			Region:         "ap-southeast-2",
+			ConfigPath:     filepath.Join(".", "eks.yaml"),
+			KubeconfigPath: filepath.Join(".", "kubeconfig"),
+			NameFromConfig: true,
+		},
+	)
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	assert.Equal(t, []string{fmt.Sprintf(
+		"get cluster --name %s --output json --region ap-southeast-2",
+		clusterName,
+	)}, readStandaloneEKSCalls(t, markerPath))
+	assert.Equal(t, 3, identityClient.describeCalls)
+}
+
+func setEKSIdentityClient(t *testing.T, client eksidentity.Client) {
+	t.Helper()
+	setEKSIdentityClientWithResolutionObserver(t, client, nil)
+}
+
+func setEKSIdentityClientWithResolutionObserver(
+	t *testing.T,
+	client eksidentity.Client,
+	observe func(string, credentials.AWSResolution),
+) {
+	t.Helper()
+
+	restore := cluster.ExportSetEKSIdentityClientFactory(
+		func(
+			_ context.Context,
+			region string,
+			resolution credentials.AWSResolution,
+		) (eksidentity.Client, error) {
+			if observe != nil {
+				observe(region, resolution)
+			}
+
+			return client, nil
+		},
+	)
+	t.Cleanup(restore)
+}
+
+func persistStandaloneEKSIdentity(
+	t *testing.T,
+	clusterName string,
+	createdAt time.Time,
+) {
+	t.Helper()
+
+	persistStandaloneEKSIdentityInRegion(
+		t,
+		clusterName,
+		"ap-southeast-2",
+		"123456789012",
+		createdAt,
+	)
+}
+
+func persistStandaloneEKSIdentityInRegion(
+	t *testing.T,
+	clusterName, region, accountID string,
+	createdAt time.Time,
+) {
+	t.Helper()
+
+	require.NoError(t, state.SaveEKSOwnershipState(
+		clusterName,
+		region,
+		&state.EKSOwnershipState{
+			Version:     state.EKSOwnershipStateVersion,
+			ClusterName: clusterName,
+			Region:      region,
+			AccountID:   accountID,
+			ClusterARN:  "arn:aws:eks:" + region + ":" + accountID + ":cluster/" + clusterName,
+			CreatedAt:   createdAt,
+		},
+	))
+}
+
+func configureStandaloneEKSIdentityInRegion(
+	t *testing.T,
+	clusterName, region string,
+) {
+	t.Helper()
+
+	persistStandaloneEKSIdentityInRegion(
+		t,
+		clusterName,
+		region,
+		"123456789012",
+		immutableIdentityTime(),
+	)
+	setEKSIdentityClient(t, &fakeEKSIdentityClient{
+		accountID: "123456789012",
+		cluster: immutableEKSClusterInRegion(
+			clusterName,
+			region,
+			immutableIdentityTime(),
+		),
+	})
+}
+
+func immutableEKSCluster(
+	clusterName string,
+	createdAt time.Time,
+) *ekstypes.Cluster {
+	return immutableEKSClusterInRegion(
+		clusterName, "ap-southeast-2", createdAt,
+	)
+}
+
+func immutableEKSClusterInRegion(
+	clusterName, region string,
+	createdAt time.Time,
+) *ekstypes.Cluster {
+	return &ekstypes.Cluster{
+		Name: aws.String(clusterName),
+		Arn: aws.String(
+			"arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
+		),
+		CreatedAt: aws.Time(createdAt),
+	}
+}
+
+func immutableIdentityTime() time.Time {
+	return time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+}

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -49,7 +49,7 @@ metadata:
 `
 
 const standaloneEKSEksctlFixture = `#!/bin/sh
-[ "${AWS_PROFILE-}" = "selected-profile" ] || exit 41
+[ -z "${AWS_PROFILE+x}" ] || exit 41
 [ "${AWS_ACCESS_KEY_ID-}" = "fixture-access" ] || exit 42
 [ "${AWS_SECRET_ACCESS_KEY-}" = "fixture-secret" ] || exit 43
 [ "${AWS_SESSION_TOKEN-}" = "fixture-session" ] || exit 44
@@ -598,6 +598,11 @@ metadata:
 				Distribution: v1alpha1.DistributionEKS,
 				Provider:     v1alpha1.ProviderAWS,
 			}))
+			persistStandaloneEKSIdentity(
+				t,
+				clusterName,
+				immutableIdentityTime(),
+			)
 
 			cmd := testCase.newCommand()
 			args := make([]string, 0, 4+len(testCase.extraArgs))
@@ -646,6 +651,7 @@ func TestStandaloneEKSStartAcceptsPersistedOwnershipWithoutConfig(t *testing.T) 
 		Distribution: v1alpha1.DistributionEKS,
 		Provider:     v1alpha1.ProviderAWS,
 	}))
+	configureStandaloneEKSIdentityInRegion(t, clusterName, "ap-southeast-2")
 
 	cmd := cluster.NewStartCmd()
 	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
@@ -657,7 +663,10 @@ func TestStandaloneEKSStartAcceptsPersistedOwnershipWithoutConfig(t *testing.T) 
 	assert.Equal(
 		t,
 		[]string{
-			fmt.Sprintf("get cluster --name %s --output json", clusterName),
+			fmt.Sprintf(
+				"get cluster --name %s --output json --region ap-southeast-2",
+				clusterName,
+			),
 			fmt.Sprintf(
 				"get nodegroup --cluster %s --output json --region ap-southeast-2",
 				clusterName,
@@ -911,6 +920,7 @@ func TestAutoDeleteEKSUsesCreatedTargetAndCreationRegion(t *testing.T) {
 	markerPath := setupStandaloneEKSLifecycleFixture(t, actualName)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("KSAIL_REGION", "us-east-1")
+	configureStandaloneEKSIdentityInRegion(t, actualName, "ap-southeast-2")
 	require.NoError(t, state.SaveClusterSpec(staleAlias, &v1alpha1.ClusterSpec{}))
 
 	clusterCfg := standaloneEKSTTLClusterConfig()
@@ -1161,6 +1171,7 @@ func TestStandaloneEKSStartUsesUniqueBareContextRegionFallback(t *testing.T) {
 		clusterName,
 		[]string{clusterName + ".us-west-2.eksctl.io"},
 	)
+	configureStandaloneEKSIdentityInRegion(t, clusterName, "us-west-2")
 
 	cmd := cluster.NewStartCmd()
 	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
@@ -1223,6 +1234,7 @@ func TestStandaloneEKSStartBindsRegionFromExactQueryWithoutContext(t *testing.T)
 	t.Setenv("KSAIL_REGION", "")
 	t.Setenv("KSAIL_EKS_DISCOVERED_REGION", "eu-north-1")
 	writeStandaloneEKSEksConfig(t, clusterName)
+	configureStandaloneEKSIdentityInRegion(t, clusterName, "eu-north-1")
 
 	cmd := cluster.NewStartCmd()
 	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
@@ -1444,6 +1456,15 @@ func setupStandaloneEKSLifecycleFixture(
 	t.Setenv("AWS_ACCESS_KEY_ID", "stale-access")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "stale-secret")
 	t.Setenv("AWS_SESSION_TOKEN", "stale-session")
+
+	persistStandaloneEKSIdentity(t, clusterName, immutableIdentityTime())
+	setEKSIdentityClient(t, &fakeEKSIdentityClient{
+		accountID: "123456789012",
+		cluster: immutableEKSCluster(
+			clusterName,
+			immutableIdentityTime(),
+		),
+	})
 
 	return markerPath
 }

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -13,7 +13,9 @@ import (
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	awsprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
@@ -25,6 +27,26 @@ import (
 	"github.com/spf13/pflag"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
+
+// ExportSetEKSIdentityClientFactory replaces SDK client construction for offline lifecycle tests.
+func ExportSetEKSIdentityClientFactory(
+	factory func(
+		context.Context,
+		string,
+		credentials.AWSResolution,
+	) (eksidentity.Client, error),
+) func() {
+	eksIdentityClientFactoryState.Lock()
+	previous := eksIdentityClientFactoryState.factory
+	eksIdentityClientFactoryState.factory = factory
+	eksIdentityClientFactoryState.Unlock()
+
+	return func() {
+		eksIdentityClientFactoryState.Lock()
+		eksIdentityClientFactoryState.factory = previous
+		eksIdentityClientFactoryState.Unlock()
+	}
+}
 
 // ExportShouldPushOCIArtifact exports ShouldPushOCIArtifact for testing.
 func ExportShouldPushOCIArtifact(clusterCfg *v1alpha1.Cluster) bool {
@@ -187,6 +209,22 @@ func ExportApplyInPlaceChanges(
 		cmd, updater, reconciler, clusterName,
 		currentSpec, ctx, diff, outputTimer, force, allowRolling,
 	)
+}
+
+// ExportExecuteRecreateFlow exposes the post-consent recreate boundary for fail-closed tests.
+func ExportExecuteRecreateFlow(
+	cmd *cobra.Command,
+	ctx *localregistry.Context,
+	clusterName string,
+) error {
+	orchestrator := &updateOrchestrator{
+		cmd:         cmd,
+		ctx:         ctx,
+		clusterName: clusterName,
+		consent:     true,
+	}
+
+	return orchestrator.executeRecreateFlow()
 }
 
 // ExportComputeUpdateDiff exposes updateOrchestrator.computeUpdateDiff for testing.
@@ -638,5 +676,7 @@ func ExportGuardUpdateTargetManaged(
 	clusterName string,
 	eksConfig *clusterprovisioner.EKSConfig,
 ) error {
-	return guardUpdateTargetManaged(ctx, clusterCfg, clusterName, eksConfig)
+	_, _, err := guardUpdateTargetManaged(ctx, clusterCfg, clusterName, eksConfig)
+
+	return err
 }

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -16,6 +17,8 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -314,14 +317,14 @@ func runClusterCreationWorkflow(
 		return err
 	}
 
-	err = prepareEKSCreateConfig(ctx)
+	err = prepareEKSCreateIdentity(cmd.Context(), ctx)
 	if err != nil {
 		return err
 	}
 
 	configureProvisionerFactory(&deps, ctx)
 
-	err = executeClusterLifecycle(cmd, ctx.ClusterCfg, deps)
+	err = executeClusterCreationAndCapture(cmd, ctx, deps)
 	if err != nil {
 		return err
 	}
@@ -378,6 +381,31 @@ func runClusterCreationWorkflow(
 	return handlePostCreationSetup(cmd, ctx.ClusterCfg, deps.Timer)
 }
 
+func prepareEKSCreateIdentity(
+	ctx context.Context,
+	clusterCtx *localregistry.Context,
+) error {
+	err := prepareEKSCreateConfig(clusterCtx)
+	if err != nil {
+		return err
+	}
+
+	return freezeEKSCreateCredentials(ctx, clusterCtx)
+}
+
+func executeClusterCreationAndCapture(
+	cmd *cobra.Command,
+	clusterCtx *localregistry.Context,
+	deps lifecycle.Deps,
+) error {
+	err := executeClusterLifecycle(cmd, clusterCtx.ClusterCfg, deps)
+	if err != nil {
+		return err
+	}
+
+	return captureCreatedEKSIdentity(cmd.Context(), clusterCtx)
+}
+
 // prepareEKSCreateConfig resolves the effective AWS region and pins the
 // kubeconfig path shared by eksctl creation and post-create setup.
 func prepareEKSCreateConfig(ctx *localregistry.Context) error {
@@ -401,6 +429,91 @@ func prepareEKSCreateConfig(ctx *localregistry.Context) error {
 		ctx.ClusterCfg.Spec.Provider.AWS,
 		&clusterprovisioner.DistributionConfig{EKS: ctx.EKSConfig},
 	)
+
+	return nil
+}
+
+func freezeEKSCreateCredentials(
+	ctx context.Context,
+	clusterCtx *localregistry.Context,
+) error {
+	if clusterCtx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	if clusterCtx.EKSConfig == nil {
+		return fmt.Errorf(
+			"freeze AWS credentials for EKS creation: %w",
+			errEKSConfigurationUnavailable,
+		)
+	}
+
+	if clusterCtx.AWSResolution != nil && clusterCtx.AWSResolution.IsFrozen() {
+		if region := strings.TrimSpace(clusterCtx.AWSResolution.Region); region != "" {
+			clusterCtx.EKSConfig.Region = region
+		}
+
+		return nil
+	}
+
+	selection := credentials.ResolveAWS(
+		credentials.NewAWSOptionsResolver(clusterCtx.ClusterCfg.Spec.Provider.AWS),
+	)
+	if clusterCtx.AWSResolution != nil {
+		selection = *clusterCtx.AWSResolution
+	}
+
+	resolution, err := credentials.FreezeAWS(ctx, selection, clusterCtx.EKSConfig.Region)
+	if err != nil {
+		return fmt.Errorf("freeze AWS credentials for EKS creation: %w", err)
+	}
+
+	clusterCtx.AWSResolution = &resolution
+	if region := strings.TrimSpace(resolution.Region); region != "" {
+		clusterCtx.EKSConfig.Region = region
+	}
+
+	return nil
+}
+
+// captureCreatedEKSIdentity makes immutable ownership persistence part of EKS create success. It
+// runs immediately after eksctl returns, before later setup or TTL can report success. The SDK
+// client uses the same credential snapshot the provisioner factory received.
+func captureCreatedEKSIdentity(
+	ctx context.Context,
+	clusterCtx *localregistry.Context,
+) error {
+	if clusterCtx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	if clusterCtx.EKSConfig == nil || clusterCtx.AWSResolution == nil {
+		return fmt.Errorf(
+			"capture immutable EKS ownership identity: %w",
+			errEKSConfigurationUnavailable,
+		)
+	}
+
+	eksIdentityClientFactoryState.RLock()
+	factory := eksIdentityClientFactoryState.factory
+	eksIdentityClientFactoryState.RUnlock()
+
+	identityClient, err := factory(ctx, clusterCtx.EKSConfig.Region, *clusterCtx.AWSResolution)
+	if err != nil {
+		return fmt.Errorf("capture immutable EKS ownership identity: create AWS client: %w", err)
+	}
+
+	ownership, err := eksidentity.Capture(
+		ctx,
+		identityClient,
+		strings.TrimSpace(clusterCtx.EKSConfig.Name),
+		strings.TrimSpace(clusterCtx.EKSConfig.Region),
+	)
+	if err != nil {
+		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
+	}
+
+	clusterCtx.EKSConfig.Region = ownership.Region
 
 	return nil
 }

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1230,6 +1230,14 @@ func applyInPlaceChanges(
 	forceDrain bool,
 	allowRolling bool,
 ) error {
+	err := lifecycle.VerifyAWSOwnershipBeforeMutation(
+		cmd.Context(),
+		ctx.AWSOwnershipVerifier,
+	)
+	if err != nil {
+		return fmt.Errorf("reverify EKS ownership before update apply: %w", err)
+	}
+
 	updateOpts := clusterupdate.UpdateOptions{
 		DryRun:               false,
 		RollingReboot:        true,
@@ -1249,6 +1257,14 @@ func applyInPlaceChanges(
 	)
 	if err != nil {
 		return fmt.Errorf("failed to apply updates: %w", err)
+	}
+
+	err = lifecycle.VerifyAWSOwnershipBeforeMutation(
+		cmd.Context(),
+		ctx.AWSOwnershipVerifier,
+	)
+	if err != nil {
+		return fmt.Errorf("reverify EKS ownership before component reconciliation: %w", err)
 	}
 
 	// Apply component-level changes (CNI, CSI, cert-manager, etc.)
@@ -1310,6 +1326,14 @@ func (o *updateOrchestrator) executeRecreateFlow() error {
 
 	if !confirmRecreate(o.cmd, o.clusterName, o.consent) {
 		return nil
+	}
+
+	err := lifecycle.VerifyAWSOwnershipBeforeMutation(
+		o.cmd.Context(),
+		o.ctx.AWSOwnershipVerifier,
+	)
+	if err != nil {
+		return fmt.Errorf("reverify EKS ownership before cluster recreation: %w", err)
 	}
 
 	// Create provisioner for delete

--- a/pkg/cli/cmd/cluster/rebind_eks_ownership.go
+++ b/pkg/cli/cmd/cluster/rebind_eks_ownership.go
@@ -1,0 +1,119 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/annotations"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/experimental"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
+	"github.com/devantler-tech/ksail/v7/pkg/notify"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/spf13/cobra"
+)
+
+var (
+	errEKSOwnershipRebindConfirmationRequired = errors.New(
+		"EKS ownership rebind requires --yes after reviewing the displayed identity",
+	)
+	errEKSOwnershipRebindProvider = errors.New(
+		"EKS ownership rebind requires provider AWS",
+	)
+)
+
+// NewRebindEKSOwnershipCmd creates the explicit, non-destructive legacy-state migration path. The
+// command performs only read-only AWS/eksctl queries, displays the selected immutable identity, and
+// writes local state only after --yes. It ships hidden and default-off while the migration UX is
+// evaluated; the long-lived mutation guard itself is always on.
+//
+//nolint:funlen // command construction keeps guard and action visibly paired.
+func NewRebindEKSOwnershipCmd() *cobra.Command {
+	var (
+		confirmed bool
+		observed  *state.EKSOwnershipState
+	)
+
+	var cmd *cobra.Command
+
+	cmd = lifecycle.NewSimpleLifecycleCmd(lifecycle.SimpleLifecycleConfig{
+		Use:   "eks-bind",
+		Short: "Bind legacy EKS state to the current immutable AWS identity",
+		Long: `Bind legacy local EKS state to the exact cluster selected by the current AWS credentials.
+
+The command performs read-only AWS and eksctl queries, prints the account, ARN, region, and creation
+time for review, and writes only local KSail state. Run once without --yes to review the target, then
+repeat with --yes to confirm. It never deletes or scales AWS resources.`,
+		TitleEmoji:   "🔐",
+		TitleContent: "Rebind EKS ownership...",
+		Activity:     "binding immutable ownership for",
+		Success:      "EKS ownership identity rebound",
+		Guard: func(ctx context.Context, resolved *lifecycle.ResolvedClusterInfo) error {
+			if resolved.Provider != v1alpha1.ProviderAWS {
+				return fmt.Errorf(
+					"%w: got %s",
+					errEKSOwnershipRebindProvider,
+					resolved.Provider,
+				)
+			}
+
+			identityClient, err := resolveAWSOwnershipTarget(ctx, resolved)
+			if err != nil {
+				return err
+			}
+
+			observed, err = eksidentity.Observe(
+				ctx,
+				identityClient,
+				resolved.ClusterName,
+				resolved.AWSRegion,
+			)
+			if err != nil {
+				return fmt.Errorf("observe EKS ownership identity: %w", err)
+			}
+
+			notify.Infof(cmd.OutOrStdout(), "AWS account: %s", observed.AccountID)
+			notify.Infof(cmd.OutOrStdout(), "cluster ARN: %s", observed.ClusterARN)
+			notify.Infof(cmd.OutOrStdout(), "region: %s", observed.Region)
+			notify.Infof(
+				cmd.OutOrStdout(),
+				"created at: %s",
+				observed.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			)
+
+			if !confirmed {
+				return errEKSOwnershipRebindConfirmationRequired
+			}
+
+			return nil
+		},
+		Action: func(
+			_ context.Context,
+			_ clusterprovisioner.Provisioner,
+			clusterName string,
+		) error {
+			if observed == nil {
+				return fmt.Errorf(
+					"persist EKS ownership identity: %w",
+					eksidentity.ErrInvalidLiveIdentity,
+				)
+			}
+
+			return eksidentity.Persist(clusterName, observed.Region, observed)
+		},
+	})
+
+	cmd.Annotations = map[string]string{
+		annotations.AnnotationPermission: permissionWrite,
+	}
+	cmd.Flags().
+		BoolVar(&confirmed, "yes", false, "confirm the displayed EKS identity and write local ownership state")
+	_ = cmd.Flags().SetAnnotation(
+		"yes", annotations.AnnotationConfirmFlag, []string{annotations.AnnotationValueTrue},
+	)
+
+	return experimental.Guard(cmd)
+}

--- a/pkg/cli/cmd/cluster/rebind_eks_ownership_test.go
+++ b/pkg/cli/cmd/cluster/rebind_eks_ownership_test.go
@@ -1,0 +1,104 @@
+package cluster_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/experimental"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/flags"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestRebindEKSOwnershipIsOffByDefault(t *testing.T) {
+	clusterName := "eks-rebind-disabled-6202"
+	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+	require.NoError(t, state.DeleteClusterState(clusterName))
+
+	cmd := cluster.NewRebindEKSOwnershipCmd()
+	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, experimental.ErrDisabled)
+	assert.Empty(t, readStandaloneEKSCalls(t, markerPath))
+}
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestRebindEKSOwnershipPrintsIdentityBeforeConfirmation(t *testing.T) {
+	clusterName := "eks-rebind-review-6202"
+	setupStandaloneEKSLifecycleFixture(t, clusterName)
+	require.NoError(t, state.DeleteClusterState(clusterName))
+
+	cmd := cluster.NewRebindEKSOwnershipCmd()
+	cmd.Flags().Bool(flags.ExperimentalFlagName, true, "")
+	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
+	cmd.SetContext(t.Context())
+
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "--yes")
+	assert.Contains(t, output.String(), "123456789012")
+	assert.Contains(
+		t,
+		output.String(),
+		"arn:aws:eks:ap-southeast-2:123456789012:cluster/"+clusterName,
+	)
+	assert.Contains(t, output.String(), immutableIdentityTime().Format("2006-01-02T15:04:05Z07:00"))
+
+	_, loadErr := state.LoadEKSOwnershipState(clusterName, "ap-southeast-2")
+	require.ErrorIs(t, loadErr, state.ErrEKSOwnershipStateNotFound)
+}
+
+//nolint:paralleltest // mutates process environment, working directory, and shared hooks.
+func TestRebindEKSOwnershipPersistsOnlyAfterExplicitConfirmation(t *testing.T) {
+	clusterName := "eks-rebind-confirmed-6202"
+	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+	require.NoError(t, state.DeleteClusterState(clusterName))
+	require.NoError(t, state.SaveEKSNodegroupState(
+		clusterName,
+		"ap-southeast-2",
+		&state.EKSNodegroupState{
+			Version:     state.EKSNodegroupStateVersion,
+			ClusterName: clusterName,
+			Region:      "ap-southeast-2",
+			Nodegroups: []state.EKSNodegroupCapacity{{
+				Name:            "workers",
+				DesiredCapacity: 3,
+				MinSize:         1,
+				MaxSize:         5,
+			}},
+		},
+	))
+
+	cmd := cluster.NewRebindEKSOwnershipCmd()
+	cmd.Flags().Bool(flags.ExperimentalFlagName, true, "")
+	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS", "--yes"})
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	require.NoError(t, cmd.Execute())
+
+	ownership, err := state.LoadEKSOwnershipState(clusterName, "ap-southeast-2")
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", ownership.AccountID)
+	assert.Equal(t, immutableIdentityTime(), ownership.CreatedAt)
+
+	_, err = state.LoadEKSNodegroupState(clusterName, "ap-southeast-2")
+	require.ErrorIs(t, err, state.ErrEKSNodegroupStateNotFound)
+
+	for _, call := range readStandaloneEKSCalls(t, markerPath) {
+		assert.NotContains(t, call, "delete cluster")
+		assert.NotContains(t, call, "scale nodegroup")
+	}
+}

--- a/pkg/cli/cmd/cluster/ttl.go
+++ b/pkg/cli/cmd/cluster/ttl.go
@@ -84,6 +84,14 @@ func autoDeleteCluster(
 	deleteCtx, cancel := context.WithTimeout(cmd.Context(), deleteTimeout)
 	defer cancel()
 
+	err = lifecycle.VerifyAWSOwnershipBeforeMutation(
+		deleteCtx,
+		options.AWSOwnershipVerifier,
+	)
+	if err != nil {
+		return fmt.Errorf("TTL auto-delete: %w", err)
+	}
+
 	err = provisioner.Delete(deleteCtx, clusterName)
 	if err != nil {
 		return fmt.Errorf("TTL auto-delete failed: %w", err)
@@ -149,6 +157,8 @@ func ttlDeleteProvisionerInputs(
 
 		eksConfig.Region = resolved.AWSRegion
 		options.AWSRegion = resolved.AWSRegion
+		options.AWSResolution = resolved.AWSResolution
+		options.AWSOwnershipVerifier = resolved.AWSOwnershipVerifier
 	}
 
 	return info, options, nil

--- a/pkg/cli/cmd/cluster/unmanaged_guard.go
+++ b/pkg/cli/cmd/cluster/unmanaged_guard.go
@@ -7,14 +7,17 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
@@ -42,6 +45,34 @@ var (
 		"exact AWS ownership query did not report an eksctl-created cluster",
 	)
 )
+
+type eksIdentityClientFactory func(
+	ctx context.Context,
+	region string,
+	resolution credentials.AWSResolution,
+) (eksidentity.Client, error)
+
+//nolint:gochecknoglobals // synchronized injectable construction seam for offline lifecycle tests.
+var eksIdentityClientFactoryState = struct {
+	sync.RWMutex
+
+	factory eksIdentityClientFactory
+}{
+	factory: func(
+		ctx context.Context,
+		region string,
+		resolution credentials.AWSResolution,
+	) (eksidentity.Client, error) {
+		options := credentials.OptionsForFrozenAWSConfig(
+			resolution,
+			eksclient.WithAWSConfig,
+			eksclient.WithCredentialValues,
+			eksclient.RequireCredentialValues,
+		)
+
+		return eksclient.NewClient(ctx, region, options...)
+	},
+}
 
 // managedClusterLister enumerates the names of clusters ksail manages across every provider and
 // reports whether discovery was complete (no provider failed). The guard fails open when discovery
@@ -243,8 +274,39 @@ func ensureAWSClusterManaged(
 	ctx context.Context,
 	resolved *lifecycle.ResolvedClusterInfo,
 ) error {
+	identityClient, err := resolveAWSOwnershipTarget(ctx, resolved)
+	if err != nil {
+		return err
+	}
+
+	clusterName := resolved.ClusterName
+	region := resolved.AWSRegion
+
+	verifier, err := eksidentity.NewVerifier(identityClient, clusterName, region)
+	if err != nil {
+		return fmt.Errorf("load immutable EKS ownership identity: %w", err)
+	}
+
+	err = verifier(ctx)
+	if err != nil {
+		return fmt.Errorf("verify immutable EKS ownership identity: %w", err)
+	}
+
+	resolved.AWSOwnershipVerifier = verifier
+
+	return nil
+}
+
+// resolveAWSOwnershipTarget performs the legacy local-intent plus exact eksctl provenance check and
+// returns an SDK client pinned to the same one-time credential snapshot. Normal mutations follow it
+// with immutable identity verification; the explicit rebind flow deliberately uses only this
+// read-only prerequisite before capturing a new identity.
+func resolveAWSOwnershipTarget(
+	ctx context.Context,
+	resolved *lifecycle.ResolvedClusterInfo,
+) (eksidentity.Client, error) {
 	if !hasLocalKSailEKSTargetEvidence(resolved) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"no local KSail ownership evidence for EKS target %q: %w",
 			resolved.ClusterName,
 			unmanagedClusterError(resolved.ClusterName),
@@ -253,10 +315,48 @@ func ensureAWSClusterManaged(
 
 	err := bindAWSRegionFromKubeconfig(resolved)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	auth := credentials.ResolveAWS(credentials.NewAWSOptionsResolver(resolved.AWSOpts))
+	auth, err := queryFrozenAWSOwnership(ctx, resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved.AWSResolution = &auth
+
+	eksIdentityClientFactoryState.RLock()
+	factory := eksIdentityClientFactoryState.factory
+	eksIdentityClientFactoryState.RUnlock()
+
+	identityClient, err := factory(ctx, resolved.AWSRegion, auth)
+	if err != nil {
+		return nil, fmt.Errorf("create immutable EKS identity client: %w", err)
+	}
+
+	return identityClient, nil
+}
+
+func queryFrozenAWSOwnership(
+	ctx context.Context,
+	resolved *lifecycle.ResolvedClusterInfo,
+) (credentials.AWSResolution, error) {
+	auth, err := credentials.ResolveFrozenAWS(
+		ctx,
+		credentials.NewAWSOptionsResolver(resolved.AWSOpts),
+		resolved.AWSRegion,
+	)
+	if err != nil {
+		return credentials.AWSResolution{}, fmt.Errorf(
+			"freeze AWS credentials for EKS ownership verification: %w",
+			err,
+		)
+	}
+
+	if resolved.AWSRegion == "" {
+		resolved.AWSRegion = strings.TrimSpace(auth.Region)
+	}
+
 	eksctlOptions := credentials.OptionsForAWSChildEnvironment(
 		auth,
 		os.Environ(),
@@ -271,13 +371,22 @@ func ensureAWSClusterManaged(
 	)
 	if err != nil {
 		if errors.Is(err, eksctlclient.ErrClusterNotFound) {
-			return awsOwnershipMismatchError(resolved, err)
+			return credentials.AWSResolution{}, awsOwnershipMismatchError(resolved, err)
 		}
 
-		return awsOwnershipQueryError(resolved, err)
+		return credentials.AWSResolution{}, awsOwnershipQueryError(resolved, err)
 	}
 
-	return validateAWSOwnershipSummary(resolved, summary)
+	err = validateAWSOwnershipSummary(resolved, summary)
+	if err != nil {
+		return credentials.AWSResolution{}, err
+	}
+
+	if auth.Region == "" {
+		auth.Region = resolved.AWSRegion
+	}
+
+	return auth, nil
 }
 
 // hasLocalKSailEKSTargetEvidence requires local KSail intent before the cloud-side eksctl marker is
@@ -415,12 +524,12 @@ func guardUpdateTargetManaged(
 	clusterCfg *v1alpha1.Cluster,
 	clusterName string,
 	eksConfig *clusterprovisioner.EKSConfig,
-) error {
+) (*credentials.AWSResolution, lifecycle.AWSOwnershipVerifier, error) {
 	kubeconfigPath, err := clusterdetector.ResolveKubeconfigPath(
 		clusterCfg.Spec.Cluster.Connection.Kubeconfig,
 	)
 	if err != nil {
-		return fmt.Errorf("resolve kubeconfig path: %w", err)
+		return nil, nil, fmt.Errorf("resolve kubeconfig path: %w", err)
 	}
 
 	// Canonicalize the user-supplied path before the guard reads the kubeconfig (repo path-safety
@@ -428,19 +537,19 @@ func guardUpdateTargetManaged(
 	// missing kubeconfig still falls through to the guard's fail-open path).
 	canonical, err := fsutil.EvalCanonicalPath(kubeconfigPath)
 	if err != nil {
-		return fmt.Errorf("canonicalize kubeconfig path %q: %w", kubeconfigPath, err)
+		return nil, nil, fmt.Errorf("canonicalize kubeconfig path %q: %w", kubeconfigPath, err)
 	}
 
 	resolved := resolveUpdateTarget(clusterCfg, clusterName, canonical, eksConfig)
 
 	err = lifecycle.ValidateStandaloneAWSTarget(resolved)
 	if err != nil {
-		return fmt.Errorf("validate AWS update target: %w", err)
+		return nil, nil, fmt.Errorf("validate AWS update target: %w", err)
 	}
 
 	err = updateUnmanagedGuardFunc(ctx, resolved)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// A regionless eks.yaml may be safely bound by an exact kubeconfig context or the exact eksctl
@@ -450,7 +559,7 @@ func guardUpdateTargetManaged(
 		eksConfig.Region = strings.TrimSpace(resolved.AWSRegion)
 	}
 
-	return nil
+	return resolved.AWSResolution, resolved.AWSOwnershipVerifier, nil
 }
 
 func resolveUpdateTarget(

--- a/pkg/cli/cmd/cluster/update.go
+++ b/pkg/cli/cmd/cluster/update.go
@@ -151,10 +151,15 @@ func handleUpdateRunE(
 	// unmanaged cluster (a managed cloud cluster, a kubeadm cluster, a colleague's cluster) the guard
 	// rejects here — before any change is computed or applied — so `cluster update` never mutates a
 	// cluster ksail does not own. Read-only operations still work. (ksail#5885, epic #5654.)
-	err = guardUpdateTargetManaged(cmd.Context(), ctx.ClusterCfg, clusterName, ctx.EKSConfig)
+	awsResolution, awsOwnershipVerifier, err := guardUpdateTargetManaged(
+		cmd.Context(), ctx.ClusterCfg, clusterName, ctx.EKSConfig,
+	)
 	if err != nil {
 		return err
 	}
+
+	ctx.AWSResolution = awsResolution
+	ctx.AWSOwnershipVerifier = awsOwnershipVerifier
 
 	clusterflags.ApplyClusterMutationFlags(cmd, ctx.ClusterCfg)
 

--- a/pkg/cli/cmd/cluster/update_test.go
+++ b/pkg/cli/cmd/cluster/update_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/ui/confirm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -175,6 +177,18 @@ type fakeUpdater struct {
 	result  *clusterupdate.UpdateResult
 	err     error
 	diffErr error
+	calls   int
+}
+
+type countingFactory struct{ calls int }
+
+func (f *countingFactory) Create(
+	context.Context,
+	*v1alpha1.Cluster,
+) (clusterprovisioner.Provisioner, any, error) {
+	f.calls++
+
+	return &fakeProvisioner{}, nil, nil
 }
 
 func (f *fakeUpdater) Update(
@@ -183,6 +197,8 @@ func (f *fakeUpdater) Update(
 	_, _ *v1alpha1.ClusterSpec,
 	_ clusterupdate.UpdateOptions,
 ) (*clusterupdate.UpdateResult, error) {
+	f.calls++
+
 	return f.result, f.err
 }
 
@@ -218,6 +234,64 @@ func TestComputeUpdateDiff_PropagatesProvisionerError(t *testing.T) {
 	)
 
 	require.ErrorIs(t, err, wantErr)
+}
+
+func TestApplyInPlaceChangesRechecksEKSIdentityBeforeUpdaterMutation(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeUpdater{result: clusterupdate.NewEmptyUpdateResult()}
+	ctx := &localregistry.Context{
+		ClusterCfg: &v1alpha1.Cluster{},
+		AWSOwnershipVerifier: func(context.Context) error {
+			return eksidentity.ErrIdentityMismatch
+		},
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cluster.ExportApplyInPlaceChanges(
+		cmd,
+		updater,
+		"replaced-eks-cluster",
+		&v1alpha1.ClusterSpec{},
+		ctx,
+		clusterupdate.NewEmptyUpdateResult(),
+		nil,
+		false,
+		false,
+	)
+
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	assert.Zero(t, updater.calls, "identity mismatch must abort before the updater mutates AWS")
+}
+
+//nolint:paralleltest // overrides the process-global provisioner factory seam.
+func TestRecreateRechecksEKSIdentityAfterConsentBeforeDeleteFactory(t *testing.T) {
+	factory := &countingFactory{}
+	restore := cluster.SetProvisionerFactoryForTests(factory)
+	t.Cleanup(restore)
+
+	ctx := &localregistry.Context{
+		ClusterCfg: &v1alpha1.Cluster{},
+		AWSOwnershipVerifier: func(context.Context) error {
+			return eksidentity.ErrIdentityMismatch
+		},
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cluster.ExportExecuteRecreateFlow(cmd, ctx, "replaced-eks-cluster")
+
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	assert.Zero(
+		t,
+		factory.calls,
+		"identity mismatch must abort before constructing a delete provisioner",
+	)
 }
 
 func TestNewUpdateCmd(t *testing.T) { //nolint:cyclop // flag assertion test

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -17,7 +17,9 @@ import (
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/k8s"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	clusterdetector "github.com/devantler-tech/ksail/v7/pkg/svc/detector/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
@@ -133,7 +135,15 @@ type ResolvedClusterInfo struct {
 	AWSRegionFromConfig bool
 	// AWSOpts retains the credential environment-variable mappings from the loaded cluster config.
 	AWSOpts v1alpha1.OptionsAWS
+	// AWSResolution pins the concrete credentials selected by the EKS ownership guard for the
+	// provisioner that performs the authorized mutation. It is never persisted.
+	AWSResolution *credentials.AWSResolution
+	// AWSOwnershipVerifier rechecks the persisted/live EKS incarnation immediately before mutation.
+	AWSOwnershipVerifier AWSOwnershipVerifier
 }
+
+// AWSOwnershipVerifier is a read-only immutable EKS identity check captured by the initial guard.
+type AWSOwnershipVerifier = eksidentity.Verifier
 
 // awsRegionEnvVarDefault is the fallback environment variable name for the AWS
 // region when spec.provider.aws.regionEnvVar is unset (mirrors the OptionsAWS
@@ -539,14 +549,21 @@ func provisionAndAct(
 		cmd.Context(),
 		clusterInfo,
 		MinimalProvisionerOptions{
-			OmniOpts:       resolved.OmniOpts,
-			KubernetesOpts: resolved.KubernetesOpts,
-			AWSOpts:        resolved.AWSOpts,
-			AWSRegion:      resolved.AWSRegion,
+			OmniOpts:             resolved.OmniOpts,
+			KubernetesOpts:       resolved.KubernetesOpts,
+			AWSOpts:              resolved.AWSOpts,
+			AWSRegion:            resolved.AWSRegion,
+			AWSResolution:        resolved.AWSResolution,
+			AWSOwnershipVerifier: resolved.AWSOwnershipVerifier,
 		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create provisioner: %w", err)
+	}
+
+	err = VerifyAWSOwnershipBeforeMutation(cmd.Context(), resolved.AWSOwnershipVerifier)
+	if err != nil {
+		return err
 	}
 
 	err = config.Action(cmd.Context(), provisioner, resolved.ClusterName)
@@ -586,11 +603,27 @@ func CreateMinimalProvisioner(
 // MinimalProvisionerOptions contains the provider-specific context needed to
 // construct a standalone lifecycle provisioner from only a resolved target.
 type MinimalProvisionerOptions struct {
-	OmniOpts       v1alpha1.OptionsOmni
-	KubernetesOpts v1alpha1.OptionsKubernetes
-	AWSOpts        v1alpha1.OptionsAWS
-	AWSRegion      string
-	DeleteStorage  bool
+	OmniOpts             v1alpha1.OptionsOmni
+	KubernetesOpts       v1alpha1.OptionsKubernetes
+	AWSOpts              v1alpha1.OptionsAWS
+	AWSRegion            string
+	AWSResolution        *credentials.AWSResolution
+	AWSOwnershipVerifier AWSOwnershipVerifier
+	DeleteStorage        bool
+}
+
+// VerifyAWSOwnershipBeforeMutation invokes the EKS identity boundary when present. Non-EKS
+// lifecycle operations carry a nil verifier and remain unchanged.
+func VerifyAWSOwnershipBeforeMutation(
+	ctx context.Context,
+	verifier AWSOwnershipVerifier,
+) error {
+	err := eksidentity.VerifyBeforeMutation(ctx, verifier)
+	if err != nil {
+		return fmt.Errorf("verify AWS ownership before lifecycle mutation: %w", err)
+	}
+
+	return nil
 }
 
 // CreateMinimalProvisionerForProvider creates provisioners for all distributions
@@ -683,6 +716,8 @@ func createMinimalEKSProvisioner(
 	clusterCfg.Spec.Provider.AWS = options.AWSOpts
 
 	factory := clusterprovisioner.DefaultFactory{
+		AWSResolution:        options.AWSResolution,
+		AWSOwnershipVerifier: options.AWSOwnershipVerifier,
 		DistributionConfig: &clusterprovisioner.DistributionConfig{
 			EKS: &clusterprovisioner.EKSConfig{
 				Name:           info.ClusterName,

--- a/pkg/cli/setup/localregistry/localregistry.go
+++ b/pkg/cli/setup/localregistry/localregistry.go
@@ -15,6 +15,7 @@ import (
 	ksailconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/ksail"
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/registry"
 	k3dv1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
@@ -107,6 +108,10 @@ type Context struct {
 	EKSConfig      *clusterprovisioner.EKSConfig
 	GKEConfig      *clusterprovisioner.GKEConfig
 	AKSConfig      *clusterprovisioner.AKSConfig
+	// AWSResolution pins one credential snapshot across EKS verification and mutation.
+	AWSResolution *credentials.AWSResolution
+	// AWSOwnershipVerifier rechecks the exact EKS incarnation at each mutation boundary.
+	AWSOwnershipVerifier lifecycle.AWSOwnershipVerifier
 	// MirrorSpecs holds resolved registry mirror specifications for the Kubernetes
 	// provider. The nested provisioner sets these up inside the DinD environment so
 	// nested clusters pull through authenticated, caching mirrors. Nil for other

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -3,7 +3,10 @@ package eks
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -33,6 +36,15 @@ const (
 	presignExpirySeconds = "60"
 )
 
+var (
+	errCallerIdentityUnavailable = errors.New(
+		"getting AWS caller identity: identity client is unavailable",
+	)
+	errCallerAccountMissing = errors.New(
+		"getting AWS caller identity: response did not include an account ID",
+	)
+)
+
 // clusterDescriber is the narrow seam over the EKS SDK operation this
 // package uses, so tests can inject a fake without AWS credentials.
 // *awseks.Client satisfies it.
@@ -54,15 +66,28 @@ type callerIdentityPresigner interface {
 	) (*v4.PresignedHTTPRequest, error)
 }
 
+// callerIdentityGetter is the seam over the read-only STS identity query used to bind lifecycle
+// state to the currently selected AWS account. *sts.Client satisfies it.
+type callerIdentityGetter interface {
+	GetCallerIdentity(
+		ctx context.Context,
+		params *sts.GetCallerIdentityInput,
+		optFns ...func(*sts.Options),
+	) (*sts.GetCallerIdentityOutput, error)
+}
+
 // Client reads EKS cluster connection details and mints bearer tokens for
 // them, hiding the SDK's request shapes and the token encoding scheme.
 type Client struct {
 	describer                 clusterDescriber
 	presigner                 callerIdentityPresigner
+	identityGetter            callerIdentityGetter
 	loadOptions               []func(*config.LoadOptions) error
+	staticCredentialProvider  aws.CredentialsProvider
 	credentialValuesAvailable bool
 	requireCredentialValues   bool
 	optionErr                 error
+	awsConfig                 *aws.Config
 }
 
 // Option customises a Client.
@@ -84,6 +109,13 @@ func WithCallerIdentityPresigner(presigner callerIdentityPresigner) Option {
 	}
 }
 
+// WithCallerIdentityGetter injects the read-only STS identity query used by ownership checks.
+func WithCallerIdentityGetter(getter callerIdentityGetter) Option {
+	return func(client *Client) {
+		client.identityGetter = getter
+	}
+}
+
 // WithCredentialValues pins the AWS identity used by the SDK-backed EKS and
 // STS clients without mutating process environment. A complete static pair
 // takes precedence over profile, matching the canonical AWS credential chain.
@@ -91,6 +123,7 @@ func WithCallerIdentityPresigner(presigner callerIdentityPresigner) Option {
 // unrelated ambient identity.
 func WithCredentialValues(profile, accessKeyID, secretAccessKey, sessionToken string) Option {
 	return func(client *Client) {
+		client.awsConfig = nil
 		hasAccessKey := accessKeyID != ""
 		hasSecretKey := secretAccessKey != ""
 
@@ -102,13 +135,10 @@ func WithCredentialValues(profile, accessKeyID, secretAccessKey, sessionToken st
 
 		if hasAccessKey {
 			client.credentialValuesAvailable = true
-			client.loadOptions = append(
-				client.loadOptions,
-				config.WithCredentialsProvider(awscredentials.NewStaticCredentialsProvider(
-					accessKeyID,
-					secretAccessKey,
-					sessionToken,
-				)),
+			client.staticCredentialProvider = awscredentials.NewStaticCredentialsProvider(
+				accessKeyID,
+				secretAccessKey,
+				sessionToken,
 			)
 
 			return
@@ -118,6 +148,26 @@ func WithCredentialValues(profile, accessKeyID, secretAccessKey, sessionToken st
 			client.credentialValuesAvailable = true
 			client.loadOptions = append(client.loadOptions, config.WithSharedConfigProfile(profile))
 		}
+	}
+}
+
+// WithAWSConfig pins a complete AWS SDK configuration snapshot. Callers can replace credentials
+// while retaining resolved endpoint, HTTP, retry, and middleware settings without re-reading
+// mutable process configuration.
+func WithAWSConfig(config aws.Config) Option {
+	return func(client *Client) {
+		if config.Credentials == nil {
+			client.optionErr = ErrExplicitCredentialsUnavailable
+
+			return
+		}
+
+		config.ConfigSources = append(config.ConfigSources[:0:0], config.ConfigSources...)
+		config.APIOptions = append(config.APIOptions[:0:0], config.APIOptions...)
+		client.awsConfig = &config
+		client.staticCredentialProvider = nil
+		client.loadOptions = nil
+		client.credentialValuesAvailable = true
 	}
 }
 
@@ -147,17 +197,22 @@ func NewClientWithCredentialRequirement(
 	return NewClient(ctx, region, result...)
 }
 
-// NewClient constructs a Client. Unless both seams are injected, it resolves
-// the AWS default configuration (env, shared config, IRSA / instance
-// role) once and builds the real SDK clients from it.
+// NewClient constructs a Client. Unless the existing DescribeCluster and token-presigning seams are
+// both injected, it resolves the AWS configuration once and builds the missing SDK clients. A
+// deliberately partial injected client must also provide WithCallerIdentityGetter before using
+// CallerAccountID; preserving that test seam avoids an unexpected config dependency for older
+// consumers that only need DescribeCluster and MintToken.
 func NewClient(ctx context.Context, region string, opts ...Option) (*Client, error) {
 	client := &Client{
 		describer:                 nil,
 		presigner:                 nil,
+		identityGetter:            nil,
 		loadOptions:               nil,
+		staticCredentialProvider:  nil,
 		credentialValuesAvailable: false,
 		requireCredentialValues:   false,
 		optionErr:                 nil,
+		awsConfig:                 nil,
 	}
 
 	for _, opt := range opts {
@@ -172,27 +227,31 @@ func NewClient(ctx context.Context, region string, opts ...Option) (*Client, err
 		return nil, ErrExplicitCredentialsUnavailable
 	}
 
-	if client.describer == nil || client.presigner == nil {
-		loadOptions := append(
-			[]func(*config.LoadOptions) error{config.WithRegion(region)},
-			client.loadOptions...,
-		)
-
-		cfg, err := config.LoadDefaultConfig(ctx, loadOptions...)
-		if err != nil {
-			return nil, fmt.Errorf("loading aws configuration: %w", err)
-		}
-
-		if client.describer == nil {
-			client.describer = awseks.NewFromConfig(cfg)
-		}
-
-		if client.presigner == nil {
-			client.presigner = sts.NewPresignClient(sts.NewFromConfig(cfg))
-		}
+	err := client.configureMissingSDKClients(ctx, region)
+	if err != nil {
+		return nil, err
 	}
 
 	return client, nil
+}
+
+// CallerAccountID returns the 12-digit AWS account selected by this client's immutable credential
+// configuration. The query never exposes or persists credentials.
+func (c *Client) CallerAccountID(ctx context.Context) (string, error) {
+	if c.identityGetter == nil {
+		return "", errCallerIdentityUnavailable
+	}
+
+	out, err := c.identityGetter.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("getting AWS caller identity: %w", err)
+	}
+
+	if out == nil || strings.TrimSpace(aws.ToString(out.Account)) == "" {
+		return "", errCallerAccountMissing
+	}
+
+	return strings.TrimSpace(aws.ToString(out.Account)), nil
 }
 
 // DescribeCluster returns the named EKS cluster's control-plane details.
@@ -229,6 +288,107 @@ func (c *Client) MintToken(ctx context.Context, clusterName string) (string, err
 	}
 
 	return v1SchemePrefix + base64.RawURLEncoding.EncodeToString([]byte(request.URL)), nil
+}
+
+func (c *Client) configureMissingSDKClients(ctx context.Context, region string) error {
+	if c.describer != nil && c.presigner != nil {
+		return nil
+	}
+
+	var (
+		cfg aws.Config
+		err error
+	)
+
+	switch {
+	case c.awsConfig != nil:
+		cfg = *c.awsConfig
+		cfg.ConfigSources = append(cfg.ConfigSources[:0:0], cfg.ConfigSources...)
+
+		cfg.APIOptions = append(cfg.APIOptions[:0:0], cfg.APIOptions...)
+		if strings.TrimSpace(region) != "" {
+			cfg.Region = strings.TrimSpace(region)
+		}
+	case c.staticCredentialProvider != nil:
+		cfg, err = loadNeutralStaticAWSConfig(ctx, region, c.staticCredentialProvider)
+		if err != nil {
+			return fmt.Errorf("loading aws configuration: %w", err)
+		}
+	default:
+		loadOptions := append(
+			[]func(*config.LoadOptions) error{config.WithRegion(region)},
+			c.loadOptions...,
+		)
+
+		cfg, err = config.LoadDefaultConfig(ctx, loadOptions...)
+		if err != nil {
+			return fmt.Errorf("loading aws configuration: %w", err)
+		}
+	}
+
+	if c.describer == nil {
+		c.describer = awseks.NewFromConfig(cfg)
+	}
+
+	c.configureMissingSTSClients(cfg)
+
+	return nil
+}
+
+func loadNeutralStaticAWSConfig(
+	ctx context.Context,
+	region string,
+	provider aws.CredentialsProvider,
+) (aws.Config, error) {
+	file, err := os.CreateTemp("", "ksail-frozen-aws-config-*")
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("create neutral AWS config: %w", err)
+	}
+
+	path := file.Name()
+	defer func() { _ = os.Remove(path) }()
+
+	const profile = "__ksail_frozen__"
+
+	_, writeErr := fmt.Fprintf(file, "[profile %s]\n", profile)
+	closeErr := file.Close()
+
+	if writeErr != nil {
+		return aws.Config{}, fmt.Errorf("write neutral AWS config: %w", writeErr)
+	}
+
+	if closeErr != nil {
+		return aws.Config{}, fmt.Errorf("close neutral AWS config: %w", closeErr)
+	}
+
+	configSnapshot, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithRegion(region),
+		config.WithCredentialsProvider(provider),
+		config.WithSharedConfigProfile(profile),
+		config.WithSharedConfigFiles([]string{path}),
+		config.WithSharedCredentialsFiles([]string{}),
+	)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("load neutral AWS configuration: %w", err)
+	}
+
+	return configSnapshot, nil
+}
+
+func (c *Client) configureMissingSTSClients(cfg aws.Config) {
+	if c.presigner != nil && c.identityGetter != nil {
+		return
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	if c.presigner == nil {
+		c.presigner = sts.NewPresignClient(stsClient)
+	}
+
+	if c.identityGetter == nil {
+		c.identityGetter = stsClient
+	}
 }
 
 // withTokenHeaders adds the signed headers that turn a plain presigned

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,6 +15,7 @@ import (
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	awsconfigutil "github.com/devantler-tech/ksail/v7/pkg/awsconfig"
 )
 
 const (
@@ -310,7 +310,12 @@ func (c *Client) configureMissingSDKClients(ctx context.Context, region string) 
 			cfg.Region = strings.TrimSpace(region)
 		}
 	case c.staticCredentialProvider != nil:
-		cfg, err = loadNeutralStaticAWSConfig(ctx, region, c.staticCredentialProvider)
+		cfg, err = awsconfigutil.LoadNeutral(
+			ctx,
+			config.LoadDefaultConfig,
+			region,
+			c.staticCredentialProvider,
+		)
 		if err != nil {
 			return fmt.Errorf("loading aws configuration: %w", err)
 		}
@@ -333,47 +338,6 @@ func (c *Client) configureMissingSDKClients(ctx context.Context, region string) 
 	c.configureMissingSTSClients(cfg)
 
 	return nil
-}
-
-func loadNeutralStaticAWSConfig(
-	ctx context.Context,
-	region string,
-	provider aws.CredentialsProvider,
-) (aws.Config, error) {
-	file, err := os.CreateTemp("", "ksail-frozen-aws-config-*")
-	if err != nil {
-		return aws.Config{}, fmt.Errorf("create neutral AWS config: %w", err)
-	}
-
-	path := file.Name()
-	defer func() { _ = os.Remove(path) }()
-
-	const profile = "__ksail_frozen__"
-
-	_, writeErr := fmt.Fprintf(file, "[profile %s]\n", profile)
-	closeErr := file.Close()
-
-	if writeErr != nil {
-		return aws.Config{}, fmt.Errorf("write neutral AWS config: %w", writeErr)
-	}
-
-	if closeErr != nil {
-		return aws.Config{}, fmt.Errorf("close neutral AWS config: %w", closeErr)
-	}
-
-	configSnapshot, err := config.LoadDefaultConfig(
-		ctx,
-		config.WithRegion(region),
-		config.WithCredentialsProvider(provider),
-		config.WithSharedConfigProfile(profile),
-		config.WithSharedConfigFiles([]string{path}),
-		config.WithSharedCredentialsFiles([]string{}),
-	)
-	if err != nil {
-		return aws.Config{}, fmt.Errorf("load neutral AWS configuration: %w", err)
-	}
-
-	return configSnapshot, nil
 }
 
 func (c *Client) configureMissingSTSClients(cfg aws.Config) {

--- a/pkg/client/eks/client_test.go
+++ b/pkg/client/eks/client_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
@@ -42,12 +46,50 @@ type fakePresigner struct {
 	err     error
 }
 
+// fakeIdentityGetter scripts the read-only STS identity query used by EKS ownership checks.
+type fakeIdentityGetter struct {
+	out *sts.GetCallerIdentityOutput
+	err error
+}
+
+func (f fakeIdentityGetter) GetCallerIdentity(
+	_ context.Context,
+	_ *sts.GetCallerIdentityInput,
+	_ ...func(*sts.Options),
+) (*sts.GetCallerIdentityOutput, error) {
+	return f.out, f.err
+}
+
 func (f fakePresigner) PresignGetCallerIdentity(
 	_ context.Context,
 	_ *sts.GetCallerIdentityInput,
 	_ ...func(*sts.PresignOptions),
 ) (*v4.PresignedHTTPRequest, error) {
 	return f.request, f.err
+}
+
+func newCallerIdentityServer(
+	t *testing.T,
+	authorization chan<- string,
+) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		authorization <- request.Header.Get("Authorization")
+
+		writer.Header().Set("Content-Type", "text/xml")
+		_, _ = writer.Write([]byte(
+			`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">` +
+				`<GetCallerIdentityResult><Account>123456789012</Account>` +
+				`<Arn>arn:aws:iam::123456789012:user/ksail-test</Arn>` +
+				`<UserId>KSailTest</UserId></GetCallerIdentityResult>` +
+				`<ResponseMetadata><RequestId>test-request</RequestId></ResponseMetadata>` +
+				`</GetCallerIdentityResponse>`,
+		))
+	}))
 }
 
 // newTestClient wires a Client from injected seams so no AWS configuration
@@ -64,10 +106,76 @@ func newTestClient(
 		"eu-central-1",
 		eksclient.WithClusterDescriber(describer),
 		eksclient.WithCallerIdentityPresigner(presigner),
+		eksclient.WithCallerIdentityGetter(fakeIdentityGetter{
+			out: &sts.GetCallerIdentityOutput{Account: aws.String("123456789012")},
+		}),
 	)
 	require.NoError(t, err)
 
 	return client
+}
+
+func TestCallerAccountIDReturnsCurrentAccount(t *testing.T) {
+	t.Parallel()
+
+	client, err := eksclient.NewClient(
+		t.Context(),
+		"eu-central-1",
+		eksclient.WithClusterDescriber(fakeDescriber{}),
+		eksclient.WithCallerIdentityPresigner(fakePresigner{}),
+		eksclient.WithCallerIdentityGetter(fakeIdentityGetter{
+			out: &sts.GetCallerIdentityOutput{Account: aws.String("123456789012")},
+		}),
+	)
+	require.NoError(t, err)
+
+	accountID, err := client.CallerAccountID(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", accountID)
+}
+
+func TestCallerAccountIDRejectsMissingAccount(t *testing.T) {
+	t.Parallel()
+
+	for name, output := range map[string]*sts.GetCallerIdentityOutput{
+		"nil response":  nil,
+		"nil account":   {},
+		"empty account": {Account: aws.String("")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := eksclient.NewClient(
+				t.Context(),
+				"eu-central-1",
+				eksclient.WithClusterDescriber(fakeDescriber{}),
+				eksclient.WithCallerIdentityPresigner(fakePresigner{}),
+				eksclient.WithCallerIdentityGetter(fakeIdentityGetter{out: output}),
+			)
+			require.NoError(t, err)
+
+			_, err = client.CallerAccountID(t.Context())
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "account ID")
+		})
+	}
+}
+
+func TestCallerAccountIDWrapsSTSFailure(t *testing.T) {
+	t.Parallel()
+
+	client, err := eksclient.NewClient(
+		t.Context(),
+		"eu-central-1",
+		eksclient.WithClusterDescriber(fakeDescriber{}),
+		eksclient.WithCallerIdentityPresigner(fakePresigner{}),
+		eksclient.WithCallerIdentityGetter(fakeIdentityGetter{err: errBoom}),
+	)
+	require.NoError(t, err)
+
+	_, err = client.CallerAccountID(t.Context())
+	require.ErrorIs(t, err, errBoom)
+	assert.ErrorContains(t, err, "getting AWS caller identity")
 }
 
 func TestDescribeClusterReturnsPayload(t *testing.T) {
@@ -182,6 +290,10 @@ func TestMintTokenSignsClusterBindingHeaders(t *testing.T) {
 // explicit static credentials win over ambient identity.
 func TestWithCredentialValues_StaticCredentialsOverrideAmbientIdentity(t *testing.T) {
 	// Not parallel: t.Setenv changes the process environment.
+	missingConfigDir := t.TempDir()
+	t.Setenv("AWS_PROFILE", "stale-profile")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(missingConfigDir, "missing-config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(missingConfigDir, "missing-credentials"))
 	t.Setenv("AWS_ACCESS_KEY_ID", "STALEAMBIENT")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "stale-ambient-secret")
 
@@ -201,6 +313,96 @@ func TestWithCredentialValues_StaticCredentialsOverrideAmbientIdentity(t *testin
 	token, err := client.MintToken(t.Context(), "eks-default")
 	require.NoError(t, err)
 	assertTokenCredentialPrefix(t, token, "SELECTEDACCESS/")
+}
+
+// TestWithCredentialValues_StaticCredentialsPreserveEndpointConfig verifies explicit static
+// credentials replace only AWS identity configuration. Non-credential settings loaded from the
+// environment must still reach the real SDK clients, even when an unrelated ambient profile is
+// stale, and construction must not mutate the process environment.
+func TestWithCredentialValues_StaticCredentialsPreserveEndpointConfig(t *testing.T) {
+	// Not parallel: t.Setenv changes the process environment.
+	authorization := make(chan string, 1)
+	server := newCallerIdentityServer(t, authorization)
+
+	defer server.Close()
+
+	missingConfigDir := t.TempDir()
+	t.Setenv("AWS_PROFILE", "stale-profile")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(missingConfigDir, "missing-config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(missingConfigDir, "missing-credentials"))
+	t.Setenv("AWS_ACCESS_KEY_ID", "STALEAMBIENT")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "stale-ambient-secret")
+	t.Setenv("AWS_ENDPOINT_URL", server.URL)
+	t.Setenv("AWS_ENDPOINT_URL_STS", server.URL)
+	t.Setenv("AWS_IGNORE_CONFIGURED_ENDPOINT_URLS", "false")
+
+	environmentBefore := append([]string(nil), os.Environ()...)
+
+	client, err := eksclient.NewClient(
+		t.Context(),
+		"eu-central-1",
+		eksclient.WithClusterDescriber(fakeDescriber{}),
+		eksclient.WithCredentialValues(
+			"ignored-profile",
+			"SELECTEDACCESS",
+			"selected-secret",
+			"selected-session",
+		),
+	)
+	require.NoError(t, err)
+
+	queryCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	accountID, err := client.CallerAccountID(queryCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", accountID)
+	assert.Equal(t, environmentBefore, os.Environ())
+
+	select {
+	case header := <-authorization:
+		assert.Contains(t, header, "Credential=SELECTEDACCESS/")
+	case <-queryCtx.Done():
+		require.Fail(t, "STS endpoint did not receive a request")
+	}
+}
+
+func TestWithAWSConfigPreservesFrozenEndpointAndCredentials(t *testing.T) {
+	t.Parallel()
+
+	authorization := make(chan string, 1)
+	server := newCallerIdentityServer(t, authorization)
+
+	defer server.Close()
+
+	client, err := eksclient.NewClient(
+		t.Context(),
+		"eu-central-1",
+		eksclient.WithClusterDescriber(fakeDescriber{}),
+		eksclient.WithAWSConfig(aws.Config{
+			Region: "stale-region",
+			Credentials: credentials.NewStaticCredentialsProvider(
+				"FROZENACCESS",
+				"frozen-secret",
+				"",
+			),
+			HTTPClient:   server.Client(),
+			BaseEndpoint: aws.String(server.URL),
+		}),
+	)
+	require.NoError(t, err)
+
+	accountID, err := client.CallerAccountID(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", accountID)
+
+	select {
+	case header := <-authorization:
+		assert.Contains(t, header, "Credential=FROZENACCESS/")
+		assert.Contains(t, header, "/eu-central-1/sts/aws4_request")
+	case <-t.Context().Done():
+		require.Fail(t, "STS endpoint did not receive a request")
+	}
 }
 
 // TestWithCredentialValues_ProfileOverridesAmbientStaticCredentials verifies an

--- a/pkg/svc/credentials/aws_environment_test.go
+++ b/pkg/svc/credentials/aws_environment_test.go
@@ -174,16 +174,16 @@ func TestAWSResolution_CustomSourcesRemoveCompetingAmbientCredentialProviders(t 
 		"AWS_WEB_IDENTITY_TOKEN_FILE",
 		"AWS_ROLE_ARN",
 		"AWS_ROLE_SESSION_NAME",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
 		"KSAIL_PROFILE",
 	} {
 		assertEnvKeyCount(t, child, key, 0)
 	}
 
 	assertEnvEntry(t, child, "PATH", "usr/bin")
-	assertEnvEntry(t, child, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "credentials/selected")
-	assertEnvEntry(t, child, "AWS_CONTAINER_CREDENTIALS_FULL_URI", "127.0.0.1/selected")
-	assertEnvEntry(t, child, "AWS_CONTAINER_AUTHORIZATION_TOKEN", "selected-token")
-	assertEnvEntry(t, child, "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", "selected-auth-token")
 }
 
 // TestAWSResolution_ReportsCustomCredentialSourcesEvenWhenUnset verifies

--- a/pkg/svc/credentials/aws_freeze.go
+++ b/pkg/svc/credentials/aws_freeze.go
@@ -1,0 +1,355 @@
+package credentials
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+var (
+	// ErrIncompleteAWSStaticCredentials reports a partial static credential tuple that must never
+	// fall through to another AWS identity provider.
+	ErrIncompleteAWSStaticCredentials = errors.New("incomplete AWS static credentials")
+	// ErrExplicitAWSCredentialsUnavailable reports configured custom sources that resolved no usable
+	// profile or static tuple.
+	ErrExplicitAWSCredentialsUnavailable = errors.New("explicit AWS credentials are unavailable")
+	// ErrAWSCredentialsUnavailable reports an AWS configuration whose provider returned no usable
+	// concrete access and secret key pair.
+	ErrAWSCredentialsUnavailable = errors.New("AWS credentials are unavailable")
+)
+
+type awsConfigLoader func(
+	context.Context,
+	...func(*config.LoadOptions) error,
+) (aws.Config, error)
+
+const frozenAWSProfile = "__ksail_frozen__"
+
+// ResolveFrozenAWS resolves the selected AWS provider exactly once and returns a concrete static
+// credential tuple. The tuple can be reused by SDK clients and eksctl child processes without
+// re-reading a rotating profile, credential_process, SSO, web-identity, or default provider chain.
+func ResolveFrozenAWS(
+	ctx context.Context,
+	resolver Resolver,
+	region string,
+) (AWSResolution, error) {
+	return FreezeAWS(ctx, ResolveAWS(resolver), region)
+}
+
+// FreezeAWS resolves an existing immutable selection to one concrete credential tuple.
+func FreezeAWS(
+	ctx context.Context,
+	selection AWSResolution,
+	region string,
+) (AWSResolution, error) {
+	return freezeAWSResolution(ctx, region, selection, config.LoadDefaultConfig)
+}
+
+func freezeAWSResolution(
+	ctx context.Context,
+	region string,
+	selection AWSResolution,
+	loader awsConfigLoader,
+) (AWSResolution, error) {
+	loadOptions, err := frozenAWSLoadOptions(region, selection)
+	if err != nil {
+		return AWSResolution{}, err
+	}
+
+	if strings.TrimSpace(region) != "" {
+		selection.Region = strings.TrimSpace(region)
+	}
+
+	cfg, err := loadFrozenAWSConfig(ctx, loader, region, selection, loadOptions)
+	if err != nil {
+		return AWSResolution{}, fmt.Errorf(
+			"load AWS configuration for credential snapshot: %w",
+			err,
+		)
+	}
+
+	credentialValues, err := resolveConcreteAWSCredentials(ctx, cfg, selection)
+	if err != nil {
+		return AWSResolution{}, err
+	}
+
+	if strings.TrimSpace(selection.Region) == "" {
+		selection.Region = frozenAWSRegion(selection, cfg)
+	}
+
+	selection.Profile = ""
+	selection.AccessKeyID = credentialValues.AccessKeyID
+	selection.SecretAccessKey = credentialValues.SecretAccessKey
+	selection.SessionToken = credentialValues.SessionToken
+	selection.frozen = true
+
+	frozenProvider := awscredentials.NewStaticCredentialsProvider(
+		credentialValues.AccessKeyID,
+		credentialValues.SecretAccessKey,
+		credentialValues.SessionToken,
+	)
+	cfg = sanitizeAWSConfigIdentity(cfg, selection.Region)
+	cfg.Region = selection.Region
+	cfg.Credentials = aws.NewCredentialsCache(frozenProvider)
+	selection.sdkConfig = &cfg
+
+	return selection, nil
+}
+
+func loadFrozenAWSConfig(
+	ctx context.Context,
+	loader awsConfigLoader,
+	region string,
+	selection AWSResolution,
+	loadOptions []func(*config.LoadOptions) error,
+) (aws.Config, error) {
+	hasStaticCredentials := selection.AccessKeyID != ""
+	if hasStaticCredentials && selection.usesUnsetCustomProfileSource() {
+		return loadNeutralAWSConfig(ctx, loader, region, selection)
+	}
+
+	cfg, err := loader(ctx, loadOptions...)
+	if err == nil || !hasStaticCredentials || !isMissingSharedConfigProfile(err) {
+		return cfg, err
+	}
+
+	// A complete static tuple is authoritative. A stale ambient profile must not block it,
+	// but valid profile/default non-identity settings are retained when the first load works.
+	return loadNeutralAWSConfig(ctx, loader, region, selection)
+}
+
+func resolveConcreteAWSCredentials(
+	ctx context.Context,
+	cfg aws.Config,
+	selection AWSResolution,
+) (aws.Credentials, error) {
+	if selection.AccessKeyID != "" {
+		return aws.Credentials{
+			AccessKeyID:     selection.AccessKeyID,
+			SecretAccessKey: selection.SecretAccessKey,
+			SessionToken:    selection.SessionToken,
+		}, nil
+	}
+
+	if cfg.Credentials == nil {
+		return aws.Credentials{}, ErrAWSCredentialsUnavailable
+	}
+
+	credentialValues, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("retrieve concrete AWS credentials: %w", err)
+	}
+
+	if credentialValues.AccessKeyID == "" || credentialValues.SecretAccessKey == "" {
+		return aws.Credentials{}, ErrAWSCredentialsUnavailable
+	}
+
+	return credentialValues, nil
+}
+
+func frozenAWSLoadOptions(
+	region string,
+	selection AWSResolution,
+) ([]func(*config.LoadOptions) error, error) {
+	hasAccessKey := selection.AccessKeyID != ""
+	hasSecretKey := selection.SecretAccessKey != ""
+
+	if hasAccessKey != hasSecretKey || (selection.SessionToken != "" && !hasAccessKey) {
+		return nil, ErrIncompleteAWSStaticCredentials
+	}
+
+	if selection.HasCustomCredentialSources() && selection.Profile == "" && !hasAccessKey {
+		return nil, ErrExplicitAWSCredentialsUnavailable
+	}
+
+	options := []func(*config.LoadOptions) error{config.WithRegion(region)}
+	if hasAccessKey {
+		options = append(options, config.WithCredentialsProvider(
+			awscredentials.NewStaticCredentialsProvider(
+				selection.AccessKeyID,
+				selection.SecretAccessKey,
+				selection.SessionToken,
+			),
+		))
+	}
+
+	if selection.Profile != "" {
+		options = append(options, config.WithSharedConfigProfile(selection.Profile))
+	}
+
+	return options, nil
+}
+
+func loadNeutralAWSConfig(
+	ctx context.Context,
+	loader awsConfigLoader,
+	region string,
+	selection AWSResolution,
+) (aws.Config, error) {
+	file, err := os.CreateTemp("", "ksail-frozen-aws-config-*")
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("create neutral AWS config: %w", err)
+	}
+
+	path := file.Name()
+	defer func() { _ = os.Remove(path) }()
+
+	_, writeErr := fmt.Fprintf(file, "[profile %s]\n", frozenAWSProfile)
+	closeErr := file.Close()
+
+	if writeErr != nil {
+		return aws.Config{}, fmt.Errorf("write neutral AWS config: %w", writeErr)
+	}
+
+	if closeErr != nil {
+		return aws.Config{}, fmt.Errorf("close neutral AWS config: %w", closeErr)
+	}
+
+	provider := awscredentials.NewStaticCredentialsProvider(
+		selection.AccessKeyID,
+		selection.SecretAccessKey,
+		selection.SessionToken,
+	)
+	options := []func(*config.LoadOptions) error{
+		config.WithRegion(region),
+		config.WithCredentialsProvider(provider),
+		config.WithSharedConfigProfile(frozenAWSProfile),
+		config.WithSharedConfigFiles([]string{path}),
+		config.WithSharedCredentialsFiles([]string{}),
+	}
+
+	return loader(ctx, options...)
+}
+
+func isMissingSharedConfigProfile(err error) bool {
+	var profileErr config.SharedConfigProfileNotExistError
+
+	return errors.As(err, &profileErr)
+}
+
+func (r AWSResolution) usesUnsetCustomProfileSource() bool {
+	return r.Profile == "" && r.sourceEnvVars[0] != "" &&
+		r.sourceEnvVars[0] != defaultAWSProfileEnvVar
+}
+
+func frozenAWSRegion(selection AWSResolution, cfg aws.Config) string {
+	if !selection.usesUnsetCustomRegionSource() {
+		return strings.TrimSpace(cfg.Region)
+	}
+
+	// A custom region alias that resolved empty must not fall back to stale canonical AWS_REGION.
+	// A valid selected/default shared profile may still provide its non-credential region.
+	for _, source := range cfg.ConfigSources {
+		switch value := source.(type) {
+		case config.SharedConfig:
+			if region := strings.TrimSpace(value.Region); region != "" {
+				return region
+			}
+		case *config.SharedConfig:
+			if value != nil {
+				if region := strings.TrimSpace(value.Region); region != "" {
+					return region
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+func (r AWSResolution) usesUnsetCustomRegionSource() bool {
+	return r.Region == "" && r.sourceRegionEnvVar != "" &&
+		r.sourceRegionEnvVar != defaultAWSRegionEnvVar
+}
+
+func sanitizeAWSConfigIdentity(cfg aws.Config, region string) aws.Config {
+	cfg.BearerAuthTokenProvider = nil
+	cfg.ConfigSources = sanitizeAWSConfigSources(cfg.ConfigSources, region)
+	cfg.APIOptions = append(cfg.APIOptions[:0:0], cfg.APIOptions...)
+
+	return cfg
+}
+
+func sanitizeAWSConfigSources(sources []any, region string) []any {
+	sanitized := make([]any, 0, len(sources))
+	for _, source := range sources {
+		switch value := source.(type) {
+		case config.EnvConfig:
+			sanitized = append(sanitized, sanitizeAWSEnvConfig(value, region))
+		case config.SharedConfig:
+			sanitized = append(sanitized, sanitizeAWSSharedConfig(value, region))
+		case config.LoadOptions:
+			sanitized = append(sanitized, sanitizeAWSLoadOptions(value, region))
+		default:
+			sanitized = append(sanitized, source)
+		}
+	}
+
+	return sanitized
+}
+
+func sanitizeAWSEnvConfig(value config.EnvConfig, region string) config.EnvConfig {
+	value.Credentials = aws.Credentials{}
+	value.ContainerCredentialsEndpoint = ""
+	value.ContainerCredentialsRelativePath = ""
+	value.ContainerAuthorizationToken = ""
+	value.SharedConfigProfile = ""
+	value.SharedCredentialsFile = ""
+	value.WebIdentityTokenFilePath = ""
+	value.RoleARN = ""
+	value.RoleSessionName = ""
+	value.Region = region
+
+	return value
+}
+
+func sanitizeAWSSharedConfig(value config.SharedConfig, region string) config.SharedConfig {
+	value.Profile = ""
+	value.Credentials = aws.Credentials{}
+	value.CredentialSource = ""
+	value.CredentialProcess = ""
+	value.WebIdentityTokenFile = ""
+	value.SSOSessionName = ""
+	value.SSOSession = nil
+	value.SSORegion = ""
+	value.SSOStartURL = ""
+	value.SSOAccountID = ""
+	value.SSORoleName = ""
+	value.RoleARN = ""
+	value.ExternalID = ""
+	value.MFASerial = ""
+	value.RoleSessionName = ""
+	value.RoleDurationSeconds = nil
+	value.SourceProfileName = ""
+	value.Source = nil
+	value.LoginSession = ""
+	value.Region = region
+
+	return value
+}
+
+func sanitizeAWSLoadOptions(value config.LoadOptions, region string) config.LoadOptions {
+	value.Region = region
+	value.Credentials = nil
+	value.BearerAuthTokenProvider = nil
+	value.SharedConfigProfile = ""
+	value.SharedConfigFiles = nil
+	value.SharedCredentialsFiles = nil
+	value.CredentialsCacheOptions = nil
+	value.BearerAuthTokenCacheOptions = nil
+	value.SSOTokenProviderOptions = nil
+	value.ProcessCredentialOptions = nil
+	value.EC2RoleCredentialOptions = nil
+	value.EndpointCredentialOptions = nil
+	value.WebIdentityRoleCredentialOptions = nil
+	value.AssumeRoleCredentialOptions = nil
+	value.SSOProviderOptions = nil
+
+	return value
+}

--- a/pkg/svc/credentials/aws_freeze.go
+++ b/pkg/svc/credentials/aws_freeze.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
+	awsconfigutil "github.com/devantler-tech/ksail/v7/pkg/awsconfig"
 )
 
 var (
@@ -28,8 +28,6 @@ type awsConfigLoader func(
 	context.Context,
 	...func(*config.LoadOptions) error,
 ) (aws.Config, error)
-
-const frozenAWSProfile = "__ksail_frozen__"
 
 // ResolveFrozenAWS resolves the selected AWS provider exactly once and returns a concrete static
 // credential tuple. The tuple can be reused by SDK clients and eksctl child processes without
@@ -192,39 +190,18 @@ func loadNeutralAWSConfig(
 	region string,
 	selection AWSResolution,
 ) (aws.Config, error) {
-	file, err := os.CreateTemp("", "ksail-frozen-aws-config-*")
-	if err != nil {
-		return aws.Config{}, fmt.Errorf("create neutral AWS config: %w", err)
-	}
-
-	path := file.Name()
-	defer func() { _ = os.Remove(path) }()
-
-	_, writeErr := fmt.Fprintf(file, "[profile %s]\n", frozenAWSProfile)
-	closeErr := file.Close()
-
-	if writeErr != nil {
-		return aws.Config{}, fmt.Errorf("write neutral AWS config: %w", writeErr)
-	}
-
-	if closeErr != nil {
-		return aws.Config{}, fmt.Errorf("close neutral AWS config: %w", closeErr)
-	}
-
 	provider := awscredentials.NewStaticCredentialsProvider(
 		selection.AccessKeyID,
 		selection.SecretAccessKey,
 		selection.SessionToken,
 	)
-	options := []func(*config.LoadOptions) error{
-		config.WithRegion(region),
-		config.WithCredentialsProvider(provider),
-		config.WithSharedConfigProfile(frozenAWSProfile),
-		config.WithSharedConfigFiles([]string{path}),
-		config.WithSharedCredentialsFiles([]string{}),
+
+	cfg, err := awsconfigutil.LoadNeutral(ctx, loader, region, provider)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("load neutral AWS configuration: %w", err)
 	}
 
-	return loader(ctx, options...)
+	return cfg, nil
 }
 
 func isMissingSharedConfigProfile(err error) bool {

--- a/pkg/svc/credentials/aws_freeze_test.go
+++ b/pkg/svc/credentials/aws_freeze_test.go
@@ -1,0 +1,290 @@
+package credentials_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errFrozenCredentialQuery = errors.New("credential query failed")
+
+type frozenResolverFixture struct {
+	envVars map[credentials.Key]string
+	values  map[credentials.Key]string
+}
+
+func (f frozenResolverFixture) EnvVar(key credentials.Key) string {
+	if name := f.envVars[key]; name != "" {
+		return name
+	}
+
+	return credentials.DefaultEnvVar(key)
+}
+
+func (f frozenResolverFixture) Value(key credentials.Key) string { return f.values[key] }
+
+type rotatingCredentialProvider struct {
+	credentials []aws.Credentials
+	calls       int
+	err         error
+}
+
+func (p *rotatingCredentialProvider) Retrieve(context.Context) (aws.Credentials, error) {
+	if p.err != nil {
+		return aws.Credentials{}, p.err
+	}
+
+	credential := p.credentials[p.calls]
+	p.calls++
+
+	return credential, nil
+}
+
+func frozenCredential(accessKeyID, secretAccessKey, sessionToken string) aws.Credentials {
+	return aws.Credentials{
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: secretAccessKey,
+		SessionToken:    sessionToken,
+	}
+}
+
+func TestResolveFrozenAWSConvertsStaticSelectionToConcreteSnapshot(t *testing.T) {
+	t.Parallel()
+
+	resolution, err := credentials.ResolveFrozenAWS(
+		t.Context(),
+		frozenResolverFixture{values: map[credentials.Key]string{
+			credentials.AWSProfile:         "ignored-profile",
+			credentials.AWSAccessKeyID:     "selected-access",
+			credentials.AWSSecretAccessKey: "selected-secret",
+			credentials.AWSSessionToken:    "selected-session",
+		}},
+		"eu-north-1",
+	)
+	require.NoError(t, err)
+	assert.True(t, resolution.IsFrozen())
+	assert.Empty(t, resolution.Profile)
+	assert.Equal(t, "selected-access", resolution.AccessKeyID)
+	assert.Equal(t, "selected-secret", resolution.SecretAccessKey)
+	assert.Equal(t, "selected-session", resolution.SessionToken)
+}
+
+// TestFreezeAWSStaticSelectionPreservesProfileRegion verifies complete static credentials replace
+// only the identity provider. A valid selected profile may still supply non-credential settings,
+// including the region that both the SDK and eksctl mutation must share.
+func TestFreezeAWSStaticSelectionPreservesProfileRegion(t *testing.T) {
+	t.Parallel()
+
+	selection := credentials.ResolveAWS(frozenResolverFixture{values: map[credentials.Key]string{
+		credentials.AWSProfile:         "region-profile",
+		credentials.AWSAccessKeyID:     "selected-access",
+		credentials.AWSSecretAccessKey: "selected-secret",
+	}})
+	loaderCalls := 0
+
+	frozen, err := credentials.FreezeAWSResolutionForTest(
+		t.Context(),
+		"",
+		selection,
+		func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+			loaderCalls++
+
+			return aws.Config{Region: "ap-southeast-2"}, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, loaderCalls)
+	assert.Equal(t, "ap-southeast-2", frozen.Region)
+	assert.Empty(t, frozen.Profile)
+	assert.Equal(t, "selected-access", frozen.AccessKeyID)
+	assert.Equal(t, "selected-secret", frozen.SecretAccessKey)
+}
+
+func TestResolveFrozenAWSStaticSelectionPreservesDefaultRegion(t *testing.T) {
+	// Not parallel: t.Setenv changes the process environment.
+	missingConfigDir := t.TempDir()
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(missingConfigDir, "missing-config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(missingConfigDir, "missing-credentials"))
+	t.Setenv("AWS_ACCESS_KEY_ID", "selected-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "selected-secret")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "ca-central-1")
+
+	frozen, err := credentials.ResolveFrozenAWS(t.Context(), nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, "ca-central-1", frozen.Region)
+	assert.Contains(t, frozen.ChildEnvironment(nil), "AWS_REGION=ca-central-1")
+	assert.NotContains(t, frozen.ChildEnvironment(nil), "AWS_DEFAULT_REGION=ca-central-1")
+}
+
+// TestFrozenAWSConfigOptionPreservesNonIdentitySettings verifies the SDK snapshot retains resolved
+// transport and endpoint behavior while removing unrelated ambient provider material and pinning
+// the selected concrete credential tuple.
+func TestFrozenAWSConfigOptionPreservesNonIdentitySettings(t *testing.T) {
+	t.Parallel()
+
+	selection := credentials.ResolveAWS(frozenResolverFixture{values: map[credentials.Key]string{
+		credentials.AWSAccessKeyID:     "selected-access",
+		credentials.AWSSecretAccessKey: "selected-secret",
+	}})
+	baseEndpoint := "https://aws.fixture.invalid"
+	profileCredentials := frozenCredential("profile-access", "", "")
+
+	frozen, err := credentials.FreezeAWSResolutionForTest(
+		t.Context(),
+		"eu-north-1",
+		selection,
+		func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+			return aws.Config{
+				HTTPClient:   http.DefaultClient,
+				BaseEndpoint: aws.String(baseEndpoint),
+				ConfigSources: []any{
+					config.EnvConfig{
+						Credentials:  frozenCredential("ambient-access", "ambient-secret", ""),
+						BaseEndpoint: baseEndpoint,
+					},
+					//nolint:gosec // synthetic credentials verify identity fields are scrubbed
+					config.SharedConfig{
+						Credentials:       profileCredentials,
+						CredentialProcess: "ambient-credential-process",
+						BaseEndpoint:      baseEndpoint,
+					},
+				},
+			}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	options := credentials.OptionsForFrozenAWSConfig(
+		frozen,
+		func(config aws.Config) aws.Config { return config },
+		func(_, _, _, _ string) aws.Config { return aws.Config{} },
+		func() aws.Config { return aws.Config{} },
+	)
+	require.Len(t, options, 2)
+	assert.Same(t, http.DefaultClient, options[0].HTTPClient)
+	assert.Equal(t, baseEndpoint, aws.ToString(options[0].BaseEndpoint))
+
+	selected, err := options[0].Credentials.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "selected-access", selected.AccessKeyID)
+	assert.Equal(t, "selected-secret", selected.SecretAccessKey)
+
+	environmentSource, isEnvironmentConfig := options[0].ConfigSources[0].(config.EnvConfig)
+	require.True(t, isEnvironmentConfig)
+	assert.Empty(t, environmentSource.Credentials.AccessKeyID)
+	assert.Equal(t, baseEndpoint, environmentSource.BaseEndpoint)
+
+	sharedSource, isSharedConfig := options[0].ConfigSources[1].(config.SharedConfig)
+	require.True(t, isSharedConfig)
+	assert.Empty(t, sharedSource.Credentials.AccessKeyID)
+	assert.Empty(t, sharedSource.CredentialProcess)
+	assert.Equal(t, baseEndpoint, sharedSource.BaseEndpoint)
+}
+
+func TestFreezeAWSResolutionRetrievesProviderOnlyOnce(t *testing.T) {
+	t.Parallel()
+
+	provider := &rotatingCredentialProvider{credentials: []aws.Credentials{
+		frozenCredential(
+			"account-a-access",
+			"account-a-secret",
+			"account-a-session",
+		),
+		frozenCredential(
+			"account-b-access",
+			"account-b-secret",
+			"account-b-session",
+		),
+	}}
+	selection := credentials.ResolveAWS(frozenResolverFixture{
+		envVars: map[credentials.Key]string{credentials.AWSProfile: "KSAIL_PROFILE"},
+		values:  map[credentials.Key]string{credentials.AWSProfile: "rotating-profile"},
+	})
+
+	frozen, err := credentials.FreezeAWSResolutionForTest(
+		t.Context(),
+		"",
+		selection,
+		func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+			return aws.Config{Region: "eu-west-3", Credentials: provider}, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, "eu-west-3", frozen.Region)
+
+	child := frozen.ChildEnvironment([]string{
+		"AWS_PROFILE=rotating-profile",
+		"KSAIL_PROFILE=rotating-profile",
+		"AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/rotating-token",
+		"AWS_REGION=stale-region",
+	})
+	assert.Contains(t, child, "AWS_ACCESS_KEY_ID=account-a-access")
+	assert.Contains(t, child, "AWS_SECRET_ACCESS_KEY=account-a-secret")
+	assert.Contains(t, child, "AWS_SESSION_TOKEN=account-a-session")
+	assert.NotContains(t, child, "AWS_PROFILE=rotating-profile")
+	assert.NotContains(t, child, "KSAIL_PROFILE=rotating-profile")
+	assert.NotContains(t, child, "AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/rotating-token")
+	assert.Contains(t, child, "AWS_REGION=eu-west-3")
+	assert.NotContains(t, child, "AWS_REGION=stale-region")
+	assert.Equal(t, 1, provider.calls, "rendering mutation options must not re-resolve credentials")
+}
+
+func TestResolveFrozenAWSFailsClosedForInvalidOrUnavailableSelection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("partial static tuple", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := credentials.ResolveFrozenAWS(
+			t.Context(),
+			frozenResolverFixture{values: map[credentials.Key]string{
+				credentials.AWSAccessKeyID: "access-only",
+			}},
+			"eu-north-1",
+		)
+		require.ErrorIs(t, err, credentials.ErrIncompleteAWSStaticCredentials)
+	})
+
+	t.Run("custom alias unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := credentials.ResolveFrozenAWS(
+			t.Context(),
+			frozenResolverFixture{
+				envVars: map[credentials.Key]string{credentials.AWSProfile: "KSAIL_PROFILE"},
+				values:  map[credentials.Key]string{},
+			},
+			"eu-north-1",
+		)
+		require.ErrorIs(t, err, credentials.ErrExplicitAWSCredentialsUnavailable)
+	})
+
+	t.Run("provider query failure", func(t *testing.T) {
+		t.Parallel()
+
+		selection := credentials.ResolveAWS(frozenResolverFixture{})
+		_, err := credentials.FreezeAWSResolutionForTest(
+			t.Context(),
+			"eu-north-1",
+			selection,
+			func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+				return aws.Config{
+					Credentials: &rotatingCredentialProvider{err: errFrozenCredentialQuery},
+				}, nil
+			},
+		)
+		require.ErrorIs(t, err, errFrozenCredentialQuery)
+	})
+}

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 )
 
@@ -174,17 +175,22 @@ func (r AWSOptionsResolver) Value(key Key) string {
 	return resolveEnvValue(key, r.EnvVar(key))
 }
 
-// AWSResolution is an immutable snapshot of the credential selection for one
-// AWS operation. Source variable names are retained privately so child process
-// environments can remove both stale canonical values and custom aliases.
+// AWSResolution is an immutable snapshot of an AWS credential selection. ResolveFrozenAWS upgrades
+// it to one concrete credential tuple for identity-sensitive operations. Source variable names are
+// retained privately so child process environments can remove both stale canonical values and
+// custom aliases.
 type AWSResolution struct {
+	Region          string
 	Profile         string
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string
 
 	sourceEnvVars          [4]string
+	sourceRegionEnvVar     string
 	hasCustomCredentialEnv bool
+	frozen                 bool
+	sdkConfig              *aws.Config
 }
 
 // ResolveAWS snapshots all AWS credential values and their configured source
@@ -197,11 +203,13 @@ func ResolveAWS(resolver Resolver) AWSResolution {
 	// Resolve every value before constructing the child environment. No parent
 	// environment mutation is needed, so concurrent invocations remain isolated.
 	resolution := AWSResolution{
+		Region:          resolver.Value(AWSRegion),
 		Profile:         resolver.Value(AWSProfile),
 		AccessKeyID:     resolver.Value(AWSAccessKeyID),
 		SecretAccessKey: resolver.Value(AWSSecretAccessKey),
 		SessionToken:    resolver.Value(AWSSessionToken),
 	}
+	resolution.sourceRegionEnvVar = resolver.EnvVar(AWSRegion)
 
 	credentialSources := [...]struct {
 		key           Key
@@ -232,6 +240,11 @@ func (r AWSResolution) HasCustomCredentialSources() bool {
 	return r.hasCustomCredentialEnv
 }
 
+// IsFrozen reports whether the selection was resolved to one concrete static credential tuple.
+func (r AWSResolution) IsFrozen() bool {
+	return r.frozen
+}
+
 // OptionsForAWSResolution maps a resolved AWS identity into a consumer's
 // option type. Custom source names add the consumer's fail-closed option so an
 // unset alias cannot silently fall back to an unrelated ambient identity.
@@ -249,7 +262,33 @@ func OptionsForAWSResolution[T any](
 
 	return optionsWithCredentialRequirement(
 		option,
-		resolution.HasCustomCredentialSources(),
+		resolution.requiresCredentialValues(),
+		requireCredentialValues,
+	)
+}
+
+// OptionsForFrozenAWSConfig maps a frozen resolution's complete SDK configuration snapshot when
+// available, preserving resolved non-credential settings while pinning the concrete credentials.
+// Mutable/non-frozen resolutions retain the value-based compatibility path.
+func OptionsForFrozenAWSConfig[T any](
+	resolution AWSResolution,
+	withAWSConfig func(config aws.Config) T,
+	withCredentialValues func(profile, accessKeyID, secretAccessKey, sessionToken string) T,
+	requireCredentialValues func() T,
+) []T {
+	if resolution.sdkConfig == nil {
+		return OptionsForAWSResolution(
+			resolution,
+			withCredentialValues,
+			requireCredentialValues,
+		)
+	}
+
+	option := withAWSConfig(cloneAWSConfig(*resolution.sdkConfig))
+
+	return optionsWithCredentialRequirement(
+		option,
+		resolution.requiresCredentialValues(),
 		requireCredentialValues,
 	)
 }
@@ -265,7 +304,7 @@ func OptionsForAWSChildEnvironment[T any](
 ) []T {
 	return optionsWithCredentialRequirement(
 		withEnvironment(resolution.ChildEnvironment(parent)),
-		resolution.HasCustomCredentialSources(),
+		resolution.requiresCredentialValues(),
 		requireCredentialValues,
 	)
 }
@@ -314,6 +353,13 @@ func optionsWithCredentialRequirement[T any](
 	return options
 }
 
+func cloneAWSConfig(config aws.Config) aws.Config {
+	config.ConfigSources = append(config.ConfigSources[:0:0], config.ConfigSources...)
+	config.APIOptions = append(config.APIOptions[:0:0], config.APIOptions...)
+
+	return config
+}
+
 // ChildEnvironment returns a copy of parent with AWS credential aliases and
 // stale canonical values removed, followed by the non-empty resolved values
 // under the canonical names eksctl understands. When a custom credential source
@@ -339,7 +385,15 @@ func (r AWSResolution) ChildEnvironment(parent []string) []string {
 		}
 	}
 
+	if r.frozen && r.Region != "" {
+		child = append(child, defaultAWSRegionEnvVar+"="+r.Region)
+	}
+
 	return child
+}
+
+func (r AWSResolution) requiresCredentialValues() bool {
+	return r.HasCustomCredentialSources() || r.IsFrozen()
 }
 
 // strippedEnvironmentNames returns normalized aliases and competing provider
@@ -361,7 +415,7 @@ func (r AWSResolution) strippedEnvironmentNames(caseInsensitive bool) map[string
 		}
 	}
 
-	if r.hasCustomCredentialEnv {
+	if r.hasCustomCredentialEnv || r.frozen {
 		for _, name := range []string{
 			"AWS_DEFAULT_PROFILE",
 			"AWS_ACCESS_KEY",
@@ -369,8 +423,24 @@ func (r AWSResolution) strippedEnvironmentNames(caseInsensitive bool) map[string
 			"AWS_WEB_IDENTITY_TOKEN_FILE",
 			"AWS_ROLE_ARN",
 			"AWS_ROLE_SESSION_NAME",
+			"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+			"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+			"AWS_CONTAINER_AUTHORIZATION_TOKEN",
+			"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
 		} {
 			strippedNames[normalizeEnvironmentName(name, caseInsensitive)] = struct{}{}
+		}
+	}
+
+	if r.frozen {
+		for _, name := range []string{
+			defaultAWSRegionEnvVar,
+			"AWS_DEFAULT_REGION",
+			r.sourceRegionEnvVar,
+		} {
+			if name != "" {
+				strippedNames[normalizeEnvironmentName(name, caseInsensitive)] = struct{}{}
+			}
 		}
 	}
 

--- a/pkg/svc/credentials/export_test.go
+++ b/pkg/svc/credentials/export_test.go
@@ -1,0 +1,18 @@
+package credentials
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+// FreezeAWSResolutionForTest exposes credential-provider injection to external package tests.
+func FreezeAWSResolutionForTest(
+	ctx context.Context,
+	region string,
+	selection AWSResolution,
+	loader func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error),
+) (AWSResolution, error) {
+	return freezeAWSResolution(ctx, region, selection, awsConfigLoader(loader))
+}

--- a/pkg/svc/eksidentity/identity.go
+++ b/pkg/svc/eksidentity/identity.go
@@ -1,0 +1,257 @@
+// Package eksidentity captures and verifies the immutable AWS identity of KSail-managed EKS
+// clusters. It deliberately contains no lifecycle mutation: callers use it as a fail-closed
+// precondition before delete or nodegroup scaling.
+package eksidentity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+)
+
+var (
+	// ErrIdentityMismatch reports that the current AWS identity or live cluster does not match the
+	// immutable ownership record captured by KSail.
+	ErrIdentityMismatch = errors.New("EKS ownership identity mismatch")
+	// ErrInvalidLiveIdentity reports an incomplete or internally inconsistent AWS response.
+	ErrInvalidLiveIdentity = errors.New("invalid live EKS identity")
+)
+
+// Client is the read-only AWS surface needed to bind and verify EKS ownership. *pkg/client/eks.Client
+// satisfies it, while tests can provide credential-free fakes.
+type Client interface {
+	CallerAccountID(ctx context.Context) (string, error)
+	DescribeCluster(ctx context.Context, name string) (*ekstypes.Cluster, error)
+}
+
+// Verifier rechecks that the current AWS account and exact live EKS incarnation still match the
+// immutable ownership record captured before a lifecycle operation began.
+type Verifier func(context.Context) error
+
+// VerifyBeforeMutation invokes verifier at the narrowest mutation boundary. A nil verifier keeps
+// non-EKS and create-only paths unchanged.
+func VerifyBeforeMutation(ctx context.Context, verifier Verifier) error {
+	if verifier == nil {
+		return nil
+	}
+
+	err := verifier(ctx)
+	if err != nil {
+		return fmt.Errorf("reverify immutable EKS ownership before mutation: %w", err)
+	}
+
+	return nil
+}
+
+// Capture observes the current caller and live cluster, validates their relationship, and atomically
+// stores the immutable identity. It performs no AWS mutation and is suitable after create or during
+// an explicit legacy-state rebind.
+func Capture(
+	ctx context.Context,
+	client Client,
+	clusterName, region string,
+) (*state.EKSOwnershipState, error) {
+	ownership, err := Observe(ctx, client, clusterName, region)
+	if err != nil {
+		return nil, err
+	}
+
+	err = Persist(clusterName, ownership.Region, ownership)
+	if err != nil {
+		return nil, err
+	}
+
+	return ownership, nil
+}
+
+// Persist replaces the immutable ownership identity only after removing any transient nodegroup
+// capacity snapshot keyed to the same name and region. Capacity state predates immutable ownership
+// and cannot safely be carried across a create or explicit rebind to another EKS incarnation.
+func Persist(clusterName, region string, ownership *state.EKSOwnershipState) error {
+	err := state.DeleteEKSNodegroupState(clusterName, region)
+	if err != nil {
+		return fmt.Errorf(
+			"clear stale EKS nodegroup capacity state before ownership capture: %w",
+			err,
+		)
+	}
+
+	err = state.SaveEKSOwnershipState(clusterName, region, ownership)
+	if err != nil {
+		return fmt.Errorf("persist immutable EKS ownership identity: %w", err)
+	}
+
+	return nil
+}
+
+// NewVerifier loads the persisted ownership identity once and returns a verifier closed over that
+// immutable snapshot. Reusing the returned verifier across prompts and read phases prevents a
+// concurrent create or rebind from silently retargeting an in-flight mutation to a replacement.
+func NewVerifier(client Client, clusterName, region string) (Verifier, error) {
+	expected, err := state.LoadEKSOwnershipState(clusterName, region)
+	if err != nil {
+		return nil, migrationRequiredError(clusterName, err)
+	}
+
+	expectedSnapshot := *expected
+
+	return func(ctx context.Context) error {
+		return verifyExpected(ctx, client, clusterName, region, &expectedSnapshot)
+	}, nil
+}
+
+// Verify fails closed unless the current AWS account and exact live EKS incarnation match the
+// currently persisted ownership identity. Callers that span prompts or other read phases should use
+// NewVerifier and reuse its immutable snapshot for every later mutation boundary.
+func Verify(ctx context.Context, client Client, clusterName, region string) error {
+	verifier, err := NewVerifier(client, clusterName, region)
+	if err != nil {
+		return err
+	}
+
+	return verifier(ctx)
+}
+
+func verifyExpected(
+	ctx context.Context,
+	client Client,
+	clusterName, region string,
+	expected *state.EKSOwnershipState,
+) error {
+	accountID, err := client.CallerAccountID(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve current AWS account for EKS ownership verification: %w", err)
+	}
+
+	accountID = strings.TrimSpace(accountID)
+	if accountID != expected.AccountID {
+		return fmt.Errorf(
+			"%w: current AWS account %q does not match persisted account %q",
+			ErrIdentityMismatch,
+			accountID,
+			expected.AccountID,
+		)
+	}
+
+	cluster, err := client.DescribeCluster(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("describe EKS cluster for ownership verification: %w", err)
+	}
+
+	live, err := identityFromCluster(clusterName, region, accountID, cluster)
+	if err != nil {
+		return err
+	}
+
+	if live.ClusterARN != expected.ClusterARN {
+		return fmt.Errorf(
+			"%w: live cluster ARN %q does not match persisted ARN %q",
+			ErrIdentityMismatch,
+			live.ClusterARN,
+			expected.ClusterARN,
+		)
+	}
+
+	if !live.CreatedAt.Equal(expected.CreatedAt) {
+		return fmt.Errorf(
+			"%w: live cluster creation time %s does not match persisted creation time %s",
+			ErrIdentityMismatch,
+			live.CreatedAt.Format("2006-01-02T15:04:05.999999999Z07:00"),
+			expected.CreatedAt.Format("2006-01-02T15:04:05.999999999Z07:00"),
+		)
+	}
+
+	return nil
+}
+
+// Observe returns the validated live identity without persisting or mutating anything. It is used by
+// the explicit rebind flow so users can review the target before confirming the local state write.
+func Observe(
+	ctx context.Context,
+	client Client,
+	clusterName, region string,
+) (*state.EKSOwnershipState, error) {
+	accountID, err := client.CallerAccountID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve current AWS account for EKS ownership capture: %w", err)
+	}
+
+	cluster, err := client.DescribeCluster(ctx, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("describe EKS cluster for ownership capture: %w", err)
+	}
+
+	return identityFromCluster(clusterName, region, strings.TrimSpace(accountID), cluster)
+}
+
+func identityFromCluster( //nolint:cyclop // one validation boundary intentionally checks every AWS identity field.
+	clusterName, region, accountID string,
+	cluster *ekstypes.Cluster,
+) (*state.EKSOwnershipState, error) {
+	clusterName = strings.TrimSpace(clusterName)
+	region = strings.TrimSpace(region)
+	accountID = strings.TrimSpace(accountID)
+
+	if cluster == nil || strings.TrimSpace(aws.ToString(cluster.Name)) != clusterName ||
+		strings.TrimSpace(aws.ToString(cluster.Arn)) == "" || cluster.CreatedAt == nil ||
+		cluster.CreatedAt.IsZero() {
+		return nil, fmt.Errorf(
+			"%w: cluster name, ARN, or creation time is missing or does not match",
+			ErrInvalidLiveIdentity,
+		)
+	}
+
+	clusterARN := strings.TrimSpace(aws.ToString(cluster.Arn))
+
+	parsedARN, err := awsarn.Parse(clusterARN)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse cluster ARN: %w", ErrInvalidLiveIdentity, err)
+	}
+
+	if region == "" {
+		region = parsedARN.Region
+	}
+
+	if parsedARN.Service != "eks" || parsedARN.Region != region ||
+		parsedARN.Resource != "cluster/"+clusterName {
+		return nil, fmt.Errorf(
+			"%w: cluster ARN does not match the resolved name and region",
+			ErrInvalidLiveIdentity,
+		)
+	}
+
+	if parsedARN.AccountID != accountID {
+		return nil, fmt.Errorf(
+			"%w: caller account %q does not own live cluster account %q",
+			ErrIdentityMismatch,
+			accountID,
+			parsedARN.AccountID,
+		)
+	}
+
+	return &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: clusterName,
+		Region:      region,
+		AccountID:   accountID,
+		ClusterARN:  clusterARN,
+		CreatedAt:   cluster.CreatedAt.UTC(),
+	}, nil
+}
+
+func migrationRequiredError(clusterName string, cause error) error {
+	return fmt.Errorf(
+		"immutable EKS ownership identity is missing or invalid for %q: %w; "+
+			"after confirming the current AWS credentials select the intended cluster, "+
+			"run `ksail cluster eks-bind --name %s --provider AWS --experimental`",
+		clusterName,
+		cause,
+		clusterName,
+	)
+}

--- a/pkg/svc/eksidentity/identity_test.go
+++ b/pkg/svc/eksidentity/identity_test.go
@@ -1,0 +1,295 @@
+package eksidentity_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errIdentityQuery = errors.New("identity query failed")
+
+type fakeClient struct {
+	accountID     string
+	accountErr    error
+	cluster       *ekstypes.Cluster
+	describeErr   error
+	describeCalls int
+}
+
+func (f *fakeClient) CallerAccountID(_ context.Context) (string, error) {
+	return f.accountID, f.accountErr
+}
+
+func (f *fakeClient) DescribeCluster(_ context.Context, _ string) (*ekstypes.Cluster, error) {
+	f.describeCalls++
+
+	return f.cluster, f.describeErr
+}
+
+func TestCapturePersistsImmutableEKSIdentity(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	client := &fakeClient{
+		accountID: "123456789012",
+		cluster: eksCluster(
+			"capture-identity",
+			"arn:aws:eks:eu-north-1:123456789012:cluster/capture-identity",
+			createdAt,
+		),
+	}
+
+	got, err := eksidentity.Capture(
+		t.Context(), client, "capture-identity", "eu-north-1",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", got.AccountID)
+	assert.Equal(t, createdAt, got.CreatedAt)
+
+	persisted, err := state.LoadEKSOwnershipState("capture-identity", "eu-north-1")
+	require.NoError(t, err)
+	assert.Equal(t, got, persisted)
+}
+
+func TestCaptureClearsStaleNodegroupCapacityState(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "capture-clears-stale-nodegroups"
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	require.NoError(t, state.SaveEKSNodegroupState(
+		clusterName,
+		"eu-north-1",
+		&state.EKSNodegroupState{
+			Version:     state.EKSNodegroupStateVersion,
+			ClusterName: clusterName,
+			Region:      "eu-north-1",
+			Nodegroups: []state.EKSNodegroupCapacity{{
+				Name:            "workers",
+				DesiredCapacity: 3,
+				MinSize:         1,
+				MaxSize:         5,
+			}},
+		},
+	))
+
+	client := &fakeClient{
+		accountID: "123456789012",
+		cluster: eksCluster(
+			clusterName,
+			"arn:aws:eks:eu-north-1:123456789012:cluster/"+clusterName,
+			identityTime(),
+		),
+	}
+
+	_, err := eksidentity.Capture(t.Context(), client, clusterName, "eu-north-1")
+	require.NoError(t, err)
+
+	_, err = state.LoadEKSNodegroupState(clusterName, "eu-north-1")
+	require.ErrorIs(t, err, state.ErrEKSNodegroupStateNotFound)
+}
+
+func TestCaptureFailsClosedWhenNodegroupCapacityStateCannotBeCleared(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "capture-nodegroup-clear-failure"
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	blockedStatePath := filepath.Join(
+		home,
+		".ksail",
+		"clusters",
+		clusterName,
+		"eks-nodegroups-eu-north-1.json",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Join(blockedStatePath, "blocker"), 0o700))
+
+	client := &fakeClient{
+		accountID: "123456789012",
+		cluster: eksCluster(
+			clusterName,
+			"arn:aws:eks:eu-north-1:123456789012:cluster/"+clusterName,
+			identityTime(),
+		),
+	}
+
+	_, err = eksidentity.Capture(t.Context(), client, clusterName, "eu-north-1")
+	require.ErrorContains(t, err, "clear stale EKS nodegroup capacity state")
+
+	_, loadErr := state.LoadEKSOwnershipState(clusterName, "eu-north-1")
+	require.ErrorIs(t, loadErr, state.ErrEKSOwnershipStateNotFound)
+}
+
+func TestVerifyRejectsDifferentAccountBeforeDescribe(t *testing.T) {
+	t.Parallel()
+
+	persistOwnership(t, "account-mismatch", identityTime())
+
+	client := &fakeClient{accountID: "210987654321"}
+
+	err := eksidentity.Verify(t.Context(), client, "account-mismatch", "eu-north-1")
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	require.ErrorContains(t, err, "AWS account")
+	assert.Zero(t, client.describeCalls)
+}
+
+func TestVerifyRejectsSameARNReplacement(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "same-arn-replacement"
+	arn := "arn:aws:eks:eu-north-1:123456789012:cluster/" + clusterName
+	persistOwnership(t, clusterName, identityTime())
+	client := &fakeClient{
+		accountID: "123456789012",
+		cluster: eksCluster(
+			clusterName,
+			arn,
+			identityTime().Add(time.Minute),
+		),
+	}
+
+	err := eksidentity.Verify(t.Context(), client, clusterName, "eu-north-1")
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	require.ErrorContains(t, err, "creation time")
+}
+
+func TestVerifyRejectsDifferentClusterARN(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "arn-mismatch"
+	persistOwnership(t, clusterName, identityTime())
+	client := &fakeClient{
+		accountID: "123456789012",
+		cluster: eksCluster(
+			clusterName,
+			"arn:aws-us-gov:eks:eu-north-1:123456789012:cluster/"+clusterName,
+			identityTime(),
+		),
+	}
+
+	err := eksidentity.Verify(t.Context(), client, clusterName, "eu-north-1")
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	require.ErrorContains(t, err, "cluster ARN")
+}
+
+func TestCapturedVerifierRejectsReplacementAfterOwnershipStateChanges(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "captured-verifier-state-replacement"
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	createdAt := identityTime()
+	persistOwnership(t, clusterName, createdAt)
+
+	client := &fakeClient{
+		accountID: "123456789012",
+		cluster: eksCluster(
+			clusterName,
+			"arn:aws:eks:eu-north-1:123456789012:cluster/"+clusterName,
+			createdAt,
+		),
+	}
+
+	verifier, err := eksidentity.NewVerifier(client, clusterName, "eu-north-1")
+	require.NoError(t, err)
+	require.NoError(t, verifier(t.Context()))
+
+	replacementTime := createdAt.Add(time.Minute)
+	persistOwnership(t, clusterName, replacementTime)
+	client.cluster = eksCluster(
+		clusterName,
+		"arn:aws:eks:eu-north-1:123456789012:cluster/"+clusterName,
+		replacementTime,
+	)
+
+	err = verifier(t.Context())
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	require.ErrorContains(t, err, "creation time")
+}
+
+func TestVerifyLegacyStateFailsClosedWithRebindCommand(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeClient{accountID: "123456789012"}
+
+	err := eksidentity.Verify(t.Context(), client, "legacy-state", "eu-north-1")
+	require.ErrorIs(t, err, state.ErrEKSOwnershipStateNotFound)
+	require.ErrorContains(
+		t,
+		err,
+		"ksail cluster eks-bind --name legacy-state --provider AWS --experimental",
+	)
+	assert.Zero(t, client.describeCalls)
+}
+
+func TestVerifyPropagatesIdentityQueriesWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "query-failure"
+	persistOwnership(t, clusterName, identityTime())
+
+	t.Run("caller identity", func(t *testing.T) {
+		t.Parallel()
+
+		client := &fakeClient{accountErr: errIdentityQuery}
+		err := eksidentity.Verify(t.Context(), client, clusterName, "eu-north-1")
+		require.ErrorIs(t, err, errIdentityQuery)
+		assert.Zero(t, client.describeCalls)
+	})
+
+	t.Run("describe cluster", func(t *testing.T) {
+		t.Parallel()
+
+		client := &fakeClient{accountID: "123456789012", describeErr: errIdentityQuery}
+		err := eksidentity.Verify(t.Context(), client, clusterName, "eu-north-1")
+		require.ErrorIs(t, err, errIdentityQuery)
+		assert.Equal(t, 1, client.describeCalls)
+	})
+}
+
+func persistOwnership(t *testing.T, clusterName string, createdAt time.Time) {
+	t.Helper()
+
+	const accountID = "123456789012"
+
+	require.NoError(t, state.SaveEKSOwnershipState(
+		clusterName,
+		"eu-north-1",
+		&state.EKSOwnershipState{
+			Version:     state.EKSOwnershipStateVersion,
+			ClusterName: clusterName,
+			Region:      "eu-north-1",
+			AccountID:   accountID,
+			ClusterARN:  "arn:aws:eks:eu-north-1:" + accountID + ":cluster/" + clusterName,
+			CreatedAt:   createdAt,
+		},
+	))
+}
+
+func eksCluster(name, arn string, createdAt time.Time) *ekstypes.Cluster {
+	return &ekstypes.Cluster{
+		Name:      aws.String(name),
+		Arn:       aws.String(arn),
+		CreatedAt: aws.Time(createdAt),
+	}
+}
+
+func identityTime() time.Time {
+	return time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+}

--- a/pkg/svc/eksidentity/main_test.go
+++ b/pkg/svc/eksidentity/main_test.go
@@ -1,0 +1,12 @@
+package eksidentity_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/internal/testutil/homeenv"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(homeenv.Run(m))
+}

--- a/pkg/svc/provider/aws/nodegroup_state.go
+++ b/pkg/svc/provider/aws/nodegroup_state.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
 
@@ -319,30 +320,52 @@ func (p *Provider) startNodegroupsWithoutSnapshot(
 			continue
 		}
 
-		// Without a snapshot the pre-stop desired size is unknowable, so fall back to the smallest
-		// running capacity that honours the group's own minimum — the behaviour every release before
-		// capacity snapshots used.
-		target := max(nodegroup.MinSize, 1)
-
-		slog.Warn(
-			"restoring EKS nodegroup without a capacity snapshot; pre-stop desired size is unknown",
-			"cluster", clusterName,
-			"nodegroup", nodegroup.Name,
-			"target", target,
-		)
-
-		err := p.client.ScaleNodegroup(
-			ctx,
-			clusterName,
-			nodegroup.Name,
-			p.region,
-			target,
-			nodegroup.MinSize,
-			nodegroup.MaxSize,
-		)
+		err := p.startNodegroupWithoutSnapshot(ctx, clusterName, nodegroup)
 		if err != nil {
-			return fmt.Errorf("start nodes: scale nodegroup %s: %w", nodegroup.Name, err)
+			return err
 		}
+	}
+
+	return nil
+}
+
+func (p *Provider) startNodegroupWithoutSnapshot(
+	ctx context.Context,
+	clusterName string,
+	nodegroup eksctlclient.NodegroupSummary,
+) error {
+	// Without a snapshot the pre-stop desired size is unknowable, so fall back to the smallest
+	// running capacity that honours the group's own minimum — the behaviour every release before
+	// capacity snapshots used.
+	target := max(nodegroup.MinSize, 1)
+
+	slog.Warn(
+		"restoring EKS nodegroup without a capacity snapshot; pre-stop desired size is unknown",
+		"cluster", clusterName,
+		"nodegroup", nodegroup.Name,
+		"target", target,
+	)
+
+	err := eksidentity.VerifyBeforeMutation(ctx, p.ownershipVerifier)
+	if err != nil {
+		return fmt.Errorf(
+			"reverify immutable EKS ownership before starting nodegroup %q: %w",
+			nodegroup.Name,
+			err,
+		)
+	}
+
+	err = p.client.ScaleNodegroup(
+		ctx,
+		clusterName,
+		nodegroup.Name,
+		p.region,
+		target,
+		nodegroup.MinSize,
+		nodegroup.MaxSize,
+	)
+	if err != nil {
+		return fmt.Errorf("start nodes: scale nodegroup %s: %w", nodegroup.Name, err)
 	}
 
 	return nil
@@ -359,7 +382,16 @@ func (p *Provider) restoreSavedNodegroups(
 			continue
 		}
 
-		err := p.client.ScaleNodegroup(
+		err := eksidentity.VerifyBeforeMutation(ctx, p.ownershipVerifier)
+		if err != nil {
+			return fmt.Errorf(
+				"reverify immutable EKS ownership before restoring nodegroup %q: %w",
+				capacity.Name,
+				err,
+			)
+		}
+
+		err = p.client.ScaleNodegroup(
 			ctx,
 			clusterName,
 			capacity.Name,

--- a/pkg/svc/provider/aws/provider.go
+++ b/pkg/svc/provider/aws/provider.go
@@ -10,6 +10,7 @@ import (
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
@@ -33,6 +34,7 @@ type Provider struct {
 	describer               clusterDescriber
 	eksClientOptions        []eksclient.Option
 	requireCredentialValues bool
+	ownershipVerifier       eksidentity.Verifier
 }
 
 // Option customises a Provider.
@@ -58,11 +60,27 @@ func WithCredentialValues(profile, accessKeyID, secretAccessKey, sessionToken st
 	}
 }
 
+// WithAWSConfig pins the complete frozen SDK configuration used by the provider's lazy EKS
+// client, retaining non-credential endpoint and transport settings from the ownership guard.
+func WithAWSConfig(config awssdk.Config) Option {
+	return func(p *Provider) {
+		p.eksClientOptions = []eksclient.Option{eksclient.WithAWSConfig(config)}
+	}
+}
+
 // RequireCredentialValues prevents the lazy SDK client from falling back to
 // ambient canonical credentials when custom sources resolved no values.
 func RequireCredentialValues() Option {
 	return func(p *Provider) {
 		p.requireCredentialValues = true
+	}
+}
+
+// WithOwnershipVerifier injects the immutable EKS identity boundary used immediately before each
+// nodegroup scaling mutation.
+func WithOwnershipVerifier(verifier eksidentity.Verifier) Option {
+	return func(p *Provider) {
+		p.ownershipVerifier = verifier
 	}
 }
 
@@ -81,6 +99,7 @@ func NewProvider(client *eksctlclient.Client, region string, opts ...Option) (*P
 		describer:               nil,
 		eksClientOptions:        nil,
 		requireCredentialValues: false,
+		ownershipVerifier:       nil,
 	}
 
 	for _, opt := range opts {
@@ -153,17 +172,9 @@ func (p *Provider) StopNodes(ctx context.Context, clusterName string) error {
 			continue
 		}
 
-		err = target.client.ScaleNodegroup(
-			ctx,
-			clusterName,
-			capacity.Name,
-			target.region,
-			0,
-			0,
-			capacity.MaxSize,
-		)
+		err = target.stopNodegroup(ctx, clusterName, capacity)
 		if err != nil {
-			return fmt.Errorf("stop nodes: scale nodegroup %s: %w", capacity.Name, err)
+			return err
 		}
 	}
 
@@ -277,6 +288,36 @@ func (p *Provider) GetClusterStatus(
 // Region returns the AWS region this provider was configured with.
 func (p *Provider) Region() string {
 	return p.region
+}
+
+func (p *Provider) stopNodegroup(
+	ctx context.Context,
+	clusterName string,
+	capacity state.EKSNodegroupCapacity,
+) error {
+	err := eksidentity.VerifyBeforeMutation(ctx, p.ownershipVerifier)
+	if err != nil {
+		return fmt.Errorf(
+			"reverify immutable EKS ownership before stopping nodegroup %q: %w",
+			capacity.Name,
+			err,
+		)
+	}
+
+	err = p.client.ScaleNodegroup(
+		ctx,
+		clusterName,
+		capacity.Name,
+		p.region,
+		0,
+		0,
+		capacity.MaxSize,
+	)
+	if err != nil {
+		return fmt.Errorf("stop nodes: scale nodegroup %s: %w", capacity.Name, err)
+	}
+
+	return nil
 }
 
 // loadLifecycleNodegroupsAndState gives both nodegroup lifecycle paths one exact-region preflight.

--- a/pkg/svc/provisioner/cluster/eks/provisioner.go
+++ b/pkg/svc/provisioner/cluster/eks/provisioner.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
 	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 )
@@ -43,6 +45,8 @@ type Provisioner struct {
 	eksClientOptions []eksclient.Option
 	// requireCredentialValues prevents ambient fallback when custom sources are unset.
 	requireCredentialValues bool
+	// ownershipVerifier rechecks immutable identity immediately before EKS mutations.
+	ownershipVerifier eksidentity.Verifier
 	// awsMu guards the lazy awsClient resolution.
 	awsMu sync.Mutex
 }
@@ -68,11 +72,27 @@ func WithCredentialValues(profile, accessKeyID, secretAccessKey, sessionToken st
 	}
 }
 
+// WithAWSConfig pins the complete frozen SDK configuration used by the provisioner's lazy EKS/STS
+// client, retaining non-credential endpoint and transport settings from the ownership guard.
+func WithAWSConfig(config aws.Config) Option {
+	return func(p *Provisioner) {
+		p.eksClientOptions = []eksclient.Option{eksclient.WithAWSConfig(config)}
+	}
+}
+
 // RequireCredentialValues prevents the lazy connector SDK client from falling
 // back to ambient canonical credentials when custom sources resolved no values.
 func RequireCredentialValues() Option {
 	return func(p *Provisioner) {
 		p.requireCredentialValues = true
+	}
+}
+
+// WithOwnershipVerifier injects the immutable EKS identity boundary used immediately before
+// delete. Nodegroup mutations receive the same verifier through the AWS provider.
+func WithOwnershipVerifier(verifier eksidentity.Verifier) Option {
+	return func(p *Provisioner) {
+		p.ownershipVerifier = verifier
 	}
 }
 
@@ -104,6 +124,7 @@ func NewProvisioner(
 		awsClient:               nil,
 		eksClientOptions:        nil,
 		requireCredentialValues: false,
+		ownershipVerifier:       nil,
 		awsMu:                   sync.Mutex{},
 	}
 
@@ -153,6 +174,11 @@ func (p *Provisioner) Delete(ctx context.Context, name string) error {
 	err := p.client.CheckAvailable()
 	if err != nil {
 		return fmt.Errorf("eksctl unavailable: %w", err)
+	}
+
+	err = eksidentity.VerifyBeforeMutation(ctx, p.ownershipVerifier)
+	if err != nil {
+		return fmt.Errorf("verify EKS ownership before delete: %w", err)
 	}
 
 	// Keep configPath empty so DeleteCluster cannot replace the validated exact

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/detector"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"sigs.k8s.io/yaml"
@@ -246,6 +247,23 @@ func (u *UpdatableProvisioner) scaleNodegroup(
 	group managedNodeGroupConfig,
 	live eksctl.NodegroupSummary,
 ) error {
+	err := eksidentity.VerifyBeforeMutation(ctx, u.ownershipVerifier)
+	if err != nil {
+		return fmt.Errorf("verify EKS ownership before scaling nodegroup: %w", err)
+	}
+
+	desiredCapacity, minSize, maxSize := nodegroupScaleTargets(group, live)
+
+	//nolint:wrapcheck // wrapped by the caller with the nodegroup name.
+	return u.client.ScaleNodegroup(
+		ctx, clusterName, group.Name, u.region, desiredCapacity, minSize, maxSize,
+	)
+}
+
+func nodegroupScaleTargets(
+	group managedNodeGroupConfig,
+	live eksctl.NodegroupSummary,
+) (int, int, int) {
 	minSize := -1
 	if group.MinSize != nil && *group.MinSize != live.MinSize {
 		minSize = *group.MinSize
@@ -269,10 +287,7 @@ func (u *UpdatableProvisioner) scaleNodegroup(
 		}
 	}
 
-	//nolint:wrapcheck // wrapped by the caller with the nodegroup name.
-	return u.client.ScaleNodegroup(
-		ctx, clusterName, group.Name, u.region, desiredCapacity, minSize, maxSize,
-	)
+	return desiredCapacity, minSize, maxSize
 }
 
 // desiredNodegroups parses the managedNodeGroups block of the declarative

--- a/pkg/svc/provisioner/cluster/eks/update_test.go
+++ b/pkg/svc/provisioner/cluster/eks/update_test.go
@@ -1,6 +1,7 @@
 package eksprovisioner_test
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
@@ -61,6 +63,7 @@ func newUpdatableProvisioner(
 	t *testing.T,
 	responses map[string][]response,
 	configPath string,
+	opts ...eksprovisioner.Option,
 ) (*eksprovisioner.UpdatableProvisioner, *scriptedRunner) {
 	t.Helper()
 
@@ -72,7 +75,7 @@ func newUpdatableProvisioner(
 	)
 
 	prov, err := eksprovisioner.NewProvisioner(
-		"ksail-test", "us-east-1", configPath, client, nil,
+		"ksail-test", "us-east-1", configPath, client, nil, opts...,
 	)
 	require.NoError(t, err)
 
@@ -215,6 +218,34 @@ func TestUpdate_AppliesNodegroupScaling(t *testing.T) {
 		"--nodes", "3",
 		"--region", "us-east-1",
 	}, scaleCall)
+}
+
+func TestUpdate_RechecksImmutableIdentityAfterReadsBeforeScaling(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeUpdateTestConfig(t, updateTestConfig)
+	verifierCalls := 0
+	prov, runner := newUpdatableProvisioner(t, map[string][]response{
+		"get nodegroup": {
+			{stdout: []byte(liveNodegroupsJSON)},
+			{stdout: []byte(liveNodegroupsJSON)},
+		},
+	}, configPath, eksprovisioner.WithOwnershipVerifier(func(_ context.Context) error {
+		verifierCalls++
+
+		return eksidentity.ErrIdentityMismatch
+	}))
+
+	_, err := prov.Update(
+		t.Context(), "", &v1alpha1.ClusterSpec{}, &v1alpha1.ClusterSpec{},
+		clusterupdateOptions(false),
+	)
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	assert.Equal(t, 1, verifierCalls)
+
+	for _, call := range runner.calls {
+		assert.NotEqual(t, "scale", call[0], "identity mismatch must abort before scaling")
+	}
 }
 
 func TestUpdate_DryRunDoesNotScale(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -9,7 +9,9 @@ import (
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/detector"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/registry"
 	k3dv1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
@@ -175,6 +177,15 @@ type DefaultFactory struct {
 	// for installed components. When non-nil it is injected into provisioners
 	// so that GetCurrentConfig returns accurate live state instead of defaults.
 	ComponentDetector *detector.ComponentDetector
+
+	// AWSResolution optionally pins one concrete credential snapshot across an EKS ownership guard
+	// and the provisioner it authorizes. Non-nil values must be frozen; nil preserves normal factory
+	// resolution for consumers outside the guarded CLI mutation path.
+	AWSResolution *credentials.AWSResolution
+
+	// AWSOwnershipVerifier rechecks the exact EKS incarnation inside the provisioner immediately
+	// before each AWS mutation. It is nil for creates and non-EKS consumers.
+	AWSOwnershipVerifier eksidentity.Verifier
 }
 
 // Create selects the correct distribution provisioner for the KSail cluster configuration.

--- a/pkg/svc/provisioner/cluster/factory_eks.go
+++ b/pkg/svc/provisioner/cluster/factory_eks.go
@@ -1,6 +1,7 @@
 package clusterprovisioner
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,6 +11,10 @@ import (
 	awsprovider "github.com/devantler-tech/ksail/v7/pkg/svc/provider/aws"
 	eksprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/eks"
 )
+
+// ErrUnfrozenAWSResolution reports an identity-sensitive EKS factory call that supplied a mutable
+// profile/default-chain selector instead of the concrete credential tuple verified by the guard.
+var ErrUnfrozenAWSResolution = errors.New("EKS mutation credentials are not frozen")
 
 func (f DefaultFactory) createEKSProvisioner(
 	cluster *v1alpha1.Cluster,
@@ -22,12 +27,27 @@ func (f DefaultFactory) createEKSProvisioner(
 	}
 
 	eksConfig := f.DistributionConfig.EKS
-	client, providerOptions, provisionerOptions := resolveEKSCredentialOptions(
+
+	client, providerOptions, provisionerOptions, err := f.resolveEKSCredentialOptions(
 		cluster.Spec.Provider.AWS,
 	)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	provisionerOptions = append(provisionerOptions,
 		eksprovisioner.WithKubeconfigPath(eksConfig.KubeconfigPath),
 	)
+	if f.AWSOwnershipVerifier != nil {
+		providerOptions = append(
+			providerOptions,
+			awsprovider.WithOwnershipVerifier(f.AWSOwnershipVerifier),
+		)
+		provisionerOptions = append(
+			provisionerOptions,
+			eksprovisioner.WithOwnershipVerifier(f.AWSOwnershipVerifier),
+		)
+	}
 
 	infraProvider, err := awsprovider.NewProvider(
 		client,
@@ -66,20 +86,41 @@ func (f DefaultFactory) createEKSProvisioner(
 
 // resolveEKSCredentialOptions snapshots one AWS resolution and derives aligned
 // eksctl, provider, and provisioner options.
-func resolveEKSCredentialOptions(
+func (f DefaultFactory) resolveEKSCredentialOptions(
 	awsOptions v1alpha1.OptionsAWS,
-) (*eksctlclient.Client, []awsprovider.Option, []eksprovisioner.Option) {
-	auth, eksctlOptions, providerOptions := credentials.ResolveAWSClientOptions(
-		credentials.NewAWSOptionsResolver(awsOptions),
+) (*eksctlclient.Client, []awsprovider.Option, []eksprovisioner.Option, error) {
+	if f.AWSOwnershipVerifier != nil && f.AWSResolution == nil {
+		return nil, nil, nil, ErrUnfrozenAWSResolution
+	}
+
+	auth := credentials.ResolveAWS(credentials.NewAWSOptionsResolver(awsOptions))
+
+	if f.AWSResolution != nil {
+		if !f.AWSResolution.IsFrozen() {
+			return nil, nil, nil, ErrUnfrozenAWSResolution
+		}
+
+		auth = *f.AWSResolution
+	}
+
+	eksctlOptions := credentials.OptionsForAWSChildEnvironment(
+		auth,
 		os.Environ(),
 		eksctlclient.WithEnvironment,
 		eksctlclient.RequireCredentialValues,
+	)
+	providerOptions := credentials.OptionsForFrozenAWSConfig(
+		auth,
+		awsprovider.WithAWSConfig,
 		awsprovider.WithCredentialValues,
 		awsprovider.RequireCredentialValues,
 	)
-	provisionerOptions := credentials.OptionsForAWSResolution(
-		auth, eksprovisioner.WithCredentialValues, eksprovisioner.RequireCredentialValues,
+	provisionerOptions := credentials.OptionsForFrozenAWSConfig(
+		auth,
+		eksprovisioner.WithAWSConfig,
+		eksprovisioner.WithCredentialValues,
+		eksprovisioner.RequireCredentialValues,
 	)
 
-	return eksctlclient.NewClient(eksctlOptions...), providerOptions, provisionerOptions
+	return eksctlclient.NewClient(eksctlOptions...), providerOptions, provisionerOptions, nil
 }

--- a/pkg/svc/provisioner/cluster/factory_eks_test.go
+++ b/pkg/svc/provisioner/cluster/factory_eks_test.go
@@ -198,3 +198,24 @@ func TestCreateEKSProvisionerWithoutConfig(t *testing.T) {
 	require.ErrorIs(t, err, clusterprovisioner.ErrMissingDistributionConfig)
 	assert.Nil(t, provisioner)
 }
+
+// TestCreateEKSProvisionerRejectsOwnershipVerifierWithoutResolution verifies an immutable
+// ownership verifier can never authorize a factory that would independently re-resolve mutable
+// ambient credentials for the ensuing EKS mutation.
+func TestCreateEKSProvisionerRejectsOwnershipVerifierWithoutResolution(t *testing.T) {
+	t.Parallel()
+
+	factory := clusterprovisioner.DefaultFactory{
+		AWSOwnershipVerifier: func(context.Context) error { return nil },
+		DistributionConfig: &clusterprovisioner.DistributionConfig{
+			EKS: &clusterprovisioner.EKSConfig{
+				Name:   "test-eks",
+				Region: "eu-west-1",
+			},
+		},
+	}
+
+	provisioner, _, err := factory.Create(context.Background(), eksTestCluster())
+	require.ErrorIs(t, err, clusterprovisioner.ErrUnfrozenAWSResolution)
+	assert.Nil(t, provisioner)
+}

--- a/pkg/svc/state/eks_ownership_state.go
+++ b/pkg/svc/state/eks_ownership_state.go
@@ -1,0 +1,193 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+)
+
+const (
+	// EKSOwnershipStateVersion is the on-disk schema version for immutable EKS ownership records.
+	EKSOwnershipStateVersion = 1
+	// eksOwnershipStateFileNameFormat keeps ownership records scoped to the AWS region. The wider
+	// per-cluster state directory remains name-keyed until its dedicated migration (ksail#6224).
+	eksOwnershipStateFileNameFormat = "eks-ownership-%s.json"
+)
+
+var (
+	// ErrEKSOwnershipStateNotFound reports a legacy or missing immutable EKS ownership record.
+	ErrEKSOwnershipStateNotFound = errors.New("EKS ownership state not found")
+	// ErrInvalidEKSOwnershipState reports malformed, incomplete, or internally inconsistent state.
+	ErrInvalidEKSOwnershipState = errors.New("invalid EKS ownership state")
+	awsAccountIDPattern         = regexp.MustCompile(`^[0-9]{12}$`)
+)
+
+// EKSOwnershipState binds a KSail-managed EKS target to the AWS account and exact EKS incarnation
+// observed after creation. EKS ARNs are name-derived and repeat after replacement, so CreatedAt is
+// part of the identity as the AWS-assigned, immutable incarnation fingerprint. No credentials are
+// persisted.
+type EKSOwnershipState struct {
+	Version     int       `json:"version"`
+	ClusterName string    `json:"clusterName"`
+	Region      string    `json:"region"`
+	AccountID   string    `json:"accountId"`
+	ClusterARN  string    `json:"clusterArn"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+// SaveEKSOwnershipState atomically persists one validated immutable ownership record.
+func SaveEKSOwnershipState(clusterName, region string, ownership *EKSOwnershipState) error {
+	statePath, err := eksOwnershipStatePath(clusterName, region)
+	if err != nil {
+		return err
+	}
+
+	err = validateEKSOwnershipState(clusterName, region, ownership)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(statePath), dirPermissions)
+	if err != nil {
+		return fmt.Errorf("failed to create EKS ownership state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(ownership, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal EKS ownership state: %w", err)
+	}
+
+	err = fsutil.AtomicWriteFile(statePath, data, filePermissions)
+	if err != nil {
+		return fmt.Errorf("failed to write EKS ownership state: %w", err)
+	}
+
+	return nil
+}
+
+// LoadEKSOwnershipState reads and strictly validates one immutable ownership record.
+func LoadEKSOwnershipState(clusterName, region string) (*EKSOwnershipState, error) {
+	statePath, err := eksOwnershipStatePath(clusterName, region)
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:gosec // clusterStateDir and validateEKSRegion constrain both path components.
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf(
+				"%w: %s in %s",
+				ErrEKSOwnershipStateNotFound,
+				clusterName,
+				region,
+			)
+		}
+
+		return nil, fmt.Errorf("failed to read EKS ownership state: %w", err)
+	}
+
+	var ownership EKSOwnershipState
+
+	err = json.Unmarshal(data, &ownership)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unmarshal EKS ownership state: %w: %w",
+			err,
+			ErrInvalidEKSOwnershipState,
+		)
+	}
+
+	err = validateEKSOwnershipState(clusterName, region, &ownership)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ownership, nil
+}
+
+func validateEKSOwnershipState(clusterName, region string, ownership *EKSOwnershipState) error {
+	if ownership == nil {
+		return fmt.Errorf("%w: state is nil", ErrInvalidEKSOwnershipState)
+	}
+
+	clusterName = strings.TrimSpace(clusterName)
+	region = strings.TrimSpace(region)
+
+	if ownership.Version != EKSOwnershipStateVersion {
+		return fmt.Errorf(
+			"%w: unsupported version %d (want %d)",
+			ErrInvalidEKSOwnershipState,
+			ownership.Version,
+			EKSOwnershipStateVersion,
+		)
+	}
+
+	err := validateEKSOwnershipFields(clusterName, region, ownership)
+	if err != nil {
+		return err
+	}
+
+	parsedARN, err := awsarn.Parse(strings.TrimSpace(ownership.ClusterARN))
+	if err != nil {
+		return fmt.Errorf("%w: parse cluster ARN: %w", ErrInvalidEKSOwnershipState, err)
+	}
+
+	return validateEKSOwnershipARN(clusterName, region, ownership.AccountID, parsedARN)
+}
+
+func validateEKSOwnershipFields(
+	clusterName, region string,
+	ownership *EKSOwnershipState,
+) error {
+	if strings.TrimSpace(ownership.ClusterName) != clusterName ||
+		strings.TrimSpace(ownership.Region) != region ||
+		!awsAccountIDPattern.MatchString(strings.TrimSpace(ownership.AccountID)) ||
+		strings.TrimSpace(ownership.ClusterARN) == "" || ownership.CreatedAt.IsZero() {
+		return fmt.Errorf(
+			"%w: required identity fields are missing or do not match the state key",
+			ErrInvalidEKSOwnershipState,
+		)
+	}
+
+	return nil
+}
+
+func validateEKSOwnershipARN(
+	clusterName, region, accountID string,
+	parsedARN awsarn.ARN,
+) error {
+	if parsedARN.Service != "eks" || parsedARN.Region != region ||
+		parsedARN.AccountID != strings.TrimSpace(accountID) ||
+		parsedARN.Resource != "cluster/"+clusterName {
+		return fmt.Errorf(
+			"%w: cluster ARN does not match name, region, and account",
+			ErrInvalidEKSOwnershipState,
+		)
+	}
+
+	return nil
+}
+
+func eksOwnershipStatePath(clusterName, region string) (string, error) {
+	dir, err := clusterStateDir(clusterName)
+	if err != nil {
+		return "", err
+	}
+
+	region = strings.TrimSpace(region)
+	if region == "" || strings.Contains(region, "/") || strings.Contains(region, "\\") ||
+		strings.Contains(region, "..") {
+		return "", ErrInvalidRegion
+	}
+
+	return filepath.Join(dir, fmt.Sprintf(eksOwnershipStateFileNameFormat, region)), nil
+}

--- a/pkg/svc/state/eks_ownership_state_test.go
+++ b/pkg/svc/state/eks_ownership_state_test.go
@@ -1,0 +1,172 @@
+package state_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveLoadEKSOwnershipState(t *testing.T) {
+	t.Parallel()
+
+	want := &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: "ownership-round-trip",
+		Region:      "eu-north-1",
+		AccountID:   "123456789012",
+		ClusterARN:  "arn:aws:eks:eu-north-1:123456789012:cluster/ownership-round-trip",
+		CreatedAt:   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+	}
+
+	require.NoError(t, state.SaveEKSOwnershipState(want.ClusterName, want.Region, want))
+
+	got, err := state.LoadEKSOwnershipState(want.ClusterName, want.Region)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestEKSOwnershipStateIsScopedPerRegion(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "ownership-region-scope"
+	north := &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: clusterName,
+		Region:      "eu-north-1",
+		AccountID:   "123456789012",
+		ClusterARN:  "arn:aws:eks:eu-north-1:123456789012:cluster/" + clusterName,
+		CreatedAt:   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+	}
+	east := &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: clusterName,
+		Region:      "us-east-1",
+		AccountID:   "210987654321",
+		ClusterARN:  "arn:aws:eks:us-east-1:210987654321:cluster/" + clusterName,
+		CreatedAt:   time.Date(2026, 7, 18, 12, 1, 0, 0, time.UTC),
+	}
+
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, north.Region, north))
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, east.Region, east))
+
+	gotNorth, err := state.LoadEKSOwnershipState(clusterName, north.Region)
+	require.NoError(t, err)
+	assert.Equal(t, north, gotNorth)
+
+	gotEast, err := state.LoadEKSOwnershipState(clusterName, east.Region)
+	require.NoError(t, err)
+	assert.Equal(t, east, gotEast)
+}
+
+func TestEKSOwnershipStateContainsNoCredentialsAndUsesPrivatePermissions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "ownership-private-state"
+		region      = "eu-north-1"
+	)
+
+	snapshot := &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: clusterName,
+		Region:      region,
+		AccountID:   "123456789012",
+		ClusterARN:  "arn:aws:eks:eu-north-1:123456789012:cluster/" + clusterName,
+		CreatedAt:   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, snapshot))
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	dir := filepath.Join(home, ".ksail", "clusters", clusterName)
+	path := filepath.Join(dir, "eks-ownership-"+region+".json")
+
+	//nolint:gosec // Every path component is fixed by this isolated test fixture.
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	for _, credentialField := range []string{
+		"accessKey", "profile", "secret", "sessionToken", "token",
+	} {
+		assert.NotContains(t, string(contents), credentialField)
+	}
+
+	dirInfo, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+
+	fileInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
+}
+
+func TestLoadEKSOwnershipStateMissingRequiresMigration(t *testing.T) {
+	t.Parallel()
+
+	_, err := state.LoadEKSOwnershipState("legacy-without-identity", "eu-north-1")
+	require.ErrorIs(t, err, state.ErrEKSOwnershipStateNotFound)
+}
+
+func TestSaveEKSOwnershipStateRejectsMalformedIdentity(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]*state.EKSOwnershipState{
+		"wrong version": {
+			Version: 2, ClusterName: "demo", Region: "eu-north-1",
+			AccountID:  "123456789012",
+			ClusterARN: "arn:aws:eks:eu-north-1:123456789012:cluster/demo",
+			CreatedAt:  time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		},
+		"missing account": {
+			Version: state.EKSOwnershipStateVersion, ClusterName: "demo", Region: "eu-north-1",
+			ClusterARN: "arn:aws:eks:eu-north-1:123456789012:cluster/demo",
+			CreatedAt:  time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		},
+		"missing arn": {
+			Version: state.EKSOwnershipStateVersion, ClusterName: "demo", Region: "eu-north-1",
+			AccountID: "123456789012",
+			CreatedAt: time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		},
+		"missing creation time": {
+			Version: state.EKSOwnershipStateVersion, ClusterName: "demo", Region: "eu-north-1",
+			AccountID:  "123456789012",
+			ClusterARN: "arn:aws:eks:eu-north-1:123456789012:cluster/demo",
+		},
+	}
+
+	for name, snapshot := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := state.SaveEKSOwnershipState("demo", "eu-north-1", snapshot)
+			require.ErrorIs(t, err, state.ErrInvalidEKSOwnershipState)
+		})
+	}
+}
+
+func TestLoadEKSOwnershipStateRejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "ownership-invalid-json"
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	dir := filepath.Join(home, ".ksail", "clusters", clusterName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "eks-ownership-eu-north-1.json"),
+		[]byte("{"),
+		0o600,
+	))
+
+	_, err = state.LoadEKSOwnershipState(clusterName, "eu-north-1")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, state.ErrEKSOwnershipStateNotFound)
+	assert.ErrorContains(t, err, "unmarshal EKS ownership state")
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

EKS lifecycle commands currently trust a cluster name plus the AWS identity available when each subprocess or SDK client happens to resolve credentials. If credentials, profile data, or a same-name cluster changes during an operation, a destructive step can be redirected to AWS infrastructure that KSail did not create.

## What

Binds each region-scoped local EKS record to its creating AWS account, exact cluster ARN, and creation timestamp. Each lifecycle operation freezes one complete AWS configuration and credential snapshot, uses it for SDK and eksctl calls, and checks the pinned identity again at the final delete or scale boundary. Missing, malformed, or mismatched ownership fails closed.

Adds a hidden, default-off experimental `eks-bind` migration for legacy local state. It previews the live identity using read-only AWS queries and persists it only after explicit `--yes` confirmation, while clearing stale nodegroup capacity state.

The local API lifecycle, cross-process state locking, state-directory region migration, and no-config alias persistence remain in their dedicated follow-ups: #6203, #6204, #6224, and #6227.

Fixes #6202. Part of #4328.