### PR TITLE
fix(clusterapi): verify EKS ownership before local API lifecycle actions

### DIFF
--- a/pkg/cli/clusterapi/eks_create_identity_test.go
+++ b/pkg/cli/clusterapi/eks_create_identity_test.go
@@ -1,0 +1,189 @@
+package clusterapi_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The names a spec can point AWS resolution at. They are deliberately not the canonical AWS_* ones,
+// because the whole point is to tell the two sources apart.
+const (
+	customRegionEnvVar  = "KSAIL_TEST_CUSTOM_AWS_REGION"
+	customRegionValue   = "eu-west-9"
+	canonicalRegionEnv  = "AWS_REGION"
+	canonicalRegionVal  = "us-east-1"
+	rebindingRegionVal  = "ap-south-7"
+)
+
+// midCreateProvisioner runs onCreate from inside Create, so a test can act at a point that is
+// provably between runCreate's snapshot and the capture that follows.
+type midCreateProvisioner struct {
+	*fakeProvisioner
+
+	onCreate func()
+}
+
+func (p *midCreateProvisioner) Create(ctx context.Context, name string) error {
+	if p.onCreate != nil {
+		p.onCreate()
+	}
+
+	return p.fakeProvisioner.Create(ctx, name)
+}
+
+type midCreateFactory struct {
+	provisioner *midCreateProvisioner
+}
+
+func (f midCreateFactory) Create(
+	_ context.Context,
+	_ *v1alpha1.Cluster,
+) (clusterprovisioner.Provisioner, any, error) {
+	return f.provisioner, nil, nil
+}
+
+// captureRecord is what the create pinned for the capture that follows it.
+type captureRecord struct {
+	name            string
+	pinned          bool
+	awsOptions      v1alpha1.OptionsAWS
+	selectionRegion string
+}
+
+// recordCaptureForCreate runs an EKS create whose spec resolves AWS through awsOptions, and returns
+// the identity the create pinned for its capture.
+func recordCaptureForCreate(
+	t *testing.T,
+	clusterName string,
+	awsOptions v1alpha1.OptionsAWS,
+	beforeCapture func(),
+) captureRecord {
+	t.Helper()
+
+	// A provisioner that runs beforeCapture from inside Create. That point is, in program order,
+	// strictly after runCreate takes its snapshot and strictly before the capture — which is what
+	// makes the mid-create assertion deterministic instead of a race against the create goroutine.
+	provisioner := &midCreateProvisioner{
+		fakeProvisioner: &fakeProvisioner{},
+		onCreate:        beforeCapture,
+	}
+	service := clusterapi.NewTestService(func(
+		_ v1alpha1.Distribution,
+		_ string,
+	) (clusterprovisioner.Factory, error) {
+		return midCreateFactory{provisioner: provisioner}, nil
+	})
+
+	records := make(chan captureRecord, 1)
+
+	service.SetEKSOwnershipCaptureRecorderForTest(
+		func(name string, pinned bool, options v1alpha1.OptionsAWS, region string) {
+			records <- captureRecord{
+				name:            name,
+				pinned:          pinned,
+				awsOptions:      options,
+				selectionRegion: region,
+			}
+		},
+	)
+
+	cluster := clusterFor(clusterName, v1alpha1.DistributionEKS)
+	cluster.Spec.Provider.AWS = awsOptions
+
+	_, err := service.Create(context.Background(), cluster)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+
+	select {
+	case got := <-records:
+		return got
+	default:
+		t.Fatal("a successful EKS create pinned no identity for its ownership capture")
+
+		return captureRecord{}
+	}
+}
+
+// TestCreateEKSCapturesUnderItsOwnCredentialNames is the regression this file exists for.
+//
+// The create provisioner resolves AWS through the cluster spec's own variable names; the capture
+// that follows used to resolve through this backend's ambient resolver, which reads the canonical
+// AWS_* names. Those are different sources, so a spec naming custom variables had its cluster
+// created in one account and its immutable ownership identity recorded from another.
+//
+// That does not fail closed. The capture finds whatever same-named cluster lives in the ambient
+// account and records it as this cluster's identity, so every later guarded delete, start or stop
+// verifies successfully against an unrelated incarnation and then mutates it.
+func TestCreateEKSCapturesUnderItsOwnCredentialNames(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// Both are set, to distinct values. Only a capture reading the spec's name can tell them apart:
+	// reading either name in isolation would pass whichever source it happened to use.
+	t.Setenv(canonicalRegionEnv, canonicalRegionVal)
+	t.Setenv(customRegionEnvVar, customRegionValue)
+
+	got := recordCaptureForCreate(t, "custom-names-eks", v1alpha1.OptionsAWS{
+		RegionEnvVar: customRegionEnvVar,
+	}, nil)
+
+	require.True(t, got.pinned,
+		"the create supplied no pinned identity, so the capture would resolve AWS independently")
+
+	assert.Equal(t, customRegionValue, got.selectionRegion,
+		"the capture resolved through the canonical AWS_* names instead of the spec's own, so it "+
+			"would record a same-named cluster in a different account as this cluster's identity")
+
+	assert.Equal(t, customRegionEnvVar, got.awsOptions.RegionEnvVar,
+		"the recorded identity does not carry the variable names it was resolved through, so a "+
+			"later verification cannot resolve the same identity this capture observed")
+}
+
+// TestCreateEKSCaptureSnapshotSurvivesAMidCreateEnvironmentChange pins the timing half.
+//
+// eksctl runs asynchronously, so an operator changing Settings while a create works would otherwise
+// move the values the capture reads afterwards. The snapshot is taken before the create starts,
+// which is what makes the recorded identity describe the cluster the create actually made.
+func TestCreateEKSCaptureSnapshotSurvivesAMidCreateEnvironmentChange(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(canonicalRegionEnv, canonicalRegionVal)
+
+	got := recordCaptureForCreate(t, "rebound-mid-create-eks", v1alpha1.OptionsAWS{}, func() {
+		t.Setenv(canonicalRegionEnv, rebindingRegionVal)
+	})
+
+	require.True(t, got.pinned)
+	assert.Equal(t, canonicalRegionVal, got.selectionRegion,
+		"the capture re-read the environment after the create, so a Settings change during an "+
+			"asynchronous create redirects the identity that gets recorded")
+}
+
+// TestCreateEKSWithDefaultOptionsStillResolvesTheCanonicalNames is the control.
+//
+// It must fail if the fix merely swapped one hard-coded source for another: a spec that names no
+// custom variables has to keep resolving exactly the canonical AWS_* names it always did. Without
+// this, the two tests above would also pass an implementation that ignored the ambient environment
+// entirely, and the default path — every cluster in the portfolio — would silently change.
+func TestCreateEKSWithDefaultOptionsStillResolvesTheCanonicalNames(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(canonicalRegionEnv, canonicalRegionVal)
+	t.Setenv(customRegionEnvVar, customRegionValue)
+
+	got := recordCaptureForCreate(t, "default-names-eks", v1alpha1.OptionsAWS{}, nil)
+
+	require.True(t, got.pinned)
+	assert.Equal(t, canonicalRegionVal, got.selectionRegion,
+		"an empty spec must fall back to the canonical AWS_* names")
+}

