### PR TITLE
fix(ci): assert the EKS teardown guard where it now lives

### DIFF
--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -178,7 +178,15 @@ func TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup(t *testing.T) {
 	require.NotEqual(t, -1, createIndex, "cluster create command is missing")
 	assert.Less(t, attemptIndex, createIndex)
 
-	cleanupStep := findHarnessStep(t, smokeJob.Steps, "🧹 Delete EKS smoke cluster")
+	assertCleanupSkipsTeardownBeforeCreate(t, smokeJob.Steps)
+}
+
+// assertCleanupSkipsTeardownBeforeCreate locks the one safety property the
+// teardown path exists for: when creation never started, nothing is deleted.
+func assertCleanupSkipsTeardownBeforeCreate(t *testing.T, steps []harnessStep) {
+	t.Helper()
+
+	cleanupStep := findHarnessStep(t, steps, "🧹 Delete EKS smoke cluster")
 	assert.Equal(
 		t,
 		"${{ steps.create.outputs.attempted }}",
@@ -186,10 +194,10 @@ func TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup(t *testing.T) {
 	)
 	// The teardown logic lives in .github/scripts/delete-eks-smoke-cluster.sh
 	// (extracted in #6363 so it is testable). The step's job is to hand the
-	// create-attempted signal to that script; the guard itself is asserted in the
-	// script below. Assert the contract where each half actually lives — pinning
-	// the guard's text to the step's inline Run is what silently rotted when the
-	// logic moved out.
+	// create-attempted signal to that script; the guard itself is proven below.
+	// Assert the contract where each half actually lives — pinning the guard's
+	// text to the step's inline Run is what silently rotted when the logic
+	// moved out.
 	require.Contains(
 		t, cleanupStep.Run, "delete-eks-smoke-cluster.sh",
 		"cleanup step must delegate to the extracted teardown script",
@@ -228,24 +236,28 @@ func runCleanupScriptWithoutCreate(t *testing.T) (string, []string) {
 	tempDir := t.TempDir()
 	binDir := filepath.Join(tempDir, "bin")
 	callLog := filepath.Join(tempDir, "invoked")
+
 	require.NoError(t, os.MkdirAll(binDir, 0o700))
 
 	// Any of these running at all means the guard let execution through.
 	for _, name := range []string{"ksail", "eksctl", "aws"} {
 		stub := "#!/bin/sh\nprintf '%s\\n' '" + name + "' >> \"$KSAIL_CLEANUP_CALL_LOG\"\nexit 0\n"
 		stubPath := filepath.Join(binDir, name)
+
 		require.NoError(t, os.WriteFile(stubPath, []byte(stub), 0o600))
 		//nolint:gosec // Owner execute is required for a PATH stub in a private temp dir.
 		require.NoError(t, os.Chmod(stubPath, 0o700))
 	}
 
 	scriptPath := filepath.Join("..", "..", ".github", "scripts", "delete-eks-smoke-cluster.sh")
+	//nolint:gosec // scriptPath is a repository-owned constant path, not user input.
 	command := exec.CommandContext(t.Context(), "bash", scriptPath,
 		"--cluster-name", "fixture-cluster",
 		"--region", "us-east-1",
 		"--workdir", tempDir,
 		"--create-attempted", "false",
 	)
+
 	command.Env = append(
 		os.Environ(),
 		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
@@ -256,7 +268,11 @@ func runCleanupScriptWithoutCreate(t *testing.T) (string, []string) {
 	// Deliberately assert, not require: a fall-through past the guard shows up
 	// both as a non-zero exit and as an invoked teardown binary, and reporting
 	// both makes the failure name the property rather than just the exit code.
-	assert.NoErrorf(t, err, "cleanup script must exit 0 when creation never started:\n%s", diagnostics)
+	//nolint:testifylint // assert, not require: a fall-through must report the invoked binaries too.
+	assert.NoErrorf(
+		t, err,
+		"cleanup script must exit 0 when creation never started:\n%s", diagnostics,
+	)
 
 	recorded, readErr := os.ReadFile(callLog) //nolint:gosec // Test-owned temporary path.
 	if os.IsNotExist(readErr) {

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -200,12 +200,72 @@ func TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup(t *testing.T) {
 	)
 
 	cleanupScript := string(readRepoFile(t, ".github/scripts/delete-eks-smoke-cluster.sh"))
-	guardIndex := strings.Index(cleanupScript, `if [[ "${create_attempted}" == "false" ]]; then`)
-	deleteIndex := strings.Index(cleanupScript, "ksail cluster delete")
+	require.Contains(
+		t, cleanupScript, "ksail cluster delete",
+		"cluster delete command is missing",
+	)
 
-	require.NotEqual(t, -1, guardIndex, "pre-create cleanup guard is missing")
-	require.NotEqual(t, -1, deleteIndex, "cluster delete command is missing")
-	assert.Less(t, guardIndex, deleteIndex, "the guard must precede the delete")
+	// Prove the property behaviourally rather than by source ordering. A
+	// guard-before-delete text check passes even if the guard's `exit 0` is
+	// removed, which is the only thing that actually stops the delete — so run the
+	// script for real with --create-attempted false and assert that no teardown
+	// tool is ever invoked.
+	diagnostics, invoked := runCleanupScriptWithoutCreate(t)
+	assert.Empty(
+		t, invoked,
+		"nothing may be invoked when creation never started, but the script ran: %v",
+		invoked,
+	)
+	assert.Contains(t, diagnostics, "nothing to clean up")
+}
+
+// runCleanupScriptWithoutCreate executes the teardown script on the
+// create-never-attempted path with every teardown binary replaced by a recorder,
+// and returns the script's output plus the names of any binaries it invoked.
+func runCleanupScriptWithoutCreate(t *testing.T) (string, []string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	callLog := filepath.Join(tempDir, "invoked")
+	require.NoError(t, os.MkdirAll(binDir, 0o700))
+
+	// Any of these running at all means the guard let execution through.
+	for _, name := range []string{"ksail", "eksctl", "aws"} {
+		stub := "#!/bin/sh\nprintf '%s\\n' '" + name + "' >> \"$KSAIL_CLEANUP_CALL_LOG\"\nexit 0\n"
+		stubPath := filepath.Join(binDir, name)
+		require.NoError(t, os.WriteFile(stubPath, []byte(stub), 0o600))
+		//nolint:gosec // Owner execute is required for a PATH stub in a private temp dir.
+		require.NoError(t, os.Chmod(stubPath, 0o700))
+	}
+
+	scriptPath := filepath.Join("..", "..", ".github", "scripts", "delete-eks-smoke-cluster.sh")
+	command := exec.CommandContext(t.Context(), "bash", scriptPath,
+		"--cluster-name", "fixture-cluster",
+		"--region", "us-east-1",
+		"--workdir", tempDir,
+		"--create-attempted", "false",
+	)
+	command.Env = append(
+		os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"KSAIL_CLEANUP_CALL_LOG="+callLog,
+	)
+
+	diagnostics, err := command.CombinedOutput()
+	// Deliberately assert, not require: a fall-through past the guard shows up
+	// both as a non-zero exit and as an invoked teardown binary, and reporting
+	// both makes the failure name the property rather than just the exit code.
+	assert.NoErrorf(t, err, "cleanup script must exit 0 when creation never started:\n%s", diagnostics)
+
+	recorded, readErr := os.ReadFile(callLog) //nolint:gosec // Test-owned temporary path.
+	if os.IsNotExist(readErr) {
+		return string(diagnostics), nil
+	}
+
+	require.NoError(t, readErr)
+
+	return string(diagnostics), strings.Fields(string(recorded))
 }
 
 //nolint:funlen // One test locks the cross-file action/workflow contract end to end.

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -184,15 +184,28 @@ func TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup(t *testing.T) {
 		"${{ steps.create.outputs.attempted }}",
 		cleanupStep.Env["EKS_CREATE_ATTEMPTED"],
 	)
-	guardIndex := strings.Index(
-		cleanupStep.Run,
-		`if [ "${EKS_CREATE_ATTEMPTED:-}" != "true" ]; then`,
+	// The teardown logic lives in .github/scripts/delete-eks-smoke-cluster.sh
+	// (extracted in #6363 so it is testable). The step's job is to hand the
+	// create-attempted signal to that script; the guard itself is asserted in the
+	// script below. Assert the contract where each half actually lives — pinning
+	// the guard's text to the step's inline Run is what silently rotted when the
+	// logic moved out.
+	require.Contains(
+		t, cleanupStep.Run, "delete-eks-smoke-cluster.sh",
+		"cleanup step must delegate to the extracted teardown script",
 	)
-	deleteIndex := strings.Index(cleanupStep.Run, "ksail cluster delete")
+	require.Contains(
+		t, cleanupStep.Run, `--create-attempted "${EKS_CREATE_ATTEMPTED:-false}"`,
+		"cleanup step must forward the create-attempted signal to the script",
+	)
+
+	cleanupScript := string(readRepoFile(t, ".github/scripts/delete-eks-smoke-cluster.sh"))
+	guardIndex := strings.Index(cleanupScript, `if [[ "${create_attempted}" == "false" ]]; then`)
+	deleteIndex := strings.Index(cleanupScript, "ksail cluster delete")
 
 	require.NotEqual(t, -1, guardIndex, "pre-create cleanup guard is missing")
 	require.NotEqual(t, -1, deleteIndex, "cluster delete command is missing")
-	assert.Less(t, guardIndex, deleteIndex)
+	assert.Less(t, guardIndex, deleteIndex, "the guard must precede the delete")
 }
 
 //nolint:funlen // One test locks the cross-file action/workflow contract end to end.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

**Why.** A test on `main` is failing right now. When the EKS teardown logic was moved into its own script (#6363), the test that guards it was left checking the old location, so it looks for something that is no longer there.

The reason nobody noticed is worth flagging: **the unit-test job was skipped on that merge**, so `main` went green without ever running the test that the change broke. It only shows up later, on the next unrelated pull request that happens to touch Go code — which is exactly where it surfaced.

**What.** Points each half of the check at where that half now lives: the workflow step has to hand the "did we actually try to create a cluster?" signal to the script, and the script has to check it before deleting anything. The safety property being protected is unchanged — don't run a delete for a cluster that was never created.

**Verified.** The test fails on unmodified `main` and passes with this change. I also confirmed the new checks genuinely catch a regression: breaking the script's guard, and dropping the forwarded signal, each fail with their own message.

**Worth a follow-up (not in this PR).** The skipped-test gap is the more serious problem — it means a change can break the test suite on `main` without CI objecting. Filed separately.
