### PR TITLE
fix(ci): bound workflow-run cleanup work

### DIFF
--- a/.github/fixtures/workflow-run-cleanup/fake-bin/gh
+++ b/.github/fixtures/workflow-run-cleanup/fake-bin/gh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+state_dir="${FAKE_GH_STATE_DIR:?FAKE_GH_STATE_DIR is required}"
+scenario="${FAKE_GH_SCENARIO:-bounded}"
+mkdir -p "${state_dir}"
+
+if [[ "${scenario}" == api-failure && "$*" == *"actions/workflows?per_page=100"* ]]; then
+	printf 'fixture workflow API failure\n' >&2
+	exit 1
+fi
+
+case "$*" in
+*"api repos/devantler-tech/ksail --jq .default_branch"*)
+	printf 'main\n'
+	;;
+*"api --paginate repos/devantler-tech/ksail/branches?per_page=100"*)
+	printf 'main\nactive-feature\n'
+	;;
+*"actions/workflows?per_page=100"*)
+	printf '101\n'
+	;;
+*"api --method GET repos/devantler-tech/ksail/actions/workflows/101/runs -f per_page=2 --jq .workflow_runs[].id"*)
+	printf '1001\n1002\n'
+	;;
+*"api --method GET repos/devantler-tech/ksail/actions/workflows/101/runs -f per_page=100 -f created=<2026-07-02"*)
+	printf '%s\n' '{"id":1001,"head_branch":"deleted-feature","pull_request_count":0}'
+	printf '%s\n' '{"id":1003,"head_branch":"active-feature","pull_request_count":0}'
+	printf '%s\n' '{"id":1004,"head_branch":"deleted-feature","pull_request_count":1}'
+	printf '%s\n' '{"id":1005,"head_branch":"deleted-feature","pull_request_count":0}'
+	printf '%s\n' '{"id":1006,"head_branch":"","pull_request_count":0}'
+	printf '%s\n' '{"id":1007,"head_branch":"deleted-feature","pull_request_count":0}'
+	;;
+*"api --method DELETE repos/devantler-tech/ksail/actions/runs/1005"*)
+	printf '1005\n' >>"${state_dir}/deleted"
+	;;
+*"api --method DELETE repos/devantler-tech/ksail/actions/runs/1006"*)
+	printf '1006\n' >>"${state_dir}/deleted"
+	;;
+*"api --method DELETE repos/devantler-tech/ksail/actions/runs/"*)
+	printf 'unexpected deletion: %s\n' "$*" >&2
+	exit 90
+	;;
+*)
+	printf 'unexpected gh invocation: %s\n' "$*" >&2
+	exit 91
+	;;
+esac

--- a/.github/fixtures/workflow-run-cleanup/fake-bin/gh
+++ b/.github/fixtures/workflow-run-cleanup/fake-bin/gh
@@ -33,10 +33,21 @@ case "$*" in
 	printf '%s\n' '{"id":1007,"head_branch":"deleted-feature","pull_request_count":0}'
 	;;
 *"api --method DELETE repos/devantler-tech/ksail/actions/runs/1005"*)
+	if [[ "${scenario}" == delete-failure ]]; then
+		printf 'fixture deletion failure\n' >&2
+		exit 42
+	fi
 	printf '1005\n' >>"${state_dir}/deleted"
 	;;
 *"api --method DELETE repos/devantler-tech/ksail/actions/runs/1006"*)
 	printf '1006\n' >>"${state_dir}/deleted"
+	;;
+*"api --method DELETE repos/devantler-tech/ksail/actions/runs/1007"*)
+	if [[ "${scenario}" != delete-failure ]]; then
+		printf 'unexpected deletion: %s\n' "$*" >&2
+		exit 90
+	fi
+	printf '1007\n' >>"${state_dir}/deleted"
 	;;
 *"api --method DELETE repos/devantler-tech/ksail/actions/runs/"*)
 	printf 'unexpected deletion: %s\n' "$*" >&2