--- a/pkg/cli/clusterapi/eks_create_identity_test.go
+++ b/pkg/cli/clusterapi/eks_create_identity_test.go
@@ -99,13 +99,16 @@ func recordCaptureForCreate(
 	_, err := service.Create(context.Background(), cluster)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
+	// EventuallyWithT, not Eventually: the condition runs on its own goroutine, and only CollectT
+	// can carry an assertion failure back out of it. Asserting on the outer t there fails the tick
+	// by exiting its goroutine, which costs the underlying error its place in the report.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		list, listErr := service.List(context.Background())
-		require.NoError(t, listErr)
+		require.NoError(collect, listErr)
 
 		phase, found := phaseOf(list, clusterName)
-
-		return found && phase == v1alpha1.ClusterPhaseReady
+		require.True(collect, found, "the cluster is not listed yet")
+		require.Equal(collect, v1alpha1.ClusterPhaseReady, phase)
 	}, eventuallyTimeout, eventuallyTick)
 
 	select {

--- a/pkg/cli/clusterapi/eks_create_identity_test.go
+++ b/pkg/cli/clusterapi/eks_create_identity_test.go
@@ -14,11 +14,11 @@ import (
 // The names a spec can point AWS resolution at. They are deliberately not the canonical AWS_* ones,
 // because the whole point is to tell the two sources apart.
 const (
-	customRegionEnvVar  = "KSAIL_TEST_CUSTOM_AWS_REGION"
-	customRegionValue   = "eu-west-9"
-	canonicalRegionEnv  = "AWS_REGION"
-	canonicalRegionVal  = "us-east-1"
-	rebindingRegionVal  = "ap-south-7"
+	customRegionEnvVar = "KSAIL_TEST_CUSTOM_AWS_REGION"
+	customRegionValue  = "eu-west-9"
+	canonicalRegionEnv = "AWS_REGION"
+	canonicalRegionVal = "us-east-1"
+	rebindingRegionVal = "ap-south-7"
 )
 
 // midCreateProvisioner runs onCreate from inside Create, so a test can act at a point that is

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -1,0 +1,158 @@
+package clusterapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+)
+
+// ErrEKSOwnershipEvidenceMissing reports a local API EKS mutation for a cluster with no target
+// binding on disk. The binding is written when a create completes, so its absence means the target
+// this action would mutate cannot be established — and an EKS delete cannot be undone.
+var ErrEKSOwnershipEvidenceMissing = errors.New("no local KSail EKS target binding")
+
+// ErrUnguardableFactory reports a provisioner factory that cannot carry the ownership guard. It
+// fails the mutation rather than proceeding unguarded: a factory that silently drops the verifier
+// would leave VerifyBeforeMutation a no-op, which is the gap this guard exists to close.
+var ErrUnguardableFactory = errors.New("provisioner factory cannot carry the EKS ownership guard")
+
+// eksGuardFunc resolves the evidence-reading half of an EKS mutation guard: the region the cluster
+// was bound to at create time, one frozen credential snapshot for it, and a verifier closed over
+// the persisted immutable identity. It is a seam so tests exercise the wiring without AWS
+// credentials or an on-disk eksctl config.
+type eksGuardFunc func(
+	ctx context.Context,
+	name string,
+) (credentials.AWSResolution, eksidentity.Verifier, error)
+
+// eksGuardableFactory is a provisioner factory that accepts the guard. clusterprovisioner's
+// DefaultFactory satisfies it; the interface keeps this package from depending on that concrete
+// type and lets a test factory observe what the service handed it.
+type eksGuardableFactory interface {
+	WithEKSMutationGuard(
+		resolution *credentials.AWSResolution,
+		verifier eksidentity.Verifier,
+	) clusterprovisioner.Factory
+}
+
+// eksMutationGuard pins one credential snapshot and the ownership verifier authorized by it. Both
+// travel together into the factory so the provisioner re-checks the same identity at its own
+// mutation boundary, rather than re-resolving an ambient one that may have changed since.
+type eksMutationGuard struct {
+	resolution credentials.AWSResolution
+	verifier   eksidentity.Verifier
+}
+
+// resolveEKSMutationGuard returns the guard an EKS mutation must carry, or nil for actions that
+// need none (every non-EKS distribution, and EKS create).
+func (s *Service) resolveEKSMutationGuard(
+	ctx context.Context,
+	distribution v1alpha1.Distribution,
+	name string,
+) (*eksMutationGuard, error) {
+	if distribution != v1alpha1.DistributionEKS {
+		return nil, nil //nolint:nilnil // no guard needed is a normal, non-error outcome.
+	}
+
+	resolution, verifier, err := s.resolveEKSGuard(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify once here so the refusal surfaces before any provisioner work starts, and hand the
+	// same verifier onward so the provisioner re-checks at the narrowest boundary. This mirrors the
+	// standalone CLI path, which also verifies during its guard and reuses the verifier afterwards.
+	err = eksidentity.VerifyBeforeMutation(ctx, verifier)
+	if err != nil {
+		return nil, err
+	}
+
+	return &eksMutationGuard{resolution: resolution, verifier: verifier}, nil
+}
+
+// applyEKSMutationGuard returns the factory the action should use, carrying the guard when one was
+// resolved. An unguardable factory is an error rather than a silent pass-through.
+func applyEKSMutationGuard(
+	factory clusterprovisioner.Factory,
+	guard *eksMutationGuard,
+) (clusterprovisioner.Factory, error) {
+	if guard == nil {
+		return factory, nil
+	}
+
+	guardable, ok := factory.(eksGuardableFactory)
+	if !ok {
+		return nil, fmt.Errorf("%w: %T", ErrUnguardableFactory, factory)
+	}
+
+	return guardable.WithEKSMutationGuard(&guard.resolution, guard.verifier), nil
+}
+
+// defaultEKSGuard reads the target the cluster was bound to when it was created, freezes one AWS
+// credential snapshot for that region, and returns a verifier closed over the persisted immutable
+// identity.
+//
+// The region comes from that binding and never from the region selected now: resolving it from the
+// current selection is precisely the redirect this guards against, and the identity check would
+// then run against a same-named cluster elsewhere.
+//
+// Freezing matters as much as verifying: the factory refuses a verifier that is not paired with a
+// frozen resolution, because a verifier proving one identity while the provisioner independently
+// re-resolves another would authorize a mutation nothing checked.
+func (s *Service) defaultEKSGuard(
+	ctx context.Context,
+	name string,
+) (credentials.AWSResolution, eksidentity.Verifier, error) {
+	bound, err := boundEKSConfig(name)
+	if err != nil {
+		return credentials.AWSResolution{}, nil, err
+	}
+
+	if bound == nil {
+		return credentials.AWSResolution{}, nil, fmt.Errorf(
+			"%w for %q: a mutation must resolve its target from the binding written when the"+
+				" cluster was created, and there is none. Run `ksail cluster eks-bind --name %s`"+
+				" to record the region it was created in",
+			ErrEKSOwnershipEvidenceMissing, name, name,
+		)
+	}
+
+	region := bound.Region
+	selection := credentials.ResolveAWS(s.discoverer.Resolver)
+
+	resolution, err := credentials.FreezeAWS(ctx, selection, region)
+	if err != nil {
+		return credentials.AWSResolution{}, nil, fmt.Errorf(
+			"freeze AWS credentials for EKS ownership verification: %w", err,
+		)
+	}
+
+	options := credentials.OptionsForFrozenAWSConfig(
+		resolution,
+		eksclient.WithAWSConfig,
+		eksclient.WithCredentialValues,
+		eksclient.RequireCredentialValues,
+	)
+
+	client, err := eksclient.NewClient(ctx, region, options...)
+	if err != nil {
+		return credentials.AWSResolution{}, nil, fmt.Errorf(
+			"create EKS identity client for ownership verification: %w", err,
+		)
+	}
+
+	verifier, err := eksidentity.NewVerifier(client, name, region)
+	if err != nil {
+		return credentials.AWSResolution{}, nil, fmt.Errorf(
+			"load immutable EKS ownership identity: %w", err,
+		)
+	}
+
+	return resolution, verifier, nil
+}

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 )
 
 // ErrEKSOwnershipEvidenceMissing reports a local API EKS mutation for a cluster with no target
@@ -101,6 +102,23 @@ func (s *Service) resolveEKSMutationGuard(
 	// standalone CLI path, which also verifies during its guard and reuses the verifier afterwards.
 	err = verifier(ctx)
 	if err != nil {
+		// Absence is the one verification failure that must not fail closed. This guard exists to
+		// stop a mutation reaching an unrelated incarnation of the name; when no live cluster
+		// answers to it there is no incarnation to reach, so refusing protects nothing and costs
+		// the caller its idempotency. Reporting it as clustererr.ErrClusterNotFound lets runDelete's
+		// existing state-cleanup and idempotent-success branches run, instead of pinning a Failed
+		// row that cannot be dismissed and retaining completed-create state that then blocks
+		// recreating the name — the trap runDelete's own idempotency handling was written to avoid.
+		//
+		// A mismatch is the opposite case and stays fail-closed: a different live cluster answering
+		// to this name is exactly what must not be mutated.
+		if errors.Is(err, eksclient.ErrClusterNotFound) {
+			return nil, fmt.Errorf(
+				"%w: %q has no live EKS cluster to verify ownership against: %w",
+				clustererr.ErrClusterNotFound, name, err,
+			)
+		}
+
 		return nil, fmt.Errorf("verify immutable EKS ownership identity for %q: %w", name, err)
 	}
 

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
 )
 
 // ErrEKSOwnershipEvidenceMissing reports a local API EKS mutation for a cluster with no target
@@ -335,7 +336,7 @@ func (s *Service) defaultEKSGuard(
 
 	region := bound.Region
 
-	client, resolution, err := s.eksIdentityClient(ctx, region)
+	client, resolution, err := s.eksIdentityClient(ctx, name, region)
 	if err != nil {
 		return credentials.AWSResolution{}, nil, err
 	}
@@ -353,11 +354,16 @@ func (s *Service) defaultEKSGuard(
 // eksIdentityClient freezes one AWS credential snapshot for a region and builds the read-only
 // identity client against it. Capture and verification share this so both run under exactly the same
 // resolved identity — a capture recorded under one and verified under another would fail forever.
+//
+// The snapshot resolves through the cluster's own ownership record where one exists, because capture
+// persisted the variable names the create resolved through. Resolving the current selection instead
+// would read a different identity — or no credentials at all — whenever the credentials that made
+// the cluster are reachable only under those recorded aliases.
 func (s *Service) eksIdentityClient(
 	ctx context.Context,
-	region string,
+	name, region string,
 ) (eksidentity.Client, credentials.AWSResolution, error) {
-	selection := credentials.ResolveAWS(s.discoverer.Resolver)
+	selection := credentials.ResolveAWS(s.eksOwnershipResolver(name, region))
 
 	resolution, err := credentials.FreezeAWS(ctx, selection, region)
 	if err != nil {
@@ -372,6 +378,22 @@ func (s *Service) eksIdentityClient(
 	}
 
 	return client, resolution, nil
+}
+
+// eksOwnershipResolver returns the resolver one cluster's lifecycle credentials must resolve through:
+// the injected resolver layered under the variable names its ownership record captured.
+//
+// A record that is missing or predates the mapping schema falls back to the injected resolver
+// untouched, deliberately. That keeps the injection seam intact for every unrecorded cluster, and it
+// leaves eksidentity.NewVerifier's migration error as the authoritative, actionable failure for a
+// legacy record rather than shadowing it with an opaque credential error here.
+func (s *Service) eksOwnershipResolver(name, region string) credentials.Resolver {
+	ownership, err := state.LoadEKSOwnershipState(name, region)
+	if err != nil {
+		return s.discoverer.Resolver
+	}
+
+	return credentials.NewRecordedAWSResolver(s.discoverer.Resolver, ownership.AWSOptions)
 }
 
 // eksIdentityClientFor builds the read-only identity client against an already-frozen snapshot.

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
@@ -21,6 +22,19 @@ var ErrEKSOwnershipEvidenceMissing = errors.New("no local KSail EKS target bindi
 // fails the mutation rather than proceeding unguarded: a factory that silently drops the verifier
 // would leave VerifyBeforeMutation a no-op, which is the gap this guard exists to close.
 var ErrUnguardableFactory = errors.New("provisioner factory cannot carry the EKS ownership guard")
+
+// defaultEKSOwnershipTimeout bounds the whole ownership resolution: the AWS config load, the STS
+// caller-identity query and the EKS DescribeCluster behind it.
+//
+// It exists because the mutation paths deliberately run on a context.WithoutCancel background
+// context, so the request that triggered the action can never cancel this work. The AWS SDK applies
+// no overall per-operation deadline of its own, so an unresponsive STS or EKS endpoint would
+// otherwise leave the job pinned in Deleting/Updating with no way to dismiss it — the exact
+// undismissable-row failure runDelete's idempotency handling already exists to avoid.
+//
+// 60s is generous enough for the SDK's default retries on a slow-but-working endpoint, and short
+// enough that a wedged one surfaces as a failed job an operator can retry.
+const defaultEKSOwnershipTimeout = 60 * time.Second
 
 // eksGuardFunc resolves the evidence-reading half of an EKS mutation guard: the region the cluster
 // was bound to at create time, one frozen credential snapshot for it, and a verifier closed over
@@ -59,6 +73,13 @@ func (s *Service) resolveEKSMutationGuard(
 	if distribution != v1alpha1.DistributionEKS {
 		return nil, nil //nolint:nilnil // no guard needed is a normal, non-error outcome.
 	}
+
+	// Bound every network call this guard makes. The caller's context is deliberately
+	// uncancellable (see defaultEKSOwnershipTimeout), so without this a hung AWS endpoint pins the
+	// job forever. The verifier handed onward is NOT closed over this context — it takes one at
+	// call time, so the provisioner re-checks under its own deadline at the mutation boundary.
+	ctx, cancel := context.WithTimeout(ctx, s.eksOwnershipTimeout)
+	defer cancel()
 
 	resolution, verifier, err := s.resolveEKSGuard(ctx, name)
 	if err != nil {

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -65,12 +65,23 @@ func (s *Service) resolveEKSMutationGuard(
 		return nil, err
 	}
 
+	// A nil verifier is refused rather than carried. eksidentity.VerifyBeforeMutation reads nil as
+	// "nothing to check" — correct for creates and non-EKS callers, and a silent fail-open here,
+	// because the guard would travel into the provisioner and authorize the mutation while checking
+	// nothing. The absence of a check is not a passing check.
+	if verifier == nil {
+		return nil, fmt.Errorf(
+			"%w for %q: ownership resolution returned no verifier",
+			ErrEKSOwnershipEvidenceMissing, name,
+		)
+	}
+
 	// Verify once here so the refusal surfaces before any provisioner work starts, and hand the
 	// same verifier onward so the provisioner re-checks at the narrowest boundary. This mirrors the
 	// standalone CLI path, which also verifies during its guard and reuses the verifier afterwards.
-	err = eksidentity.VerifyBeforeMutation(ctx, verifier)
+	err = verifier(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("verify immutable EKS ownership identity for %q: %w", name, err)
 	}
 
 	return &eksMutationGuard{resolution: resolution, verifier: verifier}, nil

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -180,9 +180,49 @@ func applyEKSMutationGuard(
 	return guardable.WithEKSMutationGuard(&guard.resolution, guard.verifier), nil
 }
 
-// eksCaptureFunc records the immutable AWS identity of a just-created EKS cluster. It is a seam so
-// tests exercise the create wiring without AWS.
-type eksCaptureFunc func(ctx context.Context, name string) error
+// eksCreateIdentity is the exact AWS identity an EKS create runs under: one frozen credential
+// snapshot, the region it was frozen for, and the variable names it was resolved through.
+//
+// It exists because the create provisioner and the capture that follows it used to resolve AWS
+// independently. The provisioner resolves from the cluster spec's own variable names
+// (resolveEKSCredentialOptions, over spec.Provider.AWS); the capture resolved from this backend's
+// ambient resolver, which reads the canonical AWS_* names. Those are different sources whenever a
+// spec names custom variables, so they can select different accounts with no Settings change at
+// all — and the eksctl create is asynchronous, so the ambient selection can also change underneath
+// a create that is still running.
+//
+// Getting this wrong does not fail closed. A capture resolved against the wrong account finds
+// whatever same-named cluster lives there and records it as this cluster's immutable identity, so
+// every later guarded delete, start or stop verifies successfully against an unrelated incarnation
+// and mutates it. Pinning one snapshot before the create and reusing it for the capture is what
+// makes the recorded identity the identity the create actually produced.
+type eksCreateIdentity struct {
+	selection  credentials.AWSResolution
+	awsOptions v1alpha1.OptionsAWS
+}
+
+// newEKSCreateIdentity snapshots the AWS selection a create is about to run under.
+//
+// It resolves through the cluster spec's own variable names — the exact source
+// resolveEKSCredentialOptions uses inside the provisioner — so the capture that follows records
+// under the credentials the create actually used rather than under an independently resolved set.
+//
+// Taking the snapshot BEFORE the create is what closes the timing half of the problem: eksctl runs
+// asynchronously, so an operator changing Settings while it works would otherwise move the values
+// the capture later reads. This is a pure read of the process environment; it deliberately does not
+// freeze, because freezing forces concrete credential retrieval (profile chain, IMDS) and a create
+// is entitled to rely on eksctl resolving its own credentials. The freeze happens at capture time,
+// against this snapshot.
+func newEKSCreateIdentity(awsOptions v1alpha1.OptionsAWS) *eksCreateIdentity {
+	return &eksCreateIdentity{
+		selection:  credentials.ResolveAWS(credentials.NewAWSOptionsResolver(awsOptions)),
+		awsOptions: awsOptions,
+	}
+}
+
+// eksCaptureFunc records the immutable AWS identity of a just-created EKS cluster, under the
+// identity that create was pinned to. It is a seam so tests exercise the create wiring without AWS.
+type eksCaptureFunc func(ctx context.Context, name string, identity *eksCreateIdentity) error
 
 // captureEKSOwnership records the immutable identity of a cluster this backend just created.
 //
@@ -193,16 +233,24 @@ type eksCaptureFunc func(ctx context.Context, name string) error
 // that blocks the path it is meant to protect.
 //
 // Capture performs read-only AWS queries and writes local state only; it mutates nothing in AWS.
-func (s *Service) captureEKSOwnership(ctx context.Context, name string) error {
+func (s *Service) captureEKSOwnership(
+	ctx context.Context,
+	name string,
+	identity *eksCreateIdentity,
+) error {
 	ctx, cancel := context.WithTimeout(ctx, s.eksOwnershipTimeout)
 	defer cancel()
 
-	return s.captureEKSIdentity(ctx, name)
+	return s.captureEKSIdentity(ctx, name, identity)
 }
 
-// defaultEKSCapture resolves the just-written binding, freezes one credential snapshot for its
-// region, and records the live identity under that region.
-func (s *Service) defaultEKSCapture(ctx context.Context, name string) error {
+// defaultEKSCapture resolves the just-written binding and records the live identity under the exact
+// credential snapshot the create was pinned to.
+func (s *Service) defaultEKSCapture(
+	ctx context.Context,
+	name string,
+	identity *eksCreateIdentity,
+) error {
 	bound, err := boundEKSConfig(name)
 	if err != nil {
 		return err
@@ -216,7 +264,25 @@ func (s *Service) defaultEKSCapture(ctx context.Context, name string) error {
 		)
 	}
 
-	client, _, err := s.eksIdentityClient(ctx, bound.Region)
+	// Refuse rather than fall back to an ambient resolution. Re-resolving here is the divergence
+	// eksCreateIdentity exists to remove, and a capture recorded under credentials the create never
+	// used is precisely the confident-but-wrong record that makes later guards authorize a mutation
+	// against an unrelated cluster.
+	if identity == nil {
+		return fmt.Errorf(
+			"%w for %q: the create pinned no AWS identity to record this cluster under",
+			ErrEKSOwnershipEvidenceMissing, name,
+		)
+	}
+
+	// Freeze the create's own selection, for the region the create actually bound to. This is the
+	// single resolution the recorded identity is read under.
+	resolution, err := credentials.FreezeAWS(ctx, identity.selection, bound.Region)
+	if err != nil {
+		return fmt.Errorf("freeze AWS credentials for EKS ownership: %w", err)
+	}
+
+	client, err := s.eksIdentityClientFor(ctx, bound.Region, resolution)
 	if err != nil {
 		return err
 	}
@@ -226,10 +292,10 @@ func (s *Service) defaultEKSCapture(ctx context.Context, name string) error {
 		client,
 		name,
 		bound.Region,
-		// The canonical mapping: this backend resolves AWS values through the Settings-backed
-		// credential overlay, which populates the standard AWS_* names. Recording those is what
-		// lets a later verification resolve the same identity this capture observed.
-		credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{}),
+		// Record the variable names the create actually resolved through, so a later verification
+		// resolves the same identity this capture observed. Recording the canonical defaults instead
+		// would misdescribe every cluster whose spec names custom variables.
+		credentials.AWSOptionsWithDefaults(identity.awsOptions),
 	)
 	if err != nil {
 		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
@@ -300,6 +366,24 @@ func (s *Service) eksIdentityClient(
 		)
 	}
 
+	client, err := s.eksIdentityClientFor(ctx, region, resolution)
+	if err != nil {
+		return nil, credentials.AWSResolution{}, err
+	}
+
+	return client, resolution, nil
+}
+
+// eksIdentityClientFor builds the read-only identity client against an already-frozen snapshot.
+//
+// Capture uses this directly with the snapshot its create was pinned to, so the recorded identity
+// is read under the credentials that made the cluster rather than under a second, independently
+// resolved selection.
+func (s *Service) eksIdentityClientFor(
+	ctx context.Context,
+	region string,
+	resolution credentials.AWSResolution,
+) (eksidentity.Client, error) {
 	client, err := eksclient.NewClient(ctx, region, credentials.OptionsForFrozenAWSConfig(
 		resolution,
 		eksclient.WithAWSConfig,
@@ -307,10 +391,8 @@ func (s *Service) eksIdentityClient(
 		eksclient.RequireCredentialValues,
 	)...)
 	if err != nil {
-		return nil, credentials.AWSResolution{}, fmt.Errorf(
-			"create EKS identity client for ownership: %w", err,
-		)
+		return nil, fmt.Errorf("create EKS identity client for ownership: %w", err)
 	}
 
-	return client, resolution, nil
+	return client, nil
 }

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -76,8 +76,7 @@ func (s *Service) resolveEKSMutationGuard(
 
 	// Bound every network call this guard makes. The caller's context is deliberately
 	// uncancellable (see defaultEKSOwnershipTimeout), so without this a hung AWS endpoint pins the
-	// job forever. The verifier handed onward is NOT closed over this context — it takes one at
-	// call time, so the provisioner re-checks under its own deadline at the mutation boundary.
+	// job forever.
 	ctx, cancel := context.WithTimeout(ctx, s.eksOwnershipTimeout)
 	defer cancel()
 
@@ -105,7 +104,22 @@ func (s *Service) resolveEKSMutationGuard(
 		return nil, fmt.Errorf("verify immutable EKS ownership identity for %q: %w", name, err)
 	}
 
-	return &eksMutationGuard{resolution: resolution, verifier: verifier}, nil
+	// Bound the carried verifier too, per invocation.
+	//
+	// This deadline ends with this function, and the provisioner re-checks identity at its own
+	// mutation boundary using the context IT was given — which is the same uncancellable background
+	// context. Handing the raw verifier onward would leave that second check unbounded, so a hung
+	// STS or EKS endpoint could still pin the job in Deleting/Updating even though the first check
+	// succeeded quickly. Wrapping is what makes the guarantee hold at both boundaries rather than
+	// only at the first one.
+	bounded := func(callCtx context.Context) error {
+		callCtx, callCancel := context.WithTimeout(callCtx, s.eksOwnershipTimeout)
+		defer callCancel()
+
+		return verifier(callCtx)
+	}
+
+	return &eksMutationGuard{resolution: resolution, verifier: bounded}, nil
 }
 
 // applyEKSMutationGuard returns the factory the action should use, carrying the guard when one was
@@ -124,6 +138,64 @@ func applyEKSMutationGuard(
 	}
 
 	return guardable.WithEKSMutationGuard(&guard.resolution, guard.verifier), nil
+}
+
+// eksCaptureFunc records the immutable AWS identity of a just-created EKS cluster. It is a seam so
+// tests exercise the create wiring without AWS.
+type eksCaptureFunc func(ctx context.Context, name string) error
+
+// captureEKSOwnership records the immutable identity of a cluster this backend just created.
+//
+// Without it the guard is unusable on the very clusters this API creates: runCreate persists only
+// spec.json, and the EKS provisioner just runs eksctl, so nothing writes the ownership record
+// NewVerifier requires. Every later delete/start/stop would then fail with the rebind error and the
+// operator would have to run `ksail cluster eks-bind` by hand after every single create — a guard
+// that blocks the path it is meant to protect.
+//
+// Capture performs read-only AWS queries and writes local state only; it mutates nothing in AWS.
+func (s *Service) captureEKSOwnership(ctx context.Context, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.eksOwnershipTimeout)
+	defer cancel()
+
+	return s.captureEKSIdentity(ctx, name)
+}
+
+// defaultEKSCapture resolves the just-written binding, freezes one credential snapshot for its
+// region, and records the live identity under that region.
+func (s *Service) defaultEKSCapture(ctx context.Context, name string) error {
+	bound, err := boundEKSConfig(name)
+	if err != nil {
+		return err
+	}
+
+	if bound == nil {
+		return fmt.Errorf(
+			"%w for %q: the create completed but wrote no target binding to record an identity"+
+				" against",
+			ErrEKSOwnershipEvidenceMissing, name,
+		)
+	}
+
+	client, _, err := s.eksIdentityClient(ctx, bound.Region)
+	if err != nil {
+		return err
+	}
+
+	_, err = eksidentity.Capture(
+		ctx,
+		client,
+		name,
+		bound.Region,
+		// The canonical mapping: this backend resolves AWS values through the Settings-backed
+		// credential overlay, which populates the standard AWS_* names. Recording those is what
+		// lets a later verification resolve the same identity this capture observed.
+		credentials.AWSOptionsWithDefaults(v1alpha1.OptionsAWS{}),
+	)
+	if err != nil {
+		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
+	}
+
+	return nil
 }
 
 // defaultEKSGuard reads the target the cluster was bound to when it was created, freezes one AWS
@@ -156,27 +228,10 @@ func (s *Service) defaultEKSGuard(
 	}
 
 	region := bound.Region
-	selection := credentials.ResolveAWS(s.discoverer.Resolver)
 
-	resolution, err := credentials.FreezeAWS(ctx, selection, region)
+	client, resolution, err := s.eksIdentityClient(ctx, region)
 	if err != nil {
-		return credentials.AWSResolution{}, nil, fmt.Errorf(
-			"freeze AWS credentials for EKS ownership verification: %w", err,
-		)
-	}
-
-	options := credentials.OptionsForFrozenAWSConfig(
-		resolution,
-		eksclient.WithAWSConfig,
-		eksclient.WithCredentialValues,
-		eksclient.RequireCredentialValues,
-	)
-
-	client, err := eksclient.NewClient(ctx, region, options...)
-	if err != nil {
-		return credentials.AWSResolution{}, nil, fmt.Errorf(
-			"create EKS identity client for ownership verification: %w", err,
-		)
+		return credentials.AWSResolution{}, nil, err
 	}
 
 	verifier, err := eksidentity.NewVerifier(client, name, region)
@@ -187,4 +242,35 @@ func (s *Service) defaultEKSGuard(
 	}
 
 	return resolution, verifier, nil
+}
+
+// eksIdentityClient freezes one AWS credential snapshot for a region and builds the read-only
+// identity client against it. Capture and verification share this so both run under exactly the same
+// resolved identity — a capture recorded under one and verified under another would fail forever.
+func (s *Service) eksIdentityClient(
+	ctx context.Context,
+	region string,
+) (eksidentity.Client, credentials.AWSResolution, error) {
+	selection := credentials.ResolveAWS(s.discoverer.Resolver)
+
+	resolution, err := credentials.FreezeAWS(ctx, selection, region)
+	if err != nil {
+		return nil, credentials.AWSResolution{}, fmt.Errorf(
+			"freeze AWS credentials for EKS ownership: %w", err,
+		)
+	}
+
+	client, err := eksclient.NewClient(ctx, region, credentials.OptionsForFrozenAWSConfig(
+		resolution,
+		eksclient.WithAWSConfig,
+		eksclient.WithCredentialValues,
+		eksclient.RequireCredentialValues,
+	)...)
+	if err != nil {
+		return nil, credentials.AWSResolution{}, fmt.Errorf(
+			"create EKS identity client for ownership: %w", err,
+		)
+	}
+
+	return client, resolution, nil
 }

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -102,27 +102,10 @@ func (s *Service) resolveEKSMutationGuard(
 	// standalone CLI path, which also verifies during its guard and reuses the verifier afterwards.
 	err = verifier(ctx)
 	if err != nil {
-		// Absence is the one verification failure that must not fail closed. This guard exists to
-		// stop a mutation reaching an unrelated incarnation of the name; when no live cluster
-		// answers to it there is no incarnation to reach, so refusing protects nothing and costs
-		// the caller its idempotency. Reporting it as clustererr.ErrClusterNotFound lets runDelete's
-		// existing state-cleanup and idempotent-success branches run, instead of pinning a Failed
-		// row that cannot be dismissed and retaining completed-create state that then blocks
-		// recreating the name — the trap runDelete's own idempotency handling was written to avoid.
-		//
-		// A mismatch is the opposite case and stays fail-closed: a different live cluster answering
-		// to this name is exactly what must not be mutated.
-		if errors.Is(err, eksclient.ErrClusterNotFound) {
-			return nil, fmt.Errorf(
-				"%w: %q has no live EKS cluster to verify ownership against: %w",
-				clustererr.ErrClusterNotFound, name, err,
-			)
-		}
-
-		return nil, fmt.Errorf("verify immutable EKS ownership identity for %q: %w", name, err)
+		return nil, normalizeEKSVerificationError(err, name)
 	}
 
-	// Bound the carried verifier too, per invocation.
+	// Bound the carried verifier too, per invocation, and normalize its result the same way.
 	//
 	// This deadline ends with this function, and the provisioner re-checks identity at its own
 	// mutation boundary using the context IT was given — which is the same uncancellable background
@@ -130,14 +113,53 @@ func (s *Service) resolveEKSMutationGuard(
 	// STS or EKS endpoint could still pin the job in Deleting/Updating even though the first check
 	// succeeded quickly. Wrapping is what makes the guarantee hold at both boundaries rather than
 	// only at the first one.
+	//
+	// The normalization has to happen here as well, not only at the call above: a cluster can be
+	// present when this guard verifies and gone by the time the provisioner re-checks — which is the
+	// very race the second check exists to catch. Normalizing only the first boundary would leave
+	// that window returning a raw eksclient error runDelete does not recognize, reaching the same
+	// undismissable Failed row one boundary later.
 	bounded := func(callCtx context.Context) error {
 		callCtx, callCancel := context.WithTimeout(callCtx, s.eksOwnershipTimeout)
 		defer callCancel()
 
-		return verifier(callCtx)
+		callErr := verifier(callCtx)
+		if callErr == nil {
+			return nil
+		}
+
+		return normalizeEKSVerificationError(callErr, name)
 	}
 
 	return &eksMutationGuard{resolution: resolution, verifier: bounded}, nil
+}
+
+// normalizeEKSVerificationError maps a verification failure caused by the cluster's absence onto
+// clustererr.ErrClusterNotFound, and leaves every other failure exactly as it was.
+//
+// Absence is the one verification failure that must not fail closed. The guard exists to stop a
+// mutation reaching an unrelated incarnation of the name; when no live cluster answers to it there
+// is no incarnation to reach, so refusing protects nothing and costs the caller its idempotency.
+// Reporting it as clustererr.ErrClusterNotFound lets runDelete's existing state-cleanup and
+// idempotent-success branches run, instead of pinning a Failed row that cannot be dismissed and
+// retaining completed-create state that then blocks recreating the name — the trap runDelete's own
+// idempotency handling was written to avoid.
+//
+// A mismatch is the opposite case and stays fail-closed: a different live cluster answering to this
+// name is exactly what must not be mutated.
+//
+// This is shared by both verification boundaries deliberately. Applying it at only one of them
+// leaves the other reporting an error runDelete cannot recognize, which is the same failure the
+// mapping exists to prevent.
+func normalizeEKSVerificationError(err error, name string) error {
+	if errors.Is(err, eksclient.ErrClusterNotFound) {
+		return fmt.Errorf(
+			"%w: %q has no live EKS cluster to verify ownership against: %w",
+			clustererr.ErrClusterNotFound, name, err,
+		)
+	}
+
+	return fmt.Errorf("verify immutable EKS ownership identity for %q: %w", name, err)
 }
 
 // applyEKSMutationGuard returns the factory the action should use, carrying the guard when one was

--- a/pkg/cli/clusterapi/eks_ownership_default_paths_internal_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_default_paths_internal_test.go
@@ -1,0 +1,132 @@
+package clusterapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file cover defaultEKSCapture and defaultEKSGuard — the capture and guard
+// closures the production factory is actually wired to (local_service.go), as opposed to the
+// injected seams every other test in this package drives.
+//
+// The distinction is not academic. Deleting the identity refusal from defaultEKSCapture outright
+// left the whole ownership suite green: the seams around it are covered at 95-100%, and these two
+// functions at 0.0%, so a security refusal could be removed from the shipped path without a single
+// test noticing. That is the same shape of gap this PR exists to close, one level down.
+//
+// Every branch asserted here returns BEFORE any AWS call, which is what makes the shipped path
+// testable without credentials at all.
+
+// eksOwnershipService builds a Service with only what these paths read.
+func eksOwnershipService() *Service {
+	return &Service{eksOwnershipTimeout: time.Second}
+}
+
+// markEKSCreated makes eksCreateCompleted report true, which is what lets boundEKSConfig proceed
+// past its "not created yet" short circuit to the binding lookup.
+func markEKSCreated(t *testing.T, name string) {
+	t.Helper()
+
+	require.NoError(t, state.SaveClusterSpec(name, &v1alpha1.ClusterSpec{
+		Distribution: v1alpha1.DistributionEKS,
+	}))
+}
+
+// TestCaptureRefusesWhenTheCreateWroteNoBinding covers the first refusal in the shipped capture
+// path. A capture with no binding has no region to record the identity against, and inventing one
+// from the ambient selection is the divergence the pinned identity exists to remove.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestCaptureRefusesWhenTheCreateWroteNoBinding(t *testing.T) {
+	isolateHome(t)
+
+	err := eksOwnershipService().
+		defaultEKSCapture(context.Background(), "unbound", &eksCreateIdentity{
+			awsOptions: recordedAliases(),
+		})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEKSOwnershipEvidenceMissing)
+}
+
+// TestCaptureRefusesWhenTheCreatePinnedNoIdentity is the branch whose deletion the suite did not
+// notice. Reaching it requires a real binding, so the refusal cannot be reached by accident from an
+// empty home — the earlier bound==nil check would answer first and the test would pass for the
+// wrong reason.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestCaptureRefusesWhenTheCreatePinnedNoIdentity(t *testing.T) {
+	isolateHome(t)
+
+	const (
+		name   = "bound-but-unpinned"
+		region = "eu-west-1"
+	)
+
+	markEKSCreated(t, name)
+	saveOwnership(t, name, region, recordedAliases())
+
+	err := eksOwnershipService().defaultEKSCapture(context.Background(), name, nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEKSOwnershipEvidenceMissing)
+	require.Contains(t, err.Error(), "pinned no AWS identity")
+}
+
+// TestCaptureReachesTheIdentityRefusalOnlyThroughARealBinding is the control that makes the test
+// above attributable. With the binding removed and everything else identical, the SAME call must
+// still fail — but on the earlier branch, with the other message. Without this, an implementation
+// that refused every capture unconditionally would satisfy the assertion above.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestCaptureReachesTheIdentityRefusalOnlyThroughARealBinding(t *testing.T) {
+	isolateHome(t)
+
+	err := eksOwnershipService().defaultEKSCapture(context.Background(), "no-binding", nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEKSOwnershipEvidenceMissing)
+	require.NotContains(t, err.Error(), "pinned no AWS identity")
+	require.Contains(t, err.Error(), "wrote no target binding")
+}
+
+// TestGuardRefusesWhenNoBindingWasEverWritten covers the shipped guard's refusal. A mutation must
+// resolve its target from the binding written at create time; resolving from the region selected
+// now is precisely the redirect the guard exists to catch, so the absence of a binding can never
+// fall back to the ambient one.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestGuardRefusesWhenNoBindingWasEverWritten(t *testing.T) {
+	isolateHome(t)
+
+	resolution, verifier, err := eksOwnershipService().
+		defaultEKSGuard(context.Background(), "unbound")
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEKSOwnershipEvidenceMissing)
+	require.Nil(t, verifier)
+	require.Equal(t, credentials.AWSResolution{}, resolution)
+	require.Contains(t, err.Error(), "eks-bind")
+}
+
+// TestGuardAndCaptureAgreeOnTheMissingEvidenceSentinel keeps the two shipped paths reporting the
+// same class of failure. They are read by one caller that decides whether a mutation may proceed;
+// a sentinel drift would make one of them fail open there while both still returned an error.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestGuardAndCaptureAgreeOnTheMissingEvidenceSentinel(t *testing.T) {
+	isolateHome(t)
+
+	_, _, guardErr := eksOwnershipService().defaultEKSGuard(context.Background(), "unbound")
+	captureErr := eksOwnershipService().
+		defaultEKSCapture(context.Background(), "unbound", &eksCreateIdentity{})
+
+	require.ErrorIs(t, guardErr, ErrEKSOwnershipEvidenceMissing)
+	require.ErrorIs(t, captureErr, ErrEKSOwnershipEvidenceMissing)
+}

