### PR TITLE
fix(ui): enforce plugin install trust on server

### DIFF
--- a/pkg/webui/api/plugins.go
+++ b/pkg/webui/api/plugins.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"mime"
 	"net/http"
 	"path"
 	"strings"
@@ -73,6 +76,10 @@ type PluginService interface {
 type PluginInstallRequest struct {
 	URL    string `json:"url"`
 	SHA256 string `json:"sha256,omitempty"`
+	// Trusted is the server-enforced acknowledgement that the caller understands the plugin will run
+	// unsandboxed as same-origin JavaScript with access to this UI's cluster APIs. The SPA sets it only
+	// after the explicit consent checkbox is checked; direct callers must opt in too.
+	Trusted bool `json:"trusted"`
 	// Signature is an optional base64-encoded ed25519 detached signature over the downloaded tarball
 	// bytes. When set, the install verifies it against KSAIL_PLUGIN_SIGNING_PUBKEY and rejects the
 	// install when no trusted key is configured (a claimed signature is never silently ignored).
@@ -249,10 +256,30 @@ func (s *Server) handleInstallPlugin(writer http.ResponseWriter, request *http.R
 		return
 	}
 
+	err := requirePluginInstallRequestGuards(request)
+	if err != nil {
+		status := http.StatusForbidden
+		if errors.Is(err, errUnsupportedContentType) {
+			status = http.StatusUnsupportedMediaType
+		}
+		writeError(writer, status, err)
+
+		return
+	}
+
 	var req PluginInstallRequest
 
-	err := decodeJSON(writer, request, &req)
+	err = decodeJSON(writer, request, &req)
 	if err != nil {
+		return
+	}
+
+	if !req.Trusted {
+		writeClientError(
+			writer,
+			fmt.Errorf("%w: plugin install requires explicit trust acknowledgement", ErrInvalid),
+		)
+
 		return
 	}
 
@@ -266,6 +293,35 @@ func (s *Server) handleInstallPlugin(writer http.ResponseWriter, request *http.R
 	}
 
 	writeJSON(writer, http.StatusCreated, info)
+}
+
+var errUnsupportedContentType = errors.New("unsupported content type: expected application/json")
+
+func requirePluginInstallRequestGuards(request *http.Request) error {
+	contentType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || contentType != "application/json" {
+		return errUnsupportedContentType
+	}
+
+	if isCrossSiteBrowserRequest(request) {
+		return errors.New("cross-site plugin install request rejected")
+	}
+
+	return nil
+}
+
+func isCrossSiteBrowserRequest(request *http.Request) bool {
+	switch request.Header.Get("Sec-Fetch-Site") {
+	case "cross-site", "none":
+		return true
+	}
+
+	origin := request.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+
+	return origin != "http://"+request.Host && origin != "https://"+request.Host
 }
 
 // handleUninstallPlugin removes an installed plugin by id. The id is validated here (and again in the

--- a/pkg/webui/api/plugins.go
+++ b/pkg/webui/api/plugins.go
@@ -344,13 +344,29 @@ func isCrossSiteBrowserRequest(request *http.Request) bool {
 		return true
 	}
 
-	// The desktop shell serves the SPA from the fixed wails:// origin; a remote page can never carry
-	// that scheme, so it is trusted like loopback.
-	if strings.EqualFold(parsed.Scheme, "wails") {
+	// The desktop shell serves the SPA from the fixed wails://wails origin (see desktop/main.go), so
+	// that one origin is trusted like loopback.
+	if isWailsDesktopOrigin(parsed) {
 		return false
 	}
 
 	return !isLoopbackOriginHost(parsed.Hostname())
+}
+
+// isWailsDesktopOrigin reports whether a parsed origin is exactly the desktop shell's `wails://wails`
+// origin. Matching the scheme alone is not enough: it would also admit `wails://attacker`, and since
+// the scheme is the only thing standing between this branch and plugin installation, any other
+// authority under it must be rejected. A browser-sent Origin carries scheme and authority and nothing
+// else, so a non-empty user, path, query or fragment marks a crafted header rather than a real one.
+func isWailsDesktopOrigin(parsed *url.URL) bool {
+	// Host, not Hostname, so a port (`wails://wails:8080`) fails the comparison rather than being
+	// stripped away before it.
+	return strings.EqualFold(parsed.Scheme, "wails") &&
+		strings.EqualFold(parsed.Host, "wails") &&
+		parsed.User == nil &&
+		parsed.Path == "" &&
+		parsed.RawQuery == "" &&
+		parsed.Fragment == ""
 }
 
 // isLoopbackOriginHost reports whether a URL hostname names this machine's loopback interface.

--- a/pkg/webui/api/plugins.go
+++ b/pkg/webui/api/plugins.go
@@ -264,6 +264,7 @@ func (s *Server) handleInstallPlugin(writer http.ResponseWriter, request *http.R
 		if errors.Is(err, errUnsupportedContentType) {
 			status = http.StatusUnsupportedMediaType
 		}
+
 		writeError(writer, status, err)
 
 		return

--- a/pkg/webui/api/plugins.go
+++ b/pkg/webui/api/plugins.go
@@ -297,7 +297,10 @@ func (s *Server) handleInstallPlugin(writer http.ResponseWriter, request *http.R
 	writeJSON(writer, http.StatusCreated, info)
 }
 
-var errUnsupportedContentType = errors.New("unsupported content type: expected application/json")
+var (
+	errUnsupportedContentType = errors.New("unsupported content type: expected application/json")
+	errCrossSitePluginInstall = errors.New("cross-site plugin install request rejected")
+)
 
 func requirePluginInstallRequestGuards(request *http.Request) error {
 	contentType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
@@ -306,7 +309,7 @@ func requirePluginInstallRequestGuards(request *http.Request) error {
 	}
 
 	if isCrossSiteBrowserRequest(request) {
-		return errors.New("cross-site plugin install request rejected")
+		return errCrossSitePluginInstall
 	}
 
 	return nil

--- a/pkg/webui/api/plugins.go
+++ b/pkg/webui/api/plugins.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"mime"
+	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 )
@@ -310,6 +312,16 @@ func requirePluginInstallRequestGuards(request *http.Request) error {
 	return nil
 }
 
+// isCrossSiteBrowserRequest reports whether a browser request came from somewhere other than the local
+// UI. The install endpoint is registered only when the service implements PluginInstaller — which only
+// the loopback-bound local backend does — and installing a plugin runs unsandboxed same-origin
+// JavaScript against the cluster, so a browser origin is trusted only when the page was itself served
+// from loopback.
+//
+// The trusted origin is deliberately NOT derived from the request: Host is client-controlled, so
+// comparing Origin against it accepts a DNS-rebinding attacker, whose page on a name rebound to
+// 127.0.0.1 presents a matching Origin/Host pair and a same-origin Sec-Fetch-Site. Anchoring on the
+// loopback identity closes that, because a browser sets Origin from the page's real URL.
 func isCrossSiteBrowserRequest(request *http.Request) bool {
 	switch request.Header.Get("Sec-Fetch-Site") {
 	case "cross-site", "none":
@@ -318,10 +330,36 @@ func isCrossSiteBrowserRequest(request *http.Request) bool {
 
 	origin := request.Header.Get("Origin")
 	if origin == "" {
+		// Non-browser client (CLI tooling, tests). Browsers always send Origin on a cross-origin POST,
+		// and the JSON content-type guard above already blocks a simple form-based cross-site post.
 		return false
 	}
 
-	return origin != "http://"+request.Host && origin != "https://"+request.Host
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return true
+	}
+
+	// The desktop shell serves the SPA from the fixed wails:// origin; a remote page can never carry
+	// that scheme, so it is trusted like loopback.
+	if strings.EqualFold(parsed.Scheme, "wails") {
+		return false
+	}
+
+	return !isLoopbackOriginHost(parsed.Hostname())
+}
+
+// isLoopbackOriginHost reports whether a URL hostname names this machine's loopback interface.
+// "localhost" is included: an attacker can rebind their own name to 127.0.0.1, but cannot make a
+// browser report "localhost" as the origin of a page they serve.
+func isLoopbackOriginHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+
+	return ip != nil && ip.IsLoopback()
 }
 
 // handleUninstallPlugin removes an installed plugin by id. The id is validated here (and again in the

--- a/pkg/webui/api/plugins.go
+++ b/pkg/webui/api/plugins.go
@@ -339,34 +339,19 @@ func isCrossSiteBrowserRequest(request *http.Request) bool {
 		return false
 	}
 
+	// The desktop shell serves the SPA from this one fixed origin (see desktop/main.go). Compare the
+	// raw header so crafted values with otherwise invisible empty delimiters (`?` or `#`) cannot be
+	// normalized into the trusted value by url.Parse.
+	if origin == "wails://wails" {
+		return false
+	}
+
 	parsed, err := url.Parse(origin)
 	if err != nil {
 		return true
 	}
 
-	// The desktop shell serves the SPA from the fixed wails://wails origin (see desktop/main.go), so
-	// that one origin is trusted like loopback.
-	if isWailsDesktopOrigin(parsed) {
-		return false
-	}
-
 	return !isLoopbackOriginHost(parsed.Hostname())
-}
-
-// isWailsDesktopOrigin reports whether a parsed origin is exactly the desktop shell's `wails://wails`
-// origin. Matching the scheme alone is not enough: it would also admit `wails://attacker`, and since
-// the scheme is the only thing standing between this branch and plugin installation, any other
-// authority under it must be rejected. A browser-sent Origin carries scheme and authority and nothing
-// else, so a non-empty user, path, query or fragment marks a crafted header rather than a real one.
-func isWailsDesktopOrigin(parsed *url.URL) bool {
-	// Host, not Hostname, so a port (`wails://wails:8080`) fails the comparison rather than being
-	// stripped away before it.
-	return strings.EqualFold(parsed.Scheme, "wails") &&
-		strings.EqualFold(parsed.Host, "wails") &&
-		parsed.User == nil &&
-		parsed.Path == "" &&
-		parsed.RawQuery == "" &&
-		parsed.Fragment == ""
 }
 
 // isLoopbackOriginHost reports whether a URL hostname names this machine's loopback interface.

--- a/pkg/webui/api/plugins_test.go
+++ b/pkg/webui/api/plugins_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/webui/api"
@@ -29,6 +31,120 @@ func (p pluginStub) PluginAsset(_ context.Context, _, _ string) (api.PluginAsset
 	}
 
 	return p.asset, nil
+}
+
+type pluginInstallerStub struct {
+	pluginStub
+
+	installCalled bool
+}
+
+func (p *pluginInstallerStub) InstallPlugin(
+	_ context.Context,
+	_ api.PluginInstallRequest,
+) (api.PluginInfo, error) {
+	p.installCalled = true
+
+	return api.PluginInfo{Name: "demo", Main: "main.js"}, nil
+}
+
+func (p *pluginInstallerStub) UninstallPlugin(_ context.Context, _ string) error {
+	return nil
+}
+
+func doPluginInstall(
+	t *testing.T,
+	server *api.Server,
+	body string,
+	headers map[string]string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	request := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/api/v1/plugins",
+		strings.NewReader(body),
+	)
+	for name, value := range headers {
+		request.Header.Set(name, value)
+	}
+
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	return recorder
+}
+
+func TestInstallPluginRequiresJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	installer := &pluginInstallerStub{}
+	server := &api.Server{Service: installer}
+	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+
+	recorder := doPluginInstall(t, server, body, map[string]string{"Content-Type": "text/plain"})
+
+	if recorder.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("install status = %d, want 415", recorder.Code)
+	}
+	if installer.installCalled {
+		t.Fatal("InstallPlugin was called for a non-JSON request")
+	}
+}
+
+func TestInstallPluginRequiresTrustedConsent(t *testing.T) {
+	t.Parallel()
+
+	installer := &pluginInstallerStub{}
+	server := &api.Server{Service: installer}
+	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz"}`
+
+	recorder := doPluginInstall(t, server, body, map[string]string{"Content-Type": "application/json"})
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("install status = %d, want 422", recorder.Code)
+	}
+	if installer.installCalled {
+		t.Fatal("InstallPlugin was called without trusted consent")
+	}
+}
+
+func TestInstallPluginRejectsCrossSiteBrowserRequest(t *testing.T) {
+	t.Parallel()
+
+	installer := &pluginInstallerStub{}
+	server := &api.Server{Service: installer}
+	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+
+	recorder := doPluginInstall(t, server, body, map[string]string{
+		"Content-Type": "application/json",
+		"Origin":       "https://evil.example",
+	})
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("install status = %d, want 403", recorder.Code)
+	}
+	if installer.installCalled {
+		t.Fatal("InstallPlugin was called for a cross-site request")
+	}
+}
+
+func TestInstallPluginAcceptsTrustedJSONRequest(t *testing.T) {
+	t.Parallel()
+
+	installer := &pluginInstallerStub{}
+	server := &api.Server{Service: installer}
+	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+
+	recorder := doPluginInstall(t, server, body, map[string]string{"Content-Type": "application/json"})
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("install status = %d, want 201; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !installer.installCalled {
+		t.Fatal("InstallPlugin was not called for a trusted JSON request")
+	}
 }
 
 func TestConfigAdvertisesPluginsCapability(t *testing.T) {

--- a/pkg/webui/api/plugins_test.go
+++ b/pkg/webui/api/plugins_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/webui/api"
 )
 