--- a/.github/scripts/delete-old-workflow-runs.sh
+++ b/.github/scripts/delete-old-workflow-runs.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  delete-old-workflow-runs.sh --repository OWNER/REPO --retain-days DAYS
+                              --keep-minimum-runs COUNT
+                              --max-deletions COUNT
+
+Delete a bounded batch of completed runs from active repository workflows.
+Runs newer than the retention cutoff, the newest COUNT runs per workflow,
+runs linked to pull requests, and runs on existing non-default branches are
+preserved. Orphan runs from deleted or organization-required workflows are
+deliberately outside this cleanup boundary.
+
+GH_TOKEN must contain actions:write for OWNER/REPO. COUNT for
+--max-deletions is capped at 750 so one execution stays within the
+repository-scoped GITHUB_TOKEN API budget.
+EOF
+}
+
+list_contains() {
+	local needle="$1"
+	local list="$2"
+	local item
+
+	while IFS= read -r item; do
+		if [[ "${item}" == "${needle}" ]]; then
+			return 0
+		fi
+	done <<<"${list}"
+
+	return 1
+}
+
+repository=""
+retain_days=""
+keep_minimum_runs=""
+max_deletions=""
+
+while (($# > 0)); do
+	case "$1" in
+	--repository)
+		repository="${2:-}"
+		shift 2
+		;;
+	--retain-days)
+		retain_days="${2:-}"
+		shift 2
+		;;
+	--keep-minimum-runs)
+		keep_minimum_runs="${2:-}"
+		shift 2
+		;;
+	--max-deletions)
+		max_deletions="${2:-}"
+		shift 2
+		;;
+	--help | -h)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'ERROR: unknown argument: %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+if [[ ! "${repository}" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ||
+	! "${retain_days}" =~ ^[1-9][0-9]*$ ||
+	! "${keep_minimum_runs}" =~ ^[1-9][0-9]*$ ||
+	! "${max_deletions}" =~ ^[1-9][0-9]*$ ||
+	"${keep_minimum_runs}" -gt 100 || "${max_deletions}" -gt 750 ]]; then
+	printf 'ERROR: valid repository, positive counts, keep <= 100, and max deletions <= 750 are required\n' >&2
+	usage >&2
+	exit 2
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+	printf 'ERROR: GH_TOKEN is required\n' >&2
+	exit 2
+fi
+
+cutoff_date="${KSAIL_MAINTENANCE_CUTOFF_DATE:-}"
+if [[ -z "${cutoff_date}" ]]; then
+	if cutoff_date="$(date -u -d "${retain_days} days ago" +%Y-%m-%d 2>/dev/null)"; then
+		:
+	else
+		cutoff_date="$(date -u -v-"${retain_days}"d +%Y-%m-%d)"
+	fi
+fi
+if [[ ! "${cutoff_date}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+	printf 'ERROR: invalid retention cutoff: %s\n' "${cutoff_date}" >&2
+	exit 2
+fi
+
+default_branch="$(gh api "repos/${repository}" --jq '.default_branch')"
+if [[ -z "${default_branch}" ]]; then
+	printf 'ERROR: repository default branch is empty\n' >&2
+	exit 1
+fi
+
+branch_output="$(
+	gh api --paginate "repos/${repository}/branches?per_page=100" --jq '.[] | .name'
+)"
+
+workflow_output="$(
+	gh api --paginate "repos/${repository}/actions/workflows?per_page=100" \
+		--jq '.workflows[] | select(.state == "active") | .id'
+)"
+workflow_ids=()
+while IFS= read -r workflow_id; do
+	if [[ "${workflow_id}" =~ ^[1-9][0-9]*$ ]]; then
+		workflow_ids+=("${workflow_id}")
+	elif [[ -n "${workflow_id}" ]]; then
+		printf 'ERROR: invalid workflow ID: %s\n' "${workflow_id}" >&2
+		exit 1
+	fi
+done <<<"${workflow_output}"
+
+deletions=0
+for workflow_id in "${workflow_ids[@]}"; do
+	keep_output="$(
+		gh api --method GET "repos/${repository}/actions/workflows/${workflow_id}/runs" \
+			-f "per_page=${keep_minimum_runs}" --jq '.workflow_runs[].id'
+	)"
+	while IFS= read -r keep_id; do
+		if [[ "${keep_id}" =~ ^[1-9][0-9]*$ ]]; then
+			:
+		elif [[ -n "${keep_id}" ]]; then
+			printf 'ERROR: invalid workflow run ID: %s\n' "${keep_id}" >&2
+			exit 1
+		fi
+	done <<<"${keep_output}"
+
+	candidate_output="$(
+		gh api --method GET "repos/${repository}/actions/workflows/${workflow_id}/runs" \
+			-f per_page=100 -f "created=<${cutoff_date}" \
+			--jq '.workflow_runs[] | select(.status == "completed") | {id, head_branch: (.head_branch // ""), pull_request_count: (.pull_requests | length)}'
+	)"
+	while IFS= read -r candidate; do
+		if [[ -z "${candidate}" ]]; then
+			continue
+		fi
+
+		run_id="$(jq -er '.id | select(type == "number")' <<<"${candidate}")"
+		head_branch="$(jq -er '.head_branch | select(type == "string")' <<<"${candidate}")"
+		pull_request_count="$(
+			jq -er '.pull_request_count | select(type == "number")' <<<"${candidate}"
+		)"
+
+		if list_contains "${run_id}" "${keep_output}" || [[ "${pull_request_count}" -gt 0 ]]; then
+			continue
+		fi
+		if [[ -n "${head_branch}" && "${head_branch}" != "${default_branch}" ]] &&
+			list_contains "${head_branch}" "${branch_output}"; then
+			continue
+		fi
+
+		gh api --method DELETE "repos/${repository}/actions/runs/${run_id}"
+		((deletions += 1))
+		printf 'Deleted workflow run %s (%s)\n' "${run_id}" "${workflow_id}"
+
+		if ((deletions == max_deletions)); then
+			printf 'Deletion limit reached: %s\n' "${max_deletions}"
+			exit 0
+		fi
+	done <<<"${candidate_output}"
+done
+
+printf 'Cleanup complete: %s workflow run(s) deleted\n' "${deletions}"

