### PR TITLE
fix(cluster): detect and repair Flux artifact-verification drift on update

### DIFF
--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -932,6 +932,10 @@ func (o *updateOrchestrator) computeUpdateDiff(
 	// Check for registry credential drift (a rotated token behind an unchanged spec)
 	checkRegistryCredentialDrift(o.cmd, o.ctx, diffEngine, diff)
 
+	// Check for signature-verification drift (spec.workload.flux.verify configured
+	// but not applied to the live OCIRepository)
+	checkFluxVerifyDrift(o.cmd, o.ctx, diffEngine, diff)
+
 	promoteUnsupportedInPlaceChanges(updater, diff)
 
 	return currentSpec, diff, nil
@@ -1018,6 +1022,10 @@ func computeSpecOnlyDiff(
 
 	// Check for Flux distribution-version drift (spec.workload.flux.distributionVersion)
 	checkFluxDistributionVersionDrift(cmd, ctx, diffEngine, diff)
+
+	// Check for signature-verification drift (spec.workload.flux.verify configured
+	// but not applied to the live OCIRepository)
+	checkFluxVerifyDrift(cmd, ctx, diffEngine, diff)
 
 	return diff
 }
@@ -1261,6 +1269,53 @@ func checkRegistryCredentialDrift(
 	}
 
 	diffEngine.CheckRegistryCredential(drifted, diff)
+}
+
+// checkFluxVerifyDrift compares signature verification on the live flux-system
+// OCIRepository against the block the resolved configuration would render, and
+// appends an in-place change when they differ.
+//
+// This is the only signal a verification change produces. spec.workload.flux.verify
+// is applied by patching the OCIRepository the flux-operator generates, so it is
+// not a field the structural diff walks: configuring it yields no change, cluster
+// update runs no handler, and the infrastructure source stays unverified while the
+// configuration reads as correct (devantler-tech/platform#2922). Flux only. Errors
+// during cluster queries are logged as warnings and skipped; they should not block
+// the rest of the update.
+func checkFluxVerifyDrift(
+	cmd *cobra.Command,
+	ctx *localregistry.Context,
+	diffEngine *specdiff.Engine,
+	diff *clusterupdate.UpdateResult,
+) {
+	gitOpsEngine := ctx.ClusterCfg.Spec.Cluster.GitOpsEngine
+	if gitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return
+	}
+
+	if !ctx.ClusterCfg.Spec.Workload.Flux.Verify.Enabled() {
+		return
+	}
+
+	kubeconfigPath, err := kubeconfig.GetKubeconfigPathFromConfig(ctx.ClusterCfg)
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot resolve kubeconfig path for Flux verification drift detection: %v", err)
+
+		return
+	}
+
+	drifted, err := fluxinstaller.VerifyDrifted(
+		cmd.Context(), kubeconfigPath, resolveKubeContext(ctx), ctx.ClusterCfg,
+	)
+	if err != nil {
+		notify.Warningf(cmd.OutOrStderr(),
+			"Cannot compare Flux artifact verification for drift detection: %v", err)
+
+		return
+	}
+
+	diffEngine.CheckFluxVerify(drifted, gitOpsEngine, diff)
 }
 
 // getCurrentArgoCDTargetRevision queries the ArgoCD Application for its current

