### PR TITLE
fix(clusterapi): bind local API EKS lifecycle actions to the creating region

### DIFF
--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -65,7 +65,12 @@ func eksDistributionConfig(
 	// A cluster that finished creating already has its region recorded in the eks.yaml written at
 	// create time. Re-rendering that file from the ambient AWS_REGION for a later delete/start/stop
 	// would point the action at a same-named cluster in whichever region is selected now, and would
-	// overwrite the only local evidence of the original target, so an existing binding always wins.
+	// overwrite the only local evidence of the original target, so an existing binding wins here.
+	//
+	// This is a lifecycle-only rule, and Create is what enforces that: it refuses a name whose
+	// completed create state remains (refuseEKSCreateOverCompletedState), so a create only ever
+	// reaches this function with no such state — the case boundEKSConfig answers with nil. Letting a
+	// binding steer a create would provision new cloud resources into the old region instead.
 	bound, err := boundEKSConfig(name)
 	if err != nil {
 		return nil, err
@@ -148,6 +153,49 @@ func eksCreateCompleted(name string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// refuseEKSCreateOverCompletedState rejects a create for a name whose completed EKS create state is
+// still on disk.
+//
+// Create otherwise gates only on live discovery and in-flight jobs, so a cluster removed out of band
+// — spec.json and eks.yaml left behind while discovery no longer reports it — lets the same name
+// through. The region binding below would then resolve against the region that cluster was created
+// in and provision new cloud resources there, while the operator believes they selected a different
+// one. This guard is what keeps the binding a lifecycle-only rule: a create can only proceed when no
+// completed state remains, and boundEKSConfig returns nil in exactly that case.
+//
+// Refusing is fail-closed rather than re-rendering the config from the ambient region. Per-provider
+// discovery failures are logged and skipped, so absence from the live set is not proof the remote
+// cluster is gone; re-rendering would overwrite the only local evidence binding a cluster that may
+// still be running, leaving it unreachable through KSail in its real region. Clearing the state is
+// therefore the operator's explicit act — and the delete path already performs it, resolving the
+// cluster from its ownership state and cleaning up when the provisioner reports nothing to delete.
+func refuseEKSCreateOverCompletedState(distribution v1alpha1.Distribution, name string) error {
+	if distribution != v1alpha1.DistributionEKS {
+		return nil
+	}
+
+	// Positive evidence only. An error here means the state store could not be read at all (an
+	// unreadable home, a name whose state records another distribution), which is not evidence that a
+	// create completed — and turning every such read into a synchronous create refusal would change a
+	// path that already has its own handling: the real factory resolves the same predicate a moment
+	// later and fails the job with the underlying error, which is where that failure is reported.
+	// Swallowing it here therefore narrows this guard to the case it exists for and leaves every
+	// other outcome exactly as it was.
+	completed, err := eksCreateCompleted(name)
+	if err != nil || !completed {
+		//nolint:nilerr // an undeterminable read is not proof of a completed create; see above.
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: %q still has local state from a completed EKS create, which binds it to the region it"+
+			" was created in. Creating it again would provision new resources in that region rather"+
+			" than the one selected now. Run `ksail cluster delete --name %s` to remove the cluster"+
+			" and clear that state — it succeeds even when the cluster is already gone — then retry",
+		api.ErrAlreadyExists, name, name,
+	)
 }
 
 // boundEKSConfig returns the EKS target recorded when the named cluster was created, or nil when

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -210,11 +210,80 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 		)
 	}
 
+	err = confirmConfigMatchesOwnership(name, configPath, parsed.Metadata.Region)
+	if err != nil {
+		return nil, err
+	}
+
 	return &clusterprovisioner.EKSConfig{
 		Name:       name,
 		Region:     parsed.Metadata.Region,
 		ConfigPath: configPath,
 	}, nil
+}
+
+// confirmConfigMatchesOwnership refuses a config whose region the immutable ownership record
+// contradicts, and refuses either way when records exist for more than one region.
+//
+// The config is a RENDERED file: before this binding existed, every delete, start and stop
+// re-rendered it from the ambient AWS_REGION, so a stale one on disk can name a region the cluster
+// was never created in. The ownership record cannot drift that way — it is written once, after AWS
+// confirmed the create, and is scoped to the region it names. Reading the config without consulting
+// the record therefore left exactly the redirect this binding exists to prevent, for any cluster
+// whose file predates it: a delete would aim at a same-named cluster in the file's region.
+//
+// The disagreement is REFUSED rather than resolved in the record's favour, even though the record is
+// the more trustworthy source. Preferring it would mean re-rendering the config, and
+// writeEKSConfig writes a DEFAULT eksctl config — so silently overwriting a file an operator had
+// customised (node groups, addons, networking) would destroy real configuration to fix a region
+// field. Naming the conflict and stopping is the only non-destructive answer; the operator can
+// delete whichever artifact is wrong.
+//
+// Multiple records mean several same-named clusters in different regions. That is unanswerable here
+// whether or not a config exists, so the presence of a file must not suppress it — picking the
+// file's region would aim a destructive action at a cluster nobody named.
+func confirmConfigMatchesOwnership(name, configPath, configRegion string) error {
+	ownerships, err := state.ListEKSOwnershipStates(name)
+	if err != nil {
+		// No usable record: the config is the only binding evidence there is, and it is already
+		// validated above. A cluster created before ownership records existed still works.
+		return nil //nolint:nilerr // absence of a record is not an error; the config binds instead.
+	}
+
+	if len(ownerships) > 1 {
+		return multiRegionOwnershipError(name, ownerships)
+	}
+
+	if len(ownerships) == 1 && ownerships[0].Region != configRegion {
+		return fmt.Errorf(
+			"%w: cluster %q has an immutable ownership record for region %s, but %s says region %s."+
+				" The config is re-rendered by ordinary commands and can be stale, while the"+
+				" ownership record is written once after the cluster was created, so acting on the"+
+				" config could target a same-named cluster in the wrong region."+
+				" KSail will not guess: delete %s to rebind from the ownership record, or remove the"+
+				" ownership record if it is the one that is wrong",
+			api.ErrInvalid, name, ownerships[0].Region, configPath, configRegion, configPath,
+		)
+	}
+
+	return nil
+}
+
+// multiRegionOwnershipError reports same-named clusters recorded in several regions.
+func multiRegionOwnershipError(name string, ownerships []*state.EKSOwnershipState) error {
+	regions := make([]string, 0, len(ownerships))
+	for _, ownership := range ownerships {
+		regions = append(regions, ownership.Region)
+	}
+
+	return fmt.Errorf(
+		"%w: cluster %q has ownership records in more than one region (%s), so KSail cannot tell"+
+			" which cluster this action means; delete the records for the regions you do not mean"+
+			" before retrying",
+		api.ErrInvalid,
+		name,
+		strings.Join(regions, ", "),
+	)
 }
 
 // bindFromOwnershipRecord binds a cluster to its creation region using the immutable EKS ownership
@@ -247,19 +316,7 @@ func bindFromOwnershipRecord(name string) (*clusterprovisioner.EKSConfig, error)
 	}
 
 	if len(ownerships) > 1 {
-		regions := make([]string, 0, len(ownerships))
-		for _, ownership := range ownerships {
-			regions = append(regions, ownership.Region)
-		}
-
-		return nil, fmt.Errorf(
-			"%w: cluster %q has ownership records in more than one region (%s), so KSail cannot tell"+
-				" which cluster this action means; delete the records for the regions you do not mean"+
-				" before retrying",
-			api.ErrInvalid,
-			name,
-			strings.Join(regions, ", "),
-		)
+		return nil, multiRegionOwnershipError(name, ownerships)
 	}
 
 	region := ownerships[0].Region

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -82,15 +82,20 @@ func eksDistributionConfig(
 		return nil, err
 	}
 
-	// An empty region would be stamped into metadata.region, and boundEKSConfig rejects such a file
-	// permanently once persisted state exists — leaving a cluster that can never be deleted, started
-	// or stopped through KSail. Refuse while nothing has been written instead.
+	// Resolve the region HERE rather than letting the scaffolder substitute its default further
+	// down. Both paths would otherwise derive it independently: writeEKSConfig renders through
+	// scaffolder.DefaultEKSConfigParams, which replaces an empty region with its own default, so
+	// metadata.region would carry that default while the region bound into persisted state stayed
+	// empty. boundEKSConfig then compares the two and rejects the file permanently — a cluster that
+	// can never be deleted, started or stopped through KSail.
+	//
+	// Refusing the create instead would be the wrong fix for that: an unset AWS_REGION is a
+	// supported path (credentials or a named profile are enough for AWS discovery), and the empty
+	// region it was said to stamp could never reach the file. One resolved value, used by both
+	// sides, keeps the binding honest without removing the path.
 	region := os.Getenv(credentials.DefaultEnvVar(credentials.AWSRegion))
 	if region == "" {
-		return nil, fmt.Errorf(
-			"%w: no AWS region is selected for EKS cluster %q; set %s and create it again",
-			api.ErrInvalid, name, credentials.DefaultEnvVar(credentials.AWSRegion),
-		)
+		region = scaffolder.DefaultEKSConfigParams(name, "").Region
 	}
 
 	configPath, err := writeEKSConfig(name, region)

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -254,19 +254,24 @@ func confirmConfigMatchesOwnership(name, configPath, configRegion string) error 
 		return multiRegionOwnershipError(name, ownerships)
 	}
 
-	if len(ownerships) == 1 && ownerships[0].Region != configRegion {
-		return fmt.Errorf(
-			"%w: cluster %q has an immutable ownership record for region %s, but %s says region %s."+
-				" The config is re-rendered by ordinary commands and can be stale, while the"+
-				" ownership record is written once after the cluster was created, so acting on the"+
-				" config could target a same-named cluster in the wrong region."+
-				" KSail will not guess: delete %s to rebind from the ownership record, or remove the"+
-				" ownership record if it is the one that is wrong",
-			api.ErrInvalid, name, ownerships[0].Region, configPath, configRegion, configPath,
-		)
+	if len(ownerships) != 1 || ownerships[0].Region == configRegion {
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf(
+		"%w: cluster %q has an immutable ownership record for region %s, but %s says region %s."+
+			" The config is re-rendered by ordinary commands and can be stale, while the"+
+			" ownership record is written once after the cluster was created, so acting on the"+
+			" config could target a same-named cluster in the wrong region."+
+			" KSail will not guess: delete %s to rebind from the ownership record, or remove"+
+			" the ownership record if it is the one that is wrong",
+		api.ErrInvalid,
+		name,
+		ownerships[0].Region,
+		configPath,
+		configRegion,
+		configPath,
+	)
 }
 
 // multiRegionOwnershipError reports same-named clusters recorded in several regions.

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -3,8 +3,10 @@ package clusterapi
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
@@ -180,6 +182,10 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 
 	content, err := fsutil.ReadFileSafe(clustersRoot, configPath)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return bindFromOwnershipRecord(name)
+		}
+
 		return nil, fmt.Errorf(
 			"%w: read the eks config that binds cluster %q to its region: %w",
 			api.ErrInvalid, name, err,
@@ -207,6 +213,65 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 	return &clusterprovisioner.EKSConfig{
 		Name:       name,
 		Region:     parsed.Metadata.Region,
+		ConfigPath: configPath,
+	}, nil
+}
+
+// bindFromOwnershipRecord binds a cluster to its creation region using the immutable EKS ownership
+// record, for a cluster whose eks.yaml is not in the state directory.
+//
+// `ksail cluster create` scaffolds eks.yaml into the PROJECT directory, while only the local API
+// backend writes one under ~/.ksail/clusters/<name>. Persisted cluster state is written by both, so
+// a CLI-created cluster reached the bound path and then failed reading a file nothing had put
+// there — breaking every start, stop and delete for exactly the clusters created the normal way.
+//
+// The ownership record is the better binding for both: it is the immutable, region-scoped identity
+// captured after AWS confirmed the create, so it cannot drift with the ambient region the way a
+// re-rendered config can. The config is materialised from that recorded region so the provisioner
+// still gets the on-disk file it requires.
+//
+// Several records mean several same-named clusters in different regions, which is a question only
+// the operator can answer. Picking one would aim a destructive action at a cluster nobody named, so
+// this refuses and lists them.
+func bindFromOwnershipRecord(name string) (*clusterprovisioner.EKSConfig, error) {
+	ownerships, err := state.ListEKSOwnershipStates(name)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: cluster %q has local KSail state but no eks config and no ownership record to bind"+
+				" it to a region; run `ksail cluster eks-bind` to record the region it was created"+
+				" in before starting, stopping or deleting it: %w",
+			api.ErrInvalid,
+			name,
+			err,
+		)
+	}
+
+	if len(ownerships) > 1 {
+		regions := make([]string, 0, len(ownerships))
+		for _, ownership := range ownerships {
+			regions = append(regions, ownership.Region)
+		}
+
+		return nil, fmt.Errorf(
+			"%w: cluster %q has ownership records in more than one region (%s), so KSail cannot tell"+
+				" which cluster this action means; delete the records for the regions you do not mean"+
+				" before retrying",
+			api.ErrInvalid,
+			name,
+			strings.Join(regions, ", "),
+		)
+	}
+
+	region := ownerships[0].Region
+
+	configPath, err := writeEKSConfig(name, region)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterprovisioner.EKSConfig{
+		Name:       name,
+		Region:     region,
 		ConfigPath: configPath,
 	}, nil
 }

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -1,6 +1,7 @@
 package clusterapi
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,9 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil/scaffolder"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 	"github.com/devantler-tech/ksail/v7/pkg/webui/api"
+	"sigs.k8s.io/yaml"
 )
 
 // File modes for the generated EKS config under ~/.ksail/clusters/<name>.
@@ -57,6 +60,19 @@ func distributionConfig(
 func eksDistributionConfig(
 	name string,
 ) (*clusterprovisioner.DistributionConfig, error) {
+	// A cluster that finished creating already has its region recorded in the eks.yaml written at
+	// create time. Re-rendering that file from the ambient AWS_REGION for a later delete/start/stop
+	// would point the action at a same-named cluster in whichever region is selected now, and would
+	// overwrite the only local evidence of the original target, so an existing binding always wins.
+	bound, err := boundEKSConfig(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if bound != nil {
+		return &clusterprovisioner.DistributionConfig{EKS: bound}, nil
+	}
+
 	region := os.Getenv(credentials.DefaultEnvVar(credentials.AWSRegion))
 
 	configPath, err := writeEKSConfig(name, region)
@@ -67,6 +83,101 @@ func eksDistributionConfig(
 	return &clusterprovisioner.DistributionConfig{
 		EKS: &clusterprovisioner.EKSConfig{Name: name, Region: region, ConfigPath: configPath},
 	}, nil
+}
+
+// eksConfigMetadata is the subset of an eksctl ClusterConfig this package reads back: the region
+// bound when the cluster was created.
+type eksConfigMetadata struct {
+	Metadata struct {
+		Region string `json:"region"`
+	} `json:"metadata"`
+}
+
+// boundEKSConfig returns the EKS target recorded when the named cluster was created, or nil when
+// there is no such record and the caller should render a fresh config.
+//
+// Persisted cluster state is the discriminator: it is written only after a provisioner reports a
+// successful create, so its absence means either a first create or a retry after a failed one —
+// both of which must honour the region selected now. Once it exists, every subsequent action is a
+// mutation of an existing remote cluster and is bound to the region that created it.
+//
+// Missing or unreadable evidence for a cluster that did complete creation is an error rather than a
+// silent fall back to the ambient region: the fallback is precisely the redirect being prevented.
+func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
+	if name == "" {
+		return nil, nil //nolint:nilnil // no cluster to bind: discovery-time factory construction.
+	}
+
+	_, err := state.LoadClusterSpec(name)
+	if err != nil {
+		if errors.Is(err, state.ErrStateNotFound) {
+			return nil, nil //nolint:nilnil // not created yet: caller renders from the ambient region.
+		}
+
+		return nil, fmt.Errorf(
+			"%w: read local KSail state for EKS cluster %q: %w", api.ErrInvalid, name, err,
+		)
+	}
+
+	configPath, err := existingEKSConfigPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:gosec // configPath is contained within ~/.ksail/clusters (see canonicalClusterDir).
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: read the eks config that binds cluster %q to its region: %w",
+			api.ErrInvalid, name, err,
+		)
+	}
+
+	var parsed eksConfigMetadata
+
+	err = yaml.Unmarshal(content, &parsed)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: parse the eks config that binds cluster %q to its region: %w",
+			api.ErrInvalid, name, err,
+		)
+	}
+
+	if parsed.Metadata.Region == "" {
+		return nil, fmt.Errorf(
+			"%w: the eks config for cluster %q records no region, so its target cannot be"+
+				" confirmed; run `ksail cluster rebind-eks-ownership --name %s` to re-establish it",
+			api.ErrInvalid, name, name,
+		)
+	}
+
+	return &clusterprovisioner.EKSConfig{
+		Name:       name,
+		Region:     parsed.Metadata.Region,
+		ConfigPath: configPath,
+	}, nil
+}
+
+// existingEKSConfigPath resolves the eks.yaml of an already-created cluster without creating any
+// directory, applying the same containment checks as the write path.
+func existingEKSConfigPath(name string) (string, error) {
+	if !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." || name == ".." {
+		return "", fmt.Errorf(
+			"%w: cluster name %q must be a single path segment", api.ErrInvalid, name,
+		)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	dir, err := canonicalClusterDir(filepath.Join(home, ".ksail", "clusters"), name)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, scaffolder.EKSConfigFile), nil
 }
 
 // writeEKSConfig renders and writes the eks.yaml for a cluster, returning its path. The name must be

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -116,6 +116,38 @@ type eksConfigMetadata struct {
 	} `json:"metadata"`
 }
 
