### PR TITLE
fix(security): audit desktop claircore upgrade

### DIFF
--- a/pkg/client/kubescape/claircore_linkage_test.go
+++ b/pkg/client/kubescape/claircore_linkage_test.go
@@ -77,26 +77,30 @@ func TestAuditedClaircoreVersionsIncludeToolkit(t *testing.T) {
 	wantModulePaths := []string{claircoreModulePath, claircoreToolkitModulePath}
 
 	for _, moduleName := range []string{"root", "desktop"} {
-		auditedVersions, ok := auditedClaircoreVersions()[moduleName]
-		if !ok {
-			t.Fatalf("module %q has no audited Claircore module versions", moduleName)
-		}
+		t.Run(moduleName, func(t *testing.T) {
+			t.Parallel()
 
-		if len(auditedVersions) != len(wantModulePaths) {
-			t.Fatalf(
-				"module %q must audit %d Claircore modules, got %d: %v",
-				moduleName,
-				len(wantModulePaths),
-				len(auditedVersions),
-				auditedVersions,
-			)
-		}
-
-		for _, modulePath := range wantModulePaths {
-			if auditedVersions[modulePath] == "" {
-				t.Errorf("module %q has no audited version for %q", moduleName, modulePath)
+			auditedVersions, ok := auditedClaircoreVersions()[moduleName]
+			if !ok {
+				t.Fatalf("module %q has no audited Claircore module versions", moduleName)
 			}
-		}
+
+			if len(auditedVersions) != len(wantModulePaths) {
+				t.Fatalf(
+					"module %q must audit %d Claircore modules, got %d: %v",
+					moduleName,
+					len(wantModulePaths),
+					len(auditedVersions),
+					auditedVersions,
+				)
+			}
+
+			for _, modulePath := range wantModulePaths {
+				if auditedVersions[modulePath] == "" {
+					t.Errorf("module %q has no audited version for %q", moduleName, modulePath)
+				}
+			}
+		})
 	}
 }
 
@@ -167,14 +171,21 @@ func assertClaircoreVersions(
 		)
 		cmd.Dir = moduleDir
 
-		out, err := cmd.CombinedOutput()
+		out, err := cmd.Output()
 		if err != nil {
+			var stderr string
+
+			exitErr := new(exec.ExitError)
+			if errors.As(err, &exitErr) {
+				stderr = string(exitErr.Stderr)
+			}
+
 			t.Fatalf(
 				"read %q version from module %q: %v\n%s",
 				modulePath,
 				moduleDir,
 				err,
-				out,
+				stderr,
 			)
 		}
 

--- a/pkg/client/kubescape/claircore_linkage_test.go
+++ b/pkg/client/kubescape/claircore_linkage_test.go
@@ -9,7 +9,27 @@ import (
 	"testing"
 )
 
-const auditedClaircoreVersion = "v1.5.35"
+const (
+	claircoreModulePath        = "github.com/quay/claircore"
+	claircoreToolkitModulePath = "github.com/quay/claircore/toolkit"
+)
+
+// auditedClaircoreVersions pins the independently selected Claircore modules
+// in every shipped KSail Go module. A toolkit-only upgrade can change linked
+// code without changing the parent Claircore module, so both versions are part
+// of the reachability verdict.
+func auditedClaircoreVersions() map[string]map[string]string {
+	return map[string]map[string]string{
+		"root": {
+			claircoreModulePath:        "v1.5.35",
+			claircoreToolkitModulePath: "v1.2.4",
+		},
+		"desktop": {
+			claircoreModulePath:        "v1.5.53",
+			claircoreToolkitModulePath: "v1.6.1",
+		},
+	}
+}
 
 // inertClaircorePackages is the full set of claircore packages the ksail
 // binary may link. They are parsing/type/local-filesystem code only — none
@@ -19,9 +39,12 @@ func inertClaircorePackages() map[string]bool {
 	return map[string]bool{
 		"github.com/quay/claircore":                   true,
 		"github.com/quay/claircore/indexer":           true,
+		"github.com/quay/claircore/internal/filterfs": true,
 		"github.com/quay/claircore/osrelease":         true,
 		"github.com/quay/claircore/pkg/cpe":           true,
 		"github.com/quay/claircore/pkg/tarfs":         true,
+		"github.com/quay/claircore/toolkit/log":       true,
+		"github.com/quay/claircore/toolkit/types":     true,
 		"github.com/quay/claircore/toolkit/types/cpe": true,
 	}
 }
@@ -42,6 +65,35 @@ func TestClaircoreModuleDirsIncludesDesktop(t *testing.T) {
 	for i := range want {
 		if got[i] != want[i] {
 			t.Errorf("module directory %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+// TestAuditedClaircoreVersionsIncludeToolkit prevents the independently
+// versioned toolkit module from dropping out of the fail-closed audit.
+func TestAuditedClaircoreVersionsIncludeToolkit(t *testing.T) {
+	t.Parallel()
+
+	wantModulePaths := []string{claircoreModulePath, claircoreToolkitModulePath}
+	for _, moduleName := range []string{"root", "desktop"} {
+		auditedVersions, ok := auditedClaircoreVersions()[moduleName]
+		if !ok {
+			t.Fatalf("module %q has no audited Claircore module versions", moduleName)
+		}
+		if len(auditedVersions) != len(wantModulePaths) {
+			t.Fatalf(
+				"module %q must audit %d Claircore modules, got %d: %v",
+				moduleName,
+				len(wantModulePaths),
+				len(auditedVersions),
+				auditedVersions,
+			)
+		}
+
+		for _, modulePath := range wantModulePaths {
+			if auditedVersions[modulePath] == "" {
+				t.Errorf("module %q has no audited version for %q", moduleName, modulePath)
+			}
 		}
 	}
 }
@@ -72,7 +124,12 @@ func TestClaircoreLinkedPackagesStayInert(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			assertClaircoreVersion(t, moduleDir)
+			versions, ok := auditedClaircoreVersions()[name]
+			if !ok {
+				t.Fatalf("module %q has no audited Claircore module versions", name)
+			}
+
+			assertClaircoreVersions(t, moduleDir, versions)
 			assertClaircorePackagesStayInert(t, moduleDir)
 		})
 	}
@@ -85,36 +142,49 @@ func claircoreModuleDirs(root string) []string {
 	return []string{root, filepath.Join(root, "desktop")}
 }
 
-// assertClaircoreVersion invalidates the reachability verdict whenever either
-// module moves away from the audited Claircore release, even if its package
-// paths remain within the existing allow-list.
-func assertClaircoreVersion(t *testing.T, moduleDir string) {
+// assertClaircoreVersions invalidates the reachability verdict whenever a
+// shipped module moves away from either audited Claircore release, even if its
+// package paths remain within the existing allow-list.
+func assertClaircoreVersions(
+	t *testing.T,
+	moduleDir string,
+	auditedVersions map[string]string,
+) {
 	t.Helper()
 
-	cmd := exec.CommandContext(
-		t.Context(),
-		"go",
-		"list",
-		"-m",
-		"-f",
-		"{{.Version}}",
-		"github.com/quay/claircore",
-	)
-	cmd.Dir = moduleDir
-
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("read Claircore version from module %q: %v\n%s", moduleDir, err, out)
-	}
-
-	if got := strings.TrimSpace(string(out)); got != auditedClaircoreVersion {
-		t.Fatalf(
-			"module %q uses Claircore %q; re-establish the #6008 SSRF reachability verdict "+
-				"before updating auditedClaircoreVersion %q",
-			moduleDir,
-			got,
-			auditedClaircoreVersion,
+	for modulePath, auditedVersion := range auditedVersions {
+		cmd := exec.CommandContext(
+			t.Context(),
+			"go",
+			"list",
+			"-m",
+			"-f",
+			"{{.Version}}",
+			modulePath,
 		)
+		cmd.Dir = moduleDir
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf(
+				"read %q version from module %q: %v\n%s",
+				modulePath,
+				moduleDir,
+				err,
+				out,
+			)
+		}
+
+		if got := strings.TrimSpace(string(out)); got != auditedVersion {
+			t.Fatalf(
+				"module %q uses %s %q; re-establish the #6008 SSRF reachability verdict "+
+					"before updating the audited version %q",
+				moduleDir,
+				modulePath,
+				got,
+				auditedVersion,
+			)
+		}
 	}
 }
 

--- a/pkg/client/kubescape/claircore_linkage_test.go
+++ b/pkg/client/kubescape/claircore_linkage_test.go
@@ -75,11 +75,13 @@ func TestAuditedClaircoreVersionsIncludeToolkit(t *testing.T) {
 	t.Parallel()
 
 	wantModulePaths := []string{claircoreModulePath, claircoreToolkitModulePath}
+
 	for _, moduleName := range []string{"root", "desktop"} {
 		auditedVersions, ok := auditedClaircoreVersions()[moduleName]
 		if !ok {
 			t.Fatalf("module %q has no audited Claircore module versions", moduleName)
 		}
+
 		if len(auditedVersions) != len(wantModulePaths) {
 			t.Fatalf(
 				"module %q must audit %d Claircore modules, got %d: %v",
@@ -153,6 +155,7 @@ func assertClaircoreVersions(
 	t.Helper()
 
 	for modulePath, auditedVersion := range auditedVersions {
+		//nolint:gosec // modulePath is selected only from the fixed audited-version map above.
 		cmd := exec.CommandContext(
 			t.Context(),
 			"go",

--- a/pkg/client/kubescape/claircore_linkage_test.go
+++ b/pkg/client/kubescape/claircore_linkage_test.go
@@ -1,7 +1,9 @@
 package kubescape_test
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,38 +16,55 @@ const (
 	claircoreToolkitModulePath = "github.com/quay/claircore/toolkit"
 )
 
-// auditedClaircoreVersions pins the independently selected Claircore modules
-// in every shipped KSail Go module. A toolkit-only upgrade can change linked
-// code without changing the parent Claircore module, so both versions are part
-// of the reachability verdict.
-func auditedClaircoreVersions() map[string]map[string]string {
-	return map[string]map[string]string{
-		"root": {
-			claircoreModulePath:        "v1.5.35",
-			claircoreToolkitModulePath: "v1.2.4",
-		},
-		"desktop": {
-			claircoreModulePath:        "v1.5.53",
-			claircoreToolkitModulePath: "v1.6.1",
-		},
-	}
+type claircoreModuleAudit struct {
+	versions      map[string]string
+	inertPackages map[string]bool
 }
 
-// inertClaircorePackages is the full set of claircore packages the ksail
-// binary may link. They are parsing/type/local-filesystem code only — none
-// performs the remote layer/manifest fetching behind the Claircore
-// manifest-URI SSRF advisory (issue #6008, Dependabot alerts #165/#166).
-func inertClaircorePackages() map[string]bool {
-	return map[string]bool{
-		"github.com/quay/claircore":                   true,
-		"github.com/quay/claircore/indexer":           true,
-		"github.com/quay/claircore/internal/filterfs": true,
-		"github.com/quay/claircore/osrelease":         true,
-		"github.com/quay/claircore/pkg/cpe":           true,
-		"github.com/quay/claircore/pkg/tarfs":         true,
-		"github.com/quay/claircore/toolkit/log":       true,
-		"github.com/quay/claircore/toolkit/types":     true,
-		"github.com/quay/claircore/toolkit/types/cpe": true,
+// goListModule mirrors the Go command's exported JSON field names.
+type goListModule struct {
+	Path    string        `json:"Path"`    //nolint:tagliatelle // Go command output contract.
+	Version string        `json:"Version"` //nolint:tagliatelle // Go command output contract.
+	Replace *goListModule `json:"Replace"` //nolint:tagliatelle // Go command output contract.
+}
+
+// auditedClaircoreModules pins the independently selected Claircore modules
+// and exact linked package set in every shipped KSail Go module. A toolkit-only
+// upgrade or a package entering only one dependency graph must invalidate that
+// module's reachability verdict without inheriting another module's audit.
+func auditedClaircoreModules() map[string]claircoreModuleAudit {
+	return map[string]claircoreModuleAudit{
+		"root": {
+			versions: map[string]string{
+				claircoreModulePath:        "v1.5.35",
+				claircoreToolkitModulePath: "v1.2.4",
+			},
+			inertPackages: map[string]bool{
+				"github.com/quay/claircore":                   true,
+				"github.com/quay/claircore/indexer":           true,
+				"github.com/quay/claircore/osrelease":         true,
+				"github.com/quay/claircore/pkg/cpe":           true,
+				"github.com/quay/claircore/pkg/tarfs":         true,
+				"github.com/quay/claircore/toolkit/types/cpe": true,
+			},
+		},
+		"desktop": {
+			versions: map[string]string{
+				claircoreModulePath:        "v1.5.53",
+				claircoreToolkitModulePath: "v1.6.1",
+			},
+			inertPackages: map[string]bool{
+				"github.com/quay/claircore":                   true,
+				"github.com/quay/claircore/indexer":           true,
+				"github.com/quay/claircore/internal/filterfs": true,
+				"github.com/quay/claircore/osrelease":         true,
+				"github.com/quay/claircore/pkg/cpe":           true,
+				"github.com/quay/claircore/pkg/tarfs":         true,
+				"github.com/quay/claircore/toolkit/log":       true,
+				"github.com/quay/claircore/toolkit/types":     true,
+				"github.com/quay/claircore/toolkit/types/cpe": true,
+			},
+		},
 	}
 }
 
@@ -80,23 +99,23 @@ func TestAuditedClaircoreVersionsIncludeToolkit(t *testing.T) {
 		t.Run(moduleName, func(t *testing.T) {
 			t.Parallel()
 
-			auditedVersions, ok := auditedClaircoreVersions()[moduleName]
+			audit, ok := auditedClaircoreModules()[moduleName]
 			if !ok {
 				t.Fatalf("module %q has no audited Claircore module versions", moduleName)
 			}
 
-			if len(auditedVersions) != len(wantModulePaths) {
+			if len(audit.versions) != len(wantModulePaths) {
 				t.Fatalf(
 					"module %q must audit %d Claircore modules, got %d: %v",
 					moduleName,
 					len(wantModulePaths),
-					len(auditedVersions),
-					auditedVersions,
+					len(audit.versions),
+					audit.versions,
 				)
 			}
 
 			for _, modulePath := range wantModulePaths {
-				if auditedVersions[modulePath] == "" {
+				if audit.versions[modulePath] == "" {
 					t.Errorf("module %q has no audited version for %q", moduleName, modulePath)
 				}
 			}
@@ -130,13 +149,13 @@ func TestClaircoreLinkedPackagesStayInert(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			versions, ok := auditedClaircoreVersions()[name]
+			audit, ok := auditedClaircoreModules()[name]
 			if !ok {
-				t.Fatalf("module %q has no audited Claircore module versions", name)
+				t.Fatalf("module %q has no Claircore audit", name)
 			}
 
-			assertClaircoreVersions(t, moduleDir, versions)
-			assertClaircorePackagesStayInert(t, moduleDir)
+			assertClaircoreVersions(t, moduleDir, audit.versions)
+			assertClaircorePackagesStayInert(t, moduleDir, audit.inertPackages)
 		})
 	}
 }
@@ -165,8 +184,7 @@ func assertClaircoreVersions(
 			"go",
 			"list",
 			"-m",
-			"-f",
-			"{{.Version}}",
+			"-json",
 			modulePath,
 		)
 		cmd.Dir = moduleDir
@@ -189,22 +207,58 @@ func assertClaircoreVersions(
 			)
 		}
 
-		if got := strings.TrimSpace(string(out)); got != auditedVersion {
-			t.Fatalf(
-				"module %q uses %s %q; re-establish the #6008 SSRF reachability verdict "+
-					"before updating the audited version %q",
-				moduleDir,
-				modulePath,
-				got,
-				auditedVersion,
-			)
+		actual := goListModule{}
+
+		decodeErr := json.Unmarshal(out, &actual)
+		if decodeErr != nil {
+			t.Fatalf("decode %q module metadata from %q: %v", modulePath, moduleDir, decodeErr)
+		}
+
+		validationFailure := validateClaircoreModuleVersion(modulePath, auditedVersion, actual)
+		if validationFailure != "" {
+			t.Fatalf("module %q: %s", moduleDir, validationFailure)
 		}
 	}
 }
 
+func validateClaircoreModuleVersion(
+	modulePath string,
+	auditedVersion string,
+	actual goListModule,
+) string {
+	if actual.Replace != nil {
+		return fmt.Sprintf(
+			"%s %q is replaced by %s %q; re-establish the #6008 SSRF reachability verdict",
+			modulePath,
+			actual.Version,
+			actual.Replace.Path,
+			actual.Replace.Version,
+		)
+	}
+
+	if actual.Path != modulePath {
+		return fmt.Sprintf("requested %s but go list returned %s", modulePath, actual.Path)
+	}
+
+	if actual.Version != auditedVersion {
+		return fmt.Sprintf(
+			"uses %s %q; re-establish the #6008 SSRF reachability verdict before updating the audited version %q",
+			modulePath,
+			actual.Version,
+			auditedVersion,
+		)
+	}
+
+	return ""
+}
+
 // assertClaircorePackagesStayInert fails when a module links any Claircore
 // package outside the audited set.
-func assertClaircorePackagesStayInert(t *testing.T, moduleDir string) {
+func assertClaircorePackagesStayInert(
+	t *testing.T,
+	moduleDir string,
+	inertPackages map[string]bool,
+) {
 	t.Helper()
 
 	cmd := exec.CommandContext(t.Context(), "go", "list", "-deps", "./...")
@@ -227,7 +281,7 @@ func assertClaircorePackagesStayInert(t *testing.T, moduleDir string) {
 	for pkg := range strings.FieldsSeq(string(out)) {
 		isClaircore := pkg == "github.com/quay/claircore" ||
 			strings.HasPrefix(pkg, "github.com/quay/claircore/")
-		if isClaircore && !inertClaircorePackages()[pkg] {
+		if isClaircore && !inertPackages[pkg] {
 			unexpected = append(unexpected, pkg)
 		}
 	}
@@ -282,14 +336,53 @@ func TestInertClaircorePackagesExcludesRemoteFetchingCode(t *testing.T) {
 		"github.com/quay/claircore/pkg/distlock",
 	}
 
-	inert := inertClaircorePackages()
+	for moduleName, audit := range auditedClaircoreModules() {
+		t.Run(moduleName, func(t *testing.T) {
+			t.Parallel()
 
-	for _, pkg := range sensitive {
-		if inert[pkg] {
-			t.Errorf(
-				"expected %q to be absent from the inert allow-list; it performs remote fetching",
-				pkg,
-			)
+			for _, pkg := range sensitive {
+				if audit.inertPackages[pkg] {
+					t.Errorf(
+						"expected %q to be absent from the inert allow-list; it performs remote fetching",
+						pkg,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestRootClaircoreAuditExcludesDesktopOnlyPackages prevents a package already
+// audited for desktop from silently entering the root dependency graph.
+func TestRootClaircoreAuditExcludesDesktopOnlyPackages(t *testing.T) {
+	t.Parallel()
+
+	rootAudit := auditedClaircoreModules()["root"]
+	for _, pkg := range []string{
+		"github.com/quay/claircore/internal/filterfs",
+		"github.com/quay/claircore/toolkit/log",
+		"github.com/quay/claircore/toolkit/types",
+	} {
+		if rootAudit.inertPackages[pkg] {
+			t.Errorf("root audit unexpectedly admits desktop-only package %q", pkg)
 		}
+	}
+}
+
+// TestValidateClaircoreModuleVersionRejectsReplacement prevents a fork or
+// local replacement from inheriting the selected release's reachability
+// verdict.
+func TestValidateClaircoreModuleVersionRejectsReplacement(t *testing.T) {
+	t.Parallel()
+
+	actual := goListModule{
+		Path:    claircoreModulePath,
+		Version: "v1.5.35",
+		Replace: &goListModule{Path: "example.com/claircore-fork", Version: "v1.5.35"},
+	}
+
+	validationFailure := validateClaircoreModuleVersion(claircoreModulePath, "v1.5.35", actual)
+	if validationFailure == "" {
+		t.Fatal("expected a replacement module to invalidate the Claircore audit")
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## What changed

- pin the independently selected Claircore and Claircore toolkit versions for both shipped Go modules
- re-establish the desktop `v1.5.53` / toolkit `v1.6.1` reachability verdict after Dependabot #6340
- admit only the newly linked local filesystem, type, and logging packages
- keep the remote manifest-fetching sink packages explicitly forbidden
- prevent a future toolkit-only upgrade from dropping out of the fail-closed audit

## Why

Dependabot #6340 advanced the desktop module to Claircore `v1.5.53` while the root module remains on `v1.5.35`. That correctly broke the security guard on current `main`. The desktop dependency graph now also links `internal/filterfs`, `toolkit/types`, and `toolkit/log`; source inspection confirms those packages perform local filesystem filtering, value handling, and structured logging rather than remote manifest or layer fetching.

The toolkit is a separately versioned module, so pinning only `github.com/quay/claircore` would let a toolkit-only code change silently inherit the SSRF reachability verdict. The guard now audits both module paths independently for root and desktop.

## Validation

- RED: current `main` fails `TestClaircoreLinkedPackagesStayInert/desktop` because it resolves Claircore `v1.5.53` against the audited `v1.5.35`
- GREEN: focused Claircore guards pass 60/60
- full `pkg/client/kubescape` package passes 17/17
- focused race suite passes 6/6
- `golangci-lint run ./pkg/client/kubescape` reports no issues
- `git diff --check`

Part of #6008
