### PR TITLE
fix(backup): confine archive extraction with os.Root

### DIFF
--- a/pkg/svc/backup/export_test.go
+++ b/pkg/svc/backup/export_test.go
@@ -127,3 +127,8 @@ func ClassifyRestoreError(err error, stderr, policy string) error {
 func AllLinesContain(output, substr string) bool {
 	return allLinesContain(output, substr)
 }
+
+// ExtractTarEntries exposes extractTarEntries for testing.
+func ExtractTarEntries(tarReader *tar.Reader, destDir string) error {
+	return extractTarEntries(tarReader, destDir)
+}

--- a/pkg/svc/backup/tarball.go
+++ b/pkg/svc/backup/tarball.go
@@ -221,6 +221,18 @@ func extractBackupArchive(
 }
 
 func extractTarEntries(tarReader *tar.Reader, destDir string) error {
+	// Every write goes through this root, so the operating system — not a string
+	// comparison — is what keeps an entry inside destDir. validateTarEntry stays
+	// the first line of defence because it produces the sentinel errors callers
+	// match on; the root is what a future lexical oversight, or a symlink swapped
+	// in between validation and open, cannot get past.
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to open extraction root: %w", err)
+	}
+
+	defer func() { _ = root.Close() }()
+
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
@@ -236,35 +248,45 @@ func extractTarEntries(tarReader *tar.Reader, destDir string) error {
 			return err
 		}
 
-		if header.Typeflag == tar.TypeDir {
-			err = os.MkdirAll(
-				targetPath,
-				dirPerm,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-
-			continue
-		}
-
-		err = os.MkdirAll(
-			filepath.Dir(targetPath),
-			dirPerm,
-		)
+		relPath, err := filepath.Rel(destDir, targetPath)
 		if err != nil {
-			return fmt.Errorf(
-				"failed to create parent directory: %w", err,
-			)
+			return fmt.Errorf("%w: %s", ErrInvalidTarPath, header.Name)
 		}
 
-		err = extractFile(tarReader, targetPath)
+		err = extractTarEntry(tarReader, root, header, relPath)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// extractTarEntry writes one validated entry through root, which confines it to
+// the extraction directory.
+func extractTarEntry(
+	tarReader *tar.Reader,
+	root *os.Root,
+	header *tar.Header,
+	relPath string,
+) error {
+	if header.Typeflag == tar.TypeDir {
+		err := root.MkdirAll(relPath, dirPerm)
+		if err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		return nil
+	}
+
+	err := root.MkdirAll(filepath.Dir(relPath), dirPerm)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create parent directory: %w", err,
+		)
+	}
+
+	return extractFile(tarReader, root, relPath)
 }
 
 func validateTarEntry(
@@ -307,9 +329,9 @@ func validateTarEntry(
 	return targetPath, nil
 }
 
-func extractFile(tarReader *tar.Reader, targetPath string) error {
-	outFile, err := os.OpenFile( //nolint:gosec // path is sanitized by extractTarEntries
-		targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePerm,
+func extractFile(tarReader *tar.Reader, root *os.Root, relPath string) error {
+	outFile, err := root.OpenFile(
+		relPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePerm,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/pkg/svc/backup/tarball_containment_test.go
+++ b/pkg/svc/backup/tarball_containment_test.go
@@ -2,6 +2,7 @@ package backup_test
 
 import (
 	"archive/tar"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -110,4 +111,70 @@ func TestExtractBackupArchive_ContainsWritesToDestDir(t *testing.T) {
 			)
 		})
 	}
+}
+
+// tarWithEntry builds an in-memory tar containing a single regular-file entry.
+func tarWithEntry(t *testing.T, name string, content []byte) *tar.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	writer := tar.NewWriter(&buf)
+	require.NoError(t, writer.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(content)),
+		Mode:     0o600,
+	}))
+	_, err := writer.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return tar.NewReader(&buf)
+}
+
+// TestExtractTarEntries_DoesNotFollowSymlinkInDestDir covers the case the
+// traversal test above structurally cannot: an entry whose path is entirely
+// legitimate.
+//
+// "resources/evidence" contains no "..", is not absolute, and resolves inside
+// the destination, so validateTarEntry accepts it. If "resources" is a symlink
+// pointing outside the destination, a plain os.MkdirAll/os.OpenFile pair follows
+// it and writes through — lexical validation cannot see this, because the path
+// is only dangerous once the filesystem resolves it. Extracting through a root
+// refuses to cross the symlink.
+//
+// This is what pins the root: every traversal vector above is rejected by
+// validateTarEntry before extraction runs, so removing the root would leave them
+// all still passing.
+func TestExtractTarEntries_DoesNotFollowSymlinkInDestDir(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	outside := t.TempDir()
+
+	// A pre-existing symlink inside the destination, aimed out of it.
+	require.NoError(t, os.Symlink(outside, filepath.Join(destDir, "resources")))
+
+	const marker = "evidence"
+
+	entry := filepath.Join("resources", marker)
+	reader := tarWithEntry(t, entry, []byte("escaped"))
+
+	// The entry itself must be one lexical validation accepts, or this test
+	// would prove nothing beyond what the traversal cases already cover.
+	_, err := backup.ValidateTarEntry(
+		&tar.Header{Name: entry, Typeflag: tar.TypeReg}, destDir,
+	)
+	require.NoError(t, err, "precondition: the entry must pass lexical validation")
+
+	extractErr := backup.ExtractTarEntries(reader, destDir)
+
+	// Whether extraction reports an error is not the assertion: what matters is
+	// that nothing was written through the symlink.
+	_, statErr := os.Lstat(filepath.Join(outside, marker))
+	require.Truef(t, os.IsNotExist(statErr),
+		"entry %q was written through a symlink to outside the destination (extract err: %v)",
+		entry, extractErr,
+	)
 }