--- a/pkg/cli/cmd/cluster/reconcile_test.go
+++ b/pkg/cli/cmd/cluster/reconcile_test.go
@@ -46,6 +46,13 @@ func TestHandlerForField_KnownFields(t *testing.T) {
 		"cluster.autoscaler.node.expander",
 		"cluster.autoscaler.node.scaleDownUnneededTime",
 		"cluster.autoscaler.node.pools[my-pool]",
+		"cluster.workload.tag",
+		"cluster.workload.flux.distributionVersion",
+		// Signature verification sits in the same FluxConfig struct as
+		// distributionVersion and is applied by the same re-assert. Without a
+		// handler the diff is reported and then silently dropped, so a configured
+		// spec.verify never reaches the live OCIRepository (platform#2922).
+		"cluster.workload.flux.verify",
 	}
 
 	for _, field := range knownFields {

--- a/pkg/cli/cmd/cluster/reconciler.go
+++ b/pkg/cli/cmd/cluster/reconciler.go
@@ -147,6 +147,10 @@ func (r *componentReconciler) handlerForField(
 	}
 	handlers[specdiff.EKSLoadBalancerControllerField] = r.reconcileLoadBalancer
 	handlers[specdiff.RegistryCredentialField] = r.reconcileRegistryCredentials
+	// Re-asserting the FluxInstance also re-applies spec.verify to the generated
+	// OCIRepository, so signature-verification drift is repaired by the same
+	// handler that repairs a distribution-version change.
+	handlers[specdiff.FluxVerifyField] = r.reconcileFluxVersion
 
 	if handler, ok := handlers[field]; ok {
 		return handler, true

--- a/pkg/svc/diff/engine.go
+++ b/pkg/svc/diff/engine.go
@@ -23,6 +23,20 @@ const EKSLoadBalancerControllerField = "cluster.eks.experimentalAWSLoadBalancerC
 //nolint:gosec // G101 false positive: a diff key, not a credential.
 const RegistryCredentialField = "cluster.localRegistry.credentials"
 
+// FluxVerifyField is the diff key for signature verification on the flux-system
+// OCIRepository KSail generates. Reconciliation uses the same constant so field
+// renames cannot silently disconnect detection from application.
+const FluxVerifyField = "cluster.workload.flux.verify"
+
+// fluxVerifyOldDisplay and fluxVerifyNewDisplay are the values rendered for a
+// verification drift. The configured matchers are a policy, not a secret, but
+// they are long multi-line regexes: rendering them inline would bury the change
+// in the update output, so the change is reported as a state transition.
+const (
+	fluxVerifyOldDisplay = "unverified or stale"
+	fluxVerifyNewDisplay = "configured verification"
+)
+
 // registryCredentialOldDisplay and registryCredentialNewDisplay are the values
 // rendered for a credential rotation. The resolved credential — and any digest
 // of it — is deliberately never placed in a Change: Change values are printed by
@@ -156,6 +170,41 @@ func (e *Engine) CheckRegistryCredential(
 		NewValue: registryCredentialNewDisplay,
 		Category: clusterupdate.ChangeCategoryInPlace,
 		Reason:   "registry credentials can be refreshed in-place by re-writing the registry Secret",
+	})
+}
+
+// CheckFluxVerify appends an in-place change when signature verification on the
+// live flux-system OCIRepository has drifted from what the resolved configuration
+// would render. Flux only.
+//
+// This is the only signal a verification change produces. spec.workload.flux.verify
+// is applied by patching the OCIRepository the flux-operator generates, not by any
+// field the structural diff walks, so configuring it produces no field change of its
+// own — leaving the configured policy inert and the infrastructure source
+// unverified indefinitely (platform#2922).
+//
+// drifted is a single bit decided by the flux installer, which reads the live
+// resource and compares it against the rendered block.
+func (e *Engine) CheckFluxVerify(
+	drifted bool,
+	gitOpsEngine v1alpha1.GitOpsEngine,
+	result *clusterupdate.UpdateResult,
+) {
+	if gitOpsEngine != v1alpha1.GitOpsEngineFlux {
+		return
+	}
+
+	if !drifted {
+		return
+	}
+
+	routeChange(result, clusterupdate.Change{
+		Field:    FluxVerifyField,
+		OldValue: fluxVerifyOldDisplay,
+		NewValue: fluxVerifyNewDisplay,
+		Category: clusterupdate.ChangeCategoryInPlace,
+		Reason: "artifact signature verification can be applied in-place by " +
+			"re-asserting the FluxInstance",
 	})
 }
 