+// eksCreateCompleted reports whether persisted state shows an EKS create completed for name.
+//
+// State is written for EVERY distribution, so its existence alone does not prove that: it may
+// belong to a Kind or Talos cluster of the same name. Entering the bound path on that would look
+// for an eks.yaml nothing wrote and report a missing-file read error, hiding the name collision the
+// user actually has. A collision is reported rather than treated as a fresh create, because two
+// clusters would otherwise share one state directory and the second create would overwrite the
+// first record.
+func eksCreateCompleted(name string) (bool, error) {
+	spec, err := state.LoadClusterSpec(name)
+	if err != nil {
+		if errors.Is(err, state.ErrStateNotFound) {
+			// Not created yet: the caller renders from the ambient region.
+			return false, nil
+		}
+
+		return false, fmt.Errorf(
+			"%w: read local KSail state for EKS cluster %q: %w", api.ErrInvalid, name, err,
+		)
+	}
+
+	if spec != nil && spec.Distribution != v1alpha1.DistributionEKS {
+		return false, fmt.Errorf(
+			"%w: local KSail state for cluster %q records the %s distribution, not EKS; "+
+				"delete that cluster or choose another name before creating it on EKS",
+			api.ErrInvalid, name, spec.Distribution,
+		)
+	}
+
+	return true, nil
+}
+
 // boundEKSConfig returns the EKS target recorded when the named cluster was created, or nil when
 // there is no such record and the caller should render a fresh config.
 //
@@ -131,29 +163,9 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 		return nil, nil //nolint:nilnil // no cluster to bind: discovery-time factory construction.
 	}
 
-	spec, err := state.LoadClusterSpec(name)
-	if err != nil {
-		if errors.Is(err, state.ErrStateNotFound) {
-			return nil, nil //nolint:nilnil // not created yet: caller renders from the ambient region.
-		}
-
-		return nil, fmt.Errorf(
-			"%w: read local KSail state for EKS cluster %q: %w", api.ErrInvalid, name, err,
-		)
-	}
-
-	// State is written for EVERY distribution, so its existence alone does not mean an EKS create
-	// completed — it may belong to a Kind or Talos cluster of the same name. Entering the bound path
-	// on that would look for an eks.yaml nothing wrote and report a missing-file read error, hiding
-	// the name collision the user actually has. Report the collision instead of treating it as a
-	// fresh create: two clusters would otherwise share one state directory, and the second create
-	// would overwrite the first record.
-	if spec != nil && spec.Distribution != v1alpha1.DistributionEKS {
-		return nil, fmt.Errorf(
-			"%w: local KSail state for cluster %q records the %s distribution, not EKS; "+
-				"delete that cluster or choose another name before creating it on EKS",
-			api.ErrInvalid, name, spec.Distribution,
-		)
+	created, err := eksCreateCompleted(name)
+	if err != nil || !created {
+		return nil, err
 	}
 
 	configPath, err := eksConfigPath(name, false)

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -175,18 +175,47 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 		return nil, err
 	}
 
-	clustersRoot, err := eksClustersRoot()
+	region, found, err := boundEKSRegionFromConfig(name, configPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if !found {
+		return bindFromOwnershipRecord(name)
+	}
+
+	err = confirmConfigMatchesOwnership(name, configPath, region)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterprovisioner.EKSConfig{
+		Name:       name,
+		Region:     region,
+		ConfigPath: configPath,
+	}, nil
+}
+
+// boundEKSRegionFromConfig reads the region out of the rendered eks config that binds the named
+// cluster to its target.
+//
+// found reports whether that config exists. It is false only when the file is absent, which leaves
+// the immutable ownership record as the sole surviving evidence of the original target; every other
+// unreadable or incomplete state is an error, because guessing a region is the redirect this
+// binding exists to prevent.
+func boundEKSRegionFromConfig(name, configPath string) (string, bool, error) {
+	clustersRoot, err := eksClustersRoot()
+	if err != nil {
+		return "", false, err
 	}
 
 	content, err := fsutil.ReadFileSafe(clustersRoot, configPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return bindFromOwnershipRecord(name)
+			return "", false, nil
 		}
 
-		return nil, fmt.Errorf(
+		return "", false, fmt.Errorf(
 			"%w: read the eks config that binds cluster %q to its region: %w",
 			api.ErrInvalid, name, err,
 		)
@@ -196,30 +225,21 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 
 	err = yaml.Unmarshal(content, &parsed)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return "", false, fmt.Errorf(
 			"%w: parse the eks config that binds cluster %q to its region: %w",
 			api.ErrInvalid, name, err,
 		)
 	}
 
 	if parsed.Metadata.Region == "" {
-		return nil, fmt.Errorf(
+		return "", false, fmt.Errorf(
 			"%w: the eks config for cluster %q records no region, so its target cannot be"+
 				" confirmed; set metadata.region in %s to the region the cluster was created in",
 			api.ErrInvalid, name, configPath,
 		)
 	}
 
-	err = confirmConfigMatchesOwnership(name, configPath, parsed.Metadata.Region)
-	if err != nil {
-		return nil, err
-	}
-
-	return &clusterprovisioner.EKSConfig{
-		Name:       name,
-		Region:     parsed.Metadata.Region,
-		ConfigPath: configPath,
-	}, nil
+	return parsed.Metadata.Region, true, nil
 }
 
 // confirmConfigMatchesOwnership refuses a config whose region the immutable ownership record

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -73,7 +73,25 @@ func eksDistributionConfig(
 		return &clusterprovisioner.DistributionConfig{EKS: bound}, nil
 	}
 
+	// Validate the name first so a malformed one keeps reporting itself. The region check below
+	// would otherwise fire for every name whenever no region is selected, masking the name error
+	// behind an environment one. This is the name check alone — resolving the full path here would
+	// canonicalize a ~/.ksail/clusters that a first create has not created yet.
+	err = validateClusterSegmentName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// An empty region would be stamped into metadata.region, and boundEKSConfig rejects such a file
+	// permanently once persisted state exists — leaving a cluster that can never be deleted, started
+	// or stopped through KSail. Refuse while nothing has been written instead.
 	region := os.Getenv(credentials.DefaultEnvVar(credentials.AWSRegion))
+	if region == "" {
+		return nil, fmt.Errorf(
+			"%w: no AWS region is selected for EKS cluster %q; set %s and create it again",
+			api.ErrInvalid, name, credentials.DefaultEnvVar(credentials.AWSRegion),
+		)
+	}
 
 	configPath, err := writeEKSConfig(name, region)
 	if err != nil {
@@ -124,8 +142,12 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 		return nil, err
 	}
 
-	//nolint:gosec // configPath is contained within ~/.ksail/clusters (see canonicalClusterDir).
-	content, err := os.ReadFile(configPath)
+	clustersRoot, err := eksClustersRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := fsutil.ReadFileSafe(clustersRoot, configPath)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"%w: read the eks config that binds cluster %q to its region: %w",
@@ -146,8 +168,8 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 	if parsed.Metadata.Region == "" {
 		return nil, fmt.Errorf(
 			"%w: the eks config for cluster %q records no region, so its target cannot be"+
-				" confirmed; run `ksail cluster rebind-eks-ownership --name %s` to re-establish it",
-			api.ErrInvalid, name, name,
+				" confirmed; set metadata.region in %s to the region the cluster was created in",
+			api.ErrInvalid, name, configPath,
 		)
 	}
 
@@ -170,20 +192,15 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 // createDir distinguishes the two callers: the write path creates the directory, while reading an
 // existing cluster's binding must not bring one into existence.
 func eksConfigPath(name string, createDir bool) (string, error) {
-	if !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." || name == ".." {
-		return "", fmt.Errorf(
-			"%w: cluster name %q must be a single path segment",
-			api.ErrInvalid,
-			name,
-		)
-	}
-
-	home, err := os.UserHomeDir()
+	err := validateClusterSegmentName(name)
 	if err != nil {
-		return "", fmt.Errorf("resolve home directory: %w", err)
+		return "", err
 	}
 
-	clustersRoot := filepath.Join(home, ".ksail", "clusters")
+	clustersRoot, err := eksClustersRoot()
+	if err != nil {
+		return "", err
+	}
 
 	if createDir {
 		mkErr := os.MkdirAll(filepath.Join(clustersRoot, name), eksConfigDirMode)
@@ -216,6 +233,36 @@ func writeEKSConfig(name, region string) (string, error) {
 	}
 
 	return configPath, nil
+}
+
+// validateClusterSegmentName rejects any cluster name that would not become exactly one directory
+// under ~/.ksail/clusters. filepath.IsLocal alone is insufficient — it still permits multi-segment
+// names like "foo/bar" and ".", which would redirect the path into an unintended nested directory —
+// so the name must also equal its own base element, and the "." / ".." specials are rejected.
+//
+// It is separated from eksConfigPath so callers can reject a bad name without touching the
+// filesystem, which matters before ~/.ksail/clusters exists.
+func validateClusterSegmentName(name string) error {
+	if !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." || name == ".." {
+		return fmt.Errorf(
+			"%w: cluster name %q must be a single path segment",
+			api.ErrInvalid,
+			name,
+		)
+	}
+
+	return nil
+}
+
+// eksClustersRoot resolves ~/.ksail/clusters — the single directory every generated cluster config
+// is confined to, and therefore the base every read of one is bounded by.
+func eksClustersRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	return filepath.Join(home, ".ksail", "clusters"), nil
 }
 
 // canonicalClusterDir canonicalizes ~/.ksail/clusters/<name> (resolving symlinks) and confirms it

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -131,7 +131,7 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 		return nil, nil //nolint:nilnil // no cluster to bind: discovery-time factory construction.
 	}
 
-	_, err := state.LoadClusterSpec(name)
+	spec, err := state.LoadClusterSpec(name)
 	if err != nil {
 		if errors.Is(err, state.ErrStateNotFound) {
 			return nil, nil //nolint:nilnil // not created yet: caller renders from the ambient region.
@@ -139,6 +139,20 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 
 		return nil, fmt.Errorf(
 			"%w: read local KSail state for EKS cluster %q: %w", api.ErrInvalid, name, err,
+		)
+	}
+
+	// State is written for EVERY distribution, so its existence alone does not mean an EKS create
+	// completed — it may belong to a Kind or Talos cluster of the same name. Entering the bound path
+	// on that would look for an eks.yaml nothing wrote and report a missing-file read error, hiding
+	// the name collision the user actually has. Report the collision instead of treating it as a
+	// fresh create: two clusters would otherwise share one state directory, and the second create
+	// would overwrite the first record.
+	if spec != nil && spec.Distribution != v1alpha1.DistributionEKS {
+		return nil, fmt.Errorf(
+			"%w: local KSail state for cluster %q records the %s distribution, not EKS; "+
+				"delete that cluster or choose another name before creating it on EKS",
+			api.ErrInvalid, name, spec.Distribution,
 		)
 	}
 

--- a/pkg/cli/clusterapi/distconfig.go
+++ b/pkg/cli/clusterapi/distconfig.go
@@ -119,7 +119,7 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 		)
 	}
 
-	configPath, err := existingEKSConfigPath(name)
+	configPath, err := eksConfigPath(name, false)
 	if err != nil {
 		return nil, err
 	}
@@ -158,37 +158,18 @@ func boundEKSConfig(name string) (*clusterprovisioner.EKSConfig, error) {
 	}, nil
 }
 
