### PR TITLE
feat(hetzner): verify a deployed node's provider-visible user-data carries no signing material

### DIFF
--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/verify.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/verify.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // metadataUserDataEndpoint is the Hetzner instance metadata document returning
@@ -18,6 +19,10 @@ import (
 // the node itself, which is why verification is expressed as a command rather
 // than an API read.
 const metadataUserDataEndpoint = "http://169.254.169.254/hetzner/v1/userdata"
+
+// metadataServiceHost is the link-local address of the metadata service, named
+// separately because it is what --noproxy must exempt.
+const metadataServiceHost = "169.254.169.254"
 
 // metadataFetchTimeoutSeconds bounds the metadata request so a node whose
 // link-local route is black-holed fails instead of hanging a verification run.
@@ -116,16 +121,40 @@ func VerifyNodeUserData(ctx context.Context, run NodeCommand) error {
 		)
 	}
 
+	// Emptiness has to be judged again AFTER decompression. A gzip stream of
+	// nothing is several non-space bytes, so the raw check above passes it
+	// through, and the document it expands to is empty -- which every guard
+	// trivially accepts. That is the same unobserved-reads-as-verified failure
+	// the raw check refuses, arriving one encoding layer down.
+	inspected, err := expandRawGzipUserData(string(stdout))
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrNodeUserDataUnreadable, err)
+	}
+
+	if strings.TrimSpace(inspected) == "" {
+		return fmt.Errorf(
+			"%w: %s returned a document that is empty once decoded",
+			ErrNodeUserDataUnreadable, metadataUserDataEndpoint,
+		)
+	}
+
 	return VerifyNoSigningMaterial(string(stdout))
 }
 
 // metadataUserDataCommand builds the metadata fetch. --fail turns an HTTP error
-// status into a non-zero exit so a proxy or error page cannot be inspected as
-// though it were user-data, and --show-error keeps the cause on stderr for the
-// caller to surface.
+// status into a non-zero exit so an error page cannot be inspected as though it
+// were user-data, and --show-error keeps the cause on stderr for the caller to
+// surface.
+//
+// --noproxy is the load-bearing one. The node may export ALL_PROXY or a
+// lowercase http_proxy, and curl honours those for this link-local address like
+// any other, so the request could be answered by a proxy instead of the metadata
+// service. A proxy returning clean content would be a false pass on the exact
+// question this function exists to answer -- what the PROVIDER holds -- so the
+// address is pinned out of proxying rather than trusted to be direct.
 func metadataUserDataCommand() string {
 	return fmt.Sprintf(
-		"curl --fail --silent --show-error --max-time %d -- %s",
-		metadataFetchTimeoutSeconds, metadataUserDataEndpoint,
+		"curl --fail --silent --show-error --noproxy %s --max-time %d -- %s",
+		metadataServiceHost, metadataFetchTimeoutSeconds, metadataUserDataEndpoint,
 	)
 }

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/verify.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/verify.go
@@ -38,13 +38,20 @@ var ErrNodeUserDataUnreadable = errors.New(
 )
 
 // NodeCommand runs a single shell command on a node and returns its standard
-// output. A non-zero exit or a transport failure must return a non-nil error so
-// the caller cannot mistake an unexecuted command for an empty result.
+// output and standard error separately. A non-zero exit or a transport failure
+// must return a non-nil error so the caller cannot mistake an unexecuted command
+// for an empty result.
+//
+// stderr is returned rather than discarded because a zero exit does not imply a
+// complete read: curl runs with --show-error, so a diagnostic can be written
+// while the command still succeeds, and an adapter is free to surface a remote's
+// stderr without failing. Folding the two streams together would hide exactly
+// that case, and the caller could not tell a full document from a truncated one.
 //
 // It is a function rather than an interface so callers adapt their own client
 // without this package depending on a transport: the bootstrap SSH client's Run
 // method fits behind a two-line adapter.
