### PR TITLE
feat(eks): reconcile AWS load balancer controller opt-in

### DIFF
--- a/charts/ksail-operator/crds/ksail.io_clusters.yaml
+++ b/charts/ksail-operator/crds/ksail.io_clusters.yaml
@@ -334,10 +334,9 @@ spec:
                           pre-created IRSA service account via
                           awsLoadBalancerControllerServiceAccount) and subnet tags are
                           prerequisites KSail does not create — see the awslbcontroller installer
-                          package docs. Installed at cluster create and by the operator's
-                          reconcile; enabling it on an existing cluster is not yet detected by
-                          `cluster update`'s diff (#6231). Not yet validated against a live EKS
-                          cluster.
+                          package docs. Installed at cluster create, by the operator's reconcile,
+                          and by `cluster update` when the opt-in changes. Not yet validated against
+                          a live EKS cluster.
                         type: boolean
                       experimentalInPlaceUpdates:
                         description: |-

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -326,10 +327,18 @@ func (r *ClusterReconciler) reconcileComponents(
 		return true
 	}
 
+	annotationsBefore := cluster.DeepCopy().Annotations
 	applied, components, err := r.InstallComponents(ctx, provisioner, cluster)
 	cluster.Status.Components = components
 
 	if err != nil {
+		ownershipErr := r.recordComponentOwnershipProgress(
+			ctx,
+			cluster,
+			annotationsBefore,
+		)
+		err = errors.Join(err, ownershipErr)
+
 		logf.FromContext(ctx).Info("install components (best-effort)", "error", err.Error())
 		setCondition(
 			cluster,

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -332,23 +332,7 @@ func (r *ClusterReconciler) reconcileComponents(
 	cluster.Status.Components = components
 
 	if err != nil {
-		ownershipErr := r.recordComponentOwnershipProgress(
-			ctx,
-			cluster,
-			annotationsBefore,
-		)
-		err = errors.Join(err, ownershipErr)
-
-		logf.FromContext(ctx).Info("install components (best-effort)", "error", err.Error())
-		setCondition(
-			cluster,
-			v1alpha1.ConditionComponentsReady,
-			metav1.ConditionFalse,
-			"ComponentsFailed",
-			err.Error(),
-		)
-
-		return false
+		return r.recordComponentInstallFailure(ctx, cluster, annotationsBefore, err)
 	}
 
 	if !applied {
@@ -393,6 +377,27 @@ func (r *ClusterReconciler) reconcileComponents(
 	)
 
 	return true
+}
+
+func (r *ClusterReconciler) recordComponentInstallFailure(
+	ctx context.Context,
+	cluster *v1alpha1.Cluster,
+	annotationsBefore map[string]string,
+	installErr error,
+) bool {
+	ownershipErr := r.recordComponentOwnershipProgress(ctx, cluster, annotationsBefore)
+	err := errors.Join(installErr, ownershipErr)
+
+	logf.FromContext(ctx).Info("install components (best-effort)", "error", err.Error())
+	setCondition(
+		cluster,
+		v1alpha1.ConditionComponentsReady,
+		metav1.ConditionFalse,
+		"ComponentsFailed",
+		err.Error(),
+	)
+
+	return false
 }
 
 // componentsUpToDate reports whether component reconciliation has settled for the cluster's current

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -508,8 +508,15 @@ func TestReconcile_ComponentFailureIsBestEffortAndRequeues(t *testing.T) {
 	reconciler.InstallComponents = func(
 		_ context.Context,
 		_ clusterprovisioner.Provisioner,
-		_ *v1alpha1.Cluster,
+		cluster *v1alpha1.Cluster,
 	) (bool, []v1alpha1.ComponentStatus, error) {
+		if cluster.Annotations == nil {
+			cluster.Annotations = map[string]string{}
+		}
+
+		cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation] = "partial-controller-release-uid"
+		cluster.Annotations["installer-transient"] = "must-not-persist"
+
 		return true, []v1alpha1.ComponentStatus{
 			{Name: "cilium", State: v1alpha1.ComponentStateFailed, Message: errBoom.Error()},
 		}, errBoom
@@ -540,6 +547,24 @@ func TestReconcile_ComponentFailureIsBestEffortAndRequeues(t *testing.T) {
 	assert.Equal(t, []v1alpha1.ComponentStatus{
 		{Name: "cilium", State: v1alpha1.ComponentStateFailed, Message: errBoom.Error()},
 	}, got.Status.Components)
+	assert.Equal(
+		t,
+		"partial-controller-release-uid",
+		got.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
+		"partial controller ownership must survive the component failure requeue",
+	)
+	assert.NotContains(
+		t,
+		got.Annotations,
+		v1alpha1.LastAppliedComponentsAnnotation,
+		"a failed component pass must not advance the full component baseline",
+	)
+	assert.NotContains(
+		t,
+		got.Annotations,
+		"installer-transient",
+		"the failure path must persist only the narrow ownership marker",
+	)
 }
 
 func TestReconcile_ComponentsSkippedReportsUnknown(t *testing.T) {

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -505,22 +505,7 @@ func TestReconcile_ComponentFailureIsBestEffortAndRequeues(t *testing.T) {
 	scheme := newScheme(t)
 	fakeClient := newFakeClient(scheme, newCluster(true))
 	reconciler := newReconciler(scheme, fakeClient, &fakeProvisioner{exists: true})
-	reconciler.InstallComponents = func(
-		_ context.Context,
-		_ clusterprovisioner.Provisioner,
-		cluster *v1alpha1.Cluster,
-	) (bool, []v1alpha1.ComponentStatus, error) {
-		if cluster.Annotations == nil {
-			cluster.Annotations = map[string]string{}
-		}
-
-		cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation] = "partial-controller-release-uid"
-		cluster.Annotations["installer-transient"] = "must-not-persist"
-
-		return true, []v1alpha1.ComponentStatus{
-			{Name: "cilium", State: v1alpha1.ComponentStateFailed, Message: errBoom.Error()},
-		}, errBoom
-	}
+	reconciler.InstallComponents = installComponentsWithPartialControllerFailure
 
 	result, err := reconciler.Reconcile(context.Background(), request())
 	// A component-install failure must not fail the reconcile.
@@ -565,6 +550,23 @@ func TestReconcile_ComponentFailureIsBestEffortAndRequeues(t *testing.T) {
 		"installer-transient",
 		"the failure path must persist only the narrow ownership marker",
 	)
+}
+
+func installComponentsWithPartialControllerFailure(
+	_ context.Context,
+	_ clusterprovisioner.Provisioner,
+	cluster *v1alpha1.Cluster,
+) (bool, []v1alpha1.ComponentStatus, error) {
+	if cluster.Annotations == nil {
+		cluster.Annotations = map[string]string{}
+	}
+
+	cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation] = "partial-controller-release-uid"
+	cluster.Annotations["installer-transient"] = "must-not-persist"
+
+	return true, []v1alpha1.ComponentStatus{
+		{Name: "cilium", State: v1alpha1.ComponentStateFailed, Message: errBoom.Error()},
+	}, errBoom
 }
 
 func TestReconcile_ComponentsSkippedReportsUnknown(t *testing.T) {

--- a/internal/controller/drift.go
+++ b/internal/controller/drift.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
@@ -142,6 +143,45 @@ func (r *ClusterReconciler) recordAppliedComponents(
 	updateErr := r.Update(ctx, updated)
 	if updateErr != nil {
 		return fmt.Errorf("record last-applied components: %w", updateErr)
+	}
+
+	cluster.Annotations = updated.Annotations
+	cluster.ResourceVersion = updated.ResourceVersion
+
+	return nil
+}
+
+// recordComponentOwnershipProgress persists only a controller release-identity change made before a
+// later component failed. The full component baseline deliberately remains unchanged so the next
+// reconcile retries the failed pass, while the narrow ownership marker survives the status update.
+func (r *ClusterReconciler) recordComponentOwnershipProgress(
+	ctx context.Context,
+	cluster *v1alpha1.Cluster,
+	previousAnnotations map[string]string,
+) error {
+	previousValue, previousPresent := previousAnnotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation]
+	currentValue, currentPresent := cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation]
+
+	if currentPresent == previousPresent && currentValue == previousValue {
+		return nil
+	}
+
+	updated := cluster.DeepCopy()
+
+	updated.Annotations = maps.Clone(previousAnnotations)
+	if currentPresent {
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+
+		updated.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation] = currentValue
+	} else {
+		delete(updated.Annotations, v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation)
+	}
+
+	updateErr := r.Update(ctx, updated)
+	if updateErr != nil {
+		return fmt.Errorf("record partial component ownership: %w", updateErr)
 	}
 
 	cluster.Annotations = updated.Annotations

--- a/pkg/apis/cluster/v1alpha1/labels.go
+++ b/pkg/apis/cluster/v1alpha1/labels.go
@@ -36,6 +36,13 @@ const LastAppliedSpecAnnotation = "ksail.io/last-applied-spec"
 // user cannot forge it.
 const LastAppliedComponentsAnnotation = "ksail.io/last-applied-components"
 
+// AWSLoadBalancerControllerReleaseIdentityAnnotation stores the Kubernetes UID
+// of a Helm storage object created or upgraded by the operator for the AWS Load
+// Balancer Controller. The operator requires this positive, concrete ownership
+// evidence before removing the release; the desired-spec baseline alone is not
+// ownership because an install may have preserved a GitOps-managed release.
+const AWSLoadBalancerControllerReleaseIdentityAnnotation = "ksail.io/aws-load-balancer-controller-release-identity"
+
 // UnmanagedAnnotation marks a Cluster that ksail surfaces from the user's kubeconfig but does not
 // manage: it was found as a kubeconfig context that no ksail infrastructure provider discovered, so
 // ksail never provisioned it and has no spec to drive it. Its value is the string "true". It lets

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -34,10 +34,9 @@ type OptionsEKS struct {
 	// pre-created IRSA service account via
 	// awsLoadBalancerControllerServiceAccount) and subnet tags are
 	// prerequisites KSail does not create — see the awslbcontroller installer
-	// package docs. Installed at cluster create and by the operator's
-	// reconcile; enabling it on an existing cluster is not yet detected by
-	// `cluster update`'s diff (#6231). Not yet validated against a live EKS
-	// cluster.
+	// package docs. Installed at cluster create, by the operator's reconcile,
+	// and by `cluster update` when the opt-in changes. Not yet validated against
+	// a live EKS cluster.
 	ExperimentalAWSLoadBalancerController bool `json:"experimentalAWSLoadBalancerController,omitzero" jsonschema_description:"Experimental: install the AWS Load Balancer Controller when spec.cluster.loadBalancer is Enabled, replacing the default in-tree Classic Load Balancer path. Default false (nothing is installed). IAM permissions and subnet tags are prerequisites KSail does not create."` //nolint:lll,tagliatelle // AWS keeps its conventional casing, like the sibling issuerURL/floatingIP fields
 
 	// AWSLoadBalancerControllerServiceAccount names a pre-created service

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -106,10 +107,7 @@ func handleCreateRunE(
 		return err
 	}
 
-	err = persistRequiredEKSComponentState(ctx, clusterName)
-	if err != nil {
-		return err
-	}
+	requiredStateErr := persistRequiredEKSComponentState(ctx, clusterName)
 
 	// Persist the ClusterSpec so that future updates have an accurate baseline
 	// for fields that cannot be detected from the live cluster (e.g., Talos ISO).
@@ -118,7 +116,15 @@ func handleCreateRunE(
 		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
 	}
 
-	return maybeWaitForTTL(cmd, clusterName, ctx.ClusterCfg, ctx.EKSConfig)
+	return finishCreateWithTTL(requiredStateErr, func() error {
+		return maybeWaitForTTL(cmd, clusterName, ctx.ClusterCfg, ctx.EKSConfig)
+	})
+}
+
+func finishCreateWithTTL(requiredStateErr error, waitForTTL func() error) error {
+	ttlErr := waitForTTL()
+
+	return errors.Join(requiredStateErr, ttlErr)
 }
 
 // newProvisionerFactory returns the cluster provisioner factory, using any test override if set.

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -107,7 +107,11 @@ func handleCreateRunE(
 		return err
 	}
 
-	requiredStateErr := persistRequiredEKSComponentState(ctx, clusterName)
+	requiredStateErr := persistRequiredEKSComponentState(
+		ctx,
+		clusterName,
+		setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
+	)
 
 	// Persist the ClusterSpec so that future updates have an accurate baseline
 	// for fields that cannot be detected from the live cluster (e.g., Talos ISO).

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -107,11 +107,7 @@ func handleCreateRunE(
 		return err
 	}
 
-	requiredStateErr := persistRequiredEKSComponentState(
-		ctx,
-		clusterName,
-		setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
-	)
+	requiredStateErr := persistCreatedEKSComponentState(cmd.Context(), ctx, clusterName)
 
 	// Persist the ClusterSpec so that future updates have an accurate baseline
 	// for fields that cannot be detected from the live cluster (e.g., Talos ISO).

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -106,6 +106,11 @@ func handleCreateRunE(
 		return err
 	}
 
+	err = persistRequiredEKSComponentState(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
 	// Persist the ClusterSpec so that future updates have an accurate baseline
 	// for fields that cannot be detected from the live cluster (e.g., Talos ISO).
 	saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -102,13 +102,19 @@ func handleCreateRunE(
 		return err
 	}
 
-	creationErr := runClusterCreationWorkflow(cmd, cfgManager, ctx, deps)
+	controllerReconciliationStarted, creationErr := runClusterCreationWorkflow(
+		cmd,
+		cfgManager,
+		ctx,
+		deps,
+	)
 
 	requiredStateErr := persistCreatedEKSComponentStateAfterWorkflow(
 		cmd.Context(),
 		ctx,
 		clusterName,
 		creationErr,
+		controllerReconciliationStarted,
 	)
 	if creationErr != nil {
 		return requiredStateErr
@@ -420,10 +426,10 @@ func handlePostCreationSetup(
 	cmd *cobra.Command,
 	clusterCfg *v1alpha1.Cluster,
 	tmr timer.Timer,
-) error {
+) (bool, error) {
 	cniInstalled, err := setup.InstallCNI(cmd, clusterCfg, tmr)
 	if err != nil {
-		return fmt.Errorf("failed to install CNI: %w", err)
+		return false, fmt.Errorf("failed to install CNI: %w", err)
 	}
 
 	factories := getInstallerFactories()
@@ -438,7 +444,7 @@ func handlePostCreationSetup(
 		cniInstalled,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to install post-CNI components: %w", err)
+		return true, fmt.Errorf("failed to install post-CNI components: %w", err)
 	}
 
 	// Configure OIDC kubeconfig entries when OIDC is enabled
@@ -454,7 +460,7 @@ func handlePostCreationSetup(
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // maybeDisableK3dFeature conditionally appends a K3s --disable flag to K3d config.

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -102,12 +102,17 @@ func handleCreateRunE(
 		return err
 	}
 
-	err = runClusterCreationWorkflow(cmd, cfgManager, ctx, deps)
-	if err != nil {
-		return err
-	}
+	creationErr := runClusterCreationWorkflow(cmd, cfgManager, ctx, deps)
 
-	requiredStateErr := persistCreatedEKSComponentState(cmd.Context(), ctx, clusterName)
+	requiredStateErr := persistCreatedEKSComponentStateAfterWorkflow(
+		cmd.Context(),
+		ctx,
+		clusterName,
+		creationErr,
+	)
+	if creationErr != nil {
+		return requiredStateErr
+	}
 
 	// Persist the ClusterSpec so that future updates have an accurate baseline
 	// for fields that cannot be detected from the live cluster (e.g., Talos ISO).

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -115,14 +116,37 @@ func handleCreateRunE(
 		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)
 	}
 
-	return finishCreateWithTTL(requiredStateErr, func() error {
-		return maybeWaitForTTL(cmd, clusterName, ctx.ClusterCfg, ctx.EKSConfig)
-	})
+	return finishCreateWithTTL(
+		requiredStateErr,
+		func() error {
+			ttlValue, _ := cmd.Flags().GetString("ttl")
+			if strings.TrimSpace(ttlValue) == "" {
+				return nil
+			}
+
+			return autoDeleteCluster(cmd, clusterName, ctx.ClusterCfg, ctx.EKSConfig)
+		},
+		func() error {
+			return maybeWaitForTTL(cmd, clusterName, ctx.ClusterCfg, ctx.EKSConfig)
+		},
+	)
 }
 
-func finishCreateWithTTL(requiredStateErr error, waitForTTL func() error) error {
+func finishCreateWithTTL(
+	requiredStateErr error,
+	cleanupFailedTTLCreate func() error,
+	waitForTTL func() error,
+) error {
 	if requiredStateErr != nil {
-		return requiredStateErr
+		cleanupErr := cleanupFailedTTLCreate()
+		if cleanupErr != nil {
+			cleanupErr = fmt.Errorf(
+				"clean up TTL cluster after required state persistence failed: %w",
+				cleanupErr,
+			)
+		}
+
+		return errors.Join(requiredStateErr, cleanupErr)
 	}
 
 	return waitForTTL()

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -122,9 +121,11 @@ func handleCreateRunE(
 }
 
 func finishCreateWithTTL(requiredStateErr error, waitForTTL func() error) error {
-	ttlErr := waitForTTL()
+	if requiredStateErr != nil {
+		return requiredStateErr
+	}
 
-	return errors.Join(requiredStateErr, ttlErr)
+	return waitForTTL()
 }
 
 // newProvisionerFactory returns the cluster provisioner factory, using any test override if set.

--- a/pkg/cli/cmd/cluster/create_test.go
+++ b/pkg/cli/cmd/cluster/create_test.go
@@ -347,7 +347,7 @@ func TestCreate_EKSCaptureFailureStopsPostCreateWorkflow(t *testing.T) {
 	require.ErrorIs(t, loadErr, state.ErrEKSOwnershipStateNotFound)
 }
 
-func TestFinishCreateWithTTL_RunsCleanupAfterPersistenceFailure(t *testing.T) {
+func TestFinishCreateWithTTL_ReturnsBeforeWaitAfterPersistenceFailure(t *testing.T) {
 	t.Parallel()
 
 	ttlCalled := false
@@ -358,9 +358,8 @@ func TestFinishCreateWithTTL_RunsCleanupAfterPersistenceFailure(t *testing.T) {
 		return errTTLCleanupFailure
 	})
 
-	assert.True(t, ttlCalled)
+	assert.False(t, ttlCalled, "a known-fatal state error must not enter the normal TTL wait")
 	require.ErrorIs(t, err, errRequiredStateFailure)
-	require.ErrorIs(t, err, errTTLCleanupFailure)
 }
 
 //nolint:paralleltest // mutates process environment, working directory, and shared hooks.

--- a/pkg/cli/cmd/cluster/create_test.go
+++ b/pkg/cli/cmd/cluster/create_test.go
@@ -29,7 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var errSTSUnavailable = errors.New("STS unavailable")
+var (
+	errSTSUnavailable       = errors.New("STS unavailable")
+	errRequiredStateFailure = errors.New("required state write failed")
+	errTTLCleanupFailure    = errors.New("TTL cleanup failed")
+)
 
 //nolint:paralleltest // uses t.Chdir and mutates shared test hooks
 func TestCreate_EnabledCertManager_PrintsInstallStage(t *testing.T) {
@@ -341,6 +345,22 @@ func TestCreate_EKSCaptureFailureStopsPostCreateWorkflow(t *testing.T) {
 
 	_, loadErr := state.LoadEKSOwnershipState("st-eks", "eu-west-1")
 	require.ErrorIs(t, loadErr, state.ErrEKSOwnershipStateNotFound)
+}
+
+func TestFinishCreateWithTTL_RunsCleanupAfterPersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	ttlCalled := false
+
+	err := cluster.ExportFinishCreateWithTTL(errRequiredStateFailure, func() error {
+		ttlCalled = true
+
+		return errTTLCleanupFailure
+	})
+
+	assert.True(t, ttlCalled)
+	require.ErrorIs(t, err, errRequiredStateFailure)
+	require.ErrorIs(t, err, errTTLCleanupFailure)
 }
 
 //nolint:paralleltest // mutates process environment, working directory, and shared hooks.

--- a/pkg/cli/cmd/cluster/create_test.go
+++ b/pkg/cli/cmd/cluster/create_test.go
@@ -347,19 +347,34 @@ func TestCreate_EKSCaptureFailureStopsPostCreateWorkflow(t *testing.T) {
 	require.ErrorIs(t, loadErr, state.ErrEKSOwnershipStateNotFound)
 }
 
-func TestFinishCreateWithTTL_ReturnsBeforeWaitAfterPersistenceFailure(t *testing.T) {
+func TestFinishCreateWithTTL_CleansUpWithoutWaitingAfterPersistenceFailure(t *testing.T) {
 	t.Parallel()
 
-	ttlCalled := false
+	cleanupCalled := false
+	waitCalled := false
 
-	err := cluster.ExportFinishCreateWithTTL(errRequiredStateFailure, func() error {
-		ttlCalled = true
+	err := cluster.ExportFinishCreateWithTTL(
+		errRequiredStateFailure,
+		func() error {
+			cleanupCalled = true
 
-		return errTTLCleanupFailure
-	})
+			return errTTLCleanupFailure
+		},
+		func() error {
+			waitCalled = true
 
-	assert.False(t, ttlCalled, "a known-fatal state error must not enter the normal TTL wait")
+			return nil
+		},
+	)
+
+	assert.True(
+		t,
+		cleanupCalled,
+		"a TTL cluster must be deleted after required state persistence fails",
+	)
+	assert.False(t, waitCalled, "a known-fatal state error must not enter the normal TTL wait")
 	require.ErrorIs(t, err, errRequiredStateFailure)
+	require.ErrorIs(t, err, errTTLCleanupFailure)
 }
 
 //nolint:paralleltest // mutates process environment, working directory, and shared hooks.

--- a/pkg/cli/cmd/cluster/delete.go
+++ b/pkg/cli/cmd/cluster/delete.go
@@ -626,7 +626,11 @@ func executeDelete(
 }
 
 func deleteResolvedClusterState(resolved *lifecycle.ResolvedClusterInfo) error {
-	if resolved.Provider == v1alpha1.ProviderAWS && strings.TrimSpace(resolved.AWSRegion) != "" {
+	if resolved.Provider == v1alpha1.ProviderAWS {
+		if strings.TrimSpace(resolved.AWSRegion) == "" {
+			return fmt.Errorf("delete exact-region EKS state: %w", state.ErrInvalidRegion)
+		}
+
 		err := state.DeleteEKSRegionState(resolved.ClusterName, resolved.AWSRegion)
 		if err != nil {
 			return fmt.Errorf("delete exact-region EKS state: %w", err)

--- a/pkg/cli/cmd/cluster/delete.go
+++ b/pkg/cli/cmd/cluster/delete.go
@@ -608,7 +608,7 @@ func executeDelete(
 
 	// Clean up persisted state (spec + TTL) for the deleted cluster.
 	// Best-effort: log a warning on failure rather than blocking success.
-	stateErr := state.DeleteClusterState(resolved.ClusterName)
+	stateErr := deleteResolvedClusterState(resolved)
 	if stateErr != nil {
 		notify.Warningf(cmd.OutOrStdout(), "failed to clean up cluster state: %v", stateErr)
 	}
@@ -621,6 +621,24 @@ func executeDelete(
 		Timer:   outputTimer,
 		Writer:  cmd.OutOrStdout(),
 	})
+
+	return nil
+}
+
+func deleteResolvedClusterState(resolved *lifecycle.ResolvedClusterInfo) error {
+	if resolved.Provider == v1alpha1.ProviderAWS && strings.TrimSpace(resolved.AWSRegion) != "" {
+		err := state.DeleteEKSRegionState(resolved.ClusterName, resolved.AWSRegion)
+		if err != nil {
+			return fmt.Errorf("delete exact-region EKS state: %w", err)
+		}
+
+		return nil
+	}
+
+	err := state.DeleteClusterState(resolved.ClusterName)
+	if err != nil {
+		return fmt.Errorf("delete cluster state: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -1,11 +1,13 @@
 package cluster
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
@@ -73,6 +75,31 @@ func persistReconciledEKSComponentState(
 	controllerManaged, err := reconciler.eksLoadBalancerControllerManagedAfterReconcile()
 	if err != nil {
 		return err
+	}
+
+	return persistRequiredEKSComponentState(ctx, clusterName, controllerManaged)
+}
+
+// persistCreatedEKSComponentState verifies post-create GitOps ownership before
+// recording a KSail marker. The shared Helm installer may succeed by skipping
+// an externally managed release, which must remain unowned.
+func persistCreatedEKSComponentState(
+	goCtx context.Context,
+	ctx *localregistry.Context,
+	clusterName string,
+) error {
+	if ctx == nil || ctx.ClusterCfg == nil ||
+		ctx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	controllerManaged, err := setup.EKSLoadBalancerControllerManagedByKSail(
+		goCtx,
+		ctx.ClusterCfg,
+		getInstallerFactories(),
+	)
+	if err != nil {
+		return fmt.Errorf("resolve EKS controller ownership after creation: %w", err)
 	}
 
 	return persistRequiredEKSComponentState(ctx, clusterName, controllerManaged)

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -1,14 +1,16 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
-	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
+
+var errEKSComponentReconcilerUnavailable = errors.New("component reconciler is unavailable")
 
 // persistRequiredEKSComponentState saves the declarative baseline needed to
 // reconcile non-introspectable EKS component ownership. Unlike the wider
@@ -17,6 +19,7 @@ import (
 func persistRequiredEKSComponentState(
 	ctx *localregistry.Context,
 	clusterName string,
+	controllerManaged bool,
 ) error {
 	if ctx == nil || ctx.ClusterCfg == nil ||
 		ctx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
@@ -35,7 +38,7 @@ func persistRequiredEKSComponentState(
 		Version:                                 state.EKSComponentStateVersion,
 		ClusterName:                             clusterName,
 		Region:                                  region,
-		AWSLoadBalancerControllerManaged:        setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
+		AWSLoadBalancerControllerManaged:        controllerManaged,
 		AWSLoadBalancerControllerServiceAccount: ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount,
 	}
 
@@ -45,4 +48,32 @@ func persistRequiredEKSComponentState(
 	}
 
 	return nil
+}
+
+// persistReconciledEKSComponentState records the ownership resulting from this
+// update pass. When the controller was not touched, the reconciler returns the
+// existing exact-region marker instead of inferring ownership from desired config.
+func persistReconciledEKSComponentState(
+	ctx *localregistry.Context,
+	clusterName string,
+	reconciler *componentReconciler,
+) error {
+	if ctx == nil || ctx.ClusterCfg == nil ||
+		ctx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	if reconciler == nil {
+		return fmt.Errorf(
+			"persist required EKS component state: %w",
+			errEKSComponentReconcilerUnavailable,
+		)
+	}
+
+	controllerManaged, err := reconciler.eksLoadBalancerControllerManagedAfterReconcile()
+	if err != nil {
+		return err
+	}
+
+	return persistRequiredEKSComponentState(ctx, clusterName, controllerManaged)
 }

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -30,13 +30,11 @@ func persistRequiredEKSComponentState(
 	}
 
 	region := strings.TrimSpace(ctx.EKSConfig.Region)
-	spec := &ctx.ClusterCfg.Spec.Cluster
 	snapshot := state.EKSComponentState{
-		Version:                               state.EKSComponentStateVersion,
-		ClusterName:                           clusterName,
-		Region:                                region,
-		LoadBalancer:                          spec.LoadBalancer,
-		ExperimentalAWSLoadBalancerController: spec.EKS.ExperimentalAWSLoadBalancerController,
+		Version:                                 state.EKSComponentStateVersion,
+		ClusterName:                             clusterName,
+		Region:                                  region,
+		AWSLoadBalancerControllerServiceAccount: ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount,
 	}
 
 	err := state.SaveEKSComponentState(clusterName, region, &snapshot)

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -52,6 +52,36 @@ func persistRequiredEKSComponentState(
 	return nil
 }
 
+// clearDeletedEKSState invalidates every state artifact that could otherwise
+// be mistaken for the replacement EKS cluster. It runs after deletion and
+// before creation so a failed recreate cannot retain ownership of a cluster
+// that no longer exists.
+func clearDeletedEKSState(ctx *localregistry.Context, clusterName string) error {
+	if ctx == nil || ctx.ClusterCfg == nil ||
+		ctx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	if ctx.EKSConfig == nil {
+		return fmt.Errorf(
+			"clear deleted EKS state: %w",
+			errEKSConfigurationUnavailable,
+		)
+	}
+
+	region := strings.TrimSpace(ctx.EKSConfig.Region)
+	if region == "" {
+		return fmt.Errorf("clear deleted EKS state: %w", state.ErrInvalidRegion)
+	}
+
+	err := state.DeleteEKSRegionState(clusterName, region)
+	if err != nil {
+		return fmt.Errorf("clear deleted EKS state: %w", err)
+	}
+
+	return nil
+}
+
 // persistReconciledEKSComponentState records the ownership resulting from this
 // update pass. When the controller was not touched, the reconciler returns the
 // existing exact-region marker instead of inferring ownership from desired config.

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -1,0 +1,48 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+)
+
+// persistRequiredEKSComponentState saves the declarative baseline needed to
+// reconcile non-introspectable EKS component ownership. Unlike the wider
+// best-effort spec snapshot, failure is fatal because a stale component
+// baseline can make a later uninstall invisible.
+func persistRequiredEKSComponentState(
+	ctx *localregistry.Context,
+	clusterName string,
+) error {
+	if ctx == nil || ctx.ClusterCfg == nil ||
+		ctx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	if ctx.EKSConfig == nil {
+		return fmt.Errorf(
+			"persist required EKS component state: %w",
+			errEKSConfigurationUnavailable,
+		)
+	}
+
+	region := strings.TrimSpace(ctx.EKSConfig.Region)
+	spec := &ctx.ClusterCfg.Spec.Cluster
+	snapshot := state.EKSComponentState{
+		Version:                               state.EKSComponentStateVersion,
+		ClusterName:                           clusterName,
+		Region:                                region,
+		LoadBalancer:                          spec.LoadBalancer,
+		ExperimentalAWSLoadBalancerController: spec.EKS.ExperimentalAWSLoadBalancerController,
+	}
+
+	err := state.SaveEKSComponentState(clusterName, region, &snapshot)
+	if err != nil {
+		return fmt.Errorf("persist required EKS component state: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -155,7 +155,12 @@ func persistCreatedEKSComponentStateAfterWorkflow(
 	ctx *localregistry.Context,
 	clusterName string,
 	workflowErr error,
+	controllerReconciliationStarted bool,
 ) error {
+	if workflowErr != nil && !controllerReconciliationStarted {
+		return workflowErr
+	}
+
 	stateErr := persistCreatedEKSComponentState(goCtx, ctx, clusterName)
 
 	return errors.Join(workflowErr, stateErr)

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -147,6 +147,20 @@ func persistCreatedEKSComponentState(
 	)
 }
 
+// persistCreatedEKSComponentStateAfterWorkflow preserves controller ownership
+// created before a later workflow stage failed, while retaining every original
+// failure for the caller.
+func persistCreatedEKSComponentStateAfterWorkflow(
+	goCtx context.Context,
+	ctx *localregistry.Context,
+	clusterName string,
+	workflowErr error,
+) error {
+	stateErr := persistCreatedEKSComponentState(goCtx, ctx, clusterName)
+
+	return errors.Join(workflowErr, stateErr)
+}
+
 // overlayOwnedEKSControllerCleanupBaseline turns positive persisted ownership
 // into a removal-only diff signal when the desired controller is disabled.
 // Live deployed status remains authoritative when the controller is desired,

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -22,6 +22,7 @@ func persistRequiredEKSComponentState(
 	ctx *localregistry.Context,
 	clusterName string,
 	controllerManaged bool,
+	releaseIdentity string,
 ) error {
 	if ctx == nil || ctx.ClusterCfg == nil ||
 		ctx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
@@ -37,11 +38,12 @@ func persistRequiredEKSComponentState(
 
 	region := strings.TrimSpace(ctx.EKSConfig.Region)
 	snapshot := state.EKSComponentState{
-		Version:                                 state.EKSComponentStateVersion,
-		ClusterName:                             clusterName,
-		Region:                                  region,
-		AWSLoadBalancerControllerManaged:        controllerManaged,
-		AWSLoadBalancerControllerServiceAccount: ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount,
+		Version:                                  state.EKSComponentStateVersion,
+		ClusterName:                              clusterName,
+		Region:                                   region,
+		AWSLoadBalancerControllerManaged:         controllerManaged,
+		AWSLoadBalancerControllerReleaseIdentity: releaseIdentity,
+		AWSLoadBalancerControllerServiceAccount:  ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount,
 	}
 
 	err := state.SaveEKSComponentState(clusterName, region, &snapshot)
@@ -102,12 +104,17 @@ func persistReconciledEKSComponentState(
 		)
 	}
 
-	controllerManaged, err := reconciler.eksLoadBalancerControllerManagedAfterReconcile()
+	controllerManaged, releaseIdentity, err := reconciler.eksLoadBalancerControllerOwnershipAfterReconcile()
 	if err != nil {
 		return err
 	}
 
-	return persistRequiredEKSComponentState(ctx, clusterName, controllerManaged)
+	return persistRequiredEKSComponentState(
+		ctx,
+		clusterName,
+		controllerManaged,
+		releaseIdentity,
+	)
 }
 
 // persistCreatedEKSComponentState verifies post-create GitOps ownership before
@@ -123,7 +130,7 @@ func persistCreatedEKSComponentState(
 		return nil
 	}
 
-	controllerManaged, err := setup.EKSLoadBalancerControllerManagedByKSail(
+	controllerManaged, releaseIdentity, err := setup.EKSLoadBalancerControllerManagedByKSail(
 		goCtx,
 		ctx.ClusterCfg,
 		getInstallerFactories(),
@@ -132,5 +139,10 @@ func persistCreatedEKSComponentState(
 		return fmt.Errorf("resolve EKS controller ownership after creation: %w", err)
 	}
 
-	return persistRequiredEKSComponentState(ctx, clusterName, controllerManaged)
+	return persistRequiredEKSComponentState(
+		ctx,
+		clusterName,
+		controllerManaged,
+		releaseIdentity,
+	)
 }

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -37,16 +37,23 @@ func persistRequiredEKSComponentState(
 	}
 
 	region := strings.TrimSpace(ctx.EKSConfig.Region)
+
+	accountID, err := resolveEKSContextAccountID(ctx, clusterName, region)
+	if err != nil {
+		return fmt.Errorf("persist required EKS component state: %w", err)
+	}
+
 	snapshot := state.EKSComponentState{
 		Version:                                  state.EKSComponentStateVersion,
 		ClusterName:                              clusterName,
 		Region:                                   region,
+		AccountID:                                accountID,
 		AWSLoadBalancerControllerManaged:         controllerManaged,
 		AWSLoadBalancerControllerReleaseIdentity: releaseIdentity,
 		AWSLoadBalancerControllerServiceAccount:  ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount,
 	}
 
-	err := state.SaveEKSComponentState(clusterName, region, &snapshot)
+	err = state.SaveEKSComponentState(clusterName, region, &snapshot)
 	if err != nil {
 		return fmt.Errorf("persist required EKS component state: %w", err)
 	}
@@ -76,7 +83,12 @@ func clearDeletedEKSState(ctx *localregistry.Context, clusterName string) error 
 		return fmt.Errorf("clear deleted EKS state: %w", state.ErrInvalidRegion)
 	}
 
-	err := state.DeleteEKSRegionState(clusterName, region)
+	accountID, err := resolveEKSContextAccountID(ctx, clusterName, region)
+	if err != nil {
+		return fmt.Errorf("clear deleted EKS state: %w", err)
+	}
+
+	err = state.DeleteEKSRegionState(clusterName, region, accountID)
 	if err != nil {
 		return fmt.Errorf("clear deleted EKS state: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
@@ -34,6 +35,7 @@ func persistRequiredEKSComponentState(
 		Version:                                 state.EKSComponentStateVersion,
 		ClusterName:                             clusterName,
 		Region:                                  region,
+		AWSLoadBalancerControllerManaged:        setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
 		AWSLoadBalancerControllerServiceAccount: ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount,
 	}
 

--- a/pkg/cli/cmd/cluster/eks_component_state.go
+++ b/pkg/cli/cmd/cluster/eks_component_state.go
@@ -146,3 +146,44 @@ func persistCreatedEKSComponentState(
 		releaseIdentity,
 	)
 }
+
+// overlayOwnedEKSControllerCleanupBaseline turns positive persisted ownership
+// into a removal-only diff signal when the desired controller is disabled.
+// Live deployed status remains authoritative when the controller is desired,
+// so an absent release still produces an install diff. On disable, however, an
+// owned failed/pending Helm revision must reach the identity-checked uninstall
+// path even though normal component detection reports it inactive.
+func overlayOwnedEKSControllerCleanupBaseline(
+	currentSpec, desiredSpec *v1alpha1.ClusterSpec,
+	clusterName, region string,
+) error {
+	if currentSpec == nil || desiredSpec == nil ||
+		desiredSpec.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	desired := &v1alpha1.Cluster{}
+
+	desired.Spec.Cluster = *desiredSpec
+	if setup.NeedsLoadBalancerInstall(desired) {
+		return nil
+	}
+
+	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	if err != nil {
+		if errors.Is(err, state.ErrEKSComponentStateNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("load EKS controller cleanup ownership: %w", err)
+	}
+
+	if !snapshot.AWSLoadBalancerControllerManaged {
+		return nil
+	}
+
+	currentSpec.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	currentSpec.EKS.ExperimentalAWSLoadBalancerController = true
+
+	return nil
+}

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -635,6 +635,90 @@ func TestApplyInPlaceChangesPersistsControllerMutationOnPartialFailure(t *testin
 	assert.Equal(t, "partial-success-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
 }
 
+// TestApplyInPlaceChangesPersistsOwnershipAfterPartialControllerInstall proves
+// a Helm error after creating a KSail-labelled revision retains the concrete
+// UID needed to clean up that partial release on a later disable.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestApplyInPlaceChangesPersistsOwnershipAfterPartialControllerInstall(t *testing.T) {
+	const (
+		clusterName = "partial-controller-install"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	owned := true
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{
+		installErr:      assert.AnError,
+		releaseIdentity: "partial-install-uid",
+		releaseOwned:    &owned,
+	})
+
+	ctx := managedEKSComponentContext(clusterName)
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
+		Field: specdiff.EKSLoadBalancerControllerField, OldValue: "false", NewValue: "true",
+	})
+
+	err := cluster.ExportApplyInPlaceChanges(
+		newReconcileTestCmd(),
+		&fakeUpdater{result: clusterupdate.NewEmptyUpdateResult()},
+		clusterName,
+		&v1alpha1.ClusterSpec{}, ctx, diff, nil, false, false,
+	)
+
+	require.ErrorIs(t, err, cluster.ErrUpdateChangesFailed)
+
+	snapshot, loadErr := state.LoadEKSComponentState(
+		clusterName,
+		region,
+		testEKSComponentAccountID,
+	)
+	require.NoError(t, loadErr)
+	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Equal(t, "partial-install-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
+}
+
+// TestApplyOrReportChangesRepairsMissingControllerOwnershipOnNoChange proves a
+// transient state-save failure can be retried after Helm has already converged.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestApplyOrReportChangesRepairsMissingControllerOwnershipOnNoChange(t *testing.T) {
+	const (
+		clusterName = "no-change-controller-state-repair"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	owned := true
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{
+		releaseIdentity: "recovered-release-uid",
+		releaseOwned:    &owned,
+	})
+
+	ctx := managedEKSComponentContext(clusterName)
+	err := cluster.ExportApplyOrReportChanges(
+		newReconcileTestCmd(),
+		ctx,
+		clusterName,
+		&fakeUpdater{result: clusterupdate.NewEmptyUpdateResult()},
+		&v1alpha1.ClusterSpec{},
+		clusterupdate.NewEmptyUpdateResult(),
+	)
+	require.NoError(t, err)
+
+	snapshot, loadErr := state.LoadEKSComponentState(
+		clusterName,
+		region,
+		testEKSComponentAccountID,
+	)
+	require.NoError(t, loadErr)
+	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Equal(t, "recovered-release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
+}
+
 func setEKSControllerTestInstaller(
 	t *testing.T,
 	fakeInstaller *recordingEKSLoadBalancerInstaller,

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -203,6 +203,34 @@ func TestFinishRecreateFlowPersistsEKSControllerOwnership(t *testing.T) {
 	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
 }
 
+// TestFinishRecreateFlowPersistsControllerOwnershipAfterPartialFailure proves
+// a later create-phase failure cannot orphan an already-installed controller.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestFinishRecreateFlowPersistsControllerOwnershipAfterPartialFailure(t *testing.T) {
+	const (
+		clusterName = "partial-recreate-component-state"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{})
+
+	creationErr := assert.AnError
+	err := cluster.ExportFinishRecreateFlow(
+		managedEKSComponentContext(clusterName),
+		clusterName,
+		creationErr,
+	)
+
+	require.ErrorIs(t, err, creationErr)
+
+	snapshot, loadErr := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, loadErr)
+	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
+}
+
 // TestFinishRecreateFlowPersistsReplacementClusterSpec proves recreation
 // restores the declarative baseline cleared immediately after deletion.
 //

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -195,7 +195,7 @@ func TestFinishRecreateFlowPersistsEKSControllerOwnership(t *testing.T) {
 	}))
 
 	ctx := managedEKSComponentContext(clusterName)
-	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil))
+	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil, true))
 
 	snapshot, err := state.LoadEKSComponentState(clusterName, region)
 	require.NoError(t, err)
@@ -221,6 +221,7 @@ func TestFinishRecreateFlowPersistsControllerOwnershipAfterPartialFailure(t *tes
 		managedEKSComponentContext(clusterName),
 		clusterName,
 		creationErr,
+		true,
 	)
 
 	require.ErrorIs(t, err, creationErr)
@@ -229,6 +230,37 @@ func TestFinishRecreateFlowPersistsControllerOwnershipAfterPartialFailure(t *tes
 	require.NoError(t, loadErr)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
 	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
+}
+
+// TestFinishRecreateFlowSkipsOwnershipLookupAfterTotalCreationFailure proves
+// an error before post-CNI reconciliation does not add a live Helm round trip
+// to the original creation failure.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestFinishRecreateFlowSkipsOwnershipLookupAfterTotalCreationFailure(t *testing.T) {
+	const (
+		clusterName = "failed-recreate-component-state"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	installer := &recordingEKSLoadBalancerInstaller{}
+	setEKSControllerTestInstaller(t, installer)
+
+	creationErr := assert.AnError
+	err := cluster.ExportFinishRecreateFlow(
+		managedEKSComponentContext(clusterName),
+		clusterName,
+		creationErr,
+		false,
+	)
+
+	require.ErrorIs(t, err, creationErr)
+	assert.Zero(t, installer.gitOpsManagedCalls)
+
+	_, loadErr := state.LoadEKSComponentState(clusterName, region)
+	require.ErrorIs(t, loadErr, state.ErrEKSComponentStateNotFound)
 }
 
 // TestFinishRecreateFlowPersistsReplacementClusterSpec proves recreation
@@ -248,7 +280,7 @@ func TestFinishRecreateFlowPersistsReplacementClusterSpec(t *testing.T) {
 
 	ctx := managedEKSComponentContext(clusterName)
 	ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount = "replacement-sa"
-	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil))
+	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil, true))
 
 	snapshot, err := state.LoadClusterSpec(clusterName)
 	require.NoError(t, err)
@@ -270,7 +302,7 @@ func TestFinishRecreateFlowDoesNotClaimGitOpsManagedController(t *testing.T) {
 	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{gitOpsManaged: true})
 
 	ctx := managedEKSComponentContext(clusterName)
-	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil))
+	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil, true))
 
 	snapshot, err := state.LoadEKSComponentState(clusterName, region)
 	require.NoError(t, err)

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -254,8 +254,14 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 			initial: new(true), wantManaged: false, wantRemove: 1,
 		},
 		{
-			name: "GitOps-skipped install remains unowned", oldOptIn: false, newOptIn: true,
-			initial: new(false), wantManaged: false, wantInstall: 1, installSkip: true, wantErr: true,
+			name:        "GitOps-skipped install remains unowned",
+			oldOptIn:    false,
+			newOptIn:    true,
+			initial:     new(false),
+			wantManaged: false,
+			wantInstall: 1,
+			installSkip: true,
+			wantErr:     true,
 		},
 	}
 

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -112,6 +112,32 @@ func TestFinishRecreateFlowPersistsEKSControllerOwnership(t *testing.T) {
 	snapshot, err := state.LoadEKSComponentState(clusterName, region)
 	require.NoError(t, err)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
+}
+
+// TestFinishRecreateFlowPersistsReplacementClusterSpec proves recreation
+// restores the declarative baseline cleared immediately after deletion.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestFinishRecreateFlowPersistsReplacementClusterSpec(t *testing.T) {
+	const clusterName = "recreated-spec-state"
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{})
+
+	oldSpec := &v1alpha1.ClusterSpec{}
+	oldSpec.Distribution = v1alpha1.DistributionEKS
+	oldSpec.Provider = v1alpha1.ProviderAWS
+	require.NoError(t, state.SaveClusterSpec(clusterName, oldSpec))
+
+	ctx := managedEKSComponentContext(clusterName)
+	ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount = "replacement-sa"
+	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil))
+
+	snapshot, err := state.LoadClusterSpec(clusterName)
+	require.NoError(t, err)
+	assert.True(t, snapshot.EKS.ExperimentalAWSLoadBalancerController)
+	assert.Equal(t, "replacement-sa", snapshot.EKS.AWSLoadBalancerControllerServiceAccount)
 }
 
 // TestFinishRecreateFlowDoesNotClaimGitOpsManagedController proves a successful recreation does
@@ -147,10 +173,11 @@ func TestClearDeletedEKSStateInvalidatesControllerOwnership(t *testing.T) {
 
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
 	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
-		Version:                          state.EKSComponentStateVersion,
-		ClusterName:                      clusterName,
-		Region:                           region,
-		AWSLoadBalancerControllerManaged: true,
+		Version:                                  state.EKSComponentStateVersion,
+		ClusterName:                              clusterName,
+		Region:                                   region,
+		AWSLoadBalancerControllerManaged:         true,
+		AWSLoadBalancerControllerReleaseIdentity: "release-uid",
 	}))
 
 	ctx := managedEKSComponentContext(clusterName)
@@ -216,6 +243,7 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 		wantInstall int
 		wantRemove  int
 		installSkip bool
+		wantErr     bool
 	}{
 		{
 			name: "successful install claims ownership", oldOptIn: false, newOptIn: true,
@@ -227,7 +255,7 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 		},
 		{
 			name: "GitOps-skipped install remains unowned", oldOptIn: false, newOptIn: true,
-			wantManaged: false, wantInstall: 1, installSkip: true,
+			initial: new(false), wantManaged: false, wantInstall: 1, installSkip: true, wantErr: true,
 		},
 	}
 
@@ -241,12 +269,19 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 				require.NoError(t, state.SaveEKSComponentState(
 					clusterName,
 					region,
-					&state.EKSComponentState{
-						Version:                          state.EKSComponentStateVersion,
-						ClusterName:                      clusterName,
-						Region:                           region,
-						AWSLoadBalancerControllerManaged: *testCase.initial,
-					},
+					func() *state.EKSComponentState {
+						snapshot := &state.EKSComponentState{
+							Version:                          state.EKSComponentStateVersion,
+							ClusterName:                      clusterName,
+							Region:                           region,
+							AWSLoadBalancerControllerManaged: *testCase.initial,
+						}
+						if *testCase.initial {
+							snapshot.AWSLoadBalancerControllerReleaseIdentity = "release-uid"
+						}
+
+						return snapshot
+					}(),
 				))
 			}
 
@@ -281,7 +316,11 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 				false,
 				false,
 			)
-			require.NoError(t, err)
+			if testCase.wantErr {
+				require.ErrorIs(t, err, cluster.ErrUpdateChangesFailed)
+			} else {
+				require.NoError(t, err)
+			}
 
 			snapshot, err := state.LoadEKSComponentState(clusterName, region)
 			require.NoError(t, err)
@@ -290,6 +329,92 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 			assert.Equal(t, testCase.wantRemove, fakeInstaller.uninstallCalls)
 		})
 	}
+}
+
+// TestApplyInPlaceChangesRejectsSkippedEKSControllerMutation proves a GitOps
+// skip cannot advance the requested service-account baseline as though Helm
+// converged it.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestApplyInPlaceChangesRejectsSkippedEKSControllerMutation(t *testing.T) {
+	const (
+		clusterName = "skipped-controller-update"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
+		Version: state.EKSComponentStateVersion, ClusterName: clusterName, Region: region,
+		AWSLoadBalancerControllerServiceAccount: "old-service-account",
+	}))
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{installSkipped: true})
+
+	ctx := managedEKSComponentContext(clusterName)
+	ctx.ClusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount = "new-service-account"
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
+		Field:    specdiff.EKSLoadBalancerControllerField,
+		OldValue: "enabled|serviceAccount=old-service-account",
+		NewValue: "enabled|serviceAccount=new-service-account",
+	})
+
+	err := cluster.ExportApplyInPlaceChanges(
+		newReconcileTestCmd(), &fakeUpdater{result: clusterupdate.NewEmptyUpdateResult()},
+		clusterName, &v1alpha1.ClusterSpec{}, ctx, diff, nil, false, false,
+	)
+
+	require.ErrorIs(t, err, cluster.ErrUpdateChangesFailed)
+
+	snapshot, loadErr := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, loadErr)
+	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Equal(t, "old-service-account", snapshot.AWSLoadBalancerControllerServiceAccount)
+}
+
+// TestApplyInPlaceChangesPersistsControllerMutationOnPartialFailure proves an
+// unrelated failed change cannot discard ownership evidence for a Helm
+// mutation that already succeeded in the same reconciliation pass.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestApplyInPlaceChangesPersistsControllerMutationOnPartialFailure(t *testing.T) {
+	const (
+		clusterName = "partial-controller-update"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{
+		releaseIdentity: "partial-success-uid",
+	})
+
+	restoreCSI := cluster.SetCSIInstallerFactoryForTests(nil)
+	t.Cleanup(restoreCSI)
+
+	ctx := managedEKSComponentContext(clusterName)
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = append(
+		diff.InPlaceChanges,
+		clusterupdate.Change{
+			Field: specdiff.EKSLoadBalancerControllerField, OldValue: "false", NewValue: "true",
+		},
+		clusterupdate.Change{
+			Field: "cluster.csi", OldValue: string(v1alpha1.CSIDisabled), NewValue: "ebs",
+		},
+	)
+
+	err := cluster.ExportApplyInPlaceChanges(
+		newReconcileTestCmd(),
+		&fakeUpdater{result: clusterupdate.NewEmptyUpdateResult()},
+		clusterName,
+		&v1alpha1.ClusterSpec{}, ctx, diff, nil, false, false,
+	)
+
+	require.ErrorIs(t, err, cluster.ErrUpdateChangesFailed)
+
+	snapshot, loadErr := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, loadErr)
+	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Equal(t, "partial-success-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
 }
 
 func setEKSControllerTestInstaller(

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -3,12 +3,16 @@ package cluster_test
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	cluster "github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,4 +84,172 @@ func TestPersistRequiredEKSComponentState_FailsClosed(t *testing.T) {
 
 	err = cluster.ExportPersistRequiredEKSComponentState(ctx, clusterName)
 	require.ErrorContains(t, err, "persist required EKS component state")
+}
+
+// TestFinishRecreateFlowPersistsEKSControllerOwnership proves the recreate path replaces a stale
+// exact-region ownership marker with the controller ownership established by the new cluster.
+//
+//nolint:paralleltest // writes exact-region state under the package-isolated test HOME.
+func TestFinishRecreateFlowPersistsEKSControllerOwnership(t *testing.T) {
+	const (
+		clusterName = "recreated-component-state"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
+		Version:                          state.EKSComponentStateVersion,
+		ClusterName:                      clusterName,
+		Region:                           region,
+		AWSLoadBalancerControllerManaged: false,
+	}))
+
+	ctx := managedEKSComponentContext(clusterName, region)
+	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil))
+
+	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, err)
+	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+}
+
+// TestApplyInPlaceChangesDoesNotClaimManualEKSController proves an unrelated successful update
+// cannot infer KSail ownership solely from an already-satisfied desired controller opt-in.
+//
+//nolint:paralleltest // writes exact-region state under the package-isolated test HOME.
+func TestApplyInPlaceChangesDoesNotClaimManualEKSController(t *testing.T) {
+	const (
+		clusterName = "manual-controller-unrelated-update"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	ctx := managedEKSComponentContext(clusterName, region)
+	result := clusterupdate.NewEmptyUpdateResult()
+	result.AppliedChanges = append(result.AppliedChanges, clusterupdate.Change{
+		Field: "controlPlanes", OldValue: "1", NewValue: "3",
+	})
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
+		Field: "controlPlanes", OldValue: "1", NewValue: "3",
+	})
+
+	err := cluster.ExportApplyInPlaceChanges(
+		newReconcileTestCmd(),
+		&fakeUpdater{result: result},
+		clusterName,
+		&v1alpha1.ClusterSpec{},
+		ctx,
+		diff,
+		nil,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+
+	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, err)
+	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
+}
+
+// TestApplyInPlaceChangesPersistsActualEKSControllerOutcome proves exact-region ownership follows
+// successful Helm activity in both directions rather than merely mirroring desired configuration.
+//
+//nolint:funlen,paralleltest // replaces the process-global installer factory and writes state.
+func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
+	const region = "eu-north-1"
+
+	testCases := []struct {
+		name        string
+		oldOptIn    bool
+		newOptIn    bool
+		initial     *bool
+		wantManaged bool
+		wantInstall int
+		wantRemove  int
+	}{
+		{
+			name: "successful install claims ownership", oldOptIn: false, newOptIn: true,
+			wantManaged: true, wantInstall: 1,
+		},
+		{
+			name: "successful uninstall releases ownership", oldOptIn: true, newOptIn: false,
+			initial: new(true), wantManaged: false, wantRemove: 1,
+		},
+	}
+
+	for index, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			clusterName := "controller-outcome-" + strconv.Itoa(index)
+
+			t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+			if testCase.initial != nil {
+				require.NoError(t, state.SaveEKSComponentState(
+					clusterName,
+					region,
+					&state.EKSComponentState{
+						Version:                          state.EKSComponentStateVersion,
+						ClusterName:                      clusterName,
+						Region:                           region,
+						AWSLoadBalancerControllerManaged: *testCase.initial,
+					},
+				))
+			}
+
+			fakeInstaller := &recordingEKSLoadBalancerInstaller{}
+			restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+				func(_ *v1alpha1.Cluster) (installer.Installer, error) {
+					return fakeInstaller, nil
+				},
+			)
+
+			t.Cleanup(restore)
+
+			ctx := managedEKSComponentContext(clusterName, region)
+			ctx.ClusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = testCase.newOptIn
+			diff := clusterupdate.NewEmptyUpdateResult()
+			diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
+				Field:    specdiff.EKSLoadBalancerControllerField,
+				OldValue: strconv.FormatBool(testCase.oldOptIn),
+				NewValue: strconv.FormatBool(testCase.newOptIn),
+			})
+
+			err := cluster.ExportApplyInPlaceChanges(
+				newReconcileTestCmd(),
+				&fakeUpdater{result: clusterupdate.NewEmptyUpdateResult()},
+				clusterName,
+				&v1alpha1.ClusterSpec{},
+				ctx,
+				diff,
+				nil,
+				false,
+				false,
+			)
+			require.NoError(t, err)
+
+			snapshot, err := state.LoadEKSComponentState(clusterName, region)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.wantManaged, snapshot.AWSLoadBalancerControllerManaged)
+			assert.Equal(t, testCase.wantInstall, fakeInstaller.installCalls)
+			assert.Equal(t, testCase.wantRemove, fakeInstaller.uninstallCalls)
+		})
+	}
+}
+
+func managedEKSComponentContext(clusterName, region string) *localregistry.Context {
+	ctx := &localregistry.Context{
+		ClusterCfg: &v1alpha1.Cluster{},
+		EKSConfig: &clusterprovisioner.EKSConfig{
+			Name:   clusterName,
+			Region: region,
+		},
+	}
+	ctx.ClusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	ctx.ClusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	ctx.ClusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	ctx.ClusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = true
+
+	return ctx
 }

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -97,6 +97,7 @@ func TestFinishRecreateFlowPersistsEKSControllerOwnership(t *testing.T) {
 	)
 
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{})
 
 	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
 		Version:                          state.EKSComponentStateVersion,
@@ -105,12 +106,33 @@ func TestFinishRecreateFlowPersistsEKSControllerOwnership(t *testing.T) {
 		AWSLoadBalancerControllerManaged: false,
 	}))
 
-	ctx := managedEKSComponentContext(clusterName, region)
+	ctx := managedEKSComponentContext(clusterName)
 	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil))
 
 	snapshot, err := state.LoadEKSComponentState(clusterName, region)
 	require.NoError(t, err)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+}
+
+// TestFinishRecreateFlowDoesNotClaimGitOpsManagedController proves a successful recreation does
+// not infer KSail ownership when the shared installer deliberately preserved a GitOps release.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestFinishRecreateFlowDoesNotClaimGitOpsManagedController(t *testing.T) {
+	const (
+		clusterName = "recreated-gitops-controller"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{gitOpsManaged: true})
+
+	ctx := managedEKSComponentContext(clusterName)
+	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil))
+
+	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, err)
+	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
 }
 
 // TestApplyInPlaceChangesDoesNotClaimManualEKSController proves an unrelated successful update
@@ -125,7 +147,7 @@ func TestApplyInPlaceChangesDoesNotClaimManualEKSController(t *testing.T) {
 
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
 
-	ctx := managedEKSComponentContext(clusterName, region)
+	ctx := managedEKSComponentContext(clusterName)
 	result := clusterupdate.NewEmptyUpdateResult()
 	result.AppliedChanges = append(result.AppliedChanges, clusterupdate.Change{
 		Field: "controlPlanes", OldValue: "1", NewValue: "3",
@@ -168,6 +190,7 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 		wantManaged bool
 		wantInstall int
 		wantRemove  int
+		installSkip bool
 	}{
 		{
 			name: "successful install claims ownership", oldOptIn: false, newOptIn: true,
@@ -176,6 +199,10 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 		{
 			name: "successful uninstall releases ownership", oldOptIn: true, newOptIn: false,
 			initial: new(true), wantManaged: false, wantRemove: 1,
+		},
+		{
+			name: "GitOps-skipped install remains unowned", oldOptIn: false, newOptIn: true,
+			wantManaged: false, wantInstall: 1, installSkip: true,
 		},
 	}
 
@@ -198,7 +225,9 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 				))
 			}
 
-			fakeInstaller := &recordingEKSLoadBalancerInstaller{}
+			fakeInstaller := &recordingEKSLoadBalancerInstaller{
+				installSkipped: testCase.installSkip,
+			}
 			restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
 				func(_ *v1alpha1.Cluster) (installer.Installer, error) {
 					return fakeInstaller, nil
@@ -207,7 +236,7 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 
 			t.Cleanup(restore)
 
-			ctx := managedEKSComponentContext(clusterName, region)
+			ctx := managedEKSComponentContext(clusterName)
 			ctx.ClusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = testCase.newOptIn
 			diff := clusterupdate.NewEmptyUpdateResult()
 			diff.InPlaceChanges = append(diff.InPlaceChanges, clusterupdate.Change{
@@ -238,12 +267,27 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 	}
 }
 
-func managedEKSComponentContext(clusterName, region string) *localregistry.Context {
+func setEKSControllerTestInstaller(
+	t *testing.T,
+	fakeInstaller *recordingEKSLoadBalancerInstaller,
+) {
+	t.Helper()
+
+	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+		func(_ *v1alpha1.Cluster) (installer.Installer, error) {
+			return fakeInstaller, nil
+		},
+	)
+
+	t.Cleanup(restore)
+}
+
+func managedEKSComponentContext(clusterName string) *localregistry.Context {
 	ctx := &localregistry.Context{
 		ClusterCfg: &v1alpha1.Cluster{},
 		EKSConfig: &clusterprovisioner.EKSConfig{
 			Name:   clusterName,
-			Region: region,
+			Region: "eu-north-1",
 		},
 	}
 	ctx.ClusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -135,6 +135,31 @@ func TestFinishRecreateFlowDoesNotClaimGitOpsManagedController(t *testing.T) {
 	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
 }
 
+// TestClearDeletedEKSStateInvalidatesControllerOwnership proves recreation clears the deleted
+// cluster's exact-region ownership evidence before any replacement cluster can be attempted.
+//
+//nolint:paralleltest // writes exact-region state under the package-isolated test HOME.
+func TestClearDeletedEKSStateInvalidatesControllerOwnership(t *testing.T) {
+	const (
+		clusterName = "failed-recreate-component-state"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
+		Version:                          state.EKSComponentStateVersion,
+		ClusterName:                      clusterName,
+		Region:                           region,
+		AWSLoadBalancerControllerManaged: true,
+	}))
+
+	ctx := managedEKSComponentContext(clusterName)
+	require.NoError(t, cluster.ExportClearDeletedEKSState(ctx, clusterName))
+
+	_, err := state.LoadEKSComponentState(clusterName, region)
+	require.ErrorIs(t, err, state.ErrEKSComponentStateNotFound)
+}
+
 // TestApplyInPlaceChangesDoesNotClaimManualEKSController proves an unrelated successful update
 // cannot infer KSail ownership solely from an already-satisfied desired controller opt-in.
 //

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -35,7 +35,8 @@ func TestPersistRequiredEKSComponentStateRecordsControllerOwnership(t *testing.T
 	)
 
 	ctx := &localregistry.Context{
-		ClusterCfg: &v1alpha1.Cluster{},
+		ClusterCfg:   &v1alpha1.Cluster{},
+		EKSAccountID: testEKSComponentAccountID,
 		EKSConfig: &clusterprovisioner.EKSConfig{
 			Name:   clusterName,
 			Region: region,
@@ -49,13 +50,13 @@ func TestPersistRequiredEKSComponentStateRecordsControllerOwnership(t *testing.T
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
 
 	require.NoError(t, cluster.ExportPersistRequiredEKSComponentState(ctx, clusterName))
-	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	snapshot, err := state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 	require.NoError(t, err)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
 
 	ctx.ClusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = false
 	require.NoError(t, cluster.ExportPersistRequiredEKSComponentState(ctx, clusterName))
-	snapshot, err = state.LoadEKSComponentState(clusterName, region)
+	snapshot, err = state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 	require.NoError(t, err)
 	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
 }
@@ -68,10 +69,12 @@ func TestOverlayOwnedEKSControllerCleanupBaselineExposesFailedReleaseForRemoval(
 	)
 
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	saveTestEKSOwnership(t, clusterName, region)
 	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
 		Version:                                  state.EKSComponentStateVersion,
 		ClusterName:                              clusterName,
 		Region:                                   region,
+		AccountID:                                testEKSComponentAccountID,
 		AWSLoadBalancerControllerManaged:         true,
 		AWSLoadBalancerControllerReleaseIdentity: "failed-release-uid",
 	}))
@@ -110,10 +113,12 @@ func TestOverlayOwnedEKSControllerCleanupBaselineDoesNotMaskMissingDesiredReleas
 	)
 
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	saveTestEKSOwnership(t, clusterName, region)
 	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
 		Version:                                  state.EKSComponentStateVersion,
 		ClusterName:                              clusterName,
 		Region:                                   region,
+		AccountID:                                testEKSComponentAccountID,
 		AWSLoadBalancerControllerManaged:         true,
 		AWSLoadBalancerControllerReleaseIdentity: "missing-release-uid",
 	}))
@@ -159,7 +164,8 @@ func TestPersistRequiredEKSComponentState_FailsClosed(t *testing.T) {
 	))
 
 	ctx := &localregistry.Context{
-		ClusterCfg: &v1alpha1.Cluster{},
+		ClusterCfg:   &v1alpha1.Cluster{},
+		EKSAccountID: testEKSComponentAccountID,
 		EKSConfig: &clusterprovisioner.EKSConfig{
 			Name:   clusterName,
 			Region: "eu-north-1",
@@ -191,13 +197,14 @@ func TestFinishRecreateFlowPersistsEKSControllerOwnership(t *testing.T) {
 		Version:                          state.EKSComponentStateVersion,
 		ClusterName:                      clusterName,
 		Region:                           region,
+		AccountID:                        testEKSComponentAccountID,
 		AWSLoadBalancerControllerManaged: false,
 	}))
 
 	ctx := managedEKSComponentContext(clusterName)
 	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil, true))
 
-	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	snapshot, err := state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 	require.NoError(t, err)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
 	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
@@ -226,7 +233,11 @@ func TestFinishRecreateFlowPersistsControllerOwnershipAfterPartialFailure(t *tes
 
 	require.ErrorIs(t, err, creationErr)
 
-	snapshot, loadErr := state.LoadEKSComponentState(clusterName, region)
+	snapshot, loadErr := state.LoadEKSComponentState(
+		clusterName,
+		region,
+		testEKSComponentAccountID,
+	)
 	require.NoError(t, loadErr)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
 	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
@@ -259,7 +270,7 @@ func TestFinishRecreateFlowSkipsOwnershipLookupAfterTotalCreationFailure(t *test
 	require.ErrorIs(t, err, creationErr)
 	assert.Zero(t, installer.gitOpsManagedCalls)
 
-	_, loadErr := state.LoadEKSComponentState(clusterName, region)
+	_, loadErr := state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 	require.ErrorIs(t, loadErr, state.ErrEKSComponentStateNotFound)
 }
 
@@ -304,7 +315,7 @@ func TestFinishRecreateFlowDoesNotClaimGitOpsManagedController(t *testing.T) {
 	ctx := managedEKSComponentContext(clusterName)
 	require.NoError(t, cluster.ExportFinishRecreateFlow(ctx, clusterName, nil, true))
 
-	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	snapshot, err := state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 	require.NoError(t, err)
 	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
 }
@@ -324,6 +335,7 @@ func TestClearDeletedEKSStateInvalidatesControllerOwnership(t *testing.T) {
 		Version:                                  state.EKSComponentStateVersion,
 		ClusterName:                              clusterName,
 		Region:                                   region,
+		AccountID:                                testEKSComponentAccountID,
 		AWSLoadBalancerControllerManaged:         true,
 		AWSLoadBalancerControllerReleaseIdentity: "release-uid",
 	}))
@@ -331,7 +343,7 @@ func TestClearDeletedEKSStateInvalidatesControllerOwnership(t *testing.T) {
 	ctx := managedEKSComponentContext(clusterName)
 	require.NoError(t, cluster.ExportClearDeletedEKSState(ctx, clusterName))
 
-	_, err := state.LoadEKSComponentState(clusterName, region)
+	_, err := state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 	require.ErrorIs(t, err, state.ErrEKSComponentStateNotFound)
 }
 
@@ -346,6 +358,7 @@ func TestApplyInPlaceChangesDoesNotClaimManualEKSController(t *testing.T) {
 	)
 
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	saveTestEKSOwnership(t, clusterName, region)
 
 	ctx := managedEKSComponentContext(clusterName)
 	result := clusterupdate.NewEmptyUpdateResult()
@@ -370,7 +383,7 @@ func TestApplyInPlaceChangesDoesNotClaimManualEKSController(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	snapshot, err := state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 	require.NoError(t, err)
 	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
 }
@@ -418,6 +431,7 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 			clusterName := "controller-outcome-" + strconv.Itoa(index)
 
 			t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+			saveTestEKSOwnership(t, clusterName, region)
 
 			if testCase.initial != nil {
 				require.NoError(t, state.SaveEKSComponentState(
@@ -428,6 +442,7 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 							Version:                          state.EKSComponentStateVersion,
 							ClusterName:                      clusterName,
 							Region:                           region,
+							AccountID:                        testEKSComponentAccountID,
 							AWSLoadBalancerControllerManaged: *testCase.initial,
 						}
 						if *testCase.initial {
@@ -476,7 +491,11 @@ func TestApplyInPlaceChangesPersistsActualEKSControllerOutcome(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			snapshot, err := state.LoadEKSComponentState(clusterName, region)
+			snapshot, err := state.LoadEKSComponentState(
+				clusterName,
+				region,
+				testEKSComponentAccountID,
+			)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.wantManaged, snapshot.AWSLoadBalancerControllerManaged)
 			assert.Equal(t, testCase.wantInstall, fakeInstaller.installCalls)
@@ -497,8 +516,10 @@ func TestApplyInPlaceChangesRejectsSkippedEKSControllerMutation(t *testing.T) {
 	)
 
 	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	saveTestEKSOwnership(t, clusterName, region)
 	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
 		Version: state.EKSComponentStateVersion, ClusterName: clusterName, Region: region,
+		AccountID:                               testEKSComponentAccountID,
 		AWSLoadBalancerControllerServiceAccount: "old-service-account",
 	}))
 	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{installSkipped: true})
@@ -519,7 +540,11 @@ func TestApplyInPlaceChangesRejectsSkippedEKSControllerMutation(t *testing.T) {
 
 	require.ErrorIs(t, err, cluster.ErrUpdateChangesFailed)
 
-	snapshot, loadErr := state.LoadEKSComponentState(clusterName, region)
+	snapshot, loadErr := state.LoadEKSComponentState(
+		clusterName,
+		region,
+		testEKSComponentAccountID,
+	)
 	require.NoError(t, loadErr)
 	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
 	assert.Equal(t, "old-service-account", snapshot.AWSLoadBalancerControllerServiceAccount)
@@ -565,7 +590,11 @@ func TestApplyInPlaceChangesPersistsControllerMutationOnPartialFailure(t *testin
 
 	require.ErrorIs(t, err, cluster.ErrUpdateChangesFailed)
 
-	snapshot, loadErr := state.LoadEKSComponentState(clusterName, region)
+	snapshot, loadErr := state.LoadEKSComponentState(
+		clusterName,
+		region,
+		testEKSComponentAccountID,
+	)
 	require.NoError(t, loadErr)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
 	assert.Equal(t, "partial-success-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
@@ -588,7 +617,8 @@ func setEKSControllerTestInstaller(
 
 func managedEKSComponentContext(clusterName string) *localregistry.Context {
 	ctx := &localregistry.Context{
-		ClusterCfg: &v1alpha1.Cluster{},
+		ClusterCfg:   &v1alpha1.Cluster{},
+		EKSAccountID: testEKSComponentAccountID,
 		EKSConfig: &clusterprovisioner.EKSConfig{
 			Name:   clusterName,
 			Region: "eu-north-1",

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -18,6 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func changeFields(changes []clusterupdate.Change) []string {
+	fields := make([]string, 0, len(changes))
+	for _, change := range changes {
+		fields = append(fields, change.Field)
+	}
+
+	return fields
+}
+
 //nolint:paralleltest // writes exact-region state under the package-isolated test HOME.
 func TestPersistRequiredEKSComponentStateRecordsControllerOwnership(t *testing.T) {
 	const (
@@ -49,6 +58,85 @@ func TestPersistRequiredEKSComponentStateRecordsControllerOwnership(t *testing.T
 	snapshot, err = state.LoadEKSComponentState(clusterName, region)
 	require.NoError(t, err)
 	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
+}
+
+//nolint:paralleltest // writes exact-region state under the package-isolated test HOME.
+func TestOverlayOwnedEKSControllerCleanupBaselineExposesFailedReleaseForRemoval(t *testing.T) {
+	const (
+		clusterName = "failed-owned-controller"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
+		Version:                                  state.EKSComponentStateVersion,
+		ClusterName:                              clusterName,
+		Region:                                   region,
+		AWSLoadBalancerControllerManaged:         true,
+		AWSLoadBalancerControllerReleaseIdentity: "failed-release-uid",
+	}))
+
+	current := clusterupdate.DefaultCurrentSpec(
+		v1alpha1.DistributionEKS,
+		v1alpha1.ProviderAWS,
+	)
+	desired := *current
+	desired.LoadBalancer = v1alpha1.LoadBalancerDisabled
+	desired.EKS.ExperimentalAWSLoadBalancerController = false
+
+	require.NoError(t, cluster.ExportOverlayOwnedEKSControllerCleanupBaseline(
+		current,
+		&desired,
+		clusterName,
+		region,
+	))
+	assert.Equal(t, v1alpha1.LoadBalancerEnabled, current.LoadBalancer)
+	assert.True(
+		t,
+		current.EKS.ExperimentalAWSLoadBalancerController,
+		"positive ownership must expose inactive Helm history as a removal diff",
+	)
+
+	result := specdiff.NewEngine(v1alpha1.DistributionEKS, v1alpha1.ProviderAWS).
+		ComputeDiff(current, &desired, nil, nil)
+	assert.Contains(t, changeFields(result.InPlaceChanges), specdiff.EKSLoadBalancerControllerField)
+}
+
+//nolint:paralleltest // writes exact-region state under the package-isolated test HOME.
+func TestOverlayOwnedEKSControllerCleanupBaselineDoesNotMaskMissingDesiredRelease(t *testing.T) {
+	const (
+		clusterName = "missing-desired-controller"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
+		Version:                                  state.EKSComponentStateVersion,
+		ClusterName:                              clusterName,
+		Region:                                   region,
+		AWSLoadBalancerControllerManaged:         true,
+		AWSLoadBalancerControllerReleaseIdentity: "missing-release-uid",
+	}))
+
+	current := clusterupdate.DefaultCurrentSpec(
+		v1alpha1.DistributionEKS,
+		v1alpha1.ProviderAWS,
+	)
+	desired := *current
+	desired.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	desired.EKS.ExperimentalAWSLoadBalancerController = true
+
+	require.NoError(t, cluster.ExportOverlayOwnedEKSControllerCleanupBaseline(
+		current,
+		&desired,
+		clusterName,
+		region,
+	))
+	assert.False(
+		t,
+		current.EKS.ExperimentalAWSLoadBalancerController,
+		"a desired but missing release must remain inactive so update reinstalls it",
+	)
 }
 
 // TestPersistRequiredEKSComponentState_FailsClosed proves an applied EKS

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -9,8 +9,43 @@ import (
 	cluster "github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+//nolint:paralleltest // writes exact-region state under the package-isolated test HOME.
+func TestPersistRequiredEKSComponentStateRecordsControllerOwnership(t *testing.T) {
+	const (
+		clusterName = "managed-component-state"
+		region      = "eu-north-1"
+	)
+
+	ctx := &localregistry.Context{
+		ClusterCfg: &v1alpha1.Cluster{},
+		EKSConfig: &clusterprovisioner.EKSConfig{
+			Name:   clusterName,
+			Region: region,
+		},
+	}
+	ctx.ClusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	ctx.ClusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	ctx.ClusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	ctx.ClusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = true
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	require.NoError(t, cluster.ExportPersistRequiredEKSComponentState(ctx, clusterName))
+	snapshot, err := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, err)
+	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+
+	ctx.ClusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = false
+	require.NoError(t, cluster.ExportPersistRequiredEKSComponentState(ctx, clusterName))
+	snapshot, err = state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, err)
+	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
+}
 
 // TestPersistRequiredEKSComponentState_FailsClosed proves an applied EKS
 // component mutation cannot report success when its exact-region baseline

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -243,6 +243,41 @@ func TestFinishRecreateFlowPersistsControllerOwnershipAfterPartialFailure(t *tes
 	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
 }
 
+// TestFinishRecreateFlowDoesNotClaimManualControllerAfterPartialFailure proves an earlier
+// post-CNI failure cannot turn a pre-existing unlabelled Helm release into KSail ownership.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestFinishRecreateFlowDoesNotClaimManualControllerAfterPartialFailure(t *testing.T) {
+	const (
+		clusterName = "partial-recreate-manual-controller"
+		region      = "eu-north-1"
+	)
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+	setEKSControllerTestInstaller(t, &recordingEKSLoadBalancerInstaller{
+		releaseOwned: new(false),
+	})
+
+	creationErr := assert.AnError
+	err := cluster.ExportFinishRecreateFlow(
+		managedEKSComponentContext(clusterName),
+		clusterName,
+		creationErr,
+		true,
+	)
+
+	require.ErrorIs(t, err, creationErr)
+
+	snapshot, loadErr := state.LoadEKSComponentState(
+		clusterName,
+		region,
+		testEKSComponentAccountID,
+	)
+	require.NoError(t, loadErr)
+	assert.False(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Empty(t, snapshot.AWSLoadBalancerControllerReleaseIdentity)
+}
+
 // TestFinishRecreateFlowSkipsOwnershipLookupAfterTotalCreationFailure proves
 // an error before post-CNI reconciliation does not add a live Helm round trip
 // to the original creation failure.

--- a/pkg/cli/cmd/cluster/eks_component_state_test.go
+++ b/pkg/cli/cmd/cluster/eks_component_state_test.go
@@ -1,0 +1,48 @@
+package cluster_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	cluster "github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPersistRequiredEKSComponentState_FailsClosed proves an applied EKS
+// component mutation cannot report success when its exact-region baseline
+// cannot be persisted.
+//
+//nolint:paralleltest // creates a deliberate path obstruction under isolated test HOME
+func TestPersistRequiredEKSComponentState_FailsClosed(t *testing.T) {
+	const clusterName = "unwritable-component-state"
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	clustersDir := filepath.Join(home, ".ksail", "clusters")
+	require.NoError(t, os.MkdirAll(clustersDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(clustersDir, clusterName),
+		[]byte("blocked"),
+		0o600,
+	))
+
+	ctx := &localregistry.Context{
+		ClusterCfg: &v1alpha1.Cluster{},
+		EKSConfig: &clusterprovisioner.EKSConfig{
+			Name:   clusterName,
+			Region: "eu-north-1",
+		},
+	}
+	ctx.ClusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	ctx.ClusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	ctx.ClusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	ctx.ClusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = true
+
+	err = cluster.ExportPersistRequiredEKSComponentState(ctx, clusterName)
+	require.ErrorContains(t, err, "persist required EKS component state")
+}

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -1181,6 +1181,7 @@ func persistEKSRegionComponentStates(t *testing.T, clusterName string) {
 			Version:     state.EKSComponentStateVersion,
 			ClusterName: clusterName,
 			Region:      region,
+			AccountID:   testEKSComponentAccountID,
 		}
 		require.NoError(t, state.SaveEKSComponentState(clusterName, region, snapshot))
 	}
@@ -1190,7 +1191,7 @@ func assertEKSRegionComponentStatesRemain(t *testing.T, clusterName string) {
 	t.Helper()
 
 	for _, region := range []string{"eu-north-1", "us-east-1"} {
-		_, err := state.LoadEKSComponentState(clusterName, region)
+		_, err := state.LoadEKSComponentState(clusterName, region, testEKSComponentAccountID)
 		require.NoError(t, err, "state for region %s must remain", region)
 	}
 }

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -1133,9 +1133,9 @@ func TestAutoDeleteEKSUsesCreatedTargetAndCreationRegion(t *testing.T) {
 
 // TestDeleteResolvedEKSStateFailsClosedWithoutRegion proves ordinary deletion cannot erase
 // every same-named EKS target's state when exact-region resolution is unavailable.
+//
+//nolint:paralleltest // writes package-isolated state for one fixed cluster name.
 func TestDeleteResolvedEKSStateFailsClosedWithoutRegion(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-
 	const clusterName = "delete-missing-region-eks-6231"
 	persistEKSRegionComponentStates(t, clusterName)
 
@@ -1149,6 +1149,8 @@ func TestDeleteResolvedEKSStateFailsClosedWithoutRegion(t *testing.T) {
 
 // TestDeleteTTLEKSStateFailsClosedWithoutRegion proves TTL cleanup cannot erase every same-named
 // EKS target's state when its exact-region configuration is absent or incomplete.
+//
+//nolint:paralleltest // subtests reuse one package-isolated cluster-state fixture.
 func TestDeleteTTLEKSStateFailsClosedWithoutRegion(t *testing.T) {
 	testCases := map[string]*clusterprovisioner.EKSConfig{
 		"missing config": nil,
@@ -1156,9 +1158,8 @@ func TestDeleteTTLEKSStateFailsClosedWithoutRegion(t *testing.T) {
 	}
 
 	for name, eksConfig := range testCases {
+		//nolint:paralleltest // subtests reuse the same cluster name and state paths.
 		t.Run(name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
-
 			const clusterName = "ttl-missing-region-eks-6231"
 			persistEKSRegionComponentStates(t, clusterName)
 

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -1131,6 +1131,70 @@ func TestAutoDeleteEKSUsesCreatedTargetAndCreationRegion(t *testing.T) {
 	assertParentAWSEnvironmentUnchanged(t)
 }
 
+// TestDeleteResolvedEKSStateFailsClosedWithoutRegion proves ordinary deletion cannot erase
+// every same-named EKS target's state when exact-region resolution is unavailable.
+func TestDeleteResolvedEKSStateFailsClosedWithoutRegion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "delete-missing-region-eks-6231"
+	persistEKSRegionComponentStates(t, clusterName)
+
+	err := cluster.ExportDeleteResolvedClusterState(&lifecycle.ResolvedClusterInfo{
+		ClusterName: clusterName,
+		Provider:    v1alpha1.ProviderAWS,
+	})
+	require.ErrorIs(t, err, state.ErrInvalidRegion)
+	assertEKSRegionComponentStatesRemain(t, clusterName)
+}
+
+// TestDeleteTTLEKSStateFailsClosedWithoutRegion proves TTL cleanup cannot erase every same-named
+// EKS target's state when its exact-region configuration is absent or incomplete.
+func TestDeleteTTLEKSStateFailsClosedWithoutRegion(t *testing.T) {
+	testCases := map[string]*clusterprovisioner.EKSConfig{
+		"missing config": nil,
+		"blank region":   {},
+	}
+
+	for name, eksConfig := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			const clusterName = "ttl-missing-region-eks-6231"
+			persistEKSRegionComponentStates(t, clusterName)
+
+			err := cluster.ExportDeleteTTLClusterState(
+				clusterName,
+				standaloneEKSTTLClusterConfig(),
+				eksConfig,
+			)
+			require.ErrorIs(t, err, state.ErrInvalidRegion)
+			assertEKSRegionComponentStatesRemain(t, clusterName)
+		})
+	}
+}
+
+func persistEKSRegionComponentStates(t *testing.T, clusterName string) {
+	t.Helper()
+
+	for _, region := range []string{"eu-north-1", "us-east-1"} {
+		snapshot := &state.EKSComponentState{
+			Version:     state.EKSComponentStateVersion,
+			ClusterName: clusterName,
+			Region:      region,
+		}
+		require.NoError(t, state.SaveEKSComponentState(clusterName, region, snapshot))
+	}
+}
+
+func assertEKSRegionComponentStatesRemain(t *testing.T, clusterName string) {
+	t.Helper()
+
+	for _, region := range []string{"eu-north-1", "us-east-1"} {
+		_, err := state.LoadEKSComponentState(clusterName, region)
+		require.NoError(t, err, "state for region %s must remain", region)
+	}
+}
+
 // TestAutoDeleteEKSFailsClosedWithoutOwnership verifies TTL never constructs a destructive
 // provisioner when ownership provenance is absent or the actual EKS target is unavailable.
 //

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -260,7 +260,7 @@ func ExportFinishRecreateFlow(
 	clusterName string,
 	creationErr error,
 ) error {
-	return finishRecreateFlow(ctx, clusterName, creationErr)
+	return finishRecreateFlow(context.Background(), ctx, clusterName, creationErr)
 }
 
 // ExportComputeUpdateDiff exposes updateOrchestrator.computeUpdateDiff for testing.

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -123,8 +123,33 @@ func ExportPersistRequiredEKSComponentState(
 }
 
 // ExportFinishCreateWithTTL exports the create finalization ordering for testing.
-func ExportFinishCreateWithTTL(requiredStateErr error, waitForTTL func() error) error {
-	return finishCreateWithTTL(requiredStateErr, waitForTTL)
+func ExportFinishCreateWithTTL(
+	requiredStateErr error,
+	cleanupFailedTTLCreate func() error,
+	waitForTTL func() error,
+) error {
+	return finishCreateWithTTL(requiredStateErr, cleanupFailedTTLCreate, waitForTTL)
+}
+
+// ExportPromoteUnsupportedInPlaceChanges exposes fail-closed updater field routing.
+func ExportPromoteUnsupportedInPlaceChanges(
+	updater clusterprovisioner.Updater,
+	diff *clusterupdate.UpdateResult,
+) {
+	promoteUnsupportedInPlaceChanges(updater, diff)
+}
+
+// ExportOverlayOwnedEKSControllerCleanupBaseline exposes the owned failed-release cleanup signal.
+func ExportOverlayOwnedEKSControllerCleanupBaseline(
+	currentSpec, desiredSpec *v1alpha1.ClusterSpec,
+	clusterName, region string,
+) error {
+	return overlayOwnedEKSControllerCleanupBaseline(
+		currentSpec,
+		desiredSpec,
+		clusterName,
+		region,
+	)
 }
 
 // ExportResolveClusterContext exports resolveClusterContext for testing.

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -221,7 +221,12 @@ func ExportApplyInPlaceChanges(
 	force bool,
 	allowRolling bool,
 ) error {
-	reconciler := newComponentReconciler(cmd, ctx.ClusterCfg, clusterName)
+	eksRegion := ""
+	if ctx.EKSConfig != nil {
+		eksRegion = ctx.EKSConfig.Region
+	}
+
+	reconciler := newComponentReconciler(cmd, ctx.ClusterCfg, clusterName, eksRegion)
 
 	return applyInPlaceChanges(
 		cmd, updater, reconciler, clusterName,
@@ -460,8 +465,9 @@ func ExportReconcileComponents(
 	clusterCfg *v1alpha1.Cluster,
 	diff *clusterupdate.UpdateResult,
 	result *clusterupdate.UpdateResult,
+	eksRegion ...string,
 ) error {
-	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster", eksRegion...)
 
 	return r.reconcileComponents(context.Background(), diff, result)
 }

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -108,7 +108,11 @@ func ExportPersistRequiredEKSComponentState(
 	ctx *localregistry.Context,
 	clusterName string,
 ) error {
-	return persistRequiredEKSComponentState(ctx, clusterName)
+	return persistRequiredEKSComponentState(
+		ctx,
+		clusterName,
+		setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
+	)
 }
 
 // ExportFinishCreateWithTTL exports the create finalization ordering for testing.
@@ -248,6 +252,15 @@ func ExportExecuteRecreateFlow(
 	}
 
 	return orchestrator.executeRecreateFlow()
+}
+
+// ExportFinishRecreateFlow exposes successful recreation finalization for safety tests.
+func ExportFinishRecreateFlow(
+	ctx *localregistry.Context,
+	clusterName string,
+	creationErr error,
+) error {
+	return finishRecreateFlow(ctx, clusterName, creationErr)
 }
 
 // ExportComputeUpdateDiff exposes updateOrchestrator.computeUpdateDiff for testing.

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -323,6 +323,24 @@ func ExportComputeUpdateDiff(
 	return orchestrator.computeUpdateDiff(updater)
 }
 
+// ExportApplyOrReportChanges exposes the no-change state-repair boundary for tests.
+func ExportApplyOrReportChanges(
+	cmd *cobra.Command,
+	ctx *localregistry.Context,
+	clusterName string,
+	updater clusterprovisioner.Updater,
+	currentSpec *v1alpha1.ClusterSpec,
+	diff *clusterupdate.UpdateResult,
+) error {
+	orchestrator := &updateOrchestrator{
+		cmd:         cmd,
+		ctx:         ctx,
+		clusterName: clusterName,
+	}
+
+	return orchestrator.applyOrReportChanges(updater, currentSpec, diff, nil)
+}
+
 // ExportReportNoApplicableChanges exports reportNoApplicableChanges for testing.
 func ExportReportNoApplicableChanges(cmd *cobra.Command, diff *clusterupdate.UpdateResult) {
 	reportNoApplicableChanges(cmd, diff)

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -111,6 +111,11 @@ func ExportPersistRequiredEKSComponentState(
 	return persistRequiredEKSComponentState(ctx, clusterName)
 }
 
+// ExportFinishCreateWithTTL exports the create finalization ordering for testing.
+func ExportFinishCreateWithTTL(requiredStateErr error, waitForTTL func() error) error {
+	return finishCreateWithTTL(requiredStateErr, waitForTTL)
+}
+
 // ExportResolveClusterContext exports resolveClusterContext for testing.
 func ExportResolveClusterContext(kubeconfigPath, clusterName string) (string, error) {
 	return resolveClusterContext(kubeconfigPath, clusterName)

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -291,8 +291,15 @@ func ExportFinishRecreateFlow(
 	ctx *localregistry.Context,
 	clusterName string,
 	creationErr error,
+	controllerReconciliationStarted bool,
 ) error {
-	return finishRecreateFlow(context.Background(), ctx, clusterName, creationErr)
+	return finishRecreateFlow(
+		context.Background(),
+		ctx,
+		clusterName,
+		creationErr,
+		controllerReconciliationStarted,
+	)
 }
 
 // ExportClearDeletedEKSState exposes the post-delete state invalidation boundary.

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -103,6 +103,14 @@ func ExportCreateAndVerifyProvisioner(
 	return createAndVerifyProvisioner(cmd, ctx, clusterName)
 }
 
+// ExportPersistRequiredEKSComponentState exports the fail-closed EKS component writer for testing.
+func ExportPersistRequiredEKSComponentState(
+	ctx *localregistry.Context,
+	clusterName string,
+) error {
+	return persistRequiredEKSComponentState(ctx, clusterName)
+}
+
 // ExportResolveClusterContext exports resolveClusterContext for testing.
 func ExportResolveClusterContext(kubeconfigPath, clusterName string) (string, error) {
 	return resolveClusterContext(kubeconfigPath, clusterName)

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -112,6 +112,13 @@ func ExportPersistRequiredEKSComponentState(
 		ctx,
 		clusterName,
 		setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
+		func() string {
+			if setup.NeedsLoadBalancerInstall(ctx.ClusterCfg) {
+				return "test-release-uid"
+			}
+
+			return ""
+		}(),
 	)
 }
 

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -263,6 +263,11 @@ func ExportFinishRecreateFlow(
 	return finishRecreateFlow(context.Background(), ctx, clusterName, creationErr)
 }
 
+// ExportClearDeletedEKSState exposes the post-delete state invalidation boundary.
+func ExportClearDeletedEKSState(ctx *localregistry.Context, clusterName string) error {
+	return clearDeletedEKSState(ctx, clusterName)
+}
+
 // ExportComputeUpdateDiff exposes updateOrchestrator.computeUpdateDiff for testing.
 func ExportComputeUpdateDiff(
 	cmd *cobra.Command,

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -378,6 +378,20 @@ func ExportAutoDeleteCluster(
 	return autoDeleteCluster(cmd, clusterName, clusterCfg, eksConfig)
 }
 
+// ExportDeleteResolvedClusterState exposes exact-target state cleanup for safety tests.
+func ExportDeleteResolvedClusterState(resolved *lifecycle.ResolvedClusterInfo) error {
+	return deleteResolvedClusterState(resolved)
+}
+
+// ExportDeleteTTLClusterState exposes TTL state cleanup for safety tests.
+func ExportDeleteTTLClusterState(
+	clusterName string,
+	clusterCfg *v1alpha1.Cluster,
+	eksConfig *clusterprovisioner.EKSConfig,
+) error {
+	return deleteTTLClusterState(clusterName, clusterCfg, eksConfig)
+}
+
 // ExportNormalizeVersionTag exposes normalizeVersionTag for testing.
 func ExportNormalizeVersionTag(tag string) string {
 	return normalizeVersionTag(tag)

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -302,7 +302,7 @@ func runClusterCreationWorkflow(
 	cfgManager *ksailconfigmanager.ConfigManager,
 	ctx *localregistry.Context,
 	deps lifecycle.Deps,
-) error {
+) (bool, error) {
 	localDeps := getLocalRegistryDeps()
 
 	err := ensureLocalRegistriesReady(
@@ -313,7 +313,7 @@ func runClusterCreationWorkflow(
 		localDeps,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	setupK3dCNI(ctx.ClusterCfg, ctx.K3dConfig)
@@ -324,19 +324,19 @@ func runClusterCreationWorkflow(
 
 	err = resolveNestedMirrorSpecs(cmd, cfgManager, ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	err = prepareEKSCreateIdentity(cmd.Context(), ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	configureProvisionerFactory(&deps, ctx)
 
 	err = executeClusterCreationAndCapture(cmd, ctx, deps)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Post-creation Docker steps are only needed for local Docker clusters.
@@ -359,7 +359,7 @@ func runClusterCreationWorkflow(
 			localDeps,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to connect local registry: %w", err)
+			return false, fmt.Errorf("failed to connect local registry: %w", err)
 		}
 	}
 
@@ -370,7 +370,7 @@ func runClusterCreationWorkflow(
 		localDeps.DockerInvoker,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to wait for local registry: %w", err)
+		return false, fmt.Errorf("failed to wait for local registry: %w", err)
 	}
 
 	// Set Connection.Context so post-CNI setup (InstallCNI, helm, kubectl) can resolve
@@ -383,7 +383,7 @@ func runClusterCreationWorkflow(
 	// If an explicit context is already configured, preserve it.
 	err = resolvePostCreateContext(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	maybeImportCachedImages(cmd, ctx, deps.Timer)

--- a/pkg/cli/cmd/cluster/mutation.go
+++ b/pkg/cli/cmd/cluster/mutation.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/clusterflags"
 	kubeconfigutil "github.com/devantler-tech/ksail/v7/pkg/cli/kubeconfig"
@@ -20,6 +21,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -523,6 +525,7 @@ func captureCreatedEKSIdentity(
 	}
 
 	clusterCtx.EKSConfig.Region = ownership.Region
+	clusterCtx.EKSAccountID = ownership.AccountID
 
 	return nil
 }
@@ -618,10 +621,16 @@ func resolveEKSPostCreateContext(ctx *localregistry.Context) error {
 		return err
 	}
 
+	accountID, err := resolveEKSContextAccountID(ctx, clusterName, region)
+	if err != nil {
+		return err
+	}
+
 	matches := make([]string, 0, len(config.Contexts))
 
 	for contextName := range config.Contexts {
-		if matchesEKSContext(contextName, clusterName, region) {
+		if matchesEKSContext(contextName, clusterName, region) &&
+			matchesEKSContextAccount(contextName, accountID) {
 			matches = append(matches, contextName)
 		}
 	}
@@ -637,6 +646,38 @@ func resolveEKSPostCreateContext(ctx *localregistry.Context) error {
 	pinEKSRegionFromContext(ctx, selected)
 
 	return nil
+}
+
+func resolveEKSContextAccountID(
+	ctx *localregistry.Context,
+	clusterName, region string,
+) (string, error) {
+	if accountID := strings.TrimSpace(ctx.EKSAccountID); accountID != "" {
+		return accountID, nil
+	}
+
+	ownership, err := state.LoadEKSOwnershipState(clusterName, region)
+	if err != nil {
+		return "", fmt.Errorf("load EKS ownership for kubeconfig context selection: %w", err)
+	}
+
+	ctx.EKSAccountID = ownership.AccountID
+
+	return ownership.AccountID, nil
+}
+
+func matchesEKSContextAccount(contextName, accountID string) bool {
+	identityEnd := strings.LastIndex(contextName, "@")
+	if identityEnd <= 0 {
+		return false
+	}
+
+	identity, err := awsarn.Parse(contextName[:identityEnd])
+	if err != nil {
+		return false
+	}
+
+	return identity.AccountID == accountID
 }
 
 // pinEKSRegionFromContext preserves the exact region eksctl selected after a create whose region was

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -937,7 +937,7 @@ func promoteUnsupportedInPlaceChanges(
 
 	supported := make([]clusterupdate.Change, 0, len(diff.InPlaceChanges))
 	for _, change := range diff.InPlaceChanges {
-		if isComponentReconcileField(change.Field) ||
+		if isComponentReconcileChange(change) ||
 			fieldSupport.SupportsInPlaceField(change.Field) {
 			supported = append(supported, change)
 
@@ -950,6 +950,15 @@ func promoteUnsupportedInPlaceChanges(
 	}
 
 	diff.InPlaceChanges = supported
+}
+
+func isComponentReconcileChange(change clusterupdate.Change) bool {
+	if change.Field == "cluster.metricsServer" &&
+		v1alpha1.MetricsServer(change.NewValue) == v1alpha1.MetricsServerDisabled {
+		return false
+	}
+
+	return isComponentReconcileField(change.Field)
 }
 
 // computeSpecOnlyDiff computes a spec-level diff using default values as

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -689,6 +689,18 @@ func createAndVerifyProvisioner(
 		}
 	}
 
+	// EKS contexts are identity- and region-qualified. When the config leaves the
+	// context implicit, bind the exact context written by eksctl before building
+	// Helm or Kubernetes clients; an empty Helm context would otherwise use the
+	// kubeconfig's unrelated ambient current-context.
+	if ctx.ClusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS &&
+		strings.TrimSpace(ctx.ClusterCfg.Spec.Cluster.Connection.Context) == "" {
+		err = resolveEKSPostCreateContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolve exact EKS kubeconfig context: %w", err)
+		}
+	}
+
 	// Build a ComponentDetector scoped to the running cluster.
 	// Now that kubeconfig is ensured, the detector can connect.
 	componentDetector := buildComponentDetector(cmd, ctx)
@@ -1312,6 +1324,11 @@ func finalizeInPlaceApply(
 
 	// Persist the updated ClusterSpec for future update baselines now that every
 	// change applied successfully.
+	err := persistRequiredEKSComponentState(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
 	saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
 	if saveErr != nil {
 		notify.Warningf(cmd.OutOrStderr(), "failed to save cluster state: %v", saveErr)

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1299,7 +1299,7 @@ func applyInPlaceChanges(
 
 	reportFailedChanges(cmd, result)
 
-	return finalizeInPlaceApply(cmd, ctx, clusterName, result, componentErr)
+	return finalizeInPlaceApply(cmd, ctx, reconciler, clusterName, result, componentErr)
 }
 
 // finalizeInPlaceApply reports the apply outcome: a non-empty FailedChanges set
@@ -1310,6 +1310,7 @@ func applyInPlaceChanges(
 func finalizeInPlaceApply(
 	cmd *cobra.Command,
 	ctx *localregistry.Context,
+	reconciler *componentReconciler,
 	clusterName string,
 	result *clusterupdate.UpdateResult,
 	componentErr error,
@@ -1331,7 +1332,7 @@ func finalizeInPlaceApply(
 
 	// Persist the updated ClusterSpec for future update baselines now that every
 	// change applied successfully.
-	err := persistRequiredEKSComponentState(ctx, clusterName)
+	err := persistReconciledEKSComponentState(ctx, clusterName, reconciler)
 	if err != nil {
 		return err
 	}
@@ -1405,6 +1406,26 @@ func (o *updateOrchestrator) executeRecreateFlow() error {
 		Writer:  o.cmd.OutOrStdout(),
 	})
 
-	// Execute create using shared workflow
-	return runClusterCreationWorkflow(o.cmd, o.cfgManager, o.ctx, o.deps)
+	// Execute create using shared workflow.
+	creationErr := runClusterCreationWorkflow(o.cmd, o.cfgManager, o.ctx, o.deps)
+
+	return finishRecreateFlow(o.ctx, o.clusterName, creationErr)
+}
+
+// finishRecreateFlow keeps successful recreation finalization separate from the
+// destructive delete/create orchestration so its required state is testable.
+func finishRecreateFlow(
+	ctx *localregistry.Context,
+	clusterName string,
+	creationErr error,
+) error {
+	if creationErr != nil {
+		return creationErr
+	}
+
+	return persistRequiredEKSComponentState(
+		ctx,
+		clusterName,
+		setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
+	)
 }

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1117,7 +1117,7 @@ func checkWorkloadTagDrift(
 
 	var currentTag string
 
-	switch gitOpsEngine { //nolint:exhaustive // None/empty already filtered above
+	switch gitOpsEngine {
 	case v1alpha1.GitOpsEngineFlux:
 		currentTag, err = fluxinstaller.GetCurrentSyncRef(
 			cmd.Context(), kubeconfigPath, kubeContext,
@@ -1126,6 +1126,8 @@ func checkWorkloadTagDrift(
 		currentTag, err = getCurrentArgoCDTargetRevision(
 			cmd.Context(), kubeconfigPath, kubeContext,
 		)
+	case v1alpha1.GitOpsEngineNone:
+		return
 	default:
 		return
 	}
@@ -1437,23 +1439,7 @@ func (o *updateOrchestrator) executeRecreateFlow() error {
 		return fmt.Errorf("failed to create provisioner: %w", err)
 	}
 
-	// Disconnect registries from Docker network before deletion.
-	// Required for distributions like VCluster and Talos because their provisioners
-	// destroy the Docker network during deletion, which fails if containers are
-	// still connected. Registries are reused on recreate, so only disconnect is needed.
-	if o.ctx.ClusterCfg.Spec.Cluster.Provider == v1alpha1.ProviderDocker {
-		clusterInfo := &clusterdetector.Info{
-			Distribution: o.ctx.ClusterCfg.Spec.Cluster.Distribution,
-			ClusterName:  o.clusterName,
-		}
-		// Discover first: the disconnect is scoped to THIS cluster's registries, because a
-		// network name does not identify a single cluster (see DisconnectRegistriesByInfo).
-		disconnectRegistriesBeforeDelete(
-			o.cmd,
-			clusterInfo,
-			discoverRegistriesBeforeDelete(o.cmd, clusterInfo),
-		)
-	}
+	o.disconnectRegistriesBeforeRecreate()
 
 	// Execute delete
 	notify.WriteMessage(notify.Message{
@@ -1493,6 +1479,27 @@ func (o *updateOrchestrator) executeRecreateFlow() error {
 		o.clusterName,
 		creationErr,
 		controllerReconciliationStarted,
+	)
+}
+
+// disconnectRegistriesBeforeRecreate releases Docker network attachments that
+// would otherwise prevent the provisioner from deleting the network. The
+// registries remain available for reuse by the create half of the workflow.
+func (o *updateOrchestrator) disconnectRegistriesBeforeRecreate() {
+	if o.ctx.ClusterCfg.Spec.Cluster.Provider != v1alpha1.ProviderDocker {
+		return
+	}
+
+	clusterInfo := &clusterdetector.Info{
+		Distribution: o.ctx.ClusterCfg.Spec.Cluster.Distribution,
+		ClusterName:  o.clusterName,
+	}
+	// Discover first: the disconnect is scoped to THIS cluster's registries, because a
+	// network name does not identify a single cluster (see DisconnectRegistriesByInfo).
+	disconnectRegistriesBeforeDelete(
+		o.cmd,
+		clusterInfo,
+		discoverRegistriesBeforeDelete(o.cmd, clusterInfo),
 	)
 }
 

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -881,6 +881,21 @@ func (o *updateOrchestrator) computeUpdateDiff(
 		)
 	}
 
+	eksRegion := ""
+	if o.ctx.EKSConfig != nil {
+		eksRegion = o.ctx.EKSConfig.Region
+	}
+
+	err = overlayOwnedEKSControllerCleanupBaseline(
+		currentSpec,
+		&o.ctx.ClusterCfg.Spec.Cluster,
+		o.clusterName,
+		eksRegion,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	diffEngine := specdiff.NewEngine(
 		o.ctx.ClusterCfg.Spec.Cluster.Distribution,
 		o.ctx.ClusterCfg.Spec.Cluster.Provider,
@@ -906,7 +921,35 @@ func (o *updateOrchestrator) computeUpdateDiff(
 	// Check for Flux distribution-version drift (spec.workload.flux.distributionVersion)
 	checkFluxDistributionVersionDrift(o.cmd, o.ctx, diffEngine, diff)
 
+	promoteUnsupportedInPlaceChanges(updater, diff)
+
 	return currentSpec, diff, nil
+}
+
+func promoteUnsupportedInPlaceChanges(
+	updater clusterprovisioner.Updater,
+	diff *clusterupdate.UpdateResult,
+) {
+	fieldSupport, declaresSupport := updater.(clusterprovisioner.InPlaceFieldSupport)
+	if !declaresSupport || diff == nil {
+		return
+	}
+
+	supported := make([]clusterupdate.Change, 0, len(diff.InPlaceChanges))
+	for _, change := range diff.InPlaceChanges {
+		if isComponentReconcileField(change.Field) ||
+			fieldSupport.SupportsInPlaceField(change.Field) {
+			supported = append(supported, change)
+
+			continue
+		}
+
+		change.Category = clusterupdate.ChangeCategoryRecreateRequired
+		change.Reason = "the selected provisioner cannot apply this field in-place"
+		diff.RecreateRequired = append(diff.RecreateRequired, change)
+	}
+
+	diff.InPlaceChanges = supported
 }
 
 // computeSpecOnlyDiff computes a spec-level diff using default values as

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1471,9 +1471,20 @@ func (o *updateOrchestrator) executeRecreateFlow() error {
 	})
 
 	// Execute create using shared workflow.
-	creationErr := runClusterCreationWorkflow(o.cmd, o.cfgManager, o.ctx, o.deps)
+	controllerReconciliationStarted, creationErr := runClusterCreationWorkflow(
+		o.cmd,
+		o.cfgManager,
+		o.ctx,
+		o.deps,
+	)
 
-	return finishRecreateFlow(o.cmd.Context(), o.ctx, o.clusterName, creationErr)
+	return finishRecreateFlow(
+		o.cmd.Context(),
+		o.ctx,
+		o.clusterName,
+		creationErr,
+		controllerReconciliationStarted,
+	)
 }
 
 // finishRecreateFlow keeps successful recreation finalization separate from the
@@ -1483,8 +1494,15 @@ func finishRecreateFlow(
 	ctx *localregistry.Context,
 	clusterName string,
 	creationErr error,
+	controllerReconciliationStarted bool,
 ) error {
-	err := persistCreatedEKSComponentStateAfterWorkflow(goCtx, ctx, clusterName, creationErr)
+	err := persistCreatedEKSComponentStateAfterWorkflow(
+		goCtx,
+		ctx,
+		clusterName,
+		creationErr,
+		controllerReconciliationStarted,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1484,11 +1484,7 @@ func finishRecreateFlow(
 	clusterName string,
 	creationErr error,
 ) error {
-	if creationErr != nil {
-		return creationErr
-	}
-
-	err := persistCreatedEKSComponentState(goCtx, ctx, clusterName)
+	err := persistCreatedEKSComponentStateAfterWorkflow(goCtx, ctx, clusterName, creationErr)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1192,7 +1192,14 @@ func (o *updateOrchestrator) applyOrReportChanges(
 		return nil
 	}
 
-	reconciler := newComponentReconciler(o.cmd, o.ctx.ClusterCfg, o.clusterName)
+	eksRegion := ""
+	if o.ctx.EKSConfig != nil {
+		eksRegion = o.ctx.EKSConfig.Region
+	}
+
+	reconciler := newComponentReconciler(
+		o.cmd, o.ctx.ClusterCfg, o.clusterName, eksRegion,
+	)
 
 	return applyInPlaceChanges(
 		o.cmd, updater, reconciler, o.clusterName,

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -881,16 +881,11 @@ func (o *updateOrchestrator) computeUpdateDiff(
 		)
 	}
 
-	eksRegion := ""
-	if o.ctx.EKSConfig != nil {
-		eksRegion = o.ctx.EKSConfig.Region
-	}
-
 	err = overlayOwnedEKSControllerCleanupBaseline(
 		currentSpec,
 		&o.ctx.ClusterCfg.Spec.Cluster,
 		o.clusterName,
-		eksRegion,
+		o.eksRegion(),
 	)
 	if err != nil {
 		return nil, nil, err
@@ -1234,6 +1229,11 @@ func (o *updateOrchestrator) applyOrReportChanges(
 	}
 
 	if !diff.HasInPlaceChanges() && !diff.HasRebootRequired() && !diff.HasRollingRecreate() {
+		err := o.repairEKSComponentState()
+		if err != nil {
+			return err
+		}
+
 		reportNoApplicableChanges(o.cmd, diff)
 
 		return nil
@@ -1246,19 +1246,43 @@ func (o *updateOrchestrator) applyOrReportChanges(
 		return nil
 	}
 
-	eksRegion := ""
-	if o.ctx.EKSConfig != nil {
-		eksRegion = o.ctx.EKSConfig.Region
-	}
-
 	reconciler := newComponentReconciler(
-		o.cmd, o.ctx.ClusterCfg, o.clusterName, eksRegion,
+		o.cmd, o.ctx.ClusterCfg, o.clusterName, o.eksRegion(),
 	)
 
 	return applyInPlaceChanges(
 		o.cmd, updater, reconciler, o.clusterName,
 		currentSpec, o.ctx, diff, outputTimer, o.forceDrain, allowRolling,
 	)
+}
+
+func (o *updateOrchestrator) eksRegion() string {
+	if o.ctx.EKSConfig == nil {
+		return ""
+	}
+
+	return o.ctx.EKSConfig.Region
+}
+
+// repairEKSComponentState restores verified controller ownership when an
+// earlier state write failed after Helm had already converged. Non-EKS updates
+// have no component state to repair.
+func (o *updateOrchestrator) repairEKSComponentState() error {
+	if o.ctx == nil || o.ctx.ClusterCfg == nil ||
+		o.ctx.ClusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	err := persistCreatedEKSComponentState(
+		o.cmd.Context(),
+		o.ctx,
+		o.clusterName,
+	)
+	if err != nil {
+		return fmt.Errorf("repair EKS component state after no-change update: %w", err)
+	}
+
+	return nil
 }
 
 // handleRecreateRequired warns about recreate-required changes and proceeds

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1409,12 +1409,13 @@ func (o *updateOrchestrator) executeRecreateFlow() error {
 	// Execute create using shared workflow.
 	creationErr := runClusterCreationWorkflow(o.cmd, o.cfgManager, o.ctx, o.deps)
 
-	return finishRecreateFlow(o.ctx, o.clusterName, creationErr)
+	return finishRecreateFlow(o.cmd.Context(), o.ctx, o.clusterName, creationErr)
 }
 
 // finishRecreateFlow keeps successful recreation finalization separate from the
 // destructive delete/create orchestration so its required state is testable.
 func finishRecreateFlow(
+	goCtx context.Context,
 	ctx *localregistry.Context,
 	clusterName string,
 	creationErr error,
@@ -1423,9 +1424,5 @@ func finishRecreateFlow(
 		return creationErr
 	}
 
-	return persistRequiredEKSComponentState(
-		ctx,
-		clusterName,
-		setup.NeedsLoadBalancerInstall(ctx.ClusterCfg),
-	)
+	return persistCreatedEKSComponentState(goCtx, ctx, clusterName)
 }

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1399,6 +1399,11 @@ func (o *updateOrchestrator) executeRecreateFlow() error {
 		return fmt.Errorf("failed to delete existing cluster: %w", err)
 	}
 
+	err = clearDeletedEKSState(o.ctx, o.clusterName)
+	if err != nil {
+		return err
+	}
+
 	notify.WriteMessage(notify.Message{
 		Type:    notify.SuccessType,
 		Content: "cluster deleted",

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -948,6 +948,13 @@ func promoteUnsupportedInPlaceChanges(
 }
 
 func isComponentReconcileChange(change clusterupdate.Change) bool {
+	if change.Field == "cluster.cni" {
+		// Distinct CNI choices use distinct Helm releases, and the component
+		// reconciler cannot yet remove the old release safely. Recreate until a
+		// transition can prove both installation and cleanup.
+		return false
+	}
+
 	if change.Field == "cluster.metricsServer" &&
 		v1alpha1.MetricsServer(change.NewValue) == v1alpha1.MetricsServerDisabled {
 		return false

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1304,9 +1304,9 @@ func applyInPlaceChanges(
 
 // finalizeInPlaceApply reports the apply outcome: a non-empty FailedChanges set
 // means the apply was partial or fully failed, so it returns a non-nil error so
-// cobra exits non-zero (issue #4935) and skips the state save (a partial apply no
-// longer matches the desired spec). Otherwise it persists the updated spec as the
-// next update baseline.
+// cobra exits non-zero (issue #4935) and skips the desired ClusterSpec save. An
+// EKS controller mutation that already succeeded still persists its narrower
+// ownership state. Otherwise it persists the updated spec as the next baseline.
 func finalizeInPlaceApply(
 	cmd *cobra.Command,
 	ctx *localregistry.Context,
@@ -1315,26 +1315,42 @@ func finalizeInPlaceApply(
 	result *clusterupdate.UpdateResult,
 	componentErr error,
 ) error {
+	var (
+		componentStateErr       error
+		componentStatePersisted bool
+	)
+
+	// Component reconciliation can continue after an unrelated failure. Persist
+	// a controller mutation that already succeeded before reporting the partial
+	// apply, otherwise a later disable loses the only safe ownership evidence.
+	if reconciler.hasEKSLoadBalancerOwnershipUpdate() {
+		componentStateErr = persistReconciledEKSComponentState(ctx, clusterName, reconciler)
+		componentStatePersisted = componentStateErr == nil
+	}
+
 	// A non-empty FailedChanges set means the apply was partial or fully failed.
 	// Provisioner-level failures (e.g. a rejected Talos config) are recorded in
 	// result.FailedChanges with a nil Update error, and reconcileComponents
 	// appends component-level failures there too. Return a non-nil error so cobra
 	// exits non-zero — otherwise automation gating on the exit code treats a
-	// failed update as success (issue #4935). Skip the state save: a partial apply
-	// no longer matches the desired spec, so it must not become the saved baseline.
+	// failed update as success (issue #4935). Skip the desired ClusterSpec save: a
+	// partial apply no longer matches the desired spec, so it must not become the
+	// saved baseline.
 	if result.HasFailedChanges() {
-		if componentErr != nil {
-			return fmt.Errorf("%w: %w", errUpdateChangesFailed, componentErr)
-		}
+		return errors.Join(errUpdateChangesFailed, componentErr, componentStateErr)
+	}
 
-		return errUpdateChangesFailed
+	if componentStateErr != nil {
+		return componentStateErr
 	}
 
 	// Persist the updated ClusterSpec for future update baselines now that every
 	// change applied successfully.
-	err := persistReconciledEKSComponentState(ctx, clusterName, reconciler)
-	if err != nil {
-		return err
+	if !componentStatePersisted {
+		err := persistReconciledEKSComponentState(ctx, clusterName, reconciler)
+		if err != nil {
+			return err
+		}
 	}
 
 	saveErr := state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
@@ -1429,5 +1445,15 @@ func finishRecreateFlow(
 		return creationErr
 	}
 
-	return persistCreatedEKSComponentState(goCtx, ctx, clusterName)
+	err := persistCreatedEKSComponentState(goCtx, ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	err = state.SaveClusterSpec(clusterName, &ctx.ClusterCfg.Spec.Cluster)
+	if err != nil {
+		return fmt.Errorf("persist recreated cluster state: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/cli/cmd/cluster/post_create_context_test.go
+++ b/pkg/cli/cmd/cluster/post_create_context_test.go
@@ -26,7 +26,7 @@ func TestResolvePostCreateContext_EKS(t *testing.T) {
 		clusterName = "st-eks"
 		region      = "eu-west-1"
 		firstMatch  = "arn:aws:iam::123456789012:role/ci@st-eks.eu-west-1.eksctl.io"
-		secondMatch = "dev@example.com@st-eks.eu-west-1.eksctl.io"
+		secondMatch = "arn:aws:iam::123456789012:role/operator@st-eks.eu-west-1.eksctl.io"
 	)
 
 	testCases := []struct {
@@ -98,7 +98,8 @@ func TestResolvePostCreateContext_EKS(t *testing.T) {
 						},
 					},
 				},
-				EKSConfig: &clusterprovisioner.EKSConfig{Name: clusterName, Region: region},
+				EKSConfig:    &clusterprovisioner.EKSConfig{Name: clusterName, Region: region},
+				EKSAccountID: "123456789012",
 			}
 
 			err := cluster.ExportResolvePostCreateContext(ctx)
@@ -176,7 +177,8 @@ func TestResolvePostCreateContext_EKSRegionDelegatedToProfile(t *testing.T) {
 				},
 			},
 		},
-		EKSConfig: &clusterprovisioner.EKSConfig{Name: "st-eks"},
+		EKSConfig:    &clusterprovisioner.EKSConfig{Name: "st-eks"},
+		EKSAccountID: "123456789012",
 	}
 
 	require.NoError(t, cluster.ExportResolvePostCreateContext(ctx))

--- a/pkg/cli/cmd/cluster/provisionerfactory_test.go
+++ b/pkg/cli/cmd/cluster/provisionerfactory_test.go
@@ -131,7 +131,7 @@ func TestCreateAndVerifyProvisioner_EKSBindsExactContext(t *testing.T) {
 	const (
 		clusterName   = "factory-coverage"
 		region        = "us-east-1"
-		ambient       = "ambient-other-cluster"
+		ambient       = "arn:aws:iam::999999999999:role/ci@factory-coverage.us-east-1.eksctl.io"
 		targetContext = "arn:aws:iam::123456789012:role/ci@factory-coverage.us-east-1.eksctl.io"
 	)
 
@@ -160,6 +160,7 @@ func TestCreateAndVerifyProvisioner_EKSBindsExactContext(t *testing.T) {
 	ctx.ClusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
 	ctx.ClusterCfg.Spec.Cluster.Connection.Kubeconfig = kubeconfigPath
 	ctx.EKSConfig.Region = region
+	ctx.EKSAccountID = "123456789012"
 
 	_, err := cluster.ExportCreateAndVerifyProvisioner(cmd, ctx, clusterName)
 	require.NoError(t, err)

--- a/pkg/cli/cmd/cluster/provisionerfactory_test.go
+++ b/pkg/cli/cmd/cluster/provisionerfactory_test.go
@@ -15,7 +15,10 @@ import (
 	k3dtypes "github.com/k3d-io/k3d/v5/pkg/config/types"
 	k3dv1alpha5 "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kindv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 )
 
@@ -117,4 +120,48 @@ func TestCreateAndVerifyProvisioner_HonorsFactoryOverride(t *testing.T) {
 	require.True(t, isFake,
 		"createAndVerifyProvisioner must build its provisioner via newProvisionerFactory "+
 			"(override-aware), got %T", provisioner)
+}
+
+// TestCreateAndVerifyProvisioner_EKSBindsExactContext proves component clients
+// never inherit an unrelated ambient kubeconfig context when EKS context is
+// implicit in ksail.yaml.
+//
+//nolint:paralleltest // mutates the global provisioner-factory override
+func TestCreateAndVerifyProvisioner_EKSBindsExactContext(t *testing.T) {
+	const (
+		clusterName   = "factory-coverage"
+		region        = "us-east-1"
+		ambient       = "ambient-other-cluster"
+		targetContext = "arn:aws:iam::123456789012:role/ci@factory-coverage.us-east-1.eksctl.io"
+	)
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = ambient
+	config.Clusters[ambient] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6443"}
+	config.AuthInfos[ambient] = &clientcmdapi.AuthInfo{Token: "ambient-token"}
+	config.Contexts[ambient] = &clientcmdapi.Context{Cluster: ambient, AuthInfo: ambient}
+	config.Clusters[targetContext] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6444"}
+	config.AuthInfos[targetContext] = &clientcmdapi.AuthInfo{Token: "target-token"}
+	config.Contexts[targetContext] = &clientcmdapi.Context{
+		Cluster:  targetContext,
+		AuthInfo: targetContext,
+	}
+	require.NoError(t, clientcmd.WriteToFile(*config, kubeconfigPath))
+
+	restore := cluster.SetProvisionerFactoryForTests(fakeFactory{})
+	defer restore()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	ctx := newFullyPopulatedFactoryContext()
+	ctx.ClusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	ctx.ClusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	ctx.ClusterCfg.Spec.Cluster.Connection.Kubeconfig = kubeconfigPath
+	ctx.EKSConfig.Region = region
+
+	_, err := cluster.ExportCreateAndVerifyProvisioner(cmd, ctx, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, targetContext, ctx.ClusterCfg.Spec.Cluster.Connection.Context)
 }

--- a/pkg/cli/cmd/cluster/reconcile_test.go
+++ b/pkg/cli/cmd/cluster/reconcile_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/spf13/cobra"
@@ -36,7 +37,7 @@ func TestHandlerForField_KnownFields(t *testing.T) {
 		"cluster.csi",
 		"cluster.metricsServer",
 		"cluster.loadBalancer",
-		"cluster.eks.experimentalAWSLoadBalancerController",
+		specdiff.EKSLoadBalancerControllerField,
 		"cluster.certManager",
 		"cluster.policyEngine",
 		"cluster.gitOpsEngine",

--- a/pkg/cli/cmd/cluster/reconcile_test.go
+++ b/pkg/cli/cmd/cluster/reconcile_test.go
@@ -36,6 +36,7 @@ func TestHandlerForField_KnownFields(t *testing.T) {
 		"cluster.csi",
 		"cluster.metricsServer",
 		"cluster.loadBalancer",
+		"cluster.eks.experimentalAWSLoadBalancerController",
 		"cluster.certManager",
 		"cluster.policyEngine",
 		"cluster.gitOpsEngine",

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,7 @@ type componentReconciler struct {
 	cmd         *cobra.Command
 	clusterCfg  *v1alpha1.Cluster
 	clusterName string
+	eksRegion   string
 	factories   *setup.InstallerFactories
 	// autoscalerReconciled tracks whether the cluster autoscaler has already been
 	// reconciled during this update pass. Multiple diff fields share the
@@ -52,11 +54,18 @@ func newComponentReconciler(
 	cmd *cobra.Command,
 	clusterCfg *v1alpha1.Cluster,
 	clusterName string,
+	eksRegion ...string,
 ) *componentReconciler {
+	region := ""
+	if len(eksRegion) > 0 {
+		region = strings.TrimSpace(eksRegion[0])
+	}
+
 	return &componentReconciler{
 		cmd:         cmd,
 		clusterCfg:  clusterCfg,
 		clusterName: clusterName,
+		eksRegion:   region,
 		factories:   getInstallerFactories(),
 	}
 }
@@ -236,7 +245,24 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 		return nil
 	}
 
-	err := setup.UninstallEKSLoadBalancerControllerSilent(ctx, r.clusterCfg, r.factories)
+	managed, err := r.eksLoadBalancerControllerManagedByKSail()
+	if err != nil {
+		return err
+	}
+
+	if !managed {
+		// A live Helm release without exact-region KSail ownership state may be
+		// manually managed. Preserve it rather than turning desired false into a
+		// destructive ownership claim.
+		return nil
+	}
+
+	err = setup.UninstallEKSLoadBalancerControllerSilent(
+		ctx,
+		r.clusterCfg,
+		r.factories,
+		managed,
+	)
 	if err != nil && errors.Is(err, helm.ErrReleaseNotFound) {
 		return nil
 	}
@@ -246,6 +272,23 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 	}
 
 	return nil
+}
+
+func (r *componentReconciler) eksLoadBalancerControllerManagedByKSail() (bool, error) {
+	if r.eksRegion == "" {
+		return false, nil
+	}
+
+	snapshot, err := state.LoadEKSComponentState(r.clusterName, r.eksRegion)
+	if err != nil {
+		if errors.Is(err, state.ErrEKSComponentStateNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("verify AWS load balancer controller ownership: %w", err)
+	}
+
+	return snapshot.AWSLoadBalancerControllerManaged, nil
 }
 
 // reconcileClusterAutoscaler installs or uninstalls the Cluster Autoscaler.

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -249,28 +249,38 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 	ctx context.Context,
 ) error {
 	if setup.NeedsLoadBalancerInstall(r.clusterCfg) {
-		controllerManaged, releaseIdentity, err := r.installLoadBalancer(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to install load balancer: %w", err)
-		}
-
-		if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS {
-			if !controllerManaged {
-				return errEKSLoadBalancerControllerMutationSkipped
-			}
-
-			r.eksLoadBalancerOwnershipUpdated = true
-			r.eksLoadBalancerManaged = true
-			r.eksLoadBalancerReleaseIdentity = releaseIdentity
-		}
-
-		return nil
+		return r.reconcileLoadBalancerInstall(ctx)
 	}
 
 	if r.clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
 		return nil
 	}
 
+	return r.reconcileLoadBalancerUninstall(ctx)
+}
+
+func (r *componentReconciler) reconcileLoadBalancerInstall(ctx context.Context) error {
+	controllerManaged, releaseIdentity, err := r.installLoadBalancer(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to install load balancer: %w", err)
+	}
+
+	if r.clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	if !controllerManaged {
+		return errEKSLoadBalancerControllerMutationSkipped
+	}
+
+	r.eksLoadBalancerOwnershipUpdated = true
+	r.eksLoadBalancerManaged = true
+	r.eksLoadBalancerReleaseIdentity = releaseIdentity
+
+	return nil
+}
+
+func (r *componentReconciler) reconcileLoadBalancerUninstall(ctx context.Context) error {
 	managed, releaseIdentity, err := r.eksLoadBalancerControllerOwnership()
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -33,6 +33,10 @@ var errEKSLoadBalancerControllerOwnershipRequired = errors.New(
 	"AWS load balancer controller ownership is unresolved; preserve the live release",
 )
 
+var errEKSLoadBalancerControllerMutationSkipped = errors.New(
+	"AWS load balancer controller update was skipped; desired state remains unresolved",
+)
+
 // componentReconciler applies component-level changes detected by the DiffEngine.
 // It maps field names from the diff to installer Install/Uninstall operations.
 type componentReconciler struct {
@@ -58,6 +62,7 @@ type componentReconciler struct {
 	// persistence preserves the prior exact-region ownership marker.
 	eksLoadBalancerOwnershipUpdated bool
 	eksLoadBalancerManaged          bool
+	eksLoadBalancerReleaseIdentity  string
 }
 
 // newComponentReconciler creates a reconciler for applying component changes.
@@ -244,14 +249,19 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 	ctx context.Context,
 ) error {
 	if setup.NeedsLoadBalancerInstall(r.clusterCfg) {
-		controllerManaged, err := r.installLoadBalancer(ctx)
+		controllerManaged, releaseIdentity, err := r.installLoadBalancer(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to install load balancer: %w", err)
 		}
 
 		if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS {
+			if !controllerManaged {
+				return errEKSLoadBalancerControllerMutationSkipped
+			}
+
 			r.eksLoadBalancerOwnershipUpdated = true
-			r.eksLoadBalancerManaged = controllerManaged
+			r.eksLoadBalancerManaged = true
+			r.eksLoadBalancerReleaseIdentity = releaseIdentity
 		}
 
 		return nil
@@ -261,7 +271,7 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 		return nil
 	}
 
-	managed, err := r.eksLoadBalancerControllerManagedByKSail()
+	managed, releaseIdentity, err := r.eksLoadBalancerControllerOwnership()
 	if err != nil {
 		return err
 	}
@@ -277,11 +287,13 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 		ctx,
 		r.clusterCfg,
 		r.factories,
-		managed,
+		releaseIdentity,
 	)
-	if err != nil && errors.Is(err, helm.ErrReleaseNotFound) {
+	if err != nil && (errors.Is(err, helm.ErrReleaseNotFound) ||
+		errors.Is(err, helm.ErrNoReleaseStorage)) {
 		r.eksLoadBalancerOwnershipUpdated = true
 		r.eksLoadBalancerManaged = false
+		r.eksLoadBalancerReleaseIdentity = ""
 
 		return nil
 	}
@@ -292,55 +304,66 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 
 	r.eksLoadBalancerOwnershipUpdated = true
 	r.eksLoadBalancerManaged = false
+	r.eksLoadBalancerReleaseIdentity = ""
 
 	return nil
 }
 
-func (r *componentReconciler) installLoadBalancer(ctx context.Context) (bool, error) {
+func (r *componentReconciler) installLoadBalancer(ctx context.Context) (bool, string, error) {
 	if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS {
-		managed, err := setup.InstallEKSLoadBalancerControllerWithResult(
+		managed, releaseIdentity, err := setup.InstallEKSLoadBalancerControllerWithResult(
 			ctx,
 			r.clusterCfg,
 			r.factories,
 		)
 		if err != nil {
-			return false, fmt.Errorf("install EKS load balancer controller: %w", err)
+			return false, "", fmt.Errorf("install EKS load balancer controller: %w", err)
 		}
 
-		return managed, nil
+		return managed, releaseIdentity, nil
 	}
 
 	err := setup.InstallLoadBalancerSilent(ctx, r.clusterCfg, r.factories)
 	if err != nil {
-		return false, fmt.Errorf("install load balancer: %w", err)
+		return false, "", fmt.Errorf("install load balancer: %w", err)
 	}
 
-	return false, nil
+	return false, "", nil
 }
 
-func (r *componentReconciler) eksLoadBalancerControllerManagedAfterReconcile() (bool, error) {
+func (r *componentReconciler) eksLoadBalancerControllerOwnershipAfterReconcile() (
+	bool,
+	string,
+	error,
+) {
 	if r.eksLoadBalancerOwnershipUpdated {
-		return r.eksLoadBalancerManaged, nil
+		return r.eksLoadBalancerManaged, r.eksLoadBalancerReleaseIdentity, nil
 	}
 
-	return r.eksLoadBalancerControllerManagedByKSail()
+	return r.eksLoadBalancerControllerOwnership()
 }
 
-func (r *componentReconciler) eksLoadBalancerControllerManagedByKSail() (bool, error) {
+func (r *componentReconciler) eksLoadBalancerControllerOwnership() (bool, string, error) {
 	if r.eksRegion == "" {
-		return false, nil
+		return false, "", nil
 	}
 
 	snapshot, err := state.LoadEKSComponentState(r.clusterName, r.eksRegion)
 	if err != nil {
 		if errors.Is(err, state.ErrEKSComponentStateNotFound) {
-			return false, nil
+			return false, "", nil
 		}
 
-		return false, fmt.Errorf("verify AWS load balancer controller ownership: %w", err)
+		return false, "", fmt.Errorf("verify AWS load balancer controller ownership: %w", err)
 	}
 
-	return snapshot.AWSLoadBalancerControllerManaged, nil
+	return snapshot.AWSLoadBalancerControllerManaged,
+		snapshot.AWSLoadBalancerControllerReleaseIdentity,
+		nil
+}
+
+func (r *componentReconciler) hasEKSLoadBalancerOwnershipUpdate() bool {
+	return r != nil && r.eksLoadBalancerOwnershipUpdated
 }
 
 // reconcileClusterAutoscaler installs or uninstalls the Cluster Autoscaler.

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -115,6 +115,7 @@ func (r *componentReconciler) handlerForField(
 		"cluster.workload.tag":                      r.reconcileWorkloadTag,
 		"cluster.workload.flux.distributionVersion": r.reconcileFluxVersion,
 	}
+	handlers["cluster.eks.experimentalAWSLoadBalancerController"] = r.reconcileLoadBalancer
 
 	if handler, ok := handlers[field]; ok {
 		return handler, true
@@ -193,13 +194,33 @@ func (r *componentReconciler) reconcileMetricsServer(
 // reconcileLoadBalancer installs or uninstalls the load balancer.
 func (r *componentReconciler) reconcileLoadBalancer(
 	ctx context.Context,
-	_ clusterupdate.Change,
+	change clusterupdate.Change,
 ) error {
 	if setup.NeedsLoadBalancerInstall(r.clusterCfg) {
 		err := setup.InstallLoadBalancerSilent(ctx, r.clusterCfg, r.factories)
 		if err != nil {
 			return fmt.Errorf("failed to install load balancer: %w", err)
 		}
+
+		return nil
+	}
+
+	if r.clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	if change.Field != "cluster.eks.experimentalAWSLoadBalancerController" &&
+		!r.clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController {
+		return nil
+	}
+
+	err := setup.UninstallEKSLoadBalancerControllerSilent(ctx, r.clusterCfg, r.factories)
+	if err != nil && errors.Is(err, helm.ErrReleaseNotFound) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to uninstall load balancer: %w", err)
 	}
 
 	return nil

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -27,6 +27,12 @@ var errMetricsServerDisableUnsupported = errors.New(
 	"disabling metrics-server in-place is not yet supported; use 'ksail cluster delete && ksail cluster create'",
 )
 
+// errEKSLoadBalancerControllerOwnershipRequired reports that desired removal
+// cannot converge while a live release lacks exact-region KSail ownership.
+var errEKSLoadBalancerControllerOwnershipRequired = errors.New(
+	"AWS load balancer controller ownership is unresolved; preserve the live release",
+)
+
 // componentReconciler applies component-level changes detected by the DiffEngine.
 // It maps field names from the diff to installer Install/Uninstall operations.
 type componentReconciler struct {
@@ -262,9 +268,9 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 
 	if !managed {
 		// A live Helm release without exact-region KSail ownership state may be
-		// manually managed. Preserve it rather than turning desired false into a
-		// destructive ownership claim.
-		return nil
+		// manually managed. Preserve it, but report unresolved convergence so the
+		// requested removal is not recorded in the applied baseline as success.
+		return errEKSLoadBalancerControllerOwnershipRequired
 	}
 
 	err = setup.UninstallEKSLoadBalancerControllerSilent(

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -162,6 +162,24 @@ func (r *componentReconciler) handlerForField(
 	return nil, false
 }
 
+func isComponentReconcileField(field string) bool {
+	switch field {
+	case "cluster.cni",
+		"cluster.csi",
+		"cluster.metricsServer",
+		"cluster.loadBalancer",
+		"cluster.certManager",
+		"cluster.policyEngine",
+		"cluster.gitOpsEngine",
+		"cluster.workload.tag",
+		"cluster.workload.flux.distributionVersion",
+		specdiff.EKSLoadBalancerControllerField:
+		return true
+	default:
+		return strings.HasPrefix(field, "cluster.autoscaler.node.")
+	}
+}
+
 // reconcileCNI switches the CNI by installing the new CNI.
 // The old CNI is not uninstalled — the new CNI replaces it via Helm upgrade.
 func (r *componentReconciler) reconcileCNI(_ context.Context, _ clusterupdate.Change) error {

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/kubeconfig"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
@@ -119,7 +120,7 @@ func (r *componentReconciler) handlerForField(
 		"cluster.workload.tag":                      r.reconcileWorkloadTag,
 		"cluster.workload.flux.distributionVersion": r.reconcileFluxVersion,
 	}
-	handlers["cluster.eks.experimentalAWSLoadBalancerController"] = r.reconcileLoadBalancer
+	handlers[specdiff.EKSLoadBalancerControllerField] = r.reconcileLoadBalancer
 
 	if handler, ok := handlers[field]; ok {
 		return handler, true
@@ -204,7 +205,7 @@ func (r *componentReconciler) reconcileLoadBalancer(
 	// intentionally a no-op. Do not consume the coalescing slot here: when the
 	// opt-in also changed, its later dedicated diff must still reach uninstall.
 	if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS &&
-		change.Field != "cluster.eks.experimentalAWSLoadBalancerController" &&
+		change.Field != specdiff.EKSLoadBalancerControllerField &&
 		!r.clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController {
 		return nil
 	}

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -40,6 +40,10 @@ type componentReconciler struct {
 	// subsequent calls surface the same failure instead of silently succeeding.
 	autoscalerReconciled bool
 	autoscalerErr        error
+	// loadBalancerReconciled coalesces the generic load-balancer field and the
+	// EKS-specific controller opt-in when both change in one update pass.
+	loadBalancerReconciled bool
+	loadBalancerErr        error
 }
 
 // newComponentReconciler creates a reconciler for applying component changes.
@@ -193,6 +197,20 @@ func (r *componentReconciler) reconcileMetricsServer(
 
 // reconcileLoadBalancer installs or uninstalls the load balancer.
 func (r *componentReconciler) reconcileLoadBalancer(
+	ctx context.Context,
+	change clusterupdate.Change,
+) error {
+	if r.loadBalancerReconciled {
+		return r.loadBalancerErr
+	}
+
+	r.loadBalancerReconciled = true
+	r.loadBalancerErr = r.doReconcileLoadBalancer(ctx, change)
+
+	return r.loadBalancerErr
+}
+
+func (r *componentReconciler) doReconcileLoadBalancer(
 	ctx context.Context,
 	change clusterupdate.Change,
 ) error {

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -279,6 +279,12 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 
 func (r *componentReconciler) reconcileLoadBalancerInstall(ctx context.Context) error {
 	controllerManaged, releaseIdentity, err := r.installLoadBalancer(ctx)
+	if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS && controllerManaged {
+		r.eksLoadBalancerOwnershipUpdated = true
+		r.eksLoadBalancerManaged = true
+		r.eksLoadBalancerReleaseIdentity = releaseIdentity
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to install load balancer: %w", err)
 	}
@@ -290,10 +296,6 @@ func (r *componentReconciler) reconcileLoadBalancerInstall(ctx context.Context) 
 	if !controllerManaged {
 		return errEKSLoadBalancerControllerMutationSkipped
 	}
-
-	r.eksLoadBalancerOwnershipUpdated = true
-	r.eksLoadBalancerManaged = true
-	r.eksLoadBalancerReleaseIdentity = releaseIdentity
 
 	return nil
 }
@@ -345,7 +347,10 @@ func (r *componentReconciler) installLoadBalancer(ctx context.Context) (bool, st
 			r.factories,
 		)
 		if err != nil {
-			return false, "", fmt.Errorf("install EKS load balancer controller: %w", err)
+			return managed, releaseIdentity, fmt.Errorf(
+				"install EKS load balancer controller: %w",
+				err,
+			)
 		}
 
 		return managed, releaseIdentity, nil

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -47,6 +47,11 @@ type componentReconciler struct {
 	// EKS-specific controller opt-in when both change in one update pass.
 	loadBalancerReconciled bool
 	loadBalancerErr        error
+	// eksLoadBalancerOwnershipUpdated is set only after this update pass actually
+	// installs/upgrades or uninstalls the EKS controller. If untouched, final state
+	// persistence preserves the prior exact-region ownership marker.
+	eksLoadBalancerOwnershipUpdated bool
+	eksLoadBalancerManaged          bool
 }
 
 // newComponentReconciler creates a reconciler for applying component changes.
@@ -238,6 +243,11 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 			return fmt.Errorf("failed to install load balancer: %w", err)
 		}
 
+		if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS {
+			r.eksLoadBalancerOwnershipUpdated = true
+			r.eksLoadBalancerManaged = true
+		}
+
 		return nil
 	}
 
@@ -264,6 +274,9 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 		managed,
 	)
 	if err != nil && errors.Is(err, helm.ErrReleaseNotFound) {
+		r.eksLoadBalancerOwnershipUpdated = true
+		r.eksLoadBalancerManaged = false
+
 		return nil
 	}
 
@@ -271,7 +284,18 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 		return fmt.Errorf("failed to uninstall load balancer: %w", err)
 	}
 
+	r.eksLoadBalancerOwnershipUpdated = true
+	r.eksLoadBalancerManaged = false
+
 	return nil
+}
+
+func (r *componentReconciler) eksLoadBalancerControllerManagedAfterReconcile() (bool, error) {
+	if r.eksLoadBalancerOwnershipUpdated {
+		return r.eksLoadBalancerManaged, nil
+	}
+
+	return r.eksLoadBalancerControllerManagedByKSail()
 }
 
 func (r *componentReconciler) eksLoadBalancerControllerManagedByKSail() (bool, error) {

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -200,19 +200,27 @@ func (r *componentReconciler) reconcileLoadBalancer(
 	ctx context.Context,
 	change clusterupdate.Change,
 ) error {
+	// A generic EKS load-balancer change with the controller opt-in disabled is
+	// intentionally a no-op. Do not consume the coalescing slot here: when the
+	// opt-in also changed, its later dedicated diff must still reach uninstall.
+	if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS &&
+		change.Field != "cluster.eks.experimentalAWSLoadBalancerController" &&
+		!r.clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController {
+		return nil
+	}
+
 	if r.loadBalancerReconciled {
 		return r.loadBalancerErr
 	}
 
 	r.loadBalancerReconciled = true
-	r.loadBalancerErr = r.doReconcileLoadBalancer(ctx, change)
+	r.loadBalancerErr = r.doReconcileLoadBalancer(ctx)
 
 	return r.loadBalancerErr
 }
 
 func (r *componentReconciler) doReconcileLoadBalancer(
 	ctx context.Context,
-	change clusterupdate.Change,
 ) error {
 	if setup.NeedsLoadBalancerInstall(r.clusterCfg) {
 		err := setup.InstallLoadBalancerSilent(ctx, r.clusterCfg, r.factories)
@@ -224,11 +232,6 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 	}
 
 	if r.clusterCfg.Spec.Cluster.Distribution != v1alpha1.DistributionEKS {
-		return nil
-	}
-
-	if change.Field != "cluster.eks.experimentalAWSLoadBalancerController" &&
-		!r.clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController {
 		return nil
 	}
 

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -238,14 +238,14 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 	ctx context.Context,
 ) error {
 	if setup.NeedsLoadBalancerInstall(r.clusterCfg) {
-		err := setup.InstallLoadBalancerSilent(ctx, r.clusterCfg, r.factories)
+		controllerManaged, err := r.installLoadBalancer(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to install load balancer: %w", err)
 		}
 
 		if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS {
 			r.eksLoadBalancerOwnershipUpdated = true
-			r.eksLoadBalancerManaged = true
+			r.eksLoadBalancerManaged = controllerManaged
 		}
 
 		return nil
@@ -288,6 +288,28 @@ func (r *componentReconciler) doReconcileLoadBalancer(
 	r.eksLoadBalancerManaged = false
 
 	return nil
+}
+
+func (r *componentReconciler) installLoadBalancer(ctx context.Context) (bool, error) {
+	if r.clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS {
+		managed, err := setup.InstallEKSLoadBalancerControllerWithResult(
+			ctx,
+			r.clusterCfg,
+			r.factories,
+		)
+		if err != nil {
+			return false, fmt.Errorf("install EKS load balancer controller: %w", err)
+		}
+
+		return managed, nil
+	}
+
+	err := setup.InstallLoadBalancerSilent(ctx, r.clusterCfg, r.factories)
+	if err != nil {
+		return false, fmt.Errorf("install load balancer: %w", err)
+	}
+
+	return false, nil
 }
 
 func (r *componentReconciler) eksLoadBalancerControllerManagedAfterReconcile() (bool, error) {

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -1,5 +1,4 @@
-//nolint:testpackage // White-box coverage verifies the unexported reconciliation seam.
-package cluster
+package cluster_test
 
 import (
 	"context"
@@ -7,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
-	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,15 +60,15 @@ func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			fakeInstaller := &recordingEKSLoadBalancerInstaller{}
 			factoryCalls := 0
-			restore := overrideInstallerFactory(func(factories *setup.InstallerFactories) {
-				factories.AWSLoadBalancerController = func(
+			restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+				func(
 					_ *v1alpha1.Cluster,
 				) (installer.Installer, error) {
 					factoryCalls++
 
 					return fakeInstaller, nil
-				}
-			})
+				},
+			)
 			t.Cleanup(restore)
 
 			clusterCfg := &v1alpha1.Cluster{}
@@ -79,19 +77,23 @@ func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
 			clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
 			clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = testCase.newValue
 
-			reconciler := newComponentReconciler(
-				&cobra.Command{Use: "test"}, clusterCfg, "eks-default",
-			)
-			err := reconciler.reconcileLoadBalancer(context.Background(), clusterupdate.Change{
+			detected := clusterupdate.NewEmptyUpdateResult()
+			detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
 				Field:    "cluster.eks.experimentalAWSLoadBalancerController",
 				OldValue: strconv.FormatBool(testCase.oldValue),
 				NewValue: strconv.FormatBool(testCase.newValue),
 			})
+			applied := clusterupdate.NewEmptyUpdateResult()
+
+			err := cluster.ExportReconcileComponents(
+				newReconcileTestCmd(), clusterCfg, detected, applied,
+			)
 
 			require.NoError(t, err)
 			assert.Equal(t, 1, factoryCalls)
 			assert.Equal(t, testCase.wantInstallCalls, fakeInstaller.installCalls)
 			assert.Equal(t, testCase.wantUninstallCalls, fakeInstaller.uninstallCalls)
+			assert.Len(t, applied.AppliedChanges, 1)
 		})
 	}
 }
@@ -99,13 +101,13 @@ func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
 //nolint:paralleltest // replaces the process-global installer factory.
 func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
 	fakeInstaller := &recordingEKSLoadBalancerInstaller{}
-	restore := overrideInstallerFactory(func(factories *setup.InstallerFactories) {
-		factories.AWSLoadBalancerController = func(
+	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+		func(
 			_ *v1alpha1.Cluster,
 		) (installer.Installer, error) {
 			return fakeInstaller, nil
-		}
-	})
+		},
+	)
 	t.Cleanup(restore)
 
 	clusterCfg := &v1alpha1.Cluster{}
@@ -129,11 +131,9 @@ func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
 		},
 	)
 	applied := clusterupdate.NewEmptyUpdateResult()
-	reconciler := newComponentReconciler(
-		&cobra.Command{Use: "test"}, clusterCfg, "eks-default",
+	err := cluster.ExportReconcileComponents(
+		newReconcileTestCmd(), clusterCfg, detected, applied,
 	)
-
-	err := reconciler.reconcileComponents(context.Background(), detected, applied)
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, fakeInstaller.installCalls)

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -72,6 +72,7 @@ var _ installer.Installer = (*recordingEKSLoadBalancerInstaller)(nil)
 
 func persistManagedEKSControllerState(t *testing.T, region string) {
 	t.Helper()
+	saveTestEKSOwnership(t, "test-cluster", region)
 
 	require.NoError(t, state.SaveEKSComponentState(
 		"test-cluster",
@@ -80,6 +81,7 @@ func persistManagedEKSControllerState(t *testing.T, region string) {
 			Version:                                  state.EKSComponentStateVersion,
 			ClusterName:                              "test-cluster",
 			Region:                                   region,
+			AccountID:                                testEKSComponentAccountID,
 			AWSLoadBalancerControllerManaged:         true,
 			AWSLoadBalancerControllerReleaseIdentity: "release-uid",
 		},
@@ -283,7 +285,11 @@ func TestReconcileLoadBalancer_EKSGitOpsTakeoverRemainsUnresolved(t *testing.T) 
 	assert.Empty(t, applied.AppliedChanges)
 	require.Len(t, applied.FailedChanges, 1)
 
-	snapshot, loadErr := state.LoadEKSComponentState("test-cluster", region)
+	snapshot, loadErr := state.LoadEKSComponentState(
+		"test-cluster",
+		region,
+		testEKSComponentAccountID,
+	)
 	require.NoError(t, loadErr)
 	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
 	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -10,6 +10,7 @@ import (
 	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,15 +38,35 @@ func (r *recordingEKSLoadBalancerInstaller) Images(_ context.Context) ([]string,
 
 var _ installer.Installer = (*recordingEKSLoadBalancerInstaller)(nil)
 
+func persistManagedEKSControllerState(t *testing.T, region string) {
+	t.Helper()
+
+	require.NoError(t, state.SaveEKSComponentState(
+		"test-cluster",
+		region,
+		&state.EKSComponentState{
+			Version:                          state.EKSComponentStateVersion,
+			ClusterName:                      "test-cluster",
+			Region:                           region,
+			AWSLoadBalancerControllerManaged: true,
+		},
+	))
+	t.Cleanup(func() { _ = state.DeleteClusterState("test-cluster") })
+}
+
+type eksOptInTransitionCase struct {
+	name               string
+	oldValue           bool
+	newValue           bool
+	wantInstallCalls   int
+	wantUninstallCalls int
+}
+
 //nolint:paralleltest // subtests replace the process-global installer factory.
 func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
-	tests := []struct {
-		name               string
-		oldValue           bool
-		newValue           bool
-		wantInstallCalls   int
-		wantUninstallCalls int
-	}{
+	const region = "eu-north-1"
+
+	tests := []eksOptInTransitionCase{
 		{
 			name: "enable installs", oldValue: false, newValue: true,
 			wantInstallCalls: 1,
@@ -59,48 +80,100 @@ func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
 	for _, testCase := range tests {
 		//nolint:paralleltest // each case replaces the process-global installer factory.
 		t.Run(testCase.name, func(t *testing.T) {
-			fakeInstaller := &recordingEKSLoadBalancerInstaller{}
-			factoryCalls := 0
-			restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
-				func(
-					_ *v1alpha1.Cluster,
-				) (installer.Installer, error) {
-					factoryCalls++
-
-					return fakeInstaller, nil
-				},
-			)
-			t.Cleanup(restore)
-
-			clusterCfg := &v1alpha1.Cluster{}
-			clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
-			clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
-			clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
-			clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = testCase.newValue
-
-			detected := clusterupdate.NewEmptyUpdateResult()
-			detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
-				Field:    specdiff.EKSLoadBalancerControllerField,
-				OldValue: strconv.FormatBool(testCase.oldValue),
-				NewValue: strconv.FormatBool(testCase.newValue),
-			})
-			applied := clusterupdate.NewEmptyUpdateResult()
-
-			err := cluster.ExportReconcileComponents(
-				newReconcileTestCmd(), clusterCfg, detected, applied,
-			)
-
-			require.NoError(t, err)
-			assert.Equal(t, 1, factoryCalls)
-			assert.Equal(t, testCase.wantInstallCalls, fakeInstaller.installCalls)
-			assert.Equal(t, testCase.wantUninstallCalls, fakeInstaller.uninstallCalls)
-			assert.Len(t, applied.AppliedChanges, 1)
+			runEKSOptInTransitionCase(t, testCase, region)
 		})
 	}
 }
 
+func runEKSOptInTransitionCase(
+	t *testing.T,
+	testCase eksOptInTransitionCase,
+	region string,
+) {
+	t.Helper()
+
+	fakeInstaller := &recordingEKSLoadBalancerInstaller{}
+	factoryCalls := 0
+	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+		func(_ *v1alpha1.Cluster) (installer.Installer, error) {
+			factoryCalls++
+
+			return fakeInstaller, nil
+		},
+	)
+	t.Cleanup(restore)
+
+	if testCase.wantUninstallCalls > 0 {
+		persistManagedEKSControllerState(t, region)
+	}
+
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = testCase.newValue
+
+	detected := clusterupdate.NewEmptyUpdateResult()
+	detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
+		Field:    specdiff.EKSLoadBalancerControllerField,
+		OldValue: strconv.FormatBool(testCase.oldValue),
+		NewValue: strconv.FormatBool(testCase.newValue),
+	})
+	applied := clusterupdate.NewEmptyUpdateResult()
+
+	err := cluster.ExportReconcileComponents(
+		newReconcileTestCmd(), clusterCfg, detected, applied, region,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, testCase.wantInstallCalls, fakeInstaller.installCalls)
+	assert.Equal(t, testCase.wantUninstallCalls, fakeInstaller.uninstallCalls)
+	assert.Len(t, applied.AppliedChanges, 1)
+}
+
+//nolint:paralleltest // replaces the process-global installer factory.
+func TestReconcileLoadBalancer_EKSManualReleaseIsPreserved(t *testing.T) {
+	fakeInstaller := &recordingEKSLoadBalancerInstaller{}
+	factoryCalls := 0
+	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+		func(
+			_ *v1alpha1.Cluster,
+		) (installer.Installer, error) {
+			factoryCalls++
+
+			return fakeInstaller, nil
+		},
+	)
+	t.Cleanup(restore)
+
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+
+	detected := clusterupdate.NewEmptyUpdateResult()
+	detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
+		Field:    specdiff.EKSLoadBalancerControllerField,
+		OldValue: "true",
+		NewValue: "false",
+	})
+	applied := clusterupdate.NewEmptyUpdateResult()
+
+	err := cluster.ExportReconcileComponents(
+		newReconcileTestCmd(), clusterCfg, detected, applied,
+	)
+
+	require.NoError(t, err)
+	assert.Zero(t, factoryCalls)
+	assert.Zero(t, fakeInstaller.uninstallCalls)
+	assert.Len(t, applied.AppliedChanges, 1)
+}
+
 //nolint:funlen,paralleltest // table coverage replaces the process-global installer factory.
 func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
+	const region = "eu-north-1"
+
 	tests := []struct {
 		name                string
 		desiredLoadBalancer v1alpha1.LoadBalancer
@@ -147,6 +220,10 @@ func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
 			)
 			t.Cleanup(restore)
 
+			if testCase.wantUninstallCalls > 0 {
+				persistManagedEKSControllerState(t, region)
+			}
+
 			clusterCfg := &v1alpha1.Cluster{}
 			clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
 			clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
@@ -169,7 +246,7 @@ func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
 			)
 			applied := clusterupdate.NewEmptyUpdateResult()
 			err := cluster.ExportReconcileComponents(
-				newReconcileTestCmd(), clusterCfg, detected, applied,
+				newReconcileTestCmd(), clusterCfg, detected, applied, region,
 			)
 
 			require.NoError(t, err)

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -176,10 +176,12 @@ func TestReconcileLoadBalancer_EKSManualReleaseIsPreserved(t *testing.T) {
 		newReconcileTestCmd(), clusterCfg, detected, applied,
 	)
 
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Zero(t, factoryCalls)
 	assert.Zero(t, fakeInstaller.uninstallCalls)
-	assert.Len(t, applied.AppliedChanges, 1)
+	assert.Empty(t, applied.AppliedChanges)
+	require.Len(t, applied.FailedChanges, 1)
+	assert.Contains(t, applied.FailedChanges[0].Reason, "ownership")
 }
 
 //nolint:funlen,paralleltest // table coverage replaces the process-global installer factory.

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -1,0 +1,97 @@
+//nolint:testpackage // White-box coverage verifies the unexported reconciliation seam.
+package cluster
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingEKSLoadBalancerInstaller struct {
+	installCalls   int
+	uninstallCalls int
+}
+
+func (r *recordingEKSLoadBalancerInstaller) Install(_ context.Context) error {
+	r.installCalls++
+
+	return nil
+}
+
+func (r *recordingEKSLoadBalancerInstaller) Uninstall(_ context.Context) error {
+	r.uninstallCalls++
+
+	return nil
+}
+
+func (r *recordingEKSLoadBalancerInstaller) Images(_ context.Context) ([]string, error) {
+	return nil, nil
+}
+
+var _ installer.Installer = (*recordingEKSLoadBalancerInstaller)(nil)
+
+//nolint:paralleltest // subtests replace the process-global installer factory.
+func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldValue           bool
+		newValue           bool
+		wantInstallCalls   int
+		wantUninstallCalls int
+	}{
+		{
+			name: "enable installs", oldValue: false, newValue: true,
+			wantInstallCalls: 1,
+		},
+		{
+			name: "disable uninstalls", oldValue: true, newValue: false,
+			wantUninstallCalls: 1,
+		},
+	}
+
+	for _, testCase := range tests {
+		//nolint:paralleltest // each case replaces the process-global installer factory.
+		t.Run(testCase.name, func(t *testing.T) {
+			fakeInstaller := &recordingEKSLoadBalancerInstaller{}
+			factoryCalls := 0
+			restore := overrideInstallerFactory(func(factories *setup.InstallerFactories) {
+				factories.AWSLoadBalancerController = func(
+					_ *v1alpha1.Cluster,
+				) (installer.Installer, error) {
+					factoryCalls++
+
+					return fakeInstaller, nil
+				}
+			})
+			t.Cleanup(restore)
+
+			clusterCfg := &v1alpha1.Cluster{}
+			clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+			clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+			clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+			clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = testCase.newValue
+
+			reconciler := newComponentReconciler(
+				&cobra.Command{Use: "test"}, clusterCfg, "eks-default",
+			)
+			err := reconciler.reconcileLoadBalancer(context.Background(), clusterupdate.Change{
+				Field:    "cluster.eks.experimentalAWSLoadBalancerController",
+				OldValue: strconv.FormatBool(testCase.oldValue),
+				NewValue: strconv.FormatBool(testCase.newValue),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, factoryCalls)
+			assert.Equal(t, testCase.wantInstallCalls, fakeInstaller.installCalls)
+			assert.Equal(t, testCase.wantUninstallCalls, fakeInstaller.uninstallCalls)
+		})
+	}
+}

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -22,6 +22,7 @@ type recordingEKSLoadBalancerInstaller struct {
 	uninstallCalls     int
 	gitOpsManagedCalls int
 	installSkipped     bool
+	installErr         error
 	gitOpsManaged      bool
 	releaseIdentity    string
 	releaseIdentityErr error
@@ -32,7 +33,7 @@ type recordingEKSLoadBalancerInstaller struct {
 func (r *recordingEKSLoadBalancerInstaller) Install(_ context.Context) error {
 	r.installCalls++
 
-	return nil
+	return r.installErr
 }
 
 func (r *recordingEKSLoadBalancerInstaller) InstallWithResult(ctx context.Context) (bool, error) {

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -98,44 +98,83 @@ func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // replaces the process-global installer factory.
+//nolint:funlen,paralleltest // table coverage replaces the process-global installer factory.
 func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
-	fakeInstaller := &recordingEKSLoadBalancerInstaller{}
-	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
-		func(
-			_ *v1alpha1.Cluster,
-		) (installer.Installer, error) {
-			return fakeInstaller, nil
+	tests := []struct {
+		name                string
+		desiredLoadBalancer v1alpha1.LoadBalancer
+		desiredOptIn        bool
+		genericOld          string
+		genericNew          string
+		optInOld            string
+		optInNew            string
+		wantInstallCalls    int
+		wantUninstallCalls  int
+	}{
+		{
+			name:                "enable installs once",
+			desiredLoadBalancer: v1alpha1.LoadBalancerEnabled,
+			desiredOptIn:        true,
+			genericOld:          string(v1alpha1.LoadBalancerDisabled),
+			genericNew:          string(v1alpha1.LoadBalancerEnabled),
+			optInOld:            "false",
+			optInNew:            "true",
+			wantInstallCalls:    1,
 		},
-	)
-	t.Cleanup(restore)
-
-	clusterCfg := &v1alpha1.Cluster{}
-	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
-	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
-	clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
-	clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = true
-
-	detected := clusterupdate.NewEmptyUpdateResult()
-	detected.InPlaceChanges = append(
-		detected.InPlaceChanges,
-		clusterupdate.Change{
-			Field:    "cluster.loadBalancer",
-			OldValue: string(v1alpha1.LoadBalancerDisabled),
-			NewValue: string(v1alpha1.LoadBalancerEnabled),
+		{
+			name:                "disable uninstalls once",
+			desiredLoadBalancer: v1alpha1.LoadBalancerDisabled,
+			desiredOptIn:        false,
+			genericOld:          string(v1alpha1.LoadBalancerEnabled),
+			genericNew:          string(v1alpha1.LoadBalancerDisabled),
+			optInOld:            "true",
+			optInNew:            "false",
+			wantUninstallCalls:  1,
 		},
-		clusterupdate.Change{
-			Field:    "cluster.eks.experimentalAWSLoadBalancerController",
-			OldValue: "false",
-			NewValue: "true",
-		},
-	)
-	applied := clusterupdate.NewEmptyUpdateResult()
-	err := cluster.ExportReconcileComponents(
-		newReconcileTestCmd(), clusterCfg, detected, applied,
-	)
+	}
 
-	require.NoError(t, err)
-	assert.Equal(t, 1, fakeInstaller.installCalls)
-	assert.Len(t, applied.AppliedChanges, 2)
+	for _, testCase := range tests {
+		//nolint:paralleltest // each case replaces the process-global installer factory.
+		t.Run(testCase.name, func(t *testing.T) {
+			fakeInstaller := &recordingEKSLoadBalancerInstaller{}
+			restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+				func(
+					_ *v1alpha1.Cluster,
+				) (installer.Installer, error) {
+					return fakeInstaller, nil
+				},
+			)
+			t.Cleanup(restore)
+
+			clusterCfg := &v1alpha1.Cluster{}
+			clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+			clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+			clusterCfg.Spec.Cluster.LoadBalancer = testCase.desiredLoadBalancer
+			clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = testCase.desiredOptIn
+
+			detected := clusterupdate.NewEmptyUpdateResult()
+			detected.InPlaceChanges = append(
+				detected.InPlaceChanges,
+				clusterupdate.Change{
+					Field:    "cluster.loadBalancer",
+					OldValue: testCase.genericOld,
+					NewValue: testCase.genericNew,
+				},
+				clusterupdate.Change{
+					Field:    "cluster.eks.experimentalAWSLoadBalancerController",
+					OldValue: testCase.optInOld,
+					NewValue: testCase.optInNew,
+				},
+			)
+			applied := clusterupdate.NewEmptyUpdateResult()
+			err := cluster.ExportReconcileComponents(
+				newReconcileTestCmd(), clusterCfg, detected, applied,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.wantInstallCalls, fakeInstaller.installCalls)
+			assert.Equal(t, testCase.wantUninstallCalls, fakeInstaller.uninstallCalls)
+			assert.Len(t, applied.AppliedChanges, 2)
+		})
+	}
 }

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -20,6 +20,7 @@ import (
 type recordingEKSLoadBalancerInstaller struct {
 	installCalls       int
 	uninstallCalls     int
+	gitOpsManagedCalls int
 	installSkipped     bool
 	gitOpsManaged      bool
 	releaseIdentity    string
@@ -40,6 +41,8 @@ func (r *recordingEKSLoadBalancerInstaller) InstallWithResult(ctx context.Contex
 }
 
 func (r *recordingEKSLoadBalancerInstaller) IsGitOpsManaged(context.Context) (bool, error) {
+	r.gitOpsManagedCalls++
+
 	return r.gitOpsManaged, nil
 }
 

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/stretchr/testify/assert"
@@ -79,7 +80,7 @@ func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
 
 			detected := clusterupdate.NewEmptyUpdateResult()
 			detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
-				Field:    "cluster.eks.experimentalAWSLoadBalancerController",
+				Field:    specdiff.EKSLoadBalancerControllerField,
 				OldValue: strconv.FormatBool(testCase.oldValue),
 				NewValue: strconv.FormatBool(testCase.newValue),
 			})
@@ -161,7 +162,7 @@ func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
 					NewValue: testCase.genericNew,
 				},
 				clusterupdate.Change{
-					Field:    "cluster.eks.experimentalAWSLoadBalancerController",
+					Field:    specdiff.EKSLoadBalancerControllerField,
 					OldValue: testCase.optInOld,
 					NewValue: testCase.optInNew,
 				},

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -18,12 +18,24 @@ import (
 type recordingEKSLoadBalancerInstaller struct {
 	installCalls   int
 	uninstallCalls int
+	installSkipped bool
+	gitOpsManaged  bool
 }
 
 func (r *recordingEKSLoadBalancerInstaller) Install(_ context.Context) error {
 	r.installCalls++
 
 	return nil
+}
+
+func (r *recordingEKSLoadBalancerInstaller) InstallWithResult(ctx context.Context) (bool, error) {
+	err := r.Install(ctx)
+
+	return !r.installSkipped, err
+}
+
+func (r *recordingEKSLoadBalancerInstaller) IsGitOpsManaged(context.Context) (bool, error) {
+	return r.gitOpsManaged, nil
 }
 
 func (r *recordingEKSLoadBalancerInstaller) Uninstall(_ context.Context) error {

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -95,3 +95,47 @@ func TestReconcileLoadBalancer_EKSOptInTransitionsReachHelm(t *testing.T) {
 		})
 	}
 }
+
+//nolint:paralleltest // replaces the process-global installer factory.
+func TestReconcileComponents_EKSLoadBalancerChangesCoalesce(t *testing.T) {
+	fakeInstaller := &recordingEKSLoadBalancerInstaller{}
+	restore := overrideInstallerFactory(func(factories *setup.InstallerFactories) {
+		factories.AWSLoadBalancerController = func(
+			_ *v1alpha1.Cluster,
+		) (installer.Installer, error) {
+			return fakeInstaller, nil
+		}
+	})
+	t.Cleanup(restore)
+
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	clusterCfg.Spec.Cluster.EKS.ExperimentalAWSLoadBalancerController = true
+
+	detected := clusterupdate.NewEmptyUpdateResult()
+	detected.InPlaceChanges = append(
+		detected.InPlaceChanges,
+		clusterupdate.Change{
+			Field:    "cluster.loadBalancer",
+			OldValue: string(v1alpha1.LoadBalancerDisabled),
+			NewValue: string(v1alpha1.LoadBalancerEnabled),
+		},
+		clusterupdate.Change{
+			Field:    "cluster.eks.experimentalAWSLoadBalancerController",
+			OldValue: "false",
+			NewValue: "true",
+		},
+	)
+	applied := clusterupdate.NewEmptyUpdateResult()
+	reconciler := newComponentReconciler(
+		&cobra.Command{Use: "test"}, clusterCfg, "eks-default",
+	)
+
+	err := reconciler.reconcileComponents(context.Background(), detected, applied)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, fakeInstaller.installCalls)
+	assert.Len(t, applied.AppliedChanges, 2)
+}

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
@@ -16,10 +17,12 @@ import (
 )
 
 type recordingEKSLoadBalancerInstaller struct {
-	installCalls   int
-	uninstallCalls int
-	installSkipped bool
-	gitOpsManaged  bool
+	installCalls       int
+	uninstallCalls     int
+	installSkipped     bool
+	gitOpsManaged      bool
+	releaseIdentity    string
+	releaseIdentityErr error
 }
 
 func (r *recordingEKSLoadBalancerInstaller) Install(_ context.Context) error {
@@ -36,6 +39,18 @@ func (r *recordingEKSLoadBalancerInstaller) InstallWithResult(ctx context.Contex
 
 func (r *recordingEKSLoadBalancerInstaller) IsGitOpsManaged(context.Context) (bool, error) {
 	return r.gitOpsManaged, nil
+}
+
+func (r *recordingEKSLoadBalancerInstaller) ReleaseIdentity(context.Context) (string, error) {
+	if r.releaseIdentityErr != nil {
+		return "", r.releaseIdentityErr
+	}
+
+	if r.releaseIdentity == "" {
+		return "release-uid", nil
+	}
+
+	return r.releaseIdentity, nil
 }
 
 func (r *recordingEKSLoadBalancerInstaller) Uninstall(_ context.Context) error {
@@ -57,10 +72,11 @@ func persistManagedEKSControllerState(t *testing.T, region string) {
 		"test-cluster",
 		region,
 		&state.EKSComponentState{
-			Version:                          state.EKSComponentStateVersion,
-			ClusterName:                      "test-cluster",
-			Region:                           region,
-			AWSLoadBalancerControllerManaged: true,
+			Version:                                  state.EKSComponentStateVersion,
+			ClusterName:                              "test-cluster",
+			Region:                                   region,
+			AWSLoadBalancerControllerManaged:         true,
+			AWSLoadBalancerControllerReleaseIdentity: "release-uid",
 		},
 	))
 	t.Cleanup(func() { _ = state.DeleteClusterState("test-cluster") })
@@ -182,6 +198,82 @@ func TestReconcileLoadBalancer_EKSManualReleaseIsPreserved(t *testing.T) {
 	assert.Empty(t, applied.AppliedChanges)
 	require.Len(t, applied.FailedChanges, 1)
 	assert.Contains(t, applied.FailedChanges[0].Reason, "ownership")
+}
+
+// TestReconcileLoadBalancer_EKSReplacementInvalidatesOwnership proves a stale
+// marker from a deleted KSail release cannot authorize deleting a later,
+// same-name Helm release installed by somebody else.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestReconcileLoadBalancer_EKSReplacementInvalidatesOwnership(t *testing.T) {
+	const region = "eu-north-1"
+
+	fakeInstaller := &recordingEKSLoadBalancerInstaller{releaseIdentity: "replacement-uid"}
+	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+		func(_ *v1alpha1.Cluster) (installer.Installer, error) {
+			return fakeInstaller, nil
+		},
+	)
+	t.Cleanup(restore)
+	persistManagedEKSControllerState(t, region)
+
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+
+	detected := clusterupdate.NewEmptyUpdateResult()
+	detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
+		Field: specdiff.EKSLoadBalancerControllerField, OldValue: "true", NewValue: "false",
+	})
+	applied := clusterupdate.NewEmptyUpdateResult()
+
+	err := cluster.ExportReconcileComponents(
+		newReconcileTestCmd(), clusterCfg, detected, applied, region,
+	)
+
+	require.Error(t, err)
+	assert.Zero(t, fakeInstaller.uninstallCalls)
+	assert.Empty(t, applied.AppliedChanges)
+	require.Len(t, applied.FailedChanges, 1)
+	assert.Contains(t, applied.FailedChanges[0].Reason, "ownership")
+}
+
+// TestReconcileLoadBalancer_EKSRemovedReleaseClearsOwnership proves an absent
+// release is a safe no-op rather than a permanent stale-ownership failure.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestReconcileLoadBalancer_EKSRemovedReleaseClearsOwnership(t *testing.T) {
+	const region = "eu-north-1"
+
+	fakeInstaller := &recordingEKSLoadBalancerInstaller{
+		releaseIdentityErr: helm.ErrNoReleaseStorage,
+	}
+	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+		func(_ *v1alpha1.Cluster) (installer.Installer, error) {
+			return fakeInstaller, nil
+		},
+	)
+	t.Cleanup(restore)
+	persistManagedEKSControllerState(t, region)
+
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	detected := clusterupdate.NewEmptyUpdateResult()
+	detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
+		Field: specdiff.EKSLoadBalancerControllerField, OldValue: "true", NewValue: "false",
+	})
+	applied := clusterupdate.NewEmptyUpdateResult()
+
+	err := cluster.ExportReconcileComponents(
+		newReconcileTestCmd(), clusterCfg, detected, applied, region,
+	)
+
+	require.NoError(t, err)
+	assert.Zero(t, fakeInstaller.uninstallCalls)
+	assert.Len(t, applied.AppliedChanges, 1)
 }
 
 //nolint:funlen,paralleltest // table coverage replaces the process-global installer factory.

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
+	awslbcontrollerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/awslbcontroller"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,7 @@ type recordingEKSLoadBalancerInstaller struct {
 	gitOpsManaged      bool
 	releaseIdentity    string
 	releaseIdentityErr error
+	uninstallErr       error
 }
 
 func (r *recordingEKSLoadBalancerInstaller) Install(_ context.Context) error {
@@ -56,7 +58,7 @@ func (r *recordingEKSLoadBalancerInstaller) ReleaseIdentity(context.Context) (st
 func (r *recordingEKSLoadBalancerInstaller) Uninstall(_ context.Context) error {
 	r.uninstallCalls++
 
-	return nil
+	return r.uninstallErr
 }
 
 func (r *recordingEKSLoadBalancerInstaller) Images(_ context.Context) ([]string, error) {
@@ -237,6 +239,51 @@ func TestReconcileLoadBalancer_EKSReplacementInvalidatesOwnership(t *testing.T) 
 	assert.Empty(t, applied.AppliedChanges)
 	require.Len(t, applied.FailedChanges, 1)
 	assert.Contains(t, applied.FailedChanges[0].Reason, "ownership")
+}
+
+// TestReconcileLoadBalancer_EKSGitOpsTakeoverRemainsUnresolved proves a
+// release that becomes GitOps-managed is preserved without advancing the
+// disabled baseline or clearing KSail's prior ownership evidence.
+//
+//nolint:paralleltest // replaces the process-global installer factory and writes state.
+func TestReconcileLoadBalancer_EKSGitOpsTakeoverRemainsUnresolved(t *testing.T) {
+	const region = "eu-north-1"
+
+	fakeInstaller := &recordingEKSLoadBalancerInstaller{
+		uninstallErr: awslbcontrollerinstaller.ErrGitOpsManagedUninstallSkipped,
+	}
+	restore := cluster.SetAWSLoadBalancerControllerInstallerFactoryForTests(
+		func(_ *v1alpha1.Cluster) (installer.Installer, error) {
+			return fakeInstaller, nil
+		},
+	)
+	t.Cleanup(restore)
+	persistManagedEKSControllerState(t, region)
+
+	clusterCfg := &v1alpha1.Cluster{}
+	clusterCfg.Spec.Cluster.Distribution = v1alpha1.DistributionEKS
+	clusterCfg.Spec.Cluster.Provider = v1alpha1.ProviderAWS
+	clusterCfg.Spec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+
+	detected := clusterupdate.NewEmptyUpdateResult()
+	detected.InPlaceChanges = append(detected.InPlaceChanges, clusterupdate.Change{
+		Field: specdiff.EKSLoadBalancerControllerField, OldValue: "true", NewValue: "false",
+	})
+	applied := clusterupdate.NewEmptyUpdateResult()
+
+	err := cluster.ExportReconcileComponents(
+		newReconcileTestCmd(), clusterCfg, detected, applied, region,
+	)
+
+	require.ErrorIs(t, err, awslbcontrollerinstaller.ErrGitOpsManagedUninstallSkipped)
+	assert.Equal(t, 1, fakeInstaller.uninstallCalls)
+	assert.Empty(t, applied.AppliedChanges)
+	require.Len(t, applied.FailedChanges, 1)
+
+	snapshot, loadErr := state.LoadEKSComponentState("test-cluster", region)
+	require.NoError(t, loadErr)
+	assert.True(t, snapshot.AWSLoadBalancerControllerManaged)
+	assert.Equal(t, "release-uid", snapshot.AWSLoadBalancerControllerReleaseIdentity)
 }
 
 // TestReconcileLoadBalancer_EKSRemovedReleaseClearsOwnership proves an absent

--- a/pkg/cli/cmd/cluster/reconciler_eks_test.go
+++ b/pkg/cli/cmd/cluster/reconciler_eks_test.go
@@ -25,6 +25,7 @@ type recordingEKSLoadBalancerInstaller struct {
 	gitOpsManaged      bool
 	releaseIdentity    string
 	releaseIdentityErr error
+	releaseOwned       *bool
 	uninstallErr       error
 }
 
@@ -56,6 +57,19 @@ func (r *recordingEKSLoadBalancerInstaller) ReleaseIdentity(context.Context) (st
 	}
 
 	return r.releaseIdentity, nil
+}
+
+func (r *recordingEKSLoadBalancerInstaller) OwnsReleaseIdentity(
+	ctx context.Context,
+	expected string,
+) (bool, error) {
+	if r.releaseOwned != nil {
+		return *r.releaseOwned, nil
+	}
+
+	identity, err := r.ReleaseIdentity(ctx)
+
+	return identity == expected, err
 }
 
 func (r *recordingEKSLoadBalancerInstaller) Uninstall(_ context.Context) error {

--- a/pkg/cli/cmd/cluster/testhelpers_test.go
+++ b/pkg/cli/cmd/cluster/testhelpers_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/internal/testutil/homeenv"
 	snapshottest "github.com/devantler-tech/ksail/v7/internal/testutil/snapshottest"
@@ -16,6 +17,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/registry"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/gkampitakis/go-snaps/snaps"
@@ -257,4 +259,27 @@ var errClusterPureTalosConfigEmpty = errors.New("talos config file is empty")
 const (
 	testFieldHetznerCPServerType = "provider.hetzner.controlPlaneServerType"
 	testFieldClusterCNI          = "cluster.cni"
+	testEKSComponentAccountID    = "123456789012"
 )
+
+func saveTestEKSOwnership(t *testing.T, clusterName, region string) {
+	t.Helper()
+
+	require.NoError(t, state.SaveEKSOwnershipState(clusterName, region, &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: clusterName,
+		Region:      region,
+		AccountID:   testEKSComponentAccountID,
+		ClusterARN: "arn:aws:eks:" + region + ":" + testEKSComponentAccountID +
+			":cluster/" + clusterName,
+		CreatedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+		//nolint:gosec // G101: environment-variable names, never credential values.
+		AWSOptions: v1alpha1.OptionsAWS{
+			ProfileEnvVar:         "AWS_PROFILE",
+			RegionEnvVar:          "AWS_REGION",
+			AccessKeyIDEnvVar:     "AWS_ACCESS_KEY_ID",
+			SecretAccessKeyEnvVar: "AWS_SECRET_ACCESS_KEY",
+			SessionTokenEnvVar:    "AWS_SESSION_TOKEN",
+		},
+	}))
+}

--- a/pkg/cli/cmd/cluster/testing.go
+++ b/pkg/cli/cmd/cluster/testing.go
@@ -86,6 +86,16 @@ func SetClusterAutoscalerInstallerFactoryForTests(
 	})
 }
 
+// SetAWSLoadBalancerControllerInstallerFactoryForTests overrides the AWS Load
+// Balancer Controller installer factory.
+func SetAWSLoadBalancerControllerInstallerFactoryForTests(
+	factory func(*v1alpha1.Cluster) (installer.Installer, error),
+) func() {
+	return overrideInstallerFactory(func(f *setup.InstallerFactories) {
+		f.AWSLoadBalancerController = factory
+	})
+}
+
 // SetEnsureArgoCDResourcesForTests overrides the Argo CD resource ensure function.
 func SetEnsureArgoCDResourcesForTests(
 	fn func(context.Context, string, *v1alpha1.Cluster, string) error,

--- a/pkg/cli/cmd/cluster/testing.go
+++ b/pkg/cli/cmd/cluster/testing.go
@@ -92,7 +92,12 @@ func SetAWSLoadBalancerControllerInstallerFactoryForTests(
 	factory func(*v1alpha1.Cluster) (installer.Installer, error),
 ) func() {
 	return overrideInstallerFactory(func(f *setup.InstallerFactories) {
-		f.AWSLoadBalancerController = factory
+		f.AWSLoadBalancerController = func(
+			clusterCfg *v1alpha1.Cluster,
+			_ bool,
+		) (installer.Installer, error) {
+			return factory(clusterCfg)
+		}
 	})
 }
 

--- a/pkg/cli/cmd/cluster/ttl.go
+++ b/pkg/cli/cmd/cluster/ttl.go
@@ -99,7 +99,7 @@ func autoDeleteCluster(
 
 	// Clean up persisted state (spec + TTL).
 	// Best-effort: warn on failure rather than blocking success.
-	stateErr := state.DeleteClusterState(clusterName)
+	stateErr := deleteTTLClusterState(clusterName, clusterCfg, eksConfig)
 	if stateErr != nil {
 		notify.Warningf(cmd.OutOrStdout(),
 			"failed to clean up cluster state: %v", stateErr)
@@ -107,6 +107,30 @@ func autoDeleteCluster(
 
 	notify.Successf(cmd.OutOrStdout(),
 		"cluster %q auto-destroyed after TTL expiry", clusterName)
+
+	return nil
+}
+
+func deleteTTLClusterState(
+	clusterName string,
+	clusterCfg *v1alpha1.Cluster,
+	eksConfig *clusterprovisioner.EKSConfig,
+) error {
+	if clusterCfg != nil &&
+		clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS &&
+		eksConfig != nil && strings.TrimSpace(eksConfig.Region) != "" {
+		err := state.DeleteEKSRegionState(clusterName, eksConfig.Region)
+		if err != nil {
+			return fmt.Errorf("delete exact-region EKS TTL state: %w", err)
+		}
+
+		return nil
+	}
+
+	err := state.DeleteClusterState(clusterName)
+	if err != nil {
+		return fmt.Errorf("delete TTL cluster state: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/cli/cmd/cluster/ttl.go
+++ b/pkg/cli/cmd/cluster/ttl.go
@@ -117,8 +117,11 @@ func deleteTTLClusterState(
 	eksConfig *clusterprovisioner.EKSConfig,
 ) error {
 	if clusterCfg != nil &&
-		clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS &&
-		eksConfig != nil && strings.TrimSpace(eksConfig.Region) != "" {
+		clusterCfg.Spec.Cluster.Distribution == v1alpha1.DistributionEKS {
+		if eksConfig == nil || strings.TrimSpace(eksConfig.Region) == "" {
+			return fmt.Errorf("delete exact-region EKS TTL state: %w", state.ErrInvalidRegion)
+		}
+
 		err := state.DeleteEKSRegionState(clusterName, eksConfig.Region)
 		if err != nil {
 			return fmt.Errorf("delete exact-region EKS TTL state: %w", err)

--- a/pkg/cli/cmd/cluster/update_test.go
+++ b/pkg/cli/cmd/cluster/update_test.go
@@ -235,6 +235,12 @@ func TestPromoteUnsupportedInPlaceChangesRequiresRecreation(t *testing.T) {
 		{Field: "cluster.localRegistry.registry", Category: clusterupdate.ChangeCategoryInPlace},
 		{Field: "cluster.cni", Category: clusterupdate.ChangeCategoryInPlace},
 		{
+			Field:    "cluster.metricsServer",
+			OldValue: string(v1alpha1.MetricsServerEnabled),
+			NewValue: string(v1alpha1.MetricsServerDisabled),
+			Category: clusterupdate.ChangeCategoryInPlace,
+		},
+		{
 			Field:    "eks.managedNodeGroups[workers].desiredCapacity",
 			Category: clusterupdate.ChangeCategoryInPlace,
 		},
@@ -252,9 +258,11 @@ func TestPromoteUnsupportedInPlaceChangesRequiresRecreation(t *testing.T) {
 		"cluster.cni",
 		"eks.managedNodeGroups[workers].desiredCapacity",
 	}, []string{diff.InPlaceChanges[0].Field, diff.InPlaceChanges[1].Field})
-	require.Len(t, diff.RecreateRequired, 1)
+	require.Len(t, diff.RecreateRequired, 2)
 	assert.Equal(t, "cluster.localRegistry.registry", diff.RecreateRequired[0].Field)
 	assert.Equal(t, clusterupdate.ChangeCategoryRecreateRequired, diff.RecreateRequired[0].Category)
+	assert.Equal(t, "cluster.metricsServer", diff.RecreateRequired[1].Field)
+	assert.Equal(t, clusterupdate.ChangeCategoryRecreateRequired, diff.RecreateRequired[1].Category)
 }
 
 // TestComputeUpdateDiff_PropagatesProvisionerError verifies live provisioner

--- a/pkg/cli/cmd/cluster/update_test.go
+++ b/pkg/cli/cmd/cluster/update_test.go
@@ -255,14 +255,38 @@ func TestPromoteUnsupportedInPlaceChangesRequiresRecreation(t *testing.T) {
 	cluster.ExportPromoteUnsupportedInPlaceChanges(updater, diff)
 
 	assert.Equal(t, []string{
-		"cluster.cni",
 		"eks.managedNodeGroups[workers].desiredCapacity",
-	}, []string{diff.InPlaceChanges[0].Field, diff.InPlaceChanges[1].Field})
-	require.Len(t, diff.RecreateRequired, 2)
+	}, []string{diff.InPlaceChanges[0].Field})
+	require.Len(t, diff.RecreateRequired, 3)
 	assert.Equal(t, "cluster.localRegistry.registry", diff.RecreateRequired[0].Field)
 	assert.Equal(t, clusterupdate.ChangeCategoryRecreateRequired, diff.RecreateRequired[0].Category)
-	assert.Equal(t, "cluster.metricsServer", diff.RecreateRequired[1].Field)
+	assert.Equal(t, "cluster.cni", diff.RecreateRequired[1].Field)
 	assert.Equal(t, clusterupdate.ChangeCategoryRecreateRequired, diff.RecreateRequired[1].Category)
+	assert.Equal(t, "cluster.metricsServer", diff.RecreateRequired[2].Field)
+	assert.Equal(t, clusterupdate.ChangeCategoryRecreateRequired, diff.RecreateRequired[2].Category)
+}
+
+func TestPromoteUnsupportedInPlaceChangesRequiresRecreationForCNISwitch(t *testing.T) {
+	t.Parallel()
+
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = []clusterupdate.Change{{
+		Field:    "cluster.cni",
+		OldValue: string(v1alpha1.CNICilium),
+		NewValue: string(v1alpha1.CNICalico),
+		Category: clusterupdate.ChangeCategoryInPlace,
+	}}
+	updater := &fieldSupportUpdater{
+		fakeUpdater: &fakeUpdater{},
+		supported:   map[string]bool{},
+	}
+
+	cluster.ExportPromoteUnsupportedInPlaceChanges(updater, diff)
+
+	assert.Empty(t, diff.InPlaceChanges)
+	require.Len(t, diff.RecreateRequired, 1)
+	assert.Equal(t, "cluster.cni", diff.RecreateRequired[0].Field)
+	assert.Equal(t, clusterupdate.ChangeCategoryRecreateRequired, diff.RecreateRequired[0].Category)
 }
 
 // TestComputeUpdateDiff_PropagatesProvisionerError verifies live provisioner

--- a/pkg/cli/cmd/cluster/update_test.go
+++ b/pkg/cli/cmd/cluster/update_test.go
@@ -180,6 +180,16 @@ type fakeUpdater struct {
 	calls   int
 }
 
+type fieldSupportUpdater struct {
+	*fakeUpdater
+
+	supported map[string]bool
+}
+
+func (u *fieldSupportUpdater) SupportsInPlaceField(field string) bool {
+	return u.supported[field]
+}
+
 type countingFactory struct{ calls int }
 
 func (f *countingFactory) Create(
@@ -215,6 +225,36 @@ func (f *fakeUpdater) GetCurrentConfig(
 	_ string,
 ) (*v1alpha1.ClusterSpec, *v1alpha1.ProviderSpec, error) {
 	return nil, nil, nil
+}
+
+func TestPromoteUnsupportedInPlaceChangesRequiresRecreation(t *testing.T) {
+	t.Parallel()
+
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = []clusterupdate.Change{
+		{Field: "cluster.localRegistry.registry", Category: clusterupdate.ChangeCategoryInPlace},
+		{Field: "cluster.cni", Category: clusterupdate.ChangeCategoryInPlace},
+		{
+			Field:    "eks.managedNodeGroups[workers].desiredCapacity",
+			Category: clusterupdate.ChangeCategoryInPlace,
+		},
+	}
+	updater := &fieldSupportUpdater{
+		fakeUpdater: &fakeUpdater{},
+		supported: map[string]bool{
+			"eks.managedNodeGroups[workers].desiredCapacity": true,
+		},
+	}
+
+	cluster.ExportPromoteUnsupportedInPlaceChanges(updater, diff)
+
+	assert.Equal(t, []string{
+		"cluster.cni",
+		"eks.managedNodeGroups[workers].desiredCapacity",
+	}, []string{diff.InPlaceChanges[0].Field, diff.InPlaceChanges[1].Field})
+	require.Len(t, diff.RecreateRequired, 1)
+	assert.Equal(t, "cluster.localRegistry.registry", diff.RecreateRequired[0].Field)
+	assert.Equal(t, clusterupdate.ChangeCategoryRecreateRequired, diff.RecreateRequired[0].Category)
 }
 
 // TestComputeUpdateDiff_PropagatesProvisionerError verifies live provisioner

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -40,6 +40,9 @@ var (
 	ErrAWSLoadBalancerControllerInstallerFactoryNil = errors.New(
 		"aws load balancer controller installer factory is nil",
 	)
+	ErrAWSLoadBalancerControllerOwnershipReporterUnavailable = errors.New(
+		"aws load balancer controller installer cannot report GitOps ownership",
+	)
 )
 
 // InstallerFactories holds factory functions for creating component installers.

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -38,7 +38,7 @@ var (
 		"cluster-autoscaler installer factory is nil",
 	)
 	ErrAWSLoadBalancerControllerInstallerFactoryNil = errors.New(
-		"AWS Load Balancer Controller installer factory is nil",
+		"aws load balancer controller installer factory is nil",
 	)
 )
 

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -46,6 +46,9 @@ var (
 	ErrAWSLoadBalancerControllerIdentityReporterUnavailable = errors.New(
 		"aws load balancer controller installer cannot report release identity",
 	)
+	ErrAWSLoadBalancerControllerReleaseOwnershipReporterUnavailable = errors.New(
+		"aws load balancer controller installer cannot verify KSail release ownership",
+	)
 	ErrAWSLoadBalancerControllerReleaseIdentityMismatch = errors.New(
 		"aws load balancer controller ownership is unresolved: release identity changed",
 	)

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -56,7 +56,10 @@ type InstallerFactories struct {
 	ArgoCD                    func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
 	KubeletCSRApprover        func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
 	ClusterAutoscaler         func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
-	AWSLoadBalancerController func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	AWSLoadBalancerController func(
+		clusterCfg *v1alpha1.Cluster,
+		ksailManaged bool,
+	) (installer.Installer, error)
 	// EnsureArgoCDResources configures default Argo CD resources post-install.
 	EnsureArgoCDResources func(
 		ctx context.Context, kubeconfig string, clusterCfg *v1alpha1.Cluster, clusterName string,
@@ -316,8 +319,9 @@ func DefaultInstallerFactories() *InstallerFactories {
 	factories.ClusterAutoscaler = clusterAutoscalerFactory(factories)
 	factories.AWSLoadBalancerController = func(
 		clusterCfg *v1alpha1.Cluster,
+		ksailManaged bool,
 	) (installer.Installer, error) {
-		return newEKSLoadBalancerInstaller(clusterCfg, factories)
+		return newEKSLoadBalancerInstaller(clusterCfg, factories, ksailManaged)
 	}
 
 	factories.EnsureArgoCDResources = EnsureArgoCDResources

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -43,6 +43,15 @@ var (
 	ErrAWSLoadBalancerControllerOwnershipReporterUnavailable = errors.New(
 		"aws load balancer controller installer cannot report GitOps ownership",
 	)
+	ErrAWSLoadBalancerControllerIdentityReporterUnavailable = errors.New(
+		"aws load balancer controller installer cannot report release identity",
+	)
+	ErrAWSLoadBalancerControllerReleaseIdentityMismatch = errors.New(
+		"aws load balancer controller ownership is unresolved: release identity changed",
+	)
+	ErrAWSLoadBalancerControllerReleaseIdentityEmpty = errors.New(
+		"aws load balancer controller release identity is empty",
+	)
 )
 
 // InstallerFactories holds factory functions for creating component installers.

--- a/pkg/cli/setup/components.go
+++ b/pkg/cli/setup/components.go
@@ -37,18 +37,26 @@ var (
 	ErrClusterAutoscalerInstallerFactoryNil = errors.New(
 		"cluster-autoscaler installer factory is nil",
 	)
+	ErrAWSLoadBalancerControllerInstallerFactoryNil = errors.New(
+		"AWS Load Balancer Controller installer factory is nil",
+	)
 )
 
 // InstallerFactories holds factory functions for creating component installers.
 // These can be overridden in tests for dependency injection.
 type InstallerFactories struct {
-	Flux               func(client helm.Interface, timeout time.Duration, operatorVersion string) installer.Installer
-	CertManager        func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
-	CSI                func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
-	PolicyEngine       func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
-	ArgoCD             func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
-	KubeletCSRApprover func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
-	ClusterAutoscaler  func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	Flux func(
+		client helm.Interface,
+		timeout time.Duration,
+		operatorVersion string,
+	) installer.Installer
+	CertManager               func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	CSI                       func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	PolicyEngine              func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	ArgoCD                    func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	KubeletCSRApprover        func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	ClusterAutoscaler         func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
+	AWSLoadBalancerController func(clusterCfg *v1alpha1.Cluster) (installer.Installer, error)
 	// EnsureArgoCDResources configures default Argo CD resources post-install.
 	EnsureArgoCDResources func(
 		ctx context.Context, kubeconfig string, clusterCfg *v1alpha1.Cluster, clusterName string,
@@ -306,6 +314,11 @@ func DefaultInstallerFactories() *InstallerFactories {
 	factories.CSI = csiFactory(factories)
 	factories.PolicyEngine = policyEngineFactory(factories)
 	factories.ClusterAutoscaler = clusterAutoscalerFactory(factories)
+	factories.AWSLoadBalancerController = func(
+		clusterCfg *v1alpha1.Cluster,
+	) (installer.Installer, error) {
+		return newEKSLoadBalancerInstaller(clusterCfg, factories)
+	}
 
 	factories.EnsureArgoCDResources = EnsureArgoCDResources
 	factories.SetupFluxInstance = fluxinstaller.SetupInstance

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -234,7 +234,7 @@ func installEKSLoadBalancer(
 		return nil
 	}
 
-	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories)
+	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, false)
 	if err != nil {
 		return err
 	}
@@ -253,8 +253,9 @@ func UninstallEKSLoadBalancerControllerSilent(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
+	ksailManaged bool,
 ) error {
-	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories)
+	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, ksailManaged)
 	if err != nil {
 		return err
 	}
@@ -270,17 +271,19 @@ func UninstallEKSLoadBalancerControllerSilent(
 func createEKSLoadBalancerInstaller(
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
+	ksailManaged bool,
 ) (installer.Installer, error) {
 	if factories.AWSLoadBalancerController == nil {
 		return nil, ErrAWSLoadBalancerControllerInstallerFactoryNil
 	}
 
-	return factories.AWSLoadBalancerController(clusterCfg)
+	return factories.AWSLoadBalancerController(clusterCfg, ksailManaged)
 }
 
 func newEKSLoadBalancerInstaller(
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
+	ksailManaged bool,
 ) (installer.Installer, error) {
 	clusterName, fileRegion, nameFromConfig, err := ksailconfigmanager.ResolveEKSClusterMetadata(
 		clusterCfg,
@@ -320,6 +323,7 @@ func newEKSLoadBalancerInstaller(
 		region,
 		clusterCfg.Spec.Cluster.EKS.AWSLoadBalancerControllerServiceAccount,
 		haEnabled,
+		ksailManaged,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -266,10 +267,16 @@ func InstallEKSLoadBalancerControllerWithResult(
 	) (bool, error) {
 		mutated, installErr := installWithResult(ctx, lbInstaller)
 		if installErr != nil {
-			return false, fmt.Errorf(
+			managed, identity, ownershipErr := loadBalancerControllerOwnershipAfterInstallAttempt(
+				ctx,
+				lbInstaller,
+			)
+			releaseIdentity = identity
+
+			return managed, errors.Join(fmt.Errorf(
 				"aws-load-balancer-controller installation failed: %w",
 				installErr,
-			)
+			), ownershipErr)
 		}
 
 		if !mutated {
@@ -324,7 +331,7 @@ func withRequiredEKSLoadBalancerInstaller(
 
 	result, err := action(lbInstaller)
 	if err != nil {
-		return false, fmt.Errorf("run required EKS load balancer controller action: %w", err)
+		return result, fmt.Errorf("run required EKS load balancer controller action: %w", err)
 	}
 
 	return result, nil
@@ -346,6 +353,13 @@ func EKSLoadBalancerControllerManagedByKSail(
 		return false, "", err
 	}
 
+	return loadBalancerControllerOwnershipAfterInstallAttempt(ctx, lbInstaller)
+}
+
+func loadBalancerControllerOwnershipAfterInstallAttempt(
+	ctx context.Context,
+	lbInstaller installer.Installer,
+) (bool, string, error) {
 	reporter, reportsOwnership := lbInstaller.(gitOpsOwnershipReporter)
 	if !reportsOwnership {
 		return false, "", ErrAWSLoadBalancerControllerOwnershipReporterUnavailable
@@ -365,6 +379,10 @@ func EKSLoadBalancerControllerManagedByKSail(
 
 	identity, err := loadBalancerControllerReleaseIdentity(ctx, lbInstaller)
 	if err != nil {
+		if errors.Is(err, helm.ErrNoReleaseStorage) || errors.Is(err, helm.ErrReleaseNotFound) {
+			return false, "", nil
+		}
+
 		return false, "", err
 	}
 

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -250,18 +250,10 @@ func InstallEKSLoadBalancerControllerWithResult(
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
 ) (bool, error) {
-	if !NeedsLoadBalancerInstall(clusterCfg) {
-		return false, nil
-	}
-
-	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, false)
-	if err != nil {
-		return false, err
-	}
-
-	resultReporter, reportsResult := lbInstaller.(installResultReporter)
-	if reportsResult {
-		mutated, installErr := resultReporter.InstallWithResult(ctx)
+	return withRequiredEKSLoadBalancerInstaller(clusterCfg, factories, func(
+		lbInstaller installer.Installer,
+	) (bool, error) {
+		mutated, installErr := installWithResult(ctx, lbInstaller)
 		if installErr != nil {
 			return false, fmt.Errorf(
 				"aws-load-balancer-controller installation failed: %w",
@@ -270,25 +262,32 @@ func InstallEKSLoadBalancerControllerWithResult(
 		}
 
 		return mutated, nil
+	})
+}
+
+func installWithResult(ctx context.Context, component installer.Installer) (bool, error) {
+	resultReporter, reportsResult := component.(installResultReporter)
+	if reportsResult {
+		mutated, err := resultReporter.InstallWithResult(ctx)
+		if err != nil {
+			return false, fmt.Errorf("install component with result: %w", err)
+		}
+
+		return mutated, nil
 	}
 
-	installErr := lbInstaller.Install(ctx)
+	installErr := component.Install(ctx)
 	if installErr != nil {
-		return false, fmt.Errorf(
-			"aws-load-balancer-controller installation failed: %w",
-			installErr,
-		)
+		return false, fmt.Errorf("install component: %w", installErr)
 	}
 
 	return true, nil
 }
 
-// EKSLoadBalancerControllerManagedByKSail verifies the ownership established by a successful
-// create/recreate workflow. A GitOps-owned release was deliberately skipped and remains unowned.
-func EKSLoadBalancerControllerManagedByKSail(
-	ctx context.Context,
+func withRequiredEKSLoadBalancerInstaller(
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
+	action func(installer.Installer) (bool, error),
 ) (bool, error) {
 	if !NeedsLoadBalancerInstall(clusterCfg) {
 		return false, nil
@@ -299,20 +298,39 @@ func EKSLoadBalancerControllerManagedByKSail(
 		return false, err
 	}
 
-	reporter, reportsOwnership := lbInstaller.(gitOpsOwnershipReporter)
-	if !reportsOwnership {
-		return false, ErrAWSLoadBalancerControllerOwnershipReporterUnavailable
-	}
-
-	gitOpsManaged, err := reporter.IsGitOpsManaged(ctx)
+	result, err := action(lbInstaller)
 	if err != nil {
-		return false, fmt.Errorf(
-			"verify AWS load balancer controller ownership after creation: %w",
-			err,
-		)
+		return false, fmt.Errorf("run required EKS load balancer controller action: %w", err)
 	}
 
-	return !gitOpsManaged, nil
+	return result, nil
+}
+
+// EKSLoadBalancerControllerManagedByKSail verifies the ownership established by a successful
+// create/recreate workflow. A GitOps-owned release was deliberately skipped and remains unowned.
+func EKSLoadBalancerControllerManagedByKSail(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+) (bool, error) {
+	return withRequiredEKSLoadBalancerInstaller(clusterCfg, factories, func(
+		lbInstaller installer.Installer,
+	) (bool, error) {
+		reporter, reportsOwnership := lbInstaller.(gitOpsOwnershipReporter)
+		if !reportsOwnership {
+			return false, ErrAWSLoadBalancerControllerOwnershipReporterUnavailable
+		}
+
+		gitOpsManaged, err := reporter.IsGitOpsManaged(ctx)
+		if err != nil {
+			return false, fmt.Errorf(
+				"verify AWS load balancer controller ownership after creation: %w",
+				err,
+			)
+		}
+
+		return !gitOpsManaged, nil
+	})
 }
 
 // UninstallEKSLoadBalancerControllerSilent removes the AWS Load Balancer Controller

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -230,21 +230,89 @@ func installEKSLoadBalancer(
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
 ) error {
+	_, err := InstallEKSLoadBalancerControllerWithResult(ctx, clusterCfg, factories)
+
+	return err
+}
+
+type installResultReporter interface {
+	InstallWithResult(ctx context.Context) (mutated bool, err error)
+}
+
+type gitOpsOwnershipReporter interface {
+	IsGitOpsManaged(ctx context.Context) (managed bool, err error)
+}
+
+// InstallEKSLoadBalancerControllerWithResult installs or upgrades the controller and reports
+// whether Helm was actually mutated. GitOps-owned releases are successful, unmodified skips.
+func InstallEKSLoadBalancerControllerWithResult(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+) (bool, error) {
 	if !NeedsLoadBalancerInstall(clusterCfg) {
-		return nil
+		return false, nil
 	}
 
 	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, false)
 	if err != nil {
-		return err
+		return false, err
+	}
+
+	resultReporter, reportsResult := lbInstaller.(installResultReporter)
+	if reportsResult {
+		mutated, installErr := resultReporter.InstallWithResult(ctx)
+		if installErr != nil {
+			return false, fmt.Errorf(
+				"aws-load-balancer-controller installation failed: %w",
+				installErr,
+			)
+		}
+
+		return mutated, nil
 	}
 
 	installErr := lbInstaller.Install(ctx)
 	if installErr != nil {
-		return fmt.Errorf("aws-load-balancer-controller installation failed: %w", installErr)
+		return false, fmt.Errorf(
+			"aws-load-balancer-controller installation failed: %w",
+			installErr,
+		)
 	}
 
-	return nil
+	return true, nil
+}
+
+// EKSLoadBalancerControllerManagedByKSail verifies the ownership established by a successful
+// create/recreate workflow. A GitOps-owned release was deliberately skipped and remains unowned.
+func EKSLoadBalancerControllerManagedByKSail(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+) (bool, error) {
+	if !NeedsLoadBalancerInstall(clusterCfg) {
+		return false, nil
+	}
+
+	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, false)
+	if err != nil {
+		return false, err
+	}
+
+	reporter, reportsOwnership := lbInstaller.(gitOpsOwnershipReporter)
+	if !reportsOwnership {
+		return false, ErrAWSLoadBalancerControllerOwnershipReporterUnavailable
+	}
+
+	gitOpsManaged, err := reporter.IsGitOpsManaged(ctx)
+	if err != nil {
+		return false, fmt.Errorf(
+			"verify AWS load balancer controller ownership after creation: %w",
+			err,
+		)
+	}
+
+	return !gitOpsManaged, nil
 }
 
 // UninstallEKSLoadBalancerControllerSilent removes the AWS Load Balancer Controller

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -331,7 +331,7 @@ func withRequiredEKSLoadBalancerInstaller(
 }
 
 // EKSLoadBalancerControllerManagedByKSail verifies the ownership established by a successful
-// create/recreate workflow. A GitOps-owned release was deliberately skipped and remains unowned.
+// create/recreate workflow. GitOps-owned and unlabelled manual releases remain unowned.
 func EKSLoadBalancerControllerManagedByKSail(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
@@ -368,7 +368,37 @@ func EKSLoadBalancerControllerManagedByKSail(
 		return false, "", err
 	}
 
+	owned, err := loadBalancerControllerReleaseManagedByKSail(ctx, lbInstaller, identity)
+	if err != nil {
+		return false, "", err
+	}
+
+	if !owned {
+		return false, "", nil
+	}
+
 	return true, identity, nil
+}
+
+func loadBalancerControllerReleaseManagedByKSail(
+	ctx context.Context,
+	lbInstaller installer.Installer,
+	releaseIdentity string,
+) (bool, error) {
+	reporter, reportsOwnership := lbInstaller.(releaseIdentityOwnershipReporter)
+	if !reportsOwnership {
+		return false, ErrAWSLoadBalancerControllerReleaseOwnershipReporterUnavailable
+	}
+
+	owned, err := reporter.OwnsReleaseIdentity(ctx, releaseIdentity)
+	if err != nil {
+		return false, fmt.Errorf(
+			"verify KSail AWS load balancer controller release ownership after creation: %w",
+			err,
+		)
+	}
+
+	return owned, nil
 }
 
 func loadBalancerControllerReleaseIdentity(

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -248,6 +248,10 @@ type releaseIdentityReporter interface {
 	ReleaseIdentity(ctx context.Context) (string, error)
 }
 
+type releaseIdentityOwnershipReporter interface {
+	OwnsReleaseIdentity(ctx context.Context, expected string) (bool, error)
+}
+
 // InstallEKSLoadBalancerControllerWithResult installs or upgrades the controller and reports
 // whether Helm was actually mutated. GitOps-owned releases are successful, unmodified skips.
 func InstallEKSLoadBalancerControllerWithResult(
@@ -402,12 +406,16 @@ func UninstallEKSLoadBalancerControllerSilent(
 		return err
 	}
 
-	liveReleaseIdentity, err := loadBalancerControllerReleaseIdentity(ctx, lbInstaller)
+	matches, err := loadBalancerControllerOwnsReleaseIdentity(
+		ctx,
+		lbInstaller,
+		expectedReleaseIdentity,
+	)
 	if err != nil {
 		return err
 	}
 
-	if liveReleaseIdentity != strings.TrimSpace(expectedReleaseIdentity) {
+	if !matches {
 		return ErrAWSLoadBalancerControllerReleaseIdentityMismatch
 	}
 
@@ -417,6 +425,36 @@ func UninstallEKSLoadBalancerControllerSilent(
 	}
 
 	return nil
+}
+
+func loadBalancerControllerOwnsReleaseIdentity(
+	ctx context.Context,
+	lbInstaller installer.Installer,
+	expectedReleaseIdentity string,
+) (bool, error) {
+	expectedReleaseIdentity = strings.TrimSpace(expectedReleaseIdentity)
+	if expectedReleaseIdentity == "" {
+		return false, ErrAWSLoadBalancerControllerReleaseIdentityEmpty
+	}
+
+	if reporter, ok := lbInstaller.(releaseIdentityOwnershipReporter); ok {
+		matches, err := reporter.OwnsReleaseIdentity(ctx, expectedReleaseIdentity)
+		if err != nil {
+			return false, fmt.Errorf(
+				"verify AWS load balancer controller release identity history: %w",
+				err,
+			)
+		}
+
+		return matches, nil
+	}
+
+	liveReleaseIdentity, err := loadBalancerControllerReleaseIdentity(ctx, lbInstaller)
+	if err != nil {
+		return false, err
+	}
+
+	return liveReleaseIdentity == expectedReleaseIdentity, nil
 }
 
 func createEKSLoadBalancerInstaller(

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -230,7 +231,7 @@ func installEKSLoadBalancer(
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
 ) error {
-	_, err := InstallEKSLoadBalancerControllerWithResult(ctx, clusterCfg, factories)
+	_, _, err := InstallEKSLoadBalancerControllerWithResult(ctx, clusterCfg, factories)
 
 	return err
 }
@@ -243,14 +244,20 @@ type gitOpsOwnershipReporter interface {
 	IsGitOpsManaged(ctx context.Context) (managed bool, err error)
 }
 
+type releaseIdentityReporter interface {
+	ReleaseIdentity(ctx context.Context) (string, error)
+}
+
 // InstallEKSLoadBalancerControllerWithResult installs or upgrades the controller and reports
 // whether Helm was actually mutated. GitOps-owned releases are successful, unmodified skips.
 func InstallEKSLoadBalancerControllerWithResult(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
-) (bool, error) {
-	return withRequiredEKSLoadBalancerInstaller(clusterCfg, factories, func(
+) (bool, string, error) {
+	var releaseIdentity string
+
+	result, err := withRequiredEKSLoadBalancerInstaller(clusterCfg, factories, func(
 		lbInstaller installer.Installer,
 	) (bool, error) {
 		mutated, installErr := installWithResult(ctx, lbInstaller)
@@ -261,8 +268,21 @@ func InstallEKSLoadBalancerControllerWithResult(
 			)
 		}
 
-		return mutated, nil
+		if !mutated {
+			return false, nil
+		}
+
+		identity, identityErr := loadBalancerControllerReleaseIdentity(ctx, lbInstaller)
+		if identityErr != nil {
+			return false, identityErr
+		}
+
+		releaseIdentity = identity
+
+		return true, nil
 	})
+
+	return result, releaseIdentity, err
 }
 
 func installWithResult(ctx context.Context, component installer.Installer) (bool, error) {
@@ -312,38 +332,83 @@ func EKSLoadBalancerControllerManagedByKSail(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
-) (bool, error) {
-	return withRequiredEKSLoadBalancerInstaller(clusterCfg, factories, func(
-		lbInstaller installer.Installer,
-	) (bool, error) {
-		reporter, reportsOwnership := lbInstaller.(gitOpsOwnershipReporter)
-		if !reportsOwnership {
-			return false, ErrAWSLoadBalancerControllerOwnershipReporterUnavailable
-		}
+) (bool, string, error) {
+	if !NeedsLoadBalancerInstall(clusterCfg) {
+		return false, "", nil
+	}
 
-		gitOpsManaged, err := reporter.IsGitOpsManaged(ctx)
-		if err != nil {
-			return false, fmt.Errorf(
-				"verify AWS load balancer controller ownership after creation: %w",
-				err,
-			)
-		}
+	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, false)
+	if err != nil {
+		return false, "", err
+	}
 
-		return !gitOpsManaged, nil
-	})
+	reporter, reportsOwnership := lbInstaller.(gitOpsOwnershipReporter)
+	if !reportsOwnership {
+		return false, "", ErrAWSLoadBalancerControllerOwnershipReporterUnavailable
+	}
+
+	gitOpsManaged, err := reporter.IsGitOpsManaged(ctx)
+	if err != nil {
+		return false, "", fmt.Errorf(
+			"verify AWS load balancer controller ownership after creation: %w",
+			err,
+		)
+	}
+
+	if gitOpsManaged {
+		return false, "", nil
+	}
+
+	identity, err := loadBalancerControllerReleaseIdentity(ctx, lbInstaller)
+	if err != nil {
+		return false, "", err
+	}
+
+	return true, identity, nil
+}
+
+func loadBalancerControllerReleaseIdentity(
+	ctx context.Context,
+	lbInstaller installer.Installer,
+) (string, error) {
+	reporter, reportsIdentity := lbInstaller.(releaseIdentityReporter)
+	if !reportsIdentity {
+		return "", ErrAWSLoadBalancerControllerIdentityReporterUnavailable
+	}
+
+	identity, err := reporter.ReleaseIdentity(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve AWS load balancer controller release identity: %w", err)
+	}
+
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return "", ErrAWSLoadBalancerControllerReleaseIdentityEmpty
+	}
+
+	return identity, nil
 }
 
 // UninstallEKSLoadBalancerControllerSilent removes the AWS Load Balancer Controller
-// Helm release from an EKS cluster during an in-place cluster update.
+// only when the live release identity still matches the persisted KSail-owned incarnation.
 func UninstallEKSLoadBalancerControllerSilent(
 	ctx context.Context,
 	clusterCfg *v1alpha1.Cluster,
 	factories *InstallerFactories,
-	ksailManaged bool,
+	expectedReleaseIdentity string,
 ) error {
-	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, ksailManaged)
+	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories, true)
 	if err != nil {
 		return err
+	}
+
+	liveReleaseIdentity, err := loadBalancerControllerReleaseIdentity(ctx, lbInstaller)
+	if err != nil {
+		return err
+	}
+
+	if liveReleaseIdentity != strings.TrimSpace(expectedReleaseIdentity) {
+		return ErrAWSLoadBalancerControllerReleaseIdentityMismatch
 	}
 
 	uninstallErr := lbInstaller.Uninstall(ctx)

--- a/pkg/cli/setup/install_infrastructure.go
+++ b/pkg/cli/setup/install_infrastructure.go
@@ -234,11 +234,59 @@ func installEKSLoadBalancer(
 		return nil
 	}
 
+	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories)
+	if err != nil {
+		return err
+	}
+
+	installErr := lbInstaller.Install(ctx)
+	if installErr != nil {
+		return fmt.Errorf("aws-load-balancer-controller installation failed: %w", installErr)
+	}
+
+	return nil
+}
+
+// UninstallEKSLoadBalancerControllerSilent removes the AWS Load Balancer Controller
+// Helm release from an EKS cluster during an in-place cluster update.
+func UninstallEKSLoadBalancerControllerSilent(
+	ctx context.Context,
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+) error {
+	lbInstaller, err := createEKSLoadBalancerInstaller(clusterCfg, factories)
+	if err != nil {
+		return err
+	}
+
+	uninstallErr := lbInstaller.Uninstall(ctx)
+	if uninstallErr != nil {
+		return fmt.Errorf("aws-load-balancer-controller uninstall failed: %w", uninstallErr)
+	}
+
+	return nil
+}
+
+func createEKSLoadBalancerInstaller(
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+) (installer.Installer, error) {
+	if factories.AWSLoadBalancerController == nil {
+		return nil, ErrAWSLoadBalancerControllerInstallerFactoryNil
+	}
+
+	return factories.AWSLoadBalancerController(clusterCfg)
+}
+
+func newEKSLoadBalancerInstaller(
+	clusterCfg *v1alpha1.Cluster,
+	factories *InstallerFactories,
+) (installer.Installer, error) {
 	clusterName, fileRegion, nameFromConfig, err := ksailconfigmanager.ResolveEKSClusterMetadata(
 		clusterCfg,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to resolve EKS cluster metadata: %w", err)
+		return nil, fmt.Errorf("failed to resolve EKS cluster metadata: %w", err)
 	}
 
 	// Honor the same region precedence as the create path: the environment
@@ -257,7 +305,10 @@ func installEKSLoadBalancer(
 
 	helmClient, _, timeout, err := helmClientSetup(clusterCfg, factories)
 	if err != nil {
-		return fmt.Errorf("failed to setup helm client for aws-load-balancer-controller: %w", err)
+		return nil, fmt.Errorf(
+			"failed to setup helm client for aws-load-balancer-controller: %w",
+			err,
+		)
 	}
 
 	haEnabled := installer.IsHAEnabled(clusterCfg.Spec.Cluster.TotalNodeCount())
@@ -271,15 +322,13 @@ func installEKSLoadBalancer(
 		haEnabled,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to configure aws-load-balancer-controller installer: %w", err)
+		return nil, fmt.Errorf(
+			"failed to configure aws-load-balancer-controller installer: %w",
+			err,
+		)
 	}
 
-	installErr := lbInstaller.Install(ctx)
-	if installErr != nil {
-		return fmt.Errorf("aws-load-balancer-controller installation failed: %w", installErr)
-	}
-
-	return nil
+	return lbInstaller, nil
 }
 
 // installTalosLoadBalancer installs the provider-appropriate load balancer for

--- a/pkg/cli/setup/localregistry/localregistry.go
+++ b/pkg/cli/setup/localregistry/localregistry.go
@@ -112,6 +112,9 @@ type Context struct {
 	AWSResolution *credentials.AWSResolution
 	// AWSOwnershipVerifier rechecks the exact EKS incarnation at each mutation boundary.
 	AWSOwnershipVerifier lifecycle.AWSOwnershipVerifier
+	// EKSAccountID binds implicit kubeconfig context selection to the AWS account
+	// whose immutable ownership was captured or verified.
+	EKSAccountID string
 	// MirrorSpecs holds resolved registry mirror specifications for the Kubernetes
 	// provider. The nested provisioner sets these up inside the DinD environment so
 	// nested clusters pull through authenticated, caching mirrors. Nil for other

--- a/pkg/client/helm/adapters.go
+++ b/pkg/client/helm/adapters.go
@@ -13,6 +13,7 @@ type actionConfig interface {
 	setWaitForJobs(wait bool)
 	setTimeout(timeout time.Duration)
 	setVersion(version string)
+	setLabels(labels map[string]string)
 }
 
 // installActionAdapter wraps Install to implement actionConfig.
@@ -22,6 +23,7 @@ func (a installActionAdapter) setWaitStrategy(s helmv4kube.WaitStrategy) { a.Wai
 func (a installActionAdapter) setWaitForJobs(w bool)                     { a.WaitForJobs = w }
 func (a installActionAdapter) setTimeout(t time.Duration)                { a.Timeout = t }
 func (a installActionAdapter) setVersion(v string)                       { a.Version = v }
+func (a installActionAdapter) setLabels(labels map[string]string)        { a.Labels = labels }
 
 // upgradeActionAdapter wraps Upgrade to implement actionConfig.
 type upgradeActionAdapter struct{ *helmv4action.Upgrade }
@@ -30,6 +32,7 @@ func (a upgradeActionAdapter) setWaitStrategy(s helmv4kube.WaitStrategy) { a.Wai
 func (a upgradeActionAdapter) setWaitForJobs(w bool)                     { a.WaitForJobs = w }
 func (a upgradeActionAdapter) setTimeout(t time.Duration)                { a.Timeout = t }
 func (a upgradeActionAdapter) setVersion(v string)                       { a.Version = v }
+func (a upgradeActionAdapter) setLabels(labels map[string]string)        { a.Labels = labels }
 
 // applyCommonActionConfig applies shared configuration from spec to action.
 //
@@ -57,4 +60,5 @@ func applyCommonActionConfig(action actionConfig, spec *ChartSpec) {
 
 	action.setTimeout(timeout)
 	action.setVersion(spec.Version)
+	action.setLabels(spec.Labels)
 }

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -551,9 +551,10 @@ func latestReleaseStorageMetadata(
 	}
 
 	return &ReleaseStorageMetadata{
-		Labels:            items[bestIdx].Labels,
-		Identity:          items[bestIdx].UID,
-		HistoryIdentities: releaseStorageIdentities(items),
+		Labels:                       items[bestIdx].Labels,
+		Identity:                     items[bestIdx].UID,
+		HistoryIdentities:            releaseStorageIdentities(items),
+		CurrentIncarnationIdentities: currentReleaseStorageIdentities(items),
 	}, nil
 }
 
@@ -566,6 +567,81 @@ func releaseStorageIdentities(items []releaseStorageItem) []string {
 	}
 
 	return identities
+}
+
+// currentReleaseStorageIdentities returns only the Helm storage UIDs that
+// belong to the current release incarnation. An uninstalled revision is an
+// incarnation boundary: `helm install --replace` retains older history but
+// starts the replacement after that boundary. When the latest revision itself
+// is uninstalled, the preceding boundary is used so callers can still
+// recognize the just-removed incarnation as their own idempotent cleanup.
+func currentReleaseStorageIdentities(items []releaseStorageItem) []string {
+	latestVersion, latestStatus := latestReleaseStorageVersionAndStatus(items)
+	boundaryVersion := releaseIncarnationBoundary(items, latestVersion, latestStatus)
+
+	return releaseStorageIdentitiesAfter(items, boundaryVersion)
+}
+
+func latestReleaseStorageVersionAndStatus(items []releaseStorageItem) (int, string) {
+	latestVersion := -1
+	latestStatus := ""
+
+	for _, item := range items {
+		version := releaseStorageVersion(item)
+		if version > latestVersion {
+			latestVersion = version
+			latestStatus = releaseStorageStatus(item)
+		}
+	}
+
+	return latestVersion, latestStatus
+}
+
+func releaseIncarnationBoundary(
+	items []releaseStorageItem,
+	latestVersion int,
+	latestStatus string,
+) int {
+	boundaryVersion := -1
+
+	for _, item := range items {
+		version := releaseStorageVersion(item)
+
+		isLatestUninstalled := latestStatus == "uninstalled" && version == latestVersion
+		if releaseStorageStatus(item) != "uninstalled" || isLatestUninstalled {
+			continue
+		}
+
+		if version > boundaryVersion {
+			boundaryVersion = version
+		}
+	}
+
+	return boundaryVersion
+}
+
+func releaseStorageIdentitiesAfter(items []releaseStorageItem, boundaryVersion int) []string {
+	identities := make([]string, 0, len(items))
+	for _, item := range items {
+		version := releaseStorageVersion(item)
+		identity := strings.TrimSpace(item.UID)
+
+		if version > boundaryVersion && identity != "" {
+			identities = append(identities, identity)
+		}
+	}
+
+	return identities
+}
+
+func releaseStorageVersion(item releaseStorageItem) int {
+	version, _ := strconv.Atoi(item.Labels["version"])
+
+	return version
+}
+
+func releaseStorageStatus(item releaseStorageItem) string {
+	return strings.ToLower(strings.TrimSpace(item.Labels["status"]))
 }
 
 func (c *Client) installRelease(

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -380,6 +380,20 @@ func (c *Client) GetReleaseStorageLabels(
 	ctx context.Context,
 	releaseName, namespace string,
 ) (map[string]string, error) {
+	metadata, err := c.GetReleaseStorageMetadata(ctx, releaseName, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata.Labels, nil
+}
+
+// GetReleaseStorageMetadata returns labels and the Kubernetes UID from the
+// latest Helm release storage object (Secret or ConfigMap).
+func (c *Client) GetReleaseStorageMetadata(
+	ctx context.Context,
+	releaseName, namespace string,
+) (*ReleaseStorageMetadata, error) {
 	if releaseName == "" {
 		return nil, errReleaseNameRequired
 	}
@@ -405,7 +419,7 @@ func (c *Client) GetReleaseStorageLabels(
 
 	selector := fmt.Sprintf("name=%s,owner=helm", releaseName)
 
-	return c.fetchStorageLabels(ctx, clientset, driver, namespace, selector)
+	return c.fetchReleaseStorageMetadata(ctx, clientset, driver, namespace, selector)
 }
 
 // GetReleaseValues returns the user-supplied values for the latest revision of
@@ -445,18 +459,19 @@ func (c *Client) GetReleaseValues(
 	return values, nil
 }
 
-// fetchStorageLabels queries either ConfigMaps or Secrets (based on driver) and
-// returns labels from the storage object with the highest version.
-func (c *Client) fetchStorageLabels(
+type releaseStorageItem struct {
+	Labels map[string]string
+	UID    string
+}
+
+// fetchReleaseStorageMetadata queries either ConfigMaps or Secrets based on
+// the configured Helm storage driver.
+func (c *Client) fetchReleaseStorageMetadata(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	driver, namespace, selector string,
-) (map[string]string, error) {
-	type labeledItem struct {
-		Labels map[string]string
-	}
-
-	var items []labeledItem
+) (*ReleaseStorageMetadata, error) {
+	var items []releaseStorageItem
 
 	switch driver {
 	case "configmap", "configmaps":
@@ -470,7 +485,10 @@ func (c *Client) fetchStorageLabels(
 		}
 
 		for i := range cmList.Items {
-			items = append(items, labeledItem{Labels: cmList.Items[i].Labels})
+			items = append(items, releaseStorageItem{
+				Labels: cmList.Items[i].Labels,
+				UID:    string(cmList.Items[i].UID),
+			})
 		}
 	default:
 		secretList, err := clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
@@ -483,10 +501,19 @@ func (c *Client) fetchStorageLabels(
 		}
 
 		for i := range secretList.Items {
-			items = append(items, labeledItem{Labels: secretList.Items[i].Labels})
+			items = append(items, releaseStorageItem{
+				Labels: secretList.Items[i].Labels,
+				UID:    string(secretList.Items[i].UID),
+			})
 		}
 	}
 
+	return latestReleaseStorageMetadata(items)
+}
+
+func latestReleaseStorageMetadata(
+	items []releaseStorageItem,
+) (*ReleaseStorageMetadata, error) {
 	if len(items) == 0 {
 		return nil, ErrNoReleaseStorage
 	}
@@ -502,7 +529,10 @@ func (c *Client) fetchStorageLabels(
 		}
 	}
 
-	return items[bestIdx].Labels, nil
+	return &ReleaseStorageMetadata{
+		Labels:   items[bestIdx].Labels,
+		Identity: items[bestIdx].UID,
+	}, nil
 }
 
 func (c *Client) installRelease(

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	helmv4action "helm.sh/helm/v4/pkg/action"
@@ -248,8 +249,9 @@ func (c *Client) UninstallRelease(ctx context.Context, releaseName, namespace st
 	return nil
 }
 
-// ReleaseExists checks whether a Helm release with the given name exists in the
-// specified namespace. It returns true when at least one revision is recorded.
+// ReleaseExists checks whether the latest Helm release revision with the given
+// name is deployed in the specified namespace. Failed, pending, uninstalled,
+// and superseded history must not be treated as a live component.
 func (c *Client) ReleaseExists(
 	_ context.Context,
 	releaseName, namespace string,
@@ -266,7 +268,6 @@ func (c *Client) ReleaseExists(
 	defer cleanup()
 
 	histClient := helmv4action.NewHistory(c.actionConfig)
-	histClient.Max = 1
 
 	releases, err := histClient.Run(releaseName)
 	if err != nil {
@@ -277,7 +278,26 @@ func (c *Client) ReleaseExists(
 		return false, fmt.Errorf("failed to check release history for %q: %w", releaseName, err)
 	}
 
-	return len(releases) > 0, nil
+	latestVersion := -1
+	latestStatus := ""
+
+	for _, release := range releases {
+		accessor, accessorErr := helmv4release.NewAccessor(release)
+		if accessorErr != nil {
+			return false, fmt.Errorf(
+				"failed to access release history for %q: %w",
+				releaseName,
+				accessorErr,
+			)
+		}
+
+		if accessor.Version() > latestVersion {
+			latestVersion = accessor.Version()
+			latestStatus = accessor.Status()
+		}
+	}
+
+	return latestVersion >= 0 && strings.EqualFold(latestStatus, "deployed"), nil
 }
 
 // ListReleases returns Helm releases across all namespaces for all statuses in a
@@ -341,6 +361,8 @@ func (c *Client) ListReleases(ctx context.Context) ([]ReleaseInfo, error) {
 		result = append(result, ReleaseInfo{
 			Name:      accessor.Name(),
 			Namespace: accessor.Namespace(),
+			Revision:  accessor.Version(),
+			Status:    accessor.Status(),
 		})
 	}
 

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -551,10 +551,9 @@ func latestReleaseStorageMetadata(
 	}
 
 	return &ReleaseStorageMetadata{
-		Labels:                       items[bestIdx].Labels,
-		Identity:                     items[bestIdx].UID,
-		HistoryIdentities:            releaseStorageIdentities(items),
-		CurrentIncarnationIdentities: currentReleaseStorageIdentities(items),
+		Labels:            items[bestIdx].Labels,
+		Identity:          items[bestIdx].UID,
+		HistoryIdentities: releaseStorageIdentities(items),
 	}, nil
 }
 
@@ -567,81 +566,6 @@ func releaseStorageIdentities(items []releaseStorageItem) []string {
 	}
 
 	return identities
-}
-
-// currentReleaseStorageIdentities returns only the Helm storage UIDs that
-// belong to the current release incarnation. An uninstalled revision is an
-// incarnation boundary: `helm install --replace` retains older history but
-// starts the replacement after that boundary. When the latest revision itself
-// is uninstalled, the preceding boundary is used so callers can still
-// recognize the just-removed incarnation as their own idempotent cleanup.
-func currentReleaseStorageIdentities(items []releaseStorageItem) []string {
-	latestVersion, latestStatus := latestReleaseStorageVersionAndStatus(items)
-	boundaryVersion := releaseIncarnationBoundary(items, latestVersion, latestStatus)
-
-	return releaseStorageIdentitiesAfter(items, boundaryVersion)
-}
-
-func latestReleaseStorageVersionAndStatus(items []releaseStorageItem) (int, string) {
-	latestVersion := -1
-	latestStatus := ""
-
-	for _, item := range items {
-		version := releaseStorageVersion(item)
-		if version > latestVersion {
-			latestVersion = version
-			latestStatus = releaseStorageStatus(item)
-		}
-	}
-
-	return latestVersion, latestStatus
-}
-
-func releaseIncarnationBoundary(
-	items []releaseStorageItem,
-	latestVersion int,
-	latestStatus string,
-) int {
-	boundaryVersion := -1
-
-	for _, item := range items {
-		version := releaseStorageVersion(item)
-
-		isLatestUninstalled := latestStatus == "uninstalled" && version == latestVersion
-		if releaseStorageStatus(item) != "uninstalled" || isLatestUninstalled {
-			continue
-		}
-
-		if version > boundaryVersion {
-			boundaryVersion = version
-		}
-	}
-
-	return boundaryVersion
-}
-
-func releaseStorageIdentitiesAfter(items []releaseStorageItem, boundaryVersion int) []string {
-	identities := make([]string, 0, len(items))
-	for _, item := range items {
-		version := releaseStorageVersion(item)
-		identity := strings.TrimSpace(item.UID)
-
-		if version > boundaryVersion && identity != "" {
-			identities = append(identities, identity)
-		}
-	}
-
-	return identities
-}
-
-func releaseStorageVersion(item releaseStorageItem) int {
-	version, _ := strconv.Atoi(item.Labels["version"])
-
-	return version
-}
-
-func releaseStorageStatus(item releaseStorageItem) string {
-	return strings.ToLower(strings.TrimSpace(item.Labels["status"]))
 }
 
 func (c *Client) installRelease(

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -25,6 +25,20 @@ const (
 	DefaultTimeout = 5 * time.Minute
 )
 
+// ValidateKubernetesReleaseStorageDriver rejects Helm backends whose release
+// records have no Kubernetes UID. Identity-bound lifecycle operations must run
+// only with Secret or ConfigMap storage so they can distinguish a same-name
+// replacement from the release incarnation KSail actually mutated.
+func ValidateKubernetesReleaseStorageDriver(driver string) error {
+	driver = strings.ToLower(strings.TrimSpace(driver))
+	switch driver {
+	case "", "secret", "secrets", "configmap", "configmaps":
+		return nil
+	default:
+		return fmt.Errorf("%w: %q", ErrReleaseStorageDriverUnsupported, driver)
+	}
+}
+
 // Client represents the default helm implementation used by KSail.
 type Client struct {
 	actionConfig *helmv4action.Configuration
@@ -403,8 +417,10 @@ func (c *Client) GetReleaseStorageMetadata(
 	}
 
 	driver := os.Getenv("HELM_DRIVER")
-	if driver == "memory" {
-		return nil, ErrNoReleaseStorage
+
+	err := ValidateKubernetesReleaseStorageDriver(driver)
+	if err != nil {
+		return nil, err
 	}
 
 	restConfig, err := c.settings.RESTClientGetter().ToRESTConfig()
@@ -471,6 +487,11 @@ func (c *Client) fetchReleaseStorageMetadata(
 	clientset kubernetes.Interface,
 	driver, namespace, selector string,
 ) (*ReleaseStorageMetadata, error) {
+	err := ValidateKubernetesReleaseStorageDriver(driver)
+	if err != nil {
+		return nil, err
+	}
+
 	var items []releaseStorageItem
 
 	switch driver {
@@ -530,9 +551,21 @@ func latestReleaseStorageMetadata(
 	}
 
 	return &ReleaseStorageMetadata{
-		Labels:   items[bestIdx].Labels,
-		Identity: items[bestIdx].UID,
+		Labels:            items[bestIdx].Labels,
+		Identity:          items[bestIdx].UID,
+		HistoryIdentities: releaseStorageIdentities(items),
 	}, nil
+}
+
+func releaseStorageIdentities(items []releaseStorageItem) []string {
+	identities := make([]string, 0, len(items))
+	for _, item := range items {
+		if identity := strings.TrimSpace(item.UID); identity != "" {
+			identities = append(identities, identity)
+		}
+	}
+
+	return identities
 }
 
 func (c *Client) installRelease(

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -30,13 +30,21 @@ const (
 // only with Secret or ConfigMap storage so they can distinguish a same-name
 // replacement from the release incarnation KSail actually mutated.
 func ValidateKubernetesReleaseStorageDriver(driver string) error {
-	driver = strings.ToLower(strings.TrimSpace(driver))
+	driver = normalizeReleaseStorageDriver(driver)
 	switch driver {
 	case "", "secret", "secrets", "configmap", "configmaps":
 		return nil
 	default:
 		return fmt.Errorf("%w: %q", ErrReleaseStorageDriverUnsupported, driver)
 	}
+}
+
+func normalizeReleaseStorageDriver(driver string) string {
+	return strings.ToLower(strings.TrimSpace(driver))
+}
+
+func configuredReleaseStorageDriver() string {
+	return normalizeReleaseStorageDriver(os.Getenv("HELM_DRIVER"))
 }
 
 // Client represents the default helm implementation used by KSail.
@@ -108,7 +116,7 @@ func newClient(
 	initErr := actionConfig.Init(
 		settings.RESTClientGetter(),
 		settings.Namespace(),
-		os.Getenv("HELM_DRIVER"),
+		configuredReleaseStorageDriver(),
 	)
 	if initErr != nil {
 		return nil, fmt.Errorf("failed to initialize helm v4 action config: %w", initErr)
@@ -163,7 +171,7 @@ func (c *Client) RefreshDiscovery() error {
 	initErr := c.actionConfig.Init(
 		settings.RESTClientGetter(),
 		settings.Namespace(),
-		os.Getenv("HELM_DRIVER"),
+		configuredReleaseStorageDriver(),
 	)
 	if initErr != nil {
 		return fmt.Errorf("reinitialize helm action config after discovery refresh: %w", initErr)
@@ -338,7 +346,7 @@ func (c *Client) ListReleases(ctx context.Context) ([]ReleaseInfo, error) {
 	reinitErr := c.actionConfig.Init(
 		c.settings.RESTClientGetter(),
 		"",
-		os.Getenv("HELM_DRIVER"),
+		configuredReleaseStorageDriver(),
 	)
 	if reinitErr != nil {
 		restoreErr := c.restoreNamespace(previousNamespace)
@@ -416,7 +424,7 @@ func (c *Client) GetReleaseStorageMetadata(
 		namespace = c.settings.Namespace()
 	}
 
-	driver := os.Getenv("HELM_DRIVER")
+	driver := configuredReleaseStorageDriver()
 
 	err := ValidateKubernetesReleaseStorageDriver(driver)
 	if err != nil {
@@ -487,6 +495,8 @@ func (c *Client) fetchReleaseStorageMetadata(
 	clientset kubernetes.Interface,
 	driver, namespace, selector string,
 ) (*ReleaseStorageMetadata, error) {
+	driver = normalizeReleaseStorageDriver(driver)
+
 	err := ValidateKubernetesReleaseStorageDriver(driver)
 	if err != nil {
 		return nil, err

--- a/pkg/client/helm/client_coverage_test.go
+++ b/pkg/client/helm/client_coverage_test.go
@@ -296,6 +296,7 @@ func TestInstallActionAdapter(t *testing.T) {
 		WaitForJobs: true,
 		Timeout:     3 * time.Minute,
 		Version:     "1.5.0",
+		Labels:      map[string]string{"ksail.io/owner": "ksail"},
 	}
 
 	helm.ApplyCommonActionConfig(adapter, spec)
@@ -305,6 +306,7 @@ func TestInstallActionAdapter(t *testing.T) {
 	assert.True(t, install.WaitForJobs)
 	assert.Equal(t, 3*time.Minute, install.Timeout)
 	assert.Equal(t, "1.5.0", install.Version)
+	assert.Equal(t, map[string]string{"ksail.io/owner": "ksail"}, install.Labels)
 }
 
 func TestUpgradeActionAdapter(t *testing.T) {
@@ -316,6 +318,7 @@ func TestUpgradeActionAdapter(t *testing.T) {
 		WaitForJobs: false,
 		Timeout:     7 * time.Minute,
 		Version:     "2.1.0",
+		Labels:      map[string]string{"ksail.io/owner": "ksail"},
 	}
 
 	helm.ApplyCommonActionConfig(adapter, spec)
@@ -325,6 +328,7 @@ func TestUpgradeActionAdapter(t *testing.T) {
 	assert.False(t, upgrade.WaitForJobs)
 	assert.Equal(t, 7*time.Minute, upgrade.Timeout)
 	assert.Equal(t, "2.1.0", upgrade.Version)
+	assert.Equal(t, map[string]string{"ksail.io/owner": "ksail"}, upgrade.Labels)
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/client/helm/client_coverage_test.go
+++ b/pkg/client/helm/client_coverage_test.go
@@ -145,10 +145,76 @@ func TestListReleases_TemplateOnlyClient(t *testing.T) {
 // check performed by helmv4action.List.Run(), since this test exercises the
 // real Client.ListReleases path (not a mock). The test cannot run in parallel
 // because it sets the HELM_DRIVER env var.
+//
+//nolint:paralleltest // helper mutates HELM_DRIVER for the real Helm memory backend.
 func TestListReleases_ReturnsAllNamespaces(t *testing.T) {
+	client, cfg := newMemoryHelmClient(t, "default")
+
+	// Seed a release in the "argocd" namespace. Memory.Create uses the release's
+	// own Namespace field to determine where to store it.
+	rel := helm.NewTestRelease(
+		"argo-cd", "argocd", "argo-cd", "v2.10.0", "",
+		releasecommon.StatusDeployed, 1, time.Now(),
+	)
+	err := cfg.Releases.Create(rel)
+	require.NoError(t, err)
+
+	// After Create the memory driver namespace is "argocd"; reset it to "default"
+	// to reproduce the regression: without the re-init in ListReleases the driver
+	// stays scoped to "default" and the "argocd" release would be invisible.
+	memDriver, ok := cfg.Releases.Driver.(*helmv4driver.Memory)
+	require.True(t, ok, "expected memory driver after HELM_DRIVER=memory init")
+	memDriver.SetNamespace("default")
+
+	releases, err := client.ListReleases(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, releases, 1, "expected release from non-default namespace to be visible")
+	assert.Equal(t, "argo-cd", releases[0].Name)
+	assert.Equal(t, "argocd", releases[0].Namespace)
+	assert.Equal(t, 1, releases[0].Revision)
+	assert.Equal(t, "deployed", releases[0].Status)
+}
+
+// TestReleaseExistsUsesLatestDeployedStatus proves retained Helm history is not
+// mistaken for a live component after the latest revision fails.
+//
+//nolint:paralleltest // helper mutates HELM_DRIVER for the real Helm memory backend.
+func TestReleaseExistsUsesLatestDeployedStatus(t *testing.T) {
+	client, cfg := newMemoryHelmClient(t, "kube-system")
+
+	deployed := helm.NewTestRelease(
+		"aws-load-balancer-controller", "kube-system", "aws-load-balancer-controller", "v1", "",
+		releasecommon.StatusDeployed, 1, time.Now(),
+	)
+	require.NoError(t, cfg.Releases.Create(deployed))
+
+	exists, err := client.ReleaseExists(
+		context.Background(), "aws-load-balancer-controller", "kube-system",
+	)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	failed := helm.NewTestRelease(
+		"aws-load-balancer-controller", "kube-system", "aws-load-balancer-controller", "v1", "",
+		releasecommon.StatusFailed, 2, time.Now(),
+	)
+	require.NoError(t, cfg.Releases.Create(failed))
+
+	exists, err = client.ReleaseExists(
+		context.Background(), "aws-load-balancer-controller", "kube-system",
+	)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func newMemoryHelmClient(
+	t *testing.T,
+	namespace string,
+) (*helm.Client, *helmv4action.Configuration) {
+	t.Helper()
 	t.Setenv("HELM_DRIVER", "memory")
 
-	// Fake Kubernetes API server — only /version is needed for IsReachable().
 	srv := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/version" {
 			resp.Header().Set("Content-Type", "application/json")
@@ -161,7 +227,6 @@ func TestListReleases_ReturnsAllNamespaces(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	// Write a kubeconfig pointing to the fake server.
 	kubeconfig := fmt.Sprintf(`apiVersion: v1
 clusters:
 - cluster:
@@ -182,37 +247,12 @@ users:
 
 	settings := helmv4cli.New()
 	settings.KubeConfig = kubeconfigPath
-	settings.SetNamespace("default")
+	settings.SetNamespace(namespace)
 
 	cfg := new(helmv4action.Configuration)
-	// Initialize at "default" namespace — simulates a client scoped to a single
-	// namespace, which would miss releases in other namespaces without the fix.
-	err := cfg.Init(settings.RESTClientGetter(), "default", "memory")
-	require.NoError(t, err)
+	require.NoError(t, cfg.Init(settings.RESTClientGetter(), namespace, "memory"))
 
-	// Seed a release in the "argocd" namespace. Memory.Create uses the release's
-	// own Namespace field to determine where to store it.
-	rel := helm.NewTestRelease(
-		"argo-cd", "argocd", "argo-cd", "v2.10.0", "",
-		releasecommon.StatusDeployed, 1, time.Now(),
-	)
-	err = cfg.Releases.Create(rel)
-	require.NoError(t, err)
-
-	// After Create the memory driver namespace is "argocd"; reset it to "default"
-	// to reproduce the regression: without the re-init in ListReleases the driver
-	// stays scoped to "default" and the "argocd" release would be invisible.
-	memDriver, ok := cfg.Releases.Driver.(*helmv4driver.Memory)
-	require.True(t, ok, "expected memory driver after HELM_DRIVER=memory init")
-	memDriver.SetNamespace("default")
-
-	client := helm.NewClientFromParts(cfg, settings)
-	releases, err := client.ListReleases(context.Background())
-
-	require.NoError(t, err)
-	require.Len(t, releases, 1, "expected release from non-default namespace to be visible")
-	assert.Equal(t, "argo-cd", releases[0].Name)
-	assert.Equal(t, "argocd", releases[0].Namespace)
+	return helm.NewClientFromParts(cfg, settings), cfg
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/client/helm/client_coverage_test.go
+++ b/pkg/client/helm/client_coverage_test.go
@@ -208,12 +208,36 @@ func TestReleaseExistsUsesLatestDeployedStatus(t *testing.T) {
 	assert.False(t, exists)
 }
 
+func TestNewClientNormalizesReleaseStorageDriver(t *testing.T) {
+	t.Setenv("HELM_DRIVER", " ConfigMap ")
+
+	client, err := helm.NewClient(newTestHelmKubeconfig(t), "fake")
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
 func newMemoryHelmClient(
 	t *testing.T,
 	namespace string,
 ) (*helm.Client, *helmv4action.Configuration) {
 	t.Helper()
 	t.Setenv("HELM_DRIVER", "memory")
+
+	kubeconfigPath := newTestHelmKubeconfig(t)
+
+	settings := helmv4cli.New()
+	settings.KubeConfig = kubeconfigPath
+	settings.SetNamespace(namespace)
+
+	cfg := new(helmv4action.Configuration)
+	require.NoError(t, cfg.Init(settings.RESTClientGetter(), namespace, "memory"))
+
+	return helm.NewClientFromParts(cfg, settings), cfg
+}
+
+func newTestHelmKubeconfig(t *testing.T) string {
+	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/version" {
@@ -245,14 +269,7 @@ users:
 	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
 	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o600))
 
-	settings := helmv4cli.New()
-	settings.KubeConfig = kubeconfigPath
-	settings.SetNamespace(namespace)
-
-	cfg := new(helmv4action.Configuration)
-	require.NoError(t, cfg.Init(settings.RESTClientGetter(), namespace, "memory"))
-
-	return helm.NewClientFromParts(cfg, settings), cfg
+	return kubeconfigPath
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/client/helm/export_test.go
+++ b/pkg/client/helm/export_test.go
@@ -55,12 +55,14 @@ type TestableActionConfig struct {
 	WaitForJobs  bool
 	Timeout      time.Duration
 	Version      string
+	Labels       map[string]string
 }
 
 func (t *TestableActionConfig) setWaitStrategy(s helmv4kube.WaitStrategy) { t.WaitStrategy = s }
 func (t *TestableActionConfig) setWaitForJobs(w bool)                     { t.WaitForJobs = w }
 func (t *TestableActionConfig) setTimeout(d time.Duration)                { t.Timeout = d }
 func (t *TestableActionConfig) setVersion(v string)                       { t.Version = v }
+func (t *TestableActionConfig) setLabels(labels map[string]string)        { t.Labels = labels }
 
 // NewInstallActionAdapter creates an installActionAdapter wrapping an Install action.
 func NewInstallActionAdapter() (actionConfig, *helmv4action.Install) {

--- a/pkg/client/helm/export_test.go
+++ b/pkg/client/helm/export_test.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"context"
 	"time"
 
 	helmv4action "helm.sh/helm/v4/pkg/action"
@@ -9,6 +10,7 @@ import (
 	helmv4kube "helm.sh/helm/v4/pkg/kube"
 	releasecommon "helm.sh/helm/v4/pkg/release/common"
 	v1 "helm.sh/helm/v4/pkg/release/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Expose unexported functions for testing.
@@ -118,4 +120,13 @@ func NewClientFromParts(cfg *helmv4action.Configuration, settings *helmv4cli.Env
 		settings:     settings,
 		debugLog:     func(string, ...any) {},
 	}
+}
+
+// FetchReleaseStorageMetadata exposes the storage-selection helper for tests.
+func FetchReleaseStorageMetadata(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	driver, namespace, selector string,
+) (*ReleaseStorageMetadata, error) {
+	return (&Client{}).fetchReleaseStorageMetadata(ctx, clientset, driver, namespace, selector)
 }

--- a/pkg/client/helm/mocks.go
+++ b/pkg/client/helm/mocks.go
@@ -175,6 +175,80 @@ func (_c *MockInterface_GetReleaseStorageLabels_Call) RunAndReturn(run func(ctx 
 	return _c
 }
 
+// GetReleaseStorageMetadata provides a mock function for the type MockInterface
+func (_mock *MockInterface) GetReleaseStorageMetadata(ctx context.Context, releaseName string, namespace string) (*ReleaseStorageMetadata, error) {
+	ret := _mock.Called(ctx, releaseName, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReleaseStorageMetadata")
+	}
+
+	var r0 *ReleaseStorageMetadata
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*ReleaseStorageMetadata, error)); ok {
+		return returnFunc(ctx, releaseName, namespace)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *ReleaseStorageMetadata); ok {
+		r0 = returnFunc(ctx, releaseName, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ReleaseStorageMetadata)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, releaseName, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockInterface_GetReleaseStorageMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReleaseStorageMetadata'
+type MockInterface_GetReleaseStorageMetadata_Call struct {
+	*mock.Call
+}
+
+// GetReleaseStorageMetadata is a helper method to define mock.On call
+//   - ctx context.Context
+//   - releaseName string
+//   - namespace string
+func (_e *MockInterface_Expecter) GetReleaseStorageMetadata(ctx interface{}, releaseName interface{}, namespace interface{}) *MockInterface_GetReleaseStorageMetadata_Call {
+	return &MockInterface_GetReleaseStorageMetadata_Call{Call: _e.mock.On("GetReleaseStorageMetadata", ctx, releaseName, namespace)}
+}
+
+func (_c *MockInterface_GetReleaseStorageMetadata_Call) Run(run func(ctx context.Context, releaseName string, namespace string)) *MockInterface_GetReleaseStorageMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetReleaseStorageMetadata_Call) Return(releaseStorageMetadata *ReleaseStorageMetadata, err error) *MockInterface_GetReleaseStorageMetadata_Call {
+	_c.Call.Return(releaseStorageMetadata, err)
+	return _c
+}
+
+func (_c *MockInterface_GetReleaseStorageMetadata_Call) RunAndReturn(run func(ctx context.Context, releaseName string, namespace string) (*ReleaseStorageMetadata, error)) *MockInterface_GetReleaseStorageMetadata_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetReleaseValues provides a mock function for the type MockInterface
 func (_mock *MockInterface) GetReleaseValues(ctx context.Context, releaseName string, namespace string) (map[string]any, error) {
 	ret := _mock.Called(ctx, releaseName, namespace)

--- a/pkg/client/helm/namespace.go
+++ b/pkg/client/helm/namespace.go
@@ -1,9 +1,6 @@
 package helm
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 func (c *Client) switchNamespace(namespace string) (func(), error) {
 	if namespace == "" {
@@ -20,7 +17,7 @@ func (c *Client) switchNamespace(namespace string) (func(), error) {
 	reinitErr := c.actionConfig.Init(
 		c.settings.RESTClientGetter(),
 		namespace,
-		os.Getenv("HELM_DRIVER"),
+		configuredReleaseStorageDriver(),
 	)
 	if reinitErr != nil {
 		_ = c.restoreNamespace(previousNamespace)
@@ -42,7 +39,7 @@ func (c *Client) restoreNamespace(namespace string) error {
 	err := c.actionConfig.Init(
 		c.settings.RESTClientGetter(),
 		namespace,
-		os.Getenv("HELM_DRIVER"),
+		configuredReleaseStorageDriver(),
 	)
 	if err != nil {
 		return fmt.Errorf("init action config for namespace %q: %w", namespace, err)

--- a/pkg/client/helm/release_storage_test.go
+++ b/pkg/client/helm/release_storage_test.go
@@ -37,6 +37,11 @@ func TestFetchReleaseStorageMetadataSelectsLatestIncarnation(t *testing.T) {
 	assert.Equal(t, "current-uid", metadata.Identity)
 	assert.Equal(t, "2", metadata.Labels["version"])
 	assert.ElementsMatch(t, []string{"old-uid", "current-uid"}, metadata.HistoryIdentities)
+	assert.ElementsMatch(
+		t,
+		[]string{"old-uid", "current-uid"},
+		metadata.CurrentIncarnationIdentities,
+	)
 }
 
 func TestFetchReleaseStorageMetadataReportsMissingRelease(t *testing.T) {
@@ -48,6 +53,45 @@ func TestFetchReleaseStorageMetadataReportsMissingRelease(t *testing.T) {
 	)
 
 	require.ErrorIs(t, err, helm.ErrNoReleaseStorage)
+}
+
+func TestFetchReleaseStorageMetadataExcludesKeepHistoryReplacement(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewSimpleClientset(
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "sh.helm.release.v1.controller.v1", Namespace: "kube-system",
+			UID: types.UID("persisted-owned-uid"),
+			Labels: map[string]string{
+				"name": "controller", "owner": "helm", "version": "1", "status": "superseded",
+			},
+		}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "sh.helm.release.v1.controller.v2", Namespace: "kube-system",
+			UID: types.UID("uninstalled-uid"),
+			Labels: map[string]string{
+				"name": "controller", "owner": "helm", "version": "2", "status": "uninstalled",
+			},
+		}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "sh.helm.release.v1.controller.v3", Namespace: "kube-system",
+			UID: types.UID("replacement-uid"),
+			Labels: map[string]string{
+				"name": "controller", "owner": "helm", "version": "3", "status": "deployed",
+			},
+		}},
+	)
+
+	metadata, err := helm.FetchReleaseStorageMetadata(
+		context.Background(), clientset, "secret", "kube-system", "name=controller,owner=helm",
+	)
+
+	require.NoError(t, err)
+	assert.ElementsMatch(
+		t,
+		[]string{"replacement-uid"},
+		metadata.CurrentIncarnationIdentities,
+	)
 }
 
 func TestFetchReleaseStorageMetadataRejectsUnsupportedDriver(t *testing.T) {

--- a/pkg/client/helm/release_storage_test.go
+++ b/pkg/client/helm/release_storage_test.go
@@ -50,6 +50,52 @@ func TestFetchReleaseStorageMetadataReportsMissingRelease(t *testing.T) {
 	require.ErrorIs(t, err, helm.ErrNoReleaseStorage)
 }
 
+func TestFetchReleaseStorageMetadataNormalizesDriver(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		driver string
+		want   string
+	}{
+		"configmap mixed case and whitespace":     {driver: " ConfigMap ", want: "configmap-uid"},
+		"secret plural mixed case and whitespace": {driver: " SECRETS ", want: "secret-uid"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			clientset := fake.NewSimpleClientset(
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: "sh.helm.release.v1.controller.v1", Namespace: "kube-system",
+					UID: types.UID("secret-uid"),
+					Labels: map[string]string{
+						"name": "controller", "owner": "helm", "version": "1",
+					},
+				}},
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+					Name: "sh.helm.release.v1.controller.v1", Namespace: "kube-system",
+					UID: types.UID("configmap-uid"),
+					Labels: map[string]string{
+						"name": "controller", "owner": "helm", "version": "1",
+					},
+				}},
+			)
+
+			metadata, err := helm.FetchReleaseStorageMetadata(
+				context.Background(),
+				clientset,
+				test.driver,
+				"kube-system",
+				"name=controller,owner=helm",
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, metadata.Identity)
+		})
+	}
+}
+
 func TestFetchReleaseStorageMetadataExcludesKeepHistoryReplacement(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/client/helm/release_storage_test.go
+++ b/pkg/client/helm/release_storage_test.go
@@ -1,0 +1,50 @@
+package helm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestFetchReleaseStorageMetadataSelectsLatestIncarnation(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewSimpleClientset(
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "sh.helm.release.v1.controller.v1", Namespace: "kube-system",
+			UID:    types.UID("old-uid"),
+			Labels: map[string]string{"name": "controller", "owner": "helm", "version": "1"},
+		}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "sh.helm.release.v1.controller.v2", Namespace: "kube-system",
+			UID:    types.UID("current-uid"),
+			Labels: map[string]string{"name": "controller", "owner": "helm", "version": "2"},
+		}},
+	)
+
+	metadata, err := helm.FetchReleaseStorageMetadata(
+		context.Background(), clientset, "secret", "kube-system", "name=controller,owner=helm",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "current-uid", metadata.Identity)
+	assert.Equal(t, "2", metadata.Labels["version"])
+}
+
+func TestFetchReleaseStorageMetadataReportsMissingRelease(t *testing.T) {
+	t.Parallel()
+
+	_, err := helm.FetchReleaseStorageMetadata(
+		context.Background(), fake.NewSimpleClientset(), "secret", "kube-system",
+		"name=missing,owner=helm",
+	)
+
+	require.ErrorIs(t, err, helm.ErrNoReleaseStorage)
+}

--- a/pkg/client/helm/release_storage_test.go
+++ b/pkg/client/helm/release_storage_test.go
@@ -36,6 +36,7 @@ func TestFetchReleaseStorageMetadataSelectsLatestIncarnation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "current-uid", metadata.Identity)
 	assert.Equal(t, "2", metadata.Labels["version"])
+	assert.ElementsMatch(t, []string{"old-uid", "current-uid"}, metadata.HistoryIdentities)
 }
 
 func TestFetchReleaseStorageMetadataReportsMissingRelease(t *testing.T) {
@@ -47,4 +48,15 @@ func TestFetchReleaseStorageMetadataReportsMissingRelease(t *testing.T) {
 	)
 
 	require.ErrorIs(t, err, helm.ErrNoReleaseStorage)
+}
+
+func TestFetchReleaseStorageMetadataRejectsUnsupportedDriver(t *testing.T) {
+	t.Parallel()
+
+	_, err := helm.FetchReleaseStorageMetadata(
+		context.Background(), fake.NewSimpleClientset(), "sql", "kube-system",
+		"name=controller,owner=helm",
+	)
+
+	require.ErrorContains(t, err, "cannot provide a Kubernetes release identity")
 }

--- a/pkg/client/helm/release_storage_test.go
+++ b/pkg/client/helm/release_storage_test.go
@@ -37,11 +37,6 @@ func TestFetchReleaseStorageMetadataSelectsLatestIncarnation(t *testing.T) {
 	assert.Equal(t, "current-uid", metadata.Identity)
 	assert.Equal(t, "2", metadata.Labels["version"])
 	assert.ElementsMatch(t, []string{"old-uid", "current-uid"}, metadata.HistoryIdentities)
-	assert.ElementsMatch(
-		t,
-		[]string{"old-uid", "current-uid"},
-		metadata.CurrentIncarnationIdentities,
-	)
 }
 
 func TestFetchReleaseStorageMetadataReportsMissingRelease(t *testing.T) {
@@ -70,7 +65,7 @@ func TestFetchReleaseStorageMetadataExcludesKeepHistoryReplacement(t *testing.T)
 			Name: "sh.helm.release.v1.controller.v2", Namespace: "kube-system",
 			UID: types.UID("uninstalled-uid"),
 			Labels: map[string]string{
-				"name": "controller", "owner": "helm", "version": "2", "status": "uninstalled",
+				"name": "controller", "owner": "helm", "version": "2", "status": "superseded",
 			},
 		}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
@@ -89,8 +84,8 @@ func TestFetchReleaseStorageMetadataExcludesKeepHistoryReplacement(t *testing.T)
 	require.NoError(t, err)
 	assert.ElementsMatch(
 		t,
-		[]string{"replacement-uid"},
-		metadata.CurrentIncarnationIdentities,
+		[]string{"persisted-owned-uid", "uninstalled-uid", "replacement-uid"},
+		metadata.HistoryIdentities,
 	)
 }
 

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -62,6 +62,7 @@ type ChartSpec struct {
 	SetValues   map[string]string
 	SetFileVals map[string]string
 	SetJSONVals map[string]string
+	Labels      map[string]string
 
 	RepoURL  string
 	Username string
@@ -106,11 +107,10 @@ type ReleaseInfo struct {
 type ReleaseStorageMetadata struct {
 	Labels   map[string]string
 	Identity string
-	// HistoryIdentities contains every retained revision and is diagnostic only.
+	// HistoryIdentities contains every retained revision. Callers must combine
+	// it with positive ownership metadata from the latest revision before using
+	// a historical identity as uninstall authority.
 	HistoryIdentities []string
-	// CurrentIncarnationIdentities excludes revisions before the latest Helm
-	// uninstalled boundary and is safe for release-ownership comparisons.
-	CurrentIncarnationIdentities []string
 }
 
 // ChartManager defines the chart lifecycle operations required by KSail.

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -103,13 +103,17 @@ type ReleaseStorageMetadata struct {
 	Identity string
 }
 
-// Interface defines the subset of Helm functionality required by KSail.
-type Interface interface {
+// ChartManager defines the chart lifecycle operations required by KSail.
+type ChartManager interface {
 	InstallChart(ctx context.Context, spec *ChartSpec) (*ReleaseInfo, error)
 	InstallOrUpgradeChart(ctx context.Context, spec *ChartSpec) (*ReleaseInfo, error)
 	UninstallRelease(ctx context.Context, releaseName, namespace string) error
 	AddRepository(ctx context.Context, entry *RepositoryEntry, timeout time.Duration) error
 	TemplateChart(ctx context.Context, spec *ChartSpec) (string, error)
+}
+
+// ReleaseInspector defines the live release queries required by KSail.
+type ReleaseInspector interface {
 	ReleaseExists(ctx context.Context, releaseName, namespace string) (bool, error)
 	// ListReleases returns Helm releases across all namespaces for all statuses.
 	// Name, Namespace, Revision, and Status are populated; the remaining fields
@@ -148,4 +152,10 @@ type Interface interface {
 	// that depend on them by another, the second install fails with "ensure CRDs
 	// are installed first" unless discovery is refreshed in between.
 	RefreshDiscovery() error
+}
+
+// Interface defines the subset of Helm functionality required by KSail.
+type Interface interface {
+	ChartManager
+	ReleaseInspector
 }

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -25,6 +25,11 @@ var (
 	// Helm release storage objects (Secrets or ConfigMaps) exist for the
 	// given release name and namespace.
 	ErrNoReleaseStorage = errors.New("helm: no release storage objects found")
+	// ErrReleaseStorageDriverUnsupported reports a Helm backend that cannot
+	// provide Kubernetes object identity for fail-closed release ownership.
+	ErrReleaseStorageDriverUnsupported = errors.New(
+		"helm storage driver cannot provide a Kubernetes release identity",
+	)
 
 	// ErrReleaseNotFound re-exports the Helm SDK sentinel so callers can
 	// check whether an uninstall failed because the release never existed
@@ -99,8 +104,9 @@ type ReleaseInfo struct {
 // is the Kubernetes object UID, so deleting and reinstalling a same-name
 // release produces different ownership evidence even when its revision resets.
 type ReleaseStorageMetadata struct {
-	Labels   map[string]string
-	Identity string
+	Labels            map[string]string
+	Identity          string
+	HistoryIdentities []string
 }
 
 // ChartManager defines the chart lifecycle operations required by KSail.

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -104,9 +104,9 @@ type Interface interface {
 	TemplateChart(ctx context.Context, spec *ChartSpec) (string, error)
 	ReleaseExists(ctx context.Context, releaseName, namespace string) (bool, error)
 	// ListReleases returns Helm releases across all namespaces for all statuses.
-	// Only the Name and Namespace fields of each ReleaseInfo are guaranteed to be
-	// populated; all other fields (Status, Revision, etc.) are left at their zero
-	// values. Use this for bulk release detection to avoid N separate ReleaseExists roundtrips.
+	// Name, Namespace, Revision, and Status are populated; the remaining fields
+	// are left at their zero values. Use this for bulk release detection to avoid
+	// N separate ReleaseExists roundtrips.
 	ListReleases(ctx context.Context) ([]ReleaseInfo, error)
 	// GetReleaseStorageLabels returns the Kubernetes object labels from the
 	// latest Helm release storage object (Secret or ConfigMap, depending on

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -95,6 +95,14 @@ type ReleaseInfo struct {
 	Notes      string
 }
 
+// ReleaseStorageMetadata identifies one concrete Helm storage object. Identity
+// is the Kubernetes object UID, so deleting and reinstalling a same-name
+// release produces different ownership evidence even when its revision resets.
+type ReleaseStorageMetadata struct {
+	Labels   map[string]string
+	Identity string
+}
+
 // Interface defines the subset of Helm functionality required by KSail.
 type Interface interface {
 	InstallChart(ctx context.Context, spec *ChartSpec) (*ReleaseInfo, error)
@@ -118,6 +126,13 @@ type Interface interface {
 		ctx context.Context,
 		releaseName, namespace string,
 	) (map[string]string, error)
+	// GetReleaseStorageMetadata returns labels and the Kubernetes UID from the
+	// latest Helm release storage object. The UID binds persisted ownership to
+	// one release incarnation rather than only to its reusable Helm name.
+	GetReleaseStorageMetadata(
+		ctx context.Context,
+		releaseName, namespace string,
+	) (*ReleaseStorageMetadata, error)
 	// GetReleaseValues returns the user-supplied values for the latest revision
 	// of the named release. Returns (nil, error) when the release does not exist
 	// or cannot be queried. Use this to introspect installed chart configuration

--- a/pkg/client/helm/types.go
+++ b/pkg/client/helm/types.go
@@ -104,9 +104,13 @@ type ReleaseInfo struct {
 // is the Kubernetes object UID, so deleting and reinstalling a same-name
 // release produces different ownership evidence even when its revision resets.
 type ReleaseStorageMetadata struct {
-	Labels            map[string]string
-	Identity          string
+	Labels   map[string]string
+	Identity string
+	// HistoryIdentities contains every retained revision and is diagnostic only.
 	HistoryIdentities []string
+	// CurrentIncarnationIdentities excludes revisions before the latest Helm
+	// uninstalled boundary and is safe for release-ownership comparisons.
+	CurrentIncarnationIdentities []string
 }
 
 // ChartManager defines the chart lifecycle operations required by KSail.

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/internal/controller"
@@ -19,6 +20,24 @@ import (
 
 // componentInstallTimeout bounds each component's Helm install.
 const componentInstallTimeout = 5 * time.Minute
+
+var (
+	errOperatorReleaseIdentityMismatch = errors.New(
+		"operator-owned release identity no longer matches",
+	)
+	errOperatorReleaseIdentityUnavailable = errors.New(
+		"operator-owned release cannot report its identity",
+	)
+	errAWSControllerOwnershipUnavailable = errors.New(
+		"AWS load balancer controller cannot report GitOps ownership",
+	)
+	errAWSControllerIdentityUnavailable = errors.New(
+		"AWS load balancer controller cannot report release identity",
+	)
+	errAWSControllerIdentityEmpty = errors.New(
+		"AWS load balancer controller operator identity is empty",
+	)
+)
 
 // installOrder lists component installers in the order they must run: CNI first (pods cannot
 // schedule without networking), then infrastructure add-ons, then GitOps last. Keys match the
@@ -113,13 +132,19 @@ func InstallComponents(
 
 	components, installErr := runInstallers(ctx, installers)
 
-	return true, components, errors.Join(uninstallErr, installErr)
+	var ownershipErr error
+
+	if uninstallErr == nil && installErr == nil {
+		ownershipErr = recordAWSLoadBalancerControllerOwnership(ctx, cluster, installers)
+	}
+
+	return true, components, errors.Join(uninstallErr, installErr, ownershipErr)
 }
 
 // newInstallerFactory constructs the operator's component lifecycle factory.
-// A component present in the operator's last-applied baseline was installed by
-// this lifecycle, so its reconstructed installer carries positive ownership
-// evidence and may uninstall it when the desired spec drops the component.
+// AWS controller uninstall authority is still enabled on reconstructed
+// installers, but removedComponentInstallers exposes one only when a concrete
+// release identity annotation supplies positive operator ownership evidence.
 func newInstallerFactory(
 	helmClient helm.Interface,
 	kubeconfigPath, eksClusterName string,
@@ -188,11 +213,155 @@ func removedComponentInstallers(
 	for key, inst := range previous {
 		_, stillDesired := desired[key]
 		if !stillDesired {
+			if key == "aws-load-balancer-controller" {
+				expectedIdentity := strings.TrimSpace(
+					cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
+				)
+				if expectedIdentity == "" {
+					continue
+				}
+
+				inst = &releaseIdentityBoundInstaller{
+					Installer:        inst,
+					expectedIdentity: expectedIdentity,
+				}
+			}
+
 			removed[key] = inst
 		}
 	}
 
 	return removed, nil
+}
+
+type gitOpsOwnershipReporter interface {
+	IsGitOpsManaged(ctx context.Context) (bool, error)
+}
+
+type releaseIdentityReporter interface {
+	ReleaseIdentity(ctx context.Context) (string, error)
+}
+
+type releaseIdentityOwnershipReporter interface {
+	OwnsReleaseIdentity(ctx context.Context, expected string) (bool, error)
+}
+
+type releaseIdentityBoundInstaller struct {
+	installer.Installer
+
+	expectedIdentity string
+}
+
+func (bound *releaseIdentityBoundInstaller) Uninstall(ctx context.Context) error {
+	releaseExists, matches, err := bound.releaseIdentityStatus(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !releaseExists {
+		return nil
+	}
+
+	if !matches {
+		return errOperatorReleaseIdentityMismatch
+	}
+
+	err = bound.Installer.Uninstall(ctx)
+	if err != nil {
+		return fmt.Errorf("uninstall operator-owned release: %w", err)
+	}
+
+	return nil
+}
+
+func (bound *releaseIdentityBoundInstaller) releaseIdentityStatus(
+	ctx context.Context,
+) (bool, bool, error) {
+	if reporter, supported := bound.Installer.(releaseIdentityOwnershipReporter); supported {
+		matches, err := reporter.OwnsReleaseIdentity(ctx, bound.expectedIdentity)
+		if err != nil {
+			if errors.Is(err, helm.ErrNoReleaseStorage) ||
+				errors.Is(err, helm.ErrReleaseNotFound) {
+				return false, false, nil
+			}
+
+			return false, false, fmt.Errorf(
+				"verify operator-owned release identity history: %w",
+				err,
+			)
+		}
+
+		return true, matches, nil
+	}
+
+	reporter, supported := bound.Installer.(releaseIdentityReporter)
+	if !supported {
+		return false, false, errOperatorReleaseIdentityUnavailable
+	}
+
+	liveIdentity, err := reporter.ReleaseIdentity(ctx)
+	if err != nil {
+		if errors.Is(err, helm.ErrNoReleaseStorage) ||
+			errors.Is(err, helm.ErrReleaseNotFound) {
+			return false, false, nil
+		}
+
+		return false, false, fmt.Errorf("read operator-owned release identity: %w", err)
+	}
+
+	return true, strings.TrimSpace(liveIdentity) == bound.expectedIdentity, nil
+}
+
+func recordAWSLoadBalancerControllerOwnership(
+	ctx context.Context,
+	cluster *v1alpha1.Cluster,
+	installers map[string]installer.Installer,
+) error {
+	component, desired := installers["aws-load-balancer-controller"]
+	if !desired {
+		delete(cluster.Annotations, v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation)
+
+		return nil
+	}
+
+	ownershipReporter, ownershipSupported := component.(gitOpsOwnershipReporter)
+	if !ownershipSupported {
+		return errAWSControllerOwnershipUnavailable
+	}
+
+	gitOpsManaged, err := ownershipReporter.IsGitOpsManaged(ctx)
+	if err != nil {
+		return fmt.Errorf("verify AWS load balancer controller operator ownership: %w", err)
+	}
+
+	if gitOpsManaged {
+		delete(cluster.Annotations, v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation)
+
+		return nil
+	}
+
+	identityReporter, identitySupported := component.(releaseIdentityReporter)
+	if !identitySupported {
+		return errAWSControllerIdentityUnavailable
+	}
+
+	identity, err := identityReporter.ReleaseIdentity(ctx)
+	if err != nil {
+		return fmt.Errorf("read AWS load balancer controller operator identity: %w", err)
+	}
+
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return errAWSControllerIdentityEmpty
+	}
+
+	if cluster.Annotations == nil {
+		cluster.Annotations = map[string]string{}
+	}
+
+	cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation] = identity
+
+	return nil
 }
 
 // lastAppliedComponentsSpec parses the component-baseline annotation into a spec. The second return

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -136,11 +136,7 @@ func InstallComponents(
 	components, installErr := runInstallers(ctx, installers)
 
 	ownershipErr := recordAWSLoadBalancerControllerOwnershipAfterApply(
-		ctx,
-		cluster,
-		installers,
-		uninstallErr,
-		installErr,
+		ctx, cluster, installers, uninstallErr, installErr,
 	)
 
 	return true, components, errors.Join(uninstallErr, installErr, ownershipErr)

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
+	awslbcontroller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/awslbcontroller"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -52,7 +53,7 @@ var installOrder = []string{
 	"cert-manager",
 	"local-path-storage", "hetzner-csi",
 	"metrics-server", "kubelet-csr-approver",
-	"metallb", "cloud-provider-kind", "hcloud-ccm", "aws-load-balancer-controller",
+	"metallb", "cloud-provider-kind", "hcloud-ccm", awslbcontroller.ReleaseName,
 	"kyverno", "gatekeeper",
 	"cluster-autoscaler",
 	"flux", "argocd",
@@ -214,7 +215,7 @@ func removedComponentInstallers(
 	for key, inst := range previous {
 		_, stillDesired := desired[key]
 		if !stillDesired {
-			if key == "aws-load-balancer-controller" {
+			if key == awslbcontroller.ReleaseName {
 				expectedIdentity := strings.TrimSpace(
 					cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
 				)
@@ -326,7 +327,7 @@ func recordAWSLoadBalancerControllerOwnership(
 	cluster *v1alpha1.Cluster,
 	installers map[string]installer.Installer,
 ) error {
-	component, desired := installers["aws-load-balancer-controller"]
+	component, desired := installers[awslbcontroller.ReleaseName]
 	if !desired {
 		delete(cluster.Annotations, v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation)
 
@@ -383,7 +384,7 @@ func recordAWSLoadBalancerControllerOwnershipAfterApply(
 	installers map[string]installer.Installer,
 	uninstallErr, installErr error,
 ) error {
-	_, controllerDesired := installers["aws-load-balancer-controller"]
+	_, controllerDesired := installers[awslbcontroller.ReleaseName]
 	if !controllerDesired && (uninstallErr != nil || installErr != nil) {
 		// The caller joins and returns both sibling errors. This helper adds no
 		// duplicate error; it only preserves the existing ownership annotation.

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -37,6 +37,9 @@ var (
 	errAWSControllerIdentityEmpty = errors.New(
 		"AWS load balancer controller operator identity is empty",
 	)
+	errOperatorOwnershipEvidenceRequired = errors.New(
+		"AWS load balancer controller operator ownership evidence is required",
+	)
 )
 
 // installOrder lists component installers in the order they must run: CNI first (pods cannot
@@ -132,11 +135,13 @@ func InstallComponents(
 
 	components, installErr := runInstallers(ctx, installers)
 
-	var ownershipErr error
-
-	if uninstallErr == nil && installErr == nil {
-		ownershipErr = recordAWSLoadBalancerControllerOwnership(ctx, cluster, installers)
-	}
+	ownershipErr := recordAWSLoadBalancerControllerOwnershipAfterApply(
+		ctx,
+		cluster,
+		installers,
+		uninstallErr,
+		installErr,
+	)
 
 	return true, components, errors.Join(uninstallErr, installErr, ownershipErr)
 }
@@ -218,12 +223,12 @@ func removedComponentInstallers(
 					cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
 				)
 				if expectedIdentity == "" {
-					continue
-				}
-
-				inst = &releaseIdentityBoundInstaller{
-					Installer:        inst,
-					expectedIdentity: expectedIdentity,
+					inst = &unresolvedRemovalInstaller{Installer: inst}
+				} else {
+					inst = &releaseIdentityBoundInstaller{
+						Installer:        inst,
+						expectedIdentity: expectedIdentity,
+					}
 				}
 			}
 
@@ -250,6 +255,14 @@ type releaseIdentityBoundInstaller struct {
 	installer.Installer
 
 	expectedIdentity string
+}
+
+type unresolvedRemovalInstaller struct {
+	installer.Installer
+}
+
+func (*unresolvedRemovalInstaller) Uninstall(context.Context) error {
+	return errOperatorOwnershipEvidenceRequired
 }
 
 func (bound *releaseIdentityBoundInstaller) Uninstall(ctx context.Context) error {
@@ -362,6 +375,27 @@ func recordAWSLoadBalancerControllerOwnership(
 	cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation] = identity
 
 	return nil
+}
+
+// recordAWSLoadBalancerControllerOwnershipAfterApply records the controller's
+// actual outcome even when a sibling component failed later in the same pass.
+// A removal only clears existing authority after the complete pass succeeds;
+// otherwise the next reconcile must retain enough evidence to retry cleanup.
+func recordAWSLoadBalancerControllerOwnershipAfterApply(
+	ctx context.Context,
+	cluster *v1alpha1.Cluster,
+	installers map[string]installer.Installer,
+	uninstallErr, installErr error,
+) error {
+	_, controllerDesired := installers["aws-load-balancer-controller"]
+	if !controllerDesired && (uninstallErr != nil || installErr != nil) {
+		// The caller joins and returns both sibling errors. This helper adds no
+		// duplicate error; it only preserves the existing ownership annotation.
+		//nolint:nilerr // sibling failures are returned by InstallComponents
+		return nil
+	}
+
+	return recordAWSLoadBalancerControllerOwnership(ctx, cluster, installers)
 }
 
 // lastAppliedComponentsSpec parses the component-baseline annotation into a spec. The second return

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -35,6 +35,9 @@ var (
 	errAWSControllerIdentityUnavailable = errors.New(
 		"AWS load balancer controller cannot report release identity",
 	)
+	errAWSControllerReleaseOwnershipUnavailable = errors.New(
+		"AWS load balancer controller cannot verify KSail release ownership",
+	)
 	errAWSControllerIdentityEmpty = errors.New(
 		"AWS load balancer controller operator identity is empty",
 	)
@@ -334,35 +337,15 @@ func recordAWSLoadBalancerControllerOwnership(
 		return nil
 	}
 
-	ownershipReporter, ownershipSupported := component.(gitOpsOwnershipReporter)
-	if !ownershipSupported {
-		return errAWSControllerOwnershipUnavailable
-	}
-
-	gitOpsManaged, err := ownershipReporter.IsGitOpsManaged(ctx)
+	identity, operatorOwned, err := resolveAWSLoadBalancerControllerOwnership(ctx, component)
 	if err != nil {
-		return fmt.Errorf("verify AWS load balancer controller operator ownership: %w", err)
+		return err
 	}
 
-	if gitOpsManaged {
+	if !operatorOwned {
 		delete(cluster.Annotations, v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation)
 
 		return nil
-	}
-
-	identityReporter, identitySupported := component.(releaseIdentityReporter)
-	if !identitySupported {
-		return errAWSControllerIdentityUnavailable
-	}
-
-	identity, err := identityReporter.ReleaseIdentity(ctx)
-	if err != nil {
-		return fmt.Errorf("read AWS load balancer controller operator identity: %w", err)
-	}
-
-	identity = strings.TrimSpace(identity)
-	if identity == "" {
-		return errAWSControllerIdentityEmpty
 	}
 
 	if cluster.Annotations == nil {
@@ -372,6 +355,59 @@ func recordAWSLoadBalancerControllerOwnership(
 	cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation] = identity
 
 	return nil
+}
+
+func resolveAWSLoadBalancerControllerOwnership(
+	ctx context.Context,
+	component installer.Installer,
+) (string, bool, error) {
+	ownershipReporter, ownershipSupported := component.(gitOpsOwnershipReporter)
+	if !ownershipSupported {
+		return "", false, errAWSControllerOwnershipUnavailable
+	}
+
+	gitOpsManaged, err := ownershipReporter.IsGitOpsManaged(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf(
+			"verify AWS load balancer controller operator ownership: %w",
+			err,
+		)
+	}
+
+	if gitOpsManaged {
+		return "", false, nil
+	}
+
+	identityReporter, identitySupported := component.(releaseIdentityReporter)
+	if !identitySupported {
+		return "", false, errAWSControllerIdentityUnavailable
+	}
+
+	identity, err := identityReporter.ReleaseIdentity(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("read AWS load balancer controller operator identity: %w", err)
+	}
+
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return "", false, errAWSControllerIdentityEmpty
+	}
+
+	releaseOwnershipReporter, releaseOwnershipSupported := component.(releaseIdentityOwnershipReporter)
+	if !releaseOwnershipSupported {
+		return "", false, errAWSControllerReleaseOwnershipUnavailable
+	}
+
+	owned, err := releaseOwnershipReporter.OwnsReleaseIdentity(ctx, identity)
+	if err != nil {
+		return "", false, fmt.Errorf("verify AWS load balancer controller KSail ownership: %w", err)
+	}
+
+	if !owned {
+		return "", false, errOperatorOwnershipEvidenceRequired
+	}
+
+	return identity, true, nil
 }
 
 // recordAWSLoadBalancerControllerOwnershipAfterApply records the controller's

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -44,6 +44,9 @@ var (
 	errOperatorOwnershipEvidenceRequired = errors.New(
 		"AWS load balancer controller operator ownership evidence is required",
 	)
+	errAWSControllerCleanupInstallerUnavailable = errors.New(
+		"partial AWS controller cleanup installer is unavailable",
+	)
 )
 
 // installOrder lists component installers in the order they must run: CNI first (pods cannot
@@ -194,23 +197,36 @@ func uninstallRemovedComponents(
 // spec via a factory built FOR that baseline's distribution (several installers are
 // distribution-dependent, so reusing the current cluster's factory would compute the wrong uninstall
 // set after a distribution change), then keeps the entries whose key is absent from the desired set.
-// It returns an empty map when no baseline is recorded (first reconcile, or an unparseable annotation).
+// A persisted AWS controller release identity is also treated as a removal candidate. This covers a
+// partial apply where the controller install succeeded but a sibling failure prevented the full
+// component baseline from advancing.
 func removedComponentInstallers(
 	newFactory func(v1alpha1.Distribution) *installer.Factory,
 	cluster *v1alpha1.Cluster,
 	desired map[string]installer.Installer,
 ) (map[string]installer.Installer, error) {
-	previousSpec, ok := lastAppliedComponentsSpec(cluster)
-	if !ok {
-		return map[string]installer.Installer{}, nil
+	previousSpec, hasBaseline := lastAppliedComponentsSpec(cluster)
+
+	previous, err := buildPreviousComponentInstallers(newFactory, previousSpec, hasBaseline)
+	if err != nil {
+		return nil, err
 	}
 
-	previousCluster := &v1alpha1.Cluster{Spec: *previousSpec}
+	expectedControllerIdentity := strings.TrimSpace(
+		cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
+	)
 
-	previous, err := newFactory(previousSpec.Cluster.Distribution).
-		CreateInstallersForConfig(previousCluster)
+	err = addPartialAWSControllerCleanupInstaller(
+		newFactory,
+		cluster,
+		previousSpec,
+		hasBaseline,
+		desired,
+		previous,
+		expectedControllerIdentity,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("build previous installers: %w", err)
+		return nil, err
 	}
 
 	removed := make(map[string]installer.Installer)
@@ -219,9 +235,7 @@ func removedComponentInstallers(
 		_, stillDesired := desired[key]
 		if !stillDesired {
 			if key == awslbcontroller.ReleaseName {
-				expectedIdentity := strings.TrimSpace(
-					cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
-				)
+				expectedIdentity := expectedControllerIdentity
 				if expectedIdentity == "" {
 					inst = &unresolvedRemovalInstaller{Installer: inst}
 				} else {
@@ -237,6 +251,65 @@ func removedComponentInstallers(
 	}
 
 	return removed, nil
+}
+
+func buildPreviousComponentInstallers(
+	newFactory func(v1alpha1.Distribution) *installer.Factory,
+	previousSpec *v1alpha1.Spec,
+	hasBaseline bool,
+) (map[string]installer.Installer, error) {
+	if !hasBaseline {
+		return map[string]installer.Installer{}, nil
+	}
+
+	previous, err := newFactory(previousSpec.Cluster.Distribution).
+		CreateInstallersForConfig(&v1alpha1.Cluster{Spec: *previousSpec})
+	if err != nil {
+		return nil, fmt.Errorf("build previous installers: %w", err)
+	}
+
+	return previous, nil
+}
+
+func addPartialAWSControllerCleanupInstaller(
+	newFactory func(v1alpha1.Distribution) *installer.Factory,
+	cluster *v1alpha1.Cluster,
+	previousSpec *v1alpha1.Spec,
+	hasBaseline bool,
+	desired, previous map[string]installer.Installer,
+	expectedIdentity string,
+) error {
+	_, controllerDesired := desired[awslbcontroller.ReleaseName]
+
+	_, controllerInBaseline := previous[awslbcontroller.ReleaseName]
+	if controllerDesired || controllerInBaseline || expectedIdentity == "" {
+		return nil
+	}
+
+	cleanupSpec := cluster.Spec
+	if hasBaseline {
+		cleanupSpec = *previousSpec
+	}
+
+	cleanupSpec.Cluster.Distribution = v1alpha1.DistributionEKS
+	cleanupSpec.Cluster.Provider = v1alpha1.ProviderAWS
+	cleanupSpec.Cluster.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	cleanupSpec.Cluster.EKS.ExperimentalAWSLoadBalancerController = true
+
+	cleanupInstallers, err := newFactory(v1alpha1.DistributionEKS).
+		CreateInstallersForConfig(&v1alpha1.Cluster{Spec: cleanupSpec})
+	if err != nil {
+		return fmt.Errorf("build partial AWS controller cleanup installer: %w", err)
+	}
+
+	controller, exists := cleanupInstallers[awslbcontroller.ReleaseName]
+	if !exists {
+		return errAWSControllerCleanupInstallerUnavailable
+	}
+
+	previous[awslbcontroller.ReleaseName] = controller
+
+	return nil
 }
 
 type gitOpsOwnershipReporter interface {

--- a/pkg/operator/components.go
+++ b/pkg/operator/components.go
@@ -95,16 +95,11 @@ func InstallComponents(
 	// for the spec it was built for; the baseline uninstall set below rebuilds
 	// one for the previously-applied distribution rather than reusing this one.
 	newFactory := func(distribution v1alpha1.Distribution) *installer.Factory {
-		return installer.NewFactory(
+		return newInstallerFactory(
 			helmClient,
-			nil, // no Docker client: child-cluster components are Helm-based
 			kubeconfigPath,
-			"",
-			componentInstallTimeout,
+			controller.ProvisionedName(cluster),
 			distribution,
-			// The AWS Load Balancer Controller chart requires the provisioned
-			// EKS cluster name; harmless for every other distribution.
-			installer.WithEKSClusterName(controller.ProvisionedName(cluster)),
 		)
 	}
 
@@ -119,6 +114,27 @@ func InstallComponents(
 	components, installErr := runInstallers(ctx, installers)
 
 	return true, components, errors.Join(uninstallErr, installErr)
+}
+
+// newInstallerFactory constructs the operator's component lifecycle factory.
+// A component present in the operator's last-applied baseline was installed by
+// this lifecycle, so its reconstructed installer carries positive ownership
+// evidence and may uninstall it when the desired spec drops the component.
+func newInstallerFactory(
+	helmClient helm.Interface,
+	kubeconfigPath, eksClusterName string,
+	distribution v1alpha1.Distribution,
+) *installer.Factory {
+	return installer.NewFactory(
+		helmClient,
+		nil, // no Docker client: child-cluster components are Helm-based
+		kubeconfigPath,
+		"",
+		componentInstallTimeout,
+		distribution,
+		installer.WithEKSClusterName(eksClusterName),
+		installer.WithAWSLoadBalancerControllerManaged(true),
+	)
 }
 
 // uninstallRemovedComponents tears down components present in the last-applied-components baseline but

--- a/pkg/operator/components_test.go
+++ b/pkg/operator/components_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +25,7 @@ const (
 	componentCilium        = "cilium"
 	componentMetricsServer = "metrics-server"
 	componentFlux          = "flux"
+	componentAWSLB         = "aws-load-balancer-controller"
 )
 
 // stubProvisioner satisfies clusterprovisioner.Provisioner without implementing Connector.
@@ -257,6 +259,51 @@ func TestRemovedComponentInstallers_ReturnsComponentsDroppedFromSpec(t *testing.
 	require.NoError(t, err)
 	assert.Contains(t, removed, componentKyverno, "a component dropped from the spec is removed")
 	assert.NotContains(t, removed, componentFlux, "a still-desired component is not removed")
+}
+
+func TestRemovedComponentInstallers_OperatorOwnedAWSControllerUninstalls(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, componentAWSLB, "kube-system").
+		Return(map[string]string{"owner": "helm"}, nil)
+	client.EXPECT().
+		UninstallRelease(mock.Anything, componentAWSLB, "kube-system").
+		Return(nil)
+
+	previous := &v1alpha1.Cluster{Spec: v1alpha1.Spec{Cluster: v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+		LoadBalancer: v1alpha1.LoadBalancerEnabled,
+		EKS: v1alpha1.OptionsEKS{
+			ExperimentalAWSLoadBalancerController: true,
+		},
+	}}}
+	baseline, err := json.Marshal(previous.Spec)
+	require.NoError(t, err)
+
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.LastAppliedComponentsAnnotation: string(baseline),
+	}
+	newFactory := func(distribution v1alpha1.Distribution) *installer.Factory {
+		return operator.NewInstallerFactory(
+			client,
+			"/tmp/kubeconfig",
+			"operator-owned-eks",
+			distribution,
+		)
+	}
+
+	removed, err := operator.RemovedComponentInstallers(
+		newFactory,
+		cluster,
+		map[string]installer.Installer{},
+	)
+	require.NoError(t, err)
+	require.Contains(t, removed, componentAWSLB)
+	require.NoError(t, operator.RunUninstallers(t.Context(), removed))
 }
 
 func TestRemovedComponentInstallers_BaselineFactoryUsesPreviousDistribution(t *testing.T) {

--- a/pkg/operator/components_test.go
+++ b/pkg/operator/components_test.go
@@ -343,6 +343,57 @@ func TestRemovedComponentInstallers_OperatorOwnedAWSControllerUninstalls(t *test
 	require.NoError(t, operator.RunUninstallers(t.Context(), removed))
 }
 
+func TestRemovedComponentInstallers_PartialAWSControllerInstallUninstalls(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageMetadata(mock.Anything, componentAWSLB, "kube-system").
+		Return(&helm.ReleaseStorageMetadata{
+			Identity: "partial-install-release-uid",
+			Labels: map[string]string{
+				awslbcontrollerinstaller.ReleaseOwnershipLabel: "ksail",
+			},
+		}, nil)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, componentAWSLB, "kube-system").
+		Return(map[string]string{"owner": "helm"}, nil)
+	client.EXPECT().
+		UninstallRelease(mock.Anything, componentAWSLB, "kube-system").
+		Return(nil)
+
+	previous := &v1alpha1.Cluster{Spec: v1alpha1.Spec{Cluster: v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+		LoadBalancer: v1alpha1.LoadBalancerDisabled,
+	}}}
+	baseline, err := json.Marshal(previous.Spec)
+	require.NoError(t, err)
+
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.LastAppliedComponentsAnnotation:                    string(baseline),
+		v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation: "partial-install-release-uid",
+	}
+	newFactory := func(distribution v1alpha1.Distribution) *installer.Factory {
+		return operator.NewInstallerFactory(
+			client,
+			"/tmp/kubeconfig",
+			"partial-install-eks",
+			distribution,
+		)
+	}
+
+	removed, err := operator.RemovedComponentInstallers(
+		newFactory,
+		cluster,
+		map[string]installer.Installer{},
+	)
+	require.NoError(t, err)
+	require.Contains(t, removed, componentAWSLB)
+	require.NoError(t, operator.RunUninstallers(t.Context(), removed))
+}
+
 func TestRecordAWSLoadBalancerControllerOwnershipUsesActualInstallOutcome(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/operator/components_test.go
+++ b/pkg/operator/components_test.go
@@ -96,6 +96,25 @@ type recordingInstaller struct {
 	uninstallOrder *[]string
 }
 
+type ownershipReportingInstaller struct {
+	gitOpsManaged bool
+	identity      string
+}
+
+func (*ownershipReportingInstaller) Install(context.Context) error   { return nil }
+func (*ownershipReportingInstaller) Uninstall(context.Context) error { return nil }
+func (*ownershipReportingInstaller) Images(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (i *ownershipReportingInstaller) IsGitOpsManaged(context.Context) (bool, error) {
+	return i.gitOpsManaged, nil
+}
+
+func (i *ownershipReportingInstaller) ReleaseIdentity(context.Context) (string, error) {
+	return i.identity, nil
+}
+
 func (r *recordingInstaller) Install(_ context.Context) error {
 	*r.order = append(*r.order, r.name)
 
@@ -266,6 +285,9 @@ func TestRemovedComponentInstallers_OperatorOwnedAWSControllerUninstalls(t *test
 
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
+		GetReleaseStorageMetadata(mock.Anything, componentAWSLB, "kube-system").
+		Return(&helm.ReleaseStorageMetadata{Identity: "operator-release-uid"}, nil)
+	client.EXPECT().
 		GetReleaseStorageLabels(mock.Anything, componentAWSLB, "kube-system").
 		Return(map[string]string{"owner": "helm"}, nil)
 	client.EXPECT().
@@ -285,7 +307,8 @@ func TestRemovedComponentInstallers_OperatorOwnedAWSControllerUninstalls(t *test
 
 	cluster := &v1alpha1.Cluster{}
 	cluster.Annotations = map[string]string{
-		v1alpha1.LastAppliedComponentsAnnotation: string(baseline),
+		v1alpha1.LastAppliedComponentsAnnotation:                    string(baseline),
+		v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation: "operator-release-uid",
 	}
 	newFactory := func(distribution v1alpha1.Distribution) *installer.Factory {
 		return operator.NewInstallerFactory(
@@ -304,6 +327,105 @@ func TestRemovedComponentInstallers_OperatorOwnedAWSControllerUninstalls(t *test
 	require.NoError(t, err)
 	require.Contains(t, removed, componentAWSLB)
 	require.NoError(t, operator.RunUninstallers(t.Context(), removed))
+}
+
+func TestRecordAWSLoadBalancerControllerOwnershipUsesActualInstallOutcome(t *testing.T) {
+	t.Parallel()
+
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation: "stale-identity",
+	}
+
+	err := operator.RecordAWSLoadBalancerControllerOwnership(
+		t.Context(),
+		cluster,
+		map[string]installer.Installer{
+			componentAWSLB: &ownershipReportingInstaller{gitOpsManaged: true},
+		},
+	)
+	require.NoError(t, err)
+	assert.NotContains(
+		t,
+		cluster.Annotations,
+		v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation,
+		"a GitOps-preserved release must not become operator-owned",
+	)
+
+	err = operator.RecordAWSLoadBalancerControllerOwnership(
+		t.Context(),
+		cluster,
+		map[string]installer.Installer{
+			componentAWSLB: &ownershipReportingInstaller{identity: "operator-release-uid"},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"operator-release-uid",
+		cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
+	)
+}
+
+func TestSanitizeForWriteDropsClientSuppliedControllerOwnership(t *testing.T) {
+	t.Parallel()
+
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation: "forged-release-uid",
+		"example.com/retained": "value",
+	}
+
+	sanitized := operator.SanitizeForWrite(cluster)
+
+	assert.NotContains(
+		t,
+		sanitized.Annotations,
+		v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation,
+	)
+	assert.Equal(t, "value", sanitized.Annotations["example.com/retained"])
+}
+
+func TestRemovedComponentInstallers_DoesNotInferAWSOwnershipFromDesiredBaseline(t *testing.T) {
+	t.Parallel()
+
+	previous := &v1alpha1.Cluster{Spec: v1alpha1.Spec{Cluster: v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+		LoadBalancer: v1alpha1.LoadBalancerEnabled,
+		EKS: v1alpha1.OptionsEKS{
+			ExperimentalAWSLoadBalancerController: true,
+		},
+	}}}
+	baseline, err := json.Marshal(previous.Spec)
+	require.NoError(t, err)
+
+	cluster := &v1alpha1.Cluster{}
+	cluster.Annotations = map[string]string{
+		v1alpha1.LastAppliedComponentsAnnotation: string(baseline),
+	}
+	client := helm.NewMockInterface(t)
+	newFactory := func(distribution v1alpha1.Distribution) *installer.Factory {
+		return operator.NewInstallerFactory(
+			client,
+			"/tmp/kubeconfig",
+			"externally-owned-eks",
+			distribution,
+		)
+	}
+
+	removed, err := operator.RemovedComponentInstallers(
+		newFactory,
+		cluster,
+		map[string]installer.Installer{},
+	)
+	require.NoError(t, err)
+	assert.NotContains(
+		t,
+		removed,
+		componentAWSLB,
+		"the desired-spec baseline alone is not positive operator ownership",
+	)
 }
 
 func TestRemovedComponentInstallers_BaselineFactoryUsesPreviousDistribution(t *testing.T) {

--- a/pkg/operator/components_test.go
+++ b/pkg/operator/components_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v7/pkg/operator"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer"
+	awslbcontrollerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/awslbcontroller"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -99,6 +100,7 @@ type recordingInstaller struct {
 type ownershipReportingInstaller struct {
 	gitOpsManaged bool
 	identity      string
+	identityOwned bool
 }
 
 func (*ownershipReportingInstaller) Install(context.Context) error   { return nil }
@@ -113,6 +115,13 @@ func (i *ownershipReportingInstaller) IsGitOpsManaged(context.Context) (bool, er
 
 func (i *ownershipReportingInstaller) ReleaseIdentity(context.Context) (string, error) {
 	return i.identity, nil
+}
+
+func (i *ownershipReportingInstaller) OwnsReleaseIdentity(
+	context.Context,
+	string,
+) (bool, error) {
+	return i.identityOwned, nil
 }
 
 func (r *recordingInstaller) Install(_ context.Context) error {
@@ -286,7 +295,12 @@ func TestRemovedComponentInstallers_OperatorOwnedAWSControllerUninstalls(t *test
 	client := helm.NewMockInterface(t)
 	client.EXPECT().
 		GetReleaseStorageMetadata(mock.Anything, componentAWSLB, "kube-system").
-		Return(&helm.ReleaseStorageMetadata{Identity: "operator-release-uid"}, nil)
+		Return(&helm.ReleaseStorageMetadata{
+			Identity: "operator-release-uid",
+			Labels: map[string]string{
+				awslbcontrollerinstaller.ReleaseOwnershipLabel: "ksail",
+			},
+		}, nil)
 	client.EXPECT().
 		GetReleaseStorageLabels(mock.Anything, componentAWSLB, "kube-system").
 		Return(map[string]string{"owner": "helm"}, nil)
@@ -356,7 +370,9 @@ func TestRecordAWSLoadBalancerControllerOwnershipUsesActualInstallOutcome(t *tes
 		t.Context(),
 		cluster,
 		map[string]installer.Installer{
-			componentAWSLB: &ownershipReportingInstaller{identity: "operator-release-uid"},
+			componentAWSLB: &ownershipReportingInstaller{
+				identity: "operator-release-uid", identityOwned: true,
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -364,6 +380,26 @@ func TestRecordAWSLoadBalancerControllerOwnershipUsesActualInstallOutcome(t *tes
 		t,
 		"operator-release-uid",
 		cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
+	)
+}
+
+func TestRecordAWSLoadBalancerControllerOwnershipRejectsManualRelease(t *testing.T) {
+	t.Parallel()
+
+	cluster := &v1alpha1.Cluster{}
+	err := operator.RecordAWSLoadBalancerControllerOwnership(
+		t.Context(),
+		cluster,
+		map[string]installer.Installer{
+			componentAWSLB: &ownershipReportingInstaller{identity: "manual-release-uid"},
+		},
+	)
+
+	require.Error(t, err)
+	assert.NotContains(
+		t,
+		cluster.Annotations,
+		v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation,
 	)
 }
 
@@ -375,7 +411,9 @@ func TestRecordAWSLoadBalancerControllerOwnershipSurvivesSiblingFailure(t *testi
 		t.Context(),
 		cluster,
 		map[string]installer.Installer{
-			componentAWSLB: &ownershipReportingInstaller{identity: "partial-apply-release-uid"},
+			componentAWSLB: &ownershipReportingInstaller{
+				identity: "partial-apply-release-uid", identityOwned: true,
+			},
 		},
 		errBoom,
 		errBoom,

--- a/pkg/operator/components_test.go
+++ b/pkg/operator/components_test.go
@@ -367,6 +367,28 @@ func TestRecordAWSLoadBalancerControllerOwnershipUsesActualInstallOutcome(t *tes
 	)
 }
 
+func TestRecordAWSLoadBalancerControllerOwnershipSurvivesSiblingFailure(t *testing.T) {
+	t.Parallel()
+
+	cluster := &v1alpha1.Cluster{}
+	err := operator.RecordAWSLoadBalancerControllerOwnershipAfterApply(
+		t.Context(),
+		cluster,
+		map[string]installer.Installer{
+			componentAWSLB: &ownershipReportingInstaller{identity: "partial-apply-release-uid"},
+		},
+		errBoom,
+		errBoom,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"partial-apply-release-uid",
+		cluster.Annotations[v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation],
+	)
+}
+
 func TestSanitizeForWriteDropsClientSuppliedControllerOwnership(t *testing.T) {
 	t.Parallel()
 
@@ -420,12 +442,9 @@ func TestRemovedComponentInstallers_DoesNotInferAWSOwnershipFromDesiredBaseline(
 		map[string]installer.Installer{},
 	)
 	require.NoError(t, err)
-	assert.NotContains(
-		t,
-		removed,
-		componentAWSLB,
-		"the desired-spec baseline alone is not positive operator ownership",
-	)
+	require.Contains(t, removed, componentAWSLB)
+	err = operator.RunUninstallers(t.Context(), removed)
+	require.ErrorContains(t, err, "operator ownership evidence is required")
 }
 
 func TestRemovedComponentInstallers_BaselineFactoryUsesPreviousDistribution(t *testing.T) {

--- a/pkg/operator/cr_service.go
+++ b/pkg/operator/cr_service.go
@@ -212,7 +212,8 @@ func sanitizeForWrite(cluster *v1alpha1.Cluster) *v1alpha1.Cluster {
 
 		for key, value := range cluster.Annotations {
 			if key == v1alpha1.LastAppliedSpecAnnotation ||
-				key == v1alpha1.LastAppliedComponentsAnnotation {
+				key == v1alpha1.LastAppliedComponentsAnnotation ||
+				key == v1alpha1.AWSLoadBalancerControllerReleaseIdentityAnnotation {
 				continue
 			}
 

--- a/pkg/operator/export_test.go
+++ b/pkg/operator/export_test.go
@@ -22,6 +22,8 @@ var (
 	NewInstallerFactory = newInstallerFactory
 	// RecordAWSLoadBalancerControllerOwnership exposes outcome-based operator ownership capture.
 	RecordAWSLoadBalancerControllerOwnership = recordAWSLoadBalancerControllerOwnership
+	// RecordAWSLoadBalancerControllerOwnershipAfterApply exposes partial-apply ownership capture.
+	RecordAWSLoadBalancerControllerOwnershipAfterApply = recordAWSLoadBalancerControllerOwnershipAfterApply
 	// SanitizeForWrite exposes the API write-boundary sanitization for testing.
 	SanitizeForWrite = sanitizeForWrite
 	// CountReadyNodes exposes countReadyNodes for testing.

--- a/pkg/operator/export_test.go
+++ b/pkg/operator/export_test.go
@@ -20,6 +20,10 @@ var (
 	RemovedComponentInstallers = removedComponentInstallers
 	// NewInstallerFactory exposes the operator-owned component factory for testing.
 	NewInstallerFactory = newInstallerFactory
+	// RecordAWSLoadBalancerControllerOwnership exposes outcome-based operator ownership capture.
+	RecordAWSLoadBalancerControllerOwnership = recordAWSLoadBalancerControllerOwnership
+	// SanitizeForWrite exposes the API write-boundary sanitization for testing.
+	SanitizeForWrite = sanitizeForWrite
 	// CountReadyNodes exposes countReadyNodes for testing.
 	CountReadyNodes = countReadyNodes
 )

--- a/pkg/operator/export_test.go
+++ b/pkg/operator/export_test.go
@@ -18,6 +18,8 @@ var (
 	RunUninstallers = runUninstallers
 	// RemovedComponentInstallers exposes removedComponentInstallers for testing.
 	RemovedComponentInstallers = removedComponentInstallers
+	// NewInstallerFactory exposes the operator-owned component factory for testing.
+	NewInstallerFactory = newInstallerFactory
 	// CountReadyNodes exposes countReadyNodes for testing.
 	CountReadyNodes = countReadyNodes
 )

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -168,6 +168,11 @@ func (d *ComponentDetector) detectAllComponents(
 		return nil, fmt.Errorf("detect LoadBalancer: %w", err)
 	}
 
+	err = d.detectEKSComponents(ctx, spec, distribution, provider)
+	if err != nil {
+		return nil, err
+	}
+
 	spec.CertManager, err = d.detectCertManager(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("detect CertManager: %w", err)
@@ -189,6 +194,42 @@ func (d *ComponentDetector) detectAllComponents(
 	}
 
 	return spec, nil
+}
+
+func (d *ComponentDetector) detectEKSComponents(
+	ctx context.Context,
+	spec *v1alpha1.ClusterSpec,
+	distribution v1alpha1.Distribution,
+	provider v1alpha1.Provider,
+) error {
+	if distribution != v1alpha1.DistributionEKS || provider != v1alpha1.ProviderAWS {
+		return nil
+	}
+
+	installed, err := d.detectEKSLoadBalancerController(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec.EKS.ExperimentalAWSLoadBalancerController = installed
+	if installed {
+		spec.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	}
+
+	return nil
+}
+
+func (d *ComponentDetector) detectEKSLoadBalancerController(ctx context.Context) (bool, error) {
+	exists, err := d.helmClient.ReleaseExists(
+		ctx,
+		ReleaseAWSLoadBalancerController,
+		NamespaceAWSLoadBalancerController,
+	)
+	if err != nil {
+		return false, fmt.Errorf("detect AWS Load Balancer Controller: %w", err)
+	}
+
+	return exists, nil
 }
 
 // releaseMapping maps a Helm release to the value returned when the release is found.
@@ -556,7 +597,8 @@ func (d *ComponentDetector) containerExists(
 		return false, nil
 	}
 
-	containers, err := d.dockerClient.ContainerList(ctx,
+	containers, err := d.dockerClient.ContainerList(
+		ctx,
 		container.ListOptions{
 			Filters: filters.NewArgs(
 				filters.Arg("name", "^/"+containerName+"$"),

--- a/pkg/svc/detector/component.go
+++ b/pkg/svc/detector/component.go
@@ -53,9 +53,9 @@ func NewComponentDetector(
 	}
 }
 
-// releaseSet is an in-memory index of Helm releases keyed by
-// name+namespace for O(1) existence checks after a single ListReleases call.
-type releaseSet map[releaseKey]struct{}
+// releaseSet is an in-memory index of the latest Helm release revision keyed
+// by name+namespace for O(1) deployed-state checks after one ListReleases call.
+type releaseSet map[releaseKey]helm.ReleaseInfo
 
 type releaseKey struct {
 	name      string
@@ -86,9 +86,12 @@ func (c *cachedHelmClient) ReleaseExists(
 		return exists, nil
 	}
 
-	_, ok := c.set[releaseKey{name: name, namespace: namespace}]
+	release, ok := c.set[releaseKey{name: name, namespace: namespace}]
+	if !ok {
+		return false, nil
+	}
 
-	return ok, nil
+	return strings.EqualFold(release.Status, "deployed"), nil
 }
 
 // DetectComponents probes the running cluster to populate a ClusterSpec that
@@ -120,7 +123,12 @@ func (d *ComponentDetector) DetectComponents(
 
 	releaseIndex := make(releaseSet, len(releases))
 	for _, r := range releases {
-		releaseIndex[releaseKey{name: r.Name, namespace: r.Namespace}] = struct{}{}
+		key := releaseKey{name: r.Name, namespace: r.Namespace}
+
+		current, exists := releaseIndex[key]
+		if !exists || r.Revision >= current.Revision {
+			releaseIndex[key] = r
+		}
 	}
 
 	cached := &ComponentDetector{

--- a/pkg/svc/detector/component_test.go
+++ b/pkg/svc/detector/component_test.go
@@ -682,6 +682,25 @@ func TestDetectComponents_Success(t *testing.T) {
 	assert.Equal(t, v1alpha1.MetricsServerEnabled, spec.MetricsServer)
 }
 
+func TestDetectComponents_EKSAWSLoadBalancerController(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ListReleases", ctx).Return([]helm.ReleaseInfo{
+		{Name: "aws-load-balancer-controller", Namespace: "kube-system"},
+	}, nil).Once()
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	spec, err := d.DetectComponents(ctx, v1alpha1.DistributionEKS, v1alpha1.ProviderAWS)
+
+	require.NoError(t, err)
+	assert.Equal(t, v1alpha1.LoadBalancerEnabled, spec.LoadBalancer)
+	assert.True(t, spec.EKS.ExperimentalAWSLoadBalancerController)
+}
+
 func TestDetectComponents_ArgoCD(t *testing.T) {
 	t.Parallel()
 
@@ -1041,11 +1060,13 @@ func TestDetectNodeAutoscaler_Enabled(t *testing.T) {
 	helmClient := helm.NewMockInterface(t)
 	k8sClientset := fake.NewClientset()
 
-	helmClient.On("ReleaseExists", ctx,
+	helmClient.On(
+		"ReleaseExists", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(true, nil)
 
-	helmClient.On("GetReleaseValues", ctx,
+	helmClient.On(
+		"GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(map[string]any{
 		"extraArgs": map[string]any{
@@ -1089,11 +1110,13 @@ func TestDetectNodeAutoscaler_CapacityBuffers(t *testing.T) {
 	helmClient := helm.NewMockInterface(t)
 	k8sClientset := fake.NewClientset()
 
-	helmClient.On("ReleaseExists", ctx,
+	helmClient.On(
+		"ReleaseExists", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(true, nil)
 
-	helmClient.On("GetReleaseValues", ctx,
+	helmClient.On(
+		"GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(map[string]any{
 		"extraArgs": map[string]any{
@@ -1116,11 +1139,13 @@ func TestDetectNodeAutoscaler_SkipNodesAndDaemonsets(t *testing.T) {
 	helmClient := helm.NewMockInterface(t)
 	k8sClientset := fake.NewClientset()
 
-	helmClient.On("ReleaseExists", ctx,
+	helmClient.On(
+		"ReleaseExists", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(true, nil)
 
-	helmClient.On("GetReleaseValues", ctx,
+	helmClient.On(
+		"GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(map[string]any{
 		"extraArgs": map[string]any{
@@ -1153,11 +1178,13 @@ func TestDetectNodeAutoscaler_SkipNodesUnsetStayNil(t *testing.T) {
 	helmClient := helm.NewMockInterface(t)
 	k8sClientset := fake.NewClientset()
 
-	helmClient.On("ReleaseExists", ctx,
+	helmClient.On(
+		"ReleaseExists", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(true, nil)
 
-	helmClient.On("GetReleaseValues", ctx,
+	helmClient.On(
+		"GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(map[string]any{
 		"extraArgs": map[string]any{},
@@ -1182,7 +1209,8 @@ func TestDetectNodeAutoscaler_NotInstalled(t *testing.T) {
 	helmClient := helm.NewMockInterface(t)
 	k8sClientset := fake.NewClientset()
 
-	helmClient.On("ReleaseExists", ctx,
+	helmClient.On(
+		"ReleaseExists", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(false, nil)
 
@@ -1201,11 +1229,13 @@ func TestDetectNodeAutoscaler_ValuesUnreadable(t *testing.T) {
 	helmClient := helm.NewMockInterface(t)
 	k8sClientset := fake.NewClientset()
 
-	helmClient.On("ReleaseExists", ctx,
+	helmClient.On(
+		"ReleaseExists", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(true, nil)
 
-	helmClient.On("GetReleaseValues", ctx,
+	helmClient.On(
+		"GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(nil, errValues)
 
@@ -1224,11 +1254,13 @@ func TestDetectNodeAutoscaler_SkipsPoolWithEmptyName(t *testing.T) {
 	helmClient := helm.NewMockInterface(t)
 	k8sClientset := fake.NewClientset()
 
-	helmClient.On("ReleaseExists", ctx,
+	helmClient.On(
+		"ReleaseExists", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(true, nil)
 
-	helmClient.On("GetReleaseValues", ctx,
+	helmClient.On(
+		"GetReleaseValues", ctx,
 		detector.ReleaseClusterAutoscaler, detector.NamespaceClusterAutoscaler,
 	).Return(map[string]any{
 		"autoscalingGroups": []any{

--- a/pkg/svc/detector/component_test.go
+++ b/pkg/svc/detector/component_test.go
@@ -667,8 +667,11 @@ func TestDetectComponents_Success(t *testing.T) {
 	// DetectComponents calls ListReleases once to build an in-memory release set.
 	// The test returns Cilium and metrics-server as installed releases.
 	helmClient.On("ListReleases", ctx).Return([]helm.ReleaseInfo{
-		{Name: detector.ReleaseCilium, Namespace: detector.NamespaceCilium},
-		{Name: detector.ReleaseMetricsServer, Namespace: detector.NamespaceMetricsServer},
+		{Name: detector.ReleaseCilium, Namespace: detector.NamespaceCilium, Status: "deployed"},
+		{
+			Name: detector.ReleaseMetricsServer, Namespace: detector.NamespaceMetricsServer,
+			Status: "deployed",
+		},
 	}, nil).Once()
 
 	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
@@ -690,7 +693,7 @@ func TestDetectComponents_EKSAWSLoadBalancerController(t *testing.T) {
 	k8sClientset := fake.NewClientset()
 
 	helmClient.On("ListReleases", ctx).Return([]helm.ReleaseInfo{
-		{Name: "aws-load-balancer-controller", Namespace: "kube-system"},
+		{Name: "aws-load-balancer-controller", Namespace: "kube-system", Status: "deployed"},
 	}, nil).Once()
 
 	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
@@ -699,6 +702,29 @@ func TestDetectComponents_EKSAWSLoadBalancerController(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, v1alpha1.LoadBalancerEnabled, spec.LoadBalancer)
 	assert.True(t, spec.EKS.ExperimentalAWSLoadBalancerController)
+}
+
+func TestDetectComponents_EKSFailedAWSLoadBalancerControllerReleaseIsInactive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	helmClient := helm.NewMockInterface(t)
+	k8sClientset := fake.NewClientset()
+
+	helmClient.On("ListReleases", ctx).Return([]helm.ReleaseInfo{
+		{
+			Name:      "aws-load-balancer-controller",
+			Namespace: "kube-system",
+			Revision:  2,
+			Status:    "failed",
+		},
+	}, nil).Once()
+
+	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
+	spec, err := d.DetectComponents(ctx, v1alpha1.DistributionEKS, v1alpha1.ProviderAWS)
+
+	require.NoError(t, err)
+	assert.False(t, spec.EKS.ExperimentalAWSLoadBalancerController)
 }
 
 func TestDetectComponents_ArgoCD(t *testing.T) {
@@ -711,7 +737,7 @@ func TestDetectComponents_ArgoCD(t *testing.T) {
 	// Regression test: ArgoCD release (name "argocd" in namespace "argocd")
 	// must be detected correctly via ListReleases → releaseSet lookup.
 	helmClient.On("ListReleases", ctx).Return([]helm.ReleaseInfo{
-		{Name: detector.ReleaseArgoCD, Namespace: detector.NamespaceArgoCD},
+		{Name: detector.ReleaseArgoCD, Namespace: detector.NamespaceArgoCD, Status: "deployed"},
 	}, nil).Once()
 
 	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)
@@ -774,7 +800,7 @@ func TestDetectComponents_ArgoCD_MultiNamespace(t *testing.T) {
 	// ListReleases returns the ArgoCD release in the "argocd" namespace — a
 	// non-default namespace. DetectComponents must correctly identify it.
 	helmClient.On("ListReleases", ctx).Return([]helm.ReleaseInfo{
-		{Name: detector.ReleaseArgoCD, Namespace: detector.NamespaceArgoCD},
+		{Name: detector.ReleaseArgoCD, Namespace: detector.NamespaceArgoCD, Status: "deployed"},
 	}, nil).Once()
 
 	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)

--- a/pkg/svc/detector/coverage_test.go
+++ b/pkg/svc/detector/coverage_test.go
@@ -35,11 +35,20 @@ func TestDetectComponents_AllReleasesFromCache(t *testing.T) {
 
 	// All installed releases are returned in a single ListReleases call.
 	helmClient.On("ListReleases", ctx).Return([]helm.ReleaseInfo{
-		{Name: detector.ReleaseCilium, Namespace: detector.NamespaceCilium},
-		{Name: detector.ReleaseMetricsServer, Namespace: detector.NamespaceMetricsServer},
-		{Name: detector.ReleaseCertManager, Namespace: detector.NamespaceCertManager},
-		{Name: detector.ReleaseKyverno, Namespace: detector.NamespaceKyverno},
-		{Name: detector.ReleaseFluxOperator, Namespace: detector.NamespaceFluxOperator},
+		{Name: detector.ReleaseCilium, Namespace: detector.NamespaceCilium, Status: "deployed"},
+		{
+			Name: detector.ReleaseMetricsServer, Namespace: detector.NamespaceMetricsServer,
+			Status: "deployed",
+		},
+		{
+			Name: detector.ReleaseCertManager, Namespace: detector.NamespaceCertManager,
+			Status: "deployed",
+		},
+		{Name: detector.ReleaseKyverno, Namespace: detector.NamespaceKyverno, Status: "deployed"},
+		{
+			Name: detector.ReleaseFluxOperator, Namespace: detector.NamespaceFluxOperator,
+			Status: "deployed",
+		},
 	}, nil).Once()
 
 	d := detector.NewComponentDetector(helmClient, k8sClientset, nil)

--- a/pkg/svc/detector/releases.go
+++ b/pkg/svc/detector/releases.go
@@ -74,4 +74,9 @@ const (
 	ReleaseClusterAutoscaler = "cluster-autoscaler"
 	// NamespaceClusterAutoscaler is the namespace where the Cluster Autoscaler is installed.
 	NamespaceClusterAutoscaler = "kube-system"
+
+	// ReleaseAWSLoadBalancerController is the EKS AWS Load Balancer Controller release.
+	ReleaseAWSLoadBalancerController = "aws-load-balancer-controller"
+	// NamespaceAWSLoadBalancerController is where KSail installs the controller.
+	NamespaceAWSLoadBalancerController = "kube-system"
 )

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -249,6 +249,10 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 					return strconv.FormatBool(false)
 				}
 
+				if e.componentBaselineUnknown(spec) {
+					return clusterupdate.UnknownBaselineValue
+				}
+
 				return eksLoadBalancerControllerValue(spec)
 			},
 		},

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -10,6 +10,11 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 )
 
+// EKSLoadBalancerControllerField is the diff key for the EKS AWS Load
+// Balancer Controller opt-in. Reconciliation uses the same constant so field
+// renames cannot silently disconnect detection from application.
+const EKSLoadBalancerControllerField = "cluster.eks.experimentalAWSLoadBalancerController"
+
 // Engine computes configuration differences and classifies their impact.
 type Engine struct {
 	distribution v1alpha1.Distribution
@@ -235,7 +240,7 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 			},
 		},
 		{
-			field:    "cluster.eks.experimentalAWSLoadBalancerController",
+			field:    EKSLoadBalancerControllerField,
 			category: clusterupdate.ChangeCategoryInPlace,
 			reason:   "AWS Load Balancer Controller can be installed/uninstalled via Helm",
 			getVal: func(spec *v1alpha1.ClusterSpec) string {

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -249,7 +249,10 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 					return strconv.FormatBool(false)
 				}
 
-				return strconv.FormatBool(spec.EKS.ExperimentalAWSLoadBalancerController)
+				return strconv.FormatBool(
+					spec.EKS.ExperimentalAWSLoadBalancerController &&
+						spec.LoadBalancer == v1alpha1.LoadBalancerEnabled,
+				)
 			},
 		},
 		{

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -249,10 +249,7 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 					return strconv.FormatBool(false)
 				}
 
-				return strconv.FormatBool(
-					spec.EKS.ExperimentalAWSLoadBalancerController &&
-						spec.LoadBalancer == v1alpha1.LoadBalancerEnabled,
-				)
+				return eksLoadBalancerControllerValue(spec)
 			},
 		},
 		{
@@ -277,6 +274,21 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 			defaultVal: string(v1alpha1.GitOpsEngineNone),
 		},
 	}
+}
+
+func eksLoadBalancerControllerValue(spec *v1alpha1.ClusterSpec) string {
+	active := spec.EKS.ExperimentalAWSLoadBalancerController &&
+		spec.LoadBalancer == v1alpha1.LoadBalancerEnabled
+	if !active {
+		return strconv.FormatBool(false)
+	}
+
+	serviceAccount := strings.TrimSpace(spec.EKS.AWSLoadBalancerControllerServiceAccount)
+	if serviceAccount == "" {
+		return strconv.FormatBool(true)
+	}
+
+	return strconv.FormatBool(true) + ":" + serviceAccount
 }
 
 // appendChange appends a single diff change to the appropriate category slice in result.

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -235,6 +235,19 @@ func (e *Engine) scalarFieldRules() []fieldRule {
 			},
 		},
 		{
+			field:    "cluster.eks.experimentalAWSLoadBalancerController",
+			category: clusterupdate.ChangeCategoryInPlace,
+			reason:   "AWS Load Balancer Controller can be installed/uninstalled via Helm",
+			getVal: func(spec *v1alpha1.ClusterSpec) string {
+				if e.distribution != v1alpha1.DistributionEKS ||
+					e.provider != v1alpha1.ProviderAWS {
+					return strconv.FormatBool(false)
+				}
+
+				return strconv.FormatBool(spec.EKS.ExperimentalAWSLoadBalancerController)
+			},
+		},
+		{
 			field:      "cluster.certManager",
 			category:   clusterupdate.ChangeCategoryInPlace,
 			reason:     "cert-manager can be installed/uninstalled via Helm",

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -235,6 +235,46 @@ func TestEngine_ComponentChanges(t *testing.T) {
 	}
 }
 
+func TestEngine_EKSAWSLoadBalancerControllerOptInChange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		oldValue bool
+		newValue bool
+	}{
+		{name: "enable", oldValue: false, newValue: true},
+		{name: "disable", oldValue: true, newValue: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			oldSpec := newBaseSpec()
+			oldSpec.Distribution = v1alpha1.DistributionEKS
+			oldSpec.Provider = v1alpha1.ProviderAWS
+			oldSpec.LoadBalancer = v1alpha1.LoadBalancerEnabled
+			oldSpec.EKS.ExperimentalAWSLoadBalancerController = testCase.oldValue
+
+			newSpec := clone(oldSpec)
+			newSpec.EKS.ExperimentalAWSLoadBalancerController = testCase.newValue
+
+			engine := diff.NewEngine(v1alpha1.DistributionEKS, v1alpha1.ProviderAWS)
+			result := engine.ComputeDiff(oldSpec, newSpec, nil, nil)
+
+			assertSingleChange(
+				t,
+				result.InPlaceChanges,
+				"cluster.eks.experimentalAWSLoadBalancerController",
+				strconv.FormatBool(testCase.oldValue),
+				strconv.FormatBool(testCase.newValue),
+				clusterupdate.ChangeCategoryInPlace,
+			)
+		})
+	}
+}
+
 func TestEngine_CSIChange_SkippedForVanilla(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -329,6 +329,32 @@ func TestEngine_EKSAWSLoadBalancerControllerEffectiveActivationChange(t *testing
 	}
 }
 
+func TestEngine_EKSAWSLoadBalancerControllerServiceAccountChange(t *testing.T) {
+	t.Parallel()
+
+	oldSpec := newBaseSpec()
+	oldSpec.Distribution = v1alpha1.DistributionEKS
+	oldSpec.Provider = v1alpha1.ProviderAWS
+	oldSpec.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	oldSpec.EKS.ExperimentalAWSLoadBalancerController = true
+	oldSpec.EKS.AWSLoadBalancerControllerServiceAccount = "old-service-account"
+
+	newSpec := clone(oldSpec)
+	newSpec.EKS.AWSLoadBalancerControllerServiceAccount = "new-service-account"
+
+	engine := diff.NewEngine(v1alpha1.DistributionEKS, v1alpha1.ProviderAWS)
+	result := engine.ComputeDiff(oldSpec, newSpec, nil, nil)
+
+	assertSingleChange(
+		t,
+		result.InPlaceChanges,
+		diff.EKSLoadBalancerControllerField,
+		"true:old-service-account",
+		"true:new-service-account",
+		clusterupdate.ChangeCategoryInPlace,
+	)
+}
+
 func TestEngine_CSIChange_SkippedForVanilla(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -275,6 +275,33 @@ func TestEngine_EKSAWSLoadBalancerControllerOptInChange(t *testing.T) {
 	}
 }
 
+func TestEngine_EKSAWSLoadBalancerControllerUnknownBaseline(t *testing.T) {
+	t.Parallel()
+
+	oldSpec := newBaseSpec()
+	oldSpec.Distribution = v1alpha1.DistributionEKS
+	oldSpec.Provider = v1alpha1.ProviderAWS
+	clusterupdate.MarkComponentsUnknown(oldSpec)
+
+	newSpec := newBaseSpec()
+	newSpec.Distribution = v1alpha1.DistributionEKS
+	newSpec.Provider = v1alpha1.ProviderAWS
+	newSpec.LoadBalancer = v1alpha1.LoadBalancerEnabled
+	newSpec.EKS.ExperimentalAWSLoadBalancerController = true
+
+	engine := diff.NewEngine(v1alpha1.DistributionEKS, v1alpha1.ProviderAWS)
+	result := engine.ComputeDiff(oldSpec, newSpec, nil, nil)
+
+	for _, change := range result.InPlaceChanges {
+		require.NotEqual(t, diff.EKSLoadBalancerControllerField, change.Field)
+	}
+
+	require.Len(t, result.UnknownBaseline, 1)
+	require.Equal(t, diff.EKSLoadBalancerControllerField, result.UnknownBaseline[0].Field)
+	require.Equal(t, clusterupdate.UnknownBaselineValue, result.UnknownBaseline[0].OldValue)
+	require.Equal(t, "true", result.UnknownBaseline[0].NewValue)
+}
+
 func TestEngine_EKSAWSLoadBalancerControllerEffectiveActivationChange(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -275,6 +275,60 @@ func TestEngine_EKSAWSLoadBalancerControllerOptInChange(t *testing.T) {
 	}
 }
 
+func TestEngine_EKSAWSLoadBalancerControllerEffectiveActivationChange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		oldLoadBalancer v1alpha1.LoadBalancer
+		newLoadBalancer v1alpha1.LoadBalancer
+		oldValue        string
+		newValue        string
+	}{
+		{
+			name:            "explicit enable activates controller",
+			oldLoadBalancer: v1alpha1.LoadBalancerDefault,
+			newLoadBalancer: v1alpha1.LoadBalancerEnabled,
+			oldValue:        "false",
+			newValue:        "true",
+		},
+		{
+			name:            "return to default deactivates controller",
+			oldLoadBalancer: v1alpha1.LoadBalancerEnabled,
+			newLoadBalancer: v1alpha1.LoadBalancerDefault,
+			oldValue:        "true",
+			newValue:        "false",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			oldSpec := newBaseSpec()
+			oldSpec.Distribution = v1alpha1.DistributionEKS
+			oldSpec.Provider = v1alpha1.ProviderAWS
+			oldSpec.LoadBalancer = testCase.oldLoadBalancer
+			oldSpec.EKS.ExperimentalAWSLoadBalancerController = true
+
+			newSpec := clone(oldSpec)
+			newSpec.LoadBalancer = testCase.newLoadBalancer
+
+			engine := diff.NewEngine(v1alpha1.DistributionEKS, v1alpha1.ProviderAWS)
+			result := engine.ComputeDiff(oldSpec, newSpec, nil, nil)
+
+			assertSingleChange(
+				t,
+				result.InPlaceChanges,
+				diff.EKSLoadBalancerControllerField,
+				testCase.oldValue,
+				testCase.newValue,
+				clusterupdate.ChangeCategoryInPlace,
+			)
+		})
+	}
+}
+
 func TestEngine_CSIChange_SkippedForVanilla(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/diff/engine_test.go
+++ b/pkg/svc/diff/engine_test.go
@@ -266,7 +266,7 @@ func TestEngine_EKSAWSLoadBalancerControllerOptInChange(t *testing.T) {
 			assertSingleChange(
 				t,
 				result.InPlaceChanges,
-				"cluster.eks.experimentalAWSLoadBalancerController",
+				diff.EKSLoadBalancerControllerField,
 				strconv.FormatBool(testCase.oldValue),
 				strconv.FormatBool(testCase.newValue),
 				clusterupdate.ChangeCategoryInPlace,

--- a/pkg/svc/installer/awslbcontroller/doc.go
+++ b/pkg/svc/installer/awslbcontroller/doc.go
@@ -21,7 +21,6 @@
 //
 // Installation is an experimental opt-in gated by
 // spec.cluster.eks.experimentalAWSLoadBalancerController together with
-// spec.cluster.loadBalancer: Enabled. It runs at cluster create and on the
-// operator's reconcile; enabling the opt-in on an EXISTING cluster via
-// `cluster update` is not yet detected by the diff engine (#6231).
+// spec.cluster.loadBalancer: Enabled. It runs at cluster create, on the
+// operator's reconcile, and during cluster update when the opt-in changes.
 package awslbcontrollerinstaller

--- a/pkg/svc/installer/awslbcontroller/doc.go
+++ b/pkg/svc/installer/awslbcontroller/doc.go
@@ -23,4 +23,7 @@
 // spec.cluster.eks.experimentalAWSLoadBalancerController together with
 // spec.cluster.loadBalancer: Enabled. It runs at cluster create, on the
 // operator's reconcile, and during cluster update when the opt-in changes.
+// Opting out during cluster update uninstalls only a release backed by
+// exact-region KSail ownership state; manually installed and GitOps-managed
+// releases are preserved.
 package awslbcontrollerinstaller

--- a/pkg/svc/installer/awslbcontroller/doc.go
+++ b/pkg/svc/installer/awslbcontroller/doc.go
@@ -25,5 +25,7 @@
 // operator's reconcile, and during cluster update when the opt-in changes.
 // Opting out during cluster update uninstalls only a release backed by
 // exact-region KSail ownership state; manually installed and GitOps-managed
-// releases are preserved.
+// releases are preserved. Live detection considers only the latest deployed
+// Helm revision, so failed or uninstalled history is repaired on the next
+// enabled update instead of masking the absent controller.
 package awslbcontrollerinstaller

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -45,6 +45,13 @@ var ErrReleaseIdentityEmpty = errors.New(
 	"aws-load-balancer-controller Helm storage UID is empty",
 )
 
+// ErrGitOpsManagedUninstallSkipped reports a release that became externally
+// managed after KSail recorded ownership. Preserving it is correct, but the
+// requested disabled state remains unresolved and must not advance baselines.
+var ErrGitOpsManagedUninstallSkipped = errors.New(
+	"aws-load-balancer-controller is managed by GitOps; uninstall skipped",
+)
+
 // Installer installs or upgrades the AWS Load Balancer Controller.
 //
 // It embeds helmutil.Base for the whole Helm lifecycle; no extra Kubernetes
@@ -192,7 +199,7 @@ func (i *Installer) OwnsReleaseIdentity(ctx context.Context, expected string) (b
 	}
 
 	return metadata.Identity == expected ||
-		slices.Contains(metadata.HistoryIdentities, expected), nil
+		slices.Contains(metadata.CurrentIncarnationIdentities, expected), nil
 }
 
 // Uninstall removes the AWS Load Balancer Controller only when the caller has
@@ -216,7 +223,7 @@ func (i *Installer) Uninstall(ctx context.Context) error {
 	}
 
 	if skip {
-		return nil
+		return ErrGitOpsManagedUninstallSkipped
 	}
 
 	err = i.Base.Uninstall(ctx)

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -1,6 +1,7 @@
 package awslbcontrollerinstaller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -42,6 +43,8 @@ var ErrInvalidServiceAccountName = errors.New(
 // resources are created outside the chart.
 type Installer struct {
 	*helmutil.Base
+
+	client helm.Interface
 }
 
 // NewInstaller creates a new AWS Load Balancer Controller installer instance.
@@ -99,7 +102,35 @@ func NewInstaller(
 				ValuesYaml:  buildValuesYaml(clusterName, region, serviceAccountName, haEnabled),
 			},
 		),
+		client: client,
 	}, nil
+}
+
+// Uninstall removes the AWS Load Balancer Controller only when KSail owns the
+// Helm release. A Flux- or ArgoCD-managed release is left untouched, and an
+// ownership lookup failure aborts before Helm can delete anything.
+func (i *Installer) Uninstall(ctx context.Context) error {
+	skip, err := helmutil.SkipIfGitOpsManaged(
+		ctx,
+		i.client,
+		"aws-load-balancer-controller",
+		awslbcRelease,
+		awslbcNamespace,
+	)
+	if err != nil {
+		return fmt.Errorf("check AWS load balancer controller release ownership: %w", err)
+	}
+
+	if skip {
+		return nil
+	}
+
+	err = i.Base.Uninstall(ctx)
+	if err != nil {
+		return fmt.Errorf("uninstall AWS load balancer controller: %w", err)
+	}
+
+	return nil
 }
 
 // buildValuesYaml generates the Helm values YAML for the chart. clusterName is

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -17,7 +17,8 @@ import (
 const (
 	awslbcRepoName = "eks"
 	awslbcRepoURL  = "https://aws.github.io/eks-charts"
-	awslbcRelease  = "aws-load-balancer-controller"
+	// ReleaseName is the canonical component and Helm release key.
+	ReleaseName = "aws-load-balancer-controller"
 	// The controller is conventionally installed into kube-system (the chart's
 	// documented default target), which always exists — no namespace creation.
 	awslbcNamespace = "kube-system"
@@ -106,7 +107,7 @@ func NewInstaller(
 
 	return &Installer{
 		Base: helmutil.NewBase(
-			"aws-load-balancer-controller",
+			ReleaseName,
 			client,
 			timeout,
 			&helm.RepositoryEntry{
@@ -114,7 +115,7 @@ func NewInstaller(
 				URL:  awslbcRepoURL,
 			},
 			&helm.ChartSpec{
-				ReleaseName:     awslbcRelease,
+				ReleaseName:     ReleaseName,
 				ChartName:       awslbcChartName,
 				Namespace:       awslbcNamespace,
 				Version:         chartVersion(),
@@ -142,7 +143,7 @@ func NewInstaller(
 // IsGitOpsManaged reports whether the current release is owned by Flux or
 // ArgoCD. Missing release storage means there is no GitOps-owned release.
 func (i *Installer) IsGitOpsManaged(ctx context.Context) (bool, error) {
-	labels, err := i.client.GetReleaseStorageLabels(ctx, awslbcRelease, awslbcNamespace)
+	labels, err := i.client.GetReleaseStorageLabels(ctx, ReleaseName, awslbcNamespace)
 	if err != nil && !errors.Is(err, helm.ErrNoReleaseStorage) {
 		return false, fmt.Errorf(
 			"check AWS load balancer controller release ownership: %w",
@@ -161,7 +162,7 @@ func (i *Installer) IsGitOpsManaged(ctx context.Context) (bool, error) {
 func (i *Installer) ReleaseIdentity(ctx context.Context) (string, error) {
 	metadata, err := i.client.GetReleaseStorageMetadata(
 		ctx,
-		awslbcRelease,
+		ReleaseName,
 		awslbcNamespace,
 	)
 	if err != nil {
@@ -191,7 +192,7 @@ func (i *Installer) ReleaseIdentity(ctx context.Context) (string, error) {
 func (i *Installer) OwnsReleaseIdentity(ctx context.Context, expected string) (bool, error) {
 	metadata, err := i.client.GetReleaseStorageMetadata(
 		ctx,
-		awslbcRelease,
+		ReleaseName,
 		awslbcNamespace,
 	)
 	if err != nil {
@@ -229,8 +230,8 @@ func (i *Installer) Uninstall(ctx context.Context) error {
 	skip, err := helmutil.SkipIfGitOpsManaged(
 		ctx,
 		i.client,
-		"aws-load-balancer-controller",
-		awslbcRelease,
+		ReleaseName,
+		ReleaseName,
 		awslbcNamespace,
 	)
 	if err != nil {

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -207,15 +207,12 @@ func (i *Installer) OwnsReleaseIdentity(ctx context.Context, expected string) (b
 		return false, nil
 	}
 
-	if metadata.Identity == expected {
-		return true, nil
-	}
-
 	if metadata.Labels[ReleaseOwnershipLabel] != releaseOwnershipValue {
 		return false, nil
 	}
 
-	return slices.Contains(metadata.HistoryIdentities, expected), nil
+	return metadata.Identity == expected ||
+		slices.Contains(metadata.HistoryIdentities, expected), nil
 }
 
 // Uninstall removes the AWS Load Balancer Controller only when the caller has

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -44,7 +44,8 @@ var ErrInvalidServiceAccountName = errors.New(
 type Installer struct {
 	*helmutil.Base
 
-	client helm.Interface
+	client       helm.Interface
+	ksailManaged bool
 }
 
 // NewInstaller creates a new AWS Load Balancer Controller installer instance.
@@ -62,6 +63,7 @@ func NewInstaller(
 	timeout time.Duration,
 	clusterName, region, serviceAccountName string,
 	haEnabled bool,
+	ksailManaged ...bool,
 ) (*Installer, error) {
 	if strings.TrimSpace(clusterName) == "" {
 		return nil, ErrClusterNameRequired
@@ -74,6 +76,8 @@ func NewInstaller(
 				ErrInvalidServiceAccountName, serviceAccountName, strings.Join(errs, "; "))
 		}
 	}
+
+	managed := len(ksailManaged) > 0 && ksailManaged[0]
 
 	return &Installer{
 		Base: helmutil.NewBase(
@@ -102,14 +106,20 @@ func NewInstaller(
 				ValuesYaml:  buildValuesYaml(clusterName, region, serviceAccountName, haEnabled),
 			},
 		),
-		client: client,
+		client:       client,
+		ksailManaged: managed,
 	}, nil
 }
 
-// Uninstall removes the AWS Load Balancer Controller only when KSail owns the
-// Helm release. A Flux- or ArgoCD-managed release is left untouched, and an
-// ownership lookup failure aborts before Helm can delete anything.
+// Uninstall removes the AWS Load Balancer Controller only when the caller has
+// supplied positive KSail ownership evidence. A Flux- or ArgoCD-managed release
+// is still left untouched, and an ownership lookup failure aborts before Helm
+// can delete anything.
 func (i *Installer) Uninstall(ctx context.Context) error {
+	if !i.ksailManaged {
+		return nil
+	}
+
 	skip, err := helmutil.SkipIfGitOpsManaged(
 		ctx,
 		i.client,

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -71,6 +73,11 @@ func NewInstaller(
 	haEnabled bool,
 	ksailManaged ...bool,
 ) (*Installer, error) {
+	err := helm.ValidateKubernetesReleaseStorageDriver(os.Getenv("HELM_DRIVER"))
+	if err != nil {
+		return nil, fmt.Errorf("validate release identity storage: %w", err)
+	}
+
 	if strings.TrimSpace(clusterName) == "" {
 		return nil, ErrClusterNameRequired
 	}
@@ -159,6 +166,33 @@ func (i *Installer) ReleaseIdentity(ctx context.Context) (string, error) {
 	}
 
 	return identity, nil
+}
+
+// OwnsReleaseIdentity reports whether the expected Kubernetes UID still
+// belongs to the current Helm release history. Helm upgrades create a new
+// storage object for each revision, so requiring only the latest UID would
+// reject cleanup after an owned failed/pending upgrade. A deleted and
+// reinstalled same-name release has a new history and therefore does not match.
+func (i *Installer) OwnsReleaseIdentity(ctx context.Context, expected string) (bool, error) {
+	metadata, err := i.client.GetReleaseStorageMetadata(
+		ctx,
+		awslbcRelease,
+		awslbcNamespace,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"read AWS load balancer controller release identity history: %w",
+			err,
+		)
+	}
+
+	expected = strings.TrimSpace(expected)
+	if expected == "" || metadata == nil {
+		return false, nil
+	}
+
+	return metadata.Identity == expected ||
+		slices.Contains(metadata.HistoryIdentities, expected), nil
 }
 
 // Uninstall removes the AWS Load Balancer Controller only when the caller has

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -37,6 +37,12 @@ var ErrInvalidServiceAccountName = errors.New(
 	"aws-load-balancer-controller service account name must be a valid DNS-1123 subdomain",
 )
 
+// ErrReleaseIdentityEmpty reports Helm storage without a Kubernetes UID. A
+// caller cannot safely bind uninstall ownership to such a release.
+var ErrReleaseIdentityEmpty = errors.New(
+	"aws-load-balancer-controller Helm storage UID is empty",
+)
+
 // Installer installs or upgrades the AWS Load Balancer Controller.
 //
 // It embeds helmutil.Base for the whole Helm lifecycle; no extra Kubernetes
@@ -125,6 +131,34 @@ func (i *Installer) IsGitOpsManaged(ctx context.Context) (bool, error) {
 	_, managed := helmutil.IsGitOpsManaged(labels)
 
 	return managed, nil
+}
+
+// ReleaseIdentity returns the Kubernetes UID of the latest Helm storage
+// object. Unlike a release name or revision, this changes when a deleted
+// same-name release is installed again.
+func (i *Installer) ReleaseIdentity(ctx context.Context) (string, error) {
+	metadata, err := i.client.GetReleaseStorageMetadata(
+		ctx,
+		awslbcRelease,
+		awslbcNamespace,
+	)
+	if err != nil {
+		return "", fmt.Errorf(
+			"read AWS load balancer controller release identity: %w",
+			err,
+		)
+	}
+
+	if metadata == nil {
+		return "", ErrReleaseIdentityEmpty
+	}
+
+	identity := strings.TrimSpace(metadata.Identity)
+	if identity == "" {
+		return "", ErrReleaseIdentityEmpty
+	}
+
+	return identity, nil
 }
 
 // Uninstall removes the AWS Load Balancer Controller only when the caller has

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -111,6 +111,22 @@ func NewInstaller(
 	}, nil
 }
 
+// IsGitOpsManaged reports whether the current release is owned by Flux or
+// ArgoCD. Missing release storage means there is no GitOps-owned release.
+func (i *Installer) IsGitOpsManaged(ctx context.Context) (bool, error) {
+	labels, err := i.client.GetReleaseStorageLabels(ctx, awslbcRelease, awslbcNamespace)
+	if err != nil && !errors.Is(err, helm.ErrNoReleaseStorage) {
+		return false, fmt.Errorf(
+			"check AWS load balancer controller release ownership: %w",
+			err,
+		)
+	}
+
+	_, managed := helmutil.IsGitOpsManaged(labels)
+
+	return managed, nil
+}
+
 // Uninstall removes the AWS Load Balancer Controller only when the caller has
 // supplied positive KSail ownership evidence. A Flux- or ArgoCD-managed release
 // is still left untouched, and an ownership lookup failure aborts before Helm

--- a/pkg/svc/installer/awslbcontroller/installer.go
+++ b/pkg/svc/installer/awslbcontroller/installer.go
@@ -22,6 +22,11 @@ const (
 	// documented default target), which always exists — no namespace creation.
 	awslbcNamespace = "kube-system"
 	awslbcChartName = "eks/aws-load-balancer-controller"
+	// ReleaseOwnershipLabel is attached to every Helm revision KSail creates.
+	// Helm upgrades preserve custom release labels, while an external
+	// `helm install --replace` starts without it even when old history remains.
+	ReleaseOwnershipLabel = "ksail.io/aws-load-balancer-controller-owner"
+	releaseOwnershipValue = "ksail"
 )
 
 // ErrClusterNameRequired is returned when no EKS cluster name is available for
@@ -122,8 +127,11 @@ func NewInstaller(
 				// upgrades leave them at the previously-installed version
 				// (helm v4 maps !UpgradeCRDs to SkipCRDs).
 				UpgradeCRDs: true,
-				Timeout:     timeout,
-				ValuesYaml:  buildValuesYaml(clusterName, region, serviceAccountName, haEnabled),
+				Labels: map[string]string{
+					ReleaseOwnershipLabel: releaseOwnershipValue,
+				},
+				Timeout:    timeout,
+				ValuesYaml: buildValuesYaml(clusterName, region, serviceAccountName, haEnabled),
 			},
 		),
 		client:       client,
@@ -198,8 +206,15 @@ func (i *Installer) OwnsReleaseIdentity(ctx context.Context, expected string) (b
 		return false, nil
 	}
 
-	return metadata.Identity == expected ||
-		slices.Contains(metadata.CurrentIncarnationIdentities, expected), nil
+	if metadata.Identity == expected {
+		return true, nil
+	}
+
+	if metadata.Labels[ReleaseOwnershipLabel] != releaseOwnershipValue {
+		return false, nil
+	}
+
+	return slices.Contains(metadata.HistoryIdentities, expected), nil
 }
 
 // Uninstall removes the AWS Load Balancer Controller only when the caller has

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -118,6 +118,29 @@ func TestNewInstaller_HAEnabled(t *testing.T) {
 	require.NotNil(t, installer)
 }
 
+func TestInstallLabelsReleaseWithKSailOwnership(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(nil, helm.ErrNoReleaseStorage)
+	client.EXPECT().
+		AddRepository(mock.Anything, mock.Anything, 5*time.Minute).
+		Return(nil)
+	client.EXPECT().
+		InstallOrUpgradeChart(mock.Anything, mock.MatchedBy(func(spec *helm.ChartSpec) bool {
+			return spec.Labels[awslbcontrollerinstaller.ReleaseOwnershipLabel] == "ksail"
+		})).
+		Return(&helm.ReleaseInfo{}, nil)
+
+	component, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+	require.NoError(t, component.Install(t.Context()))
+}
+
 func TestNewInstallerRejectsStorageWithoutKubernetesReleaseIdentity(t *testing.T) {
 	t.Setenv("HELM_DRIVER", "sql")
 
@@ -203,18 +226,19 @@ func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.
 		{
 			name: "owned failed upgrade retains the persisted revision UID",
 			metadata: &helm.ReleaseStorageMetadata{
-				Identity:                     "failed-upgrade-uid",
-				HistoryIdentities:            []string{"persisted-owned-uid", "failed-upgrade-uid"},
-				CurrentIncarnationIdentities: []string{"persisted-owned-uid", "failed-upgrade-uid"},
+				Labels: map[string]string{
+					awslbcontrollerinstaller.ReleaseOwnershipLabel: "ksail",
+				},
+				Identity:          "failed-upgrade-uid",
+				HistoryIdentities: []string{"persisted-owned-uid", "failed-upgrade-uid"},
 			},
 			want: true,
 		},
 		{
 			name: "same-name replacement has a disjoint release history",
 			metadata: &helm.ReleaseStorageMetadata{
-				Identity:                     "replacement-uid",
-				HistoryIdentities:            []string{"replacement-uid"},
-				CurrentIncarnationIdentities: []string{"replacement-uid"},
+				Identity:          "replacement-uid",
+				HistoryIdentities: []string{"replacement-uid"},
 			},
 			want: false,
 		},
@@ -227,7 +251,6 @@ func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.
 					"uninstalled-uid",
 					"replacement-uid",
 				},
-				CurrentIncarnationIdentities: []string{"replacement-uid"},
 			},
 			want: false,
 		},

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -215,14 +215,15 @@ func TestReleaseIdentityReturnsStorageUID(t *testing.T) {
 	assert.Equal(t, "release-uid", identity)
 }
 
-func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.T) {
-	t.Parallel()
+type releaseIdentityOwnershipCase struct {
+	name     string
+	metadata *helm.ReleaseStorageMetadata
+	expected string
+	want     bool
+}
 
-	for _, testCase := range []struct {
-		name     string
-		metadata *helm.ReleaseStorageMetadata
-		want     bool
-	}{
+func releaseIdentityOwnershipCases() []releaseIdentityOwnershipCase {
+	return []releaseIdentityOwnershipCase{
 		{
 			name: "owned failed upgrade retains the persisted revision UID",
 			metadata: &helm.ReleaseStorageMetadata{
@@ -232,7 +233,17 @@ func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.
 				Identity:          "failed-upgrade-uid",
 				HistoryIdentities: []string{"persisted-owned-uid", "failed-upgrade-uid"},
 			},
-			want: true,
+			expected: "persisted-owned-uid",
+			want:     true,
+		},
+		{
+			name: "unlabelled manual release cannot own its current UID",
+			metadata: &helm.ReleaseStorageMetadata{
+				Identity:          "manual-release-uid",
+				HistoryIdentities: []string{"manual-release-uid"},
+			},
+			expected: "manual-release-uid",
+			want:     false,
 		},
 		{
 			name: "same-name replacement has a disjoint release history",
@@ -240,7 +251,8 @@ func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.
 				Identity:          "replacement-uid",
 				HistoryIdentities: []string{"replacement-uid"},
 			},
-			want: false,
+			expected: "persisted-owned-uid",
+			want:     false,
 		},
 		{
 			name: "keep-history replacement excludes the prior incarnation",
@@ -252,9 +264,16 @@ func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.
 					"replacement-uid",
 				},
 			},
-			want: false,
+			expected: "persisted-owned-uid",
+			want:     false,
 		},
-	} {
+	}
+}
+
+func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range releaseIdentityOwnershipCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -271,7 +290,7 @@ func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.
 			)
 			require.NoError(t, err)
 
-			owned, err := component.OwnsReleaseIdentity(t.Context(), "persisted-owned-uid")
+			owned, err := component.OwnsReleaseIdentity(t.Context(), testCase.expected)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.want, owned)
 		})

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -126,7 +126,7 @@ func TestUninstallPreservesGitOpsOwnership(t *testing.T) {
 		GetReleaseStorageLabels(mock.Anything, "aws-load-balancer-controller", "kube-system").
 		Return(map[string]string{"helm.toolkit.fluxcd.io/name": "aws-load-balancer-controller"}, nil)
 	installer, err := awslbcontrollerinstaller.NewInstaller(
-		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false, true,
 	)
 	require.NoError(t, err)
 
@@ -146,7 +146,7 @@ func TestUninstallAllowsKSailOwnedRelease(t *testing.T) {
 		UninstallRelease(mock.Anything, "aws-load-balancer-controller", "kube-system").
 		Return(nil)
 	installer, err := awslbcontrollerinstaller.NewInstaller(
-		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false, true,
 	)
 	require.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestUninstallFailsClosedWhenOwnershipUnknown(t *testing.T) {
 		GetReleaseStorageLabels(mock.Anything, "aws-load-balancer-controller", "kube-system").
 		Return(nil, assert.AnError)
 	installer, err := awslbcontrollerinstaller.NewInstaller(
-		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false, true,
 	)
 	require.NoError(t, err)
 
@@ -171,6 +171,20 @@ func TestUninstallFailsClosedWhenOwnershipUnknown(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "check release ownership for aws-load-balancer-controller")
+}
+
+func TestUninstallPreservesReleaseWithoutKSailOwnership(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+
+	err = installer.Uninstall(context.Background())
+
+	require.NoError(t, err)
 }
 
 type buildValuesCase struct {

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -118,6 +118,27 @@ func TestNewInstaller_HAEnabled(t *testing.T) {
 	require.NotNil(t, installer)
 }
 
+func TestNewInstallerRejectsStorageWithoutKubernetesReleaseIdentity(t *testing.T) {
+	t.Setenv("HELM_DRIVER", "sql")
+
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		helm.NewMockInterface(t),
+		5*time.Minute,
+		"prod-eks",
+		"eu-north-1",
+		"",
+		false,
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot provide a Kubernetes release identity")
+	assert.Nil(
+		t,
+		installer,
+		"unsupported identity storage must fail before Helm mutates the cluster",
+	)
+}
+
 func TestUninstallPreservesGitOpsOwnership(t *testing.T) {
 	t.Parallel()
 
@@ -169,6 +190,54 @@ func TestReleaseIdentityReturnsStorageUID(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "release-uid", identity)
+}
+
+func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name     string
+		metadata *helm.ReleaseStorageMetadata
+		want     bool
+	}{
+		{
+			name: "owned failed upgrade retains the persisted revision UID",
+			metadata: &helm.ReleaseStorageMetadata{
+				Identity:          "failed-upgrade-uid",
+				HistoryIdentities: []string{"persisted-owned-uid", "failed-upgrade-uid"},
+			},
+			want: true,
+		},
+		{
+			name: "same-name replacement has a disjoint release history",
+			metadata: &helm.ReleaseStorageMetadata{
+				Identity:          "replacement-uid",
+				HistoryIdentities: []string{"replacement-uid"},
+			},
+			want: false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := helm.NewMockInterface(t)
+			client.EXPECT().
+				GetReleaseStorageMetadata(
+					mock.Anything,
+					"aws-load-balancer-controller",
+					"kube-system",
+				).
+				Return(testCase.metadata, nil)
+			component, err := awslbcontrollerinstaller.NewInstaller(
+				client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+			)
+			require.NoError(t, err)
+
+			owned, err := component.OwnsReleaseIdentity(t.Context(), "persisted-owned-uid")
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, owned)
+		})
+	}
 }
 
 func TestReleaseIdentityRejectsEmptyStorageUID(t *testing.T) {

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -1,6 +1,7 @@
 package awslbcontrollerinstaller_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	awslbcontrollerinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/awslbcontroller"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -114,6 +116,61 @@ func TestNewInstaller_HAEnabled(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, installer)
+}
+
+func TestUninstallPreservesGitOpsOwnership(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(map[string]string{"helm.toolkit.fluxcd.io/name": "aws-load-balancer-controller"}, nil)
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+
+	err = installer.Uninstall(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestUninstallAllowsKSailOwnedRelease(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(map[string]string{"owner": "helm"}, nil)
+	client.EXPECT().
+		UninstallRelease(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(nil)
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+
+	err = installer.Uninstall(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestUninstallFailsClosedWhenOwnershipUnknown(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(nil, assert.AnError)
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+
+	err = installer.Uninstall(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check release ownership for aws-load-balancer-controller")
 }
 
 type buildValuesCase struct {

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -153,7 +153,7 @@ func TestUninstallPreservesGitOpsOwnership(t *testing.T) {
 
 	err = installer.Uninstall(context.Background())
 
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "managed by GitOps")
 }
 
 func TestIsGitOpsManagedReportsFluxOwnership(t *testing.T) {
@@ -203,16 +203,31 @@ func TestOwnsReleaseIdentityAcceptsOwnedHistoryButRejectsReplacement(t *testing.
 		{
 			name: "owned failed upgrade retains the persisted revision UID",
 			metadata: &helm.ReleaseStorageMetadata{
-				Identity:          "failed-upgrade-uid",
-				HistoryIdentities: []string{"persisted-owned-uid", "failed-upgrade-uid"},
+				Identity:                     "failed-upgrade-uid",
+				HistoryIdentities:            []string{"persisted-owned-uid", "failed-upgrade-uid"},
+				CurrentIncarnationIdentities: []string{"persisted-owned-uid", "failed-upgrade-uid"},
 			},
 			want: true,
 		},
 		{
 			name: "same-name replacement has a disjoint release history",
 			metadata: &helm.ReleaseStorageMetadata{
-				Identity:          "replacement-uid",
-				HistoryIdentities: []string{"replacement-uid"},
+				Identity:                     "replacement-uid",
+				HistoryIdentities:            []string{"replacement-uid"},
+				CurrentIncarnationIdentities: []string{"replacement-uid"},
+			},
+			want: false,
+		},
+		{
+			name: "keep-history replacement excludes the prior incarnation",
+			metadata: &helm.ReleaseStorageMetadata{
+				Identity: "replacement-uid",
+				HistoryIdentities: []string{
+					"persisted-owned-uid",
+					"uninstalled-uid",
+					"replacement-uid",
+				},
+				CurrentIncarnationIdentities: []string{"replacement-uid"},
 			},
 			want: false,
 		},

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -135,6 +135,24 @@ func TestUninstallPreservesGitOpsOwnership(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIsGitOpsManagedReportsFluxOwnership(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageLabels(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(map[string]string{"helm.toolkit.fluxcd.io/name": "aws-load-balancer-controller"}, nil)
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+
+	managed, err := installer.IsGitOpsManaged(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, managed)
+}
+
 func TestUninstallAllowsKSailOwnedRelease(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/awslbcontroller/installer_test.go
+++ b/pkg/svc/installer/awslbcontroller/installer_test.go
@@ -153,6 +153,41 @@ func TestIsGitOpsManagedReportsFluxOwnership(t *testing.T) {
 	assert.True(t, managed)
 }
 
+func TestReleaseIdentityReturnsStorageUID(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageMetadata(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(&helm.ReleaseStorageMetadata{Identity: "release-uid"}, nil)
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+
+	identity, err := installer.ReleaseIdentity(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, "release-uid", identity)
+}
+
+func TestReleaseIdentityRejectsEmptyStorageUID(t *testing.T) {
+	t.Parallel()
+
+	client := helm.NewMockInterface(t)
+	client.EXPECT().
+		GetReleaseStorageMetadata(mock.Anything, "aws-load-balancer-controller", "kube-system").
+		Return(&helm.ReleaseStorageMetadata{}, nil)
+	installer, err := awslbcontrollerinstaller.NewInstaller(
+		client, 5*time.Minute, "prod-eks", "eu-north-1", "", false,
+	)
+	require.NoError(t, err)
+
+	_, err = installer.ReleaseIdentity(context.Background())
+
+	require.ErrorIs(t, err, awslbcontrollerinstaller.ErrReleaseIdentityEmpty)
+}
+
 func TestUninstallAllowsKSailOwnedRelease(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/installer/awslbcontroller/version.go
+++ b/pkg/svc/installer/awslbcontroller/version.go
@@ -14,5 +14,5 @@ var chartYAML string
 // ecosystem). The chart version diverges from the controller image version
 // history, so it cannot be tracked via a Dockerfile image tag.
 func chartVersion() string {
-	return parser.ParseChartVersionFromChartYaml(chartYAML, "aws-load-balancer-controller")
+	return parser.ParseChartVersionFromChartYaml(chartYAML, ReleaseName)
 }

--- a/pkg/svc/installer/factory.go
+++ b/pkg/svc/installer/factory.go
@@ -39,6 +39,9 @@ type Factory struct {
 	// Load Balancer Controller chart. Only callers that know the provisioned
 	// name (e.g. the operator) can supply it — see WithEKSClusterName.
 	eksClusterName string
+	// awsLoadBalancerControllerManaged is positive ownership evidence supplied
+	// by callers whose own baseline proves KSail installed the controller.
+	awsLoadBalancerControllerManaged bool
 }
 
 // Option configures optional Factory dependencies.
@@ -49,6 +52,16 @@ type Option func(*Factory)
 func WithEKSClusterName(name string) Option {
 	return func(f *Factory) {
 		f.eksClusterName = name
+	}
+}
+
+// WithAWSLoadBalancerControllerManaged supplies positive KSail ownership
+// evidence for lifecycle paths that rebuild an installer from their own
+// last-applied baseline. The default remains false so ordinary discovery can
+// never infer ownership from a live Helm release alone.
+func WithAWSLoadBalancerControllerManaged(managed bool) Option {
+	return func(f *Factory) {
+		f.awsLoadBalancerControllerManaged = managed
 	}
 }
 
@@ -324,6 +337,7 @@ func (f *Factory) addLoadBalancerInstaller(
 			"", // region: rely on the chart's own discovery
 			spec.EKS.AWSLoadBalancerControllerServiceAccount,
 			haEnabled,
+			f.awsLoadBalancerControllerManaged,
 		)
 		if err != nil {
 			return fmt.Errorf(

--- a/pkg/svc/installer/internal/helmutil/base.go
+++ b/pkg/svc/installer/internal/helmutil/base.go
@@ -51,18 +51,26 @@ func NewBase(
 // (Flux or ArgoCD), the install is skipped to avoid overwriting externally
 // managed values.
 func (b *Base) Install(ctx context.Context) error {
+	_, err := b.InstallWithResult(ctx)
+
+	return err
+}
+
+// InstallWithResult installs or upgrades the chart and reports whether Helm
+// was actually mutated. A GitOps-owned release returns false with no error.
+func (b *Base) InstallWithResult(ctx context.Context) (bool, error) {
 	skip, err := SkipIfGitOpsManaged(ctx, b.client, b.name, b.spec.ReleaseName, b.spec.Namespace)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if skip {
-		return nil
+		return false, nil
 	}
 
 	err = b.client.AddRepository(ctx, b.repo, b.timeout)
 	if err != nil {
-		return fmt.Errorf("failed to add %s repository: %w", b.repo.Name, err)
+		return false, fmt.Errorf("failed to add %s repository: %w", b.repo.Name, err)
 	}
 
 	installCtx, cancel := context.WithTimeout(ctx, b.timeout+helm.ContextTimeoutBuffer)
@@ -70,10 +78,10 @@ func (b *Base) Install(ctx context.Context) error {
 
 	err = helm.InstallChartWithRetry(installCtx, b.client, b.spec, b.name)
 	if err != nil {
-		return fmt.Errorf("installing %s chart: %w", b.name, err)
+		return false, fmt.Errorf("installing %s chart: %w", b.name, err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // Uninstall removes the Helm release.

--- a/pkg/svc/installer/internal/helmutil/helmutil_test.go
+++ b/pkg/svc/installer/internal/helmutil/helmutil_test.go
@@ -38,9 +38,10 @@ func TestBaseInstallSuccess(t *testing.T) {
 		InstallOrUpgradeChart(mock.Anything, mock.Anything).
 		Return(nil, nil)
 
-	err := base.Install(context.Background())
+	mutated, err := base.InstallWithResult(context.Background())
 
 	require.NoError(t, err)
+	assert.True(t, mutated)
 }
 
 func TestBaseInstallProceedsWhenNoReleaseSecrets(t *testing.T) {
@@ -76,9 +77,10 @@ func TestBaseInstallSkipsWhenFluxManaged(t *testing.T) {
 		}, nil)
 
 	// AddRepository and InstallOrUpgradeChart should NOT be called.
-	err := base.Install(context.Background())
+	mutated, err := base.InstallWithResult(context.Background())
 
 	require.NoError(t, err)
+	assert.False(t, mutated)
 }
 
 func TestBaseInstallSkipsWhenArgoCDManaged(t *testing.T) {

--- a/pkg/svc/installer/internal/helmutil/ownership.go
+++ b/pkg/svc/installer/internal/helmutil/ownership.go
@@ -39,16 +39,17 @@ func IsGitOpsManaged(labels map[string]string) (string, bool) {
 	return "", false
 }
 
-// SkipIfGitOpsManaged reports whether a component's Helm install should be
-// skipped because the release Secret is already owned by a GitOps controller
-// (Flux or ArgoCD). It queries the release storage labels, tolerating
+// SkipIfGitOpsManaged reports whether a component's Helm lifecycle mutation
+// should be skipped because the release Secret is already owned by a GitOps
+// controller (Flux or ArgoCD). It queries the release storage labels, tolerating
 // [helm.ErrNoReleaseStorage] (no release yet), and when ownership is detected
 // it prints a skip notice to stderr and returns true.
 //
 // name identifies the component in the skip message and error wrapping (e.g.
 // "cilium", "flux-operator"); releaseName and namespace identify the Helm
 // release Secret to inspect. This single-sources the ownership-skip sequence
-// shared by Base.Install, the CNI installers, and the Flux installer.
+// shared by Base.Install, the CNI installers, the Flux installer, and the AWS
+// Load Balancer Controller's guarded uninstall path.
 func SkipIfGitOpsManaged(
 	ctx context.Context,
 	client helm.Interface,
@@ -66,7 +67,7 @@ func SkipIfGitOpsManaged(
 
 	fmt.Fprintf(
 		os.Stderr,
-		"%s: skipping install — release %q is managed by %s\n",
+		"%s: skipping KSail-managed Helm change — release %q is managed by %s\n",
 		name,
 		releaseName,
 		controller,

--- a/pkg/svc/provisioner/cluster/clusterupdate/state.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state.go
@@ -21,8 +21,6 @@ import (
 //     node's containerd config at creation (Kind/K3s baselines otherwise carry the
 //     zero value, so a configured mirrorsDir reads as recreate-required every run;
 //     see kind.DiffConfig and diff/engine.go's documented LocalRegistry limitation).
-//   - EKS.ExperimentalAWSLoadBalancerController — an explicit component ownership
-//     choice that cannot be inferred from generic component detection alone.
 //
 // It is a no-op (returns nil) when no state exists for clusterName
 // (state.ErrStateNotFound). Any other failure (I/O, corrupt JSON, permission)
@@ -58,10 +56,36 @@ func MergePersistedState(spec *v1alpha1.ClusterSpec, clusterName string) error {
 		spec.Vanilla.MirrorsDir = saved.Vanilla.MirrorsDir
 	}
 
-	// The AWS Load Balancer Controller opt-in is declarative KSail ownership
-	// state. Preserve both true and false so enable and disable transitions are
-	// each compared against the last successfully applied configuration.
-	spec.EKS.ExperimentalAWSLoadBalancerController = saved.EKS.ExperimentalAWSLoadBalancerController
+	return nil
+}
+
+// MergePersistedEKSState restores declarative EKS component choices from the
+// exact target region. A missing baseline is a no-op so an existing cluster can
+// adopt the feature; corrupt or unreadable state fails closed.
+func MergePersistedEKSState(
+	spec *v1alpha1.ClusterSpec,
+	clusterName, region string,
+) error {
+	if spec == nil {
+		return nil
+	}
+
+	saved, err := state.LoadEKSComponentState(clusterName, region)
+	if err != nil {
+		if errors.Is(err, state.ErrEKSComponentStateNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"load persisted EKS component state for %q in %q: %w",
+			clusterName,
+			region,
+			err,
+		)
+	}
+
+	spec.LoadBalancer = saved.LoadBalancer
+	spec.EKS.ExperimentalAWSLoadBalancerController = saved.ExperimentalAWSLoadBalancerController
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/clusterupdate/state.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state.go
@@ -59,9 +59,10 @@ func MergePersistedState(spec *v1alpha1.ClusterSpec, clusterName string) error {
 	return nil
 }
 
-// MergePersistedEKSState restores declarative EKS component choices from the
-// exact target region. A missing baseline is a no-op so an existing cluster can
-// adopt the feature; corrupt or unreadable state fails closed.
+// MergePersistedEKSState restores non-introspectable EKS installer inputs from
+// the exact target region. Live Helm detection remains authoritative for
+// activation. A missing baseline is a no-op so an existing cluster can adopt
+// the feature; corrupt or unreadable state fails closed.
 func MergePersistedEKSState(
 	spec *v1alpha1.ClusterSpec,
 	clusterName, region string,
@@ -84,8 +85,9 @@ func MergePersistedEKSState(
 		)
 	}
 
-	spec.LoadBalancer = saved.LoadBalancer
-	spec.EKS.ExperimentalAWSLoadBalancerController = saved.ExperimentalAWSLoadBalancerController
+	// Activation is live state and must come from the Helm detector. Only the
+	// installer input that Helm release existence cannot reveal is restored.
+	spec.EKS.AWSLoadBalancerControllerServiceAccount = saved.AWSLoadBalancerControllerServiceAccount
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/clusterupdate/state.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state.go
@@ -66,12 +66,13 @@ func MergePersistedState(spec *v1alpha1.ClusterSpec, clusterName string) error {
 func MergePersistedEKSState(
 	spec *v1alpha1.ClusterSpec,
 	clusterName, region string,
+	accountIDs ...string,
 ) error {
 	if spec == nil {
 		return nil
 	}
 
-	saved, err := state.LoadEKSComponentState(clusterName, region)
+	saved, err := state.LoadEKSComponentState(clusterName, region, accountIDs...)
 	if err != nil {
 		if errors.Is(err, state.ErrEKSComponentStateNotFound) {
 			return nil

--- a/pkg/svc/provisioner/cluster/clusterupdate/state.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state.go
@@ -21,6 +21,8 @@ import (
 //     node's containerd config at creation (Kind/K3s baselines otherwise carry the
 //     zero value, so a configured mirrorsDir reads as recreate-required every run;
 //     see kind.DiffConfig and diff/engine.go's documented LocalRegistry limitation).
+//   - EKS.ExperimentalAWSLoadBalancerController — an explicit component ownership
+//     choice that cannot be inferred from generic component detection alone.
 //
 // It is a no-op (returns nil) when no state exists for clusterName
 // (state.ErrStateNotFound). Any other failure (I/O, corrupt JSON, permission)
@@ -55,6 +57,11 @@ func MergePersistedState(spec *v1alpha1.ClusterSpec, clusterName string) error {
 	if saved.Vanilla.MirrorsDir != "" {
 		spec.Vanilla.MirrorsDir = saved.Vanilla.MirrorsDir
 	}
+
+	// The AWS Load Balancer Controller opt-in is declarative KSail ownership
+	// state. Preserve both true and false so enable and disable transitions are
+	// each compared against the last successfully applied configuration.
+	spec.EKS.ExperimentalAWSLoadBalancerController = saved.EKS.ExperimentalAWSLoadBalancerController
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
@@ -88,3 +88,36 @@ func TestMergePersistedState_ForwardCompatibleWithCurrentRelease(t *testing.T) {
 	assert.Equal(t, "localhost:5050", baseline.LocalRegistry.Registry,
 		"persisted localRegistry must merge back so it is not a false recreate-required diff")
 }
+
+// TestMergePersistedState_PreservesEKSLoadBalancerControllerOptIn verifies the
+// non-introspectable EKS component choice comes from the last successfully
+// applied spec. Both transitions matter: otherwise disable is invisible, or an
+// enabled controller is offered for installation on every update.
+//
+//nolint:paralleltest // writes/reads cluster state files under the shared isolated $HOME
+func TestMergePersistedState_PreservesEKSLoadBalancerControllerOptIn(t *testing.T) {
+	for _, savedOptIn := range []bool{false, true} {
+		clusterName := "eks-lb-disabled"
+		if savedOptIn {
+			clusterName = "eks-lb-enabled"
+		}
+
+		saved := &v1alpha1.ClusterSpec{
+			Distribution: v1alpha1.DistributionEKS,
+			Provider:     v1alpha1.ProviderAWS,
+		}
+		saved.EKS.ExperimentalAWSLoadBalancerController = savedOptIn
+		require.NoError(t, state.SaveClusterSpec(clusterName, saved))
+		t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+		baseline := clusterupdate.DefaultCurrentSpec(
+			v1alpha1.DistributionEKS,
+			v1alpha1.ProviderAWS,
+		)
+		baseline.EKS.ExperimentalAWSLoadBalancerController = !savedOptIn
+
+		err := clusterupdate.MergePersistedState(baseline, clusterName)
+		require.NoError(t, err)
+		assert.Equal(t, savedOptIn, baseline.EKS.ExperimentalAWSLoadBalancerController)
+	}
+}

--- a/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
@@ -110,44 +110,41 @@ func TestMergePersistedState_ForwardCompatibleWithCurrentRelease(t *testing.T) {
 		"persisted localRegistry must merge back so it is not a false recreate-required diff")
 }
 
-// TestMergePersistedEKSState_PreservesComponentActivation verifies the
-// non-introspectable EKS component choices come from the last successfully
-// applied state in the exact target region.
+// TestMergePersistedEKSState_RestoresOnlyInstallerInputs verifies persisted
+// configuration enriches the live baseline without overriding live activation.
 //
 //nolint:paralleltest // writes/reads cluster state files under the shared isolated $HOME
-func TestMergePersistedEKSState_PreservesComponentActivation(t *testing.T) {
-	const region = "eu-north-1"
+func TestMergePersistedEKSState_RestoresOnlyInstallerInputs(t *testing.T) {
+	const (
+		region      = "eu-north-1"
+		clusterName = "eks-live-baseline-wins"
+	)
 
-	for _, savedOptIn := range []bool{false, true} {
-		clusterName := "eks-lb-disabled"
-		if savedOptIn {
-			clusterName = "eks-lb-enabled"
-		}
-
-		saved := state.EKSComponentState{
-			Version:                               state.EKSComponentStateVersion,
-			ClusterName:                           clusterName,
-			Region:                                region,
-			LoadBalancer:                          v1alpha1.LoadBalancerEnabled,
-			ExperimentalAWSLoadBalancerController: savedOptIn,
-		}
-		require.NoError(t, state.SaveEKSComponentState(clusterName, region, &saved))
-
-		t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
-
-		baseline := clusterupdate.DefaultCurrentSpec(
-			v1alpha1.DistributionEKS,
-			v1alpha1.ProviderAWS,
-		)
-		baseline.EKS.ExperimentalAWSLoadBalancerController = !savedOptIn
-
-		baseline.LoadBalancer = v1alpha1.LoadBalancerDefault
-
-		err := clusterupdate.MergePersistedEKSState(baseline, clusterName, region)
-		require.NoError(t, err)
-		assert.Equal(t, savedOptIn, baseline.EKS.ExperimentalAWSLoadBalancerController)
-		assert.Equal(t, v1alpha1.LoadBalancerEnabled, baseline.LoadBalancer)
+	saved := state.EKSComponentState{
+		Version:                                 state.EKSComponentStateVersion,
+		ClusterName:                             clusterName,
+		Region:                                  region,
+		AWSLoadBalancerControllerServiceAccount: "persisted-service-account",
 	}
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &saved))
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	baseline := clusterupdate.DefaultCurrentSpec(
+		v1alpha1.DistributionEKS,
+		v1alpha1.ProviderAWS,
+	)
+	baseline.LoadBalancer = v1alpha1.LoadBalancerDefault
+	baseline.EKS.ExperimentalAWSLoadBalancerController = false
+
+	err := clusterupdate.MergePersistedEKSState(baseline, clusterName, region)
+	require.NoError(t, err)
+	assert.Equal(t, v1alpha1.LoadBalancerDefault, baseline.LoadBalancer)
+	assert.False(t, baseline.EKS.ExperimentalAWSLoadBalancerController)
+	assert.Equal(
+		t,
+		"persisted-service-account",
+		baseline.EKS.AWSLoadBalancerControllerServiceAccount,
+	)
 }
 
 // TestMergePersistedEKSState_IsRegionScoped prevents same-named clusters in
@@ -159,18 +156,16 @@ func TestMergePersistedEKSState_IsRegionScoped(t *testing.T) {
 
 	for _, saved := range []state.EKSComponentState{
 		{
-			Version:                               state.EKSComponentStateVersion,
-			ClusterName:                           clusterName,
-			Region:                                "eu-north-1",
-			LoadBalancer:                          v1alpha1.LoadBalancerEnabled,
-			ExperimentalAWSLoadBalancerController: true,
+			Version:                                 state.EKSComponentStateVersion,
+			ClusterName:                             clusterName,
+			Region:                                  "eu-north-1",
+			AWSLoadBalancerControllerServiceAccount: "north-service-account",
 		},
 		{
-			Version:                               state.EKSComponentStateVersion,
-			ClusterName:                           clusterName,
-			Region:                                "us-east-1",
-			LoadBalancer:                          v1alpha1.LoadBalancerDefault,
-			ExperimentalAWSLoadBalancerController: false,
+			Version:                                 state.EKSComponentStateVersion,
+			ClusterName:                             clusterName,
+			Region:                                  "us-east-1",
+			AWSLoadBalancerControllerServiceAccount: "east-service-account",
 		},
 	} {
 		snapshot := saved
@@ -186,6 +181,11 @@ func TestMergePersistedEKSState_IsRegionScoped(t *testing.T) {
 
 	err := clusterupdate.MergePersistedEKSState(baseline, clusterName, "eu-north-1")
 	require.NoError(t, err)
-	assert.Equal(t, v1alpha1.LoadBalancerEnabled, baseline.LoadBalancer)
-	assert.True(t, baseline.EKS.ExperimentalAWSLoadBalancerController)
+	assert.Equal(t, v1alpha1.LoadBalancerDefault, baseline.LoadBalancer)
+	assert.False(t, baseline.EKS.ExperimentalAWSLoadBalancerController)
+	assert.Equal(
+		t,
+		"north-service-account",
+		baseline.EKS.AWSLoadBalancerControllerServiceAccount,
+	)
 }

--- a/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
@@ -89,25 +89,29 @@ func TestMergePersistedState_ForwardCompatibleWithCurrentRelease(t *testing.T) {
 		"persisted localRegistry must merge back so it is not a false recreate-required diff")
 }
 
-// TestMergePersistedState_PreservesEKSLoadBalancerControllerOptIn verifies the
-// non-introspectable EKS component choice comes from the last successfully
-// applied spec. Both transitions matter: otherwise disable is invisible, or an
-// enabled controller is offered for installation on every update.
+// TestMergePersistedEKSState_PreservesComponentActivation verifies the
+// non-introspectable EKS component choices come from the last successfully
+// applied state in the exact target region.
 //
 //nolint:paralleltest // writes/reads cluster state files under the shared isolated $HOME
-func TestMergePersistedState_PreservesEKSLoadBalancerControllerOptIn(t *testing.T) {
+func TestMergePersistedEKSState_PreservesComponentActivation(t *testing.T) {
+	const region = "eu-north-1"
+
 	for _, savedOptIn := range []bool{false, true} {
 		clusterName := "eks-lb-disabled"
 		if savedOptIn {
 			clusterName = "eks-lb-enabled"
 		}
 
-		saved := &v1alpha1.ClusterSpec{
-			Distribution: v1alpha1.DistributionEKS,
-			Provider:     v1alpha1.ProviderAWS,
+		saved := state.EKSComponentState{
+			Version:                               state.EKSComponentStateVersion,
+			ClusterName:                           clusterName,
+			Region:                                region,
+			LoadBalancer:                          v1alpha1.LoadBalancerEnabled,
+			ExperimentalAWSLoadBalancerController: savedOptIn,
 		}
-		saved.EKS.ExperimentalAWSLoadBalancerController = savedOptIn
-		require.NoError(t, state.SaveClusterSpec(clusterName, saved))
+		require.NoError(t, state.SaveEKSComponentState(clusterName, region, &saved))
+
 		t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
 
 		baseline := clusterupdate.DefaultCurrentSpec(
@@ -116,8 +120,51 @@ func TestMergePersistedState_PreservesEKSLoadBalancerControllerOptIn(t *testing.
 		)
 		baseline.EKS.ExperimentalAWSLoadBalancerController = !savedOptIn
 
-		err := clusterupdate.MergePersistedState(baseline, clusterName)
+		baseline.LoadBalancer = v1alpha1.LoadBalancerDefault
+
+		err := clusterupdate.MergePersistedEKSState(baseline, clusterName, region)
 		require.NoError(t, err)
 		assert.Equal(t, savedOptIn, baseline.EKS.ExperimentalAWSLoadBalancerController)
+		assert.Equal(t, v1alpha1.LoadBalancerEnabled, baseline.LoadBalancer)
 	}
+}
+
+// TestMergePersistedEKSState_IsRegionScoped prevents same-named clusters in
+// different regions from sharing the controller ownership baseline.
+//
+//nolint:paralleltest // writes/reads cluster state files under the shared isolated $HOME
+func TestMergePersistedEKSState_IsRegionScoped(t *testing.T) {
+	const clusterName = "same-name-eks"
+
+	for _, saved := range []state.EKSComponentState{
+		{
+			Version:                               state.EKSComponentStateVersion,
+			ClusterName:                           clusterName,
+			Region:                                "eu-north-1",
+			LoadBalancer:                          v1alpha1.LoadBalancerEnabled,
+			ExperimentalAWSLoadBalancerController: true,
+		},
+		{
+			Version:                               state.EKSComponentStateVersion,
+			ClusterName:                           clusterName,
+			Region:                                "us-east-1",
+			LoadBalancer:                          v1alpha1.LoadBalancerDefault,
+			ExperimentalAWSLoadBalancerController: false,
+		},
+	} {
+		snapshot := saved
+		require.NoError(t, state.SaveEKSComponentState(clusterName, saved.Region, &snapshot))
+	}
+
+	t.Cleanup(func() { _ = state.DeleteClusterState(clusterName) })
+
+	baseline := clusterupdate.DefaultCurrentSpec(
+		v1alpha1.DistributionEKS,
+		v1alpha1.ProviderAWS,
+	)
+
+	err := clusterupdate.MergePersistedEKSState(baseline, clusterName, "eu-north-1")
+	require.NoError(t, err)
+	assert.Equal(t, v1alpha1.LoadBalancerEnabled, baseline.LoadBalancer)
+	assert.True(t, baseline.EKS.ExperimentalAWSLoadBalancerController)
 }

--- a/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
@@ -43,6 +43,27 @@ func TestMergePersistedState_NilSpecIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestMergePersistedEKSState_NoStateIsNoOp preserves adoption behavior when no
+// exact-region component baseline has been written yet.
+func TestMergePersistedEKSState_NoStateIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	baseline := clusterupdate.DefaultCurrentSpec(
+		v1alpha1.DistributionEKS,
+		v1alpha1.ProviderAWS,
+	)
+	baseline.LoadBalancer = v1alpha1.LoadBalancerDefault
+
+	err := clusterupdate.MergePersistedEKSState(
+		baseline,
+		"eks-component-state-not-yet-written",
+		"eu-north-1",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, v1alpha1.LoadBalancerDefault, baseline.LoadBalancer)
+	assert.False(t, baseline.EKS.ExperimentalAWSLoadBalancerController)
+}
+
 // TestMergePersistedState_ForwardCompatibleWithCurrentRelease persists a spec
 // using the CURRENT release's state writer (state.SaveClusterSpec) — the exact
 // on-disk spec.json format an already-deployed binary would have written — then

--- a/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
+++ b/pkg/svc/provisioner/cluster/clusterupdate/state_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testEKSComponentAccountID = "123456789012"
+
 // TestMain redirects $HOME to a throwaway directory so the state-persistence
 // tests below never read from or write to the developer's real ~/.ksail/.
 func TestMain(m *testing.M) {
@@ -58,6 +60,7 @@ func TestMergePersistedEKSState_NoStateIsNoOp(t *testing.T) {
 		baseline,
 		"eks-component-state-not-yet-written",
 		"eu-north-1",
+		testEKSComponentAccountID,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, v1alpha1.LoadBalancerDefault, baseline.LoadBalancer)
@@ -124,6 +127,7 @@ func TestMergePersistedEKSState_RestoresOnlyInstallerInputs(t *testing.T) {
 		Version:                                 state.EKSComponentStateVersion,
 		ClusterName:                             clusterName,
 		Region:                                  region,
+		AccountID:                               testEKSComponentAccountID,
 		AWSLoadBalancerControllerServiceAccount: "persisted-service-account",
 	}
 	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &saved))
@@ -136,7 +140,12 @@ func TestMergePersistedEKSState_RestoresOnlyInstallerInputs(t *testing.T) {
 	baseline.LoadBalancer = v1alpha1.LoadBalancerDefault
 	baseline.EKS.ExperimentalAWSLoadBalancerController = false
 
-	err := clusterupdate.MergePersistedEKSState(baseline, clusterName, region)
+	err := clusterupdate.MergePersistedEKSState(
+		baseline,
+		clusterName,
+		region,
+		testEKSComponentAccountID,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, v1alpha1.LoadBalancerDefault, baseline.LoadBalancer)
 	assert.False(t, baseline.EKS.ExperimentalAWSLoadBalancerController)
@@ -159,12 +168,14 @@ func TestMergePersistedEKSState_IsRegionScoped(t *testing.T) {
 			Version:                                 state.EKSComponentStateVersion,
 			ClusterName:                             clusterName,
 			Region:                                  "eu-north-1",
+			AccountID:                               testEKSComponentAccountID,
 			AWSLoadBalancerControllerServiceAccount: "north-service-account",
 		},
 		{
 			Version:                                 state.EKSComponentStateVersion,
 			ClusterName:                             clusterName,
 			Region:                                  "us-east-1",
+			AccountID:                               testEKSComponentAccountID,
 			AWSLoadBalancerControllerServiceAccount: "east-service-account",
 		},
 	} {
@@ -179,7 +190,12 @@ func TestMergePersistedEKSState_IsRegionScoped(t *testing.T) {
 		v1alpha1.ProviderAWS,
 	)
 
-	err := clusterupdate.MergePersistedEKSState(baseline, clusterName, "eu-north-1")
+	err := clusterupdate.MergePersistedEKSState(
+		baseline,
+		clusterName,
+		"eu-north-1",
+		testEKSComponentAccountID,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, v1alpha1.LoadBalancerDefault, baseline.LoadBalancer)
 	assert.False(t, baseline.EKS.ExperimentalAWSLoadBalancerController)

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -20,27 +20,47 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// UpdatableProvisioner wraps Provisioner with the Updater capability:
-// managed node-group scaling changes declared in eksctl.yaml are applied
-// in-place via `eksctl scale nodegroup` instead of the recreate flow.
-//
-// It is a separate type (rather than methods on Provisioner) so the
-// capability can be gated: the orchestrator discovers Updater by type
-// assertion, and the factory only returns this wrapper when
-// spec.cluster.eks.experimentalInPlaceUpdates is set. Graduating the flag
-// (once the path is validated against a live EKS cluster) means moving the
-// methods onto Provisioner and deleting the wrapper and the spec field.
+// UpdatableProvisioner wraps Provisioner with the Updater capability needed by
+// the orchestrator for both component reconciliation and managed node-group
+// scaling. Component reconciliation is always available; managed node-group
+// mutation remains gated by spec.cluster.eks.experimentalInPlaceUpdates.
 type UpdatableProvisioner struct {
 	*Provisioner
+
+	managedNodegroupUpdates bool
 
 	// componentDetector probes the running cluster's components for the
 	// update baseline; injected by the orchestrator via SetComponentDetector.
 	componentDetector *detector.ComponentDetector
 }
 
-// NewUpdatableProvisioner wraps an EKS provisioner with in-place update support.
-func NewUpdatableProvisioner(provisioner *Provisioner) *UpdatableProvisioner {
-	return &UpdatableProvisioner{Provisioner: provisioner}
+// UpdatableOption configures optional EKS update capabilities.
+type UpdatableOption func(*UpdatableProvisioner)
+
+// WithManagedNodegroupUpdates controls whether eksctl-managed node-group
+// changes may be detected and applied. It does not affect component updates.
+func WithManagedNodegroupUpdates(enabled bool) UpdatableOption {
+	return func(provisioner *UpdatableProvisioner) {
+		provisioner.managedNodegroupUpdates = enabled
+	}
+}
+
+// NewUpdatableProvisioner wraps an EKS provisioner with component update
+// support. Managed node-group updates default to enabled for compatibility;
+// the cluster factory supplies the user's explicit experimental opt-in.
+func NewUpdatableProvisioner(
+	provisioner *Provisioner,
+	options ...UpdatableOption,
+) *UpdatableProvisioner {
+	updatable := &UpdatableProvisioner{
+		Provisioner:             provisioner,
+		managedNodegroupUpdates: true,
+	}
+	for _, option := range options {
+		option(updatable)
+	}
+
+	return updatable
 }
 
 // SetComponentDetector implements the ComponentDetectorAware capability so
@@ -87,6 +107,9 @@ func (u *UpdatableProvisioner) DiffConfig(
 	_, _ *v1alpha1.ClusterSpec,
 ) (*clusterupdate.UpdateResult, error) {
 	result := clusterupdate.NewEmptyUpdateResult()
+	if !u.managedNodegroupUpdates {
+		return result, nil
+	}
 
 	desired, declared, err := u.desiredNodegroups()
 	if err != nil {
@@ -187,6 +210,10 @@ func (u *UpdatableProvisioner) applyNodegroupScaling(
 	name string,
 	result *clusterupdate.UpdateResult,
 ) error {
+	if !u.managedNodegroupUpdates {
+		return nil
+	}
+
 	clusterName := u.resolveName(name)
 
 	desired, declared, err := u.desiredNodegroups()

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -69,6 +69,13 @@ func (u *UpdatableProvisioner) SetComponentDetector(d *detector.ComponentDetecto
 	u.componentDetector = d
 }
 
+// SupportsInPlaceField reports the provisioner-level fields the EKS updater
+// actually mutates. Component fields are handled separately by the CLI
+// component reconciler and therefore are not listed here.
+func (u *UpdatableProvisioner) SupportsInPlaceField(field string) bool {
+	return strings.HasPrefix(field, "eks.managedNodeGroups[")
+}
+
 // managedNodeGroupConfig is the subset of an eksctl.yaml managedNodeGroups
 // entry the updater diffs. Pointer fields distinguish "not declared" (nil,
 // dimension is skipped) from an explicit zero.

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -73,7 +73,7 @@ func (u *UpdatableProvisioner) SetComponentDetector(d *detector.ComponentDetecto
 // actually mutates. Component fields are handled separately by the CLI
 // component reconciler and therefore are not listed here.
 func (u *UpdatableProvisioner) SupportsInPlaceField(field string) bool {
-	return strings.HasPrefix(field, "eks.managedNodeGroups[")
+	return u.managedNodegroupUpdates && strings.HasPrefix(field, "eks.managedNodeGroups[")
 }
 
 // managedNodeGroupConfig is the subset of an eksctl.yaml managedNodeGroups

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -199,6 +199,11 @@ func (u *UpdatableProvisioner) GetCurrentConfig(
 		return nil, nil, fmt.Errorf("merge persisted state: %w", err)
 	}
 
+	err = clusterupdate.MergePersistedEKSState(spec, clusterName, u.region)
+	if err != nil {
+		return nil, nil, fmt.Errorf("merge persisted EKS state: %w", err)
+	}
+
 	return spec, nil, nil
 }
 

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -169,7 +169,7 @@ func (u *UpdatableProvisioner) DiffConfig(
 // GetCurrentConfig retrieves the current cluster configuration: component
 // state via the injected detector when available (marked Unknown otherwise,
 // so the diff engine never fabricates confident component diffs from
-// defaults), merged with persisted non-introspectable state.
+// defaults), enriched with persisted non-introspectable installer inputs.
 func (u *UpdatableProvisioner) GetCurrentConfig(
 	ctx context.Context,
 	clusterName string,

--- a/pkg/svc/provisioner/cluster/eks/update_test.go
+++ b/pkg/svc/provisioner/cluster/eks/update_test.go
@@ -116,6 +116,7 @@ func TestDiffConfig_NodegroupUpdatesDisabledSkipsEksctl(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, diff.InPlaceChanges)
 	assert.Empty(t, diff.RecreateRequired)
+	assert.False(t, prov.SupportsInPlaceField("eks.managedNodeGroups[ng-1].desiredCapacity"))
 	assert.Empty(t, runner.calls, "disabled node updates must not query or mutate EKS node groups")
 }
 

--- a/pkg/svc/provisioner/cluster/eks/update_test.go
+++ b/pkg/svc/provisioner/cluster/eks/update_test.go
@@ -91,6 +91,34 @@ func TestBaseProvisionerDoesNotImplementUpdater(t *testing.T) {
 	assert.False(t, ok, "the base EKS provisioner must not expose Updater; the capability is gated")
 }
 
+func TestDiffConfig_NodegroupUpdatesDisabledSkipsEksctl(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeUpdateTestConfig(t, updateTestConfig)
+	runner := &scriptedRunner{t: t, responses: map[string][]response{}}
+	client := eksctlclient.NewClient(
+		eksctlclient.WithBinary(testBinary),
+		eksctlclient.WithRunner(runner),
+	)
+	base, err := eksprovisioner.NewProvisioner(
+		"ksail-test", "us-east-1", configPath, client, nil,
+	)
+	require.NoError(t, err)
+
+	prov := eksprovisioner.NewUpdatableProvisioner(
+		base,
+		eksprovisioner.WithManagedNodegroupUpdates(false),
+	)
+
+	diff, err := prov.DiffConfig(
+		t.Context(), "", &v1alpha1.ClusterSpec{}, &v1alpha1.ClusterSpec{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, diff.InPlaceChanges)
+	assert.Empty(t, diff.RecreateRequired)
+	assert.Empty(t, runner.calls, "disabled node updates must not query or mutate EKS node groups")
+}
+
 func TestDiffConfig_ScalingChangeIsInPlace(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/factory_eks.go
+++ b/pkg/svc/provisioner/cluster/factory_eks.go
@@ -70,18 +70,16 @@ func (f DefaultFactory) createEKSProvisioner(
 		return nil, nil, fmt.Errorf("failed to create EKS provisioner: %w", err)
 	}
 
-	// The Updater capability is discovered by type assertion, so the
-	// experimental in-place update path is gated at construction: without the
-	// opt-in the orchestrator sees no Updater and keeps today's recreate flow.
-	// A config path is required too — with no declared eksctl.yaml (e.g. the
-	// operator's name/region-only construction) the updater would have no
-	// source of truth and silently report zero changes, which is worse than
-	// falling back to the existing flow.
-	if cluster.Spec.Cluster.EKS.ExperimentalInPlaceUpdates && eksConfig.ConfigPath != "" {
-		return eksprovisioner.NewUpdatableProvisioner(provisioner), eksConfig, nil
-	}
+	// EKS always exposes Updater so component-only changes can reconcile without
+	// opting into experimental node-group mutation. Managed node-group updates
+	// remain gated by both the explicit flag and a declared eksctl config path.
+	managedNodegroupUpdates := cluster.Spec.Cluster.EKS.ExperimentalInPlaceUpdates &&
+		eksConfig.ConfigPath != ""
 
-	return provisioner, eksConfig, nil
+	return eksprovisioner.NewUpdatableProvisioner(
+		provisioner,
+		eksprovisioner.WithManagedNodegroupUpdates(managedNodegroupUpdates),
+	), eksConfig, nil
 }
 
 // resolveEKSCredentialOptions snapshots one AWS resolution and derives aligned

--- a/pkg/svc/provisioner/cluster/factory_eks_test.go
+++ b/pkg/svc/provisioner/cluster/factory_eks_test.go
@@ -187,39 +187,37 @@ func TestCreateEKSProvisionerWithConfig(t *testing.T) {
 
 	provisioner, config, err := factory.Create(context.Background(), eksTestCluster())
 	require.NoError(t, err)
-	assert.IsType(t, &eksprovisioner.Provisioner{}, provisioner)
+	assert.IsType(t, &eksprovisioner.UpdatableProvisioner{}, provisioner)
 
 	eksConfig, isEKSConfig := config.(*clusterprovisioner.EKSConfig)
 	require.True(t, isEKSConfig)
 	assert.Equal(t, "test-eks", eksConfig.GetClusterName())
 }
 
-// TestCreateEKSProvisionerUpdaterGate asserts the experimental in-place
-// update capability is opt-in: the default returns the plain provisioner
-// (no Updater), and the spec flag switches to the updatable wrapper.
-func TestCreateEKSProvisionerUpdaterGate(t *testing.T) {
+// TestCreateEKSProvisionerUpdaterAvailableForComponents asserts EKS always
+// exposes the update orchestration path needed for component reconciliation.
+// The experimental flag gates managed node-group mutation inside the updater;
+// it must not hide unrelated component changes such as the load-balancer opt-in.
+func TestCreateEKSProvisionerUpdaterAvailableForComponents(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name           string
 		inPlaceUpdates bool
 		configPath     string
-		wantUpdater    bool
 	}{
 		{
-			name: "default is recreate flow", inPlaceUpdates: false,
-			configPath: "eks.yaml", wantUpdater: false,
+			name: "default supports component reconciliation", inPlaceUpdates: false,
+			configPath: "eks.yaml",
 		},
 		{
-			name: "opt-in enables Updater", inPlaceUpdates: true,
-			configPath: "eks.yaml", wantUpdater: true,
+			name: "node update opt-in also supports reconciliation", inPlaceUpdates: true,
+			configPath: "eks.yaml",
 		},
 		{
-			// No declared config (e.g. the operator's name/region-only
-			// construction): the updater would have no source of truth and
-			// silently report zero changes, so the capability stays off.
-			name: "opt-in without a config path stays recreate flow", inPlaceUpdates: true,
-			configPath: "", wantUpdater: false,
+			name:           "component reconciliation does not require an eksctl config path",
+			inPlaceUpdates: true,
+			configPath:     "",
 		},
 	}
 
@@ -244,11 +242,8 @@ func TestCreateEKSProvisionerUpdaterGate(t *testing.T) {
 			require.NoError(t, err)
 
 			_, hasUpdater := provisioner.(clusterprovisioner.Updater)
-			assert.Equal(t, testCase.wantUpdater, hasUpdater)
-
-			if testCase.wantUpdater {
-				assert.IsType(t, &eksprovisioner.UpdatableProvisioner{}, provisioner)
-			}
+			assert.True(t, hasUpdater)
+			assert.IsType(t, &eksprovisioner.UpdatableProvisioner{}, provisioner)
 		})
 	}
 }

--- a/pkg/svc/provisioner/cluster/factory_test.go
+++ b/pkg/svc/provisioner/cluster/factory_test.go
@@ -79,7 +79,7 @@ func TestCreateProvisioner_WithDistributionConfig(t *testing.T) {
 					ConfigPath: "/tmp/eksctl.yaml",
 				},
 			},
-			expectedType: &eksprovisioner.Provisioner{},
+			expectedType: &eksprovisioner.UpdatableProvisioner{},
 			expectError:  false,
 		},
 		{

--- a/pkg/svc/provisioner/cluster/provisioner.go
+++ b/pkg/svc/provisioner/cluster/provisioner.go
@@ -67,6 +67,14 @@ type Updater interface {
 	) (*v1alpha1.ClusterSpec, *v1alpha1.ProviderSpec, error)
 }
 
+// InPlaceFieldSupport is an optional capability for updaters that implement a
+// deliberately narrow subset of the spec-level in-place diff vocabulary. The
+// orchestrator promotes any unhandled field to recreate-required rather than
+// recording an unapplied desired value as the new baseline.
+type InPlaceFieldSupport interface {
+	SupportsInPlaceField(field string) bool
+}
+
 // ProviderAware is an optional interface for provisioners that can use a provider
 // for infrastructure operations (start/stop nodes).
 type ProviderAware interface {

--- a/pkg/svc/state/eks_component_state.go
+++ b/pkg/svc/state/eks_component_state.go
@@ -75,10 +75,15 @@ func LoadEKSComponentState(clusterName, region string) (*EKSComponentState, erro
 		return nil, err
 	}
 
-	//nolint:gosec // the cluster name and region path components are validated.
-	data, err := os.ReadFile(statePath)
+	data, err := fsutil.ReadFileSafe(filepath.Dir(statePath), statePath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		missingState := os.IsNotExist(err)
+		if errors.Is(err, fsutil.ErrPathOutsideBase) {
+			_, statErr := os.Stat(statePath)
+			missingState = os.IsNotExist(statErr)
+		}
+
+		if missingState {
 			return nil, fmt.Errorf(
 				"%w: %s in %s",
 				ErrEKSComponentStateNotFound,

--- a/pkg/svc/state/eks_component_state.go
+++ b/pkg/svc/state/eks_component_state.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// EKSComponentStateVersion is the on-disk schema version for declarative EKS component state.
-	EKSComponentStateVersion = 1
+	EKSComponentStateVersion = 2
 	// eksComponentStateFileNameFormat is region-scoped because EKS cluster names
 	// are unique only within an AWS region.
 	eksComponentStateFileNameFormat = "eks-components-%s.json"
@@ -29,11 +29,12 @@ var (
 // EKSComponentState preserves declarative choices that cannot be inferred
 // unambiguously from the live EKS cluster.
 type EKSComponentState struct {
-	Version                                 int    `json:"version"`
-	ClusterName                             string `json:"clusterName"`
-	Region                                  string `json:"region"`
-	AWSLoadBalancerControllerManaged        bool   `json:"awsLoadBalancerControllerManaged,omitzero"`         //nolint:lll // exact component ownership marker
-	AWSLoadBalancerControllerServiceAccount string `json:"awsLoadBalancerControllerServiceAccount,omitempty"` //nolint:lll // matches public EKS option key
+	Version                                  int    `json:"version"`
+	ClusterName                              string `json:"clusterName"`
+	Region                                   string `json:"region"`
+	AWSLoadBalancerControllerManaged         bool   `json:"awsLoadBalancerControllerManaged,omitzero"`          //nolint:lll // exact component ownership marker
+	AWSLoadBalancerControllerReleaseIdentity string `json:"awsLoadBalancerControllerReleaseIdentity,omitempty"` //nolint:lll // Helm storage object UID
+	AWSLoadBalancerControllerServiceAccount  string `json:"awsLoadBalancerControllerServiceAccount,omitempty"`  //nolint:lll // matches public EKS option key
 }
 
 // SaveEKSComponentState atomically persists an exact-region component baseline.
@@ -128,6 +129,16 @@ func validateEKSComponentState(
 		strings.TrimSpace(snapshot.Region) != region {
 		return fmt.Errorf(
 			"%w: identity or version does not match",
+			ErrInvalidEKSComponentState,
+		)
+	}
+
+	hasReleaseIdentity := strings.TrimSpace(
+		snapshot.AWSLoadBalancerControllerReleaseIdentity,
+	) != ""
+	if snapshot.AWSLoadBalancerControllerManaged != hasReleaseIdentity {
+		return fmt.Errorf(
+			"%w: controller ownership and release identity do not match",
 			ErrInvalidEKSComponentState,
 		)
 	}

--- a/pkg/svc/state/eks_component_state.go
+++ b/pkg/svc/state/eks_component_state.go
@@ -32,6 +32,7 @@ type EKSComponentState struct {
 	Version                                 int    `json:"version"`
 	ClusterName                             string `json:"clusterName"`
 	Region                                  string `json:"region"`
+	AWSLoadBalancerControllerManaged        bool   `json:"awsLoadBalancerControllerManaged,omitzero"`         //nolint:lll // exact component ownership marker
 	AWSLoadBalancerControllerServiceAccount string `json:"awsLoadBalancerControllerServiceAccount,omitempty"` //nolint:lll // matches public EKS option key
 }
 
@@ -153,8 +154,10 @@ func eksRegionScopedStatePath(clusterName, region, fileNameFormat string) (strin
 	return filepath.Join(dir, fmt.Sprintf(fileNameFormat, region)), nil
 }
 
-// DeleteEKSRegionState removes only state scoped to one exact EKS target,
-// retaining same-named clusters in other AWS regions.
+// DeleteEKSRegionState removes state scoped to one exact EKS target, retaining
+// same-named clusters in other AWS regions. The legacy TTL file is name-scoped,
+// so it is also removed: retaining it can auto-delete or misreport a later
+// same-named cluster, while it cannot safely identify another region.
 func DeleteEKSRegionState(clusterName, region string) error {
 	componentPath, err := eksComponentStatePath(clusterName, region)
 	if err != nil {
@@ -171,9 +174,14 @@ func DeleteEKSRegionState(clusterName, region string) error {
 		return err
 	}
 
+	ttlPath, err := clusterTTLPath(clusterName)
+	if err != nil {
+		return err
+	}
+
 	var cleanupErrs []error
 
-	for _, statePath := range []string{componentPath, nodegroupPath, ownershipPath} {
+	for _, statePath := range []string{componentPath, nodegroupPath, ownershipPath, ttlPath} {
 		removeErr := os.Remove(statePath)
 		if removeErr != nil && !os.IsNotExist(removeErr) {
 			cleanupErrs = append(cleanupErrs, fmt.Errorf(

--- a/pkg/svc/state/eks_component_state.go
+++ b/pkg/svc/state/eks_component_state.go
@@ -1,0 +1,153 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+)
+
+const (
+	// EKSComponentStateVersion is the on-disk schema version for declarative EKS component state.
+	EKSComponentStateVersion = 1
+	// eksComponentStateFileNameFormat is region-scoped because EKS cluster names
+	// are unique only within an AWS region.
+	eksComponentStateFileNameFormat = "eks-components-%s.json"
+)
+
+var (
+	// ErrEKSComponentStateNotFound reports that no EKS component baseline exists.
+	ErrEKSComponentStateNotFound = errors.New("EKS component state not found")
+	// ErrInvalidEKSComponentState reports malformed or mismatched component state.
+	ErrInvalidEKSComponentState = errors.New("invalid EKS component state")
+)
+
+// EKSComponentState preserves declarative choices that cannot be inferred
+// unambiguously from the live EKS cluster.
+type EKSComponentState struct {
+	Version                               int                   `json:"version"`
+	ClusterName                           string                `json:"clusterName"`
+	Region                                string                `json:"region"`
+	LoadBalancer                          v1alpha1.LoadBalancer `json:"loadBalancer"`
+	ExperimentalAWSLoadBalancerController bool                  `json:"experimentalAWSLoadBalancerController"` //nolint:lll,tagliatelle // matches public EKS option key
+}
+
+// SaveEKSComponentState atomically persists an exact-region component baseline.
+func SaveEKSComponentState(clusterName, region string, snapshot *EKSComponentState) error {
+	statePath, err := eksComponentStatePath(clusterName, region)
+	if err != nil {
+		return err
+	}
+
+	err = validateEKSComponentState(clusterName, region, snapshot)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(statePath), dirPermissions)
+	if err != nil {
+		return fmt.Errorf("failed to create EKS component state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal EKS component state: %w", err)
+	}
+
+	err = fsutil.AtomicWriteFile(statePath, data, filePermissions)
+	if err != nil {
+		return fmt.Errorf("failed to write EKS component state: %w", err)
+	}
+
+	return nil
+}
+
+// LoadEKSComponentState reads and validates an exact-region component baseline.
+func LoadEKSComponentState(clusterName, region string) (*EKSComponentState, error) {
+	statePath, err := eksComponentStatePath(clusterName, region)
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:gosec // the cluster name and region path components are validated.
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf(
+				"%w: %s in %s",
+				ErrEKSComponentStateNotFound,
+				clusterName,
+				region,
+			)
+		}
+
+		return nil, fmt.Errorf("failed to read EKS component state: %w", err)
+	}
+
+	var snapshot EKSComponentState
+
+	err = json.Unmarshal(data, &snapshot)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unmarshal EKS component state: %w: %w",
+			err,
+			ErrInvalidEKSComponentState,
+		)
+	}
+
+	err = validateEKSComponentState(clusterName, region, &snapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &snapshot, nil
+}
+
+func validateEKSComponentState(
+	clusterName, region string,
+	snapshot *EKSComponentState,
+) error {
+	if snapshot == nil {
+		return fmt.Errorf("%w: state is nil", ErrInvalidEKSComponentState)
+	}
+
+	clusterName = strings.TrimSpace(clusterName)
+	region = strings.TrimSpace(region)
+
+	if snapshot.Version != EKSComponentStateVersion ||
+		strings.TrimSpace(snapshot.ClusterName) != clusterName ||
+		strings.TrimSpace(snapshot.Region) != region ||
+		!slices.Contains(v1alpha1.ValidLoadBalancers(), snapshot.LoadBalancer) {
+		return fmt.Errorf(
+			"%w: identity, version, or load-balancer value does not match",
+			ErrInvalidEKSComponentState,
+		)
+	}
+
+	return nil
+}
+
+func eksComponentStatePath(clusterName, region string) (string, error) {
+	return eksRegionScopedStatePath(clusterName, region, eksComponentStateFileNameFormat)
+}
+
+func eksRegionScopedStatePath(clusterName, region, fileNameFormat string) (string, error) {
+	dir, err := clusterStateDir(clusterName)
+	if err != nil {
+		return "", err
+	}
+
+	region = strings.TrimSpace(region)
+	if region == "" || strings.Contains(region, "/") || strings.Contains(region, "\\") ||
+		strings.Contains(region, "..") {
+		return "", ErrInvalidRegion
+	}
+
+	return filepath.Join(dir, fmt.Sprintf(fileNameFormat, region)), nil
+}

--- a/pkg/svc/state/eks_component_state.go
+++ b/pkg/svc/state/eks_component_state.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
-	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 )
 
@@ -31,11 +29,10 @@ var (
 // EKSComponentState preserves declarative choices that cannot be inferred
 // unambiguously from the live EKS cluster.
 type EKSComponentState struct {
-	Version                               int                   `json:"version"`
-	ClusterName                           string                `json:"clusterName"`
-	Region                                string                `json:"region"`
-	LoadBalancer                          v1alpha1.LoadBalancer `json:"loadBalancer"`
-	ExperimentalAWSLoadBalancerController bool                  `json:"experimentalAWSLoadBalancerController"` //nolint:lll,tagliatelle // matches public EKS option key
+	Version                                 int    `json:"version"`
+	ClusterName                             string `json:"clusterName"`
+	Region                                  string `json:"region"`
+	AWSLoadBalancerControllerServiceAccount string `json:"awsLoadBalancerControllerServiceAccount,omitempty"` //nolint:lll // matches public EKS option key
 }
 
 // SaveEKSComponentState atomically persists an exact-region component baseline.
@@ -77,10 +74,10 @@ func LoadEKSComponentState(clusterName, region string) (*EKSComponentState, erro
 
 	data, err := fsutil.ReadFileSafe(filepath.Dir(statePath), statePath)
 	if err != nil {
-		missingState := os.IsNotExist(err)
+		missingState := errors.Is(err, os.ErrNotExist)
 		if errors.Is(err, fsutil.ErrPathOutsideBase) {
 			_, statErr := os.Stat(statePath)
-			missingState = os.IsNotExist(statErr)
+			missingState = errors.Is(statErr, os.ErrNotExist)
 		}
 
 		if missingState {
@@ -127,10 +124,9 @@ func validateEKSComponentState(
 
 	if snapshot.Version != EKSComponentStateVersion ||
 		strings.TrimSpace(snapshot.ClusterName) != clusterName ||
-		strings.TrimSpace(snapshot.Region) != region ||
-		!slices.Contains(v1alpha1.ValidLoadBalancers(), snapshot.LoadBalancer) {
+		strings.TrimSpace(snapshot.Region) != region {
 		return fmt.Errorf(
-			"%w: identity, version, or load-balancer value does not match",
+			"%w: identity or version does not match",
 			ErrInvalidEKSComponentState,
 		)
 	}
@@ -155,4 +151,38 @@ func eksRegionScopedStatePath(clusterName, region, fileNameFormat string) (strin
 	}
 
 	return filepath.Join(dir, fmt.Sprintf(fileNameFormat, region)), nil
+}
+
+// DeleteEKSRegionState removes only state scoped to one exact EKS target,
+// retaining same-named clusters in other AWS regions.
+func DeleteEKSRegionState(clusterName, region string) error {
+	componentPath, err := eksComponentStatePath(clusterName, region)
+	if err != nil {
+		return err
+	}
+
+	nodegroupPath, err := eksNodegroupStatePath(clusterName, region)
+	if err != nil {
+		return err
+	}
+
+	ownershipPath, err := eksOwnershipStatePath(clusterName, region)
+	if err != nil {
+		return err
+	}
+
+	var cleanupErrs []error
+
+	for _, statePath := range []string{componentPath, nodegroupPath, ownershipPath} {
+		removeErr := os.Remove(statePath)
+		if removeErr != nil && !os.IsNotExist(removeErr) {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf(
+				"remove EKS region state %q: %w",
+				statePath,
+				removeErr,
+			))
+		}
+	}
+
+	return errors.Join(cleanupErrs...)
 }

--- a/pkg/svc/state/eks_component_state.go
+++ b/pkg/svc/state/eks_component_state.go
@@ -155,9 +155,10 @@ func eksRegionScopedStatePath(clusterName, region, fileNameFormat string) (strin
 }
 
 // DeleteEKSRegionState removes state scoped to one exact EKS target, retaining
-// same-named clusters in other AWS regions. The legacy TTL file is name-scoped,
-// so it is also removed: retaining it can auto-delete or misreport a later
-// same-named cluster, while it cannot safely identify another region.
+// same-named clusters in other AWS regions. The legacy TTL and ClusterSpec files
+// are name-scoped, so they are also removed: retaining either can auto-delete or
+// misconfigure a later same-named cluster, while neither can safely identify
+// another region.
 func DeleteEKSRegionState(clusterName, region string) error {
 	componentPath, err := eksComponentStatePath(clusterName, region)
 	if err != nil {
@@ -179,9 +180,20 @@ func DeleteEKSRegionState(clusterName, region string) error {
 		return err
 	}
 
+	specPath, err := clusterStatePath(clusterName)
+	if err != nil {
+		return err
+	}
+
 	var cleanupErrs []error
 
-	for _, statePath := range []string{componentPath, nodegroupPath, ownershipPath, ttlPath} {
+	for _, statePath := range []string{
+		componentPath,
+		nodegroupPath,
+		ownershipPath,
+		ttlPath,
+		specPath,
+	} {
 		removeErr := os.Remove(statePath)
 		if removeErr != nil && !os.IsNotExist(removeErr) {
 			cleanupErrs = append(cleanupErrs, fmt.Errorf(

--- a/pkg/svc/state/eks_component_state.go
+++ b/pkg/svc/state/eks_component_state.go
@@ -13,10 +13,10 @@ import (
 
 const (
 	// EKSComponentStateVersion is the on-disk schema version for declarative EKS component state.
-	EKSComponentStateVersion = 2
-	// eksComponentStateFileNameFormat is region-scoped because EKS cluster names
-	// are unique only within an AWS region.
-	eksComponentStateFileNameFormat = "eks-components-%s.json"
+	EKSComponentStateVersion = 3
+	// eksComponentStateFileNameFormat is account-and-region-scoped because EKS cluster names are
+	// unique only within one AWS account and region.
+	eksComponentStateFileNameFormat = "eks-components-%s-%s.json"
 )
 
 var (
@@ -32,19 +32,25 @@ type EKSComponentState struct {
 	Version                                  int    `json:"version"`
 	ClusterName                              string `json:"clusterName"`
 	Region                                   string `json:"region"`
+	AccountID                                string `json:"accountId"`
 	AWSLoadBalancerControllerManaged         bool   `json:"awsLoadBalancerControllerManaged,omitzero"`          //nolint:lll // exact component ownership marker
 	AWSLoadBalancerControllerReleaseIdentity string `json:"awsLoadBalancerControllerReleaseIdentity,omitempty"` //nolint:lll // Helm storage object UID
 	AWSLoadBalancerControllerServiceAccount  string `json:"awsLoadBalancerControllerServiceAccount,omitempty"`  //nolint:lll // matches public EKS option key
 }
 
-// SaveEKSComponentState atomically persists an exact-region component baseline.
+// SaveEKSComponentState atomically persists an exact-account-and-region component baseline.
 func SaveEKSComponentState(clusterName, region string, snapshot *EKSComponentState) error {
-	statePath, err := eksComponentStatePath(clusterName, region)
+	accountID := ""
+	if snapshot != nil {
+		accountID = snapshot.AccountID
+	}
+
+	err := validateEKSComponentState(clusterName, region, accountID, snapshot)
 	if err != nil {
 		return err
 	}
 
-	err = validateEKSComponentState(clusterName, region, snapshot)
+	statePath, err := eksComponentStatePath(clusterName, region, accountID)
 	if err != nil {
 		return err
 	}
@@ -67,9 +73,19 @@ func SaveEKSComponentState(clusterName, region string, snapshot *EKSComponentSta
 	return nil
 }
 
-// LoadEKSComponentState reads and validates an exact-region component baseline.
-func LoadEKSComponentState(clusterName, region string) (*EKSComponentState, error) {
-	statePath, err := eksComponentStatePath(clusterName, region)
+// LoadEKSComponentState reads and validates an exact-account-and-region component baseline. Normal
+// callers omit accountID so the immutable ownership record supplies it; tests and migrations may
+// provide one explicit account ID without creating a live ownership binding.
+func LoadEKSComponentState(
+	clusterName, region string,
+	accountIDs ...string,
+) (*EKSComponentState, error) {
+	accountID, err := resolveEKSComponentAccountID(clusterName, region, accountIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	statePath, err := eksComponentStatePath(clusterName, region, accountID)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +121,7 @@ func LoadEKSComponentState(clusterName, region string) (*EKSComponentState, erro
 		)
 	}
 
-	err = validateEKSComponentState(clusterName, region, &snapshot)
+	err = validateEKSComponentState(clusterName, region, accountID, &snapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +130,7 @@ func LoadEKSComponentState(clusterName, region string) (*EKSComponentState, erro
 }
 
 func validateEKSComponentState(
-	clusterName, region string,
+	clusterName, region, accountID string,
 	snapshot *EKSComponentState,
 ) error {
 	if snapshot == nil {
@@ -123,10 +139,13 @@ func validateEKSComponentState(
 
 	clusterName = strings.TrimSpace(clusterName)
 	region = strings.TrimSpace(region)
+	accountID = strings.TrimSpace(accountID)
 
 	if snapshot.Version != EKSComponentStateVersion ||
 		strings.TrimSpace(snapshot.ClusterName) != clusterName ||
-		strings.TrimSpace(snapshot.Region) != region {
+		strings.TrimSpace(snapshot.Region) != region ||
+		strings.TrimSpace(snapshot.AccountID) != accountID ||
+		!awsAccountIDPattern.MatchString(accountID) {
 		return fmt.Errorf(
 			"%w: identity or version does not match",
 			ErrInvalidEKSComponentState,
@@ -146,8 +165,51 @@ func validateEKSComponentState(
 	return nil
 }
 
-func eksComponentStatePath(clusterName, region string) (string, error) {
-	return eksRegionScopedStatePath(clusterName, region, eksComponentStateFileNameFormat)
+func eksComponentStatePath(clusterName, region, accountID string) (string, error) {
+	accountID = strings.TrimSpace(accountID)
+	if !awsAccountIDPattern.MatchString(accountID) {
+		return "", fmt.Errorf("%w: invalid AWS account ID", ErrInvalidEKSComponentState)
+	}
+
+	return eksRegionScopedStatePath(
+		clusterName,
+		region,
+		fmt.Sprintf(eksComponentStateFileNameFormat, accountID, "%s"),
+	)
+}
+
+func resolveEKSComponentAccountID(
+	clusterName, region string,
+	accountIDs []string,
+) (string, error) {
+	if len(accountIDs) > 1 {
+		return "", fmt.Errorf("%w: multiple AWS account IDs", ErrInvalidEKSComponentState)
+	}
+
+	if len(accountIDs) == 1 {
+		accountID := strings.TrimSpace(accountIDs[0])
+		if !awsAccountIDPattern.MatchString(accountID) {
+			return "", fmt.Errorf("%w: invalid AWS account ID", ErrInvalidEKSComponentState)
+		}
+
+		return accountID, nil
+	}
+
+	ownership, err := LoadEKSOwnershipState(clusterName, region)
+	if err != nil {
+		if errors.Is(err, ErrEKSOwnershipStateNotFound) {
+			return "", fmt.Errorf(
+				"%w: %s in %s has no account binding",
+				ErrEKSComponentStateNotFound,
+				clusterName,
+				region,
+			)
+		}
+
+		return "", fmt.Errorf("resolve EKS component account binding: %w", err)
+	}
+
+	return ownership.AccountID, nil
 }
 
 func eksRegionScopedStatePath(clusterName, region, fileNameFormat string) (string, error) {
@@ -170,8 +232,13 @@ func eksRegionScopedStatePath(clusterName, region, fileNameFormat string) (strin
 // are name-scoped, so they are also removed: retaining either can auto-delete or
 // misconfigure a later same-named cluster, while neither can safely identify
 // another region.
-func DeleteEKSRegionState(clusterName, region string) error {
-	componentPath, err := eksComponentStatePath(clusterName, region)
+func DeleteEKSRegionState(clusterName, region string, accountIDs ...string) error {
+	accountID, err := resolveEKSComponentAccountID(clusterName, region, accountIDs)
+	if err != nil {
+		return err
+	}
+
+	componentPath, err := eksComponentStatePath(clusterName, region, accountID)
 	if err != nil {
 		return err
 	}

--- a/pkg/svc/state/eks_component_state_test.go
+++ b/pkg/svc/state/eks_component_state_test.go
@@ -50,7 +50,7 @@ func TestLoadEKSComponentStateRejectsSymlinkEscape(t *testing.T) {
 }
 
 func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
-	t.Parallel()
+	t.Setenv("HOME", t.TempDir())
 
 	const clusterName = "same-name-region-delete"
 

--- a/pkg/svc/state/eks_component_state_test.go
+++ b/pkg/svc/state/eks_component_state_test.go
@@ -1,0 +1,52 @@
+package state_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadEKSComponentStateRejectsSymlinkEscape proves a state filename cannot
+// redirect the constrained read outside its per-cluster directory.
+func TestLoadEKSComponentStateRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	const (
+		clusterName = "eks-component-symlink-escape"
+		region      = "eu-north-1"
+	)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	clusterDir := filepath.Join(home, ".ksail", "clusters", clusterName)
+	require.NoError(t, os.MkdirAll(clusterDir, 0o700))
+
+	snapshot := state.EKSComponentState{
+		Version:                               state.EKSComponentStateVersion,
+		ClusterName:                           clusterName,
+		Region:                                region,
+		LoadBalancer:                          v1alpha1.LoadBalancerEnabled,
+		ExperimentalAWSLoadBalancerController: true,
+	}
+	data, err := json.Marshal(&snapshot)
+	require.NoError(t, err)
+
+	outsidePath := filepath.Join(t.TempDir(), "outside-state.json")
+	require.NoError(t, os.WriteFile(outsidePath, data, 0o600))
+
+	statePath := filepath.Join(clusterDir, "eks-components-"+region+".json")
+	require.NoError(t, os.Symlink(outsidePath, statePath))
+
+	_, err = state.LoadEKSComponentState(clusterName, region)
+	require.ErrorIs(t, err, fsutil.ErrPathOutsideBase)
+}

--- a/pkg/svc/state/eks_component_state_test.go
+++ b/pkg/svc/state/eks_component_state_test.go
@@ -11,7 +11,13 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	accountScopeClusterName = "same-name-account-scope"
+	accountScopeRegion      = "eu-north-1"
 )
 
 // TestLoadEKSComponentStateRejectsSymlinkEscape proves a state filename cannot
@@ -24,6 +30,7 @@ func TestLoadEKSComponentStateRejectsSymlinkEscape(t *testing.T) {
 	const (
 		clusterName = "eks-component-symlink-escape"
 		region      = "eu-north-1"
+		accountID   = "123456789012"
 	)
 
 	home := t.TempDir()
@@ -36,6 +43,7 @@ func TestLoadEKSComponentStateRejectsSymlinkEscape(t *testing.T) {
 		Version:     state.EKSComponentStateVersion,
 		ClusterName: clusterName,
 		Region:      region,
+		AccountID:   accountID,
 	}
 	data, err := json.Marshal(&snapshot)
 	require.NoError(t, err)
@@ -43,23 +51,27 @@ func TestLoadEKSComponentStateRejectsSymlinkEscape(t *testing.T) {
 	outsidePath := filepath.Join(t.TempDir(), "outside-state.json")
 	require.NoError(t, os.WriteFile(outsidePath, data, 0o600))
 
-	statePath := filepath.Join(clusterDir, "eks-components-"+region+".json")
+	statePath := filepath.Join(clusterDir, "eks-components-"+accountID+"-"+region+".json")
 	require.NoError(t, os.Symlink(outsidePath, statePath))
 
-	_, err = state.LoadEKSComponentState(clusterName, region)
+	_, err = state.LoadEKSComponentState(clusterName, region, accountID)
 	require.ErrorIs(t, err, fsutil.ErrPathOutsideBase)
 }
 
 func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	const clusterName = "same-name-region-delete"
+	const (
+		clusterName = "same-name-region-delete"
+		accountID   = "123456789012"
+	)
 
 	for _, region := range []string{"eu-north-1", "us-east-1"} {
 		snapshot := state.EKSComponentState{
 			Version:     state.EKSComponentStateVersion,
 			ClusterName: clusterName,
 			Region:      region,
+			AccountID:   accountID,
 		}
 		require.NoError(t, state.SaveEKSComponentState(clusterName, region, &snapshot))
 	}
@@ -73,12 +85,12 @@ func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 		},
 	}))
 
-	require.NoError(t, state.DeleteEKSRegionState(clusterName, "eu-north-1"))
+	require.NoError(t, state.DeleteEKSRegionState(clusterName, "eu-north-1", accountID))
 
-	_, err := state.LoadEKSComponentState(clusterName, "eu-north-1")
+	_, err := state.LoadEKSComponentState(clusterName, "eu-north-1", accountID)
 	require.ErrorIs(t, err, state.ErrEKSComponentStateNotFound)
 
-	_, err = state.LoadEKSComponentState(clusterName, "us-east-1")
+	_, err = state.LoadEKSComponentState(clusterName, "us-east-1", accountID)
 	require.NoError(t, err)
 
 	_, err = state.LoadClusterTTL(clusterName)
@@ -94,6 +106,72 @@ func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 	)
 }
 
+func TestEKSComponentStateIsScopedByAccountAndRegion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		clusterName = "same-name-account-scope"
+		region      = "eu-north-1"
+		accountA    = "123456789012"
+		accountB    = "210987654321"
+	)
+
+	saveComponentOwnershipBinding(t, accountA)
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
+		Version:                                 state.EKSComponentStateVersion,
+		ClusterName:                             clusterName,
+		Region:                                  region,
+		AccountID:                               accountA,
+		AWSLoadBalancerControllerServiceAccount: "account-a-service-account",
+	}))
+
+	saveComponentOwnershipBinding(t, accountB)
+	require.NoError(t, state.SaveEKSComponentState(clusterName, region, &state.EKSComponentState{
+		Version:                                 state.EKSComponentStateVersion,
+		ClusterName:                             clusterName,
+		Region:                                  region,
+		AccountID:                               accountB,
+		AWSLoadBalancerControllerServiceAccount: "account-b-service-account",
+	}))
+
+	current, err := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, err)
+	assert.Equal(t, accountB, current.AccountID)
+	assert.Equal(t, "account-b-service-account", current.AWSLoadBalancerControllerServiceAccount)
+
+	require.NoError(t, state.DeleteEKSRegionState(clusterName, region))
+
+	saveComponentOwnershipBinding(t, accountB)
+
+	_, err = state.LoadEKSComponentState(clusterName, region)
+	require.ErrorIs(t, err, state.ErrEKSComponentStateNotFound)
+
+	saveComponentOwnershipBinding(t, accountA)
+
+	retained, err := state.LoadEKSComponentState(clusterName, region)
+	require.NoError(t, err)
+	assert.Equal(t, accountA, retained.AccountID)
+	assert.Equal(t, "account-a-service-account", retained.AWSLoadBalancerControllerServiceAccount)
+}
+
+func saveComponentOwnershipBinding(t *testing.T, accountID string) {
+	t.Helper()
+
+	require.NoError(t, state.SaveEKSOwnershipState(
+		accountScopeClusterName,
+		accountScopeRegion,
+		&state.EKSOwnershipState{
+			Version:     state.EKSOwnershipStateVersion,
+			ClusterName: accountScopeClusterName,
+			Region:      accountScopeRegion,
+			AccountID:   accountID,
+			ClusterARN: "arn:aws:eks:" + accountScopeRegion + ":" + accountID +
+				":cluster/" + accountScopeClusterName,
+			CreatedAt:  time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+			AWSOptions: canonicalAWSOptions(),
+		}))
+}
+
 func TestSaveEKSComponentStateRequiresIdentityForManagedRelease(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -104,6 +182,7 @@ func TestSaveEKSComponentStateRequiresIdentityForManagedRelease(t *testing.T) {
 			Version:                          state.EKSComponentStateVersion,
 			ClusterName:                      "managed-without-identity",
 			Region:                           "eu-north-1",
+			AccountID:                        "123456789012",
 			AWSLoadBalancerControllerManaged: true,
 		},
 	)
@@ -121,6 +200,7 @@ func TestSaveEKSComponentStateRejectsIdentityForUnmanagedRelease(t *testing.T) {
 			Version:                                  state.EKSComponentStateVersion,
 			ClusterName:                              "unmanaged-with-identity",
 			Region:                                   "eu-north-1",
+			AccountID:                                "123456789012",
 			AWSLoadBalancerControllerReleaseIdentity: "stale-uid",
 		},
 	)

--- a/pkg/svc/state/eks_component_state_test.go
+++ b/pkg/svc/state/eks_component_state_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/stretchr/testify/require"
@@ -32,11 +31,9 @@ func TestLoadEKSComponentStateRejectsSymlinkEscape(t *testing.T) {
 	require.NoError(t, os.MkdirAll(clusterDir, 0o700))
 
 	snapshot := state.EKSComponentState{
-		Version:                               state.EKSComponentStateVersion,
-		ClusterName:                           clusterName,
-		Region:                                region,
-		LoadBalancer:                          v1alpha1.LoadBalancerEnabled,
-		ExperimentalAWSLoadBalancerController: true,
+		Version:     state.EKSComponentStateVersion,
+		ClusterName: clusterName,
+		Region:      region,
 	}
 	data, err := json.Marshal(&snapshot)
 	require.NoError(t, err)
@@ -49,4 +46,27 @@ func TestLoadEKSComponentStateRejectsSymlinkEscape(t *testing.T) {
 
 	_, err = state.LoadEKSComponentState(clusterName, region)
 	require.ErrorIs(t, err, fsutil.ErrPathOutsideBase)
+}
+
+func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "same-name-region-delete"
+
+	for _, region := range []string{"eu-north-1", "us-east-1"} {
+		snapshot := state.EKSComponentState{
+			Version:     state.EKSComponentStateVersion,
+			ClusterName: clusterName,
+			Region:      region,
+		}
+		require.NoError(t, state.SaveEKSComponentState(clusterName, region, &snapshot))
+	}
+
+	require.NoError(t, state.DeleteEKSRegionState(clusterName, "eu-north-1"))
+
+	_, err := state.LoadEKSComponentState(clusterName, "eu-north-1")
+	require.ErrorIs(t, err, state.ErrEKSComponentStateNotFound)
+
+	_, err = state.LoadEKSComponentState(clusterName, "us-east-1")
+	require.NoError(t, err)
 }

--- a/pkg/svc/state/eks_component_state_test.go
+++ b/pkg/svc/state/eks_component_state_test.go
@@ -93,3 +93,37 @@ func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 		"deleted EKS targets must not retain a stale name-scoped spec baseline",
 	)
 }
+
+func TestSaveEKSComponentStateRequiresIdentityForManagedRelease(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	err := state.SaveEKSComponentState(
+		"managed-without-identity",
+		"eu-north-1",
+		&state.EKSComponentState{
+			Version:                          state.EKSComponentStateVersion,
+			ClusterName:                      "managed-without-identity",
+			Region:                           "eu-north-1",
+			AWSLoadBalancerControllerManaged: true,
+		},
+	)
+
+	require.ErrorIs(t, err, state.ErrInvalidEKSComponentState)
+}
+
+func TestSaveEKSComponentStateRejectsIdentityForUnmanagedRelease(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	err := state.SaveEKSComponentState(
+		"unmanaged-with-identity",
+		"eu-north-1",
+		&state.EKSComponentState{
+			Version:                                  state.EKSComponentStateVersion,
+			ClusterName:                              "unmanaged-with-identity",
+			Region:                                   "eu-north-1",
+			AWSLoadBalancerControllerReleaseIdentity: "stale-uid",
+		},
+	)
+
+	require.ErrorIs(t, err, state.ErrInvalidEKSComponentState)
+}

--- a/pkg/svc/state/eks_component_state_test.go
+++ b/pkg/svc/state/eks_component_state_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/stretchr/testify/require"
@@ -64,6 +65,13 @@ func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 	}
 
 	require.NoError(t, state.SaveClusterTTL(clusterName, time.Hour))
+	require.NoError(t, state.SaveClusterSpec(clusterName, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+		LocalRegistry: v1alpha1.LocalRegistry{
+			Registry: "stale.example.test",
+		},
+	}))
 
 	require.NoError(t, state.DeleteEKSRegionState(clusterName, "eu-north-1"))
 
@@ -77,5 +85,11 @@ func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 	require.ErrorIs(
 		t, err, state.ErrTTLNotSet,
 		"deleted EKS targets must not retain a stale name-scoped TTL",
+	)
+
+	_, err = state.LoadClusterSpec(clusterName)
+	require.ErrorIs(
+		t, err, state.ErrStateNotFound,
+		"deleted EKS targets must not retain a stale name-scoped spec baseline",
 	)
 }

--- a/pkg/svc/state/eks_component_state_test.go
+++ b/pkg/svc/state/eks_component_state_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
@@ -62,6 +63,8 @@ func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 		require.NoError(t, state.SaveEKSComponentState(clusterName, region, &snapshot))
 	}
 
+	require.NoError(t, state.SaveClusterTTL(clusterName, time.Hour))
+
 	require.NoError(t, state.DeleteEKSRegionState(clusterName, "eu-north-1"))
 
 	_, err := state.LoadEKSComponentState(clusterName, "eu-north-1")
@@ -69,4 +72,10 @@ func TestDeleteEKSRegionStateRetainsOtherRegions(t *testing.T) {
 
 	_, err = state.LoadEKSComponentState(clusterName, "us-east-1")
 	require.NoError(t, err)
+
+	_, err = state.LoadClusterTTL(clusterName)
+	require.ErrorIs(
+		t, err, state.ErrTTLNotSet,
+		"deleted EKS targets must not retain a stale name-scoped TTL",
+	)
 }

--- a/pkg/svc/state/eks_nodegroup_state.go
+++ b/pkg/svc/state/eks_nodegroup_state.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 )
@@ -122,21 +121,5 @@ func DeleteEKSNodegroupState(clusterName, region string) error {
 // share — and clobber — a single snapshot: a stop in one region would be restored from the other's
 // capacities, or rejected outright by the snapshot's own region identity check.
 func eksNodegroupStatePath(clusterName, region string) (string, error) {
-	dir, err := clusterStateDir(clusterName)
-	if err != nil {
-		return "", err
-	}
-
-	region = strings.TrimSpace(region)
-	if region == "" {
-		return "", ErrInvalidRegion
-	}
-
-	if strings.Contains(region, "/") ||
-		strings.Contains(region, "\\") ||
-		strings.Contains(region, "..") {
-		return "", ErrInvalidRegion
-	}
-
-	return filepath.Join(dir, fmt.Sprintf(eksNodegroupStateFileNameFormat, region)), nil
+	return eksRegionScopedStatePath(clusterName, region, eksNodegroupStateFileNameFormat)
 }

--- a/pkg/svc/state/eks_ownership_state.go
+++ b/pkg/svc/state/eks_ownership_state.go
@@ -266,16 +266,5 @@ func validateEKSOwnershipARN(
 }
 
 func eksOwnershipStatePath(clusterName, region string) (string, error) {
-	dir, err := clusterStateDir(clusterName)
-	if err != nil {
-		return "", err
-	}
-
-	region = strings.TrimSpace(region)
-	if region == "" || strings.Contains(region, "/") || strings.Contains(region, "\\") ||
-		strings.Contains(region, "..") {
-		return "", ErrInvalidRegion
-	}
-
-	return filepath.Join(dir, fmt.Sprintf(eksOwnershipStateFileNameFormat, region)), nil
+	return eksRegionScopedStatePath(clusterName, region, eksOwnershipStateFileNameFormat)
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- detect `spec.cluster.eks.experimentalAWSLoadBalancerController` changes as in-place EKS/AWS drift
- route both opt-in directions through the cluster-update component reconciler
- install on enable and uninstall the Helm release on disable, treating an absent release as an idempotent no-op
- persist the non-introspectable ownership baseline fail-closed and per EKS account and region
- bind component reconciliation to the exact verified EKS kubeconfig context
- detect live controller presence so manual drift is repaired instead of masked by stale state
- treat only the latest deployed Helm revision as active, so failed or retained history is repaired
- require exact-region KSail ownership evidence before uninstalling and preserve manual Helm releases
- bind that ownership evidence to the Kubernetes UID of the concrete Helm release-storage object
- report preserved unowned releases as unresolved instead of recording false convergence
- reconcile service-account changes while activation remains enabled
- retain exact-region EKS state in other regions while deleting unsafe name-scoped TTL/spec state
- clear deleted-target ownership before recreation and restore operator-owned uninstall authority from its baseline
- surface an unreadable controller baseline as Unknown and return required state failures before any TTL wait
- derive operator ownership only from the actual Helm result and keep the release UID reserved from API clients
- reject Helm storage backends that cannot supply Kubernetes object identity
- promote unsupported EKS spec changes to recreation instead of advancing an unapplied baseline
- label each KSail-created Helm revision and use that stable marker to keep owned failed or pending upgrades cleanable without trusting retained replacement history
- delete a failed TTL create immediately when required state persistence cannot complete
- refresh the API and generated CRD descriptions now that update reconciliation is wired

## Evidence

EKS reports load-balancer support by default, so the existing `cluster.loadBalancer` diff compares `Enabled` to `Enabled` when only this experimental opt-in changes. The update command consequently never reached the AWS Load Balancer Controller installer.

The new dedicated diff field compares effective activation (`opt-in && loadBalancer == Enabled`) plus the controller service-account input while preserving the distribution default. A narrow installer factory seam lets the update tests prove the requested lifecycle calls without requiring live AWS credentials. Live Helm detection remains authoritative for activation, exact-region state stores the non-introspectable installer input plus KSail's positive ownership marker, and account-qualified context binding prevents Helm from inheriting an unrelated ambient kubeconfig target. Both the update boundary and installer now fail closed when ownership is absent; bulk and fallback Helm detection both select the latest revision and require `deployed` status.

## Validation

- RED: both enable and disable initially produced no `cluster.eks.experimentalAWSLoadBalancerController` change
- RED review regressions: a manual Helm release was uninstalled, EKS deletion retained stale `ttl.json`/`spec.json`, failed Helm history was treated as live, regionless ordinary/TTL cleanup erased every same-named EKS region's state, recreation left stale ownership, an unrelated update claimed a manual release, a GitOps-skipped install was treated as a KSail mutation, operator removal silently skipped an operator-owned controller, preserved external releases were recorded as applied, unreadable live state fabricated a controller install, and fatal state persistence entered the normal TTL wait
- GREEN after review repairs: missing-region cleanup preserves exact-region snapshots and returns `state.ErrInvalidRegion`; deletion removes ambiguous name-scoped state; recreation clears old ownership before creation; unrelated updates preserve the prior marker; install/uninstall records the actual outcome; GitOps skips remain explicitly unowned; operator baselines authorize only their own removals; manual ownership ambiguity is failed/unresolved; unreadable baselines remain Unknown; and fatal persistence returns before TTL waiting
- RED latest review regressions: a removed KSail release's boolean marker authorized deletion of a later same-name release, a GitOps-skipped service-account update advanced the baseline, a successful controller mutation lost ownership evidence when a later component failed, and recreation did not restore the cleared `ClusterSpec`
- GREEN latest review repairs: ownership is bound to the latest Helm storage object's Kubernetes UID and mismatches preserve replacements; skipped mutations are failed/unresolved; successful controller mutations persist their narrow state before a partial apply returns non-zero; and successful recreation persists both component ownership and the replacement `ClusterSpec`
- affected packages: 657 tests passed normally and under the race detector
- final ownership repair: all 611 cluster-command tests passed normally and under the race detector
- GitOps ownership repair: all 864 tests across cluster, setup, Helm base, and AWS controller packages passed normally and under the race detector
- exact-head lint repair: `jscpd` reports zero clones; the same 864 tests pass normally and under the race detector, with affected `go vet`, `golangci-lint`, and `go build ./...` clean
- prior-head full repository suite: 5,944 tests passed with package parallelism disabled; the initial parallel run passed 5,952 tests and reproduced six unrelated `open/chat` subprocess-fixture failures, while that package immediately passed 127/127 alone (tracked separately in #6347)
- latest local full repository suite: 5,947 tests passed across 78 packages with package parallelism disabled; after the lint-driven metadata-helper refactor, all 1,024 affected tests passed normally and under the race detector
- RED exact-head CI repair: the reusable Go validator rejected `doReconcileLoadBalancer` at cyclomatic complexity 12 (limit 10) and the 11-method Helm interface (limit 10); local PR-diff lint reproduced both findings plus the workflow's auto-fixable line wrap
- GREEN exact-head CI repair: load-balancer install/uninstall branches are focused helpers, the Helm contract composes two narrow interfaces without changing its method set, and the line wrap is explicit; all 1,024 affected tests pass normally and under the race detector, `go vet ./...` is clean, pinned Mockery 3.5.4 produces no drift, and PR-diff golangci-lint reports zero findings
- RED current-head review regressions: the operator inferred controller ownership from the desired baseline after preserving a GitOps release; a TTL create left a live cluster behind when required state persistence failed; SQL/memory Helm storage could not provide a Kubernetes UID; unsupported EKS in-place fields were silently recorded as applied; and an owned failed/pending Helm revision was invisible to disable reconciliation
- GREEN current-head review repairs: the operator records only the concrete post-install release identity and rejects client-forged ownership annotations; required-state failure immediately invokes TTL cleanup and preserves both errors; identity-bound installers reject non-Kubernetes Helm storage; unsupported provisioner fields become recreate-required; and the persisted UID is matched against retained Helm history while a disjoint same-name replacement remains protected
- current-head affected suites: all 1,065 tests across operator, cluster command, setup, Helm, AWS controller, and EKS provisioner packages passed normally and under the race detector
- current-head full repository suite: 5,935 tests passed across 78 packages with package parallelism disabled
- current-head structural checks: pinned Mockery 3.5.4 produced no drift; `jscpd` analyzed 792 Go files and found zero clones; `go vet ./...`, both root and desktop `go build ./...`, PR-diff golangci-lint, and `git diff --check` all passed
- RED final exact-head regressions: `helm uninstall --keep-history` followed by `helm install --replace` retained the former KSail UID in flat history and could authorize deletion of the external replacement; a release that became GitOps-managed was preserved but reported as a successful uninstall, allowing CLI/operator baselines to advance while the controller remained installed
- GREEN final exact-head repairs: GitOps takeover returns a typed skip error so both callers leave ownership and desired-state convergence unresolved; release ownership is carried by a KSail Helm label rather than inferred from mutable status boundaries
- final follow-up suites: all 786 affected tests across Helm, the AWS controller installer, and EKS reconciliation passed normally and under the race detector; 5,937 repository tests passed across 78 packages with package parallelism disabled
- final follow-up structural checks: pinned Mockery 3.5.4 produced no drift; `jscpd` again found zero clones across 792 Go files; `go vet ./...`, both root and desktop `go build ./...`, PR-diff golangci-lint, and `git diff --check` all passed
- RED post-follow-up review regressions: an operator removal without recorded ownership silently advanced its disabled baseline; an installed controller lost ownership when a sibling component failed; CLI create/recreate skipped ownership persistence after a later workflow failure; and Helm 4 rewrote a retained `uninstalled` revision to `superseded` during `install --replace`, invalidating a status-derived incarnation boundary
- GREEN post-follow-up review repairs: unowned operator removals remain explicitly unresolved; operator and CLI paths persist the controller's concrete ownership outcome through partial failures; and KSail labels every Helm revision it creates, accepting a retained historical UID only while the latest revision carries that stable ownership marker
- latest affected suites: all 831 tests across operator, cluster command, Helm, and AWS controller packages passed normally and under the race detector
- latest full repository suite: 5,938 tests passed across 79 packages with package parallelism disabled
- latest structural checks: pinned Mockery 3.5.4 produced no drift; `jscpd` found zero clones across 792 Go files; `go vet ./...`, both root and desktop `go build ./...`, PR-diff golangci-lint, and `git diff --check` all passed
- RED latest CI repair: the workflow's golangci-lint 2.11.4 counted `InstallComponents` at 61 lines against the 60-line `funlen` limit, which local 2.8.0 did not report
- GREEN latest CI repair: the ownership-helper arguments are grouped without changing behavior; all 43 operator tests pass and exact golangci-lint 2.11.4 reports zero findings for the affected package
- RED post-CI review regressions: a total create/recreate failure still opened a live Helm ownership query even though controller reconciliation never started, and mixed-case or whitespace-padded `HELM_DRIVER` values passed validation but dispatched to the wrong Kubernetes storage backend
- GREEN post-CI review repairs: the creation workflow explicitly reports whether post-CNI component reconciliation started so early failures preserve the original error without another API round trip, while later partial failures still persist concrete ownership; Helm normalizes the configured driver once for action initialization and release-storage dispatch; and operator lookups share the controller installer's canonical release key
- post-CI affected validation: 836 tests passed under the race detector across cluster reconciliation, Helm, operator, and AWS controller packages; the full repository suite passed with package parallelism disabled; `go vet`, exact CI golangci-lint 2.11.4, both root and desktop builds, and `git diff --check` are clean
- exact-head race detector: 1,512 tests passed across state, cluster reconciliation, operator, and installer packages; the final TTL/unknown-baseline repair passed another 734 tests across its two affected packages
- RED final review regressions: a partial operator component failure lost the controller release UID because only the status subresource was written; EKS metrics-server `Enabled → Disabled` repeatedly entered an unsupported in-place handler instead of recreation; and same-name, same-region component baselines could be reused or cleared across AWS accounts
- GREEN final review repairs: the operator persists only a changed release-identity annotation before requeueing without advancing the full baseline; metrics-server disable is promoted to recreation; and component schema v3 keys and validates state by immutable ownership account plus region so account B cleanup retains account A state
- RED final ownership regression: a post-CNI failure before controller mutation completed caused a pre-existing unlabelled manual release UID to be persisted as KSail ownership
- GREEN final ownership repair: post-create persistence now requires the concrete release UID to carry KSail's Helm ownership evidence; genuine KSail partial success remains recoverable while manual and GitOps releases remain unowned
- exact-head validation at `ac3fb71b6e8d951c9490628f9f71f6ccdb2e96e2`: all affected packages passed normally and under the race detector; exact golangci-lint 2.11.4 reported zero issues; affected `go vet` and `git diff --check` passed; the complete root-module suite passed with package parallelism disabled; and the nested desktop module tested and built successfully
- RED exact-merge CI regression: current `main` combined with the feature head exceeded the 60-line `funlen` limit in component reconciliation, its partial-failure regression, and recreation orchestration; after rebasing, current `main` also made the workload-tag switch non-exhaustive by adding `GitOpsEngineNone`
- GREEN exact-head repair at `dc94c6d545562b76def883ec7124cde9ce03cdc7`: the long paths are behavior-preserving helpers, `GitOpsEngineNone` is an explicit no-op, both affected Go packages pass, pinned golangci-lint 2.11.4 with Linux package selection reports zero issues across the full repository, and `git diff --check` passes
- RED final ownership regressions: an unlabelled manual release could satisfy ownership with its current UID in both CLI and operator paths; a KSail-labelled partial Helm install lost its UID when Helm returned an error; and a transient component-state save failure could not be retried after Helm had already converged
- GREEN final ownership repairs at `f369339aa8ef3b817af8895cd86bf6946c6b73ee`: current and historical UIDs require the stable KSail Helm label; operator ownership uses the same verifier; install errors preserve verified labelled ownership alongside the original failure; and no-change EKS updates repair verified component state before reporting success
- final reviewer cleanup: EKS region resolution is shared, the managed-nodegroup support contract reflects its feature gate, and redundant per-test HOME overrides are removed while the shared-state serial constraint remains documented
- final affected validation: all five changed packages pass normally and under the race detector; the three packages touched by the lint-driven ownership extraction pass another race run; affected `go vet`, exact Linux golangci-lint 2.11.4, and `git diff --check` are clean
- the merged fail-closed Claircore package passed all 23 tests; the focused Claircore checks passed 12/12
- `go vet ./...` passed
- the CLI and nested desktop binaries both built successfully
- `golangci-lint run --new-from-rev origin/main ./...` reported no issues
- `make generate` passed and refreshed the operator CRD description
- `git diff --check` passed

## User-path evaluation

The update seam was exercised in both directions with a recording installer: `false → true` called `Install` exactly once, while an exact-region KSail-owned `true → false` called `Uninstall` exactly once. An identical transition without positive ownership preserved the manual release, reported unresolved convergence, and never constructed the installer. A stale UID marker also preserves a same-name replacement, while a genuinely absent release clears stale ownership as an idempotent no-op. Adversarial tests additionally cover a GitOps-skipped service-account update, a successful controller mutation followed by another component's failure, recreation baseline restoration, `Default ↔ Enabled` activation, deployed-to-failed Helm history, operator-owned removal, an unreadable detector baseline, fatal state persistence with a long TTL callback, stale TTL/spec deletion while retaining another region's exact-target state, same-name and same-region state isolation across AWS accounts, a current kubeconfig context from the wrong AWS account, and a component-state symlink escaping its constrained cluster directory. A live EKS mutation was not performed; the API remains explicitly experimental and still documents that live-cluster validation is outstanding.

Fixes #6231
Part of #4328


## Latest exact-head review repair

- RED at `f369339aa8ef3b817af8895cd86bf6946c6b73ee`: an operator-owned controller installed during a partial pass was orphaned when the unchanged full baseline omitted it; Cilium-to-Calico and CNI-to-Default EKS changes were incorrectly accepted as in-place despite leaving the old release installed.
- GREEN at `212ebd8c096636077f24d676e89a007207fb1660`: a persisted controller release UID synthesizes an identity-bound cleanup candidate even without full-baseline membership, while CNI transitions are promoted to recreation until the reconciler can prove old-release cleanup.
- Focused regressions failed before the repair and now pass; both affected packages pass normally and under the race detector; affected `go vet`, `git diff --check`, and exact Linux golangci-lint 2.11.4 are clean (`0 issues`).