### PR TITLE
ci: adopt the default-branch validation flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -354,6 +354,24 @@ jobs:
       && github.event.pull_request.head.repo.full_name == github.repository
       && needs.changes.outputs.govuln-allowlist == 'true')
     uses: devantler-tech/actions/.github/workflows/validate-go-project.yaml@4f9b2bb971efb754b719e8ecb39bdf74b2490c33 # v13.0.0
+    # Both inputs make a default-branch run answer "did the check run" rather than
+    # "did the diff touch a Go file". On main the branch's green IS the protection
+    # signal, so a path filter that skips the suite or the scan leaves main green
+    # over breakage it never looked at:
+    #
+    #   * scan-default-branch — an advisory published against already-merged code
+    #     makes unchanged code vulnerable. A diff filter structurally cannot see
+    #     that, so main stayed unscanned until someone happened to touch a Go file.
+    #
+    #   * test-default-branch — a Go test may read a non-Go file as its subject, so
+    #     a commit touching only those files skips the suite while breaking it.
+    #
+    # Both ship default-false in the reusable workflow so consumers adopt them one
+    # at a time; ksail is its only caller, so this completes the rollout and both
+    # inputs can then be retired (devantler-tech/actions#788, ksail#6373).
+    with:
+      scan-default-branch: true
+      test-default-branch: true
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

KSail's `main` reports green when nobody actually checked. Its CI decides whether to run the Go test suite and the vulnerability scan by asking *"did this diff touch a Go file"* — a reasonable question on a pull request, and the wrong one on the default branch, where that green **is** the branch-protection signal.

Two ways it goes wrong today: a security advisory published against code that was already merged makes unchanged code vulnerable, and a diff filter structurally cannot see that; and a Go test can read a non-Go file as its subject, so a commit touching only those files skips the suite while breaking it.

Both corrections shipped some time ago behind opt-in switches, defaulted off so consumers could adopt them one at a time. Nobody adopted them. KSail is the only caller in the organisation, so the rollout has been sitting at zero and the fixes have been protecting nothing.

## What

KSail now turns both on. A default-branch run scans for vulnerabilities and runs the Go suite regardless of what the diff touched.

The intended consequence is that `main` can now go red where it was previously green — that is the point, not a regression. Anything it surfaces is real and gets triaged as such.

With this the rollout is complete for the only consumer, so both switches can be retired next (devantler-tech/actions#788, #6373).

Fixes #6446


**Merge order: #6487 lands first.** The K3s system tests here are red because of the k3s unpromoted-release defect (#6486), not because of this change; #6487 fixes it and turns them green.
