### PR TITLE
fix(talos): discover only published kubelet versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,7 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+              - '.govulncheck-allow.txt'
               - '.github/actions/**'
             system-test:
               # NOTE: Do not use negative patterns (!) here.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,6 +122,7 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      govuln-allowlist: ${{ steps.filter.outputs.govuln-allowlist }}
       system-test: ${{ steps.filter.outputs.system-test }}
       schema: ${{ steps.filter.outputs.schema }}
       cli: ${{ steps.filter.outputs.cli }}
@@ -151,6 +152,8 @@ jobs:
               - 'go.sum'
               - '.govulncheck-allow.txt'
               - '.github/actions/**'
+            govuln-allowlist:
+              - '.govulncheck-allow.txt'
             system-test:
               # NOTE: Do not use negative patterns (!) here.
               # dorny/paths-filter v4 uses picomatch where negated patterns
@@ -317,7 +320,12 @@ jobs:
 
   ci-go:
     name: ✅ Validate Go Project
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [changes]
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && needs.changes.outputs.govuln-allowlist == 'true')
     uses: devantler-tech/actions/.github/workflows/validate-go-project.yaml@5c284fdf432754a697710c336fc2c26bc99868bb # v10.2.0
     permissions:
       contents: write

--- a/.govulncheck-allow.txt
+++ b/.govulncheck-allow.txt
@@ -10,8 +10,8 @@
 # Policy: the allowlist is for UNPATCHABLE findings only. The moment an
 # upstream fix ships, delete the entry and bump the affected module instead.
 #
-# Verified with `govulncheck ./...` against ksail main (re-validated 2026-06-25):
-#   the 6 reachable advisories below, each "Fixed in: N/A" for the version
+# Verified with `govulncheck ./...` against ksail main (re-validated 2026-07-22):
+#   the reachable advisories below, each "Fixed in: N/A" for the version
 #   pinned (transitively) in go.mod. Re-validate when bumping docker, k8s.io,
 #   or containerd deps. NOTE: x/image GO-2026-5061 is deliberately NOT listed —
 #   it has an upstream fix (v0.43.0) and is bumped per policy, not allowlisted.
@@ -73,3 +73,16 @@ GO-2026-5622  # containerd v1 CRI checkpoint/restore arbitrary host log read via
 # untrusted PGP-signed input. Re-evaluate if kubescape migrates off
 # x/crypto/openpgp.
 GO-2026-5932  # x/crypto/openpgp unmaintained/unsafe-by-design (transitive via kubescape core.Scan; no fix; local-input-only path)
+
+# --- github.com/quay/claircore @ v1.5.35 (transitive via kubescape) ---------
+# Published 2026-07-17. GO-2026-5939 covers SSRF when an unauthenticated
+# Claircore service accepts manifests whose layer URIs point to internal or
+# cloud-metadata endpoints. The advisory provides no symbol metadata, so
+# govulncheck conservatively reports any linked Claircore package as reachable.
+# KSail does not run a Claircore service or link its remote manifest fetchers:
+# `ksail workload scan` passes a local directory to Kubescape, and
+# TestClaircoreLinkedPackagesStayInert pins both shipped modules to v1.5.35 and
+# fails if anything beyond the audited parsing/type/local-filesystem packages
+# becomes linked (issue #6008, delivered by #6012). No patched release exists;
+# remove this entry and upgrade both modules as soon as one ships.
+GO-2026-5939  # Claircore manifest-URI SSRF (CVE-2026-10517; sink not linked; no fix)

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -78,6 +78,9 @@ type ciWorkflow struct {
 	Jobs map[string]struct {
 		Permissions map[string]string `yaml:"permissions"`
 		Steps       []harnessStep     `yaml:"steps"`
+		If          string            `yaml:"if"`
+		Needs       []string          `yaml:"needs"`
+		Uses        string            `yaml:"uses"`
 	} `yaml:"jobs"`
 }
 
@@ -88,8 +91,16 @@ func TestGoValidationIncludesVulnerabilityAllowlistChanges(t *testing.T) {
 	changesJob, found := workflow.Jobs["changes"]
 	require.True(t, found, "changes job is missing")
 	filterStep := findHarnessStep(t, changesJob.Steps, "🔍 Filter paths")
+	filters := stringValue(filterStep.With["filters"])
+	assert.Contains(t, filters, "govuln-allowlist:\n  - '.govulncheck-allow.txt'")
 
-	assert.Contains(t, stringValue(filterStep.With["filters"]), ".govulncheck-allow.txt")
+	validateJob, found := workflow.Jobs["ci-go"]
+	require.True(t, found, "ci-go job is missing")
+	assert.Contains(t, validateJob.Needs, "changes")
+	assert.Contains(t, validateJob.If, "github.event_name == 'pull_request'")
+	assert.Contains(t, validateJob.If, "github.event.pull_request.head.repo.full_name == github.repository")
+	assert.Contains(t, validateJob.If, "needs.changes.outputs.govuln-allowlist == 'true'")
+	assert.Contains(t, validateJob.Uses, "validate-go-project.yaml")
 }
 
 func TestEKSSmokeDeclaresOIDCRoleWithoutSecret(t *testing.T) {

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -98,7 +98,11 @@ func TestGoValidationIncludesVulnerabilityAllowlistChanges(t *testing.T) {
 	require.True(t, found, "ci-go job is missing")
 	assert.Contains(t, validateJob.Needs, "changes")
 	assert.Contains(t, validateJob.If, "github.event_name == 'pull_request'")
-	assert.Contains(t, validateJob.If, "github.event.pull_request.head.repo.full_name == github.repository")
+	assert.Contains(
+		t,
+		validateJob.If,
+		"github.event.pull_request.head.repo.full_name == github.repository",
+	)
 	assert.Contains(t, validateJob.If, "needs.changes.outputs.govuln-allowlist == 'true'")
 	assert.Contains(t, validateJob.Uses, "validate-go-project.yaml")
 }

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -81,6 +81,17 @@ type ciWorkflow struct {
 	} `yaml:"jobs"`
 }
 
