### PR TITLE
fix(ci): declare the EKS smoke OIDC role

### DIFF
--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -21,8 +21,8 @@ name: "System Test - EKS"
 #      Never grant AdministratorAccess.
 #   4. Set the role's MaxSessionDuration to 7200 seconds — the smoke test job
 #      may run up to 120 minutes and must keep credentials through cleanup.
-#   5. Store the role ARN as the `AWS_OIDC_ROLE_ARN` secret on the `ci`
-#      environment. The workflow skips cleanly while it is absent.
+#   5. Keep the non-secret role ARN in this workflow so the trusted repository
+#      owns the complete OIDC configuration path declaratively.
 
 on:
   workflow_dispatch:
@@ -45,6 +45,7 @@ env:
   GOPROXY: "https://proxy.golang.org|direct"
   GOMEMLIMIT: "6GiB"
   EKSCTL_VERSION: "v0.229.0"
+  AWS_OIDC_ROLE_ARN: "arn:aws:iam::939001610192:role/eks-ci"
 
 concurrency:
   group: system-test-eks
@@ -65,7 +66,7 @@ jobs:
         id: aws
         shell: bash
         env:
-          AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          AWS_OIDC_ROLE_ARN: ${{ env.AWS_OIDC_ROLE_ARN }}
         run: |
           if [ -z "${AWS_OIDC_ROLE_ARN:-}" ]; then
             echo "::notice::Skipping EKS smoke test because AWS_OIDC_ROLE_ARN is not configured."
@@ -111,7 +112,7 @@ jobs:
     environment: ci
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required to exchange GitHub's OIDC token for the scoped AWS role.
     env:
       AWS_REGION: ${{ inputs.region }}
       AWS_DEFAULT_REGION: ${{ inputs.region }}
@@ -126,7 +127,7 @@ jobs:
       - name: 🔐 Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
           role-session-name: ksail-system-test-eks-${{ github.run_id }}
           aws-region: ${{ inputs.region }}
           # Must cover the full 120-minute job (create + reconcile + always()

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -69,9 +69,8 @@ jobs:
           AWS_OIDC_ROLE_ARN: ${{ env.AWS_OIDC_ROLE_ARN }}
         run: |
           if [ -z "${AWS_OIDC_ROLE_ARN:-}" ]; then
-            echo "::notice::Skipping EKS smoke test because AWS_OIDC_ROLE_ARN is not configured."
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::AWS_OIDC_ROLE_ARN is required for the EKS smoke test."
+            exit 1
           fi
 
           echo "available=true" >> "$GITHUB_OUTPUT"
@@ -209,10 +208,12 @@ jobs:
             --name "$KSAIL_EKS_CLUSTER_NAME"
             --distribution EKS
             --provider AWS
-            --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests
           )
           if [ "$GITOPS_ENGINE" != "None" ]; then
-            args+=(--gitops-engine "$GITOPS_ENGINE")
+            args+=(
+              --gitops-engine "$GITOPS_ENGINE"
+              --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests
+            )
           fi
 
           ksail "${args[@]}"

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -209,6 +209,7 @@ jobs:
             --name "$KSAIL_EKS_CLUSTER_NAME"
             --distribution EKS
             --provider AWS
+            --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests
           )
           if [ "$GITOPS_ENGINE" != "None" ]; then
             args+=(--gitops-engine "$GITOPS_ENGINE")
@@ -242,11 +243,13 @@ jobs:
           '
 
       - name: 🧪 ksail cluster create
+        id: create
         timeout-minutes: 30
         shell: bash
         run: |
           set -euo pipefail
           cd "$KSAIL_EKS_WORKDIR"
+          echo "attempted=true" >> "$GITHUB_OUTPUT"
           ksail cluster create
 
       - name: 🧪 ksail cluster info
@@ -270,8 +273,15 @@ jobs:
         if: always()
         timeout-minutes: 45
         shell: bash
+        env:
+          EKS_CREATE_ATTEMPTED: ${{ steps.create.outputs.attempted }}
         run: |
           set +e
+          if [ "${EKS_CREATE_ATTEMPTED:-}" != "true" ]; then
+            echo "Cluster creation did not start; nothing to clean up."
+            exit 0
+          fi
+
           if [ ! -d "$KSAIL_EKS_WORKDIR" ]; then
             echo "No EKS smoke workdir exists; nothing to clean up."
             exit 0

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -112,6 +112,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # Required to exchange GitHub's OIDC token for the scoped AWS role.
+      packages: write # Publish the ephemeral GitOps artifact when it is not already present.
     env:
       AWS_REGION: ${{ inputs.region }}
       AWS_DEFAULT_REGION: ${{ inputs.region }}
