### PR TITLE
fix(cluster): refresh the root registry credential on a credential-only rotation

### DIFF
--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -858,10 +858,23 @@ func resolveKubeContext(ctx *localregistry.Context) string {
 	// Trim to match ensureConfiguredContextResolvable: a whitespace-padded pinned
 	// context must resolve to the same value the guard validated, otherwise it
 	// would pass the guard yet break the REST clients the probes build.
-	k8sContext := strings.TrimSpace(ctx.ClusterCfg.Spec.Cluster.Connection.Context)
+	if strings.TrimSpace(ctx.ClusterCfg.Spec.Cluster.Connection.Context) != "" {
+		return kubeContextFor(ctx.ClusterCfg, "")
+	}
+
+	return kubeContextFor(ctx.ClusterCfg, resolveClusterNameFromContext(ctx))
+}
+
+// kubeContextFor resolves the kubeconfig context for a cluster from its pinned
+// spec.cluster.connection.context, falling back to the distribution's derived
+// context name for clusterName. Callers that hold a resolved cluster name but
+// not the full localregistry.Context use this directly, so a cluster read and
+// the write that follows it always target the same context — writing to the
+// ambient current-context instead would land the change on another cluster.
+func kubeContextFor(clusterCfg *v1alpha1.Cluster, clusterName string) string {
+	k8sContext := strings.TrimSpace(clusterCfg.Spec.Cluster.Connection.Context)
 	if k8sContext == "" {
-		clusterName := resolveClusterNameFromContext(ctx)
-		k8sContext = ctx.ClusterCfg.Spec.Cluster.Distribution.ContextName(clusterName)
+		k8sContext = clusterCfg.Spec.Cluster.Distribution.ContextName(clusterName)
 	}
 
 	return k8sContext

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1237,16 +1237,8 @@ func checkRegistryCredentialDrift(
 		return
 	}
 
-	desiredDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(ctx.ClusterCfg)
-	if err != nil {
-		notify.Warningf(cmd.OutOrStderr(),
-			"Cannot resolve desired registry credentials for drift detection: %v", err)
-
-		return
-	}
-
 	// No external registry, or no credentials configured — nothing to refresh.
-	if desiredDigest == "" {
+	if !fluxinstaller.HasExternalRegistryCredentials(ctx.ClusterCfg) {
 		return
 	}
 
@@ -1258,17 +1250,17 @@ func checkRegistryCredentialDrift(
 		return
 	}
 
-	currentDigest, err := fluxinstaller.CurrentRegistryCredentialDigest(
-		cmd.Context(), kubeconfigPath, resolveKubeContext(ctx),
+	drifted, err := fluxinstaller.RegistryCredentialDrifted(
+		cmd.Context(), kubeconfigPath, resolveKubeContext(ctx), ctx.ClusterCfg,
 	)
 	if err != nil {
 		notify.Warningf(cmd.OutOrStderr(),
-			"Cannot query current registry credentials for drift detection: %v", err)
+			"Cannot compare registry credentials for drift detection: %v", err)
 
 		return
 	}
 
-	diffEngine.CheckRegistryCredential(currentDigest, desiredDigest, diff)
+	diffEngine.CheckRegistryCredential(drifted, diff)
 }
 
 // getCurrentArgoCDTargetRevision queries the ArgoCD Application for its current

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -916,6 +916,9 @@ func (o *updateOrchestrator) computeUpdateDiff(
 	// Check for Flux distribution-version drift (spec.workload.flux.distributionVersion)
 	checkFluxDistributionVersionDrift(o.cmd, o.ctx, diffEngine, diff)
 
+	// Check for registry credential drift (a rotated token behind an unchanged spec)
+	checkRegistryCredentialDrift(o.cmd, o.ctx, diffEngine, diff)
+
 	promoteUnsupportedInPlaceChanges(updater, diff)
 
 	return currentSpec, diff, nil
@@ -1198,6 +1201,61 @@ func checkFluxDistributionVersionDrift(
 		gitOpsEngine,
 		diff,
 	)
+}
+
+// checkRegistryCredentialDrift compares the credential held in the
+// KSail-managed registry Secret against the credential the resolved
+// configuration would write, and appends an in-place change when they differ.
+//
+// This is the only signal a credential-only rotation produces: registry
+// passwords are redacted from the structural diff, so rotating the environment
+// variable behind an otherwise identical configuration yields no field change
+// and the cluster keeps authenticating with the revoked value (issue #6107).
+// Flux only — the Secret is Flux's root pull Secret. Errors during cluster
+// queries are logged as warnings and skipped; they should not block the rest of
+// the update.
+func checkRegistryCredentialDrift(
+	cmd *cobra.Command,
+	ctx *localregistry.Context,
+	diffEngine *specdiff.Engine,
+	diff *clusterupdate.UpdateResult,
+) {
+	if ctx.ClusterCfg.Spec.Cluster.GitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return
+	}
+
+	desiredDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(ctx.ClusterCfg)
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot resolve desired registry credentials for drift detection: %v", err)
+
+		return
+	}
+
+	// No external registry, or no credentials configured — nothing to refresh.
+	if desiredDigest == "" {
+		return
+	}
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(ctx.ClusterCfg)
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot resolve kubeconfig path for registry credential drift detection: %v", err)
+
+		return
+	}
+
+	currentDigest, err := fluxinstaller.CurrentRegistryCredentialDigest(
+		cmd.Context(), kubeconfigPath, resolveKubeContext(ctx),
+	)
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot query current registry credentials for drift detection: %v", err)
+
+		return
+	}
+
+	diffEngine.CheckRegistryCredential(currentDigest, desiredDigest, diff)
 }
 
 // getCurrentArgoCDTargetRevision queries the ArgoCD Application for its current

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -596,6 +596,22 @@ func (r *componentReconciler) uninstallGitOpsEngine(
 	}
 }
 
+// fluxKubeconfigPath resolves the kubeconfig path for the Flux-only reconcile
+// handlers. isFlux is false when the cluster runs a different GitOps engine, in
+// which case those handlers have nothing to do and the path is empty.
+func (r *componentReconciler) fluxKubeconfigPath() (string, bool, error) {
+	if r.clusterCfg.Spec.Cluster.GitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return "", false, nil
+	}
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(r.clusterCfg)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get kubeconfig path: %w", err)
+	}
+
+	return kubeconfigPath, true, nil
+}
+
 // reconcileFluxVersion re-asserts the FluxInstance so a changed
 // spec.workload.flux.distributionVersion (or a newly repo-declared FluxInstance)
 // takes effect in-place on cluster update. Flux only — ArgoCD has no equivalent
