### PR TITLE
fix(talos): discover available kubelet versions

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/upgrade_test.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_test.go
@@ -17,6 +17,14 @@ import (
 // LifecycleService/ImageService upgrade APIs.
 const talosVersionLifecycleGA = "v1.13.0"
 
+func TestKubernetesImageRefUsesTalosKubeletAvailability(t *testing.T) {
+	t.Parallel()
+
+	provisioner := talosprovisioner.NewProvisioner(nil, nil)
+
+	assert.Equal(t, "ghcr.io/siderolabs/kubelet", provisioner.KubernetesImageRef())
+}
+
 // TestSupportsLifecycleUpgradeAPI verifies that the upgrade path dispatch picks
 // the LifecycleService/ImageService APIs only for Talos >= 1.13 and otherwise
 // falls back to the legacy MachineService.Upgrade API. The v1.12.4 → false case

--- a/pkg/svc/provisioner/cluster/talos/upgrader.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrader.go
@@ -320,11 +320,11 @@ func lowestTalosVersion(tags []string) (string, error) {
 	return lowestTag, nil
 }
 
-// KubernetesImageRef returns the Kubernetes apiserver image repository, which is
-// used for version discovery. While Talos manages K8s versions internally through
-// machine configuration, we need a registry to query for available versions.
+// KubernetesImageRef returns the Talos kubelet image repository used for version
+// discovery. The kubelet is the Talos-specific artifact required by every
+// Kubernetes upgrade, so its published tags are the safe availability boundary.
 func (p *Provisioner) KubernetesImageRef() string {
-	return constants.KubernetesAPIServerImage
+	return constants.KubeletImage
 }
 
 // DistributionImageRef returns the OCI repository for Talos node images.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## What changed

- discover Talos Kubernetes upgrade candidates from `ghcr.io/siderolabs/kubelet`
- keep the generic version resolver unchanged for other distributions
- add a regression test pinning the Talos-specific availability boundary

## Why

Talos upgrades require both upstream Kubernetes control-plane images and the SideroLabs kubelet image. `registry.k8s.io/kube-apiserver` published `v1.36.3` before `ghcr.io/siderolabs/kubelet:v1.36.3` existed, so KSail selected a three-step upgrade path and failed only after successfully reaching `v1.36.2`.

The kubelet repository is the limiting Talos-specific artifact. Discovering from it prevents unpublished Talos kubelet patches from entering the upgrade path while preserving normal semver path construction.

## Validation

- RED: `TestKubernetesImageRefUsesTalosKubeletAvailability` expected the SideroLabs kubelet repository and observed `registry.k8s.io/kube-apiserver`
- GREEN: targeted regression test passes 100/100
- targeted race test passes 10/10
- full `pkg/svc/provisioner/cluster/talos` package passes
- changed-lines `golangci-lint` clean
- `git diff --check`

Fixes #6335

Unblocks #6334