@@ -197,6 +198,8 @@ jobs:
         shell: bash
         env:
           AWS_PERMISSIONS_BOUNDARY_ARN: ${{ steps.permissions-boundary.outputs.arn }}
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_USER: ${{ github.actor }}
           GITOPS_ENGINE: ${{ inputs.gitops_engine }}
         run: |
           set -euo pipefail
@@ -210,9 +213,13 @@ jobs:
             --provider AWS
           )
           if [ "$GITOPS_ENGINE" != "None" ]; then
+            if [ -z "${GHCR_USER:-}" ] || [ -z "${GHCR_TOKEN:-}" ]; then
+              echo "::error::GitOps EKS smoke runs require GHCR write credentials."
+              exit 1
+            fi
             args+=(
               --gitops-engine "$GITOPS_ENGINE"
-              --local-registry ghcr.io/devantler-tech/ksail/system-test-manifests
+              --local-registry "${GHCR_USER}:${GHCR_TOKEN}@ghcr.io/devantler-tech/ksail/system-test-manifests"
             )
           fi
 

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -94,6 +94,15 @@ func TestEKSSmokeDeclaresOIDCRoleWithoutSecret(t *testing.T) {
 	preflightStep := findHarnessStep(t, preflightJob.Steps, "🔎 Check required AWS OIDC role")
 	assert.Equal(t, "${{ env.AWS_OIDC_ROLE_ARN }}", preflightStep.Env["AWS_OIDC_ROLE_ARN"])
 
+	preflightOutput, diagnostics, err := executeOIDCPreflight(t, preflightStep.Run, "")
+	require.Error(t, err, "empty checked-in OIDC role must fail the dispatch")
+	assert.Empty(t, preflightOutput)
+	assert.Contains(t, diagnostics, "AWS_OIDC_ROLE_ARN is required")
+
+	preflightOutput, diagnostics, err = executeOIDCPreflight(t, preflightStep.Run, roleARN)
+	require.NoErrorf(t, err, "declared OIDC role was rejected:\n%s", diagnostics)
+	assert.Equal(t, "available=true\n", preflightOutput)
+
 	smokeJob, found := workflow.Jobs["smoke-test"]
 	require.True(t, found, "smoke-test job is missing")
 	configureStep := findHarnessStep(t, smokeJob.Steps, "🔐 Configure AWS credentials (OIDC)")
@@ -111,11 +120,22 @@ func TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup(t *testing.T) {
 	require.True(t, found, "smoke-test job is missing")
 
 	initStep := findHarnessStep(t, smokeJob.Steps, "🔧 Initialize EKS project")
-	assert.Contains(
-		t,
+	gitopsGuardIndex := strings.Index(
+		initStep.Run,
+		`if [ "$GITOPS_ENGINE" != "None" ]; then`,
+	)
+	registryIndex := strings.Index(
 		initStep.Run,
 		"--local-registry ghcr.io/devantler-tech/ksail/system-test-manifests",
 	)
+
+	require.NotEqual(t, -1, gitopsGuardIndex, "GitOps engine guard is missing")
+	require.NotEqual(t, -1, registryIndex, "GitOps registry argument is missing")
+
+	gitopsEndIndex := strings.Index(initStep.Run[gitopsGuardIndex:], "\nfi")
+	require.NotEqual(t, -1, gitopsEndIndex, "GitOps engine guard is unterminated")
+	assert.Greater(t, registryIndex, gitopsGuardIndex)
+	assert.Less(t, registryIndex, gitopsGuardIndex+gitopsEndIndex)
 
 	createStep := findHarnessStep(t, smokeJob.Steps, "🧪 ksail cluster create")
 	assert.Equal(t, "create", createStep.ID)
@@ -507,6 +527,33 @@ esac
 	require.NoError(t, err)
 
 	return string(boundaryOutput), string(diagnostics), commandErr
+}
+
+func executeOIDCPreflight(
+	t *testing.T,
+	workflowRun string,
+	roleARN string,
+) (string, string, error) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "github-output")
+	require.NoError(t, os.WriteFile(outputPath, nil, 0o600))
+
+	// The shell source is repository-owned workflow content.
+	command := exec.CommandContext(t.Context(), "bash", "-c", workflowRun) //nolint:gosec
+
+	command.Env = append(
+		os.Environ(),
+		"AWS_OIDC_ROLE_ARN="+roleARN,
+		"GITHUB_OUTPUT="+outputPath,
+	)
+	diagnostics, commandErr := command.CombinedOutput()
+
+	preflightOutput, err := os.ReadFile(outputPath) //nolint:gosec // Test-owned path.
+	require.NoError(t, err)
+
+	return string(preflightOutput), string(diagnostics), commandErr
 }
 
 func assertEKSSmokeMutation(t *testing.T, config map[string]any) {

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -74,9 +74,34 @@ type compositeAction struct {
 }
 
 type ciWorkflow struct {
+	Env  map[string]string `yaml:"env"`
 	Jobs map[string]struct {
 		Steps []harnessStep `yaml:"steps"`
 	} `yaml:"jobs"`
+}
+
+func TestEKSSmokeDeclaresOIDCRoleWithoutSecret(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := ".github/workflows/system-test-eks.yaml"
+	workflow := readCIWorkflow(t, workflowPath)
+
+	roleARN := workflow.Env["AWS_OIDC_ROLE_ARN"]
+	require.Regexp(t, `^arn:aws:iam::[0-9]{12}:role/eks-ci$`, roleARN)
+
+	preflightJob, ok := workflow.Jobs["preflight"]
+	require.True(t, ok, "preflight job is missing")
+	preflightStep := findHarnessStep(t, preflightJob.Steps, "🔎 Check required AWS OIDC role")
+	assert.Equal(t, "${{ env.AWS_OIDC_ROLE_ARN }}", preflightStep.Env["AWS_OIDC_ROLE_ARN"])
+
+	smokeJob, ok := workflow.Jobs["smoke-test"]
+	require.True(t, ok, "smoke-test job is missing")
+	configureStep := findHarnessStep(t, smokeJob.Steps, "🔐 Configure AWS credentials (OIDC)")
+	assert.Equal(t, "${{ env.AWS_OIDC_ROLE_ARN }}", configureStep.With["role-to-assume"])
+
+	workflowSource, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(workflowSource), "secrets.AWS_OIDC_ROLE_ARN")
 }
 
 //nolint:funlen // One test locks the cross-file action/workflow contract end to end.

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -76,7 +76,8 @@ type compositeAction struct {
 type ciWorkflow struct {
 	Env  map[string]string `yaml:"env"`
 	Jobs map[string]struct {
-		Steps []harnessStep `yaml:"steps"`
+		Permissions map[string]string `yaml:"permissions"`
+		Steps       []harnessStep     `yaml:"steps"`
 	} `yaml:"jobs"`
 }
 
@@ -118,19 +119,24 @@ func TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup(t *testing.T) {
 	workflow := readCIWorkflow(t, ".github/workflows/system-test-eks.yaml")
 	smokeJob, found := workflow.Jobs["smoke-test"]
 	require.True(t, found, "smoke-test job is missing")
+	assert.Equal(t, "write", smokeJob.Permissions["packages"])
 
 	initStep := findHarnessStep(t, smokeJob.Steps, "🔧 Initialize EKS project")
+	assert.Equal(t, "${{ github.actor }}", initStep.Env["GHCR_USER"])
+	assert.Equal(t, "${{ github.token }}", initStep.Env["GHCR_TOKEN"])
 	gitopsGuardIndex := strings.Index(
 		initStep.Run,
 		`if [ "$GITOPS_ENGINE" != "None" ]; then`,
 	)
 	registryIndex := strings.Index(
 		initStep.Run,
-		"--local-registry ghcr.io/devantler-tech/ksail/system-test-manifests",
+		"${GHCR_USER}:${GHCR_TOKEN}@ghcr.io/devantler-tech/ksail/system-test-manifests",
 	)
 
 	require.NotEqual(t, -1, gitopsGuardIndex, "GitOps engine guard is missing")
 	require.NotEqual(t, -1, registryIndex, "GitOps registry argument is missing")
+	assert.Contains(t, initStep.Run, `[ -z "${GHCR_USER:-}" ]`)
+	assert.Contains(t, initStep.Run, `[ -z "${GHCR_TOKEN:-}" ]`)
 
 	gitopsEndIndex := strings.Index(initStep.Run[gitopsGuardIndex:], "\nfi")
 	require.NotEqual(t, -1, gitopsEndIndex, "GitOps engine guard is unterminated")

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -89,18 +89,17 @@ func TestEKSSmokeDeclaresOIDCRoleWithoutSecret(t *testing.T) {
 	roleARN := workflow.Env["AWS_OIDC_ROLE_ARN"]
 	require.Regexp(t, `^arn:aws:iam::[0-9]{12}:role/eks-ci$`, roleARN)
 
-	preflightJob, ok := workflow.Jobs["preflight"]
-	require.True(t, ok, "preflight job is missing")
+	preflightJob, found := workflow.Jobs["preflight"]
+	require.True(t, found, "preflight job is missing")
 	preflightStep := findHarnessStep(t, preflightJob.Steps, "🔎 Check required AWS OIDC role")
 	assert.Equal(t, "${{ env.AWS_OIDC_ROLE_ARN }}", preflightStep.Env["AWS_OIDC_ROLE_ARN"])
 
-	smokeJob, ok := workflow.Jobs["smoke-test"]
-	require.True(t, ok, "smoke-test job is missing")
+	smokeJob, found := workflow.Jobs["smoke-test"]
+	require.True(t, found, "smoke-test job is missing")
 	configureStep := findHarnessStep(t, smokeJob.Steps, "🔐 Configure AWS credentials (OIDC)")
 	assert.Equal(t, "${{ env.AWS_OIDC_ROLE_ARN }}", configureStep.With["role-to-assume"])
 
-	workflowSource, err := os.ReadFile(workflowPath)
-	require.NoError(t, err)
+	workflowSource := readRepoFile(t, workflowPath)
 	assert.NotContains(t, string(workflowSource), "secrets.AWS_OIDC_ROLE_ARN")
 }
 

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -103,6 +103,46 @@ func TestEKSSmokeDeclaresOIDCRoleWithoutSecret(t *testing.T) {
 	assert.NotContains(t, string(workflowSource), "secrets.AWS_OIDC_ROLE_ARN")
 }
 
+func TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup(t *testing.T) {
+	t.Parallel()
+
+	workflow := readCIWorkflow(t, ".github/workflows/system-test-eks.yaml")
+	smokeJob, found := workflow.Jobs["smoke-test"]
+	require.True(t, found, "smoke-test job is missing")
+
+	initStep := findHarnessStep(t, smokeJob.Steps, "🔧 Initialize EKS project")
+	assert.Contains(
+		t,
+		initStep.Run,
+		"--local-registry ghcr.io/devantler-tech/ksail/system-test-manifests",
+	)
+
+	createStep := findHarnessStep(t, smokeJob.Steps, "🧪 ksail cluster create")
+	assert.Equal(t, "create", createStep.ID)
+	attemptIndex := strings.Index(createStep.Run, `echo "attempted=true" >> "$GITHUB_OUTPUT"`)
+	createIndex := strings.Index(createStep.Run, "ksail cluster create")
+
+	require.NotEqual(t, -1, attemptIndex, "cluster create must record its attempt")
+	require.NotEqual(t, -1, createIndex, "cluster create command is missing")
+	assert.Less(t, attemptIndex, createIndex)
+
+	cleanupStep := findHarnessStep(t, smokeJob.Steps, "🧹 Delete EKS smoke cluster")
+	assert.Equal(
+		t,
+		"${{ steps.create.outputs.attempted }}",
+		cleanupStep.Env["EKS_CREATE_ATTEMPTED"],
+	)
+	guardIndex := strings.Index(
+		cleanupStep.Run,
+		`if [ "${EKS_CREATE_ATTEMPTED:-}" != "true" ]; then`,
+	)
+	deleteIndex := strings.Index(cleanupStep.Run, "ksail cluster delete")
+
+	require.NotEqual(t, -1, guardIndex, "pre-create cleanup guard is missing")
+	require.NotEqual(t, -1, deleteIndex, "cluster delete command is missing")
+	assert.Less(t, guardIndex, deleteIndex)
+}
+
 //nolint:funlen // One test locks the cross-file action/workflow contract end to end.
 func TestSystemTestHarnessBoundsReservedSandboxRecovery(t *testing.T) {
 	t.Parallel()

--- a/pkg/client/eksctl/client_test.go
+++ b/pkg/client/eksctl/client_test.go
@@ -317,7 +317,7 @@ func TestRequireCredentialValuesAcceptsProfileOrStaticPair(t *testing.T) {
 	}
 }
 
-func TestCreateCluster_InvokesCorrectArgs(t *testing.T) {
+func TestCreateCluster_ConfigRegionIsNotDuplicatedAsAFlag(t *testing.T) {
 	t.Parallel()
 
 	runner := &fakeRunner{}
@@ -328,7 +328,7 @@ func TestCreateCluster_InvokesCorrectArgs(t *testing.T) {
 
 	assert.Equal(t, "eksctl-under-test", runner.lastName)
 	assert.Equal(t,
-		[]string{"create", "cluster", "--config-file", "eks.yaml", "--region", "us-east-1"},
+		[]string{"create", "cluster", "--config-file", "eks.yaml"},
 		runner.lastArgs,
 	)
 }
@@ -366,7 +366,6 @@ func TestCreateCluster_WithKubeconfigPinsOutputPath(t *testing.T) {
 		[]string{
 			"create", "cluster",
 			"--config-file", "eks.yaml",
-			"--region", "eu-west-1",
 			"--kubeconfig", "/tmp/ksail-kubeconfig",
 		},
 		runner.lastArgs,

--- a/pkg/client/eksctl/commands.go
+++ b/pkg/client/eksctl/commands.go
@@ -54,33 +54,30 @@ type NodegroupSummary struct {
 }
 
 // CreateCluster invokes `eksctl create cluster -f <configPath>`.
-// Pass "" for region unless overriding what the config file specifies.
-func (c *Client) CreateCluster(ctx context.Context, configPath, region string) error {
-	return c.createCluster(ctx, configPath, region, "")
+// The retained region parameter is ignored because eksctl requires the config
+// file to be the sole region source for config-driven creates.
+func (c *Client) CreateCluster(ctx context.Context, configPath, _ string) error {
+	return c.createCluster(ctx, configPath, "")
 }
 
 // CreateClusterWithKubeconfig invokes eksctl create while pinning the output
 // kubeconfig path used by subsequent KSail setup.
 func (c *Client) CreateClusterWithKubeconfig(
 	ctx context.Context,
-	configPath, region, kubeconfigPath string,
+	configPath, _, kubeconfigPath string,
 ) error {
-	return c.createCluster(ctx, configPath, region, kubeconfigPath)
+	return c.createCluster(ctx, configPath, kubeconfigPath)
 }
 
 func (c *Client) createCluster(
 	ctx context.Context,
-	configPath, region, kubeconfigPath string,
+	configPath, kubeconfigPath string,
 ) error {
 	if strings.TrimSpace(configPath) == "" {
 		return ErrEmptyConfigPath
 	}
 
 	args := []string{"create", subcommandCluster, "--config-file", configPath}
-	if region != "" {
-		args = append(args, "--region", region)
-	}
-
 	if path := strings.TrimSpace(kubeconfigPath); path != "" {
 		args = append(args, "--kubeconfig", path)
 	}

--- a/pkg/svc/provisioner/cluster/eks/provisioner.go
+++ b/pkg/svc/provisioner/cluster/eks/provisioner.go
@@ -2,15 +2,26 @@ package eksprovisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
 	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	errEKSCreateConfigMetadataRequired = errors.New("metadata is required")
+	errEKSCreateConfigMetadataType     = errors.New("metadata must be an object")
 )
 
 // Provisioner manages Amazon EKS clusters via the eksctl CLI.
@@ -154,9 +165,15 @@ func (p *Provisioner) Create(ctx context.Context, name string) error {
 		return fmt.Errorf("eksctl unavailable: %w", err)
 	}
 
+	effectiveConfigPath, cleanup, err := p.effectiveCreateConfig()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
 	err = p.client.CreateClusterWithKubeconfig(
 		ctx,
-		p.configPath,
+		effectiveConfigPath,
 		p.region,
 		p.kubeconfigPath,
 	)
@@ -288,4 +305,87 @@ func (p *Provisioner) resolveName(name string) string {
 	}
 
 	return p.name
+}
+
+// effectiveCreateConfig copies the declarative eksctl config to a private temporary file and
+// replaces metadata.region with the region selected by KSail's credential/lifecycle resolver. This
+// keeps eksctl's config-file-only invocation aligned with the exact region used for identity capture
+// and cleanup without modifying the user's source file.
+func (p *Provisioner) effectiveCreateConfig() (string, func(), error) {
+	region := strings.TrimSpace(p.region)
+	if region == "" {
+		return p.configPath, func() {}, nil
+	}
+
+	effectiveData, err := effectiveCreateConfigData(p.configPath, region)
+	if err != nil {
+		return "", func() {}, err
+	}
+
+	return writeEffectiveCreateConfig(effectiveData)
+}
+
+func effectiveCreateConfigData(configPath, region string) ([]byte, error) {
+	canonical, err := fsutil.EvalCanonicalPath(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize EKS create config: %w", err)
+	}
+
+	data, err := fsutil.ReadFileSafe(filepath.Dir(canonical), canonical)
+	if err != nil {
+		return nil, fmt.Errorf("read EKS create config: %w", err)
+	}
+
+	var config map[string]any
+
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, fmt.Errorf("parse EKS create config: %w", err)
+	}
+
+	metadataValue, exists := config["metadata"]
+	if !exists {
+		return nil, fmt.Errorf("parse EKS create config: %w", errEKSCreateConfigMetadataRequired)
+	}
+
+	metadata, ok := metadataValue.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("parse EKS create config: %w", errEKSCreateConfigMetadataType)
+	}
+
+	metadata["region"] = region
+
+	effectiveData, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal effective EKS create config: %w", err)
+	}
+
+	return effectiveData, nil
+}
+
+func writeEffectiveCreateConfig(data []byte) (string, func(), error) {
+	tempFile, err := os.CreateTemp("", "ksail-eks-create-*.yaml")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create effective EKS create config: %w", err)
+	}
+
+	tempPath := tempFile.Name()
+	cleanup := func() { _ = os.Remove(tempPath) }
+
+	_, writeErr := tempFile.Write(data)
+	closeErr := tempFile.Close()
+
+	if writeErr != nil {
+		cleanup()
+
+		return "", func() {}, fmt.Errorf("write effective EKS create config: %w", writeErr)
+	}
+
+	if closeErr != nil {
+		cleanup()
+
+		return "", func() {}, fmt.Errorf("close effective EKS create config: %w", closeErr)
+	}
+
+	return tempPath, cleanup, nil
 }

--- a/pkg/svc/provisioner/cluster/eks/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/eks/provisioner_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	eksctlclient "github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
@@ -93,6 +95,13 @@ func newProvisioner(
 	t.Helper()
 
 	runner := &scriptedRunner{t: t, responses: responses}
+	configPath := filepath.Join(t.TempDir(), "eksctl.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: ksail-test
+  region: us-east-1
+`), 0o600))
 
 	client := eksctlclient.NewClient(
 		eksctlclient.WithBinary(testBinary),
@@ -100,7 +109,7 @@ func newProvisioner(
 	)
 
 	prov, err := eksprovisioner.NewProvisioner(
-		"ksail-test", "us-east-1", "/tmp/eksctl.yaml",
+		"ksail-test", "us-east-1", configPath,
 		client, infra, eksprovisioner.WithKubeconfigPath("/tmp/kubeconfig"),
 	)
 	require.NoError(t, err)
@@ -125,11 +134,12 @@ func TestCreate_ShellsOutWithConfig(t *testing.T) {
 	require.NoError(t, prov.Create(context.Background(), ""))
 
 	require.Len(t, runner.calls, 1)
+	require.Len(t, runner.calls[0], 6)
 	assert.Equal(
 		t,
 		[]string{
 			"create", "cluster",
-			"--config-file", "/tmp/eksctl.yaml",
+			"--config-file", runner.calls[0][3],
 			"--kubeconfig", "/tmp/kubeconfig",
 		},
 		runner.calls[0],

--- a/pkg/svc/provisioner/cluster/eks/provisioner_test.go
+++ b/pkg/svc/provisioner/cluster/eks/provisioner_test.go
@@ -130,7 +130,6 @@ func TestCreate_ShellsOutWithConfig(t *testing.T) {
 		[]string{
 			"create", "cluster",
 			"--config-file", "/tmp/eksctl.yaml",
-			"--region", "us-east-1",
 			"--kubeconfig", "/tmp/kubeconfig",
 		},
 		runner.calls[0],

--- a/pkg/svc/provisioner/cluster/factory_eks_test.go
+++ b/pkg/svc/provisioner/cluster/factory_eks_test.go
@@ -23,7 +23,7 @@ func eksTestCluster() *v1alpha1.Cluster {
 	return cluster
 }
 
-func TestCreateEKSProvisionerPinsKubeconfigPath(t *testing.T) {
+func TestCreateEKSProvisionerPinsKubeconfigPathWithoutOverridingConfigRegion(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script eksctl fixture is not portable to Windows")
 	}
@@ -82,7 +82,6 @@ printf '%s\n' "$@" > "$KSAIL_EKSCTL_ARGS"
 	assert.Equal(t, []string{
 		"create", "cluster",
 		"--config-file", "eks.yaml",
-		"--region", "eu-west-1",
 		"--kubeconfig", "/tmp/ksail-kubeconfig",
 	}, strings.Fields(string(args)))
 }

--- a/pkg/svc/provisioner/cluster/factory_eks_test.go
+++ b/pkg/svc/provisioner/cluster/factory_eks_test.go
@@ -13,6 +13,7 @@ import (
 	eksprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/eks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 // eksTestCluster returns a cluster shaped for the EKS factory path.
@@ -23,35 +24,14 @@ func eksTestCluster() *v1alpha1.Cluster {
 	return cluster
 }
 
+//nolint:paralleltest // exercises explicit process environment isolation for the child eksctl binary.
 func TestCreateEKSProvisionerPinsKubeconfigPathWithoutOverridingConfigRegion(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script eksctl fixture is not portable to Windows")
 	}
 
-	binDir := t.TempDir()
-	argsPath := filepath.Join(t.TempDir(), "args")
-	eksctlPath := filepath.Join(binDir, "eksctl")
-	writeExecutableFixture(t, eksctlPath, `#!/bin/sh
-[ "${AWS_PROFILE-}" = "selected-profile" ] || exit 41
-[ "${AWS_ACCESS_KEY_ID-}" = "fixture-access" ] || exit 42
-[ "${AWS_SECRET_ACCESS_KEY-}" = "fixture-secret" ] || exit 43
-[ "${AWS_SESSION_TOKEN-}" = "fixture-session" ] || exit 44
-[ -z "${KSAIL_PROFILE+x}" ] || exit 45
-[ -z "${KSAIL_ACCESS+x}" ] || exit 46
-[ -z "${KSAIL_SECRET+x}" ] || exit 47
-[ -z "${KSAIL_SESSION+x}" ] || exit 48
-printf '%s\n' "$@" > "$KSAIL_EKSCTL_ARGS"
-`)
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("KSAIL_EKSCTL_ARGS", argsPath)
-	t.Setenv("KSAIL_PROFILE", "selected-profile")
-	t.Setenv("KSAIL_ACCESS", "fixture-access")
-	t.Setenv("KSAIL_SECRET", "fixture-secret")
-	t.Setenv("KSAIL_SESSION", "fixture-session")
-	t.Setenv("AWS_PROFILE", "stale-profile")
-	t.Setenv("AWS_ACCESS_KEY_ID", "stale-access")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "stale-secret")
-	t.Setenv("AWS_SESSION_TOKEN", "stale-session")
+	argsPath, effectiveConfigPath := configureEKSCreateFixture(t)
+	sourceConfigPath, sourceConfig := writeEKSCreateConfigFixture(t)
 
 	cluster := eksTestCluster()
 	cluster.Spec.Provider.AWS = v1alpha1.OptionsAWS{
@@ -66,7 +46,7 @@ printf '%s\n' "$@" > "$KSAIL_EKSCTL_ARGS"
 			EKS: &clusterprovisioner.EKSConfig{
 				Name:           "test-eks",
 				Region:         "eu-west-1",
-				ConfigPath:     "eks.yaml",
+				ConfigPath:     sourceConfigPath,
 				KubeconfigPath: "/tmp/ksail-kubeconfig",
 			},
 		},
@@ -79,11 +59,101 @@ printf '%s\n' "$@" > "$KSAIL_EKSCTL_ARGS"
 	//nolint:gosec // argsPath is created inside this test's private temporary directory
 	args, err := os.ReadFile(argsPath)
 	require.NoError(t, err)
+
+	argFields := strings.Fields(string(args))
+	require.Len(t, argFields, 6)
 	assert.Equal(t, []string{
 		"create", "cluster",
-		"--config-file", "eks.yaml",
+		"--config-file", argFields[3],
 		"--kubeconfig", "/tmp/ksail-kubeconfig",
-	}, strings.Fields(string(args)))
+	}, argFields)
+	assert.NotEqual(t, sourceConfigPath, argFields[3])
+
+	assert.Equal(t, "eu-west-1", readEKSConfigRegion(t, effectiveConfigPath))
+
+	//nolint:gosec // sourceConfigPath is created inside this test's private temporary directory.
+	unchangedSource, err := os.ReadFile(sourceConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, sourceConfig, unchangedSource)
+	//nolint:gosec // argFields[3] is emitted by the local eksctl fixture from KSail's temp path.
+	_, err = os.Stat(argFields[3])
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func configureEKSCreateFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	argsPath := filepath.Join(t.TempDir(), "args")
+	effectiveConfigPath := filepath.Join(t.TempDir(), "effective-config.yaml")
+	eksctlPath := filepath.Join(binDir, "eksctl")
+	writeExecutableFixture(t, eksctlPath, `#!/bin/sh
+[ "${AWS_PROFILE-}" = "selected-profile" ] || exit 41
+[ "${AWS_ACCESS_KEY_ID-}" = "fixture-access" ] || exit 42
+[ "${AWS_SECRET_ACCESS_KEY-}" = "fixture-secret" ] || exit 43
+[ "${AWS_SESSION_TOKEN-}" = "fixture-session" ] || exit 44
+[ -z "${KSAIL_PROFILE+x}" ] || exit 45
+[ -z "${KSAIL_ACCESS+x}" ] || exit 46
+[ -z "${KSAIL_SECRET+x}" ] || exit 47
+[ -z "${KSAIL_SESSION+x}" ] || exit 48
+printf '%s\n' "$@" > "$KSAIL_EKSCTL_ARGS"
+config_path=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--config-file" ]; then
+    shift
+    config_path=$1
+    break
+  fi
+  shift
+done
+[ -n "$config_path" ] || exit 49
+cp "$config_path" "$KSAIL_EKSCTL_CONFIG"
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KSAIL_EKSCTL_ARGS", argsPath)
+	t.Setenv("KSAIL_EKSCTL_CONFIG", effectiveConfigPath)
+	t.Setenv("KSAIL_PROFILE", "selected-profile")
+	t.Setenv("KSAIL_ACCESS", "fixture-access")
+	t.Setenv("KSAIL_SECRET", "fixture-secret")
+	t.Setenv("KSAIL_SESSION", "fixture-session")
+	t.Setenv("AWS_PROFILE", "stale-profile")
+	t.Setenv("AWS_ACCESS_KEY_ID", "stale-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "stale-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "stale-session")
+
+	return argsPath, effectiveConfigPath
+}
+
+func writeEKSCreateConfigFixture(t *testing.T) (string, []byte) {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "eks.yaml")
+	config := []byte(`apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: test-eks
+  region: eu-central-1
+`)
+	require.NoError(t, os.WriteFile(configPath, config, 0o600))
+
+	return configPath, config
+}
+
+func readEKSConfigRegion(t *testing.T, configPath string) string {
+	t.Helper()
+
+	//nolint:gosec // configPath is a private test capture path supplied by the caller.
+	configData, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var config struct {
+		Metadata struct {
+			Region string `json:"region"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, yaml.Unmarshal(configData, &config))
+
+	return config.Metadata.Region
 }
 
 // writeExecutableFixture writes a private executable used to stand in for eksctl.


### PR DESCRIPTION
## Why

The EKS smoke workflow had a live, scoped OIDC role but depended on an unset environment secret, so successful dispatches skipped both build and smoke jobs.

## What

- declare the non-secret scoped role reference as trusted workflow configuration
- use that single declaration for preflight and OIDC exchange
- fail the dispatch when that required role delivery is empty
- add a regression test that rejects secret-based or malformed role delivery
- use the existing external test artifact for cloud GitOps initialization
- authorize GitOps smoke runs to publish the ephemeral artifact with the job-scoped Actions token
- keep lifecycle-only (`gitops_engine=None`) runs independent of that unused registry
- make pre-create cleanup a successful no-op while preserving cleanup after every create attempt
- keep config-driven eksctl creates free of the conflicting CLI region flag
- align the effective config region with the region selected by the credential/lifecycle resolver without mutating the user's source file
- document the required GitHub OIDC token permission for security linting

Fixes #6278
Fixes #6280
Fixes #6281
Fixes #6282
Part of https://github.com/devantler-tech/platform/issues/2327

> Authored by the 🤖 Daily AI Engineer (Codex routine).
