### PR TITLE
fix(hetzner): reject private keys in provider user-data

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -1,10 +1,18 @@
 package hetznerbase
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"io"
+	"regexp"
+	"strings"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"gopkg.in/yaml.v3"
 )
 
 // DefaultImageName is the stock OS image every cloud-init-bootstrapped node
@@ -14,6 +22,20 @@ import (
 // ([hetzner.CreateServerOpts.ImageName]), so no client-side image lookup is
 // needed.
 const DefaultImageName = "ubuntu-24.04"
+
+const maxDecodedUserDataBytes = 1 << 20
+
+// ErrPrivateKeyInUserData is returned when a server spec would deliver private
+// key material through provider-readable user-data. The cloud-init ssh_keys
+// module is the deliberate exception: it carries the per-node SSH host identity
+// used to pin the bootstrap connection, never cluster-signing PKI.
+var ErrPrivateKeyInUserData = errors.New(
+	"hetzner: provider user-data contains private key material",
+)
+
+var privateKeyPEMHeader = regexp.MustCompile(
+	`-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----`,
+)
 
 // NodeSpec pairs a planned node's identity with the cloud-init user_data that
 // bootstraps it — the distribution-agnostic per-node shape both the k3s and
@@ -70,6 +92,11 @@ func DeriveServerSpecs(
 	specs := make([]hetzner.CreateServerOpts, 0, len(nodes))
 
 	for _, node := range nodes {
+		err := validateProviderUserData(node.UserData)
+		if err != nil {
+			return nil, fmt.Errorf("validate user-data for node %d: %w", node.Index, err)
+		}
+
 		name, err := hetzner.NodeName(clusterName, node.NodeType, node.Index)
 		if err != nil {
 			return nil, fmt.Errorf("derive server name for node %d: %w", node.Index, err)
@@ -90,6 +117,144 @@ func DeriveServerSpecs(
 	}
 
 	return specs, nil
+}
+
+// validateProviderUserData rejects raw or encoded PEM private keys anywhere in
+// the cloud-init document except its top-level ssh_keys module. That module is
+// the intentional per-node host identity; every other private key would be
+// retained in Hetzner's provider-readable user-data.
+func validateProviderUserData(userData string) error {
+	var document yaml.Node
+
+	err := yaml.Unmarshal([]byte(userData), &document)
+	if err != nil {
+		return fmt.Errorf("parse cloud-init user-data: %w", err)
+	}
+
+	if yamlNodeContainsPrivateKey(&document, true) {
+		return ErrPrivateKeyInUserData
+	}
+
+	return nil
+}
+
+// yamlNodeContainsPrivateKey walks scalar values while exempting only the
+// top-level cloud-init ssh_keys value. Nested keys with the same name are not
+// identities and remain subject to inspection.
+func yamlNodeContainsPrivateKey(node *yaml.Node, topLevel bool) bool {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		return yamlChildrenContainPrivateKey(node.Content, true)
+	case yaml.MappingNode:
+		return yamlMappingContainsPrivateKey(node.Content, topLevel)
+	case yaml.SequenceNode:
+		return yamlChildrenContainPrivateKey(node.Content, false)
+	case yaml.ScalarNode:
+		return containsPrivateKeyMaterial(node.Value)
+	case yaml.AliasNode:
+		return node.Alias != nil && yamlNodeContainsPrivateKey(node.Alias, false)
+	}
+
+	return false
+}
+
+func yamlChildrenContainPrivateKey(children []*yaml.Node, topLevel bool) bool {
+	for _, child := range children {
+		if yamlNodeContainsPrivateKey(child, topLevel) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func yamlMappingContainsPrivateKey(content []*yaml.Node, topLevel bool) bool {
+	for index := 0; index+1 < len(content); index += 2 {
+		key := content[index]
+		value := content[index+1]
+
+		if topLevel && key.Value == "ssh_keys" {
+			continue
+		}
+
+		if yamlNodeContainsPrivateKey(value, false) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsPrivateKeyMaterial(value string) bool {
+	if containsPrivateKeyPEM(value) {
+		return true
+	}
+
+	decoded, ok := decodeBase64(value)
+	if !ok {
+		return false
+	}
+
+	return decodedContainsPrivateKey(decoded)
+}
+
+func decodeBase64(value string) ([]byte, bool) {
+	compact := strings.Map(func(character rune) rune {
+		if character == ' ' || character == '\n' || character == '\r' || character == '\t' {
+			return -1
+		}
+
+		return character
+	}, value)
+
+	decoded, err := base64.StdEncoding.DecodeString(compact)
+	if err != nil {
+		decoded, err = base64.RawStdEncoding.DecodeString(compact)
+	}
+
+	if err != nil || len(decoded) == 0 {
+		return nil, false
+	}
+
+	return decoded, true
+}
+
+func decodedContainsPrivateKey(decoded []byte) bool {
+	if containsPrivateKeyPEM(string(decoded)) {
+		return true
+	}
+
+	if len(decoded) < 2 || decoded[0] != 0x1f || decoded[1] != 0x8b {
+		return false
+	}
+
+	return gzipContainsPrivateKey(decoded)
+}
+
+func gzipContainsPrivateKey(compressed []byte) bool {
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return false
+	}
+
+	decompressed, readErr := io.ReadAll(io.LimitReader(reader, maxDecodedUserDataBytes+1))
+
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil {
+		return false
+	}
+
+	// Provider user-data is small. An encoded scalar expanding beyond this bound
+	// is refused rather than allowed to hide a marker past the inspected prefix.
+	if len(decompressed) > maxDecodedUserDataBytes {
+		return true
+	}
+
+	return containsPrivateKeyPEM(string(decompressed))
+}
+
+func containsPrivateKeyPEM(value string) bool {
+	return privateKeyPEMHeader.MatchString(value)
 }
 
 // nodeServerType selects the configured Hetzner server type for a node's role.

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -120,47 +120,73 @@ func DeriveServerSpecs(
 }
 
 // validateProviderUserData rejects raw or encoded PEM private keys anywhere in
-// the cloud-init document except its top-level ssh_keys module. That module is
-// the intentional per-node host identity; every other private key would be
-// retained in Hetzner's provider-readable user-data.
+// the cloud-init YAML stream except a document's top-level ssh_keys module.
+// That module is the intentional per-node host identity; every other private
+// key would be retained in Hetzner's provider-readable user-data.
 func validateProviderUserData(userData string) error {
-	var document yaml.Node
+	decoder := yaml.NewDecoder(strings.NewReader(userData))
 
-	err := yaml.Unmarshal([]byte(userData), &document)
-	if err != nil {
-		return fmt.Errorf("parse cloud-init user-data: %w", err)
+	for {
+		var document yaml.Node
+
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("parse cloud-init user-data: %w", err)
+		}
+
+		if yamlNodeContainsPrivateKey(&document, true, make(map[*yaml.Node]struct{})) {
+			return ErrPrivateKeyInUserData
+		}
 	}
-
-	if yamlNodeContainsPrivateKey(&document, true) {
-		return ErrPrivateKeyInUserData
-	}
-
-	return nil
 }
 
-// yamlNodeContainsPrivateKey walks scalar values while exempting only the
-// top-level cloud-init ssh_keys value. Nested keys with the same name are not
-// identities and remain subject to inspection.
-func yamlNodeContainsPrivateKey(node *yaml.Node, topLevel bool) bool {
+// yamlNodeContainsPrivateKey walks scalar mapping keys and values while
+// exempting only the top-level cloud-init ssh_keys value. Nested keys with the
+// same name are not identities and remain subject to inspection. Active nodes
+// stop recursive aliases from cycling without suppressing later sibling paths.
+func yamlNodeContainsPrivateKey(
+	node *yaml.Node,
+	topLevel bool,
+	active map[*yaml.Node]struct{},
+) bool {
+	if node == nil {
+		return false
+	}
+
+	if _, visited := active[node]; visited {
+		return false
+	}
+
+	active[node] = struct{}{}
+	defer delete(active, node)
+
 	switch node.Kind {
 	case yaml.DocumentNode:
-		return yamlChildrenContainPrivateKey(node.Content, true)
+		return yamlChildrenContainPrivateKey(node.Content, true, active)
 	case yaml.MappingNode:
-		return yamlMappingContainsPrivateKey(node.Content, topLevel)
+		return yamlMappingContainsPrivateKey(node.Content, topLevel, active)
 	case yaml.SequenceNode:
-		return yamlChildrenContainPrivateKey(node.Content, false)
+		return yamlChildrenContainPrivateKey(node.Content, false, active)
 	case yaml.ScalarNode:
 		return containsPrivateKeyMaterial(node.Value)
 	case yaml.AliasNode:
-		return node.Alias != nil && yamlNodeContainsPrivateKey(node.Alias, false)
+		return yamlNodeContainsPrivateKey(node.Alias, false, active)
 	}
 
 	return false
 }
 
-func yamlChildrenContainPrivateKey(children []*yaml.Node, topLevel bool) bool {
+func yamlChildrenContainPrivateKey(
+	children []*yaml.Node,
+	topLevel bool,
+	active map[*yaml.Node]struct{},
+) bool {
 	for _, child := range children {
-		if yamlNodeContainsPrivateKey(child, topLevel) {
+		if yamlNodeContainsPrivateKey(child, topLevel, active) {
 			return true
 		}
 	}
@@ -168,16 +194,24 @@ func yamlChildrenContainPrivateKey(children []*yaml.Node, topLevel bool) bool {
 	return false
 }
 
-func yamlMappingContainsPrivateKey(content []*yaml.Node, topLevel bool) bool {
+func yamlMappingContainsPrivateKey(
+	content []*yaml.Node,
+	topLevel bool,
+	active map[*yaml.Node]struct{},
+) bool {
 	for index := 0; index+1 < len(content); index += 2 {
 		key := content[index]
 		value := content[index+1]
 
-		if topLevel && key.Value == "ssh_keys" {
+		if yamlNodeContainsPrivateKey(key, false, active) {
+			return true
+		}
+
+		if topLevel && key.Kind == yaml.ScalarNode && key.Value == "ssh_keys" {
 			continue
 		}
 
-		if yamlNodeContainsPrivateKey(value, false) {
+		if yamlNodeContainsPrivateKey(value, false, active) {
 			return true
 		}
 	}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_test.go
@@ -194,3 +194,63 @@ write_files:
 		})
 	}
 }
+
+func TestDeriveServerSpecsRejectsPrivateKeyInMappingKey(t *testing.T) {
+	t.Parallel()
+
+	nodes := twoNodeSpecs()
+	nodes[1].UserData = `#cloud-config
+? |-
+  -----BEGIN PRIVATE KEY-----
+  AAAA
+  -----END PRIVATE KEY-----
+: harmless
+`
+
+	specs, err := hetznerbase.DeriveServerSpecs(
+		specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+	)
+
+	require.ErrorIs(t, err, hetznerbase.ErrPrivateKeyInUserData)
+	assert.Nil(t, specs)
+}
+
+func TestDeriveServerSpecsRejectsPrivateKeyInLaterYAMLDocument(t *testing.T) {
+	t.Parallel()
+
+	nodes := twoNodeSpecs()
+	nodes[1].UserData = `#cloud-config
+hostname: worker
+---
+write_files:
+  - path: /etc/kubernetes/pki/ca.key
+    content: |-
+      -----BEGIN PRIVATE KEY-----
+      AAAA
+      -----END PRIVATE KEY-----
+`
+
+	specs, err := hetznerbase.DeriveServerSpecs(
+		specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+	)
+
+	require.ErrorIs(t, err, hetznerbase.ErrPrivateKeyInUserData)
+	assert.Nil(t, specs)
+}
+
+func TestDeriveServerSpecsHandlesCyclicYAMLAlias(t *testing.T) {
+	t.Parallel()
+
+	nodes := twoNodeSpecs()
+	nodes[1].UserData = `#cloud-config
+loop: &loop
+  again: *loop
+`
+
+	specs, err := hetznerbase.DeriveServerSpecs(
+		specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, specs, len(nodes))
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_test.go
@@ -1,6 +1,10 @@
 package hetznerbase_test
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -136,4 +140,57 @@ func TestDeriveServerSpecsNameTooLong(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, hetzner.ErrNodeNameTooLong)
 	assert.Nil(t, specs)
+}
+
+func TestDeriveServerSpecsRejectsPrivateKeyMaterial(t *testing.T) {
+	t.Parallel()
+
+	privateKey := "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----"
+
+	var compressed bytes.Buffer
+
+	zipper := gzip.NewWriter(&compressed)
+	_, err := zipper.Write([]byte(privateKey))
+	require.NoError(t, err)
+	require.NoError(t, zipper.Close())
+
+	// These deliberately invalid synthetic bodies exercise only the PEM
+	// envelopes; no credential is present in the fixture.
+	//nolint:gosec // Synthetic PEM markers test the private-key rejection boundary.
+	tests := map[string]string{
+		"PKCS8": privateKey,
+		"RSA":   "-----BEGIN RSA PRIVATE KEY-----\nAAAA\n-----END RSA PRIVATE KEY-----",
+		"EC":    "-----BEGIN EC PRIVATE KEY-----\nAAAA\n-----END EC PRIVATE KEY-----",
+		"OpenSSH": "-----BEGIN OPENSSH PRIVATE KEY-----\nAAAA\n" +
+			"-----END OPENSSH PRIVATE KEY-----",
+		"encrypted": "-----BEGIN ENCRYPTED PRIVATE KEY-----\nAAAA\n" +
+			"-----END ENCRYPTED PRIVATE KEY-----",
+		"embedded": "printf '%s' '-----BEGIN PRIVATE KEY-----' > /tmp/cluster.key",
+		"base64":   base64.StdEncoding.EncodeToString([]byte(privateKey)),
+		"base64 without padding": base64.RawStdEncoding.EncodeToString(
+			[]byte(privateKey),
+		),
+		"gzip plus base64": base64.StdEncoding.EncodeToString(compressed.Bytes()),
+	}
+
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes := twoNodeSpecs()
+			nodes[1].UserData = fmt.Sprintf(`#cloud-config
+write_files:
+  - path: /etc/kubernetes/pki/ca.key
+    content: |-
+      %s
+`, strings.ReplaceAll(content, "\n", "\n      "))
+
+			specs, err := hetznerbase.DeriveServerSpecs(
+				specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+			)
+
+			require.ErrorIs(t, err, hetznerbase.ErrPrivateKeyInUserData)
+			assert.Nil(t, specs)
+		})
+	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The original kubeadm Hetzner signing-key exposure was already removed, but the remaining guard only checked two raw PEM markers on the init-node composition. An alternate composer or joining-node path could still carry another PEM form or an encoded key into provider user-data.

## What

- validate every composed node at the shared server-spec boundary before deriving Hetzner API options
- reject raw or embedded PKCS#8, RSA, EC, OpenSSH, and encrypted PEM plus padded/unpadded base64 and gzip+base64 encodings
- retain the deliberate top-level `ssh_keys` host identity used for pinned bootstrap SSH
- leave kubeadm Hetzner HA refused; this slice does not claim live E2E proof

## Validation

- TDD RED: all private-key fixtures passed through before implementation; embedded PEM and unpadded base64 were separately RED-proved
- `go build -o /private/tmp/ksail-maint-e107 .`
- `go vet ./...`
- `go test ./pkg/svc/provisioner/cluster/internal/hetznerbase ./pkg/svc/provisioner/cluster/kubeadmhetzner -count=1`
- `go test -race ./pkg/svc/provisioner/cluster/internal/hetznerbase -run '^TestDeriveServerSpecs' -count=1`
- affected-package `golangci-lint`: 0 issues
- `go test ./... -count=1`: all packages passed except one unrelated chat helper-process cohort killed under concurrent load; its isolated rerun passed in 4.959s

Full-repository lint still reports 21 unrelated baseline findings; the changed packages are clean.

Part of #6428.