### PR TITLE
fix(release): refresh terminal cask branches

### DIFF
--- a/.github/scripts/cask-pr-handoff-workflow.test.sh
+++ b/.github/scripts/cask-pr-handoff-workflow.test.sh
@@ -219,12 +219,23 @@ assert_contains 'pulls?state=open&head=' \
 assert_contains 'head.repo.full_name == $full' \
 	"${repo_root}/.github/scripts/redraft-evergreen-cask-prs.sh" \
 	'the checkpoint script must scope matches to the tap-owned devantler PR (full head-repo name)'
+assert_contains 'git/matching-refs/heads/${branch}' \
+	"${repo_root}/.github/scripts/redraft-evergreen-cask-prs.sh" \
+	'the checkpoint script must inspect retained evergreen branch refs when no PR is open'
+assert_contains '--force-with-lease="refs/heads/${branch}:${branch_sha}"' \
+	"${repo_root}/.github/scripts/redraft-evergreen-cask-prs.sh" \
+	'the checkpoint script must delete terminal branches with an exact-SHA compare-and-swap'
 # The checkpoint script is release-critical: CI must both re-run this suite when it
 # changes and shellcheck it (a filter/shellcheck omission lets it break unnoticed).
 assert_contains "- '.github/scripts/redraft-evergreen-cask-prs.sh'" "${ci_workflow}" \
 	'CI paths filter must trigger the handoff job on checkpoint-script changes'
 if [ "$(grep -Fc -- '.github/scripts/redraft-evergreen-cask-prs.sh' "${ci_workflow}")" -lt 2 ]; then
 	fail 'CI must also shellcheck the checkpoint script, not just path-filter it'
+fi
+assert_contains "- '.github/scripts/redraft-evergreen-cask-prs.test.sh'" "${ci_workflow}" \
+	'CI paths filter must trigger the handoff job on checkpoint-test changes'
+if [ "$(grep -Fc -- '.github/scripts/redraft-evergreen-cask-prs.test.sh' "${ci_workflow}")" -lt 3 ]; then
+	fail 'CI must shellcheck and execute the checkpoint behavior test'
 fi
 assert_contains 'release-asset digest evidence is missing' \
 	"${repo_root}/.github/scripts/validate-cask-pr-handoff.sh" \