-type NodeCommand func(ctx context.Context, command string) ([]byte, error)
+type NodeCommand func(ctx context.Context, command string) (stdout, stderr []byte, err error)
 
 // VerifyNoSigningMaterial reports whether userData carries cluster signing
 // material, applying the same guards the create path applies.
@@ -86,9 +93,20 @@ func VerifyNodeUserData(ctx context.Context, run NodeCommand) error {
 		return fmt.Errorf("%w: no command runner was supplied", ErrNodeUserDataUnreadable)
 	}
 
-	stdout, err := run(ctx, metadataUserDataCommand())
+	stdout, stderr, err := run(ctx, metadataUserDataCommand())
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrNodeUserDataUnreadable, err)
+	}
+
+	// A zero exit with a diagnostic on stderr is an incomplete read, not a clean
+	// node: curl's --show-error puts the cause here, and reporting "no signing
+	// material" from a document we know was not fully retrieved is the same
+	// unobserved-reads-as-verified failure the empty-document guard below refuses.
+	if len(bytes.TrimSpace(stderr)) != 0 {
+		return fmt.Errorf(
+			"%w: %s wrote to stderr: %s",
+			ErrNodeUserDataUnreadable, metadataUserDataEndpoint, bytes.TrimSpace(stderr),
+		)
 	}
 
 	if len(bytes.TrimSpace(stdout)) == 0 {

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/verify.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/verify.go
@@ -1,0 +1,113 @@
+package hetznerbase
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+)
+
+// metadataUserDataEndpoint is the Hetzner instance metadata document returning
+// the user-data the provider actually stored for a server.
+//
+// This is the only provider-visible view of that value. The Cloud API accepts
+// user_data on server create and rebuild but never returns it: hcloud-go
+// exposes it on ServerCreateOpts and ServerRebuildOpts and not on Server, and
+// its metadata client offers hostname, instance ID, region and private networks
+// with no user-data accessor. So a deployed node's copy is only observable from
+// the node itself, which is why verification is expressed as a command rather
+// than an API read.
+const metadataUserDataEndpoint = "http://169.254.169.254/hetzner/v1/userdata"
+
+// metadataFetchTimeoutSeconds bounds the metadata request so a node whose
+// link-local route is black-holed fails instead of hanging a verification run.
+const metadataFetchTimeoutSeconds = 10
+
+// ErrNodeUserDataUnreadable is returned when a node's provider-visible
+// user-data could not be observed at all: the fetch failed, or it produced an
+// empty document.
+//
+// It is deliberately distinct from [ErrPrivateKeyInUserData] and
+// [ErrSigningTransportInUserData]. Those two report that signing material WAS
+// found; this one reports that nothing was looked at, which must never be
+// reported as a clean node. That distinction is the whole value of the check —
+// an unobserved node and a verified-clean node are the same silence, and only
+// one of them is evidence.
+var ErrNodeUserDataUnreadable = errors.New(
+	"hetzner: node provider-visible user-data could not be read",
+)
+
+// NodeCommand runs a single shell command on a node and returns its standard
+// output. A non-zero exit or a transport failure must return a non-nil error so
+// the caller cannot mistake an unexecuted command for an empty result.
+//
+// It is a function rather than an interface so callers adapt their own client
+// without this package depending on a transport: the bootstrap SSH client's Run
+// method fits behind a two-line adapter.
+type NodeCommand func(ctx context.Context, command string) ([]byte, error)
+
+// VerifyNoSigningMaterial reports whether userData carries cluster signing
+// material, applying the same guards the create path applies.
+//
+// It differs from the create path in what it deliberately leaves out. The
+// provider-acceptance ceiling and the user-data shape check are decisions about
+// what may be SENT; a node that has already booted is past both, so applying
+// them to a readback would report a leak-free node as a failure for a reason
+// unrelated to leakage. Gzip expansion is kept, because compression hides a
+// marker just as effectively on the way back as on the way out.
+//
+// The input may come from anywhere — a live node, an audit capture, a
+// provisioner under test — which is the point: the create-path guard can only
+// inspect user-data this process just composed, and so can say nothing about
+// what a running cluster actually carries.
+func VerifyNoSigningMaterial(userData string) error {
+	inspected, err := expandRawGzipUserData(userData)
+	if err != nil {
+		return err
+	}
+
+	err = validatePEMPrivateKeys(inspected)
+	if err != nil {
+		return err
+	}
+
+	return validateSigningTransport(inspected)
+}
+
+// VerifyNodeUserData fetches a node's provider-visible user-data from the
+// Hetzner metadata service and verifies it carries no cluster signing material.
+//
+// An empty document is refused rather than accepted. cURL exits zero for a
+// request that returns nothing, and an empty string trivially contains no
+// signing material, so treating it as clean would turn "we could not see the
+// user-data" into the strongest result this function can report.
+func VerifyNodeUserData(ctx context.Context, run NodeCommand) error {
+	if run == nil {
+		return fmt.Errorf("%w: no command runner was supplied", ErrNodeUserDataUnreadable)
+	}
+
+	stdout, err := run(ctx, metadataUserDataCommand())
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrNodeUserDataUnreadable, err)
+	}
+
+	if len(bytes.TrimSpace(stdout)) == 0 {
+		return fmt.Errorf(
+			"%w: %s returned an empty document",
+			ErrNodeUserDataUnreadable, metadataUserDataEndpoint,
+		)
+	}
+
+	return VerifyNoSigningMaterial(string(stdout))
+}
+
+// metadataUserDataCommand builds the metadata fetch. --fail turns an HTTP error
+// status into a non-zero exit so a proxy or error page cannot be inspected as
+// though it were user-data, and --show-error keeps the cause on stderr for the
+// caller to surface.
+func metadataUserDataCommand() string {
+	return fmt.Sprintf(
+		"curl --fail --silent --show-error --max-time %d -- %s",
+		metadataFetchTimeoutSeconds, metadataUserDataEndpoint,
+	)
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/verify_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/verify_test.go
@@ -1,0 +1,217 @@
+package hetznerbase_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/internal/hetznerbase"
+)
+
+// errFetchFailed stands in for a non-zero remote exit.
+var errFetchFailed = errors.New("exit status 7")
+
+const cleanUserData = `#cloud-config
+runcmd:
+  - [kubeadm, init, --config, /etc/kubernetes/kubeadm.yaml]
+`
+
+// The PEM body is meaningless filler, not a credential: this fixture exists
+// because the guard under test is what detects exactly this shape.
+//
+//nolint:gosec // deliberately fake PEM fixture for the guard under test
+const leakingUserData = `#cloud-config
+write_files:
+  - path: /etc/kubernetes/pki/ca.key
+    content: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEowIBAAKCAQEA
+      -----END RSA PRIVATE KEY-----
+`
+
+// gzipOf compresses text the way cloud-init accepts raw gzip user-data, so a
+// marker hidden behind compression is exercised rather than assumed.
+func gzipOf(t *testing.T, text string) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	writer := gzip.NewWriter(&buf)
+
+	_, err := writer.Write([]byte(text))
+	if err != nil {
+		t.Fatalf("write gzip: %v", err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+
+	return buf.String()
+}
+
+func TestVerifyNoSigningMaterialAcceptsCleanUserData(t *testing.T) {
+	t.Parallel()
+
+	err := hetznerbase.VerifyNoSigningMaterial(cleanUserData)
+	if err != nil {
+		t.Fatalf("clean user-data rejected: %v", err)
+	}
+}
+
+func TestVerifyNoSigningMaterialRejectsPEMPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	err := hetznerbase.VerifyNoSigningMaterial(leakingUserData)
+	if !errors.Is(err, hetznerbase.ErrPrivateKeyInUserData) {
+		t.Fatalf("want ErrPrivateKeyInUserData, got %v", err)
+	}
+}
+
+func TestVerifyNoSigningMaterialRejectsSigningTransport(t *testing.T) {
+	t.Parallel()
+
+	userData := "#cloud-config\nruncmd:\n  - kubeadm init --upload-certs\n"
+
+	err := hetznerbase.VerifyNoSigningMaterial(userData)
+	if !errors.Is(err, hetznerbase.ErrSigningTransportInUserData) {
+		t.Fatalf("want ErrSigningTransportInUserData, got %v", err)
+	}
+}
+
+func TestVerifyNoSigningMaterialRejectsBase64EncodedKey(t *testing.T) {
+	t.Parallel()
+
+	encoded := base64.StdEncoding.EncodeToString(
+		[]byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEow\n-----END RSA PRIVATE KEY-----"),
+	)
+	userData := "#cloud-config\nwrite_files:\n  - encoding: b64\n    content: " + encoded + "\n"
+
+	err := hetznerbase.VerifyNoSigningMaterial(userData)
+	if !errors.Is(err, hetznerbase.ErrPrivateKeyInUserData) {
+		t.Fatalf("want ErrPrivateKeyInUserData for base64 payload, got %v", err)
+	}
+}
+
+func TestVerifyNoSigningMaterialRejectsGzipHiddenKey(t *testing.T) {
+	t.Parallel()
+
+	err := hetznerbase.VerifyNoSigningMaterial(gzipOf(t, leakingUserData))
+	if !errors.Is(err, hetznerbase.ErrPrivateKeyInUserData) {
+		t.Fatalf("want ErrPrivateKeyInUserData behind gzip, got %v", err)
+	}
+}
+
+// A readback must not fail for a write-path reason. The provider-acceptance
+// ceiling bounds what may be SENT; a node that already booted is past that
+// decision, so applying it here would report a leak-free node as a failure.
+func TestVerifyNoSigningMaterialIgnoresProviderSizeCeiling(t *testing.T) {
+	t.Parallel()
+
+	large := "#cloud-config\nruncmd:\n" + strings.Repeat("  - [echo, padding]\n", 4000)
+	if len(large) <= 32768 {
+		t.Fatalf("fixture must exceed the provider ceiling, got %d bytes", len(large))
+	}
+
+	err := hetznerbase.VerifyNoSigningMaterial(large)
+	if err != nil {
+		t.Fatalf("oversize but clean user-data rejected: %v", err)
+	}
+}
+
+// An empty metadata document means the provider-visible copy was not observed.
+// Reading that as "clean" would make the strongest possible pass out of the
+// weakest possible evidence.
+func TestVerifyNodeUserDataRejectsEmptyDocument(t *testing.T) {
+	t.Parallel()
+
+	run := func(_ context.Context, _ string) ([]byte, error) {
+		return []byte("   \n"), nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if !errors.Is(err, hetznerbase.ErrNodeUserDataUnreadable) {
+		t.Fatalf("want ErrNodeUserDataUnreadable for empty document, got %v", err)
+	}
+}
+
+func TestVerifyNodeUserDataSurfacesFetchFailure(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errFetchFailed
+	run := func(_ context.Context, _ string) ([]byte, error) {
+		return nil, sentinel
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if !errors.Is(err, hetznerbase.ErrNodeUserDataUnreadable) {
+		t.Fatalf("want ErrNodeUserDataUnreadable, got %v", err)
+	}
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("fetch cause not preserved: %v", err)
+	}
+}
+
+func TestVerifyNodeUserDataDetectsLeakOnNode(t *testing.T) {
+	t.Parallel()
+
+	run := func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(leakingUserData), nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if !errors.Is(err, hetznerbase.ErrPrivateKeyInUserData) {
+		t.Fatalf("want ErrPrivateKeyInUserData from node, got %v", err)
+	}
+}
+
+func TestVerifyNodeUserDataAcceptsCleanNode(t *testing.T) {
+	t.Parallel()
+
+	run := func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(cleanUserData), nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if err != nil {
+		t.Fatalf("clean node reported unclean: %v", err)
+	}
+}
+
+// The verifier is only meaningful if it reads the provider's own copy, so the
+// endpoint it queries is pinned rather than left to drift.
+func TestVerifyNodeUserDataQueriesTheMetadataUserDataEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var seen string
+
+	run := func(_ context.Context, command string) ([]byte, error) {
+		seen = command
+
+		return []byte(cleanUserData), nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(seen, "http://169.254.169.254/hetzner/v1/userdata") {
+		t.Fatalf("metadata user-data endpoint not queried, command was %q", seen)
+	}
+}
+
+func TestVerifyNodeUserDataRejectsMissingRunner(t *testing.T) {
+	t.Parallel()
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), nil)
+	if !errors.Is(err, hetznerbase.ErrNodeUserDataUnreadable) {
+		t.Fatalf("want ErrNodeUserDataUnreadable for nil runner, got %v", err)
+	}
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/verify_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/verify_test.go
@@ -252,3 +252,59 @@ func TestVerifyNodeUserDataIgnoresWhitespaceOnlyStderr(t *testing.T) {
 		t.Fatalf("whitespace-only stderr must not be treated as a diagnostic: %v", err)
 	}
 }