--- a/pkg/svc/diff/flux_verify_test.go
+++ b/pkg/svc/diff/flux_verify_test.go
@@ -1,0 +1,87 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+)
+
+func newVerifyEngine() *specdiff.Engine {
+	return specdiff.NewEngine(v1alpha1.DistributionTalos, v1alpha1.ProviderHetzner)
+}
+
+// TestCheckFluxVerifyDetectsDrift is the core of platform#2922: spec.verify is
+// applied by patching a resource the flux-operator generates, so it is not a
+// field the structural diff walks. Without this change the configured policy
+// produces no diff entry, cluster update runs no handler, and the infrastructure
+// source stays unverified while the configuration reads as correct.
+func TestCheckFluxVerifyDetectsDrift(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	newVerifyEngine().CheckFluxVerify(true, v1alpha1.GitOpsEngineFlux, result)
+
+	if len(result.InPlaceChanges) != 1 {
+		t.Fatalf(
+			"drifted verification must produce exactly one in-place change, got %d",
+			len(result.InPlaceChanges),
+		)
+	}
+
+	change := result.InPlaceChanges[0]
+	if change.Field != specdiff.FluxVerifyField {
+		t.Errorf("field = %q, want %q", change.Field, specdiff.FluxVerifyField)
+	}
+
+	if change.Category != clusterupdate.ChangeCategoryInPlace {
+		t.Errorf(
+			"category = %q, want in-place — re-asserting the FluxInstance never demands recreation",
+			change.Category,
+		)
+	}
+}
+
+// TestCheckFluxVerifyIgnoresUndriftedState is the discriminating control: an
+// engine that appended unconditionally would pass the test above and make every
+// update report a phantom verification change.
+func TestCheckFluxVerifyIgnoresUndriftedState(t *testing.T) {
+	t.Parallel()
+
+	result := clusterupdate.NewEmptyUpdateResult()
+	newVerifyEngine().CheckFluxVerify(false, v1alpha1.GitOpsEngineFlux, result)
+
+	if len(result.InPlaceChanges) != 0 {
+		t.Errorf(
+			"undrifted verification must produce no change, got %d",
+			len(result.InPlaceChanges),
+		)
+	}
+}
+
+// TestCheckFluxVerifyIgnoresNonFluxEngines pins the engine guard. spec.verify is
+// a Flux OCIRepository field; reporting it against ArgoCD would surface a change
+// whose handler has nothing to patch.
+func TestCheckFluxVerifyIgnoresNonFluxEngines(t *testing.T) {
+	t.Parallel()
+
+	for _, engine := range []v1alpha1.GitOpsEngine{
+		v1alpha1.GitOpsEngineArgoCD,
+		v1alpha1.GitOpsEngineNone,
+	} {
+		t.Run(string(engine), func(t *testing.T) {
+			t.Parallel()
+
+			result := clusterupdate.NewEmptyUpdateResult()
+			newVerifyEngine().CheckFluxVerify(true, engine, result)
+
+			if len(result.InPlaceChanges) != 0 {
+				t.Errorf(
+					"engine %q must produce no verification change, got %d",
+					engine, len(result.InPlaceChanges),
+				)
+			}
+		})
+	}
+}

--- a/pkg/svc/installer/flux/export_test.go
+++ b/pkg/svc/installer/flux/export_test.go
@@ -73,6 +73,11 @@ func BuildVerifyPatch(cfg v1alpha1.FluxVerifySpec) map[string]any {
 	return buildVerifyPatch(cfg)
 }
 