--- a/.github/scripts/redraft-evergreen-cask-prs.sh
+++ b/.github/scripts/redraft-evergreen-cask-prs.sh
@@ -33,7 +33,7 @@ if [[ ! "${tap}" =~ ^[^/]+/[^/]+$ || $# -lt 1 ]]; then
 fi
 tap_owner="${tap%%/*}"
 
-trusted_open_prs() {
+open_branch_prs() {
 	local branch="$1" matches
 	if ! matches="$(gh api \
 		"repos/${tap}/pulls?state=open&head=${tap_owner}:${branch}&per_page=100")"; then
@@ -41,9 +41,12 @@ trusted_open_prs() {
 			"${tap}" "${branch}" >&2
 		return 1
 	fi
-	if ! jq -ec --arg full "${tap}" '
-      [.[] | select(.head.repo.full_name == $full and .user.login == "devantler")
-        | {number, isDraft: .draft, id: .node_id}]
+	if ! jq -ec --arg full "${tap}" --arg branch "${branch}" '
+      [
+        .[]
+        | select(.head.repo.full_name == $full and .head.ref == $branch)
+        | {number, isDraft: .draft, id: .node_id, author: .user.login}
+      ]
     ' <<<"${matches}"; then
 		printf 'ERROR: could not filter cask PR candidates for branch %s\n' "${branch}" >&2
 		return 1
@@ -127,20 +130,22 @@ prune_terminal_branch() {
 	# Close the discovery-to-delete race as far as the APIs permit: recheck both the open-PR keep
 	# set and the branch SHA immediately before a compare-and-swap delete. The force-with-lease
 	# refuses if another actor moves the ref after this evidence was gathered.
-	if ! open_now="$(trusted_open_prs "${branch}")"; then
-		return 1
-	fi
-	if [[ "$(jq -r 'length' <<<"${open_now}")" -ne 0 ]]; then
-		printf 'ERROR: retained branch %s acquired an open PR before deletion; refusing to delete it\n' \
-			"${branch}" >&2
-		return 1
-	fi
 	if ! current_sha="$(current_branch_sha "${branch}")"; then
 		return 1
 	fi
 	if [[ "${current_sha}" != "${branch_sha}" ]]; then
 		printf 'ERROR: retained branch %s moved before deletion; expected %s, found %s\n' \
 			"${branch}" "${branch_sha}" "${current_sha:-missing}" >&2
+		return 1
+	fi
+	# Keep the any-author open-PR lookup as the final remote-state check. A leased push protects
+	# the ref value, but it cannot detect a new PR that points at an unchanged ref.
+	if ! open_now="$(open_branch_prs "${branch}")"; then
+		return 1
+	fi
+	if [[ "$(jq -r 'length' <<<"${open_now}")" -ne 0 ]]; then
+		printf 'ERROR: retained branch %s acquired an open PR before deletion; refusing to delete it\n' \
+			"${branch}" >&2
 		return 1
 	fi
 	if [[ -z "${GH_TOKEN:-}" ]]; then
@@ -164,7 +169,7 @@ for name in "$@"; do
 	# branch-name filter, so same-name fork branches could fill a client-side page
 	# before any jq filter runs). The owner qualifier still admits a same-owner
 	# sibling repo's branch, so keep the full_name + author checks below.
-	if ! ours="$(trusted_open_prs "${branch}")"; then
+	if ! ours="$(open_branch_prs "${branch}")"; then
 		exit 1
 	fi
 	count="$(jq -r 'length' <<<"${ours}")"
@@ -179,6 +184,11 @@ for name in "$@"; do
 		exit 1
 	fi
 	pr="$(jq -r '.[0].number' <<<"${ours}")"
+	if [[ "$(jq -r '.[0].author' <<<"${ours}")" != "devantler" ]]; then
+		printf 'ERROR: %s#%s references %s but is not trusted for re-draft; refusing to rewrite it\n' \
+			"${tap}" "${pr}" "${branch}" >&2
+		exit 1
+	fi
 	if [[ "$(jq -r '.[0].isDraft' <<<"${ours}")" == "true" ]]; then
 		printf '%s#%s is already a draft; checkpoint holds\n' "${tap}" "${pr}"
 		continue

--- a/.github/scripts/redraft-evergreen-cask-prs.sh
+++ b/.github/scripts/redraft-evergreen-cask-prs.sh
@@ -33,27 +33,145 @@ if [[ ! "${tap}" =~ ^[^/]+/[^/]+$ || $# -lt 1 ]]; then
 fi
 tap_owner="${tap%%/*}"
 
+trusted_open_prs() {
+	local branch="$1" matches
+	if ! matches="$(gh api \
+		"repos/${tap}/pulls?state=open&head=${tap_owner}:${branch}&per_page=100")"; then
+		printf 'ERROR: could not enumerate open cask PRs on %s for branch %s\n' \
+			"${tap}" "${branch}" >&2
+		return 1
+	fi
+	if ! jq -ec --arg full "${tap}" '
+      [.[] | select(.head.repo.full_name == $full and .user.login == "devantler")
+        | {number, isDraft: .draft, id: .node_id}]
+    ' <<<"${matches}"; then
+		printf 'ERROR: could not filter cask PR candidates for branch %s\n' "${branch}" >&2
+		return 1
+	fi
+}
+
+current_branch_sha() {
+	local branch="$1" refs exact count sha
+	if ! refs="$(gh api "repos/${tap}/git/matching-refs/heads/${branch}")"; then
+		printf 'ERROR: could not inspect retained cask branch %s on %s\n' "${branch}" "${tap}" >&2
+		return 1
+	fi
+	if ! exact="$(jq -ec --arg ref "refs/heads/${branch}" \
+		'[.[] | select(.ref == $ref)]' <<<"${refs}")"; then
+		printf 'ERROR: malformed retained-branch response for %s\n' "${branch}" >&2
+		return 1
+	fi
+	count="$(jq -r 'length' <<<"${exact}")"
+	if [[ "${count}" -eq 0 ]]; then
+		return 0
+	fi
+	if [[ "${count}" -ne 1 ]]; then
+		printf 'ERROR: expected at most one retained branch ref for %s, found %s\n' \
+			"${branch}" "${count}" >&2
+		return 1
+	fi
+	sha="$(jq -r '.[0].object.sha // ""' <<<"${exact}")"
+	if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+		printf 'ERROR: retained branch %s has an invalid object SHA\n' "${branch}" >&2
+		return 1
+	fi
+	printf '%s\n' "${sha}"
+}
+
+prune_terminal_branch() {
+	local branch="$1" branch_sha closed_pages evidence_count open_now current_sha remote_url
+	if ! branch_sha="$(current_branch_sha "${branch}")"; then
+		return 1
+	fi
+	if [[ -z "${branch_sha}" ]]; then
+		printf 'No reusable open cask PR and no retained branch on %s for %s; GoReleaser will open a fresh draft\n' \
+			"${tap}" "${branch}"
+		return 0
+	fi
+
+	# A no-open-PR branch can still carry the history of a squash-merged evergreen PR. GoReleaser
+	# appends to that retained history, producing a fresh PR that conflicts with main. Delete only
+	# when a terminal PR record accounts for the branch's exact current SHA; otherwise preserve it.
+	if ! closed_pages="$(gh api --paginate --slurp \
+		"repos/${tap}/pulls?state=closed&head=${tap_owner}:${branch}&per_page=100")"; then
+		printf 'ERROR: could not enumerate terminal cask PRs for retained branch %s\n' "${branch}" >&2
+		return 1
+	fi
+	if ! jq -e 'type == "array" and all(.[]; type == "array")' \
+		<<<"${closed_pages}" >/dev/null; then
+		printf 'ERROR: malformed terminal-PR response for retained branch %s\n' "${branch}" >&2
+		return 1
+	fi
+	evidence_count="$(jq -r \
+		--arg full "${tap}" \
+		--arg branch "${branch}" \
+		--arg sha "${branch_sha}" '
+      [
+        .[][]
+        | select(
+            .state == "closed"
+            and .user.login == "devantler"
+            and .head.repo.full_name == $full
+            and .head.ref == $branch
+            and .head.sha == $sha
+          )
+      ]
+      | length
+    ' <<<"${closed_pages}")"
+	if [[ "${evidence_count}" -eq 0 ]]; then
+		printf 'ERROR: retained branch %s has no terminal PR evidence matching SHA %s; refusing to delete it\n' \
+			"${branch}" "${branch_sha}" >&2
+		return 1
+	fi
+
+	# Close the discovery-to-delete race as far as the APIs permit: recheck both the open-PR keep
+	# set and the branch SHA immediately before a compare-and-swap delete. The force-with-lease
+	# refuses if another actor moves the ref after this evidence was gathered.
+	if ! open_now="$(trusted_open_prs "${branch}")"; then
+		return 1
+	fi
+	if [[ "$(jq -r 'length' <<<"${open_now}")" -ne 0 ]]; then
+		printf 'ERROR: retained branch %s acquired an open PR before deletion; refusing to delete it\n' \
+			"${branch}" >&2
+		return 1
+	fi
+	if ! current_sha="$(current_branch_sha "${branch}")"; then
+		return 1
+	fi
+	if [[ "${current_sha}" != "${branch_sha}" ]]; then
+		printf 'ERROR: retained branch %s moved before deletion; expected %s, found %s\n' \
+			"${branch}" "${branch_sha}" "${current_sha:-missing}" >&2
+		return 1
+	fi
+	if [[ -z "${GH_TOKEN:-}" ]]; then
+		printf 'ERROR: GH_TOKEN is required for the exact-SHA retained-branch delete\n' >&2
+		return 1
+	fi
+	remote_url="https://x-access-token:${GH_TOKEN}@github.com/${tap}.git"
+	if ! git push --force-with-lease="refs/heads/${branch}:${branch_sha}" \
+		"${remote_url}" ":refs/heads/${branch}" >/dev/null 2>&1; then
+		printf 'ERROR: could not delete terminal branch %s at expected SHA %s; refusing to continue\n' \
+			"${branch}" "${branch_sha}" >&2
+		return 1
+	fi
+	printf 'Removed terminal branch %s at %s before GoReleaser creates the next PR\n' \
+		"${branch}" "${branch_sha}"
+}
+
 for name in "$@"; do
 	branch="goreleaser/${name}"
 	# REST `head=<owner>:<branch>` filters SERVER-side (gh pr list --head is a bare
 	# branch-name filter, so same-name fork branches could fill a client-side page
 	# before any jq filter runs). The owner qualifier still admits a same-owner
 	# sibling repo's branch, so keep the full_name + author checks below.
-	if ! matches="$(gh api \
-		"repos/${tap}/pulls?state=open&head=${tap_owner}:${branch}&per_page=100")"; then
-		printf 'ERROR: could not enumerate open cask PRs on %s for branch %s\n' "${tap}" "${branch}" >&2
-		exit 1
-	fi
-	if ! ours="$(jq -ec --arg full "${tap}" '
-      [.[] | select(.head.repo.full_name == $full and .user.login == "devantler")
-        | {number, isDraft: .draft, id: .node_id}]
-    ' <<<"${matches}")"; then
-		printf 'ERROR: could not filter cask PR candidates for branch %s\n' "${branch}" >&2
+	if ! ours="$(trusted_open_prs "${branch}")"; then
 		exit 1
 	fi
 	count="$(jq -r 'length' <<<"${ours}")"
 	if [[ "${count}" -eq 0 ]]; then
-		printf 'No reusable open cask PR on %s for %s; GoReleaser will open a fresh draft\n' "${tap}" "${branch}"
+		if ! prune_terminal_branch "${branch}"; then
+			exit 1
+		fi
 		continue
 	fi
 	if [[ "${count}" -ne 1 ]]; then

--- a/.github/scripts/redraft-evergreen-cask-prs.test.sh
+++ b/.github/scripts/redraft-evergreen-cask-prs.test.sh
@@ -21,18 +21,29 @@ new_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls?state=open&head=devantler-tech:goreleaser/ksail&per_page=100" ]]; then
 	if [[ "${scenario}" == open ]]; then
-		printf '%s\n' '[{"number":77,"draft":true,"node_id":"PR_77","user":{"login":"devantler"},"head":{"repo":{"full_name":"devantler-tech/homebrew-tap"}}}]'
+		printf '%s\n' '[{"number":77,"draft":true,"node_id":"PR_77","user":{"login":"devantler"},"head":{"ref":"goreleaser/ksail","repo":{"full_name":"devantler-tech/homebrew-tap"}}}]'
+	elif [[ "${scenario}" == untrusted-open ]]; then
+		printf '%s\n' '[{"number":78,"draft":false,"node_id":"PR_78","user":{"login":"another-author"},"head":{"ref":"goreleaser/ksail","repo":{"full_name":"devantler-tech/homebrew-tap"}}}]'
+	elif [[ "${scenario}" == pr-appeared && -f "${state_dir}/ref-read-final" ]]; then
+		printf '%s\n' '[{"number":79,"draft":true,"node_id":"PR_79","user":{"login":"another-author"},"head":{"ref":"goreleaser/ksail","repo":{"full_name":"devantler-tech/homebrew-tap"}}}]'
 	else
 		printf '%s\n' '[]'
 	fi
 elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/git/matching-refs/heads/goreleaser/ksail" ]]; then
 	if [[ "${scenario}" == no-branch ]]; then
 		printf '%s\n' '[]'
-	elif [[ "${scenario}" == moved-ref && -f "${state_dir}/ref-read" ]]; then
-		printf '[{"ref":"refs/heads/goreleaser/ksail","object":{"sha":"%s"}}]\n' "${new_sha}"
 	else
-		touch "${state_dir}/ref-read"
-		printf '[{"ref":"refs/heads/goreleaser/ksail","object":{"sha":"%s"}}]\n' "${old_sha}"
+		if [[ -f "${state_dir}/ref-read" ]]; then
+			touch "${state_dir}/ref-read-final"
+			if [[ "${scenario}" == moved-ref ]]; then
+				printf '[{"ref":"refs/heads/goreleaser/ksail","object":{"sha":"%s"}}]\n' "${new_sha}"
+			else
+				printf '[{"ref":"refs/heads/goreleaser/ksail","object":{"sha":"%s"}}]\n' "${old_sha}"
+			fi
+		else
+			touch "${state_dir}/ref-read"
+			printf '[{"ref":"refs/heads/goreleaser/ksail","object":{"sha":"%s"}}]\n' "${old_sha}"
+		fi
 	fi
 elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/pulls?state=closed&head=devantler-tech:goreleaser/ksail&per_page=100" ]]; then
 	evidence_sha="${old_sha}"
@@ -95,7 +106,9 @@ run_case() {
 
 run_case no-branch 0 'no retained branch' false
 run_case open 0 'already a draft' false
+run_case untrusted-open 1 'not trusted for re-draft' false
 run_case terminal 0 'Removed terminal branch' true
+run_case pr-appeared 1 'acquired an open PR' false
 run_case moved-ref 1 'moved before deletion' false
 run_case delete-failure 1 'could not delete terminal branch' true
 run_case no-evidence 1 'no terminal PR evidence matching' false

--- a/.github/scripts/redraft-evergreen-cask-prs.test.sh
+++ b/.github/scripts/redraft-evergreen-cask-prs.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+checkpoint="${script_dir}/redraft-evergreen-cask-prs.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+fake_bin="${tmp_dir}/bin"
+mkdir -p "${fake_bin}"
+
+cat >"${fake_bin}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${CHECKPOINT_SCENARIO:?}"
+state_dir="${CHECKPOINT_STATE_DIR:?}"
+command_line="$*"
+old_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+new_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+if [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/pulls?state=open&head=devantler-tech:goreleaser/ksail&per_page=100" ]]; then
+	if [[ "${scenario}" == open ]]; then
+		printf '%s\n' '[{"number":77,"draft":true,"node_id":"PR_77","user":{"login":"devantler"},"head":{"repo":{"full_name":"devantler-tech/homebrew-tap"}}}]'
+	else
+		printf '%s\n' '[]'
+	fi
+elif [[ "${command_line}" == "api repos/devantler-tech/homebrew-tap/git/matching-refs/heads/goreleaser/ksail" ]]; then
+	if [[ "${scenario}" == no-branch ]]; then
+		printf '%s\n' '[]'
+	elif [[ "${scenario}" == moved-ref && -f "${state_dir}/ref-read" ]]; then
+		printf '[{"ref":"refs/heads/goreleaser/ksail","object":{"sha":"%s"}}]\n' "${new_sha}"
+	else
+		touch "${state_dir}/ref-read"
+		printf '[{"ref":"refs/heads/goreleaser/ksail","object":{"sha":"%s"}}]\n' "${old_sha}"
+	fi
+elif [[ "${command_line}" == "api --paginate --slurp repos/devantler-tech/homebrew-tap/pulls?state=closed&head=devantler-tech:goreleaser/ksail&per_page=100" ]]; then
+	evidence_sha="${old_sha}"
+	[[ "${scenario}" == no-evidence ]] && evidence_sha="${new_sha}"
+	printf '[[{"number":42,"state":"closed","merged_at":"2026-07-19T00:00:00Z","user":{"login":"devantler"},"head":{"sha":"%s","ref":"goreleaser/ksail","repo":{"full_name":"devantler-tech/homebrew-tap"}}}]]\n' "${evidence_sha}"
+else
+	printf 'unexpected fake gh invocation: %s\n' "${command_line}" >&2
+	exit 2
+fi
+EOF
+
+cat >"${fake_bin}/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"${CHECKPOINT_STATE_DIR:?}/git-call"
+[[ "${CHECKPOINT_SCENARIO:?}" == delete-failure ]] && exit 1
+exit 0
+EOF
+chmod +x "${fake_bin}/gh" "${fake_bin}/git"
+
+pass_count=0
+run_case() {
+	local scenario="$1" expected_status="$2" expected_output="$3" expected_delete="$4"
+	local case_dir="${tmp_dir}/${scenario}" output status
+	mkdir -p "${case_dir}"
+	set +e
+	output="$(PATH="${fake_bin}:${PATH}" \
+		GH_TOKEN=test-token \
+		CHECKPOINT_SCENARIO="${scenario}" \
+		CHECKPOINT_STATE_DIR="${case_dir}" \
+		"${checkpoint}" --tap devantler-tech/homebrew-tap ksail 2>&1)"
+	status=$?
+	set -e
+
+	if [[ "${status}" -ne "${expected_status}" ]]; then
+		printf 'FAIL: %s: expected status %s, got %s\n%s\n' \
+			"${scenario}" "${expected_status}" "${status}" "${output}" >&2
+		return 1
+	fi
+	if [[ "${output}" != *"${expected_output}"* ]]; then
+		printf 'FAIL: %s: expected output containing %q, got:\n%s\n' \
+			"${scenario}" "${expected_output}" "${output}" >&2
+		return 1
+	fi
+	if [[ "${expected_delete}" == true ]]; then
+		if [[ ! -s "${case_dir}/git-call" ]] ||
+			! grep -Fq -- '--force-with-lease=refs/heads/goreleaser/ksail:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
+				"${case_dir}/git-call"; then
+			printf 'FAIL: %s: expected an exact-SHA leased branch delete\n' "${scenario}" >&2
+			return 1
+		fi
+	elif [[ -e "${case_dir}/git-call" ]]; then
+		printf 'FAIL: %s: branch deletion must not be attempted\n' "${scenario}" >&2
+		return 1
+	fi
+
+	pass_count=$((pass_count + 1))
+	printf 'PASS: %s\n' "${scenario}"
+}
+
+run_case no-branch 0 'no retained branch' false
+run_case open 0 'already a draft' false
+run_case terminal 0 'Removed terminal branch' true
+run_case moved-ref 1 'moved before deletion' false
+run_case delete-failure 1 'could not delete terminal branch' true
+run_case no-evidence 1 'no terminal PR evidence matching' false
+
+printf 'All %d evergreen cask checkpoint cases passed.\n' "${pass_count}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,6 +275,7 @@ jobs:
               - '.github/scripts/find-merged-cask-pr-handoff.sh'
               - '.github/scripts/find-merged-cask-pr-handoff.test.sh'
               - '.github/scripts/redraft-evergreen-cask-prs.sh'
+              - '.github/scripts/redraft-evergreen-cask-prs.test.sh'
               - '.github/scripts/validate-cask-pr-handoff.sh'
               - '.github/scripts/validate-cask-pr-handoff.test.sh'
               - '.github/workflows/cd.yaml'
@@ -303,11 +304,13 @@ jobs:
             .github/scripts/find-merged-cask-pr-handoff.sh \
             .github/scripts/find-merged-cask-pr-handoff.test.sh \
             .github/scripts/redraft-evergreen-cask-prs.sh \
+            .github/scripts/redraft-evergreen-cask-prs.test.sh \
             .github/scripts/validate-cask-pr-handoff.sh \
             .github/scripts/validate-cask-pr-handoff.test.sh \
             .github/scripts/cask-pr-handoff-workflow.test.sh
           .github/scripts/collect-cask-pr-handoff.test.sh
           .github/scripts/find-merged-cask-pr-handoff.test.sh
+          .github/scripts/redraft-evergreen-cask-prs.test.sh
           .github/scripts/validate-cask-pr-handoff.test.sh
           .github/scripts/cask-pr-handoff-workflow.test.sh
 


### PR DESCRIPTION
## Summary

- remove retained evergreen cask branches only when a terminal PR accounts for the branch's exact current SHA
- recheck the open-PR keep set and branch SHA immediately before an exact-SHA `--force-with-lease` delete
- fail closed on missing evidence, moved refs, API failures, delete failures, or a newly opened PR
- add executable checkpoint coverage and wire it into the cask handoff CI contract

## Production evidence

KSail `v7.175.2` CD run [29666276667](https://github.com/devantler-tech/ksail/actions/runs/29666276667) published successfully but failed in `🍺 Prepare Homebrew cask PRs`:

- `homebrew-tap#1219` inherited the already squash-merged evergreen CLI history and became `DIRTY` against tap `main`.
- `homebrew-tap#1218` temporarily changed both casks, so the strict desktop validator rejected it.
- the pre-release checkpoint had reported no reusable open PRs, but it did not remove the retained remote branches before GoReleaser wrote the new release.

## Validation

- 6 checkpoint behavior cases: absent branch, existing open PR, terminal exact-SHA cleanup, moved ref, delete failure, and missing evidence
- 19 collector cases
- 52 validator cases
- 8 merged-finder cases
- cask handoff workflow contract
- ShellCheck and `shfmt -d -i 0`
- `jscpd` 5.0.11: zero clones
- `git diff --check`

The local Actionlint version still rejects the pre-existing `code-quality: write` permission on both this branch and `origin/main`; the repository's pinned CI Actionlint remains authoritative for that unrelated newer permission.

Fixes #6265
