### PR TITLE
fix(credentials): rank an EKS ownership record above ambient AWS variables

### DIFF
--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -189,6 +189,21 @@ func (r AWSOptionsResolver) Value(key Key) string {
 	return resolveEnvValue(key, r.EnvVar(key))
 }
 
+// ExplicitResolver is the optional half of Resolver that separates a credential the operator set
+// deliberately — a secure-store entry, a Settings override — from one a resolver merely read out of
+// the ambient process environment.
+//
+// Resolver alone cannot express that difference: Value returns a string either way. The distinction
+// only matters where something more authoritative than current configuration exists to compare
+// against, which today is an EKS ownership record. Implement it on any resolver that has both
+// halves; a resolver whose values are all deliberate may return Value, and one with no deliberate
+// half should not implement it at all.
+type ExplicitResolver interface {
+	// ExplicitValue returns the deliberately-configured value for key, or "" when the resolver holds
+	// none — including when it could still resolve one from the ambient environment.
+	ExplicitValue(key Key) string
+}
+
 // RecordedAWSResolver resolves a cluster's lifecycle credentials through the variable names its own
 // immutable ownership record captured, while still honoring a base resolver's resolved values.
 //
@@ -214,7 +229,8 @@ type RecordedAWSResolver struct {
 }
 
 // NewRecordedAWSResolver layers one ownership record's captured variable names over base. A nil base