-// existingEKSConfigPath resolves the eks.yaml of an already-created cluster without creating any
-// directory, applying the same containment checks as the write path.
-func existingEKSConfigPath(name string) (string, error) {
-	if !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." || name == ".." {
-		return "", fmt.Errorf(
-			"%w: cluster name %q must be a single path segment", api.ErrInvalid, name,
-		)
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory: %w", err)
-	}
-
-	dir, err := canonicalClusterDir(filepath.Join(home, ".ksail", "clusters"), name)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(dir, scaffolder.EKSConfigFile), nil
-}
-
-// writeEKSConfig renders and writes the eks.yaml for a cluster, returning its path. The name must be
-// a single path segment, and the resolved directory is verified to stay under ~/.ksail/clusters even
-// after symlink resolution, so neither a crafted name nor a symlinked cluster directory can redirect
-// the write outside the intended tree.
-func writeEKSConfig(name, region string) (string, error) {
-	// The name becomes exactly one directory under ~/.ksail/clusters, so it must be a single path
-	// segment. filepath.IsLocal alone is insufficient — it still permits multi-segment names like
-	// "foo/bar" and ".", which would redirect the write into an unintended nested directory — so also
-	// require the name to equal its own base element and reject the "." / ".." specials.
+// eksConfigPath resolves ~/.ksail/clusters/<name>/eks.yaml.
+//
+// The name becomes exactly one directory under ~/.ksail/clusters, so it must be a single path
+// segment. filepath.IsLocal alone is insufficient — it still permits multi-segment names like
+// "foo/bar" and ".", which would redirect the path into an unintended nested directory — so the
+// name must also equal its own base element, and the "." / ".." specials are rejected. The resolved
+// directory is then verified to stay under ~/.ksail/clusters even after symlink resolution, so
+// neither a crafted name nor a symlinked cluster directory can redirect it out of the intended tree.
+//
+// createDir distinguishes the two callers: the write path creates the directory, while reading an
+// existing cluster's binding must not bring one into existence.
+func eksConfigPath(name string, createDir bool) (string, error) {
 	if !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." || name == ".." {
 		return "", fmt.Errorf(
 			"%w: cluster name %q must be a single path segment",
@@ -204,9 +185,11 @@ func writeEKSConfig(name, region string) (string, error) {
 
 	clustersRoot := filepath.Join(home, ".ksail", "clusters")
 
-	mkErr := os.MkdirAll(filepath.Join(clustersRoot, name), eksConfigDirMode)
-	if mkErr != nil {
-		return "", fmt.Errorf("create eks config directory: %w", mkErr)
+	if createDir {
+		mkErr := os.MkdirAll(filepath.Join(clustersRoot, name), eksConfigDirMode)
+		if mkErr != nil {
+			return "", fmt.Errorf("create eks config directory: %w", mkErr)
+		}
 	}
 
 	dir, err := canonicalClusterDir(clustersRoot, name)
@@ -214,11 +197,19 @@ func writeEKSConfig(name, region string) (string, error) {
 		return "", err
 	}
 
-	configPath := filepath.Join(dir, scaffolder.EKSConfigFile)
+	return filepath.Join(dir, scaffolder.EKSConfigFile), nil
+}
+
+// writeEKSConfig renders and writes the eks.yaml for a cluster, returning its path.
+func writeEKSConfig(name, region string) (string, error) {
+	configPath, err := eksConfigPath(name, true)
+	if err != nil {
+		return "", err
+	}
+
 	content := scaffolder.RenderEKSConfig(scaffolder.DefaultEKSConfigParams(name, region))
 
-	// dir is canonicalized and verified within ~/.ksail/clusters by canonicalClusterDir above.
-	//nolint:gosec // configPath is contained within ~/.ksail/clusters (see canonicalClusterDir)
+	//nolint:gosec // eksConfigPath canonicalizes and contains configPath within ~/.ksail/clusters.
 	writeErr := os.WriteFile(configPath, content, eksConfigFileMode)
 	if writeErr != nil {
 		return "", fmt.Errorf("write eks config: %w", writeErr)

--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -128,3 +128,20 @@ func ExportEKSConfigForCreate(name string) (string, string, error) {
 
 	return config.EKS.ConfigPath, config.EKS.Region, nil
 }
+
+// ReplaceJobWithAnotherFailedEKSCreateForTest swaps the tracked job for a DIFFERENT job that is also
+// a failed EKS create. Every field the failed-create predicate tests is identical, so only comparing
+// the entry's identity can tell the two apart — which is what stops a delete clearing (and hiding)
+// the failure of a create it never approved.
+func (s *Service) ReplaceJobWithAnotherFailedEKSCreateForTest(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.jobs[name] = &job{
+		distribution: v1alpha1.DistributionEKS,
+		provider:     v1alpha1.ProviderAWS,
+		phase:        v1alpha1.ClusterPhaseFailed,
+		origin:       v1alpha1.ClusterPhaseProvisioning,
+		startedAt:    time.Now(),
+	}
+}

--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -2,6 +2,7 @@ package clusterapi
 
 import (
 	"context"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
@@ -63,6 +64,43 @@ func (s *Service) SetDockerStatusForTest(
 	probe func(ctx context.Context, distribution v1alpha1.Distribution, name string) clusterdiscovery.RunState,
 ) {
 	s.discoverer.DockerStatus = probe
+}
+
+// SetLoadClusterSpecForTest overrides the ownership-state read that clearedFailedEKSCreate performs
+// with the lock released. A test substitutes a loader that mutates the service's job table, which
+// lands the mutation precisely inside the unlocked window and makes the race deterministic — no
+// goroutines, no sleeps, no flakiness.
+func (s *Service) SetLoadClusterSpecForTest(
+	load func(clusterName string) (*v1alpha1.ClusterSpec, error),
+) {
+	s.loadClusterSpec = load
+}
+
+// ReplaceJobWithFailedStopForTest swaps the tracked job for one that began as a stop and ended in
+// Failed, mirroring what a start/stop registration does. It is the state a failed-create clearing
+// path must refuse: the remote cluster may well still be running.
+func (s *Service) ReplaceJobWithFailedStopForTest(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.jobs[name] = &job{
+		distribution: v1alpha1.DistributionEKS,
+		provider:     v1alpha1.ProviderAWS,
+		phase:        v1alpha1.ClusterPhaseFailed,
+		origin:       v1alpha1.ClusterPhaseStopped,
+		startedAt:    time.Now(),
+	}
+}
+
+// JobPresentForTest reports whether a job is still tracked for the cluster, so a test can assert the
+// refusal preserved the row rather than clearing it.
+func (s *Service) JobPresentForTest(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, found := s.jobs[name]
+
+	return found
 }
 
 // NewTestService returns a Service whose provisioner factory is overridden, so black-box tests can

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -44,7 +44,13 @@ type job struct {
 	distribution v1alpha1.Distribution
 	provider     v1alpha1.Provider
 	phase        v1alpha1.ClusterPhase
-	err          error
+	// origin is the phase the job was registered in, and it never changes. `phase` does: create,
+	// delete and start/stop all converge on Failed, so once a job has failed `phase` can no longer
+	// say which operation failed. Anything scoped to one operation must read this instead —
+	// clearedFailedEKSCreate is scoped to a failed CREATE, and without `origin` it could not tell
+	// that from a failed stop whose cluster is still live in AWS.
+	origin v1alpha1.ClusterPhase
+	err    error
 	// startedAt is when the operation began; it drives the status condition's transition time so the
 	// UI can show how long a create/delete has been running or has been failed.
 	startedAt time.Time
@@ -388,6 +394,7 @@ func (s *Service) Create(
 		distribution: distribution,
 		provider:     provider,
 		phase:        v1alpha1.ClusterPhaseProvisioning,
+		origin:       v1alpha1.ClusterPhaseProvisioning,
 		startedAt:    time.Now(),
 	}
 	s.mu.Unlock()
@@ -550,6 +557,7 @@ func (s *Service) startJob(
 		distribution: distribution,
 		provider:     provider,
 		phase:        phase,
+		origin:       phase,
 		startedAt:    time.Now(),
 	}
 	s.mu.Unlock()
@@ -691,6 +699,12 @@ func (s *Service) clearedFailedEKSCreate(name string) bool {
 
 // jobIsFailedEKS reports whether the tracked job for the cluster is an EKS create that ended in the
 // Failed phase. Split out so the ownership-state read in clearedFailedEKSCreate happens off the lock.
+//
+// `origin` is what makes this a CREATE test rather than merely a "failed EKS job" test. Delete and
+// start/stop also end in Failed, and a failed one of those describes a cluster the provisioner may
+// well have left running: clearing it locally would drop the row and report success while the AWS
+// cluster is still there. Only a create that never persisted state is safe to clear, because only
+// that job can be certain no confirmed cluster is being abandoned.
 func (s *Service) jobIsFailedEKS(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -699,6 +713,7 @@ func (s *Service) jobIsFailedEKS(name string) bool {
 
 	return found &&
 		current.phase == v1alpha1.ClusterPhaseFailed &&
+		current.origin == v1alpha1.ClusterPhaseProvisioning &&
 		current.distribution == v1alpha1.DistributionEKS
 }
 

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -402,6 +402,10 @@ func (s *Service) Create(
 // Delete starts deleting a cluster and returns immediately, marking it Deleting. The deletion runs
 // in a background goroutine.
 func (s *Service) Delete(ctx context.Context, _, name string) error {
+	if s.clearedFailedEKSCreate(name) {
+		return nil
+	}
+
 	spec, err := s.startJob(ctx, name, v1alpha1.ClusterPhaseDeleting)
 	if err != nil {
 		return err
@@ -611,32 +615,91 @@ func confirmEKSOwnership(
 // unconfirmedEKSRecovery returns the recovery step for a mutation KSail refused because it cannot
 // identify the remote cluster.
 //
-// `ksail cluster eks-bind` leads on every path: it re-establishes the missing binding from the
-// cluster the current AWS credentials select, and it never deletes or scales anything, so the
-// refused action can simply be retried afterwards. eksidentity.migrationRequiredError already points
-// at the same command for the same underlying condition, so the two agree.
+// `ksail cluster eks-bind` is deliberately NOT offered here, even though it is the obvious-looking
+// candidate. It writes the region-scoped immutable-identity record (eksidentity.Persist ->
+// state.SaveEKSOwnershipState), whereas this refusal comes from the missing create-time spec.json
+// that state.LoadClusterSpec reads. Those are different files, so eks-bind cannot satisfy this check:
+// naming it would send the operator round a loop ending in this same refusal.
+// eksidentity.migrationRequiredError does point at eks-bind, but for the identity record it actually
+// writes — a different condition, not this one.
 //
-// Deleting is offered only when deleting is what was asked for. Start and Stop are node-group
-// operations, so answering them with a destructive step — for a cluster KSail has just said it
-// cannot identify — would be actively wrong.
+// KSail has no command that rebuilds create-time ownership state for a cluster it did not create, so
+// the honest step is to act on the cluster through AWS directly. Deleting is spelled out only when
+// deleting is what was asked for: Start and Stop are node-group operations, so answering them with a
+// destructive step — for a cluster KSail has just said it cannot identify — would be actively wrong.
 func unconfirmedEKSRecovery(name string, phase v1alpha1.ClusterPhase) string {
-	rebind := fmt.Sprintf(
-		"after confirming the current AWS credentials select the intended cluster, run"+
-			" `ksail cluster eks-bind --name %s --provider AWS --experimental` to restore the"+
-			" binding",
-		name,
-	)
+	const confirm = "KSail cannot rebuild the create-time ownership state for a cluster it did not" +
+		" create, so confirm which cluster the current AWS credentials select and act on it with the" +
+		" AWS tooling directly"
 
 	if phase == v1alpha1.ClusterPhaseDeleting {
 		return fmt.Sprintf(
-			"%s; or, if you intend to delete it, use the AWS tooling directly"+
-				" (`eksctl delete cluster --name %s --region <region>`) once you have confirmed"+
+			"%s (`eksctl delete cluster --name %s --region <region>`) once you have confirmed"+
 				" its region",
-			rebind, name,
+			confirm, name,
 		)
 	}
 
-	return rebind + ", then retry"
+	return confirm + " (`eksctl`)"
+}
+
+// clearedFailedEKSCreate removes the local job left by an EKS create that failed before persisting
+// ownership state, and reports whether it did.
+//
+// runCreate writes spec.json only after the provisioner succeeds, so such a job records a create that
+// never completed. Create refuses while any jobs entry exists and confirmEKSOwnership refuses the
+// delete, which together would leave the cluster neither clearable nor retryable until the server
+// restarts. TestDeleteClearsFailedClusterWithNoUnderlyingCluster pins the same "a failed create must
+// stay clearable" invariant for the local distributions; this keeps EKS to it.
+//
+// The removal is deliberately local-only, and narrow. The provisioner may have created the remote
+// cluster and failed afterwards — persisting the spec is itself a step that can fail — so KSail
+// cannot claim the cluster is absent, only that it never confirmed which cluster it was. Aiming a
+// delete at AWS on the strength of a name is the exact unconfirmed mutation the ownership guard
+// exists to prevent, so the operator is warned to check instead. A cluster that is merely missing its
+// state while live is not covered: that one is still refused.
+func (s *Service) clearedFailedEKSCreate(name string) bool {
+	if !s.jobIsFailedEKS(name) {
+		return false
+	}
+
+	// Read ownership state outside the lock: it is disk I/O, and a create that has already failed
+	// will not begin writing state now.
+	_, err := state.LoadClusterSpec(name)
+	if !errors.Is(err, state.ErrStateNotFound) {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, found := s.jobs[name]
+	if !found || current.phase != v1alpha1.ClusterPhaseFailed {
+		return false
+	}
+
+	delete(s.jobs, name)
+
+	slog.Warn(
+		"cleared a failed EKS create that never recorded ownership state; no AWS resources were"+
+			" deleted, so check the account for a partially created cluster",
+		"cluster", name,
+	)
+
+	return true
+}
+
+// jobIsFailedEKS reports whether the tracked job for the cluster is an EKS create that ended in the
+// Failed phase. Split out so the ownership-state read in clearedFailedEKSCreate happens off the lock.
+func (s *Service) jobIsFailedEKS(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, found := s.jobs[name]
+
+	return found &&
+		current.phase == v1alpha1.ClusterPhaseFailed &&
+		current.distribution == v1alpha1.DistributionEKS
 }
 
 // jobInProgress reports whether a lifecycle action is already running for the cluster. It is a

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -413,11 +413,33 @@ func (s *Service) Create(
 	return &created, nil
 }
 
+// ErrEKSCreateClearedLocally reports a Delete that dropped a failed EKS create's job without
+// deleting anything in AWS. The create failed before persisting ownership state, so KSail never
+// confirmed which remote cluster the name referred to and must not aim a delete at an account on the
+// strength of a name alone.
+//
+// Clearing the job is still correct — Create rejects an existing entry, so keeping it would strand
+// the operator with a cluster they can neither remove nor retry. Reporting it is what changed:
+// runCreate marks the job Failed when the state write fails *after* the provisioner returned, so a
+// billable cluster can exist behind that Failed row. Answering the caller with success asserts the
+// cluster is gone, which is precisely what KSail has not established. It carries no api sentinel, so
+// clientErrorStatus maps it to 500 and writeError surfaces the whole message — the actionable half
+// is the message, not the code.
+var ErrEKSCreateClearedLocally = errors.New(
+	"cleared a failed EKS create without deleting remote resources",
+)
+
 // Delete starts deleting a cluster and returns immediately, marking it Deleting. The deletion runs
 // in a background goroutine.
 func (s *Service) Delete(ctx context.Context, _, name string) error {
 	if s.clearedFailedEKSCreate(name) {
-		return nil
+		return fmt.Errorf(
+			"%w: %q never recorded ownership state, so KSail could not identify the remote cluster."+
+				" Check the AWS account for a partially created cluster of that name and delete it"+
+				" there. The failed job has been cleared, so create can be retried",
+			ErrEKSCreateClearedLocally,
+			name,
+		)
 	}
 
 	spec, err := s.startJob(ctx, name, v1alpha1.ClusterPhaseDeleting)

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -525,16 +525,14 @@ func (s *Service) startJob(
 
 	target := v1alpha1.ClusterSpec{Distribution: distribution, Provider: provider}
 
-	// EKS mutations reach a remote AWS account, so they must run against the target bound when the
-	// cluster was created rather than whatever the caller has selected since. Resolving this before
-	// the job is registered keeps a refused mutation from leaving an in-flight job behind.
+	// EKS mutations reach a remote AWS account, so refuse one whose target KSail cannot confirm it
+	// owns. Checking before the job is registered keeps a refused mutation from leaving an in-flight
+	// job behind.
 	if distribution == v1alpha1.DistributionEKS {
-		bound, bindErr := eksMutationTarget(name, distribution, provider)
+		bindErr := confirmEKSOwnership(name, distribution, provider)
 		if bindErr != nil {
 			return v1alpha1.Spec{}, bindErr
 		}
-
-		target = *bound
 	}
 
 	s.mu.Lock()
@@ -555,43 +553,45 @@ func (s *Service) startJob(
 	return v1alpha1.Spec{Cluster: target}, nil
 }
 
-// eksMutationTarget returns the ownership state persisted when the cluster was created, for use as
-// the target of a delete/start/stop.
+// confirmEKSOwnership reports whether KSail can confirm it owns the named EKS cluster, so a
+// delete/start/stop is refused rather than aimed at a remote cluster it cannot account for. State
+// persisted at create time is the evidence: its presence marks the create as complete, and the
+// distribution/provider it records must match how the cluster resolved now.
 //
-// The EKS provisioner regenerates eks.yaml from the spec it is handed, and a spec carrying only a
-// distribution and provider leaves the region to be resolved from the ambient environment at action
-// time. Changing the AWS region between creating a cluster and operating on it would therefore
-// redirect the action to a same-named cluster in the newly selected region, so the mutation target
-// is read back from disk instead of being rebuilt.
+// It deliberately does NOT supply the action's target spec. The region binding is carried by the
+// on-disk eks.yaml, which the provisioner factory reads back through distributionConfig for the
+// cluster name — the spec never conveys it. Persisted state is also a sanitized snapshot (registry
+// credentials are redacted on the way in), so promoting it to the runtime target would hand the
+// provisioner values that were never meant to be replayed, while binding nothing extra.
 //
 // Missing or inconsistent state fails the mutation rather than falling back to ambient settings:
 // delete is destructive, and a same-named cluster in another reachable region is the exact outcome
-// the fallback would produce. `ksail cluster rebind-eks-ownership` re-establishes the binding for a
-// cluster whose state predates it or was lost.
-func eksMutationTarget(
+// the fallback would produce.
+func confirmEKSOwnership(
 	name string,
 	distribution v1alpha1.Distribution,
 	provider v1alpha1.Provider,
-) (*v1alpha1.ClusterSpec, error) {
+) error {
 	persisted, err := state.LoadClusterSpec(name)
 	if err != nil {
 		if errors.Is(err, state.ErrStateNotFound) {
-			return nil, fmt.Errorf(
-				"%w: no local KSail ownership state for EKS cluster %q, so its region cannot be"+
-					" confirmed; run `ksail cluster rebind-eks-ownership --name %s` to re-establish"+
-					" it, or use `ksail cluster delete --name %s` to act on an explicit target",
-				api.ErrInvalid, name, name, name,
+			return fmt.Errorf(
+				"%w: no local KSail ownership state for EKS cluster %q, so KSail cannot confirm"+
+					" which remote cluster this would act on; delete it with the AWS tooling"+
+					" directly (`eksctl delete cluster --name %s --region <region>`) once you have"+
+					" confirmed its region",
+				api.ErrInvalid, name, name,
 			)
 		}
 
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"%w: read local KSail ownership state for EKS cluster %q: %w",
 			api.ErrInvalid, name, err,
 		)
 	}
 
 	if persisted.Distribution != distribution || persisted.Provider != provider {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"%w: local KSail ownership state for EKS cluster %q records %s/%s but the cluster"+
 				" resolved as %s/%s; refusing to mutate an unconfirmed target",
 			api.ErrInvalid, name,
@@ -600,7 +600,7 @@ func eksMutationTarget(
 		)
 	}
 
-	return persisted, nil
+	return nil
 }
 
 // jobInProgress reports whether a lifecycle action is already running for the cluster. It is a

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -384,46 +384,14 @@ func (s *Service) Create(
 	// returned cluster all agree on the backend that will actually be provisioned.
 	cluster.Spec.Cluster.Provider = provider
 
-	live := s.enumerate(ctx)
+	// Read the on-disk create state before reserving the name (it is keyed by name and needs no
+	// shared state). reserveCreateJob decides when to apply it.
+	staleStateErr := refuseEKSCreateOverCompletedState(distribution, name)
 
-	s.mu.Lock()
-
-	_, inLive := live[name]
-	_, inJobs := s.jobs[name]
-
-	if inLive || inJobs {
-		s.mu.Unlock()
-
-		return nil, fmt.Errorf("%w: %q", api.ErrAlreadyExists, name)
-	}
-
-	s.mu.Unlock()
-
-	err = refuseEKSCreateOverCompletedState(distribution, name)
+	err = s.reserveCreateJob(s.enumerate(ctx), name, distribution, provider, staleStateErr)
 	if err != nil {
 		return nil, err
 	}
-
-	s.mu.Lock()
-
-	// Re-check under the reacquired lock: the state read above released it, so a concurrent Create
-	// for the same name may have registered its job in the meantime. Without this the two would both
-	// proceed and the second would overwrite the first's job record.
-	_, inJobs = s.jobs[name]
-	if inJobs {
-		s.mu.Unlock()
-
-		return nil, fmt.Errorf("%w: %q", api.ErrAlreadyExists, name)
-	}
-
-	s.jobs[name] = &job{
-		distribution: distribution,
-		provider:     provider,
-		phase:        v1alpha1.ClusterPhaseProvisioning,
-		origin:       v1alpha1.ClusterPhaseProvisioning,
-		startedAt:    time.Now(),
-	}
-	s.mu.Unlock()
 
 	go s.runCreate(context.WithoutCancel(ctx), name, cluster.Spec)
 
@@ -875,6 +843,45 @@ func (s *Service) runLifecycleAction(
 	}
 
 	delete(s.jobs, name)
+}
+
+// reserveCreateJob claims name for a create by registering its Provisioning job, or reports why the
+// name is unavailable.
+//
+// staleStateErr is the already-evaluated verdict on the name's on-disk EKS create state. It is
+// applied only after the live/in-flight check so a cluster that genuinely exists still reports the
+// plain already-exists error: the stale-state message tells the operator to delete the cluster to
+// clear its state, which is the wrong instruction for one that is running fine.
+func (s *Service) reserveCreateJob(
+	live map[string]clusterdiscovery.Cluster,
+	name string,
+	distribution v1alpha1.Distribution,
+	provider v1alpha1.Provider,
+	staleStateErr error,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, inLive := live[name]
+	_, inJobs := s.jobs[name]
+
+	if inLive || inJobs {
+		return fmt.Errorf("%w: %q", api.ErrAlreadyExists, name)
+	}
+
+	if staleStateErr != nil {
+		return staleStateErr
+	}
+
+	s.jobs[name] = &job{
+		distribution: distribution,
+		provider:     provider,
+		phase:        v1alpha1.ClusterPhaseProvisioning,
+		origin:       v1alpha1.ClusterPhaseProvisioning,
+		startedAt:    time.Now(),
+	}
+
+	return nil
 }
 
 func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec) {

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -609,24 +609,34 @@ func confirmEKSOwnership(
 }
 
 // unconfirmedEKSRecovery returns the recovery step for a mutation KSail refused because it cannot
-// identify the remote cluster. Deleting is suggested only when deleting is what was asked for;
-// Start/Stop are node-group operations, so their guidance stays non-destructive and names no KSail
-// subcommand, because none exists to re-establish the binding.
+// identify the remote cluster.
+//
+// `ksail cluster eks-bind` leads on every path: it re-establishes the missing binding from the
+// cluster the current AWS credentials select, and it never deletes or scales anything, so the
+// refused action can simply be retried afterwards. eksidentity.migrationRequiredError already points
+// at the same command for the same underlying condition, so the two agree.
+//
+// Deleting is offered only when deleting is what was asked for. Start and Stop are node-group
+// operations, so answering them with a destructive step — for a cluster KSail has just said it
+// cannot identify — would be actively wrong.
 func unconfirmedEKSRecovery(name string, phase v1alpha1.ClusterPhase) string {
+	rebind := fmt.Sprintf(
+		"after confirming the current AWS credentials select the intended cluster, run"+
+			" `ksail cluster eks-bind --name %s --provider AWS --experimental` to restore the"+
+			" binding",
+		name,
+	)
+
 	if phase == v1alpha1.ClusterPhaseDeleting {
 		return fmt.Sprintf(
-			"delete it with the AWS tooling directly"+
+			"%s; or, if you intend to delete it, use the AWS tooling directly"+
 				" (`eksctl delete cluster --name %s --region <region>`) once you have confirmed"+
 				" its region",
-			name,
+			rebind, name,
 		)
 	}
 
-	return fmt.Sprintf(
-		"start or stop its node groups with the AWS tooling directly once you have confirmed its"+
-			" region, or re-create %q with KSail so the binding is recorded",
-		name,
-	)
+	return rebind + ", then retry"
 }
 
 // jobInProgress reports whether a lifecycle action is already running for the cluster. It is a

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -715,23 +715,10 @@ func (s *Service) clearedFailedEKSCreate(name string) bool {
 	return true
 }
 
-// jobIsFailedEKS reports whether the tracked job for the cluster is an EKS create that ended in the
-// Failed phase. Split out so the ownership-state read in clearedFailedEKSCreate happens off the lock.
-//
-// `origin` is what makes this a CREATE test rather than merely a "failed EKS job" test. Delete and
-// start/stop also end in Failed, and a failed one of those describes a cluster the provisioner may
-// well have left running: clearing it locally would drop the row and report success while the AWS
-// cluster is still there. Only a create that never persisted state is safe to clear, because only
-// that job can be certain no confirmed cluster is being abandoned.
-func (s *Service) jobIsFailedEKS(name string) bool {
-	_, ok := s.failedEKSCreate(name)
-
-	return ok
-}
-
-// failedEKSCreate returns the tracked job when it is a failed EKS create, so the caller can hold on
-// to the exact entry it approved rather than re-deriving it later from fields that a replacement may
-// also satisfy.
+// failedEKSCreate returns the tracked job when it is an EKS create that ended in the Failed phase.
+// Split out so the ownership-state read in clearedFailedEKSCreate happens off the lock, and it
+// returns the job itself so the caller can hold on to the exact entry it approved rather than
+// re-deriving it later from fields a replacement may also satisfy.
 func (s *Service) failedEKSCreate(name string) (*job, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -743,10 +730,14 @@ func (s *Service) failedEKSCreate(name string) (*job, bool) {
 	return s.jobs[name], true
 }
 
-// jobIsFailedEKSLocked is jobIsFailedEKS's predicate with the locking left to the caller, which must
-// hold s.mu. It exists so clearedFailedEKSCreate can re-apply the whole test after reacquiring the
-// lock instead of restating part of it — a partial restatement is what let a replacement failed stop
-// through, and keeping one definition is what stops the two copies drifting again.
+// jobIsFailedEKSLocked is the failed-EKS-create predicate with the locking left to the caller, which
+// must hold s.mu.
+//
+// `origin` is what makes this a CREATE test rather than merely a "failed EKS job" test. Delete and
+// start/stop also end in Failed, and a failed one of those describes a cluster the provisioner may
+// well have left running: clearing it locally would drop the row and report success while the AWS
+// cluster is still there. Only a create that never persisted state is safe to clear, because only
+// that job can be certain no confirmed cluster is being abandoned.
 func (s *Service) jobIsFailedEKSLocked(name string) bool {
 	current, found := s.jobs[name]
 

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -143,6 +143,12 @@ type Service struct {
 	// verification is unavailable, so an install carrying cosign material is rejected.
 	cosign cosignVerifier
 
+	// loadClusterSpec reads a cluster's persisted ownership state. clearedFailedEKSCreate drops the
+	// lock across this call, so it is the seam a test uses to act inside that window — substituting a
+	// loader that mutates s.jobs reproduces the interleaving deterministically, without goroutines or
+	// sleeps. The default is state.LoadClusterSpec.
+	loadClusterSpec func(clusterName string) (*v1alpha1.ClusterSpec, error)
+
 	mu   sync.Mutex
 	jobs map[string]*job
 }
@@ -155,6 +161,7 @@ func NewService() *Service {
 		kubeconfigPath:    k8s.DefaultKubeconfigPath,
 		plugins:           pluginStore{dir: defaultPluginsDir},
 		pluginCatalog:     defaultPluginCatalog(),
+		loadClusterSpec:   state.LoadClusterSpec,
 		jobs:              map[string]*job{},
 	}
 	service.discoverer = &clusterdiscovery.Discoverer{
@@ -673,7 +680,7 @@ func (s *Service) clearedFailedEKSCreate(name string) bool {
 
 	// Read ownership state outside the lock: it is disk I/O, and a create that has already failed
 	// will not begin writing state now.
-	_, err := state.LoadClusterSpec(name)
+	_, err := s.loadClusterSpec(name)
 	if !errors.Is(err, state.ErrStateNotFound) {
 		return false
 	}
@@ -681,8 +688,12 @@ func (s *Service) clearedFailedEKSCreate(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	current, found := s.jobs[name]
-	if !found || current.phase != v1alpha1.ClusterPhaseFailed {
+	// Re-apply the predicate in FULL, not just the phase. The lock was released for the read above, so
+	// this is not necessarily the entry jobIsFailedEKS approved: ownership state can be restored out of
+	// band and a start/stop then registered and failed in that window. Such a replacement is also
+	// Failed, so a phase-only re-check would clear it — and a failed stop describes a cluster that may
+	// still be running, which is the case `origin` exists to distinguish.
+	if !s.jobIsFailedEKSLocked(name) {
 		return false
 	}
 
@@ -709,6 +720,14 @@ func (s *Service) jobIsFailedEKS(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	return s.jobIsFailedEKSLocked(name)
+}
+
+// jobIsFailedEKSLocked is jobIsFailedEKS's predicate with the locking left to the caller, which must
+// hold s.mu. It exists so clearedFailedEKSCreate can re-apply the whole test after reacquiring the
+// lock instead of restating part of it — a partial restatement is what let a replacement failed stop
+// through, and keeping one definition is what stops the two copies drifting again.
+func (s *Service) jobIsFailedEKSLocked(name string) bool {
 	current, found := s.jobs[name]
 
 	return found &&

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -516,15 +516,32 @@ func (s *Service) startJob(
 		return v1alpha1.Spec{}, fmt.Errorf("%w: %q", api.ErrNotFound, name)
 	}
 
+	// Reject an overlapping operation before reading ownership state. A create that is still in
+	// flight has not written its state yet, so binding first would report that absence instead of
+	// the accurate "already in progress". The authoritative check is repeated under the lock below.
+	if s.jobInProgress(name) {
+		return v1alpha1.Spec{}, overlappingJobError(name)
+	}
+
+	target := v1alpha1.ClusterSpec{Distribution: distribution, Provider: provider}
+
+	// EKS mutations reach a remote AWS account, so they must run against the target bound when the
+	// cluster was created rather than whatever the caller has selected since. Resolving this before
+	// the job is registered keeps a refused mutation from leaving an in-flight job behind.
+	if distribution == v1alpha1.DistributionEKS {
+		bound, bindErr := eksMutationTarget(name, distribution, provider)
+		if bindErr != nil {
+			return v1alpha1.Spec{}, bindErr
+		}
+
+		target = *bound
+	}
+
 	s.mu.Lock()
 	if current, found := s.jobs[name]; found && jobIsInProgress(current.phase) {
 		s.mu.Unlock()
 
-		return v1alpha1.Spec{}, fmt.Errorf(
-			"%w: operation already in progress for %q",
-			api.ErrAlreadyExists,
-			name,
-		)
+		return v1alpha1.Spec{}, overlappingJobError(name)
 	}
 
 	s.jobs[name] = &job{
@@ -535,9 +552,70 @@ func (s *Service) startJob(
 	}
 	s.mu.Unlock()
 
-	return v1alpha1.Spec{
-		Cluster: v1alpha1.ClusterSpec{Distribution: distribution, Provider: provider},
-	}, nil
+	return v1alpha1.Spec{Cluster: target}, nil
+}
+
+// eksMutationTarget returns the ownership state persisted when the cluster was created, for use as
+// the target of a delete/start/stop.
+//
+// The EKS provisioner regenerates eks.yaml from the spec it is handed, and a spec carrying only a
+// distribution and provider leaves the region to be resolved from the ambient environment at action
+// time. Changing the AWS region between creating a cluster and operating on it would therefore
+// redirect the action to a same-named cluster in the newly selected region, so the mutation target
+// is read back from disk instead of being rebuilt.
+//
+// Missing or inconsistent state fails the mutation rather than falling back to ambient settings:
+// delete is destructive, and a same-named cluster in another reachable region is the exact outcome
+// the fallback would produce. `ksail cluster rebind-eks-ownership` re-establishes the binding for a
+// cluster whose state predates it or was lost.
+func eksMutationTarget(
+	name string,
+	distribution v1alpha1.Distribution,
+	provider v1alpha1.Provider,
+) (*v1alpha1.ClusterSpec, error) {
+	persisted, err := state.LoadClusterSpec(name)
+	if err != nil {
+		if errors.Is(err, state.ErrStateNotFound) {
+			return nil, fmt.Errorf(
+				"%w: no local KSail ownership state for EKS cluster %q, so its region cannot be"+
+					" confirmed; run `ksail cluster rebind-eks-ownership --name %s` to re-establish"+
+					" it, or use `ksail cluster delete --name %s` to act on an explicit target",
+				api.ErrInvalid, name, name, name,
+			)
+		}
+
+		return nil, fmt.Errorf(
+			"%w: read local KSail ownership state for EKS cluster %q: %w",
+			api.ErrInvalid, name, err,
+		)
+	}
+
+	if persisted.Distribution != distribution || persisted.Provider != provider {
+		return nil, fmt.Errorf(
+			"%w: local KSail ownership state for EKS cluster %q records %s/%s but the cluster"+
+				" resolved as %s/%s; refusing to mutate an unconfirmed target",
+			api.ErrInvalid, name,
+			persisted.Distribution, persisted.Provider,
+			distribution, provider,
+		)
+	}
+
+	return persisted, nil
+}
+
+// jobInProgress reports whether a lifecycle action is already running for the cluster. It is a
+// point-in-time probe used to order startJob's error cases; registration re-checks under the lock.
+func (s *Service) jobInProgress(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, found := s.jobs[name]
+
+	return found && jobIsInProgress(current.phase)
+}
+
+func overlappingJobError(name string) error {
+	return fmt.Errorf("%w: operation already in progress for %q", api.ErrAlreadyExists, name)
 }
 
 func jobIsInProgress(phase v1alpha1.ClusterPhase) bool {

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -501,10 +501,28 @@ func (s *Service) resolveCluster(
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if current, ok := s.jobs[name]; ok {
+		s.mu.Unlock()
+
 		return current.distribution, current.provider, true
+	}
+
+	s.mu.Unlock()
+
+	// Persisted EKS ownership is the last resort, and it is what makes a bound cluster reachable at
+	// all. Live enumeration lists only the region selected NOW, so an EKS cluster created in another
+	// region — or simply one the UI has been repointed away from since — disappears from the listing
+	// and every start, stop and delete reported "not found" before the ownership check could run.
+	// That is the same ambient-region redirect this binding exists to prevent, arriving as an
+	// absence rather than as a wrong target.
+	//
+	// Resolving here does NOT authorize the mutation: it only says KSail has a record of owning a
+	// cluster by this name. confirmEKSOwnership still runs, and still refuses anything it cannot
+	// account for.
+	_, ownershipErr := state.ListEKSOwnershipStates(name)
+	if ownershipErr == nil {
+		return v1alpha1.DistributionEKS, v1alpha1.ProviderAWS, true
 	}
 
 	return "", "", false

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -529,7 +529,7 @@ func (s *Service) startJob(
 	// owns. Checking before the job is registered keeps a refused mutation from leaving an in-flight
 	// job behind.
 	if distribution == v1alpha1.DistributionEKS {
-		bindErr := confirmEKSOwnership(name, distribution, provider)
+		bindErr := confirmEKSOwnership(name, distribution, provider, phase)
 		if bindErr != nil {
 			return v1alpha1.Spec{}, bindErr
 		}
@@ -567,20 +567,25 @@ func (s *Service) startJob(
 // Missing or inconsistent state fails the mutation rather than falling back to ambient settings:
 // delete is destructive, and a same-named cluster in another reachable region is the exact outcome
 // the fallback would produce.
+//
+// The phase selects the recovery guidance, because this refusal is reached from every mutating entry
+// point: Delete arrives as ClusterPhaseDeleting, while Start and Stop both arrive as
+// ClusterPhaseUpdating. Only the delete path may suggest deleting the cluster — an operator who asked
+// to start or stop one must never be handed a destructive recovery step for a cluster KSail has just
+// said it cannot identify.
 func confirmEKSOwnership(
 	name string,
 	distribution v1alpha1.Distribution,
 	provider v1alpha1.Provider,
+	phase v1alpha1.ClusterPhase,
 ) error {
 	persisted, err := state.LoadClusterSpec(name)
 	if err != nil {
 		if errors.Is(err, state.ErrStateNotFound) {
 			return fmt.Errorf(
 				"%w: no local KSail ownership state for EKS cluster %q, so KSail cannot confirm"+
-					" which remote cluster this would act on; delete it with the AWS tooling"+
-					" directly (`eksctl delete cluster --name %s --region <region>`) once you have"+
-					" confirmed its region",
-				api.ErrInvalid, name, name,
+					" which remote cluster this would act on; %s",
+				api.ErrInvalid, name, unconfirmedEKSRecovery(name, phase),
 			)
 		}
 
@@ -601,6 +606,27 @@ func confirmEKSOwnership(
 	}
 
 	return nil
+}
+
+// unconfirmedEKSRecovery returns the recovery step for a mutation KSail refused because it cannot
+// identify the remote cluster. Deleting is suggested only when deleting is what was asked for;
+// Start/Stop are node-group operations, so their guidance stays non-destructive and names no KSail
+// subcommand, because none exists to re-establish the binding.
+func unconfirmedEKSRecovery(name string, phase v1alpha1.ClusterPhase) string {
+	if phase == v1alpha1.ClusterPhaseDeleting {
+		return fmt.Sprintf(
+			"delete it with the AWS tooling directly"+
+				" (`eksctl delete cluster --name %s --region <region>`) once you have confirmed"+
+				" its region",
+			name,
+		)
+	}
+
+	return fmt.Sprintf(
+		"start or stop its node groups with the AWS tooling directly once you have confirmed its"+
+			" region, or re-create %q with KSail so the binding is recorded",
+		name,
+	)
 }
 
 // jobInProgress reports whether a lifecycle action is already running for the cluster. It is a

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -674,7 +674,8 @@ func unconfirmedEKSRecovery(name string, phase v1alpha1.ClusterPhase) string {
 // exists to prevent, so the operator is warned to check instead. A cluster that is merely missing its
 // state while live is not covered: that one is still refused.
 func (s *Service) clearedFailedEKSCreate(name string) bool {
-	if !s.jobIsFailedEKS(name) {
+	approved, ok := s.failedEKSCreate(name)
+	if !ok {
 		return false
 	}
 
@@ -688,12 +689,18 @@ func (s *Service) clearedFailedEKSCreate(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Re-apply the predicate in FULL, not just the phase. The lock was released for the read above, so
-	// this is not necessarily the entry jobIsFailedEKS approved: ownership state can be restored out of
-	// band and a start/stop then registered and failed in that window. Such a replacement is also
-	// Failed, so a phase-only re-check would clear it — and a failed stop describes a cluster that may
-	// still be running, which is the case `origin` exists to distinguish.
-	if !s.jobIsFailedEKSLocked(name) {
+	// Delete the entry that was approved, not merely one that still looks like it. The lock was
+	// released for the read above, so the map may hold a different job now: ownership state can be
+	// restored out of band and a start/stop registered and failed in that window, and a replacement is
+	// also Failed — so a phase-only re-check would clear it, even though a failed stop describes a
+	// cluster that may still be running.
+	//
+	// Re-applying the full predicate is necessary but NOT sufficient, which is why this compares the
+	// pointer. A second failed EKS create of the same name satisfies every field the predicate tests,
+	// so a value comparison would clear the new job and hide its failure. Identity is the only test
+	// that distinguishes "the job I approved" from "a job just like it".
+	current, found := s.jobs[name]
+	if !found || current != approved {
 		return false
 	}
 
@@ -717,10 +724,23 @@ func (s *Service) clearedFailedEKSCreate(name string) bool {
 // cluster is still there. Only a create that never persisted state is safe to clear, because only
 // that job can be certain no confirmed cluster is being abandoned.
 func (s *Service) jobIsFailedEKS(name string) bool {
+	_, ok := s.failedEKSCreate(name)
+
+	return ok
+}
+
+// failedEKSCreate returns the tracked job when it is a failed EKS create, so the caller can hold on
+// to the exact entry it approved rather than re-deriving it later from fields that a replacement may
+// also satisfy.
+func (s *Service) failedEKSCreate(name string) (*job, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.jobIsFailedEKSLocked(name)
+	if !s.jobIsFailedEKSLocked(name) {
+		return nil, false
+	}
+
+	return s.jobs[name], true
 }
 
 // jobIsFailedEKSLocked is jobIsFailedEKS's predicate with the locking left to the caller, which must

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -397,6 +397,25 @@ func (s *Service) Create(
 		return nil, fmt.Errorf("%w: %q", api.ErrAlreadyExists, name)
 	}
 
+	s.mu.Unlock()
+
+	err = refuseEKSCreateOverCompletedState(distribution, name)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+
+	// Re-check under the reacquired lock: the state read above released it, so a concurrent Create
+	// for the same name may have registered its job in the meantime. Without this the two would both
+	// proceed and the second would overwrite the first's job record.
+	_, inJobs = s.jobs[name]
+	if inJobs {
+		s.mu.Unlock()
+
+		return nil, fmt.Errorf("%w: %q", api.ErrAlreadyExists, name)
+	}
+
 	s.jobs[name] = &job{
 		distribution: distribution,
 		provider:     provider,

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1873,6 +1873,82 @@ func TestDeleteEKSRefusesLiveClusterWithoutOwnershipState(t *testing.T) {
 	assert.Empty(t, provisioner.deletedNames())
 }
 
+// TestDeleteEKSRefusesFailedLifecycleJobWithoutOwnershipState is the second negative control, and it
+// covers the case the first one cannot see. TestDeleteEKSRefusesLiveClusterWithoutOwnershipState has
+// no tracked job at all, so it never reaches the clearing path; this one arrives there with a job in
+// exactly the state that path inspects.
+//
+// Create, delete and start/stop all converge on Failed, so "failed EKS job with no ownership state"
+// does not mean "failed create". A stop that fails leaves the remote cluster running — the stop is
+// precisely the operation that did not take — and if its ownership state is then removed out of band,
+// a clearing path keyed only on phase and distribution would drop the row and answer Delete with
+// success while the AWS cluster is still there. That is worse than the refusal it replaced: the
+// operator is told the cluster is gone.
+//
+// The distinguishing fact is the job's `origin`, which is fixed at registration and never changes.
+func TestDeleteEKSRefusesFailedLifecycleJobWithoutOwnershipState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "stop-failed-eks"
+
+	provisioner := &fakeProvisioner{stopErr: errSimulatedDeleteFailure}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: provisioner,
+	})
+
+	// A create that SUCCEEDS, so ownership state is persisted and the cluster is confirmed KSail's.
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, ok := phaseOf(list, clusterName)
+
+		return ok && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+
+	// A stop that fails. The job now sits in Failed — the same phase a failed create reaches, which
+	// is what makes phase alone insufficient to tell them apart.
+	require.NoError(t, service.Stop(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, ok := phaseOf(list, clusterName)
+
+		return ok && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	// The ownership state disappears underneath the failed job — removed out of band, or by a
+	// delete run from the CLI while the server holds this job in memory. Only now do the two cases
+	// look alike to a phase-and-distribution test.
+	require.NoError(t, state.DeleteClusterState(clusterName))
+
+	_, loadErr := state.LoadClusterSpec(clusterName)
+	require.ErrorIs(t, loadErr, state.ErrStateNotFound)
+
+	// Delete must still be refused: this was never a create, so KSail cannot claim no cluster was
+	// left behind, and it must not aim a delete at AWS on the strength of a name either.
+	err = service.Delete(context.Background(), "default", clusterName)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Empty(t, provisioner.deletedNames(),
+		"a refused delete must not have reached the provisioner")
+
+	// The failed job must survive the refusal. Clearing it would destroy the only record of why the
+	// stop did not take, which is the operator's route back to a working cluster.
+	list, listErr := service.List(context.Background())
+	require.NoError(t, listErr)
+
+	phase, present := phaseOf(list, clusterName)
+	assert.True(t, present, "the refused delete must not have cleared the failed job")
+	assert.Equal(t, v1alpha1.ClusterPhaseFailed, phase,
+		"the job must still report why the stop failed")
+}
+
 // TestDeleteFailedLocalCreateStillReachesTheProvisioner pins the distribution scope of the
 // failed-create clearing path. Clearing the job locally is right for EKS, where the ownership guard
 // stands between KSail and a remote account it cannot identify. It would be wrong for a local

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2158,13 +2158,11 @@ func TestBoundEKSConfigBindsFromOwnershipWhenTheStateConfigIsAbsent(t *testing.T
 	// Assert the region inside the FILE, not just the returned one. eksctl reads the file, so a
 	// config written from the ambient region while the returned value carried the bound one would
 	// aim the action at us-west-2 and still satisfy every assertion above.
-	written, readErr := os.ReadFile(
-		configPath,
-	) //nolint:gosec // test-controlled path under a temp HOME.
-	require.NoError(t, readErr)
-	assert.Contains(t, string(written), "region: eu-north-1",
+	data, err := os.ReadFile(configPath) //nolint:gosec // test-controlled path under a temp HOME.
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "region: eu-north-1",
 		"the generated eks.yaml must carry the bound region, not the ambient one")
-	assert.NotContains(t, string(written), "us-west-2",
+	assert.NotContains(t, string(data), "us-west-2",
 		"the ambient region must not reach the file the provisioner reads")
 }
 

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -617,9 +617,11 @@ func TestDeleteEKSClearsJobWhenOnlyLocalStateCleanupFails(t *testing.T) {
 	}
 
 	clustersDir := filepath.Join(home, ".ksail", "clusters")
+	//nolint:gosec // 0500 is a directory mode: it keeps the state readable while removing write.
 	require.NoError(t, os.Chmod(clustersDir, 0o500))
 
 	t.Cleanup(func() {
+		//nolint:gosec // 0700 is a directory mode: restores write so TempDir cleanup can remove it.
 		_ = os.Chmod(clustersDir, 0o700)
 	})
 
@@ -1394,7 +1396,10 @@ func TestDeleteEKSRefusesWithoutPersistedOwnershipState(t *testing.T) {
 	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
 		v1alpha1.DistributionEKS: provisioner,
 	})
-	_, err := service.Create(context.Background(), clusterFor(clusterName, v1alpha1.DistributionEKS))
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		list, listErr := service.List(context.Background())
@@ -1424,7 +1429,10 @@ func TestDeleteEKSRefusesWhenPersistedOwnershipStateDisagrees(t *testing.T) {
 	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
 		v1alpha1.DistributionEKS: provisioner,
 	})
-	_, err := service.Create(context.Background(), clusterFor(clusterName, v1alpha1.DistributionEKS))
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		list, listErr := service.List(context.Background())

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1525,6 +1525,7 @@ func TestDeleteEKSReachesProvisionerBoundToCreationRegion(t *testing.T) {
 
 	// The operator selects a different region before deleting.
 	beforeDelete := recorder.count()
+
 	t.Setenv("AWS_REGION", "us-east-1")
 
 	require.NoError(t, service.Delete(context.Background(), "default", clusterName))

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1610,3 +1610,97 @@ func TestDeleteEKSRefusesWhenPersistedOwnershipStateDisagrees(t *testing.T) {
 	require.ErrorIs(t, err, api.ErrInvalid)
 	assert.Empty(t, provisioner.deletedNames())
 }
+
+// newReadyUnboundEKSService creates an EKS cluster, waits for it to settle, then removes the
+// ownership state — the state an operator is in when KSail can no longer identify the remote target.
+func newReadyUnboundEKSService(
+	t *testing.T,
+	clusterName string,
+) (*clusterapi.Service, *fakeProvisioner) {
+	t.Helper()
+
+	provisioner := &fakeProvisioner{}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: provisioner,
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+
+	require.NoError(t, state.DeleteClusterState(clusterName))
+
+	return service, provisioner
+}
+
+// TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction pins the recovery guidance to the
+// action the operator actually asked for. All three mutating entry points reach the same refusal —
+// Delete as ClusterPhaseDeleting, Start and Stop as ClusterPhaseUpdating — so a single shared message
+// told an operator who asked to start a cluster to delete it instead. Deleting is suggested only on
+// the delete path.
+func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	for _, testCase := range []struct {
+		name        string
+		invoke      func(*clusterapi.Service, string) error
+		wantDelete  bool
+		wantMessage string
+	}{
+		{
+			name: "delete",
+			invoke: func(s *clusterapi.Service, cluster string) error {
+				return s.Delete(context.Background(), "default", cluster)
+			},
+			wantDelete:  true,
+			wantMessage: "eksctl delete cluster",
+		},
+		{
+			name: "start",
+			invoke: func(s *clusterapi.Service, cluster string) error {
+				return s.Start(context.Background(), "default", cluster)
+			},
+			wantDelete:  false,
+			wantMessage: "start or stop its node groups",
+		},
+		{
+			name: "stop",
+			invoke: func(s *clusterapi.Service, cluster string) error {
+				return s.Stop(context.Background(), "default", cluster)
+			},
+			wantDelete:  false,
+			wantMessage: "start or stop its node groups",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			clusterName := "unbound-eks-" + testCase.name
+			service, provisioner := newReadyUnboundEKSService(t, clusterName)
+
+			err := testCase.invoke(service, clusterName)
+
+			require.ErrorIs(t, err, api.ErrInvalid,
+				"an unconfirmable EKS target must be refused on every mutating path")
+			assert.Contains(t, err.Error(), testCase.wantMessage,
+				"the recovery guidance must address the action the operator requested")
+			assert.Empty(t, provisioner.deletedNames(),
+				"a refused mutation must never reach the provisioner")
+
+			if !testCase.wantDelete {
+				assert.NotContains(t, err.Error(), "eksctl delete cluster",
+					"a non-destructive action must not be answered with a destructive recovery step")
+			}
+		})
+	}
+}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1643,11 +1643,43 @@ func newReadyUnboundEKSService(
 	return service, provisioner
 }
 
+// assertUnconfirmedEKSGuidance checks one refusal message: it must be an api.ErrInvalid, address the
+// action the operator requested, always name the registered rebind command, and offer deletion only
+// on the delete path.
+func assertUnconfirmedEKSGuidance(
+	t *testing.T,
+	err error,
+	clusterName string,
+	wantMessage string,
+	wantDelete bool,
+) {
+	t.Helper()
+
+	require.ErrorIs(t, err, api.ErrInvalid,
+		"an unconfirmable EKS target must be refused on every mutating path")
+	assert.Contains(t, err.Error(), wantMessage,
+		"the recovery guidance must address the action the operator requested")
+	assert.Contains(t, err.Error(),
+		"ksail cluster eks-bind --name "+clusterName+" --provider AWS --experimental",
+		"every path must name the registered command that restores the binding")
+
+	if !wantDelete {
+		assert.NotContains(t, err.Error(), "eksctl delete cluster",
+			"a non-destructive action must not be answered with a destructive recovery step")
+	}
+}
+
 // TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction pins the recovery guidance to the
 // action the operator actually asked for. All three mutating entry points reach the same refusal —
 // Delete as ClusterPhaseDeleting, Start and Stop as ClusterPhaseUpdating — so a single shared message
 // told an operator who asked to start a cluster to delete it instead. Deleting is suggested only on
 // the delete path.
+//
+// Every path must also lead with `ksail cluster eks-bind`, the registered command that restores the
+// missing binding without touching AWS resources. That assertion is deliberate: an earlier round on
+// this PR shipped guidance naming a command the CLI does not expose, and this round briefly claimed
+// no such command existed at all. Pinning the exact string makes both mistakes a test failure rather
+// than something only a reviewer catches.
 func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -1671,7 +1703,7 @@ func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 				return s.Start(context.Background(), "default", cluster)
 			},
 			wantDelete:  false,
-			wantMessage: "start or stop its node groups",
+			wantMessage: "then retry",
 		},
 		{
 			name: "stop",
@@ -1679,7 +1711,7 @@ func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 				return s.Stop(context.Background(), "default", cluster)
 			},
 			wantDelete:  false,
-			wantMessage: "start or stop its node groups",
+			wantMessage: "then retry",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -1690,17 +1722,10 @@ func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 
 			err := testCase.invoke(service, clusterName)
 
-			require.ErrorIs(t, err, api.ErrInvalid,
-				"an unconfirmable EKS target must be refused on every mutating path")
-			assert.Contains(t, err.Error(), testCase.wantMessage,
-				"the recovery guidance must address the action the operator requested")
+			assertUnconfirmedEKSGuidance(t, err, clusterName, testCase.wantMessage,
+				testCase.wantDelete)
 			assert.Empty(t, provisioner.deletedNames(),
 				"a refused mutation must never reach the provisioner")
-
-			if !testCase.wantDelete {
-				assert.NotContains(t, err.Error(), "eksctl delete cluster",
-					"a non-destructive action must not be answered with a destructive recovery step")
-			}
 		})
 	}
 }

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1949,6 +1949,74 @@ func TestDeleteEKSRefusesFailedLifecycleJobWithoutOwnershipState(t *testing.T) {
 		"the job must still report why the stop failed")
 }
 
+// TestDeleteEKSRefusesJobReplacedDuringOwnershipRead is the third negative control, and it covers a
+// window the other two cannot reach. clearedFailedEKSCreate releases the lock to read ownership state
+// from disk, so the entry it validated before that read is not necessarily the entry it removes after
+// it: the job can be replaced in between — ownership state restored out of band, then a start/stop
+// registered and failed.
+//
+// Re-checking only the phase on the way out is therefore not enough. Create, delete and start/stop all
+// converge on Failed, so a replacement failed *stop* satisfies a phase-only re-check while describing
+// a cluster that may still be running in AWS. That is precisely the confusion `origin` was introduced
+// to prevent, and TestDeleteEKSRefusesFailedLifecycleJobWithoutOwnershipState pins it for the
+// steady-state case; this pins it across the unlocked window, where the check has to be repeated in
+// full rather than assumed to still hold.
+//
+// The replacement is driven through the ownership-read seam rather than a competing goroutine, so the
+// interleaving is exact and the test cannot flake.
+func TestDeleteEKSRefusesJobReplacedDuringOwnershipRead(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "replaced-during-read"
+
+	provisioner := &fakeProvisioner{createErr: errSimulatedCreateFailure}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: provisioner,
+	})
+
+	// A create that fails, so the job really is a failed create: the pre-read check passes and the
+	// clearing path proceeds into the unlocked ownership read.
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, ok := phaseOf(list, clusterName)
+
+		return ok && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	// Act inside the unlocked window: replace the failed create with a failed stop, then answer the
+	// read exactly as the real loader would for a cluster with no persisted state.
+	reads := 0
+
+	service.SetLoadClusterSpecForTest(func(name string) (*v1alpha1.ClusterSpec, error) {
+		reads++
+
+		service.ReplaceJobWithFailedStopForTest(name)
+
+		return nil, state.ErrStateNotFound
+	})
+
+	err = service.Delete(context.Background(), "default", clusterName)
+
+	// Without the read actually happening the test would pass vacuously — it would be asserting the
+	// steady-state refusal, not the windowed one.
+	require.Equal(t, 1, reads,
+		"the unlocked ownership read must have run, or the window under test was never entered")
+	require.ErrorIs(t, err, api.ErrInvalid,
+		"a job that became a failed stop during the read must not be cleared as a failed create")
+	assert.Empty(t, provisioner.deletedNames(),
+		"a refused delete must not have reached the provisioner")
+	assert.True(t, service.JobPresentForTest(clusterName),
+		"the replacement failed stop must survive: it is the only record of a cluster"+
+			" that may still be running")
+}
+
 // TestDeleteFailedLocalCreateStillReachesTheProvisioner pins the distribution scope of the
 // failed-create clearing path. Clearing the job locally is right for EKS, where the ownership guard
 // stands between KSail and a remote account it cannot identify. It would be wrong for a local

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1658,12 +1658,12 @@ func newReadyUnboundEKSService(
 }
 
 // assertUnconfirmedEKSGuidance checks one refusal message: it must be an api.ErrInvalid, address the
-// action the operator requested, always name the registered rebind command, and offer deletion only
-// on the delete path.
+// action the operator requested, point at recovery that can actually resolve this refusal, and offer
+// deletion only on the delete path.
 func assertUnconfirmedEKSGuidance(
 	t *testing.T,
 	err error,
-	clusterName string,
+	_ string,
 	wantMessage string,
 	wantDelete bool,
 ) {
@@ -1673,9 +1673,11 @@ func assertUnconfirmedEKSGuidance(
 		"an unconfirmable EKS target must be refused on every mutating path")
 	assert.Contains(t, err.Error(), wantMessage,
 		"the recovery guidance must address the action the operator requested")
-	assert.Contains(t, err.Error(),
-		"ksail cluster eks-bind --name "+clusterName+" --provider AWS --experimental",
-		"every path must name the registered command that restores the binding")
+	assert.Contains(t, err.Error(), "eksctl",
+		"every path must point at recovery that can actually resolve this refusal")
+	assert.NotContains(t, err.Error(), "ksail cluster eks-bind",
+		"eks-bind writes the immutable-identity record, not the create-time ownership state this "+
+			"refusal reads, so offering it here loops the operator back to this same refusal")
 
 	if !wantDelete {
 		assert.NotContains(t, err.Error(), "eksctl delete cluster",
@@ -1689,11 +1691,14 @@ func assertUnconfirmedEKSGuidance(
 // told an operator who asked to start a cluster to delete it instead. Deleting is suggested only on
 // the delete path.
 //
-// Every path must also lead with `ksail cluster eks-bind`, the registered command that restores the
-// missing binding without touching AWS resources. That assertion is deliberate: an earlier round on
-// this PR shipped guidance naming a command the CLI does not expose, and this round briefly claimed
-// no such command existed at all. Pinning the exact string makes both mistakes a test failure rather
-// than something only a reviewer catches.
+// Every path must also point at recovery that can actually clear the refusal, and must NOT offer
+// `ksail cluster eks-bind`. This assertion has been wrong twice in opposite directions, so it is
+// worth stating precisely: an earlier round named a command the CLI does not expose, the next round
+// claimed no such command existed, and the round after that named eks-bind — which does exist, but
+// writes the region-scoped immutable-identity record (state.SaveEKSOwnershipState) rather than the
+// create-time spec.json that state.LoadClusterSpec reads here. Naming an existing command is not the
+// same claim as naming one that resolves this refusal; asserting only that the string is present
+// pinned the second claim while testing the first.
 func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -1717,7 +1722,7 @@ func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 				return s.Start(context.Background(), "default", cluster)
 			},
 			wantDelete:  false,
-			wantMessage: "then retry",
+			wantMessage: "act on it with the AWS tooling directly",
 		},
 		{
 			name: "stop",
@@ -1725,7 +1730,7 @@ func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 				return s.Stop(context.Background(), "default", cluster)
 			},
 			wantDelete:  false,
-			wantMessage: "then retry",
+			wantMessage: "act on it with the AWS tooling directly",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -1797,4 +1802,73 @@ func TestEKSCreateRejectsStateBelongingToAnotherDistribution(t *testing.T) {
 		"the error must name the distribution that actually owns the state")
 	assert.NotContains(t, err.Error(), "read the eks config",
 		"a name collision must not surface as a missing-eks.yaml read error")
+}
+
+// TestDeleteEKSClearsFailedCreateWithoutOwnershipState is the EKS analogue of
+// TestDeleteClearsFailedClusterWithNoUnderlyingCluster: a create that failed before persisting
+// ownership state must still be clearable. runCreate only writes spec.json once the provisioner
+// succeeded, so a failed EKS create leaves the job Failed with no state — and because Create rejects
+// any existing jobs entry, refusing the delete as well would strand the operator with a cluster they
+// can neither clear nor retry until the server restarts.
+//
+// Clearing is local only: KSail never confirmed which remote cluster this was, so it must not aim a
+// delete at AWS on the strength of a name.
+func TestDeleteEKSClearsFailedCreateWithoutOwnershipState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "failed-eks"
+
+	provisioner := &fakeProvisioner{createErr: errSimulatedCreateFailure}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: provisioner,
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, ok := phaseOf(list, clusterName)
+
+		return ok && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	// Precondition: the failed create left no ownership state behind.
+	_, loadErr := state.LoadClusterSpec(clusterName)
+	require.ErrorIs(t, loadErr, state.ErrStateNotFound)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		_, present := phaseOf(list, clusterName)
+
+		return !present
+	}, eventuallyTimeout, eventuallyTick)
+
+	// The remote cluster was never confirmed, so no AWS mutation may have been attempted.
+	assert.Empty(t, provisioner.deletedNames())
+}
+
+// TestDeleteEKSRefusesLiveClusterWithoutOwnershipState is the negative control for the clearing path
+// above: the exemption is scoped to a *failed create*, not to "ownership state is missing". A live
+// EKS cluster whose state KSail cannot find is exactly the unconfirmed target the guard exists to
+// protect, so it must still be refused.
+func TestDeleteEKSRefusesLiveClusterWithoutOwnershipState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "live-eks"
+
+	service, provisioner := newReadyUnboundEKSService(t, clusterName)
+
+	err := service.Delete(context.Background(), "default", clusterName)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Empty(t, provisioner.deletedNames())
 }

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2105,3 +2105,117 @@ func TestDeleteEKSRefusesADifferentFailedCreateInTheSameWindow(t *testing.T) {
 	assert.True(t, service.JobPresentForTest(clusterName),
 		"the replacement create's failure must survive: clearing it discards the only record of it")
 }
+
+// ownershipRecordFor is the immutable identity AWS confirmed at create time, which is what binds a
+// cluster to a region once its create completed.
+func ownershipRecordFor(name, region string) *state.EKSOwnershipState {
+	return &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: name,
+		Region:      region,
+		AccountID:   "123456789012",
+		ClusterARN:  "arn:aws:eks:" + region + ":123456789012:cluster/" + name,
+		CreatedAt:   time.Date(2026, 7, 29, 8, 0, 0, 0, time.UTC),
+		AWSOptions: v1alpha1.OptionsAWS{ //nolint:gosec // G101: env-var NAMES, never credential values.
+			ProfileEnvVar:         "AWS_PROFILE",
+			RegionEnvVar:          "AWS_REGION",
+			AccessKeyIDEnvVar:     "AWS_ACCESS_KEY_ID",
+			SecretAccessKeyEnvVar: "AWS_SECRET_ACCESS_KEY",
+			SessionTokenEnvVar:    "AWS_SESSION_TOKEN",
+		},
+	}
+}
+
+// TestBoundEKSConfigBindsFromOwnershipWhenTheStateConfigIsAbsent covers clusters created the NORMAL
+// way. `ksail cluster create` writes persisted cluster state (which marks the create complete) but
+// scaffolds eks.yaml into the PROJECT directory, while only the local API backend writes one under
+// ~/.ksail/clusters/<name>. The bound path therefore entered on state it trusted and then failed
+// reading a file nothing had put there — breaking every start, stop and delete for exactly the
+// clusters created the ordinary way. The ownership record is the authoritative binding for both.
+func TestBoundEKSConfigBindsFromOwnershipWhenTheStateConfigIsAbsent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// A region that is NOT the recorded one: binding must come from the record, never the ambient
+	// environment, or this test would pass while the redirect it guards was still possible.
+	t.Setenv("AWS_REGION", "us-west-2")
+
+	const name = "cli-created"
+
+	require.NoError(t, state.SaveClusterSpec(name, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+	}))
+	require.NoError(
+		t,
+		state.SaveEKSOwnershipState(name, "eu-north-1", ownershipRecordFor(name, "eu-north-1")),
+	)
+
+	configPath, region, err := clusterapi.ExportEKSConfigForCreate(name)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-north-1", region, "the creation region must come from the ownership record")
+	assert.FileExists(t, configPath, "the provisioner still needs the config on disk")
+}
+
+// TestBoundEKSConfigRefusesAmbiguousOwnership is the destructive-path guard on that binding. Two
+// ownership records mean two same-named clusters in different AWS regions, and nothing on disk says
+// which one an operator meant. Choosing either would aim a delete at a cluster nobody named, so the
+// only safe answer is to refuse and say what it found.
+func TestBoundEKSConfigRefusesAmbiguousOwnership(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-north-1")
+
+	const name = "two-regions"
+
+	require.NoError(t, state.SaveClusterSpec(name, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+	}))
+
+	for _, region := range []string{"eu-north-1", "us-east-1"} {
+		require.NoError(
+			t,
+			state.SaveEKSOwnershipState(name, region, ownershipRecordFor(name, region)),
+		)
+	}
+
+	_, _, err := clusterapi.ExportEKSConfigForCreate(name)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Contains(t, err.Error(), "more than one region")
+	assert.Contains(t, err.Error(), "eu-north-1")
+	assert.Contains(t, err.Error(), "us-east-1")
+}
+
+// TestDeleteResolvesAPersistedEKSTargetOutsideTheSelectedRegion covers the other half of the same
+// binding. Live enumeration lists only the region selected NOW, so an EKS cluster created in another
+// region — or one the UI has simply been repointed away from since, which is reproducible by
+// restarting it with a different AWS_REGION — vanished from the listing, and start/stop/delete
+// reported "not found" before the ownership check could run. The cluster is not missing; the ambient
+// region is just pointed elsewhere, and the persisted record says so.
+//
+// The assertion is deliberately about which ANSWER is reached, not about the mutation succeeding:
+// resolving must hand the request to confirmEKSOwnership rather than short-circuit it, so a target
+// KSail cannot account for is still refused — just never as an absence.
+func TestDeleteResolvesAPersistedEKSTargetOutsideTheSelectedRegion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "other-region"
+
+	// No provisioner lists this cluster: discovery in the currently-selected region cannot see it.
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: {},
+	})
+
+	// The control: with no record either, "not found" is the correct and expected answer.
+	require.ErrorIs(t,
+		service.Delete(context.Background(), "default", clusterName),
+		api.ErrNotFound,
+		"a cluster with no live listing and no ownership record really is unknown")
+
+	require.NoError(t, state.SaveEKSOwnershipState(
+		clusterName, "ap-southeast-2", ownershipRecordFor(clusterName, "ap-southeast-2"),
+	))
+
+	err := service.Delete(context.Background(), "default", clusterName)
+	require.NotErrorIs(t, err, api.ErrNotFound,
+		"a cluster KSail holds an ownership record for is not missing; the selected region is")
+}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2232,18 +2232,18 @@ func TestDeleteResolvesAPersistedEKSTargetOutsideTheSelectedRegion(t *testing.T)
 
 // writeStateEKSConfig puts an eks.yaml under ~/.ksail/clusters/<name> carrying region, standing in
 // for a file an earlier KSail wrote from whatever region happened to be selected at the time.
-func writeStateEKSConfig(t *testing.T, name, region string) string {
+func writeStateEKSConfig(t *testing.T, name, region string) {
 	t.Helper()
 
 	dir := filepath.Join(os.Getenv("HOME"), ".ksail", "clusters", name)
+	//nolint:gosec // G703: test-controlled path under the temp HOME set by t.Setenv.
 	require.NoError(t, os.MkdirAll(dir, 0o750))
 
 	path := filepath.Join(dir, "eks.yaml")
+	//nolint:gosec // G703: test-controlled path under the temp HOME set by t.Setenv.
 	require.NoError(t, os.WriteFile(path, []byte(
 		"apiVersion: eksctl.io/v1alpha5\nkind: ClusterConfig\nmetadata:\n  name: "+name+
 			"\n  region: "+region+"\n"), 0o600))
-
-	return path
 }
 
 func saveEKSClusterSpec(t *testing.T, name string) {

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1812,7 +1812,14 @@ func TestEKSCreateRejectsStateBelongingToAnotherDistribution(t *testing.T) {
 // can neither clear nor retry until the server restarts.
 //
 // Clearing is local only: KSail never confirmed which remote cluster this was, so it must not aim a
-// delete at AWS on the strength of a name.
+// delete at AWS on the strength of a name. That is exactly why the caller must not be answered with
+// success. runCreate marks the job Failed when the state write fails *after* the provisioner
+// returned, so a billable cluster can exist behind a Failed row; answering Delete with 204 tells the
+// operator the cluster is gone when KSail has established no such thing.
+//
+// The two halves are asserted together on purpose. Clearing without reporting hides the remote
+// resources, and reporting without clearing strands the retry — so this test fails if either is
+// dropped, and the negative controls below fail if the report is widened into a refusal.
 func TestDeleteEKSClearsFailedCreateWithoutOwnershipState(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -1842,7 +1849,13 @@ func TestDeleteEKSClearsFailedCreateWithoutOwnershipState(t *testing.T) {
 	_, loadErr := state.LoadClusterSpec(clusterName)
 	require.ErrorIs(t, loadErr, state.ErrStateNotFound)
 
-	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	err = service.Delete(context.Background(), "default", clusterName)
+
+	// Reported, not silently succeeded: the create may have left resources in AWS that KSail cannot
+	// see, and the caller is the only party who can go and look.
+	require.ErrorIs(t, err, clusterapi.ErrEKSCreateClearedLocally)
+	assert.Contains(t, err.Error(), clusterName,
+		"the operator has to know which cluster name to search the account for")
 
 	require.Eventually(t, func() bool {
 		list, listErr := service.List(context.Background())
@@ -1855,6 +1868,18 @@ func TestDeleteEKSClearsFailedCreateWithoutOwnershipState(t *testing.T) {
 
 	// The remote cluster was never confirmed, so no AWS mutation may have been attempted.
 	assert.Empty(t, provisioner.deletedNames())
+
+	// The report must not have cost the operator the retry. Create rejects any existing jobs entry,
+	// so this only succeeds if the failed job was genuinely dropped — which is what distinguishes
+	// this path from the refusals below, and what a fix that merely returned an error would break.
+	provisioner.createErr = nil
+
+	_, retryErr := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, retryErr,
+		"clearing the job is what makes the create retryable; reporting must not undo it")
 }
 
 // TestDeleteEKSRefusesLiveClusterWithoutOwnershipState is the negative control for the clearing path

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/internal/testutil/rootcheck"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil/scaffolder"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
@@ -1028,24 +1029,36 @@ func TestEKSConfigRejectsNonSegmentName(t *testing.T) {
 	}
 }
 
-// TestEKSCreateRefusesWhenNoRegionIsSelected covers the create-time trap: an unset AWS_REGION would
-// otherwise be stamped into metadata.region, and boundEKSConfig rejects such a file permanently once
-// persisted state exists — leaving a cluster that can never be deleted, started or stopped through
-// KSail. Nothing may be written on this path.
-func TestEKSCreateRefusesWhenNoRegionIsSelected(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("AWS_REGION", "")
+// TestEKSCreateBindsTheRegionItWrites is the invariant the removed refusal was reaching for, stated
+// directly. The hazard was never the empty environment variable: it was the bound region and
+// metadata.region disagreeing, because boundEKSConfig compares them and rejects the file
+// permanently once persisted state exists — a cluster that can never be deleted, started or
+// stopped through KSail.
+//
+// Refusing the create only avoided that by removing a supported path. Resolving one value and
+// using it on both sides prevents the disagreement outright, so this asserts the agreement in both
+// environments rather than the refusal in one.
+func TestEKSCreateBindsTheRegionItWrites(t *testing.T) {
+	for _, env := range []struct{ name, region string }{
+		{"region set", "eu-central-1"},
+		{"region unset", ""},
+	} {
+		t.Run(env.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("AWS_REGION", env.region)
 
-	const clusterName = "no-region-eks"
+			const clusterName = "bound-region-eks"
 
-	_, _, err := clusterapi.ExportEKSConfigForCreate(clusterName)
-	require.ErrorIs(t, err, api.ErrInvalid)
-	assert.Contains(t, err.Error(), "no AWS region is selected")
+			configPath, bound, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+			require.NoError(t, err)
+			require.NotEmpty(t, bound, "a bound region must never be empty")
 
-	home, homeErr := os.UserHomeDir()
-	require.NoError(t, homeErr)
-	assert.NoFileExists(t, filepath.Join(home, ".ksail", "clusters", clusterName, "eks.yaml"),
-		"a refused create must leave no region-less binding behind")
+			data, readErr := os.ReadFile(configPath)
+			require.NoError(t, readErr)
+			assert.Contains(t, string(data), "region: "+bound,
+				"metadata.region must equal the region bound into persisted state")
+		})
+	}
 }
 
 // TestEKSConfigReportsNameErrorAheadOfMissingRegion pins the precedence between the two create-time
@@ -1728,4 +1741,32 @@ func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 				"a refused mutation must never reach the provisioner")
 		})
 	}
+}
+
+// TestEKSCreateFallsBackToTheScaffolderDefaultRegion is the regression Codex found: refusing the
+// create when AWS_REGION is unset broke the supported default-region path, on a premise that does
+// not hold. writeEKSConfig renders through scaffolder.DefaultEKSConfigParams, which substitutes its
+// own default for an empty region — so an empty AWS_REGION was never going to reach metadata.region,
+// and there was no region-less binding to protect against.
+//
+// What DOES matter for this PR is that the region bound into persisted state is the same one the
+// file carries. Resolving the fallback at the call site is what guarantees that: both sides now read
+// one value instead of deriving it independently.
+func TestEKSCreateFallsBackToTheScaffolderDefaultRegion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "")
+
+	const clusterName = "default-region-eks"
+
+	configPath, region, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.NoError(t, err, "an unset AWS_REGION must not refuse the create")
+
+	expected := scaffolder.DefaultEKSConfigParams(clusterName, "").Region
+	require.NotEmpty(t, expected, "the scaffolder default must be a real region")
+	assert.Equal(t, expected, region, "the bound region must be the scaffolder default")
+
+	data, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "region: "+expected,
+		"the written metadata.region must equal the region bound into persisted state")
 }

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -3,6 +3,7 @@ package clusterapi_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1480,7 +1481,7 @@ func newRegionRecordingEKSService(
 		if name != "" {
 			_, region, err := clusterapi.ExportEKSConfigForCreate(name)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("resolve EKS config for %q: %w", name, err)
 			}
 
 			recorder.record(region)

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2053,3 +2053,55 @@ func TestDeleteFailedLocalCreateStillReachesTheProvisioner(t *testing.T) {
 		return slices.Contains(provisioner.deletedNames(), clusterName)
 	}, eventuallyTimeout, eventuallyTick)
 }
+
+// TestDeleteEKSRefusesADifferentFailedCreateInTheSameWindow is the sharper half of the windowed race,
+// and the one a full re-check of the predicate does NOT catch. A replacement that is itself a failed
+// EKS create matches phase, origin and distribution exactly, so every field-based test passes while
+// the entry is a different operation's failure.
+//
+// Clearing it would report success for a delete that never inspected this create, and silently
+// discard the record of why the second create failed. Only the job's identity separates "the entry I
+// approved" from "an entry just like it".
+func TestDeleteEKSRefusesADifferentFailedCreateInTheSameWindow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "replaced-by-a-twin"
+
+	provisioner := &fakeProvisioner{createErr: errSimulatedCreateFailure}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: provisioner,
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, ok := phaseOf(list, clusterName)
+
+		return ok && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	reads := 0
+
+	service.SetLoadClusterSpecForTest(func(name string) (*v1alpha1.ClusterSpec, error) {
+		reads++
+
+		service.ReplaceJobWithAnotherFailedEKSCreateForTest(name)
+
+		return nil, state.ErrStateNotFound
+	})
+
+	err = service.Delete(context.Background(), "default", clusterName)
+
+	require.Equal(t, 1, reads,
+		"the unlocked ownership read must have run, or the window under test was never entered")
+	require.ErrorIs(t, err, api.ErrInvalid,
+		"a delete must not clear a failed create it never approved, however alike the two look")
+	assert.True(t, service.JobPresentForTest(clusterName),
+		"the replacement create's failure must survive: clearing it discards the only record of it")
+}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devantler-tech/ksail/v7/internal/testutil/rootcheck"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
@@ -584,7 +585,8 @@ func saveEKSCapacitySnapshot(t *testing.T, clusterName string) {
 // an undismissable row in the web UI for a cluster that no longer exists — the very trap the
 // idempotent-delete behaviour exists to avoid. The cleanup failure is a warning, not a job failure.
 func TestDeleteEKSClearsJobWhenOnlyLocalStateCleanupFails(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
 	const clusterName = "cleanup-fails"
 
@@ -605,10 +607,21 @@ func TestDeleteEKSClearsJobWhenOnlyLocalStateCleanupFails(t *testing.T) {
 		return found && phase == v1alpha1.ClusterPhaseReady
 	}, eventuallyTimeout, eventuallyTick)
 
-	// Force local state cleanup to fail deterministically: with no resolvable home directory the
-	// state layer cannot locate — and therefore cannot remove — the cluster's state directory. The
-	// provisioner still reports a clean deletion.
-	t.Setenv("HOME", "")
+	// Force local state cleanup to fail deterministically while leaving the state itself readable:
+	// dropping write permission on the parent directory keeps the ownership state loadable (delete
+	// binds its target from it) but makes removing the cluster's state directory fail. Blanking HOME
+	// would instead make the state unreadable, which the EKS mutation guard rejects up front — a
+	// different failure than the cleanup-only one this test pins.
+	if rootcheck.IsRootUser() {
+		t.Skip("root bypasses directory permissions, so cleanup cannot be made to fail")
+	}
+
+	clustersDir := filepath.Join(home, ".ksail", "clusters")
+	require.NoError(t, os.Chmod(clustersDir, 0o500))
+
+	t.Cleanup(func() {
+		_ = os.Chmod(clustersDir, 0o700)
+	})
 
 	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
 	require.Eventually(t, func() bool {
@@ -1290,4 +1303,144 @@ func TestListWithoutKubeconfigSurfacesNoUnmanaged(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, list.Items, 1)
 	assert.False(t, list.Items[0].IsUnmanaged())
+}
+
+// TestEKSActionAfterCreateBindsRegionToCreationNotCurrentSettings is the core guard for #6203: once
+// a cluster exists, a later delete/start/stop must target the region that created it. Re-resolving
+// the region from Settings would send the action to a same-named cluster in whichever region is
+// selected at action time — and delete is destructive.
+func TestEKSActionAfterCreateBindsRegionToCreationNotCurrentSettings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-north-1")
+
+	const clusterName = "bound-eks"
+
+	createPath, createRegion, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.NoError(t, err)
+	require.Equal(t, "eu-north-1", createRegion)
+
+	// Persisted cluster state is what marks the create as complete, turning every later resolution
+	// into a mutation of an existing remote cluster.
+	require.NoError(t, state.SaveClusterSpec(clusterName, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+	}))
+
+	// The operator now picks a different region in Settings.
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	mutatePath, mutateRegion, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-north-1", mutateRegion,
+		"a post-create action must target the region the cluster was created in")
+	assert.Equal(t, createPath, mutatePath)
+
+	// The binding is also the only local evidence of the original target, so it must survive rather
+	// than be rewritten with the newly selected region.
+	data, err := os.ReadFile(createPath) //nolint:gosec // test-controlled path under a temp HOME.
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "region: eu-north-1")
+	assert.NotContains(t, string(data), "us-east-1")
+}
+
+// TestEKSConfigFollowsCurrentRegionUntilCreateCompletes pins the other side of the discriminator: a
+// first create — and a retry after a failed one, which leaves no persisted state — must honour the
+// region selected now, so a corrected region is not ignored.
+func TestEKSConfigFollowsCurrentRegionUntilCreateCompletes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-north-1")
+
+	const clusterName = "retried-eks"
+
+	_, region, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.NoError(t, err)
+	require.Equal(t, "eu-north-1", region)
+
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	_, retryRegion, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", retryRegion,
+		"with no completed create, the region selected now must still apply")
+}
+
+// TestEKSConfigRefusesWhenBindingEvidenceIsMissing covers the fail-closed path: the cluster
+// completed creation but its region evidence is gone, so the target cannot be confirmed. Falling
+// back to the ambient region here is exactly the redirect this change prevents.
+func TestEKSConfigRefusesWhenBindingEvidenceIsMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-north-1")
+
+	const clusterName = "evidence-gone"
+
+	require.NoError(t, state.SaveClusterSpec(clusterName, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+	}))
+
+	_, _, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.ErrorIs(t, err, api.ErrInvalid)
+}
+
+// TestDeleteEKSRefusesWithoutPersistedOwnershipState guards the destructive path directly: with no
+// ownership state the backend cannot confirm which remote cluster it would delete, so it must
+// refuse rather than proceed against an ambient target.
+func TestDeleteEKSRefusesWithoutPersistedOwnershipState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "unbound-eks"
+
+	provisioner := &fakeProvisioner{}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: provisioner,
+	})
+	_, err := service.Create(context.Background(), clusterFor(clusterName, v1alpha1.DistributionEKS))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+
+	require.NoError(t, state.DeleteClusterState(clusterName))
+
+	err = service.Delete(context.Background(), "default", clusterName)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Empty(t, provisioner.deletedNames(),
+		"an unconfirmed target must never reach the provisioner")
+}
+
+// TestDeleteEKSRefusesWhenPersistedOwnershipStateDisagrees covers the inconsistent case: state that
+// records a different backend than the cluster resolved as cannot describe this target.
+func TestDeleteEKSRefusesWhenPersistedOwnershipStateDisagrees(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "mismatched-eks"
+
+	provisioner := &fakeProvisioner{}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: provisioner,
+	})
+	_, err := service.Create(context.Background(), clusterFor(clusterName, v1alpha1.DistributionEKS))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+
+	require.NoError(t, state.SaveClusterSpec(clusterName, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderDocker,
+	}))
+
+	err = service.Delete(context.Background(), "default", clusterName)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Empty(t, provisioner.deletedNames())
 }

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2385,3 +2385,54 @@ func TestBoundEKSConfigAcceptsAConfigWithNoOwnershipRecord(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "eu-north-1", region, "the config alone still binds when no record exists")
 }
