### PR TITLE
docs(security): stop the claircore allowlist entry inviting its own removal

### DIFF
--- a/.govulncheck-allow.txt
+++ b/.govulncheck-allow.txt
@@ -10,11 +10,16 @@
 # Policy: the allowlist is for UNPATCHABLE findings only. The moment an
 # upstream fix ships, delete the entry and bump the affected module instead.
 #
-# Verified with `govulncheck ./...` against ksail main (re-validated 2026-07-22):
-#   the reachable advisories below, each "Fixed in: N/A" for the version
-#   pinned (transitively) in go.mod. Re-validate when bumping docker, k8s.io,
-#   or containerd deps. NOTE: x/image GO-2026-5061 is deliberately NOT listed —
-#   it has an upstream fix (v0.43.0) and is bumped per policy, not allowlisted.
+# Verified with `govulncheck ./...` against ksail main (whole-file re-validation
+# 2026-07-22): the reachable advisories below, each "Fixed in: N/A" for the
+#   version pinned (transitively) in go.mod. Re-validate when bumping docker,
+#   k8s.io, or containerd deps. NOTE: x/image GO-2026-5061 is deliberately NOT
+#   listed — it has an upstream fix (v0.43.0) and is bumped per policy, not
+#   allowlisted.
+#   That date covers the SET as a whole. An individual entry may carry a later
+#   measurement of its own — a targeted probe of one advisory, sometimes at a
+#   version main has not reached yet — and that does not re-date the sweep
+#   above. Read the per-entry date where one is given; otherwise this one.
 # ---------------------------------------------------------------------------
 
 # --- github.com/docker/docker (Moby) @ v28.5.2+incompatible -----------------

--- a/.govulncheck-allow.txt
+++ b/.govulncheck-allow.txt
@@ -12,8 +12,12 @@
 #
 # Verified with `govulncheck ./...` against ksail main (whole-file re-validation
 # 2026-07-22): the reachable advisories below, each "Fixed in: N/A" for the
-#   version pinned (transitively) in go.mod. Re-validate when bumping docker,
-#   k8s.io, or containerd deps. NOTE: x/image GO-2026-5061 is deliberately NOT
+#   version pinned (transitively) in go.mod. Re-validate when bumping any
+#   dependency that pins an allowlisted module. Today that is docker, k8s.io,
+#   containerd, and kubescape — kubescape pins BOTH x/crypto/openpgp and
+#   claircore transitively, so bumping it can move a pinned version, change a
+#   linked package, or alter reachability without any edit to this file naming
+#   those modules. NOTE: x/image GO-2026-5061 is deliberately NOT
 #   listed — it has an upstream fix (v0.43.0) and is bumped per policy, not
 #   allowlisted.
 #   That date covers the SET as a whole. An individual entry may carry a later

--- a/.govulncheck-allow.txt
+++ b/.govulncheck-allow.txt
@@ -74,15 +74,27 @@ GO-2026-5622  # containerd v1 CRI checkpoint/restore arbitrary host log read via
 # x/crypto/openpgp.
 GO-2026-5932  # x/crypto/openpgp unmaintained/unsafe-by-design (transitive via kubescape core.Scan; no fix; local-input-only path)
 
-# --- github.com/quay/claircore @ v1.5.35 (transitive via kubescape) ---------
+# --- github.com/quay/claircore (transitive via kubescape) -------------------
 # Published 2026-07-17. GO-2026-5939 covers SSRF when an unauthenticated
 # Claircore service accepts manifests whose layer URIs point to internal or
 # cloud-metadata endpoints. The advisory provides no symbol metadata, so
 # govulncheck conservatively reports any linked Claircore package as reachable.
 # KSail does not run a Claircore service or link its remote manifest fetchers:
 # `ksail workload scan` passes a local directory to Kubescape, and
-# TestClaircoreLinkedPackagesStayInert pins both shipped modules to v1.5.35 and
-# fails if anything beyond the audited parsing/type/local-filesystem packages
-# becomes linked (issue #6008, delivered by #6012). No patched release exists;
-# remove this entry and upgrade both modules as soon as one ships.
-GO-2026-5939  # Claircore manifest-URI SSRF (CVE-2026-10517; sink not linked; no fix)
+# TestClaircoreLinkedPackagesStayInert pins each shipped module's exact version
+# and linked package set, and fails if anything beyond the audited
+# parsing/type/local-filesystem packages becomes linked (issue #6008, delivered
+# by #6012). The two modules are independently selected and are NOT on the same
+# version, so this entry is deliberately not tied to one.
+#
+# ⚠️ THIS ENTRY IS NOT REMOVABLE ON A VERSION BUMP, despite the general policy
+# above. GitHub's advisory (GHSA-698x-9w2p-7vvp) records `<= 1.5.52` as
+# affected, so a reader checking there concludes v1.5.53 is patched — but the
+# GO ADVISORY IS THE ONE govulncheck READS, and GO-2026-5939 declares only
+# `introduced: 0` with NO fixed event, i.e. every version is affected.
+# Measured 2026-07-28 against claircore v1.5.53: govulncheck still reports
+# `Fixed in: N/A`, and its findings still carry a non-empty `trace[0].function`
+# — which is exactly the reachability test the CI gate applies — so dropping
+# this line turns the gate red rather than clean. Remove it only when the GO
+# advisory itself gains a fixed version, never on the strength of the GHSA.
+GO-2026-5939  # Claircore manifest-URI SSRF (CVE-2026-10517; sink not linked; no GO-advisory fix at any version)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A note in the vulnerability allowlist tells whoever reads it next to delete one of its entries "as
soon as a patched release ships". A patched release now appears to have shipped, and acting on that
instruction would break the build rather than tighten anything — the two vulnerability databases
involved disagree about whether the fix exists, and the one our CI actually consults still says it
does not. The trigger is imminent: the bump that looks like the all-clear is already open as an
automated dependency update.

## What

Rewrites that note to say plainly that this entry is not removable on a version bump, and what the
real removal condition is. Also drops a version number from the block heading that described only
one of the two components it covers — they are upgraded independently and already differ.

No advisory is added or removed, so the gate itself behaves exactly as before.

Fixes #6075
Part of #6198
