### PR TITLE
fix(ci): reject unsafe generated file additions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -603,7 +603,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
-          persist-credentials: true
+          persist-credentials: false
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: 📥 Download patches
@@ -654,9 +654,8 @@ jobs:
       # A CLI commit here is unsigned and makes the pull request permanently unmergeable.
       #
       # Limitation: the API's FileAddition carries only a path and its contents, so file
-      # modes are not expressible. Everything this pipeline generates is a regular 0644
-      # file and the repository tracks no symlinks, so this is inert today; a generated
-      # executable or symlink would need a different mechanism.
+      # modes are not expressible. Reject anything other than a regular 0644 file below
+      # rather than dereferencing a symlink or silently losing an executable bit.
       - name: 📤 Commit and push generated changes (PR branch)
         if: github.event_name == 'pull_request'
         env:
@@ -690,6 +689,13 @@ jobs:
                 jq -n --arg p "$entry_path" '{path: $p}' >>"$deletions"
                 ;;
               *)
+                # FileAddition cannot represent symlinks, special files, or executable
+                # modes. In particular, reading a symlink here would dereference it and
+                # could publish sensitive runner files as an ordinary repository file.
+                if [ -L "$entry_path" ] || [ ! -f "$entry_path" ] || [ -x "$entry_path" ]; then
+                  echo "::error file=${entry_path}::Generated change is not a regular non-executable file"
+                  exit 1
+                fi
                 # File content must never reach argv. Linux caps a single argv entry at
                 # MAX_ARG_STRLEN (128 KiB) independently of ARG_MAX, and generated files
                 # here run to hundreds of KiB (pkg/svc/chat/docs_generated.go alone is


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

- Prevent the auto-commit job from dereferencing symlinks or special files and publishing their targets, which can leak runner/checkout secrets when the job checks out with an App token.
- Avoid persisting the generated GitHub App credential in local git config during the auto-commit path so tokens are not left on disk in the worktree metadata.
- Ensure the GraphQL `FileAddition` payload only contains regular non-executable files that the API can faithfully represent instead of silently losing mode info or dereferencing symlinks.

### Description

- Disable credential persistence in the auto-commit checkout by setting `persist-credentials: false` for the job checkout step so the App token is not written into local git config.
- Add a fail-closed guard in the commit payload builder that rejects any changed path that is a symlink, not a regular file, or is executable, and aborts before reading the file contents.
- Update the inline workflow comments to document that file modes/symlinks are not expressible via the API and that the pipeline rejects non-regular/non-representable generated files rather than dereferencing them.

### Testing

- Ran a static workflow assertion that verifies `persist-credentials: false` is present for the checkout step and that the file-type guard appears before the `base64 -w0` content read; assertion succeeded.
- Executed a shell regression PoC that created a symlink to a secret, then validated the workflow logic rejects the symlink before any `base64` read; the symlink was rejected as expected.
- Performed `git diff --check` and `git diff --cached --check` to validate the change and ensure no accidental whitespace/check failures; both checks passed in this environment.
- `mega-linter-runner -f go` and `actionlint` could not be run because those executables are not available in the current environment (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f38433318832bb860363ff08d1721)