+
+// TestCreateRefusesANameWhoseEKSCreateStateRemains covers the CREATE half of the region binding.
+//
+// The binding that makes delete/start/stop follow the creation region must never steer a create.
+// A cluster removed out of band leaves spec.json and eks.yaml behind while discovery stops
+// reporting it, so Create accepts the name again — and resolving the stale binding there would
+// provision NEW cloud resources into the old region while the operator believes they selected a
+// different one.
+//
+// Refusing is the fail-closed answer rather than rendering a fresh config: per-provider discovery
+// failures are logged and skipped, so a name missing from the live set is not proof the remote
+// cluster is gone. Re-rendering would overwrite the only local evidence binding a cluster that may
+// still be running, leaving it unreachable by KSail in its real region.
+func TestCreateRefusesANameWhoseEKSCreateStateRemains(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-north-1")
+
+	const name = "recreated-eks"
+
+	// A completed create: state plus the config and record binding it to eu-north-1.
+	saveEKSClusterSpec(t, name)
+	writeStateEKSConfig(t, name, "eu-north-1")
+	require.NoError(
+		t,
+		state.SaveEKSOwnershipState(name, "eu-north-1", ownershipRecordFor(name, "eu-north-1")),
+	)
+
+	// The cluster is then removed out of band and the operator selects a different region.
+	t.Setenv("AWS_REGION", "us-west-2")
+
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionEKS: {},
+	})
+
+	_, err := service.Create(context.Background(), clusterFor(name, v1alpha1.DistributionEKS))
+	require.ErrorIs(t, err, api.ErrAlreadyExists,
+		"a create for a name that still carries a completed EKS create's state must be refused")
+	assert.Contains(t, err.Error(), "cluster delete",
+		"the refusal must name the command that clears the stale state, or it just moves the surprise")
+
+	// Deterministic discriminator: Create registers the job synchronously before spawning the
+	// background provisioner, so an unrefused create leaves a tracked job behind.
+	assert.False(t, service.JobPresentForTest(name),
+		"the refusal must happen before a job is registered, so nothing is provisioned")
+
+	// Control: the refusal must leave the binding evidence intact, not consume it.
+	_, region, err := clusterapi.ExportEKSConfigForCreate(name)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-north-1", region,
+		"a refused create must preserve the original region binding")
+}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1872,3 +1872,40 @@ func TestDeleteEKSRefusesLiveClusterWithoutOwnershipState(t *testing.T) {
 	require.ErrorIs(t, err, api.ErrInvalid)
 	assert.Empty(t, provisioner.deletedNames())
 }