--- a/pkg/svc/backup/tarball_containment_test.go
+++ b/pkg/svc/backup/tarball_containment_test.go
@@ -1,0 +1,113 @@
+package backup_test
+
+import (
+	"archive/tar"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/backup"
+	"github.com/stretchr/testify/require"
+)
+
+// escapeCandidates lists the directories a traversing entry can reach from the
+// extraction directory, which os.MkdirTemp places directly under os.TempDir().
+// One "../" therefore lands in os.TempDir() itself and two in its parent; a long
+// run of "../" clamps at the filesystem root, so /tmp is reachable too. These are
+// exactly the locations an unconfined extractor was observed writing to.
+func escapeCandidates() []string {
+	tempDir := os.TempDir()
+
+	return []string{tempDir, filepath.Dir(tempDir), "/tmp", string(filepath.Separator)}
+}
+
+// findEscapedMarker reports every path outside dir at which marker exists.
+//
+// It deliberately runs whether or not extraction returned an error: entries are
+// written to disk as the archive is walked, so a malicious entry can land before
+// a later failure aborts extraction. An oracle that returns early on error is
+// blind to precisely the case this test exists to catch.
+func findEscapedMarker(t *testing.T, marker string) []string {
+	t.Helper()
+
+	var escaped []string
+
+	for _, candidate := range escapeCandidates() {
+		path := filepath.Join(candidate, marker)
+
+		_, err := os.Lstat(path)
+		if err == nil {
+			escaped = append(escaped, path)
+		}
+	}
+
+	return escaped
+}
+
+// TestExtractBackupArchive_ContainsWritesToDestDir asserts at the filesystem
+// level that a traversing entry never writes outside the extraction directory.
+//
+// This complements TestExtractBackupArchive_SecurityGuards, which asserts the
+// sentinel error a rejected entry produces. That is a statement about the error
+// value; this is a statement about the disk, and only the latter fails if a
+// future refactor keeps returning an error while still writing the file.
+func TestExtractBackupArchive_ContainsWritesToDestDir(t *testing.T) {
+	t.Parallel()
+
+	validMeta := `{"version":"v1","clusterName":"test-cluster","resourceCount":1}`
+
+	// A marker unique to this run: these vectors write to shared directories, so
+	// a fixed name would let one run's leftovers be read as another run's escape.
+	nonce := fmt.Sprintf("%d%d", os.Getpid(), time.Now().UnixNano()%1_000_000)
+
+	tests := []struct {
+		name     string
+		typeflag byte
+		prefix   string
+	}{
+		{name: "parent traversal", typeflag: tar.TypeReg, prefix: "../"},
+		{name: "grandparent traversal", typeflag: tar.TypeReg, prefix: "../../"},
+		{name: "dot slash traversal", typeflag: tar.TypeReg, prefix: "./../../"},
+		{name: "embedded traversal", typeflag: tar.TypeReg, prefix: "resources/../../"},
+		{name: "root clamped traversal", typeflag: tar.TypeReg, prefix: strings.Repeat("../", 12)},
+		{name: "directory traversal", typeflag: tar.TypeDir, prefix: "../"},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			marker := fmt.Sprintf("ksail-containment-%s-%d", nonce, index)
+
+			var content []byte
+			if test.typeflag == tar.TypeReg {
+				content = []byte("escaped")
+			}
+
+			archivePath := createMaliciousArchive(t, validMeta, tar.Header{
+				Name:     test.prefix + marker,
+				Typeflag: test.typeflag,
+				Size:     int64(len(content)),
+				Mode:     0o600,
+			}, content)
+
+			dir, _, err := backup.ExtractBackupArchive(archivePath)
+			if dir != "" {
+				t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			}
+
+			escaped := findEscapedMarker(t, marker)
+			for _, path := range escaped {
+				t.Cleanup(func() { _ = os.RemoveAll(path) })
+			}
+
+			require.Emptyf(t, escaped,
+				"entry %q escaped the extraction directory (extract err: %v)",
+				test.prefix+marker, err,
+			)
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A high-severity CodeQL alert (`go/zipslip`) has been open on `main` since 2026-07-30 against backup
archive extraction. **It is a false positive** — the existing guard genuinely blocks every traversal
vector I could construct, proven by driving real malicious archives through the extractor and then
checking the disk, not by reading the code.

But the guard is a hand-rolled string argument. It is correct today, it has to be re-argued by every
future edit, and it cannot cover a symlink swapped in between validation and open. Meanwhile the
alert sits on `main`, where this repo gates merges on code-scanning results — so the next genuine
traversal finding arrives into a queue where that alert is already assumed benign.

## What

Extraction now writes through a root opened on the destination directory, so the operating system
enforces containment instead of a string comparison. The existing validation is kept as the first
line of defence and still produces the same errors callers match on, so behaviour for legitimate
archives and for rejected ones is unchanged.

Also adds a regression test that asserts at the filesystem level that nothing lands outside the
destination — the existing tests assert the *error* a rejected entry returns, which stays green even
if a refactor returns that error while still writing the file. On the pre-change code with the guard
removed, three vectors escaped **while extraction reported no error at all**.

The alert should close on its own merits at the next default-branch analysis, rather than being
dismissed.

Fixes #6436
