### PR TITLE
fix(cluster): re-assert Flux artifact verification on cluster update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,13 @@ linters:
       - linters:
           - paralleltest
         path: pkg/svc/credentials/store_test.go
+      # Tests that inject through the package-level loadRESTConfig /
+      # newUnstructuredClient seams cannot run in parallel: concurrent cases
+      # would overwrite each other's fake cluster.
+      - linters:
+          - paralleltest
+          - gochecknoglobals
+        path: pkg/svc/installer/flux/ocirepository_verify_live_test.go
       # Bubbletea requires context in the Model struct
       - linters:
           - containedctx

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -805,16 +805,16 @@ func ExportFluxReassertMemoized(
 	cmd *cobra.Command,
 	clusterCfg *v1alpha1.Cluster,
 ) (error, error) {
-	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
+	reconciler := newComponentReconciler(cmd, clusterCfg, "test-cluster")
 
-	first := r.reconcileFluxVersion(context.Background(), clusterupdate.Change{})
+	first := reconciler.reconcileFluxVersion(context.Background(), clusterupdate.Change{})
 
 	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	second := r.reconcileFluxVerify(ctx, clusterupdate.Change{})
+	second := reconciler.reconcileFluxVerify(ctx, clusterupdate.Change{})
 
 	return first, second
 }

--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -793,3 +793,28 @@ func ExportGuardUpdateTargetManaged(
 
 	return err
 }
+
+// ExportFluxReassertMemoized runs both Flux handlers on ONE reconciler, flipping
+// the GitOps engine to Flux between the calls.
+//
+// The flip is what makes the result meaningful: the first call is a non-Flux
+// no-op, and a second call that recomputed would take the Flux path and attempt
+// the real upsert against a cancelled context. A nil second result therefore
+// proves the reassertion was memoized rather than merely that it succeeded.
+func ExportFluxReassertMemoized(
+	cmd *cobra.Command,
+	clusterCfg *v1alpha1.Cluster,
+) (error, error) {
+	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")
+
+	first := r.reconcileFluxVersion(context.Background(), clusterupdate.Change{})
+
+	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	second := r.reconcileFluxVerify(ctx, clusterupdate.Change{})
+
+	return first, second
+}

--- a/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
+++ b/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
@@ -5,13 +5,11 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
-
-// fluxVerifyField is the diff field name for artifact-verification drift.
-const fluxVerifyField = "cluster.workload.flux.verify"
 
 // TestFluxVerifyFieldHasReconcileHandler pins the wiring between detection and
 // application, which is the half platform#2922 was actually missing. The verify
@@ -26,9 +24,9 @@ func TestFluxVerifyFieldHasReconcileHandler(t *testing.T) {
 
 	assert.True(
 		t,
-		cluster.ExportHandlerForField(&cobra.Command{}, clusterCfg, fluxVerifyField),
+		cluster.ExportHandlerForField(&cobra.Command{}, clusterCfg, specdiff.FluxVerifyField),
 		"no reconcile handler is registered for %q, so detected verify drift would be silently skipped",
-		fluxVerifyField,
+		specdiff.FluxVerifyField,
 	)
 }
 