+
+// TestDeleteFailedLocalCreateStillReachesTheProvisioner pins the distribution scope of the
+// failed-create clearing path. Clearing the job locally is right for EKS, where the ownership guard
+// stands between KSail and a remote account it cannot identify. It would be wrong for a local
+// distribution: a half-finished Kind or vCluster create leaves containers behind, and the
+// provisioner's Delete is what removes them. Local distributions must therefore still go through the
+// provisioner rather than having their job quietly dropped.
+func TestDeleteFailedLocalCreateStillReachesTheProvisioner(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "half-made"
+
+	provisioner := &fakeProvisioner{createErr: errSimulatedCreateFailure}
+	service := newTestService(map[v1alpha1.Distribution]*fakeProvisioner{
+		v1alpha1.DistributionVanilla: provisioner,
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionVanilla),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, ok := phaseOf(list, clusterName)
+
+		return ok && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(provisioner.deletedNames(), clusterName)
+	}, eventuallyTimeout, eventuallyTick)
+}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2154,6 +2154,18 @@ func TestBoundEKSConfigBindsFromOwnershipWhenTheStateConfigIsAbsent(t *testing.T
 	require.NoError(t, err)
 	assert.Equal(t, "eu-north-1", region, "the creation region must come from the ownership record")
 	assert.FileExists(t, configPath, "the provisioner still needs the config on disk")
+
+	// Assert the region inside the FILE, not just the returned one. eksctl reads the file, so a
+	// config written from the ambient region while the returned value carried the bound one would
+	// aim the action at us-west-2 and still satisfy every assertion above.
+	written, readErr := os.ReadFile(
+		configPath,
+	) //nolint:gosec // test-controlled path under a temp HOME.
+	require.NoError(t, readErr)
+	assert.Contains(t, string(written), "region: eu-north-1",
+		"the generated eks.yaml must carry the bound region, not the ambient one")
+	assert.NotContains(t, string(written), "us-west-2",
+		"the ambient region must not reach the file the provisioner reads")
 }
 
 // TestBoundEKSConfigRefusesAmbiguousOwnership is the destructive-path guard on that binding. Two

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1053,6 +1053,7 @@ func TestEKSCreateBindsTheRegionItWrites(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, bound, "a bound region must never be empty")
 
