### PR TITLE
fix(ci): address the container image user by its numeric id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ARG TARGETPLATFORM
 # GoReleaser v2 places binaries in ${TARGETPLATFORM}/ subdirectories
 COPY ${TARGETPLATFORM}/ksail /ksail
 
-# Use nonroot user from distroless
-USER nonroot:nonroot
+# Use the distroless nonroot user by its numeric id. A name is not resolvable
+# without /etc/passwd, and Kubernetes runAsNonRoot can only verify a numeric id.
+USER 65532:65532
 
 # Add a simple healthcheck compatible with distroless (exec form only)
 # This verifies the binary is present and runnable.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Every open pull request on this repository is currently failing its lint check, including the dependency bots' own. The cause is not in any of those changes — a code-quality rule now objects to how the container image names the user it runs as, and that check only runs on pull requests, so `main` stays green while nothing can get through.

### What

Refers to the same user by its number instead of its name. The base image already defines that user with this exact number, so the image runs as it did before.

It is also the form Kubernetes can actually act on: its "must not run as root" safety check can only verify a user given by number, and silently cannot when given a name.

**Security floor:** the one place that safety check could not be enforced now can be.
**Everyday path:** unchanged — no new step for anyone building or running the image.

Unblocks the pull-request queue.