### PR TITLE
fix(release): recognize coalesced cask handoffs

### DIFF
--- a/.github/fixtures/cask-pr-handoff/fake-bin/gh
+++ b/.github/fixtures/cask-pr-handoff/fake-bin/gh
@@ -4,10 +4,37 @@ set -euo pipefail
 
 scenario="${FAKE_GH_SCENARIO:-valid}"
 command_line="$*"
+state_dir="${FAKE_GH_STATE_DIR:-}"
 
-if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls/42" ]]; then
+merged_scenario=false
+if [[ "${scenario}" == merged* ]]; then
+	merged_scenario=true
+fi
+
+if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls/43" ]]; then
+	if [[ "${scenario}" == merged-newest-invalid ]]; then
+		printf 'simulated invalid newest candidate\n' >&2
+		exit 1
+	fi
+	printf 'unexpected candidate 43 lookup\n' >&2
+	exit 2
+elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls/42" ]]; then
 	[[ "${scenario}" == pr-failure ]] && exit 1
-	printf '%s\n' '{
+	if [[ "${merged_scenario}" == true ]]; then
+		printf '%s\n' '{
+    "state":"closed",
+    "draft":false,
+    "merged":true,
+    "merged_at":"2026-07-18T19:58:28Z",
+    "merge_commit_sha":"4444444444444444444444444444444444444444",
+    "user":{"login":"devantler"},
+    "head":{"ref":"goreleaser/ksail","sha":"1111111111111111111111111111111111111111","repo":{"full_name":"devantler-tech/homebrew-tap"}},
+    "base":{"ref":"main","repo":{"full_name":"devantler-tech/homebrew-tap"}},
+    "title":"chore(cask): update ksail to v7.166.0",
+    "labels":[{"name":"automation"},{"name":"dependencies"}]
+  }'
+	else
+		printf '%s\n' '{
     "state":"open",
     "draft":true,
     "user":{"login":"devantler"},
@@ -16,12 +43,15 @@ if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls/42" ]]; 
     "title":"chore(cask): update ksail to v7.166.1",
     "labels":[{"name":"automation"},{"name":"dependencies"}]
   }'
+	fi
 elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/pulls/42/files?per_page=100" ]]; then
 	[[ "${scenario}" == files-failure ]] && exit 1
 	if [[ "${scenario}" == malformed-files ]]; then
 		printf '%s\n' '{}'
 	elif [[ "${scenario}" == paginated-files ]]; then
 		printf '%s\n' '[[{"filename":"Casks/ksail.rb"}],[{"filename":"README.md"}]]'
+	elif [[ "${merged_scenario}" == true ]]; then
+		printf '%s\n' '[[{"filename":"Casks/ksail.rb","sha":"2222222222222222222222222222222222222222"}]]'
 	else
 		printf '%s\n' '[[{"filename":"Casks/ksail.rb"}]]'
 	fi
@@ -44,7 +74,47 @@ elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/contents/Cas
 	if [[ "${scenario}" == malformed-contents ]]; then
 		printf '%s\n' '{"path":"Casks/ksail.rb"}'
 	else
-		printf '%s\n' '{"path":"Casks/ksail.rb","content":"Y2FzayAia3NhaWwiIGRvCiAgdmVyc2lvbiAiNy4xNjYuMSIKICBzaGEyNTYgIjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiCgogIHVybCAiaHR0cHM6Ly9naXRodWIuY29tL2RldmFudGxlci10ZWNoL2tzYWlsL3JlbGVhc2VzL2Rvd25sb2FkL3Y3LjE2Ni4xL2tzYWlsXzcuMTY2LjFfZGFyd2luX2FybTY0LnRhci5neiIKZW5kCg=="}'
+		printf '%s\n' '{"path":"Casks/ksail.rb","sha":"2222222222222222222222222222222222222222","content":"Y2FzayAia3NhaWwiIGRvCiAgdmVyc2lvbiAiNy4xNjYuMSIKICBzaGEyNTYgIjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiCgogIHVybCAiaHR0cHM6Ly9naXRodWIuY29tL2RldmFudGxlci10ZWNoL2tzYWlsL3JlbGVhc2VzL2Rvd25sb2FkL3Y3LjE2Ni4xL2tzYWlsXzcuMTY2LjFfZGFyd2luX2FybTY0LnRhci5neiIKZW5kCg=="}'
+	fi
+elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/git/ref/heads/main" ]]; then
+	[[ "${scenario}" == merged-main-ref-failure ]] && exit 1
+	if [[ "${scenario}" == merged-moving-main && -n "${state_dir}" ]]; then
+		if [[ -f "${state_dir}/main-ref-read" ]]; then
+			printf '%s\n' '{"object":{"sha":"7777777777777777777777777777777777777777"}}'
+		else
+			touch "${state_dir}/main-ref-read"
+			printf '%s\n' '{"object":{"sha":"5555555555555555555555555555555555555555"}}'
+		fi
+	else
+		printf '%s\n' '{"object":{"sha":"5555555555555555555555555555555555555555"}}'
+	fi
+elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/contents/Casks/ksail.rb?ref=4444444444444444444444444444444444444444" ]]; then
+	[[ "${scenario}" == merged-merge-file-failure ]] && exit 1
+	printf '%s\n' '{"path":"Casks/ksail.rb","sha":"2222222222222222222222222222222222222222","content":"Y2FzayAia3NhaWwiIGRvCiAgdmVyc2lvbiAiNy4xNjYuMSIKICBzaGEyNTYgIjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiCgogIHVybCAiaHR0cHM6Ly9naXRodWIuY29tL2RldmFudGxlci10ZWNoL2tzYWlsL3JlbGVhc2VzL2Rvd25sb2FkL3Y3LjE2Ni4xL2tzYWlsXzcuMTY2LjFfZGFyd2luX2FybTY0LnRhci5neiIKZW5kCg=="}'
+elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/contents/Casks/ksail.rb?ref=5555555555555555555555555555555555555555" ]]; then
+	[[ "${scenario}" == merged-main-file-failure ]] && exit 1
+	if [[ "${scenario}" == merged-malformed-main-file ]]; then
+		printf '%s\n' '{"path":"Casks/ksail.rb"}'
+	else
+		printf '%s\n' '{"path":"Casks/ksail.rb","sha":"2222222222222222222222222222222222222222","content":"Y2FzayAia3NhaWwiIGRvCiAgdmVyc2lvbiAiNy4xNjYuMSIKICBzaGEyNTYgIjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiCgogIHVybCAiaHR0cHM6Ly9naXRodWIuY29tL2RldmFudGxlci10ZWNoL2tzYWlsL3JlbGVhc2VzL2Rvd25sb2FkL3Y3LjE2Ni4xL2tzYWlsXzcuMTY2LjFfZGFyd2luX2FybTY0LnRhci5neiIKZW5kCg=="}'
+	fi
+elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/compare/4444444444444444444444444444444444444444...5555555555555555555555555555555555555555" ]]; then
+	[[ "${scenario}" == merged-comparison-failure ]] && exit 1
+	printf '%s\n' '{"status":"ahead","behind_by":0,"merge_base_commit":{"sha":"4444444444444444444444444444444444444444"}}'
+elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/pulls?state=closed&head=devantler-tech:goreleaser/ksail&per_page=100" ]]; then
+	[[ "${scenario}" == merged-list-failure ]] && exit 1
+	author="devantler"
+	merged_at='"2026-07-18T19:58:28Z"'
+	[[ "${scenario}" == merged-wrong-list-author ]] && author="someone-else"
+	[[ "${scenario}" == merged-closed-unmerged ]] && merged_at=null
+	candidate="{\"number\":42,\"merged_at\":${merged_at},\"user\":{\"login\":\"${author}\"},\"head\":{\"ref\":\"goreleaser/ksail\",\"repo\":{\"full_name\":\"devantler-tech/homebrew-tap\"}},\"base\":{\"ref\":\"main\",\"repo\":{\"full_name\":\"devantler-tech/homebrew-tap\"}}}"
+	if [[ "${scenario}" == merged-later-page ]]; then
+		printf '[[],[%s]]\n' "${candidate}"
+	elif [[ "${scenario}" == merged-newest-invalid ]]; then
+		newest="{\"number\":43,\"merged_at\":\"2026-07-18T20:58:28Z\",\"user\":{\"login\":\"devantler\"},\"head\":{\"ref\":\"goreleaser/ksail\",\"repo\":{\"full_name\":\"devantler-tech/homebrew-tap\"}},\"base\":{\"ref\":\"main\",\"repo\":{\"full_name\":\"devantler-tech/homebrew-tap\"}}}"
+		printf '[[%s,%s]]\n' "${candidate}" "${newest}"
+	else
+		printf '[[%s]]\n' "${candidate}"
 	fi
 else
 	printf 'unexpected fake gh invocation: %s\n' "${command_line}" >&2

