### PR TITLE
fix(ci): consume govulncheck timeout hotfix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -361,7 +361,7 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository
       && needs.changes.outputs.govuln-allowlist == 'true')
-    uses: devantler-tech/actions/.github/workflows/validate-go-project.yaml@8349b0935ade387313cf1a92d17dc068d92daee1 # v13.0.1
+    uses: devantler-tech/actions/.github/workflows/validate-go-project.yaml@c30955b658e89794e87651fa12867c2f2f50e7ce # v13.0.2
     # Both inputs make a default-branch run answer "did the check run" rather than
     # "did the diff touch a Go file". On main the branch's green IS the protection
     # signal, so a path filter that skips the suite or the scan leaves main green


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## What changed

- Pin only the `validate-go-project` reusable workflow from Actions v13.0.1 to v13.0.2.
- Leave KSail’s unrelated shared-action references on their existing pins.

## Why

KSail main run [31209007757](https://github.com/devantler-tech/ksail/actions/runs/31209007757) completed govulncheck after 17m44s, then GitHub cancelled the job during `actions/setup-go` cache-save cleanup at the old 20-minute ceiling. [Actions #909](https://github.com/devantler-tech/actions/pull/909) raised the finite ceiling to 25 minutes, retained `GOMEMLIMIT: 12GiB`, added a 24-minute failing-input test, and shipped as [v13.0.2](https://github.com/devantler-tech/actions/releases/tag/v13.0.2).

## Validation

- `go test ./internal/ciharness`
- `actionlint -oneline .github/workflows/ci.yaml` (only the repository-documented `code-quality` scope warning)
- `git diff --check`
- Verified tag `v13.0.2` resolves to `c30955b658e89794e87651fa12867c2f2f50e7ce`
- Verified the pinned workflow sets `timeout-minutes: 25` and `GOMEMLIMIT: 12GiB`

The real user-facing proof is this PR’s required Go vulnerability scan completing through its cache-save post-step.