### PR TITLE
fix(image): repair and retry when an exported archive fails integrity validation

### DIFF
--- a/pkg/svc/image/exporter.go
+++ b/pkg/svc/image/exporter.go
@@ -12,6 +12,7 @@ import (
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	dockerclient "github.com/devantler-tech/ksail/v7/pkg/client/docker"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 )
 
 // File permission constant.
@@ -76,6 +77,20 @@ func (e *Exporter) Export(
 	// Set default output path
 	if opts.OutputPath == "" {
 		opts.OutputPath = "images.tar"
+	}
+
+	// Canonicalize the user-supplied destination once, before any write. The archive is
+	// written twice on the repair path (initial copy, then the post-repair re-export), so
+	// resolving it here is what guarantees both writes land on the same file rather than
+	// re-resolving a symlink that moved in between.
+	err = os.MkdirAll(filepath.Dir(opts.OutputPath), dirPerm)
+	if err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	opts.OutputPath, err = fsutil.EvalCanonicalPath(opts.OutputPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve export output path: %w", err)
 	}
 
 	// Find a suitable node for export

--- a/pkg/svc/image/exporter.go
+++ b/pkg/svc/image/exporter.go
@@ -179,22 +179,59 @@ func (e *Exporter) exportImagesFromNode(
 		}
 	}
 
-	// Copy the tar file from container to host
-	err = e.copyFromContainer(ctx, nodeName, tmpPath, outputPath)
-	if err != nil {
-		return fmt.Errorf("failed to copy export file from container: %w", err)
-	}
-
-	// Validate blob integrity in the exported OCI tar archive.
-	// Catches truncated or corrupted blobs that ctr export may silently produce
-	// when the containerd content store has incomplete data.
-	err = ValidateExportedTar(outputPath)
+	err = e.collectExportedArchive(
+		ctx,
+		nodeName,
+		tmpPath,
+		outputPath,
+		platform,
+		exportImages,
+		repairImages,
+	)
 	if err != nil {
 		return err
 	}
 
 	// Clean up temporary file in container
 	_, _ = e.executor.ExecInContainer(ctx, nodeName, []string{"rm", "-f", tmpPath})
+
+	return nil
+}
+
+// collectExportedArchive copies the exported archive to the host and validates it,
+// repairing and re-exporting once if the archive turns out to be truncated.
+//
+// An incomplete containerd content store surfaces two ways: ctr export exits non-zero
+// (handled by tryExportImagesWithRepair), or it exits zero and silently writes a truncated
+// archive, which only this validation sees. Both have the same remedy, so the validation
+// failure refreshes the content store and re-exports once as well.
+func (e *Exporter) collectExportedArchive(
+	ctx context.Context,
+	nodeName string,
+	tmpPath string,
+	outputPath string,
+	platform string,
+	exportImages []string,
+	repairImages []string,
+) error {
+	err := e.copyFromContainer(ctx, nodeName, tmpPath, outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to copy export file from container: %w", err)
+	}
+
+	err = ValidateExportedTar(outputPath)
+	if err != nil {
+		return e.repairAndReExport(
+			ctx,
+			nodeName,
+			tmpPath,
+			outputPath,
+			platform,
+			exportImages,
+			repairImages,
+			err,
+		)
+	}
 
 	return nil
 }

--- a/pkg/svc/image/repair.go
+++ b/pkg/svc/image/repair.go
@@ -43,6 +43,69 @@ func (e *Exporter) tryExportImagesWithRepair(
 	)
 }
 
