### PR TITLE
feat(bootstrap): give the pinned SSH channel a write primitive

### DIFF
--- a/pkg/svc/bootstrap/ssh/client.go
+++ b/pkg/svc/bootstrap/ssh/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -160,48 +161,7 @@ func DialWithRetry(
 // non-zero exit returns [RunResult] alongside an error wrapping
 // [ErrCommandFailed]; transport failures return only the error.
 func (c *Client) Run(ctx context.Context, command string) (RunResult, error) {
-	session, err := c.conn.NewSession()
-	if err != nil {
-		return RunResult{}, fmt.Errorf("open session: %w", err)
-	}
-
-	defer func() { _ = session.Close() }()
-
-	var stdout, stderr bytes.Buffer
-
-	session.Stdout = &stdout
-	session.Stderr = &stderr
-
-	// Session.Run is not context-aware; closing the session on cancellation
-	// unblocks it.
-	stop := closeOnDone(ctx, session)
-
-	err = session.Run(command)
-
-	stop()
-
-	result := RunResult{Stdout: stdout.Bytes(), Stderr: stderr.Bytes(), ExitCode: 0}
-
-	var exitErr *ssh.ExitError
-	if errors.As(err, &exitErr) {
-		result.ExitCode = exitErr.ExitStatus()
-
-		return result, fmt.Errorf(
-			"%w: %q exited %d: %s",
-			ErrCommandFailed, command, result.ExitCode,
-			strings.TrimSpace(stderr.String()),
-		)
-	}
-
-	if err != nil {
-		if ctx.Err() != nil {
-			return result, fmt.Errorf("run %q: %w", command, ctx.Err())
-		}
-
-		return result, fmt.Errorf("run %q: %w", command, err)
-	}
-
-	return result, nil
+	return c.exec(ctx, command, nil)
 }
 
 // ReadFile streams a remote file's contents over the exec channel (`cat`), so
@@ -241,6 +201,63 @@ func (c *Client) Close() error {
 	}
 
 	return nil
+}
+
+// exec runs command with an optional stdin stream. A nil stdin keeps the
+// remote reading an empty input, which is what every command-only caller
+// wants; [Client.WriteFile] passes a reader so file content travels here
+// instead of on the command line.
+func (c *Client) exec(
+	ctx context.Context,
+	command string,
+	stdin io.Reader,
+) (RunResult, error) {
+	session, err := c.conn.NewSession()
+	if err != nil {
+		return RunResult{}, fmt.Errorf("open session: %w", err)
+	}
+
+	defer func() { _ = session.Close() }()
+
+	var stdout, stderr bytes.Buffer
+
+	if stdin != nil {
+		session.Stdin = stdin
+	}
+
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+
+	// Session.Run is not context-aware; closing the session on cancellation
+	// unblocks it.
+	stop := closeOnDone(ctx, session)
+
+	err = session.Run(command)
+
+	stop()
+
+	result := RunResult{Stdout: stdout.Bytes(), Stderr: stderr.Bytes(), ExitCode: 0}
+
+	var exitErr *ssh.ExitError
+	if errors.As(err, &exitErr) {
+		result.ExitCode = exitErr.ExitStatus()
+
+		return result, fmt.Errorf(
+			"%w: %q exited %d: %s",
+			ErrCommandFailed, command, result.ExitCode,
+			strings.TrimSpace(stderr.String()),
+		)
+	}
+
+	if err != nil {
+		if ctx.Err() != nil {
+			return result, fmt.Errorf("run %q: %w", command, ctx.Err())
+		}
+
+		return result, fmt.Errorf("run %q: %w", command, err)
+	}
+
+	return result, nil
 }
 
 // closeOnDone closes closer when ctx is cancelled, and returns a stop func

