### PR TITLE
fix(gke): avoid leaking operator env values

### DIFF
--- a/pkg/client/gke/client.go
+++ b/pkg/client/gke/client.go
@@ -192,7 +192,7 @@ func (c *Client) ListClusters(
 
 	response, err := c.manager.ListClusters(ctx, request)
 	if err != nil {
-		return nil, fmt.Errorf("listing GKE clusters in %q: %w", location, err)
+		return nil, fmt.Errorf("listing GKE clusters: %w", err)
 	}
 
 	return response.GetClusters(), nil

--- a/pkg/client/gke/client_test.go
+++ b/pkg/client/gke/client_test.go
@@ -344,6 +344,7 @@ func TestListClustersWrapsError(t *testing.T) {
 	_, err := client.ListClusters(t.Context(), "proj", "loc")
 
 	require.ErrorIs(t, err, errBoom)
+	assert.NotContains(t, err.Error(), "loc")
 }
 
 func TestCloseWrapsError(t *testing.T) {

--- a/pkg/operator/provisioner.go
+++ b/pkg/operator/provisioner.go
@@ -213,18 +213,18 @@ func awsRegion(cluster *v1alpha1.Cluster) string {
 	return resolveEnvVar(cluster.Spec.Provider.AWS.RegionEnvVar, defaultAWSRegionEnvVar)
 }
 
-// gcpProject resolves the GKE project from the environment variable named by the cluster's GCP
-// options (default GOOGLE_CLOUD_PROJECT). An empty result lets the GKE provisioner surface a
-// clear ErrProjectRequired.
-func gcpProject(cluster *v1alpha1.Cluster) string {
-	return resolveEnvVar(cluster.Spec.Provider.GCP.ProjectEnvVar, defaultGCPProjectEnvVar)
+// gcpProject resolves the GKE project from the operator's fixed GOOGLE_CLOUD_PROJECT environment
+// variable. Cluster resources cannot select arbitrary operator environment variables because
+// reconciliation failures are reflected in public Cluster status conditions.
+func gcpProject(_ *v1alpha1.Cluster) string {
+	return resolveEnvVar("", defaultGCPProjectEnvVar)
 }
 
-// gcpLocation resolves the GKE location from the environment variable named by the cluster's GCP
-// options (default GOOGLE_CLOUD_LOCATION). An empty result leaves the location unpinned: reads
-// resolve the cluster's own location, while create fails with a clear ErrLocationRequired.
-func gcpLocation(cluster *v1alpha1.Cluster) string {
-	return resolveEnvVar(cluster.Spec.Provider.GCP.LocationEnvVar, defaultGCPLocationEnvVar)
+// gcpLocation resolves the GKE location from the operator's fixed GOOGLE_CLOUD_LOCATION environment
+// variable. An empty result leaves the location unpinned: reads resolve the cluster's own location,
+// while create fails with a clear ErrLocationRequired.
+func gcpLocation(_ *v1alpha1.Cluster) string {
+	return resolveEnvVar("", defaultGCPLocationEnvVar)
 }
 
 // azureSubscriptionID resolves the AKS subscription from the environment variable named by the

--- a/pkg/operator/provisioner_test.go
+++ b/pkg/operator/provisioner_test.go
@@ -142,14 +142,30 @@ func TestBuildDistributionConfig_EKS(t *testing.T) {
 	assert.Equal(t, "eu-west-1", config.EKS.Region)
 }
 
+func TestBuildDistributionConfig_GKEIgnoresCustomEnvVarNames(t *testing.T) {
+	// No t.Parallel(): this test uses t.Setenv, which is incompatible with parallel tests.
+	cluster := clusterWithDistribution("c1", v1alpha1.DistributionGKE)
+	cluster.Spec.Provider.GCP.ProjectEnvVar = "KSAIL_TEST_GCP_SECRET_PROJECT"
+	cluster.Spec.Provider.GCP.LocationEnvVar = "KSAIL_TEST_GCP_SECRET_LOCATION"
+
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "safe-project")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "safe-location")
+	t.Setenv("KSAIL_TEST_GCP_SECRET_PROJECT", "secret-project")
+	t.Setenv("KSAIL_TEST_GCP_SECRET_LOCATION", "secret-location")
+
+	config, err := operator.BuildDistributionConfig(cluster)
+	require.NoError(t, err)
+	require.NotNil(t, config.GKE)
+	assert.Equal(t, "safe-project", config.GKE.Project)
+	assert.Equal(t, "safe-location", config.GKE.Location)
+}
+
 func TestBuildDistributionConfig_GKE(t *testing.T) {
 	// No t.Parallel(): this test uses t.Setenv, which is incompatible with parallel tests.
 	cluster := clusterWithDistribution("c1", v1alpha1.DistributionGKE)
-	cluster.Spec.Provider.GCP.ProjectEnvVar = "KSAIL_TEST_GCP_PROJECT"
-	cluster.Spec.Provider.GCP.LocationEnvVar = "KSAIL_TEST_GCP_LOCATION"
 
-	t.Setenv("KSAIL_TEST_GCP_PROJECT", "my-project")
-	t.Setenv("KSAIL_TEST_GCP_LOCATION", "europe-north1")
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "europe-north1")
 
 	config, err := operator.BuildDistributionConfig(cluster)
 	require.NoError(t, err)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

- A Cluster custom resource could choose which operator environment variables supplied GKE `project` and `location` values. Those values could then reach public reconciliation status and wrapped errors, allowing an untrusted resource author to probe operator environment values.

### Description

- Resolve operator-managed GKE project and location only from the fixed `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` variables.
- Stop including the raw GKE location in `ListClusters` errors.
- Cover both boundaries with regression tests that fail against current `main` before the implementation is applied.

### Testing

- RED on current `main`: `TestBuildDistributionConfig_GKEIgnoresCustomEnvVarNames` returned the attacker-selected values, and `TestListClustersWrapsError` exposed `loc`.
- `go test ./pkg/operator ./pkg/client/gke -run 'TestBuildDistributionConfig_GKEIgnoresCustomEnvVarNames|TestBuildDistributionConfig_GKE|TestListClustersWrapsError' -count=1`
- `go test -race ./pkg/operator ./pkg/client/gke -run 'TestBuildDistributionConfig_GKEIgnoresCustomEnvVarNames|TestBuildDistributionConfig_GKE|TestListClustersWrapsError' -count=1`
- `go vet ./...`
- `go build -o /tmp/ksail-6246-build .`
- `golangci-lint run ./pkg/operator/... ./pkg/client/gke/... --timeout 5m` (0 issues)
- A concurrent full `go test ./...` run completed the repository except for process-timeout failures in the unrelated `pkg/cli/cmd/open/chat` package; that package passed immediately in isolation with `go test ./pkg/cli/cmd/open/chat -count=1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a61a77a8832badc14f0c5220a302)