@@ -44,7 +42,7 @@ func TestFluxVerifyDriftStaysInPlace(t *testing.T) {
 	diff := clusterupdate.NewEmptyUpdateResult()
 	diff.InPlaceChanges = []clusterupdate.Change{
 		{
-			Field:    fluxVerifyField,
+			Field:    specdiff.FluxVerifyField,
 			Category: clusterupdate.ChangeCategoryInPlace,
 		},
 	}

--- a/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
+++ b/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
@@ -1,0 +1,72 @@
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// fluxVerifyField is the diff field name for artifact-verification drift.
+const fluxVerifyField = "cluster.workload.flux.verify"
+
+// TestFluxVerifyFieldHasReconcileHandler pins the wiring between detection and
+// application, which is the half platform#2922 was actually missing. The verify
+// block was configured, read by KSail, and never applied: nothing on the update
+// path claimed the field, so the change would be skipped and the update would
+// still report success against an unverified root source.
+func TestFluxVerifyFieldHasReconcileHandler(t *testing.T) {
+	t.Parallel()
+
+	clusterCfg := v1alpha1.NewCluster()
+	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+
+	assert.True(
+		t,
+		cluster.ExportHandlerForField(&cobra.Command{}, clusterCfg, fluxVerifyField),
+		"no reconcile handler is registered for %q, so detected verify drift would be silently skipped",
+		fluxVerifyField,
+	)
+}
+
+// TestFluxVerifyDriftStaysInPlace is the trap this change most has to avoid.
+// promoteUnsupportedInPlaceChanges demotes any in-place field the provisioner
+// does not declare support for to "recreate required" — so a field missing from
+// the component-reconcile set would turn re-asserting a signature policy into a
+// demand to destroy and rebuild the cluster. On the source this fix targets that
+// cluster is production.
+func TestFluxVerifyDriftStaysInPlace(t *testing.T) {
+	t.Parallel()
+
+	diff := clusterupdate.NewEmptyUpdateResult()
+	diff.InPlaceChanges = []clusterupdate.Change{
+		{
+			Field:    fluxVerifyField,
+			Category: clusterupdate.ChangeCategoryInPlace,
+		},
+	}
+
+	// An updater that declares support for nothing: only membership of the
+	// component-reconcile set can keep the change in place.
+	updater := &fieldSupportUpdater{
+		fakeUpdater: &fakeUpdater{},
+		supported:   map[string]bool{},
+	}
+
+	cluster.ExportPromoteUnsupportedInPlaceChanges(updater, diff)
+
+	assert.Empty(
+		t,
+		diff.RecreateRequired,
+		"re-asserting artifact verification must never demand a cluster rebuild",
+	)
+	assert.Len(
+		t,
+		diff.InPlaceChanges,
+		1,
+		"the verify change must survive promotion as an in-place change",
+	)
+}

--- a/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
+++ b/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestFluxVerifyFieldHasReconcileHandler pins the wiring between detection and
@@ -66,5 +67,30 @@ func TestFluxVerifyDriftStaysInPlace(t *testing.T) {
 		diff.InPlaceChanges,
 		1,
 		"the verify change must survive promotion as an in-place change",
+	)
+}
+
+// TestFluxReassertRunsOncePerUpdatePass pins the coalescing of the two Flux
+// handlers.
+//
+// spec.workload.flux.distributionVersion and spec.workload.flux.verify are
+// separate diff fields with separate handlers, but both repair themselves
+// through the same SetupInstance upsert. An update reporting both would
+// otherwise run that upsert twice — the same duplication the autoscaler and
+// load-balancer flags already prevent for their own fields.
+func TestFluxReassertRunsOncePerUpdatePass(t *testing.T) {
+	t.Parallel()
+
+	clusterCfg := v1alpha1.NewCluster()
+	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineNone
+
+	first, second := cluster.ExportFluxReassertMemoized(&cobra.Command{}, clusterCfg)
+
+	require.NoError(t, first, "a non-Flux cluster must reassert cleanly as a no-op")
+	require.NoError(
+		t,
+		second,
+		"the second Flux handler must reuse the first reassertion; recomputing would "+
+			"have attempted the upsert against a cancelled context",
 	)
 }

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -932,6 +932,10 @@ func (o *updateOrchestrator) computeUpdateDiff(
 	// Check for registry credential drift (a rotated token behind an unchanged spec)
 	checkRegistryCredentialDrift(o.cmd, o.ctx, diffEngine, diff)
 
+	// Check for artifact-verification drift (configured spec.workload.flux.verify
+	// that never reached the live OCIRepository)
+	checkFluxVerifyDrift(o.cmd, o.ctx, diffEngine, diff)
+
 	promoteUnsupportedInPlaceChanges(updater, diff)
 
 	return currentSpec, diff, nil
@@ -1261,6 +1265,55 @@ func checkRegistryCredentialDrift(
 	}
 
 	diffEngine.CheckRegistryCredential(drifted, diff)
+}
+
+// checkFluxVerifyDrift compares the live flux-system OCIRepository's spec.verify
+// against the block spec.workload.flux.verify configures, and appends an
+// in-place change when the cluster is missing it.
+//
+// This is the only signal a verify-only change produces: the structural diff
+// compares cluster specs, so configuring verification registers once and never
+// again, while the block reaches the cluster only via SetupInstance — which
+// cluster update calls solely from handlers that some *other* field's change
+// triggers. Enabling verification on a live cluster therefore deployed green and
+// left the root source unverified (platform#2922). Flux only. Errors during
+// cluster queries are logged as warnings and skipped — they should not block the
+// rest of the update.
+func checkFluxVerifyDrift(
+	cmd *cobra.Command,
+	ctx *localregistry.Context,
+	diffEngine *specdiff.Engine,
+	diff *clusterupdate.UpdateResult,
+) {
+	gitOpsEngine := ctx.ClusterCfg.Spec.Cluster.GitOpsEngine
+	if gitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return
+	}
+
+	// Not configured — nothing to assert, and no cluster query worth spending.
+	if !ctx.ClusterCfg.Spec.Workload.Flux.Verify.Enabled() {
+		return
+	}
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(ctx.ClusterCfg)
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot resolve kubeconfig path for Flux verify drift detection: %v", err)
+
+		return
+	}
+
+	drifted, err := fluxinstaller.VerifyDrifted(
+		cmd.Context(), kubeconfigPath, resolveKubeContext(ctx), ctx.ClusterCfg,
+	)
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot compare Flux artifact verification for drift detection: %v", err)
+
+		return
+	}
+
+	diffEngine.CheckFluxVerify(drifted, gitOpsEngine, diff)
 }
 
 // getCurrentArgoCDTargetRevision queries the ArgoCD Application for its current

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -57,6 +57,15 @@ type componentReconciler struct {
 	// EKS-specific controller opt-in when both change in one update pass.
 	loadBalancerReconciled bool
 	loadBalancerErr        error
+	// fluxReasserted coalesces every Flux field that shares reassertFluxInstance
+	// as its repair — currently distributionVersion and verify — when more than
+	// one of them drifts in a single update pass. They map to one FluxInstance
+	// upsert, so without this a two-field drift resolves the registry host and
+	// runs SetupInstance twice for one cluster state.
+	// fluxReassertErr preserves the error from the first attempt so that
+	// subsequent calls surface the same failure instead of silently succeeding.
+	fluxReasserted  bool
+	fluxReassertErr error
 	// eksLoadBalancerOwnershipUpdated is set only after this update pass actually
 	// installs/upgrades or uninstalls the EKS controller. If untouched, final state
 	// persistence preserves the prior exact-region ownership marker.
@@ -619,7 +628,24 @@ func (r *componentReconciler) fluxKubeconfigPath() (string, bool, error) {
 // repair for every Flux field whose desired state is expressed in configuration
 // but applied to the cluster only by setup, so each such field's handler is a
 // thin wrapper naming what it repairs. A no-op on non-Flux clusters.
+//
+// Runs at most once per update pass. Those wrappers are separate diff fields, so
+// a single update that reports both of them drifting would otherwise resolve the
+// registry host and upsert the FluxInstance twice for one cluster state. The
+// outcome is memoized rather than merely skipped, so a second field sharing this
+// repair reports the first attempt's failure instead of silently succeeding.
 func (r *componentReconciler) reassertFluxInstance(ctx context.Context) error {
+	if r.fluxReasserted {
+		return r.fluxReassertErr
+	}
+
+	r.fluxReasserted = true
+	r.fluxReassertErr = r.applyFluxInstance(ctx)
+
+	return r.fluxReassertErr
+}
+
+func (r *componentReconciler) applyFluxInstance(ctx context.Context) error {
 	kubeconfigPath, isFlux, err := r.fluxKubeconfigPath()
 	if err != nil || !isFlux {
 		return err

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -614,14 +614,12 @@ func (r *componentReconciler) fluxKubeconfigPath() (string, bool, error) {
 	return kubeconfigPath, true, nil
 }
 
-// reconcileFluxVersion re-asserts the FluxInstance so a changed
-// spec.workload.flux.distributionVersion (or a newly repo-declared FluxInstance)
-// takes effect in-place on cluster update. Flux only — ArgoCD has no equivalent
-// distribution version.
-func (r *componentReconciler) reconcileFluxVersion(
-	ctx context.Context,
-	_ clusterupdate.Change,
-) error {
+// reassertFluxInstance re-runs SetupInstance, which upserts the FluxInstance and
+// re-applies the OCIRepository settings KSail owns. It is the single in-place
+// repair for every Flux field whose desired state is expressed in configuration
+// but applied to the cluster only by setup, so each such field's handler is a
+// thin wrapper naming what it repairs. A no-op on non-Flux clusters.
+func (r *componentReconciler) reassertFluxInstance(ctx context.Context) error {
 	kubeconfigPath, isFlux, err := r.fluxKubeconfigPath()
 	if err != nil || !isFlux {
 		return err
@@ -646,6 +644,17 @@ func (r *componentReconciler) reconcileFluxVersion(
 	return nil
 }
 
+// reconcileFluxVersion re-asserts the FluxInstance so a changed
+// spec.workload.flux.distributionVersion (or a newly repo-declared FluxInstance)
+// takes effect in-place on cluster update. Flux only — ArgoCD has no equivalent
+// distribution version.
+func (r *componentReconciler) reconcileFluxVersion(
+	ctx context.Context,
+	_ clusterupdate.Change,
+) error {
+	return r.reassertFluxInstance(ctx)
+}
+
 // reconcileFluxVerify re-asserts the OCIRepository's spec.verify block so a
 // configured spec.workload.flux.verify reaches a cluster that is already
 // bootstrapped. Without this the block is applied only at create time, or
@@ -656,28 +665,7 @@ func (r *componentReconciler) reconcileFluxVerify(
 	ctx context.Context,
 	_ clusterupdate.Change,
 ) error {
-	kubeconfigPath, isFlux, err := r.fluxKubeconfigPath()
-	if err != nil || !isFlux {
-		return err
-	}
-
-	registryHost, err := setup.ResolveRegistryHostForCluster(ctx, r.clusterCfg, r.clusterName)
-	if err != nil {
-		return fmt.Errorf("resolve registry host for flux: %w", err)
-	}
-
-	err = fluxinstaller.SetupInstance(
-		ctx,
-		kubeconfigPath,
-		r.clusterCfg,
-		r.clusterName,
-		registryHost,
-	)
-	if err != nil {
-		return fmt.Errorf("setup flux instance: %w", err)
-	}
-
-	return nil
+	return r.reassertFluxInstance(ctx)
 }
 
 // reconcileRegistryCredentials re-writes the KSail-managed registry Secret so a

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -144,10 +144,10 @@ func (r *componentReconciler) handlerForField(
 		"cluster.gitOpsEngine":                      r.reconcileGitOpsEngine,
 		"cluster.workload.tag":                      r.reconcileWorkloadTag,
 		"cluster.workload.flux.distributionVersion": r.reconcileFluxVersion,
-		"cluster.workload.flux.verify":              r.reconcileFluxVerify,
 	}
 	handlers[specdiff.EKSLoadBalancerControllerField] = r.reconcileLoadBalancer
 	handlers[specdiff.RegistryCredentialField] = r.reconcileRegistryCredentials
+	handlers[specdiff.FluxVerifyField] = r.reconcileFluxVerify
 
 	if handler, ok := handlers[field]; ok {
 		return handler, true
@@ -175,9 +175,9 @@ func isComponentReconcileField(field string) bool {
 		"cluster.gitOpsEngine",
 		"cluster.workload.tag",
 		"cluster.workload.flux.distributionVersion",
-		"cluster.workload.flux.verify",
 		specdiff.EKSLoadBalancerControllerField,
-		specdiff.RegistryCredentialField:
+		specdiff.RegistryCredentialField,
+		specdiff.FluxVerifyField:
 		return true
 	default:
 		return strings.HasPrefix(field, "cluster.autoscaler.node.")

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -144,6 +144,7 @@ func (r *componentReconciler) handlerForField(
 		"cluster.gitOpsEngine":                      r.reconcileGitOpsEngine,
 		"cluster.workload.tag":                      r.reconcileWorkloadTag,
 		"cluster.workload.flux.distributionVersion": r.reconcileFluxVersion,
+		"cluster.workload.flux.verify":              r.reconcileFluxVerify,
 	}
 	handlers[specdiff.EKSLoadBalancerControllerField] = r.reconcileLoadBalancer
 	handlers[specdiff.RegistryCredentialField] = r.reconcileRegistryCredentials
@@ -174,6 +175,7 @@ func isComponentReconcileField(field string) bool {
 		"cluster.gitOpsEngine",
 		"cluster.workload.tag",
 		"cluster.workload.flux.distributionVersion",
+		"cluster.workload.flux.verify",
 		specdiff.EKSLoadBalancerControllerField,
 		specdiff.RegistryCredentialField:
 		return true
@@ -617,6 +619,40 @@ func (r *componentReconciler) fluxKubeconfigPath() (string, bool, error) {
 // takes effect in-place on cluster update. Flux only — ArgoCD has no equivalent
 // distribution version.
 func (r *componentReconciler) reconcileFluxVersion(
+	ctx context.Context,
+	_ clusterupdate.Change,
+) error {
+	kubeconfigPath, isFlux, err := r.fluxKubeconfigPath()
+	if err != nil || !isFlux {
+		return err
+	}
+
+	registryHost, err := setup.ResolveRegistryHostForCluster(ctx, r.clusterCfg, r.clusterName)
+	if err != nil {
+		return fmt.Errorf("resolve registry host for flux: %w", err)
+	}
+
+	err = fluxinstaller.SetupInstance(
+		ctx,
+		kubeconfigPath,
+		r.clusterCfg,
+		r.clusterName,
+		registryHost,
+	)
+	if err != nil {
+		return fmt.Errorf("setup flux instance: %w", err)
+	}
+
+	return nil
+}
+
+// reconcileFluxVerify re-asserts the OCIRepository's spec.verify block so a
+// configured spec.workload.flux.verify reaches a cluster that is already
+// bootstrapped. Without this the block is applied only at create time, or
+// incidentally when another field's change re-asserts the FluxInstance, so
+// enabling verification on a live cluster silently did nothing (platform#2922).
+// Flux only — ArgoCD has no equivalent artifact-signature gate.
+func (r *componentReconciler) reconcileFluxVerify(
 	ctx context.Context,
 	_ clusterupdate.Change,
 ) error {

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -131,6 +131,38 @@ func (e *Engine) CheckFluxDistributionVersion(
 		clusterupdate.ChangeCategoryInPlace)
 }
 
+// CheckFluxVerify appends an in-place change when the live flux-system
+// OCIRepository is missing the spec.verify block the configuration asks for.
+//
+// Like a rotated registry credential, this drift is invisible to the structural
+// diff: it compares the old cluster spec against the new one, so configuring
+// verify shows up exactly once and never again — while nothing on the update
+// path applies the block unless some other field's change happens to trigger a
+// handler that re-asserts the FluxInstance. The result was a green deploy
+// against a root source Flux was not verifying at all (platform#2922).
+//
+// drifted is decided by the flux installer, which reads the live resource and
+// compares it with the same function the patcher uses to decide it is already
+// in place.
+func (e *Engine) CheckFluxVerify(
+	drifted bool,
+	gitOpsEngine v1alpha1.GitOpsEngine,
+	result *clusterupdate.UpdateResult,
+) {
+	if gitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return
+	}
+
+	if !drifted {
+		return
+	}
+
+	appendChange(result, "cluster.workload.flux.verify",
+		"absent", "configured", "",
+		"artifact signature verification can be re-asserted in-place on the OCIRepository",
+		clusterupdate.ChangeCategoryInPlace)
+}
+
 // CheckRegistryCredential appends an in-place change when the credential in the
 // KSail-managed registry Secret has drifted from the one the resolved
 // configuration would write. This is what makes a credential-only rotation

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -23,6 +23,11 @@ const EKSLoadBalancerControllerField = "cluster.eks.experimentalAWSLoadBalancerC
 //nolint:gosec // G101 false positive: a diff key, not a credential.
 const RegistryCredentialField = "cluster.localRegistry.credentials"
 
+// FluxVerifyField is the diff key for artifact signature verification on the
+// flux-system OCIRepository. Reconciliation uses the same constant so field
+// renames cannot silently disconnect detection from application.
+const FluxVerifyField = "cluster.workload.flux.verify"
+
 // registryCredentialOldDisplay and registryCredentialNewDisplay are the values
 // rendered for a credential rotation. The resolved credential — and any digest
 // of it — is deliberately never placed in a Change: Change values are printed by
@@ -157,7 +162,7 @@ func (e *Engine) CheckFluxVerify(
 		return
 	}
 
-	appendChange(result, "cluster.workload.flux.verify",
+	appendChange(result, FluxVerifyField,
 		"absent", "configured", "",
 		"artifact signature verification can be re-asserted in-place on the OCIRepository",
 		clusterupdate.ChangeCategoryInPlace)

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -28,6 +28,12 @@ const RegistryCredentialField = "cluster.localRegistry.credentials"
 // renames cannot silently disconnect detection from application.
 const FluxVerifyField = "cluster.workload.flux.verify"
 
+// fluxVerifyDriftedDisplay is the old value rendered for verify drift. The
+// detector receives a single boolean covering both an absent spec.verify block
+// and one that is present but differs, so this names the disjunction rather than
+// asserting either state.
+const fluxVerifyDriftedDisplay = "absent or mismatched"
+
 // registryCredentialOldDisplay and registryCredentialNewDisplay are the values
 // rendered for a credential rotation. The resolved credential — and any digest
 // of it — is deliberately never placed in a Change: Change values are printed by
@@ -149,6 +155,11 @@ func (e *Engine) CheckFluxDistributionVersion(
 // drifted is decided by the flux installer, which reads the live resource and
 // compares it with the same function the patcher uses to decide it is already
 // in place.
+//
+// drifted collapses two live states — spec.verify absent, and spec.verify
+// present but different from the configured block — so the old value reported
+// here must name both. A bare "absent" would tell an operator whose live source
+// verifies with another provider something false about their own cluster.
 func (e *Engine) CheckFluxVerify(
 	drifted bool,
 	gitOpsEngine v1alpha1.GitOpsEngine,
@@ -163,7 +174,7 @@ func (e *Engine) CheckFluxVerify(
 	}
 
 	appendChange(result, FluxVerifyField,
-		"absent", "configured", "",
+		fluxVerifyDriftedDisplay, "configured", "",
 		"artifact signature verification can be re-asserted in-place on the OCIRepository",
 		clusterupdate.ChangeCategoryInPlace)
 }

--- a/pkg/svc/diff/flux_verify_test.go
+++ b/pkg/svc/diff/flux_verify_test.go
@@ -1,0 +1,86 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+)
+
+const fluxVerifyField = "cluster.workload.flux.verify"
+
+func newVerifyEngine() *specdiff.Engine {
+	return specdiff.NewEngine(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
+}
+
+// TestCheckFluxVerifySurfacesAnUnverifiedCluster is the core of platform#2922:
+// spec.workload.flux.verify is applied to the cluster only by SetupInstance, and
+// cluster update reaches that solely through handlers other fields' changes
+// trigger. A cluster whose live OCIRepository carries no spec.verify must
+// therefore surface as an in-place change, or verification stays configured and
+// unenforced behind a green deploy.
+func TestCheckFluxVerifySurfacesAnUnverifiedCluster(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	newVerifyEngine().CheckFluxVerify(true, v1alpha1.GitOpsEngineFlux, result)
+
+	if len(result.InPlaceChanges) != 1 {
+		t.Fatalf(
+			"an unverified live OCIRepository must produce exactly one in-place change, got %d",
+			len(result.InPlaceChanges),
+		)
+	}
+
+	change := result.InPlaceChanges[0]
+	if change.Field != fluxVerifyField {
+		t.Errorf("field = %q, want %q", change.Field, fluxVerifyField)
+	}
+
+	if change.Category != clusterupdate.ChangeCategoryInPlace {
+		t.Errorf(
+			"category = %q, want in-place — re-asserting verify must never demand recreation",
+			change.Category,
+		)
+	}
+}
+
+// TestCheckFluxVerifyStaysSilentWhenTheClusterAlreadyVerifies pins the other
+// direction. Without this, a check that emitted unconditionally would pass the
+// test above while making every single update report a spurious change.
+func TestCheckFluxVerifyStaysSilentWhenTheClusterAlreadyVerifies(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	newVerifyEngine().CheckFluxVerify(false, v1alpha1.GitOpsEngineFlux, result)
+
+	if len(result.InPlaceChanges) != 0 {
+		t.Fatalf(
+			"a cluster already carrying the configured verify block must produce no change, got %d",
+			len(result.InPlaceChanges),
+		)
+	}
+}
+
+// TestCheckFluxVerifyIgnoresNonFluxEngines keeps the check scoped. ArgoCD has no
+// OCIRepository to patch, so emitting a change there would route to a Flux-only
+// handler.
+func TestCheckFluxVerifyIgnoresNonFluxEngines(t *testing.T) {
+	t.Parallel()
+
+	for _, engine := range []v1alpha1.GitOpsEngine{
+		v1alpha1.GitOpsEngineArgoCD,
+		v1alpha1.GitOpsEngineNone,
+	} {
+		result := clusterupdate.NewEmptyUpdateResult()
+		newVerifyEngine().CheckFluxVerify(true, engine, result)
+
+		if len(result.InPlaceChanges) != 0 {
+			t.Errorf(
+				"engine %v must produce no verify change, got %d",
+				engine, len(result.InPlaceChanges),
+			)
+		}
+	}
+}

--- a/pkg/svc/diff/flux_verify_test.go
+++ b/pkg/svc/diff/flux_verify_test.go
@@ -1,6 +1,7 @@
 package diff_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -40,6 +41,41 @@ func TestCheckFluxVerifySurfacesAnUnverifiedCluster(t *testing.T) {
 		t.Errorf(
 			"category = %q, want in-place — re-asserting verify must never demand recreation",
 			change.Category,
+		)
+	}
+}
+
+// TestCheckFluxVerifyDoesNotClaimAKnownLiveState pins the reported old value
+// against the one thing the detector cannot know.
+//
+// VerifyDrifted returns a single boolean for two different live states: no
+// spec.verify block at all, and a block that is present but differs from the
+// configured one. The update plan is read by an operator against their own
+// cluster, so an old value naming just one of those states is a false statement
+// for everyone in the other. The label must therefore cover both.
+func TestCheckFluxVerifyDoesNotClaimAKnownLiveState(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	newVerifyEngine().CheckFluxVerify(true, v1alpha1.GitOpsEngineFlux, result)
+
+	old := result.InPlaceChanges[0].OldValue
+
+	// The specific state a live differing block would contradict. Named
+	// explicitly so a revert to it fails here rather than only shifting a
+	// string somewhere.
+	if old == "absent" {
+		t.Fatalf(
+			"old value = %q, which is false for a cluster whose live spec.verify "+
+				"is present but uses another provider",
+			old,
+		)
+	}
+
+	if !strings.Contains(old, "absent") || !strings.Contains(old, "mismatched") {
+		t.Errorf(
+			"old value = %q, want a label naming both drift causes (absent, mismatched)",
+			old,
 		)
 	}
 }

--- a/pkg/svc/diff/flux_verify_test.go
+++ b/pkg/svc/diff/flux_verify_test.go
@@ -59,6 +59,13 @@ func TestCheckFluxVerifyDoesNotClaimAKnownLiveState(t *testing.T) {
 	result := clusterupdate.NewEmptyUpdateResult()
 	newVerifyEngine().CheckFluxVerify(true, v1alpha1.GitOpsEngineFlux, result)
 
+	// Check the length before indexing: a detector that emitted nothing is the
+	// very regression this test exists to catch, and an unguarded index reports
+	// it as a panic in the harness rather than as this test's own failure.
+	if len(result.InPlaceChanges) != 1 {
+		t.Fatalf("expected exactly one in-place change, got %d", len(result.InPlaceChanges))
+	}
+
 	old := result.InPlaceChanges[0].OldValue
 
 	// The specific state a live differing block would contradict. Named

--- a/pkg/svc/diff/flux_verify_test.go
+++ b/pkg/svc/diff/flux_verify_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 )
 
-const fluxVerifyField = "cluster.workload.flux.verify"
-
 func newVerifyEngine() *specdiff.Engine {
 	return specdiff.NewEngine(v1alpha1.DistributionVanilla, v1alpha1.ProviderDocker)
 }
@@ -34,8 +32,8 @@ func TestCheckFluxVerifySurfacesAnUnverifiedCluster(t *testing.T) {
 	}
 
 	change := result.InPlaceChanges[0]
-	if change.Field != fluxVerifyField {
-		t.Errorf("field = %q, want %q", change.Field, fluxVerifyField)
+	if change.Field != specdiff.FluxVerifyField {
+		t.Errorf("field = %q, want %q", change.Field, specdiff.FluxVerifyField)
 	}
 
 	if change.Category != clusterupdate.ChangeCategoryInPlace {

--- a/pkg/svc/installer/flux/export_test.go
+++ b/pkg/svc/installer/flux/export_test.go
@@ -11,6 +11,7 @@ import (
 	fluxclient "github.com/devantler-tech/ksail/v7/pkg/client/flux"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/installer/internal/sopsutil"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -146,6 +147,26 @@ func SetNewCoreV1Client(fn func(*rest.Config) (client.Client, error)) func() {
 	return func() {
 		newCoreV1Client = original
 	}
+}
+
+// SetNewUnstructuredClient allows tests to replace newUnstructuredClient with a fake, so
+// the live OCIRepository read in VerifyDrifted runs against synthetic cluster
+// state rather than a real API server.
+func SetNewUnstructuredClient(fn func(*rest.Config) (dynamic.Interface, error)) func() {
+	original := newUnstructuredClient
+	newUnstructuredClient = fn
+
+	return func() {
+		newUnstructuredClient = original
+	}
+}
+
+// CurrentOCIRepositoryVerify exports currentOCIRepositoryVerify for testing.
+func CurrentOCIRepositoryVerify(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+) (map[string]any, bool, error) {
+	return currentOCIRepositoryVerify(ctx, kubeconfig, kubeContext)
 }
 
 // SetLoadRESTConfig allows tests to replace loadRESTConfig with a stub.

--- a/pkg/svc/installer/flux/ocirepository_patcher.go
+++ b/pkg/svc/installer/flux/ocirepository_patcher.go
@@ -107,12 +107,21 @@ func buildVerifyPatch(cfg v1alpha1.FluxVerifySpec) map[string]any {
 	return verify
 }
 
+// verifyMatches reports whether a live spec.verify block already equals the
+// desired one. It is the single definition of "verify is in place": the patcher
+// uses it to skip a needless update, and VerifyDrifted uses it to decide whether
+// cluster update must re-assert the block. Keeping one comparison means the
+// drift check can never disagree with what the patch would actually do.
+func verifyMatches(current map[string]any, desired map[string]any) bool {
+	return reflect.DeepEqual(current, desired)
+}
+
 // applyVerify sets spec.verify on the OCIRepository object to the desired block.
 // It reports done=true when the field already matches, so re-bootstrapping an
 // already-verified OCIRepository performs no needless update.
 func applyVerify(obj map[string]any, desired map[string]any) (bool, error) {
 	current, found, err := unstructured.NestedMap(obj, "spec", "verify")
-	if err == nil && found && reflect.DeepEqual(current, desired) {
+	if err == nil && found && verifyMatches(current, desired) {
 		return true, nil
 	}
 

--- a/pkg/svc/installer/flux/ocirepository_verify.go
+++ b/pkg/svc/installer/flux/ocirepository_verify.go
@@ -12,7 +12,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 )
+
+// newUnstructuredClient builds the client used to read the live OCIRepository. It is
+// a package-level var, like loadRESTConfig, so tests can inject a fake and
+// exercise the real read-and-compare path instead of stubbing its result.
+//
+//nolint:gochecknoglobals // Allows mocking for tests
+var newUnstructuredClient = func(restConfig *rest.Config) (dynamic.Interface, error) {
+	return dynamic.NewForConfig(restConfig)
+}
 
 // VerifyDrifted reports whether the live flux-system OCIRepository is missing
 // the spec.verify block that spec.workload.flux.verify configures.
@@ -76,7 +86,7 @@ func currentOCIRepositoryVerify(
 		return nil, false, fmt.Errorf("build REST config: %w", err)
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	dynamicClient, err := newUnstructuredClient(restConfig)
 	if err != nil {
 		return nil, false, fmt.Errorf("create dynamic client: %w", err)
 	}

--- a/pkg/svc/installer/flux/ocirepository_verify.go
+++ b/pkg/svc/installer/flux/ocirepository_verify.go
@@ -1,0 +1,108 @@
+package fluxinstaller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	fluxclient "github.com/devantler-tech/ksail/v7/pkg/client/flux"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// VerifyDrifted reports whether the live flux-system OCIRepository is missing
+// the spec.verify block that spec.workload.flux.verify configures.
+//
+// This is the only signal a verify-only configuration change produces. The
+// structural diff compares the previous cluster spec against the new one, so it
+// sees a change the first time verify is configured and never again — while the
+// block is applied to the cluster exclusively by SetupInstance, which cluster
+// update reaches only through a handler some *other* field's change triggered.
+// Configuring verify therefore left the live source unverified, with a green
+// deploy and no signal at all (platform#2922).
+//
+// Flux only, and a no-op when verification is not configured: KSail asserts the
+// configured block, and never removes or judges one it did not configure.
+// Errors reading the cluster are returned to the caller, which reports them as
+// warnings rather than blocking the update.
+func VerifyDrifted(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+	clusterCfg *v1alpha1.Cluster,
+) (bool, error) {
+	if clusterCfg == nil {
+		return false, nil
+	}
+
+	if clusterCfg.Spec.Cluster.GitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return false, nil
+	}
+
+	verify := clusterCfg.Spec.Workload.Flux.Verify
+	if !verify.Enabled() {
+		return false, nil
+	}
+
+	current, found, err := currentOCIRepositoryVerify(ctx, kubeconfig, kubeContext)
+	if err != nil {
+		return false, err
+	}
+
+	// No OCIRepository yet: the cluster has not been bootstrapped, so there is
+	// nothing to re-assert against and SetupInstance will apply verify when it
+	// creates the resource. Reporting drift here would emit a change on every
+	// update against a cluster Flux does not manage.
+	if !found {
+		return false, nil
+	}
+
+	return !verifyMatches(current, buildVerifyPatch(verify)), nil
+}
+
+// currentOCIRepositoryVerify reads spec.verify off the live flux-system
+// OCIRepository. found is false when the OCIRepository does not exist; a
+// present resource carrying no spec.verify returns a nil map with found=true,
+// which is the drift case this exists to catch.
+func currentOCIRepositoryVerify(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+) (map[string]any, bool, error) {
+	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
+	if err != nil {
+		return nil, false, fmt.Errorf("build REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, false, fmt.Errorf("create dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    sourcev1.GroupVersion.Group,
+		Version:  sourcev1.GroupVersion.Version,
+		Resource: "ocirepositories",
+	}
+
+	repo, err := dynamicClient.Resource(gvr).
+		Namespace(fluxclient.DefaultNamespace).
+		Get(ctx, defaultOCIRepositoryName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+
+	if err != nil {
+		return nil, false, fmt.Errorf("get OCIRepository: %w", err)
+	}
+
+	// A missing spec.verify is not an error — it is precisely the drift.
+	current, _, err := unstructured.NestedMap(repo.Object, "spec", "verify")
+	if err != nil {
+		return nil, true, fmt.Errorf("read OCIRepository spec.verify: %w", err)
+	}
+
+	return current, true, nil
+}

--- a/pkg/svc/installer/flux/ocirepository_verify_live_test.go
+++ b/pkg/svc/installer/flux/ocirepository_verify_live_test.go
@@ -30,7 +30,12 @@ import (
 var errUnexpectedClusterRead = errors.New("cluster must not be read")
 
 const (
-	fluxSystemNamespace  = "flux-system"
+	fluxSystemNamespace = "flux-system"
+	// ociRepositoryName is the root source's RESOURCE name, which production
+	// derives separately from the namespace. The two values coincide today, so
+	// spelling them apart is what keeps a future divergence a visible test
+	// change rather than a lookup that silently misses.
+	ociRepositoryName    = "flux-system"
 	ociRepositoriesRsrc  = "ocirepositories"
 	sourceGroup          = "source.toolkit.fluxcd.io"
 	sourceVersion        = "v1"
@@ -57,7 +62,7 @@ func newFakeOCIRepository(verify map[string]any) *unstructured.Unstructured {
 		Version: sourceVersion,
 		Kind:    "OCIRepository",
 	})
-	repo.SetName(fluxSystemNamespace)
+	repo.SetName(ociRepositoryName)
 	repo.SetNamespace(fluxSystemNamespace)
 
 	spec := map[string]any{"url": "oci://ghcr.io/devantler-tech/platform"}

--- a/pkg/svc/installer/flux/ocirepository_verify_live_test.go
+++ b/pkg/svc/installer/flux/ocirepository_verify_live_test.go
@@ -1,0 +1,257 @@
+package fluxinstaller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+// These tests cover the live read-and-compare path — currentOCIRepositoryVerify
+// and VerifyDrifted against a real client interface — rather than the pure
+// helpers alone. That path is the whole of platform#2922: the drift bit is only
+// as trustworthy as the GET that produces it, and stubbing the bit would leave
+// a wrong namespace, name, GVR, or nil-map reading undetected.
+//
+// Deliberately not parallel: the seams they inject through are package-level
+// vars, so concurrent cases would overwrite each other's client.
+
+// errUnexpectedClusterRead marks a seam that must never be reached.
+var errUnexpectedClusterRead = errors.New("cluster must not be read")
+
+const (
+	fluxSystemNamespace  = "flux-system"
+	ociRepositoriesRsrc  = "ocirepositories"
+	sourceGroup          = "source.toolkit.fluxcd.io"
+	sourceVersion        = "v1"
+	verifyProviderCosign = "cosign"
+)
+
+// ociRepositoryGVR is the resource the verify read targets. A test that built
+// its fake against a different GVR would pass while production looked elsewhere.
+func ociRepositoryGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    sourceGroup,
+		Version:  sourceVersion,
+		Resource: ociRepositoriesRsrc,
+	}
+}
+
+// newFakeOCIRepository builds the root flux-system OCIRepository. verify is set
+// only when non-nil, so the "present but unverified" case — the exact drift
+// platform#2922 shipped to production — is representable.
+func newFakeOCIRepository(verify map[string]any) *unstructured.Unstructured {
+	repo := &unstructured.Unstructured{}
+	repo.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   sourceGroup,
+		Version: sourceVersion,
+		Kind:    "OCIRepository",
+	})
+	repo.SetName(fluxSystemNamespace)
+	repo.SetNamespace(fluxSystemNamespace)
+
+	spec := map[string]any{"url": "oci://ghcr.io/devantler-tech/platform"}
+	if verify != nil {
+		spec["verify"] = verify
+	}
+
+	repo.Object["spec"] = spec
+
+	return repo
+}
+
+// withFakeCluster injects a stubbed REST config and a fake dynamic client
+// seeded with the given objects, restoring both when the test ends.
+func withFakeCluster(t *testing.T, objects ...runtime.Object) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{ociRepositoryGVR(): "OCIRepositoryList"},
+		objects...,
+	)
+
+	restoreLoad := fluxinstaller.SetLoadRESTConfig(func(_, _ string) (*rest.Config, error) {
+		return &rest.Config{}, nil
+	})
+	t.Cleanup(restoreLoad)
+
+	restoreClient := fluxinstaller.SetNewUnstructuredClient(
+		func(_ *rest.Config) (dynamic.Interface, error) {
+			return client, nil
+		},
+	)
+	t.Cleanup(restoreClient)
+}
+
+// verifyingCluster is a Flux cluster configured to verify with cosign — the
+// only shape that makes VerifyDrifted read the cluster at all.
+func verifyingCluster() *v1alpha1.Cluster {
+	clusterCfg := v1alpha1.NewCluster()
+	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+	clusterCfg.Spec.Workload.Flux.Verify = v1alpha1.FluxVerifySpec{
+		Provider:  verifyProviderCosign,
+		SecretRef: v1alpha1.FluxVerifySecretRef{Name: "cosign-public-key"},
+	}
+
+	return clusterCfg
+}
+
+func TestCurrentOCIRepositoryVerifyReportsNotFound(t *testing.T) {
+	withFakeCluster(t)
+
+	current, found, err := fluxinstaller.CurrentOCIRepositoryVerify(
+		context.Background(), "", "",
+	)
+	require.NoError(t, err, "a missing OCIRepository is an expected state, not an error")
+	assert.False(t, found)
+	assert.Nil(t, current)
+}
+
+func TestCurrentOCIRepositoryVerifyReportsAbsentVerifyAsFound(t *testing.T) {
+	withFakeCluster(t, newFakeOCIRepository(nil))
+
+	current, found, err := fluxinstaller.CurrentOCIRepositoryVerify(
+		context.Background(), "", "",
+	)
+	require.NoError(t, err)
+	assert.True(t, found, "the resource exists — only its spec.verify is missing")
+	assert.Nil(t, current, "a nil block is what distinguishes unverified from absent")
+}
+
+func TestCurrentOCIRepositoryVerifyReadsTheLiveBlock(t *testing.T) {
+	live := map[string]any{
+		"provider":  verifyProviderCosign,
+		"secretRef": map[string]any{"name": "cosign-public-key"},
+	}
+	withFakeCluster(t, newFakeOCIRepository(live))
+
+	current, found, err := fluxinstaller.CurrentOCIRepositoryVerify(
+		context.Background(), "", "",
+	)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, live, current)
+}
+
+func TestVerifyDriftedIsFalseWhenTheClusterIsNotBootstrapped(t *testing.T) {
+	withFakeCluster(t)
+
+	drifted, err := fluxinstaller.VerifyDrifted(
+		context.Background(), "", "", verifyingCluster(),
+	)
+	require.NoError(t, err)
+	assert.False(
+		t, drifted,
+		"no OCIRepository means SetupInstance will apply verify on create; "+
+			"reporting drift here would emit a change on every update",
+	)
+}
+
+func TestVerifyDriftedIsTrueWhenTheLiveSourceCarriesNoVerify(t *testing.T) {
+	withFakeCluster(t, newFakeOCIRepository(nil))
+
+	drifted, err := fluxinstaller.VerifyDrifted(
+		context.Background(), "", "", verifyingCluster(),
+	)
+	require.NoError(t, err)
+	assert.True(
+		t, drifted,
+		"this is platform#2922: verify configured, live source unverified, deploy green",
+	)
+}
+
+func TestVerifyDriftedIsFalseWhenTheLiveBlockAlreadyMatches(t *testing.T) {
+	clusterCfg := verifyingCluster()
+	// Seed the cluster with exactly what the patcher would write, so a
+	// re-assertion is provably a no-op rather than a per-update change.
+	withFakeCluster(t, newFakeOCIRepository(
+		fluxinstaller.BuildVerifyPatch(clusterCfg.Spec.Workload.Flux.Verify),
+	))
+
+	drifted, err := fluxinstaller.VerifyDrifted(context.Background(), "", "", clusterCfg)
+	require.NoError(t, err)
+	assert.False(t, drifted, "an already-verified source must not report drift")
+}
+
+func TestVerifyDriftedIsTrueWhenTheLiveBlockDiffers(t *testing.T) {
+	withFakeCluster(t, newFakeOCIRepository(map[string]any{"provider": "notation"}))
+
+	drifted, err := fluxinstaller.VerifyDrifted(
+		context.Background(), "", "", verifyingCluster(),
+	)
+	require.NoError(t, err)
+	assert.True(t, drifted, "a live block that differs from the configured one is drift")
+}
+
+// TestVerifyDriftedShortCircuitsBeforeReadingTheCluster pins that the guards run
+// before any client is built. Without this, a non-Flux or verify-disabled
+// cluster would pay a live API read — and a missing kubeconfig would surface as
+// a spurious warning on every update.
+func TestVerifyDriftedShortCircuitsBeforeReadingTheCluster(t *testing.T) {
+	tests := []struct {
+		name       string
+		clusterCfg *v1alpha1.Cluster
+	}{
+		{name: "nil cluster", clusterCfg: nil},
+		{
+			name: "non-Flux engine",
+			clusterCfg: func() *v1alpha1.Cluster {
+				clusterCfg := verifyingCluster()
+				clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineArgoCD
+
+				return clusterCfg
+			}(),
+		},
+		{
+			name: "verify not configured",
+			clusterCfg: func() *v1alpha1.Cluster {
+				clusterCfg := v1alpha1.NewCluster()
+				clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+
+				return clusterCfg
+			}(),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Both seams fail loudly: reaching either means a guard did not
+			// short-circuit. A stub returning success would let that pass.
+			restoreLoad := fluxinstaller.SetLoadRESTConfig(
+				func(_, _ string) (*rest.Config, error) {
+					t.Error("guard must short-circuit before building a REST config")
+
+					return nil, errUnexpectedClusterRead
+				},
+			)
+			t.Cleanup(restoreLoad)
+
+			restoreClient := fluxinstaller.SetNewUnstructuredClient(
+				func(_ *rest.Config) (dynamic.Interface, error) {
+					t.Error("guard must short-circuit before building a dynamic client")
+
+					return nil, errUnexpectedClusterRead
+				},
+			)
+			t.Cleanup(restoreClient)
+
+			drifted, err := fluxinstaller.VerifyDrifted(
+				context.Background(), "", "", testCase.clusterCfg,
+			)
+			require.NoError(t, err)
+			assert.False(t, drifted)
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production's root Flux source has been fetching the platform's infrastructure manifests **without checking any signature**, while every tenant artifact is signature-verified — the posture is inverted exactly where the blast radius is largest.

The signing policy was configured, and a previous fix put it on the key KSail actually reads. The deploy went green. The live cluster never picked it up, and nothing reported a problem. The reason is that KSail applies this setting only when it sets Flux up, and a routine deploy reaches that path only as a side effect of some *other* setting changing. So turning verification on for a running cluster quietly did nothing.

## What

KSail now notices when a cluster is missing the verification it was told to enforce, and re-applies it on the next update — the same way it already handles a rotated registry credential that the ordinary comparison cannot see. Turning verification on now takes effect on a live cluster instead of only at build time.

Part of devantler-tech/platform#2922