--- a/pkg/cli/clusterapi/eks_ownership_internal_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_internal_test.go
@@ -1,0 +1,108 @@
+package clusterapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTheProductionFactoryCanCarryTheGuard closes the gap every other test in this package leaves
+// open: they all inject a fake factory, and a fake satisfies eksGuardableFactory because it was
+// written to. Nothing in them touches the factory the shipped binary builds.
+//
+// That matters because applyEKSMutationGuard fails closed on a factory it cannot guard. If
+// DefaultFactory ever stopped satisfying the interface, every real EKS mutation would be refused
+// with ErrUnguardableFactory while this package's tests stayed green — the failure would surface
+// only to an operator, on a cluster.
+func TestTheProductionFactoryCanCarryTheGuard(t *testing.T) {
+	t.Parallel()
+
+	production := defaultProductionFactory(t)
+
+	guarded, err := applyEKSMutationGuard(production, &eksMutationGuard{
+		resolution: credentials.AWSResolution{},
+		verifier:   func(context.Context) error { return nil },
+	})
+	require.NoError(t, err, "the production factory could not carry the EKS mutation guard")
+
+	typed, ok := guarded.(clusterprovisioner.DefaultFactory)
+	require.True(t, ok, "guarding the production factory changed its concrete type")
+	assert.NotNil(t, typed.AWSOwnershipVerifier, "the verifier did not reach the factory")
+	assert.NotNil(t, typed.AWSResolution, "the frozen resolution did not reach the factory")
+}
+
+// TestGuardingTheFactoryDoesNotMutateTheOriginal pins the value receiver on
+// WithEKSMutationGuard. A pointer receiver would leave one action's identity attached to a shared
+// factory, so the next, unrelated action would be authorized by an identity nobody verified for it.
+func TestGuardingTheFactoryDoesNotMutateTheOriginal(t *testing.T) {
+	t.Parallel()
+
+	production := defaultProductionFactory(t)
+
+	_, err := applyEKSMutationGuard(production, &eksMutationGuard{
+		resolution: credentials.AWSResolution{},
+		verifier:   func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+
+	original, ok := production.(clusterprovisioner.DefaultFactory)
+	require.True(t, ok)
+	assert.Nil(t, original.AWSOwnershipVerifier,
+		"guarding one action left the verifier on the shared factory")
+	assert.Nil(t, original.AWSResolution,
+		"guarding one action left the credential snapshot on the shared factory")
+}
+
+// TestAnUnguardableFactoryIsRefused pins the fail-closed direction: a factory that cannot carry the
+// guard must fail the mutation rather than silently run it unguarded.
+func TestAnUnguardableFactoryIsRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := applyEKSMutationGuard(unguardableFactory{}, &eksMutationGuard{
+		resolution: credentials.AWSResolution{},
+		verifier:   func(context.Context) error { return nil },
+	})
+
+	require.ErrorIs(t, err, ErrUnguardableFactory)
+}
+
+// TestNoGuardLeavesTheFactoryUntouched is the scope control for the two tests above: a create, and
+// every non-EKS action, must reach the same factory they always did.
+func TestNoGuardLeavesTheFactoryUntouched(t *testing.T) {
+	t.Parallel()
+
+	original := unguardableFactory{}
+
+	same, err := applyEKSMutationGuard(original, nil)
+	require.NoError(t, err, "an unguarded action was refused")
+	assert.Equal(t, original, same)
+}
+
+// defaultProductionFactory builds the factory the shipped binary uses for a distribution whose
+// config needs no on-disk state, so the assertion is about the real type rather than a stand-in.
+func defaultProductionFactory(t *testing.T) clusterprovisioner.Factory {
+	t.Helper()
+
+	factory, err := defaultFactory(v1alpha1.DistributionVanilla, "guard-shape-probe")
+	require.NoError(t, err)
+
+	return factory
+}
+
+// unguardableFactory is a factory that deliberately does NOT implement the guard interface.
+type unguardableFactory struct{}
+
+func (unguardableFactory) Create(
+	context.Context,
+	*v1alpha1.Cluster,
+) (clusterprovisioner.Provisioner, any, error) {
+	return nil, nil, nil
+}
+
+var _ eksidentity.Verifier = func(context.Context) error { return nil }

--- a/pkg/cli/clusterapi/eks_ownership_resolver_internal_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_resolver_internal_test.go
@@ -1,0 +1,176 @@
+package clusterapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateHome points state reads and writes at a throwaway home so this package never touches the
+// developer's real ~/.ksail/clusters. t.Setenv forbids t.Parallel, which is why these tests are
+// serial.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	return dir
+}
+
+// recordedAliases is a complete variable-name mapping. Completeness is not decoration: an ownership
+// record whose mapping is partial fails validation on load, so a record that reaches the resolver
+// always names every key.
+func recordedAliases() v1alpha1.OptionsAWS {
+	return v1alpha1.OptionsAWS{
+		ProfileEnvVar:         "RECORDED_PROFILE",
+		RegionEnvVar:          "RECORDED_REGION",
+		AccessKeyIDEnvVar:     "RECORDED_ACCESS",
+		SecretAccessKeyEnvVar: "RECORDED_SECRET",
+		SessionTokenEnvVar:    "RECORDED_SESSION",
+	}
+}
+
+func saveOwnership(t *testing.T, name, region string, options v1alpha1.OptionsAWS) {
+	t.Helper()
+
+	require.NoError(t, state.SaveEKSOwnershipState(name, region, &state.EKSOwnershipState{
+		Version:     state.EKSOwnershipStateVersion,
+		ClusterName: name,
+		Region:      region,
+		AccountID:   "123456789012",
+		ClusterARN:  "arn:aws:eks:" + region + ":123456789012:cluster/" + name,
+		CreatedAt:   time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC),
+		AWSOptions:  options,
+	}))
+}
+
+// writeLegacyOwnership plants a record with no awsOptions mapping. SaveEKSOwnershipState cannot
+// produce one — it validates completeness — so the only faithful way to exercise a record written
+// before the mapping schema is to write the file the way that older KSail did.
+func writeLegacyOwnership(t *testing.T, home, name, region string) {
+	t.Helper()
+
+	dir := filepath.Join(home, ".ksail", "clusters", name)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+
+	body := `{"version":1,"clusterName":"` + name + `","region":"` + region + `",` +
+		`"accountId":"123456789012",` +
+		`"clusterArn":"arn:aws:eks:` + region + `:123456789012:cluster/` + name + `",` +
+		`"createdAt":"2026-08-02T12:00:00Z"}`
+
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "eks-ownership-"+region+".json"), []byte(body), 0o600))
+}
+
+// TestLifecycleCredentialsResolveThroughTheOwnershipRecord is the defect this guards against.
+//
+// Capture persists the variable names the create actually resolved through. Delete, Start, and Stop
+// then built their identity client before eksidentity.NewVerifier ever loaded that record, so the
+// record could not influence credential resolution at all: a cluster created with custom
+// spec.provider.aws names failed with unavailable credentials, or verified against whatever identity
+// the canonical variables happened to name.
+
+func TestLifecycleCredentialsResolveThroughTheOwnershipRecord(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("RECORDED_ACCESS", "made-this-cluster")
+
+	const (
+		name   = "recorded-alias-cluster"
+		region = "eu-north-1"
+	)
+
+	saveOwnership(t, name, region, recordedAliases())
+
+	service := NewService()
+
+	resolver := service.eksOwnershipResolver(name, region)
+
+	assert.Equal(t, "RECORDED_ACCESS", resolver.EnvVar(credentials.AWSAccessKeyID),
+		"the lifecycle path did not resolve through the name the record captured")
+	assert.Equal(t, "made-this-cluster", resolver.Value(credentials.AWSAccessKeyID),
+		"the credentials that created the cluster did not resolve for its lifecycle mutation")
+}
+
+// TestTheRecordIsScopedToItsOwnRegion pins that the record consulted is the one for the region the
+// mutation is bound to. Records are region-scoped precisely because a same-named cluster can exist
+// elsewhere, and resolving a sibling region's aliases would authorize against the wrong target.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestTheRecordIsScopedToItsOwnRegion(t *testing.T) {
+	isolateHome(t)
+
+	const name = "two-region-cluster"
+
+	saveOwnership(t, name, "eu-north-1", recordedAliases())
+
+	injected := credentials.NewAWSOptionsResolver(v1alpha1.OptionsAWS{
+		AccessKeyIDEnvVar: "INJECTED_ACCESS",
+	})
+	service := NewService()
+	service.UseCredentials(injected)
+
+	resolver := service.eksOwnershipResolver(name, "us-east-1")
+
+	assert.Equal(t, "INJECTED_ACCESS", resolver.EnvVar(credentials.AWSAccessKeyID),
+		"a region with no record of its own borrowed another region's recorded aliases")
+}
+
+// TestAnUnrecordedClusterKeepsTheInjectedResolver protects the injection seam. UseCredentials points
+// discovery at a Settings-backed resolver, and consulting the record must not replace it for a
+// cluster that has none — every unrecorded path has to resolve exactly as it did before.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestAnUnrecordedClusterKeepsTheInjectedResolver(t *testing.T) {
+	isolateHome(t)
+
+	injected := credentials.NewAWSOptionsResolver(v1alpha1.OptionsAWS{
+		AccessKeyIDEnvVar: "INJECTED_ACCESS",
+	})
+	service := NewService()
+	service.UseCredentials(injected)
+
+	resolver := service.eksOwnershipResolver("no-record-cluster", "eu-north-1")
+
+	assert.Equal(t, "INJECTED_ACCESS", resolver.EnvVar(credentials.AWSAccessKeyID),
+		"a cluster with no ownership record lost the injected resolver")
+}
+
+// TestALegacyRecordKeepsTheInjectedResolver covers a record written before the mapping schema. It
+// carries no names to honour, so it must leave resolution exactly as it is today. The authoritative,
+// actionable failure for a legacy record belongs to eksidentity.NewVerifier's migration error, which
+// names the rebind command; shadowing it with an opaque credential error here would lose that.
+//
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestALegacyRecordKeepsTheInjectedResolver(t *testing.T) {
+	home := isolateHome(t)
+
+	const (
+		name   = "legacy-record-cluster"
+		region = "eu-north-1"
+	)
+
+	writeLegacyOwnership(t, home, name, region)
+
+	_, err := state.LoadEKSOwnershipState(name, region)
+	require.Error(t, err, "the legacy fixture validated, so it no longer models a legacy record")
+
+	injected := credentials.NewAWSOptionsResolver(v1alpha1.OptionsAWS{
+		AccessKeyIDEnvVar: "INJECTED_ACCESS",
+	})
+	service := NewService()
+	service.UseCredentials(injected)
+
+	resolver := service.eksOwnershipResolver(name, region)
+
+	assert.Equal(t, "INJECTED_ACCESS", resolver.EnvVar(credentials.AWSAccessKeyID),
+		"a legacy record displaced the injected resolver instead of leaving it alone")
+}

