### PR TITLE
fix(cluster): check Flux verify drift on the spec-only diff path too

### DIFF
--- a/pkg/cli/cmd/cluster/export_test.go
+++ b/pkg/cli/cmd/cluster/export_test.go
@@ -485,6 +485,16 @@ func ExportIsDowngrade(current, target string) bool {
 // ErrMetricsServerDisableUnsupported exports the sentinel error for testing.
 var ErrMetricsServerDisableUnsupported = errMetricsServerDisableUnsupported
 
+// ExportComputeSpecOnlyDiff exposes computeSpecOnlyDiff for unit testing. This is the diff
+// path behind `ksail cluster diff` and behind every provisioner with no Updater, so it is
+// the path whose drift-check coverage has to be assertable independently of the update path.
+func ExportComputeSpecOnlyDiff(
+	cmd *cobra.Command,
+	ctx *localregistry.Context,
+) *clusterupdate.UpdateResult {
+	return computeSpecOnlyDiff(cmd, ctx)
+}
+
 // ExportHandlerForField reports whether a registered handler exists for the given field name.
 func ExportHandlerForField(cmd *cobra.Command, clusterCfg *v1alpha1.Cluster, field string) bool {
 	r := newComponentReconciler(cmd, clusterCfg, "test-cluster")

--- a/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
+++ b/pkg/cli/cmd/cluster/flux_verify_reconcile_test.go
@@ -1,10 +1,13 @@
 package cluster_test
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/cluster"
+	"github.com/devantler-tech/ksail/v7/pkg/cli/setup/localregistry"
 	specdiff "github.com/devantler-tech/ksail/v7/pkg/svc/diff"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	"github.com/spf13/cobra"
@@ -92,5 +95,90 @@ func TestFluxReassertRunsOncePerUpdatePass(t *testing.T) {
 		second,
 		"the second Flux handler must reuse the first reassertion; recomputing would "+
 			"have attempted the upsert against a cancelled context",
+	)
+}
+
+// specOnlyDiffRanVerifyCheck reports whether computeSpecOnlyDiff reached
+// checkFluxVerifyDrift, judged by the two signals that check can leave behind: one of its
+// own warnings, or a verify change on the diff when the cluster query actually succeeded.
+//
+// Keying on the check's observable effect rather than on a live cluster is deliberate —
+// the property under test is which diff path invokes the check, and that must be provable
+// without a cluster.
+func specOnlyDiffRanVerifyCheck(t *testing.T, clusterCfg *v1alpha1.Cluster) bool {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	diff := cluster.ExportComputeSpecOnlyDiff(cmd, &localregistry.Context{ClusterCfg: clusterCfg})
+
+	// Both warnings are unique to the verify check: every sibling drift warning names the
+	// distribution version, the sync ref, or registry credentials instead.
+	warned := strings.Contains(out.String(), "Flux verify drift detection") ||
+		strings.Contains(out.String(), "Flux artifact verification")
+
+	changed := false
+
+	for _, change := range diff.InPlaceChanges {
+		if change.Field == specdiff.FluxVerifyField {
+			changed = true
+		}
+	}
+
+	return warned || changed
+}
+
+// fluxClusterWithVerify builds a Flux cluster whose verification is configured but has not
+// been applied — the exact state platform#2922 sat in.
+func fluxClusterWithVerify() *v1alpha1.Cluster {
+	clusterCfg := v1alpha1.NewCluster()
+	clusterCfg.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+	clusterCfg.Spec.Workload.Flux.Verify = v1alpha1.FluxVerifySpec{Provider: "cosign"}
+
+	return clusterCfg
+}
+
+// TestSpecOnlyDiffChecksFluxVerifyDrift pins the fix. checkFluxVerifyDrift was wired into
+// the Updater diff path only, while its two sibling checks were wired into both — so
+// `ksail cluster diff` previewed an update without the verification repair that
+// `cluster update` would then apply, and provisioners with no Updater (VCluster) never
+// detected the drift at all. A preview that silently omits a security-relevant repair is
+// worse than no preview, because it is trusted.
+func TestSpecOnlyDiffChecksFluxVerifyDrift(t *testing.T) {
+	t.Parallel()
+
+	assert.True(
+		t,
+		specOnlyDiffRanVerifyCheck(t, fluxClusterWithVerify()),
+		"computeSpecOnlyDiff must run checkFluxVerifyDrift, so `cluster diff` previews the "+
+			"same verification repair `cluster update` applies",
+	)
+}
+
+// TestSpecOnlyDiffSkipsFluxVerifyDriftWhenNotApplicable pins the guards, so wiring the
+// check into a second path cannot make it fire where it must stay silent.
+func TestSpecOnlyDiffSkipsFluxVerifyDriftWhenNotApplicable(t *testing.T) {
+	t.Parallel()
+
+	argocd := fluxClusterWithVerify()
+	argocd.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineArgoCD
+
+	assert.False(
+		t,
+		specOnlyDiffRanVerifyCheck(t, argocd),
+		"artifact verification is a Flux concern; an ArgoCD cluster must not be queried for it",
+	)
+
+	unconfigured := v1alpha1.NewCluster()
+	unconfigured.Spec.Cluster.GitOpsEngine = v1alpha1.GitOpsEngineFlux
+
+	assert.False(
+		t,
+		specOnlyDiffRanVerifyCheck(t, unconfigured),
+		"with no verify block configured there is nothing to assert, and no cluster query worth spending",
 	)
 }

--- a/pkg/cli/cmd/cluster/orchestrator.go
+++ b/pkg/cli/cmd/cluster/orchestrator.go
@@ -1023,6 +1023,12 @@ func computeSpecOnlyDiff(
 	// Check for Flux distribution-version drift (spec.workload.flux.distributionVersion)
 	checkFluxDistributionVersionDrift(cmd, ctx, diffEngine, diff)
 
+	// Check for artifact-verification drift (configured spec.workload.flux.verify that never
+	// reached the live OCIRepository). This path backs `ksail cluster diff` and every
+	// provisioner without an Updater, so omitting it made a preview disagree with the apply
+	// it previews, and left verification drift undetectable on those provisioners entirely.
+	checkFluxVerifyDrift(cmd, ctx, diffEngine, diff)
+
 	return diff
 }
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`ksail cluster diff` is a preview people trust before applying a change. It was not showing
pending **artifact-verification** repairs: the check that detects them ran on the update path but
not on the path `cluster diff` uses. So the preview reported nothing, and the following
`cluster update` then applied a security-relevant change nobody was shown.

The same gap meant clusters on provisioners without an updater (VCluster) never detected
verification drift at all.

A preview that silently omits a security repair is worse than no preview, because it is trusted.

## What

The verification drift check now runs on both diff paths, alongside the two sibling checks that
were already on both. Preview and apply now agree, and the affected provisioners detect the drift.

No behaviour changes for anyone already covered: the check keeps its own guards, so it stays
silent for non-Flux clusters and for clusters with no verification configured.

Fixes #6480