### PR TITLE
fix(webui): enforce same-origin policy for pod exec WebSocket

### DIFF
--- a/pkg/webui/api/exec_handler.go
+++ b/pkg/webui/api/exec_handler.go
@@ -92,9 +92,11 @@ func (s *Server) handleExec(writer http.ResponseWriter, request *http.Request) {
 		command = []string{"/bin/sh"}
 	}
 
-	// CheckOrigin allows any origin: the endpoint is already behind the auth guard (when OIDC is on)
-	// and the read-only check above, and the desktop connects cross-origin (wails:// → loopback).
-	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	// Use gorilla/websocket's default origin policy: requests without an Origin header are allowed,
+	// and browser requests must be same-origin (Origin host equals Host). The local UI is
+	// unauthenticated and bound to loopback, so allowing arbitrary browser origins would let a
+	// malicious page drive pod exec through a victim's local kubeconfig.
+	upgrader := websocket.Upgrader{}
 
 	conn, err := upgrader.Upgrade(writer, request, nil)
 	if err != nil {

--- a/pkg/webui/api/exec_handler.go
+++ b/pkg/webui/api/exec_handler.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -92,11 +95,7 @@ func (s *Server) handleExec(writer http.ResponseWriter, request *http.Request) {
 		command = []string{"/bin/sh"}
 	}
 
-	// Use gorilla/websocket's default origin policy: requests without an Origin header are allowed,
-	// and browser requests must be same-origin (Origin host equals Host). The local UI is
-	// unauthenticated and bound to loopback, so allowing arbitrary browser origins would let a
-	// malicious page drive pod exec through a victim's local kubeconfig.
-	upgrader := websocket.Upgrader{}
+	upgrader := websocket.Upgrader{CheckOrigin: execCheckOrigin}
 
 	conn, err := upgrader.Upgrade(writer, request, nil)
 	if err != nil {
@@ -111,6 +110,52 @@ func (s *Server) handleExec(writer http.ResponseWriter, request *http.Request) {
 		Container: query.Get("container"),
 		Command:   command,
 	})
+}
+
+// execCheckOrigin decides whether a WebSocket upgrade may proceed. The exec endpoint is served only by
+// the loopback-bound local backend (the operator's service does not implement ExecService, so the route
+// is never registered there) and is unauthenticated, so a browser origin is trusted only when the page
+// was itself served from loopback.
+//
+// gorilla/websocket's default policy is not enough here: it only requires the Origin host to equal the
+// request Host, and under DNS rebinding an attacker controls both. A page on attacker.example whose name
+// has been rebound to 127.0.0.1 sends Origin: http://attacker.example and Host: attacker.example, which
+// the default policy accepts — handing a remote page a shell in the victim's cluster. Anchoring on the
+// loopback identity closes that: a browser sets Origin from the page's real URL, so only a page actually
+// served from loopback can present a loopback origin.
+func execCheckOrigin(request *http.Request) bool {
+	origin := request.Header.Get("Origin")
+	if origin == "" {
+		// Non-browser client (CLI tooling, tests). Browsers always send Origin on a WebSocket upgrade,
+		// so an absent header is not a cross-site request.
+		return true
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	// The desktop shell serves the SPA from the fixed wails:// origin through the Wails AssetServer, with
+	// no TCP listener at all. A remote page can never carry that scheme, so it is trusted like loopback.
+	if strings.EqualFold(parsed.Scheme, "wails") {
+		return true
+	}
+
+	return isLoopbackHost(parsed.Hostname())
+}
+
+// isLoopbackHost reports whether a URL hostname names this machine's loopback interface. "localhost" is
+// included: an attacker can rebind their own name to 127.0.0.1, but cannot make a browser report
+// "localhost" as the origin of a page they serve.
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+
+	return ip != nil && ip.IsLoopback()
 }
 
 // runExecSession bridges the WebSocket connection to the ExecService: client frames feed stdin/resize,

