### PR TITLE
fix(update): only offer Kubernetes upgrades the distribution has promoted

### DIFF
--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -176,7 +176,7 @@ func (o *updateOrchestrator) reconcileClusterVersions(
 		return false, fmt.Errorf("failed to get current versions: %w", err)
 	}
 
-	resolver := versionresolver.NewOCIResolver()
+	resolver := versionresolver.NewPromotionAwareResolver(versionresolver.NewOCIResolver())
 
 	// Distribution version first (the runtime must support the target K8s version).
 	recreated, err := o.reconcileDistributionVersion(upgrader, resolver, currentVersions)

--- a/pkg/cli/cmd/cluster/version_drift.go
+++ b/pkg/cli/cmd/cluster/version_drift.go
@@ -51,7 +51,7 @@ func mergeVersionDrift(
 		return
 	}
 
-	resolver := versionresolver.NewOCIResolver()
+	resolver := versionresolver.NewPromotionAwareResolver(versionresolver.NewOCIResolver())
 
 	for _, dimension := range versionDimensions(ctx, upgrader, current) {
 		mergeDimensionDrift(cmd, mainDiff, resolver, dimension)

--- a/pkg/svc/versionresolver/k3schannel.go
+++ b/pkg/svc/versionresolver/k3schannel.go
@@ -58,9 +58,16 @@ type k3sChannelsResponse struct {
 }
 
 // PromotedTags returns the registry tags k3s has promoted, taken from the
-// "latest" pointer of every channel it publishes. Each channel names the newest
-// promoted release for its stream, so the union across channels is the set of
-// releases k3s considers out.
+// "latest" pointer of every channel it publishes that names a final release.
+// Each channel names the newest promoted release for its stream, so the union
+// across channels is the set of releases k3s considers out.
+//
+// Pre-releases are excluded. k3s publishes "testing" channels alongside the
+// stable ones, and their latest is a release candidate rather than a release, so
+// an unfiltered union would offer a cluster an upgrade onto an rc build — the
+// same class of unreleased-version upgrade this source exists to prevent. The
+// test is the version's own semver pre-release segment rather than the channel
+// name, so a differently-named pre-release channel is caught too.
 func (s *K3sChannelSource) PromotedTags(ctx context.Context) (map[string]struct{}, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, K3sChannelsURL, nil)
 	if err != nil {
@@ -90,7 +97,7 @@ func (s *K3sChannelSource) PromotedTags(ctx context.Context) (map[string]struct{
 	tags := make(map[string]struct{}, len(parsed.Data))
 
 	for _, channel := range parsed.Data {
-		if channel.Latest == "" {
+		if channel.Latest == "" || k3sVersionIsPreRelease(channel.Latest) {
 			continue
 		}
 
@@ -104,6 +111,19 @@ func (s *K3sChannelSource) PromotedTags(ctx context.Context) (map[string]struct{
 	}
 
 	return tags, nil
+}
+
+// k3sVersionIsPreRelease reports whether a channel version names a pre-release
+// ("v1.18.2-rc3+k3s1") rather than a final release ("v1.36.2+k3s1").
+//
+// In semver the pre-release segment sits between the version core and the "+"
+// build metadata, and k3s puts its "k3s1" suffix in that build metadata. The
+// version core is digits and dots only, so a "-" anywhere before the "+" is a
+// pre-release marker and nothing else.
+func k3sVersionIsPreRelease(version string) bool {
+	core, _, _ := strings.Cut(version, "+")
+
+	return strings.Contains(core, "-")
 }
 
 // K3sChannelVersionToTag converts a k3s channel version to its registry tag.

--- a/pkg/svc/versionresolver/k3schannel.go
+++ b/pkg/svc/versionresolver/k3schannel.go
@@ -1,0 +1,115 @@
+package versionresolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// K3sImageRef is the repository k3d pulls its node image from.
+	K3sImageRef = "rancher/k3s"
+
+	// K3sChannelsURL is k3s' own release-channel index — the authority the k3s
+	// installer itself consults. A release appears here only once k3s promotes
+	// it, which is what makes it usable as a promotion signal; the registry tag
+	// appears earlier.
+	K3sChannelsURL = "https://update.k3s.io/v1-release/channels"
+
+	// k3sChannelTimeout bounds the channel lookup so a hung endpoint cannot
+	// stall a cluster update indefinitely.
+	k3sChannelTimeout = 15 * time.Second
+)
+
+// K3sChannelSource reports the k3s releases that have been promoted to a
+// release channel.
+//
+// The endpoint is fixed: there is no legitimate reason to ask a different host
+// which k3s releases exist, so the URL is a constant rather than a field. Tests
+// redirect it by supplying a client whose transport points elsewhere.
+type K3sChannelSource struct {
+	client *http.Client
+}
+
+// NewK3sChannelSource returns a source backed by k3s' public channel index.
+func NewK3sChannelSource() *K3sChannelSource {
+	return &K3sChannelSource{client: &http.Client{Timeout: k3sChannelTimeout}}
+}
+
+// NewK3sChannelSourceWithClient injects the HTTP client, so a caller (or a
+// test) can supply its own transport, timeout, or proxy.
+func NewK3sChannelSourceWithClient(client *http.Client) *K3sChannelSource {
+	if client == nil {
+		client = &http.Client{Timeout: k3sChannelTimeout}
+	}
+
+	return &K3sChannelSource{client: client}
+}
+
+// k3sChannelsResponse is the subset of the channel index this package reads.
+type k3sChannelsResponse struct {
+	Data []struct {
+		Name   string `json:"name"`
+		Latest string `json:"latest"`
+	} `json:"data"`
+}
+
+// PromotedTags returns the registry tags k3s has promoted, taken from the
+// "latest" pointer of every channel it publishes. Each channel names the newest
+// promoted release for its stream, so the union across channels is the set of
+// releases k3s considers out.
+func (s *K3sChannelSource) PromotedTags(ctx context.Context) (map[string]struct{}, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, K3sChannelsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building k3s channel request: %w", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("querying k3s release channels: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"%w: k3s release channels returned %s", ErrRegistryAccess, resp.Status,
+		)
+	}
+
+	var parsed k3sChannelsResponse
+
+	err = json.NewDecoder(resp.Body).Decode(&parsed)
+	if err != nil {
+		return nil, fmt.Errorf("decoding k3s release channels: %w", err)
+	}
+
+	tags := make(map[string]struct{}, len(parsed.Data))
+
+	for _, channel := range parsed.Data {
+		if channel.Latest == "" {
+			continue
+		}
+
+		tags[K3sChannelVersionToTag(channel.Latest)] = struct{}{}
+	}
+
+	if len(tags) == 0 {
+		return nil, fmt.Errorf(
+			"%w: k3s release channels listed no promoted versions", ErrNoVersionsFound,
+		)
+	}
+
+	return tags, nil
+}
+
+// K3sChannelVersionToTag converts a k3s channel version to its registry tag.
+// The channel index uses semver build metadata ("v1.36.2+k3s1") while the
+// registry tag replaces "+" with "-" ("v1.36.2-k3s1"), because "+" is not a
+// legal character in an OCI tag.
+func K3sChannelVersionToTag(version string) string {
+	return strings.ReplaceAll(version, "+", "-")
+}

--- a/pkg/svc/versionresolver/promotion.go
+++ b/pkg/svc/versionresolver/promotion.go
@@ -1,0 +1,91 @@
+package versionresolver
+
+import (
+	"context"
+	"fmt"
+)
+
+// PromotionSource reports the registry tags a distribution has promoted to a
+// release channel.
+//
+// An OCI registry serves an image the moment its tag is pushed. For some
+// distributions that happens well before — or entirely without — the release
+// being promoted for general use, so the tag list alone cannot answer "is this
+// release out yet". k3s is the standing example: it pushes rancher/k3s:<tag> at
+// tag time and moves its stable channel only after the release is promoted.
+type PromotionSource interface {
+	// PromotedTags returns the registry tags (e.g. "v1.36.2-k3s1") the
+	// distribution has promoted. An empty result is an error, not an empty set:
+	// silently returning nothing would read as "no upgrades available" and hide
+	// a broken source.
+	PromotedTags(ctx context.Context) (map[string]struct{}, error)
+}
+
+// promotionAwareResolver constrains a base Resolver to the versions the
+// distribution publishing the image has actually promoted.
+type promotionAwareResolver struct {
+	base    Resolver
+	sources map[string]PromotionSource
+}
+
+// NewPromotionAwareResolver wraps base so that images from a distribution with
+// a known release channel are filtered to promoted versions only. Images with
+// no registered source pass through unchanged, so distributions whose registry
+// tags already mean "released" keep their existing behaviour.
+func NewPromotionAwareResolver(base Resolver) Resolver {
+	return &promotionAwareResolver{base: base, sources: defaultPromotionSources()}
+}
+
+// NewPromotionAwareResolverWithSources injects the promotion sources instead of
+// using the defaults, so a caller (or a test) can resolve without reaching the
+// network.
+func NewPromotionAwareResolverWithSources(
+	base Resolver, sources map[string]PromotionSource,
+) Resolver {
+	return &promotionAwareResolver{base: base, sources: sources}
+}
+
+// defaultPromotionSources maps an image reference to the authority on whether a
+// given tag of it has been promoted.
+func defaultPromotionSources() map[string]PromotionSource {
+	return map[string]PromotionSource{
+		K3sImageRef: NewK3sChannelSource(),
+	}
+}
+
+// ListVersions returns the base resolver's versions, minus any the
+// distribution has not promoted.
+func (r *promotionAwareResolver) ListVersions(
+	ctx context.Context, imageRef string,
+) ([]Version, error) {
+	versions, err := r.base.ListVersions(ctx, imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("listing versions for %s: %w", imageRef, err)
+	}
+
+	source, ok := r.sources[imageRef]
+	if !ok {
+		return versions, nil
+	}
+
+	promoted, err := source.PromotedTags(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving promoted versions for %s: %w", imageRef, err)
+	}
+
+	return FilterPromoted(versions, promoted), nil
+}
+
+// FilterPromoted returns only the versions whose original tag appears in
+// promoted.
+func FilterPromoted(versions []Version, promoted map[string]struct{}) []Version {
+	result := make([]Version, 0, len(versions))
+
+	for _, v := range versions {
+		if _, ok := promoted[v.Original]; ok {
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/pkg/svc/versionresolver/promotion_test.go
+++ b/pkg/svc/versionresolver/promotion_test.go
@@ -197,6 +197,51 @@ func TestK3sChannelSource_PromotedTags(t *testing.T) {
 	}
 }
 
+// TestK3sChannelSource_ExcludesPreReleases pins that a channel pointing at a
+// pre-release is not promotion evidence. k3s publishes "testing" channels whose
+// latest is a release candidate (live index, 2026-08-05: testing and
+// v1.18-testing both point at v1.18.2-rc3+k3s1), so a plain union across every
+// channel would offer a cluster an upgrade onto an rc build.
+func TestK3sChannelSource_ExcludesPreReleases(t *testing.T) {
+	t.Parallel()
+
+	body := `{"data":[
+		{"name":"stable","latest":"v1.36.2+k3s1"},
+		{"name":"v1.18","latest":"v1.18.20+k3s1"},
+		{"name":"testing","latest":"v1.18.2-rc3+k3s1"},
+		{"name":"v1.18-testing","latest":"v1.18.2-rc3+k3s1"}
+	]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	source := versionresolver.NewK3sChannelSourceWithClient(channelClientFor(t, server))
+
+	tags, err := source.PromotedTags(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := tags["v1.18.2-rc3-k3s1"]; ok {
+		t.Errorf("release candidate v1.18.2-rc3-k3s1 was read as promoted, got %v", tags)
+	}
+
+	// The stable streams either side of it must still be offered — excluding
+	// pre-releases must not also exclude a minor stream's real release.
+	for _, want := range []string{"v1.36.2-k3s1", "v1.18.20-k3s1"} {
+		if _, ok := tags[want]; !ok {
+			t.Errorf("expected promoted release %q to survive, got %v", want, tags)
+		}
+	}
+
+	if len(tags) != 2 {
+		t.Fatalf("expected exactly 2 promoted tags, got %d (%v)", len(tags), tags)
+	}
+}
+
 // TestK3sChannelSource_EmptyIsAnError pins that an index listing nothing is
 // reported rather than read as "no upgrades available".
 func TestK3sChannelSource_EmptyIsAnError(t *testing.T) {

--- a/pkg/svc/versionresolver/promotion_test.go
+++ b/pkg/svc/versionresolver/promotion_test.go
@@ -1,0 +1,216 @@
+package versionresolver_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/versionresolver"
+)
+
+// errPromotion is returned by the failing stub below.
+var errPromotion = errors.New("channel unavailable")
+
+// stubPromotionSource implements PromotionSource without network access.
+type stubPromotionSource struct {
+	tags map[string]struct{}
+	err  error
+}
+
+func (s *stubPromotionSource) PromotedTags(_ context.Context) (map[string]struct{}, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.tags, nil
+}
+
+// rewriteTransport redirects every request to target, so a test can exercise
+// the fixed channel URL against a local server.
+type rewriteTransport struct {
+	target *url.URL
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = t.target.Scheme
+	clone.URL.Host = t.target.Host
+
+	//nolint:wrapcheck // test transport: the caller asserts on the original error
+	return http.DefaultTransport.RoundTrip(clone)
+}
+
+// channelClientFor returns a client whose requests land on server.
+func channelClientFor(t *testing.T, server *httptest.Server) *http.Client {
+	t.Helper()
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parsing test server URL: %v", err)
+	}
+
+	return &http.Client{Transport: &rewriteTransport{target: parsed}}
+}
+
+func promotedSet(tags ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		set[t] = struct{}{}
+	}
+
+	return set
+}
+
+// TestComputeUpgradePath_SkipsUnpromotedK3sRelease reproduces the live defect:
+// k3s pushed rancher/k3s:v1.36.3-k3s1 to the registry on 2026-08-04 but had not
+// promoted it to any release channel, so a cluster already at v1.36.2-k3s1 must
+// see no upgrade. Before promotion awareness this returned a one-step path and
+// recreated the cluster.
+func TestComputeUpgradePath_SkipsUnpromotedK3sRelease(t *testing.T) {
+	t.Parallel()
+
+	base := &mockResolver{
+		versions: parseTags([]string{"v1.36.1-k3s1", "v1.36.2-k3s1", "v1.36.3-k3s1"}),
+	}
+	resolver := versionresolver.NewPromotionAwareResolverWithSources(
+		base,
+		map[string]versionresolver.PromotionSource{
+			versionresolver.K3sImageRef: &stubPromotionSource{
+				tags: promotedSet("v1.36.1-k3s1", "v1.36.2-k3s1"),
+			},
+		},
+	)
+
+	_, err := versionresolver.ComputeUpgradePath(
+		context.Background(), resolver, versionresolver.K3sImageRef, "v1.36.2-k3s1", "k3s1",
+	)
+	if !errors.Is(err, versionresolver.ErrNoUpgradesAvailable) {
+		t.Fatalf("expected ErrNoUpgradesAvailable for an unpromoted release, got %v", err)
+	}
+}
+
+// TestComputeUpgradePath_UsesPromotedK3sRelease is the positive control: once
+// k3s promotes the release, the same inputs must yield the upgrade.
+func TestComputeUpgradePath_UsesPromotedK3sRelease(t *testing.T) {
+	t.Parallel()
+
+	base := &mockResolver{
+		versions: parseTags([]string{"v1.36.1-k3s1", "v1.36.2-k3s1", "v1.36.3-k3s1"}),
+	}
+	resolver := versionresolver.NewPromotionAwareResolverWithSources(
+		base,
+		map[string]versionresolver.PromotionSource{
+			versionresolver.K3sImageRef: &stubPromotionSource{
+				tags: promotedSet("v1.36.1-k3s1", "v1.36.2-k3s1", "v1.36.3-k3s1"),
+			},
+		},
+	)
+
+	steps, err := versionresolver.ComputeUpgradePath(
+		context.Background(), resolver, versionresolver.K3sImageRef, "v1.36.2-k3s1", "k3s1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(steps) != 1 || steps[0].Version.Original != "v1.36.3-k3s1" {
+		t.Fatalf("expected a single step to v1.36.3-k3s1, got %+v", steps)
+	}
+}
+
+// TestPromotionAwareResolver_PassesThroughUnknownImage pins that distributions
+// without a registered channel keep their previous behaviour.
+func TestPromotionAwareResolver_PassesThroughUnknownImage(t *testing.T) {
+	t.Parallel()
+
+	base := &mockResolver{versions: parseTags([]string{"v1.35.0", "v1.36.0"})}
+	resolver := versionresolver.NewPromotionAwareResolverWithSources(
+		base, map[string]versionresolver.PromotionSource{},
+	)
+
+	versions, err := resolver.ListVersions(context.Background(), "kindest/node")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 2 {
+		t.Fatalf("expected the base versions to pass through, got %d", len(versions))
+	}
+}
+
+// TestPromotionAwareResolver_FailsClosed pins that a broken channel source
+// surfaces an error rather than silently falling back to raw registry tags —
+// falling back would reinstate the defect exactly when the check is needed.
+func TestPromotionAwareResolver_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	base := &mockResolver{versions: parseTags([]string{"v1.36.2-k3s1", "v1.36.3-k3s1"})}
+	resolver := versionresolver.NewPromotionAwareResolverWithSources(
+		base,
+		map[string]versionresolver.PromotionSource{
+			versionresolver.K3sImageRef: &stubPromotionSource{err: errPromotion},
+		},
+	)
+
+	_, err := resolver.ListVersions(context.Background(), versionresolver.K3sImageRef)
+	if !errors.Is(err, errPromotion) {
+		t.Fatalf("expected the source error to surface, got %v", err)
+	}
+}
+
+// TestK3sChannelSource_PromotedTags pins the channel-index parse, including the
+// "+" → "-" conversion between the channel version and the registry tag.
+func TestK3sChannelSource_PromotedTags(t *testing.T) {
+	t.Parallel()
+
+	body := `{"data":[
+		{"name":"stable","latest":"v1.36.2+k3s1"},
+		{"name":"latest","latest":"v1.36.2+k3s1"},
+		{"name":"v1.35","latest":"v1.35.6+k3s1"},
+		{"name":"v1.16-testing","latest":""}
+	]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	source := versionresolver.NewK3sChannelSourceWithClient(channelClientFor(t, server))
+
+	tags, err := source.PromotedTags(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tags) != 2 {
+		t.Fatalf("expected 2 distinct promoted tags, got %d (%v)", len(tags), tags)
+	}
+
+	for _, want := range []string{"v1.36.2-k3s1", "v1.35.6-k3s1"} {
+		if _, ok := tags[want]; !ok {
+			t.Errorf("expected %q among promoted tags, got %v", want, tags)
+		}
+	}
+}
+
+// TestK3sChannelSource_EmptyIsAnError pins that an index listing nothing is
+// reported rather than read as "no upgrades available".
+func TestK3sChannelSource_EmptyIsAnError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	source := versionresolver.NewK3sChannelSourceWithClient(channelClientFor(t, server))
+
+	_, err := source.PromotedTags(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for an empty channel index")
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`ksail cluster update` was recreating people's K3s clusters onto a Kubernetes version that k3s had not released.

k3s publishes its container image the moment a release is tagged, but only promotes that release to its update channels later — sometimes much later. KSail read the image registry's tag list as though it were the list of released versions, so a tag appearing upstream was immediately treated as an available upgrade. On 2026-08-04 k3s pushed `v1.36.3-k3s1` without promoting it, and from that moment `ksail cluster update` deleted and recreated any K3s cluster it was pointed at — no configuration change from the user, and a destructive operation. It also turned every K3s System Test red.

## What

Version discovery now only offers versions the distribution has actually promoted, read from k3s' own release-channel index — the same source the k3s installer uses. Distributions with no promotion source behave exactly as before, and if the channel lookup fails KSail declines to upgrade rather than falling back to raw registry tags, so the check cannot quietly stop protecting anything.

Verified against the live k3s index: `v1.36.2-k3s1` (promoted) is offered, `v1.36.3-k3s1` (not promoted) is not.

Fixes #6486
