### PR TITLE
fix(eks): persist AWS credential mappings in ownership state

### DIFF
--- a/pkg/cli/cmd/cluster/create_test.go
+++ b/pkg/cli/cmd/cluster/create_test.go
@@ -373,6 +373,16 @@ func TestCreate_EKSProfileRegionFeedsIdentityCapture(t *testing.T) {
 	cmd.SetArgs([]string{"--gitops-engine", "ArgoCD"})
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, "eu-north-1", capturedRegion)
+
+	ownership, err := state.LoadEKSOwnershipState("st-eks", "eu-north-1")
+	require.NoError(t, err)
+	assert.Equal(t, v1alpha1.OptionsAWS{
+		ProfileEnvVar:         "KSAIL_PROFILE",
+		RegionEnvVar:          "AWS_REGION",
+		AccessKeyIDEnvVar:     "AWS_ACCESS_KEY_ID",
+		SecretAccessKeyEnvVar: "AWS_SECRET_ACCESS_KEY",
+		SessionTokenEnvVar:    "AWS_SESSION_TOKEN",
+	}, ownership.AWSOptions)
 }
 
 func writeEKSProfileRegionCreateTestFiles(t *testing.T, workingDir string) {

--- a/pkg/cli/cmd/cluster/create_test.go
+++ b/pkg/cli/cmd/cluster/create_test.go
@@ -376,6 +376,7 @@ func TestCreate_EKSProfileRegionFeedsIdentityCapture(t *testing.T) {
 
 	ownership, err := state.LoadEKSOwnershipState("st-eks", "eu-north-1")
 	require.NoError(t, err)
+	//nolint:gosec // G101: these are environment-variable names, never credential values.
 	assert.Equal(t, v1alpha1.OptionsAWS{
 		ProfileEnvVar:         "KSAIL_PROFILE",
 		RegionEnvVar:          "AWS_REGION",

--- a/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
+++ b/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
@@ -469,6 +469,7 @@ func persistStandaloneEKSIdentityInRegion(
 			AccountID:   accountID,
 			ClusterARN:  "arn:aws:eks:" + region + ":" + accountID + ":cluster/" + clusterName,
 			CreatedAt:   createdAt,
+			AWSOptions:  credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{}),
 		},
 	))
 }

--- a/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
+++ b/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
@@ -142,18 +142,26 @@ func TestStandaloneEKSLifecycleRechecksSameARNReplacementImmediatelyBeforeMutati
 	}
 }
 
