### PR TITLE
fix(ci): exclude img.shields.io badges from the lychee link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -53,4 +53,8 @@ exclude_path = [
 #     from the lychee runner.
 #   - ksail.local: placeholder OIDC redirect/ingress host in chart template
 #     permutations; an unresolvable .local address, not a real link.
-exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'git\.k8s\.io', 'localhost', '127\.0\.0\.1', 'ksail\.local', 'www\.gnu\.org/licenses/gpl-3\.0']
+#   - img.shields.io: README badge images. shields.io rate-limits/degrades
+#     requests from shared GitHub Actions runner IPs (503 through all retries
+#     while returning 200 elsewhere — see #6272); badges are rendered images,
+#     not navigation targets, so their availability is not a docs defect.
+exclude = ['^/', '%s', '\$%7B', 'siderolabs\.com/platform/saas-for-kubernetes', 'starlight\.astro\.build', 'git\.k8s\.io', 'localhost', '127\.0\.0\.1', 'ksail\.local', 'www\.gnu\.org/licenses/gpl-3\.0', 'img\.shields\.io']


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
PR #6269 burned two CI cycles on shields.io badge 503s — shields.io degrades requests from shared GitHub Actions runner IPs, so any PR can go red on decorative badge availability rather than anything it changed.

## What
Excludes the `img.shields.io` host from the lychee link check, following the existing precedent for CI-runner-IP-hostile hosts (git.k8s.io, codecov badge). Proven with the real config: badge URLs report Excluded while a dead documentation link still fails.

Fixes #6272