### PR TITLE
fix(webui): trust only the desktop origin on the exec upgrade

### DIFF
--- a/pkg/webui/api/exec_handler.go
+++ b/pkg/webui/api/exec_handler.go
@@ -136,10 +136,19 @@ func execCheckOrigin(request *http.Request) bool {
 		return false
 	}
 
-	// The desktop shell serves the SPA from the fixed wails:// origin through the Wails AssetServer, with
-	// no TCP listener at all. A remote page can never carry that scheme, so it is trusted like loopback.
+	// The desktop shell serves the SPA from the fixed wails://wails origin (see desktop/main.go) through
+	// the Wails AssetServer, with no TCP listener at all, so that one origin is trusted like loopback.
+	// The scheme alone is not enough: it would also admit wails://attacker, and on this path the check is
+	// the only thing between the caller and a shell in the cluster. A browser-sent Origin carries scheme
+	// and authority and nothing else, so a non-empty user, path, query or fragment marks a crafted header.
 	if strings.EqualFold(parsed.Scheme, "wails") {
-		return true
+		// Host, not Hostname, so a port (wails://wails:8080) fails the comparison rather than being
+		// stripped away before it.
+		return strings.EqualFold(parsed.Host, "wails") &&
+			parsed.User == nil &&
+			parsed.Path == "" &&
+			parsed.RawQuery == "" &&
+			parsed.Fragment == ""
 	}
 
 	return isLoopbackHost(parsed.Hostname())

--- a/pkg/webui/api/exec_handler.go
+++ b/pkg/webui/api/exec_handler.go
@@ -139,16 +139,14 @@ func execCheckOrigin(request *http.Request) bool {
 	// The desktop shell serves the SPA from the fixed wails://wails origin (see desktop/main.go) through
 	// the Wails AssetServer, with no TCP listener at all, so that one origin is trusted like loopback.
 	// The scheme alone is not enough: it would also admit wails://attacker, and on this path the check is
-	// the only thing between the caller and a shell in the cluster. A browser-sent Origin carries scheme
-	// and authority and nothing else, so a non-empty user, path, query or fragment marks a crafted header.
+	// the only thing between the caller and a shell in the cluster.
 	if strings.EqualFold(parsed.Scheme, "wails") {
-		// Host, not Hostname, so a port (wails://wails:8080) fails the comparison rather than being
-		// stripped away before it.
-		return strings.EqualFold(parsed.Host, "wails") &&
-			parsed.User == nil &&
-			parsed.Path == "" &&
-			parsed.RawQuery == "" &&
-			parsed.Fragment == ""
+		// Compare the raw header, not the parsed fields. A browser-sent Origin is scheme and authority
+		// and nothing else, and an empty delimiter parses away to nothing: "wails://wails?" and
+		// "wails://wails#" both leave RawQuery and Fragment empty, so a field-by-field comparison
+		// accepts them. Matching the whole string rejects every such variant, and any port, user info
+		// or path along with them.
+		return strings.EqualFold(origin, "wails://wails")
 	}
 
 	return isLoopbackHost(parsed.Hostname())

--- a/pkg/webui/api/exec_test.go
+++ b/pkg/webui/api/exec_test.go
@@ -192,6 +192,11 @@ func TestExecRejectsForeignWailsAuthority(t *testing.T) {
 		"wails://wails/path",
 		"wails://wails?x=1",
 		"wails://wails#frag",
+		// An empty delimiter parses away to nothing — RawQuery and Fragment are both "" here — so a
+		// field-by-field comparison accepts these while the raw header is not the desktop origin.
+		"wails://wails?",
+		"wails://wails#",
+		"wails://wails?#",
 	} {
 		t.Run(origin, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/webui/api/exec_test.go
+++ b/pkg/webui/api/exec_test.go
@@ -154,6 +154,66 @@ func TestExecAllowsLocalhostOrigin(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 }
 
+// TestExecAllowsDesktopWailsOrigin pins the desktop shell's path: the SPA is served from the fixed
+// wails://wails origin through the Wails AssetServer (see desktop/main.go), with no TCP listener at
+// all, so that one origin upgrades even though it is not loopback.
+func TestExecAllowsDesktopWailsOrigin(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer((&api.Server{Service: execStub{}}).Handler())
+	defer server.Close()
+
+	url := execWebSocketURL(server.URL)
+	header := http.Header{}
+	header.Set("Origin", "wails://wails")
+
+	conn, response, err := websocket.DefaultDialer.Dial(url, header)
+	require.NoError(t, err)
+
+	if response != nil {
+		defer func() { _ = response.Body.Close() }()
+	}
+
+	defer func() { _ = conn.Close() }()
+}
+
+// TestExecRejectsForeignWailsAuthority pins that the desktop carve-out is the single wails://wails
+// origin and not the scheme. Trusting the scheme alone would admit any authority under it, and on this
+// path that check is the only thing between the caller and a shell in the cluster. A browser-sent
+// Origin carries scheme and authority and nothing else, so a port, user info, path, query or fragment
+// marks a crafted header rather than a real one.
+func TestExecRejectsForeignWailsAuthority(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range []string{
+		"wails://attacker",
+		"wails://wails:8080",
+		"wails://user@wails",
+		"wails://wails/path",
+		"wails://wails?x=1",
+		"wails://wails#frag",
+	} {
+		t.Run(origin, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer((&api.Server{Service: execStub{}}).Handler())
+			defer server.Close()
+
+			url := execWebSocketURL(server.URL)
+			header := http.Header{}
+			header.Set("Origin", origin)
+
+			_, response, err := websocket.DefaultDialer.Dial(url, header)
+			require.Error(t, err)
+			require.NotNil(t, response)
+
+			defer func() { _ = response.Body.Close() }()
+
+			assert.Equal(t, http.StatusForbidden, response.StatusCode)
+		})
+	}
+}
+
 func TestExecBlockedWhenReadOnly(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The web UI's terminal endpoint hands the caller a shell inside the cluster, so it only accepts
connections from a page the user actually opened locally. It also has to allow the native desktop app,
which serves its pages from a fixed internal address rather than from the local server.

That desktop exception was too wide: it accepted anything using the desktop's address *scheme*, rather
than the one address the desktop app actually uses. A page that could present any other address under
that scheme would have been let through.

### What this changes

The exception now matches the desktop app's single real address exactly, and rejects anything with
extra detail attached to it. The desktop app keeps working unchanged, and the everyday local-browser
path is untouched.

Reachable only from inside the desktop app's own web view, so this is hardening rather than a live
remote hole — but it is the endpoint least worth leaving loose.

Fixes #6576