-// resolves from the canonical process environment.
+// resolves from the canonical process environment — which, carrying no deliberate operator intent,
+// now ranks behind the record rather than ahead of it.
 func NewRecordedAWSResolver(base Resolver, recorded v1alpha1.OptionsAWS) RecordedAWSResolver {
 	if base == nil {
 		base = EnvResolver{}
@@ -226,14 +242,35 @@ func NewRecordedAWSResolver(base Resolver, recorded v1alpha1.OptionsAWS) Recorde
 // EnvVar returns the variable name the ownership record captured for key.
 func (r RecordedAWSResolver) EnvVar(key Key) string { return r.recorded.EnvVar(key) }
 
-// Value returns the base resolver's value for key, falling back to the recorded alias when the base
-// resolves nothing.
+// Value resolves key as deliberate operator intent first, the ownership record second, and the
+// ambient environment last.
+//
+// Only a base that declares ExplicitResolver can outrank the record, and only with a value it holds
+// deliberately (a secure-store credential or a Settings override). A base's ambient fall-through
+// must not, because that is precisely the identity the record exists to pin: resolving it would
+// hand a mutation whatever AWS_ACCESS_KEY_ID happens to be exported, under a cluster whose create
+// ran through a different alias entirely.
+//
+// A base that declares no explicit channel is treated as ambient in full. That is the fail-closed
+// direction: a resolver that forgets to distinguish its two halves loses to the record rather than
+// silently overriding it.
 func (r RecordedAWSResolver) Value(key Key) string {
-	if value := r.base.Value(key); value != "" {
+	if explicit, ok := r.base.(ExplicitResolver); ok {
+		if value := explicit.ExplicitValue(key); value != "" {
+			return value
+		}
+	}
+
+	if value := r.recorded.Value(key); value != "" {
 		return value
 	}
 
-	return r.recorded.Value(key)
+	// Defensive: the constructor never leaves base nil, but the zero value can.
+	if r.base == nil {
+		return ""
+	}
+
+	return r.base.Value(key)
 }
 
 // AWSResolution is an immutable snapshot of an AWS credential selection. ResolveFrozenAWS upgrades

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -190,8 +190,9 @@ func (r AWSOptionsResolver) Value(key Key) string {
 }
 
 // ExplicitResolver is the optional half of Resolver that separates a credential the operator set
-// deliberately — a secure-store entry, a Settings override — from one a resolver merely read out of
-// the ambient process environment.
+// deliberately — a secure-store entry — from one a resolver merely read out of the ambient process
+// environment. A Settings entry is not deliberate in this sense: it names the variable to read, but
+// the value still comes from the environment, so it ranks as ambient.
 //
 // Resolver alone cannot express that difference: Value returns a string either way. The distinction
 // only matters where something more authoritative than current configuration exists to compare
@@ -214,9 +215,10 @@ type ExplicitResolver interface {
 // nothing about the record.
 //
 // Values rank deliberate operator intent first, the record second, and the ambient environment last
-// — see Value. A secure-store credential or Settings override still resolves exactly as before,
-// because it is name-independent intent; a base's environment fall-through does not, because that is
-// the ambient identity the record exists to pin. Names, by contrast, always come from the record,
+// — see Value. A secure-store credential still resolves exactly as before, because it is a stored
+// value rather than a name to read; a base's environment fall-through does not, because that is the
+// ambient identity the record exists to pin — and that includes a value read under a Settings-
+// configured name, which selects the variable but not its contents. Names always come from the record,
 // because the frozen resolution carries them onward to scrub child process environments — reporting
 // a canonical name for a value read from an alias would leave the alias in place for the provisioner
 // to re-resolve.

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -213,16 +213,18 @@ type ExplicitResolver interface {
 // A base resolver alone cannot do that, because it reports names from current settings and knows
 // nothing about the record.
 //
-// Values stay base-first, so this is strictly additive: a credential the base already resolves keeps
-// resolving exactly as before (including a secure-store value, which is name-independent operator
-// intent), and the recorded alias is consulted only where the base resolves nothing. Names, by
-// contrast, come from the record, because the frozen resolution carries them onward to scrub child
-// process environments — reporting a canonical name for a value read from an alias would leave the
-// alias in place for the provisioner to re-resolve.
+// Values rank deliberate operator intent first, the record second, and the ambient environment last
+// — see Value. A secure-store credential or Settings override still resolves exactly as before,
+// because it is name-independent intent; a base's environment fall-through does not, because that is
+// the ambient identity the record exists to pin. Names, by contrast, always come from the record,
+// because the frozen resolution carries them onward to scrub child process environments — reporting
+// a canonical name for a value read from an alias would leave the alias in place for the provisioner
+// to re-resolve.
 //
-// This narrows, and never widens, what a mutation may act on: where both the base and the record
-// resolve credentials for different accounts, the ownership verifier still fails closed on the
-// mismatch. The resolver owns its map and is safe for concurrent use.
+// This narrows, and never widens, what a mutation may act on: where the base and the record resolve
+// credentials for different accounts, the ownership verifier still fails closed on the mismatch.
+// Ranking the record above the ambient environment turns one such case from a refused mutation into
+// a working one, and never the reverse. The resolver owns its map and is safe for concurrent use.
 type RecordedAWSResolver struct {
 	base     Resolver
 	recorded AWSOptionsResolver

--- a/pkg/svc/credentials/credentials.go
+++ b/pkg/svc/credentials/credentials.go
@@ -243,17 +243,39 @@ func NewRecordedAWSResolver(base Resolver, recorded v1alpha1.OptionsAWS) Recorde
 	return RecordedAWSResolver{base: base, recorded: NewAWSOptionsResolver(recorded)}
 }
 
-// EnvVar returns the variable name the ownership record captured for key.
-func (r RecordedAWSResolver) EnvVar(key Key) string { return r.recorded.EnvVar(key) }
+// EnvVar returns the variable name the ownership record captured for key, or the base's name when
+// the record captured none.
+//
+// The captured name is checked directly rather than through recorded.EnvVar, which resolves an
+// absent mapping to the canonical default (see AWSOptionsResolver.EnvVar). Returning that default
+// would report a canonical name for a value the base resolved through its own alias, so the frozen
+// resolution would scrub the wrong variable and leave the alias in place.
+func (r RecordedAWSResolver) EnvVar(key Key) string {
+	if name := r.recorded.envVars[key]; name != "" {
+		return name
+	}
+
+	if r.base == nil {
+		return DefaultEnvVar(key)
+	}
+
+	return r.base.EnvVar(key)
+}
 
 // Value resolves key as deliberate operator intent first, the ownership record second, and the
 // ambient environment last.
 //
 // Only a base that declares ExplicitResolver can outrank the record, and only with a value it holds
-// deliberately (a secure-store credential or a Settings override). A base's ambient fall-through
-// must not, because that is precisely the identity the record exists to pin: resolving it would
-// hand a mutation whatever AWS_ACCESS_KEY_ID happens to be exported, under a cluster whose create
-// ran through a different alias entirely.
+// deliberately (a secure-store credential). A base's ambient fall-through must not, because that is
+// precisely the identity the record exists to pin: resolving it would hand a mutation whatever
+// AWS_ACCESS_KEY_ID happens to be exported, under a cluster whose create ran through a different
+// alias entirely. A Settings entry is ambient by this test — it selects the variable to read, not
+// its contents.
+//
+// The record only outranks the base for a key it actually captured. Consulting it for an unrecorded
+// key would resolve AWSOptionsResolver.EnvVar's canonical default and hand back the plain ambient
+// value — an opinion the record does not hold — which would beat the base's own Settings-selected
+// alias. So the captured name gates the lookup, not the resolved value.
 //
 // A base that declares no explicit channel is treated as ambient in full. That is the fail-closed
 // direction: a resolver that forgets to distinguish its two halves loses to the record rather than
@@ -265,8 +287,10 @@ func (r RecordedAWSResolver) Value(key Key) string {
 		}
 	}
 
-	if value := r.recorded.Value(key); value != "" {
-		return value
+	if r.recorded.envVars[key] != "" {
+		if value := r.recorded.Value(key); value != "" {
+			return value
+		}
 	}
 
 	// Defensive: the constructor never leaves base nil, but the zero value can.

--- a/pkg/svc/credentials/manager.go
+++ b/pkg/svc/credentials/manager.go
@@ -137,6 +137,18 @@ func (m *Manager) Value(key Key) string {
 	return resolveEnvValue(key, name)
 }
 
+// ExplicitValue returns only the stored secure-store value for key, never the environment fall-
+// through Value also performs. It is what lets a composed resolver tell an operator's deliberate
+// override apart from whatever the surrounding shell happens to export — see ExplicitResolver.
+func (m *Manager) ExplicitValue(key Key) string {
+	value, ok, err := m.store.Get(key)
+	if err != nil || !ok {
+		return ""
+	}
+
+	return value
+}
+
 // Overlay reconciles the process environment to match the stored credentials: it exports every
 // stored value under its configured variable name and unsets any variable it previously exported
 // that is no longer backed by a stored value (a cleared secret) or whose variable name changed. It

--- a/pkg/svc/credentials/recorded_aws_resolver_ambient_test.go
+++ b/pkg/svc/credentials/recorded_aws_resolver_ambient_test.go
@@ -140,3 +140,27 @@ func TestRecordedAWSResolverOverARealManager(t *testing.T) {
 	assert.Equal(t, "from-secure-store", resolver.Value(credentials.AWSAccessKeyID),
 		"a stored secure-store credential stopped outranking the ownership record")
 }
+
+// TestRecordedAWSResolverKeepsTheBaseAliasForAnUnrecordedKey pins a precedence gap that ranking the
+// record above the ambient environment introduced. The record captures a name for AccessKeyID only;
+// for every other key AWSOptionsResolver.EnvVar resolves the absent mapping to the CANONICAL
+// default, so consulting the record for an unrecorded key fabricated an opinion it does not hold —
+// the plain ambient value — and that outranked the base's own Settings-selected alias, which had
+// won before. Gating the lookup on the captured NAME rather than the resolved value is the fix.
+//
+// TestRecordedAWSResolverFallsBackToAmbientForAnUnrecordedKey cannot catch this: its stub configures
+// no alias, so the base and the record's canonical fallback read the same variable and agree.
+func TestRecordedAWSResolverKeepsTheBaseAliasForAnUnrecordedKey(t *testing.T) {
+	t.Setenv("AWS_SESSION_TOKEN", "ambient-canonical")
+	t.Setenv("SETTINGS_SESSION", "settings-alias")
+
+	base := explicitStubResolver{names: map[credentials.Key]string{
+		credentials.AWSSessionToken: "SETTINGS_SESSION",
+	}}
+	resolver := credentials.NewRecordedAWSResolver(base, aliasedOptions())
+
+	assert.Equal(t, "settings-alias", resolver.Value(credentials.AWSSessionToken),
+		"the record has no mapping here, so its canonical fallback must not beat the base alias")
+	assert.Equal(t, "SETTINGS_SESSION", resolver.EnvVar(credentials.AWSSessionToken),
+		"name and value must agree, or the frozen resolution scrubs the wrong variable")
+}

--- a/pkg/svc/credentials/recorded_aws_resolver_ambient_test.go
+++ b/pkg/svc/credentials/recorded_aws_resolver_ambient_test.go
@@ -1,0 +1,142 @@
+package credentials_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// explicitStubResolver stands in for the Settings/secure-store manager: it separates a *stored*
+// value (deliberate operator intent, name-independent) from the ambient environment value it would
+// otherwise fall through to. Only the stored half may outrank an ownership record.
+type explicitStubResolver struct {
+	stored map[credentials.Key]string
+	names  map[credentials.Key]string
+}
+
+func (s explicitStubResolver) EnvVar(key credentials.Key) string {
+	if name := s.names[key]; name != "" {
+		return name
+	}
+
+	return credentials.DefaultEnvVar(key)
+}
+
+// Value mirrors Manager.Value: a stored value when present, otherwise the process-environment value
+// for the configured (canonical, by default) variable name.
+func (s explicitStubResolver) Value(key credentials.Key) string {
+	if value := s.stored[key]; value != "" {
+		return value
+	}
+
+	return os.Getenv(s.EnvVar(key))
+}
+
+func (s explicitStubResolver) ExplicitValue(key credentials.Key) string { return s.stored[key] }
+
+func aliasedOptions() v1alpha1.OptionsAWS {
+	return v1alpha1.OptionsAWS{AccessKeyIDEnvVar: "RECORDED_ACCESS"}
+}
+
+// TestRecordedAWSResolverPrefersTheRecordOverAmbientCanonical is the defect this file was written
+// for. The web UI resolves through credentials.Manager, whose Value falls through to the canonical
+// process environment whenever nothing is stored. Composed under an ownership record, that fall-
+// through outranked the record — so a cluster created under a custom alias resolved whatever
+// AWS_ACCESS_KEY_ID happened to be set to, which is the ambient identity the record exists to pin.
+func TestRecordedAWSResolverPrefersTheRecordOverAmbientCanonical(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-account-a")
+	t.Setenv("RECORDED_ACCESS", "recorded-account-b")
+
+	resolver := credentials.NewRecordedAWSResolver(explicitStubResolver{}, aliasedOptions())
+
+	assert.Equal(t, "recorded-account-b", resolver.Value(credentials.AWSAccessKeyID),
+		"the ambient canonical variable displaced the alias the ownership record captured")
+}
+
+// TestRecordedAWSResolverStillPrefersAStoredValue keeps the deliberate half of the precedence
+// intact: a secure-store credential is name-independent operator intent and must still outrank the
+// record, exactly as before. This is the control for the test above — without it, the fix could
+// simply be "the record always wins", which would silently break Settings overrides.
+func TestRecordedAWSResolverStillPrefersAStoredValue(t *testing.T) {
+	t.Setenv("RECORDED_ACCESS", "recorded-account-b")
+
+	resolver := credentials.NewRecordedAWSResolver(
+		explicitStubResolver{stored: map[credentials.Key]string{
+			credentials.AWSAccessKeyID: "from-secure-store",
+		}},
+		aliasedOptions(),
+	)
+
+	assert.Equal(t, "from-secure-store", resolver.Value(credentials.AWSAccessKeyID),
+		"a stored secure-store credential stopped outranking the ownership record")
+}
+
+// TestRecordedAWSResolverFallsBackToAmbientForAnUnrecordedKey pins that the fix narrows nothing it
+// should not: a key the record carries no alias for still resolves from the environment, so an
+// operator who aliased only one variable does not lose the rest.
+func TestRecordedAWSResolverFallsBackToAmbientForAnUnrecordedKey(t *testing.T) {
+	t.Setenv("AWS_SESSION_TOKEN", "ambient-session")
+
+	resolver := credentials.NewRecordedAWSResolver(explicitStubResolver{}, aliasedOptions())
+
+	assert.Equal(t, "ambient-session", resolver.Value(credentials.AWSSessionToken),
+		"a key the record carries no alias for stopped resolving from the environment")
+}
+
+// TestRecordedAWSResolverWithNilBasePrefersTheRecord covers the CLI shape, where no Settings
+// resolver is injected at all. A nil base used to become a plain canonical EnvResolver, which put
+// the ambient environment ahead of the record for exactly the same reason.
+func TestRecordedAWSResolverWithNilBasePrefersTheRecord(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-account-a")
+	t.Setenv("RECORDED_ACCESS", "recorded-account-b")
+
+	resolver := credentials.NewRecordedAWSResolver(nil, aliasedOptions())
+
+	assert.Equal(t, "recorded-account-b", resolver.Value(credentials.AWSAccessKeyID),
+		"with no injected resolver the ambient canonical variable still displaced the record")
+}
+
+// TestRecordedAWSResolverNameAndValueAgree pins the property that made the defect more than a
+// precedence question. The frozen resolution carries EnvVar onward to scrub the child process
+// environment, so reporting the record's alias while returning a value read from the canonical
+// variable left the two describing different variables — and the scrub then missed the one the
+// value actually came from.
+func TestRecordedAWSResolverNameAndValueAgree(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-account-a")
+	t.Setenv("RECORDED_ACCESS", "recorded-account-b")
+
+	resolver := credentials.NewRecordedAWSResolver(explicitStubResolver{}, aliasedOptions())
+
+	name := resolver.EnvVar(credentials.AWSAccessKeyID)
+	require.Equal(t, "RECORDED_ACCESS", name)
+
+	assert.Equal(t, "recorded-account-b", resolver.Value(credentials.AWSAccessKeyID),
+		"EnvVar reported %q while Value came from a different variable", name)
+}
+
+// TestRecordedAWSResolverOverARealManager is the production shape: `ksail open web` composes the
+// ownership record over credentials.Manager, not over a stub. Manager.Value falls through to the
+// canonical environment whenever the secure store holds nothing, and that fall-through is what used
+// to outrank the record. Both arms run against a real Manager so the composition is proven where it
+// actually happens.
+func TestRecordedAWSResolverOverARealManager(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-account-a")
+	t.Setenv("RECORDED_ACCESS", "recorded-account-b")
+
+	manager, store := newManager(t)
+	resolver := credentials.NewRecordedAWSResolver(manager, aliasedOptions())
+
+	// Nothing stored: the record's alias must win over the ambient canonical variable.
+	assert.Equal(t, "recorded-account-b", resolver.Value(credentials.AWSAccessKeyID),
+		"Manager's ambient fall-through displaced the ownership record's alias")
+
+	// Stored: deliberate operator intent still outranks the record.
+	require.NoError(t, store.Set(credentials.AWSAccessKeyID, "from-secure-store"))
+	assert.Equal(t, "from-secure-store", resolver.Value(credentials.AWSAccessKeyID),
+		"a stored secure-store credential stopped outranking the ownership record")
+}

--- a/pkg/svc/credentials/recorded_aws_resolver_test.go
+++ b/pkg/svc/credentials/recorded_aws_resolver_test.go
@@ -26,6 +26,11 @@ func (s stubResolver) EnvVar(key credentials.Key) string {
 
 func (s stubResolver) Value(key credentials.Key) string { return s.values[key] }
 
+// ExplicitValue marks these values as deliberate operator intent — the secure-store half this stub
+// stands in for — rather than an ambient environment fall-through. Only that half may outrank an
+// ownership record; see credentials.ExplicitResolver.
+func (s stubResolver) ExplicitValue(key credentials.Key) string { return s.values[key] }
+
 func recordedOptions() v1alpha1.OptionsAWS {
 	return v1alpha1.OptionsAWS{
 		ProfileEnvVar:         "RECORDED_PROFILE",


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

An EKS cluster created through the web UI records the AWS variable names its create actually ran through, so later delete/start/stop can resolve the same identity. That record was being ignored whenever the operator also had a plain `AWS_ACCESS_KEY_ID` exported — the ambient value won instead.

The practical effect is a dead end: an operator whose shell points at a different account can no longer operate a cluster through the UI, even though the correct credentials are available under the recorded name. Ownership verification then refuses the mutation, so nothing acts on the wrong account — but the cluster becomes stuck rather than manageable.

## What

Credentials the operator set deliberately (secure store / Settings) still win, exactly as before. What changed is that a resolver's *ambient* fall-through no longer outranks the cluster's own ownership record — the record now sits between the two.

The safe direction is the default: a credential source that does not distinguish "deliberately configured" from "found in the environment" is treated as ambient, so it loses to the record rather than silently overriding it.

Fixes #6427