### PR TITLE
ci: stop cancelling in-progress runs on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,11 @@ env:
 
 concurrency:
   group: "ci-ksail-${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  # Superseded pull-request and merge-queue runs still cancel: each carries its
+  # own ref, so the group key is unique per subject. Every push to main shares
+  # one ref, so cancelling there would evict the previous merge's checks
+  # mid-flight and settle main on verification that never completed.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions: {}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,15 @@ env:
   GOMEMLIMIT: "6GiB"
 
 concurrency:
-  group: "ci-ksail-${{ github.workflow }}-${{ github.ref }}"
-  # Superseded pull-request and merge-queue runs still cancel: each carries its
-  # own ref, so the group key is unique per subject. Every push to main shares
-  # one ref, so cancelling there would evict the previous merge's checks
-  # mid-flight and settle main on verification that never completed.
+  # On main each run is its own verification record, so it gets a run-unique
+  # group. Sharing a group there is not made safe by cancel-in-progress alone: a
+  # group holds one running plus one pending run, and a third merge cancels the
+  # pending one — so the second merge's checks would still be lost. A unique key
+  # means nothing on main ever queues behind, or evicts, anything else.
+  #
+  # Pull requests and merge-queue entries keep the ref-keyed group, so superseded
+  # runs there still cancel exactly as before.
+  group: "ci-ksail-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}"
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions: {}

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -100,10 +100,11 @@ func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
 
 		assert.Falsef(
 			t,
-			cancelsUnconditionally(workflow.Concurrency.CancelInProgress),
-			"%s runs on main and cancels in progress unconditionally, so one merge evicts "+
-				"the previous merge's checks before they complete",
+			mayCancelDefaultBranchRuns(workflow.Concurrency.CancelInProgress),
+			"%s runs on main and may cancel in progress there, so one merge evicts the "+
+				"previous merge's checks before they complete (allowed: absent, false, or %s)",
 			filepath.Base(path),
+			approvedCancelExpression,
 		)
 	}
 
@@ -120,23 +121,70 @@ func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
 	)
 }
 
-// cancelsUnconditionally reports whether a cancel-in-progress value cancels runs
-// on every branch. A literal `true` is the obvious form, but GitHub also accepts
-// an expression, and YAML hands those back as strings — so `${{ true }}` renders
-// as a non-"true" string while still cancelling everything. An expression that
-// never mentions github.ref cannot be branch-conditional either, so it is
-// treated as unconditional rather than assumed safe.
-func cancelsUnconditionally(value any) bool {
-	rendered := strings.TrimSpace(fmt.Sprintf("%v", value))
-	if rendered == "true" {
-		return true
-	}
+// approvedCancelExpression is the only expression form allowed to gate
+// cancellation on a workflow that runs on the default branch.
+const approvedCancelExpression = "${{ github.ref != 'refs/heads/main' }}"
 
-	if !strings.HasPrefix(rendered, "${{") || !strings.HasSuffix(rendered, "}}") {
+// mayCancelDefaultBranchRuns reports whether a cancel-in-progress value could
+// cancel a run on main. It FAILS CLOSED: only an absent value, an explicit
+// false, or the exact approved expression are accepted.
+//
+// Inspecting the tokens of an arbitrary expression does not work, because what
+// matters is the value it evaluates to when github.ref is refs/heads/main —
+// which a substring check cannot tell. Both `${{ github.ref && true }}` and
+// `${{ github.ref != 'refs/heads/main' || true }}` mention github.ref and look
+// branch-conditional, yet both evaluate true on main and cancel the previous
+// run. Evaluating GitHub expressions here would mean shipping an interpreter
+// that itself needs testing, so an allowlist is the honest guard: a new form is
+// added deliberately, with its behaviour on main reasoned about once.
+func mayCancelDefaultBranchRuns(value any) bool {
+	if value == nil {
 		return false
 	}
 
-	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(rendered, "${{"), "}}"))
+	switch strings.TrimSpace(fmt.Sprintf("%v", value)) {
+	case "false", approvedCancelExpression:
+		return false
+	default:
+		return true
+	}
+}
 