--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -94,7 +94,7 @@ chmod +x "${race_root}/.github/scripts/find-merged-cask-pr-handoff.sh"
 	RECONCILE_RACE_STATE="${race_root}/calls"
 	export TAP GITHUB_REPOSITORY TAG evidence_dir GITHUB_STEP_SUMMARY RECONCILE_RACE_STATE
 	handoff_failed=0
-	# shellcheck disable=SC2329 # Invoked by the sourced workflow function.
+	# shellcheck disable=SC2317,SC2329 # Invoked by the sourced workflow function.
 	sleep() { :; }
 	# shellcheck source=/dev/null
 	source "${reconcile_function}"

--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -11,6 +11,7 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 homebrew_block="${tmp_dir}/homebrew.yaml"
 execution_surface="${tmp_dir}/execution-surface.sh"
+selected_open_block="${tmp_dir}/selected-open-block.sh"
 
 awk '
   /^  homebrew:/ { in_homebrew = 1 }
@@ -21,9 +22,18 @@ awk '
 awk '1' \
 	"${homebrew_block}" \
 	"${repo_root}/.github/scripts/collect-cask-pr-handoff.sh" \
+	"${repo_root}/.github/scripts/find-merged-cask-pr-handoff.sh" \
 	"${repo_root}/.github/scripts/validate-cask-pr-handoff.sh" \
 	"${repo_root}/.github/scripts/redraft-evergreen-cask-prs.sh" \
 	>"${execution_surface}"
