### PR TITLE
test(kubeadmhetzner): guard user-data against every signing-key transport

### DIFF
--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/multinode_test.go
@@ -65,6 +65,7 @@ func TestComposeInitNodeKeepsPKIOutOfUserData(t *testing.T) {
 
 	assert.NotContains(t, spec.UserData, "BEGIN CERTIFICATE")
 	assert.NotContains(t, spec.UserData, "BEGIN RSA PRIVATE KEY")
+	assertNoSigningMaterial(t, spec.UserData, "the initial control plane")
 }
 
 // adminKubeconfig returns a kubeadm-shaped admin.conf with a generated CA and
@@ -148,6 +149,8 @@ func TestComposeJoiningNodesPinsJoinNameAndCA(t *testing.T) {
 			assert.NotContains(t, spec.UserData, path,
 				"joining nodes must never receive private PKI material")
 		}
+
+		assertNoSigningMaterial(t, spec.UserData, "a joining node")
 	}
 }
 

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
@@ -13,27 +13,50 @@ import (
 // covers every encoding a key could arrive in rather than one chosen spelling.
 const pemPrivateKeyMarker = "PRIVATE KEY"
 
+// pemPrivateKeyLabels are the PEM block labels the guard must reach. Each is a
+// label only: the fixtures below wrap them around a placeholder body, so no
+// test carries key-shaped bytes.
+func pemPrivateKeyLabels() []string {
+	return []string{
+		"RSA PRIVATE KEY",
+		"PRIVATE KEY",
+		"EC PRIVATE KEY",
+		"DSA PRIVATE KEY",
+		"ENCRYPTED PRIVATE KEY",
+		"OPENSSH PRIVATE KEY",
+	}
+}
+
 // kubeadmCertificateTransportMarkers are the kubeadm settings that move control
 // plane signing material between nodes. `--upload-certs` stores the cluster PKI
 // in a cluster Secret and `certificateKey` is the symmetric key that decrypts
 // it, so either one in provider user-data hands the provider the cluster
 // identity even though no PEM block appears.
-var kubeadmCertificateTransportMarkers = []string{
-	"certificateKey",
-	"certificate-key",
-	"upload-certs",
-	"uploadCerts",
+func kubeadmCertificateTransportMarkers() []string {
+	return []string{
+		"certificateKey",
+		"certificate-key",
+		"upload-certs",
+		"uploadCerts",
+	}
 }
 
 // pkiPathMarkers are the on-disk locations of the private halves of the cluster
 // PKI. kubeadm mints these on the initial control plane; a path appearing in
 // user-data means the renderer is writing the material rather than letting
 // kubeadm generate it.
-var pkiPathMarkers = []string{
-	"/etc/kubernetes/pki/ca.key",
-	"/etc/kubernetes/pki/front-proxy-ca.key",
-	"/etc/kubernetes/pki/etcd/ca.key",
-	"/etc/kubernetes/pki/sa.key",
+func pkiPathMarkers() []string {
+	return []string{
+		"/etc/kubernetes/pki/ca.key",
+		"/etc/kubernetes/pki/front-proxy-ca.key",
+		"/etc/kubernetes/pki/etcd/ca.key",
+		"/etc/kubernetes/pki/sa.key",
+	}
+}
+
+// pemBlock wraps a placeholder body in a PEM block carrying the given label.
+func pemBlock(label string) string {
+	return "-----BEGIN " + label + "-----\nredacted\n-----END " + label + "-----"
 }
 
 // signingMaterialMarkersIn reports every marker of cluster-signing material
@@ -46,13 +69,13 @@ func signingMaterialMarkersIn(userData string) []string {
 		found = append(found, pemPrivateKeyMarker)
 	}
 
-	for _, marker := range kubeadmCertificateTransportMarkers {
+	for _, marker := range kubeadmCertificateTransportMarkers() {
 		if strings.Contains(userData, marker) {
 			found = append(found, marker)
 		}
 	}
 
-	for _, marker := range pkiPathMarkers {
+	for _, marker := range pkiPathMarkers() {
 		if strings.Contains(userData, marker) {
 			found = append(found, marker)
 		}
@@ -73,22 +96,33 @@ func assertNoSigningMaterial(t *testing.T, userData, subject string) {
 
 // TestSigningMaterialGuardCatchesEveryPrivateKeyEncoding pins the guard's own
 // reach. A guard written against one PEM spelling passes over a key that
-// arrives in another encoding, so each supported encoding and each kubeadm
-// certificate-transport setting is exercised individually.
+// arrives in another encoding, so every supported label is exercised.
 func TestSigningMaterialGuardCatchesEveryPrivateKeyEncoding(t *testing.T) {
 	t.Parallel()
 
+	for _, label := range pemPrivateKeyLabels() {
+		userData := "#cloud-config\nwrite_files:\n  - content: |\n      " + pemBlock(label) + "\n"
+
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotEmpty(t, signingMaterialMarkersIn(userData),
+				"a %s block must be reported as signing material", label)
+		})
+	}
+}
+
+// TestSigningMaterialGuardCatchesKubeadmCertificateTransports pins the reach
+// over kubeadm's own certificate sharing, which moves signing material without
+// emitting a PEM block at all.
+func TestSigningMaterialGuardCatchesKubeadmCertificateTransports(t *testing.T) {
+	t.Parallel()
+
 	for name, sample := range map[string]string{
-		"pkcs1 rsa":       "-----BEGIN RSA PRIVATE KEY-----\nMIIE\n-----END RSA PRIVATE KEY-----",
-		"pkcs8":           "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----",
-		"sec1 ec":         "-----BEGIN EC PRIVATE KEY-----\nMHc\n-----END EC PRIVATE KEY-----",
-		"dsa":             "-----BEGIN DSA PRIVATE KEY-----\nMIIB\n-----END DSA PRIVATE KEY-----",
-		"encrypted pkcs8": "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE\n-----END ENCRYPTED PRIVATE KEY-----",
-		"openssh":         "-----BEGIN OPENSSH PRIVATE KEY-----\nb3Bl\n-----END OPENSSH PRIVATE KEY-----",
-		"kubeadm certificateKey": "write_files:\n  - content: |\n" +
-			"      certificateKey: 0123456789abcdef0123456789abcdef\n",
-		"kubeadm upload-certs": "runcmd:\n  - kubeadm init --upload-certs\n",
-		"ca key path":          "write_files:\n  - path: /etc/kubernetes/pki/ca.key\n",
+		"certificateKey": "write_files:\n  - content: |\n" +
+			"      certificateKey: " + strings.Repeat("0", 64) + "\n",
+		"upload-certs": "runcmd:\n  - kubeadm init --upload-certs\n",
+		"ca key path":  "write_files:\n  - path: /etc/kubernetes/pki/ca.key\n",
 	} {
 		userData := "#cloud-config\n" + sample
 

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
@@ -1,0 +1,119 @@
+package kubeadmhetzner_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// pemPrivateKeyMarker is the trailing half of every PEM private-key label.
+// PKCS#1 ("RSA PRIVATE KEY"), PKCS#8 ("PRIVATE KEY"), SEC 1 ("EC PRIVATE KEY"),
+// DSA, encrypted, and OpenSSH blocks all end in it, so matching the suffix
+// covers every encoding a key could arrive in rather than one chosen spelling.
+const pemPrivateKeyMarker = "PRIVATE KEY"
+
+// kubeadmCertificateTransportMarkers are the kubeadm settings that move control
+// plane signing material between nodes. `--upload-certs` stores the cluster PKI
+// in a cluster Secret and `certificateKey` is the symmetric key that decrypts
+// it, so either one in provider user-data hands the provider the cluster
+// identity even though no PEM block appears.
+var kubeadmCertificateTransportMarkers = []string{
+	"certificateKey",
+	"certificate-key",
+	"upload-certs",
+	"uploadCerts",
+}
+
+// pkiPathMarkers are the on-disk locations of the private halves of the cluster
+// PKI. kubeadm mints these on the initial control plane; a path appearing in
+// user-data means the renderer is writing the material rather than letting
+// kubeadm generate it.
+var pkiPathMarkers = []string{
+	"/etc/kubernetes/pki/ca.key",
+	"/etc/kubernetes/pki/front-proxy-ca.key",
+	"/etc/kubernetes/pki/etcd/ca.key",
+	"/etc/kubernetes/pki/sa.key",
+}
+
+// signingMaterialMarkersIn reports every marker of cluster-signing material
+// present in the rendered user-data. An empty result means the provider sees no
+// signing key material by any of the known transports.
+func signingMaterialMarkersIn(userData string) []string {
+	var found []string
+
+	if strings.Contains(userData, pemPrivateKeyMarker) {
+		found = append(found, pemPrivateKeyMarker)
+	}
+
+	for _, marker := range kubeadmCertificateTransportMarkers {
+		if strings.Contains(userData, marker) {
+			found = append(found, marker)
+		}
+	}
+
+	for _, marker := range pkiPathMarkers {
+		if strings.Contains(userData, marker) {
+			found = append(found, marker)
+		}
+	}
+
+	return found
+}
+
+// assertNoSigningMaterial fails when the rendered user-data carries cluster
+// signing material by any transport, naming the markers so a regression points
+// straight at what leaked.
+func assertNoSigningMaterial(t *testing.T, userData, subject string) {
+	t.Helper()
+
+	assert.Empty(t, signingMaterialMarkersIn(userData),
+		"%s must expose no cluster-signing material through provider user-data", subject)
+}
+
+// TestSigningMaterialGuardCatchesEveryPrivateKeyEncoding pins the guard's own
+// reach. A guard written against one PEM spelling passes over a key that
+// arrives in another encoding, so each supported encoding and each kubeadm
+// certificate-transport setting is exercised individually.
+func TestSigningMaterialGuardCatchesEveryPrivateKeyEncoding(t *testing.T) {
+	t.Parallel()
+
+	for name, sample := range map[string]string{
+		"pkcs1 rsa":       "-----BEGIN RSA PRIVATE KEY-----\nMIIE\n-----END RSA PRIVATE KEY-----",
+		"pkcs8":           "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----",
+		"sec1 ec":         "-----BEGIN EC PRIVATE KEY-----\nMHc\n-----END EC PRIVATE KEY-----",
+		"dsa":             "-----BEGIN DSA PRIVATE KEY-----\nMIIB\n-----END DSA PRIVATE KEY-----",
+		"encrypted pkcs8": "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE\n-----END ENCRYPTED PRIVATE KEY-----",
+		"openssh":         "-----BEGIN OPENSSH PRIVATE KEY-----\nb3Bl\n-----END OPENSSH PRIVATE KEY-----",
+		"kubeadm certificateKey": "#cloud-config\nwrite_files:\n  - content: |\n" +
+			"      certificateKey: 0123456789abcdef0123456789abcdef\n",
+		"kubeadm upload-certs": "#cloud-config\nruncmd:\n  - kubeadm init --upload-certs\n",
+		"ca key path":          "#cloud-config\nwrite_files:\n  - path: /etc/kubernetes/pki/ca.key\n",
+	} {
+		userData := "#cloud-config\n" + sample
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotEmpty(t, signingMaterialMarkersIn(userData),
+				"a %s transport must be reported as signing material", name)
+		})
+	}
+}
+
+// TestSigningMaterialGuardAcceptsMaterialFreeUserData is the guard's negative
+// control. Public material a node legitimately receives — an SSH authorized
+// key, the CA discovery pin, a bootstrap token — must not trip it, otherwise an
+// always-firing guard says nothing about the render it is protecting.
+func TestSigningMaterialGuardAcceptsMaterialFreeUserData(t *testing.T) {
+	t.Parallel()
+
+	userData := "#cloud-config\n" +
+		"ssh_authorized_keys:\n  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 operator\n" +
+		"runcmd:\n" +
+		"  - kubeadm join test-cluster-api.ksail.internal:6443" +
+		" --token abcdef.0123456789abcdef" +
+		" --discovery-token-ca-cert-hash sha256:0123456789abcdef\n"
+
+	assert.Empty(t, signingMaterialMarkersIn(userData))
+}

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
@@ -85,10 +85,10 @@ func TestSigningMaterialGuardCatchesEveryPrivateKeyEncoding(t *testing.T) {
 		"dsa":             "-----BEGIN DSA PRIVATE KEY-----\nMIIB\n-----END DSA PRIVATE KEY-----",
 		"encrypted pkcs8": "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE\n-----END ENCRYPTED PRIVATE KEY-----",
 		"openssh":         "-----BEGIN OPENSSH PRIVATE KEY-----\nb3Bl\n-----END OPENSSH PRIVATE KEY-----",
-		"kubeadm certificateKey": "#cloud-config\nwrite_files:\n  - content: |\n" +
+		"kubeadm certificateKey": "write_files:\n  - content: |\n" +
 			"      certificateKey: 0123456789abcdef0123456789abcdef\n",
-		"kubeadm upload-certs": "#cloud-config\nruncmd:\n  - kubeadm init --upload-certs\n",
-		"ca key path":          "#cloud-config\nwrite_files:\n  - path: /etc/kubernetes/pki/ca.key\n",
+		"kubeadm upload-certs": "runcmd:\n  - kubeadm init --upload-certs\n",
+		"ca key path":          "write_files:\n  - path: /etc/kubernetes/pki/ca.key\n",
 	} {
 		userData := "#cloud-config\n" + sample
 

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/pki_userdata_guard_test.go
@@ -112,27 +112,74 @@ func TestSigningMaterialGuardCatchesEveryPrivateKeyEncoding(t *testing.T) {
 	}
 }
 
-// TestSigningMaterialGuardCatchesKubeadmCertificateTransports pins the reach
+// TestSigningMaterialGuardCatchesEveryKubeadmCertificateTransport pins the reach
 // over kubeadm's own certificate sharing, which moves signing material without
-// emitting a PEM block at all.
-func TestSigningMaterialGuardCatchesKubeadmCertificateTransports(t *testing.T) {
+// emitting a PEM block at all. The cases are generated from the declared marker
+// set so that dropping a marker fails here rather than silently narrowing the
+// guard.
+func TestSigningMaterialGuardCatchesEveryKubeadmCertificateTransport(t *testing.T) {
 	t.Parallel()
 
-	for name, sample := range map[string]string{
-		"certificateKey": "write_files:\n  - content: |\n" +
-			"      certificateKey: " + strings.Repeat("0", 64) + "\n",
-		"upload-certs": "runcmd:\n  - kubeadm init --upload-certs\n",
-		"ca key path":  "write_files:\n  - path: /etc/kubernetes/pki/ca.key\n",
-	} {
-		userData := "#cloud-config\n" + sample
+	for _, marker := range kubeadmCertificateTransportMarkers() {
+		userData := "#cloud-config\nwrite_files:\n  - content: |\n      " + marker + ": placeholder\n"
 
-		t.Run(name, func(t *testing.T) {
+		t.Run(marker, func(t *testing.T) {
 			t.Parallel()
 
 			assert.NotEmpty(t, signingMaterialMarkersIn(userData),
-				"a %s transport must be reported as signing material", name)
+				"the %s transport must be reported as signing material", marker)
 		})
 	}
+}
+
+// TestSigningMaterialGuardCatchesEveryPKIPath pins the reach over the on-disk
+// locations of the private PKI, generated from the declared set for the same
+// reason.
+func TestSigningMaterialGuardCatchesEveryPKIPath(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range pkiPathMarkers() {
+		userData := "#cloud-config\nwrite_files:\n  - path: " + path + "\n"
+
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotEmpty(t, signingMaterialMarkersIn(userData),
+				"writing %s must be reported as signing material", path)
+		})
+	}
+}
+
+// TestSigningMaterialMarkerSetsAreComplete pins the declared marker sets against
+// an independent literal. The behavioural tests above generate their cases from
+// these sets, so dropping a marker there would delete its own case and pass
+// silently; comparing against a literal written out here is what actually fails
+// when the guard is narrowed.
+func TestSigningMaterialMarkerSetsAreComplete(t *testing.T) {
+	t.Parallel()
+
+	assert.ElementsMatch(t, []string{
+		"certificateKey",
+		"certificate-key",
+		"upload-certs",
+		"uploadCerts",
+	}, kubeadmCertificateTransportMarkers())
+
+	assert.ElementsMatch(t, []string{
+		"/etc/kubernetes/pki/ca.key",
+		"/etc/kubernetes/pki/front-proxy-ca.key",
+		"/etc/kubernetes/pki/etcd/ca.key",
+		"/etc/kubernetes/pki/sa.key",
+	}, pkiPathMarkers())
+
+	assert.ElementsMatch(t, []string{
+		"RSA PRIVATE KEY",
+		"PRIVATE KEY",
+		"EC PRIVATE KEY",
+		"DSA PRIVATE KEY",
+		"ENCRYPTED PRIVATE KEY",
+		"OPENSSH PRIVATE KEY",
+	}, pemPrivateKeyLabels())
 }
 
 // TestSigningMaterialGuardAcceptsMaterialFreeUserData is the guard's negative


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Cluster signing keys must never reach Hetzner's provider-readable initialization data. That property currently holds, but the checks protecting it only recognised one way a key can be written. A key stored in any other standard format, or moved by kubeadm's own built-in cert-sharing option, would have slipped past unnoticed — so the protection would have looked intact while the exposure came back.

This matters most for the multi-control-plane work that is deliberately on hold: the usual way to enable it is exactly the cert-sharing option that was invisible here.

### What

Broadens the check so it recognises signing material by any storage format rather than one spelling, and adds kubeadm's cert-sharing settings. Existing checks are kept alongside it.

Tests only — no change to what KSail builds or how a cluster is created.

**Security floor:** a signing key reaching provider data is now caught however it is stored or transported.
**Everyday path:** unchanged.

Part of #6428