### PR TITLE
fix(ci): judge EKS smoke teardown by whether a cluster remains

### DIFF
--- a/.github/scripts/delete-eks-smoke-cluster.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.sh
@@ -114,14 +114,18 @@ if [[ "${create_attempted}" == "false" ]]; then
 fi
 
 # ksail needs the scaffolded project directory; eksctl addresses the cluster by
-# name and region. A missing workdir therefore removes one teardown path, never
-# the obligation to verify that nothing is left running.
-if [[ -d "${workdir}" ]]; then
-	cd "${workdir}"
+# name and region. An unusable workdir therefore removes one teardown path, never
+# the obligation to verify that nothing is left running. The directory can also
+# exist and still refuse entry, so the change of directory is a tested condition:
+# under strict mode a bare `cd` would end the script here, skipping the eksctl
+# fallback and the absence check and stranding a billable cluster in silence.
+if [[ ! -d "${workdir}" ]]; then
+	echo "::warning::No EKS smoke workdir at ${workdir}; skipping ksail and using eksctl."
+elif ! cd "${workdir}"; then
+	echo "::warning::EKS smoke workdir ${workdir} could not be entered; skipping ksail and using eksctl."
+else
 	ksail cluster delete --provider AWS --name "${cluster_name}" --force ||
 		echo "::warning::ksail cluster delete failed."
-else
-	echo "::warning::No EKS smoke workdir at ${workdir}; skipping ksail and using eksctl."
 fi
 
 # A zero exit from ksail does not prove the cluster is gone, so the fallback is

--- a/.github/scripts/delete-eks-smoke-cluster.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.sh
@@ -98,20 +98,37 @@ cluster_absent() {
 	esac
 }
 
-if [[ "${create_attempted}" != "true" ]]; then
+# Anything other than an explicit false is treated as "a cluster may exist".
+# Silently skipping teardown on a typo is the one failure this script exists to
+# prevent, so an unrecognised value is a usage error rather than a skip.
+if [[ "${create_attempted}" != "true" && "${create_attempted}" != "false" ]]; then
+	printf -- '--create-attempted must be exactly true or false (got %s).\n\n' \
+		"${create_attempted:-<empty>}" >&2
+	usage >&2
+	exit 2
+fi
+
+if [[ "${create_attempted}" == "false" ]]; then
 	echo "Cluster creation did not start; nothing to clean up."
 	exit 0
 fi
 
-if [[ ! -d "${workdir}" ]]; then
-	echo "No EKS smoke workdir exists; nothing to clean up."
-	exit 0
+# ksail needs the scaffolded project directory; eksctl addresses the cluster by
+# name and region. A missing workdir therefore removes one teardown path, never
+# the obligation to verify that nothing is left running.
+if [[ -d "${workdir}" ]]; then
+	cd "${workdir}"
+	ksail cluster delete --provider AWS --name "${cluster_name}" --force ||
+		echo "::warning::ksail cluster delete failed."
+else
+	echo "::warning::No EKS smoke workdir at ${workdir}; skipping ksail and using eksctl."
 fi
 
-cd "${workdir}"
-
-if ! ksail cluster delete --provider AWS --name "${cluster_name}" --force; then
-	echo "::warning::ksail cluster delete failed; falling back to eksctl delete cluster."
+# A zero exit from ksail does not prove the cluster is gone, so the fallback is
+# driven by what AWS reports rather than by the previous command's status —
+# otherwise a delete that silently no-ops spends only one of the two attempts.
+if ! cluster_absent; then
+	echo "::warning::Cluster still present; falling back to eksctl delete cluster."
 	eksctl delete cluster \
 		--name "${cluster_name}" \
 		--region "${region}" \

--- a/.github/scripts/delete-eks-smoke-cluster.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.sh
@@ -63,16 +63,26 @@ if [[ -z "${cluster_name}" || -z "${region}" || -z "${workdir}" ]]; then
 	exit 2
 fi
 
