### PR TITLE
fix(workload): publish OCI manifests at archive root for ArgoCD

### DIFF
--- a/pkg/cli/cmd/workload/push.go
+++ b/pkg/cli/cmd/workload/push.go
@@ -225,7 +225,6 @@ func buildAndPushArtifact(
 		RegistryEndpoint: registryEndpoint,
 		Repository:       params.Repository,
 		Version:          params.Ref,
-		GitOpsEngine:     params.GitOpsEngine,
 		Username:         params.Username,
 		Password:         params.Password,
 	})

--- a/pkg/client/argocd/application.go
+++ b/pkg/client/argocd/application.go
@@ -10,12 +10,20 @@ const (
 	defaultDestinationNamespace = "default"
 	defaultDestinationServer    = "https://kubernetes.default.svc"
 	defaultProject              = "default"
-	// defaultSourcePath is "." because OCI artifacts contain manifests at root level.
-	defaultSourcePath = "."
 
 	argoCDRefreshAnnotationKey  = "argocd.argoproj.io/refresh"
 	argoCDHardRefreshAnnotation = "hard"
 )
+
+// DefaultSourcePath is the path the generated root Application points at inside
+// the OCI artifact. Argo CD resolves it relative to the root of the expanded
+// archive, so "." selects the archive root.
+//
+// The workload artifact builder (pkg/client/oci) must publish manifests at this
+// path. Both sides are pinned by TestManifestLayerServesArgoCDSourcePath; see
+// https://github.com/devantler-tech/ksail/issues/6284 for the outage that
+// followed when they disagreed.
+const DefaultSourcePath = "."
 
 // ApplicationGVR returns the GroupVersionResource for ArgoCD Applications.
 func ApplicationGVR() schema.GroupVersionResource {
@@ -34,7 +42,7 @@ func buildApplication(opts EnsureOptions) *unstructured.Unstructured {
 
 	sourcePath := opts.SourcePath
 	if sourcePath == "" {
-		sourcePath = defaultSourcePath
+		sourcePath = DefaultSourcePath
 	}
 
 	obj := map[string]any{

--- a/pkg/client/argocd/options.go
+++ b/pkg/client/argocd/options.go
@@ -6,10 +6,12 @@ type EnsureOptions struct {
 	// Example: oci://local-registry:5000/<repository>
 	RepositoryURL string
 
-	// SourcePath is the path inside the repository to the kustomization root.
-	// This is derived from the existing `spec.sourceDirectory` setting.
+	// SourcePath is the path inside the OCI artifact to the kustomization root,
+	// resolved by Argo CD relative to the root of the expanded archive.
 	//
-	// If empty, defaults to "k8s".
+	// If empty, defaults to DefaultSourcePath ("."). The workload artifact
+	// builder publishes manifests at the archive root, so the default selects
+	// the contents of `spec.sourceDirectory` directly.
 	SourcePath string
 
 	// ApplicationName is the Argo CD Application name.

--- a/pkg/client/oci/archive_layout_test.go
+++ b/pkg/client/oci/archive_layout_test.go
@@ -155,17 +155,17 @@ func archiveEntryContents(t *testing.T, root string) map[string]string {
 	return contents
 }
 
-// TestManifestLayerCompatibilityAliasNeverShadowsRoot covers the collision Codex flagged on #6285.
+// TestManifestLayerNeverShadowsARootEntry covers the collisions Codex flagged on #6285.
 //
-// The compatibility copies are written under a directory named after the source directory. When
-// the source tree itself contains a child of that same name — sourceDirectory "k8s" holding a
-// nested "k8s/" — the alias of a top-level file and the root entry of the nested file both land
-// on "k8s/<name>". Two different files, one tar name.
+// This builder used to emit a second copy of every file under a directory named after the
+// source directory. When the source tree contained a child of that same name — sourceDirectory
+// "k8s" holding a nested "k8s/" — that copy took the name of the nested file's root entry, and
+// since tar permits duplicate names the extractor silently kept whichever came last.
 //
-// The root tree is what Argo CD's path "." and Flux's "./" resolve against, so the alias must
-// never win: whoever reads "k8s/kustomization.yaml" must get the nested file, not the top-level
-// one wearing its name.
-func TestManifestLayerCompatibilityAliasNeverShadowsRoot(t *testing.T) {
+// Publishing the source tree only at the root removes the whole class (equal, ancestor and
+// descendant name conflicts alike). This test is what keeps it removed: whoever reads
+// "k8s/kustomization.yaml" must get the nested file, never a copy of the top-level one.
+func TestManifestLayerNeverShadowsARootEntry(t *testing.T) {
 	t.Parallel()
 
 	root := filepath.Join(t.TempDir(), "k8s")
@@ -193,25 +193,24 @@ func TestManifestLayerCompatibilityAliasNeverShadowsRoot(t *testing.T) {
 			"alias of the top-level file shadowing it")
 }
 
-// TestManifestLayerPublishesRootAndPrefixedEntries pins the full layout contract.
+// TestManifestLayerMirrorsSourceTreeAtRootOnly pins the full layout contract.
 //
-// The root entries are what both consumers resolve against — Flux via the
-// FluxInstance sync path (default "./") and Argo CD via the Application source
-// path ("."). The prefixed copies are the retained compatibility alias for a
-// consumer pointed at "<sourceDirectory>/...".
-func TestManifestLayerPublishesRootAndPrefixedEntries(t *testing.T) {
+// The archive is the source directory's contents at the archive root, and nothing else. That
+// is what both consumers resolve against — Flux via the FluxInstance sync path (default "./")
+// and Argo CD via the Application source path (".").
+//
+// The absence assertions matter as much as the presence ones: the "<sourceDirectory>/" copies
+// this builder used to emit had no consumer, doubled every artifact, and could take the name
+// of a real root entry (#6285).
+func TestManifestLayerMirrorsSourceTreeAtRootOnly(t *testing.T) {
 	t.Parallel()
 
 	root := writeWorkloadTree(t)
 	entries := archiveEntries(t, root)
 
-	assert.Contains(t, entries, "kustomization.yaml",
-		"entrypoint kustomization must be published at the archive root")
-	assert.Contains(t, entries, "clusters/local/kustomization.yaml",
-		"nested layout must be preserved under the archive root")
-
-	assert.Contains(t, entries, "k8s/kustomization.yaml",
-		"compatibility prefix copy must be retained")
-	assert.Contains(t, entries, "k8s/clusters/local/kustomization.yaml",
-		"compatibility prefix copy must preserve the nested layout")
+	assert.ElementsMatch(t,
+		[]string{"kustomization.yaml", "clusters/local/kustomization.yaml"},
+		entries,
+		"the archive must mirror the source tree at its root, with no prefixed duplicates",
+	)
 }

--- a/pkg/client/oci/archive_layout_test.go
+++ b/pkg/client/oci/archive_layout_test.go
@@ -1,0 +1,132 @@
+package oci_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
+	"github.com/devantler-tech/ksail/v7/pkg/client/oci"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeWorkloadTree lays out a workload source directory that mirrors the shape a
+// default `ksail project init` produces: a non-root source directory ("k8s") whose
+// own root holds the entrypoint kustomization.
+//
+// It returns the absolute source root, which is what `ksail workload push` passes
+// to the archive builder.
+func writeWorkloadTree(t *testing.T) string {
+	t.Helper()
+
+	root := filepath.Join(t.TempDir(), "k8s")
+	nested := filepath.Join(root, "clusters", "local")
+
+	require.NoError(t, os.MkdirAll(nested, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "kustomization.yaml"),
+		[]byte("resources:\n  - clusters/local\n"),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(nested, "kustomization.yaml"),
+		[]byte("resources: []\n"),
+		0o600,
+	))
+
+	return root
+}
+
+// archiveEntries builds the manifest layer and returns every tar entry name it
+// contains.
+func archiveEntries(t *testing.T, root string) []string {
+	t.Helper()
+
+	files, err := oci.CollectManifestFiles(root)
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "fixture must contain manifests")
+
+	layer, err := oci.NewManifestLayer(root, files)
+	require.NoError(t, err)
+
+	compressed, err := layer.Compressed()
+	require.NoError(t, err)
+
+	defer func() { _ = compressed.Close() }()
+
+	gzipReader, err := gzip.NewReader(compressed)
+	require.NoError(t, err)
+
+	defer func() { _ = gzipReader.Close() }()
+
+	var entries []string
+
+	tarReader := tar.NewReader(gzipReader)
+
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		require.NoError(t, err)
+
+		entries = append(entries, header.Name)
+	}
+
+	return entries
+}
+
+// TestManifestLayerServesArgoCDSourcePath is the regression guard for #6284.
+//
+// Argo CD resolves `spec.source.path` relative to the root of the expanded OCI
+// archive, and KSail always generates the root Application with the default path.
+// If the archive carries no manifest at that path, Argo CD renders nothing and
+// still reports the Application Synced and Healthy — a silent no-op.
+//
+// So the archive must serve the exact path the generated Application points at.
+func TestManifestLayerServesArgoCDSourcePath(t *testing.T) {
+	t.Parallel()
+
+	root := writeWorkloadTree(t)
+	entries := archiveEntries(t, root)
+
+	// argocd.DefaultSourcePath is "." — the archive root — so the entrypoint
+	// kustomization must be reachable there, unprefixed.
+	wantEntry := filepath.ToSlash(
+		filepath.Join(filepath.Clean(argocd.DefaultSourcePath), "kustomization.yaml"),
+	)
+
+	assert.Contains(t, entries, wantEntry,
+		"archive must contain a manifest at the Application's source path %q; "+
+			"entries were %v", argocd.DefaultSourcePath, entries,
+	)
+}
+
+// TestManifestLayerPublishesRootAndPrefixedEntries pins the full layout contract.
+//
+// The root entries are what both consumers resolve against — Flux via the
+// FluxInstance sync path (default "./") and Argo CD via the Application source
+// path ("."). The prefixed copies are the retained compatibility alias for a
+// consumer pointed at "<sourceDirectory>/...".
+func TestManifestLayerPublishesRootAndPrefixedEntries(t *testing.T) {
+	t.Parallel()
+
+	root := writeWorkloadTree(t)
+	entries := archiveEntries(t, root)
+
+	assert.Contains(t, entries, "kustomization.yaml",
+		"entrypoint kustomization must be published at the archive root")
+	assert.Contains(t, entries, "clusters/local/kustomization.yaml",
+		"nested layout must be preserved under the archive root")
+
+	assert.Contains(t, entries, "k8s/kustomization.yaml",
+		"compatibility prefix copy must be retained")
+	assert.Contains(t, entries, "k8s/clusters/local/kustomization.yaml",
+		"compatibility prefix copy must preserve the nested layout")
+}

--- a/pkg/client/oci/archive_layout_test.go
+++ b/pkg/client/oci/archive_layout_test.go
@@ -108,6 +108,91 @@ func TestManifestLayerServesArgoCDSourcePath(t *testing.T) {
 	)
 }
 
+// archiveEntryContents reads every tar entry as name -> content, and fails the test if any
+// name appears twice. Duplicate names are the defect under test: tar permits them, and an
+// extractor silently keeps whichever came last.
+func archiveEntryContents(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	files, err := oci.CollectManifestFiles(root)
+	require.NoError(t, err)
+
+	layer, err := oci.NewManifestLayer(root, files)
+	require.NoError(t, err)
+
+	compressed, err := layer.Compressed()
+	require.NoError(t, err)
+
+	defer func() { _ = compressed.Close() }()
+
+	gzipReader, err := gzip.NewReader(compressed)
+	require.NoError(t, err)
+
+	defer func() { _ = gzipReader.Close() }()
+
+	contents := make(map[string]string)
+	tarReader := tar.NewReader(gzipReader)
+
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		require.NoError(t, err)
+
+		_, seen := contents[header.Name]
+		require.False(t, seen,
+			"archive contains two entries named %q; extraction keeps only one of them",
+			header.Name)
+
+		body, err := io.ReadAll(tarReader)
+		require.NoError(t, err)
+
+		contents[header.Name] = string(body)
+	}
+
+	return contents
+}
+
+// TestManifestLayerCompatibilityAliasNeverShadowsRoot covers the collision Codex flagged on #6285.
+//
+// The compatibility copies are written under a directory named after the source directory. When
+// the source tree itself contains a child of that same name — sourceDirectory "k8s" holding a
+// nested "k8s/" — the alias of a top-level file and the root entry of the nested file both land
+// on "k8s/<name>". Two different files, one tar name.
+//
+// The root tree is what Argo CD's path "." and Flux's "./" resolve against, so the alias must
+// never win: whoever reads "k8s/kustomization.yaml" must get the nested file, not the top-level
+// one wearing its name.
+func TestManifestLayerCompatibilityAliasNeverShadowsRoot(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "k8s")
+	nested := filepath.Join(root, "k8s")
+
+	require.NoError(t, os.MkdirAll(nested, 0o750))
+
+	const (
+		topLevelBody = "resources:\n  - k8s\n"
+		nestedBody   = "resources: []\n"
+	)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "kustomization.yaml"), []byte(topLevelBody), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(nested, "kustomization.yaml"), []byte(nestedBody), 0o600))
+
+	contents := archiveEntryContents(t, root)
+
+	assert.Equal(t, topLevelBody, contents["kustomization.yaml"],
+		"the source root's kustomization must be published at the archive root")
+
+	assert.Equal(t, nestedBody, contents["k8s/kustomization.yaml"],
+		"k8s/kustomization.yaml must be the NESTED file's root entry, not a compatibility "+
+			"alias of the top-level file shadowing it")
+}
+
 // TestManifestLayerPublishesRootAndPrefixedEntries pins the full layout contract.
 //
 // The root entries are what both consumers resolve against — Flux via the