+// trustedInstallBody is the install request every trust-gate test posts; the tests differ only in the
+// headers they present, so the body is fixed to keep that the single variable.
+const trustedInstallBody = `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz",` +
+	`"trusted":true}`
+
 // pluginStub is a ClusterService that also implements api.PluginService, returning canned plugin
 // metadata and asset bytes so the plugin routes and capability can be exercised without a filesystem.
 type pluginStub struct {
@@ -90,7 +95,7 @@ func TestInstallPluginRequiresJSONContentType(t *testing.T) {
 
 	installer := &pluginInstallerStub{}
 	server := &api.Server{Service: installer}
-	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+	body := trustedInstallBody
 
 	recorder := doPluginInstall(t, server, body, map[string]string{"Content-Type": "text/plain"})
 
@@ -128,7 +133,7 @@ func TestInstallPluginRejectsRebindingOriginMatchingHost(t *testing.T) {
 
 	installer := &pluginInstallerStub{}
 	server := &api.Server{Service: installer}
-	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+	body := trustedInstallBody
 
 	recorder := doPluginInstall(t, server, body, map[string]string{
 		"Content-Type":   "application/json",
@@ -153,7 +158,7 @@ func TestInstallPluginAcceptsLoopbackOrigin(t *testing.T) {
 
 	installer := &pluginInstallerStub{}
 	server := &api.Server{Service: installer}
-	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+	body := trustedInstallBody
 
 	recorder := doPluginInstall(t, server, body, map[string]string{
 		"Content-Type":   "application/json",
@@ -176,7 +181,7 @@ func TestInstallPluginRejectsCrossSiteBrowserRequest(t *testing.T) {
 
 	installer := &pluginInstallerStub{}
 	server := &api.Server{Service: installer}
-	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+	body := trustedInstallBody
 
 	recorder := doPluginInstall(t, server, body, map[string]string{
 		"Content-Type": "application/json",
@@ -196,7 +201,7 @@ func TestInstallPluginAcceptsTrustedJSONRequest(t *testing.T) {
 
 	installer := &pluginInstallerStub{}
 	server := &api.Server{Service: installer}
-	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+	body := trustedInstallBody
 
 	recorder := doPluginInstall(t, server, body, map[string]string{"Content-Type": "application/json"})
 

--- a/pkg/webui/api/plugins_test.go
+++ b/pkg/webui/api/plugins_test.go
@@ -102,6 +102,7 @@ func TestInstallPluginRequiresJSONContentType(t *testing.T) {
 	if recorder.Code != http.StatusUnsupportedMediaType {
 		t.Fatalf("install status = %d, want 415", recorder.Code)
 	}
+
 	if installer.installCalled {
 		t.Fatal("InstallPlugin was called for a non-JSON request")
 	}
@@ -114,11 +115,17 @@ func TestInstallPluginRequiresTrustedConsent(t *testing.T) {
 	server := &api.Server{Service: installer}
 	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz"}`
 
-	recorder := doPluginInstall(t, server, body, map[string]string{"Content-Type": "application/json"})
+	recorder := doPluginInstall(
+		t,
+		server,
+		body,
+		map[string]string{"Content-Type": "application/json"},
+	)
 
 	if recorder.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("install status = %d, want 422", recorder.Code)
 	}
+
 	if installer.installCalled {
 		t.Fatal("InstallPlugin was called without trusted consent")
 	}
@@ -191,6 +198,7 @@ func TestInstallPluginRejectsCrossSiteBrowserRequest(t *testing.T) {
 	if recorder.Code != http.StatusForbidden {
 		t.Fatalf("install status = %d, want 403", recorder.Code)
 	}
+
 	if installer.installCalled {
 		t.Fatal("InstallPlugin was called for a cross-site request")
 	}
@@ -203,11 +211,17 @@ func TestInstallPluginAcceptsTrustedJSONRequest(t *testing.T) {
 	server := &api.Server{Service: installer}
 	body := trustedInstallBody
 
-	recorder := doPluginInstall(t, server, body, map[string]string{"Content-Type": "application/json"})
+	recorder := doPluginInstall(
+		t,
+		server,
+		body,
+		map[string]string{"Content-Type": "application/json"},
+	)
 
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("install status = %d, want 201; body=%s", recorder.Code, recorder.Body.String())
 	}
+
 	if !installer.installCalled {
 		t.Fatal("InstallPlugin was not called for a trusted JSON request")
 	}

--- a/pkg/webui/api/plugins_test.go
+++ b/pkg/webui/api/plugins_test.go
@@ -399,6 +399,8 @@ func TestInstallPluginRejectsForeignWailsOrigin(t *testing.T) {
 		"wails://wails:8080",
 		"wails://user@wails",
 		"wails://wails/path",
+		"wails://wails?",
+		"wails://wails#",
 	} {
 		t.Run(origin, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/webui/api/plugins_test.go
+++ b/pkg/webui/api/plugins_test.go
@@ -387,3 +387,59 @@ func TestPluginContentType(t *testing.T) {
 		}
 	}
 }
+
+// TestInstallPluginRejectsForeignWailsOrigin pins that the desktop carve-out matches ONE origin. The
+// check previously trusted the `wails` scheme alone, which also admits `wails://attacker` — and the
+// scheme is the only thing standing between this branch and plugin installation.
+func TestInstallPluginRejectsForeignWailsOrigin(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range []string{
+		"wails://attacker",
+		"wails://wails:8080",
+		"wails://user@wails",
+		"wails://wails/path",
+	} {
+		t.Run(origin, func(t *testing.T) {
+			t.Parallel()
+
+			installer := &pluginInstallerStub{}
+			server := &api.Server{Service: installer}
+
+			recorder := doPluginInstall(t, server, trustedInstallBody, map[string]string{
+				"Content-Type": "application/json",
+				"Origin":       origin,
+			})
+
+			if recorder.Code != http.StatusForbidden {
+				t.Fatalf("install status = %d, want 403 for Origin %q", recorder.Code, origin)
+			}
+
+			if installer.installCalled {
+				t.Fatalf("InstallPlugin was called for Origin %q", origin)
+			}
+		})
+	}
+}
+
+// TestInstallPluginAcceptsDesktopWailsOrigin pins the everyday desktop path, so tightening the check
+// above cannot silently break the shell it exists to allow (see desktop/main.go).
+func TestInstallPluginAcceptsDesktopWailsOrigin(t *testing.T) {
+	t.Parallel()
+
+	installer := &pluginInstallerStub{}
+	server := &api.Server{Service: installer}
+
+	recorder := doPluginInstall(t, server, trustedInstallBody, map[string]string{
+		"Content-Type": "application/json",
+		"Origin":       "wails://wails",
+	})
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("install status = %d, want 201; body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	if !installer.installCalled {
+		t.Fatal("InstallPlugin was not called for the desktop wails://wails origin")
+	}
+}

--- a/pkg/webui/api/plugins_test.go
+++ b/pkg/webui/api/plugins_test.go
@@ -66,7 +66,16 @@ func doPluginInstall(
 		"/api/v1/plugins",
 		strings.NewReader(body),
 	)
+
 	for name, value := range headers {
+		// Host is not a normal header on an inbound request — net/http lifts it onto Request.Host — so
+		// it must be assigned there for a test to control what the handler sees.
+		if strings.EqualFold(name, "Host") {
+			request.Host = value
+
+			continue
+		}
+
 		request.Header.Set(name, value)
 	}
 
@@ -107,6 +116,58 @@ func TestInstallPluginRequiresTrustedConsent(t *testing.T) {
 	}
 	if installer.installCalled {
 		t.Fatal("InstallPlugin was called without trusted consent")
+	}
+}
+
+// TestInstallPluginRejectsRebindingOriginMatchingHost pins the DNS-rebinding case that a Host-derived
+// origin comparison cannot catch: the attacker's name has been rebound to loopback, so Origin and Host
+// agree and the browser reports Sec-Fetch-Site: same-origin. Only anchoring on the loopback identity
+// rejects it, and the installer must never be reached.
+func TestInstallPluginRejectsRebindingOriginMatchingHost(t *testing.T) {
+	t.Parallel()
+
+	installer := &pluginInstallerStub{}
+	server := &api.Server{Service: installer}
+	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+
+	recorder := doPluginInstall(t, server, body, map[string]string{
+		"Content-Type":   "application/json",
+		"Host":           "attacker.example",
+		"Origin":         "http://attacker.example",
+		"Sec-Fetch-Site": "same-origin",
+	})
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("install status = %d, want 403", recorder.Code)
+	}
+
+	if installer.installCalled {
+		t.Fatal("InstallPlugin was called for a DNS-rebound cross-site request")
+	}
+}
+
+// TestInstallPluginAcceptsLoopbackOrigin pins the everyday path: the SPA served from the loopback
+// listener still installs, so the hardening costs the local operator nothing.
+func TestInstallPluginAcceptsLoopbackOrigin(t *testing.T) {
+	t.Parallel()
+
+	installer := &pluginInstallerStub{}
+	server := &api.Server{Service: installer}
+	body := `{"url":"https://github.com/example/plugin/releases/download/v1/plugin.tar.gz","trusted":true}`
+
+	recorder := doPluginInstall(t, server, body, map[string]string{
+		"Content-Type":   "application/json",
+		"Host":           "127.0.0.1:8080",
+		"Origin":         "http://127.0.0.1:8080",
+		"Sec-Fetch-Site": "same-origin",
+	})
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("install status = %d, want 201", recorder.Code)
+	}
+
+	if !installer.installCalled {
+		t.Fatal("InstallPlugin was not called for a loopback-origin request")
 	}
 }
 

--- a/web/ui/src/api.ts
+++ b/web/ui/src/api.ts
@@ -759,10 +759,12 @@ export interface PluginCosign {
 // strongest; sha256 (hex, optional) pins the download (integrity); signature (base64 ed25519 detached
 // signature over the tarball bytes, optional) authenticates against the backend's trusted public key
 // (KSAIL_PLUGIN_SIGNING_PUBKEY) — the backend rejects a claimed signature when no key is configured;
-// name (optional) overrides the install id.
+// trusted is the server-enforced acknowledgement that the plugin runs unsandboxed; name (optional)
+// overrides the install id.
 export interface PluginInstallRequest {
   url: string;
   sha256?: string;
+  trusted: boolean;
   signature?: string;
   cosign?: PluginCosign;
   name?: string;

--- a/web/ui/src/components/PluginsView.tsx
+++ b/web/ui/src/components/PluginsView.tsx
@@ -110,6 +110,7 @@ function PluginInstallForm({ onInstalled }: { onInstalled: () => void }) {
       await installPlugin({
         url: url.trim(),
         sha256: sha256.trim() || undefined,
+        trusted: consent,
         signature: signature.trim() || undefined,
         cosign: cleanCosign(cosign),
       });
@@ -412,7 +413,7 @@ function CatalogEntryRow({
 
     try {
       // Forward the catalog's published SHA-256 (when present) so the install flow verifies integrity.
-      await installPlugin({ url: entry.url, sha256: entry.checksum });
+      await installPlugin({ url: entry.url, sha256: entry.checksum, trusted: consented });
       setInstalled(true);
       onInstalled();
     } catch (err) {


### PR DESCRIPTION
### Motivation
- Close a CSRF/trust-gate gap in the plugin installer so unsandboxed same-origin plugins cannot be installed via cross-site or non-JSON requests without server-verifiable consent. 
- The endpoint previously accepted arbitrary POSTs (including `text/plain`) and relied only on a client-side checkbox, enabling a remote page that can reach loopback to persist malicious plugins. 

### Description
- Add a server-enforced `trusted` acknowledgement to `PluginInstallRequest` and refuse installs when `trusted` is not set. (`pkg/webui/api/plugins.go`) 
- Guard `POST /api/v1/plugins` with `requirePluginInstallRequestGuards()` which enforces `Content-Type: application/json` and rejects cross-site browser requests (checks `Sec-Fetch-Site` / `Origin`) before decoding or invoking `InstallPlugin`. (`pkg/webui/api/plugins.go`) 
- Propagate the consent value from the SPA by adding `trusted` to the TypeScript API and sending it from both the manual install form and the catalog install flow. (`web/ui/src/api.ts`, `web/ui/src/components/PluginsView.tsx`) 
- Add targeted server-side tests covering rejected non-JSON requests, missing `trusted`, cross-site origin rejection, and an accepted trusted JSON install. (`pkg/webui/api/plugins_test.go`) 

### Testing
- Attempted `go test ./pkg/webui/api -run 'TestInstallPlugin'`, but the run was blocked by an external module fetch failure (`proxy.golang.org` returned 403) so the Go unit tests could not complete in this environment. 
- `npm --prefix web/ui run build` completed successfully and the SPA build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52c94a27f8832bbadefd4e35b814ca)