--- a/.github/scripts/delete-old-workflow-runs.sh
+++ b/.github/scripts/delete-old-workflow-runs.sh
@@ -16,8 +16,8 @@ preserved. Orphan runs from deleted or organization-required workflows are
 deliberately outside this cleanup boundary.
 
 GH_TOKEN must contain actions:write for OWNER/REPO. COUNT for
---max-deletions is capped at 750 so one execution stays within the
-repository-scoped GITHUB_TOKEN API budget.
+--max-deletions is capped at 750 and counts every deletion attempt so one
+execution stays within the repository-scoped GITHUB_TOKEN API budget.
 EOF
 }
 
@@ -122,6 +122,8 @@ while IFS= read -r workflow_id; do
 	fi
 done <<<"${workflow_output}"
 
+deletion_attempts=0
+deletion_failures=0
 deletions=0
 for workflow_id in "${workflow_ids[@]}"; do
 	keep_output="$(
@@ -161,15 +163,27 @@ for workflow_id in "${workflow_ids[@]}"; do
 			continue
 		fi
 
-		gh api --method DELETE "repos/${repository}/actions/runs/${run_id}"
-		((deletions += 1))
-		printf 'Deleted workflow run %s (%s)\n' "${run_id}" "${workflow_id}"
+		((deletion_attempts += 1))
+		if gh api --method DELETE "repos/${repository}/actions/runs/${run_id}"; then
+			((deletions += 1))
+			printf 'Deleted workflow run %s (%s)\n' "${run_id}" "${workflow_id}"
+		else
+			((deletion_failures += 1))
+			printf 'ERROR: failed to delete workflow run %s (%s)\n' \
+				"${run_id}" "${workflow_id}" >&2
+		fi
 
-		if ((deletions == max_deletions)); then
+		if ((deletion_attempts == max_deletions)); then
 			printf 'Deletion limit reached: %s\n' "${max_deletions}"
-			exit 0
+			break 2
 		fi
 	done <<<"${candidate_output}"
 done
+
+if ((deletion_failures > 0)); then
+	printf 'ERROR: Cleanup completed with %s failed deletion attempt(s)\n' \
+		"${deletion_failures}" >&2
+	exit 1
+fi
 
 printf 'Cleanup complete: %s workflow run(s) deleted\n' "${deletions}"

--- a/.github/scripts/delete-old-workflow-runs.test.sh
+++ b/.github/scripts/delete-old-workflow-runs.test.sh
@@ -59,12 +59,13 @@ if PATH="${fake_bin}:${PATH}" \
 	--repository devantler-tech/ksail \
 	--retain-days 30 \
 	--keep-minimum-runs 2 \
-	--max-deletions 3 >"${tmp_dir}/delete-failure-output" 2>&1; then
+	--max-deletions 2 >"${tmp_dir}/delete-failure-output" 2>&1; then
 	printf 'FAIL: cleanup hid a workflow-run deletion failure\n' >&2
 	exit 1
 fi
