### PR TITLE
fix(ci): run Go validation on pull requests that change Go code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -360,7 +360,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
       || (github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository
-      && needs.changes.outputs.govuln-allowlist == 'true')
+      && needs.changes.outputs.code == 'true')
     uses: devantler-tech/actions/.github/workflows/validate-go-project.yaml@61d9c87b302523778789c7cf09655b87b6716e87 # v13.0.4
     # Both inputs make a default-branch run answer "did the check run" rather than
     # "did the diff touch a Go file". On main the branch's green IS the protection

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -88,7 +88,7 @@ type ciWorkflow struct {
 	} `yaml:"jobs"`
 }
 
-func TestGoValidationIncludesVulnerabilityAllowlistChanges(t *testing.T) {
+func TestGoValidationRunsOnGoCodeAndAllowlistChanges(t *testing.T) {
 	t.Parallel()
 
 	workflow := readCIWorkflow(t, ".github/workflows/ci.yaml")
@@ -96,7 +96,11 @@ func TestGoValidationIncludesVulnerabilityAllowlistChanges(t *testing.T) {
 	require.True(t, found, "changes job is missing")
 	filterStep := findHarnessStep(t, changesJob.Steps, "🔍 Filter paths")
 	filters := stringValue(filterStep.With["filters"])
-	assert.Contains(t, filters, "govuln-allowlist:\n  - '.govulncheck-allow.txt'")
+	assert.Contains(
+		t,
+		filters,
+		"code:\n  - '**/*.go'\n  - 'go.mod'\n  - 'go.sum'\n  - '.govulncheck-allow.txt'",
+	)
 
 	validateJob, found := workflow.Jobs["ci-go"]
 	require.True(t, found, "ci-go job is missing")
@@ -107,7 +111,7 @@ func TestGoValidationIncludesVulnerabilityAllowlistChanges(t *testing.T) {
 		validateJob.If,
 		"github.event.pull_request.head.repo.full_name == github.repository",
 	)
-	assert.Contains(t, validateJob.If, "needs.changes.outputs.govuln-allowlist == 'true'")
+	assert.Contains(t, validateJob.If, "needs.changes.outputs.code == 'true'")
 	assert.Contains(t, validateJob.Uses, "validate-go-project.yaml")
 }
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Go tests, linting and the vulnerability scan have not been running on pull requests that change Go
code. They run only after the change merges, so a Go regression shows up as a broken `main` rather
than as a pull request that cannot merge. Confirmed on merged #6550 and #6528 — both changed Go
files, both skipped the suite.

### What

Gates the Go suite on the filter that actually means "this diff touched Go", instead of one that
matches a single allowlist file. One line; the push-to-`main` behaviour is unchanged.

Expect more pull requests to start running the Go suite — that is the point, and it is where the
time is meant to be spent.

Fixes #6563