+			//nolint:gosec // test-controlled path under a temp HOME.
 			data, readErr := os.ReadFile(configPath)
 			require.NoError(t, readErr)
 			assert.Contains(t, string(data), "region: "+bound,
@@ -1765,6 +1766,7 @@ func TestEKSCreateFallsBackToTheScaffolderDefaultRegion(t *testing.T) {
 	require.NotEmpty(t, expected, "the scaffolder default must be a real region")
 	assert.Equal(t, expected, region, "the bound region must be the scaffolder default")
 
+	//nolint:gosec // test-controlled path under a temp HOME.
 	data, readErr := os.ReadFile(configPath)
 	require.NoError(t, readErr)
 	assert.Contains(t, string(data), "region: "+expected,

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -224,6 +224,28 @@ func phaseOf(list *v1alpha1.ClusterList, name string) (v1alpha1.ClusterPhase, bo
 	return "", false
 }
 
+// requireEventuallyPhase waits for a cluster to reach a phase. Create and Delete are asynchronous, so
+// a test that stops at the call has not observed the operation — and, because the service writes
+// state under HOME, one that returns while a goroutine is still running lets that write land after
+// t.Setenv and t.TempDir have unwound, i.e. under the real home directory.
+func requireEventuallyPhase(
+	t *testing.T,
+	service *clusterapi.Service,
+	name string,
+	want v1alpha1.ClusterPhase,
+) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, ok := phaseOf(list, name)
+
+		return ok && phase == want
+	}, eventuallyTimeout, eventuallyTick)
+}
+
 func TestListMapsExistingClusters(t *testing.T) {
 	t.Parallel()
 
@@ -1835,15 +1857,7 @@ func TestDeleteEKSClearsFailedCreateWithoutOwnershipState(t *testing.T) {
 		clusterFor(clusterName, v1alpha1.DistributionEKS),
 	)
 	require.NoError(t, err)
-
-	require.Eventually(t, func() bool {
-		list, listErr := service.List(context.Background())
-		require.NoError(t, listErr)
-
-		phase, ok := phaseOf(list, clusterName)
-
-		return ok && phase == v1alpha1.ClusterPhaseFailed
-	}, eventuallyTimeout, eventuallyTick)
+	requireEventuallyPhase(t, service, clusterName, v1alpha1.ClusterPhaseFailed)
 
 	// Precondition: the failed create left no ownership state behind.
 	_, loadErr := state.LoadClusterSpec(clusterName)
@@ -1880,6 +1894,9 @@ func TestDeleteEKSClearsFailedCreateWithoutOwnershipState(t *testing.T) {
 	)
 	require.NoError(t, retryErr,
 		"clearing the job is what makes the create retryable; reporting must not undo it")
+
+	// The retry must be allowed to finish inside the test — see requireEventuallyPhase.
+	requireEventuallyPhase(t, service, clusterName, v1alpha1.ClusterPhaseReady)
 }
 
 // TestDeleteEKSRefusesLiveClusterWithoutOwnershipState is the negative control for the clearing path

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1021,8 +1021,46 @@ func TestEKSConfigRejectsNonSegmentName(t *testing.T) {
 
 			_, _, err := clusterapi.ExportEKSConfigForCreate(name)
 			require.ErrorIs(t, err, api.ErrInvalid)
+			assert.NotContains(t, err.Error(), "no AWS region is selected",
+				"the name must be what is rejected, not the ambient region")
 		})
 	}
