### PR TITLE
fix(netretry): retry a truncated fetch that surfaces as a bare EOF

### DIFF
--- a/pkg/client/netretry/netretry.go
+++ b/pkg/client/netretry/netretry.go
@@ -40,11 +40,25 @@ var httpStatusCodePattern = regexp.MustCompile(`\b(429|5\d{2})\b`)
 // (e.g., "stopped after 10 redirects").
 var redirectLimitPattern = regexp.MustCompile(`stopped after \d+ redirects`)
 
+// bareEOFPattern matches a plain io.EOF surfacing as an error detail. A
+// truncated schema-registry fetch can end as io.EOF ("EOF") rather than
+// io.ErrUnexpectedEOF ("unexpected EOF"), and the "unexpected EOF" substring
+// above does not cover it — which reds a whole validation run on a transient
+// fetch (CI - KSail on main, a9849b6d30).
+//
+// Anchoring on start-or-": " keeps this to a detail-position EOF (the shape
+// produced by error wrapping and by the kubeconform client's per-resource
+// formatting) so prose that merely mentions EOF, and words such as "EOFError",
+// stay non-retryable. A trailing \b rather than $ keeps it matching when a
+// suffix follows, e.g. kubeconform's " (from <source>)" attribution.
+var bareEOFPattern = regexp.MustCompile(`(?:^|: )EOF\b`)
+
 // IsRetryable returns true if the error indicates a transient network error
 // that should be retried. This covers HTTP 429 and 5xx status codes, TCP-level
