### PR TITLE
fix(k3d): honor caller-supplied k3k kubeconfig name

### DIFF
--- a/pkg/svc/provisioner/cluster/k3d/export_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/export_test.go
@@ -57,7 +57,7 @@ func (p *K3kProvisioner) BuildClusterCRForTest(
 
 // EnsureNamespaceForTest exposes ensureNamespace for unit testing.
 func (p *K3kProvisioner) EnsureNamespaceForTest(ctx context.Context, namespace string) error {
-	return p.ensureNamespace(ctx, namespace)
+	return p.ensureNamespace(ctx, p.effectiveClusterName(""), namespace)
 }
 
 // WithRunnerForTest injects a command runner so lifecycle operations can be

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -317,9 +317,9 @@ func (p *K3kProvisioner) List(ctx context.Context) ([]string, error) {
 // clustererr.ErrKubeconfigNotReady while the k3k-<name>-kubeconfig Secret has not been published
 // yet.
 func (p *K3kProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
-	clusterName := p.clusterName
+	clusterName := name
 	if clusterName == "" {
-		clusterName = name
+		clusterName = p.clusterName
 	}
 
 	conn := ConnectionFor(clusterName)

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -168,10 +168,7 @@ func NewK3kProvisioner(cfg K3kProvisionerConfig) (*K3kProvisioner, error) {
 
 // Create provisions a K3s cluster using the k3k operator on the host Kubernetes cluster.
 func (p *K3kProvisioner) Create(ctx context.Context, name string) error {
-	clusterName := p.clusterName
-	if clusterName == "" {
-		clusterName = name
-	}
+	clusterName := p.effectiveClusterName(name)
 
 	namespace := k3kNamespacePrefix + clusterName
 
@@ -233,10 +230,7 @@ func (p *K3kProvisioner) Create(ctx context.Context, name string) error {
 
 // Delete removes the k3k cluster by deleting the Cluster CR and namespace.
 func (p *K3kProvisioner) Delete(ctx context.Context, name string) error {
-	clusterName := p.clusterName
-	if clusterName == "" {
-		clusterName = name
-	}
+	clusterName := p.effectiveClusterName(name)
 
 	p.closeAPIServerPortForward()
 
@@ -261,10 +255,7 @@ func (p *K3kProvisioner) Delete(ctx context.Context, name string) error {
 
 // Exists checks whether the k3k cluster namespace exists.
 func (p *K3kProvisioner) Exists(ctx context.Context, name string) (bool, error) {
-	clusterName := p.clusterName
-	if clusterName == "" {
-		clusterName = name
-	}
+	clusterName := p.effectiveClusterName(name)
 
 	namespace := k3kNamespacePrefix + clusterName
 
@@ -346,6 +337,9 @@ func (p *K3kProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, e
 }
 
 func (p *K3kProvisioner) effectiveClusterName(name string) string {
+	// The operator passes a namespace-qualified provisioned name. It must win over
+	// the factory's unqualified fallback for every lifecycle operation so Create,
+	// Exists, Delete, and Kubeconfig address the same k3k resources.
 	if name != "" {
 		return name
 	}
@@ -543,7 +537,7 @@ func (p *K3kProvisioner) setupCluster(
 
 	_, _ = fmt.Fprintf(os.Stdout, "► creating namespace %s\n", namespace)
 
-	err = p.ensureNamespace(ctx, namespace)
+	err = p.ensureNamespace(ctx, clusterName, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("ensure namespace: %w", err)
 	}
@@ -643,13 +637,13 @@ func (p *K3kProvisioner) ensureK3kOperator(ctx context.Context) error {
 }
 
 // ensureNamespace creates the namespace if it doesn't exist, with ksail labels.
-func (p *K3kProvisioner) ensureNamespace(ctx context.Context, namespace string) error {
+func (p *K3kProvisioner) ensureNamespace(ctx context.Context, clusterName, namespace string) error {
 	nsObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 			Labels: map[string]string{
 				"ksail.io/managed-by": "ksail",
-				"ksail.io/cluster":    p.clusterName,
+				"ksail.io/cluster":    clusterName,
 				// The k3k server runs embedded k3s and requires a privileged container.
 				// Hosts that enforce Pod Security Admission at the "baseline" level (e.g.
 				// Talos, which defaults namespaces to baseline) would otherwise reject the

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -317,11 +317,7 @@ func (p *K3kProvisioner) List(ctx context.Context) ([]string, error) {
 // clustererr.ErrKubeconfigNotReady while the k3k-<name>-kubeconfig Secret has not been published
 // yet.
 func (p *K3kProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, error) {
-	clusterName := name
-	if clusterName == "" {
-		clusterName = p.clusterName
-	}
-
+	clusterName := p.effectiveClusterName(name)
 	conn := ConnectionFor(clusterName)
 
 	raw, err := nested.ConnectorKubeconfig(
@@ -347,6 +343,14 @@ func (p *K3kProvisioner) Kubeconfig(ctx context.Context, name string) ([]byte, e
 	}
 
 	return out, nil
+}
+
+func (p *K3kProvisioner) effectiveClusterName(name string) string {
+	if name != "" {
+		return name
+	}
+
+	return p.clusterName
 }
 
 // connectAndMergeKubeconfig waits for the k3k kubeconfig Secret, rewrites the kubeconfig to

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -218,8 +218,11 @@ func TestKubeconfig_PrefersCallerSuppliedName(t *testing.T) {
 			Data:       map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
 		},
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: configuredConn.SecretName, Namespace: configuredConn.Namespace},
-			Data:       map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configuredConn.SecretName,
+				Namespace: configuredConn.Namespace,
+			},
+			Data: map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
 		},
 	)
 	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -207,6 +207,38 @@ func TestKubeconfig_RewritesServerToInClusterServiceEndpoint(t *testing.T) {
 	}
 }
 
+func TestKubeconfig_PrefersCallerSuppliedName(t *testing.T) {
+	t.Parallel()
+
+	safeConn := k3dprovisioner.ConnectionFor("safe-namespace-qualified")
+	configuredConn := k3dprovisioner.ConnectionFor("configured-from-cli-context")
+	clientset := k8sfake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: safeConn.SecretName, Namespace: safeConn.Namespace},
+			Data:       map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: configuredConn.SecretName, Namespace: configuredConn.Namespace},
+			Data:       map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
+		},
+	)
+	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
+		HostClientset: clientset,
+		ClusterName:   "configured-from-cli-context",
+	})
+	require.NoError(t, err)
+
+	out, err := provisioner.Kubeconfig(context.Background(), "safe-namespace-qualified")
+	require.NoError(t, err)
+
+	config, err := clientcmd.Load(out)
+	require.NoError(t, err)
+
+	for _, cluster := range config.Clusters {
+		assert.Equal(t, safeConn.Endpoint, cluster.Server)
+	}
+}
+
 func TestKubeconfig_FallsBackToNameArgument(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -3,6 +3,7 @@ package k3dprovisioner_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,17 +213,29 @@ func TestKubeconfig_PrefersCallerSuppliedName(t *testing.T) {
 
 	safeConn := k3dprovisioner.ConnectionFor("safe-namespace-qualified")
 	configuredConn := k3dprovisioner.ConnectionFor("configured-from-cli-context")
+	safeKubeconfig := strings.Replace(
+		k3kPublishedKubeconfig,
+		"user: {}",
+		"user:\n    token: safe-selected-token",
+		1,
+	)
+	configuredKubeconfig := strings.Replace(
+		k3kPublishedKubeconfig,
+		"user: {}",
+		"user:\n    token: configured-fallback-token",
+		1,
+	)
 	clientset := k8sfake.NewClientset(
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: safeConn.SecretName, Namespace: safeConn.Namespace},
-			Data:       map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
+			Data:       map[string][]byte{"kubeconfig.yaml": []byte(safeKubeconfig)},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configuredConn.SecretName,
 				Namespace: configuredConn.Namespace,
 			},
-			Data: map[string][]byte{"kubeconfig.yaml": []byte(k3kPublishedKubeconfig)},
+			Data: map[string][]byte{"kubeconfig.yaml": []byte(configuredKubeconfig)},
 		},
 	)
 	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
@@ -240,6 +253,9 @@ func TestKubeconfig_PrefersCallerSuppliedName(t *testing.T) {
 	for _, cluster := range config.Clusters {
 		assert.Equal(t, safeConn.Endpoint, cluster.Server)
 	}
+
+	assert.Contains(t, string(out), "safe-selected-token")
+	assert.NotContains(t, string(out), "configured-fallback-token")
 }
 
 func TestKubeconfig_FallsBackToNameArgument(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_test.go
@@ -258,6 +258,24 @@ func TestKubeconfig_PrefersCallerSuppliedName(t *testing.T) {
 	assert.NotContains(t, string(out), "configured-fallback-token")
 }
 
+func TestExists_PrefersCallerSuppliedName(t *testing.T) {
+	t.Parallel()
+
+	callerConn := k3dprovisioner.ConnectionFor("team-a-nested-k3s")
+	clientset := k8sfake.NewClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: callerConn.Namespace},
+	})
+	provisioner, err := k3dprovisioner.NewK3kProvisioner(k3dprovisioner.K3kProvisionerConfig{
+		HostClientset: clientset,
+		ClusterName:   "nested-k3s",
+	})
+	require.NoError(t, err)
+
+	exists, err := provisioner.Exists(context.Background(), "team-a-nested-k3s")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
 func TestKubeconfig_FallsBackToNameArgument(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

- Component installation uses the safe namespace-qualified provisioned name supplied by the operator to select a child-cluster kubeconfig Secret. Preferring an internally configured name creates a confused-deputy risk where credentials for another cluster can be fetched.

### Description

- Make `Create`, `Exists`, `Delete`, and `Kubeconfig` all prefer the caller-provided provisioned name and use the configured cluster name only as an empty-argument fallback.
- Keep that lifecycle-wide precedence rule in a private `effectiveClusterName` helper so creation and credential retrieval cannot address different k3k resources.
- Label the child namespace with the same resolved cluster name used for its namespace, Cluster CR, exposure, and kubeconfig Secret.
- Strengthen `TestKubeconfig_PrefersCallerSuppliedName` with distinct selected and fallback credential tokens.
- Assert the returned kubeconfig contains the caller-selected token and excludes the configured fallback token, in addition to checking the selected endpoint.

### Testing

- Mutation proof: temporarily restoring the old wrong precedence made `TestKubeconfig_PrefersCallerSuppliedName` fail on endpoint, selected-token, and fallback-token assertions; production code was then restored byte-for-byte.
- Added `TestExists_PrefersCallerSuppliedName`: it returned false on the previous configured-name-first lifecycle code, then passed after all lifecycle operations shared the resolver.
- Focused and full K3d tests passed.
- Changed-package `golangci-lint` passed with zero issues.
- `jscpd` across K3d and Talos reported zero clones after the helper extraction.
- Production build and diff hygiene passed.
- The full Go suite passed apart from transient concurrent chat subprocess timeouts; those chat tests passed immediately in isolated rerun.
- Fresh GitHub checks are running at `170eac0906e77b1a3b53d278169a0664822e7061`.