--- a/pkg/cli/clusterapi/eks_ownership_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -365,4 +366,156 @@ func TestEKSOwnershipVerificationIsBounded(t *testing.T) {
 		"the ownership guard ran without a deadline, so a hung AWS endpoint would pin the job")
 	assert.Empty(t, provisioner.deletedNames(),
 		"a delete proceeded despite ownership verification never completing")
+}
+
+// TestCarriedVerifierIsBoundedPerInvocation pins the deadline on the verifier handed to the
+// provisioner, not only on this package's own first check.
+//
+// The provisioner re-checks identity at its own mutation boundary using the context IT was given —
+// which is the same uncancellable background context. Handing the raw verifier onward would leave
+// that second check unbounded, so a hung STS or EKS endpoint could still pin the job even though the
+// first check returned quickly. The guarantee has to hold at both boundaries.
+func TestCarriedVerifierIsBoundedPerInvocation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "carried-verifier-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, nil)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	service.SetEKSOwnershipTimeoutForTest(50 * time.Millisecond)
+	// This is the exact scenario the finding describes: the FIRST check succeeds quickly, so a
+	// guard is built and carried onward, and only the later mutation-boundary check hangs. A
+	// verifier that hung immediately would fail the first check and never reach the factory at all.
+	var calls atomic.Int32
+
+	service.SetEKSOwnershipGuardForTest(
+		func(
+			_ context.Context,
+			_ string,
+		) (credentials.AWSResolution, eksidentity.Verifier, error) {
+			return credentials.AWSResolution{}, func(ctx context.Context) error {
+				if calls.Add(1) == 1 {
+					return nil
+				}
+
+				<-ctx.Done()
+
+				return ctx.Err()
+			}, nil
+		},
+	)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		return recorder.recordedVerifier() != nil
+	}, eventuallyTimeout, eventuallyTick)
+
+	carried := recorder.recordedVerifier()
+	require.NotNil(t, carried)
+
+	// Invoke it exactly as the provisioner does: with the uncancellable background context.
+	done := make(chan error, 1)
+
+	go func() { done <- carried(context.WithoutCancel(context.Background())) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a hung verifier returned success")
+	case <-time.After(2 * time.Second):
+		t.Fatal("the carried verifier ran unbounded — a hung AWS endpoint would pin the job here")
+	}
+}
+
+// TestCreateEKSCapturesOwnershipIdentity pins that a successful create records the identity the
+// guard later verifies against. Without it the guard blocks the very clusters this API creates.
+func TestCreateEKSCapturesOwnershipIdentity(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "captured-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, nil)
+
+	captured := make(chan string, 1)
+
+	service.SetEKSOwnershipCaptureForTest(func(_ context.Context, name string) error {
+		captured <- name
+
+		return nil
+	})
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	select {
+	case got := <-captured:
+		assert.Equal(t, clusterName, got)
+	default:
+		t.Fatal("a successful EKS create recorded no ownership identity, so every later " +
+			"delete/start/stop would fail with the rebind error")
+	}
+}
+
+// TestCreateEKSFailsWhenOwnershipCannotBeCaptured is the fail-loud half: the remote cluster exists
+// either way, so reporting success while leaving it unoperatable would hide the problem until the
+// first delete. This mirrors how a SaveClusterSpec failure is already handled.
+func TestCreateEKSFailsWhenOwnershipCannotBeCaptured(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "uncapturable-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, nil)
+
+	service.SetEKSOwnershipCaptureForTest(func(_ context.Context, _ string) error {
+		return errGuardRefused
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+}
+
+// TestNonEKSCreateCapturesNothing is the scope control: capture is an AWS identity concern.
+func TestNonEKSCreateCapturesNothing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionVanilla, provisioner, recorder, nil)
+
+	service.SetEKSOwnershipCaptureForTest(func(_ context.Context, _ string) error {
+		t.Error("a non-EKS create attempted an AWS ownership capture")
+
+		return nil
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor("plain-cluster", v1alpha1.DistributionVanilla),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, "plain-cluster")
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
 }

--- a/pkg/cli/clusterapi/eks_ownership_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
@@ -309,4 +310,59 @@ func createEKSClusterForTest(t *testing.T, service *clusterapi.Service, name str
 
 		return found && phase == v1alpha1.ClusterPhaseReady
 	}, eventuallyTimeout, eventuallyTick)