-# Returns 0 only when AWS explicitly reports the cluster as absent.
+# Returns 0 only when the cluster is gone or is irreversibly on its way out.
 cluster_absent() {
 	local output
 	local status=0
 
 	output="$(aws eks describe-cluster \
 		--name "${cluster_name}" \
-		--region "${region}" 2>&1)" || status=$?
+		--region "${region}" \
+		--query 'cluster.status' \
+		--output text 2>&1)" || status=$?
 
 	if ((status == 0)); then
+		# Teardown is asynchronous, so a cluster still reporting DELETING is a
+		# delete that took effect rather than a leak. Treating it as one would
+		# just move the false alarm from failed creates to successful deletes.
+		if [[ "${output}" == "DELETING" ]]; then
+			printf 'Cluster %s is already tearing down in %s.\n' "${cluster_name}" "${region}"
+			return 0
+		fi
+
 		return 1
 	fi
 

--- a/.github/scripts/delete-eks-smoke-cluster.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  delete-eks-smoke-cluster.sh --cluster-name NAME --region REGION
+                              --workdir DIR --create-attempted true|false
+
+Tear down the ephemeral EKS smoke-test cluster and confirm it is gone.
+
+Success is judged by a post-condition — that no cluster of that name remains —
+not by the exit status of any single delete command. A create that failed before
+the cluster existed has nothing to tear down and reports success, which keeps a
+failed teardown meaning the one thing worth acting on: a billable cluster may
+still be running.
+
+Absence must be proven by an explicit not-found response. Any other probe error
+leaves the cluster state unknown and fails closed, because reporting a clean
+teardown that was never confirmed is what strands a billable cluster silently.
+EOF
+}
+
+cluster_name=""
+region=""
+workdir=""
+create_attempted=""
+
+while (($# > 0)); do
+	case "$1" in
+	--help | -h)
+		usage
+		exit 0
+		;;
+	--cluster-name)
+		cluster_name="${2:-}"
+		shift 2
+		;;
+	--region)
+		region="${2:-}"
+		shift 2
+		;;
+	--workdir)
+		workdir="${2:-}"
+		shift 2
+		;;
+	--create-attempted)
+		create_attempted="${2:-}"
+		shift 2
+		;;
+	*)
+		printf 'Unknown argument: %s\n\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+if [[ -z "${cluster_name}" || -z "${region}" || -z "${workdir}" ]]; then
+	printf '--cluster-name, --region and --workdir are required.\n\n' >&2
+	usage >&2
+	exit 2
+fi
+
+# Returns 0 only when AWS explicitly reports the cluster as absent.
+cluster_absent() {
+	local output
+	local status=0
+
+	output="$(aws eks describe-cluster \
+		--name "${cluster_name}" \
+		--region "${region}" 2>&1)" || status=$?
+
+	if ((status == 0)); then
+		return 1
+	fi
+
+	case "${output}" in
+	*ResourceNotFoundException*)
+		return 0
+		;;
+	*)
+		printf '::warning::Could not determine whether cluster %s still exists in %s: %s\n' \
+			"${cluster_name}" "${region}" "${output}" >&2
+		return 1
+		;;
+	esac
+}
+
+if [[ "${create_attempted}" != "true" ]]; then
+	echo "Cluster creation did not start; nothing to clean up."
+	exit 0
+fi
+
+if [[ ! -d "${workdir}" ]]; then
+	echo "No EKS smoke workdir exists; nothing to clean up."
+	exit 0
+fi
+
+cd "${workdir}"
+
+if ! ksail cluster delete --provider AWS --name "${cluster_name}" --force; then
+	echo "::warning::ksail cluster delete failed; falling back to eksctl delete cluster."
+	eksctl delete cluster \
+		--name "${cluster_name}" \
+		--region "${region}" \
+		--wait || true
+fi
+
+if cluster_absent; then
+	printf 'No cluster %s remains in %s.\n' "${cluster_name}" "${region}"
+	exit 0
+fi
+
+printf '::error::EKS cleanup did not complete. Cluster %s is still present in %s and may be billable.\n' \
+	"${cluster_name}" "${region}" >&2
+exit 1