-	return inner == "true" || !strings.Contains(inner, "github.ref")
+func TestMayCancelDefaultBranchRuns(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value any
+		want  bool
+	}{
+		"absent":              {value: nil, want: false},
+		"explicit false":      {value: false, want: false},
+		"approved expression": {value: approvedCancelExpression, want: false},
+
+		"literal true":    {value: true, want: true},
+		"quoted true":     {value: "true", want: true},
+		"expression true": {value: "${{ true }}", want: true},
+
+		// Both mention github.ref and read as branch-conditional, yet each
+		// evaluates true when github.ref is refs/heads/main.
+		"truthy ref conjunction": {value: "${{ github.ref && true }}", want: true},
+		"disjunction with true": {
+			value: "${{ github.ref != 'refs/heads/main' || true }}",
+			want:  true,
+		},
+
+		// Fail closed on anything not explicitly approved, including forms that
+		// may well be correct — adding one is a deliberate act.
+		"unreviewed variant": {
+			value: "${{ github.ref != format('refs/heads/{0}', 'main') }}",
+			want:  true,
+		},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, testCase.want, mayCancelDefaultBranchRuns(testCase.value))
+		})
+	}
 }

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -59,20 +59,16 @@ func TestCIWorkflowKeepsDefaultBranchRunsAlive(t *testing.T) {
 		"main must be bound to the run-unique key; an inverted condition gives main the shared ref key",
 	)
 
-	// A ref-keyed group gives every push to main the same key, so cancelling
-	// unconditionally evicts the previous merge's checks mid-flight. main then
-	// reports green on verification that never finished.
-	cancel, isExpression := workflow.Concurrency.CancelInProgress.(string)
-	require.Truef(
+	// Hold cancel-in-progress to the same allowlist the repo-wide test uses.
+	// Substring checks would be misleading here for exactly the reason they were
+	// wrong there: `${{ github.ref != 'refs/heads/main' || true }}` contains
+	// "github.ref", "refs/heads/main" and "!=" while still cancelling on main.
+	assert.Equalf(
 		t,
-		isExpression,
-		"cancel-in-progress must be an expression excluding the default branch, got %#v",
+		approvedCancelExpression,
 		workflow.Concurrency.CancelInProgress,
+		"cancel-in-progress must be exactly the approved expression",
 	)
-
-	assert.Contains(t, cancel, "github.ref")
-	assert.Contains(t, cancel, "refs/heads/main")
-	assert.Contains(t, cancel, "!=")
 }
 
 func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -1,0 +1,103 @@
+package ciharness_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// concurrencyWorkflow captures the trigger and concurrency surface that decides
+// whether a run on the default branch can be evicted by a later one.
+//
+//nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
+type concurrencyWorkflow struct {
+	On struct {
+		Push struct {
+			Branches []string `yaml:"branches"`
+		} `yaml:"push"`
+	} `yaml:"on"`
+	Concurrency struct {
+		Group            string `yaml:"group"`
+		CancelInProgress any    `yaml:"cancel-in-progress"`
+	} `yaml:"concurrency"`
+}
+
+func TestCIWorkflowKeepsDefaultBranchRunsAlive(t *testing.T) {
+	t.Parallel()
+
+	contents := readRepoFile(t, ".github/workflows/ci.yaml")
+
+	var workflow concurrencyWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	// The group stays ref-keyed so superseded pull-request runs still cancel:
+	// each pull request carries its own refs/pull/<n>/merge ref, and each merge
+	// queue entry its own gh-readonly-queue ref.
+	assert.Contains(t, workflow.Concurrency.Group, "github.ref")
+
+	// A ref-keyed group gives every push to main the same key, so cancelling
+	// unconditionally evicts the previous merge's checks mid-flight. main then
+	// reports green on verification that never finished.
+	cancel, isExpression := workflow.Concurrency.CancelInProgress.(string)
+	require.Truef(
+		t,
+		isExpression,
+		"cancel-in-progress must be an expression excluding the default branch, got %#v",
+		workflow.Concurrency.CancelInProgress,
+	)
+
+	assert.Contains(t, cancel, "github.ref")
+	assert.Contains(t, cancel, "refs/heads/main")
+	assert.Contains(t, cancel, "!=")
+}
+
+func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
+	t.Parallel()
+
+	paths, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.y*ml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, paths)
+
+	checked := 0
+
+	for _, path := range paths {
+		// The glob supplies repository-owned workflow paths, never user input.
+		contents, readErr := os.ReadFile(path) //nolint:gosec
+		require.NoError(t, readErr)
+
+		var workflow concurrencyWorkflow
+		require.NoErrorf(t, yaml.Unmarshal(contents, &workflow), "parsing %s", path)
+
+		if !slices.Contains(workflow.On.Push.Branches, "main") {
+			continue
+		}
+
+		checked++
+
+		assert.NotEqualf(
+			t,
+			true,
+			workflow.Concurrency.CancelInProgress,
+			"%s runs on main and cancels in progress unconditionally, so one merge evicts "+
+				"the previous merge's checks before they complete",
+			filepath.Base(path),
+		)
+	}
+
+	// Guard the guard: were the glob or the trigger shape to stop matching, the
+	// loop above would pass over an empty set and assert nothing at all. Five
+	// workflows push to main today (ci, desktop, release, todos, web-ui); the
+	// floor stays low so removing one does not fail this test spuriously.
+	assert.GreaterOrEqualf(
+		t,
+		checked,
+		2,
+		"expected several workflows to trigger on push to main, matched %d",
+		checked,
+	)
+}

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -201,7 +201,10 @@ func runsOnDefaultBranch(on map[string]any) bool {
 	}
 
 	if ignore := patternList(filters["branches-ignore"]); len(ignore) > 0 {
-		return !matchesDefaultBranch(ignore)
+		// Inverted sense: a pattern we cannot read must NOT be taken to exclude
+		// main, or an unreadable ignore-pattern would skip the workflow — the
+		// same silent hole, arrived at from the other side.
+		return !matchesDefaultBranch(ignore, false)
 	}
 
 	branches := patternList(filters["branches"])