+}
+
+// TestEKSOwnershipVerificationIsBounded pins the deadline on the guard's network calls.
+//
+// The mutation paths run on a context.WithoutCancel background context, so the HTTP request that
+// triggered the action can never cancel this work, and the AWS SDK applies no overall per-operation
+// deadline of its own. Without an explicit bound, an unresponsive STS or EKS endpoint leaves the job
+// pinned in Deleting with no way to dismiss it — the undismissable-row failure runDelete's
+// idempotency handling already exists to avoid. A hung guard must therefore fail the job, not hang.
+func TestEKSOwnershipVerificationIsBounded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "hung-endpoint-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, nil)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	// A guard that never answers, exactly as an unresponsive AWS endpoint behaves.
+	sawDeadline := make(chan bool, 1)
+
+	service.SetEKSOwnershipTimeoutForTest(50 * time.Millisecond)
+	service.SetEKSOwnershipGuardForTest(
+		func(
+			ctx context.Context,
+			_ string,
+		) (credentials.AWSResolution, eksidentity.Verifier, error) {
+			_, hasDeadline := ctx.Deadline()
+			select {
+			case sawDeadline <- hasDeadline:
+			default:
+			}
+
+			<-ctx.Done()
+
+			return credentials.AWSResolution{}, nil, ctx.Err()
+		},
+	)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	assert.True(t, <-sawDeadline,
+		"the ownership guard ran without a deadline, so a hung AWS endpoint would pin the job")
+	assert.Empty(t, provisioner.deletedNames(),
+		"a delete proceeded despite ownership verification never completing")
 }

--- a/pkg/cli/clusterapi/eks_ownership_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_test.go
@@ -630,3 +630,174 @@ func TestDeleteEKSStillRefusesAnIdentityMismatch(t *testing.T) {
 	assert.Empty(t, provisioner.deletedNames(),
 		"a delete reached the provisioner despite an ownership identity mismatch")
 }
+
+// carriedVerifierFactory hands the recorded verifier to a provisioner that actually CALLS it, so a
+// test can exercise the second verification boundary. The real EKS provisioner re-checks ownership
+// at its own mutation boundary via VerifyBeforeMutation and returns whatever that yields; the fakes
+// used elsewhere in this file only record the verifier, so they cannot reach this path at all.
+type carriedVerifierFactory struct {
+	provisioner *fakeProvisioner
+	recorder    *guardRecorder
+}
+
+func (f carriedVerifierFactory) Create(
+	_ context.Context,
+	_ *v1alpha1.Cluster,
+) (clusterprovisioner.Provisioner, any, error) {
+	return &carriedVerifierProvisioner{
+		inner:    f.provisioner,
+		verifier: f.recorder.recordedVerifier(),
+	}, nil, nil
+}
+
+func (f carriedVerifierFactory) WithEKSMutationGuard(
+	_ *credentials.AWSResolution,
+	verifier eksidentity.Verifier,
+) clusterprovisioner.Factory {
+	f.recorder.record(verifier)
+
+	return f
+}
+
+// carriedVerifierProvisioner re-checks ownership before delegating, exactly as the real provisioner
+// does at its mutation boundary.
+type carriedVerifierProvisioner struct {
+	inner    *fakeProvisioner
+	verifier eksidentity.Verifier
+}
+
+func (p *carriedVerifierProvisioner) Create(ctx context.Context, name string) error {
+	return p.inner.Create(ctx, name)
+}
+
+func (p *carriedVerifierProvisioner) Delete(ctx context.Context, name string) error {
+	if p.verifier != nil {
+		err := p.verifier(ctx)
+		if err != nil {
+			return fmt.Errorf("verify before mutation: %w", err)
+		}
+	}
+
+	return p.inner.Delete(ctx, name)
+}
+
+func (p *carriedVerifierProvisioner) Start(ctx context.Context, name string) error {
+	return p.inner.Start(ctx, name)
+}
+
+func (p *carriedVerifierProvisioner) Stop(ctx context.Context, name string) error {
+	return p.inner.Stop(ctx, name)
+}
+
+func (p *carriedVerifierProvisioner) List(ctx context.Context) ([]string, error) {
+	return p.inner.List(ctx)
+}
+
+func (p *carriedVerifierProvisioner) Exists(ctx context.Context, name string) (bool, error) {
+	return p.inner.Exists(ctx, name)
+}
+
+// newCarriedVerifierService wires a service whose provisioner calls the CARRIED verifier, with a
+// verifier that succeeds on its first call (the guard's own check) and fails on the second (the
+// provisioner's mutation-boundary re-check).
+func newCarriedVerifierService(
+	t *testing.T,
+	provisioner *fakeProvisioner,
+	recorder *guardRecorder,
+	secondCallErr error,
+) *clusterapi.Service {
+	t.Helper()
+
+	empty := &fakeProvisioner{}
+	service := clusterapi.NewTestService(func(
+		distribution v1alpha1.Distribution,
+		_ string,
+	) (clusterprovisioner.Factory, error) {
+		if distribution != v1alpha1.DistributionEKS {
+			return fakeFactory{provisioner: empty}, nil
+		}
+
+		return carriedVerifierFactory{provisioner: provisioner, recorder: recorder}, nil
+	})
+
+	var calls atomic.Int32
+
+	service.SetEKSOwnershipGuardForTest(
+		func(
+			_ context.Context,
+			_ string,
+		) (credentials.AWSResolution, eksidentity.Verifier, error) {
+			return credentials.AWSResolution{}, func(context.Context) error {
+				if calls.Add(1) == 1 {
+					return nil
+				}
+
+				return secondCallErr
+			}, nil
+		},
+	)
+
+	return service
+}
+
+// TestDeleteEKSStaysIdempotentWhenTheClusterVanishesBeforeTheCarriedCheck covers the window the
+// carried verifier exists for: the cluster is present when the guard verifies and gone by the time
+// the provisioner re-checks at its own mutation boundary.
+//
+// Normalizing absence only at the guard's own call would leave this second boundary returning a raw
+// eksclient error that runDelete does not recognize — the same undismissable Failed row and retained
+// state, reached one boundary later.
+func TestDeleteEKSStaysIdempotentWhenTheClusterVanishesBeforeTheCarriedCheck(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "vanished-late-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newCarriedVerifierService(t, provisioner, recorder,
+		fmt.Errorf("describe EKS cluster for ownership verification: %w",
+			fmt.Errorf("%w: %s", eksclient.ErrClusterNotFound, clusterName)))
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		_, found := phaseOf(list, clusterName)
+
+		return !found
+	}, eventuallyTimeout, eventuallyTick,
+		"a cluster that vanished before the carried verification stayed pinned Failed")
+}
+
+// TestDeleteEKSStillRefusesALateIdentityMismatch is the other direction at the same boundary: a
+// mismatch discovered by the carried verifier must still fail closed.
+func TestDeleteEKSStillRefusesALateIdentityMismatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "mismatched-late-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newCarriedVerifierService(t, provisioner, recorder,
+		fmt.Errorf("%w: live cluster ARN does not match persisted ARN",
+			eksidentity.ErrIdentityMismatch))
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick,
+		"a late identity mismatch did not fail closed")
+
+	assert.Empty(t, provisioner.deletedNames(),
+		"a delete was delegated despite the carried verifier reporting a mismatch")
+}