+
+# Once an open PR is selected it can auto-merge between any API call. No later failure may set the
+# global failure bit directly: it must first pass through the immutable merged-current-main proof.
+awk '
+  /pr="\$\(jq -r '\''\.\[0\]\.number'\''/ { in_selected_open = 1 }
+  /if \[ "\$handoff_failed" -ne 0 \]/ { in_selected_open = 0 }
+  in_selected_open { print }
+' "${homebrew_block}" >"${selected_open_block}"
 
 fail() {
 	printf 'FAIL: %s\n' "$1" >&2
@@ -67,10 +77,41 @@ assert_contains 'failed prepared revalidation' "${homebrew_block}" \
 	'release job must fail the rerun red when an already-ready cask PR no longer passes prepared revalidation'
 # A partial rerun may find the first cask ALREADY MERGED by the tap auto-merge; the open-only query
 # then returns zero, so the job must check for a merged, this-tag cask before failing red (#6134).
-assert_contains 'pulls?state=closed&head=' "${homebrew_block}" \
+assert_contains 'find-merged-cask-pr-handoff.sh' "${homebrew_block}" \
+	'release job must route every zero-open-PR result through the fully validated merged finder'
+assert_contains 'reconcile_merged_handoff "$name"' "${selected_open_block}" \
+	'open-PR failures must retry through the merged-current-main proof after an auto-merge race'
+assert_not_contains 'handoff_failed=1' "${selected_open_block}" \
+	'no failure after selecting an open PR may bypass merged-current-main reconciliation'
+reconciliation_calls="$(grep -Fc -- 'reconcile_merged_handoff "$name"' \
+	"${selected_open_block}" || true)"
+if [[ "${reconciliation_calls}" -ne 9 ]]; then
+	fail "every selected-open failure must reconcile an auto-merge race; expected 9 call sites, found ${reconciliation_calls}"
+fi
+for context in \
+	'failed ready-PR revalidation' \
+	'failed draft validation after open enumeration' \
+	'brew became unavailable while preparing' \
+	'could not be confirmed brew-style-clean' \
+	'failed post-style validation' \
+	'could not receive normalized metadata' \
+	'metadata could not be completed' \
+	'failed prepared validation' \
+	'could not be marked ready'; do
+	assert_contains "${context}" "${selected_open_block}" \
+		"selected-open failure is missing merged reconciliation context: ${context}"
+done
+assert_not_contains 'and .title == $title' "${homebrew_block}" \
+	'release job must not trust an exact merged PR title without immutable cask evidence'
+assert_contains 'pulls?state=closed&head=' \
+	"${repo_root}/.github/scripts/find-merged-cask-pr-handoff.sh" \
 	'release job must check for an already-merged cask PR on a rerun (open-only query misses it)'
-assert_contains 'merged_at != null' "${homebrew_block}" \
-	'release job must count only MERGED closed cask PRs when treating a rerun as already handed off'
+assert_contains '--include-main' \
+	"${repo_root}/.github/scripts/find-merged-cask-pr-handoff.sh" \
+	'merged finder must collect pinned-main and immutable merge evidence before accepting a handoff'
+assert_contains '--merged' \
+	"${repo_root}/.github/scripts/find-merged-cask-pr-handoff.sh" \
+	'merged finder must apply the fail-closed merged validator to every candidate'
 # A generated cask the runner could not style-clean (clone/tempdir/push failure) would be rejected by
 # the tap's brew-style gate, silently blocking auto-merge — the job must go red, not promote it (#6134).
 assert_contains 'could not ensure it is brew-style-clean' "${homebrew_block}" \
@@ -149,6 +190,22 @@ assert_contains '.github/scripts/validate-cask-pr-handoff.test.sh' "${ci_workflo
 	'CI must execute the handoff fixture suite'
 assert_contains '.github/scripts/collect-cask-pr-handoff.test.sh' "${ci_workflow}" \
 	'CI must execute the handoff collector suite'
+assert_contains '.github/scripts/find-merged-cask-pr-handoff.test.sh' "${ci_workflow}" \
+	'CI must include the paginated merged-handoff finder suite'
+assert_contains "- '.github/scripts/find-merged-cask-pr-handoff.sh'" "${ci_workflow}" \
+	'CI paths filter must trigger the handoff job on merged-finder changes'
+assert_contains "- '.github/scripts/find-merged-cask-pr-handoff.test.sh'" "${ci_workflow}" \
+	'CI paths filter must trigger the handoff job on merged-finder test changes'
+if [[ "$(grep -Fc -- '.github/scripts/find-merged-cask-pr-handoff.sh' "${ci_workflow}" || true)" -lt 2 ]]; then
+	fail 'CI must shellcheck the merged finder in addition to path-filtering it'
+fi
+if [[ "$(grep -Fc -- '.github/scripts/find-merged-cask-pr-handoff.test.sh' "${ci_workflow}" || true)" -lt 3 ]]; then
+	fail 'CI must path-filter, shellcheck, and execute the merged-finder test'
+fi
+if ! grep -Eq '^[[:space:]]+\.github/scripts/find-merged-cask-pr-handoff\.test\.sh[[:space:]]*$' \
+	"${ci_workflow}"; then
+	fail 'CI must execute the paginated merged-handoff finder suite as a standalone command'
+fi
 assert_contains '.github/scripts/cask-pr-handoff-workflow.test.sh' "${ci_workflow}" \
 	'CI must execute the handoff workflow contract suite'
 

--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -12,6 +12,7 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 homebrew_block="${tmp_dir}/homebrew.yaml"
 execution_surface="${tmp_dir}/execution-surface.sh"
 selected_open_block="${tmp_dir}/selected-open-block.sh"
+reconcile_function="${tmp_dir}/reconcile-merged-handoff.sh"
 
 awk '
   /^  homebrew:/ { in_homebrew = 1 }
@@ -35,6 +36,19 @@ awk '
   in_selected_open { print }
 ' "${homebrew_block}" >"${selected_open_block}"
 
+# Exercise the workflow's real reconciliation function, not a copied test helper. A selected open
+# PR can merge after the finder's first closed-PR enumeration, so the function must retry within a
+# fixed bound before it records a failed handoff.
+awk '
+  /^[[:space:]]+reconcile_merged_handoff\(\) \{/ { in_function = 1 }
+  in_function {
+    line = $0
+    sub(/^          /, "", line)
+    print line
+  }
+  in_function && /^          }[[:space:]]*$/ { exit }
+' "${homebrew_block}" >"${reconcile_function}"
+
 fail() {
 	printf 'FAIL: %s\n' "$1" >&2
 	exit 1
@@ -51,6 +65,43 @@ assert_not_contains() {
 		fail "${message}"
 	fi
 }
+
+race_root="${tmp_dir}/merged-race"
+mkdir -p "${race_root}/.github/scripts" "${race_root}/evidence"
+cat >"${race_root}/.github/scripts/find-merged-cask-pr-handoff.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+calls=0
+if [[ -f "${RECONCILE_RACE_STATE}" ]]; then
+	calls="$(<"${RECONCILE_RACE_STATE}")"
+fi
+calls=$((calls + 1))
+printf '%s\n' "${calls}" >"${RECONCILE_RACE_STATE}"
+if [[ "${calls}" -eq 1 ]]; then
+	printf 'simulated just-merged list lag\n' >&2
+	exit 1
+fi
+printf '42\n'
+EOF
+chmod +x "${race_root}/.github/scripts/find-merged-cask-pr-handoff.sh"
+(
+	cd "${race_root}"
+	TAP="devantler-tech/homebrew-tap"
+	GITHUB_REPOSITORY="devantler-tech/ksail"
+	TAG="v7.175.1"
+	evidence_dir="${race_root}/evidence"
+	GITHUB_STEP_SUMMARY="${race_root}/summary.md"
+	RECONCILE_RACE_STATE="${race_root}/calls"
+	export TAP GITHUB_REPOSITORY TAG evidence_dir GITHUB_STEP_SUMMARY RECONCILE_RACE_STATE
+	handoff_failed=0
+	# shellcheck disable=SC2329 # Invoked by the sourced workflow function.
+	sleep() { :; }
+	# shellcheck source=/dev/null
+	source "${reconcile_function}"
+	reconcile_merged_handoff ksail 'simulated open-to-merged race'
+	[[ "${handoff_failed}" -eq 0 ]] || exit 1
+	[[ "$(<"${RECONCILE_RACE_STATE}")" -eq 2 ]] || exit 1
+) || fail 'merged reconciliation must retry a just-merged PR before recording failure'
 
 assert_contains 'name: 🍺 Prepare Homebrew cask PRs' "${homebrew_block}" \
 	'release job must be a prepare-and-handoff step'

--- a/.github/scripts/collect-cask-pr-handoff.sh
+++ b/.github/scripts/collect-cask-pr-handoff.sh
@@ -7,12 +7,17 @@ usage() {
 Usage:
   collect-cask-pr-handoff.sh --tap OWNER/REPO --pr NUMBER
                              --source-repo OWNER/REPO --tag TAG --output FILE
+                             [--include-main]
 
 Collect a stable normalized snapshot of a generated Homebrew cask pull request:
 REST PR identity, every paginated changed file, the repository label inventory,
 the source release's asset digests for TAG, and — when exactly one file changed —
 that file's content at the PR head, so the validator can prove the cask actually
 pins the release (and the exact artifacts) being handed off.
+With --include-main, require a closed merged PR and also capture the cask at its
+immutable merge commit, the cask at a pinned tap-main SHA, and ancestry evidence.
+The tap-main ref is read again before publishing the snapshot; movement fails
+collection instead of mixing evidence from two main revisions.
 Any API or response-shape failure exits non-zero without publishing partial output.
 EOF
 }
@@ -22,6 +27,7 @@ pr=""
 source_repo=""
 tag=""
 output=""
+include_main=false
 
 while (($# > 0)); do
 	case "$1" in
@@ -44,6 +50,10 @@ while (($# > 0)); do
 	--output)
 		output="${2:-}"
 		shift 2
+		;;
+	--include-main)
+		include_main=true
+		shift
 		;;
 	--help | -h)
 		usage
@@ -110,18 +120,83 @@ if [[ -n "${head_sha}" && -n "${single_file}" ]]; then
   ' "${work}/head-file.json" >/dev/null
 fi
 
+# Merged fallback evidence is deliberately opt-in so the normal open-PR handoff does not gain
+# extra mutable-main API dependencies. For a coalesced release, bind the PR's one changed cask to
+# both its immutable merge result and a pinned current-main snapshot, and prove the merge commit is
+# in that main history. Re-read main before publishing so a concurrent tap merge cannot mix refs.
+printf 'null\n' >"${work}/merge-file.json"
+printf 'null\n' >"${work}/main-ref.json"
+printf 'null\n' >"${work}/main-file.json"
+printf 'null\n' >"${work}/merge-comparison.json"
+if [[ "${include_main}" == true ]]; then
+	jq -e '
+    .state == "closed"
+    and .merged == true
+    and (.merged_at | type == "string" and length > 0)
+    and (.merge_commit_sha | type == "string" and test("^[0-9a-fA-F]{40}$"))
+  ' "${work}/pr.json" >/dev/null
+	if [[ -z "${single_file}" ]]; then
+		printf 'ERROR: --include-main requires exactly one changed PR file\n' >&2
+		exit 1
+	fi
+
+	gh api "repos/${tap}/git/ref/heads/main" >"${work}/main-ref-raw.json"
+	jq -e '
+    .object.sha
+    | type == "string" and test("^[0-9a-fA-F]{40}$")
+  ' "${work}/main-ref-raw.json" >/dev/null
+	merge_commit_sha="$(jq -r '.merge_commit_sha' "${work}/pr.json")"
+	main_sha="$(jq -r '.object.sha' "${work}/main-ref-raw.json")"
+
+	gh api "repos/${tap}/contents/${single_file}?ref=${merge_commit_sha}" \
+		>"${work}/merge-file.json"
+	gh api "repos/${tap}/contents/${single_file}?ref=${main_sha}" \
+		>"${work}/main-file.json"
+	gh api "repos/${tap}/compare/${merge_commit_sha}...${main_sha}" \
+		>"${work}/merge-comparison.json"
+	for content_file in merge-file main-file; do
+		jq -e --arg path "${single_file}" '
+      type == "object"
+      and .path == $path
+      and (.sha | type == "string" and test("^[0-9a-fA-F]{40}$"))
+      and (.content | type == "string")
+    ' "${work}/${content_file}.json" >/dev/null
+	done
+	jq -e '
+    type == "object"
+    and (.status | type == "string")
+    and (.behind_by | type == "number")
+    and (.merge_base_commit.sha | type == "string")
+  ' "${work}/merge-comparison.json" >/dev/null
+
+	gh api "repos/${tap}/git/ref/heads/main" >"${work}/main-ref-after.json"
+	if [[ "$(jq -r '.object.sha // empty' "${work}/main-ref-after.json")" != "${main_sha}" ]]; then
+		printf 'ERROR: tap main moved while merged handoff evidence was collected\n' >&2
+		exit 1
+	fi
+	jq -n --arg sha "${main_sha}" '{sha: $sha}' >"${work}/main-ref.json"
+fi
+
 jq -n \
 	--slurpfile pr "${work}/pr.json" \
 	--slurpfile pages "${work}/file-pages.json" \
 	--slurpfile label_pages "${work}/label-pages.json" \
 	--slurpfile release_assets "${work}/release-assets.json" \
-	--slurpfile head_file "${work}/head-file.json" '
+	--slurpfile head_file "${work}/head-file.json" \
+	--slurpfile merge_file "${work}/merge-file.json" \
+	--slurpfile main_ref "${work}/main-ref.json" \
+	--slurpfile main_file "${work}/main-file.json" \
+	--slurpfile merge_comparison "${work}/merge-comparison.json" '
     {
       pr: $pr[0],
       files: [$pages[0][][]],
       availableLabels: [$label_pages[0][][]],
       releaseAssets: $release_assets[0],
-      headFile: $head_file[0]
+      headFile: $head_file[0],
+      mergeFile: $merge_file[0],
+      mainRef: $main_ref[0],
+      mainFile: $main_file[0],
+      mergeComparison: $merge_comparison[0]
     }
   ' >"${work}/evidence.json"
 

--- a/.github/scripts/collect-cask-pr-handoff.test.sh
+++ b/.github/scripts/collect-cask-pr-handoff.test.sh
@@ -16,14 +16,22 @@ if [[ ! -x "${fake_bin}/gh" ]]; then
 fi
 
 run_collector() {
-	local scenario="$1" output="$2"
-	PATH="${fake_bin}:${PATH}" FAKE_GH_SCENARIO="${scenario}" \
-		"${collector}" \
-		--tap devantler-tech/homebrew-tap \
-		--pr 42 \
-		--source-repo devantler-tech/ksail \
-		--tag v7.166.1 \
+	local scenario="$1" output="$2" include_main="${3:-false}"
+	local state_dir="${tmp_dir}/state-${scenario}"
+	local args=(
+		--tap devantler-tech/homebrew-tap
+		--pr 42
+		--source-repo devantler-tech/ksail
+		--tag v7.166.1
 		--output "${output}"
+	)
+	rm -rf "${state_dir}"
+	mkdir -p "${state_dir}"
+	if [[ "${include_main}" == true ]]; then
+		args+=(--include-main)
+	fi
+	PATH="${fake_bin}:${PATH}" FAKE_GH_SCENARIO="${scenario}" FAKE_GH_STATE_DIR="${state_dir}" \
+		"${collector}" "${args[@]}"
 }
 
 valid="${tmp_dir}/valid.json"
@@ -61,12 +69,50 @@ if "${validator}" \
 fi
 printf 'PASS: paginated extra file remains visible and blocks\n'
 
+# A coalesced release is merged through an older-titled evergreen PR. Collection must pin main,
+# capture the immutable merge-result cask, prove merge ancestry, and re-read main so the validator
+# can bind the trusted merged PR to the cask that is actually current.
+merged="${tmp_dir}/merged.json"
+run_collector merged "${merged}" true
+jq -e '
+  .pr.merged == true
+  and .pr.merge_commit_sha == "4444444444444444444444444444444444444444"
+  and .files[0].sha == "2222222222222222222222222222222222222222"
+  and .mergeFile.sha == "2222222222222222222222222222222222222222"
+  and .mainRef.sha == "5555555555555555555555555555555555555555"
+  and .mainFile.sha == "2222222222222222222222222222222222222222"
+  and .mergeComparison.status == "ahead"
+  and .mergeComparison.behind_by == 0
+  and .mergeComparison.merge_base_commit.sha == "4444444444444444444444444444444444444444"
+' "${merged}" >/dev/null
+"${validator}" \
+	--evidence "${merged}" \
+	--tap devantler-tech/homebrew-tap \
+	--cask-name ksail \
+	--tag v7.166.1 \
+	--merged >/dev/null
+printf 'PASS: merged collector-to-validator round trip\n'
+
+if run_collector valid "${tmp_dir}/open-with-main.json" true >/dev/null 2>&1; then
+	printf 'FAIL: collector accepted --include-main for an open PR\n' >&2
+	exit 1
+fi
+printf 'PASS: merged collection rejects an open PR\n'
+
 for scenario in pr-failure files-failure labels-failure malformed-files malformed-labels contents-failure malformed-contents release-failure malformed-release; do
 	if run_collector "${scenario}" "${tmp_dir}/${scenario}.json" >/dev/null 2>&1; then
 		printf 'FAIL: collector accepted %s\n' "${scenario}" >&2
 		exit 1
 	fi
 	printf 'PASS: collector fails closed on %s\n' "${scenario}"
+done
+
+for scenario in merged-main-ref-failure merged-merge-file-failure merged-main-file-failure merged-malformed-main-file merged-comparison-failure merged-moving-main; do
+	if run_collector "${scenario}" "${tmp_dir}/${scenario}.json" true >/dev/null 2>&1; then
+		printf 'FAIL: merged collector accepted %s\n' "${scenario}" >&2
+		exit 1
+	fi
+	printf 'PASS: merged collector fails closed on %s\n' "${scenario}"
 done
 
 printf 'All cask PR handoff collector cases passed.\n'

--- a/.github/scripts/find-merged-cask-pr-handoff.sh
+++ b/.github/scripts/find-merged-cask-pr-handoff.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  find-merged-cask-pr-handoff.sh --tap OWNER/REPO --cask-name NAME
+                                 --source-repo OWNER/REPO --tag TAG
+                                 --output-dir DIR
+
+Find the newest fully validated merged PR for an evergreen GoReleaser cask
+branch. Titles are not trusted: a later release can coalesce into the older-
+titled open PR. Every candidate is refetched and validated against its immutable
+merge result, a pinned current-main cask blob, release digests, and merge ancestry.
+Print the validated PR number. Fail closed when enumeration or every candidate
+validation fails.
+EOF
+}
+
+tap=""
+cask_name=""
+source_repo=""
+tag=""
+output_dir=""
+
+while (($# > 0)); do
+	case "$1" in
+	--tap)
+		tap="${2:-}"
+		shift 2
+		;;
+	--cask-name)
+		cask_name="${2:-}"
+		shift 2
+		;;
+	--source-repo)
+		source_repo="${2:-}"
+		shift 2
+		;;
+	--tag)
+		tag="${2:-}"
+		shift 2
+		;;
+	--output-dir)
+		output_dir="${2:-}"
+		shift 2
+		;;
+	--help | -h)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'ERROR: unknown argument: %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+if [[ ! "${tap}" =~ ^[^/]+/[^/]+$ || -z "${cask_name}" ||
+	! "${source_repo}" =~ ^[^/]+/[^/]+$ || -z "${tag}" ||
+	! -d "${output_dir}" ]]; then
+	printf 'ERROR: --tap OWNER/REPO, --cask-name NAME, --source-repo OWNER/REPO, --tag TAG, and an existing --output-dir DIR are required\n' >&2
+	exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+branch="goreleaser/${cask_name}"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+if ! gh api --paginate --slurp \
+	"repos/${tap}/pulls?state=closed&head=${tap%%/*}:${branch}&per_page=100" \
+	>"${work}/pages.json"; then
+	printf 'BLOCKED: could not enumerate merged cask PRs for %s\n' "${branch}" >&2
+	exit 1
+fi
+if ! jq -e 'type == "array" and all(.[]; type == "array")' \
+	"${work}/pages.json" >/dev/null 2>&1; then
+	printf 'BLOCKED: could not enumerate merged cask PRs for %s: malformed response\n' \
+		"${branch}" >&2
+	exit 1
+fi
+
+# The list response is discovery only. Filter obvious mismatches, deduplicate across pages, then
+# refetch every candidate through the collector before trusting any field or content evidence.
+jq -r \
+	--arg full "${tap}" \
+	--arg branch "${branch}" '
+    [
+      .[][]
+      | select(
+          (.number | type == "number")
+          and (.merged_at | type == "string" and length > 0)
+          and .user.login == "devantler"
+          and .head.repo.full_name == $full
+          and .head.ref == $branch
+          and .base.repo.full_name == $full
+          and .base.ref == "main"
+        )
+    ]
+    | unique_by(.number)
+    | sort_by(.merged_at)
+    | reverse
+    | .[].number
+  ' "${work}/pages.json" >"${work}/candidates"
+
+if [[ ! -s "${work}/candidates" ]]; then
+	printf 'BLOCKED: no trusted merged cask PR found for %s\n' "${branch}" >&2
+	exit 1
+fi
+
+while IFS= read -r pr; do
+	[[ "${pr}" =~ ^[1-9][0-9]*$ ]] || continue
+	evidence="${output_dir}/merged-${pr}.json"
+	candidate_log="${work}/candidate-${pr}.log"
+	if {
+		"${script_dir}/collect-cask-pr-handoff.sh" \
+			--tap "${tap}" \
+			--pr "${pr}" \
+			--source-repo "${source_repo}" \
+			--tag "${tag}" \
+			--output "${evidence}" \
+			--include-main &&
+			"${script_dir}/validate-cask-pr-handoff.sh" \
+				--evidence "${evidence}" \
+				--tap "${tap}" \
+				--cask-name "${cask_name}" \
+				--tag "${tag}" \
+				--merged
+	} >"${candidate_log}" 2>&1; then
+		printf '%s\n' "${pr}"
+		exit 0
+	fi
+	printf '%s\n' "${pr}" >>"${work}/rejected"
+done <"${work}/candidates"
+
+printf 'BLOCKED: no valid merged cask PR found for %s and %s\n' "${branch}" "${tag}" >&2
+if [[ -s "${work}/rejected" ]]; then
+	while IFS= read -r pr; do
+		candidate_log="${work}/candidate-${pr}.log"
+		reason="$(<"${candidate_log}")"
+		reason="${reason//$'\n'/; }"
+		printf -- '- PR #%s: %s\n' "${pr}" "${reason:-validation failed without diagnostics}" >&2
+	done <"${work}/rejected"
+fi
+exit 1