--- a/.github/scripts/delete-eks-smoke-cluster.test.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.test.sh
@@ -23,6 +23,16 @@ deleting)
 	echo 'DELETING'
 	exit 0
 	;;
+until-fallback)
+	# Present until eksctl runs, so the eksctl path is only reached if the
+	# script probes AWS rather than trusting ksail's exit status.
+	if [[ ! -f "${FAKE_STATE_DIR}/eksctl-ran" ]]; then
+		echo 'ACTIVE'
+		exit 0
+	fi
+	echo 'An error occurred (ResourceNotFoundException) when calling the DescribeCluster operation: No cluster found for name: st-eks-1-1.' >&2
+	exit 254
+	;;
 denied)
 	echo 'An error occurred (AccessDeniedException) when calling the DescribeCluster operation: not authorized' >&2
 	exit 254
@@ -41,6 +51,7 @@ EOF
 
 cat >"${fake_bin}/eksctl" <<'EOF'
 #!/usr/bin/env bash
+touch "${FAKE_STATE_DIR}/eksctl-ran"
 exit "${FAKE_EKSCTL_DELETE_STATUS:-0}"
 EOF
 
@@ -61,18 +72,22 @@ expect_substring() {
 run_case() {
 	local scenario="$1" expected_status="$2" expected_output="$3"
 	local describe_mode="$4" ksail_status="$5" eksctl_status="$6" case_workdir="$7"
-	local output status
+	local attempted="${8:-true}"
+	local output status state_dir="${tmp_dir}/state-${scenario}"
+
+	mkdir -p "${state_dir}"
 
 	set +e
 	output="$(PATH="${fake_bin}:${PATH}" \
 		FAKE_AWS_DESCRIBE_MODE="${describe_mode}" \
 		FAKE_KSAIL_DELETE_STATUS="${ksail_status}" \
 		FAKE_EKSCTL_DELETE_STATUS="${eksctl_status}" \
+		FAKE_STATE_DIR="${state_dir}" \
 		"${cleaner}" \
 		--cluster-name st-eks-1-1 \
 		--region us-east-1 \
 		--workdir "${case_workdir}" \
-		--create-attempted true 2>&1)"
+		--create-attempted "${attempted}" 2>&1)"
 	status=$?
 	set -e
 
@@ -108,8 +123,21 @@ run_case deleting-in-progress 0 'already tearing down' deleting 0 0 "${workdir}"
 # reported as a clean teardown, because that is what strands a billable cluster silently.
 run_case probe-inconclusive 1 'Could not determine whether cluster' denied 0 0 "${workdir}"
 
-# A create that never started leaves nothing to do, even before the workdir exists.
-run_case missing-workdir 0 'nothing to clean up' not-found 0 0 "${tmp_dir}/absent"
+# A zero exit from ksail does not prove deletion. AWS keeps reporting the cluster until eksctl
+# actually runs, so this only passes if the fallback is driven by the probe rather than by ksail's
+# status — otherwise cleanup spends one of its two teardown attempts and then gives up.
+run_case fallback-after-silent-ksail-noop 0 'No cluster st-eks-1-1 remains' until-fallback 0 0 "${workdir}"
+
+# ksail needs the scaffolded project directory but eksctl does not, so a missing workdir must not
+# skip verification: a cluster can still be running with no local trace of it.
+run_case missing-workdir-still-present 1 'may be billable' found 0 0 "${tmp_dir}/absent"
+
+# Same path, nothing actually left — verified rather than assumed.
+run_case missing-workdir-verified-clean 0 'No cluster st-eks-1-1 remains' not-found 0 0 "${tmp_dir}/absent"
+
+# A typo in the creation-attempt flag must not read as "nothing was created". Silently skipping
+# teardown is precisely the failure this script exists to prevent.
+run_case invalid-create-attempted 2 'must be exactly true or false' not-found 0 0 "${workdir}" maybe
 
 set +e
 skipped_output="$(PATH="${fake_bin}:${PATH}" "${cleaner}" \

--- a/.github/scripts/delete-eks-smoke-cluster.test.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.test.sh
@@ -5,12 +5,25 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 cleaner="${script_dir}/delete-eks-smoke-cluster.sh"
 tmp_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_dir}"' EXIT