--- a/pkg/cli/clusterapi/eks_ownership_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_test.go
@@ -1,0 +1,268 @@
+package clusterapi_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errGuardRefused stands in for any reason the ownership guard fails closed (a missing immutable
+// record, an account mismatch, an unreachable AWS identity endpoint).
+var errGuardRefused = errors.New("ownership guard refused")
+
+// guardRecorder captures whether the factory the service built for an action carried an EKS
+// mutation guard, so a test can assert the wiring without reaching AWS.
+type guardRecorder struct {
+	mu       sync.Mutex
+	guarded  bool
+	verifier eksidentity.Verifier
+}
+
+func (r *guardRecorder) record(verifier eksidentity.Verifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.guarded = true
+	r.verifier = verifier
+}
+
+func (r *guardRecorder) wasGuarded() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.guarded
+}
+
+func (r *guardRecorder) recordedVerifier() eksidentity.Verifier {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.verifier
+}
+
+// guardObservingFactory is a fake factory that also satisfies the optional guard-carrying interface, so
+// the assertion is about what the service handed the factory rather than about AWS behaviour.
+type guardObservingFactory struct {
+	provisioner *fakeProvisioner
+	recorder    *guardRecorder
+}
+
+func (f guardObservingFactory) Create(
+	_ context.Context,
+	_ *v1alpha1.Cluster,
+) (clusterprovisioner.Provisioner, any, error) {
+	return f.provisioner, nil, nil
+}
+
+func (f guardObservingFactory) WithEKSMutationGuard(
+	_ *credentials.AWSResolution,
+	verifier eksidentity.Verifier,
+) clusterprovisioner.Factory {
+	f.recorder.record(verifier)
+
+	return f
+}
+
+// newGuardRecordingService wires a service whose EKS factory records the guard it receives and
+// whose guard resolution is stubbed, so no test touches AWS.
+func newGuardRecordingService(
+	t *testing.T,
+	observed v1alpha1.Distribution,
+	provisioner *fakeProvisioner,
+	recorder *guardRecorder,
+	guardErr error,
+) *clusterapi.Service {
+	t.Helper()
+
+	// Route only the distribution under test to the observed provisioner. Discovery is restricted
+	// to the Docker provider, so handing it the same provisioner would make it enumerate the
+	// cluster as a Docker one; a lifecycle action would then resolve the distribution as Vanilla,
+	// the guard would correctly decline to fire, and the assertion would be measuring the harness
+	// rather than the product.
+	empty := &fakeProvisioner{}
+	service := clusterapi.NewTestService(func(
+		distribution v1alpha1.Distribution,
+		_ string,
+	) (clusterprovisioner.Factory, error) {
+		if distribution != observed {
+			return fakeFactory{provisioner: empty}, nil
+		}
+
+		return guardObservingFactory{provisioner: provisioner, recorder: recorder}, nil
+	})
+	service.SetEKSOwnershipGuardForTest(
+		func(
+			_ context.Context,
+			_ string,
+		) (credentials.AWSResolution, eksidentity.Verifier, error) {
+			if guardErr != nil {
+				return credentials.AWSResolution{}, nil, guardErr
+			}
+
+			return credentials.AWSResolution{}, func(context.Context) error { return nil }, nil
+		},
+	)
+
+	return service
+}
+
+// TestDeleteEKSCarriesOwnershipVerifierIntoTheFactory pins the wiring this issue is about: a local
+// API EKS delete must hand the provisioner the immutable-ownership verifier, so the provisioner
+// re-checks identity at its own mutation boundary exactly as the standalone CLI path does. Without
+// it the factory is built with a nil verifier and VerifyBeforeMutation is a no-op — a destructive
+// action with no ownership query at all.
+func TestDeleteEKSCarriesOwnershipVerifierIntoTheFactory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "guarded-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, nil)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		return len(provisioner.deletedNames()) == 1
+	}, eventuallyTimeout, eventuallyTick)
+
+	assert.True(t, recorder.wasGuarded(),
+		"EKS delete built its factory without an ownership guard")
+	assert.NotNil(t, recorder.recordedVerifier(),
+		"EKS delete carried a nil ownership verifier, which VerifyBeforeMutation skips")
+}
+
+// TestDeleteEKSRefusesWhenOwnershipCannotBeVerified pins the fail-closed half: when the immutable
+// identity cannot be established the destructive action must not reach the provisioner at all.
+func TestDeleteEKSRefusesWhenOwnershipCannotBeVerified(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "unverifiable-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	assert.Empty(t, provisioner.deletedNames(),
+		"an unverifiable EKS target was deleted anyway")
+}
+
+// TestStopEKSRefusesWhenOwnershipCannotBeVerified covers the nodegroup-scaling boundary: stop scales
+// managed nodegroups to zero, so it is a mutation and carries the same guard as delete.
+func TestStopEKSRefusesWhenOwnershipCannotBeVerified(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "unverifiable-stop-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	require.NoError(t, service.Stop(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	assert.Empty(t, provisioner.stoppedNames(),
+		"an unverifiable EKS target was stopped anyway")
+}
+
+// TestCreateEKSDoesNotRequireOwnershipVerification is the over-tightening control. A create has no
+// prior incarnation to verify and no persisted identity yet, so demanding a guard there would make
+// every first EKS create from the web UI fail. It must still succeed with the guard refusing.
+func TestCreateEKSDoesNotRequireOwnershipVerification(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "fresh-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	assert.False(t, recorder.wasGuarded(),
+		"an EKS create resolved an ownership guard, which no first create can satisfy")
+}
+
+// TestDeleteNonEKSDoesNotResolveAnOwnershipGuard is the scope control: the guard is an AWS identity
+// concern, so a Docker-backed distribution must be untouched by it.
+func TestDeleteNonEKSDoesNotResolveAnOwnershipGuard(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "vanilla-cluster"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(
+		t, v1alpha1.DistributionVanilla, provisioner, recorder, errGuardRefused,
+	)
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor(clusterName, v1alpha1.DistributionVanilla),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		return len(provisioner.deletedNames()) == 1
+	}, eventuallyTimeout, eventuallyTick)
+
+	assert.False(t, recorder.wasGuarded(),
+		"a non-EKS delete resolved an EKS ownership guard")
+}
+
+// createEKSClusterForTest drives a cluster through the async create path to Ready, which is the
+// precondition every lifecycle assertion above starts from.
+func createEKSClusterForTest(t *testing.T, service *clusterapi.Service, name string) {
+	t.Helper()
+
+	_, err := service.Create(context.Background(), clusterFor(name, v1alpha1.DistributionEKS))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, name)
+
+		return found && phase == v1alpha1.ClusterPhaseReady
+	}, eventuallyTimeout, eventuallyTick)
+}

--- a/pkg/cli/clusterapi/eks_ownership_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_test.go
@@ -3,6 +3,7 @@ package clusterapi_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
@@ -518,4 +520,113 @@ func TestNonEKSCreateCapturesNothing(t *testing.T) {
 
 		return found && phase == v1alpha1.ClusterPhaseReady
 	}, eventuallyTimeout, eventuallyTick)
+}
+
+// newGuardRecordingServiceWithVerifierErr wires a service whose ownership resolution succeeds but
+// whose verifier fails. Resolution and verification fail for different reasons — resolution fails
+// when the evidence cannot be read, verification when the live cluster contradicts it — so a test
+// about verification outcomes has to drive the verifier itself.
+func newGuardRecordingServiceWithVerifierErr(
+	t *testing.T,
+	provisioner *fakeProvisioner,
+	recorder *guardRecorder,
+	verifyErr error,
+) *clusterapi.Service {
+	t.Helper()
+
+	empty := &fakeProvisioner{}
+	service := clusterapi.NewTestService(func(
+		distribution v1alpha1.Distribution,
+		_ string,
+	) (clusterprovisioner.Factory, error) {
+		if distribution != v1alpha1.DistributionEKS {
+			return fakeFactory{provisioner: empty}, nil
+		}
+
+		return guardObservingFactory{provisioner: provisioner, recorder: recorder}, nil
+	})
+	service.SetEKSOwnershipGuardForTest(
+		func(
+			_ context.Context,
+			_ string,
+		) (credentials.AWSResolution, eksidentity.Verifier, error) {
+			return credentials.AWSResolution{}, func(context.Context) error {
+				return verifyErr
+			}, nil
+		},
+	)
+
+	return service
+}
+
+// TestDeleteEKSStaysIdempotentWhenTheClusterIsAlreadyGone pins the distinction the guard has to
+// draw: a cluster that is absent is not a cluster that is wrong.
+//
+// Verification cannot succeed against a cluster that no longer exists, so a guard that treats every
+// verification failure alike turns the ordinary out-of-band-deletion case into a permanent Failed
+// row plus retained completed-create state, which then blocks recreating the same name. That is the
+// undismissable-row trap runDelete's idempotency handling exists to avoid — reintroduced one layer
+// above it.
+func TestDeleteEKSStaysIdempotentWhenTheClusterIsAlreadyGone(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "vanished-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingServiceWithVerifierErr(
+		t, provisioner, recorder,
+		// The shape production produces: eksidentity wraps whatever DescribeCluster returned.
+		fmt.Errorf("describe EKS cluster for ownership verification: %w",
+			fmt.Errorf("%w: %s", eksclient.ErrClusterNotFound, clusterName)),
+	)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		_, found := phaseOf(list, clusterName)
+
+		return !found
+	}, eventuallyTimeout, eventuallyTick,
+		"an EKS delete for an already-absent cluster stayed pinned instead of clearing")
+
+	assert.Empty(t, provisioner.deletedNames(),
+		"a delete was issued against a cluster the guard had established was gone")
+}
+
+// TestDeleteEKSStillRefusesAnIdentityMismatch is the other direction, and the reason the test above
+// cannot simply relax the guard: an identity mismatch means a DIFFERENT live cluster answers to this
+// name, so the mutation must still be refused. Absence and mismatch must not collapse into one case.
+func TestDeleteEKSStillRefusesAnIdentityMismatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "mismatched-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingServiceWithVerifierErr(
+		t, provisioner, recorder,
+		fmt.Errorf("%w: live cluster ARN does not match persisted ARN",
+			eksidentity.ErrIdentityMismatch),
+	)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick,
+		"an identity mismatch did not fail closed")
+
+	assert.Empty(t, provisioner.deletedNames(),
+		"a delete reached the provisioner despite an ownership identity mismatch")
 }

--- a/pkg/cli/clusterapi/eks_ownership_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_test.go
@@ -151,7 +151,9 @@ func TestDeleteEKSRefusesWhenOwnershipCannotBeVerified(t *testing.T) {
 
 	provisioner := &fakeProvisioner{}
 	recorder := &guardRecorder{}
-	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused)
+	service := newGuardRecordingService(
+		t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused,
+	)
 
 	createEKSClusterForTest(t, service, clusterName)
 
@@ -169,6 +171,44 @@ func TestDeleteEKSRefusesWhenOwnershipCannotBeVerified(t *testing.T) {
 		"an unverifiable EKS target was deleted anyway")
 }
 
