### PR TITLE
fix(hetznerbase): reject signing transports the PEM guard cannot see

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/starlight": "^0.41.7",
-        "astro": "^7.2.0",
+        "astro": "^7.2.1",
         "astro-mermaid": "^2.1.0",
         "mermaid": "^11.16.1",
         "sharp": "^0.35.3",
-        "starlight-links-validator": "^0.25.2"
+        "starlight-links-validator": "^0.25.3"
       },
       "devDependencies": {
         "starlight-github-alerts": "^0.4.0"
@@ -2728,9 +2728,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.0.tgz",
-      "integrity": "sha512-lLTYzx3fOvCmtwD3JVBLQcbORbIOW1/j0R+3IvJx/XKwMGrk7mFnF0BYSOeRiNw1qHUR5mdA6+hRnyvyDfqrWQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.1.tgz",
+      "integrity": "sha512-ynyMTiyF//GLcd8+gRNbvcKgS1ht+qTgp/fkkHIpGYNILLseQqQRuPZ9PqXYKfsact4J1emZaXRDpg2bl35Pag==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.2",
@@ -7363,9 +7363,9 @@
       }
     },
     "node_modules/starlight-links-validator": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.25.2.tgz",
-      "integrity": "sha512-RQiHkM8FHKermsjMkSb+uS/q50Dv5P0O0ECWKxJyTv4stuO8QTorIEKnITDDLEf9/xyg7M69arxiK2ola3OMqA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.25.3.tgz",
+      "integrity": "sha512-kNE2F8fwdq7r8l6Zx2nH3SDnLlVu2VRmbmyV/nSpbtWzf9+S81H2VBZ6GRevIKbm8qOoYSZvXzNATT8ZXw9bmw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-satteri": "^0.3.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.7",
-    "astro": "^7.2.0",
+    "astro": "^7.2.1",
     "astro-mermaid": "^2.1.0",
     "mermaid": "^11.16.1",
     "sharp": "^0.35.3",
