### PR TITLE
fix(ci): sign generated-file commits pushed to PR branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -649,14 +649,84 @@ jobs:
             fi
           done
 
+      # Commits through the GitHub API rather than the git CLI, because the repository
+      # requires signed commits and API-created commits are signed by GitHub automatically.
+      # A CLI commit here is unsigned and makes the pull request permanently unmergeable.
       - name: 📤 Commit and push generated changes (PR branch)
         if: github.event_name == 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          commit_message: "chore: sync modules and update generated files"
-          commit_user_name: generator-bot
-          commit_user_email: generator-bot@users.noreply.github.com
-          branch: ${{ github.head_ref }}
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BRANCH: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          additions='[]'
+          deletions='[]'
+          changed=0
+          while IFS= read -r -d '' entry; do
+            entry_status="${entry:0:2}"
+            entry_path="${entry:3}"
+            [ -n "$entry_path" ] || continue
+            changed=1
+            case "$entry_status" in
+              *D*)
+                deletions="$(jq -c --arg p "$entry_path" '. + [{path: $p}]' <<<"$deletions")"
+                ;;
+              *)
+                contents="$(base64 -w0 <"$entry_path")"
+                additions="$(jq -c --arg p "$entry_path" --arg c "$contents" \
+                  '. + [{path: $p, contents: $c}]' <<<"$additions")"
+                ;;
+            esac
+          # -uall lists untracked files individually; without it git collapses a new
+          # directory into a single "dir/" entry, which is not a file we can encode.
+          done < <(git status --porcelain -z --no-renames -uall)
+
+          if [ "$changed" -eq 0 ]; then
+            echo "No generated changes to commit."
+            exit 0
+          fi
+
+          jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg oid "$(git rev-parse HEAD)" \
+            --argjson additions "$additions" \
+            --argjson deletions "$deletions" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: $repo,
+                    branchName: $branch
+                  },
+                  message: { headline: "chore: sync modules and update generated files" },
+                  expectedHeadOid: $oid,
+                  fileChanges: { additions: $additions, deletions: $deletions }
+                }
+              }
+            }' >/tmp/create-commit.json
+
+          response="$(gh api graphql --input /tmp/create-commit.json)"
+          if jq -e 'has("errors")' >/dev/null <<<"$response"; then
+            echo "::error::createCommitOnBranch failed"
+            jq '.errors' <<<"$response"
+            exit 1
+          fi
+
+          oid="$(jq -r '.data.createCommitOnBranch.commit.oid' <<<"$response")"
+          echo "Committed generated changes as ${oid}."
+
+          # The whole point of using the API is that the commit is signed, so prove it
+          # rather than assuming it: an unsigned commit here blocks the pull request.
+          verified="$(gh api "repos/${REPO}/commits/${oid}" --jq '.commit.verification.verified')"
+          if [ "$verified" != "true" ]; then
+            echo "::error::Generated commit ${oid} is not signed (verified=${verified})."
+            exit 1
+          fi
+          echo "Verified signature on ${oid}."
 
       - name: 📤 Open PR for generated changes (protected branch)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -704,8 +704,31 @@ jobs:
             esac
           done <"$workdir/status"
 
+          # The whole point of using the API is that the commit is signed, so prove it
+          # rather than assuming it: an unsigned commit here blocks the pull request.
+          verify_signed() {
+            local sha="$1"
+            local verified
+            verified="$(gh api "repos/${REPO}/commits/${sha}" --jq '.commit.verification.verified')"
+            if [ "$verified" != "true" ]; then
+              echo "::error::Generated commit ${sha} is not signed (verified=${verified})."
+              exit 1
+            fi
+            echo "Verified signature on ${sha}."
+          }
+
           if [ ! -s "$additions" ] && [ ! -s "$deletions" ]; then
             echo "No generated changes to commit."
+            # Committing below pushes to the PR branch, which raises `synchronize`. That new
+            # run shares this workflow's concurrency group with cancel-in-progress, so it can
+            # cancel the committing run before it verifies. The replacement run then lands
+            # here, with the work already committed and nothing left to do — so verify the
+            # head instead of exiting blind, or a signing regression escapes unreported and
+            # silently re-creates the unmergeable-PR condition this step exists to prevent.
+            if [ "$(git log -1 --format=%s)" = "chore: sync modules and update generated files" ]; then
+              echo "Head is a generated commit; verifying it here in case the run that created it was cancelled."
+              verify_signed "$(git rev-parse HEAD)"
+            fi
             exit 0
           fi
 