+unenterable_workdir="${tmp_dir}/unenterable"
+# The unenterable case is created without search permission, so restore it before
+# the recursive delete or the trap cannot clean up after itself.
+trap 'chmod 700 "${unenterable_workdir}" 2>/dev/null || true; rm -rf "${tmp_dir}"' EXIT
 fake_bin="${tmp_dir}/fake-bin"
 workdir="${tmp_dir}/workdir"
 pass_count=0
 
-mkdir -p "${fake_bin}" "${workdir}"
+mkdir -p "${fake_bin}" "${workdir}" "${unenterable_workdir}"
+chmod 000 "${unenterable_workdir}"
+
+# A directory the process cannot enter is the whole point of the cases below, and
+# root can enter one regardless of its mode. Prove the precondition holds rather
+# than letting those cases pass without exercising anything.
+if (cd "${unenterable_workdir}") 2>/dev/null; then
+	printf 'FAIL: harness precondition — %s is enterable, so the unenterable-workdir cases prove nothing (running as root?).\n' \
+		"${unenterable_workdir}" >&2
+	exit 1
+fi
 
 cat >"${fake_bin}/aws" <<'EOF'
 #!/usr/bin/env bash
@@ -134,6 +147,14 @@ run_case missing-workdir-still-present 1 'may be billable' found 0 0 "${tmp_dir}
 
 # Same path, nothing actually left — verified rather than assumed.
 run_case missing-workdir-verified-clean 0 'No cluster st-eks-1-1 remains' not-found 0 0 "${tmp_dir}/absent"
+
+# A workdir that exists but cannot be entered reaches the same place as a missing one: ksail is
+# unusable, eksctl and the probe are not. Under strict mode an unguarded `cd` would end the script
+# on the spot, so the cluster would still be running and nothing would say so.
+run_case unenterable-workdir-still-present 1 'may be billable' found 0 0 "${unenterable_workdir}"
+
+# And the clean variant, so the guard cannot be satisfied by failing everything.
+run_case unenterable-workdir-verified-clean 0 'No cluster st-eks-1-1 remains' not-found 0 0 "${unenterable_workdir}"
 
 # A typo in the creation-attempt flag must not read as "nothing was created". Silently skipping
 # teardown is precisely the failure this script exists to prevent.

--- a/.github/scripts/delete-eks-smoke-cluster.test.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.test.sh
@@ -16,7 +16,11 @@ cat >"${fake_bin}/aws" <<'EOF'
 #!/usr/bin/env bash
 case "${FAKE_AWS_DESCRIBE_MODE:-not-found}" in
 found)
-	echo '{"cluster":{"status":"ACTIVE"}}'
+	echo 'ACTIVE'
+	exit 0
+	;;
+deleting)
+	echo 'DELETING'
 	exit 0
 	;;
 denied)
@@ -90,6 +94,11 @@ run_case deleted-by-eksctl-fallback 0 'No cluster st-eks-1-1 remains' not-found 
 # The case that must stay red: every delete "succeeded" but the cluster is still there, so it is
 # still accruing cost and a human has to look.
 run_case still-present 1 'may be billable' found 0 0 "${workdir}"
