### PR TITLE
fix(talos): preserve externally managed node annotations

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -61,6 +61,12 @@ var errMissingControlPlanePKI = errors.New(
 		"a control-plane node's config is required to realign worker configs",
 )
 
+// errManagedNodeAnnotationKeysExpectedJSONArray is returned when the persisted
+// ownership marker is valid JSON but not an array (for example, JSON null).
+var errManagedNodeAnnotationKeysExpectedJSONArray = errors.New(
+	"decode managed node-annotation keys: expected JSON array",
+)
+
 // detectInPlaceMachineConfigDrift reports whether the desired Talos machine
 // config (base config + current patch files) differs from what is running on the
 // cluster, returning one in-place change per role (control-plane, worker) that
@@ -565,7 +571,7 @@ func previousNodeAnnotationKeys(
 		return nil, true, fmt.Errorf("decode managed node-annotation keys: %w", err)
 	}
 	if keys == nil {
-		return nil, true, errors.New("decode managed node-annotation keys: expected JSON array")
+		return nil, true, errManagedNodeAnnotationKeysExpectedJSONArray
 	}
 
 	keySet := make(map[string]struct{}, len(keys))

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -570,6 +570,7 @@ func previousNodeAnnotationKeys(
 	if err != nil {
 		return nil, true, fmt.Errorf("decode managed node-annotation keys: %w", err)
 	}
+
 	if keys == nil {
 		return nil, true, errManagedNodeAnnotationKeysExpectedJSONArray
 	}

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -564,6 +564,9 @@ func previousNodeAnnotationKeys(
 	if err != nil {
 		return nil, true, fmt.Errorf("decode managed node-annotation keys: %w", err)
 	}
+	if keys == nil {
+		return nil, true, errors.New("decode managed node-annotation keys: expected JSON array")
+	}
 
 	keySet := make(map[string]struct{}, len(keys))
 	for _, key := range keys {

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -33,6 +35,12 @@ const redactedSecretPlaceholder = "<redacted>"
 // maxDriftDiffLines caps how much of the machine-config diff is echoed to the
 // change summary so it stays readable; the full config is re-applied regardless.
 const maxDriftDiffLines = 60
+
+// managedNodeAnnotationKeys records which machine.nodeAnnotations keys came
+// from KSail's desired patch set on the previous successful render. The marker
+// lets a later render distinguish an intentionally removed KSail key from a
+// live-only key owned by another controller.
+const managedNodeAnnotationKeys = "ksail.devantler.tech/managed-node-annotation-keys"
 
 // MachineConfigField is the change field reported when the desired Talos machine
 // config differs from what is running on the nodes.
@@ -450,7 +458,13 @@ func graftNodeManagedSections(
 		// in its rendered desired config; preserve live-only keys so another
 		// controller can annotate nodes without making every KSail update delete
 		// those entries and re-apply the whole machine config (#6549).
-		graftExternalNodeAnnotations(cfg.MachineConfig, runningRaw.MachineConfig)
+		err := graftExternalNodeAnnotations(
+			cfg.MachineConfig,
+			runningRaw.MachineConfig,
+		)
+		if err != nil {
+			return err
+		}
 
 		graftHCloudVIP(cfg.MachineConfig, runningRaw.MachineConfig)
 
@@ -464,25 +478,99 @@ func graftNodeManagedSections(
 }
 
 // graftExternalNodeAnnotations merges live-only node-annotation keys into the
-// desired config. Desired values win on collisions, keeping KSail authoritative
-// for every key explicitly declared by its current Talos patch set.
-func graftExternalNodeAnnotations(desired, running *v1alpha1.MachineConfig) {
-	if len(running.MachineNodeAnnotations) == 0 {
-		return
+// desired config. Desired values win on collisions, while the managed-key
+// marker prevents a key removed from KSail's patch set from being reclassified
+// as external and copied back.
+func graftExternalNodeAnnotations(desired, running *v1alpha1.MachineConfig) error {
+	currentOwnedKeys := nodeAnnotationKeys(desired.MachineNodeAnnotations)
+	sort.Strings(currentOwnedKeys)
+
+	previousOwnedKeys, hasMarker, err := previousNodeAnnotationKeys(
+		running.MachineNodeAnnotations,
+	)
+	if err != nil {
+		return err
 	}
 
-	if desired.MachineNodeAnnotations == nil {
+	if desired.MachineNodeAnnotations == nil &&
+		(len(running.MachineNodeAnnotations) > 0 || hasMarker) {
 		desired.MachineNodeAnnotations = make(
 			map[string]string,
-			len(running.MachineNodeAnnotations),
+			len(running.MachineNodeAnnotations)+1,
 		)
 	}
 
-	for key, value := range running.MachineNodeAnnotations {
-		if _, owned := desired.MachineNodeAnnotations[key]; !owned {
-			desired.MachineNodeAnnotations[key] = value
+	mergeExternalNodeAnnotations(
+		desired.MachineNodeAnnotations,
+		running.MachineNodeAnnotations,
+		previousOwnedKeys,
+	)
+
+	if hasMarker || len(currentOwnedKeys) > 0 {
+		encodedKeys, err := json.Marshal(currentOwnedKeys)
+		if err != nil {
+			return fmt.Errorf("encode managed node-annotation keys: %w", err)
+		}
+
+		desired.MachineNodeAnnotations[managedNodeAnnotationKeys] = string(encodedKeys)
+	}
+
+	return nil
+}
+
+func mergeExternalNodeAnnotations(
+	desired, running map[string]string,
+	previousOwnedKeys map[string]struct{},
+) {
+	for key, value := range running {
+		if key == managedNodeAnnotationKeys {
+			continue
+		}
+
+		if _, ownedNow := desired[key]; ownedNow {
+			continue
+		}
+
+		if _, ownedBefore := previousOwnedKeys[key]; ownedBefore {
+			continue
+		}
+
+		desired[key] = value
+	}
+}
+
+func nodeAnnotationKeys(annotations map[string]string) []string {
+	keys := make([]string, 0, len(annotations))
+	for key := range annotations {
+		if key != managedNodeAnnotationKeys {
+			keys = append(keys, key)
 		}
 	}
+
+	return keys
+}
+
+func previousNodeAnnotationKeys(
+	annotations map[string]string,
+) (map[string]struct{}, bool, error) {
+	markerValue, hasMarker := annotations[managedNodeAnnotationKeys]
+	if !hasMarker {
+		return nil, false, nil
+	}
+
+	var keys []string
+
+	err := json.Unmarshal([]byte(markerValue), &keys)
+	if err != nil {
+		return nil, true, fmt.Errorf("decode managed node-annotation keys: %w", err)
+	}
+
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keySet[key] = struct{}{}
+	}
+
+	return keySet, true, nil
 }
 
 // graftHCloudVIP preserves the runtime-injected Hetzner VIP on its network

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -415,10 +415,10 @@ func (p *Provisioner) alignKubernetesVersion(
 	return updated, nil
 }
 
-// graftNodeManagedSections copies the machine-config sections that ksail injects
-// post-generation — registry mirrors/auth, cert SANs, and the Hetzner HCloud VIP
-// endpoint — from the running config into the desired config, so they don't read
-// as removable drift. These are node/setup-managed rather than user patch content.
+// graftNodeManagedSections copies machine-config state that must survive a
+// regeneration — registry mirrors/auth, cert SANs, externally managed node
+// annotations, and the Hetzner HCloud VIP endpoint — from the running config
+// into the desired config, so it does not read as removable drift.
 //
 // If ksail gains another post-generation machine-config transform, graft its
 // section here too (otherwise it will surface as phantom drift). The per-node
@@ -446,6 +446,11 @@ func graftNodeManagedSections(
 		if len(cfg.MachineConfig.MachineCertSANs) == 0 {
 			cfg.MachineConfig.MachineCertSANs = runningRaw.MachineConfig.MachineCertSANs
 		}
+		// machine.nodeAnnotations is a shared extension map. KSail owns keys present
+		// in its rendered desired config; preserve live-only keys so another
+		// controller can annotate nodes without making every KSail update delete
+		// those entries and re-apply the whole machine config (#6549).
+		graftExternalNodeAnnotations(cfg.MachineConfig, runningRaw.MachineConfig)
 
 		graftHCloudVIP(cfg.MachineConfig, runningRaw.MachineConfig)
 
@@ -456,6 +461,28 @@ func graftNodeManagedSections(
 	}
 
 	return grafted, nil
+}
+
+// graftExternalNodeAnnotations merges live-only node-annotation keys into the
+// desired config. Desired values win on collisions, keeping KSail authoritative
+// for every key explicitly declared by its current Talos patch set.
+func graftExternalNodeAnnotations(desired, running *v1alpha1.MachineConfig) {
+	if len(running.MachineNodeAnnotations) == 0 {
+		return
+	}
+
+	if desired.MachineNodeAnnotations == nil {
+		desired.MachineNodeAnnotations = make(
+			map[string]string,
+			len(running.MachineNodeAnnotations),
+		)
+	}
+
+	for key, value := range running.MachineNodeAnnotations {
+		if _, owned := desired.MachineNodeAnnotations[key]; !owned {
+			desired.MachineNodeAnnotations[key] = value
+		}
+	}
 }
 
 // graftHCloudVIP preserves the runtime-injected Hetzner VIP on its network

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace.go
@@ -42,6 +42,17 @@ const maxDriftDiffLines = 60
 // live-only key owned by another controller.
 const managedNodeAnnotationKeys = "ksail.devantler.tech/managed-node-annotation-keys"
 
+// bootstrapManagedNodeAnnotationKeys is an explicit, one-time migration input
+// for clusters that predate ownership tracking. It is consumed from the desired
+// patch and never applied to a node; operators list legacy KSail-owned keys here
+// when removing them during the first update after upgrading KSail.
+const bootstrapManagedNodeAnnotationKeys = "ksail.devantler.tech/bootstrap-managed-node-annotation-keys"
+
+// maxNodeAnnotationBytes matches Kubernetes' aggregate annotation key/value
+// limit. Ownership metadata is stored in the same map, so KSail must account for
+// its bytes before returning a config that Talos would later reject on apply.
+const maxNodeAnnotationBytes = 256 * 1024
+
 // MachineConfigField is the change field reported when the desired Talos machine
 // config differs from what is running on the nodes.
 const MachineConfigField = "machine.config"
@@ -65,6 +76,14 @@ var errMissingControlPlanePKI = errors.New(
 // ownership marker is valid JSON but not an array (for example, JSON null).
 var errManagedNodeAnnotationKeysExpectedJSONArray = errors.New(
 	"decode managed node-annotation keys: expected JSON array",
+)
+
+var errManagedNodeAnnotationKeysReserved = errors.New(
+	"managed node-annotation ownership key is reserved by KSail",
+)
+
+var errNodeAnnotationOwnershipMetadataLimit = errors.New(
+	"node annotations exceed 256 KiB after ownership metadata",
 )
 
 // detectInPlaceMachineConfigDrift reports whether the desired Talos machine
@@ -488,15 +507,16 @@ func graftNodeManagedSections(
 // marker prevents a key removed from KSail's patch set from being reclassified
 // as external and copied back.
 func graftExternalNodeAnnotations(desired, running *v1alpha1.MachineConfig) error {
-	currentOwnedKeys := nodeAnnotationKeys(desired.MachineNodeAnnotations)
-	sort.Strings(currentOwnedKeys)
-
-	previousOwnedKeys, hasMarker, err := previousNodeAnnotationKeys(
+	previousOwnedKeys, hasMarker, err := resolvePreviousNodeAnnotationKeys(
+		desired.MachineNodeAnnotations,
 		running.MachineNodeAnnotations,
 	)
 	if err != nil {
 		return err
 	}
+
+	currentOwnedKeys := nodeAnnotationKeys(desired.MachineNodeAnnotations)
+	sort.Strings(currentOwnedKeys)
 
 	if desired.MachineNodeAnnotations == nil &&
 		(len(running.MachineNodeAnnotations) > 0 || hasMarker) {
@@ -512,16 +532,80 @@ func graftExternalNodeAnnotations(desired, running *v1alpha1.MachineConfig) erro
 		previousOwnedKeys,
 	)
 
+	return persistNodeAnnotationOwnership(
+		desired.MachineNodeAnnotations,
+		currentOwnedKeys,
+		hasMarker,
+	)
+}
+
+func resolvePreviousNodeAnnotationKeys(
+	desired, running map[string]string,
+) (map[string]struct{}, bool, error) {
+	if _, claimsOwnershipMarker := desired[managedNodeAnnotationKeys]; claimsOwnershipMarker {
+		return nil, false, errManagedNodeAnnotationKeysReserved
+	}
+
+	bootstrapOwnedKeys, hasBootstrapMarker, err := previousNodeAnnotationKeys(
+		desired,
+		bootstrapManagedNodeAnnotationKeys,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode bootstrap managed node-annotation keys: %w", err)
+	}
+
+	// The bootstrap directive is input only. Strip it before deriving the current
+	// ownership set and before returning a config that Talos can apply.
+	delete(desired, bootstrapManagedNodeAnnotationKeys)
+
+	previousOwnedKeys, hasRunningMarker, err := previousNodeAnnotationKeys(
+		running,
+		managedNodeAnnotationKeys,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !hasRunningMarker && hasBootstrapMarker {
+		previousOwnedKeys = bootstrapOwnedKeys
+	}
+
+	return previousOwnedKeys, hasRunningMarker || hasBootstrapMarker, nil
+}
+
+func persistNodeAnnotationOwnership(
+	annotations map[string]string,
+	currentOwnedKeys []string,
+	hasMarker bool,
+) error {
 	if hasMarker || len(currentOwnedKeys) > 0 {
 		encodedKeys, err := json.Marshal(currentOwnedKeys)
 		if err != nil {
 			return fmt.Errorf("encode managed node-annotation keys: %w", err)
 		}
 
-		desired.MachineNodeAnnotations[managedNodeAnnotationKeys] = string(encodedKeys)
+		annotations[managedNodeAnnotationKeys] = string(encodedKeys)
+
+		annotationBytes := nodeAnnotationBytes(annotations)
+		if annotationBytes > maxNodeAnnotationBytes {
+			return fmt.Errorf(
+				"%w: %d bytes",
+				errNodeAnnotationOwnershipMetadataLimit,
+				annotationBytes,
+			)
+		}
 	}
 
 	return nil
+}
+
+func nodeAnnotationBytes(annotations map[string]string) int {
+	total := 0
+	for key, value := range annotations {
+		total += len(key) + len(value)
+	}
+
+	return total
 }
 
 func mergeExternalNodeAnnotations(
@@ -548,7 +632,7 @@ func mergeExternalNodeAnnotations(
 func nodeAnnotationKeys(annotations map[string]string) []string {
 	keys := make([]string, 0, len(annotations))
 	for key := range annotations {
-		if key != managedNodeAnnotationKeys {
+		if key != managedNodeAnnotationKeys && key != bootstrapManagedNodeAnnotationKeys {
 			keys = append(keys, key)
 		}
 	}
@@ -558,8 +642,9 @@ func nodeAnnotationKeys(annotations map[string]string) []string {
 
 func previousNodeAnnotationKeys(
 	annotations map[string]string,
+	markerKey string,
 ) (map[string]struct{}, bool, error) {
-	markerValue, hasMarker := annotations[managedNodeAnnotationKeys]
+	markerValue, hasMarker := annotations[markerKey]
 	if !hasMarker {
 		return nil, false, nil
 	}

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -423,6 +423,11 @@ func TestBuildDesiredNodeConfig_RejectsNullManagedNodeAnnotationKeys(t *testing.
 	require.EqualError(t, err,
 		"graft node-managed config sections: "+
 			"decode managed node-annotation keys: expected JSON array")
+	require.ErrorIs(
+		t,
+		err,
+		talosprovisioner.ErrManagedNodeAnnotationKeysExpectedJSONArrayForTest,
+	)
 }
 
 // TestBuildDesiredNodeConfig_PreservesCreateInjectedMirrors reproduces the Docker

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -1,6 +1,7 @@
 package talosprovisioner_test
 
 import (
+	"strings"
 	"testing"
 
 	talosconfigmanager "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
@@ -14,10 +15,11 @@ import (
 )
 
 const (
-	sysctlRmemMax            = "net.core.rmem_max"
-	sysctlKptr               = "kernel.kptr_restrict"
-	mirrorEndpoint           = "http://talos-default-docker.io:5000"
-	managedNodeAnnotationKey = "ksail.devantler.tech/managed-node-annotation-keys"
+	sysctlRmemMax              = "net.core.rmem_max"
+	sysctlKptr                 = "kernel.kptr_restrict"
+	mirrorEndpoint             = "http://talos-default-docker.io:5000"
+	managedNodeAnnotationKey   = "ksail.devantler.tech/managed-node-annotation-keys"
+	bootstrapNodeAnnotationKey = "ksail.devantler.tech/bootstrap-managed-node-annotation-keys"
 )
 
 // wrapConfig wraps a v1alpha1.Config as a full Talos config provider.
@@ -383,6 +385,85 @@ func TestBuildDesiredNodeConfig_RemovesPreviouslyDesiredNodeAnnotation(t *testin
 		"a previously desired annotation must not be reclassified as external")
 	assert.Equal(t, "preserved",
 		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations["example.com/external"])
+}
+
+// TestGraftNodeManagedSections_BootstrapsLegacyAnnotationRemoval verifies the
+// explicit migration path for a cluster created before KSail persisted annotation
+// ownership. A bootstrap directive seeds the previous ownership set once; KSail
+// strips it, persists the current set, and preserves unrelated live-only keys.
+func TestGraftNodeManagedSections_BootstrapsLegacyAnnotationRemoval(t *testing.T) {
+	t.Parallel()
+
+	desired := wrapConfig(&v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineNodeAnnotations: map[string]string{
+				bootstrapNodeAnnotationKey: `["example.com/owned"]`,
+			},
+		},
+	})
+	running := wrapConfig(&v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineNodeAnnotations: map[string]string{
+				"example.com/owned":    "removed",
+				"example.com/external": "preserved",
+			},
+		},
+	})
+
+	grafted, err := talosprovisioner.GraftNodeManagedSectionsForTest(desired, running)
+	require.NoError(t, err)
+
+	annotations := grafted.RawV1Alpha1().MachineConfig.MachineNodeAnnotations
+	assert.NotContains(t, annotations, "example.com/owned",
+		"the explicit legacy ownership seed must keep the removed key removable")
+	assert.Equal(t, "preserved", annotations["example.com/external"],
+		"the migration seed must not absorb unrelated live-only annotations")
+	assert.Equal(t, "[]", annotations[managedNodeAnnotationKey],
+		"the one-time seed must be replaced by the current ownership set")
+}
+
+// TestGraftNodeManagedSections_RejectsDesiredOwnershipMarkerCollision guards
+// the reserved annotation key at patch-loading time. An arbitrary user value
+// must fail before it can be applied and poison every subsequent update.
+func TestGraftNodeManagedSections_RejectsDesiredOwnershipMarkerCollision(t *testing.T) {
+	t.Parallel()
+
+	desired := wrapConfig(&v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineNodeAnnotations: map[string]string{
+				managedNodeAnnotationKey: `[]`,
+			},
+		},
+	})
+	running := wrapConfig(&v1alpha1.Config{MachineConfig: &v1alpha1.MachineConfig{}})
+
+	_, err := talosprovisioner.GraftNodeManagedSectionsForTest(desired, running)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ownership key is reserved by KSail")
+}
+
+// TestGraftNodeManagedSections_RejectsOwnershipMarkerPastAnnotationLimit proves
+// KSail accounts for its metadata before returning a config for Talos to apply.
+// The user's annotation map is valid at the Kubernetes 256 KiB ceiling by itself,
+// but adding the ownership marker must return a clear preflight error.
+func TestGraftNodeManagedSections_RejectsOwnershipMarkerPastAnnotationLimit(t *testing.T) {
+	t.Parallel()
+
+	const annotationSizeLimit = 256 * 1024
+
+	key := "example.com/owned"
+	desired := wrapConfig(&v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineNodeAnnotations: map[string]string{
+				key: strings.Repeat("x", annotationSizeLimit-len(key)),
+			},
+		},
+	})
+	running := wrapConfig(&v1alpha1.Config{MachineConfig: &v1alpha1.MachineConfig{}})
+
+	_, err := talosprovisioner.GraftNodeManagedSectionsForTest(desired, running)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node annotations exceed 256 KiB after ownership metadata")
 }
 
 // TestBuildDesiredNodeConfig_RejectsNullManagedNodeAnnotationKeys guards the

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -336,6 +336,54 @@ func TestBuildDesiredNodeConfig_ReconcilesDesiredNodeAnnotation(t *testing.T) {
 		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations["example.com/external"])
 }
 
+// TestBuildDesiredNodeConfig_RemovesPreviouslyDesiredNodeAnnotation guards the
+// ownership boundary across updates: once KSail has rendered an annotation from
+// its patch set, removing that key from the patch must remain an intentional
+// deletion while unrelated live-only annotations stay preserved.
+func TestBuildDesiredNodeConfig_RemovesPreviouslyDesiredNodeAnnotation(t *testing.T) {
+	t.Parallel()
+
+	ownedPatch := sysctlPatch("machine:\n  nodeAnnotations:\n    example.com/owned: old\n")
+	running := runningFromPatches(t, ownedPatch)
+	running, err := running.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		cfg.MachineConfig.MachineNodeAnnotations["example.com/external"] = "preserved"
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	trackedConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{ownedPatch},
+	)
+	require.NoError(t, err)
+
+	tracked, err := talosprovisioner.NewProvisioner(trackedConfigs, nil).
+		BuildDesiredNodeConfigForTest(
+			running, running, talosprovisioner.RoleControlPlane,
+		)
+	require.NoError(t, err)
+
+	removedConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(nil)
+	require.NoError(t, err)
+
+	desired, err := talosprovisioner.NewProvisioner(removedConfigs, nil).
+		BuildDesiredNodeConfigForTest(
+			tracked, tracked, talosprovisioner.RoleControlPlane,
+		)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(tracked, desired)
+	require.NoError(t, err)
+	assert.Contains(t, diff, "example.com/owned",
+		"removing a previously desired annotation must remain visible as drift")
+	assert.NotContains(t,
+		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations,
+		"example.com/owned",
+		"a previously desired annotation must not be reclassified as external")
+	assert.Equal(t, "preserved",
+		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations["example.com/external"])
+}
+
 // TestBuildDesiredNodeConfig_PreservesCreateInjectedMirrors reproduces the Docker
 // system-test scenario: the running config carries registry mirrors injected at
 // create (which a regenerate lacks). An unchanged config must still report no

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	sysctlRmemMax  = "net.core.rmem_max"
-	sysctlKptr     = "kernel.kptr_restrict"
-	mirrorEndpoint = "http://talos-default-docker.io:5000"
+	sysctlRmemMax            = "net.core.rmem_max"
+	sysctlKptr               = "kernel.kptr_restrict"
+	mirrorEndpoint           = "http://talos-default-docker.io:5000"
+	managedNodeAnnotationKey = "ksail.devantler.tech/managed-node-annotation-keys"
 )
 
 // wrapConfig wraps a v1alpha1.Config as a full Talos config provider.
@@ -382,6 +383,46 @@ func TestBuildDesiredNodeConfig_RemovesPreviouslyDesiredNodeAnnotation(t *testin
 		"a previously desired annotation must not be reclassified as external")
 	assert.Equal(t, "preserved",
 		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations["example.com/external"])
+}
+
+// TestBuildDesiredNodeConfig_RejectsNullManagedNodeAnnotationKeys guards the
+// ownership boundary against a malformed marker that would otherwise erase
+// KSail's prior ownership set and restore intentionally removed annotations.
+func TestBuildDesiredNodeConfig_RejectsNullManagedNodeAnnotationKeys(t *testing.T) {
+	t.Parallel()
+
+	ownedPatch := sysctlPatch("machine:\n  nodeAnnotations:\n    example.com/owned: old\n")
+	running := runningFromPatches(t, ownedPatch)
+
+	trackedConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{ownedPatch},
+	)
+	require.NoError(t, err)
+
+	tracked, err := talosprovisioner.NewProvisioner(trackedConfigs, nil).
+		BuildDesiredNodeConfigForTest(
+			running, running, talosprovisioner.RoleControlPlane,
+		)
+	require.NoError(t, err)
+
+	malformed, err := tracked.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		cfg.MachineConfig.MachineNodeAnnotations[managedNodeAnnotationKey] = "null"
+		delete(cfg.MachineConfig.MachineNodeAnnotations, "example.com/owned")
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	removedConfigs, err := talosconfigmanager.NewDefaultConfigsWithPatches(nil)
+	require.NoError(t, err)
+
+	_, err = talosprovisioner.NewProvisioner(removedConfigs, nil).
+		BuildDesiredNodeConfigForTest(
+			malformed, malformed, talosprovisioner.RoleControlPlane,
+		)
+	require.EqualError(t, err,
+		"graft node-managed config sections: "+
+			"decode managed node-annotation keys: expected JSON array")
 }
 
 // TestBuildDesiredNodeConfig_PreservesCreateInjectedMirrors reproduces the Docker

--- a/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
+++ b/pkg/svc/provisioner/cluster/talos/detect_inplace_test.go
@@ -236,6 +236,106 @@ func TestBuildDesiredNodeConfig_NoFalsePositive(t *testing.T) {
 	assert.Empty(t, diff, "an unchanged config must not report drift")
 }
 
+// TestBuildDesiredNodeConfig_PreservesExternallyManagedNodeAnnotations is the
+// regression guard for #6549. A controller may extend machine.nodeAnnotations
+// after KSail creates the cluster. Those additional map entries are not owned by
+// KSail's desired patch set and must not make every subsequent update delete
+// them, report phantom machine.config drift, and re-apply all node configs.
+func TestBuildDesiredNodeConfig_PreservesExternallyManagedNodeAnnotations(t *testing.T) {
+	t.Parallel()
+
+	patch := sysctlPatch("machine:\n  sysctls:\n    net.core.rmem_max: \"1\"\n")
+	running := runningFromPatches(t, patch)
+
+	running, err := running.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		cfg.MachineConfig.MachineNodeAnnotations = map[string]string{
+			"example.com/external-proof": "verified",
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{patch},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(configs, nil)
+
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
+	require.NoError(t, err)
+	assert.Empty(t, diff,
+		"an external node annotation must not report machine-config drift")
+
+	changes, err := prov.DetectRoleMachineConfigDriftForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changes,
+		"the update planner must not schedule a machine-config apply for an external annotation")
+	assert.Equal(t, "verified",
+		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations["example.com/external-proof"],
+		"the externally managed annotation must survive a later real config apply")
+
+	// Model the next cluster-update invocation after the first desired config was
+	// applied. The same desired input and external annotation must now converge,
+	// rather than reappearing as the same phantom change on every run.
+	nextDesired, err := prov.BuildDesiredNodeConfigForTest(
+		desired, desired, talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	nextDiff, err := talosprovisioner.MachineConfigDiffForTest(desired, nextDesired)
+	require.NoError(t, err)
+	assert.Empty(t, nextDiff, "two consecutive updates must remain converged")
+}
+
+// TestBuildDesiredNodeConfig_ReconcilesDesiredNodeAnnotation verifies the
+// ownership boundary: preserving live-only keys must not hide drift for an
+// annotation that KSail's current desired patch explicitly declares.
+func TestBuildDesiredNodeConfig_ReconcilesDesiredNodeAnnotation(t *testing.T) {
+	t.Parallel()
+
+	runningPatch := sysctlPatch("machine:\n  nodeAnnotations:\n    example.com/owned: old\n")
+	running := runningFromPatches(t, runningPatch)
+	running, err := running.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		cfg.MachineConfig.MachineNodeAnnotations["example.com/external"] = "preserved"
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	desiredPatch := sysctlPatch("machine:\n  nodeAnnotations:\n    example.com/owned: new\n")
+	configs, err := talosconfigmanager.NewDefaultConfigsWithPatches(
+		[]talosconfigmanager.Patch{desiredPatch},
+	)
+	require.NoError(t, err)
+
+	prov := talosprovisioner.NewProvisioner(configs, nil)
+	desired, err := prov.BuildDesiredNodeConfigForTest(
+		running, running, talosprovisioner.RoleControlPlane,
+	)
+	require.NoError(t, err)
+
+	diff, err := talosprovisioner.MachineConfigDiffForTest(running, desired)
+	require.NoError(t, err)
+	assert.Contains(t, diff, "example.com/owned",
+		"a changed KSail-owned annotation must remain visible as drift")
+	assert.Equal(
+		t,
+		"new",
+		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations["example.com/owned"],
+	)
+	assert.Equal(t, "preserved",
+		desired.RawV1Alpha1().MachineConfig.MachineNodeAnnotations["example.com/external"])
+}
+
 // TestBuildDesiredNodeConfig_PreservesCreateInjectedMirrors reproduces the Docker
 // system-test scenario: the running config carries registry mirrors injected at
 // create (which a regenerate lacks). An unchanged config must still report no

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -27,6 +27,10 @@ import (
 
 var errUpdateApplyStepNotFoundForTest = errors.New("update apply step not found")
 
+// ErrManagedNodeAnnotationKeysExpectedJSONArrayForTest exposes the stable error
+// identity expected when the persisted ownership marker is JSON null.
+var ErrManagedNodeAnnotationKeysExpectedJSONArrayForTest = errManagedNodeAnnotationKeysExpectedJSONArray
+
 // NodeWithRoleForTest is the exported alias of nodeWithRole for testing.
 type NodeWithRoleForTest = nodeWithRole
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- preserve live-only Talos `machine.nodeAnnotations` when KSail regenerates desired machine config
- keep KSail authoritative for annotation keys explicitly present in its current patch set
- prove the update planner emits no `machine.config` change for external annotations and remains converged across consecutive runs

## Root cause

KSail regenerated a whole desired Talos config and grafted known create/runtime-managed sections before comparing it to the live config. `machine.nodeAnnotations` is a shared extension map, but it was not included in that ownership-aware graft.

A controller adding live-only annotations therefore created permanent false drift: KSail proposed deleting the keys, applied config to every node, and the controller added them again. Platform production runs 31575519600 and 31578345741 both exhibited the identical diff for `ghcr-pull-verified-*`.

The fix merges only live annotation keys absent from KSail's rendered desired map. Desired values win on collisions, so actual changes to KSail-declared annotations still reconcile.

## Validation

- TDD regression failed before the implementation and passed after it
- focused external-vs-owned annotation tests: pass
- two-consecutive-update convergence assertion: pass
- full Talos provisioner package: pass
- focused race detector: pass
- `go vet ./pkg/svc/provisioner/cluster/talos`: pass
- `golangci-lint run --timeout 10m ./pkg/svc/provisioner/cluster/talos/...`: 0 issues
- `go build -o /private/tmp/ksail-6549-bin .`: pass
- `go test ./...`: all packages passed with normal loopback/network access except the unrelated `pkg/cli/cmd/open/chat` package, whose subprocess helper exceeded its 5s timeout under full-suite parallel load; that package passed immediately in isolation
- no live cluster or cloud mutation performed

Fixes #6549