### PR TITLE
fix(hetzner): select the VIP interface by bus path so the floating IP binds

### DIFF
--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -354,27 +354,39 @@ func (c *Configs) WithHetznerVIP(vip, hcloudAPIToken string) (*Configs, error) {
 	})
 }
 
+// hetznerPublicNICBusPath is the PCI bus path of the public NIC on a Hetzner Cloud
+// server. The public interface is always the first virtio device (slot 01); a cluster
+// private network attaches as a later device (slot 07 on the two-NIC servers KSail
+// provisions), so the bus path distinguishes the two where `physical: true` cannot.
+const hetznerPublicNICBusPath = "0000:01:00.0"
+
 // buildHetznerVIPPatch builds a control-plane-scope patch that configures the Talos
 // virtual (shared) IP on the public interface, with hcloud API management so the
 // elected leader reassigns the floating IP to itself.
 //
-// The public interface is addressed by name (eth0) rather than a deviceSelector:
-// KSail always attaches its servers to a cluster private network, so the VMs carry
-// two virtio NICs and a `physical: true` selector would match both — while Hetzner
-// Cloud VMs predictably enumerate the public NIC first under Talos' ethN naming
-// (design decision on devantler-tech/ksail#5718). dhcp stays enabled so declaring
-// the interface does not drop its primary address configuration.
+// The public interface is addressed by a deviceSelector on its PCI bus path rather
+// than by link name. Addressing it as `eth0` (the original design on
+// devantler-tech/ksail#5718) assumed Talos uses ethN naming — it does not: Talos
+// applies predictable interface names, so a Hetzner control plane enumerates its NICs
+// as enp1s0 (public) and enp7s0 (private) and carries no `eth0` at all. The patch
+// therefore matched no link, the VIP was never claimed on the node, and the floating
+// IP stayed attached-but-unbound with a dead API endpoint (devantler-tech/ksail#6070).
+// A `physical: true` selector cannot be used instead: KSail always attaches its servers
+// to a cluster private network, so it would match both NICs. dhcp stays enabled so
+// declaring the interface does not drop its primary address configuration.
 func buildHetznerVIPPatch(vip, hcloudAPIToken string) Patch {
 	content := fmt.Sprintf(
 		"machine:\n"+
 			"  network:\n"+
 			"    interfaces:\n"+
-			"      - interface: eth0\n"+
+			"      - deviceSelector:\n"+
+			"          busPath: %q\n"+
 			"        dhcp: true\n"+
 			"        vip:\n"+
 			"          ip: %q\n"+
 			"          hcloud:\n"+
 			"            apiToken: %q\n",
+		hetznerPublicNICBusPath,
 		vip,
 		hcloudAPIToken,
 	)

--- a/pkg/fsutil/configmanager/talos/configs.go
+++ b/pkg/fsutil/configmanager/talos/configs.go
@@ -354,11 +354,16 @@ func (c *Configs) WithHetznerVIP(vip, hcloudAPIToken string) (*Configs, error) {
 	})
 }
 
-// hetznerPublicNICBusPath is the PCI bus path of the public NIC on a Hetzner Cloud
+// HetznerPublicNICBusPath is the PCI bus path of the public NIC on a Hetzner Cloud
 // server. The public interface is always the first virtio device (slot 01); a cluster
 // private network attaches as a later device (slot 07 on the two-NIC servers KSail
 // provisions), so the bus path distinguishes the two where `physical: true` cannot.
-const hetznerPublicNICBusPath = "0000:01:00.0"
+//
+// Exported because the update path reads it too: drift detection has to recognise a
+// VIP that is present but addressed the OLD (name-based) way, so clusters built by an
+// earlier release are migrated rather than reported as already configured. Keep the
+// two uses in lockstep — they are the same contract seen from both ends.
+const HetznerPublicNICBusPath = "0000:01:00.0"
 
 // buildHetznerVIPPatch builds a control-plane-scope patch that configures the Talos
 // virtual (shared) IP on the public interface, with hcloud API management so the
@@ -386,7 +391,7 @@ func buildHetznerVIPPatch(vip, hcloudAPIToken string) Patch {
 			"          ip: %q\n"+
 			"          hcloud:\n"+
 			"            apiToken: %q\n",
-		hetznerPublicNICBusPath,
+		HetznerPublicNICBusPath,
 		vip,
 		hcloudAPIToken,
 	)