+// repairAndReExport refreshes the node's containerd content store and re-exports once
+// after the exported archive failed its integrity validation.
+//
+// A silent truncation and a "content digest not found" export failure share one cause —
+// an incomplete content store — so this reuses the same refresh-and-re-export remedy that
+// tryExportImagesWithRepair applies to the non-zero-exit form.
+//
+// The refresh is deliberately scoped to repairImages, exactly like the existing repair
+// path: those are populated only when the caller named specific images. Without that
+// scope a validation failure on a whole-cluster export would re-pull every image in the
+// cluster, so the original validation error is returned unchanged instead.
+//
+// validationErr is the failure that triggered the retry. It is returned when no repair is
+// possible, so the caller's error is never replaced by a less specific one.
+func (e *Exporter) repairAndReExport(
+	ctx context.Context,
+	nodeName string,
+	tmpPath string,
+	outputPath string,
+	platform string,
+	exportImages []string,
+	repairImages []string,
+	validationErr error,
+) error {
+	if len(repairImages) == 0 {
+		return validationErr
+	}
+
+	successfulRepairRefs, refreshErr := e.refreshImageContent(
+		ctx,
+		nodeName,
+		platform,
+		repairImages,
+	)
+	if refreshErr != nil && len(successfulRepairRefs) == 0 {
+		return validationErr
+	}
+
+	retryImages := preferSuccessfulRepairRefs(exportImages, successfulRepairRefs)
+
+	err := e.tryExportImages(ctx, nodeName, tmpPath, platform, retryImages)
+	if err != nil {
+		return fmt.Errorf("%w (re-export after content repair also failed: %w)", validationErr, err)
+	}
+
+	err = e.copyFromContainer(ctx, nodeName, tmpPath, outputPath)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to copy export file from container after content repair: %w",
+			err,
+		)
+	}
+
+	// A second failure is terminal: the content store did not recover, and retrying again
+	// would loop on the same cause.
+	err = ValidateExportedTar(outputPath)
+	if err != nil {
+		return fmt.Errorf("%w (persisted after content repair and re-export)", err)
+	}
+
+	return nil
+}
+
 func (e *Exporter) fallbackExportImages(
 	ctx context.Context,
 	nodeName string,

--- a/pkg/svc/image/repair_retry_test.go
+++ b/pkg/svc/image/repair_retry_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -105,14 +106,44 @@ func wrapInDockerCopyTar(t *testing.T, content []byte) []byte {
 	return buf.Bytes()
 }
 
+// isCtrContentFetch reports whether cmd is a `ctr content fetch` invocation. It matches the
+// verb prefix that buildCtrContentFetchCommand emits rather than a fully-built command, so
+// the check stays valid regardless of which image reference the repair ends up fetching —
+// the assertion is about how many refreshes happen, not which ref each one names.
+func isCtrContentFetch(cmd []string) bool {
+	fetchPrefix := buildCtrContentFetchCommand("linux/amd64", "example:latest")[:4]
+	if len(cmd) < len(fetchPrefix) {
+		return false
+	}
+
+	for i, want := range fetchPrefix {
+		if cmd[i] != want {
+			return false
+		}
+	}
+
+	return true
+}
+
 // allowAnyExec makes every ContainerExec* call succeed with empty output, any number of
 // times. The retry path issues a variable number of repair commands (images rm, pull,
-// content fetch, re-export, cleanup); this test pins the observable outcome and the
-// export-command count rather than an exact transcript of every exec.
-func allowAnyExec(ctx context.Context, mockClient *docker.MockAPIClient) {
+// content fetch, re-export, cleanup), so an exact transcript would be brittle.
+//
+// It returns a reader for the number of `ctr content fetch` execs observed. Counting those
+// is what stops the surrounding tests passing vacuously: CopyFromContainer.Twice() pins the
+// number of re-exports, but without this a repair that refreshed the content store several
+// times before re-exporting would satisfy every other assertion, and "repair once" is
+// precisely the property these tests exist to hold.
+func allowAnyExec(ctx context.Context, mockClient *docker.MockAPIClient) func() int {
+	var contentFetches atomic.Int64
+
 	mockClient.EXPECT().
 		ContainerExecCreate(ctx, mock.Anything, mock.Anything).
-		RunAndReturn(func(_ context.Context, _ string, _ container.ExecOptions) (container.ExecCreateResponse, error) {
+		RunAndReturn(func(_ context.Context, _ string, opts container.ExecOptions) (container.ExecCreateResponse, error) {
+			if isCtrContentFetch(opts.Cmd) {
+				contentFetches.Add(1)
+			}
+
 			return container.ExecCreateResponse{ID: "exec-any"}, nil
 		})
 
@@ -125,6 +156,8 @@ func allowAnyExec(ctx context.Context, mockClient *docker.MockAPIClient) {
 	mockClient.EXPECT().
 		ContainerExecInspect(ctx, mock.Anything).
 		Return(container.ExecInspect{ExitCode: 0}, nil)
+
+	return func() int { return int(contentFetches.Load()) }
 }
 
 func setupSingleNodeList(ctx context.Context, mockClient *docker.MockAPIClient) {
@@ -150,7 +183,7 @@ func TestExportRepairsAndRetriesAfterIntegrityFailure(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "images.tar")
 
 	setupSingleNodeList(ctx, mockClient)
-	allowAnyExec(ctx, mockClient)
+	contentFetches := allowAnyExec(ctx, mockClient)
 
 	// First copy delivers the silently-truncated archive, second the repaired one.
 	corrupt := wrapInDockerCopyTar(t, corruptOCITar(t))
@@ -178,6 +211,10 @@ func TestExportRepairsAndRetriesAfterIntegrityFailure(t *testing.T) {
 
 	require.NoError(t, err, "a repairable content-store truncation must not fail the export")
 
+	assert.Equal(t, 1, contentFetches(),
+		"the content store must be refreshed exactly once; more than one refresh means the "+
+			"repair looped, which the single re-export assertion alone cannot detect")
+
 	// Both copies must have been consumed — that is what proves the retry ran rather than
 	// the first archive somehow passing validation.
 	mockClient.AssertExpectations(t)
@@ -194,7 +231,7 @@ func TestExportFailsWhenIntegrityStillBrokenAfterRepair(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "images.tar")
 
 	setupSingleNodeList(ctx, mockClient)
-	allowAnyExec(ctx, mockClient)
+	contentFetches := allowAnyExec(ctx, mockClient)
 
 	corrupt := wrapInDockerCopyTar(t, corruptOCITar(t))
 
@@ -227,6 +264,10 @@ func TestExportFailsWhenIntegrityStillBrokenAfterRepair(t *testing.T) {
 		"persisted after content repair",
 		"the error must say the repair was attempted, so the next reader is not sent hunting for a cause already ruled out",
 	)
+
+	assert.Equal(t, 1, contentFetches(),
+		"the terminal case must attempt exactly one refresh before giving up; a second refresh "+
+			"would be the loop this path exists to prevent")
 
 	mockClient.AssertExpectations(t)
 }

--- a/pkg/svc/image/repair_retry_test.go
+++ b/pkg/svc/image/repair_retry_test.go
@@ -1,0 +1,232 @@
+package image_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/docker"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/image"
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// corruptOCITar returns bytes that parse as a tar archive for at least one entry and then
+// break, which is what ctr export silently produces when the containerd content store is
+// incomplete. A wholly unparseable blob would not do: ValidateExportedTar deliberately
+// skips validation when the very first header fails, so the truncation must come after a
+// good entry.
+func corruptOCITar(t *testing.T) []byte {
+	t.Helper()
+
+	payload := []byte("oci-layout")
+
+	var buf bytes.Buffer
+
+	tarWriter := tar.NewWriter(&buf)
+
+	err := tarWriter.WriteHeader(&tar.Header{
+		Name:     "oci-layout",
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	})
+	require.NoError(t, err)
+
+	_, err = tarWriter.Write(payload)
+	require.NoError(t, err)
+
+	// Flush completes the entry without writing the end-of-archive marker, so the
+	// following bytes are read as the start of a second header.
+	err = tarWriter.Flush()
+	require.NoError(t, err)
+
+	// A partial header block: enough to start reading, too short to finish.
+	buf.Write(bytes.Repeat([]byte{'A'}, 200))
+
+	return buf.Bytes()
+}
+
+// validOCITar returns a well-formed archive that passes integrity validation.
+func validOCITar(t *testing.T) []byte {
+	t.Helper()
+
+	payload := []byte("oci-layout")
+
+	var buf bytes.Buffer
+
+	tarWriter := tar.NewWriter(&buf)
+
+	err := tarWriter.WriteHeader(&tar.Header{
+		Name:     "oci-layout",
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	})
+	require.NoError(t, err)
+
+	_, err = tarWriter.Write(payload)
+	require.NoError(t, err)
+
+	require.NoError(t, tarWriter.Close())
+
+	return buf.Bytes()
+}
+
+// wrapInDockerCopyTar wraps content the way CopyFromContainer delivers it: a tar stream
+// whose single regular entry is the file being copied.
+func wrapInDockerCopyTar(t *testing.T, content []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	tarWriter := tar.NewWriter(&buf)
+
+	err := tarWriter.WriteHeader(&tar.Header{
+		Name:     "ksail-images-export.tar",
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	})
+	require.NoError(t, err)
+
+	_, err = tarWriter.Write(content)
+	require.NoError(t, err)
+
+	require.NoError(t, tarWriter.Close())
+
+	return buf.Bytes()
+}
+
+// allowAnyExec makes every ContainerExec* call succeed with empty output, any number of
+// times. The retry path issues a variable number of repair commands (images rm, pull,
+// content fetch, re-export, cleanup); this test pins the observable outcome and the
+// export-command count rather than an exact transcript of every exec.
+func allowAnyExec(ctx context.Context, mockClient *docker.MockAPIClient) {
+	mockClient.EXPECT().
+		ContainerExecCreate(ctx, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ container.ExecOptions) (container.ExecCreateResponse, error) {
+			return container.ExecCreateResponse{ID: "exec-any"}, nil
+		})
+
+	mockClient.EXPECT().
+		ContainerExecAttach(ctx, mock.Anything, container.ExecStartOptions{}).
+		RunAndReturn(func(_ context.Context, _ string, _ container.ExecStartOptions) (dockertypes.HijackedResponse, error) {
+			return mockDockerStreamResponse("", ""), nil
+		})
+
+	mockClient.EXPECT().
+		ContainerExecInspect(ctx, mock.Anything).
+		Return(container.ExecInspect{ExitCode: 0}, nil)
+}
+
+func setupSingleNodeList(ctx context.Context, mockClient *docker.MockAPIClient) {
+	mockClient.EXPECT().
+		ContainerList(ctx, mock.Anything).
+		Return([]container.Summary{
+			{
+				Names:  []string{"/my-cluster-control-plane"},
+				Labels: map[string]string{"io.x-k8s.kind.role": "control-plane"},
+			},
+		}, nil)
+}
+
+// TestExportRepairsAndRetriesAfterIntegrityFailure pins the fix: ctr export exits zero but
+// writes a truncated archive, so the only signal is the integrity validation. That must
+// reach the same content-refresh repair the non-zero-exit path already uses, and the
+// re-export must succeed.
+func TestExportRepairsAndRetriesAfterIntegrityFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockClient := docker.NewMockAPIClient(t)
+	outputPath := filepath.Join(t.TempDir(), "images.tar")
+
+	setupSingleNodeList(ctx, mockClient)
+	allowAnyExec(ctx, mockClient)
+
+	// First copy delivers the silently-truncated archive, second the repaired one.
+	corrupt := wrapInDockerCopyTar(t, corruptOCITar(t))
+	repaired := wrapInDockerCopyTar(t, validOCITar(t))
+
+	mockClient.EXPECT().
+		CopyFromContainer(ctx, "my-cluster-control-plane", "/root/ksail-images-export.tar").
+		Return(io.NopCloser(bytes.NewReader(corrupt)), container.PathStat{}, nil).Once()
+
+	mockClient.EXPECT().
+		CopyFromContainer(ctx, "my-cluster-control-plane", "/root/ksail-images-export.tar").
+		Return(io.NopCloser(bytes.NewReader(repaired)), container.PathStat{}, nil).Once()
+
+	exporter := image.NewExporter(mockClient)
+	err := exporter.Export(
+		ctx,
+		"my-cluster",
+		v1alpha1.DistributionVanilla,
+		v1alpha1.ProviderDocker,
+		image.ExportOptions{
+			OutputPath: outputPath,
+			Images:     []string{"nginx:latest"},
+		},
+	)
+
+	require.NoError(t, err, "a repairable content-store truncation must not fail the export")
+
+	// Both copies must have been consumed — that is what proves the retry ran rather than
+	// the first archive somehow passing validation.
+	mockClient.AssertExpectations(t)
+}
+
+// TestExportFailsWhenIntegrityStillBrokenAfterRepair pins the terminal case: the repair is
+// attempted once and, when the content store does not recover, the command fails rather
+// than looping.
+func TestExportFailsWhenIntegrityStillBrokenAfterRepair(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockClient := docker.NewMockAPIClient(t)
+	outputPath := filepath.Join(t.TempDir(), "images.tar")
+
+	setupSingleNodeList(ctx, mockClient)
+	allowAnyExec(ctx, mockClient)
+
+	corrupt := wrapInDockerCopyTar(t, corruptOCITar(t))
+
+	// Exactly twice: the initial copy and the single post-repair retry. A third call would
+	// fail the mock, which is the assertion that the retry does not loop.
+	mockClient.EXPECT().
+		CopyFromContainer(ctx, "my-cluster-control-plane", "/root/ksail-images-export.tar").
+		RunAndReturn(func(_ context.Context, _ string, _ string) (io.ReadCloser, container.PathStat, error) {
+			return io.NopCloser(bytes.NewReader(corrupt)), container.PathStat{}, nil
+		}).
+		Twice()
+
+	exporter := image.NewExporter(mockClient)
+	err := exporter.Export(
+		ctx,
+		"my-cluster",
+		v1alpha1.DistributionVanilla,
+		v1alpha1.ProviderDocker,
+		image.ExportOptions{
+			OutputPath: outputPath,
+			Images:     []string{"nginx:latest"},
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blob integrity check failed")
+	assert.Contains(
+		t,
+		err.Error(),
+		"persisted after content repair",
+		"the error must say the repair was attempted, so the next reader is not sent hunting for a cause already ruled out",
+	)
+
+	mockClient.AssertExpectations(t)
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`ksail workload export` intermittently fails with "blob integrity check failed: tar archive is
truncated or corrupted". The same failure has been filed and closed twice before as transient
(#4091, #4491) and keeps coming back — most recently red-lighting an unrelated PR's CI.

It is not actually transient. KSail already knows how to fix the underlying cause (an incomplete
containerd content store) by refreshing the content and re-exporting — but that repair only ran when
`ctr export` exited non-zero. When the same bad state instead makes `ctr export` exit *zero* and
write a truncated archive, the repair was never reached and the command just failed.

## What

A failed integrity check now triggers the same repair-and-retry the other failure form already gets,
so a recoverable export succeeds instead of failing. If it still fails after one repair, the command
stops and says the repair was already attempted.

The repair stays scoped to explicitly-named images, so exporting a whole cluster can't turn one bad
archive into a re-pull of every image.

Fixes #6488