--- a/.github/scripts/find-merged-cask-pr-handoff.sh
+++ b/.github/scripts/find-merged-cask-pr-handoff.sh
@@ -26,6 +26,10 @@ output_dir=""
 
 while (($# > 0)); do
 	case "$1" in
+	--help | -h)
+		usage
+		exit 0
+		;;
 	--tap)
 		tap="${2:-}"
 		shift 2
@@ -45,10 +49,6 @@ while (($# > 0)); do
 	--output-dir)
 		output_dir="${2:-}"
 		shift 2
-		;;
-	--help | -h)
-		usage
-		exit 0
 		;;
 	*)
 		printf 'ERROR: unknown argument: %s\n' "$1" >&2

--- a/.github/scripts/find-merged-cask-pr-handoff.test.sh
+++ b/.github/scripts/find-merged-cask-pr-handoff.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+finder="${script_dir}/find-merged-cask-pr-handoff.sh"
+fake_bin="${repo_root}/.github/fixtures/cask-pr-handoff/fake-bin"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+pass_count=0
+
+run_case() {
+	local scenario="$1" expected_status="$2" expected_output="$3"
+	local case_dir="${tmp_dir}/${scenario}" output status
+	mkdir -p "${case_dir}/evidence" "${case_dir}/state"
+	set +e
+	output="$(PATH="${fake_bin}:${PATH}" \
+		FAKE_GH_SCENARIO="${scenario}" \
+		FAKE_GH_STATE_DIR="${case_dir}/state" \
+		"${finder}" \
+		--tap devantler-tech/homebrew-tap \
+		--cask-name ksail \
+		--source-repo devantler-tech/ksail \
+		--tag v7.166.1 \
+		--output-dir "${case_dir}/evidence" 2>&1)"
+	status=$?
+	set -e
+
+	if [[ "${status}" -ne "${expected_status}" ]]; then
+		printf 'FAIL: %s: expected status %s, got %s\n%s\n' \
+			"${scenario}" "${expected_status}" "${status}" "${output}" >&2
+		return 1
+	fi
+	if [[ "${expected_status}" -eq 0 && "${output}" != "${expected_output}" ]]; then
+		printf 'FAIL: %s: expected exact successful output %q, got:\n%s\n' \
+			"${scenario}" "${expected_output}" "${output}" >&2
+		return 1
+	fi
+	if [[ "${expected_status}" -ne 0 && "${output}" != *"${expected_output}"* ]]; then
+		printf 'FAIL: %s: expected output containing %q, got:\n%s\n' \
+			"${scenario}" "${expected_output}" "${output}" >&2
+		return 1
+	fi
+	if [[ "${expected_status}" -eq 0 && ! -s "${case_dir}/evidence/merged-42.json" ]]; then
+		printf 'FAIL: %s: successful lookup did not preserve validated evidence\n' "${scenario}" >&2
+		return 1
+	fi
+
+	pass_count=$((pass_count + 1))
+	printf 'PASS: %s\n' "${scenario}"
+}
+
+# The fake merged PR deliberately carries the older v7.166.0 title while its immutable merge and
+# pinned-main cask content prove v7.166.1. The title-independent full validator must accept it.
+run_case merged 0 '42'
+# `gh api --paginate --slurp` must expose a candidate that is absent from page one.
+run_case merged-later-page 0 '42'
+# A rejected newer candidate must not contaminate stdout when an older candidate has the same
+# current-main cask and validates successfully. CD captures both streams into the PR-number variable.
+run_case merged-newest-invalid 0 '42'
+run_case merged-wrong-list-author 1 'no trusted merged cask PR'
+run_case merged-closed-unmerged 1 'no trusted merged cask PR'
+run_case merged-list-failure 1 'could not enumerate merged cask PRs'
+run_case merged-main-file-failure 1 'no valid merged cask PR'
+run_case merged-moving-main 1 'no valid merged cask PR'
+
+printf 'All %d merged cask handoff finder cases passed.\n' "${pass_count}"