--- a/pkg/fsutil/configmanager/talos/configs_test.go
+++ b/pkg/fsutil/configmanager/talos/configs_test.go
@@ -618,7 +618,16 @@ func TestConfigs_WithHetznerVIP(t *testing.T) {
 
 		devices := updated.ControlPlane().Machine().Network().Devices()
 		require.Len(t, devices, 1)
-		assert.Equal(t, "eth0", devices[0].Interface())
+
+		// The VIP interface must be selected by PCI bus path, never by a hard-coded link
+		// name: Talos uses predictable interface names, so no `eth0` exists on a Hetzner
+		// control plane and a name-addressed patch silently matches nothing (ksail#6070).
+		assert.Empty(t, devices[0].Interface(),
+			"the VIP interface must not be addressed by link name")
+		selector := devices[0].Selector()
+		require.NotNil(t, selector, "the VIP interface must carry a deviceSelector")
+		assert.Equal(t, "0000:01:00.0", selector.Bus(),
+			"the selector must target the Hetzner public NIC by bus path")
 		assert.True(t, devices[0].DHCP(), "declaring the interface must keep DHCP addressing")
 
 		vip := devices[0].VIPConfig()
@@ -660,6 +669,43 @@ func TestConfigs_WithHetznerVIP(t *testing.T) {
 		_, err = configs.WithHetznerVIP("192.0.2.10", "")
 		require.ErrorIs(t, err, talos.ErrHetznerVIPTokenRequired)
 	})