-printf '1006\n1007\n' >"${tmp_dir}/expected-delete-failure-deletions"
+printf '1006\n' >"${tmp_dir}/expected-delete-failure-deletions"
 diff -u "${tmp_dir}/expected-delete-failure-deletions" "${delete_failure_state}/deleted"
 grep -Fq 'ERROR: failed to delete workflow run 1005 (101)' "${tmp_dir}/delete-failure-output"
+grep -Fq 'Deletion limit reached: 2' "${tmp_dir}/delete-failure-output"
 grep -Fq 'Cleanup completed with 1 failed deletion attempt(s)' "${tmp_dir}/delete-failure-output"
 printf 'PASS: cleanup continues its bounded batch and reports deletion failures\n'

--- a/.github/scripts/delete-old-workflow-runs.test.sh
+++ b/.github/scripts/delete-old-workflow-runs.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+cleanup="${script_dir}/delete-old-workflow-runs.sh"
+fake_bin="${repo_root}/.github/fixtures/workflow-run-cleanup/fake-bin"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+state_dir="${tmp_dir}/bounded"
+mkdir -p "${state_dir}"
+
+PATH="${fake_bin}:${PATH}" \
+	GH_TOKEN=fixture \
+	FAKE_GH_STATE_DIR="${state_dir}" \
+	KSAIL_MAINTENANCE_CUTOFF_DATE=2026-07-02 \
+	"${cleanup}" \
+	--repository devantler-tech/ksail \
+	--retain-days 30 \
+	--keep-minimum-runs 2 \
+	--max-deletions 2 >"${tmp_dir}/output"
+
+printf '1005\n1006\n' >"${tmp_dir}/expected-deletions"
+diff -u "${tmp_dir}/expected-deletions" "${state_dir}/deleted"
+grep -Fq 'Deletion limit reached: 2' "${tmp_dir}/output"
+printf 'PASS: cleanup preserves protected runs and stops at the deletion limit\n'
+
+failure_state="${tmp_dir}/api-failure"
+mkdir -p "${failure_state}"
+if PATH="${fake_bin}:${PATH}" \
+	GH_TOKEN=fixture \
+	FAKE_GH_SCENARIO=api-failure \
+	FAKE_GH_STATE_DIR="${failure_state}" \
+	KSAIL_MAINTENANCE_CUTOFF_DATE=2026-07-02 \
+	"${cleanup}" \
+	--repository devantler-tech/ksail \
+	--retain-days 30 \
+	--keep-minimum-runs 2 \
+	--max-deletions 2 >"${tmp_dir}/failure-output" 2>&1; then
+	printf 'FAIL: cleanup accepted a workflow API failure\n' >&2
+	exit 1
+fi
+if [[ -e "${failure_state}/deleted" ]]; then
+	printf 'FAIL: cleanup deleted runs after an API failure\n' >&2
+	exit 1
+fi
+printf 'PASS: cleanup fails closed before deletion on an API error\n'

--- a/.github/scripts/delete-old-workflow-runs.test.sh
+++ b/.github/scripts/delete-old-workflow-runs.test.sh
@@ -47,3 +47,24 @@ if [[ -e "${failure_state}/deleted" ]]; then
 	exit 1
 fi
 printf 'PASS: cleanup fails closed before deletion on an API error\n'
+
+delete_failure_state="${tmp_dir}/delete-failure"
+mkdir -p "${delete_failure_state}"
+if PATH="${fake_bin}:${PATH}" \
+	GH_TOKEN=fixture \
+	FAKE_GH_SCENARIO=delete-failure \
+	FAKE_GH_STATE_DIR="${delete_failure_state}" \
+	KSAIL_MAINTENANCE_CUTOFF_DATE=2026-07-02 \
+	"${cleanup}" \
+	--repository devantler-tech/ksail \
+	--retain-days 30 \
+	--keep-minimum-runs 2 \
+	--max-deletions 3 >"${tmp_dir}/delete-failure-output" 2>&1; then
+	printf 'FAIL: cleanup hid a workflow-run deletion failure\n' >&2
+	exit 1
+fi
+printf '1006\n1007\n' >"${tmp_dir}/expected-delete-failure-deletions"
+diff -u "${tmp_dir}/expected-delete-failure-deletions" "${delete_failure_state}/deleted"
+grep -Fq 'ERROR: failed to delete workflow run 1005 (101)' "${tmp_dir}/delete-failure-output"
+grep -Fq 'Cleanup completed with 1 failed deletion attempt(s)' "${tmp_dir}/delete-failure-output"
+printf 'PASS: cleanup continues its bounded batch and reports deletion failures\n'

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   delete-old-workflow-runs:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 360
     permissions:
       actions: write
       contents: read