+
+# EKS teardown is asynchronous, so a delete that has taken effect can still report DELETING for a
+# while. That is not a leak, and calling it one would just move the false alarm from failed creates
+# onto successful deletes.
+run_case deleting-in-progress 0 'already tearing down' deleting 0 0 "${workdir}"
 
 # Fail closed. A probe that cannot prove absence (denied, throttled, unreachable) must never be
 # reported as a clean teardown, because that is what strands a billable cluster silently.

--- a/.github/scripts/delete-eks-smoke-cluster.test.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.test.sh
@@ -46,6 +46,18 @@ EOF
 
 chmod +x "${fake_bin}/aws" "${fake_bin}/ksail" "${fake_bin}/eksctl"
 
+expect_status() {
+	[[ "$3" == "$2" ]] && return 0
+	printf 'FAIL: %s\n  want exit %s, got %s\n  output:\n%s\n' "$1" "$2" "$3" "$4" >&2
+	return 1
+}
+
+expect_substring() {
+	[[ "$3" == *"$2"* ]] && return 0
+	printf 'FAIL: %s\n  want output containing: %s\n  output:\n%s\n' "$1" "$2" "$3" >&2
+	return 1
+}
+
 run_case() {
 	local scenario="$1" expected_status="$2" expected_output="$3"
 	local describe_mode="$4" ksail_status="$5" eksctl_status="$6" case_workdir="$7"
@@ -64,16 +76,8 @@ run_case() {
 	status=$?
 	set -e
 
-	if [[ "${status}" -ne "${expected_status}" ]]; then
-		printf 'FAIL: %s: expected status %s, got %s\n%s\n' \
-			"${scenario}" "${expected_status}" "${status}" "${output}" >&2
-		return 1
-	fi
-	if [[ "${output}" != *"${expected_output}"* ]]; then
-		printf 'FAIL: %s: expected output containing %q, got:\n%s\n' \
-			"${scenario}" "${expected_output}" "${output}" >&2
-		return 1
-	fi
+	expect_status "${scenario}" "${expected_status}" "${status}" "${output}" || return 1
+	expect_substring "${scenario}" "${expected_output}" "${output}" || return 1
 
 	pass_count=$((pass_count + 1))
 	printf 'PASS: %s\n' "${scenario}"

--- a/.github/scripts/delete-eks-smoke-cluster.test.sh
+++ b/.github/scripts/delete-eks-smoke-cluster.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cleaner="${script_dir}/delete-eks-smoke-cluster.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+fake_bin="${tmp_dir}/fake-bin"
+workdir="${tmp_dir}/workdir"
+pass_count=0
+
+mkdir -p "${fake_bin}" "${workdir}"
+
+cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+case "${FAKE_AWS_DESCRIBE_MODE:-not-found}" in
+found)
+	echo '{"cluster":{"status":"ACTIVE"}}'
+	exit 0
+	;;
+denied)
+	echo 'An error occurred (AccessDeniedException) when calling the DescribeCluster operation: not authorized' >&2
+	exit 254
+	;;
+*)
+	echo 'An error occurred (ResourceNotFoundException) when calling the DescribeCluster operation: No cluster found for name: st-eks-1-1.' >&2
+	exit 254
+	;;
+esac
+EOF
+
+cat >"${fake_bin}/ksail" <<'EOF'
+#!/usr/bin/env bash
+exit "${FAKE_KSAIL_DELETE_STATUS:-0}"
+EOF
+
+cat >"${fake_bin}/eksctl" <<'EOF'
+#!/usr/bin/env bash
+exit "${FAKE_EKSCTL_DELETE_STATUS:-0}"
+EOF
+
+chmod +x "${fake_bin}/aws" "${fake_bin}/ksail" "${fake_bin}/eksctl"
+
+run_case() {
+	local scenario="$1" expected_status="$2" expected_output="$3"
+	local describe_mode="$4" ksail_status="$5" eksctl_status="$6" case_workdir="$7"
+	local output status
+
+	set +e
+	output="$(PATH="${fake_bin}:${PATH}" \
+		FAKE_AWS_DESCRIBE_MODE="${describe_mode}" \
+		FAKE_KSAIL_DELETE_STATUS="${ksail_status}" \
+		FAKE_EKSCTL_DELETE_STATUS="${eksctl_status}" \
+		"${cleaner}" \
+		--cluster-name st-eks-1-1 \
+		--region us-east-1 \
+		--workdir "${case_workdir}" \
+		--create-attempted true 2>&1)"
+	status=$?
+	set -e
+
+	if [[ "${status}" -ne "${expected_status}" ]]; then
+		printf 'FAIL: %s: expected status %s, got %s\n%s\n' \
+			"${scenario}" "${expected_status}" "${status}" "${output}" >&2
+		return 1
+	fi
+	if [[ "${output}" != *"${expected_output}"* ]]; then
+		printf 'FAIL: %s: expected output containing %q, got:\n%s\n' \
+			"${scenario}" "${expected_output}" "${output}" >&2
+		return 1
+	fi
+
+	pass_count=$((pass_count + 1))
+	printf 'PASS: %s\n' "${scenario}"
+}
+
+# Regression for the failure seen in run 29822971789: `ksail cluster create` died before any
+# cluster existed, so both delete paths returned not-found and the step failed the job. Nothing
+# was left running, so cleanup must report success — otherwise a red cleanup no longer means
+# "a billable cluster may still be up".
+run_case nothing-to-clean 0 'No cluster st-eks-1-1 remains' not-found 1 1 "${workdir}"
+
+# The ordinary success path: ksail tears the cluster down and AWS confirms it is gone.
+run_case deleted-by-ksail 0 'No cluster st-eks-1-1 remains' not-found 0 0 "${workdir}"
+
+# ksail fails, the eksctl fallback succeeds, and absence is confirmed.
+run_case deleted-by-eksctl-fallback 0 'No cluster st-eks-1-1 remains' not-found 1 0 "${workdir}"
+
+# The case that must stay red: every delete "succeeded" but the cluster is still there, so it is
+# still accruing cost and a human has to look.
+run_case still-present 1 'may be billable' found 0 0 "${workdir}"
+
+# Fail closed. A probe that cannot prove absence (denied, throttled, unreachable) must never be
+# reported as a clean teardown, because that is what strands a billable cluster silently.
+run_case probe-inconclusive 1 'Could not determine whether cluster' denied 0 0 "${workdir}"
+
+# A create that never started leaves nothing to do, even before the workdir exists.
+run_case missing-workdir 0 'nothing to clean up' not-found 0 0 "${tmp_dir}/absent"
+
+set +e
+skipped_output="$(PATH="${fake_bin}:${PATH}" "${cleaner}" \
+	--cluster-name st-eks-1-1 \
+	--region us-east-1 \
+	--workdir "${workdir}" \
+	--create-attempted false 2>&1)"
+skipped_status=$?
+set -e
+if [[ "${skipped_status}" -ne 0 || "${skipped_output}" != *"Cluster creation did not start"* ]]; then
+	printf 'FAIL: create-not-attempted: expected clean skip, got status %s:\n%s\n' \
+		"${skipped_status}" "${skipped_output}" >&2
+	exit 1
+fi
+pass_count=$((pass_count + 1))
+printf 'PASS: create-not-attempted\n'
+
+set +e
+"${cleaner}" --cluster-name st-eks-1-1 --region us-east-1 >/dev/null 2>&1
+missing_arg_status=$?
+set -e
+if [[ "${missing_arg_status}" -ne 2 ]]; then
+	printf 'FAIL: missing-required-args: expected status 2, got %s\n' "${missing_arg_status}" >&2
+	exit 1
+fi
+pass_count=$((pass_count + 1))
+printf 'PASS: missing-required-args\n'
+
+printf '\n%s cases passed.\n' "${pass_count}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,7 @@ jobs:
       desktop: ${{ steps.filter.outputs.desktop }}
       calico-cni: ${{ steps.filter.outputs.calico-cni }}
       cask-pr-handoff: ${{ steps.filter.outputs.cask-pr-handoff }}