+}
+
+// TestEKSCreateRefusesWhenNoRegionIsSelected covers the create-time trap: an unset AWS_REGION would
+// otherwise be stamped into metadata.region, and boundEKSConfig rejects such a file permanently once
+// persisted state exists — leaving a cluster that can never be deleted, started or stopped through
+// KSail. Nothing may be written on this path.
+func TestEKSCreateRefusesWhenNoRegionIsSelected(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "")
+
+	const clusterName = "no-region-eks"
+
+	_, _, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Contains(t, err.Error(), "no AWS region is selected")
+
+	home, homeErr := os.UserHomeDir()
+	require.NoError(t, homeErr)
+	assert.NoFileExists(t, filepath.Join(home, ".ksail", "clusters", clusterName, "eks.yaml"),
+		"a refused create must leave no region-less binding behind")
+}
+
+// TestEKSConfigReportsNameErrorAheadOfMissingRegion pins the precedence between the two create-time
+// preconditions. Both are api.ErrInvalid, so without this the region check could silently take over
+// every rejection in TestEKSConfigRejectsNonSegmentName and make that guard vacuous whenever the
+// environment happens to carry no region.
+func TestEKSConfigReportsNameErrorAheadOfMissingRegion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "")
+
+	// "." is the discriminating case: unlike "foo/bar" it survives the state store's own name
+	// validation, so the segment check added ahead of the region check is what must reject it.
+	_, _, err := clusterapi.ExportEKSConfigForCreate(".")
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Contains(t, err.Error(), "single path segment")
+	assert.NotContains(t, err.Error(), "no AWS region is selected")
 }
 
 // TestCreatePassesProviderToFactory is the Phase 4 regression guard: the create path must route the