+func TestGoValidationIncludesVulnerabilityAllowlistChanges(t *testing.T) {
+	t.Parallel()
+
+	workflow := readCIWorkflow(t, ".github/workflows/ci.yaml")
+	changesJob, found := workflow.Jobs["changes"]
+	require.True(t, found, "changes job is missing")
+	filterStep := findHarnessStep(t, changesJob.Steps, "🔍 Filter paths")
+
+	assert.Contains(t, stringValue(filterStep.With["filters"]), ".govulncheck-allow.txt")
+}
+
 func TestEKSSmokeDeclaresOIDCRoleWithoutSecret(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/svc/provisioner/cluster/talos/upgrade_test.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_test.go
@@ -17,6 +17,14 @@ import (
 // LifecycleService/ImageService upgrade APIs.
 const talosVersionLifecycleGA = "v1.13.0"
 
+func TestKubernetesImageRefUsesTalosKubeletAvailability(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil)
+
+	assert.Equal(t, "ghcr.io/siderolabs/kubelet", provisioner.KubernetesImageRef())
+}
+
 // TestSupportsLifecycleUpgradeAPI verifies that the upgrade path dispatch picks
 // the LifecycleService/ImageService APIs only for Talos >= 1.13 and otherwise
 // falls back to the legacy MachineService.Upgrade API. The v1.12.4 → false case

--- a/pkg/svc/provisioner/cluster/talos/upgrader.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrader.go
@@ -320,11 +320,11 @@ func lowestTalosVersion(tags []string) (string, error) {
 	return lowestTag, nil
 }
 
-// KubernetesImageRef returns the Kubernetes apiserver image repository, which is
-// used for version discovery. While Talos manages K8s versions internally through
-// machine configuration, we need a registry to query for available versions.
+// KubernetesImageRef returns the Talos kubelet image repository used for version
+// discovery. The kubelet is the Talos-specific artifact required by every
+// Kubernetes upgrade, so its published tags are the safe availability boundary.
 func (p *Provisioner) KubernetesImageRef() string {
-	return constants.KubernetesAPIServerImage
+	return constants.KubeletImage
 }
 
 // DistributionImageRef returns the OCI repository for Talos node images.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## What changed

- discover Talos Kubernetes upgrade candidates from `ghcr.io/siderolabs/kubelet`, the limiting Talos-specific artifact
- accept `GO-2026-5939` in the strict govulncheck allowlist with the existing Claircore SSRF reachability evidence
- keep that acceptance fail-closed: the existing linkage guard still pins both shipped modules and rejects newly linked Claircore packages
- route same-repository `.govulncheck-allow.txt` pull requests through the reusable Go validation workflow, including the vulnerability scan, while keeping fork code out of its write-capable path
- refresh the allowlist verification date and remove its stale numeric advisory count

## Why

The PR pipeline first surfaced `GO-2026-5939` as a newly blocking database ID for the already tracked Claircore manifest-URI SSRF. There is no patched Claircore release, and the reachability assessment delivered by #6012 remains current: KSail links only audited parsing/type/local-filesystem packages, not Claircore's remote manifest fetchers.

The first CI run then exposed that allowlist-only changes skipped Go validation. After that gate was restored, the full matrix exposed a second current-fire: Kubernetes `v1.36.3` was visible in `registry.k8s.io` before `ghcr.io/siderolabs/kubelet:v1.36.3` existed. Four independent Talos variants selected the unavailable patch and failed. Talos now discovers from the kubelet repository, preventing unpublished required images from entering the upgrade path.

## Validation

- RED/GREEN: the workflow contract test failed when an allowlist-only pull request could not reach the reusable validator, and again when the privileged route lacked a same-repository boundary; the hardened contract passes 10/10 and the full CI-harness package passes 14/14
- RED/GREEN: the Talos discovery regression observed `registry.k8s.io/kube-apiserver`, then passed 100/100 against `ghcr.io/siderolabs/kubelet`
- targeted Talos race test passes 10/10; full Talos package and changed-lines lint pass
- Claircore linkage guards pass 40/40 across root and desktop modules
- the vulnerability scan passed with `GO-2026-5939` accepted before the Talos matrix exposed the publication-order defect
- `git diff --check`

Fixes #6335
Part of #6008
Part of #6198
