### PR TITLE
fix(vcluster): report D-Bus recovery lifecycle

### DIFF
--- a/pkg/svc/provisioner/cluster/vcluster/provisioner.go
+++ b/pkg/svc/provisioner/cluster/vcluster/provisioner.go
@@ -363,14 +363,14 @@ func tryDBusRecovery(
 	logger loftlog.Logger,
 	recoverDBus dbusRecoverFn,
 ) error {
-	logger.Infof("ksail.vcluster.dbus_recovery state=entered cluster=%q", clusterName)
+	logger.Info("ksail.vcluster.dbus_recovery state=entered")
 
 	recoverErr := recoverDBus(ctx, globalFlags, clusterName, logger)
 	if recoverErr != nil {
 		return fmt.Errorf("D-Bus recovery failed: %w", recoverErr)
 	}
 
-	logger.Infof("ksail.vcluster.dbus_recovery state=completed cluster=%q", clusterName)
+	logger.Info("ksail.vcluster.dbus_recovery state=completed")
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/vcluster/provisioner.go
+++ b/pkg/svc/provisioner/cluster/vcluster/provisioner.go
@@ -363,12 +363,14 @@ func tryDBusRecovery(
 	logger loftlog.Logger,
 	recoverDBus dbusRecoverFn,
 ) error {
-	logger.Infof("D-Bus not ready in container — recovering in place...")
+	logger.Infof("ksail.vcluster.dbus_recovery state=entered cluster=%q", clusterName)
 
 	recoverErr := recoverDBus(ctx, globalFlags, clusterName, logger)
 	if recoverErr != nil {
 		return fmt.Errorf("D-Bus recovery failed: %w", recoverErr)
 	}
+
+	logger.Infof("ksail.vcluster.dbus_recovery state=completed cluster=%q", clusterName)
 
 	return nil
 }

--- a/pkg/svc/provisioner/cluster/vcluster/retry_test.go
+++ b/pkg/svc/provisioner/cluster/vcluster/retry_test.go
@@ -1,6 +1,7 @@
 package vclusterprovisioner_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -43,6 +44,21 @@ var (
 
 func newTestLogger() loftlog.Logger {
 	return loftlog.NewStreamLogger(io.Discard, io.Discard, logrus.WarnLevel)
+}
+
+func assertDBusRecoveryMarkers(t *testing.T, output string, wantMarkers bool) {
+	t.Helper()
+
+	for _, marker := range []string{
+		"ksail.vcluster.dbus_recovery state=entered",
+		"ksail.vcluster.dbus_recovery state=completed",
+	} {
+		if wantMarkers {
+			assert.Contains(t, output, marker)
+		} else {
+			assert.NotContains(t, output, marker)
+		}
+	}
 }
 
 // --- isTransientCreateError tests ---
@@ -256,6 +272,61 @@ func TestCreateWithRetry_DBusErrorTriggersRecovery(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, recoverCalls, "D-Bus recovery should be called once")
+}
+
+func TestCreateWithRetry_DBusRecoveryMarkers(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name        string
+		createErr   error
+		wantMarkers bool
+	}{
+		{"recovery_path_reports_start_and_completion", errDBus, true},
+		{"happy_path_reports_no_recovery_marker", nil, false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+
+			logger := loftlog.NewStreamLogger(&output, &output, logrus.InfoLevel)
+			create := func(
+				_ context.Context,
+				_ *cli.CreateOptions,
+				_ *flags.GlobalFlags,
+				_ string,
+				_ loftlog.Logger,
+			) error {
+				return testCase.createErr
+			}
+			cleanup := func(_ context.Context, _ *flags.GlobalFlags, _ string, _ loftlog.Logger) {
+				t.Error("cleanup should not be called")
+			}
+			recoverDBus := func(
+				_ context.Context,
+				_ *flags.GlobalFlags,
+				_ string,
+				_ loftlog.Logger,
+			) error {
+				return nil
+			}
+
+			err := vclusterprovisioner.CreateWithRetryForTest(
+				context.Background(),
+				&cli.CreateOptions{},
+				&flags.GlobalFlags{},
+				"test-cluster",
+				logger,
+				time.Millisecond,
+				create, cleanup, recoverDBus,
+			)
+
+			require.NoError(t, err)
+
+			assertDBusRecoveryMarkers(t, output.String(), testCase.wantMarkers)
+		})
+	}
 }
 
 // TestCreateWithRetry_DBusRecoveryFailureFallsBackToRetry is the regression guard

--- a/pkg/svc/provisioner/cluster/vcluster/retry_test.go
+++ b/pkg/svc/provisioner/cluster/vcluster/retry_test.go
@@ -282,7 +282,7 @@ func TestCreateWithRetry_DBusRecoveryMarkers(t *testing.T) {
 		createErr   error
 		wantMarkers bool
 	}{
-		{"recovery_path_reports_start_and_completion", errDBus, true},
+		{"recovery_path_reports_start_and_completion_without_user_input", errDBus, true},
 		{"happy_path_reports_no_recovery_marker", nil, false},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -316,7 +316,7 @@ func TestCreateWithRetry_DBusRecoveryMarkers(t *testing.T) {
 				context.Background(),
 				&cli.CreateOptions{},
 				&flags.GlobalFlags{},
-				"test-cluster",
+				"user-controlled\ncluster",
 				logger,
 				time.Millisecond,
 				create, cleanup, recoverDBus,
@@ -325,6 +325,7 @@ func TestCreateWithRetry_DBusRecoveryMarkers(t *testing.T) {
 			require.NoError(t, err)
 
 			assertDBusRecoveryMarkers(t, output.String(), testCase.wantMarkers)
+			assert.NotContains(t, output.String(), "user-controlled")
 		})
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The D-Bus recovery workaround can run in CI without leaving a stable signal that says when recovery started or completed. That makes the parent removal decision depend on repeated source audits instead of observed behavior.

## What

- emit a stable Info-level marker when in-place D-Bus recovery starts
- emit a matching completion marker only after recovery succeeds
- cover the recovery and ordinary create paths through the real stream logger

This changes observability only; retry and recovery behavior are unchanged.

## Validation

- strict TDD RED: the recovery-path test failed on both missing markers while the happy path passed
- focused GREEN: 3/3 marker subtests passed
- affected package race suite: 101/101 passed
- go vet ./... passed
- go build passed
- diff-only golangci-lint reported no issues
- host-enabled go test ./... passed 5,837 tests; six unrelated open/chat child-process fixtures failed under full-suite contention, then that package passed 127/127 alone

Fixes #6295
Part of #2261