@@ -761,15 +784,7 @@ jobs:
             exit 1
           fi
           echo "Committed generated changes as ${oid}."
-
-          # The whole point of using the API is that the commit is signed, so prove it
-          # rather than assuming it: an unsigned commit here blocks the pull request.
-          verified="$(gh api "repos/${REPO}/commits/${oid}" --jq '.commit.verification.verified')"
-          if [ "$verified" != "true" ]; then
-            echo "::error::Generated commit ${oid} is not signed (verified=${verified})."
-            exit 1
-          fi
-          echo "Verified signature on ${oid}."
+          verify_signed "$oid"
 
       - name: 📤 Open PR for generated changes (protected branch)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -652,6 +652,11 @@ jobs:
       # Commits through the GitHub API rather than the git CLI, because the repository
       # requires signed commits and API-created commits are signed by GitHub automatically.
       # A CLI commit here is unsigned and makes the pull request permanently unmergeable.
+      #
+      # Limitation: the API's FileAddition carries only a path and its contents, so file
+      # modes are not expressible. Everything this pipeline generates is a regular 0644
+      # file and the repository tracks no symlinks, so this is inert today; a generated
+      # executable or symlink would need a different mechanism.
       - name: 📤 Commit and push generated changes (PR branch)
         if: github.event_name == 'pull_request'
         env:
@@ -661,39 +666,57 @@ jobs:
         run: |
           set -euo pipefail
 
-          additions='[]'
-          deletions='[]'
-          changed=0
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+          additions="$workdir/additions.ndjson"
+          deletions="$workdir/deletions.ndjson"
+          : >"$additions"
+          : >"$deletions"
+
+          # Written to a file rather than read through process substitution: a process
+          # substitution's exit status is invisible to both `set -e` and `pipefail`, so a
+          # failing `git status` would otherwise look exactly like "nothing to commit" and
+          # leave the branch silently stale with a green build.
+          # -uall lists untracked files individually; without it git collapses a new
+          # directory into a single "dir/" entry, which is not a file we can encode.
+          git status --porcelain -z --no-renames -uall >"$workdir/status"
+
           while IFS= read -r -d '' entry; do
             entry_status="${entry:0:2}"
             entry_path="${entry:3}"
             [ -n "$entry_path" ] || continue
-            changed=1
             case "$entry_status" in
               *D*)
-                deletions="$(jq -c --arg p "$entry_path" '. + [{path: $p}]' <<<"$deletions")"
+                jq -n --arg p "$entry_path" '{path: $p}' >>"$deletions"
                 ;;
               *)
-                contents="$(base64 -w0 <"$entry_path")"
-                additions="$(jq -c --arg p "$entry_path" --arg c "$contents" \
-                  '. + [{path: $p, contents: $c}]' <<<"$additions")"
+                # File content must never reach argv. Linux caps a single argv entry at
+                # MAX_ARG_STRLEN (128 KiB) independently of ARG_MAX, and generated files
+                # here run to hundreds of KiB (pkg/svc/chat/docs_generated.go alone is
+                # ~0.5 MB, ~0.67 MB once base64-encoded). Passing it with --arg fails with
+                # E2BIG on exactly the pull requests this step exists to serve. --rawfile
+                # reads it from disk instead, and base64 output is ASCII so binary inputs
+                # survive the round trip.
+                base64 -w0 <"$entry_path" >"$workdir/content.b64"
+                jq -n --arg p "$entry_path" --rawfile c "$workdir/content.b64" \
+                  '{path: $p, contents: ($c | gsub("\\s"; ""))}' >>"$additions"
                 ;;
             esac
-          # -uall lists untracked files individually; without it git collapses a new
-          # directory into a single "dir/" entry, which is not a file we can encode.
-          done < <(git status --porcelain -z --no-renames -uall)
+          done <"$workdir/status"
 