-// errors such as connection resets, timeouts, and unexpected EOF, and a
-// truncated/malformed downloaded document (e.g. a partially-served Helm
-// repository index) surfaced as a YAML->JSON conversion failure.
+// errors such as connection resets, timeouts, and unexpected EOF, a bare io.EOF
+// surfacing as an error detail (a truncated fetch), and a truncated/malformed
+// downloaded document (e.g. a partially-served Helm repository index) surfaced
+// as a YAML->JSON conversion failure.
 // Callers that need to handle additional domain-specific transient errors (e.g.,
 // Copilot auth "fetch failed") should augment this function with a local helper.
 func IsRetryable(err error) bool {
@@ -64,6 +78,11 @@ func IsRetryable(err error) bool {
 	// Match HTTP 429/5xx numeric codes at word boundaries to avoid false positives
 	// on port numbers like ":5000". Uses regexp for precise matching.
 	if httpStatusCodePattern.MatchString(errMsg) {
+		return true
+	}
+
+	// Match a bare io.EOF surfacing as an error detail (truncated fetch).
+	if bareEOFPattern.MatchString(errMsg) {
 		return true
 	}
 

--- a/pkg/client/netretry/netretry.go
+++ b/pkg/client/netretry/netretry.go
@@ -49,9 +49,15 @@ var redirectLimitPattern = regexp.MustCompile(`stopped after \d+ redirects`)
 // Anchoring on start-or-": " keeps this to a detail-position EOF (the shape
 // produced by error wrapping and by the kubeconform client's per-resource
 // formatting) so prose that merely mentions EOF, and words such as "EOFError",
-// stay non-retryable. A trailing \b rather than $ keeps it matching when a
-// suffix follows, e.g. kubeconform's " (from <source>)" attribution.
-var bareEOFPattern = regexp.MustCompile(`(?:^|: )EOF\b`)
+// stay non-retryable.
+//
+// The trailing alternation requires EOF to END its detail segment, which is what
+// a bare io.EOF looks like once stringified. Prose keeps going ("invalid values:
+// EOF is not allowed"), so requiring a terminator is what separates the two. The
+// three terminators are the only ways a detail segment ends here: end of message,
+// kubeconform's "; " join between failing resources (processResults), and its
+// " (from <source>)" attribution suffix (formatFailure).
+var bareEOFPattern = regexp.MustCompile(`(?:^|: )EOF(?:$|; | \(from )`)
 
 // IsRetryable returns true if the error indicates a transient network error
 // that should be retried. This covers HTTP 429 and 5xx status codes, TCP-level

--- a/pkg/client/netretry/netretry_test.go
+++ b/pkg/client/netretry/netretry_test.go
@@ -84,16 +84,29 @@ var (
 	// stay non-retryable — these pin the predicate against over-matching.
 	errProseEOF    = errors.New("check EOF handling in the parser")
 	errEOFPrefixed = errors.New("EOFError: malformed input")
+	// Prose whose EOF sits in detail position but continues into more words.
+	// A truncated fetch's io.EOF is the terminal token of its detail segment,
+	// so a continuing sentence is prose and must stay non-retryable.
+	errProseEOFAfterColon = errors.New("invalid values: EOF is not allowed")
+	// processResults joins multiple failing resources with "; ", so a truncated
+	// fetch's EOF is not the final token when a later resource fails differently.
+	errKubeconformEOFJoined = errors.New(
+		"validation failed: Namespace/a: EOF; Deployment/b: invalid schema",
+	)
 )
 
-func TestIsRetryable(t *testing.T) {
-	t.Parallel()
+// isRetryableCase is one row of the IsRetryable truth table.
+type isRetryableCase struct {
+	name     string
+	err      error
+	expected bool
+}
 
-	tests := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
+// isRetryableCases returns the IsRetryable truth table. It is a function rather
+// than an inline literal so the table can grow without pushing the test body
+// past the funlen limit.
+func isRetryableCases() []isRetryableCase {
+	return []isRetryableCase{
 		// Non-retryable cases.
 		{name: "nil error", err: nil, expected: false},
 		{name: "generic error", err: errGeneric, expected: false},
@@ -147,9 +160,24 @@ func TestIsRetryable(t *testing.T) {
 		// Over-match guards: EOF in prose is not a transient fetch failure.
 		{name: "prose mentioning EOF not retried", err: errProseEOF, expected: false},
 		{name: "EOF-prefixed word not retried", err: errEOFPrefixed, expected: false},
+		{
+			name:     "prose EOF after a colon not retried",
+			err:      errProseEOFAfterColon,
+			expected: false,
+		},
+		// A joined multi-resource failure keeps the EOF retryable.
+		{
+			name:     "kubeconform EOF joined with a later failure",
+			err:      errKubeconformEOFJoined,
+			expected: true,
+		},
 	}
+}
 
-	for _, tt := range tests {
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range isRetryableCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/client/netretry/netretry_test.go
+++ b/pkg/client/netretry/netretry_test.go
@@ -67,6 +67,23 @@ var (
 	errInvalidValuesYAML = errors.New(
 		"yaml: unmarshal errors:\n  line 3: cannot unmarshal !!str `oops` into int",
 	)
+	// A truncated schema-registry fetch can surface as plain io.EOF ("EOF")
+	// rather than io.ErrUnexpectedEOF ("unexpected EOF"). The kubeconform client
+	// stringifies each failing result, so the io.EOF identity is gone by the time
+	// the retry predicate sees it and only this text remains.
+	errBareEOF        = errors.New("EOF")
+	errKubeconformEOF = errors.New(
+		"validate file /tmp/x/namespace.yaml: validation failed: Namespace/test-namespace: EOF",
+	)
+	// Same failure with formatFailure's " (from <source>)" attribution suffix,
+	// so EOF is not the final token.
+	errKubeconformEOFAttributed = errors.New(
+		"validation failed: Namespace/test-namespace: EOF (from base)",
+	)
+	// Prose that merely mentions EOF is not a transient fetch failure and must
+	// stay non-retryable — these pin the predicate against over-matching.
+	errProseEOF    = errors.New("check EOF handling in the parser")
+	errEOFPrefixed = errors.New("EOFError: malformed input")
 )
 
 func TestIsRetryable(t *testing.T) {
@@ -119,6 +136,17 @@ func TestIsRetryable(t *testing.T) {
 		},
 		// Genuine invalid user values must NOT be retried (narrow-scope guard).
 		{name: "invalid values yaml not retried", err: errInvalidValuesYAML, expected: false},
+		// Truncated schema fetch surfacing as a bare io.EOF detail.
+		{name: "bare EOF", err: errBareEOF, expected: true},
+		{name: "kubeconform EOF detail", err: errKubeconformEOF, expected: true},
+		{
+			name:     "kubeconform EOF with attribution",
+			err:      errKubeconformEOFAttributed,
+			expected: true,
+		},
+		// Over-match guards: EOF in prose is not a transient fetch failure.
+		{name: "prose mentioning EOF not retried", err: errProseEOF, expected: false},
+		{name: "EOF-prefixed word not retried", err: errEOFPrefixed, expected: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`CI - KSail` went red on `main`: a manifest-validation test failed with `Namespace/test-namespace: EOF`. Validation downloads its schemas from a remote registry, and a truncated download already has a retry built for it — but the retry only recognised one of the two ways a truncated download reports itself, so it never fired and a momentary network hiccup failed the whole run.

This is the kind of failure that reds `main` at random and trains people to re-run rather than look, so it is worth closing properly rather than dismissing as flaky.

## What

Teaches the retry to recognise the second form too, so a truncated schema download is retried instead of failing the run. Deliberately narrow: text that merely mentions the term is still treated as a genuine error, and both directions are pinned by tests.