+
+// A node may export ALL_PROXY or a lowercase http_proxy, and curl honours those
+// for a link-local address like any other. A proxy answering this request could
+// return clean content and produce a false pass on the one question the function
+// exists to answer -- what the PROVIDER holds -- so the address must be pinned
+// out of proxying rather than assumed to be reached directly.
+func TestVerifyNodeUserDataBypassesProxiesForTheMetadataAddress(t *testing.T) {
+	t.Parallel()
+
+	var seen string
+
+	run := func(_ context.Context, command string) ([]byte, []byte, error) {
+		seen = command
+
+		return []byte(cleanUserData), nil, nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(seen, "--noproxy 169.254.169.254") {
+		t.Fatalf("metadata request does not bypass proxies, command was %q", seen)
+	}
+}
+
+// A gzip stream of nothing is several non-space bytes, so the raw emptiness
+// check passes it through; the document it expands to is empty, which every
+// guard trivially accepts. Emptiness therefore has to be re-judged after
+// decompression or "we could not look" reads as the strongest possible result.
+func TestVerifyNodeUserDataRejectsGzipOfEmptyDocument(t *testing.T) {
+	t.Parallel()
+
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return []byte(gzipOf(t, "")), nil, nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if !errors.Is(err, hetznerbase.ErrNodeUserDataUnreadable) {
+		t.Fatalf("want ErrNodeUserDataUnreadable for a gzip of nothing, got %v", err)
+	}
+}
+
+func TestVerifyNodeUserDataRejectsGzipOfWhitespaceOnlyDocument(t *testing.T) {
+	t.Parallel()
+
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return []byte(gzipOf(t, "  \n\t\n")), nil, nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if !errors.Is(err, hetznerbase.ErrNodeUserDataUnreadable) {
+		t.Fatalf("want ErrNodeUserDataUnreadable for a gzip of whitespace, got %v", err)
+	}
+}

--- a/pkg/svc/provisioner/cluster/internal/hetznerbase/verify_test.go
+++ b/pkg/svc/provisioner/cluster/internal/hetznerbase/verify_test.go
@@ -130,8 +130,8 @@ func TestVerifyNoSigningMaterialIgnoresProviderSizeCeiling(t *testing.T) {
 func TestVerifyNodeUserDataRejectsEmptyDocument(t *testing.T) {
 	t.Parallel()
 
-	run := func(_ context.Context, _ string) ([]byte, error) {
-		return []byte("   \n"), nil
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return []byte("   \n"), nil, nil
 	}
 
 	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
@@ -144,8 +144,8 @@ func TestVerifyNodeUserDataSurfacesFetchFailure(t *testing.T) {
 	t.Parallel()
 
 	sentinel := errFetchFailed
-	run := func(_ context.Context, _ string) ([]byte, error) {
-		return nil, sentinel
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return nil, nil, sentinel
 	}
 
 	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
@@ -161,8 +161,8 @@ func TestVerifyNodeUserDataSurfacesFetchFailure(t *testing.T) {
 func TestVerifyNodeUserDataDetectsLeakOnNode(t *testing.T) {
 	t.Parallel()
 
-	run := func(_ context.Context, _ string) ([]byte, error) {
-		return []byte(leakingUserData), nil
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return []byte(leakingUserData), nil, nil
 	}
 
 	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
@@ -174,8 +174,8 @@ func TestVerifyNodeUserDataDetectsLeakOnNode(t *testing.T) {
 func TestVerifyNodeUserDataAcceptsCleanNode(t *testing.T) {
 	t.Parallel()
 
-	run := func(_ context.Context, _ string) ([]byte, error) {
-		return []byte(cleanUserData), nil
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return []byte(cleanUserData), nil, nil
 	}
 
 	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
@@ -191,10 +191,10 @@ func TestVerifyNodeUserDataQueriesTheMetadataUserDataEndpoint(t *testing.T) {
 
 	var seen string
 
-	run := func(_ context.Context, command string) ([]byte, error) {
+	run := func(_ context.Context, command string) ([]byte, []byte, error) {
 		seen = command
 
-		return []byte(cleanUserData), nil
+		return []byte(cleanUserData), nil, nil
 	}
 
 	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
@@ -213,5 +213,42 @@ func TestVerifyNodeUserDataRejectsMissingRunner(t *testing.T) {
 	err := hetznerbase.VerifyNodeUserData(t.Context(), nil)
 	if !errors.Is(err, hetznerbase.ErrNodeUserDataUnreadable) {
 		t.Fatalf("want ErrNodeUserDataUnreadable for nil runner, got %v", err)
+	}
+}
+
+// A zero exit with a diagnostic on stderr is the case a stdout-only runner
+// cannot express: the document may be truncated, yet nothing in stdout says so.
+// Reporting it clean would turn a partial read into the strongest result the
+// function can return, which is the same failure the empty-document guard
+// refuses. curl runs with --show-error, so this is the shape a real fetch takes
+// when it warns without failing.
+func TestVerifyNodeUserDataRejectsStderrOnZeroExit(t *testing.T) {
+	t.Parallel()
+
+	diagnostic := []byte("curl: (18) transfer closed with outstanding read data")
+
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return []byte(cleanUserData), diagnostic, nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if !errors.Is(err, hetznerbase.ErrNodeUserDataUnreadable) {
+		t.Fatalf("want ErrNodeUserDataUnreadable for stderr on a zero exit, got %v", err)
+	}
+}
+
+// Whitespace-only stderr is not a diagnostic — a runner that always allocates a
+// buffer would otherwise make every node unreadable, which would be a guard that
+// fails closed so hard it can never pass.
+func TestVerifyNodeUserDataIgnoresWhitespaceOnlyStderr(t *testing.T) {
+	t.Parallel()
+
+	run := func(_ context.Context, _ string) ([]byte, []byte, error) {
+		return []byte(cleanUserData), []byte("  \n\t"), nil
+	}
+
+	err := hetznerbase.VerifyNodeUserData(t.Context(), run)
+	if err != nil {
+		t.Fatalf("whitespace-only stderr must not be treated as a diagnostic: %v", err)
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

We can currently prove that KSail does not *put* cluster signing keys into Hetzner's
provider-readable user-data, but nothing can check what a **running** cluster actually carries. The
existing guard only inspects user-data KSail has just built, moments before sending it — so any route
that sets user-data another way is invisible to it, and a live cluster cannot be audited at all.

That gap is the last open acceptance criterion on #6428, and it had no way in: Hetzner's API accepts
user-data on create but never gives it back, so the only provider-visible copy lives on the node.

### What

Makes the leak checks usable against user-data from any source, and adds the node-side read of the
provider's own copy. The security bar is unchanged — the same checks, now also runnable after the
fact rather than only before sending.

One deliberate behaviour worth flagging for review: if the node returns nothing, this reports a
failure rather than a pass. An unobserved node and a verified-clean node otherwise look identical,
and only one of them is evidence.

No change to how clusters are created; nothing is switched on for users by this PR. It gives #6428's
remaining end-to-end proof something to call.

Fixes #6626
Part of #6428