-          if [ "$changed" -eq 0 ]; then
+          if [ ! -s "$additions" ] && [ ! -s "$deletions" ]; then
             echo "No generated changes to commit."
             exit 0
           fi
 
+          # --slurpfile keeps the aggregate off argv too: the combined payload is bounded
+          # by total changed content, which routinely exceeds the same 128 KiB cap.
           jq -n \
             --arg repo "$REPO" \
             --arg branch "$BRANCH" \
             --arg oid "$(git rev-parse HEAD)" \
-            --argjson additions "$additions" \
-            --argjson deletions "$deletions" \
+            --slurpfile additions "$additions" \
+            --slurpfile deletions "$deletions" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
               variables: {
@@ -707,9 +730,17 @@ jobs:
                   fileChanges: { additions: $additions, deletions: $deletions }
                 }
               }
-            }' >/tmp/create-commit.json
+            }' >"$workdir/mutation.json"
 
-          response="$(gh api graphql --input /tmp/create-commit.json)"
+          # `gh api graphql` exits non-zero on a GraphQL error, so the assignment itself
+          # would abort under `set -e` and skip these diagnostics. Handle the failure
+          # inline so the operator gets a labelled annotation instead of one stderr line.
+          if ! response="$(gh api graphql --input "$workdir/mutation.json" 2>"$workdir/stderr")"; then
+            echo "::error::createCommitOnBranch failed"
+            cat "$workdir/stderr" >&2
+            jq '.errors // .' <<<"$response" 2>/dev/null || printf '%s\n' "$response"
+            exit 1
+          fi
           if jq -e 'has("errors")' >/dev/null <<<"$response"; then
             echo "::error::createCommitOnBranch failed"
             jq '.errors' <<<"$response"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -741,13 +741,25 @@ jobs:
             jq '.errors // .' <<<"$response" 2>/dev/null || printf '%s\n' "$response"
             exit 1
           fi
-          if jq -e 'has("errors")' >/dev/null <<<"$response"; then
+          # Capture first, then assert with a builtin. `jq -e` as the if-condition cannot
+          # distinguish "the filter was false" (exit 1) from "jq itself failed" (exit 4 on
+          # empty input, 5 on malformed), so a truncated or non-JSON response would take
+          # the no-errors path and continue. Capturing instead puts jq's failure where
+          # `set -e` catches it, so a bad response stops here rather than surfacing later
+          # as an unrelated error against a commit id of "null".
+          errors="$(jq -c '.errors // empty' <<<"$response")"
+          if [ -n "$errors" ]; then
             echo "::error::createCommitOnBranch failed"
-            jq '.errors' <<<"$response"
+            printf '%s\n' "$errors"
             exit 1
           fi
 
-          oid="$(jq -r '.data.createCommitOnBranch.commit.oid' <<<"$response")"
+          oid="$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<"$response")"
+          if [ -z "$oid" ]; then
+            echo "::error::createCommitOnBranch returned no commit oid"
+            printf '%s\n' "$response"
+            exit 1
+          fi
           echo "Committed generated changes as ${oid}."
 
           # The whole point of using the API is that the commit is signed, so prove it


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Three dependency pull requests on this repo have been **green, mergeable and permanently stuck** —
#6212, #6341 and #6342 — with no red gate and nothing in the conversation explaining it.

The cause is a workflow in this repository fighting a ruleset in this repository. CI commits
regenerated files onto the pull request's branch using the git CLI, which produces an **unsigned**
commit; the `Require signed commits` ruleset then refuses to merge that PR ever again. Rebasing does
not help, because the rebase re-runs the generator and pushes another unsigned commit.

The visible cost is a **stalled security bump**: #6342 is the claircore SSRF advisory update tracked
by #6198, green and unmergeable for 10 days.

## What

The generator now commits through the GitHub API using the App token this job already creates, which
GitHub signs automatically — the same mechanism the sibling step in this workflow already uses for the
protected-branch path. It then asserts the resulting commit is actually signed, so if this regresses
the job fails loudly instead of silently poisoning a pull request.

No new action dependency is introduced, and no signing key needs to be stored.

Once this lands, the three stalled PRs each need one rebase so their unsigned commit is replaced.

Fixes #6441
Part of #6198