@@ -216,7 +219,7 @@ func runsOnDefaultBranch(on map[string]any) bool {
 		return !tagOnly
 	}
 
-	return matchesDefaultBranch(branches)
+	return matchesDefaultBranch(branches, true)
 }
 
 func patternList(raw any) []string {
@@ -233,7 +236,11 @@ func patternList(raw any) []string {
 	return patterns
 }
 
-func matchesDefaultBranch(patterns []string) bool {
+// matchesDefaultBranch reports whether any pattern selects main. whenUnparseable
+// is the answer for a pattern Go's matcher rejects, and differs by caller: an
+// inclusion list should assume it matches, an exclusion list should assume it
+// does not, so that either way the workflow stays in the checked set.
+func matchesDefaultBranch(patterns []string, whenUnparseable bool) bool {
 	for _, pattern := range patterns {
 		if pattern == "main" || strings.Contains(pattern, "**") {
 			return true
@@ -241,8 +248,21 @@ func matchesDefaultBranch(patterns []string) bool {
 
 		// filepath.Match covers *, ? and character classes; branch names here
 		// carry no slash, so its separator handling does not matter.
+		//
+		// A malformed pattern, or one using syntax GitHub accepts and Go does
+		// not, errors here. Treat that as a match: this function fails open
+		// toward inclusion, and silently skipping a pattern we cannot read is
+		// precisely the hole this matcher exists to close.
 		matched, err := filepath.Match(pattern, "main")
-		if err == nil && matched {
+		if err != nil {
+			if whenUnparseable {
+				return true
+			}
+
+			continue
+		}
+
+		if matched {
 			return true
 		}
 	}
@@ -268,6 +288,14 @@ func TestRunsOnDefaultBranch(t *testing.T) {
 		"ignore other":     {yaml: "on:\n  push:\n    branches-ignore: [develop]\n", want: true},
 		"ignore main":      {yaml: "on:\n  push:\n    branches-ignore: [main]\n", want: false},
 		"ignore main glob": {yaml: "on:\n  push:\n    branches-ignore: ['mai?']\n", want: false},
+
+		// A pattern Go's matcher cannot parse must not silently skip the
+		// workflow; inclusion is the safe direction.
+		"unparseable pattern": {yaml: "on:\n  push:\n    branches: ['[main']\n", want: true},
+		"unparseable ignore": {
+			yaml: "on:\n  push:\n    branches-ignore: ['[main']\n",
+			want: true,
+		},
 	}
 
 	for name, testCase := range tests {

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -1,6 +1,7 @@
 package ciharness_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -79,10 +80,13 @@ func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
 
 		checked++
 
-		assert.NotEqualf(
+		// Both the YAML boolean and a quoted "true" are truthy to GitHub, so
+		// compare on the rendered value rather than the parsed type.
+		cancels := fmt.Sprintf("%v", workflow.Concurrency.CancelInProgress) == "true"
+
+		assert.Falsef(
 			t,
-			true,
-			workflow.Concurrency.CancelInProgress,
+			cancels,
 			"%s runs on main and cancels in progress unconditionally, so one merge evicts "+
 				"the previous merge's checks before they complete",
 			filepath.Base(path),

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
@@ -18,11 +17,7 @@ import (
 //
 //nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
 type concurrencyWorkflow struct {
-	On struct {
-		Push struct {
-			Branches []string `yaml:"branches"`
-		} `yaml:"push"`
-	} `yaml:"on"`
+	On          map[string]any `yaml:"on"`
 	Concurrency struct {
 		Group            string `yaml:"group"`
 		CancelInProgress any    `yaml:"cancel-in-progress"`
@@ -37,26 +32,17 @@ func TestCIWorkflowKeepsDefaultBranchRunsAlive(t *testing.T) {
 	var workflow concurrencyWorkflow
 	require.NoError(t, yaml.Unmarshal(contents, &workflow))
 
-	// The group stays ref-keyed so superseded pull-request runs still cancel:
-	// each pull request carries its own refs/pull/<n>/merge ref, and each merge
-	// queue entry its own gh-readonly-queue ref.
-	assert.Contains(t, workflow.Concurrency.Group, "github.ref")
-
-	// On main the group must be run-unique. cancel-in-progress alone does not
-	// make a shared group safe there: a concurrency group holds one running plus
-	// one pending run, and a third push cancels the pending one — so the second
-	// push's checks are lost even with cancellation disabled.
-	//
-	// Assert the whole conditional rather than the tokens separately. Checking
-	// "github.run_id", "refs/heads/main" and "github.ref" as independent
-	// substrings also passes for the INVERTED expression
-	//   github.ref != 'refs/heads/main' && github.run_id || github.ref
-	// which hands main the shared ref key and reinstates the eviction.
-	assert.Containsf(
+	// Assert the whole group expression, not fragments of it. Every partial form
+	// tried here has admitted a bypass: independent substrings admit the inverted
+	// conditional, and asserting only the true-branch admits
+	//   github.ref == 'refs/heads/main' && github.run_id || github.run_id
+	// whose fallback gives pull-request and merge-queue runs unique groups too,
+	// so superseded runs there can no longer cancel each other.
+	assert.Equalf(
 		t,
+		approvedGroupExpression,
 		workflow.Concurrency.Group,
-		"github.ref == 'refs/heads/main' && github.run_id",
-		"main must be bound to the run-unique key; an inverted condition gives main the shared ref key",
+		"concurrency group must be exactly the approved expression",
 	)
 
 	// Hold cancel-in-progress to the same allowlist the repo-wide test uses.
@@ -88,7 +74,7 @@ func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
 		var workflow concurrencyWorkflow
 		require.NoErrorf(t, yaml.Unmarshal(contents, &workflow), "parsing %s", path)
 
-		if !slices.Contains(workflow.On.Push.Branches, "main") {
+		if !runsOnDefaultBranch(workflow.On) {
 			continue
 		}
 
@@ -105,9 +91,11 @@ func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
 	}
 
 	// Guard the guard: were the glob or the trigger shape to stop matching, the
-	// loop above would pass over an empty set and assert nothing at all. Five
-	// workflows push to main today (ci, desktop, release, todos, web-ui); the
-	// floor stays low so removing one does not fail this test spuriously.
+	// loop above would pass over an empty set and assert nothing at all. Six
+	// workflows can run on main today — ci, desktop, release, todos and web-ui
+	// name it literally, and copilot-setup-steps.yml reaches it through an
+	// unfiltered push, which a literal-name check silently skipped. The floor
+	// stays low so removing one does not fail this test spuriously.
 	assert.GreaterOrEqualf(
 		t,
 		checked,
@@ -181,6 +169,114 @@ func TestMayCancelDefaultBranchRuns(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, testCase.want, mayCancelDefaultBranchRuns(testCase.value))
+		})
+	}
+}
+
+// approvedGroupExpression is the only concurrency group allowed for ci.yaml. It
+// gives main a run-unique key while leaving every other ref — pull requests and
+// merge-queue entries — sharing the ref-keyed group so superseded runs cancel.
+const approvedGroupExpression = "ci-ksail-${{ github.workflow }}-" +
+	"${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}"
+
+// runsOnDefaultBranch reports whether a workflow's triggers admit a push to
+// main. It FAILS OPEN toward inclusion: anything that might run there is
+// checked, because a workflow wrongly skipped is a silent hole, while a
+// workflow wrongly included merely has to satisfy the same cancellation rule.
+//
+// A literal branch list is not sufficient to decide this. An `on: push` with no
+// branch filter runs on every branch; `branches-ignore` selects by exclusion;
+// and both filters accept glob patterns, so `main` can be matched by `ma*n`,
+// `*` or `**` without appearing literally.
+func runsOnDefaultBranch(on map[string]any) bool {
+	raw, present := on["push"]
+	if !present {
+		return false
+	}
+
+	filters, isMapping := raw.(map[string]any)
+	if !isMapping {
+		// `push:` with no body runs on every branch.
+		return true
+	}
+
+	if ignore := patternList(filters["branches-ignore"]); len(ignore) > 0 {
+		return !matchesDefaultBranch(ignore)
+	}
+
+	branches := patternList(filters["branches"])
+	if len(branches) == 0 {
+		// Only tag filters, or none at all. A tag-only push never targets a
+		// branch; anything else reaches every branch.
+		_, tagOnly := filters["tags"]
+		if !tagOnly {
+			_, tagOnly = filters["tags-ignore"]
+		}
+
+		return !tagOnly
+	}
+
+	return matchesDefaultBranch(branches)
+}
+
+func patternList(raw any) []string {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+
+	patterns := make([]string, 0, len(items))
+	for _, item := range items {
+		patterns = append(patterns, fmt.Sprintf("%v", item))
+	}
+
+	return patterns
+}
+
+func matchesDefaultBranch(patterns []string) bool {
+	for _, pattern := range patterns {
+		if pattern == "main" || strings.Contains(pattern, "**") {
+			return true
+		}
+
+		// filepath.Match covers *, ? and character classes; branch names here
+		// carry no slash, so its separator handling does not matter.
+		matched, err := filepath.Match(pattern, "main")
+		if err == nil && matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestRunsOnDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		yaml string
+		want bool
+	}{
+		"literal main":     {yaml: "on:\n  push:\n    branches: [main]\n", want: true},
+		"no push trigger":  {yaml: "on:\n  pull_request:\n", want: false},
+		"tags only":        {yaml: "on:\n  push:\n    tags: ['v*']\n", want: false},
+		"other branch":     {yaml: "on:\n  push:\n    branches: [develop]\n", want: false},
+		"unfiltered push":  {yaml: "on:\n  push:\n", want: true},
+		"glob star":        {yaml: "on:\n  push:\n    branches: ['*']\n", want: true},
+		"glob doublestar":  {yaml: "on:\n  push:\n    branches: ['**']\n", want: true},
+		"glob prefix":      {yaml: "on:\n  push:\n    branches: ['ma*n']\n", want: true},
+		"ignore other":     {yaml: "on:\n  push:\n    branches-ignore: [develop]\n", want: true},
+		"ignore main":      {yaml: "on:\n  push:\n    branches-ignore: [main]\n", want: false},
+		"ignore main glob": {yaml: "on:\n  push:\n    branches-ignore: ['mai?']\n", want: false},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var workflow concurrencyWorkflow
+			require.NoError(t, yaml.Unmarshal([]byte(testCase.yaml), &workflow))
+			assert.Equal(t, testCase.want, runsOnDefaultBranch(workflow.On))
 		})
 	}
 }

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -41,6 +41,18 @@ func TestCIWorkflowKeepsDefaultBranchRunsAlive(t *testing.T) {
 	// queue entry its own gh-readonly-queue ref.
 	assert.Contains(t, workflow.Concurrency.Group, "github.ref")
 
+	// On main the group must be run-unique. cancel-in-progress alone does not
+	// make a shared group safe there: a concurrency group holds one running plus
+	// one pending run, and a third push cancels the pending one — so the second
+	// push's checks are lost even with cancellation disabled.
+	assert.Containsf(
+		t,
+		workflow.Concurrency.Group,
+		"github.run_id",
+		"main must get a run-unique concurrency group, else a queued run is evicted by the next push",
+	)
+	assert.Contains(t, workflow.Concurrency.Group, "refs/heads/main")
+
 	// A ref-keyed group gives every push to main the same key, so cancelling
 	// unconditionally evicts the previous merge's checks mid-flight. main then
 	// reports green on verification that never finished.

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,13 +46,18 @@ func TestCIWorkflowKeepsDefaultBranchRunsAlive(t *testing.T) {
 	// make a shared group safe there: a concurrency group holds one running plus
 	// one pending run, and a third push cancels the pending one — so the second
 	// push's checks are lost even with cancellation disabled.
+	//
+	// Assert the whole conditional rather than the tokens separately. Checking
+	// "github.run_id", "refs/heads/main" and "github.ref" as independent
+	// substrings also passes for the INVERTED expression
+	//   github.ref != 'refs/heads/main' && github.run_id || github.ref
+	// which hands main the shared ref key and reinstates the eviction.
 	assert.Containsf(
 		t,
 		workflow.Concurrency.Group,
-		"github.run_id",
-		"main must get a run-unique concurrency group, else a queued run is evicted by the next push",
+		"github.ref == 'refs/heads/main' && github.run_id",
+		"main must be bound to the run-unique key; an inverted condition gives main the shared ref key",
 	)
-	assert.Contains(t, workflow.Concurrency.Group, "refs/heads/main")
 
 	// A ref-keyed group gives every push to main the same key, so cancelling
 	// unconditionally evicts the previous merge's checks mid-flight. main then
@@ -92,13 +98,9 @@ func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
 
 		checked++
 
-		// Both the YAML boolean and a quoted "true" are truthy to GitHub, so
-		// compare on the rendered value rather than the parsed type.
-		cancels := fmt.Sprintf("%v", workflow.Concurrency.CancelInProgress) == "true"
-
 		assert.Falsef(
 			t,
-			cancels,
+			cancelsUnconditionally(workflow.Concurrency.CancelInProgress),
 			"%s runs on main and cancels in progress unconditionally, so one merge evicts "+
 				"the previous merge's checks before they complete",
 			filepath.Base(path),
@@ -116,4 +118,25 @@ func TestNoDefaultBranchWorkflowCancelsRunsInProgress(t *testing.T) {
 		"expected several workflows to trigger on push to main, matched %d",
 		checked,
 	)
+}
+
+// cancelsUnconditionally reports whether a cancel-in-progress value cancels runs
+// on every branch. A literal `true` is the obvious form, but GitHub also accepts
+// an expression, and YAML hands those back as strings — so `${{ true }}` renders
+// as a non-"true" string while still cancelling everything. An expression that
+// never mentions github.ref cannot be branch-conditional either, so it is
+// treated as unconditional rather than assumed safe.
+func cancelsUnconditionally(value any) bool {
+	rendered := strings.TrimSpace(fmt.Sprintf("%v", value))
+	if rendered == "true" {
+		return true
+	}
+
+	if !strings.HasPrefix(rendered, "${{") || !strings.HasSuffix(rendered, "}}") {
+		return false
+	}
+
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(rendered, "${{"), "}}"))
+
+	return inner == "true" || !strings.Contains(inner, "github.ref")
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`main` can report green on tests that never ran. Every merge to `main` shares one concurrency key, so a merge landing while the previous merge's checks are still running **cancels them** — and a cancelled check is not a failed check, so the commit status settles green anyway.

That is how a broken Go test suite reached `main` unnoticed and then surfaced as an unrelated PR author's problem days later.

## What

Runs on `main` are now allowed to finish. Superseded pull-request and merge-queue runs still cancel exactly as before, so the fast-feedback behaviour developers rely on is unchanged — only the default branch, where each commit's run is its own verification record, stops being evicted.

Also adds a guard so no future workflow can reintroduce the same eviction on `main`.

Fixes #6384
Part of #6373