@@ -31,7 +31,7 @@ jobs:
 
   delete-old-images:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
     permissions:
       packages: write
     steps:

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -2,7 +2,8 @@ name: Maintenance
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 1 * *" # Monthly at 00:00 on the 1st
+    - cron: "0 0 * * *" # Daily bounded workflow-run cleanup
+    - cron: "15 0 1 * *" # Monthly package cleanup
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -13,23 +14,34 @@ permissions:
 
 jobs:
   delete-old-workflow-runs:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.schedule == '0 0 * * *'
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 30
     permissions:
       actions: write
       contents: read
     steps:
-      - name: Delete old workflow runs
-        uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee # v2.1.0
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          retain_days: 30
-          keep_minimum_runs: 6
-          check_branch_existence: true
-          check_pullrequest_exist: true
+          persist-credentials: false
+
+      - name: Delete old workflow runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          .github/scripts/delete-old-workflow-runs.sh \
+            --repository "${{ github.repository }}" \
+            --retain-days 30 \
+            --keep-minimum-runs 6 \
+            --max-deletions 750
 
   delete-old-images:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.schedule == '15 0 1 * *'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/internal/ciharness/maintenance_workflow_test.go
+++ b/internal/ciharness/maintenance_workflow_test.go
@@ -1,6 +1,7 @@
 package ciharness_test
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,19 +9,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	workflowRunCleanupMinimumMinutes = 180
-	packageCleanupMinimumMinutes     = 30
-)
-
 //nolint:tagliatelle // GitHub Actions defines this external key in kebab-case.
 type maintenanceWorkflow struct {
+	On struct {
+		Schedule []struct {
+			Cron string `yaml:"cron"`
+		} `yaml:"schedule"`
+	} `yaml:"on"`
 	Jobs map[string]struct {
-		TimeoutMinutes int `yaml:"timeout-minutes"`
+		If             string            `yaml:"if"`
+		TimeoutMinutes int               `yaml:"timeout-minutes"`
+		Permissions    map[string]string `yaml:"permissions"`
+		Steps          []harnessStep     `yaml:"steps"`
 	} `yaml:"jobs"`
 }
 
