### PR TITLE
fix(webui): force kube proxy JSON content type

### DIFF
--- a/pkg/webui/api/kubeproxy.go
+++ b/pkg/webui/api/kubeproxy.go
@@ -52,14 +52,11 @@ func (s *Server) handleKubeProxy(writer http.ResponseWriter, request *http.Reque
 
 	defer func() { _ = result.Body.Close() }()
 
-	contentType := result.ContentType
-	if contentType == "" {
-		contentType = "application/json"
-	}
-
-	// nosniff keeps the upstream content type authoritative; the body is streamed (not buffered) so a
-	// large list response does not balloon server memory.
-	writer.Header().Set("Content-Type", contentType)
+	// Always serve kube-apiserver proxy responses as JSON. Kubernetes proxy subresources can return
+	// attacker-controlled active content (for example text/html or application/javascript); preserving
+	// that upstream Content-Type would make it executable in the KSail UI origin. The body remains
+	// streamed (not buffered) so a large list response does not balloon server memory.
+	writer.Header().Set("Content-Type", "application/json")
 	writer.Header().Set("X-Content-Type-Options", "nosniff")
 	writer.WriteHeader(result.Status)
 	_, _ = io.Copy(writer, result.Body)

--- a/pkg/webui/api/kubeproxy_test.go
+++ b/pkg/webui/api/kubeproxy_test.go
@@ -17,9 +17,10 @@ import (
 type kubeProxyStub struct {
 	stubClusterService
 
-	body     string
-	gotPath  string
-	gotQuery string
+	body        string
+	contentType string
+	gotPath     string
+	gotQuery    string
 }
 
 func (k *kubeProxyStub) ProxyKubeGet(
@@ -32,7 +33,7 @@ func (k *kubeProxyStub) ProxyKubeGet(
 
 	return api.KubeProxyResponse{
 		Status:      http.StatusOK,
-		ContentType: "application/json",
+		ContentType: k.contentType,
 		Body:        io.NopCloser(strings.NewReader(k.body)),
 	}, nil
 }
@@ -64,6 +65,35 @@ func TestKubeProxyStreamsResponseAndForwardsPathQuery(t *testing.T) {
 
 	if stub.gotQuery != "labelSelector=app%3Dx" {
 		t.Errorf("forwarded query = %q, want labelSelector=app%%3Dx", stub.gotQuery)
+	}
+}
+
+func TestKubeProxyForcesJSONContentTypeForUpstreamActiveContent(t *testing.T) {
+	t.Parallel()
+
+	stub := &kubeProxyStub{
+		body:        `<!doctype html><script src="/api/v1/clusters/default/kind/proxy/api/v1/namespaces/default/services/http:evil/proxy/pwn.js"></script>`,
+		contentType: "text/html; charset=utf-8",
+	}
+	server := &api.Server{Service: stub}
+
+	target := "/api/v1/clusters/default/kind/proxy/api/v1/namespaces/default/services/http:evil/proxy/"
+	recorder := doRequest(server.Handler(), http.MethodGet, target, "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("proxy status = %d, want 200", recorder.Code)
+	}
+
+	if got := recorder.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content type = %q, want application/json", got)
+	}
+
+	if got := recorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("x-content-type-options = %q, want nosniff", got)
+	}
+
+	if got := recorder.Body.String(); !strings.Contains(got, "<!doctype html>") {
+		t.Errorf("proxy body = %q, want streamed upstream body", got)
 	}
 }
 

--- a/pkg/webui/api/kubeproxy_test.go
+++ b/pkg/webui/api/kubeproxy_test.go
@@ -92,8 +92,11 @@ func TestKubeProxyForcesJSONContentTypeForUpstreamActiveContent(t *testing.T) {
 		t.Errorf("x-content-type-options = %q, want nosniff", got)
 	}
 
-	if got := recorder.Body.String(); !strings.Contains(got, "<!doctype html>") {
-		t.Errorf("proxy body = %q, want streamed upstream body", got)
+	// Compare the whole body: the handler neutralizes active content by forcing the response content
+	// type, never by rewriting the payload, so a substring check would still pass if the body were
+	// truncated or sanitized.
+	if got := recorder.Body.String(); got != stub.body {
+		t.Errorf("proxy body = %q, want %q", got, stub.body)
 	}
 }
 

--- a/pkg/webui/api/kubeproxy_test.go
+++ b/pkg/webui/api/kubeproxy_test.go
@@ -72,7 +72,8 @@ func TestKubeProxyForcesJSONContentTypeForUpstreamActiveContent(t *testing.T) {
 	t.Parallel()
 
 	stub := &kubeProxyStub{
-		body:        `<!doctype html><script src="/api/v1/clusters/default/kind/proxy/api/v1/namespaces/default/services/http:evil/proxy/pwn.js"></script>`,
+		body: `<!doctype html><script src="/api/v1/clusters/default/kind/proxy/` +
+			`api/v1/namespaces/default/services/http:evil/proxy/pwn.js"></script>`,
 		contentType: "text/html; charset=utf-8",
 	}
 	server := &api.Server{Service: stub}


### PR DESCRIPTION
### Motivation

- Prevent the local kube-apiserver proxy from serving attacker-controlled active content (HTML/JS) under the KSail UI origin which could enable same-origin XSS and access to local APIs and credentials.
- Preserve the read-only, streaming proxy behaviour while ensuring upstream proxy subresources are rendered inert in the browser.

### Description

- In `pkg/webui/api/kubeproxy.go` always set `Content-Type: application/json` (keep `X-Content-Type-Options: nosniff`) and continue streaming the upstream body to avoid executing upstream active content in the KSail origin.
- Add a regression unit test `TestKubeProxyForcesJSONContentTypeForUpstreamActiveContent` in `pkg/webui/api/kubeproxy_test.go` and extend the test stub to surface upstream `Content-Type` so proxy subresource responses can be simulated.
- Commit message: `fix(webui): force kube proxy JSON content type` with the relevant files updated: `pkg/webui/api/kubeproxy.go` and `pkg/webui/api/kubeproxy_test.go`.

### Testing

- Ran `git diff --check` and created the commit containing the change.
- Attempted to run `go test ./pkg/webui/api` (including the new test) but the test run in this environment was blocked by module download failures from `proxy.golang.org` (fetch of `mvdan.cc/sh/v3` returned `Forbidden`), so tests could not be completed here.
- The added unit test asserts the handler forces `Content-Type: application/json`, preserves `X-Content-Type-Options: nosniff`, and still streams the upstream body, and should pass in a normal development environment where module downloads are allowed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52f36aa740832b88d1250afd385d9f)