+// TestDeleteEKSRefusesWhenOwnershipResolutionReturnsNoVerifier pins the fail-open this guard is
+// most likely to acquire by accident: resolution succeeding but yielding no verifier. Downstream a
+// nil verifier reads as "nothing to check", so carrying it would produce a mutation that looks
+// guarded at every layer and checks nothing.
+func TestDeleteEKSRefusesWhenOwnershipResolutionReturnsNoVerifier(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const clusterName = "verifierless-eks"
+
+	provisioner := &fakeProvisioner{}
+	recorder := &guardRecorder{}
+	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, nil)
+
+	createEKSClusterForTest(t, service, clusterName)
+
+	service.SetEKSOwnershipGuardForTest(
+		func(
+			_ context.Context,
+			_ string,
+		) (credentials.AWSResolution, eksidentity.Verifier, error) {
+			return credentials.AWSResolution{}, nil, nil
+		},
+	)
+
+	require.NoError(t, service.Delete(context.Background(), "default", clusterName))
+	require.Eventually(t, func() bool {
+		list, listErr := service.List(context.Background())
+		require.NoError(t, listErr)
+
+		phase, found := phaseOf(list, clusterName)
+
+		return found && phase == v1alpha1.ClusterPhaseFailed
+	}, eventuallyTimeout, eventuallyTick)
+
+	assert.Empty(t, provisioner.deletedNames(),
+		"a nil ownership verifier was carried into the mutation instead of refusing it")
+}
+
 // TestStopEKSRefusesWhenOwnershipCannotBeVerified covers the nodegroup-scaling boundary: stop scales
 // managed nodegroups to zero, so it is a mutation and carries the same guard as delete.
 func TestStopEKSRefusesWhenOwnershipCannotBeVerified(t *testing.T) {
@@ -178,7 +218,9 @@ func TestStopEKSRefusesWhenOwnershipCannotBeVerified(t *testing.T) {
 
 	provisioner := &fakeProvisioner{}
 	recorder := &guardRecorder{}
-	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused)
+	service := newGuardRecordingService(
+		t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused,
+	)
 
 	createEKSClusterForTest(t, service, clusterName)
 
@@ -206,7 +248,9 @@ func TestCreateEKSDoesNotRequireOwnershipVerification(t *testing.T) {
 
 	provisioner := &fakeProvisioner{}
 	recorder := &guardRecorder{}
-	service := newGuardRecordingService(t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused)
+	service := newGuardRecordingService(
+		t, v1alpha1.DistributionEKS, provisioner, recorder, errGuardRefused,
+	)
 
 	createEKSClusterForTest(t, service, clusterName)
 

--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -118,6 +118,7 @@ func NewTestService(factory FactoryFunc) *Service {
 	service.kubeconfigPath = func() string { return "" }
 	// Stub the AWS-touching half of the EKS mutation guard so tests stay hermetic. Tests that are
 	// about the guard itself override it with SetEKSOwnershipGuardForTest.
+	service.captureEKSIdentity = func(context.Context, string) error { return nil }
 	service.resolveEKSGuard = func(
 		context.Context,
 		string,
@@ -126,6 +127,14 @@ func NewTestService(factory FactoryFunc) *Service {
 	}
 
 	return service
+}
+
+// SetEKSOwnershipCaptureForTest overrides the create-time identity capture, so a test can drive a
+// failing capture without AWS.
+func (s *Service) SetEKSOwnershipCaptureForTest(
+	capture func(ctx context.Context, name string) error,
+) {
+	s.captureEKSIdentity = capture
 }
 
 // SetEKSOwnershipTimeoutForTest shortens the bound on the ownership resolution's network calls, so a

--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -128,6 +128,12 @@ func NewTestService(factory FactoryFunc) *Service {
 	return service
 }
 
+// SetEKSOwnershipTimeoutForTest shortens the bound on the ownership resolution's network calls, so a
+// test can drive the deadline path without waiting the production budget.
+func (s *Service) SetEKSOwnershipTimeoutForTest(d time.Duration) {
+	s.eksOwnershipTimeout = d
+}
+
 // SetEKSOwnershipGuardForTest overrides the AWS-touching half of the EKS mutation guard, so a test
 // can drive a refusing or accepting immutable-identity check without AWS credentials.
 func (s *Service) SetEKSOwnershipGuardForTest(

--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -114,8 +116,27 @@ func NewTestService(factory FactoryFunc) *Service {
 	// Point the kubeconfig at nowhere by default so List's endpoint enrichment never reads the
 	// developer's real kubeconfig; tests that need one inject it via SetKubeconfigPathForTest.
 	service.kubeconfigPath = func() string { return "" }
+	// Stub the AWS-touching half of the EKS mutation guard so tests stay hermetic. Tests that are
+	// about the guard itself override it with SetEKSOwnershipGuardForTest.
+	service.resolveEKSGuard = func(
+		context.Context,
+		string,
+	) (credentials.AWSResolution, eksidentity.Verifier, error) {
+		return credentials.AWSResolution{}, func(context.Context) error { return nil }, nil
+	}
 
 	return service
+}
+
+// SetEKSOwnershipGuardForTest overrides the AWS-touching half of the EKS mutation guard, so a test
+// can drive a refusing or accepting immutable-identity check without AWS credentials.
+func (s *Service) SetEKSOwnershipGuardForTest(
+	guard func(
+		ctx context.Context,
+		name string,
+	) (credentials.AWSResolution, eksidentity.Verifier, error),
+) {
+	s.resolveEKSGuard = guard
 }
 
 // ExportEKSConfigForCreate exposes eksDistributionConfig for testing the generated eks.yaml. It

--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -118,7 +118,7 @@ func NewTestService(factory FactoryFunc) *Service {
 	service.kubeconfigPath = func() string { return "" }
 	// Stub the AWS-touching half of the EKS mutation guard so tests stay hermetic. Tests that are
 	// about the guard itself override it with SetEKSOwnershipGuardForTest.
-	service.captureEKSIdentity = func(context.Context, string) error { return nil }
+	service.captureEKSIdentity = func(context.Context, string, *eksCreateIdentity) error { return nil }
 	service.resolveEKSGuard = func(
 		context.Context,
 		string,
@@ -131,10 +131,41 @@ func NewTestService(factory FactoryFunc) *Service {
 
 // SetEKSOwnershipCaptureForTest overrides the create-time identity capture, so a test can drive a
 // failing capture without AWS.
+// The pinned create identity is deliberately not exposed here: it is an internal type, and the
+// tests that assert it reaches the capture live in the internal test package.
 func (s *Service) SetEKSOwnershipCaptureForTest(
 	capture func(ctx context.Context, name string) error,
 ) {
-	s.captureEKSIdentity = capture
+	s.captureEKSIdentity = func(ctx context.Context, name string, _ *eksCreateIdentity) error {
+		return capture(ctx, name)
+	}
+}
+
+// SetEKSOwnershipCaptureRecorderForTest overrides the create-time identity capture and reports the
+// identity the create pinned for it: whether one was supplied at all, the AWS variable-name options
+// it carries, and the region its snapshot resolved to.
+//
+// The pinned identity is an internal type, so it is reported as plain values rather than exposed. A
+// test asserting on these is asserting the property that matters — that the capture records under
+// the credentials the create actually ran with, not an independently resolved set.
+func (s *Service) SetEKSOwnershipCaptureRecorderForTest(
+	record func(name string, pinned bool, awsOptions v1alpha1.OptionsAWS, selectionRegion string),
+) {
+	s.captureEKSIdentity = func(
+		_ context.Context,
+		name string,
+		identity *eksCreateIdentity,
+	) error {
+		if identity == nil {
+			record(name, false, v1alpha1.OptionsAWS{}, "")
+
+			return nil
+		}
+
+		record(name, true, identity.awsOptions, identity.selection.Region)
+
+		return nil
+	}
 }
 
 // SetEKSOwnershipTimeoutForTest shortens the bound on the ownership resolution's network calls, so a

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -100,6 +100,10 @@ type Service struct {
 	// deadline path without waiting the real budget.
 	eksOwnershipTimeout time.Duration
 
+	// captureEKSIdentity records the immutable AWS identity of a cluster this backend just created,
+	// so the guard above has something to verify against. Injectable alongside resolveEKSGuard.
+	captureEKSIdentity eksCaptureFunc
+
 	// discoverer enumerates existing clusters across providers for List/Get; discoverProviders is
 	// the set it queries. NewService queries every provider the machine can reach so cloud clusters
 	// (Hetzner/Omni/EKS) are visible, not just local Docker ones.
@@ -180,6 +184,7 @@ func NewService() *Service {
 	service.ResourceAdapter = api.ResourceAdapter{Provider: service}
 	service.resolveEKSGuard = service.defaultEKSGuard
 	service.eksOwnershipTimeout = defaultEKSOwnershipTimeout
+	service.captureEKSIdentity = service.defaultEKSCapture
 	service.useDefaultClients()
 
 	return service
@@ -907,6 +912,25 @@ func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec
 		err = state.SaveClusterSpec(name, &spec.Cluster)
 		if err != nil {
 			err = fmt.Errorf("persist local EKS cluster ownership state: %w", err)
+		}
+
+		// Record the immutable AWS identity while we still know the cluster is ours. Without this
+		// the guard on every later delete/start/stop has nothing to verify against, so a cluster
+		// created here could not be operated here — the operator would have to run
+		// `ksail cluster eks-bind` by hand after every create.
+		//
+		// A capture failure fails the job, matching the SaveClusterSpec handling directly above:
+		// the remote cluster exists either way, and reporting success while leaving it unoperatable
+		// would hide the problem until the first delete.
+		if err == nil {
+			err = s.captureEKSOwnership(ctx, name)
+			if err != nil {
+				err = fmt.Errorf(
+					"record immutable EKS ownership identity for %q (the cluster was created;"+
+						" run `ksail cluster eks-bind --name %s` to record it): %w",
+					name, name, err,
+				)
+			}
 		}
 	}
 

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -1003,6 +1003,9 @@ func (s *Service) runProvisioner(
 	return s.runProvisionerWithGuard(ctx, name, spec, nil, action)
 }
 
+// runProvisionerWithGuard is the shared body of the guarded and unguarded paths. A nil guard is the
+// unguarded case and leaves the factory exactly as it was, so a create and every non-EKS action
+// reach the provisioner they always did.
 func (s *Service) runProvisionerWithGuard(
 	ctx context.Context,
 	name string,

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -96,6 +96,10 @@ type Service struct {
 	// every EKS mutation must carry. Injectable so tests exercise the guard wiring without AWS.
 	resolveEKSGuard eksGuardFunc
 
+	// eksOwnershipTimeout bounds that resolution's network calls. Injectable so a test can drive the
+	// deadline path without waiting the real budget.
+	eksOwnershipTimeout time.Duration
+
 	// discoverer enumerates existing clusters across providers for List/Get; discoverProviders is
 	// the set it queries. NewService queries every provider the machine can reach so cloud clusters
 	// (Hetzner/Omni/EKS) are visible, not just local Docker ones.
@@ -175,6 +179,7 @@ func NewService() *Service {
 	}
 	service.ResourceAdapter = api.ResourceAdapter{Provider: service}
 	service.resolveEKSGuard = service.defaultEKSGuard
+	service.eksOwnershipTimeout = defaultEKSOwnershipTimeout
 	service.useDefaultClients()
 
 	return service

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -92,6 +92,10 @@ type Service struct {
 
 	newFactory FactoryFunc
 
+	// resolveEKSGuard resolves the frozen AWS credential snapshot and immutable-ownership verifier
+	// every EKS mutation must carry. Injectable so tests exercise the guard wiring without AWS.
+	resolveEKSGuard eksGuardFunc
+
 	// discoverer enumerates existing clusters across providers for List/Get; discoverProviders is
 	// the set it queries. NewService queries every provider the machine can reach so cloud clusters
 	// (Hetzner/Omni/EKS) are visible, not just local Docker ones.
@@ -170,6 +174,7 @@ func NewService() *Service {
 		ProbeRunState: true,
 	}
 	service.ResourceAdapter = api.ResourceAdapter{Provider: service}
+	service.resolveEKSGuard = service.defaultEKSGuard
 	service.useDefaultClients()
 
 	return service
@@ -822,7 +827,7 @@ func (s *Service) runLifecycleAction(
 	spec v1alpha1.Spec,
 	action func(context.Context, clusterprovisioner.Provisioner) error,
 ) {
-	err := s.runProvisioner(ctx, name, spec, action)
+	err := s.runGuardedProvisioner(ctx, name, spec, action)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -922,7 +927,7 @@ func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec
 }
 
 func (s *Service) runDelete(ctx context.Context, name string, spec v1alpha1.Spec) {
-	err := s.runProvisioner(
+	err := s.runGuardedProvisioner(
 		ctx,
 		name,
 		spec,
@@ -967,6 +972,26 @@ func (s *Service) runDelete(ctx context.Context, name string, spec v1alpha1.Spec
 	delete(s.jobs, name)
 }
 
+// runGuardedProvisioner runs a mutating action (delete, start, stop) behind the EKS ownership
+// guard. Resolving the guard first means an unverifiable target is refused before any provisioner
+// is built, and the same verified identity travels into the provisioner for its own re-check.
+//
+// Create deliberately does not take this path: it has no prior incarnation to verify and no
+// persisted identity yet, so demanding a guard there would refuse every first EKS create.
+func (s *Service) runGuardedProvisioner(
+	ctx context.Context,
+	name string,
+	spec v1alpha1.Spec,
+	action func(context.Context, clusterprovisioner.Provisioner) error,
+) error {
+	guard, err := s.resolveEKSMutationGuard(ctx, spec.Cluster.Distribution, name)
+	if err != nil {
+		return err
+	}
+
+	return s.runProvisionerWithGuard(ctx, name, spec, guard, action)
+}
+
 // runProvisioner builds a provisioner for the requested spec and runs the supplied action against
 // it. The spec carries the provider (so Talos routes to Hetzner/Omni/Docker) and node counts.
 func (s *Service) runProvisioner(
@@ -975,7 +1000,17 @@ func (s *Service) runProvisioner(
 	spec v1alpha1.Spec,
 	action func(context.Context, clusterprovisioner.Provisioner) error,
 ) error {
-	provisioner, err := s.buildProvisioner(ctx, spec, name)
+	return s.runProvisionerWithGuard(ctx, name, spec, nil, action)
+}
+
+func (s *Service) runProvisionerWithGuard(
+	ctx context.Context,
+	name string,
+	spec v1alpha1.Spec,
+	guard *eksMutationGuard,
+	action func(context.Context, clusterprovisioner.Provisioner) error,
+) error {
+	provisioner, err := s.buildProvisioner(ctx, spec, name, guard)
 	if err != nil {
 		return err
 	}
@@ -1010,10 +1045,16 @@ func (s *Service) buildProvisioner(
 	ctx context.Context,
 	spec v1alpha1.Spec,
 	name string,
+	guard *eksMutationGuard,
 ) (clusterprovisioner.Provisioner, error) {
 	distribution := spec.Cluster.Distribution
 
 	factory, err := s.newFactory(distribution, name)
+	if err != nil {
+		return nil, err
+	}
+
+	factory, err = applyEKSMutationGuard(factory, guard)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -900,6 +900,18 @@ func (s *Service) reserveCreateJob(
 }
 
 func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec) {
+	isEKS := spec.Cluster.Distribution == v1alpha1.DistributionEKS
+
+	// Snapshot the AWS selection BEFORE the create starts, so the capture afterwards records under
+	// the credentials this create ran with. Re-resolving it after an asynchronous create — from a
+	// different source, and after Settings may have moved — is what let a create in one account be
+	// recorded as a same-named cluster in another.
+	var identity *eksCreateIdentity
+
+	if isEKS {
+		identity = newEKSCreateIdentity(spec.Provider.AWS)
+	}
+
 	err := s.runProvisioner(
 		ctx,
 		name,
@@ -908,7 +920,7 @@ func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec
 			return p.Create(actionCtx, name)
 		},
 	)
-	if err == nil && spec.Cluster.Distribution == v1alpha1.DistributionEKS {
+	if err == nil && isEKS {
 		err = state.SaveClusterSpec(name, &spec.Cluster)
 		if err != nil {
 			err = fmt.Errorf("persist local EKS cluster ownership state: %w", err)
@@ -923,7 +935,7 @@ func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec
 		// the remote cluster exists either way, and reporting success while leaving it unoperatable
 		// would hide the problem until the first delete.
 		if err == nil {
-			err = s.captureEKSOwnership(ctx, name)
+			err = s.captureEKSOwnership(ctx, name, identity)
 			if err != nil {
 				err = fmt.Errorf(
 					"record immutable EKS ownership identity for %q (the cluster was created;"+

--- a/pkg/cli/clusterapi/local_service_test.go
+++ b/pkg/cli/clusterapi/local_service_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil/scaffolder"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/clusterdiscovery"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
@@ -186,6 +188,15 @@ func (f fakeFactory) Create(
 	_ *v1alpha1.Cluster,
 ) (clusterprovisioner.Provisioner, any, error) {
 	return f.provisioner, nil, nil
+}
+
+// WithEKSMutationGuard satisfies the guard-carrying interface an EKS mutation requires. The fake
+// ignores the guard because it never reaches AWS; refusing to carry one would fail the mutation.
+func (f fakeFactory) WithEKSMutationGuard(
+	_ *credentials.AWSResolution,
+	_ eksidentity.Verifier,
+) clusterprovisioner.Factory {
+	return f
 }
 
 // newTestService wires a Service whose factory routes each distribution to a supplied provisioner.

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -261,6 +261,15 @@ func (c *Client) DescribeCluster(ctx context.Context, name string) (*ekstypes.Cl
 		&awseks.DescribeClusterInput{Name: aws.String(name)},
 	)
 	if err != nil {
+		// A cluster EKS has never heard of is absence, not a query failure, and it is the shape
+		// absence actually takes in production — the empty-payload case below is the rarer one.
+		// Reporting both through ErrClusterNotFound gives callers a single sentinel to test, so
+		// "the cluster is gone" cannot be mistaken for "the lookup broke".
+		var notFound *ekstypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return nil, fmt.Errorf("%w: %s: %w", ErrClusterNotFound, name, err)
+		}
+
 		return nil, fmt.Errorf("describing eks cluster %s: %w", name, err)
 	}
 

--- a/pkg/client/eks/client_test.go
+++ b/pkg/client/eks/client_test.go
@@ -509,3 +509,38 @@ func assertTokenCredentialPrefix(t *testing.T, token, expected string) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(signedURL.Query().Get("X-Amz-Credential"), expected))
 }
+
+func TestDescribeClusterMapsResourceNotFoundToSentinel(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(
+		t,
+		fakeDescriber{
+			out: nil,
+			err: &ekstypes.ResourceNotFoundException{
+				Message: aws.String("No cluster found for name: eks-default."),
+			},
+		},
+		fakePresigner{request: nil, err: nil},
+	)
+
+	_, err := client.DescribeCluster(t.Context(), "eks-default")
+	require.ErrorIs(t, err, eksclient.ErrClusterNotFound)
+}
+
+func TestDescribeClusterKeepsOtherAPIErrorsDistinctFromAbsence(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(
+		t,
+		fakeDescriber{
+			out: nil,
+			err: &ekstypes.ServerException{Message: aws.String("internal failure")},
+		},
+		fakePresigner{request: nil, err: nil},
+	)
+
+	_, err := client.DescribeCluster(t.Context(), "eks-default")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, eksclient.ErrClusterNotFound)
+}

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -189,6 +189,53 @@ func (r AWSOptionsResolver) Value(key Key) string {
 	return resolveEnvValue(key, r.EnvVar(key))
 }
 
+// RecordedAWSResolver resolves a cluster's lifecycle credentials through the variable names its own
+// immutable ownership record captured, while still honoring a base resolver's resolved values.
+//
+// A recorded cluster is the one case where the variable names are not a matter of current
+// configuration: capture persisted the names the create actually resolved through, so a later Delete,
+// Start, or Stop must read the same aliases or it resolves a different identity — or none at all.
+// A base resolver alone cannot do that, because it reports names from current settings and knows
+// nothing about the record.
+//
+// Values stay base-first, so this is strictly additive: a credential the base already resolves keeps
+// resolving exactly as before (including a secure-store value, which is name-independent operator
+// intent), and the recorded alias is consulted only where the base resolves nothing. Names, by
+// contrast, come from the record, because the frozen resolution carries them onward to scrub child
+// process environments — reporting a canonical name for a value read from an alias would leave the
+// alias in place for the provisioner to re-resolve.
+//
+// This narrows, and never widens, what a mutation may act on: where both the base and the record
+// resolve credentials for different accounts, the ownership verifier still fails closed on the
+// mismatch. The resolver owns its map and is safe for concurrent use.
+type RecordedAWSResolver struct {
+	base     Resolver
+	recorded AWSOptionsResolver
+}
+
+// NewRecordedAWSResolver layers one ownership record's captured variable names over base. A nil base
+// resolves from the canonical process environment.
+func NewRecordedAWSResolver(base Resolver, recorded v1alpha1.OptionsAWS) RecordedAWSResolver {
+	if base == nil {
+		base = EnvResolver{}
+	}
+
+	return RecordedAWSResolver{base: base, recorded: NewAWSOptionsResolver(recorded)}
+}
+
+// EnvVar returns the variable name the ownership record captured for key.
+func (r RecordedAWSResolver) EnvVar(key Key) string { return r.recorded.EnvVar(key) }
+
+// Value returns the base resolver's value for key, falling back to the recorded alias when the base
+// resolves nothing.
+func (r RecordedAWSResolver) Value(key Key) string {
+	if value := r.base.Value(key); value != "" {
+		return value
+	}
+
+	return r.recorded.Value(key)
+}
+
 // AWSResolution is an immutable snapshot of an AWS credential selection. ResolveFrozenAWS upgrades
 // it to one concrete credential tuple for identity-sensitive operations. Source variable names are
 // retained privately so child process environments can remove both stale canonical values and

--- a/pkg/svc/credentials/recorded_aws_resolver_test.go
+++ b/pkg/svc/credentials/recorded_aws_resolver_test.go
@@ -1,0 +1,110 @@
+package credentials_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubResolver stands in for an injected resolver (the Settings/secure-store one the local API
+// service carries). It reports names and values independently so a test can pin which of the two
+// layers a result came from.
+type stubResolver struct {
+	names  map[credentials.Key]string
+	values map[credentials.Key]string
+}
+
+func (s stubResolver) EnvVar(key credentials.Key) string {
+	if name := s.names[key]; name != "" {
+		return name
+	}
+
+	return credentials.DefaultEnvVar(key)
+}
+
+func (s stubResolver) Value(key credentials.Key) string { return s.values[key] }
+
+func recordedOptions() v1alpha1.OptionsAWS {
+	return v1alpha1.OptionsAWS{
+		ProfileEnvVar:         "RECORDED_PROFILE",
+		RegionEnvVar:          "RECORDED_REGION",
+		AccessKeyIDEnvVar:     "RECORDED_ACCESS",
+		SecretAccessKeyEnvVar: "RECORDED_SECRET",
+		SessionTokenEnvVar:    "RECORDED_SESSION",
+	}
+}
+
+// TestRecordedAWSResolverReportsTheRecordedNames pins the half of the composition that cannot come
+// from the base resolver. The frozen resolution carries these names onward to scrub the child
+// process environment, so reporting the base's canonical name for a value that was read from a
+// recorded alias would leave the alias in place for the provisioner to re-resolve.
+func TestRecordedAWSResolverReportsTheRecordedNames(t *testing.T) {
+	t.Parallel()
+
+	resolver := credentials.NewRecordedAWSResolver(
+		stubResolver{names: map[credentials.Key]string{
+			credentials.AWSAccessKeyID: "SETTINGS_ACCESS",
+		}},
+		recordedOptions(),
+	)
+
+	assert.Equal(t, "RECORDED_ACCESS", resolver.EnvVar(credentials.AWSAccessKeyID),
+		"the record's captured variable name did not survive the composition")
+	assert.Equal(t, "RECORDED_PROFILE", resolver.EnvVar(credentials.AWSProfile))
+	assert.Equal(t, "RECORDED_REGION", resolver.EnvVar(credentials.AWSRegion))
+}
+
+// TestRecordedAWSResolverPrefersTheBaseValue keeps the composition strictly additive. A secure-store
+// value is name-independent operator intent, so a credential the injected resolver already resolves
+// must keep resolving exactly as it did before the record was consulted.
+func TestRecordedAWSResolverPrefersTheBaseValue(t *testing.T) {
+	t.Setenv("RECORDED_ACCESS", "from-recorded-alias")
+
+	resolver := credentials.NewRecordedAWSResolver(
+		stubResolver{values: map[credentials.Key]string{
+			credentials.AWSAccessKeyID: "from-secure-store",
+		}},
+		recordedOptions(),
+	)
+
+	assert.Equal(t, "from-secure-store", resolver.Value(credentials.AWSAccessKeyID),
+		"layering the record over the base displaced a value the base already resolved")
+}
+
+// TestRecordedAWSResolverFallsBackToTheRecordedAlias is the defect itself: credentials that made the
+// cluster remain reachable only under the names capture persisted. Without this fallback a Delete,
+// Start, or Stop resolves nothing and fails as unavailable credentials.
+func TestRecordedAWSResolverFallsBackToTheRecordedAlias(t *testing.T) {
+	t.Setenv("RECORDED_SECRET", "from-recorded-alias")
+
+	resolver := credentials.NewRecordedAWSResolver(stubResolver{}, recordedOptions())
+
+	assert.Equal(t, "from-recorded-alias", resolver.Value(credentials.AWSSecretAccessKey),
+		"a credential reachable only under the recorded alias did not resolve")
+}
+
+// TestRecordedAWSResolverWithoutABaseResolvesFromTheEnvironment covers the nil base the local API
+// service passes whenever no Settings resolver was injected, which is the default for the CLI.
+func TestRecordedAWSResolverWithoutABaseResolvesFromTheEnvironment(t *testing.T) {
+	t.Setenv("RECORDED_PROFILE", "recorded-profile")
+
+	resolver := credentials.NewRecordedAWSResolver(nil, recordedOptions())
+
+	assert.Equal(t, "recorded-profile", resolver.Value(credentials.AWSProfile),
+		"a nil base resolver did not fall through to the recorded alias")
+}
+
+// TestRecordedAWSResolverKeepsCanonicalNamesForALegacyRecord pins the empty-mapping case. A record
+// predating the mapping schema must resolve exactly as the canonical environment does, so composing
+// one can never make an already-working cluster stop resolving.
+func TestRecordedAWSResolverKeepsCanonicalNamesForALegacyRecord(t *testing.T) {
+	t.Parallel()
+
+	resolver := credentials.NewRecordedAWSResolver(stubResolver{}, v1alpha1.OptionsAWS{})
+
+	assert.Equal(t, credentials.DefaultEnvVar(credentials.AWSAccessKeyID),
+		resolver.EnvVar(credentials.AWSAccessKeyID),
+		"an empty recorded mapping did not fall back to the canonical variable name")
+}

--- a/pkg/svc/provisioner/cluster/factory.go
+++ b/pkg/svc/provisioner/cluster/factory.go
@@ -188,6 +188,24 @@ type DefaultFactory struct {
 	AWSOwnershipVerifier eksidentity.Verifier
 }
 
+// WithEKSMutationGuard returns a copy of the factory pinned to one frozen credential snapshot and
+// the ownership verifier that snapshot authorized. The value receiver is what makes it a copy: a
+// caller that guards one mutation must not leave a shared factory carrying that identity for the
+// next, unrelated action.
+//
+// The two arguments belong together and are set together. A verifier without its frozen resolution
+// is refused downstream, because proving one identity while the provisioner independently
+// re-resolves another would authorize a mutation nothing actually checked.
+func (f DefaultFactory) WithEKSMutationGuard(
+	resolution *credentials.AWSResolution,
+	verifier eksidentity.Verifier,
+) Factory {
+	f.AWSResolution = resolution
+	f.AWSOwnershipVerifier = verifier
+
+	return f
+}
+
 // Create selects the correct distribution provisioner for the KSail cluster configuration.
 // It requires DistributionConfig to be set with the appropriate pre-loaded config.
 func (f DefaultFactory) Create(


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Deleting, starting or stopping an EKS cluster from the local web UI ran **no ownership check at
all**. The check exists and the standalone command-line path performs it — the web backend simply
never switched it on, so the safeguard was silently inactive on exactly the surface where a click is
cheapest. A delete cannot be undone, so an action aimed at the wrong account or at a replacement
cluster of the same name had nothing standing in its way.

## What

Every EKS action that changes something now confirms, before any work starts, that the cluster in
front of it is still the same cluster this machine created — same AWS account, same cluster, same
creation moment. If that cannot be confirmed, the action is refused and says how to recover instead
of proceeding on an unconfirmed target.

Creating a cluster now **records** that identity as part of the create, so clusters made here can be
operated here. Without it the guard would have blocked its own happy path: every cluster created
through the UI would have failed its first delete, start or stop and needed a manual re-binding step
first. A create that cannot record the identity fails rather than reporting success on a cluster
nobody could later operate.

The confirmed identity is also handed to the layer that actually calls AWS, so the final check
happens as close to the change as possible rather than only up front.

Part of #6203
Fixes #6443