-    "starlight-links-validator": "^0.25.2"
+    "starlight-links-validator": "^0.25.3"
   },
   "devDependencies": {
     "starlight-github-alerts": "^0.4.0"

--- a/pkg/svc/installer/flux/Dockerfile
+++ b/pkg/svc/installer/flux/Dockerfile
@@ -10,5 +10,5 @@
 #   breaks Flux bootstrap when the manifests' bundled Flux distribution restructures a
 #   CRD the operator patches (see ksail#5595).
 
-FROM ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.58.0@sha256:1ccf038123198fab1923b3fc4977154bd4cc3729f4c7d957dedf09478d9d19d5
-FROM ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.58.0@sha256:698f1da558800d820cb2ffab2f11606d132f912d9925364be8957050ca0c2bbd
+FROM ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.58.1@sha256:b93eb18c9dfb62554e2cb750ecdd9f4ff58ca7e1c7bde260c6bf0c3452b786f8
+FROM ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.58.1@sha256:16da32ffa89c350c2c9e039b6a0400758fe74e7a9a5c2440dd55f74828c2d7ed

--- a/pkg/svc/installer/kyverno/Dockerfile
+++ b/pkg/svc/installer/kyverno/Dockerfile
@@ -4,4 +4,4 @@
 # Image mappings:
 # - ghcr.io/kyverno/charts/kyverno → chart version (OCI chart artifact tag)
 
-FROM ghcr.io/kyverno/charts/kyverno:3.8.2@sha256:2d267f9a36a0cf42efb735f5e984acac8a9f5eabe501f48138825f1cf07efafe
+FROM ghcr.io/kyverno/charts/kyverno:3.9.0@sha256:12f0567d8ca52c858eef0628ee5214348e6d6f554cc71de5b50379b93d6d46c1

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -283,7 +283,7 @@ func decodedContainsPrivateKey(decoded []byte) bool {
 		return true
 	}
 
-	if len(decoded) < 2 || decoded[0] != 0x1f || decoded[1] != 0x8b {
+	if !looksLikeGzip(decoded) {
 		return false
 	}
 
@@ -421,7 +421,7 @@ func decodedContainsSigningTransport(value string) bool {
 		return true
 	}
 
-	if len(decoded) < 2 || decoded[0] != 0x1f || decoded[1] != 0x8b {
+	if !looksLikeGzip(decoded) {
 		return false
 	}
 
@@ -435,6 +435,13 @@ func decodedContainsSigningTransport(value string) bool {
 	}
 
 	return matchesSigningTransport(expanded)
+}
+
+// looksLikeGzip reports whether payload opens with the gzip magic bytes. All
+// three unwrap paths -- both scalar guards and the top-level one -- ask the same
+// question, so the magic lives here rather than being spelled out at each site.
+func looksLikeGzip(payload []byte) bool {
+	return len(payload) >= 2 && payload[0] == 0x1f && payload[1] == 0x8b
 }
 
 // gunzipLimited expands a gzip payload up to the inspection bound. oversize
@@ -464,11 +471,50 @@ func gunzipLimited(compressed []byte) (string, bool, bool) {
 // validateProviderUserData rejects any transport that would retain cluster
 // signing material in Hetzner's provider-readable user-data. PEM material is
 // checked first so a leaked key keeps reporting the more specific error.
+//
+// Top-level raw gzip is expanded before either guard runs. cloud-init accepts
+// gzip-compressed user-data directly, and the compressed bytes are not YAML, so
+// without this the document scan fails to parse and legitimate compressed
+// user-data is refused with a parse error. Expanding first is also what lets a
+// marker hidden in compressed user-data report its own error rather than that
+// same parse error. Both guards then run against the expanded text, so PEM-first
+// priority is preserved across the unwrap.
 func validateProviderUserData(userData string) error {
-	err := validatePEMPrivateKeys(userData)
+	inspected, err := expandRawGzipUserData(userData)
 	if err != nil {
 		return err
 	}
 
-	return validateSigningTransport(userData)
+	pemErr := validatePEMPrivateKeys(inspected)
+	if pemErr != nil {
+		return pemErr
+	}
+
+	return validateSigningTransport(inspected)
+}
+
+// expandRawGzipUserData returns the text the guards should inspect: the gzip
+// payload's contents when userData is raw gzip, and userData unchanged
+// otherwise. Anything that is not gzip is returned untouched rather than
+// refused, so uncompressed user-data keeps its existing behaviour exactly.
+//
+// A payload expanding past the inspection bound is REFUSED rather than passed
+// through, matching decodedContainsSigningTransport, which treats oversize as a
+// positive: a marker could sit past the inspected prefix, so allowing it would
+// let compression hide exactly what this guard exists to catch. A payload that
+// announces itself as gzip and then fails to expand is refused for the same
+// reason -- it cannot be inspected, and unparseable input must not be the way
+// past a security guard.
+func expandRawGzipUserData(userData string) (string, error) {
+	raw := []byte(userData)
+	if !looksLikeGzip(raw) {
+		return userData, nil
+	}
+
+	expanded, oversize, ok := gunzipLimited(raw)
+	if oversize || !ok {
+		return "", ErrSigningTransportInUserData
+	}
+
+	return expanded, nil
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -347,15 +347,26 @@ var ErrSigningTransportInUserData = errors.New(
 var clusterPKIKeyPath = regexp.MustCompile(`/etc/kubernetes/pki/[^\s"']*\.key`)
 
 // spacedTransportAssignment matches a transport setting whose marker is split by
-// whitespace AND used as an assignment -- `certificate key: <hex>`, `upload certs
-// = true`. normaliseTransportText deliberately treats whitespace as a token
-// boundary so ordinary prose does not collapse into a marker, which alone would
-// stop matching this shape; the assignment punctuation is what separates the two.
-// A field carrying a value is material in provider-readable user-data whether or
-// not kubeadm would parse that exact field name, while a sentence containing the
-// same two words is not.
+// whitespace AND whose VALUE carries the material -- `certificate key: <hex>`,
+// `upload certs = true`. normaliseTransportText deliberately treats whitespace as
+// a token boundary so ordinary prose does not collapse into a marker, which alone
+// would stop matching this shape; this rule is what rescues the spaced spelling.
+//
+// The VALUE is the discriminator, not the assignment punctuation. User-data
+// legitimately carries shell that PRINTS this shape and comments that document
+// it -- `echo "certificate key: generated during bootstrap"`,
+// `# certificate key: documented here` -- and matching the shape alone refuses a
+// valid bring-up on content that exposes nothing. A kubeadm certificate key is a
+// long hex token, and an upload-certs setting only matters when it is switched
+// ON, so a prose value and a disabled setting are both material-free.
+//
+// This narrows only the hand-written SPACED spelling. The spellings a tool
+// actually emits -- `certificateKey`, `--certificate-key`, `--upload-certs` --
+// are matched by normalisation whatever their value, so nothing kubeadm produces
+// depends on this rule.
 var spacedTransportAssignment = regexp.MustCompile(
-	`(?i)(certificate\s+key|upload\s+certs)\s*[:=]`,
+	`(?i)(?:certificate\s+key\s*[:=]\s*["']?[A-Fa-f0-9]{12,}` +
+		`|upload\s+certs\s*[:=]\s*["']?(?:true|yes|on|enabled|1)\b)`,
 )
 
 // signingTransportMarkers are the kubeadm certificate-transport settings in

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -26,6 +26,24 @@ const DefaultImageName = "ubuntu-24.04"
 
 const maxDecodedUserDataBytes = 1 << 20
 
+// maxProviderUserDataBytes is Hetzner Cloud's hard ceiling on a server's
+// user_data field (32 KiB). It is a different bound from
+// maxDecodedUserDataBytes, which caps how much text the guards will READ so a
+// marker cannot hide past the inspected prefix; this one caps what the provider
+// will ACCEPT. The Talos autoscaler path pins the same ceiling as
+// hetznerUserDataLimitBytes, where exceeding it makes Hetzner reject the request
+// with "invalid input in field 'user_data'".
+const maxProviderUserDataBytes = 32768
+
+// ErrUserDataTooLargeForProvider is returned when the user-data a node would be
+// created with exceeds what Hetzner accepts. Expanding compressed user-data
+// before forwarding it is what makes this reachable: a payload well under the
+// ceiling while compressed can expand past it, and forwarding the expanded text
+// would turn a deployable node into an opaque provider rejection.
+var ErrUserDataTooLargeForProvider = errors.New(
+	"hetzner: provider user-data exceeds the maximum the provider accepts",
+)
+
 // ErrPrivateKeyInUserData is returned when a server spec would deliver private
 // key material through provider-readable user-data. The cloud-init ssh_keys
 // module is the deliberate exception: it carries the per-node SSH host identity
@@ -577,6 +595,10 @@ func gunzipLimited(compressed []byte) (string, bool, bool) {
 // priority is preserved across the unwrap. Returning that expanded text is
 // load-bearing: raw gzip bytes are not valid JSON text and must not be forwarded
 // to the provider after only their expanded form was validated.
+//
+// The returned text is finally bounded by what the provider accepts, which is a
+// separate ceiling from the inspection bound and is only reachable because the
+// expansion above can grow an acceptable input past it.
 func validateProviderUserData(userData string) (string, error) {
 	inspected, err := expandRawGzipUserData(userData)
 	if err != nil {
@@ -591,6 +613,17 @@ func validateProviderUserData(userData string) (string, error) {
 	err = validateSigningTransport(inspected)
 	if err != nil {
 		return "", err
+	}
+
+	// The guards have passed, so the remaining question is whether the provider
+	// will take this value at all. Checked here rather than at the call site
+	// because this function decides what gets forwarded, and expanding gzip is
+	// what lets an acceptable input become an unacceptable output.
+	if len(inspected) > maxProviderUserDataBytes {
+		return "", fmt.Errorf(
+			"%w: %d bytes exceeds the %d-byte limit",
+			ErrUserDataTooLargeForProvider, len(inspected), maxProviderUserDataBytes,
+		)
 	}
 
 	return inspected, nil

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -44,6 +44,17 @@ var ErrUserDataTooLargeForProvider = errors.New(
 	"hetzner: provider user-data exceeds the maximum the provider accepts",
 )
 
+// ErrUserDataNotInspectable is returned when user-data announces itself as gzip
+// and then cannot be read: it either fails to expand, or expands past
+// maxDecodedUserDataBytes. Such input is refused rather than forwarded, because
+// unparseable input must not be the way past a security guard -- but no signing
+// material was observed in it, so it does not report ErrSigningTransportInUserData.
+// It is a distinct condition from ErrUserDataTooLargeForProvider, which is about
+// the separate ceiling the PROVIDER accepts rather than the inspection bound.
+var ErrUserDataNotInspectable = errors.New(
+	"hetzner: provider user-data announces gzip but cannot be inspected",
+)
+
 // ErrPrivateKeyInUserData is returned when a server spec would deliver private
 // key material through provider-readable user-data. The cloud-init ssh_keys
 // module is the deliberate exception: it carries the per-node SSH host identity
@@ -641,6 +652,11 @@ func validateProviderUserData(userData string) (string, error) {
 // announces itself as gzip and then fails to expand is refused for the same
 // reason -- it cannot be inspected, and unparseable input must not be the way
 // past a security guard.
+//
+// Both cases report ErrUserDataNotInspectable rather than
+// ErrSigningTransportInUserData: the refusal is correct, but no marker was
+// observed, and an operator triaging a failed create must be able to tell "we
+// found signing material" from "we could not look".
 func expandRawGzipUserData(userData string) (string, error) {
 	raw := []byte(userData)
 	if !looksLikeGzip(raw) {
@@ -649,7 +665,7 @@ func expandRawGzipUserData(userData string) (string, error) {
 
 	expanded, oversize, ok := gunzipLimited(raw)
 	if oversize || !ok {
-		return "", ErrSigningTransportInUserData
+		return "", ErrUserDataNotInspectable
 	}
 
 	return expanded, nil

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -119,11 +119,11 @@ func DeriveServerSpecs(
 	return specs, nil
 }
 
-// validateProviderUserData rejects raw or encoded PEM private keys anywhere in
+// validatePEMPrivateKeys rejects raw or encoded PEM private keys anywhere in
 // the cloud-init YAML stream except a document's top-level ssh_keys module.
 // That module is the intentional per-node host identity; every other private
 // key would be retained in Hetzner's provider-readable user-data.
-func validateProviderUserData(userData string) error {
+func validatePEMPrivateKeys(userData string) error {
 	decoder := yaml.NewDecoder(strings.NewReader(userData))
 
 	for {
@@ -310,4 +310,195 @@ func firewallIDs(firewallID int64) []int64 {
 	}
 
 	return []int64{firewallID}
+}
+
+// ErrSigningTransportInUserData is returned when a server spec would deliver
+// cluster-signing material through provider-readable user-data by a transport
+// that carries no PEM block. kubeadm's --upload-certs stores the cluster PKI in
+// a Secret and the certificate key decrypts it, so either one hands the provider
+// the cluster identity as surely as the key itself would. A path to a private
+// half of the cluster PKI means the renderer is writing that material rather
+// than letting kubeadm mint it on the node.
+var ErrSigningTransportInUserData = errors.New(
+	"hetzner: provider user-data contains cluster-signing transport material",
+)
+
+// clusterPKIKeyPath matches a path to a private half of the cluster PKI. It
+// keys on the directory plus the .key extension rather than enumerating the
+// four file names, so a PKI key this package does not yet know about is still
+// caught. The public .crt halves are deliberately not matched.
+var clusterPKIKeyPath = regexp.MustCompile(`/etc/kubernetes/pki/[^\s"']*\.key`)
+
+// signingTransportMarkers are the kubeadm certificate-transport settings in
+// normalised form. Each is stored as normaliseTransportText renders it, so one
+// entry covers every separator and casing spelling of that setting.
+func signingTransportMarkers() []string {
+	return []string{"certificatekey", "uploadcerts"}
+}
+
+// normaliseTransportText lowercases and drops the separators that distinguish
+// otherwise identical spellings, collapsing certificateKey, certificate-key and
+// certificate_key onto one token. Matching the normalised form is what keeps
+// this guard from being evaded by a spelling it does not enumerate.
+func normaliseTransportText(value string) string {
+	return strings.NewReplacer("-", "", "_", "").Replace(strings.ToLower(value))
+}
+
+// matchesSigningTransport reports whether the text carries a certificate
+// transport marker or a cluster PKI private-key path.
+func matchesSigningTransport(value string) bool {
+	if clusterPKIKeyPath.MatchString(value) {
+		return true
+	}
+
+	normalised := normaliseTransportText(value)
+	for _, marker := range signingTransportMarkers() {
+		if strings.Contains(normalised, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// validateSigningTransport rejects certificate-transport markers and cluster PKI
+// key paths anywhere in the user-data.
+//
+// Unlike the PEM guard this applies no ssh_keys exemption: that module carries
+// the node's SSH host identity, which legitimately contains a private key but
+// never a kubeadm certificate transport, so exempting it here would leave a
+// blind spot rather than avoid a false positive.
+//
+// The raw document is scanned first so the result cannot be changed by how the
+// YAML is structured, then each scalar's decoded form is inspected so a marker
+// hidden in a base64 or gzip payload is caught by the same unwrapping the PEM
+// guard performs.
+func validateSigningTransport(userData string) error {
+	if matchesSigningTransport(userData) {
+		return ErrSigningTransportInUserData
+	}
+
+	decoder := yaml.NewDecoder(strings.NewReader(userData))
+
+	for {
+		var document yaml.Node
+
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("parse cloud-init user-data: %w", err)
+		}
+
+		if encodedSigningTransport(&document, make(map[*yaml.Node]struct{})) {
+			return ErrSigningTransportInUserData
+		}
+	}
+}
+
+// decodedContainsSigningTransport reports whether a scalar's base64 or gzip
+// payload carries a transport marker. The plaintext form is already covered by
+// the raw-document scan, so only the decoded shapes are inspected here.
+func decodedContainsSigningTransport(value string) bool {
+	decoded, decodedOK := decodeBase64(value)
+	if !decodedOK {
+		return false
+	}
+
+	if matchesSigningTransport(string(decoded)) {
+		return true
+	}
+
+	if len(decoded) < 2 || decoded[0] != 0x1f || decoded[1] != 0x8b {
+		return false
+	}
+
+	expanded, oversize, expandedOK := gunzipLimited(decoded)
+	if oversize {
+		return true
+	}
+
+	if !expandedOK {
+		return false
+	}
+
+	return matchesSigningTransport(expanded)
+}
+
+// gunzipLimited expands a gzip payload up to the inspection bound. oversize
+// reports a payload expanding past that bound, which callers refuse rather than
+// allow to hide a marker past the inspected prefix; ok reports whether expanded
+// holds a usable result.
+func gunzipLimited(compressed []byte) (string, bool, bool) {
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return "", false, false
+	}
+
+	decompressed, readErr := io.ReadAll(io.LimitReader(reader, maxDecodedUserDataBytes+1))
+
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil {
+		return "", false, false
+	}
+
+	if len(decompressed) > maxDecodedUserDataBytes {
+		return "", true, false
+	}
+
+	return string(decompressed), false, true
+}
+
+// validateProviderUserData rejects any transport that would retain cluster
+// signing material in Hetzner's provider-readable user-data. PEM material is
+// checked first so a leaked key keeps reporting the more specific error.
+func validateProviderUserData(userData string) error {
+	err := validatePEMPrivateKeys(userData)
+	if err != nil {
+		return err
+	}
+
+	return validateSigningTransport(userData)
+}
+
+// encodedSigningTransport walks every scalar and inspects its decoded form.
+// Active nodes stop recursive aliases from cycling.
+func encodedSigningTransport(node *yaml.Node, active map[*yaml.Node]struct{}) bool {
+	if node == nil {
+		return false
+	}
+
+	if _, visited := active[node]; visited {
+		return false
+	}
+
+	active[node] = struct{}{}
+	defer delete(active, node)
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return decodedContainsSigningTransport(node.Value)
+	case yaml.AliasNode:
+		return encodedSigningTransport(node.Alias, active)
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.MappingNode:
+		return encodedSigningTransportInChildren(node.Content, active)
+	}
+
+	return false
+}
+
+// encodedSigningTransportInChildren inspects each child in order.
+func encodedSigningTransportInChildren(
+	children []*yaml.Node,
+	active map[*yaml.Node]struct{},
+) bool {
+	for _, child := range children {
+		if encodedSigningTransport(child, active) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -93,7 +93,7 @@ func DeriveServerSpecs(
 	specs := make([]hetzner.CreateServerOpts, 0, len(nodes))
 
 	for _, node := range nodes {
-		err := validateProviderUserData(node.UserData)
+		validatedUserData, err := validateProviderUserData(node.UserData)
 		if err != nil {
 			return nil, fmt.Errorf("validate user-data for node %d: %w", node.Index, err)
 		}
@@ -109,7 +109,7 @@ func DeriveServerSpecs(
 			ImageName:        DefaultImageName,
 			Location:         opts.Location,
 			Labels:           node.Labels,
-			UserData:         node.UserData,
+			UserData:         validatedUserData,
 			NetworkID:        infra.NetworkID,
 			PlacementGroupID: infra.PlacementGroupID,
 			SSHKeyID:         infra.SSHKeyID,
@@ -346,6 +346,15 @@ var ErrSigningTransportInUserData = errors.New(
 // caught. The public .crt halves are deliberately not matched.
 var clusterPKIKeyPath = regexp.MustCompile(`/etc/kubernetes/pki/[^\s"']*\.key`)
 
+// clusterPKIWorkingDirectoryKeyPath matches a private-key basename used after
+// shell changes its working directory into the cluster PKI tree. At execution
+// time `cd /etc/kubernetes/pki && install ... ca.key` writes the same file as an
+// absolute path, so inspecting only contiguous path spellings leaves a bypass.
+var clusterPKIWorkingDirectoryKeyPath = regexp.MustCompile(
+	`(?is)\bcd\s+(?:--\s+)?/etc/kubernetes/pki(?:/[^\s;&|]*)?\s*(?:&&|;|\n)` +
+		`[^;&|]*[^\s/;&|]*\.key\b`,
+)
+
 // spacedTransportAssignment matches a transport setting whose marker is split by
 // whitespace AND whose VALUE carries the material -- `certificate key: <hex>`,
 // `upload certs = true`. normaliseTransportText deliberately treats whitespace as
@@ -409,18 +418,34 @@ func normaliseTransportText(value string) string {
 	}, value)
 }
 
+// normaliseShellSpelling removes syntax that the shell removes before command
+// execution. Quoted token fragments and backslash-newline continuations can
+// otherwise split a protected flag or path while still producing it verbatim
+// at runtime.
+func normaliseShellSpelling(value string) string {
+	return strings.NewReplacer(
+		"\\\r\n", "",
+		"\\\n", "",
+		`"`, "",
+		`'`, "",
+	).Replace(value)
+}
+
 // matchesSigningTransport reports whether the text carries a certificate
 // transport marker or a cluster PKI private-key path.
 func matchesSigningTransport(value string) bool {
-	if clusterPKIKeyPath.MatchString(value) {
+	shellValue := normaliseShellSpelling(value)
+
+	if clusterPKIKeyPath.MatchString(shellValue) ||
+		clusterPKIWorkingDirectoryKeyPath.MatchString(shellValue) {
 		return true
 	}
 
-	if spacedTransportAssignment.MatchString(value) {
+	if spacedTransportAssignment.MatchString(shellValue) {
 		return true
 	}
 
-	normalised := normaliseTransportText(value)
+	normalised := normaliseTransportText(shellValue)
 	for _, marker := range signingTransportMarkers() {
 		if strings.Contains(normalised, marker) {
 			return true
@@ -521,9 +546,10 @@ func gunzipLimited(compressed []byte) (string, bool, bool) {
 	return string(decompressed), false, true
 }
 
-// validateProviderUserData rejects any transport that would retain cluster
-// signing material in Hetzner's provider-readable user-data. PEM material is
-// checked first so a leaked key keeps reporting the more specific error.
+// validateProviderUserData returns the inspected text that is safe to send to
+// Hetzner, rejecting any transport that would retain cluster signing material
+// in provider-readable user-data. PEM material is checked first so a leaked key
+// keeps reporting the more specific error.
 //
 // Top-level raw gzip is expanded before either guard runs. cloud-init accepts
 // gzip-compressed user-data directly, and the compressed bytes are not YAML, so
@@ -531,19 +557,26 @@ func gunzipLimited(compressed []byte) (string, bool, bool) {
 // user-data is refused with a parse error. Expanding first is also what lets a
 // marker hidden in compressed user-data report its own error rather than that
 // same parse error. Both guards then run against the expanded text, so PEM-first
-// priority is preserved across the unwrap.
-func validateProviderUserData(userData string) error {
+// priority is preserved across the unwrap. Returning that expanded text is
+// load-bearing: raw gzip bytes are not valid JSON text and must not be forwarded
+// to the provider after only their expanded form was validated.
+func validateProviderUserData(userData string) (string, error) {
 	inspected, err := expandRawGzipUserData(userData)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	pemErr := validatePEMPrivateKeys(inspected)
 	if pemErr != nil {
-		return pemErr
+		return "", pemErr
 	}
 
-	return validateSigningTransport(inspected)
+	err = validateSigningTransport(inspected)
+	if err != nil {
+		return "", err
+	}
+
+	return inspected, nil
 }
 
 // expandRawGzipUserData returns the text the guards should inspect: the gzip

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -350,8 +350,11 @@ var clusterPKIKeyPath = regexp.MustCompile(`/etc/kubernetes/pki/[^\s"']*\.key`)
 // shell changes its working directory into the cluster PKI tree. At execution
 // time `cd /etc/kubernetes/pki && install ... ca.key` writes the same file as an
 // absolute path, so inspecting only contiguous path spellings leaves a bypass.
+// Shell short options can be separate or clustered; accept the no-argument cd
+// option alphabet conservatively so combinations such as `-P -e` and `-Pe`
+// cannot hide the working directory from the guard.
 var clusterPKIWorkingDirectoryKeyPath = regexp.MustCompile(
-	`(?is)\bcd\s+(?:-[LP]\s+|--\s+)?/etc/kubernetes/pki(?:/[^\s;&|]*)?\s*(?:&&|;|\n)` +
+	`(?is)\bcd\s+(?:(?:-[LPe@]+|--)\s+)*/etc/kubernetes/pki(?:/[^\s;&|]*)?\s*(?:&&|;|\n)` +
 		`[^;&|]*[^\s/;&|]*\.key\b`,
 )
 

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
@@ -352,12 +353,21 @@ func signingTransportMarkers() []string {
 	return []string{"certificatekey", "uploadcerts"}
 }
 
-// normaliseTransportText lowercases and drops the separators that distinguish
-// otherwise identical spellings, collapsing certificateKey, certificate-key and
-// certificate_key onto one token. Matching the normalised form is what keeps
-// this guard from being evaded by a spelling it does not enumerate.
+// normaliseTransportText lowercases and drops every non-alphanumeric character,
+// collapsing certificateKey, certificate-key, certificate_key, certificate.key,
+// certificate/key and certificate key onto one token. The separator class is
+// open-ended, so the guard keeps a whitelist of the characters that carry
+// meaning rather than a blacklist of the separators it knows about: enumerating
+// separators fails for exactly the reason enumerating spellings does, one
+// unlisted member at a time.
 func normaliseTransportText(value string) string {
-	return strings.NewReplacer("-", "", "_", "").Replace(strings.ToLower(value))
+	return strings.Map(func(character rune) rune {
+		if unicode.IsLetter(character) || unicode.IsDigit(character) {
+			return unicode.ToLower(character)
+		}
+
+		return -1
+	}, value)
 }
 
 // matchesSigningTransport reports whether the text carries a certificate

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -353,9 +353,23 @@ var clusterPKIKeyPath = regexp.MustCompile(`/etc/kubernetes/pki/[^\s"']*\.key`)
 // Shell short options can be separate or clustered; accept the no-argument cd
 // option alphabet conservatively so combinations such as `-P -e` and `-Pe`
 // cannot hide the working directory from the guard.
+//
+// The trailing filename is anchored to a WHITESPACE boundary, which is what
+// keeps the `/`-exclusion in `[^\s/;&|]*` load-bearing. Without the anchor the
+// preceding `[^;&|]*` simply consumes up to the last separator, so an ABSOLUTE
+// path elsewhere on the command -- `curl ... -o /etc/apt/keyrings/k8s.key` --
+// satisfies the rule and a bring-up that leaks nothing is refused. An absolute
+// path does not resolve relative to the working directory, so it is not this
+// rule's business; the absolute-path rule above owns it.
+//
+// Deliberately NOT bounded to a single line. `cd` persists until the next one,
+// so `cd /etc/kubernetes/pki && cat ca.crt` followed by `install ca.key` on the
+// FOLLOWING line is a real leak. Excluding the newline from the trailing segment
+// would silence the false positive above by also dropping that case, trading a
+// noisy refusal for a silent miss.
 var clusterPKIWorkingDirectoryKeyPath = regexp.MustCompile(
 	`(?is)\bcd\s+(?:(?:-[LPe@]+|--)\s+)*/etc/kubernetes/pki(?:/[^\s;&|]*)?\s*(?:&&|;|\n)` +
-		`[^;&|]*[^\s/;&|]*\.key\b`,
+		`[^;&|]*(?:^|\s)[^\s/;&|]*\.key\b`,
 )
 
 // spacedTransportAssignment matches a transport setting whose marker is split by

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -346,6 +346,18 @@ var ErrSigningTransportInUserData = errors.New(
 // caught. The public .crt halves are deliberately not matched.
 var clusterPKIKeyPath = regexp.MustCompile(`/etc/kubernetes/pki/[^\s"']*\.key`)
 
+// spacedTransportAssignment matches a transport setting whose marker is split by
+// whitespace AND used as an assignment -- `certificate key: <hex>`, `upload certs
+// = true`. normaliseTransportText deliberately treats whitespace as a token
+// boundary so ordinary prose does not collapse into a marker, which alone would
+// stop matching this shape; the assignment punctuation is what separates the two.
+// A field carrying a value is material in provider-readable user-data whether or
+// not kubeadm would parse that exact field name, while a sentence containing the
+// same two words is not.
+var spacedTransportAssignment = regexp.MustCompile(
+	`(?i)(certificate\s+key|upload\s+certs)\s*[:=]`,
+)
+
 // signingTransportMarkers are the kubeadm certificate-transport settings in
 // normalised form. Each is stored as normaliseTransportText renders it, so one
 // entry covers every separator and casing spelling of that setting.
@@ -353,20 +365,36 @@ func signingTransportMarkers() []string {
 	return []string{"certificatekey", "uploadcerts"}
 }
 
-// normaliseTransportText lowercases and drops every non-alphanumeric character,
-// collapsing certificateKey, certificate-key, certificate_key, certificate.key,
-// certificate/key and certificate key onto one token. The separator class is
-// open-ended, so the guard keeps a whitelist of the characters that carry
-// meaning rather than a blacklist of the separators it knows about: enumerating
-// separators fails for exactly the reason enumerating spellings does, one
-// unlisted member at a time.
+// normaliseTransportText lowercases and drops every non-alphanumeric character
+// EXCEPT whitespace, collapsing certificateKey, certificate-key, certificate_key,
+// certificate.key and certificate/key onto one token. The separator class is
+// open-ended, so the guard keeps a whitelist of the characters that carry meaning
+// rather than a blacklist of the separators it knows about: enumerating separators
+// fails for exactly the reason enumerating spellings does, one unlisted member at
+// a time.
+//
+// Whitespace is the deliberate exception, and it is a HARD token boundary rather
+// than another separator to drop. Dropping it too joins adjacent words, so any
+// prose that ends one sentence in "certificate" and opens the next with "Key"
+// normalises to a marker hit -- "Install the TLS certificate. Key material stays
+// in OpenBao." is rejected as a signing transport. User-data legitimately carries
+// comments and documentation, so that is a false positive on ordinary content, and
+// it reaches scalars via write_files: content:.
+//
+// Keeping the boundary costs no real detection: no kubeadm spelling of either
+// setting contains an internal space. A space-separated "certificate key" is not a
+// YAML field or a CLI flag, so it delivers nothing and matching it would only
+// resurface the prose case.
 func normaliseTransportText(value string) string {
 	return strings.Map(func(character rune) rune {
-		if unicode.IsLetter(character) || unicode.IsDigit(character) {
+		switch {
+		case unicode.IsLetter(character) || unicode.IsDigit(character):
 			return unicode.ToLower(character)
+		case unicode.IsSpace(character):
+			return ' '
+		default:
+			return -1
 		}
-
-		return -1
 	}, value)
 }
 
@@ -374,6 +402,10 @@ func normaliseTransportText(value string) string {
 // transport marker or a cluster PKI private-key path.
 func matchesSigningTransport(value string) bool {
 	if clusterPKIKeyPath.MatchString(value) {
+		return true
+	}
+
+	if spacedTransportAssignment.MatchString(value) {
 		return true
 	}
 

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -351,7 +351,7 @@ var clusterPKIKeyPath = regexp.MustCompile(`/etc/kubernetes/pki/[^\s"']*\.key`)
 // time `cd /etc/kubernetes/pki && install ... ca.key` writes the same file as an
 // absolute path, so inspecting only contiguous path spellings leaves a bypass.
 var clusterPKIWorkingDirectoryKeyPath = regexp.MustCompile(
-	`(?is)\bcd\s+(?:--\s+)?/etc/kubernetes/pki(?:/[^\s;&|]*)?\s*(?:&&|;|\n)` +
+	`(?is)\bcd\s+(?:-[LP]\s+|--\s+)?/etc/kubernetes/pki(?:/[^\s;&|]*)?\s*(?:&&|;|\n)` +
 		`[^;&|]*[^\s/;&|]*\.key\b`,
 )
 

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -124,6 +124,20 @@ func DeriveServerSpecs(
 // That module is the intentional per-node host identity; every other private
 // key would be retained in Hetzner's provider-readable user-data.
 func validatePEMPrivateKeys(userData string) error {
+	return scanDocuments(userData, ErrPrivateKeyInUserData, func(document *yaml.Node) bool {
+		return yamlNodeMatches(
+			document, true, make(map[*yaml.Node]struct{}), containsPrivateKeyMaterial, true,
+		)
+	})
+}
+
+// scalarMatch reports whether a scalar value carries material the caller refuses.
+type scalarMatch func(string) bool
+
+// scanDocuments decodes every YAML document in the user-data and returns
+// refusal when inspect reports a match. Both guards share it so the stream
+// handling cannot drift between them.
+func scanDocuments(userData string, refusal error, inspect func(*yaml.Node) bool) error {
 	decoder := yaml.NewDecoder(strings.NewReader(userData))
 
 	for {
@@ -138,20 +152,27 @@ func validatePEMPrivateKeys(userData string) error {
 			return fmt.Errorf("parse cloud-init user-data: %w", err)
 		}
 
-		if yamlNodeContainsPrivateKey(&document, true, make(map[*yaml.Node]struct{})) {
-			return ErrPrivateKeyInUserData
+		if inspect(&document) {
+			return refusal
 		}
 	}
 }
 
-// yamlNodeContainsPrivateKey walks scalar mapping keys and values while
-// exempting only the top-level cloud-init ssh_keys value. Nested keys with the
-// same name are not identities and remain subject to inspection. Active nodes
-// stop recursive aliases from cycling without suppressing later sibling paths.
-func yamlNodeContainsPrivateKey(
+// yamlNodeMatches walks scalar mapping keys and values, applying match to every
+// scalar. Active nodes stop recursive aliases from cycling without suppressing
+// later sibling paths.
+//
+// exemptSSHKeys skips a document top-level ssh_keys value. Only the PEM guard
+// sets it: that module is the intentional per-node host identity, so its private
+// key is expected there. The transport guard leaves it false, because no kubeadm
+// certificate transport legitimately appears under ssh_keys and exempting it
+// would be a blind spot rather than a false-positive fix.
+func yamlNodeMatches(
 	node *yaml.Node,
 	topLevel bool,
 	active map[*yaml.Node]struct{},
+	match scalarMatch,
+	exemptSSHKeys bool,
 ) bool {
 	if node == nil {
 		return false
@@ -166,27 +187,29 @@ func yamlNodeContainsPrivateKey(
 
 	switch node.Kind {
 	case yaml.DocumentNode:
-		return yamlChildrenContainPrivateKey(node.Content, true, active)
+		return yamlChildrenMatch(node.Content, true, active, match, exemptSSHKeys)
 	case yaml.MappingNode:
-		return yamlMappingContainsPrivateKey(node.Content, topLevel, active)
+		return yamlMappingMatches(node.Content, topLevel, active, match, exemptSSHKeys)
 	case yaml.SequenceNode:
-		return yamlChildrenContainPrivateKey(node.Content, false, active)
+		return yamlChildrenMatch(node.Content, false, active, match, exemptSSHKeys)
 	case yaml.ScalarNode:
-		return containsPrivateKeyMaterial(node.Value)
+		return match(node.Value)
 	case yaml.AliasNode:
-		return yamlNodeContainsPrivateKey(node.Alias, false, active)
+		return yamlNodeMatches(node.Alias, false, active, match, exemptSSHKeys)
 	}
 
 	return false
 }
 
-func yamlChildrenContainPrivateKey(
+func yamlChildrenMatch(
 	children []*yaml.Node,
 	topLevel bool,
 	active map[*yaml.Node]struct{},
+	match scalarMatch,
+	exemptSSHKeys bool,
 ) bool {
 	for _, child := range children {
-		if yamlNodeContainsPrivateKey(child, topLevel, active) {
+		if yamlNodeMatches(child, topLevel, active, match, exemptSSHKeys) {
 			return true
 		}
 	}
@@ -194,24 +217,26 @@ func yamlChildrenContainPrivateKey(
 	return false
 }
 
-func yamlMappingContainsPrivateKey(
+func yamlMappingMatches(
 	content []*yaml.Node,
 	topLevel bool,
 	active map[*yaml.Node]struct{},
+	match scalarMatch,
+	exemptSSHKeys bool,
 ) bool {
 	for index := 0; index+1 < len(content); index += 2 {
 		key := content[index]
 		value := content[index+1]
 
-		if yamlNodeContainsPrivateKey(key, false, active) {
+		if yamlNodeMatches(key, false, active, match, exemptSSHKeys) {
 			return true
 		}
 
-		if topLevel && key.Kind == yaml.ScalarNode && key.Value == "ssh_keys" {
+		if exemptSSHKeys && topLevel && key.Kind == yaml.ScalarNode && key.Value == "ssh_keys" {
 			continue
 		}
 
-		if yamlNodeContainsPrivateKey(value, false, active) {
+		if yamlNodeMatches(value, false, active, match, exemptSSHKeys) {
 			return true
 		}
 	}
@@ -266,25 +291,16 @@ func decodedContainsPrivateKey(decoded []byte) bool {
 }
 
 func gzipContainsPrivateKey(compressed []byte) bool {
-	reader, err := gzip.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		return false
-	}
-
-	decompressed, readErr := io.ReadAll(io.LimitReader(reader, maxDecodedUserDataBytes+1))
-
-	closeErr := reader.Close()
-	if readErr != nil || closeErr != nil {
-		return false
-	}
-
-	// Provider user-data is small. An encoded scalar expanding beyond this bound
-	// is refused rather than allowed to hide a marker past the inspected prefix.
-	if len(decompressed) > maxDecodedUserDataBytes {
+	expanded, oversize, ok := gunzipLimited(compressed)
+	if oversize {
 		return true
 	}
 
-	return containsPrivateKeyPEM(string(decompressed))
+	if !ok {
+		return false
+	}
+
+	return containsPrivateKeyPEM(expanded)
 }
 
 func containsPrivateKeyPEM(value string) bool {
@@ -374,28 +390,22 @@ func matchesSigningTransport(value string) bool {
 // hidden in a base64 or gzip payload is caught by the same unwrapping the PEM
 // guard performs.
 func validateSigningTransport(userData string) error {
-	if matchesSigningTransport(userData) {
-		return ErrSigningTransportInUserData
+	return scanDocuments(userData, ErrSigningTransportInUserData, func(document *yaml.Node) bool {
+		return yamlNodeMatches(
+			document, true, make(map[*yaml.Node]struct{}), containsSigningTransportMaterial, false,
+		)
+	})
+}
+
+// containsSigningTransportMaterial reports whether a scalar carries a transport
+// marker in plain text or inside an encoded payload. It mirrors
+// containsPrivateKeyMaterial so both guards inspect the same shapes.
+func containsSigningTransportMaterial(value string) bool {
+	if matchesSigningTransport(value) {
+		return true
 	}
 
-	decoder := yaml.NewDecoder(strings.NewReader(userData))
-
-	for {
-		var document yaml.Node
-
-		err := decoder.Decode(&document)
-		if errors.Is(err, io.EOF) {
-			return nil
-		}
-
-		if err != nil {
-			return fmt.Errorf("parse cloud-init user-data: %w", err)
-		}
-
-		if encodedSigningTransport(&document, make(map[*yaml.Node]struct{})) {
-			return ErrSigningTransportInUserData
-		}
-	}
+	return decodedContainsSigningTransport(value)
 }
 
 // decodedContainsSigningTransport reports whether a scalar's base64 or gzip
@@ -461,44 +471,4 @@ func validateProviderUserData(userData string) error {
 	}
 
 	return validateSigningTransport(userData)
-}
-
-// encodedSigningTransport walks every scalar and inspects its decoded form.
-// Active nodes stop recursive aliases from cycling.
-func encodedSigningTransport(node *yaml.Node, active map[*yaml.Node]struct{}) bool {
-	if node == nil {
-		return false
-	}
-
-	if _, visited := active[node]; visited {
-		return false
-	}
-
-	active[node] = struct{}{}
-	defer delete(active, node)
-
-	switch node.Kind {
-	case yaml.ScalarNode:
-		return decodedContainsSigningTransport(node.Value)
-	case yaml.AliasNode:
-		return encodedSigningTransport(node.Alias, active)
-	case yaml.DocumentNode, yaml.SequenceNode, yaml.MappingNode:
-		return encodedSigningTransportInChildren(node.Content, active)
-	}
-
-	return false
-}
-
-// encodedSigningTransportInChildren inspects each child in order.
-func encodedSigningTransportInChildren(
-	children []*yaml.Node,
-	active map[*yaml.Node]struct{},
-) bool {
-	for _, child := range children {
-		if encodedSigningTransport(child, active) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -1,0 +1,137 @@
+package hetznerbase_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// userDataCarrying wraps a fixture body in a minimal cloud-config document so
+// each case exercises the real YAML walk rather than a bare scalar.
+func userDataCarrying(body string) string {
+	return fmt.Sprintf(`#cloud-config
+write_files:
+  - path: /etc/kubernetes/ksail/kubeadm-config.yaml
+    content: |-
+      %s
+`, strings.ReplaceAll(body, "\n", "\n      "))
+}
+
+// TestDeriveServerSpecsRejectsCertificateTransportMarkers pins the guard against
+// the kubeadm certificate-transport class. `--upload-certs` stores the cluster
+// PKI in a Secret and the certificate key decrypts it, so either one in
+// provider user-data hands the provider the cluster identity even though no PEM
+// block appears anywhere.
+//
+// Every fixture is deliberately free of PEM private-key material, so a failure
+// is attributable only to the transport marker and never to the pre-existing
+// PEM detection.
+func TestDeriveServerSpecsRejectsCertificateTransportMarkers(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"camelCase field":   "certificateKey: abcdef0123456789",
+		"kebab-case flag":   "kubeadm join --certificate-key abcdef0123456789",
+		"upload-certs flag": "kubeadm init --upload-certs",
+		"camelCase option":  "uploadCerts: true",
+		// Neither the kebab nor the camel spelling: a literal-list guard misses
+		// this, so it pins that detection normalises rather than enumerates.
+		"snake_case field": "certificate_key: abcdef0123456789",
+		// Reuses the guard's existing base64 unwrapping, proving the marker
+		// class is inspected through the same nesting pipeline as PEM material.
+		"base64 nested": base64.StdEncoding.EncodeToString(
+			[]byte("certificateKey: abcdef0123456789"),
+		),
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes := twoNodeSpecs()
+			nodes[1].UserData = userDataCarrying(body)
+
+			specs, err := hetznerbase.DeriveServerSpecs(
+				specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+			)
+
+			require.ErrorIs(t, err, hetznerbase.ErrSigningTransportInUserData)
+			assert.Nil(t, specs)
+		})
+	}
+}
+
+// TestDeriveServerSpecsRejectsClusterPKIKeyPaths pins the on-disk half. kubeadm
+// mints the private cluster PKI on the initial control plane, so a path under
+// the PKI directory ending in .key appearing in user-data means the renderer is
+// writing that material rather than letting kubeadm generate it.
+//
+// The fixtures carry the path only — no PEM body — so the pre-existing PEM
+// detection cannot account for the rejection.
+func TestDeriveServerSpecsRejectsClusterPKIKeyPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"cluster CA":      "cp /tmp/staged /etc/kubernetes/pki/ca.key",
+		"front proxy CA":  "cp /tmp/staged /etc/kubernetes/pki/front-proxy-ca.key",
+		"etcd CA":         "cp /tmp/staged /etc/kubernetes/pki/etcd/ca.key",
+		"service account": "cp /tmp/staged /etc/kubernetes/pki/sa.key",
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes := twoNodeSpecs()
+			nodes[1].UserData = userDataCarrying(body)
+
+			specs, err := hetznerbase.DeriveServerSpecs(
+				specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+			)
+
+			require.ErrorIs(t, err, hetznerbase.ErrSigningTransportInUserData)
+			assert.Nil(t, specs)
+		})
+	}
+}
+
+// TestDeriveServerSpecsAcceptsMaterialFreeUserData is the negative control. A
+// guard that rejects everything proves nothing, so each fixture is user-data the
+// supported bring-up legitimately produces and must keep accepting.
+func TestDeriveServerSpecsAcceptsMaterialFreeUserData(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		// The bootstrap token is provider-visible by design and is not signing
+		// material; rejecting it would break the supported join path.
+		"bootstrap token": "token: abcdef.0123456789abcdef",
+		// The public CA certificate and its discovery hash are public halves.
+		"discovery hash": "discoveryTokenCACertHash: sha256:0123456789abcdef",
+		// The rendered kubeadm config's own path sits under a different
+		// directory and must not trip the PKI-path rule.
+		"kubeadm config path": "cat /etc/kubernetes/ksail/kubeadm-config.yaml",
+		// A public certificate under the PKI directory is not a private key.
+		"public PKI cert": "cat /etc/kubernetes/pki/ca.crt",
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes := twoNodeSpecs()
+			nodes[1].UserData = userDataCarrying(body)
+
+			specs, err := hetznerbase.DeriveServerSpecs(
+				specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+			)
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, specs)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -351,6 +351,15 @@ func TestDeriveServerSpecsBoundsForwardedUserData(t *testing.T) {
 		require.ErrorIs(t, err, hetznerbase.ErrUserDataTooLargeForProvider)
 		assert.Nil(t, specs)
 	})
+}
+
+// TestDeriveServerSpecsPinsProviderCeilingBoundary pins the comparison at the
+// provider ceiling itself. The pair below is what discriminates `>` from `>=`:
+// a payload at exactly the ceiling must be accepted and one byte more refused,
+// so an off-by-one that turned away a legitimate 32768-byte node cannot pass
+// unnoticed.
+func TestDeriveServerSpecsPinsProviderCeilingBoundary(t *testing.T) {
+	t.Parallel()
 
 	// The control: a payload at EXACTLY the ceiling still goes through, so the
 	// bound is a ceiling rather than a blanket refusal of large user-data.

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -100,6 +100,9 @@ func TestDeriveServerSpecsRejectsClusterPKIKeyPaths(t *testing.T) {
 		"PKI working directory":          "cd /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 		"PKI logical working directory":  "cd -L /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 		"PKI physical working directory": "cd -P /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI physical error options":     "cd -P -e /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI combined physical error":    "cd -Pe /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI reordered physical error":   "cd -eP /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 	}
 
 	for name, body := range tests {

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -39,6 +39,7 @@ func TestDeriveServerSpecsRejectsCertificateTransportMarkers(t *testing.T) {
 	tests := map[string]string{
 		"camelCase field":   "certificateKey: abcdef0123456789",
 		"kebab-case flag":   "kubeadm join --certificate-key abcdef0123456789",
+		"continued flag":    "kubeadm join --certificate-\\\nkey abcdef0123456789",
 		"upload-certs flag": "kubeadm init --upload-certs",
 		"camelCase option":  "uploadCerts: true",
 		// Neither the kebab nor the camel spelling: a literal-list guard misses
@@ -91,10 +92,12 @@ func TestDeriveServerSpecsRejectsClusterPKIKeyPaths(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
-		"cluster CA":      "cp /tmp/staged /etc/kubernetes/pki/ca.key",
-		"front proxy CA":  "cp /tmp/staged /etc/kubernetes/pki/front-proxy-ca.key",
-		"etcd CA":         "cp /tmp/staged /etc/kubernetes/pki/etcd/ca.key",
-		"service account": "cp /tmp/staged /etc/kubernetes/pki/sa.key",
+		"cluster CA":            "cp /tmp/staged /etc/kubernetes/pki/ca.key",
+		"front proxy CA":        "cp /tmp/staged /etc/kubernetes/pki/front-proxy-ca.key",
+		"etcd CA":               "cp /tmp/staged /etc/kubernetes/pki/etcd/ca.key",
+		"service account":       "cp /tmp/staged /etc/kubernetes/pki/sa.key",
+		"quoted key suffix":     `cp /tmp/staged /etc/kubernetes/pki/ca."key"`,
+		"PKI working directory": "cd /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 	}
 
 	for name, body := range tests {
@@ -131,6 +134,9 @@ func TestDeriveServerSpecsAcceptsMaterialFreeUserData(t *testing.T) {
 		"kubeadm config path": "cat /etc/kubernetes/ksail/kubeadm-config.yaml",
 		// A public certificate under the PKI directory is not a private key.
 		"public PKI cert": "cat /etc/kubernetes/pki/ca.crt",
+		// Changing into the PKI directory is not itself a leak; the relative
+		// path rule must still discriminate a public certificate from a key.
+		"public PKI cert from working directory": "cd /etc/kubernetes/pki && cat ca.crt",
 		// PROSE, not a setting. User-data legitimately carries comments and
 		// operator documentation, and a normaliser that drops whitespace along
 		// with every other separator joins the words either side of a sentence
@@ -234,7 +240,8 @@ func TestDeriveServerSpecsHandlesRawGzipUserData(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.NotNil(t, specs)
+		require.Len(t, specs, 2)
+		assert.Equal(t, userDataCarrying("runcmd:\n  - echo hello"), specs[1].UserData)
 	})
 
 	// Announcing gzip and then failing to expand must not be the way past the

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -107,9 +107,9 @@ func TestDeriveServerSpecsRejectsClusterPKIKeyPaths(t *testing.T) {
 		// into a silent miss.
 		"PKI working directory, key on a later line": "cd /etc/kubernetes/pki && cat ca.crt\n" +
 			"install -m 0600 /tmp/staged ca.key",
-		"PKI physical error options":     "cd -P -e /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
-		"PKI combined physical error":    "cd -Pe /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
-		"PKI reordered physical error":   "cd -eP /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI physical error options":   "cd -P -e /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI combined physical error":  "cd -Pe /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI reordered physical error": "cd -eP /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 	}
 
 	for name, body := range tests {
@@ -283,5 +283,87 @@ func TestDeriveServerSpecsHandlesRawGzipUserData(t *testing.T) {
 
 		require.ErrorIs(t, err, hetznerbase.ErrSigningTransportInUserData)
 		assert.Nil(t, specs)
+	})
+}
+
+// TestDeriveServerSpecsBoundsForwardedUserData pins the PROVIDER bound on the
+// value that is actually sent, which is a different limit from the inspection
+// bound and exists for a different reason.
+//
+// maxDecodedUserDataBytes caps how much text the guards will read, so a marker
+// cannot hide past the inspected prefix. It says nothing about what Hetzner will
+// accept. Hetzner's ceiling on user_data is 32 KiB -- the same limit the Talos
+// autoscaler path already pins as hetznerUserDataLimitBytes, where exceeding it
+// makes the API reject the request with "invalid input in field 'user_data'".
+//
+// Expanding compressed user-data before forwarding it is what makes the two
+// bounds diverge: a payload that is comfortably under the provider ceiling while
+// compressed can expand well past it, so forwarding the expanded text turns a
+// deployable node into an opaque provider rejection. Refusing locally names the
+// real problem instead.
+func TestDeriveServerSpecsBoundsForwardedUserData(t *testing.T) {
+	t.Parallel()
+
+	// Compresses to far under the provider ceiling, expands to far over it, so
+	// the two bounds disagree about this exact payload.
+	oversized := userDataCarrying(
+		"runcmd:\n  - echo hello\n" + strings.Repeat("# padding\n", 6000),
+	)
+
+	t.Run("gzip expanding past the provider ceiling is refused", func(t *testing.T) {
+		t.Parallel()
+
+		compressed := gzipUserData(t, oversized)
+		require.Less(t, len(compressed), 32768,
+			"fixture must be under the provider ceiling while compressed, "+
+				"or it would not distinguish the two bounds")
+		require.Greater(t, len(oversized), 32768,
+			"fixture must exceed the provider ceiling once expanded")
+
+		nodes := twoNodeSpecs()
+		nodes[1].UserData = compressed
+
+		specs, err := hetznerbase.DeriveServerSpecs(
+			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+		)
+
+		require.ErrorIs(t, err, hetznerbase.ErrUserDataTooLargeForProvider)
+		assert.Nil(t, specs)
+	})
+
+	// The bound governs the forwarded value whatever produced it, so uncompressed
+	// user-data over the ceiling is refused on the same terms rather than being
+	// handed to the provider to reject.
+	t.Run("uncompressed user-data over the ceiling is refused", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := twoNodeSpecs()
+		nodes[1].UserData = oversized
+
+		specs, err := hetznerbase.DeriveServerSpecs(
+			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+		)
+
+		require.ErrorIs(t, err, hetznerbase.ErrUserDataTooLargeForProvider)
+		assert.Nil(t, specs)
+	})
+
+	// The control: a payload at the ceiling still goes through, so the bound is a
+	// ceiling rather than a blanket refusal of large user-data.
+	t.Run("user-data at the ceiling is accepted", func(t *testing.T) {
+		t.Parallel()
+
+		atLimit := userDataCarrying("runcmd:\n  - echo hello")
+		require.LessOrEqual(t, len(atLimit), 32768)
+
+		nodes := twoNodeSpecs()
+		nodes[1].UserData = atLimit
+
+		specs, err := hetznerbase.DeriveServerSpecs(
+			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+		)
+
+		require.NoError(t, err)
+		require.Len(t, specs, 2)
 	})
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -144,6 +144,17 @@ func TestDeriveServerSpecsAcceptsMaterialFreeUserData(t *testing.T) {
 			"Keys live in the vault.",
 		"plural inside one sentence": "# Renew the certificate keys every 90 days.",
 		"upload certs in prose":      "# Upload certs are handled by the operator.",
+
+		// ASSIGNMENT-SHAPED but material-free. The spaced-assignment rule exists
+		// to catch a hand-written `certificate key: <hex>`, but user-data
+		// legitimately carries shell that PRINTS that shape and comments that
+		// document it. Matching on the shape alone refuses a valid bring-up, so
+		// the VALUE is what decides: a kubeadm certificate key is a long hex
+		// token, and an upload-certs setting that matters is one being switched
+		// ON. Prose values and a disabled setting carry nothing.
+		"shell echoing a log line":         `echo "certificate key: generated during bootstrap"`,
+		"shell echoing a disabled setting": `echo "upload certs: disabled"`,
+		"comment documenting the field":    "# certificate key: documented here",
 	}
 
 	for name, body := range tests {

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -100,6 +100,13 @@ func TestDeriveServerSpecsRejectsClusterPKIKeyPaths(t *testing.T) {
 		"PKI working directory":          "cd /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 		"PKI logical working directory":  "cd -L /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 		"PKI physical working directory": "cd -P /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		// `cd` persists until the next one, so a key written on a LATER line is
+		// still written into the PKI directory. This pins that the fix for the
+		// absolute-path false positive did not buy quiet by bounding the rule to a
+		// single line -- doing so drops exactly this case, turning a noisy refusal
+		// into a silent miss.
+		"PKI working directory, key on a later line": "cd /etc/kubernetes/pki && cat ca.crt\n" +
+			"install -m 0600 /tmp/staged ca.key",
 		"PKI physical error options":     "cd -P -e /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 		"PKI combined physical error":    "cd -Pe /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 		"PKI reordered physical error":   "cd -eP /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
@@ -166,6 +173,17 @@ func TestDeriveServerSpecsAcceptsMaterialFreeUserData(t *testing.T) {
 		"shell echoing a log line":         `echo "certificate key: generated during bootstrap"`,
 		"shell echoing a disabled setting": `echo "upload certs: disabled"`,
 		"comment documenting the field":    "# certificate key: documented here",
+
+		// A LATER LINE is a different command. The working-directory rule exists
+		// to catch `cd /etc/kubernetes/pki && install ... ca.key`, where the key
+		// is the argument of the command the `&&` chains. Once the shell moves to
+		// the next LINE it is no longer operating in that chained command, so a
+		// `.key` there is unrelated -- here an apt keyring written to a wholly
+		// different directory. Without a newline bound the rule reads the whole
+		// scalar after one `cd`, and refuses a bring-up that leaks nothing.
+		"apt keyring on a line after a PKI cd": "cd /etc/kubernetes/pki && cat ca.crt\n" +
+			"curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key " +
+			"-o /etc/apt/keyrings/k8s.key",
 	}
 
 	for name, body := range tests {

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -44,6 +44,13 @@ func TestDeriveServerSpecsRejectsCertificateTransportMarkers(t *testing.T) {
 		// Neither the kebab nor the camel spelling: a literal-list guard misses
 		// this, so it pins that detection normalises rather than enumerates.
 		"snake_case field": "certificate_key: abcdef0123456789",
+		// The separator class is open-ended, so enumerating members of it is the
+		// same mistake as enumerating spellings: each of these is a separator no
+		// enumerating normaliser strips, and each rewrites the marker into a
+		// token the guard would otherwise not recognise.
+		"dot-separated field":   "certificate.key: abcdef0123456789",
+		"slash-separated field": "certificate/key: abcdef0123456789",
+		"space-separated field": "certificate key: abcdef0123456789",
 		// Reuses the guard's existing base64 unwrapping, proving the marker
 		// class is inspected through the same nesting pipeline as PEM material.
 		"base64 nested": base64.StdEncoding.EncodeToString(

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -15,6 +15,10 @@ import (
 
 // userDataCarrying wraps a fixture body in a minimal cloud-config document so
 // each case exercises the real YAML walk rather than a bare scalar.
+// providerCeilingBytes mirrors the package's maxProviderUserDataBytes. Declared
+// once here so the boundary cases below cannot drift apart from each other.
+const providerCeilingBytes = 32768
+
 func userDataCarrying(body string) string {
 	return fmt.Sprintf(`#cloud-config
 write_files:
@@ -281,7 +285,7 @@ func TestDeriveServerSpecsHandlesRawGzipUserData(t *testing.T) {
 			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
 		)
 
-		require.ErrorIs(t, err, hetznerbase.ErrSigningTransportInUserData)
+		require.ErrorIs(t, err, hetznerbase.ErrUserDataNotInspectable)
 		assert.Nil(t, specs)
 	})
 }
@@ -314,10 +318,10 @@ func TestDeriveServerSpecsBoundsForwardedUserData(t *testing.T) {
 		t.Parallel()
 
 		compressed := gzipUserData(t, oversized)
-		require.Less(t, len(compressed), 32768,
+		require.Less(t, len(compressed), providerCeilingBytes,
 			"fixture must be under the provider ceiling while compressed, "+
 				"or it would not distinguish the two bounds")
-		require.Greater(t, len(oversized), 32768,
+		require.Greater(t, len(oversized), providerCeilingBytes,
 			"fixture must exceed the provider ceiling once expanded")
 
 		nodes := twoNodeSpecs()
@@ -348,13 +352,18 @@ func TestDeriveServerSpecsBoundsForwardedUserData(t *testing.T) {
 		assert.Nil(t, specs)
 	})
 
-	// The control: a payload at the ceiling still goes through, so the bound is a
-	// ceiling rather than a blanket refusal of large user-data.
+	// The control: a payload at EXACTLY the ceiling still goes through, so the
+	// bound is a ceiling rather than a blanket refusal of large user-data.
+	//
+	// The exact length is the point. A comfortably-small payload satisfies this
+	// assertion for every fixture in the file, so it would not discriminate `>`
+	// from `>=` in the runtime check -- an off-by-one that refused a legitimate
+	// 32768-byte node would pass such a control unnoticed.
 	t.Run("user-data at the ceiling is accepted", func(t *testing.T) {
 		t.Parallel()
 
-		atLimit := userDataCarrying("runcmd:\n  - echo hello")
-		require.LessOrEqual(t, len(atLimit), 32768)
+		atLimit := userDataAtExactly(t, providerCeilingBytes)
+		require.Len(t, atLimit, providerCeilingBytes)
 
 		nodes := twoNodeSpecs()
 		nodes[1].UserData = atLimit
@@ -366,4 +375,35 @@ func TestDeriveServerSpecsBoundsForwardedUserData(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, specs, 2)
 	})
+
+	// The paired case one byte over: together with the control above this pins
+	// the comparison itself, not merely that some large payload is refused.
+	t.Run("user-data one byte over the ceiling is refused", func(t *testing.T) {
+		t.Parallel()
+
+		overBySingleByte := userDataAtExactly(t, providerCeilingBytes+1)
+		require.Len(t, overBySingleByte, providerCeilingBytes+1)
+
+		nodes := twoNodeSpecs()
+		nodes[1].UserData = overBySingleByte
+
+		specs, err := hetznerbase.DeriveServerSpecs(
+			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+		)
+
+		require.ErrorIs(t, err, hetznerbase.ErrUserDataTooLargeForProvider)
+		assert.Nil(t, specs)
+	})
+}
+
+// userDataAtExactly returns valid cloud-config user-data of exactly total bytes,
+// padded with a trailing YAML comment run so the document still parses. The
+// boundary cases above need the length to be exact, not approximate.
+func userDataAtExactly(t *testing.T, total int) string {
+	t.Helper()
+
+	base := userDataCarrying("runcmd:\n  - echo hello")
+	require.LessOrEqual(t, len(base), total, "base fixture already exceeds the target length")
+
+	return base + strings.Repeat("#", total-len(base))
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -1,6 +1,8 @@
 package hetznerbase_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -134,4 +136,86 @@ func TestDeriveServerSpecsAcceptsMaterialFreeUserData(t *testing.T) {
 			assert.NotEmpty(t, specs)
 		})
 	}
+}
+
+// gzipUserData compresses a cloud-config body the way cloud-init accepts it:
+// raw gzip bytes as the whole user-data, with no base64 wrapper.
+func gzipUserData(t *testing.T, body string) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.String()
+}
+
+// TestDeriveServerSpecsHandlesRawGzipUserData pins top-level compressed
+// user-data, which reaches the guards as gzip bytes rather than YAML.
+//
+// Before the unwrap, the document scan simply failed to parse those bytes. That
+// failed CLOSED rather than open — nothing leaked — but it made the guard reject
+// legitimate compressed user-data, and it reported a marker inside compressed
+// user-data as a parse error rather than as the transport error that names the
+// actual problem. Both halves are pinned here: the control is what would regress
+// if the unwrap were removed, and the marker case is what would regress if the
+// unwrap were added without re-running the guards over the expanded text.
+func TestDeriveServerSpecsHandlesRawGzipUserData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("marker inside raw gzip is rejected by its own error", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := twoNodeSpecs()
+		nodes[1].UserData = gzipUserData(
+			t, userDataCarrying("certificateKey: abcdef0123456789"),
+		)
+
+		specs, err := hetznerbase.DeriveServerSpecs(
+			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+		)
+
+		require.ErrorIs(t, err, hetznerbase.ErrSigningTransportInUserData)
+		assert.Nil(t, specs)
+	})
+
+	// The material-free control. This is the case the missing unwrap actually
+	// broke: valid compressed user-data carrying no signing material at all was
+	// refused because the compressed bytes are not YAML.
+	t.Run("material-free raw gzip is accepted", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := twoNodeSpecs()
+		nodes[1].UserData = gzipUserData(
+			t, userDataCarrying("runcmd:\n  - echo hello"),
+		)
+
+		specs, err := hetznerbase.DeriveServerSpecs(
+			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, specs)
+	})
+
+	// Announcing gzip and then failing to expand must not be the way past the
+	// guard: uninspectable input is refused, not passed through.
+	t.Run("truncated gzip is refused rather than passed through", func(t *testing.T) {
+		t.Parallel()
+
+		full := gzipUserData(t, userDataCarrying("runcmd:\n  - echo hello"))
+
+		nodes := twoNodeSpecs()
+		nodes[1].UserData = full[:len(full)/2]
+
+		specs, err := hetznerbase.DeriveServerSpecs(
+			specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+		)
+
+		require.ErrorIs(t, err, hetznerbase.ErrSigningTransportInUserData)
+		assert.Nil(t, specs)
+	})
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -92,12 +92,14 @@ func TestDeriveServerSpecsRejectsClusterPKIKeyPaths(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
-		"cluster CA":            "cp /tmp/staged /etc/kubernetes/pki/ca.key",
-		"front proxy CA":        "cp /tmp/staged /etc/kubernetes/pki/front-proxy-ca.key",
-		"etcd CA":               "cp /tmp/staged /etc/kubernetes/pki/etcd/ca.key",
-		"service account":       "cp /tmp/staged /etc/kubernetes/pki/sa.key",
-		"quoted key suffix":     `cp /tmp/staged /etc/kubernetes/pki/ca."key"`,
-		"PKI working directory": "cd /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"cluster CA":                     "cp /tmp/staged /etc/kubernetes/pki/ca.key",
+		"front proxy CA":                 "cp /tmp/staged /etc/kubernetes/pki/front-proxy-ca.key",
+		"etcd CA":                        "cp /tmp/staged /etc/kubernetes/pki/etcd/ca.key",
+		"service account":                "cp /tmp/staged /etc/kubernetes/pki/sa.key",
+		"quoted key suffix":              `cp /tmp/staged /etc/kubernetes/pki/ca."key"`,
+		"PKI working directory":          "cd /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI logical working directory":  "cd -L /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
+		"PKI physical working directory": "cd -P /etc/kubernetes/pki && install -m 0600 /tmp/staged ca.key",
 	}
 
 	for name, body := range tests {

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_signing_transport_test.go
@@ -50,7 +50,12 @@ func TestDeriveServerSpecsRejectsCertificateTransportMarkers(t *testing.T) {
 		// token the guard would otherwise not recognise.
 		"dot-separated field":   "certificate.key: abcdef0123456789",
 		"slash-separated field": "certificate/key: abcdef0123456789",
-		"space-separated field": "certificate key: abcdef0123456789",
+		// Whitespace inside the marker is a token boundary, so these are caught
+		// by the assignment shape rather than by normalisation: a field carrying
+		// a value is material in provider-readable user-data whatever the field
+		// is called, while the same two words in a sentence are not.
+		"space-separated field":        "certificate key: abcdef0123456789",
+		"space-separated upload-certs": "upload certs = true",
 		// Reuses the guard's existing base64 unwrapping, proving the marker
 		// class is inspected through the same nesting pipeline as PEM material.
 		"base64 nested": base64.StdEncoding.EncodeToString(
@@ -126,6 +131,19 @@ func TestDeriveServerSpecsAcceptsMaterialFreeUserData(t *testing.T) {
 		"kubeadm config path": "cat /etc/kubernetes/ksail/kubeadm-config.yaml",
 		// A public certificate under the PKI directory is not a private key.
 		"public PKI cert": "cat /etc/kubernetes/pki/ca.crt",
+		// PROSE, not a setting. User-data legitimately carries comments and
+		// operator documentation, and a normaliser that drops whitespace along
+		// with every other separator joins the words either side of a sentence
+		// boundary: "certificate." + "Key" becomes the marker token and the
+		// deploy is refused on ordinary content. These pin the token boundary
+		// that keeps that from happening; none of them assigns a value, which
+		// is what separates them from the space-separated FIELD above.
+		"sentence boundary before Key": "# Install the TLS certificate. " +
+			"Key material stays in OpenBao.",
+		"sentence boundary before Keys": "# Rotate the certificate. " +
+			"Keys live in the vault.",
+		"plural inside one sentence": "# Renew the certificate keys every 90 days.",
+		"upload certs in prose":      "# Upload certs are handled by the operator.",
 	}
 
 	for name, body := range tests {

--- a/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata_guard_integration_test.go
+++ b/pkg/svc/provisioner/cluster/kubeadmhetzner/userdata_guard_integration_test.go
@@ -1,0 +1,83 @@
+package kubeadmhetzner_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/stretchr/testify/require"
+)
+
+// productionBootstrapMaterial mirrors what the live bring-up assembles, host
+// identity included. The composition-only fixtures elsewhere leave HostKeys nil,
+// so they never exercise the one PEM private key the supported path legitimately
+// ships — which is exactly the shape a guard is most likely to reject by mistake.
+func productionBootstrapMaterial(t *testing.T) hetznerbase.BootstrapMaterial {
+	t.Helper()
+
+	host, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	client, err := sshbootstrap.GenerateKeyPair()
+	require.NoError(t, err)
+
+	return hetznerbase.BootstrapMaterial{
+		Signer:        client.Signer,
+		AuthorizedKey: client.AuthorizedKey,
+		HostKeys: &cloudinitbootstrap.HostKeys{
+			ED25519Private: string(host.PrivateKeyPEM),
+			ED25519Public:  host.AuthorizedKey,
+		},
+	}
+}
+
+// TestDeriveServerSpecsAcceptsRealBringUpUserData is the end-to-end negative
+// control for the provider user-data guard.
+//
+// The guard's own unit tests feed it hand-written fixtures, and the composition
+// tests check rendered user-data with a separate test-only matcher. Neither
+// combination puts REAL renderer output through the REAL guard, so a guard that
+// rejected something the supported bring-up actually emits would pass both and
+// break `ksail create` at the first node. This closes that gap: every node the
+// supported topology composes must survive spec derivation untouched.
+func TestDeriveServerSpecsAcceptsRealBringUpUserData(t *testing.T) {
+	t.Parallel()
+
+	prov := newProvisioner(&fakeInfra{}, 1, 2)
+	material := productionBootstrapMaterial(t)
+
+	initNode, err := prov.ComposeInitNode(
+		testClusterName, "abcdef.0123456789abcdef", material,
+	)
+	require.NoError(t, err)
+
+	initKubeconfig, _ := adminKubeconfig(t)
+
+	joiners, err := prov.ComposeJoiningNodes(
+		testClusterName, "abcdef.0123456789abcdef",
+		net.ParseIP("10.0.1.5"), initKubeconfig, material,
+	)
+	require.NoError(t, err)
+
+	nodes := append([]hetznerbase.NodeSpec{initNode}, joiners...)
+	require.Len(t, nodes, 3, "one control plane plus two agents")
+
+	specs, err := hetznerbase.DeriveServerSpecs(
+		testClusterName,
+		nodes,
+		v1alpha1.OptionsHetzner{
+			ControlPlaneServerType: "cx23",
+			WorkerServerType:       "cx33",
+			Location:               "fsn1",
+		},
+		hetznerbase.ResolvedInfra{
+			NetworkID: 100, FirewallID: 200, PlacementGroupID: 300, SSHKeyID: 400,
+		},
+	)
+
+	require.NoError(t, err, "the supported bring-up must survive the user-data guard")
+	require.Len(t, specs, 3)
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The check that stops KSail handing cluster-signing material to the Hetzner provider only recognised
material that *looks* like a key. kubeadm has two other ways to move the same trust — a setting that
uploads the cluster PKI and the key that decrypts it, and writing a private PKI file directly — and
neither presents anything the check was looking for. Both were accepted silently.

A companion check added in #6604 does cover these, but it only runs in tests, and only on the
multi-node path. On the ordinary single-node create there was nothing.

### What

The runtime check now rejects cluster-signing material by any of the three transports, not just the
one. It recognises the setting by meaning rather than by spelling, so a variant spelling cannot slip
past, and it treats any private key file under the cluster PKI directory as material — including ones
not named today.

Nothing the supported bring-up produces changes: the bootstrap token, the public certificate hash and
the node's own SSH identity are all still accepted, and a leaked key still reports the same specific
error it did before.

**Security floor:** a whole class of silent regression becomes impossible on both create paths.
**Everyday path:** unchanged — no new flag, step, or configuration.

Fixes #6608
Part of #6428