+      eks-smoke-scripts: ${{ steps.filter.outputs.eks-smoke-scripts }}
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -284,6 +285,32 @@ jobs:
               - '.github/scripts/validate-cask-pr-handoff.test.sh'
               - '.github/workflows/cd.yaml'
               - '.github/workflows/ci.yaml'
+            eks-smoke-scripts:
+              - '.github/scripts/delete-eks-smoke-cluster.sh'
+              - '.github/scripts/delete-eks-smoke-cluster.test.sh'
+              - '.github/workflows/system-test-eks.yaml'
+              - '.github/workflows/ci.yaml'
+
+  eks-smoke-scripts:
+    name: 🧹 Validate EKS Smoke Teardown
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes]
+    if: needs.changes.outputs.eks-smoke-scripts == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: 🧹 Verify EKS smoke teardown reports only real leaks
+        run: |
+          shellcheck \
+            .github/scripts/delete-eks-smoke-cluster.sh \
+            .github/scripts/delete-eks-smoke-cluster.test.sh
+          .github/scripts/delete-eks-smoke-cluster.test.sh
 
   cask-pr-handoff:
     name: 🔐 Validate Cask PR Handoff

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -284,30 +284,8 @@ jobs:
         env:
           EKS_CREATE_ATTEMPTED: ${{ steps.create.outputs.attempted }}
         run: |