@@ -604,13 +620,9 @@ func (r *componentReconciler) reconcileFluxVersion(
 	ctx context.Context,
 	_ clusterupdate.Change,
 ) error {
-	if r.clusterCfg.Spec.Cluster.GitOpsEngine != v1alpha1.GitOpsEngineFlux {
-		return nil
-	}
-
-	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(r.clusterCfg)
-	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig path: %w", err)
+	kubeconfigPath, isFlux, err := r.fluxKubeconfigPath()
+	if err != nil || !isFlux {
+		return err
 	}
 
 	registryHost, err := setup.ResolveRegistryHostForCluster(ctx, r.clusterCfg, r.clusterName)
@@ -640,13 +652,9 @@ func (r *componentReconciler) reconcileRegistryCredentials(
 	ctx context.Context,
 	_ clusterupdate.Change,
 ) error {
-	if r.clusterCfg.Spec.Cluster.GitOpsEngine != v1alpha1.GitOpsEngineFlux {
-		return nil
-	}
-
-	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(r.clusterCfg)
-	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig path: %w", err)
+	kubeconfigPath, isFlux, err := r.fluxKubeconfigPath()
+	if err != nil || !isFlux {
+		return err
 	}
 
 	err = fluxinstaller.EnsureRegistryCredentials(

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -146,6 +146,7 @@ func (r *componentReconciler) handlerForField(
 		"cluster.workload.flux.distributionVersion": r.reconcileFluxVersion,
 	}
 	handlers[specdiff.EKSLoadBalancerControllerField] = r.reconcileLoadBalancer
+	handlers[specdiff.RegistryCredentialField] = r.reconcileRegistryCredentials
 
 	if handler, ok := handlers[field]; ok {
 		return handler, true
@@ -173,7 +174,8 @@ func isComponentReconcileField(field string) bool {
 		"cluster.gitOpsEngine",
 		"cluster.workload.tag",
 		"cluster.workload.flux.distributionVersion",
-		specdiff.EKSLoadBalancerControllerField:
+		specdiff.EKSLoadBalancerControllerField,
+		specdiff.RegistryCredentialField:
 		return true
 	default:
 		return strings.HasPrefix(field, "cluster.autoscaler.node.")
@@ -625,6 +627,31 @@ func (r *componentReconciler) reconcileFluxVersion(
 	)
 	if err != nil {
 		return fmt.Errorf("setup flux instance: %w", err)
+	}
+
+	return nil
+}
+
+// reconcileRegistryCredentials re-writes the KSail-managed registry Secret so a
+// rotated pull credential reaches the cluster. The upsert is idempotent and
+// carries no other FluxInstance state, so it is safe to run whenever credential
+// drift is detected.
+func (r *componentReconciler) reconcileRegistryCredentials(
+	ctx context.Context,
+	_ clusterupdate.Change,
+) error {
+	if r.clusterCfg.Spec.Cluster.GitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return nil
+	}
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(r.clusterCfg)
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig path: %w", err)
+	}
+
+	err = fluxinstaller.EnsureRegistryCredentials(ctx, kubeconfigPath, r.clusterCfg)
+	if err != nil {
+		return fmt.Errorf("refresh registry credentials: %w", err)
 	}
 
 	return nil

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -649,7 +649,9 @@ func (r *componentReconciler) reconcileRegistryCredentials(
 		return fmt.Errorf("failed to get kubeconfig path: %w", err)
 	}
 
-	err = fluxinstaller.EnsureRegistryCredentials(ctx, kubeconfigPath, r.clusterCfg)
+	err = fluxinstaller.EnsureRegistryCredentials(
+		ctx, kubeconfigPath, kubeContextFor(r.clusterCfg, r.clusterName), r.clusterCfg,
+	)
 	if err != nil {
 		return fmt.Errorf("refresh registry credentials: %w", err)
 	}

--- a/pkg/cli/cmd/cluster/registry_credential_reconcile_test.go
+++ b/pkg/cli/cmd/cluster/registry_credential_reconcile_test.go
@@ -1,0 +1,62 @@
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistryCredentialFieldHasReconcileHandler pins the wiring between
+// detection and application. Detecting credential drift is useless if no
+// handler claims the field: reconcileComponents would skip it and the revoked
+// credential would stay in the cluster while the update reported success.
+func TestRegistryCredentialFieldHasReconcileHandler(t *testing.T) {
+	t.Parallel()
+
+	clusterCfg := v1alpha1.NewCluster()
+	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+
+	assert.True(t,
+		cluster.ExportHandlerForField(&cobra.Command{}, clusterCfg, specdiff.RegistryCredentialField),
+		"no reconcile handler is registered for %q, so detected credential drift would be silently skipped",
+		specdiff.RegistryCredentialField,
+	)
+}
+
+// TestRegistryCredentialDriftStaysInPlace is the trap this change most has to
+// avoid. promoteUnsupportedInPlaceChanges demotes any in-place field the
+// provisioner does not declare support for to "recreate required" — so a field
+// missing from the component-reconcile set turns a routine token rotation into
+// a demand to destroy and rebuild the cluster.
+func TestRegistryCredentialDriftStaysInPlace(t *testing.T) {
+	t.Parallel()
+
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = []clusterupdate.Change{
+		{
+			Field:    specdiff.RegistryCredentialField,
+			Category: clusterupdate.ChangeCategoryInPlace,
+		},
+	}
+
+	// An updater that declares support for nothing: only membership of the
+	// component-reconcile set can keep the change in place.
+	updater := &fieldSupportUpdater{
+		fakeUpdater: &fakeUpdater{},
+		supported:   map[string]bool{},
+	}
+
+	cluster.ExportPromoteUnsupportedInPlaceChanges(updater, diff)
+
+	require.Len(t, diff.InPlaceChanges, 1,
+		"a credential rotation must remain an in-place change")
+	assert.Equal(t, specdiff.RegistryCredentialField, diff.InPlaceChanges[0].Field)
+	assert.Empty(t, diff.RecreateRequired,
+		"a credential rotation must never be promoted to cluster recreation")
+}

--- a/pkg/cli/cmd/cluster/registry_credential_reconcile_test.go
+++ b/pkg/cli/cmd/cluster/registry_credential_reconcile_test.go
@@ -22,8 +22,13 @@ func TestRegistryCredentialFieldHasReconcileHandler(t *testing.T) {
 	clusterCfg := v1alpha1.NewCluster()
 	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
 
-	assert.True(t,
-		cluster.ExportHandlerForField(&cobra.Command{}, clusterCfg, specdiff.RegistryCredentialField),
+	assert.True(
+		t,
+		cluster.ExportHandlerForField(
+			&cobra.Command{},
+			clusterCfg,
+			specdiff.RegistryCredentialField,
+		),
 		"no reconcile handler is registered for %q, so detected credential drift would be silently skipped",
 		specdiff.RegistryCredentialField,
 	)

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -15,6 +15,22 @@ import (
 // renames cannot silently disconnect detection from application.
 const EKSLoadBalancerControllerField = "cluster.eks.experimentalAWSLoadBalancerController"
 
+// RegistryCredentialField is the diff key for the root registry pull credential
+// held in the KSail-managed registry Secret. Reconciliation uses the same
+// constant so field renames cannot silently disconnect detection from
+// application.
+const RegistryCredentialField = "cluster.localRegistry.credentials"
+
+// registryCredentialOldDisplay and registryCredentialNewDisplay are the values
+// rendered for a credential rotation. The resolved credential — and any digest
+// of it — is deliberately never placed in a Change: Change values are printed by
+// the update output, and a digest of a low-entropy password with a known
+// registry and username is guessable offline.
+const (
+	registryCredentialOldDisplay = "stale (redacted)"
+	registryCredentialNewDisplay = "rotated (redacted)"
+)
+
 // Engine computes configuration differences and classifies their impact.
 type Engine struct {
 	distribution v1alpha1.Distribution
@@ -107,6 +123,39 @@ func (e *Engine) CheckFluxDistributionVersion(
 		oldVersion, newVersion, "",
 		"Flux distribution version can be updated in-place by re-asserting the FluxInstance",
 		clusterupdate.ChangeCategoryInPlace)
+}
+
+// CheckRegistryCredential compares a digest of the credential currently held in
+// the KSail-managed registry Secret against a digest of the credential the
+// resolved configuration would write, and appends an in-place change when they
+// differ. This is what makes a credential-only rotation visible: the structural
+// diff redacts registry passwords, so a rotated token with otherwise identical
+// configuration produces no field change and would otherwise leave the cluster
+// authenticating with a revoked value.
+//
+// Both digests are computed by the caller and never rendered — see
+// registryCredentialOldDisplay. An empty currentDigest means the Secret is
+// absent or is not KSail-managed, which suppresses the change so KSail never
+// claims a Secret owned by something else (e.g. an ExternalSecret).
+func (e *Engine) CheckRegistryCredential(
+	currentDigest, desiredDigest string,
+	result *clusterupdate.UpdateResult,
+) {
+	if currentDigest == "" || desiredDigest == "" {
+		return
+	}
+
+	if currentDigest == desiredDigest {
+		return
+	}
+
+	routeChange(result, clusterupdate.Change{
+		Field:    RegistryCredentialField,
+		OldValue: registryCredentialOldDisplay,
+		NewValue: registryCredentialNewDisplay,
+		Category: clusterupdate.ChangeCategoryInPlace,
+		Reason:   "registry credentials can be refreshed in-place by re-writing the registry Secret",
+	})
 }
 
 // fieldRule describes how to diff a single scalar field.

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -131,27 +131,22 @@ func (e *Engine) CheckFluxDistributionVersion(
 		clusterupdate.ChangeCategoryInPlace)
 }
 
-// CheckRegistryCredential compares a digest of the credential currently held in
-// the KSail-managed registry Secret against a digest of the credential the
-// resolved configuration would write, and appends an in-place change when they
-// differ. This is what makes a credential-only rotation visible: the structural
-// diff redacts registry passwords, so a rotated token with otherwise identical
-// configuration produces no field change and would otherwise leave the cluster
-// authenticating with a revoked value.
+// CheckRegistryCredential appends an in-place change when the credential in the
+// KSail-managed registry Secret has drifted from the one the resolved
+// configuration would write. This is what makes a credential-only rotation
+// visible: the structural diff redacts registry passwords, so a rotated token
+// with otherwise identical configuration produces no field change and would
+// otherwise leave the cluster authenticating with a revoked value.
 //
-// Both digests are computed by the caller and never rendered — see
-// registryCredentialOldDisplay. An empty currentDigest means the Secret is
-// absent or is not KSail-managed, which suppresses the change so KSail never
-// claims a Secret owned by something else (e.g. an ExternalSecret).
+// drifted is a single bit decided by the flux installer, which holds both
+// credentials and compares them in constant time. No credential — and nothing
+// derived from one — crosses into this package, so there is nothing here that
+// could reach a rendered Change value; see registryCredentialOldDisplay.
 func (e *Engine) CheckRegistryCredential(
-	currentDigest, desiredDigest string,
+	drifted bool,
 	result *clusterupdate.UpdateResult,
 ) {
-	if currentDigest == "" || desiredDigest == "" {
-		return
-	}
-
-	if currentDigest == desiredDigest {
+	if !drifted {
 		return
 	}
 

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -19,6 +19,8 @@ const EKSLoadBalancerControllerField = "cluster.eks.experimentalAWSLoadBalancerC
 // held in the KSail-managed registry Secret. Reconciliation uses the same
 // constant so field renames cannot silently disconnect detection from
 // application.
+//
+//nolint:gosec // G101 false positive: a diff key, not a credential.
 const RegistryCredentialField = "cluster.localRegistry.credentials"
 
 // registryCredentialOldDisplay and registryCredentialNewDisplay are the values
@@ -26,8 +28,12 @@ const RegistryCredentialField = "cluster.localRegistry.credentials"
 // of it — is deliberately never placed in a Change: Change values are printed by
 // the update output, and a digest of a low-entropy password with a known
 // registry and username is guessable offline.
+// These are exactly the strings a reader sees in place of a credential, so
+// G101 flagging them is the inverse of the truth.
 const (
+	//nolint:gosec // G101 false positive: a redaction label, not a credential.
 	registryCredentialOldDisplay = "stale (redacted)"
+	//nolint:gosec // G101 false positive: a redaction label, not a credential.
 	registryCredentialNewDisplay = "rotated (redacted)"
 )
 

--- a/pkg/svc/diff/registry_credential_test.go
+++ b/pkg/svc/diff/registry_credential_test.go
@@ -31,7 +31,7 @@ func TestCheckRegistryCredentialDetectsRotation(t *testing.T) {
 	t.Parallel()
 
 	result := clusterupdate.NewEmptyUpdateResult()
-	newCredentialEngine().CheckRegistryCredential("digest-old", "digest-new", result)
+	newCredentialEngine().CheckRegistryCredential(true, result)
 
 	if len(result.InPlaceChanges) != 1 {
 		t.Fatalf(
@@ -54,15 +54,14 @@ func TestCheckRegistryCredentialDetectsRotation(t *testing.T) {
 }
 
 // TestCheckRegistryCredentialNeverRendersTheCredential pins the redaction
-// property. A digest is not safe to render either: with a known registry and
-// username, a digest of a low-entropy password is guessable offline.
+// property. The engine is given a single bit rather than the credential or a
+// digest of it, so the only thing it can render is its own fixed placeholder —
+// this test is what proves that placeholder stayed placeholder.
 func TestCheckRegistryCredentialNeverRendersTheCredential(t *testing.T) {
 	t.Parallel()
 
-	digestOfSecret := "sha256-of-" + theSecretPassword
-
 	result := clusterupdate.NewEmptyUpdateResult()
-	newCredentialEngine().CheckRegistryCredential(digestOfSecret, "digest-new", result)
+	newCredentialEngine().CheckRegistryCredential(true, result)
 
 	if len(result.InPlaceChanges) != 1 {
 		t.Fatalf("expected one in-place change, got %d", len(result.InPlaceChanges))
@@ -73,59 +72,27 @@ func TestCheckRegistryCredentialNeverRendersTheCredential(t *testing.T) {
 		if strings.Contains(rendered, theSecretPassword) {
 			t.Errorf("rendered value %q leaks the credential", rendered)
 		}
-
-		if strings.Contains(rendered, digestOfSecret) {
-			t.Errorf("rendered value %q leaks a digest of the credential", rendered)
-		}
 	}
 }
 
+// TestCheckRegistryCredentialSuppressesNonDrift covers every reason the drift
+// check reports false: an unrotated credential, a Secret KSail does not own, and
+// a configuration with no credential to write. The flux installer collapses all
+// three into "not drifted" so no credential material reaches this package; the
+// per-reason coverage lives with that comparison, in the flux installer tests.
 func TestCheckRegistryCredentialSuppressesNonDrift(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name    string
-		current string
-		desired string
-		why     string
-	}{
-		{
-			name:    "unchanged credential",
-			current: "same-digest",
-			desired: "same-digest",
-			why:     "an unrotated credential must not produce a change every update",
-		},
-		{
-			name:    "secret absent or not ksail-managed",
-			current: "",
-			desired: "digest-new",
-			why: "an empty current digest means KSail does not own the Secret; " +
-				"claiming it would overwrite an ExternalSecret-managed credential",
-		},
-		{
-			name:    "no external registry credentials configured",
-			current: "digest-old",
-			desired: "",
-			why:     "there is no credential to write",
-		},
-	}
+	result := clusterupdate.NewEmptyUpdateResult()
+	newCredentialEngine().CheckRegistryCredential(false, result)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := clusterupdate.NewEmptyUpdateResult()
-			newCredentialEngine().CheckRegistryCredential(testCase.current, testCase.desired, result)
-
-			total := len(result.InPlaceChanges) +
-				len(result.RecreateRequired) +
-				len(result.RebootRequired) +
-				len(result.WipeRequired) +
-				len(result.RollingRecreate) +
-				len(result.UnknownBaseline)
-			if total != 0 {
-				t.Errorf("expected no change (%s), got %d", testCase.why, total)
-			}
-		})
+	total := len(result.InPlaceChanges) +
+		len(result.RecreateRequired) +
+		len(result.RebootRequired) +
+		len(result.WipeRequired) +
+		len(result.RollingRecreate) +
+		len(result.UnknownBaseline)
+	if total != 0 {
+		t.Errorf("expected no change when the credential has not drifted, got %d", total)
 	}
 }

--- a/pkg/svc/diff/registry_credential_test.go
+++ b/pkg/svc/diff/registry_credential_test.go
@@ -1,0 +1,126 @@
+package diff_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+)
+
+// theSecretPassword is the credential a rotation moves away from. Every
+// assertion below checks it never reaches a Change, because Change values are
+// rendered by the cluster-update output.
+const theSecretPassword = "ghp_rotated_token_value_9f3a"
+
+func newCredentialEngine() *specdiff.Engine {
+	return specdiff.NewEngine(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+}
+
+// TestCheckRegistryCredentialDetectsRotation is the core of issue #6107: the
+// structural diff redacts registry passwords, so a rotated token behind an
+// otherwise identical configuration must still surface as an in-place change or
+// the cluster keeps authenticating with the revoked value.
+func TestCheckRegistryCredentialDetectsRotation(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	newCredentialEngine().CheckRegistryCredential("digest-old", "digest-new", result)
+
+	if len(result.InPlaceChanges) != 1 {
+		t.Fatalf(
+			"a rotated credential must produce exactly one in-place change, got %d",
+			len(result.InPlaceChanges),
+		)
+	}
+
+	change := result.InPlaceChanges[0]
+	if change.Field != specdiff.RegistryCredentialField {
+		t.Errorf("field = %q, want %q", change.Field, specdiff.RegistryCredentialField)
+	}
+
+	if change.Category != clusterupdate.ChangeCategoryInPlace {
+		t.Errorf(
+			"category = %q, want in-place — a credential rotation must never demand recreation",
+			change.Category,
+		)
+	}
+}
+
+// TestCheckRegistryCredentialNeverRendersTheCredential pins the redaction
+// property. A digest is not safe to render either: with a known registry and
+// username, a digest of a low-entropy password is guessable offline.
+func TestCheckRegistryCredentialNeverRendersTheCredential(t *testing.T) {
+	t.Parallel()
+
+	digestOfSecret := "sha256-of-" + theSecretPassword
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	newCredentialEngine().CheckRegistryCredential(digestOfSecret, "digest-new", result)
+
+	if len(result.InPlaceChanges) != 1 {
+		t.Fatalf("expected one in-place change, got %d", len(result.InPlaceChanges))
+	}
+
+	change := result.InPlaceChanges[0]
+	for _, rendered := range []string{change.OldValue, change.NewValue, change.Reason} {
+		if strings.Contains(rendered, theSecretPassword) {
+			t.Errorf("rendered value %q leaks the credential", rendered)
+		}
+
+		if strings.Contains(rendered, digestOfSecret) {
+			t.Errorf("rendered value %q leaks a digest of the credential", rendered)
+		}
+	}
+}
+
+func TestCheckRegistryCredentialSuppressesNonDrift(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		current string
+		desired string
+		why     string
+	}{
+		{
+			name:    "unchanged credential",
+			current: "same-digest",
+			desired: "same-digest",
+			why:     "an unrotated credential must not produce a change every update",
+		},
+		{
+			name:    "secret absent or not ksail-managed",
+			current: "",
+			desired: "digest-new",
+			why: "an empty current digest means KSail does not own the Secret; " +
+				"claiming it would overwrite an ExternalSecret-managed credential",
+		},
+		{
+			name:    "no external registry credentials configured",
+			current: "digest-old",
+			desired: "",
+			why:     "there is no credential to write",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := clusterupdate.NewEmptyUpdateResult()
+			newCredentialEngine().CheckRegistryCredential(testCase.current, testCase.desired, result)
+
+			total := len(result.InPlaceChanges) +
+				len(result.RecreateRequired) +
+				len(result.RebootRequired) +
+				len(result.WipeRequired) +
+				len(result.RollingRecreate) +
+				len(result.UnknownBaseline)
+			if total != 0 {
+				t.Errorf("expected no change (%s), got %d", testCase.why, total)
+			}
+		})
+	}
+}

--- a/pkg/svc/diff/registry_credential_test.go
+++ b/pkg/svc/diff/registry_credential_test.go
@@ -12,6 +12,11 @@ import (
 // theSecretPassword is the credential a rotation moves away from. Every
 // assertion below checks it never reaches a Change, because Change values are
 // rendered by the cluster-update output.
+//
+// It is a fabricated literal that has never been a real credential — it exists
+// precisely so a test can prove this value does NOT escape into output.
+//
+//nolint:gosec // G101: an intentional fake credential, and the subject of the leak assertions.
 const theSecretPassword = "ghp_rotated_token_value_9f3a"
 
 func newCredentialEngine() *specdiff.Engine {

--- a/pkg/svc/diff/registry_credential_test.go
+++ b/pkg/svc/diff/registry_credential_test.go
@@ -1,23 +1,12 @@
 package diff_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 )
-
-// theSecretPassword is the credential a rotation moves away from. Every
-// assertion below checks it never reaches a Change, because Change values are
-// rendered by the cluster-update output.
-//
-// It is a fabricated literal that has never been a real credential — it exists
-// precisely so a test can prove this value does NOT escape into output.
-//
-//nolint:gosec // G101: an intentional fake credential, and the subject of the leak assertions.
-const theSecretPassword = "ghp_rotated_token_value_9f3a"
 
 func newCredentialEngine() *specdiff.Engine {
 	return specdiff.NewEngine(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
@@ -53,11 +42,16 @@ func TestCheckRegistryCredentialDetectsRotation(t *testing.T) {
 	}
 }
 
-// TestCheckRegistryCredentialNeverRendersTheCredential pins the redaction
-// property. The engine is given a single bit rather than the credential or a
-// digest of it, so the only thing it can render is its own fixed placeholder —
-// this test is what proves that placeholder stayed placeholder.
-func TestCheckRegistryCredentialNeverRendersTheCredential(t *testing.T) {
+// TestCheckRegistryCredentialRendersOnlyRedactedPlaceholders pins the redaction
+// property.
+//
+// The engine now receives a single bit rather than the credential or a digest of
+// it, so no input it is given can reach a rendered value — asserting that some
+// secret literal is absent would be unfalsifiable here. What is still worth
+// pinning, and what this asserts, is that the rendered values are the fixed
+// placeholders: reintroducing a value-carrying parameter and rendering it fails
+// this test.
+func TestCheckRegistryCredentialRendersOnlyRedactedPlaceholders(t *testing.T) {
 	t.Parallel()
 
 	result := clusterupdate.NewEmptyUpdateResult()
@@ -68,10 +62,12 @@ func TestCheckRegistryCredentialNeverRendersTheCredential(t *testing.T) {
 	}
 
 	change := result.InPlaceChanges[0]
-	for _, rendered := range []string{change.OldValue, change.NewValue, change.Reason} {
-		if strings.Contains(rendered, theSecretPassword) {
-			t.Errorf("rendered value %q leaks the credential", rendered)
-		}
+	if change.OldValue != "stale (redacted)" {
+		t.Errorf("old value = %q, want the fixed redacted placeholder", change.OldValue)
+	}
+
+	if change.NewValue != "rotated (redacted)" {
+		t.Errorf("new value = %q, want the fixed redacted placeholder", change.NewValue)
 	}
 }
 

--- a/pkg/svc/installer/flux/export_test.go
+++ b/pkg/svc/installer/flux/export_test.go
@@ -58,6 +58,11 @@ func BuildRegistrySecret(clusterCfg *v1alpha1.Cluster) (*corev1.Secret, error) {
 	return buildRegistrySecret(clusterCfg)
 }
 
+// DockerConfigsDiffer exports dockerConfigsDiffer for testing.
+func DockerConfigsDiffer(current, desired []byte) bool {
+	return dockerConfigsDiffer(current, desired)
+}
+
 // IsTransientAPIError exports isTransientAPIError for testing.
 func IsTransientAPIError(err error) bool {
 	return isTransientAPIError(err)

--- a/pkg/svc/installer/flux/export_test.go
+++ b/pkg/svc/installer/flux/export_test.go
@@ -137,6 +137,17 @@ func SetNewFluxResourcesClient(fn func(*rest.Config) (any, error)) func() {
 	}
 }
 
+// SetNewCoreV1Client allows tests to replace newCoreV1Client with a fake, so the registry-Secret
+// read paths can be exercised against a synthetic cluster state.
+func SetNewCoreV1Client(fn func(*rest.Config) (client.Client, error)) func() {
+	original := newCoreV1Client
+	newCoreV1Client = fn
+
+	return func() {
+		newCoreV1Client = original
+	}
+}
+
 // SetLoadRESTConfig allows tests to replace loadRESTConfig with a stub.
 func SetLoadRESTConfig(fn func(string, string) (*rest.Config, error)) func() {
 	original := loadRESTConfig

--- a/pkg/svc/installer/flux/registry_credentials.go
+++ b/pkg/svc/installer/flux/registry_credentials.go
@@ -30,9 +30,14 @@ const (
 //
 // It is a no-op when the configured registry is not external or carries no
 // credentials.
+//
+// kubeContext must be the same context the drift check read from. An empty
+// context falls back to the kubeconfig's ambient current-context, which can be
+// a different cluster entirely — so a rotation detected on one cluster would be
+// written to another.
 func EnsureRegistryCredentials(
 	ctx context.Context,
-	kubeconfig string,
+	kubeconfig, kubeContext string,
 	clusterCfg *v1alpha1.Cluster,
 ) error {
 	if clusterCfg == nil {
@@ -43,7 +48,7 @@ func EnsureRegistryCredentials(
 		ctx = context.Background()
 	}
 
-	restConfig, err := loadRESTConfig(kubeconfig, "")
+	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/svc/installer/flux/registry_credentials.go
+++ b/pkg/svc/installer/flux/registry_credentials.go
@@ -1,0 +1,144 @@
+package fluxinstaller
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	fluxclient "github.com/devantler-tech/ksail/v7/pkg/client/flux"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// managedByLabel and managedByKSail identify a registry Secret KSail owns.
+// buildRegistrySecret stamps them on every Secret it writes, so their absence
+// means the Secret was created by something else — an ExternalSecret, a
+// platform bootstrap, or an operator — and KSail must not overwrite it.
+const (
+	managedByLabel = "app.kubernetes.io/managed-by"
+	managedByKSail = "ksail"
+)
+
+// EnsureRegistryCredentials writes the resolved registry pull credential to the
+// KSail-managed registry Secret. It is idempotent and independent of the
+// structural configuration diff, so a caller can refresh a rotated credential
+// without a configuration change and before any workload reconciliation that
+// depends on the Secret.
+//
+// It is a no-op when the configured registry is not external or carries no
+// credentials.
+func EnsureRegistryCredentials(
+	ctx context.Context,
+	kubeconfig string,
+	clusterCfg *v1alpha1.Cluster,
+) error {
+	if clusterCfg == nil {
+		return errInvalidClusterConfig
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	restConfig, err := loadRESTConfig(kubeconfig, "")
+	if err != nil {
+		return err
+	}
+
+	return ensureExternalRegistrySecret(ctx, restConfig, clusterCfg)
+}
+
+// DesiredRegistryCredentialDigest returns a digest of the docker config KSail
+// would write for the resolved configuration, or an empty string when the
+// registry is not external or carries no credentials.
+//
+// The digest never leaves the process: it exists so a rotation can be detected
+// without the caller ever handling — or rendering — the credential itself.
+func DesiredRegistryCredentialDigest(clusterCfg *v1alpha1.Cluster) (string, error) {
+	if clusterCfg == nil {
+		return "", nil
+	}
+
+	localRegistry := clusterCfg.Spec.Cluster.LocalRegistry
+	if !localRegistry.IsExternal() || !localRegistry.HasCredentials() {
+		return "", nil
+	}
+
+	secret, err := buildRegistrySecret(clusterCfg)
+	if err != nil {
+		return "", fmt.Errorf("build desired registry secret: %w", err)
+	}
+
+	return digestDockerConfig(secret.Data[corev1.DockerConfigJsonKey]), nil
+}
+
+// CurrentRegistryCredentialDigest reads the registry Secret from the cluster and
+// returns a digest of its docker config.
+//
+// It returns an empty digest — never an error — when there is nothing KSail may
+// safely compare against: the Secret does not exist, it holds no docker config,
+// or it is not labelled as KSail-managed. That last case is the ownership
+// boundary: a Secret supplied by an ExternalSecret must not be diffed into a
+// change that would have KSail overwrite it.
+func CurrentRegistryCredentialDigest(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
+	if err != nil {
+		return "", fmt.Errorf("build REST config: %w", err)
+	}
+
+	k8sClient, err := newCoreV1Client(restConfig)
+	if err != nil {
+		return "", err
+	}
+
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{
+		Name:      ExternalRegistrySecretName,
+		Namespace: fluxclient.DefaultNamespace,
+	}
+
+	err = k8sClient.Get(ctx, key, secret)
+	if apierrors.IsNotFound(err) {
+		return "", nil
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("get registry secret: %w", err)
+	}
+
+	if secret.Labels[managedByLabel] != managedByKSail {
+		return "", nil
+	}
+
+	dockerConfig := secret.Data[corev1.DockerConfigJsonKey]
+	if len(dockerConfig) == 0 {
+		return "", nil
+	}
+
+	return digestDockerConfig(dockerConfig), nil
+}
+
+// digestDockerConfig reduces a docker config to a comparable digest. An empty
+// input yields an empty digest so "absent" never collides with a real value —
+// a digest of the empty string is a fixed constant, and returning it would make
+// a missing credential compare equal to another missing credential and, worse,
+// unequal to every real one.
+func digestDockerConfig(dockerConfig []byte) string {
+	if len(dockerConfig) == 0 {
+		return ""
+	}
+
+	sum := sha256.Sum256(dockerConfig)
+
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/svc/installer/flux/registry_credentials.go
+++ b/pkg/svc/installer/flux/registry_credentials.go
@@ -2,8 +2,7 @@ package fluxinstaller
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
+	"crypto/subtle"
 	"fmt"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -52,50 +51,91 @@ func EnsureRegistryCredentials(
 	return ensureExternalRegistrySecret(ctx, restConfig, clusterCfg)
 }
 
-// DesiredRegistryCredentialDigest returns a digest of the docker config KSail
-// would write for the resolved configuration, or an empty string when the
-// registry is not external or carries no credentials.
-//
-// The digest never leaves the process: it exists so a rotation can be detected
-// without the caller ever handling — or rendering — the credential itself.
-func DesiredRegistryCredentialDigest(clusterCfg *v1alpha1.Cluster) (string, error) {
+// HasExternalRegistryCredentials reports whether the resolved configuration
+// carries a registry credential KSail would write. It reads only the shape of
+// the configuration, never the credential, so a caller can skip the cluster
+// query below without handling secret material.
+func HasExternalRegistryCredentials(clusterCfg *v1alpha1.Cluster) bool {
 	if clusterCfg == nil {
-		return "", nil
+		return false
 	}
 
 	localRegistry := clusterCfg.Spec.Cluster.LocalRegistry
-	if !localRegistry.IsExternal() || !localRegistry.HasCredentials() {
-		return "", nil
-	}
 
-	secret, err := buildRegistrySecret(clusterCfg)
-	if err != nil {
-		return "", fmt.Errorf("build desired registry secret: %w", err)
-	}
-
-	return digestDockerConfig(secret.Data[corev1.DockerConfigJsonKey]), nil
+	return localRegistry.IsExternal() && localRegistry.HasCredentials()
 }
 
-// CurrentRegistryCredentialDigest reads the registry Secret from the cluster and
-// returns a digest of its docker config.
+// RegistryCredentialDrifted reports whether the credential held in the
+// KSail-managed registry Secret differs from the one the resolved configuration
+// would write. Both values are compared inside this package, in constant time,
+// and neither the credential nor anything derived from it is returned — the
+// answer a caller needs is a single bit, so a single bit is all it gets.
 //
-// It returns an empty digest — never an error — when there is nothing KSail may
-// safely compare against: the Secret does not exist, it holds no docker config,
-// or it is not labelled as KSail-managed. That last case is the ownership
-// boundary: a Secret supplied by an ExternalSecret must not be diffed into a
-// change that would have KSail overwrite it.
-func CurrentRegistryCredentialDigest(
+// It reports false — never an error — when there is nothing KSail may safely
+// compare against: the Secret does not exist, it holds no docker config, or it
+// is not labelled as KSail-managed. That last case is the ownership boundary: a
+// Secret supplied by an ExternalSecret must not be diffed into a change that
+// would have KSail overwrite it.
+//
+// kubeContext selects the cluster to read. It must be the same context the
+// subsequent credential write targets, or drift detected on one cluster would be
+// repaired on another.
+func RegistryCredentialDrifted(
 	ctx context.Context,
 	kubeconfig, kubeContext string,
-) (string, error) {
+	clusterCfg *v1alpha1.Cluster,
+) (bool, error) {
+	if !HasExternalRegistryCredentials(clusterCfg) {
+		return false, nil
+	}
+
+	desired, err := buildRegistrySecret(clusterCfg)
+	if err != nil {
+		return false, fmt.Errorf("build desired registry secret: %w", err)
+	}
+
+	desiredConfig := desired.Data[corev1.DockerConfigJsonKey]
+	if len(desiredConfig) == 0 {
+		return false, nil
+	}
+
+	currentConfig, err := currentRegistryDockerConfig(ctx, kubeconfig, kubeContext)
+	if err != nil {
+		return false, err
+	}
+
+	return dockerConfigsDiffer(currentConfig, desiredConfig), nil
+}
+
+// dockerConfigsDiffer compares two docker configs in constant time.
+//
+// An empty side is never drift: an absent current config means the Secret does
+// not exist or is not KSail-managed, and reporting drift there would have KSail
+// overwrite a Secret it does not own. Comparing the credentials directly — rather
+// than digests of them — keeps the secret material inside this package and leaves
+// nothing guessable for a caller to leak.
+func dockerConfigsDiffer(current, desired []byte) bool {
+	if len(current) == 0 || len(desired) == 0 {
+		return false
+	}
+
+	return subtle.ConstantTimeCompare(current, desired) == 0
+}
+
+// currentRegistryDockerConfig reads the docker config from the KSail-managed
+// registry Secret, or returns nil when there is none KSail owns.
+func currentRegistryDockerConfig(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+) ([]byte, error) {
 	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
-		return "", fmt.Errorf("build REST config: %w", err)
+		return nil, fmt.Errorf("build REST config: %w", err)
 	}
 
 	k8sClient, err := newCoreV1Client(restConfig)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	secret := &corev1.Secret{}
@@ -106,36 +146,16 @@ func CurrentRegistryCredentialDigest(
 
 	err = k8sClient.Get(ctx, key, secret)
 	if apierrors.IsNotFound(err) {
-		return "", nil
+		return nil, nil
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("get registry secret: %w", err)
+		return nil, fmt.Errorf("get registry secret: %w", err)
 	}
 
 	if secret.Labels[managedByLabel] != managedByKSail {
-		return "", nil
+		return nil, nil
 	}
 
-	dockerConfig := secret.Data[corev1.DockerConfigJsonKey]
-	if len(dockerConfig) == 0 {
-		return "", nil
-	}
-
-	return digestDockerConfig(dockerConfig), nil
-}
-
-// digestDockerConfig reduces a docker config to a comparable digest. An empty
-// input yields an empty digest so "absent" never collides with a real value —
-// a digest of the empty string is a fixed constant, and returning it would make
-// a missing credential compare equal to another missing credential and, worse,
-// unequal to every real one.
-func digestDockerConfig(dockerConfig []byte) string {
-	if len(dockerConfig) == 0 {
-		return ""
-	}
-
-	sum := sha256.Sum256(dockerConfig)
-
-	return hex.EncodeToString(sum[:])
+	return secret.Data[corev1.DockerConfigJsonKey], nil
 }

--- a/pkg/svc/installer/flux/registry_credentials.go
+++ b/pkg/svc/installer/flux/registry_credentials.go
@@ -43,6 +43,13 @@ func EnsureRegistryCredentials(
 		return errInvalidClusterConfig
 	}
 
+	// Honour the documented no-op before reaching for the cluster. ensureExternalRegistrySecret
+	// already returns nil for a registry KSail would not write to, but only after a REST config has
+	// been resolved — so on a machine with no usable kubeconfig the "no-op" failed instead.
+	if !HasExternalRegistryCredentials(clusterCfg) {
+		return nil
+	}
+
 	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
 		return err
@@ -72,10 +79,14 @@ func HasExternalRegistryCredentials(clusterCfg *v1alpha1.Cluster) bool {
 // answer a caller needs is a single bit, so a single bit is all it gets.
 //
 // It reports false — never an error — when there is nothing KSail may safely
-// compare against: the Secret does not exist, it holds no docker config, or it
-// is not labelled as KSail-managed. That last case is the ownership boundary: a
-// Secret supplied by an ExternalSecret must not be diffed into a change that
-// would have KSail overwrite it.
+// compare against: the Secret does not exist, or it is not labelled as
+// KSail-managed. That second case is the ownership boundary: a Secret supplied
+// by an ExternalSecret must not be diffed into a change that would have KSail
+// overwrite it.
+//
+// A KSail-managed Secret carrying no docker config is the opposite case and
+// reports true. It is KSail's own Secret, so writing it is in bounds, and
+// leaving it alone would leave Flux unable to authenticate indefinitely.
 //
 // kubeContext selects the cluster to read. It must be the same context the
 // subsequent credential write targets, or drift detected on one cluster would be
@@ -99,9 +110,20 @@ func RegistryCredentialDrifted(
 		return false, nil
 	}
 
-	currentConfig, err := currentRegistryDockerConfig(ctx, kubeconfig, kubeContext)
+	currentConfig, owned, err := currentRegistryDockerConfig(ctx, kubeconfig, kubeContext)
 	if err != nil {
 		return false, err
+	}
+
+	// Absent or externally managed: nothing KSail may safely compare against, so never drift.
+	if !owned {
+		return false, nil
+	}
+
+	// Owned but carrying no docker config. Suppressing here would leave Flux unable to authenticate
+	// with no path back — the Secret is KSail's own, so refreshing it is safe and is the repair.
+	if len(currentConfig) == 0 {
+		return true, nil
 	}
 
 	return dockerConfigsDiffer(currentConfig, desiredConfig), nil
@@ -123,19 +145,26 @@ func dockerConfigsDiffer(current, desired []byte) bool {
 }
 
 // currentRegistryDockerConfig reads the docker config from the KSail-managed
-// registry Secret, or returns nil when there is none KSail owns.
+// registry Secret.
+//
+// owned reports whether the Secret exists AND is labelled KSail-managed — the
+// question of whether KSail may write it at all. It is returned separately from
+// the bytes because the two answers differ: an owned Secret carrying no docker
+// config is malformed rather than off-limits, and collapsing both into an empty
+// slice made that case indistinguishable from an absent one, so it was silently
+// left unrepaired.
 func currentRegistryDockerConfig(
 	ctx context.Context,
 	kubeconfig, kubeContext string,
-) ([]byte, error) {
+) ([]byte, bool, error) {
 	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
-		return nil, fmt.Errorf("build REST config: %w", err)
+		return nil, false, fmt.Errorf("build REST config: %w", err)
 	}
 
 	k8sClient, err := newCoreV1Client(restConfig)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	secret := &corev1.Secret{}
@@ -146,16 +175,16 @@ func currentRegistryDockerConfig(
 
 	err = k8sClient.Get(ctx, key, secret)
 	if apierrors.IsNotFound(err) {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("get registry secret: %w", err)
+		return nil, false, fmt.Errorf("get registry secret: %w", err)
 	}
 
 	if secret.Labels[managedByLabel] != managedByKSail {
-		return nil, nil
+		return nil, false, nil
 	}
 
-	return secret.Data[corev1.DockerConfigJsonKey], nil
+	return secret.Data[corev1.DockerConfigJsonKey], true, nil
 }

--- a/pkg/svc/installer/flux/registry_credentials.go
+++ b/pkg/svc/installer/flux/registry_credentials.go
@@ -44,10 +44,6 @@ func EnsureRegistryCredentials(
 		return errInvalidClusterConfig
 	}
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
 		return err
@@ -92,10 +88,6 @@ func CurrentRegistryCredentialDigest(
 	ctx context.Context,
 	kubeconfig, kubeContext string,
 ) (string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
 	if err != nil {
 		return "", fmt.Errorf("build REST config: %w", err)

--- a/pkg/svc/installer/flux/registry_credentials_test.go
+++ b/pkg/svc/installer/flux/registry_credentials_test.go
@@ -1,0 +1,96 @@
+package fluxinstaller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+// errStubREST stops the call before it reaches a real API server: this test is
+// about which context the write resolves, not about the write itself.
+var errStubREST = errors.New("stub rest config")
+
+// newExternalRegistryCluster builds a cluster whose registry carries inline
+// credentials. token is the password half — the value a rotation replaces.
+func newExternalRegistryCluster(kubeContext, token string) *v1alpha1.Cluster {
+	clusterCfg := v1alpha1.NewCluster()
+	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+	clusterCfg.Spec.Cluster.Connection.Context = kubeContext
+	clusterCfg.Spec.Cluster.LocalRegistry.Registry = "ksail-bot:" + token + "@ghcr.io/devantler-tech/repo"
+
+	return clusterCfg
+}
+
+// TestEnsureRegistryCredentialsUsesTheGivenContext pins the wiring, not the
+// logic. An empty kube context falls back to the kubeconfig's ambient
+// current-context, so a credential rotation detected on one cluster would be
+// written to whichever cluster the operator's kubeconfig happens to point at.
+// The threading is invisible to an end-to-end test that runs with a single
+// context, so assert the value the production call actually passes.
+func TestEnsureRegistryCredentialsUsesTheGivenContext(t *testing.T) {
+	var gotContext string
+
+	restore := fluxinstaller.SetLoadRESTConfig(
+		func(_, kubeContext string) (*rest.Config, error) {
+			gotContext = kubeContext
+
+			return nil, errStubREST
+		},
+	)
+	defer restore()
+
+	clusterCfg := newExternalRegistryCluster("admin@prod", "rotated-token")
+
+	err := fluxinstaller.EnsureRegistryCredentials(
+		context.Background(), "/tmp/kubeconfig", "admin@prod", clusterCfg,
+	)
+
+	require.ErrorIs(t, err, errStubREST)
+	assert.Equal(t, "admin@prod", gotContext,
+		"the credential write must target the context the drift check read from, "+
+			"not the ambient current-context")
+}
+
+// TestDesiredRegistryCredentialDigestSeparatesRotations is the property the
+// drift check depends on: two different credentials must not produce the same
+// digest, and an unchanged credential must reproduce its digest exactly.
+func TestDesiredRegistryCredentialDigestSeparatesRotations(t *testing.T) {
+	t.Parallel()
+
+	before := newExternalRegistryCluster("admin@prod", "first-token")
+
+	firstDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(before)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstDigest, "an external registry with credentials must yield a digest")
+
+	repeatDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(before)
+	require.NoError(t, err)
+	assert.Equal(t, firstDigest, repeatDigest,
+		"an unrotated credential must be stable, or every update reports false drift")
+
+	after := newExternalRegistryCluster("admin@prod", "a-different-token")
+
+	rotatedDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(after)
+	require.NoError(t, err)
+	assert.NotEqual(t, firstDigest, rotatedDigest,
+		"a rotated credential must change the digest, or the rotation is invisible")
+}
+
+// TestDesiredRegistryCredentialDigestEmptyWithoutCredentials keeps the drift
+// check inert when there is nothing for KSail to write.
+func TestDesiredRegistryCredentialDigestEmptyWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	clusterCfg := v1alpha1.NewCluster()
+
+	digest, err := fluxinstaller.DesiredRegistryCredentialDigest(clusterCfg)
+
+	require.NoError(t, err)
+	assert.Empty(t, digest)
+}

--- a/pkg/svc/installer/flux/registry_credentials_test.go
+++ b/pkg/svc/installer/flux/registry_credentials_test.go
@@ -33,6 +33,8 @@ func newExternalRegistryCluster(kubeContext, token string) *v1alpha1.Cluster {
 // written to whichever cluster the operator's kubeconfig happens to point at.
 // The threading is invisible to an end-to-end test that runs with a single
 // context, so assert the value the production call actually passes.
+//
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
 func TestEnsureRegistryCredentialsUsesTheGivenContext(t *testing.T) {
 	var gotContext string
 

--- a/pkg/svc/installer/flux/registry_credentials_test.go
+++ b/pkg/svc/installer/flux/registry_credentials_test.go
@@ -17,12 +17,17 @@ import (
 // about which context the write resolves, not about the write itself.
 var errStubREST = errors.New("stub rest config")
 
+// testKubeContext is the context every case below resolves. The drift read and
+// the credential write must both land on it: a test that let them differ would
+// pass while production delivered a rotated credential to the wrong cluster.
+const testKubeContext = "admin@prod"
+
 // newExternalRegistryCluster builds a cluster whose registry carries inline
 // credentials. token is the password half — the value a rotation replaces.
-func newExternalRegistryCluster(kubeContext, token string) *v1alpha1.Cluster {
+func newExternalRegistryCluster(token string) *v1alpha1.Cluster {
 	clusterCfg := v1alpha1.NewCluster()
 	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
-	clusterCfg.Spec.Cluster.Connection.Context = kubeContext
+	clusterCfg.Spec.Cluster.Connection.Context = testKubeContext
 	clusterCfg.Spec.Cluster.LocalRegistry.Registry = "ksail-bot:" + token + "@ghcr.io/devantler-tech/repo"
 
 	return clusterCfg
@@ -48,14 +53,14 @@ func TestEnsureRegistryCredentialsUsesTheGivenContext(t *testing.T) {
 	)
 	defer restore()
 
-	clusterCfg := newExternalRegistryCluster("admin@prod", "rotated-token")
+	clusterCfg := newExternalRegistryCluster("rotated-token")
 
 	err := fluxinstaller.EnsureRegistryCredentials(
-		context.Background(), "/tmp/kubeconfig", "admin@prod", clusterCfg,
+		context.Background(), "/tmp/kubeconfig", testKubeContext, clusterCfg,
 	)
 
 	require.ErrorIs(t, err, errStubREST)
-	assert.Equal(t, "admin@prod", gotContext,
+	assert.Equal(t, testKubeContext, gotContext,
 		"the credential write must target the context the drift check read from, "+
 			"not the ambient current-context")
 }
@@ -79,14 +84,14 @@ func TestRegistryCredentialDriftedReadsTheGivenContext(t *testing.T) {
 	)
 	defer restore()
 
-	clusterCfg := newExternalRegistryCluster("admin@prod", "rotated-token")
+	clusterCfg := newExternalRegistryCluster("rotated-token")
 
 	_, err := fluxinstaller.RegistryCredentialDrifted(
-		context.Background(), "/tmp/kubeconfig", "admin@prod", clusterCfg,
+		context.Background(), "/tmp/kubeconfig", testKubeContext, clusterCfg,
 	)
 
 	require.ErrorIs(t, err, errStubREST)
-	assert.Equal(t, "admin@prod", gotContext,
+	assert.Equal(t, testKubeContext, gotContext,
 		"the drift check must read the context the credential write targets, "+
 			"not the ambient current-context")
 }
@@ -104,7 +109,7 @@ func TestRegistryCredentialDriftedSkipsClusterWithoutCredentials(t *testing.T) {
 	defer restore()
 
 	drifted, err := fluxinstaller.RegistryCredentialDrifted(
-		context.Background(), "/tmp/kubeconfig", "admin@prod", v1alpha1.NewCluster(),
+		context.Background(), "/tmp/kubeconfig", testKubeContext, v1alpha1.NewCluster(),
 	)
 
 	require.NoError(t, err)
@@ -121,7 +126,7 @@ func TestHasExternalRegistryCredentials(t *testing.T) {
 		"a default cluster has no external registry")
 	assert.True(t,
 		fluxinstaller.HasExternalRegistryCredentials(
-			newExternalRegistryCluster("admin@prod", "a-token"),
+			newExternalRegistryCluster("a-token"),
 		),
 		"an external registry with inline credentials is worth a drift check")
 }
@@ -133,22 +138,26 @@ func TestBuildRegistrySecretSeparatesRotations(t *testing.T) {
 	t.Parallel()
 
 	before, err := fluxinstaller.BuildRegistrySecret(
-		newExternalRegistryCluster("admin@prod", "first-token"),
+		newExternalRegistryCluster("first-token"),
 	)
 	require.NoError(t, err)
 
 	repeat, err := fluxinstaller.BuildRegistrySecret(
-		newExternalRegistryCluster("admin@prod", "first-token"),
+		newExternalRegistryCluster("first-token"),
 	)
 	require.NoError(t, err)
 
 	after, err := fluxinstaller.BuildRegistrySecret(
-		newExternalRegistryCluster("admin@prod", "a-different-token"),
+		newExternalRegistryCluster("a-different-token"),
 	)
 	require.NoError(t, err)
 
 	firstConfig := before.Data[corev1.DockerConfigJsonKey]
-	require.NotEmpty(t, firstConfig, "an external registry with credentials must yield a docker config")
+	require.NotEmpty(
+		t,
+		firstConfig,
+		"an external registry with credentials must yield a docker config",
+	)
 
 	assert.False(t,
 		fluxinstaller.DockerConfigsDiffer(firstConfig, repeat.Data[corev1.DockerConfigJsonKey]),

--- a/pkg/svc/installer/flux/registry_credentials_test.go
+++ b/pkg/svc/installer/flux/registry_credentials_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // errStubREST stops the call before it reaches a real API server: this test is
@@ -114,6 +117,134 @@ func TestRegistryCredentialDriftedSkipsClusterWithoutCredentials(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.False(t, drifted)
+}
+
+// TestEnsureRegistryCredentialsSkipsClusterWithoutCredentials is the write-side
+// twin of the drift-check skip above. EnsureRegistryCredentials documents itself
+// as a no-op when the registry carries nothing KSail would write, but it used to
+// resolve a REST config first — so on a machine with no usable kubeconfig the
+// no-op failed. The stub fails any REST config build, so reaching for one at all
+// fails the test.
+//
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestEnsureRegistryCredentialsSkipsClusterWithoutCredentials(t *testing.T) {
+	restore := fluxinstaller.SetLoadRESTConfig(
+		func(_, _ string) (*rest.Config, error) { return nil, errStubREST },
+	)
+	defer restore()
+
+	err := fluxinstaller.EnsureRegistryCredentials(
+		context.Background(), "/tmp/kubeconfig", testKubeContext, v1alpha1.NewCluster(),
+	)
+
+	require.NoError(t, err, "a cluster with no external credential must be a no-op, not a failure")
+}
+
+// newFakeCoreV1Client returns a seam replacement serving the given objects, and
+// a restore func.
+func newFakeCoreV1Client(t *testing.T, objects ...client.Object) func() {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	restoreREST := fluxinstaller.SetLoadRESTConfig(
+		func(_, _ string) (*rest.Config, error) { return &rest.Config{}, nil },
+	)
+	restoreClient := fluxinstaller.SetNewCoreV1Client(
+		func(*rest.Config) (client.Client, error) { return fakeClient, nil },
+	)
+
+	return func() {
+		restoreClient()
+		restoreREST()
+	}
+}
+
+// registrySecret builds a Secret at the name/namespace the drift check reads,
+// with the given ownership label and docker config.
+func registrySecret(owned bool, dockerConfig []byte) *corev1.Secret {
+	secret := &corev1.Secret{}
+	secret.Name = fluxinstaller.ExternalRegistrySecretName
+	secret.Namespace = "flux-system"
+	secret.Type = corev1.SecretTypeDockerConfigJson
+
+	if owned {
+		secret.Labels = map[string]string{"app.kubernetes.io/managed-by": "ksail"}
+	} else {
+		secret.Labels = map[string]string{"app.kubernetes.io/managed-by": "external-secrets"}
+	}
+
+	if dockerConfig != nil {
+		secret.Data = map[string][]byte{corev1.DockerConfigJsonKey: dockerConfig}
+	}
+
+	return secret
+}
+
+// TestRegistryCredentialDriftedRepairsAnOwnedSecretWithNoDockerConfig covers the
+// case the ownership suppression used to swallow: a Secret KSail owns but whose
+// docker config is missing or empty is malformed, not off-limits. Reporting no
+// drift there leaves Flux unable to authenticate with nothing to trigger a
+// repair, whereas the Secret is KSail's own so rewriting it is in bounds.
+//
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestRegistryCredentialDriftedRepairsAnOwnedSecretWithNoDockerConfig(t *testing.T) {
+	for name, dockerConfig := range map[string][]byte{
+		"missing key": nil,
+		"empty value": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			restore := newFakeCoreV1Client(t, registrySecret(true, dockerConfig))
+			defer restore()
+
+			drifted, err := fluxinstaller.RegistryCredentialDrifted(
+				context.Background(), "/tmp/kubeconfig", testKubeContext,
+				newExternalRegistryCluster("a-token"),
+			)
+
+			require.NoError(t, err)
+			assert.True(t, drifted,
+				"a KSail-owned Secret with no docker config must be refreshed, not suppressed")
+		})
+	}
+}
+
+// TestRegistryCredentialDriftedSuppressesSecretsKSailDoesNotOwn is the boundary
+// the case above must not erode: an absent Secret and one managed by something
+// else both stay suppressed, because writing either would have KSail overwrite a
+// Secret it does not own.
+//
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestRegistryCredentialDriftedSuppressesSecretsKSailDoesNotOwn(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		restore := newFakeCoreV1Client(t)
+		defer restore()
+
+		drifted, err := fluxinstaller.RegistryCredentialDrifted(
+			context.Background(), "/tmp/kubeconfig", testKubeContext,
+			newExternalRegistryCluster("a-token"),
+		)
+
+		require.NoError(t, err)
+		assert.False(t, drifted)
+	})
+
+	t.Run("externally managed and empty", func(t *testing.T) {
+		restore := newFakeCoreV1Client(t, registrySecret(false, nil))
+		defer restore()
+
+		drifted, err := fluxinstaller.RegistryCredentialDrifted(
+			context.Background(), "/tmp/kubeconfig", testKubeContext,
+			newExternalRegistryCluster("a-token"),
+		)
+
+		require.NoError(t, err)
+		assert.False(t, drifted,
+			"ownership, not emptiness, is what suppresses a Secret KSail did not write")
+	})
 }
 
 // TestHasExternalRegistryCredentials pins the cheap predicate that decides

--- a/pkg/svc/installer/flux/registry_credentials_test.go
+++ b/pkg/svc/installer/flux/registry_credentials_test.go
@@ -9,6 +9,7 @@ import (
 	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -59,40 +60,119 @@ func TestEnsureRegistryCredentialsUsesTheGivenContext(t *testing.T) {
 			"not the ambient current-context")
 }
 
-// TestDesiredRegistryCredentialDigestSeparatesRotations is the property the
-// drift check depends on: two different credentials must not produce the same
-// digest, and an unchanged credential must reproduce its digest exactly.
-func TestDesiredRegistryCredentialDigestSeparatesRotations(t *testing.T) {
-	t.Parallel()
+// TestRegistryCredentialDriftedReadsTheGivenContext is the read-side twin of the
+// test above. The drift check and the credential write must resolve the same
+// cluster: detecting a rotation on one and repairing it on another would leave
+// the rotated cluster authenticating with the revoked value while KSail reports
+// success.
+//
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestRegistryCredentialDriftedReadsTheGivenContext(t *testing.T) {
+	var gotContext string
 
-	before := newExternalRegistryCluster("admin@prod", "first-token")
+	restore := fluxinstaller.SetLoadRESTConfig(
+		func(_, kubeContext string) (*rest.Config, error) {
+			gotContext = kubeContext
 
-	firstDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(before)
-	require.NoError(t, err)
-	require.NotEmpty(t, firstDigest, "an external registry with credentials must yield a digest")
+			return nil, errStubREST
+		},
+	)
+	defer restore()
 
-	repeatDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(before)
-	require.NoError(t, err)
-	assert.Equal(t, firstDigest, repeatDigest,
-		"an unrotated credential must be stable, or every update reports false drift")
+	clusterCfg := newExternalRegistryCluster("admin@prod", "rotated-token")
 
-	after := newExternalRegistryCluster("admin@prod", "a-different-token")
+	_, err := fluxinstaller.RegistryCredentialDrifted(
+		context.Background(), "/tmp/kubeconfig", "admin@prod", clusterCfg,
+	)
 
-	rotatedDigest, err := fluxinstaller.DesiredRegistryCredentialDigest(after)
-	require.NoError(t, err)
-	assert.NotEqual(t, firstDigest, rotatedDigest,
-		"a rotated credential must change the digest, or the rotation is invisible")
+	require.ErrorIs(t, err, errStubREST)
+	assert.Equal(t, "admin@prod", gotContext,
+		"the drift check must read the context the credential write targets, "+
+			"not the ambient current-context")
 }
 
-// TestDesiredRegistryCredentialDigestEmptyWithoutCredentials keeps the drift
-// check inert when there is nothing for KSail to write.
-func TestDesiredRegistryCredentialDigestEmptyWithoutCredentials(t *testing.T) {
-	t.Parallel()
+// TestRegistryCredentialDriftedSkipsClusterWithoutCredentials keeps the drift
+// check inert — and off the network — when there is nothing for KSail to write.
+// The stub fails any REST config build, so reaching the cluster at all fails the
+// test.
+//
+//nolint:paralleltest // Mutates shared test seams exposed by export_test.go.
+func TestRegistryCredentialDriftedSkipsClusterWithoutCredentials(t *testing.T) {
+	restore := fluxinstaller.SetLoadRESTConfig(
+		func(_, _ string) (*rest.Config, error) { return nil, errStubREST },
+	)
+	defer restore()
 
-	clusterCfg := v1alpha1.NewCluster()
-
-	digest, err := fluxinstaller.DesiredRegistryCredentialDigest(clusterCfg)
+	drifted, err := fluxinstaller.RegistryCredentialDrifted(
+		context.Background(), "/tmp/kubeconfig", "admin@prod", v1alpha1.NewCluster(),
+	)
 
 	require.NoError(t, err)
-	assert.Empty(t, digest)
+	assert.False(t, drifted)
+}
+
+// TestHasExternalRegistryCredentials pins the cheap predicate that decides
+// whether the cluster is worth querying at all.
+func TestHasExternalRegistryCredentials(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, fluxinstaller.HasExternalRegistryCredentials(nil))
+	assert.False(t, fluxinstaller.HasExternalRegistryCredentials(v1alpha1.NewCluster()),
+		"a default cluster has no external registry")
+	assert.True(t,
+		fluxinstaller.HasExternalRegistryCredentials(
+			newExternalRegistryCluster("admin@prod", "a-token"),
+		),
+		"an external registry with inline credentials is worth a drift check")
+}
+
+// TestBuildRegistrySecretSeparatesRotations is the property the drift check
+// depends on: rotating the password must change the docker config KSail would
+// write, or the comparison has nothing to see.
+func TestBuildRegistrySecretSeparatesRotations(t *testing.T) {
+	t.Parallel()
+
+	before, err := fluxinstaller.BuildRegistrySecret(
+		newExternalRegistryCluster("admin@prod", "first-token"),
+	)
+	require.NoError(t, err)
+
+	repeat, err := fluxinstaller.BuildRegistrySecret(
+		newExternalRegistryCluster("admin@prod", "first-token"),
+	)
+	require.NoError(t, err)
+
+	after, err := fluxinstaller.BuildRegistrySecret(
+		newExternalRegistryCluster("admin@prod", "a-different-token"),
+	)
+	require.NoError(t, err)
+
+	firstConfig := before.Data[corev1.DockerConfigJsonKey]
+	require.NotEmpty(t, firstConfig, "an external registry with credentials must yield a docker config")
+
+	assert.False(t,
+		fluxinstaller.DockerConfigsDiffer(firstConfig, repeat.Data[corev1.DockerConfigJsonKey]),
+		"an unrotated credential must be stable, or every update reports false drift")
+	assert.True(t,
+		fluxinstaller.DockerConfigsDiffer(firstConfig, after.Data[corev1.DockerConfigJsonKey]),
+		"a rotated credential must be visible, or the rotation is invisible to the update")
+}
+
+// TestDockerConfigsDifferSuppressesAnAbsentSide is the ownership boundary: an
+// absent current config means the Secret does not exist or is not KSail-managed,
+// and reporting drift there would have KSail overwrite a Secret owned by
+// something else (an ExternalSecret, a platform bootstrap).
+func TestDockerConfigsDifferSuppressesAnAbsentSide(t *testing.T) {
+	t.Parallel()
+
+	present := []byte(`{"auths":{"ghcr.io":{"auth":"dXNlcjpwYXNz"}}}`)
+
+	assert.False(t, fluxinstaller.DockerConfigsDiffer(nil, present),
+		"an absent current config is not drift — KSail does not own that Secret")
+	assert.False(t, fluxinstaller.DockerConfigsDiffer([]byte{}, present),
+		"an empty current config is not drift either")
+	assert.False(t, fluxinstaller.DockerConfigsDiffer(present, nil),
+		"no desired credential means there is nothing to write")
+	assert.False(t, fluxinstaller.DockerConfigsDiffer(present, present),
+		"an unrotated credential must not produce a change every update")
 }

--- a/pkg/svc/installer/flux/registry_secret.go
+++ b/pkg/svc/installer/flux/registry_secret.go
@@ -63,8 +63,11 @@ func ensureRegistrySecret(
 	return upsertSecret(ctx, k8sClient, secret)
 }
 
-// newCoreV1Client creates a Kubernetes client with core/v1 types registered.
-func newCoreV1Client(restConfig *rest.Config) (client.Client, error) {
+// newCoreV1Client creates a Kubernetes client with core/v1 types registered. It is a variable so
+// tests can substitute a fake, matching newKubernetesClient and the other client seams here.
+//
+//nolint:gochecknoglobals // Allows mocking for tests
+var newCoreV1Client = func(restConfig *rest.Config) (client.Client, error) {
 	scheme := runtime.NewScheme()
 
 	err := corev1.AddToScheme(scheme)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Rotating a registry token used to leave the cluster using the old one. `ksail cluster update`
deliberately hides registry passwords from the change summary, so rotating the token behind an
otherwise identical configuration looked like "nothing changed" and the update did nothing —
the cluster kept authenticating with the revoked credential until someone changed something
unrelated.

This is not theoretical: it took down a Platform production deploy on 2026-07-13, where every
pull failed on a revoked token and the deploy could not reach the step that would have refreshed
it.

## What

`ksail cluster update` now notices that the credential itself has changed and rewrites it, as an
ordinary in-place change alongside the others. Two properties worth knowing:

- **The credential is never shown.** The rotation is reported as "stale → rotated (redacted)";
  neither the token nor any fingerprint of it reaches the output.
- **A credential KSail does not own is left alone.** If the secret was supplied by something else
  (an ExternalSecret, a platform bootstrap), KSail reports no change and does not overwrite it.

Rotating a token stays an in-place operation — it never asks to rebuild the cluster.

Fixes #6107
