### PR TITLE
chore(ci): say why ci-go's pull-request gate is deliberately narrow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,6 +356,26 @@ jobs:
   ci-go:
     name: ✅ Validate Go Project
     needs: [changes]
+    # The two arms below cover what the ORG-REQUIRED workflow does not, and nothing
+    # more. validate-go-project.yaml carries its own `pull_request:` / `merge_group:`
+    # triggers alongside its `workflow_call` interface, so GitHub already runs the
+    # complete Go suite directly on every pull request here, with no help from this
+    # file. That direct run publishes its checks WITHOUT the `✅ Validate Go Project /`
+    # prefix, which is why a prefix-filtered read of a pull request shows "skipped"
+    # over a suite that has in fact passed (ksail#6563, ksail#6564 — both closed as
+    # measurement errors of exactly that shape).
+    #
+    #   * push to main — the required workflow is pull-request scoped and never runs
+    #     on the default branch, so this arm is the ONLY Go validation main gets.
+    #
+    #   * pull_request, gated on govuln-allowlist — DELIBERATELY NARROW. The required
+    #     run takes `scan-default-branch`'s default of false, so it will not scan a
+    #     pull request that edits only a .govulncheck-allow.txt; this arm exists so a
+    #     risk acceptance is validated by the scanner it applies to. Do NOT widen this
+    #     to `code`: .govulncheck-allow.txt is already a member of the `code` filter,
+    #     so `code` is a strict superset whose extra region is precisely where the
+    #     required workflow already runs the identical nine jobs. Widening it buys no
+    #     coverage and doubles the Go suite on every Go pull request.
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
       || (github.event_name == 'pull_request'

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -88,6 +88,21 @@ type ciWorkflow struct {
 	} `yaml:"jobs"`
 }
 
+// TestGoValidationIncludesVulnerabilityAllowlistChanges pins ci-go's pull-request gate to
+// govuln-allowlist ON PURPOSE. The assertion below looks like it pins a stale contract, and
+// twice it has been "corrected" to needs.changes.outputs.code (ksail#6563, ksail#6564 — both
+// closed once measured). It is not stale:
+//
+// devantler-tech/actions/.github/workflows/validate-go-project.yaml declares its own
+// pull_request: trigger as well as workflow_call, so it already runs org-required on every
+// pull request in this repository, publishing its checks without the "✅ Validate Go Project /"
+// prefix. ci-go's pull-request arm therefore adds nothing on a Go diff. What it uniquely adds
+// is the scan-default-branch: true behaviour on an allowlist-only pull request, which the
+// required run — taking that input's false default — does not perform.
+//
+// .govulncheck-allow.txt is itself a member of the code filter, so widening this gate to code
+// is a strict superset that duplicates all nine required-workflow jobs on every Go pull
+// request and buys no coverage. If this assertion fails, fix the workflow, not the test.
 func TestGoValidationIncludesVulnerabilityAllowlistChanges(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

`ci-go`'s pull-request gate has been read as a bug by three engineering runs in a row. Two of them
opened work to "fix" it — #6563 and #6564, both now closed — and one came close to merging a change
that would have doubled the Go suite on every Go pull request while adding no coverage at all.

The gate is correct. It just does not say so anywhere, and the fact that makes it correct lives in
another repository, so each reader re-derives it from scratch and gets it wrong.

### What

Records the rationale at the two places it is actually read: the workflow gate itself, and the test
that pins it. No workflow logic changes — comments only.

Fixes #6568