-          set +e
-          if [ "${EKS_CREATE_ATTEMPTED:-}" != "true" ]; then
-            echo "Cluster creation did not start; nothing to clean up."
-            exit 0
-          fi
-
-          if [ ! -d "$KSAIL_EKS_WORKDIR" ]; then
-            echo "No EKS smoke workdir exists; nothing to clean up."
-            exit 0
-          fi
-
-          cd "$KSAIL_EKS_WORKDIR"
-          ksail cluster delete --provider AWS --name "$KSAIL_EKS_CLUSTER_NAME" --force
-          delete_status=$?
-          if [ "$delete_status" -ne 0 ]; then
-            echo "::warning::ksail cluster delete failed; falling back to eksctl delete cluster."
-            eksctl delete cluster \
-              --name "$KSAIL_EKS_CLUSTER_NAME" \
-              --region "$AWS_REGION" \
-              --wait
-            delete_status=$?
-          fi
-
-          if [ "$delete_status" -ne 0 ]; then
-            echo "::warning::EKS cleanup did not complete. Check AWS for cluster '$KSAIL_EKS_CLUSTER_NAME' in region '$AWS_REGION'."
-            exit "$delete_status"
-          fi
+          "$GITHUB_WORKSPACE/.github/scripts/delete-eks-smoke-cluster.sh" \
+            --cluster-name "$KSAIL_EKS_CLUSTER_NAME" \
+            --region "$AWS_REGION" \
+            --workdir "$KSAIL_EKS_WORKDIR" \
+            --create-attempted "${EKS_CREATE_ATTEMPTED:-false}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The EKS smoke test's cleanup step failed the job whenever there was nothing to clean up. A red cleanup is meant to mean one specific thing — a billable AWS cluster may still be running and someone needs to look — but because it also fired on every failed cluster creation, a real stranded-cluster alarm became indistinguishable from routine noise. It also hid the actual cause of a failure behind a second red step.

## What

Cleanup now succeeds or fails on whether a cluster is actually still there, rather than on what the delete commands happened to return. If it cannot confirm the cluster is gone, it fails rather than claiming success — an unconfirmed teardown is exactly how a billable cluster gets left running unnoticed.

The teardown logic moved into a tested script alongside the existing handoff scripts, so this behaviour is now covered by CI instead of living untested inside the workflow.

Fixes #6362
Part of devantler-tech/platform#2327