--- a/pkg/svc/bootstrap/ssh/client_test.go
+++ b/pkg/svc/bootstrap/ssh/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -23,7 +24,10 @@ const (
 var errUnknownClientKey = errors.New("unknown client key")
 
 // execHandler scripts the in-process server's response to one exec request.
-type execHandler func(command string) (stdout string, stderr string, exitCode uint32)
+// execHandler scripts one exec request. stdin carries everything the client
+// streamed on the session's input channel, so a write test can assert that
+// secret content travelled there and never in the command line.
+type execHandler func(command string, stdin []byte) (stdout string, stderr string, exitCode uint32)
 
 // exitStatusPayload is the SSH exit-status request payload (RFC 4254 §6.10).
 type exitStatusPayload struct {
@@ -149,7 +153,13 @@ func serveSession(channel ssh.Channel, requests <-chan *ssh.Request, handler exe
 
 		_ = request.Reply(true, nil)
 
-		stdout, stderr, exitCode := handler(payload.Command)
+		// Drain the input channel first: the client streams file content here, and
+		// the handler needs it to assert what actually crossed the wire. The client
+		// always closes its write side (x/crypto/ssh does so even for a nil Stdin),
+		// so this returns promptly for commands that send nothing.
+		stdin, _ := io.ReadAll(channel)
+
+		stdout, stderr, exitCode := handler(payload.Command, stdin)
 
 		_, _ = channel.Write([]byte(stdout))
 		_, _ = channel.Stderr().Write([]byte(stderr))
@@ -214,7 +224,7 @@ func TestFileExists(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string) (string, string, uint32) {
+		func(command string, _ []byte) (string, string, uint32) {
 			switch command {
 			case "test -f '/present'":
 				return "", "", 0
@@ -353,7 +363,7 @@ func TestRunCapturesOutputAndZeroExit(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string) (string, string, uint32) {
+		func(command string, _ []byte) (string, string, uint32) {
 			if command != "uname -r" {
 				return "", "unexpected command: " + command, 1
 			}
@@ -386,9 +396,14 @@ func TestRunSurfacesNonZeroExit(t *testing.T) {
 	t.Parallel()
 
 	pair := mustGenerateKeyPair(t)
-	addr, hostKey := startServer(t, pair.Signer.PublicKey(), func(string) (string, string, uint32) {
-		return "", "boom\n", 7
-	}, 0)
+	addr, hostKey := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(string, []byte) (string, string, uint32) {
+			return "", "boom\n", 7
+		},
+		0,
+	)
 
 	client := mustDial(t, addr, pair, hostKey)
 
@@ -420,7 +435,7 @@ func TestReadFileFetchesQuotedPath(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string) (string, string, uint32) {
+		func(command string, _ []byte) (string, string, uint32) {
 			sawCommand = command
 
 			return kubeconfig, "", 0
@@ -456,7 +471,7 @@ func TestReadFileEscapesSingleQuotes(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string) (string, string, uint32) {
+		func(command string, _ []byte) (string, string, uint32) {
 			sawCommand = command
 
 			return "", "", 0
@@ -485,9 +500,14 @@ func TestDialRejectsUnknownHostKey(t *testing.T) {
 	pair := mustGenerateKeyPair(t)
 	otherPair := mustGenerateKeyPair(t)
 
-	addr, _ := startServer(t, pair.Signer.PublicKey(), func(string) (string, string, uint32) {
-		return "", "", 0
-	}, 0)
+	addr, _ := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(string, []byte) (string, string, uint32) {
+			return "", "", 0
+		},
+		0,
+	)
 
 	// Pin the WRONG host key: the handshake must fail.
 	_, err := sshbootstrap.Dial(
@@ -503,9 +523,14 @@ func TestDialWithRetryRecoversFromEarlyRefusals(t *testing.T) {
 	t.Parallel()
 
 	pair := mustGenerateKeyPair(t)
-	addr, hostKey := startServer(t, pair.Signer.PublicKey(), func(string) (string, string, uint32) {
-		return "up\n", "", 0
-	}, 2)
+	addr, hostKey := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(string, []byte) (string, string, uint32) {
+			return "up\n", "", 0
+		},
+		2,
+	)
 
 	ctx, cancel := context.WithTimeout(t.Context(), testRunBudget)
 	defer cancel()

--- a/pkg/svc/bootstrap/ssh/client_test.go
+++ b/pkg/svc/bootstrap/ssh/client_test.go
@@ -27,7 +27,7 @@ var errUnknownClientKey = errors.New("unknown client key")
 // execHandler scripts one exec request. stdin carries everything the client
 // streamed on the session's input channel, so a write test can assert that
 // secret content travelled there and never in the command line.
-type execHandler func(command string, stdin []byte) (stdout string, stderr string, exitCode uint32)
+type execHandler func(command string, stdin io.Reader) (stdout string, stderr string, exitCode uint32)
 
 // exitStatusPayload is the SSH exit-status request payload (RFC 4254 §6.10).
 type exitStatusPayload struct {
@@ -153,13 +153,11 @@ func serveSession(channel ssh.Channel, requests <-chan *ssh.Request, handler exe
 
 		_ = request.Reply(true, nil)
 
-		// Drain the input channel first: the client streams file content here, and
-		// the handler needs it to assert what actually crossed the wire. The client
-		// always closes its write side (x/crypto/ssh does so even for a nil Stdin),
-		// so this returns promptly for commands that send nothing.
-		stdin, _ := io.ReadAll(channel)
+		// Hand the handler the LIVE input stream rather than a drained copy: a
+		// handler that exits without reading must stop consuming while the client
+		// is still writing, which is how a real remote refusal behaves.
 
-		stdout, stderr, exitCode := handler(payload.Command, stdin)
+		stdout, stderr, exitCode := handler(payload.Command, channel)
 
 		_, _ = channel.Write([]byte(stdout))
 		_, _ = channel.Stderr().Write([]byte(stderr))
@@ -224,7 +222,7 @@ func TestFileExists(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string, _ []byte) (string, string, uint32) {
+		func(command string, _ io.Reader) (string, string, uint32) {
 			switch command {
 			case "test -f '/present'":
 				return "", "", 0
@@ -363,7 +361,7 @@ func TestRunCapturesOutputAndZeroExit(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string, _ []byte) (string, string, uint32) {
+		func(command string, _ io.Reader) (string, string, uint32) {
 			if command != "uname -r" {
 				return "", "unexpected command: " + command, 1
 			}
@@ -399,7 +397,7 @@ func TestRunSurfacesNonZeroExit(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(string, []byte) (string, string, uint32) {
+		func(string, io.Reader) (string, string, uint32) {
 			return "", "boom\n", 7
 		},
 		0,
@@ -435,7 +433,7 @@ func TestReadFileFetchesQuotedPath(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string, _ []byte) (string, string, uint32) {
+		func(command string, _ io.Reader) (string, string, uint32) {
 			sawCommand = command
 
 			return kubeconfig, "", 0
@@ -471,7 +469,7 @@ func TestReadFileEscapesSingleQuotes(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string, _ []byte) (string, string, uint32) {
+		func(command string, _ io.Reader) (string, string, uint32) {
 			sawCommand = command
 
 			return "", "", 0
@@ -503,7 +501,7 @@ func TestDialRejectsUnknownHostKey(t *testing.T) {
 	addr, _ := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(string, []byte) (string, string, uint32) {
+		func(string, io.Reader) (string, string, uint32) {
 			return "", "", 0
 		},
 		0,
@@ -526,7 +524,7 @@ func TestDialWithRetryRecoversFromEarlyRefusals(t *testing.T) {
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(string, []byte) (string, string, uint32) {
+		func(string, io.Reader) (string, string, uint32) {
 			return "up\n", "", 0
 		},
 		2,

--- a/pkg/svc/bootstrap/ssh/errors.go
+++ b/pkg/svc/bootstrap/ssh/errors.go
@@ -37,4 +37,11 @@ var (
 	// after the byte count matches — so a caller seeing this never has a short
 	// file masquerading as a complete one.
 	ErrWriteTruncated = errors.New("ssh bootstrap: remote file write was truncated")
+
+	// ErrRelativeRemotePath is returned by [Client.WriteFile] for a path that is
+	// not absolute. A relative path would resolve against whatever directory the
+	// login shell happens to start in, which is not a property callers should
+	// depend on, and it is the only way an argument could begin with a dash and
+	// be mistaken for a command-line option.
+	ErrRelativeRemotePath = errors.New("ssh bootstrap: remote path must be absolute")
 )

--- a/pkg/svc/bootstrap/ssh/errors.go
+++ b/pkg/svc/bootstrap/ssh/errors.go
@@ -30,4 +30,11 @@ var (
 	// stderr) when a remote command runs but exits non-zero. Callers branch on it
 	// with errors.Is and read the exit code from [RunResult.ExitCode].
 	ErrCommandFailed = errors.New("ssh bootstrap: remote command failed")
+
+	// ErrWriteTruncated is returned (wrapped) by [Client.WriteFile] when the
+	// remote received fewer bytes than the client announced. The destination is
+	// left untouched — content is staged beside it and renamed into place only
+	// after the byte count matches — so a caller seeing this never has a short
+	// file masquerading as a complete one.
+	ErrWriteTruncated = errors.New("ssh bootstrap: remote file write was truncated")
 )

--- a/pkg/svc/bootstrap/ssh/write.go
+++ b/pkg/svc/bootstrap/ssh/write.go
@@ -50,6 +50,10 @@ func (c *Client) WriteFile(
 	content []byte,
 	mode fs.FileMode,
 ) error {
+	if !path.IsAbs(remotePath) {
+		return fmt.Errorf("%w: %s", ErrRelativeRemotePath, remotePath)
+	}
+
 	if mode == 0 {
 		mode = DefaultSecretFileMode
 	}
@@ -63,7 +67,7 @@ func (c *Client) WriteFile(
 
 	if errors.Is(err, ErrCommandFailed) && result.ExitCode == WriteTruncatedExitCode {
 		return fmt.Errorf(
-			"%w: %s: remote received fewer than %d byte(s); destination left unchanged",
+			"%w: %s: remote did not receive the expected %d byte(s); destination left unchanged",
 			ErrWriteTruncated, remotePath, len(content),
 		)
 	}
@@ -86,6 +90,11 @@ func writeScript(remotePath string, size int, mode fs.FileMode) string {
 		// the mode, but only after the bytes have landed, and a secret must not
 		// be world-readable even for that window.
 		"umask 077",
+		// Remove any pre-existing staging entry before creating it. The name is
+		// predictable, and a redirect onto a symlink someone left there would
+		// write the secret straight through to its target; unlinking first means
+		// the redirect always creates a fresh regular file owned by us.
+		"rm -f -- " + staging,
 		"cat > " + staging,
 		// Count what actually arrived. $n is deliberately unquoted so any padding
 		// some wc implementations emit is split away; an empty or non-numeric
@@ -96,6 +105,8 @@ func writeScript(remotePath string, size int, mode fs.FileMode) string {
 			"; exit " + strconv.Itoa(WriteTruncatedExitCode) + "; }",
 		// Set the mode before publishing, so the file is never visible at its
 		// final path with the wrong permissions.
+		// No "--" here: BSD chmod rejects it. remotePath is validated absolute, so
+		// the argument can never begin with a dash and be read as an option.
 		"chmod " + fmt.Sprintf("%04o", mode.Perm()) + " " + staging,
 		"mv -f -- " + staging + " " + shellQuote(remotePath),
 	}, "\n")

--- a/pkg/svc/bootstrap/ssh/write.go
+++ b/pkg/svc/bootstrap/ssh/write.go
@@ -95,6 +95,12 @@ func writeScript(remotePath string, size int, mode fs.FileMode) string {
 		// write the secret straight through to its target; unlinking first means
 		// the redirect always creates a fresh regular file owned by us.
 		"rm -f -- " + staging,
+		// noclobber: the unlink above and this redirect are not atomic, so a racing
+		// re-creation of the staging path could still be waiting here. Exclusive
+		// creation refuses ANY existing entry — regular file, symlink, or dangling
+		// symlink (verified on sh, dash and bash) — so "set -e" fails the write
+		// closed instead of following it.
+		"set -C",
 		"cat > " + staging,
 		// Count what actually arrived. $n is deliberately unquoted so any padding
 		// some wc implementations emit is split away; an empty or non-numeric

--- a/pkg/svc/bootstrap/ssh/write.go
+++ b/pkg/svc/bootstrap/ssh/write.go
@@ -1,0 +1,102 @@
+package sshbootstrap
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const (
+	// DefaultSecretFileMode is the mode [Client.WriteFile] applies when the
+	// caller passes a zero mode. Bootstrap writes carry cluster signing
+	// material, so the default is owner-only rather than whatever the login
+	// shell's umask happens to yield.
+	DefaultSecretFileMode fs.FileMode = 0o600
+
+	// WriteTruncatedExitCode is the status the remote script exits with when it
+	// received fewer bytes than the client announced. It sits outside the range
+	// shells use for their own failures (1, 2, 126, 127) so a short transfer is
+	// never mistaken for a command that merely failed.
+	WriteTruncatedExitCode = 65
+
+	// stagingSuffix names the file content streams into before it is published.
+	// It sits beside the destination so the final rename is atomic — same
+	// directory means same filesystem.
+	stagingSuffix = ".ksail-partial"
+)
+
+// WriteFile places content at remotePath with the given mode, creating parent
+// directories as needed. A zero mode means [DefaultSecretFileMode].
+//
+// Content streams over the session's input channel rather than the command
+// line, so secret material never reaches the node's process arguments, its
+// /proc entry, or the login shell's history. That is the property that makes
+// this usable for cluster PKI, which cloud-init user-data cannot carry because
+// the provider can read it back.
+//
+// The write is staged beside the destination and published with an atomic
+// rename only after the remote has verified it received every byte, so an
+// interrupted or truncated transfer returns an error wrapping
+// [ErrWriteTruncated] and leaves the destination untouched — never a short
+// file that looks complete.
+func (c *Client) WriteFile(
+	ctx context.Context,
+	remotePath string,
+	content []byte,
+	mode fs.FileMode,
+) error {
+	if mode == 0 {
+		mode = DefaultSecretFileMode
+	}
+
+	script := writeScript(remotePath, len(content), mode)
+
+	result, err := c.exec(ctx, script, bytes.NewReader(content))
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, ErrCommandFailed) && result.ExitCode == WriteTruncatedExitCode {
+		return fmt.Errorf(
+			"%w: %s: remote received fewer than %d byte(s); destination left unchanged",
+			ErrWriteTruncated, remotePath, len(content),
+		)
+	}
+
+	return fmt.Errorf("write remote file %s: %w", remotePath, err)
+}
+
+// writeScript renders the remote half of [Client.WriteFile]. Every path is
+// single-quoted against shell interpretation, and the content itself is absent
+// by construction — it arrives on stdin.
+func writeScript(remotePath string, size int, mode fs.FileMode) string {
+	staging := shellQuote(remotePath + stagingSuffix)
+
+	return strings.Join([]string{
+		// Abort on the first failure so a failed mkdir or chmod can never fall
+		// through to the rename that publishes the file.
+		"set -eu",
+		"mkdir -p -- " + shellQuote(path.Dir(remotePath)),
+		// Create the staging file owner-only from the outset: chmod below fixes
+		// the mode, but only after the bytes have landed, and a secret must not
+		// be world-readable even for that window.
+		"umask 077",
+		"cat > " + staging,
+		// Count what actually arrived. $n is deliberately unquoted so any padding
+		// some wc implementations emit is split away; an empty or non-numeric
+		// value makes the test false, which takes the discard branch — the
+		// fail-closed direction.
+		"n=$(wc -c < " + staging + ")",
+		"[ $n -eq " + strconv.Itoa(size) + " ] || { rm -f -- " + staging +
+			"; exit " + strconv.Itoa(WriteTruncatedExitCode) + "; }",
+		// Set the mode before publishing, so the file is never visible at its
+		// final path with the wrong permissions.
+		"chmod " + fmt.Sprintf("%04o", mode.Perm()) + " " + staging,
+		"mv -f -- " + staging + " " + shellQuote(remotePath),
+	}, "\n")
+}

--- a/pkg/svc/bootstrap/ssh/write_test.go
+++ b/pkg/svc/bootstrap/ssh/write_test.go
@@ -19,6 +19,8 @@ import (
 
 // payloadMarker is a token that must never reach the remote command line. It
 // stands in for cluster signing material without being a usable key.
+const osWindows = "windows"
+
 const payloadMarker = "MARKER-cbf29ce484222325"
 
 // writeRecorder captures what the stubbed server observed for one write, so a
@@ -255,7 +257,7 @@ func exitCodeOf(exitErr *exec.ExitError) int {
 func TestWriteFileScriptRunsInARealShell(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("the remote half is a POSIX shell script; nodes are Linux")
 	}
 
@@ -337,7 +339,7 @@ func assertPublished(t *testing.T, dest string, want []byte) {
 func TestWriteFileDoesNotFollowAPrePlacedStagingSymlink(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("the remote half is a POSIX shell script; nodes are Linux")
 	}
 
@@ -401,5 +403,56 @@ func TestWriteFileRejectsARelativePath(t *testing.T) {
 	command, _ := recorder.snapshot()
 	if command != "" {
 		t.Fatalf("a rejected path must not reach the node: %q", command)
+	}
+}
+
+// TestWriteFileReportsAFailureThatPreemptsTheStream covers the case the scripted
+// stub cannot reach: the remote aborts at mkdir and never drains stdin, while
+// the client is still streaming a payload larger than the SSH window. The exit
+// status must still win over the interrupted copy, and the failure must not be
+// dressed up as truncation — the bytes never got as far as being counted.
+func TestWriteFileReportsAFailureThatPreemptsTheStream(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("the remote half is a POSIX shell script; nodes are Linux")
+	}
+
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+
+	seed := []byte("a file, not a directory\n")
+
+	err := os.WriteFile(blocker, seed, 0o600)
+	if err != nil {
+		t.Fatalf("seed blocker: %v", err)
+	}
+
+	// The parent of dest is a regular file, so `mkdir -p` fails immediately and
+	// `set -e` aborts the script before `cat` ever reads the stream.
+	dest := filepath.Join(blocker, "sub", "ca.key")
+	payload := bytes.Repeat([]byte("A"), 4<<20)
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(
+		t, pair.Signer.PublicKey(), shellExecHandler(t.Context(), &writeRecorder{}), 0,
+	)
+	client := mustDial(t, addr, pair, hostKey)
+
+	err = client.WriteFile(t.Context(), dest, payload, 0o600)
+	if !errors.Is(err, sshbootstrap.ErrCommandFailed) {
+		t.Fatalf("want ErrCommandFailed, got %v", err)
+	}
+
+	if errors.Is(err, sshbootstrap.ErrWriteTruncated) {
+		t.Fatalf("a refusal before the stream was read is not truncation: %v", err)
+	}
+
+	// dest's parent is a regular file, so nothing could have been created under
+	// it — assert the blocker itself came through untouched.
+	//nolint:gosec // G304: reads a file just written under the test's own t.TempDir().
+	after, err := os.ReadFile(blocker)
+	if err != nil || !bytes.Equal(after, seed) {
+		t.Fatalf("blocker changed: %q err=%v", after, err)
 	}
 }

--- a/pkg/svc/bootstrap/ssh/write_test.go
+++ b/pkg/svc/bootstrap/ssh/write_test.go
@@ -1,0 +1,330 @@
+package sshbootstrap_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
+)
+
+// payloadMarker is a token that must never reach the remote command line. It
+// stands in for cluster signing material without being a usable key.
+const payloadMarker = "MARKER-cbf29ce484222325"
+
+// writeRecorder captures what the stubbed server observed for one write, so a
+// test can assert where the content travelled rather than only that the call
+// succeeded.
+type writeRecorder struct {
+	mu      sync.Mutex
+	command string
+	stdin   []byte
+}
+
+func (r *writeRecorder) record(command string, stdin []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.command = command
+
+	r.stdin = append([]byte(nil), stdin...)
+}
+
+func (r *writeRecorder) snapshot() (string, []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.command, append([]byte(nil), r.stdin...)
+}
+
+// writeServer dials a stub that records the write it saw and answers with the
+// scripted exit code and stderr.
+func writeServer(
+	t *testing.T,
+	exitCode uint32,
+	stderr string,
+) (*sshbootstrap.Client, *writeRecorder) {
+	t.Helper()
+
+	pair := mustGenerateKeyPair(t)
+	recorder := &writeRecorder{}
+
+	addr, hostKey := startServer(
+		t,
+		pair.Signer.PublicKey(),
+		func(command string, stdin []byte) (string, string, uint32) {
+			recorder.record(command, stdin)
+
+			return "", stderr, exitCode
+		},
+		0,
+	)
+
+	return mustDial(t, addr, pair, hostKey), recorder
+}
+
+// TestWriteFileKeepsContentOutOfTheCommandLine pins the security property the
+// primitive exists for: secret bytes travel on stdin, so they never land in the
+// node's process arguments or shell history.
+func TestWriteFileKeepsContentOutOfTheCommandLine(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte(
+		"-----BEGIN PRIVATE KEY-----\n" + payloadMarker + "\n-----END PRIVATE KEY-----\n",
+	)
+	client, recorder := writeServer(t, 0, "")
+
+	err := client.WriteFile(t.Context(), "/etc/kubernetes/pki/ca.key", secret, 0o600)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	command, stdin := recorder.snapshot()
+
+	if string(stdin) != string(secret) {
+		t.Fatalf("stdin: got %q, want the file content", stdin)
+	}
+
+	if strings.Contains(command, payloadMarker) {
+		t.Fatalf("secret content reached the command line: %q", command)
+	}
+
+	if !strings.Contains(command, "/etc/kubernetes/pki/ca.key") {
+		t.Fatalf("command does not name the destination: %q", command)
+	}
+
+	// The remote side must be able to detect a short transfer, which means the
+	// expected byte count has to cross with the request.
+	if !strings.Contains(command, strconv.Itoa(len(secret))) {
+		t.Fatalf("command carries no expected byte count: %q", command)
+	}
+}
+
+// TestWriteFileAppliesTheRequestedMode asserts the caller's mode is the mode
+// applied, rather than whatever umask the login shell happens to carry.
+func TestWriteFileAppliesTheRequestedMode(t *testing.T) {
+	t.Parallel()
+
+	for name, testCase := range map[string]struct {
+		mode fs.FileMode
+		want string
+	}{
+		"explicit owner only":   {mode: 0o600, want: "0600"},
+		"group readable":        {mode: 0o640, want: "0640"},
+		"zero means owner only": {mode: 0, want: "0600"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client, recorder := writeServer(t, 0, "")
+
+			err := client.WriteFile(t.Context(), "/tmp/material", []byte("x"), testCase.mode)
+			if err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			command, _ := recorder.snapshot()
+
+			if !strings.Contains(command, "chmod "+testCase.want) {
+				t.Fatalf("mode %v: want chmod %s in %q", testCase.mode, testCase.want, command)
+			}
+		})
+	}
+}
+
+// TestWriteFileCreatesParentDirectories covers the "creating parent directories
+// as needed" half of the contract.
+func TestWriteFileCreatesParentDirectories(t *testing.T) {
+	t.Parallel()
+
+	client, recorder := writeServer(t, 0, "")
+
+	err := client.WriteFile(t.Context(), "/etc/kubernetes/pki/ca.key", []byte("x"), 0o600)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	command, _ := recorder.snapshot()
+
+	if !strings.Contains(command, "mkdir -p -- '/etc/kubernetes/pki'") {
+		t.Fatalf("command does not create the parent directory: %q", command)
+	}
+}
+
+// TestWriteFileReportsARemoteFailure covers the two remote refusals a caller
+// must not mistake for success.
+func TestWriteFileReportsARemoteFailure(t *testing.T) {
+	t.Parallel()
+
+	for name, stderr := range map[string]string{
+		"missing parent":    "mkdir: cannot create directory '/etc/kubernetes/pki': Read-only file system",
+		"permission denied": "chmod: changing permissions of '/etc/kubernetes/pki/ca.key': Permission denied",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client, _ := writeServer(t, 1, stderr)
+
+			err := client.WriteFile(t.Context(), "/etc/kubernetes/pki/ca.key", []byte("x"), 0o600)
+			if err == nil {
+				t.Fatal("want an error, got nil")
+			}
+
+			if !errors.Is(err, sshbootstrap.ErrCommandFailed) {
+				t.Fatalf("want ErrCommandFailed, got %v", err)
+			}
+
+			if errors.Is(err, sshbootstrap.ErrWriteTruncated) {
+				t.Fatalf("a refusal must not be reported as truncation: %v", err)
+			}
+		})
+	}
+}
+
+// TestWriteFileReportsATruncatedTransfer pins "never silently partial": the
+// remote counts what it received and refuses to publish a short file.
+func TestWriteFileReportsATruncatedTransfer(t *testing.T) {
+	t.Parallel()
+
+	client, _ := writeServer(t, sshbootstrap.WriteTruncatedExitCode, "")
+
+	err := client.WriteFile(t.Context(), "/etc/kubernetes/pki/ca.key", []byte("xyz"), 0o600)
+	if err == nil {
+		t.Fatal("want an error, got nil")
+	}
+
+	if !errors.Is(err, sshbootstrap.ErrWriteTruncated) {
+		t.Fatalf("want ErrWriteTruncated, got %v", err)
+	}
+}
+
+// shellExecHandler answers an exec request by actually running the command in
+// /bin/sh with the received stdin, so the remote half is exercised for real
+// rather than through a scripted exit code.
+func shellExecHandler(ctx context.Context, captured *writeRecorder) execHandler {
+	return func(command string, stdin []byte) (string, string, uint32) {
+		captured.record(command, stdin)
+
+		//nolint:gosec // G204: the command is this package's own rendered script,
+		// captured from the stub server; exercising it is the point of the test.
+		cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command)
+		cmd.Stdin = bytes.NewReader(stdin)
+
+		var errBuf bytes.Buffer
+
+		cmd.Stderr = &errBuf
+
+		err := cmd.Run()
+		code := 0
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			code = exitCodeOf(exitErr)
+		}
+
+		return "", errBuf.String(), uint32(code)
+	}
+}
+
+// exitCodeOf reads an exit status, mapping a signal death (-1) onto a plain
+// failure so it fits the SSH exit-status request's unsigned range.
+func exitCodeOf(exitErr *exec.ExitError) int {
+	code := exitErr.ExitCode()
+	if code < 0 {
+		return 1
+	}
+
+	return code
+}
+
+// TestWriteFileScriptRunsInARealShell proves the rendered script is valid POSIX
+// shell that does what the scripted-exit-code tests above only assert the shape
+// of: it creates parents, applies the mode, publishes the exact bytes, and — on
+// a short transfer — refuses without touching the destination it would have
+// replaced. Everything runs locally against a temp directory; no network, no
+// cluster, no credentials.
+func TestWriteFileScriptRunsInARealShell(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("the remote half is a POSIX shell script; nodes are Linux")
+	}
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "nested", "deeper", "ca.key")
+	secret := []byte(
+		"-----BEGIN PRIVATE KEY-----\n" + payloadMarker + "\n-----END PRIVATE KEY-----\n",
+	)
+
+	pair := mustGenerateKeyPair(t)
+	recorder := &writeRecorder{}
+	addr, hostKey := startServer(
+		t, pair.Signer.PublicKey(), shellExecHandler(t.Context(), recorder), 0,
+	)
+	client := mustDial(t, addr, pair, hostKey)
+
+	err := client.WriteFile(t.Context(), dest, secret, 0o600)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	assertPublished(t, dest, secret)
+
+	// Replay the very same script with a short stdin: the destination now holds
+	// known-good content, so clobbering it would be visible.
+	command, _ := recorder.snapshot()
+	//nolint:gosec // G204: replays the script this package just rendered.
+	replay := exec.CommandContext(t.Context(), "/bin/sh", "-c", command)
+	replay.Stdin = strings.NewReader("short")
+
+	var exitErr *exec.ExitError
+	if !errors.As(replay.Run(), &exitErr) ||
+		exitErr.ExitCode() != sshbootstrap.WriteTruncatedExitCode {
+		t.Fatalf(
+			"truncated replay: want exit %d, got %v",
+			sshbootstrap.WriteTruncatedExitCode,
+			exitErr,
+		)
+	}
+
+	assertPublished(t, dest, secret)
+}
+
+// assertPublished checks the destination holds exactly want, owner-only, with
+// no staging file left beside it.
+func assertPublished(t *testing.T, dest string, want []byte) {
+	t.Helper()
+
+	//nolint:gosec // G304: reads a file just written under the test's own t.TempDir().
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("destination not readable: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("destination content: got %q, want %q", got, want)
+	}
+
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat destination: %v", err)
+	}
+
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("destination mode: got %04o, want 0600", info.Mode().Perm())
+	}
+
+	_, err = os.Stat(dest + ".ksail-partial")
+	if !os.IsNotExist(err) {
+		t.Fatal("staging file left beside the destination")
+	}
+}

--- a/pkg/svc/bootstrap/ssh/write_test.go
+++ b/pkg/svc/bootstrap/ssh/write_test.go
@@ -34,6 +34,8 @@ type writeRecorder struct {
 	stdin   []byte
 }
 
+// record stores what one exec request carried. stdin may be nil when the
+// handler streamed the input straight through instead of draining it.
 func (r *writeRecorder) record(command string, stdin []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -43,6 +45,8 @@ func (r *writeRecorder) record(command string, stdin []byte) {
 	r.stdin = append([]byte(nil), stdin...)
 }
 
+// snapshot returns a copy of the recorded command and stdin, safe to read
+// while the server goroutine is still running.
 func (r *writeRecorder) snapshot() (string, []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/svc/bootstrap/ssh/write_test.go
+++ b/pkg/svc/bootstrap/ssh/write_test.go
@@ -328,3 +328,78 @@ func assertPublished(t *testing.T, dest string, want []byte) {
 		t.Fatal("staging file left beside the destination")
 	}
 }
+
+// TestWriteFileDoesNotFollowAPrePlacedStagingSymlink pins a real attack the
+// staging step would otherwise enable: the staging name is derived from the
+// destination and therefore predictable, so anything already sitting there is
+// attacker-chosen. A shell redirect follows a symlink and writes through to its
+// target, which would deliver the secret to a file of someone else's choosing.
+func TestWriteFileDoesNotFollowAPrePlacedStagingSymlink(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("the remote half is a POSIX shell script; nodes are Linux")
+	}
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "ca.key")
+	victim := filepath.Join(dir, "victim")
+	untouched := []byte("VICTIM-CONTENT\n")
+
+	err := os.WriteFile(victim, untouched, 0o600)
+	if err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	// Someone gets there first and points the staging name at the victim.
+	err = os.Symlink(victim, dest+".ksail-partial")
+	if err != nil {
+		t.Fatalf("pre-place symlink: %v", err)
+	}
+
+	secret := []byte(
+		"-----BEGIN PRIVATE KEY-----\n" + payloadMarker + "\n-----END PRIVATE KEY-----\n",
+	)
+
+	pair := mustGenerateKeyPair(t)
+	addr, hostKey := startServer(
+		t, pair.Signer.PublicKey(), shellExecHandler(t.Context(), &writeRecorder{}), 0,
+	)
+	client := mustDial(t, addr, pair, hostKey)
+
+	err = client.WriteFile(t.Context(), dest, secret, 0o600)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	//nolint:gosec // G304: reads a file just written under the test's own t.TempDir().
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+
+	if !bytes.Equal(got, untouched) {
+		t.Fatalf("secret was written through the symlink into %s: %q", victim, got)
+	}
+
+	assertPublished(t, dest, secret)
+}
+
+// TestWriteFileRejectsARelativePath covers the guard that keeps the remote
+// argument unambiguous: a relative path would resolve against whatever
+// directory the login shell starts in.
+func TestWriteFileRejectsARelativePath(t *testing.T) {
+	t.Parallel()
+
+	client, recorder := writeServer(t, 0, "")
+
+	err := client.WriteFile(t.Context(), "etc/kubernetes/pki/ca.key", []byte("x"), 0o600)
+	if !errors.Is(err, sshbootstrap.ErrRelativeRemotePath) {
+		t.Fatalf("want ErrRelativeRemotePath, got %v", err)
+	}
+
+	command, _ := recorder.snapshot()
+	if command != "" {
+		t.Fatalf("a rejected path must not reach the node: %q", command)
+	}
+}

--- a/pkg/svc/bootstrap/ssh/write_test.go
+++ b/pkg/svc/bootstrap/ssh/write_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -17,10 +18,11 @@ import (
 	sshbootstrap "github.com/devantler-tech/ksail/v7/pkg/svc/bootstrap/ssh"
 )
 
-// payloadMarker is a token that must never reach the remote command line. It
-// stands in for cluster signing material without being a usable key.
+// osWindows names the one platform whose shell cannot run the remote half.
 const osWindows = "windows"
 
+// payloadMarker is a token that must never reach the remote command line. It
+// stands in for cluster signing material without being a usable key.
 const payloadMarker = "MARKER-cbf29ce484222325"
 
 // writeRecorder captures what the stubbed server observed for one write, so a
@@ -63,8 +65,9 @@ func writeServer(
 	addr, hostKey := startServer(
 		t,
 		pair.Signer.PublicKey(),
-		func(command string, stdin []byte) (string, string, uint32) {
-			recorder.record(command, stdin)
+		func(command string, stdin io.Reader) (string, string, uint32) {
+			drained, _ := io.ReadAll(stdin)
+			recorder.record(command, drained)
 
 			return "", stderr, exitCode
 		},
@@ -213,13 +216,15 @@ func TestWriteFileReportsATruncatedTransfer(t *testing.T) {
 // /bin/sh with the received stdin, so the remote half is exercised for real
 // rather than through a scripted exit code.
 func shellExecHandler(ctx context.Context, captured *writeRecorder) execHandler {
-	return func(command string, stdin []byte) (string, string, uint32) {
-		captured.record(command, stdin)
+	return func(command string, stdin io.Reader) (string, string, uint32) {
+		// Record the command only: stdin is streamed straight to the shell, so
+		// draining it here would defeat the point of handing over a live reader.
+		captured.record(command, nil)
 
 		//nolint:gosec // G204: the command is this package's own rendered script,
 		// captured from the stub server; exercising it is the point of the test.
 		cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command)
-		cmd.Stdin = bytes.NewReader(stdin)
+		cmd.Stdin = stdin
 
 		var errBuf bytes.Buffer
 
@@ -454,5 +459,71 @@ func TestWriteFileReportsAFailureThatPreemptsTheStream(t *testing.T) {
 	after, err := os.ReadFile(blocker)
 	if err != nil || !bytes.Equal(after, seed) {
 		t.Fatalf("blocker changed: %q err=%v", after, err)
+	}
+}
+
+// TestWriteFileFailsClosedIfTheStagingPathIsRecreated covers the window the
+// unlink alone cannot close: the unlink and the redirect are two separate
+// syscalls, so an attacker who re-creates the staging path in between would be
+// followed by a plain redirect. Simulated deterministically by neutralising the
+// unlink in the rendered script and leaving a symlink in place, which is
+// exactly the state the losing side of that race produces.
+func TestWriteFileFailsClosedIfTheStagingPathIsRecreated(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("the remote half is a POSIX shell script; nodes are Linux")
+	}
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "ca.key")
+	victim := filepath.Join(dir, "victim")
+	untouched := []byte("VICTIM-CONTENT\n")
+
+	err := os.WriteFile(victim, untouched, 0o600)
+	if err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	// Capture the script the client would send.
+	client, recorder := writeServer(t, 0, "")
+	secret := []byte(
+		"-----BEGIN PRIVATE KEY-----\n" + payloadMarker + "\n-----END PRIVATE KEY-----\n",
+	)
+
+	err = client.WriteFile(t.Context(), dest, secret, 0o600)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	script, _ := recorder.snapshot()
+
+	if !strings.Contains(script, "set -C") {
+		t.Fatal("script does not enable noclobber, so the race window is open")
+	}
+
+	// Drop the unlink: this is the attacker winning the race.
+	raced := strings.Replace(script, "rm -f -- '"+dest+".ksail-partial'", "true", 1)
+	if raced == script {
+		t.Fatal("could not neutralise the unlink; the simulation would be vacuous")
+	}
+
+	err = os.Symlink(victim, dest+".ksail-partial")
+	if err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	//nolint:gosec // G204: replays this package's own rendered script.
+	replay := exec.CommandContext(t.Context(), "/bin/sh", "-c", raced)
+	replay.Stdin = bytes.NewReader(secret)
+
+	if replay.Run() == nil {
+		t.Fatal("the write succeeded through a re-created staging path")
+	}
+
+	//nolint:gosec // G304: reads a file just written under the test's own t.TempDir().
+	after, err := os.ReadFile(victim)
+	if err != nil || !bytes.Equal(after, untouched) {
+		t.Fatalf("secret reached the victim through the race: %q err=%v", after, err)
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

KSail refuses to build more than one kubeadm control plane on Hetzner. Joining control planes need the cluster's signing material, and the only channel available today is cloud-init user-data — which the provider can read back. So the feature is blocked on a safe way to hand a node a secret.

The channel that would carry it already exists and is already trust-anchored, but it can only read. Nothing can start until it can also write.

### What

Adds a write capability to that channel: a caller can now place a file on a node with a chosen permission, and the content travels on a private input stream instead of the command line, so it never shows up in the node's running-process list or shell history.

A half-finished transfer is refused rather than published — the file is staged and only swapped into place once the node confirms it received every byte, so a dropped connection leaves the previous file untouched instead of a truncated one that looks complete.

No existing behaviour changes and multi-control-plane creation stays refused; this only adds the capability the next slice needs.

Fixes #6548
Part of #6428