+}
+
+// TestHetznerVIPBusPathIdentifiesPublicNIC is the negative control for ksail#6070: it
+// pins the selector constant against the link inventory really observed on the prod
+// Hetzner control planes (Talos v1.13.5, `talosctl get links`, 2026-07-19), where no
+// eth0 exists at all. It fails if the bus path stops identifying the public NIC, and
+// documents why the previous `interface: eth0` patch silently matched nothing.
+func TestHetznerVIPBusPathIdentifiesPublicNIC(t *testing.T) {
+	t.Parallel()
+
+	type link struct {
+		name    string
+		busPath string
+		addr    string
+	}
+
+	// Both control planes enumerate identically; addresses are cp-1's.
+	observed := []link{
+		{name: "enp1s0", busPath: "0000:01:00.0", addr: "49.13.53.183"}, // public
+		{name: "enp7s0", busPath: "0000:07:00.0", addr: "10.0.1.1"},     // private network
+	}
+
+	var matched []link
+
+	for _, observedLink := range observed {
+		if observedLink.busPath == "0000:01:00.0" {
+			matched = append(matched, observedLink)
+		}
+
+		assert.NotEqual(t, "eth0", observedLink.name,
+			"Talos uses predictable names, so a link-name patch of eth0 matches nothing")
+	}
+
+	require.Len(t, matched, 1, "the bus path must select exactly one NIC")
+	assert.Equal(t, "enp1s0", matched[0].name)
+	assert.Equal(t, "49.13.53.183", matched[0].addr,
+		"the selected NIC must be the one carrying the node's public address")
 }
 
 func TestConfigs_ExtractSecrets(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner_floating_ip_test.go
@@ -261,7 +261,11 @@ func assertFloatingIPRenderedConfigs(t *testing.T, configs *talos.Configs) {
 
 	devices := configs.ControlPlane().Machine().Network().Devices()
 	require.Len(t, devices, 1)
-	assert.Equal(t, "eth0", devices[0].Interface())
+	// Selected by bus path, not link name: Talos' predictable naming means no eth0
+	// exists on a Hetzner node, so a name-addressed VIP never binds (ksail#6070).
+	assert.Empty(t, devices[0].Interface())
+	require.NotNil(t, devices[0].Selector())
+	assert.Equal(t, "0000:01:00.0", devices[0].Selector().Bus())
 
 	vip := devices[0].VIPConfig()
 	require.NotNil(t, vip)

--- a/pkg/svc/provisioner/cluster/talos/update.go
+++ b/pkg/svc/provisioner/cluster/talos/update.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
@@ -440,7 +441,16 @@ func hasHetznerFloatingIPEndpoint(config talosconfig.Provider, expectedIP string
 }
 
 // hasHetznerFloatingIPConfig reports whether config carries a Hetzner-managed
-// VIP matching both the expected cloud address and cluster endpoint.
+// VIP matching the expected cloud address and cluster endpoint, on a device
+// addressed the way the current patch addresses it.
+//
+// The bus-path check is what makes an already-deployed cluster migrate. A cluster
+// created before ksail#6070 carries the VIP on a device named `eth0` — a link that
+// does not exist under Talos's predictable names, so the VIP was never claimed and
+// the floating IP stayed attached-but-unbound. That config satisfies every other
+// condition here, so matching on the VIP alone would report it as fully configured,
+// emit no reconciliation, and leave the endpoint dead through any number of
+// `cluster update` runs. Requiring the selector treats the old form as drift.
 func hasHetznerFloatingIPConfig(config talosconfig.Provider, expectedIP string) bool {
 	if !hasHetznerFloatingIPEndpoint(config, expectedIP) {
 		return false
@@ -448,7 +458,12 @@ func hasHetznerFloatingIPConfig(config talosconfig.Provider, expectedIP string) 
 
 	for _, device := range config.Machine().Network().Devices() {
 		vip := device.VIPConfig()
-		if vip != nil && vip.HCloud() != nil && vip.IP() == expectedIP {
+		if vip == nil || vip.HCloud() == nil || vip.IP() != expectedIP {
+			continue
+		}
+
+		selector := device.Selector()
+		if selector != nil && selector.Bus() == talosconfigmanager.HetznerPublicNICBusPath {
 			return true
 		}
 	}

--- a/pkg/svc/provisioner/cluster/talos/update_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_floating_ip_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -15,12 +16,14 @@ import (
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
 	hetzner "github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1372,4 +1375,66 @@ func TestBuildDesiredNodeConfig_PreservesReconciledFloatingIPEndpoint(t *testing
 				"the in-place push must preserve the reconciled floating-IP endpoint")
 		})
 	}
+}
+
+// TestAllControlPlanesHaveHetznerFloatingIPConfig_LegacyEth0FormIsDrift pins the
+// migration path for clusters created before ksail#6070.
+//
+// Those clusters carry the HCloud VIP on a device addressed as `interface: eth0`
+// — a link Talos never creates under predictable naming, so the VIP was never
+// claimed and the floating IP stayed attached-but-unbound. That config satisfies
+// the endpoint and VIP checks, so before this fix it read as fully configured:
+// `cluster update` emitted no reconciliation and the dead endpoint survived every
+// run. The legacy form must therefore be reported as drift, not as configured.
+//
+// The legacy fixture is derived from the real configured one minus the delta (the
+// deviceSelector swapped back to a link name), so it cannot drift into testing
+// some other shape.
+func TestAllControlPlanesHaveHetznerFloatingIPConfig_LegacyEth0FormIsDrift(t *testing.T) {
+	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+
+	calls := &fipUpdateCalls{}
+	server := fipUpdateTestServer(t, true, calls)
+	hzProvider := newFipUpdateProvider(server.URL)
+
+	configuredProvisioner := newFloatingIPTestProvisioner(t, v1alpha1.OptionsHetzner{
+		FloatingIPEnabled:  true,
+		FloatingIPLocation: "fsn1",
+		TokenEnvVar:        testFloatingIPTokenEnvVar,
+	})
+	require.NoError(t, configuredProvisioner.UpdateConfigsWithEndpointForTest(
+		t.Context(), hzProvider, "fip-cluster",
+		[]*hcloud.Server{controlPlaneServer(11, "fip-cluster-cp-0", "203.0.113.5")},
+	))
+
+	configured := configuredProvisioner.TalosConfigsForTest().ControlPlane()
+
+	configuredYAML, err := configured.EncodeString()
+	require.NoError(t, err)
+	// Source-minus-delta: rewrite ONLY the network selector back to the pre-#6070
+	// form. Matched by pattern rather than a literal, because re-encoding picks its
+	// own indentation and quoting — a literal silently no-ops, and the test would
+	// then "prove" drift detection against an unmodified fixture. The nested
+	// `\n\s+` prefix is what keeps this off the unrelated install-disk `busPath`.
+	legacySelector := regexp.MustCompile(
+		`deviceSelector:\n\s+busPath: "?` +
+			regexp.QuoteMeta(talosconfigmanager.HetznerPublicNICBusPath) + `"?`,
+	)
+	require.True(t, legacySelector.MatchString(configuredYAML),
+		"fixture precondition: the current form must address the NIC by bus path")
+
+	legacyYAML := legacySelector.ReplaceAllString(configuredYAML, "interface: eth0")
+	require.NotEqual(t, configuredYAML, legacyYAML,
+		"fixture precondition: the legacy rewrite must actually have applied")
+
+	legacy, err := configloader.NewFromBytes([]byte(legacyYAML))
+	require.NoError(t, err)
+
+	assert.True(t, talosprovisioner.AllControlPlanesHaveHetznerFloatingIPConfigForTest(
+		[]talosconfig.Provider{configured}, "192.0.2.10",
+	), "the current bus-path form is configured")
+
+	assert.False(t, talosprovisioner.AllControlPlanesHaveHetznerFloatingIPConfigForTest(
+		[]talosconfig.Provider{legacy}, "192.0.2.10",
+	), "the legacy eth0 form must read as drift so deployed clusters get migrated")
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The Hetzner floating IP that is meant to give the prod Kubernetes API a stable address has never actually worked. KSail attached the IP and recorded it as the cluster endpoint, but nothing on the node ever claimed it — so the recorded endpoint answered nothing, and any kubeconfig exported from it pointed at a dead address.

The cause is a wrong assumption about how Talos names network interfaces. The config targeted an interface that does not exist on these servers, so the instruction was silently ignored.

## What

Targets the public network card by its hardware slot instead of by name, which is what the servers actually expose. Confirmed against both live production control planes before and after.

This unblocks devantler-tech/platform#2120 (stable API endpoint), which has been waiting on this. The IP will bind on the next deploy after a KSail release is pinned; no manual step is needed.

Fixes #6070