+// VerifyDrift exports verifyDrift for testing.
+func VerifyDrift(current map[string]any, repoFound bool, cfg v1alpha1.FluxVerifySpec) bool {
+	return verifyDrift(current, repoFound, cfg)
+}
+
 // ApplyVerify exports applyVerify for testing.
 func ApplyVerify(obj map[string]any, desired map[string]any) (bool, error) {
 	return applyVerify(obj, desired)

--- a/pkg/svc/installer/flux/ocirepository_verify_drift.go
+++ b/pkg/svc/installer/flux/ocirepository_verify_drift.go
@@ -1,0 +1,124 @@
+package fluxinstaller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	fluxclient "github.com/devantler-tech/ksail/v7/pkg/client/flux"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// VerifyDrifted reports whether the live flux-system OCIRepository's spec.verify
+// differs from the block the resolved configuration would render.
+//
+// It exists because signature verification is applied by patching a resource the
+// flux-operator generates, not by a field the structural diff walks. Without this
+// comparison, configuring spec.workload.flux.verify produces no change at all, so
+// cluster update runs no handler and the infrastructure source stays unverified —
+// the config half correct and the enforcement half off (platform#2922).
+//
+// It reports false — never an error — when there is nothing to compare against:
+// verification is not configured, or the OCIRepository does not exist yet. A
+// missing resource is a bootstrap that has not reached the patch step, not drift.
+//
+// Verification being configured while the live resource carries no spec.verify is
+// the opposite case and reports true. That is precisely the reported defect, and
+// re-asserting the FluxInstance is the repair.
+//
+// kubeContext selects the cluster to read. It must be the same context the
+// subsequent patch targets, or drift detected on one cluster would be repaired on
+// another.
+func VerifyDrifted(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+	clusterCfg *v1alpha1.Cluster,
+) (bool, error) {
+	if clusterCfg == nil {
+		return false, nil
+	}
+
+	cfg := clusterCfg.Spec.Workload.Flux.Verify
+	if !cfg.Enabled() {
+		return false, nil
+	}
+
+	current, found, err := currentOCIRepositoryVerify(ctx, kubeconfig, kubeContext)
+	if err != nil {
+		return false, err
+	}
+
+	return verifyDrift(current, found, cfg), nil
+}
+
+// verifyDrift decides the drift bit from the live spec.verify block and the
+// configured one. Split out so the decision is testable without a cluster.
+//
+// repoFound=false means the OCIRepository does not exist yet: bootstrap has not
+// reached the patch step, so there is nothing an update could repair.
+func verifyDrift(
+	current map[string]any,
+	repoFound bool,
+	cfg v1alpha1.FluxVerifySpec,
+) bool {
+	if !repoFound {
+		return false
+	}
+
+	return !reflect.DeepEqual(current, buildVerifyPatch(cfg))
+}
+
+// currentOCIRepositoryVerify reads spec.verify from the live flux-system
+// OCIRepository. found reports whether the OCIRepository itself exists; a resource
+// that exists with no spec.verify returns (nil, true, nil), which is drift when
+// verification is configured.
+func currentOCIRepositoryVerify(
+	ctx context.Context,
+	kubeconfig, kubeContext string,
+) (map[string]any, bool, error) {
+	restConfig, err := loadRESTConfig(kubeconfig, kubeContext)
+	if err != nil {
+		return nil, false, fmt.Errorf("build REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, false, fmt.Errorf("create dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    sourcev1.GroupVersion.Group,
+		Version:  sourcev1.GroupVersion.Version,
+		Resource: "ocirepositories",
+	}
+
+	repo, err := dynamicClient.Resource(gvr).
+		Namespace(fluxclient.DefaultNamespace).
+		Get(ctx, defaultOCIRepositoryName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+
+		return nil, false, fmt.Errorf("get OCIRepository: %w", err)
+	}
+
+	verify, verifyFound, err := unstructured.NestedMap(repo.Object, "spec", "verify")
+	if err != nil {
+		// A spec.verify of an unexpected shape is not a value KSail can compare
+		// against, so report it absent and let the patch overwrite it.
+		return nil, true, nil //nolint:nilerr // malformed live value is drift, not a caller error
+	}
+
+	if !verifyFound {
+		return nil, true, nil
+	}
+
+	return verify, true, nil
+}

--- a/pkg/svc/installer/flux/ocirepository_verify_drift_test.go
+++ b/pkg/svc/installer/flux/ocirepository_verify_drift_test.go
@@ -33,8 +33,11 @@ func TestVerifyDriftUnverifiedRepositoryIsDrift(t *testing.T) {
 
 	drifted := fluxinstaller.VerifyDrift(nil, true, keylessVerifySpec())
 
-	assert.True(t, drifted,
-		"a configured verification policy over a live OCIRepository with no spec.verify must be drift")
+	assert.True(
+		t,
+		drifted,
+		"a configured verification policy over a live OCIRepository with no spec.verify must be drift",
+	)
 }
 
 // TestVerifyDriftMatchingBlockIsNotDrift is the discriminating control for the
@@ -64,13 +67,13 @@ func TestVerifyDriftChangedMatcherIsDrift(t *testing.T) {
 	live := fluxinstaller.BuildVerifyPatch(spec)
 
 	// Same shape, different signer subject — the live policy trusts someone else.
-	matchers, ok := live["matchOIDCIdentity"].([]any)
-	if !ok || len(matchers) == 0 {
+	matchers, isSlice := live["matchOIDCIdentity"].([]any)
+	if !isSlice || len(matchers) == 0 {
 		t.Fatalf("expected rendered matchOIDCIdentity, got %#v", live["matchOIDCIdentity"])
 	}
 
-	matcher, ok := matchers[0].(map[string]any)
-	if !ok {
+	matcher, isMap := matchers[0].(map[string]any)
+	if !isMap {
 		t.Fatalf("expected matcher map, got %#v", matchers[0])
 	}
 
@@ -91,4 +94,53 @@ func TestVerifyDriftAbsentRepositoryIsNotDrift(t *testing.T) {
 
 	assert.False(t, drifted,
 		"an OCIRepository that does not exist yet is a bootstrap gap, not drift")
+}
+
+// TestVerifyDriftAgreesWithApplyVerify pins the two halves of the loop against
+// each other.
+//
+// The detector decides whether cluster update reports a change; applyVerify
+// decides whether the resulting patch actually writes anything. They compare the
+// same two values today, and nothing but this test stops them drifting apart. If
+// the detector ever calls drift on a block applyVerify considers settled, every
+// update reports a verification change forever and the handler quietly no-ops —
+// a permanently dirty diff that no amount of reconciling clears.
+//
+// The states are asserted in both directions, so a detector hardwired to either
+// answer fails.
+func TestVerifyDriftAgreesWithApplyVerify(t *testing.T) {
+	t.Parallel()
+
+	spec := keylessVerifySpec()
+
+	for name, live := range map[string]map[string]any{
+		"already verified": fluxinstaller.BuildVerifyPatch(spec),
+		"unverified":       nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := map[string]any{"spec": map[string]any{}}
+			if live != nil {
+				obj["spec"] = map[string]any{"verify": live}
+			}
+
+			settled, err := fluxinstaller.ApplyVerify(obj, fluxinstaller.BuildVerifyPatch(spec))
+			if err != nil {
+				t.Fatalf("applyVerify: %v", err)
+			}
+
+			drifted := fluxinstaller.VerifyDrift(live, true, spec)
+
+			assert.Equal(
+				t,
+				settled,
+				!drifted,
+				"detector and patcher disagree on %q: applyVerify settled=%v, VerifyDrift drifted=%v",
+				name,
+				settled,
+				drifted,
+			)
+		})
+	}
 }

--- a/pkg/svc/installer/flux/ocirepository_verify_drift_test.go
+++ b/pkg/svc/installer/flux/ocirepository_verify_drift_test.go
@@ -1,0 +1,94 @@
+package fluxinstaller_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	fluxinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/flux"
+	"github.com/stretchr/testify/assert"
+)
+
+// keylessVerifySpec is the shape the platform actually configures: cosign
+// keyless with pinned OIDC identity matchers.
+func keylessVerifySpec() v1alpha1.FluxVerifySpec {
+	return v1alpha1.FluxVerifySpec{
+		Provider: "cosign",
+		MatchOIDCIdentity: []v1alpha1.FluxVerifyOIDCIdentity{
+			{
+				Issuer:  `^https://token\.actions\.githubusercontent\.com$`,
+				Subject: `^https://github\.com/devantler-tech/platform/.+$`,
+			},
+		},
+	}
+}
+
+// TestVerifyDriftUnverifiedRepositoryIsDrift is the core of platform#2922: the
+// configuration carries a verification policy and the live OCIRepository carries
+// no spec.verify at all. That is exactly the state read off the prod cluster —
+// config half correct, enforcement half off — and it must register as drift, or
+// cluster update has nothing to act on and the infrastructure source stays
+// unverified indefinitely.
+func TestVerifyDriftUnverifiedRepositoryIsDrift(t *testing.T) {
+	t.Parallel()
+
+	drifted := fluxinstaller.VerifyDrift(nil, true, keylessVerifySpec())
+
+	assert.True(t, drifted,
+		"a configured verification policy over a live OCIRepository with no spec.verify must be drift")
+}
+
+// TestVerifyDriftMatchingBlockIsNotDrift is the discriminating control for the
+// test above: the same spec against a live block that already matches must NOT
+// report drift. Without this, a VerifyDrift that simply returned true would pass
+// the defect test and make every update re-patch an already-correct resource.
+func TestVerifyDriftMatchingBlockIsNotDrift(t *testing.T) {
+	t.Parallel()
+
+	spec := keylessVerifySpec()
+	live := fluxinstaller.BuildVerifyPatch(spec)
+
+	drifted := fluxinstaller.VerifyDrift(live, true, spec)
+
+	assert.False(t, drifted,
+		"a live spec.verify already equal to the configured block must not report drift")
+}
+
+// TestVerifyDriftChangedMatcherIsDrift pins that the comparison actually reads
+// the matcher contents rather than merely checking that some verify block is
+// present. A relaxed or repointed signer identity is a security-relevant change
+// and must be repaired.
+func TestVerifyDriftChangedMatcherIsDrift(t *testing.T) {
+	t.Parallel()
+
+	spec := keylessVerifySpec()
+	live := fluxinstaller.BuildVerifyPatch(spec)
+
+	// Same shape, different signer subject — the live policy trusts someone else.
+	matchers, ok := live["matchOIDCIdentity"].([]any)
+	if !ok || len(matchers) == 0 {
+		t.Fatalf("expected rendered matchOIDCIdentity, got %#v", live["matchOIDCIdentity"])
+	}
+
+	matcher, ok := matchers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected matcher map, got %#v", matchers[0])
+	}
+
+	matcher["subject"] = `^https://github\.com/someone-else/.+$`
+
+	drifted := fluxinstaller.VerifyDrift(live, true, spec)
+
+	assert.True(t, drifted, "a live matcher trusting a different signer must report drift")
+}
+
+// TestVerifyDriftAbsentRepositoryIsNotDrift pins the bootstrap guard. Before the
+// flux-operator has generated the OCIRepository there is nothing an update could
+// patch, so reporting drift would fabricate a change that no handler can satisfy.
+func TestVerifyDriftAbsentRepositoryIsNotDrift(t *testing.T) {
+	t.Parallel()
+
+	drifted := fluxinstaller.VerifyDrift(nil, false, keylessVerifySpec())
+
+	assert.False(t, drifted,
+		"an OCIRepository that does not exist yet is a bootstrap gap, not drift")
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A cluster can be configured to require signed infrastructure artifacts and still run completely unverified, with nothing anywhere reporting a problem.

Signature verification is configured under `spec.workload.flux.verify`. KSail applies it by patching the OCIRepository that the flux-operator generates — which means it is not one of the fields `cluster update` compares. So configuring verification produced no detected change, `cluster update` had no work to do, and the setting never reached the running cluster. The config read as correct, validation passed, and the artifact source was still accepting anything.

This was found live on a production cluster: the policy had been configured and merged, deploys had run since, and the live resource still carried no verification at all.

## What

`cluster update` now compares verification on the live resource against what the configuration asks for, and repairs the difference — the same way it already handles a rotated registry credential. Because it compares against live state rather than reacting to a config edit, it also repairs a cluster that has drifted for any other reason, and it stays quiet when everything already matches.

A cluster still being built for the first time is deliberately left alone: there is nothing to repair before the resource exists.

Part of devantler-tech/platform#2922