### PR TITLE
fix(security): declare Go 1.26.6 to clear seven reachable stdlib advisories

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -1,6 +1,6 @@
 module github.com/devantler-tech/ksail/desktop
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/devantler-tech/ksail/v7 => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devantler-tech/ksail/v7
 
-go 1.26.5
+go 1.26.6
 
 // Exclude the standalone google.golang.org/grpc/stats/opentelemetry module to avoid
 // ambiguous import errors. The opentelemetry stats package is included in the main


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

KSail is built against a Go version with seven **reachable** standard-library vulnerabilities —
reachable meaning the vulnerability scanner traced actual call paths to them, not just that the
version is old. They ship in the binaries we release.

They went unnoticed because the Go vulnerability scan has never run on a pull request (#6563). The fix
for that gate is #6564, and its first genuine run surfaced these immediately — so this is the gate
earning its keep on day one.

`main` is green only because nothing has pushed since the advisories were published. The next merge
would turn it red.

### What

Declares the current patched Go version. One line.

Fixed at the version rather than waved through the risk-acceptance allowlist — nothing is added to
`.govulncheck-allow.txt`.

Kept separate from #6564 on purpose: that PR fixes the gate, this fixes an exposure the gate revealed.
Merging this first also unblocks #6564, which cannot go green while the scan it re-enables is failing.

Fixes #6565