--- a/.github/scripts/validate-cask-pr-handoff.sh
+++ b/.github/scripts/validate-cask-pr-handoff.sh
@@ -6,7 +6,7 @@ usage() {
 	cat <<'EOF'
 Usage:
   validate-cask-pr-handoff.sh --evidence FILE --tap OWNER/REPO
-                              --cask-name NAME --tag TAG [--prepared] [--ready]
+                              --cask-name NAME --tag TAG [--prepared] [--ready] [--merged]
 
 Fail closed unless a GoReleaser cask PR is the expected trusted draft, from the
 tap itself, into main, with exactly its matching cask file. With --prepared,
@@ -14,6 +14,10 @@ also require the normalized title and every requested label that exists in the
 repository's available-label inventory. With --ready, require the PR to already
 be marked ready for review instead of a draft — used to revalidate an
 already-handed-off PR on an idempotent rerun.
+With --merged, require a trusted closed-and-merged PR whose exact cask blob is
+still current on tap main. This mode intentionally does not trust the PR title:
+an evergreen branch can receive the next release before its previous-titled PR
+auto-merges, coalescing both releases into that older-titled PR.
 EOF
 }
 
@@ -23,6 +27,7 @@ cask_name=""
 tag=""
 prepared=false
 ready=false
+merged=false
 
 while (($# > 0)); do
 	case "$1" in
@@ -50,6 +55,10 @@ while (($# > 0)); do
 		ready=true
 		shift
 		;;
+	--merged)
+		merged=true
+		shift
+		;;
 	--help | -h)
 		usage
 		exit 0
@@ -69,6 +78,10 @@ if [[ -z "${evidence_file}" || -z "${tap}" || -z "${cask_name}" || -z "${tag}" ]
 fi
 if [[ ! -f "${evidence_file}" ]]; then
 	printf 'ERROR: evidence file does not exist: %s\n' "${evidence_file}" >&2
+	exit 2
+fi
+if [[ "${merged}" == true && ("${prepared}" == true || "${ready}" == true) ]]; then
+	printf 'ERROR: --merged cannot be combined with --prepared or --ready\n' >&2
 	exit 2
 fi
 if ! jq -e . "${evidence_file}" >/dev/null 2>&1; then
@@ -92,17 +105,33 @@ json_string() {
 	jq -r "${expression} // empty" "${evidence_file}" 2>/dev/null || true
 }
 
-if [[ "$(json_string '.pr.state | ascii_downcase')" != "open" ]]; then
-	block 'PR state must be open'
-fi
-if [[ "${ready}" == true ]]; then
-	# Revalidating an already-handed-off PR: it has been promoted, so it must NOT be a draft.
+if [[ "${merged}" == true ]]; then
+	if [[ "$(json_string '.pr.state | ascii_downcase')" != "closed" ]]; then
+		block 'merged PR state must be closed'
+	fi
+	if ! jq -e '.pr.merged_at | type == "string" and length > 0' \
+		"${evidence_file}" >/dev/null 2>&1; then
+		block 'merged PR must have a merged_at timestamp'
+	fi
+	if ! jq -e '.pr.merged == true' "${evidence_file}" >/dev/null 2>&1; then
+		block 'merged PR must be marked merged'
+	fi
 	if ! jq -e '.pr.draft == false' "${evidence_file}" >/dev/null 2>&1; then
-		block 'already-handed-off PR must be marked ready for review'
+		block 'merged PR must not be a draft'
 	fi
 else
-	if ! jq -e '.pr.draft == true' "${evidence_file}" >/dev/null 2>&1; then
-		block 'PR must remain a draft for maintainer promotion'
+	if [[ "$(json_string '.pr.state | ascii_downcase')" != "open" ]]; then
+		block 'PR state must be open'
+	fi
+	if [[ "${ready}" == true ]]; then
+		# Revalidating an already-handed-off PR: it has been promoted, so it must NOT be a draft.
+		if ! jq -e '.pr.draft == false' "${evidence_file}" >/dev/null 2>&1; then
+			block 'already-handed-off PR must be marked ready for review'
+		fi
+	else
+		if ! jq -e '.pr.draft == true' "${evidence_file}" >/dev/null 2>&1; then
+			block 'PR must remain a draft for maintainer promotion'
+		fi
 	fi
 fi
 if [[ "$(json_string '.pr.user.login')" != "devantler" ]]; then
@@ -117,9 +146,19 @@ fi
 if [[ "$(json_string '.pr.base.ref')" != "main" ]]; then
 	block 'base branch must exactly equal main'
 fi
+if [[ "${merged}" == true && "$(json_string '.pr.base.repo.full_name')" != "${tap}" ]]; then
+	block "base repository must exactly equal ${tap}"
+fi
 head_sha="$(json_string '.pr.head.sha')"
 if [[ ! "${head_sha}" =~ ^[[:xdigit:]]{40}$ ]]; then
 	block 'head SHA is missing or invalid'
+fi
+merge_commit_sha=""
+if [[ "${merged}" == true ]]; then
+	merge_commit_sha="$(json_string '.pr.merge_commit_sha')"
+	if [[ ! "${merge_commit_sha}" =~ ^[[:xdigit:]]{40}$ ]]; then
+		block 'merge commit SHA is missing or invalid'
+	fi
 fi
 
 if ! jq -e '.files | type == "array"' "${evidence_file}" >/dev/null 2>&1; then
@@ -128,6 +167,13 @@ elif ! jq -e --arg path "${expected_path}" \
 	'.files | length == 1 and .[0].filename == $path' \
 	"${evidence_file}" >/dev/null 2>&1; then
 	block "only ${expected_path} may change"
+fi
+pr_file_sha=""
+if [[ "${merged}" == true ]]; then
+	pr_file_sha="$(json_string '.files[0].sha')"
+	if [[ ! "${pr_file_sha}" =~ ^[[:xdigit:]]{40}$ ]]; then
+		block 'merged PR cask blob SHA is missing or invalid'
+	fi
 fi
 
 # Evergreen branches are reused across releases, so PR identity alone cannot prove
@@ -142,8 +188,79 @@ if ! jq -e --arg path "${expected_path}" \
 elif ! cask_content="$(jq -r '.headFile.content' "${evidence_file}" | base64 -d 2>/dev/null)"; then
 	cask_content=""
 	block 'cask head content is not valid base64'
-elif ! grep -Fq "version \"${expected_version}\"" <<<"${cask_content}"; then
-	block "cask at head must pin version ${expected_version}"
+elif [[ -z "${cask_content}" ]]; then
+	block 'cask head content must not be empty'
+fi
+content_location='at head'
+if [[ "${merged}" == true ]]; then
+	head_file_sha="$(json_string '.headFile.sha')"
+	if [[ -z "${pr_file_sha}" || "${head_file_sha}" != "${pr_file_sha}" ]]; then
+		block 'merged PR head cask blob must match its changed-file blob'
+	fi
+	merge_file_sha=""
+	if ! jq -e --arg path "${expected_path}" '
+      .mergeFile
+      | type == "object"
+        and .path == $path
+        and (.sha | type == "string")
+        and (.content | type == "string")
+    ' "${evidence_file}" >/dev/null 2>&1; then
+		block 'merge-result cask evidence is missing'
+	else
+		merge_file_sha="$(json_string '.mergeFile.sha')"
+		if [[ ! "${merge_file_sha}" =~ ^[[:xdigit:]]{40}$ || -z "${pr_file_sha}" ||
+			"${merge_file_sha}" != "${pr_file_sha}" ]]; then
+			block 'merge-result cask blob must match the merged PR changed-file blob'
+		fi
+	fi
+	main_ref_sha="$(json_string '.mainRef.sha')"
+	if [[ ! "${main_ref_sha}" =~ ^[[:xdigit:]]{40}$ ]]; then
+		block 'pinned main SHA is missing or invalid'
+	fi
+	main_file_sha=""
+	if ! jq -e --arg path "${expected_path}" '
+      .mainFile
+      | type == "object"
+        and .path == $path
+        and (.sha | type == "string")
+        and (.content | type == "string")
+    ' "${evidence_file}" >/dev/null 2>&1; then
+		block 'current-main cask evidence is missing'
+	else
+		main_file_sha="$(json_string '.mainFile.sha')"
+		if [[ ! "${main_file_sha}" =~ ^[[:xdigit:]]{40}$ || -z "${merge_file_sha}" ||
+			"${main_file_sha}" != "${merge_file_sha}" ]]; then
+			block 'merged PR cask blob must still be current on main'
+		fi
+		if ! cask_content="$(jq -r '.mainFile.content' "${evidence_file}" | base64 -d 2>/dev/null)"; then
+			cask_content=""
+			block 'current-main cask content is not valid base64'
+		elif [[ -z "${cask_content}" ]]; then
+			block 'current-main cask content must not be empty'
+		fi
+		content_location='on main'
+	fi
+	if ! jq -e '.mergeComparison | type == "object"' \
+		"${evidence_file}" >/dev/null 2>&1; then
+		block 'merge ancestry evidence is missing or invalid'
+	else
+		comparison_status="$(json_string '.mergeComparison.status')"
+		comparison_behind="$(json_string '.mergeComparison.behind_by')"
+		comparison_base="$(json_string '.mergeComparison.merge_base_commit.sha')"
+		if [[ "${comparison_status}" != "ahead" && "${comparison_status}" != "identical" ]]; then
+			block 'merge commit must be an ancestor of pinned main'
+		fi
+		if [[ "${comparison_behind}" != "0" ]]; then
+			block 'merge commit must not be behind the pinned-main merge base'
+		fi
+		if [[ -z "${merge_commit_sha}" || "${comparison_base}" != "${merge_commit_sha}" ]]; then
+			block 'pinned main must descend from the merge commit'
+		fi
+	fi
+fi
+if [[ -n "${cask_content}" ]] &&
+	! grep -Fq "version \"${expected_version}\"" <<<"${cask_content}"; then
+	block "cask ${content_location} must pin version ${expected_version}"
 fi
 
 # A version match alone is not enough on a rerun of the SAME tag: a stale evergreen PR
@@ -205,7 +322,9 @@ if ((${#failures[@]} > 0)); then
 	exit 1
 fi
 
-if [[ "${prepared}" == true ]]; then
+if [[ "${merged}" == true ]]; then
+	printf 'PASS: merged generated cask PR identity and scope are valid at %s\n' "${head_sha}"
+elif [[ "${prepared}" == true ]]; then
 	printf 'PASS: generated cask PR identity, scope, and metadata are valid at %s\n' "${head_sha}"
 else
 	printf 'PASS: generated cask PR identity and scope are valid at %s\n' "${head_sha}"

--- a/.github/scripts/validate-cask-pr-handoff.test.sh
+++ b/.github/scripts/validate-cask-pr-handoff.test.sh
@@ -12,7 +12,7 @@ pass_count=0
 
 run_case() {
 	local name="$1" expected_status="$2" expected_output="$3"
-	local filter="${4:-.}" prepared="${5:-false}" ready="${6:-false}"
+	local filter="${4:-.}" prepared="${5:-false}" ready="${6:-false}" merged="${7:-false}"
 	local evidence="${tmp_dir}/${name}.json" output status
 	local args=(--evidence "${evidence}" --tap devantler-tech/homebrew-tap --cask-name ksail --tag v7.166.1)
 
@@ -22,6 +22,9 @@ run_case() {
 	fi
 	if [[ "${ready}" == true ]]; then
 		args+=(--ready)
+	fi
+	if [[ "${merged}" == true ]]; then
+		args+=(--merged)
 	fi
 
 	set +e
@@ -69,6 +72,7 @@ run_case empty-release-assets 1 'release-asset digest evidence is missing' '.rel
 run_case stale-cask-sha 1 'does not match any published release asset digest' '.releaseAssets[0].digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"'
 # base64 of a cask with a version but no sha256 stanza at all.
 run_case no-cask-sha 1 'cask at head must pin at least one sha256' '.headFile.content = "Y2FzayAia3NhaWwiIGRvCiAgdmVyc2lvbiAiNy4xNjYuMSIKCiAgdXJsICJodHRwczovL2dpdGh1Yi5jb20vZGV2YW50bGVyLXRlY2gva3NhaWwvcmVsZWFzZXMvZG93bmxvYWQvdjcuMTY2LjEva3NhaWxfNy4xNjYuMV9kYXJ3aW5fYXJtNjQudGFyLmd6IgplbmQK"'
+run_case empty-head-content 1 'cask head content must not be empty' '.headFile.content = ""'
 run_case invalid-base64-content 1 'cask head content is not valid base64' '.headFile.content = "%%%not-base64%%%"'
 run_case missing-title 1 'title must exactly equal chore(cask): update ksail to v7.166.1' '.pr.title = "Brew cask update"' true
 run_case missing-label-inventory 1 'available-label inventory is missing' 'del(.availableLabels)' true
@@ -80,5 +84,88 @@ run_case unavailable-label 0 'PASS: generated cask PR identity, scope, and metad
 # pass on a non-draft PR and fail on one still in draft, the inverse of the default draft requirement.
 run_case ready-nondraft 0 'PASS: generated cask PR identity, scope, and metadata are valid' '.pr.draft = false' true true
 run_case ready-still-draft 1 'already-handed-off PR must be marked ready for review' '.' true true
+
+# A newer release can update an evergreen branch while the previous release's PR is still open. The
+# tap then merges the newer cask through the older-titled PR. A merged handoff is valid only when the
+# immutable PR file blob is still the current blob on tap main and that current content proves the
+# requested version and published asset digest. Its title is deliberately not part of that proof
+# because it records the earlier release that opened the PR.
+merged_fixture='.
+  | .pr.state = "closed"
+  | .pr.draft = false
+  | .pr.merged = true
+  | .pr.merged_at = "2026-07-18T19:58:28Z"
+  | .pr.merge_commit_sha = "4444444444444444444444444444444444444444"
+  | .pr.title = "chore(cask): update ksail to v7.166.0"
+  | .pr.base.repo.full_name = "devantler-tech/homebrew-tap"
+  | .files[0].sha = "2222222222222222222222222222222222222222"
+  | .headFile.sha = "2222222222222222222222222222222222222222"
+  | .mergeFile = {
+      "path": "Casks/ksail.rb",
+      "sha": "2222222222222222222222222222222222222222",
+      "content": .headFile.content
+    }
+  | .mainRef = {"sha": "5555555555555555555555555555555555555555"}
+  | .mainFile = {
+      "path": "Casks/ksail.rb",
+      "sha": "2222222222222222222222222222222222222222",
+      "content": .headFile.content
+    }
+  | .mergeComparison = {
+      "status": "ahead",
+      "behind_by": 0,
+      "merge_base_commit": {"sha": "4444444444444444444444444444444444444444"}
+    }
+'
+run_case coalesced-merged 0 'PASS: merged generated cask PR identity and scope are valid' \
+	"${merged_fixture}" \
+	false false true
+run_case merged-without-merge 1 'merged PR must have a merged_at timestamp' \
+	"${merged_fixture} | .pr.merged_at = null" false false true
+run_case merged-flag-false 1 'merged PR must be marked merged' \
+	"${merged_fixture} | .pr.merged = false" false false true
+run_case merged-invalid-commit 1 'merge commit SHA is missing or invalid' \
+	"${merged_fixture} | .pr.merge_commit_sha = \"short\"" false false true
+run_case merged-mode-open 1 'merged PR state must be closed' \
+	"${merged_fixture} | .pr.state = \"open\"" false false true
+run_case merged-wrong-author 1 'PR author must be devantler' \
+	"${merged_fixture} | .pr.user.login = \"someone-else\"" \
+	false false true
+run_case merged-wrong-branch 1 'head branch must exactly equal goreleaser/ksail' \
+	"${merged_fixture} | .pr.head.ref = \"feature/untrusted\"" \
+	false false true
+run_case merged-wrong-base-repository 1 'base repository must exactly equal devantler-tech/homebrew-tap' \
+	"${merged_fixture} | .pr.base.repo.full_name = \"someone-else/homebrew-tap\"" false false true
+run_case merged-missing-main 1 'current-main cask evidence is missing' \
+	"${merged_fixture} | del(.mainFile)" false false true
+run_case merged-wrong-main-path 1 'current-main cask evidence is missing' \
+	"${merged_fixture} | .mainFile.path = \"Casks/other.rb\"" false false true
+run_case merged-missing-pr-blob 1 'merged PR cask blob SHA is missing or invalid' \
+	"${merged_fixture} | del(.files[0].sha)" false false true
+run_case merged-head-blob-mismatch 1 'merged PR head cask blob must match its changed-file blob' \
+	"${merged_fixture} | .headFile.sha = \"3333333333333333333333333333333333333333\"" false false true
+run_case merged-missing-result 1 'merge-result cask evidence is missing' \
+	"${merged_fixture} | del(.mergeFile)" false false true
+run_case merged-result-blob-mismatch 1 'merge-result cask blob must match the merged PR changed-file blob' \
+	"${merged_fixture} | .mergeFile.sha = \"3333333333333333333333333333333333333333\"" false false true
+run_case merged-invalid-main-ref 1 'pinned main SHA is missing or invalid' \
+	"${merged_fixture} | .mainRef.sha = \"short\"" false false true
+run_case merged-main-blob-mismatch 1 'merged PR cask blob must still be current on main' \
+	"${merged_fixture} | .mainFile.sha = \"3333333333333333333333333333333333333333\"" false false true
+run_case merged-empty-main-content 1 'current-main cask content must not be empty' \
+	"${merged_fixture} | .mainFile.content = \"\"" false false true
+run_case merged-missing-ancestry 1 'merge ancestry evidence is missing or invalid' \
+	"${merged_fixture} | del(.mergeComparison)" false false true
+run_case merged-diverged-main 1 'merge commit must be an ancestor of pinned main' \
+	"${merged_fixture} | .mergeComparison.status = \"diverged\"" false false true
+run_case merged-behind-main 1 'merge commit must not be behind the pinned-main merge base' \
+	"${merged_fixture} | .mergeComparison.behind_by = 1" false false true
+run_case merged-wrong-merge-base 1 'pinned main must descend from the merge commit' \
+	"${merged_fixture} | .mergeComparison.merge_base_commit.sha = \"6666666666666666666666666666666666666666\"" false false true
+# base64 of the otherwise-valid cask changed to version 7.160.0: current main must not merely carry
+# the merged blob, it must still prove the exact release this CD run is handing off.
+run_case merged-stale-main-version 1 'cask on main must pin version 7.166.1' \
+	"${merged_fixture} | .mainFile.content = \"Y2FzayBcImtzYWlsXCIgZG8KICB2ZXJzaW9uIFwiNy4xNjAuMFwiCiAgc2hhMjU2IFwiMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMFwiCmVuZAo=\"" \
+	false false true
 
 printf 'All %d cask PR handoff cases passed.\n' "${pass_count}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -819,6 +819,31 @@ jobs:
           # never deletes a good release.
           handoff_failed=0
 
+          reconcile_merged_handoff() {
+            local name="$1" context="$2" branch="goreleaser/$1"
+            local merged_pr merged_reason
+
+            # An initially-open evergreen PR can auto-merge at any point in this step. Every failure
+            # after selecting that PR comes through here: only immutable merge evidence plus an
+            # unchanged pinned-main cask can turn the race into success. If it is still open, or any
+            # proof is unavailable, preserve the original fail-closed outcome.
+            if merged_pr="$(.github/scripts/find-merged-cask-pr-handoff.sh \
+              --tap "$TAP" \
+              --cask-name "$name" \
+              --source-repo "$GITHUB_REPOSITORY" \
+              --tag "$TAG" \
+              --output-dir "$evidence_dir" 2>&1)"; then
+              echo "::notice::${TAP}#${merged_pr} cask ${name} is merged and current for ${TAG}; ${context}"
+              printf -- '- %s#%s cask %s already merged for %s (immutable current-main proof)\n' \
+                "$TAP" "$merged_pr" "$name" "$TAG" >>"$GITHUB_STEP_SUMMARY"
+              return 0
+            fi
+
+            merged_reason="${merged_pr//$'\n'/; }"
+            echo "::warning::${context}; no fully validated merged handoff for ${branch}: ${merged_reason:-no merged evidence}"
+            handoff_failed=1
+          }
+
           for name in ksail ksail-desktop; do
             branch="goreleaser/${name}"
             # `|| true` keeps the job fail-soft: a transient API failure (5xx, rate limit,
@@ -839,24 +864,13 @@ jobs:
               continue
             fi
             if [ "$count" -eq 0 ]; then
-              # A partial rerun may already have MERGED this cask: the tap's auto-merge can land the
-              # first cask before this job is rerun. A merged PR is no longer `open`, so the open-only
-              # query returns nothing — treat a merged, this-tag-titled, tap-owned cask as done rather
-              # than failing the rerun red. `state=closed` returns merged AND closed-unmerged, so filter
-              # on `merged_at != null`. Fail-soft: an enumeration hiccup falls through to the pending path.
-              merged="$(gh api \
-                "repos/$TAP/pulls?state=closed&head=${TAP%%/*}:${branch}&per_page=100" 2>/dev/null \
-                | jq -er --arg full "$TAP" --arg title "chore(cask): update ${name} to ${TAG}" \
-                    '[.[] | select(.merged_at != null and .head.repo.full_name == $full and .user.login == "devantler" and .title == $title)] | length' \
-                2>/dev/null || echo 0)"
-              if [ "${merged:-0}" -ge 1 ]; then
-                echo "${TAP} cask ${name} already merged for ${TAG}; nothing to do"
-                printf -- '- %s cask %s already merged for %s (idempotent retry)\n' \
-                  "$TAP" "$name" "$TAG" >>"$GITHUB_STEP_SUMMARY"
-                continue
-              fi
-              echo "::warning::No open or merged tap-owned cask PR on $TAP for branch ${branch}; leaving it pending"
-              handoff_failed=1
+              # The tap may merge the evergreen PR while the next release is still publishing, so
+              # this tag can be coalesced into a PR whose title names the previous tag. Titles are not
+              # release evidence. Accept the zero-open-PR state only when the paginated finder proves
+              # a trusted merged PR's immutable result and the pinned current-main cask are identical,
+              # contain this release, match its asset digests, and remain on main after collection.
+              reconcile_merged_handoff "$name" \
+                "No open tap-owned cask PR was found for ${branch}"
               continue
             fi
             if [ "$count" -ne 1 ]; then
@@ -897,7 +911,8 @@ jobs:
               echo "::warning::${TAP}#${pr} is ready and titled but failed prepared revalidation: ${validation}"
               printf -- '- %s#%s ready but revalidation failed: %s\n' \
                 "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} failed ready-PR revalidation"
               continue
             fi
 
@@ -908,7 +923,8 @@ jobs:
               validation="${validation//$'\n'/; }"
               echo "::warning::Refusing to mutate ${TAP}#${pr}: ${validation}"
               printf -- '- %s#%s left untouched: %s\n' "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} failed draft validation after open enumeration"
               continue
             fi
             echo "Preparing ${TAP}#${pr} (${branch})"
@@ -938,7 +954,8 @@ jobs:
                 if ! command -v brew >/dev/null 2>&1; then
                   echo "::error::brew is not available on this runner; cannot style-check ${name}"
                   rm -rf "$work"
-                  handoff_failed=1
+                  reconcile_merged_handoff "$name" \
+                    "brew became unavailable while preparing ${TAP}#${pr}"
                   continue
                 fi
                 # `brew style --fix` can apply partial autocorrections yet still exit non-zero when
@@ -982,7 +999,8 @@ jobs:
               echo "::error::Could not ensure ${name} cask is brew-style-clean; the tap's style gate would block auto-merge for ${TAG}"
               printf -- '- %s cask %s left draft/open: could not ensure it is brew-style-clean\n' \
                 "$TAP" "$name" >>"$GITHUB_STEP_SUMMARY"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} could not be confirmed brew-style-clean"
               continue
             fi
 
@@ -993,7 +1011,8 @@ jobs:
               echo "::warning::Post-style validation failed for ${TAP}#${pr}: ${validation}"
               printf -- '- %s#%s remains open after style validation failed: %s\n' \
                 "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} failed post-style validation"
               continue
             fi
 
@@ -1007,7 +1026,8 @@ jobs:
             title="chore(cask): update ${name} to ${TAG}"
             if ! gh api -X PATCH "repos/${TAP}/pulls/${pr}" -f title="$title" >/dev/null; then
               echo "::warning::Could not normalize the title on ${TAP}#${pr}; leaving it draft/open"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} could not receive normalized metadata"
               continue
             fi
             metadata_ok=true
@@ -1034,7 +1054,8 @@ jobs:
             done
             if [ "$metadata_ok" != true ]; then
               echo "::warning::${TAP}#${pr} metadata is incomplete; leaving it draft/open"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} metadata could not be completed"
               continue
             fi
 
@@ -1043,7 +1064,8 @@ jobs:
               echo "::warning::Prepared handoff validation failed for ${TAP}#${pr}: ${validation}"
               printf -- '- %s#%s remains open with incomplete handoff metadata: %s\n' \
                 "$TAP" "$pr" "$validation" >>"$GITHUB_STEP_SUMMARY"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} failed prepared validation"
               continue
             fi
 
@@ -1069,7 +1091,8 @@ jobs:
               echo "::error::Could not mark ${TAP}#${pr} ready; it remains draft and the tap will NOT pick up ${TAG}"
               printf -- '- %s#%s remains draft/open: could not mark it ready after validation\n' \
                 "$TAP" "$pr" >>"$GITHUB_STEP_SUMMARY"
-              handoff_failed=1
+              reconcile_merged_handoff "$name" \
+                "${TAP}#${pr} could not be marked ready"
             fi
           done
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -821,23 +821,28 @@ jobs:
 
           reconcile_merged_handoff() {
             local name="$1" context="$2" branch="goreleaser/$1"
-            local merged_pr merged_reason
+            local attempt merged_pr merged_reason
 
             # An initially-open evergreen PR can auto-merge at any point in this step. Every failure
             # after selecting that PR comes through here: only immutable merge evidence plus an
             # unchanged pinned-main cask can turn the race into success. If it is still open, or any
             # proof is unavailable, preserve the original fail-closed outcome.
-            if merged_pr="$(.github/scripts/find-merged-cask-pr-handoff.sh \
-              --tap "$TAP" \
-              --cask-name "$name" \
-              --source-repo "$GITHUB_REPOSITORY" \
-              --tag "$TAG" \
-              --output-dir "$evidence_dir" 2>&1)"; then
-              echo "::notice::${TAP}#${merged_pr} cask ${name} is merged and current for ${TAG}; ${context}"
-              printf -- '- %s#%s cask %s already merged for %s (immutable current-main proof)\n' \
-                "$TAP" "$merged_pr" "$name" "$TAG" >>"$GITHUB_STEP_SUMMARY"
-              return 0
-            fi
+            for attempt in 1 2; do
+              if merged_pr="$(.github/scripts/find-merged-cask-pr-handoff.sh \
+                --tap "$TAP" \
+                --cask-name "$name" \
+                --source-repo "$GITHUB_REPOSITORY" \
+                --tag "$TAG" \
+                --output-dir "$evidence_dir" 2>&1)"; then
+                echo "::notice::${TAP}#${merged_pr} cask ${name} is merged and current for ${TAG}; ${context}"
+                printf -- '- %s#%s cask %s already merged for %s (immutable current-main proof)\n' \
+                  "$TAP" "$merged_pr" "$name" "$TAG" >>"$GITHUB_STEP_SUMMARY"
+                return 0
+              fi
+              if [[ "$attempt" -eq 1 ]]; then
+                sleep 1
+              fi
+            done
 
             merged_reason="${merged_pr//$'\n'/; }"
             echo "::warning::${context}; no fully validated merged handoff for ${branch}: ${merged_reason:-no merged evidence}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,6 +272,8 @@ jobs:
               - '.github/scripts/cask-pr-handoff-workflow.test.sh'
               - '.github/scripts/collect-cask-pr-handoff.sh'
               - '.github/scripts/collect-cask-pr-handoff.test.sh'
+              - '.github/scripts/find-merged-cask-pr-handoff.sh'
+              - '.github/scripts/find-merged-cask-pr-handoff.test.sh'
               - '.github/scripts/redraft-evergreen-cask-prs.sh'
               - '.github/scripts/validate-cask-pr-handoff.sh'
               - '.github/scripts/validate-cask-pr-handoff.test.sh'
@@ -298,11 +300,14 @@ jobs:
             .github/fixtures/cask-pr-handoff/fake-bin/gh \
             .github/scripts/collect-cask-pr-handoff.sh \
             .github/scripts/collect-cask-pr-handoff.test.sh \
+            .github/scripts/find-merged-cask-pr-handoff.sh \
+            .github/scripts/find-merged-cask-pr-handoff.test.sh \
             .github/scripts/redraft-evergreen-cask-prs.sh \
             .github/scripts/validate-cask-pr-handoff.sh \
             .github/scripts/validate-cask-pr-handoff.test.sh \
             .github/scripts/cask-pr-handoff-workflow.test.sh
           .github/scripts/collect-cask-pr-handoff.test.sh
+          .github/scripts/find-merged-cask-pr-handoff.test.sh
           .github/scripts/validate-cask-pr-handoff.test.sh
           .github/scripts/cask-pr-handoff-workflow.test.sh
 


### PR DESCRIPTION
Fixes #6243

## Root cause

KSail publishes both Homebrew casks through evergreen GoReleaser branches. A later release can update an already-open cask PR before tap automation merges it, so the merge retains the older release title while its cask content contains the newer release. CD trusted an exact merged-PR title and therefore reported a false-negative handoff for v7.175.1. An open PR could also auto-merge after enumeration and before validation.

## Change

- Find merged evergreen cask PRs across every closed-PR page without trusting titles.
- Bind the trusted PR file blob to its immutable merge result and a pinned, unchanged tap main snapshot.
- Require merge ancestry, exact repo/ref/file identity, the requested version, and published release digests.
- Reconcile every post-selection open-to-merged race through the same fail-closed proof.
- Keep rejected-candidate diagnostics out of successful numeric finder output.
- Add CI path, ShellCheck, workflow-contract, race, provenance, empty-content, pagination, and main-movement controls.

## Validation

- 19 collector cases passed.
- 52 validator cases passed.
- 8 merged-finder cases passed.
- Cask workflow contract passed.
- ShellCheck and shfmt passed for every touched shell script.
- Actionlint passed for the changed CD workflow; git diff --check passed.
- Live user-path replay against v7.175.1 resolved ksail to homebrew-tap#1216 and ksail-desktop to homebrew-tap#1214, despite both PR titles naming v7.175.0.
- Two independent final diff reviews reported no actionable findings.

## Follow-up

#6249 separately tracks binding each cask URL to its corresponding release asset digest; this hotfix does not widen into that adjacent parser hardening.