-func TestMaintenanceCleanupBudgetsCoverObservedWork(t *testing.T) {
+func TestMaintenanceWorkflowUsesBoundedDailyRunCleanup(t *testing.T) {
 	t.Parallel()
 
 	contents := readRepoFile(t, ".github/workflows/maintenance.yaml")
@@ -28,21 +32,53 @@ func TestMaintenanceCleanupBudgetsCoverObservedWork(t *testing.T) {
 	var workflow maintenanceWorkflow
 	require.NoError(t, yaml.Unmarshal(contents, &workflow))
 
+	crons := make([]string, 0, len(workflow.On.Schedule))
+	for _, schedule := range workflow.On.Schedule {
+		crons = append(crons, schedule.Cron)
+	}
+
+	assert.ElementsMatch(t, []string{"0 0 * * *", "15 0 1 * *"}, crons)
+
 	workflowRunCleanup, found := workflow.Jobs["delete-old-workflow-runs"]
 	require.True(t, found, "workflow-run cleanup job is missing")
-	assert.GreaterOrEqual(
-		t,
-		workflowRunCleanup.TimeoutMinutes,
-		workflowRunCleanupMinimumMinutes,
-		"workflow-run cleanup previously needed about 143 minutes",
-	)
+	assert.Equal(t, 30, workflowRunCleanup.TimeoutMinutes)
+	assert.Contains(t, workflowRunCleanup.If, "github.event_name == 'workflow_dispatch'")
+	assert.Contains(t, workflowRunCleanup.If, "github.event.schedule == '0 0 * * *'")
+	assert.Equal(t, "write", workflowRunCleanup.Permissions["actions"])
+	assert.Equal(t, "read", workflowRunCleanup.Permissions["contents"])
+
+	checkout := findHarnessStep(t, workflowRunCleanup.Steps, "📄 Checkout")
+	assert.Contains(t, checkout.Uses, "actions/checkout@")
+	assert.Equal(t, false, checkout.With["persist-credentials"])
+
+	cleanup := findHarnessStep(t, workflowRunCleanup.Steps, "Delete old workflow runs")
+	assert.Equal(t, "${{ github.token }}", cleanup.Env["GH_TOKEN"])
+	assert.Contains(t, cleanup.Run, ".github/scripts/delete-old-workflow-runs.sh")
+	assert.Contains(t, cleanup.Run, "--max-deletions 750")
+	assert.Empty(t, cleanup.Uses)
 
 	packageCleanup, found := workflow.Jobs["delete-old-images"]
 	require.True(t, found, "package cleanup job is missing")
-	assert.GreaterOrEqual(
+	assert.Equal(t, 60, packageCleanup.TimeoutMinutes)
+	assert.Contains(t, packageCleanup.If, "github.event_name == 'workflow_dispatch'")
+	assert.Contains(
 		t,
-		packageCleanup.TimeoutMinutes,
-		packageCleanupMinimumMinutes,
-		"package cleanup has repeatedly exceeded its previous 10-minute budget",
+		packageCleanup.If,
+		"github.event.schedule == '15 0 1 * *'",
 	)
+}
+
+func TestWorkflowRunCleanupScript(t *testing.T) {
+	t.Parallel()
+	requireTestExecutable(t, "bash")
+
+	command := exec.CommandContext(
+		t.Context(),
+		"bash",
+		"../../.github/scripts/delete-old-workflow-runs.test.sh",
+	)
+	output, err := command.CombinedOutput()
+	require.NoErrorf(t, err, "workflow-run cleanup contract failed:\n%s", output)
+	assert.Contains(t, string(output), "PASS: cleanup preserves protected runs")
+	assert.Contains(t, string(output), "PASS: cleanup fails closed")
 }

--- a/internal/ciharness/maintenance_workflow_test.go
+++ b/internal/ciharness/maintenance_workflow_test.go
@@ -1,0 +1,48 @@
+package ciharness_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	workflowRunCleanupMinimumMinutes = 180
+	packageCleanupMinimumMinutes     = 30
+)
+
+//nolint:tagliatelle // GitHub Actions defines this external key in kebab-case.
+type maintenanceWorkflow struct {
+	Jobs map[string]struct {
+		TimeoutMinutes int `yaml:"timeout-minutes"`
+	} `yaml:"jobs"`
+}
+
+func TestMaintenanceCleanupBudgetsCoverObservedWork(t *testing.T) {
+	t.Parallel()
+
+	contents := readRepoFile(t, ".github/workflows/maintenance.yaml")
+
+	var workflow maintenanceWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	workflowRunCleanup, found := workflow.Jobs["delete-old-workflow-runs"]
+	require.True(t, found, "workflow-run cleanup job is missing")
+	assert.GreaterOrEqual(
+		t,
+		workflowRunCleanup.TimeoutMinutes,
+		workflowRunCleanupMinimumMinutes,
+		"workflow-run cleanup previously needed about 143 minutes",
+	)
+
+	packageCleanup, found := workflow.Jobs["delete-old-images"]
+	require.True(t, found, "package cleanup job is missing")
+	assert.GreaterOrEqual(
+		t,
+		packageCleanup.TimeoutMinutes,
+		packageCleanupMinimumMinutes,
+		"package cleanup has repeatedly exceeded its previous 10-minute budget",
+	)
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

- Monthly Maintenance cancelled on every scheduled run since May.
- Raising the third-party cleanup to the six-hour GitHub maximum still cancelled: run 30692828720 discovered 19,069 orphan runs and deleted them serially for six hours.
- That orphan sweep also targeted current organization-required workflow runs, so a larger timeout was not a safe steady-state fix.

## What

- Replace the automatic orphan sweep with a repository-owned cleanup limited to active repository workflows.
- Preserve the newest six runs, runs linked to pull requests, and runs on existing non-default branches.
- Delete at most 750 runs per daily pass, below the repository GITHUB_TOKEN request budget.
- Keep package cleanup monthly with its behaviorally proven 60-minute bound.

## Validation

- Behavioral cleanup test failed before the script existed, then passed against the implementation.
- Workflow contract test failed against the unbounded monthly action, then passed with the bounded daily wiring.
- `go test ./...`
- cleanup contract repeated 10 times
- `shellcheck`
- `actionlint .github/workflows/maintenance.yaml`
- `golangci-lint run --timeout 5m`
- `go build -o /tmp/ksail-maint .`

Live exact-head cleanup evaluation will be repeated before promotion.