### PR TITLE
fix(eks): honour --name when scaffolding eks.yaml

### DIFF
--- a/pkg/fsutil/scaffolder/scaffolder_eks.go
+++ b/pkg/fsutil/scaffolder/scaffolder_eks.go
@@ -40,7 +40,12 @@ func (s *Scaffolder) generateEKSConfig(output string, force bool) error {
 		return nil
 	}
 
-	content := RenderEKSConfig(DefaultEKSConfigParams(defaultEKSClusterName, defaultEKSRegion))
+	clusterName := defaultEKSClusterName
+	if s.ClusterName != "" {
+		clusterName = s.ClusterName
+	}
+
+	content := RenderEKSConfig(DefaultEKSConfigParams(clusterName, defaultEKSRegion))
 
 	err := os.WriteFile(configPath, content, filePerm)
 	if err != nil {

--- a/pkg/fsutil/scaffolder/scaffolder_eks_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_eks_test.go
@@ -1,11 +1,43 @@
 package scaffolder_test
 
 import (
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil/scaffolder"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func createEKSCluster(name string) v1alpha1.Cluster {
+	cluster := createTestCluster(name)
+	cluster.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	cluster.Spec.Cluster.DistributionConfig = scaffolder.EKSConfigFile
+
+	return cluster
+}
+
+// scaffoldEKSConfig scaffolds an EKS project and returns the generated eks.yaml.
+func scaffoldEKSConfig(t *testing.T, clusterName string) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	instance := scaffolder.NewScaffolder(createEKSCluster("eks"), io.Discard, nil)
+
+	if clusterName != "" {
+		instance = instance.WithClusterName(clusterName)
+	}
+
+	require.NoError(t, instance.Scaffold(tempDir, false))
+
+	content, err := os.ReadFile(filepath.Join(tempDir, scaffolder.EKSConfigFile))
+	require.NoError(t, err)
+
+	return string(content)
+}
 
 func TestDefaultEKSConfigParams_AppliesNameAndRegion(t *testing.T) {
 	t.Parallel()
@@ -38,4 +70,32 @@ func TestRenderEKSConfig_RendersClusterNameAndRegion(t *testing.T) {
 	assert.Contains(t, rendered, "name: prod")
 	assert.Contains(t, rendered, "region: eu-central-1")
 	assert.Contains(t, rendered, "managedNodeGroups:")
+}
+
+// TestScaffoldEKSConfigUsesClusterName pins the wiring, not the plumbing: the helpers above already
+// render whatever name they are handed, so only an end-to-end scaffold catches a call site that
+// hands them the package default instead of the requested name (#6307).
+func TestScaffoldEKSConfigUsesClusterName(t *testing.T) {
+	t.Parallel()
+
+	rendered := scaffoldEKSConfig(t, "my-eks-cluster")
+
+	assert.Contains(t, rendered, "name: my-eks-cluster")
+	assert.NotContains(
+		t,
+		rendered,
+		"name: eks-default",
+		"an explicit cluster name must not leave the scaffolding default in eks.yaml",
+	)
+}
+
+// TestScaffoldEKSConfigFallsBackToDefaultName is the negative control for the test above: without an
+// explicit name the scaffolding default must still be written, so the fix cannot pass by emitting an
+// empty name.
+func TestScaffoldEKSConfigFallsBackToDefaultName(t *testing.T) {
+	t.Parallel()
+
+	rendered := scaffoldEKSConfig(t, "")
+
+	assert.Contains(t, rendered, "name: eks-default")
 }

--- a/pkg/fsutil/scaffolder/scaffolder_eks_test.go
+++ b/pkg/fsutil/scaffolder/scaffolder_eks_test.go
@@ -33,6 +33,7 @@ func scaffoldEKSConfig(t *testing.T, clusterName string) string {
 
 	require.NoError(t, instance.Scaffold(tempDir, false))
 
+	//nolint:gosec // test reads from t.TempDir()
 	content, err := os.ReadFile(filepath.Join(tempDir, scaffolder.EKSConfigFile))
 	require.NoError(t, err)
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Asking for an EKS cluster by name didn't work. `ksail project init --name my-cluster --distribution EKS`
looked like it succeeded, but the name only reached `ksail.yaml` — the file that actually defines the
cluster still said `eks-default`. So every EKS project anyone scaffolds gets the same cluster name,
two projects or two CI runs in one AWS account collide, and any later command that goes looking for
the name you asked for can't find the cluster that was made.

## What

EKS now uses the requested name, like every other distribution already did. Without `--name`, nothing
changes.

Found while getting the EKS smoke test running end-to-end: it inits with a per-run cluster name, and
its create and cleanup steps were both working against a different name than the one that existed.

Fixes #6307