+// setDefaultAWSOptionsOnOwnership stamps the canonical mapping onto an already-persisted ownership
+// record, mirroring what creation now captures.
+func setDefaultAWSOptionsOnOwnership(t *testing.T, clusterName, region string) {
+	t.Helper()
+
+	ownership, err := state.LoadEKSOwnershipState(clusterName, region)
+	require.NoError(t, err)
+
+	ownership.AWSOptions = credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{})
+
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, ownership))
+}
+
 //nolint:paralleltest // mutates process environment, working directory, and shared hooks.
 func TestStandaloneEKSLifecycleFreezesCustomAWSCredentialsForEveryConsumer(t *testing.T) {
 	const clusterName = "ksail-eks-start-frozen-credentials-6202"
 
 	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
-	ownership, err := state.LoadEKSOwnershipState(clusterName, "ap-southeast-2")
-	require.NoError(t, err)
-	ownership.AWSOptions = credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{})
-	require.NoError(
-		t,
-		state.SaveEKSOwnershipState(clusterName, "ap-southeast-2", ownership),
-	)
+	setDefaultAWSOptionsOnOwnership(t, clusterName, "ap-southeast-2")
+
 	identityClient := &fakeEKSIdentityClient{
 		accountID: "123456789012",
 		cluster: immutableEKSCluster(

--- a/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
+++ b/pkg/cli/cmd/cluster/eks_immutable_identity_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
@@ -146,6 +147,13 @@ func TestStandaloneEKSLifecycleFreezesCustomAWSCredentialsForEveryConsumer(t *te
 	const clusterName = "ksail-eks-start-frozen-credentials-6202"
 
 	markerPath := setupStandaloneEKSLifecycleFixture(t, clusterName)
+	ownership, err := state.LoadEKSOwnershipState(clusterName, "ap-southeast-2")
+	require.NoError(t, err)
+	ownership.AWSOptions = credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{})
+	require.NoError(
+		t,
+		state.SaveEKSOwnershipState(clusterName, "ap-southeast-2", ownership),
+	)
 	identityClient := &fakeEKSIdentityClient{
 		accountID: "123456789012",
 		cluster: immutableEKSCluster(

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -681,10 +681,26 @@ func TestStandaloneEKSStartAcceptsPersistedOwnershipWithoutConfig(t *testing.T) 
 	)
 }
 
+// setCustomAWSMappingEnvironment points the custom KSAIL_* variables at the values the eksctl
+// fixture demands, while every canonical AWS_* variable holds a decoy. A run that resolves through
+// the default mapping therefore hands eksctl the ambient values and the fixture rejects it.
+func setCustomAWSMappingEnvironment(t *testing.T, region string) {
+	t.Helper()
+
+	t.Setenv("KSAIL_PROFILE", "selected-profile")
+	t.Setenv("KSAIL_REGION", region)
+	t.Setenv("KSAIL_ACCESS", "fixture-access")
+	t.Setenv("KSAIL_SECRET", "fixture-secret")
+	t.Setenv("KSAIL_SESSION", "fixture-session")
+	t.Setenv("AWS_PROFILE", "ambient-profile")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "ambient-session")
+}
+
 // TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState verifies a no-config
 // lifecycle command uses the same custom AWS environment-variable names captured at creation.
-//
-//nolint:paralleltest // mutates process environment and working directory
 func TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState(t *testing.T) {
 	const (
 		clusterName = "ksail-eks-start-state-custom-mappings-6227"
@@ -703,16 +719,7 @@ func TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState(t *testin
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("KSAIL_EKSCTL_MARKER", markerPath)
 	t.Setenv("KSAIL_EKS_CLUSTER", clusterName)
-	t.Setenv("KSAIL_PROFILE", "selected-profile")
-	t.Setenv("KSAIL_REGION", region)
-	t.Setenv("KSAIL_ACCESS", "fixture-access")
-	t.Setenv("KSAIL_SECRET", "fixture-secret")
-	t.Setenv("KSAIL_SESSION", "fixture-session")
-	t.Setenv("AWS_PROFILE", "ambient-profile")
-	t.Setenv("AWS_REGION", "us-east-1")
-	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-access")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
-	t.Setenv("AWS_SESSION_TOKEN", "ambient-session")
+	setCustomAWSMappingEnvironment(t, region)
 	t.Setenv("KUBECONFIG", filepath.Join(workingDir, "kubeconfig"))
 
 	require.NoError(t, state.SaveClusterSpec(clusterName, &v1alpha1.ClusterSpec{
@@ -724,6 +731,7 @@ func TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState(t *testin
 
 	ownership, err := state.LoadEKSOwnershipState(clusterName, region)
 	require.NoError(t, err)
+
 	ownership.AWSOptions = v1alpha1.OptionsAWS{
 		ProfileEnvVar:         "KSAIL_PROFILE",
 		RegionEnvVar:          "KSAIL_REGION",
@@ -752,6 +760,44 @@ func TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState(t *testin
 	assert.Equal(t, "ambient-session", os.Getenv("AWS_SESSION_TOKEN"))
 }
 
+// TestLegacyOwnershipRecordDefersToAuthoritativeMigrationError proves a record predating the
+// awsOptions schema does not surface an opaque restore failure. The actionable error — the one
+// naming the rebind command — belongs to eksidentity.NewVerifier, so the restore step must decline
+// quietly rather than shadow it. The command still fails closed downstream.
+func TestLegacyOwnershipRecordDefersToAuthoritativeMigrationError(t *testing.T) {
+	const (
+		clusterName = "legacy-defers-to-verifier-6270"
+		region      = "eu-north-1"
+	)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".ksail", "clusters", clusterName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	legacy := fmt.Sprintf(`{
+  "version": %d,
+  "clusterName": %q,
+  "region": %q,
+  "accountId": "123456789012",
+  "clusterArn": "arn:aws:eks:%s:123456789012:cluster/%s",
+  "createdAt": "2026-07-18T12:00:00Z"
+}`, state.EKSOwnershipStateVersion, clusterName, region, region, clusterName)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "eks-ownership-"+region+".json"),
+		[]byte(legacy),
+		0o600,
+	))
+
+	resolved := &lifecycle.ResolvedClusterInfo{ClusterName: clusterName, AWSRegion: region}
+
+	require.NoError(t, cluster.ExportRestorePersistedAWSOptions(resolved))
+	assert.Empty(t, resolved.AWSOpts.AccessKeyIDEnvVar)
+	assert.Empty(t, resolved.AWSOpts.RegionEnvVar)
+}
+
 func TestPersistedAWSMappingsDoNotOverrideLoadedConfigDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -766,7 +812,6 @@ func TestPersistedAWSMappingsDoNotOverrideLoadedConfigDefaults(t *testing.T) {
 	assert.Empty(t, resolved.AWSOpts.RegionEnvVar)
 }
 
-//nolint:paralleltest // mutates HOME and process environment.
 func TestPersistedRegionAliasSelectsStateBeforeRegionResolution(t *testing.T) {
 	const (
 		clusterName = "state-region-alias-6270"
@@ -782,6 +827,7 @@ func TestPersistedRegionAliasSelectsStateBeforeRegionResolution(t *testing.T) {
 		AccountID:   "123456789012",
 		ClusterARN:  "arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
 		CreatedAt:   time.Now().UTC(),
+		//nolint:gosec // G101: these are environment-variable names, never credential values.
 		AWSOptions: v1alpha1.OptionsAWS{
 			ProfileEnvVar:         "AWS_PROFILE",
 			RegionEnvVar:          "KSAIL_REGION",

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
@@ -749,6 +750,50 @@ func TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState(t *testin
 	assert.Equal(t, "ambient-access", os.Getenv("AWS_ACCESS_KEY_ID"))
 	assert.Equal(t, "ambient-secret", os.Getenv("AWS_SECRET_ACCESS_KEY"))
 	assert.Equal(t, "ambient-session", os.Getenv("AWS_SESSION_TOKEN"))
+}
+
+func TestPersistedAWSMappingsDoNotOverrideLoadedConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	resolved := &lifecycle.ResolvedClusterInfo{
+		ClusterName:  "loaded-config-keeps-defaults-6270",
+		ConfigSource: true,
+		AWSRegion:    "eu-north-1",
+	}
+
+	require.NoError(t, cluster.ExportRestorePersistedAWSOptions(resolved))
+	assert.Empty(t, resolved.AWSOpts.AccessKeyIDEnvVar)
+	assert.Empty(t, resolved.AWSOpts.RegionEnvVar)
+}
+
+//nolint:paralleltest // mutates HOME and process environment.
+func TestPersistedRegionAliasSelectsStateBeforeRegionResolution(t *testing.T) {
+	const (
+		clusterName = "state-region-alias-6270"
+		region      = "ap-southeast-2"
+	)
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KSAIL_REGION", region)
+	ownership := &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: clusterName,
+		Region:      region,
+		AccountID:   "123456789012",
+		ClusterARN:  "arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
+		CreatedAt:   time.Now().UTC(),
+		AWSOptions: v1alpha1.OptionsAWS{
+			RegionEnvVar:      "KSAIL_REGION",
+			AccessKeyIDEnvVar: "KSAIL_ACCESS",
+		},
+	}
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, ownership))
+
+	resolved := &lifecycle.ResolvedClusterInfo{ClusterName: clusterName}
+	require.NoError(t, cluster.ExportRestorePersistedAWSOptions(resolved))
+	assert.Equal(t, region, resolved.AWSRegion)
+	assert.Equal(t, "KSAIL_REGION", resolved.AWSOpts.RegionEnvVar)
+	assert.Equal(t, "KSAIL_ACCESS", resolved.AWSOpts.AccessKeyIDEnvVar)
 }
 
 // TestEKSMutationCommandsRejectNameOverrideMismatch proves create and update cannot claim a name

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -680,6 +680,77 @@ func TestStandaloneEKSStartAcceptsPersistedOwnershipWithoutConfig(t *testing.T) 
 	)
 }
 
+// TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState verifies a no-config
+// lifecycle command uses the same custom AWS environment-variable names captured at creation.
+//
+//nolint:paralleltest // mutates process environment and working directory
+func TestStandaloneEKSStartRestoresCustomAWSMappingsFromOwnershipState(t *testing.T) {
+	const (
+		clusterName = "ksail-eks-start-state-custom-mappings-6227"
+		region      = "ap-southeast-2"
+	)
+
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	binDir := t.TempDir()
+	markerPath := filepath.Join(t.TempDir(), "eksctl-calls")
+	writeExecutableFixture(t, filepath.Join(binDir, "eksctl"), standaloneEKSEksctlFixture)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KSAIL_EKSCTL_MARKER", markerPath)
+	t.Setenv("KSAIL_EKS_CLUSTER", clusterName)
+	t.Setenv("KSAIL_PROFILE", "selected-profile")
+	t.Setenv("KSAIL_REGION", region)
+	t.Setenv("KSAIL_ACCESS", "fixture-access")
+	t.Setenv("KSAIL_SECRET", "fixture-secret")
+	t.Setenv("KSAIL_SESSION", "fixture-session")
+	t.Setenv("AWS_PROFILE", "ambient-profile")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "ambient-session")
+	t.Setenv("KUBECONFIG", filepath.Join(workingDir, "kubeconfig"))
+
+	require.NoError(t, state.SaveClusterSpec(clusterName, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+	}))
+	writeStandaloneEKSKubeconfig(t, clusterName, region)
+	configureStandaloneEKSIdentityInRegion(t, clusterName, region)
+
+	ownership, err := state.LoadEKSOwnershipState(clusterName, region)
+	require.NoError(t, err)
+	ownership.AWSOptions = v1alpha1.OptionsAWS{
+		ProfileEnvVar:         "KSAIL_PROFILE",
+		RegionEnvVar:          "KSAIL_REGION",
+		AccessKeyIDEnvVar:     "KSAIL_ACCESS",
+		SecretAccessKeyEnvVar: "KSAIL_SECRET",
+		SessionTokenEnvVar:    "KSAIL_SESSION",
+	}
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, ownership))
+
+	cmd := cluster.NewStartCmd()
+	cmd.SetArgs([]string{"--name", clusterName, "--provider", "AWS"})
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(
+		t,
+		standaloneEKSLifecycleCases()[1].expectedCalls(clusterName),
+		readStandaloneEKSCalls(t, markerPath),
+	)
+	assert.Equal(t, "ambient-profile", os.Getenv("AWS_PROFILE"))
+	assert.Equal(t, "us-east-1", os.Getenv("AWS_REGION"))
+	assert.Equal(t, "ambient-access", os.Getenv("AWS_ACCESS_KEY_ID"))
+	assert.Equal(t, "ambient-secret", os.Getenv("AWS_SECRET_ACCESS_KEY"))
+	assert.Equal(t, "ambient-session", os.Getenv("AWS_SESSION_TOKEN"))
+}
+
 // TestEKSMutationCommandsRejectNameOverrideMismatch proves create and update cannot claim a name
 // that eksctl will ignore because the actual create/delete source is eks.yaml.
 //

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -783,8 +783,11 @@ func TestPersistedRegionAliasSelectsStateBeforeRegionResolution(t *testing.T) {
 		ClusterARN:  "arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
 		CreatedAt:   time.Now().UTC(),
 		AWSOptions: v1alpha1.OptionsAWS{
-			RegionEnvVar:      "KSAIL_REGION",
-			AccessKeyIDEnvVar: "KSAIL_ACCESS",
+			ProfileEnvVar:         "AWS_PROFILE",
+			RegionEnvVar:          "KSAIL_REGION",
+			AccessKeyIDEnvVar:     "KSAIL_ACCESS",
+			SecretAccessKeyEnvVar: "AWS_SECRET_ACCESS_KEY",
+			SessionTokenEnvVar:    "AWS_SESSION_TOKEN",
 		},
 	}
 	require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, ownership))

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -64,6 +64,11 @@ func ExportAWSProviderStatus(
 	return awsProviderStatus(ctx, client, clusterName, region, opts...)
 }
 