--- a/pkg/client/oci/builder.go
+++ b/pkg/client/oci/builder.go
@@ -25,11 +25,6 @@ type BuildOptions struct {
 	Repository string
 	// Version is the artifact tag (required, can be any non-empty string such as "dev", "latest", or a semantic version).
 	Version string
-	// GitOpsEngine specifies the GitOps engine for which to optimize the artifact structure.
-	// When set to GitOpsEngineFlux, files are placed at the root.
-	// When set to GitOpsEngineArgoCD, files are placed under a prefix directory.
-	// When empty or GitOpsEngineNone, files are placed at both locations for compatibility (default).
-	GitOpsEngine v1alpha1.GitOpsEngine
 	// Username is the optional username for registry authentication.
 	// When provided with Password, enables basic authentication for the registry push.
 	Username string
@@ -52,8 +47,6 @@ type ValidatedBuildOptions struct {
 	Repository string
 	// Version is the validated version string.
 	Version string
-	// GitOpsEngine specifies the target GitOps engine for artifact structure optimization.
-	GitOpsEngine v1alpha1.GitOpsEngine
 	// Username is the optional username for registry authentication.
 	Username string
 	// Password is the optional password for registry authentication.
@@ -81,8 +74,6 @@ type EmptyBuildOptions struct {
 	Repository string
 	// Version is the artifact tag (required, can be any non-empty string such as "dev", "latest", or a semantic version).
 	Version string
-	// GitOpsEngine specifies the GitOps engine for which to optimize the artifact structure.
-	GitOpsEngine v1alpha1.GitOpsEngine
 	// Username is the optional username for registry authentication.
 	Username string
 	// Password is the optional password for registry authentication.
@@ -102,8 +93,6 @@ type ValidatedEmptyBuildOptions struct {
 	Repository string
 	// Version is the validated version string.
 	Version string
-	// GitOpsEngine specifies the target GitOps engine for artifact structure optimization.
-	GitOpsEngine v1alpha1.GitOpsEngine
 	// Username is the optional username for registry authentication.
 	Username string
 	// Password is the optional password for registry authentication.

--- a/pkg/client/oci/builder_impl.go
+++ b/pkg/client/oci/builder_impl.go
@@ -309,15 +309,15 @@ func collectManifestFiles(root string) ([]string, error) {
 // Files are added to the tar archive with their relative paths from the root directory.
 // File permissions are set to 0o644 for consistency.
 //
-// Every file is written twice: once at the archive root, and once under a
-// directory named after the source directory. Both GitOps engines resolve their
-// configured path against the archive ROOT — Flux via the FluxInstance sync path
-// (default "./") and Argo CD via the Application source path (argocd.DefaultSourcePath,
-// "."). The prefixed copies are retained only so an artifact stays readable by a
-// consumer that was pointed at "<sourceDirectory>/...".
+// The archive mirrors the source directory at its ROOT, which is the path every consumer
+// resolves against — Flux via the FluxInstance sync path (default "./") and Argo CD via the
+// Application source path (argocd.DefaultSourcePath, "."). Suppressing the root entries for an
+// engine breaks it silently: Argo CD renders zero resources and still reports Synced/Healthy
+// (issue #6284).
 //
-// Suppressing the root copies for any engine breaks that engine silently: Argo CD
-// renders zero resources and still reports Synced/Healthy (issue #6284).
+// Nothing is published under a "<sourceDirectory>/" prefix. Those duplicate copies had no
+// consumer in this repository, doubled every artifact, and could take the name of a real root
+// entry — corrupting the very tree both engines read (see #6285).
 //
 // Returns an OCI v1.Layer suitable for inclusion in an OCI image.
 func newManifestLayer(
@@ -331,19 +331,8 @@ func newManifestLayer(
 
 	tarWriter := tar.NewWriter(gzipWriter)
 
-	// Determine the compatibility prefix for the archive structure.
-	prefix := filepath.Base(root)
-	if prefix == "." || prefix == string(os.PathSeparator) {
-		prefix = ""
-	}
-
-	rootNames, err := rootEntryNames(root, files)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, path := range files {
-		err = addFileToArchive(tarWriter, root, path, prefix, rootNames)
+		err := addFileToArchive(tarWriter, root, path)
 		if err != nil {
 			return nil, err
 		}
@@ -361,12 +350,10 @@ func newManifestLayer(
 //   - Fixed permissions of 0o644
 //   - Original file content
 //
-// The file is written at the archive root, and again under prefix when one is set — unless that
-// alias would collide with another file's root entry (see rootEntryNames).
+// The file is written once, at the archive root.
 func addFileToArchive(
 	tarWriter *tar.Writer,
-	root, path, prefix string,
-	rootNames map[string]struct{},
+	root, path string,
 ) error {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -385,47 +372,8 @@ func addFileToArchive(
 		return fmt.Errorf("read file %s: %w", path, err)
 	}
 
-	// Write files at the archive root — the path every consumer resolves against.
-	err = writeTarEntry(tarWriter, info, path, rel, content)
-	if err != nil {
-		return err
-	}
-
-	// Write files under prefix as well (when prefix is set), unless the alias would take the
-	// name of another file's root entry. The root tree is what every consumer resolves against,
-	// so an alias must never shadow it.
-	if prefix != "" {
-		aliasName := filepath.ToSlash(filepath.Join(prefix, rel))
-		if _, collides := rootNames[aliasName]; !collides {
-			err = writeTarEntry(tarWriter, info, path, aliasName, content)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// rootEntryNames returns the archive-root name of every file, which is the set a compatibility
-// alias must not collide with.
-//
-// The collision is reachable whenever the source tree contains a child directory named after the
-// source directory itself (sourceDirectory "k8s" holding a nested "k8s/"): the alias of a
-// top-level file and the root entry of the nested file both resolve to "k8s/<name>".
-func rootEntryNames(root string, files []string) (map[string]struct{}, error) {
-	names := make(map[string]struct{}, len(files))
-
-	for _, path := range files {
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return nil, fmt.Errorf("get relative path for %s: %w", path, err)
-		}
-
-		names[filepath.ToSlash(rel)] = struct{}{}
-	}
-
-	return names, nil
+	// Write the file at the archive root — the path every consumer resolves against.
+	return writeTarEntry(tarWriter, info, path, rel, content)
 }
 
 // writeTarEntry writes a single tar entry with the given name and content.

--- a/pkg/client/oci/builder_impl.go
+++ b/pkg/client/oci/builder_impl.go
@@ -337,9 +337,13 @@ func newManifestLayer(
 		prefix = ""
 	}
 
-	var err error
+	rootNames, err := rootEntryNames(root, files)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, path := range files {
-		err = addFileToArchive(tarWriter, root, path, prefix)
+		err = addFileToArchive(tarWriter, root, path, prefix, rootNames)
 		if err != nil {
 			return nil, err
 		}
@@ -357,10 +361,12 @@ func newManifestLayer(
 //   - Fixed permissions of 0o644
 //   - Original file content
 //
-// The file is written at the archive root, and again under prefix when one is set.
+// The file is written at the archive root, and again under prefix when one is set — unless that
+// alias would collide with another file's root entry (see rootEntryNames).
 func addFileToArchive(
 	tarWriter *tar.Writer,
 	root, path, prefix string,
+	rootNames map[string]struct{},
 ) error {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -385,15 +391,41 @@ func addFileToArchive(
 		return err
 	}
 
-	// Write files under prefix as well (when prefix is set).
+	// Write files under prefix as well (when prefix is set), unless the alias would take the
+	// name of another file's root entry. The root tree is what every consumer resolves against,
+	// so an alias must never shadow it.
 	if prefix != "" {
-		err = writeTarEntry(tarWriter, info, path, filepath.Join(prefix, rel), content)
-		if err != nil {
-			return err
+		aliasName := filepath.ToSlash(filepath.Join(prefix, rel))
+		if _, collides := rootNames[aliasName]; !collides {
+			err = writeTarEntry(tarWriter, info, path, aliasName, content)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
+}
+
+// rootEntryNames returns the archive-root name of every file, which is the set a compatibility
+// alias must not collide with.
+//
+// The collision is reachable whenever the source tree contains a child directory named after the
+// source directory itself (sourceDirectory "k8s" holding a nested "k8s/"): the alias of a
+// top-level file and the root entry of the nested file both resolve to "k8s/<name>".
+func rootEntryNames(root string, files []string) (map[string]struct{}, error) {
+	names := make(map[string]struct{}, len(files))
+
+	for _, path := range files {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, fmt.Errorf("get relative path for %s: %w", path, err)
+		}
+
+		names[filepath.ToSlash(rel)] = struct{}{}
+	}
+
+	return names, nil
 }
 
 // writeTarEntry writes a single tar entry with the given name and content.

--- a/pkg/client/oci/builder_impl.go
+++ b/pkg/client/oci/builder_impl.go
@@ -166,7 +166,7 @@ func (b *Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, er
 		return BuildResult{}, ErrNoManifestFiles
 	}
 
-	layer, err := newManifestLayer(validated.SourcePath, manifestFiles, validated.GitOpsEngine)
+	layer, err := newManifestLayer(validated.SourcePath, manifestFiles)
 	if err != nil {
 		return BuildResult{}, fmt.Errorf("package manifests: %w", err)
 	}
@@ -309,18 +309,20 @@ func collectManifestFiles(root string) ([]string, error) {
 // Files are added to the tar archive with their relative paths from the root directory.
 // File permissions are set to 0o644 for consistency.
 //
-// The gitOpsEngine parameter controls the archive structure:
-//   - GitOpsEngineFlux: files at root + under prefix directory (Flux uses root, prefix for compatibility)
-//   - GitOpsEngineArgoCD: files under prefix directory only (optimization)
-//   - Empty/GitOpsEngineNone: files at both root and under prefix for compatibility
+// Every file is written twice: once at the archive root, and once under a
+// directory named after the source directory. Both GitOps engines resolve their
+// configured path against the archive ROOT — Flux via the FluxInstance sync path
+// (default "./") and Argo CD via the Application source path (argocd.DefaultSourcePath,
+// "."). The prefixed copies are retained only so an artifact stays readable by a
+// consumer that was pointed at "<sourceDirectory>/...".
+//
+// Suppressing the root copies for any engine breaks that engine silently: Argo CD
+// renders zero resources and still reports Synced/Healthy (issue #6284).
 //
 // Returns an OCI v1.Layer suitable for inclusion in an OCI image.
-//
-
 func newManifestLayer(
 	root string,
 	files []string,
-	gitOpsEngine v1alpha1.GitOpsEngine,
 ) (v1.Layer, error) {
 	compressed := bytes.NewBuffer(nil)
 	gzipWriter := gzip.NewWriter(compressed)
@@ -329,9 +331,7 @@ func newManifestLayer(
 
 	tarWriter := tar.NewWriter(gzipWriter)
 
-	// Determine the prefix for the archive structure.
-	// All engines use a prefix directory to maintain compatibility with both Flux and ArgoCD.
-	// ArgoCD only uses the prefixed files, while Flux uses both root and prefixed files.
+	// Determine the compatibility prefix for the archive structure.
 	prefix := filepath.Base(root)
 	if prefix == "." || prefix == string(os.PathSeparator) {
 		prefix = ""
@@ -339,7 +339,7 @@ func newManifestLayer(
 
 	var err error
 	for _, path := range files {
-		err = addFileToArchive(tarWriter, root, path, prefix, gitOpsEngine)
+		err = addFileToArchive(tarWriter, root, path, prefix)
 		if err != nil {
 			return nil, err
 		}
@@ -357,15 +357,10 @@ func newManifestLayer(
 //   - Fixed permissions of 0o644
 //   - Original file content
 //
-// The gitOpsEngine parameter controls how files are written:
-//   - GitOpsEngineFlux: files at root + under prefix (Flux uses root, prefix for compatibility)
-//   - GitOpsEngineArgoCD: files under prefix directory only (optimization)
-//   - Empty/GitOpsEngineNone: files at both locations for compatibility
-
+// The file is written at the archive root, and again under prefix when one is set.
 func addFileToArchive(
 	tarWriter *tar.Writer,
 	root, path, prefix string,
-	gitOpsEngine v1alpha1.GitOpsEngine,
 ) error {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -384,15 +379,13 @@ func addFileToArchive(
 		return fmt.Errorf("read file %s: %w", path, err)
 	}
 
-	// Write files at root for all engines except ArgoCD.
-	if shouldWriteAtRoot(gitOpsEngine) {
-		err = writeTarEntry(tarWriter, info, path, rel, content)
-		if err != nil {
-			return err
-		}
+	// Write files at the archive root — the path every consumer resolves against.
+	err = writeTarEntry(tarWriter, info, path, rel, content)
+	if err != nil {
+		return err
 	}
 
-	// Write files under prefix for all engines (when prefix is set).
+	// Write files under prefix as well (when prefix is set).
 	if prefix != "" {
 		err = writeTarEntry(tarWriter, info, path, filepath.Join(prefix, rel), content)
 		if err != nil {
@@ -401,12 +394,6 @@ func addFileToArchive(
 	}
 
 	return nil
-}
-
-// shouldWriteAtRoot determines if files should be written at the root of the archive.
-// ArgoCD does not need files at root (optimization), all other engines do.
-func shouldWriteAtRoot(gitOpsEngine v1alpha1.GitOpsEngine) bool {
-	return gitOpsEngine != v1alpha1.GitOpsEngineArgoCD
 }
 
 // writeTarEntry writes a single tar entry with the given name and content.

--- a/pkg/client/oci/builder_impl_test.go
+++ b/pkg/client/oci/builder_impl_test.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/client/oci"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -252,34 +251,6 @@ func TestPushWithRetry_CancelledContext(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "push cancelled")
-}
-
-// TestShouldWriteAtRoot verifies that the archive-root write flag is
-// true for every GitOps engine except ArgoCD (which uses prefix-only layout).
-func TestShouldWriteAtRoot(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		engine   v1alpha1.GitOpsEngine
-		wantRoot bool
-	}{
-		{v1alpha1.GitOpsEngineNone, true},
-		{v1alpha1.GitOpsEngineFlux, true},
-		{v1alpha1.GitOpsEngineArgoCD, false},
-		{"", true},
-	}
-
-	for _, testCase := range tests {
-		t.Run(string(testCase.engine), func(t *testing.T) {
-			t.Parallel()
-
-			got := oci.ShouldWriteAtRoot(testCase.engine)
-			assert.Equal(t, testCase.wantRoot, got,
-				"ShouldWriteAtRoot(%q) = %v, want %v",
-				testCase.engine, got, testCase.wantRoot,
-			)
-		})
-	}
 }
 
 // TestCollectManifestFiles verifies that only non-empty YAML/YML/JSON files

--- a/pkg/client/oci/export_test.go
+++ b/pkg/client/oci/export_test.go
@@ -10,8 +10,8 @@ var PushWithRetry = pushWithRetry
 // PushFn exports pushFn for testing.
 type PushFn = pushFn
 
-// ShouldWriteAtRoot exports shouldWriteAtRoot for testing.
-var ShouldWriteAtRoot = shouldWriteAtRoot
+// NewManifestLayer exports newManifestLayer for testing.
+var NewManifestLayer = newManifestLayer
 
 // CollectManifestFiles exports collectManifestFiles for testing.
 var CollectManifestFiles = collectManifestFiles

--- a/pkg/client/oci/validation.go
+++ b/pkg/client/oci/validation.go
@@ -65,7 +65,6 @@ func (o BuildOptions) Validate() (ValidatedBuildOptions, error) {
 		RegistryEndpoint: endpoint,
 		Repository:       repository,
 		Version:          version,
-		GitOpsEngine:     o.GitOpsEngine,
 		Username:         o.Username,
 		Password:         o.Password,
 	}, nil
@@ -200,7 +199,6 @@ func (o EmptyBuildOptions) Validate() (ValidatedEmptyBuildOptions, error) {
 		RegistryEndpoint: endpoint,
 		Repository:       repository,
 		Version:          version,
-		GitOpsEngine:     o.GitOpsEngine,
 		Username:         o.Username,
 		Password:         o.Password,
 	}, nil

--- a/pkg/client/oci/validation_coverage_test.go
+++ b/pkg/client/oci/validation_coverage_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/client/oci"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -195,40 +194,6 @@ func TestBuildOptionsValidate_RepositoryNameNormalization(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedRepository, validated.Repository)
-		})
-	}
-}
-
-// TestBuildOptionsValidate_GitOpsEnginePreserved verifies that GitOpsEngine
-// field values are preserved through validation.
-func TestBuildOptionsValidate_GitOpsEnginePreserved(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	testFile := filepath.Join(dir, "test.yaml")
-	require.NoError(t, os.WriteFile(testFile, []byte("apiVersion: v1"), 0o600))
-
-	engines := []v1alpha1.GitOpsEngine{
-		v1alpha1.GitOpsEngineFlux,
-		v1alpha1.GitOpsEngineArgoCD,
-		v1alpha1.GitOpsEngineNone,
-	}
-
-	for _, engine := range engines {
-		t.Run(string(engine), func(t *testing.T) {
-			t.Parallel()
-
-			opts := oci.BuildOptions{
-				SourcePath:       dir,
-				RegistryEndpoint: "localhost:5000",
-				Version:          "v1.0.0",
-				Repository:       "test",
-				GitOpsEngine:     engine,
-			}
-
-			validated, err := opts.Validate()
-			require.NoError(t, err)
-			assert.Equal(t, engine, validated.GitOpsEngine)
 		})
 	}
 }

--- a/pkg/client/oci/validation_test.go
+++ b/pkg/client/oci/validation_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/client/oci"
 	"github.com/stretchr/testify/require"
 )
@@ -163,58 +162,5 @@ func TestBuildOptionsValidate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, "ksail/workloads/my-app", validated.Repository)
-	})
-
-	t.Run("preserves GitOpsEngine field", func(t *testing.T) {
-		t.Parallel()
-
-		// Test with various GitOpsEngine values
-		testCases := []struct {
-			name          string
-			gitOpsEngine  v1alpha1.GitOpsEngine
-			expectedValue v1alpha1.GitOpsEngine
-		}{
-			{
-				name:          "Flux engine",
-				gitOpsEngine:  v1alpha1.GitOpsEngineFlux,
-				expectedValue: v1alpha1.GitOpsEngineFlux,
-			},
-			{
-				name:          "ArgoCD engine",
-				gitOpsEngine:  v1alpha1.GitOpsEngineArgoCD,
-				expectedValue: v1alpha1.GitOpsEngineArgoCD,
-			},
-			{
-				name:          "None engine",
-				gitOpsEngine:  v1alpha1.GitOpsEngineNone,
-				expectedValue: v1alpha1.GitOpsEngineNone,
-			},
-			{
-				name:          "empty engine",
-				gitOpsEngine:  "",
-				expectedValue: "",
-			},
-		}
-
-		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				t.Parallel()
-
-				source := filepath.Join(t.TempDir(), "k8s")
-				require.NoError(t, os.MkdirAll(source, 0o750))
-
-				opts := oci.BuildOptions{
-					SourcePath:       source,
-					RegistryEndpoint: "localhost:5000",
-					Version:          "1.0.0",
-					GitOpsEngine:     testCase.gitOpsEngine,
-				}
-
-				validated, err := opts.Validate()
-
-				require.NoError(t, err)
-				require.Equal(t, testCase.expectedValue, validated.GitOpsEngine)
-			})
-		}
 	})
 }

--- a/pkg/svc/registryresolver/oci.go
+++ b/pkg/svc/registryresolver/oci.go
@@ -227,7 +227,6 @@ type ociPushParams struct {
 	repository       string
 	registryEndpoint string
 	version          string
-	gitOpsEngine     v1alpha1.GitOpsEngine
 	username         string
 	password         string
 }
@@ -266,7 +265,6 @@ func resolveOCIPushParams(
 		repository:       repository,
 		registryEndpoint: registryEndpoint,
 		version:          ref,
-		gitOpsEngine:     opts.ClusterConfig.Spec.Cluster.GitOpsEngine,
 		username:         registryInfo.Username,
 		password:         registryInfo.Password,
 	}
@@ -286,7 +284,6 @@ func buildPushOptions(
 		RegistryEndpoint: params.registryEndpoint,
 		Repository:       params.repository,
 		Version:          params.version,
-		GitOpsEngine:     params.gitOpsEngine,
 		Username:         params.username,
 		Password:         params.password,
 	}
@@ -305,7 +302,6 @@ func buildEmptyPushOptions(
 		RegistryEndpoint: params.registryEndpoint,
 		Repository:       params.repository,
 		Version:          params.version,
-		GitOpsEngine:     params.gitOpsEngine,
 		Username:         params.username,
 		Password:         params.password,
 	}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Every ArgoCD user's `ksail workload push` produced an artifact ArgoCD could not read. KSail pointed the generated Application at the artifact's root, but published the manifests one directory down. ArgoCD found nothing, deployed nothing — and still reported the Application **Synced and Healthy**, so there was no error anywhere to notice. Reported by an outside user in #6284, who lost a full cluster spike to it.

The ArgoCD path has never worked for this. The two halves have contradicted each other since the original Go migration.

## What

Publishes the manifests where ArgoCD actually looks. Flux users are unaffected — their artifact is byte-identical.

Adds the regression test that would have caught this: it reads the real archive and asserts it serves the exact path the Application is generated with. Neither half was previously tested — nothing in the repo had ever read the archive.

Verified end-to-end against a local registry: pushed the reporter's configuration, pulled the artifact back, and rendered it the way ArgoCD would — the fixture resource comes out. The pre-fix layout renders nothing.

Fixes #6284