--- a/pkg/webui/api/exec_test.go
+++ b/pkg/webui/api/exec_test.go
@@ -57,7 +57,10 @@ func TestExecWebSocketBridge(t *testing.T) {
 
 	url := execWebSocketURL(server.URL, "/api/v1/clusters/default/c1/exec?pod=p1")
 
-	conn, response, err := websocket.DefaultDialer.Dial(url, nil)
+	header := http.Header{}
+	header.Set("Origin", server.URL)
+
+	conn, response, err := websocket.DefaultDialer.Dial(url, header)
 	require.NoError(t, err)
 
 	if response != nil {
@@ -78,6 +81,24 @@ func TestExecWebSocketBridge(t *testing.T) {
 	require.NoError(t, conn.ReadJSON(&msg))
 	assert.Equal(t, "stdout", msg.Op)
 	assert.Equal(t, "hello", msg.Data)
+}
+
+func TestExecRejectsCrossOriginWebSocket(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer((&api.Server{Service: execStub{}}).Handler())
+	defer server.Close()
+
+	url := execWebSocketURL(server.URL, "/api/v1/clusters/default/c1/exec?pod=p1")
+	header := http.Header{}
+	header.Set("Origin", "https://attacker.example")
+
+	_, response, err := websocket.DefaultDialer.Dial(url, header)
+	require.Error(t, err)
+	require.NotNil(t, response)
+	defer func() { _ = response.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
 }
 
 func TestExecBlockedWhenReadOnly(t *testing.T) {

--- a/pkg/webui/api/exec_test.go
+++ b/pkg/webui/api/exec_test.go
@@ -96,6 +96,7 @@ func TestExecRejectsCrossOriginWebSocket(t *testing.T) {
 	_, response, err := websocket.DefaultDialer.Dial(url, header)
 	require.Error(t, err)
 	require.NotNil(t, response)
+
 	defer func() { _ = response.Body.Close() }()
 
 	assert.Equal(t, http.StatusForbidden, response.StatusCode)

--- a/pkg/webui/api/exec_test.go
+++ b/pkg/webui/api/exec_test.go
@@ -34,8 +34,12 @@ func (execStub) Exec(
 	return nil
 }
 
-func execWebSocketURL(httpURL, path string) string {
-	return "ws" + strings.TrimPrefix(httpURL, "http") + path
+// execPath is the exec endpoint every exec test drives; it is fixed so the tests differ only in the
+// headers they present.
+const execPath = "/api/v1/clusters/default/c1/exec?pod=p1"
+
+func execWebSocketURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http") + execPath
 }
 
 func TestConfigReportsWorkloadExec(t *testing.T) {
@@ -55,7 +59,7 @@ func TestExecWebSocketBridge(t *testing.T) {
 	server := httptest.NewServer((&api.Server{Service: execStub{}}).Handler())
 	defer server.Close()
 
-	url := execWebSocketURL(server.URL, "/api/v1/clusters/default/c1/exec?pod=p1")
+	url := execWebSocketURL(server.URL)
 
 	header := http.Header{}
 	header.Set("Origin", server.URL)
@@ -89,7 +93,7 @@ func TestExecRejectsCrossOriginWebSocket(t *testing.T) {
 	server := httptest.NewServer((&api.Server{Service: execStub{}}).Handler())
 	defer server.Close()
 
-	url := execWebSocketURL(server.URL, "/api/v1/clusters/default/c1/exec?pod=p1")
+	url := execWebSocketURL(server.URL)
 	header := http.Header{}
 	header.Set("Origin", "https://attacker.example")
 
@@ -102,13 +106,61 @@ func TestExecRejectsCrossOriginWebSocket(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, response.StatusCode)
 }
 
+// TestExecRejectsRebindingOriginMatchingHost pins the DNS-rebinding case, which a same-origin policy
+// cannot catch: the attacker's hostname has been rebound to loopback, so Origin and Host agree and
+// gorilla's default CheckOrigin would accept the upgrade. Only anchoring on the loopback identity
+// rejects it.
+func TestExecRejectsRebindingOriginMatchingHost(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer((&api.Server{Service: execStub{}}).Handler())
+	defer server.Close()
+
+	url := execWebSocketURL(server.URL)
+	header := http.Header{}
+	// gorilla's Dialer promotes a "Host" header into the request's Host field, so this reproduces a
+	// rebound name resolving to the loopback listener with a self-consistent Origin/Host pair.
+	header.Set("Host", "attacker.example")
+	header.Set("Origin", "http://attacker.example")
+
+	_, response, err := websocket.DefaultDialer.Dial(url, header)
+	require.Error(t, err)
+	require.NotNil(t, response)
+
+	defer func() { _ = response.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
+}
+
+// TestExecAllowsLocalhostOrigin pins the everyday path: the SPA served from the loopback listener under
+// the "localhost" spelling still upgrades, so the hardening costs the operator nothing.
+func TestExecAllowsLocalhostOrigin(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer((&api.Server{Service: execStub{}}).Handler())
+	defer server.Close()
+
+	url := execWebSocketURL(server.URL)
+	header := http.Header{}
+	header.Set("Origin", "http://localhost:8080")
+
+	conn, response, err := websocket.DefaultDialer.Dial(url, header)
+	require.NoError(t, err)
+
+	if response != nil {
+		defer func() { _ = response.Body.Close() }()
+	}
+
+	defer func() { _ = conn.Close() }()
+}
+
 func TestExecBlockedWhenReadOnly(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer((&api.Server{Service: execStub{}, ReadOnly: true}).Handler())
 	defer server.Close()
 
-	url := execWebSocketURL(server.URL, "/api/v1/clusters/default/c1/exec?pod=p1")
+	url := execWebSocketURL(server.URL)
 
 	_, response, err := websocket.DefaultDialer.Dial(url, nil)
 	require.Error(t, err) // upgrade refused before switching protocols


### PR DESCRIPTION
### Motivation
- The pod exec WebSocket previously used an upgrader with `CheckOrigin` returning `true`, which allowed browser pages from arbitrary origins to open WebSocket connections to a local, unauthenticated UI and drive `kubectl`-style exec into pods using the user's kubeconfig.
- This created a cross-origin security boundary break enabling a malicious webpage to execute commands in cluster workloads when the local UI was running.

### Description
- Replace the permissive upgrader with the default gorilla/websocket policy by changing the upgrader in `pkg/webui/api/exec_handler.go` from `websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}` to `websocket.Upgrader{}` so browser-initiated connections must be same-origin while non-browser/no-origin clients are still allowed.
- Add regression coverage in `pkg/webui/api/exec_test.go` that verifies a same-origin `Origin` header succeeds and that a cross-origin `Origin` (e.g. `https://attacker.example`) is rejected with `403 Forbidden`.
- The change preserves behavior for non-browser clients and for same-origin local UI/desktop flows while closing the cross-origin attack vector.

### Testing
- Ran `gofmt` to apply formatting changes on the modified files and verified the working tree diff for correctness; no formatting issues remain.
- Attempted unit tests: ran `go test ./pkg/webui/api -run 'TestExec(WebSocketBridge|RejectsCrossOriginWebSocket)' -count=1`, but the run was blocked by environment module fetch restrictions (failed to download `mvdan.cc/sh/v3` from the proxy), so the tests could not be executed to completion in this environment.
- Also attempted `GOPROXY=direct go test ...` which was similarly blocked by network/registry fetch restrictions; test code and assertions are present and intended to pass when dependencies are available in an unrestricted environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a531022448c832bae3d1b1d2afabc57)