+// ExportRestorePersistedAWSOptions exposes persisted AWS option restoration for focused tests.
+func ExportRestorePersistedAWSOptions(resolved *lifecycle.ResolvedClusterInfo) error {
+	return restorePersistedAWSOptions(resolved)
+}
+
 // ErrProviderNotConfigured exports errProviderNotConfigured for testing.
 var ErrProviderNotConfigured = errProviderNotConfigured
 

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -503,21 +503,13 @@ func captureCreatedEKSIdentity(
 		return fmt.Errorf("capture immutable EKS ownership identity: create AWS client: %w", err)
 	}
 
-	ownership, err := eksidentity.Observe(
+	ownership, err := eksidentity.Capture(
 		ctx,
 		identityClient,
 		strings.TrimSpace(clusterCtx.EKSConfig.Name),
 		strings.TrimSpace(clusterCtx.EKSConfig.Region),
+		credentials.AWSOptionsWithDefaults(clusterCtx.ClusterCfg.Spec.Provider.AWS),
 	)
-	if err != nil {
-		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
-	}
-
-	ownership.AWSOptions = credentials.AWSOptionsWithDefaults(
-		clusterCtx.ClusterCfg.Spec.Provider.AWS,
-	)
-
-	err = eksidentity.Persist(ownership.ClusterName, ownership.Region, ownership)
 	if err != nil {
 		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -503,12 +503,21 @@ func captureCreatedEKSIdentity(
 		return fmt.Errorf("capture immutable EKS ownership identity: create AWS client: %w", err)
 	}
 
-	ownership, err := eksidentity.Capture(
+	ownership, err := eksidentity.Observe(
 		ctx,
 		identityClient,
 		strings.TrimSpace(clusterCtx.EKSConfig.Name),
 		strings.TrimSpace(clusterCtx.EKSConfig.Region),
 	)
+	if err != nil {
+		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
+	}
+
+	ownership.AWSOptions = credentials.AWSOptionsWithDefaults(
+		clusterCtx.ClusterCfg.Spec.Provider.AWS,
+	)
+
+	err = eksidentity.Persist(ownership.ClusterName, ownership.Region, ownership)
 	if err != nil {
 		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/rebind_eks_ownership.go
+++ b/pkg/cli/cmd/cluster/rebind_eks_ownership.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/experimental"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/lifecycle"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
@@ -60,7 +61,7 @@ repeat with --yes to confirm. It never deletes or scales AWS resources.`,
 				)
 			}
 
-			identityClient, err := resolveAWSOwnershipTarget(ctx, resolved)
+			identityClient, err := resolveAWSOwnershipTarget(ctx, resolved, false)
 			if err != nil {
 				return err
 			}
@@ -74,6 +75,8 @@ repeat with --yes to confirm. It never deletes or scales AWS resources.`,
 			if err != nil {
 				return fmt.Errorf("observe EKS ownership identity: %w", err)
 			}
+
+			observed.AWSOptions = credentials.AWSOptionsWithDefaults(resolved.AWSOpts)
 
 			notify.Infof(cmd.OutOrStdout(), "AWS account: %s", observed.AccountID)
 			notify.Infof(cmd.OutOrStdout(), "cluster ARN: %s", observed.ClusterARN)

--- a/pkg/cli/cmd/cluster/rebind_eks_ownership_test.go
+++ b/pkg/cli/cmd/cluster/rebind_eks_ownership_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/experimental"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/flags"
@@ -93,6 +94,13 @@ func TestRebindEKSOwnershipPersistsOnlyAfterExplicitConfirmation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "123456789012", ownership.AccountID)
 	assert.Equal(t, immutableIdentityTime(), ownership.CreatedAt)
+	assert.Equal(t, v1alpha1.OptionsAWS{
+		ProfileEnvVar:         "KSAIL_PROFILE",
+		RegionEnvVar:          "KSAIL_REGION",
+		AccessKeyIDEnvVar:     "KSAIL_ACCESS",
+		SecretAccessKeyEnvVar: "KSAIL_SECRET",
+		SessionTokenEnvVar:    "KSAIL_SESSION",
+	}, ownership.AWSOptions)
 
 	_, err = state.LoadEKSNodegroupState(clusterName, "ap-southeast-2")
 	require.ErrorIs(t, err, state.ErrEKSNodegroupStateNotFound)

--- a/pkg/cli/cmd/cluster/unmanaged_guard.go
+++ b/pkg/cli/cmd/cluster/unmanaged_guard.go
@@ -354,8 +354,7 @@ func restorePersistedAWSOptions(resolved *lifecycle.ResolvedClusterInfo) error {
 	if region != "" {
 		ownership, err := state.LoadEKSOwnershipState(resolved.ClusterName, region)
 		if err != nil {
-			if errors.Is(err, state.ErrEKSOwnershipStateNotFound) ||
-				errors.Is(err, state.ErrInvalidEKSOwnershipState) {
+			if errors.Is(err, state.ErrEKSOwnershipStateNotFound) {
 				return nil
 			}
 

--- a/pkg/cli/cmd/cluster/unmanaged_guard.go
+++ b/pkg/cli/cmd/cluster/unmanaged_guard.go
@@ -346,49 +346,103 @@ func resolveAWSOwnershipTarget(
 }
 
 func restorePersistedAWSOptions(resolved *lifecycle.ResolvedClusterInfo) error {
-	if strings.TrimSpace(resolved.AWSRegion) == "" {
+	if resolved.ConfigSource {
 		return nil
 	}
 
-	ownership, err := state.LoadEKSOwnershipState(resolved.ClusterName, resolved.AWSRegion)
+	region := strings.TrimSpace(resolved.AWSRegion)
+	if region != "" {
+		ownership, err := state.LoadEKSOwnershipState(resolved.ClusterName, region)
+		if err != nil {
+			if errors.Is(err, state.ErrEKSOwnershipStateNotFound) ||
+				errors.Is(err, state.ErrInvalidEKSOwnershipState) {
+				return nil
+			}
+
+			return fmt.Errorf("load persisted AWS credential mappings: %w", err)
+		}
+
+		resolved.AWSOpts = mergeAWSOptions(resolved.AWSOpts, ownership.AWSOptions)
+
+		return nil
+	}
+
+	ownerships, err := state.ListEKSOwnershipStates(resolved.ClusterName)
 	if err != nil {
-		if errors.Is(err, state.ErrEKSOwnershipStateNotFound) ||
-			errors.Is(err, state.ErrInvalidEKSOwnershipState) {
+		if errors.Is(err, state.ErrEKSOwnershipStateNotFound) {
 			return nil
 		}
 
 		return fmt.Errorf("load persisted AWS credential mappings: %w", err)
 	}
 
+	ownership, err := selectPersistedAWSOwnership(ownerships)
+	if err != nil {
+		return err
+	}
+
 	resolved.AWSOpts = mergeAWSOptions(resolved.AWSOpts, ownership.AWSOptions)
+	resolved.AWSRegion = strings.TrimSpace(ownership.Region)
 
 	return nil
 }
 
-func mergeAWSOptions(
-	current, persisted v1alpha1.OptionsAWS,
-) v1alpha1.OptionsAWS {
+func mergeAWSOptions(current, persisted v1alpha1.OptionsAWS) v1alpha1.OptionsAWS {
 	if current.ProfileEnvVar == "" {
 		current.ProfileEnvVar = persisted.ProfileEnvVar
 	}
-
 	if current.RegionEnvVar == "" {
 		current.RegionEnvVar = persisted.RegionEnvVar
 	}
-
 	if current.AccessKeyIDEnvVar == "" {
 		current.AccessKeyIDEnvVar = persisted.AccessKeyIDEnvVar
 	}
-
 	if current.SecretAccessKeyEnvVar == "" {
 		current.SecretAccessKeyEnvVar = persisted.SecretAccessKeyEnvVar
 	}
-
 	if current.SessionTokenEnvVar == "" {
 		current.SessionTokenEnvVar = persisted.SessionTokenEnvVar
 	}
 
 	return current
+}
+
+func selectPersistedAWSOwnership(
+	ownerships []*state.EKSOwnershipState,
+) (*state.EKSOwnershipState, error) {
+	requestedRegions := make(map[string]struct{})
+
+	for _, ownership := range ownerships {
+		options := credentials.AWSOptionsWithDefaults(ownership.AWSOptions)
+		if region := strings.TrimSpace(os.Getenv(options.RegionEnvVar)); region != "" {
+			requestedRegions[region] = struct{}{}
+		}
+	}
+
+	if len(requestedRegions) == 1 {
+		for requestedRegion := range requestedRegions {
+			for _, ownership := range ownerships {
+				if strings.TrimSpace(ownership.Region) == requestedRegion {
+					return ownership, nil
+				}
+			}
+
+			return nil, fmt.Errorf(
+				"no persisted EKS ownership state for configured region %q",
+				requestedRegion,
+			)
+		}
+	}
+
+	if len(requestedRegions) > 1 || len(ownerships) != 1 {
+		return nil, fmt.Errorf(
+			"%w %q: persisted ownership state does not select one region",
+			errAWSOwnershipRegionAmbiguous,
+			ownerships[0].ClusterName,
+		)
+	}
+
+	return ownerships[0], nil
 }
 
 func queryFrozenAWSOwnership(
@@ -644,6 +698,7 @@ func resolveUpdateTarget(
 	resolved.EKSConfigSource = eksConfig.NameFromConfig &&
 		strings.TrimSpace(eksConfig.ConfigPath) != "" &&
 		resolved.ConfigClusterName != ""
+	resolved.ConfigSource = resolved.EKSConfigSource
 	resolved.AWSRegion = effectiveAWSRegion
 	resolved.AWSRegionFromConfig = effectiveAWSRegion != "" &&
 		effectiveAWSRegion == configuredAWSRegion

--- a/pkg/cli/cmd/cluster/unmanaged_guard.go
+++ b/pkg/cli/cmd/cluster/unmanaged_guard.go
@@ -41,6 +41,9 @@ var (
 	errAWSOwnershipRegionAmbiguous = errors.New(
 		"multiple kubeconfig regions match EKS cluster",
 	)
+	errAWSOwnershipRegionUnrecorded = errors.New(
+		"no persisted EKS ownership state for configured region",
+	)
 	errAWSOwnershipProvenanceMissing = errors.New(
 		"exact AWS ownership query did not report an eksctl-created cluster",
 	)
@@ -314,16 +317,20 @@ func resolveAWSOwnershipTarget(
 		)
 	}
 
-	err := bindAWSRegionFromKubeconfig(resolved)
-	if err != nil {
-		return nil, err
-	}
-
+	// Restore before the kubeconfig fallback: the persisted mapping may name a custom region
+	// variable, and bindAWSRegionFromKubeconfig is a no-op once a region is known. Binding first
+	// would let a stale or duplicated same-name kubeconfig context pin (or reject) the region
+	// before the captured RegionEnvVar is ever consulted.
 	if restorePersistedOptions {
-		err = restorePersistedAWSOptions(resolved)
+		err := restorePersistedAWSOptions(resolved)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	err := bindAWSRegionFromKubeconfig(resolved)
+	if err != nil {
+		return nil, err
 	}
 
 	auth, err := queryFrozenAWSOwnership(ctx, resolved)
@@ -345,6 +352,16 @@ func resolveAWSOwnershipTarget(
 	return identityClient, nil
 }
 
+// isRestorableOwnershipStateAbsence reports that no usable credential mapping could be restored,
+// which is never fatal here. A legacy record predating the mapping schema is deliberately treated
+// like a missing one: the authoritative, actionable failure belongs to eksidentity.NewVerifier,
+// whose migrationRequiredError names the rebind command. Returning early keeps that message intact
+// instead of shadowing it with an opaque validation error, and still fails closed downstream.
+func isRestorableOwnershipStateAbsence(err error) bool {
+	return errors.Is(err, state.ErrEKSOwnershipStateNotFound) ||
+		errors.Is(err, state.ErrInvalidEKSOwnershipState)
+}
+
 func restorePersistedAWSOptions(resolved *lifecycle.ResolvedClusterInfo) error {
 	if resolved.ConfigSource {
 		return nil
@@ -354,7 +371,7 @@ func restorePersistedAWSOptions(resolved *lifecycle.ResolvedClusterInfo) error {
 	if region != "" {
 		ownership, err := state.LoadEKSOwnershipState(resolved.ClusterName, region)
 		if err != nil {
-			if errors.Is(err, state.ErrEKSOwnershipStateNotFound) {
+			if isRestorableOwnershipStateAbsence(err) {
 				return nil
 			}
 
@@ -368,7 +385,7 @@ func restorePersistedAWSOptions(resolved *lifecycle.ResolvedClusterInfo) error {
 
 	ownerships, err := state.ListEKSOwnershipStates(resolved.ClusterName)
 	if err != nil {
-		if errors.Is(err, state.ErrEKSOwnershipStateNotFound) {
+		if isRestorableOwnershipStateAbsence(err) {
 			return nil
 		}
 
@@ -390,15 +407,19 @@ func mergeAWSOptions(current, persisted v1alpha1.OptionsAWS) v1alpha1.OptionsAWS
 	if current.ProfileEnvVar == "" {
 		current.ProfileEnvVar = persisted.ProfileEnvVar
 	}
+
 	if current.RegionEnvVar == "" {
 		current.RegionEnvVar = persisted.RegionEnvVar
 	}
+
 	if current.AccessKeyIDEnvVar == "" {
 		current.AccessKeyIDEnvVar = persisted.AccessKeyIDEnvVar
 	}
+
 	if current.SecretAccessKeyEnvVar == "" {
 		current.SecretAccessKeyEnvVar = persisted.SecretAccessKeyEnvVar
 	}
+
 	if current.SessionTokenEnvVar == "" {
 		current.SessionTokenEnvVar = persisted.SessionTokenEnvVar
 	}
@@ -427,7 +448,8 @@ func selectPersistedAWSOwnership(
 			}
 
 			return nil, fmt.Errorf(
-				"no persisted EKS ownership state for configured region %q",
+				"%w %q",
+				errAWSOwnershipRegionUnrecorded,
 				requestedRegion,
 			)
 		}

--- a/pkg/cli/cmd/cluster/unmanaged_guard.go
+++ b/pkg/cli/cmd/cluster/unmanaged_guard.go
@@ -274,7 +274,7 @@ func ensureAWSClusterManaged(
 	ctx context.Context,
 	resolved *lifecycle.ResolvedClusterInfo,
 ) error {
-	identityClient, err := resolveAWSOwnershipTarget(ctx, resolved)
+	identityClient, err := resolveAWSOwnershipTarget(ctx, resolved, true)
 	if err != nil {
 		return err
 	}
@@ -304,6 +304,7 @@ func ensureAWSClusterManaged(
 func resolveAWSOwnershipTarget(
 	ctx context.Context,
 	resolved *lifecycle.ResolvedClusterInfo,
+	restorePersistedOptions bool,
 ) (eksidentity.Client, error) {
 	if !hasLocalKSailEKSTargetEvidence(resolved) {
 		return nil, fmt.Errorf(
@@ -316,6 +317,13 @@ func resolveAWSOwnershipTarget(
 	err := bindAWSRegionFromKubeconfig(resolved)
 	if err != nil {
 		return nil, err
+	}
+
+	if restorePersistedOptions {
+		err = restorePersistedAWSOptions(resolved)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	auth, err := queryFrozenAWSOwnership(ctx, resolved)
@@ -335,6 +343,52 @@ func resolveAWSOwnershipTarget(
 	}
 
 	return identityClient, nil
+}
+
+func restorePersistedAWSOptions(resolved *lifecycle.ResolvedClusterInfo) error {
+	if strings.TrimSpace(resolved.AWSRegion) == "" {
+		return nil
+	}
+
+	ownership, err := state.LoadEKSOwnershipState(resolved.ClusterName, resolved.AWSRegion)
+	if err != nil {
+		if errors.Is(err, state.ErrEKSOwnershipStateNotFound) ||
+			errors.Is(err, state.ErrInvalidEKSOwnershipState) {
+			return nil
+		}
+
+		return fmt.Errorf("load persisted AWS credential mappings: %w", err)
+	}
+
+	resolved.AWSOpts = mergeAWSOptions(resolved.AWSOpts, ownership.AWSOptions)
+
+	return nil
+}
+
+func mergeAWSOptions(
+	current, persisted v1alpha1.OptionsAWS,
+) v1alpha1.OptionsAWS {
+	if current.ProfileEnvVar == "" {
+		current.ProfileEnvVar = persisted.ProfileEnvVar
+	}
+
+	if current.RegionEnvVar == "" {
+		current.RegionEnvVar = persisted.RegionEnvVar
+	}
+
+	if current.AccessKeyIDEnvVar == "" {
+		current.AccessKeyIDEnvVar = persisted.AccessKeyIDEnvVar
+	}
+
+	if current.SecretAccessKeyEnvVar == "" {
+		current.SecretAccessKeyEnvVar = persisted.SecretAccessKeyEnvVar
+	}
+
+	if current.SessionTokenEnvVar == "" {
+		current.SessionTokenEnvVar = persisted.SessionTokenEnvVar
+	}
+
+	return current
 }
 
 func queryFrozenAWSOwnership(

--- a/pkg/cli/lifecycle/simple.go
+++ b/pkg/cli/lifecycle/simple.go
@@ -119,6 +119,9 @@ func BindNameAndProviderFlags(
 type ResolvedClusterInfo struct {
 	ClusterName       string
 	ConfigClusterName string
+	// ConfigSource reports that a real ksail.yaml was loaded. Empty AWS option names from a loaded
+	// config deliberately select canonical defaults and must not be overwritten by persisted aliases.
+	ConfigSource bool
 	// EKSConfigSource reports that ConfigClusterName came from an actual loaded eks.yaml, rather
 	// than another distribution config or a synthetic fallback.
 	EKSConfigSource bool
@@ -325,6 +328,7 @@ func resolveFromConfig(
 		return nil
 	}
 
+	resolved.ConfigSource = true
 	resolveClusterIdentityFromConfig(resolved, cfg, distCfg)
 
 	resolved.OmniOpts = cfg.Spec.Provider.Omni

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -152,6 +152,20 @@ func NewAWSOptionsResolver(options v1alpha1.OptionsAWS) AWSOptionsResolver {
 	}}
 }
 
+// AWSOptionsWithDefaults returns a complete set of AWS environment-variable names without
+// resolving or persisting any credential values.
+func AWSOptionsWithDefaults(options v1alpha1.OptionsAWS) v1alpha1.OptionsAWS {
+	resolver := NewAWSOptionsResolver(options)
+
+	return v1alpha1.OptionsAWS{
+		ProfileEnvVar:         resolver.EnvVar(AWSProfile),
+		RegionEnvVar:          resolver.EnvVar(AWSRegion),
+		AccessKeyIDEnvVar:     resolver.EnvVar(AWSAccessKeyID),
+		SecretAccessKeyEnvVar: resolver.EnvVar(AWSSecretAccessKey),
+		SessionTokenEnvVar:    resolver.EnvVar(AWSSessionToken),
+	}
+}
+
 // EnvVar returns the default environment-variable name for key.
 func (EnvResolver) EnvVar(key Key) string { return DefaultEnvVar(key) }
 

--- a/pkg/svc/credentials/credentials_test.go
+++ b/pkg/svc/credentials/credentials_test.go
@@ -59,6 +59,23 @@ func TestDefaultEnvVar_UnknownKeyIsEmpty(t *testing.T) {
 	assert.Empty(t, credentials.DefaultEnvVar(credentials.Key("nope.nope")))
 }
 
+func TestAWSOptionsWithDefaultsPreservesCustomNamesAndFillsEmptyNames(t *testing.T) {
+	t.Parallel()
+
+	got := credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{
+		ProfileEnvVar: "KSAIL_PROFILE",
+		RegionEnvVar:  "KSAIL_REGION",
+	})
+
+	assert.Equal(t, v1alpha1.OptionsAWS{
+		ProfileEnvVar:         "KSAIL_PROFILE",
+		RegionEnvVar:          "KSAIL_REGION",
+		AccessKeyIDEnvVar:     "AWS_ACCESS_KEY_ID",
+		SecretAccessKeyEnvVar: "AWS_SECRET_ACCESS_KEY",
+		SessionTokenEnvVar:    "AWS_SESSION_TOKEN",
+	}, got)
+}
+
 // TestEnvResolver_CopilotTokenFallback verifies the Copilot credential resolves from COPILOT_TOKEN when
 // the primary KSAIL_COPILOT_TOKEN is unset, mirroring webchat.copilotToken()'s two-variable lookup.
 func TestEnvResolver_CopilotTokenFallback(t *testing.T) {

--- a/pkg/svc/credentials/credentials_test.go
+++ b/pkg/svc/credentials/credentials_test.go
@@ -59,6 +59,7 @@ func TestDefaultEnvVar_UnknownKeyIsEmpty(t *testing.T) {
 	assert.Empty(t, credentials.DefaultEnvVar(credentials.Key("nope.nope")))
 }
 
+//nolint:gosec // G101: these are environment-variable names, never credential values.
 func TestAWSOptionsWithDefaultsPreservesCustomNamesAndFillsEmptyNames(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/eksidentity/identity.go
+++ b/pkg/svc/eksidentity/identity.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
 
@@ -52,15 +53,23 @@ func VerifyBeforeMutation(ctx context.Context, verifier Verifier) error {
 // Capture observes the current caller and live cluster, validates their relationship, and atomically
 // stores the immutable identity. It performs no AWS mutation and is suitable after create or during
 // an explicit legacy-state rebind.
+//
+// awsOptions must be a complete environment-variable-name mapping (see
+// credentials.AWSOptionsWithDefaults). It is required rather than defaulted so a caller operating a
+// cluster through custom credential variables cannot silently persist canonical names and later
+// resolve a different ambient identity.
 func Capture(
 	ctx context.Context,
 	client Client,
 	clusterName, region string,
+	awsOptions v1alpha1.OptionsAWS,
 ) (*state.EKSOwnershipState, error) {
 	ownership, err := Observe(ctx, client, clusterName, region)
 	if err != nil {
 		return nil, err
 	}
+
+	ownership.AWSOptions = awsOptions
 
 	err = Persist(clusterName, ownership.Region, ownership)
 	if err != nil {

--- a/pkg/svc/eksidentity/identity_test.go
+++ b/pkg/svc/eksidentity/identity_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +19,12 @@ import (
 )
 
 var errIdentityQuery = errors.New("identity query failed")
+
+// captureAWSOptions is the canonical default mapping used by Capture call sites that do not
+// exercise custom credential variables.
+func captureAWSOptions() v1alpha1.OptionsAWS {
+	return credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{})
+}
 
 type fakeClient struct {
 	accountID     string
@@ -50,7 +58,7 @@ func TestCapturePersistsImmutableEKSIdentity(t *testing.T) {
 	}
 
 	got, err := eksidentity.Capture(
-		t.Context(), client, "capture-identity", "eu-north-1",
+		t.Context(), client, "capture-identity", "eu-north-1", captureAWSOptions(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "123456789012", got.AccountID)
@@ -93,7 +101,9 @@ func TestCaptureClearsStaleNodegroupCapacityState(t *testing.T) {
 		),
 	}
 
-	_, err := eksidentity.Capture(t.Context(), client, clusterName, "eu-north-1")
+	_, err := eksidentity.Capture(
+		t.Context(), client, clusterName, "eu-north-1", captureAWSOptions(),
+	)
 	require.NoError(t, err)
 
 	_, err = state.LoadEKSNodegroupState(clusterName, "eu-north-1")
@@ -128,7 +138,9 @@ func TestCaptureFailsClosedWhenNodegroupCapacityStateCannotBeCleared(t *testing.
 		),
 	}
 
-	_, err = eksidentity.Capture(t.Context(), client, clusterName, "eu-north-1")
+	_, err = eksidentity.Capture(
+		t.Context(), client, clusterName, "eu-north-1", captureAWSOptions(),
+	)
 	require.ErrorContains(t, err, "clear stale EKS nodegroup capacity state")
 
 	_, loadErr := state.LoadEKSOwnershipState(clusterName, "eu-north-1")
@@ -278,6 +290,7 @@ func persistOwnership(t *testing.T, clusterName string, createdAt time.Time) {
 			AccountID:   accountID,
 			ClusterARN:  "arn:aws:eks:eu-north-1:" + accountID + ":cluster/" + clusterName,
 			CreatedAt:   createdAt,
+			AWSOptions:  captureAWSOptions(),
 		},
 	))
 }

--- a/pkg/svc/state/eks_ownership_state.go
+++ b/pkg/svc/state/eks_ownership_state.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -116,6 +117,64 @@ func LoadEKSOwnershipState(clusterName, region string) (*EKSOwnershipState, erro
 	}
 
 	return &ownership, nil
+}
+
+// ListEKSOwnershipStates loads every region-scoped immutable ownership record for a cluster.
+// Callers use this only when no region was resolved from config or kubeconfig; multiple records
+// remain ambiguous until an explicitly configured region environment variable selects one.
+func ListEKSOwnershipStates(clusterName string) ([]*EKSOwnershipState, error) {
+	dir, err := clusterStateDir(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	paths, err := filepath.Glob(filepath.Join(dir, "eks-ownership-*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("list EKS ownership state: %w", err)
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrEKSOwnershipStateNotFound, clusterName)
+	}
+
+	ownerships := make([]*EKSOwnershipState, 0, len(paths))
+	for _, path := range paths {
+		//nolint:gosec // glob is rooted under the validated per-cluster state directory.
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("read EKS ownership state: %w", readErr)
+		}
+
+		var ownership EKSOwnershipState
+		if unmarshalErr := json.Unmarshal(data, &ownership); unmarshalErr != nil {
+			return nil, fmt.Errorf(
+				"unmarshal EKS ownership state: %w: %w",
+				unmarshalErr,
+				ErrInvalidEKSOwnershipState,
+			)
+		}
+
+		region := strings.TrimSpace(ownership.Region)
+		if validateErr := validateEKSOwnershipState(clusterName, region, &ownership); validateErr != nil {
+			return nil, validateErr
+		}
+
+		expectedPath, pathErr := eksOwnershipStatePath(clusterName, region)
+		if pathErr != nil || filepath.Clean(expectedPath) != filepath.Clean(path) {
+			return nil, fmt.Errorf(
+				"%w: ownership filename does not match region %q",
+				ErrInvalidEKSOwnershipState,
+				region,
+			)
+		}
+
+		ownerships = append(ownerships, &ownership)
+	}
+
+	sort.Slice(ownerships, func(i, j int) bool {
+		return ownerships[i].Region < ownerships[j].Region
+	})
+
+	return ownerships, nil
 }
 
 func validateEKSOwnershipState(clusterName, region string, ownership *EKSOwnershipState) error {

--- a/pkg/svc/state/eks_ownership_state.go
+++ b/pkg/svc/state/eks_ownership_state.go
@@ -123,6 +123,13 @@ func LoadEKSOwnershipState(clusterName, region string) (*EKSOwnershipState, erro
 // ListEKSOwnershipStates loads every region-scoped immutable ownership record for a cluster.
 // Callers use this only when no region was resolved from config or kubeconfig; multiple records
 // remain ambiguous until an explicitly configured region environment variable selects one.
+//
+// Individually unusable records — unreadable, malformed, failing validation, or predating the
+// awsOptions schema — are skipped rather than failing the whole listing, so one stale record in an
+// unrelated region cannot strand a cluster whose target region is recorded correctly. When nothing
+// usable survives, the result is indistinguishable from having no record at all, and the caller's
+// absence path applies. Selecting a region from the survivors never weakens the ownership check:
+// eksidentity.NewVerifier still loads and strictly validates the selected region's record.
 func ListEKSOwnershipStates(clusterName string) ([]*EKSOwnershipState, error) {
 	dir, err := clusterStateDir(clusterName)
 	if err != nil {
@@ -133,42 +140,18 @@ func ListEKSOwnershipStates(clusterName string) ([]*EKSOwnershipState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list EKS ownership state: %w", err)
 	}
-	if len(paths) == 0 {
-		return nil, fmt.Errorf("%w: %s", ErrEKSOwnershipStateNotFound, clusterName)
-	}
 
 	ownerships := make([]*EKSOwnershipState, 0, len(paths))
+
 	for _, path := range paths {
-		//nolint:gosec // glob is rooted under the validated per-cluster state directory.
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return nil, fmt.Errorf("read EKS ownership state: %w", readErr)
+		ownership := loadUsableEKSOwnershipRecord(clusterName, path)
+		if ownership != nil {
+			ownerships = append(ownerships, ownership)
 		}
+	}
 
-		var ownership EKSOwnershipState
-		if unmarshalErr := json.Unmarshal(data, &ownership); unmarshalErr != nil {
-			return nil, fmt.Errorf(
-				"unmarshal EKS ownership state: %w: %w",
-				unmarshalErr,
-				ErrInvalidEKSOwnershipState,
-			)
-		}
-
-		region := strings.TrimSpace(ownership.Region)
-		if validateErr := validateEKSOwnershipState(clusterName, region, &ownership); validateErr != nil {
-			return nil, validateErr
-		}
-
-		expectedPath, pathErr := eksOwnershipStatePath(clusterName, region)
-		if pathErr != nil || filepath.Clean(expectedPath) != filepath.Clean(path) {
-			return nil, fmt.Errorf(
-				"%w: ownership filename does not match region %q",
-				ErrInvalidEKSOwnershipState,
-				region,
-			)
-		}
-
-		ownerships = append(ownerships, &ownership)
+	if len(ownerships) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrEKSOwnershipStateNotFound, clusterName)
 	}
 
 	sort.Slice(ownerships, func(i, j int) bool {
@@ -176,6 +159,38 @@ func ListEKSOwnershipStates(clusterName string) ([]*EKSOwnershipState, error) {
 	})
 
 	return ownerships, nil
+}
+
+// loadUsableEKSOwnershipRecord returns the record at path, or nil when it cannot be trusted to
+// contribute a credential mapping. The filename must match the region it claims, so a record cannot
+// be read under another region's key.
+func loadUsableEKSOwnershipRecord(clusterName, path string) *EKSOwnershipState {
+	//nolint:gosec // glob is rooted under the validated per-cluster state directory.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var ownership EKSOwnershipState
+
+	err = json.Unmarshal(data, &ownership)
+	if err != nil {
+		return nil
+	}
+
+	region := strings.TrimSpace(ownership.Region)
+
+	err = validateEKSOwnershipState(clusterName, region, &ownership)
+	if err != nil {
+		return nil
+	}
+
+	expectedPath, err := eksOwnershipStatePath(clusterName, region)
+	if err != nil || filepath.Clean(expectedPath) != filepath.Clean(path) {
+		return nil
+	}
+
+	return &ownership
 }
 
 func validateEKSOwnershipState(clusterName, region string, ownership *EKSOwnershipState) error {

--- a/pkg/svc/state/eks_ownership_state.go
+++ b/pkg/svc/state/eks_ownership_state.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 )
 
@@ -41,6 +42,9 @@ type EKSOwnershipState struct {
 	AccountID   string    `json:"accountId"`
 	ClusterARN  string    `json:"clusterArn"`
 	CreatedAt   time.Time `json:"createdAt"`
+	// AWSOptions stores only the environment-variable names used to resolve AWS credentials.
+	// Credential values are never persisted.
+	AWSOptions v1alpha1.OptionsAWS `json:"awsOptions,omitzero"`
 }
 
 // SaveEKSOwnershipState atomically persists one validated immutable ownership record.

--- a/pkg/svc/state/eks_ownership_state.go
+++ b/pkg/svc/state/eks_ownership_state.go
@@ -43,8 +43,9 @@ type EKSOwnershipState struct {
 	AccountID   string    `json:"accountId"`
 	ClusterARN  string    `json:"clusterArn"`
 	CreatedAt   time.Time `json:"createdAt"`
-	// AWSOptions stores only the environment-variable names used to resolve AWS credentials.
-	// Credential values are never persisted.
+	// AWSOptions stores the complete environment-variable-name mapping used to resolve AWS
+	// credentials. Credential values are never persisted. Records without this mapping predate the
+	// schema extension and require explicit rebind before state-only lifecycle commands may use them.
 	AWSOptions v1alpha1.OptionsAWS `json:"awsOptions,omitzero"`
 }
 
@@ -214,7 +215,8 @@ func validateEKSOwnershipFields(
 	if strings.TrimSpace(ownership.ClusterName) != clusterName ||
 		strings.TrimSpace(ownership.Region) != region ||
 		!awsAccountIDPattern.MatchString(strings.TrimSpace(ownership.AccountID)) ||
-		strings.TrimSpace(ownership.ClusterARN) == "" || ownership.CreatedAt.IsZero() {
+		strings.TrimSpace(ownership.ClusterARN) == "" || ownership.CreatedAt.IsZero() ||
+		!hasCompleteAWSOptions(ownership.AWSOptions) {
 		return fmt.Errorf(
 			"%w: required identity fields are missing or do not match the state key",
 			ErrInvalidEKSOwnershipState,
@@ -222,6 +224,14 @@ func validateEKSOwnershipFields(
 	}
 
 	return nil
+}
+
+func hasCompleteAWSOptions(options v1alpha1.OptionsAWS) bool {
+	return strings.TrimSpace(options.ProfileEnvVar) != "" &&
+		strings.TrimSpace(options.RegionEnvVar) != "" &&
+		strings.TrimSpace(options.AccessKeyIDEnvVar) != "" &&
+		strings.TrimSpace(options.SecretAccessKeyEnvVar) != "" &&
+		strings.TrimSpace(options.SessionTokenEnvVar) != ""
 }
 
 func validateEKSOwnershipARN(

--- a/pkg/svc/state/eks_ownership_state_test.go
+++ b/pkg/svc/state/eks_ownership_state_test.go
@@ -1,11 +1,13 @@
 package state_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +23,13 @@ func TestSaveLoadEKSOwnershipState(t *testing.T) {
 		AccountID:   "123456789012",
 		ClusterARN:  "arn:aws:eks:eu-north-1:123456789012:cluster/ownership-round-trip",
 		CreatedAt:   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		AWSOptions: v1alpha1.OptionsAWS{
+			ProfileEnvVar:         "KSAIL_PROFILE",
+			RegionEnvVar:          "KSAIL_REGION",
+			AccessKeyIDEnvVar:     "KSAIL_ACCESS",
+			SecretAccessKeyEnvVar: "KSAIL_SECRET",
+			SessionTokenEnvVar:    "KSAIL_SESSION",
+		},
 	}
 
 	require.NoError(t, state.SaveEKSOwnershipState(want.ClusterName, want.Region, want))
@@ -78,6 +87,13 @@ func TestEKSOwnershipStateContainsNoCredentialsAndUsesPrivatePermissions(t *test
 		AccountID:   "123456789012",
 		ClusterARN:  "arn:aws:eks:eu-north-1:123456789012:cluster/" + clusterName,
 		CreatedAt:   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		AWSOptions: v1alpha1.OptionsAWS{
+			ProfileEnvVar:         "KSAIL_PROFILE",
+			RegionEnvVar:          "KSAIL_REGION",
+			AccessKeyIDEnvVar:     "KSAIL_ACCESS",
+			SecretAccessKeyEnvVar: "KSAIL_SECRET",
+			SessionTokenEnvVar:    "KSAIL_SESSION",
+		},
 	}
 	require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, snapshot))
 
@@ -91,11 +107,16 @@ func TestEKSOwnershipStateContainsNoCredentialsAndUsesPrivatePermissions(t *test
 	contents, err := os.ReadFile(path)
 	require.NoError(t, err)
 
+	var persisted map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(contents, &persisted))
+
 	for _, credentialField := range []string{
-		"accessKey", "profile", "secret", "sessionToken", "token",
+		"accessKeyId", "secretAccessKey", "sessionToken", "profile",
 	} {
-		assert.NotContains(t, string(contents), credentialField)
+		assert.NotContains(t, persisted, credentialField)
 	}
+	assert.Contains(t, string(persisted["awsOptions"]), `"accessKeyIdEnvVar": "KSAIL_ACCESS"`)
+	assert.Contains(t, string(persisted["awsOptions"]), `"secretAccessKeyEnvVar": "KSAIL_SECRET"`)
 
 	dirInfo, err := os.Stat(dir)
 	require.NoError(t, err)

--- a/pkg/svc/state/eks_ownership_state_test.go
+++ b/pkg/svc/state/eks_ownership_state_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func canonicalAWSOptions() v1alpha1.OptionsAWS {
+	return v1alpha1.OptionsAWS{
+		ProfileEnvVar:         "AWS_PROFILE",
+		RegionEnvVar:          "AWS_REGION",
+		AccessKeyIDEnvVar:     "AWS_ACCESS_KEY_ID",
+		SecretAccessKeyEnvVar: "AWS_SECRET_ACCESS_KEY",
+		SessionTokenEnvVar:    "AWS_SESSION_TOKEN",
+	}
+}
+
 func TestSaveLoadEKSOwnershipState(t *testing.T) {
 	t.Parallel()
 
@@ -50,6 +60,7 @@ func TestEKSOwnershipStateIsScopedPerRegion(t *testing.T) {
 		AccountID:   "123456789012",
 		ClusterARN:  "arn:aws:eks:eu-north-1:123456789012:cluster/" + clusterName,
 		CreatedAt:   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		AWSOptions:  canonicalAWSOptions(),
 	}
 	east := &state.EKSOwnershipState{
 		Version:     state.EKSOwnershipStateVersion,
@@ -58,6 +69,7 @@ func TestEKSOwnershipStateIsScopedPerRegion(t *testing.T) {
 		AccountID:   "210987654321",
 		ClusterARN:  "arn:aws:eks:us-east-1:210987654321:cluster/" + clusterName,
 		CreatedAt:   time.Date(2026, 7, 18, 12, 1, 0, 0, time.UTC),
+		AWSOptions:  canonicalAWSOptions(),
 	}
 
 	require.NoError(t, state.SaveEKSOwnershipState(clusterName, north.Region, north))
@@ -84,6 +96,7 @@ func TestListEKSOwnershipStatesReturnsSortedValidatedRegions(t *testing.T) {
 			AccountID:   "123456789012",
 			ClusterARN:  "arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
 			CreatedAt:   time.Now().UTC(),
+			AWSOptions:  canonicalAWSOptions(),
 		}
 		require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, ownership))
 	}
@@ -155,6 +168,38 @@ func TestLoadEKSOwnershipStateMissingRequiresMigration(t *testing.T) {
 
 	_, err := state.LoadEKSOwnershipState("legacy-without-identity", "eu-north-1")
 	require.ErrorIs(t, err, state.ErrEKSOwnershipStateNotFound)
+}
+
+func TestLoadEKSOwnershipStateRejectsLegacyRecordWithoutAWSOptions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "legacy-without-aws-options"
+		region      = "eu-north-1"
+	)
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	dir := filepath.Join(home, ".ksail", "clusters", clusterName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	legacy := map[string]any{
+		"version":     state.EKSOwnershipStateVersion,
+		"clusterName": clusterName,
+		"region":      region,
+		"accountId":   "123456789012",
+		"clusterArn":  "arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
+		"createdAt":   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+	}
+	data, err := json.Marshal(legacy)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "eks-ownership-"+region+".json"),
+		data,
+		0o600,
+	))
+
+	_, err = state.LoadEKSOwnershipState(clusterName, region)
+	require.ErrorIs(t, err, state.ErrInvalidEKSOwnershipState)
 }
 
 func TestSaveEKSOwnershipStateRejectsMalformedIdentity(t *testing.T) {

--- a/pkg/svc/state/eks_ownership_state_test.go
+++ b/pkg/svc/state/eks_ownership_state_test.go
@@ -72,6 +72,29 @@ func TestEKSOwnershipStateIsScopedPerRegion(t *testing.T) {
 	assert.Equal(t, east, gotEast)
 }
 
+func TestListEKSOwnershipStatesReturnsSortedValidatedRegions(t *testing.T) {
+	t.Parallel()
+
+	clusterName := "ownership-list-regions"
+	for _, region := range []string{"us-west-2", "eu-north-1"} {
+		ownership := &state.EKSOwnershipState{
+			Version:     state.EKSOwnershipStateVersion,
+			ClusterName: clusterName,
+			Region:      region,
+			AccountID:   "123456789012",
+			ClusterARN:  "arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
+			CreatedAt:   time.Now().UTC(),
+		}
+		require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, ownership))
+	}
+
+	ownerships, err := state.ListEKSOwnershipStates(clusterName)
+	require.NoError(t, err)
+	require.Len(t, ownerships, 2)
+	assert.Equal(t, "eu-north-1", ownerships[0].Region)
+	assert.Equal(t, "us-west-2", ownerships[1].Region)
+}
+
 func TestEKSOwnershipStateContainsNoCredentialsAndUsesPrivatePermissions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/state/eks_ownership_state_test.go
+++ b/pkg/svc/state/eks_ownership_state_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// canonicalAWSOptions is the default environment-variable-name mapping.
+//
+//nolint:gosec // G101: these are environment-variable names, never credential values.
 func canonicalAWSOptions() v1alpha1.OptionsAWS {
 	return v1alpha1.OptionsAWS{
 		ProfileEnvVar:         "AWS_PROFILE",
@@ -108,6 +111,75 @@ func TestListEKSOwnershipStatesReturnsSortedValidatedRegions(t *testing.T) {
 	assert.Equal(t, "us-west-2", ownerships[1].Region)
 }
 
+// TestListEKSOwnershipStatesSkipsUnusableRecords proves one legacy record in an unrelated region
+// cannot strand a cluster whose target region is recorded correctly. Before ListEKSOwnershipStates
+// skipped unusable records, the legacy file below aborted the whole listing.
+func TestListEKSOwnershipStatesSkipsUnusableRecords(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "ownership-list-skips-legacy"
+
+	valid := &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: clusterName,
+		Region:      "eu-north-1",
+		AccountID:   "123456789012",
+		ClusterARN:  "arn:aws:eks:eu-north-1:123456789012:cluster/" + clusterName,
+		CreatedAt:   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		AWSOptions:  canonicalAWSOptions(),
+	}
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, valid.Region, valid))
+
+	writeLegacyOwnershipRecord(t, clusterName, "us-west-2")
+
+	ownerships, err := state.ListEKSOwnershipStates(clusterName)
+	require.NoError(t, err)
+	require.Len(t, ownerships, 1)
+	assert.Equal(t, "eu-north-1", ownerships[0].Region)
+}
+
+// TestListEKSOwnershipStatesReportsAbsenceWhenNoRecordIsUsable proves skipping never degrades into
+// silently succeeding with nothing: an all-legacy directory is indistinguishable from no record,
+// so the caller's absence path applies and the authoritative rebind error is still produced later.
+func TestListEKSOwnershipStatesReportsAbsenceWhenNoRecordIsUsable(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "ownership-list-all-legacy"
+
+	writeLegacyOwnershipRecord(t, clusterName, "eu-north-1")
+
+	_, err := state.ListEKSOwnershipStates(clusterName)
+	require.ErrorIs(t, err, state.ErrEKSOwnershipStateNotFound)
+}
+
+// writeLegacyOwnershipRecord writes an ownership record in the pre-awsOptions schema.
+func writeLegacyOwnershipRecord(t *testing.T, clusterName, region string) {
+	t.Helper()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	dir := filepath.Join(home, ".ksail", "clusters", clusterName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	legacy := map[string]any{
+		"version":     state.EKSOwnershipStateVersion,
+		"clusterName": clusterName,
+		"region":      region,
+		"accountId":   "123456789012",
+		"clusterArn":  "arn:aws:eks:" + region + ":123456789012:cluster/" + clusterName,
+		"createdAt":   time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(legacy)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "eks-ownership-"+region+".json"),
+		data,
+		0o600,
+	))
+}
+
 func TestEKSOwnershipStateContainsNoCredentialsAndUsesPrivatePermissions(t *testing.T) {
 	t.Parallel()
 
@@ -151,6 +223,7 @@ func TestEKSOwnershipStateContainsNoCredentialsAndUsesPrivatePermissions(t *test
 	} {
 		assert.NotContains(t, persisted, credentialField)
 	}
+
 	assert.Contains(t, string(persisted["awsOptions"]), `"accessKeyIdEnvVar": "KSAIL_ACCESS"`)
 	assert.Contains(t, string(persisted["awsOptions"]), `"secretAccessKeyEnvVar": "KSAIL_SECRET"`)
 
@@ -177,8 +250,10 @@ func TestLoadEKSOwnershipStateRejectsLegacyRecordWithoutAWSOptions(t *testing.T)
 		clusterName = "legacy-without-aws-options"
 		region      = "eu-north-1"
 	)
+
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
+
 	dir := filepath.Join(home, ".ksail", "clusters", clusterName)
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 


### PR DESCRIPTION
## Why

A cluster created from a `ksail.yaml` with custom `spec.provider.aws.*EnvVar` credential names could later be driven from a directory with no config. That path never loaded the AWS options, so eksctl ran through the default `AWS_*` names — failing, or worse, acting under a different ambient AWS identity while the persisted state still said the cluster was KSail-managed.

## What

Creation and rebind now record which environment-variable **names** resolve a cluster's credentials (never the values), and no-config lifecycle commands restore them. Clusters using the default names behave exactly as before.

## ⚠️ One-time migration for existing EKS clusters

Ownership records written by released ksail predate this mapping, so they are now rejected rather than silently falling back to the default names — that silent fallback is the bug being fixed, and KSail cannot tell whether an old record's cluster used custom names.

**Anyone with an existing EKS cluster must run `ksail cluster eks-bind --name <cluster> --provider AWS --experimental` once** before `start`/`stop`/`delete` will work again. The failure names that command, so users are not left guessing.

Worth a deliberate call on your side: the remedy is gated behind `--experimental`, and the title stays `fix:` so this releases as a patch. Marking it breaking would trigger a major bump, which the `/v7` module path can't absorb without a path migration.

Fixes #6227
