### PR TITLE
fix(reconcile): keep ArgoCD cold-start transients from failing the readiness poll

### DIFF
--- a/pkg/cli/cmd/workload/reconcile.go
+++ b/pkg/cli/cmd/workload/reconcile.go
@@ -812,6 +812,10 @@ func buildArgoCDApplicationTasks(
 // pollUntilApplicationReady polls a named ArgoCD Application until it is
 // synced and healthy, or the context's deadline expires. On permanent failure,
 // it returns an actionable error including the resource name and failure details.
+// A source-availability error inside the cold-start warm-up window is treated as
+// "not ready yet" rather than a permanent failure, because ArgoCD resolves those
+// itself within seconds of the control plane coming up.
+//
 // The caller is expected to provide a context with a deadline (shared across all
 // application tasks) so that the total reconcile time is bounded.
 func pollUntilApplicationReady(
@@ -819,12 +823,18 @@ func pollUntilApplicationReady(
 	argoReconciler *argocd.Reconciler,
 	name string,
 ) error {
+	start := time.Now()
+
 	return reconcilerclient.PollUntilReady( //nolint:wrapcheck // identity preserved
 		ctx,
 		argoCDApplicationPollInterval,
 		func(ctx context.Context) (reconcilerclient.CheckResult, error) {
 			ready, err := argoReconciler.CheckNamedApplicationReady(ctx, name)
 			if err != nil {
+				if argocd.IsColdStartTransient(err, time.Since(start), argoCDSourceWarmupGrace) {
+					return reconcilerclient.CheckResult{Ready: false}, nil
+				}
+
 				return reconcilerclient.CheckResult{}, err //nolint:wrapcheck // identity preserved
 			}
 

--- a/pkg/cli/cmd/workload/shared.go
+++ b/pkg/cli/cmd/workload/shared.go
@@ -245,8 +245,13 @@ const (
 	defaultReconcileTimeout       = 5 * time.Minute
 	fluxKustomizationPollInterval = 500 * time.Millisecond
 	argoCDApplicationPollInterval = 500 * time.Millisecond
-	reconcileConcurrency          = 5
-	reconcileCmdLong              = "Trigger reconciliation/sync and wait for completion. " +
+	// argoCDSourceWarmupGrace bounds how long a source-availability error is
+	// treated as a control-plane cold start rather than a real failure. ArgoCD
+	// self-heals these within seconds; a source still unavailable after this
+	// window is a genuine misconfiguration and fails with an actionable error.
+	argoCDSourceWarmupGrace = 90 * time.Second
+	reconcileConcurrency    = 5
+	reconcileCmdLong        = "Trigger reconciliation/sync and wait for completion. " +
 		"For Flux, tracks the OCIRepository and each Kustomization individually. " +
 		"For ArgoCD, tracks each Application until synced and healthy."
 	// kwokReconcileSkipMsg is emitted when reconciliation is skipped for KWOK.

--- a/pkg/client/argocd/reconciler.go
+++ b/pkg/client/argocd/reconciler.go
@@ -224,3 +224,25 @@ func isApplicationSynced(app *unstructured.Unstructured) bool {
 
 	return true
 }
+
+// IsColdStartTransient reports whether err is a source-availability failure
+// that ArgoCD is expected to resolve on its own, given how long the caller has
+// been polling.
+//
+// During a control-plane cold start ArgoCD's repo-server and redis are still
+// coming up, so the first comparison of the root Application briefly reports a
+// connection failure. ArgoCD retries internally and self-heals seconds later,
+// but the message is indistinguishable from a genuinely unreachable source, so
+// the classifier cannot tell the two apart from the text alone. Elapsed poll
+// time is what separates them: a source that is still unavailable once the
+// warm-up window has passed is a real misconfiguration.
+//
+// Only ErrSourceNotAvailable is eligible. A failed operation, or any other
+// error, stays terminal so a genuine failure is never masked into a timeout.
+func IsColdStartTransient(err error, elapsed, grace time.Duration) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, ErrSourceNotAvailable) && elapsed < grace
+}

--- a/pkg/client/argocd/reconciler_test.go
+++ b/pkg/client/argocd/reconciler_test.go
@@ -3,7 +3,9 @@ package argocd_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
 	"github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
@@ -461,6 +463,77 @@ func TestCheckNamedApplicationReady(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, testCase.wantReady, ready)
+		})
+	}
+}
+
+// TestIsColdStartTransient pins the readiness gate that keeps a control-plane
+// cold start from being reported as a permanent source failure.
+//
+// ArgoCD's own repo-server and redis are still coming up while the root
+// Application is first compared, so the Application briefly carries a
+// ComparisonError naming a connection failure. ArgoCD self-heals seconds later
+// ("will retry" in its own logs), but the reconcile poll had already given up.
+//
+// Both states are asserted deliberately: inside the warm-up window such an
+// error must be retryable, and outside it — or for a genuinely failed
+// operation — it must stay terminal, so a real misconfiguration is never
+// masked into a timeout.
+func TestIsColdStartTransient(t *testing.T) {
+	t.Parallel()
+
+	const grace = 90 * time.Second
+
+	tests := []struct {
+		name    string
+		err     error
+		elapsed time.Duration
+		want    bool
+	}{
+		{
+			name:    "source unavailable inside the warm-up window is retryable",
+			err:     fmt.Errorf("%w: %s", argocd.ErrSourceNotAvailable, "connection refused"),
+			elapsed: 5 * time.Second,
+			want:    true,
+		},
+		{
+			name:    "source unavailable outside the warm-up window stays terminal",
+			err:     fmt.Errorf("%w: %s", argocd.ErrSourceNotAvailable, "repository not found"),
+			elapsed: grace + time.Second,
+			want:    false,
+		},
+		{
+			name:    "a failed operation is never masked, even inside the window",
+			err:     fmt.Errorf("%w: %s", argocd.ErrOperationFailed, "sync operation failed"),
+			elapsed: time.Second,
+			want:    false,
+		},
+		{
+			name:    "an unrelated error is never masked",
+			err:     errSimulatedAPIFailure,
+			elapsed: time.Second,
+			want:    false,
+		},
+		{
+			name:    "no error is not a transient",
+			err:     nil,
+			elapsed: time.Second,
+			want:    false,
+		},
+		{
+			name:    "the window boundary itself is already terminal",
+			err:     fmt.Errorf("%w: %s", argocd.ErrSourceNotAvailable, "connection refused"),
+			elapsed: grace,
+			want:    false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := argocd.IsColdStartTransient(testCase.err, testCase.elapsed, grace)
+			assert.Equal(t, testCase.want, got)
 		})
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Setting up a cluster sometimes failed for no real reason. While the cluster is still starting, ArgoCD's own internal pieces are not up yet, so the very first check of the deployment reports a connection problem. ArgoCD fixes that by itself within seconds — but KSail had already declared the whole thing broken and given up.

Because it depended on timing, it failed at random. It repeatedly blocked our own changes and the automated dependency updates from getting through, which made a green build something you had to retry rather than trust.

### What

KSail now waits out that brief start-up period instead of failing on the first stumble, and only reports a failure if the source is *still* unreachable once things have had time to come up.

A genuinely wrong setting — a bad repository address, for example — still fails with the same actionable message as before. That distinction is deliberate: the goal is to stop reporting a problem that isn't there, without ever hiding one that is.

Part of #5948