@@ -1307,11 +1345,11 @@ func TestListWithoutKubeconfigSurfacesNoUnmanaged(t *testing.T) {
 	assert.False(t, list.Items[0].IsUnmanaged())
 }
 
-// TestEKSActionAfterCreateBindsRegionToCreationNotCurrentSettings is the core guard for #6203: once
-// a cluster exists, a later delete/start/stop must target the region that created it. Re-resolving
-// the region from Settings would send the action to a same-named cluster in whichever region is
-// selected at action time — and delete is destructive.
-func TestEKSActionAfterCreateBindsRegionToCreationNotCurrentSettings(t *testing.T) {
+// TestEKSConfigResolutionAfterCreateBindsToCreationRegion pins the resolution half of #6203: once a
+// cluster exists, resolving its EKS config yields the region that created it rather than the one
+// selected now. TestDeleteEKSReachesProvisionerBoundToCreationRegion covers the lifecycle half —
+// that a successful action actually runs against that resolved region.
+func TestEKSConfigResolutionAfterCreateBindsToCreationRegion(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("AWS_REGION", "eu-north-1")
 
@@ -1382,6 +1420,124 @@ func TestEKSConfigRefusesWhenBindingEvidenceIsMissing(t *testing.T) {
 
 	_, _, err := clusterapi.ExportEKSConfigForCreate(clusterName)
 	require.ErrorIs(t, err, api.ErrInvalid)
+}
+
+// regionRecorder collects the region each named EKS factory build resolved, in order.
+type regionRecorder struct {
+	mu      sync.Mutex
+	regions []string
+}
+
+func (r *regionRecorder) record(region string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.regions = append(r.regions, region)
+}
+
+// since returns the regions recorded at or after index n, so a test can assert about one phase
+// without the earlier phase's resolutions bleeding into it.
+func (r *regionRecorder) since(n int) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.regions[min(n, len(r.regions)):])
+}
+
+func (r *regionRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.regions)
+}
+
+// newRegionRecordingEKSService wires a Service whose factory resolves the EKS distribution config
+// exactly as the production defaultFactory does — from the cluster name alone — and records the
+// region that resolution produced. That is what makes the region observable in a test: the region
+// never travels in the action's Spec, it is read back from the on-disk eks.yaml when the provisioner
+// is built.
+func newRegionRecordingEKSService(
+	t *testing.T,
+	provisioner *fakeProvisioner,
+	recorder *regionRecorder,
+) *clusterapi.Service {
+	t.Helper()
+
+	// Only EKS gets the cluster-bearing provisioner. Handing the same one to every distribution
+	// would let discovery find the cluster under Vanilla first, so the action would resolve as a
+	// Vanilla cluster and never take the EKS path this test exists to exercise.
+	empty := &fakeProvisioner{}
+
+	return clusterapi.NewTestService(func(
+		distribution v1alpha1.Distribution,
+		name string,
+	) (clusterprovisioner.Factory, error) {
+		if distribution != v1alpha1.DistributionEKS {
+			return fakeFactory{provisioner: empty}, nil
+		}
+
+		// Discovery builds a factory with no cluster name; only a named build resolves a config.
+		if name != "" {
+			_, region, err := clusterapi.ExportEKSConfigForCreate(name)
+			if err != nil {
+				return nil, err
+			}
+
+			recorder.record(region)
+		}
+
+		return fakeFactory{provisioner: provisioner}, nil
+	})
+}
+
+// TestDeleteEKSReachesProvisionerBoundToCreationRegion is the lifecycle guard #6203 needs: a
+// *successful* delete must reach the provisioner, and the config resolved to build that provisioner
+// must carry the creation region even though a different one is selected now. The refusal tests
+// below only prove that unconfirmed targets are blocked; without this one, a regression that bound
+// the happy path to the current region would pass the whole suite.
+func TestDeleteEKSReachesProvisionerBoundToCreationRegion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-north-1")
+
+	const clusterName = "lifecycle-eks"
+
+	recorder := &regionRecorder{}
+	provisioner := &fakeProvisioner{}
+	service := newRegionRecordingEKSService(t, provisioner, recorder)
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+
+	require.Equal(t, []string{"eu-north-1"}, recorder.since(0),
+		"create must bind to the region selected at create time")
+
+	// The operator selects a different region before deleting.
+	beforeDelete := recorder.count()
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		return slices.Equal(provisioner.deletedNames(), []string{clusterName})
+	}, eventuallyTimeout, eventuallyTick)
+
+	deleteRegions := recorder.since(beforeDelete)
+	require.NotEmpty(t, deleteRegions, "the delete must have built a provisioner for this cluster")
+
+	for _, region := range deleteRegions {
+		assert.Equal(t, "eu-north-1", region,
+			"a successful delete must run against the creation region, not the one selected now")
+	}
 }
 
 // TestDeleteEKSRefusesWithoutPersistedOwnershipState guards the destructive path directly: with no

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1698,8 +1698,12 @@ func TestUnconfirmedEKSMutationGuidanceMatchesTheRequestedAction(t *testing.T) {
 				"a refused mutation must never reach the provisioner")
 
 			if !testCase.wantDelete {
-				assert.NotContains(t, err.Error(), "eksctl delete cluster",
-					"a non-destructive action must not be answered with a destructive recovery step")
+				assert.NotContains(
+					t,
+					err.Error(),
+					"eksctl delete cluster",
+					"a non-destructive action must not be answered with a destructive recovery step",
+				)
 			}
 		})
 	}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2229,3 +2229,117 @@ func TestDeleteResolvesAPersistedEKSTargetOutsideTheSelectedRegion(t *testing.T)
 	require.NotErrorIs(t, err, api.ErrNotFound,
 		"a cluster KSail holds an ownership record for is not missing; the selected region is")
 }
+
+// writeStateEKSConfig puts an eks.yaml under ~/.ksail/clusters/<name> carrying region, standing in
+// for a file an earlier KSail wrote from whatever region happened to be selected at the time.
+func writeStateEKSConfig(t *testing.T, name, region string) string {
+	t.Helper()
+
+	dir := filepath.Join(os.Getenv("HOME"), ".ksail", "clusters", name)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+
+	path := filepath.Join(dir, "eks.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(
+		"apiVersion: eksctl.io/v1alpha5\nkind: ClusterConfig\nmetadata:\n  name: "+name+
+			"\n  region: "+region+"\n"), 0o600))
+
+	return path
+}
+
+func saveEKSClusterSpec(t *testing.T, name string) {
+	t.Helper()
+
+	require.NoError(t, state.SaveClusterSpec(name, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+		Provider:     v1alpha1.ProviderAWS,
+	}))
+}
+
+// TestBoundEKSConfigRefusesAStaleConfigTheOwnershipRecordContradicts is a destructive-path guard.
+//
+// eks.yaml is a RENDERED file: before this binding existed, every delete/start/stop re-rendered it
+// from the ambient AWS_REGION, so a file left by that behaviour can name a region the cluster was
+// never created in. Reading it without consulting the immutable ownership record left exactly the
+// redirect this binding exists to prevent — a delete aimed at a same-named cluster in the file's
+// region — for any cluster whose config predates the record.
+func TestBoundEKSConfigRefusesAStaleConfigTheOwnershipRecordContradicts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "us-west-2")
+
+	const name = "stale-config"
+
+	saveEKSClusterSpec(t, name)
+	writeStateEKSConfig(t, name, "us-west-2")
+	require.NoError(
+		t,
+		state.SaveEKSOwnershipState(name, "eu-north-1", ownershipRecordFor(name, "eu-north-1")),
+	)
+
+	_, _, err := clusterapi.ExportEKSConfigForCreate(name)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Contains(t, err.Error(), "eu-north-1", "the error must name the recorded region")
+	assert.Contains(t, err.Error(), "us-west-2", "the error must name the config's region")
+}
+
+// TestBoundEKSConfigRefusesAmbiguousOwnershipWithAConfigPresent closes the same hole for the
+// multi-region case. Reading the config first meant a materialised eks.yaml silently answered a
+// question that has no answer: two records mean two same-named clusters, and the file's region is
+// not evidence of which one an operator meant.
+func TestBoundEKSConfigRefusesAmbiguousOwnershipWithAConfigPresent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-north-1")
+
+	const name = "two-regions-with-config"
+
+	saveEKSClusterSpec(t, name)
+	writeStateEKSConfig(t, name, "eu-north-1")
+
+	for _, region := range []string{"eu-north-1", "us-east-1"} {
+		require.NoError(
+			t,
+			state.SaveEKSOwnershipState(name, region, ownershipRecordFor(name, region)),
+		)
+	}
+
+	_, _, err := clusterapi.ExportEKSConfigForCreate(name)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Contains(t, err.Error(), "more than one region")
+}
+
+// TestBoundEKSConfigAcceptsAConfigTheOwnershipRecordAgreesWith is the over-tightening control for
+// both tests above: the ordinary case, where the record and the file say the same thing, must stay
+// silent. A guard that failed the normal path would be routed around rather than fixed.
+func TestBoundEKSConfigAcceptsAConfigTheOwnershipRecordAgreesWith(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "us-west-2")
+
+	const name = "agreeing-config"
+
+	saveEKSClusterSpec(t, name)
+	writeStateEKSConfig(t, name, "eu-north-1")
+	require.NoError(
+		t,
+		state.SaveEKSOwnershipState(name, "eu-north-1", ownershipRecordFor(name, "eu-north-1")),
+	)
+
+	_, region, err := clusterapi.ExportEKSConfigForCreate(name)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-north-1", region, "an agreeing config still binds to the creation region")
+}
+
+// TestBoundEKSConfigAcceptsAConfigWithNoOwnershipRecord is the second over-tightening control.
+// Clusters created before ownership records existed have only the config, and it remains their one
+// piece of binding evidence — requiring a record would break every one of them.
+func TestBoundEKSConfigAcceptsAConfigWithNoOwnershipRecord(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "us-west-2")
+
+	const name = "legacy-config-only"
+
+	saveEKSClusterSpec(t, name)
+	writeStateEKSConfig(t, name, "eu-north-1")
+
+	_, region, err := clusterapi.ExportEKSConfigForCreate(name)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-north-1", region, "the config alone still binds when no record exists")
+}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -1770,3 +1770,29 @@ func TestEKSCreateFallsBackToTheScaffolderDefaultRegion(t *testing.T) {
 	assert.Contains(t, string(data), "region: "+expected,
 		"the written metadata.region must equal the region bound into persisted state")
 }
+
+// TestEKSCreateRejectsStateBelongingToAnotherDistribution covers the second finding on this PR:
+// LoadClusterSpec persists state for EVERY distribution, so treating the mere existence of
+// spec.json as proof that an EKS create completed misreads a Kind or Talos cluster of the same
+// name. The bound path then looks for an eks.yaml that was never written, and the user sees a
+// confusing read error instead of the name collision they actually have.
+//
+// A name collision is reported rather than silently treated as a fresh create: two clusters would
+// otherwise share one state directory, and the second create would overwrite the first's record.
+func TestEKSCreateRejectsStateBelongingToAnotherDistribution(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_REGION", "eu-central-1")
+
+	const clusterName = "not-an-eks-cluster"
+
+	require.NoError(t, state.SaveClusterSpec(clusterName, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionVanilla,
+	}))
+
+	_, _, err := clusterapi.ExportEKSConfigForCreate(clusterName)
+	require.ErrorIs(t, err, api.ErrInvalid)
+	assert.Contains(t, err.Error(), "Vanilla",
+		"the error must name the distribution that actually owns the state")
+	assert.NotContains(t, err.Error(), "read the eks config",
+		"a name collision must not surface as a missing-eks.yaml read error")
+}

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -2422,8 +2422,12 @@ func TestCreateRefusesANameWhoseEKSCreateStateRemains(t *testing.T) {
 	_, err := service.Create(context.Background(), clusterFor(name, v1alpha1.DistributionEKS))
 	require.ErrorIs(t, err, api.ErrAlreadyExists,
 		"a create for a name that still carries a completed EKS create's state must be refused")
-	assert.Contains(t, err.Error(), "cluster delete",
-		"the refusal must name the command that clears the stale state, or it just moves the surprise")
+	assert.Contains(
+		t,
+		err.Error(),
+		"cluster delete",
+		"the refusal must name the command that clears the stale state, or it just moves the surprise",
+	)
 
 	// Deterministic discriminator: Create registers the job synchronously before spawning the
 	// background provisioner, so an unrefused create leaves a tracked job behind.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Creating an EKS cluster from the local web UI binds it to the AWS region selected in Settings at that moment. Deleting, starting or stopping it later did **not** reuse that binding — it rebuilt the target from whatever region was selected at action time.

So changing the region in Settings between creating a cluster and operating on it could point a **destructive** action at a different, same-named cluster in the newly selected region. The same code path also overwrote the only local record of the original target, so the evidence needed to notice the mistake was destroyed by the action itself.

## What

Actions on an EKS cluster that has finished creating now resolve their target from the binding written when it was created, instead of from the current selection. When that evidence is missing or disagrees with the cluster being acted on, the action is refused rather than falling back to an unconfirmed target — falling back is exactly the redirect being prevented, and delete cannot be undone.

A refusal now tells the operator how to recover, and the advice matches what they asked for: it leads with the KSail command that restores the missing binding — which touches nothing in AWS, so the original action can simply be retried — and only suggests deleting the cluster when deleting is what was requested. Previously every refusal, including start and stop, advised deleting a cluster KSail had just said it could not identify.

Creating a cluster is unchanged, including retrying after a failed create: until a create succeeds there is no binding, so the region selected now still applies and a corrected region is never ignored.

Part of #6203 — the first slice. The remaining acceptance criteria (an exact read-only ownership query before each mutation, and alignment with the immutable AWS account/cluster identity in #6202) need AWS identity calls and are deliberately not in this change.

