### PR TITLE
fix(clusterapi): bind EKS capture to create account

### DIFF
--- a/pkg/cli/clusterapi/eks_create_identity_test.go
+++ b/pkg/cli/clusterapi/eks_create_identity_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/clusterapi"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +55,7 @@ type captureRecord struct {
 	pinned          bool
 	awsOptions      v1alpha1.OptionsAWS
 	selectionRegion string
+	accountID       string
 }
 
 // recordCaptureForCreate runs an EKS create whose spec resolves AWS through awsOptions, and returns
@@ -83,12 +85,13 @@ func recordCaptureForCreate(
 	records := make(chan captureRecord, 1)
 
 	service.SetEKSOwnershipCaptureRecorderForTest(
-		func(name string, pinned bool, options v1alpha1.OptionsAWS, region string) {
+		func(name string, pinned bool, options v1alpha1.OptionsAWS, region, accountID string) {
 			records <- captureRecord{
 				name:            name,
 				pinned:          pinned,
 				awsOptions:      options,
 				selectionRegion: region,
+				accountID:       accountID,
 			}
 		},
 	)
@@ -121,6 +124,105 @@ func recordCaptureForCreate(
 	}
 }
 
+func TestCreateEKSResolvesAccountOnceBeforeProvisioning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	events := make(chan string, 4)
+	provisioner := &midCreateProvisioner{
+		fakeProvisioner: &fakeProvisioner{},
+		onCreate:        func() { events <- "create" },
+	}
+	service := clusterapi.NewTestService(func(
+		_ v1alpha1.Distribution,
+		_ string,
+	) (clusterprovisioner.Factory, error) {
+		return midCreateFactory{provisioner: provisioner}, nil
+	})
+	service.SetEKSCreateAccountResolverForTest(func(
+		_ context.Context,
+		_ credentials.AWSResolution,
+	) (string, error) {
+		events <- "resolve-account"
+
+		return "210987654321", nil
+	})
+	service.SetEKSOwnershipCaptureRecorderForTest(func(
+		_ string,
+		_ bool,
+		_ v1alpha1.OptionsAWS,
+		_ string,
+		accountID string,
+	) {
+		events <- "capture:" + accountID
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor("account-pinned-eks", v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		list, listErr := service.List(context.Background())
+		require.NoError(collect, listErr)
+
+		phase, found := phaseOf(list, "account-pinned-eks")
+		require.True(collect, found)
+		require.Equal(collect, v1alpha1.ClusterPhaseReady, phase)
+	}, eventuallyTimeout, eventuallyTick)
+
+	assert.Equal(t, "resolve-account", <-events)
+	assert.Equal(t, "create", <-events)
+	assert.Equal(t, "capture:210987654321", <-events)
+
+	select {
+	case event := <-events:
+		t.Fatalf("account resolution ran more than once: unexpected event %q", event)
+	default:
+	}
+}
+
+func TestCreateEKSStopsBeforeProvisioningWhenAccountResolutionFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	created := make(chan struct{}, 1)
+	provisioner := &midCreateProvisioner{
+		fakeProvisioner: &fakeProvisioner{},
+		onCreate:        func() { created <- struct{}{} },
+	}
+	service := clusterapi.NewTestService(func(
+		_ v1alpha1.Distribution,
+		_ string,
+	) (clusterprovisioner.Factory, error) {
+		return midCreateFactory{provisioner: provisioner}, nil
+	})
+	service.SetEKSCreateAccountResolverForTest(func(
+		context.Context,
+		credentials.AWSResolution,
+	) (string, error) {
+		return "", assert.AnError
+	})
+
+	_, err := service.Create(
+		context.Background(),
+		clusterFor("unresolved-account-eks", v1alpha1.DistributionEKS),
+	)
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		list, listErr := service.List(context.Background())
+		require.NoError(collect, listErr)
+
+		phase, found := phaseOf(list, "unresolved-account-eks")
+		require.True(collect, found)
+		require.Equal(collect, v1alpha1.ClusterPhaseFailed, phase)
+	}, eventuallyTimeout, eventuallyTick)
+
+	select {
+	case <-created:
+		t.Fatal("EKS provisioning started without a resolved create-time AWS account")
+	default:
+	}
+}
+
 // TestCreateEKSCapturesUnderItsOwnCredentialNames is the regression this file exists for.
 //
 // The create provisioner resolves AWS through the cluster spec's own variable names; the capture
@@ -144,6 +246,8 @@ func TestCreateEKSCapturesUnderItsOwnCredentialNames(t *testing.T) {
 
 	require.True(t, got.pinned,
 		"the create supplied no pinned identity, so the capture would resolve AWS independently")
+	require.Equal(t, "123456789012", got.accountID,
+		"the create supplied no pinned account, so profile contents could be repointed mid-create")
 
 	assert.Equal(t, customRegionValue, got.selectionRegion,
 		"the capture resolved through the canonical AWS_* names instead of the spec's own, so it "+

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -315,8 +315,9 @@ func (s *Service) captureEKSOwnership(
 }
 
 // defaultEKSCapture resolves the just-written binding and records the live identity under the exact
-// credential snapshot the create was pinned to. It verifies both the selector and the AWS account:
-// a same-named profile can be rewritten mid-create without changing selector equality.
+// credential snapshot the create was pinned to. It compares the capture-time AWS account with the
+// account resolved at create start and refuses before persistence when they differ, including when a
+// same-named profile's contents are repointed without changing selector equality.
 func (s *Service) defaultEKSCapture(
 	ctx context.Context,
 	name string,

--- a/pkg/cli/clusterapi/eks_ownership.go
+++ b/pkg/cli/clusterapi/eks_ownership.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -32,6 +33,15 @@ var ErrUnguardableFactory = errors.New("provisioner factory cannot carry the EKS
 var ErrEKSOwnershipSelectorChanged = errors.New(
 	"AWS selector changed between EKS create and capture",
 )
+
+// ErrEKSOwnershipAccountChanged reports that the selector still has the same name at capture time,
+// but now resolves to a different AWS account than it did before create began. Profile contents are
+// mutable independently of the profile name, so selector equality alone cannot establish identity.
+var ErrEKSOwnershipAccountChanged = errors.New(
+	"AWS account changed between EKS create and capture",
+)
+
+var errEKSCreateAccountMissing = errors.New("AWS account ID is empty before EKS create")
 
 // defaultEKSOwnershipTimeout bounds the whole ownership resolution: the AWS config load, the STS
 // caller-identity query and the EKS DescribeCluster behind it.
@@ -189,8 +199,9 @@ func applyEKSMutationGuard(
 	return guardable.WithEKSMutationGuard(&guard.resolution, guard.verifier), nil
 }
 
-// eksCreateIdentity is the exact AWS identity an EKS create runs under: one frozen credential
-// snapshot, the region it was frozen for, and the variable names it was resolved through.
+// eksCreateIdentity is the exact AWS identity an EKS create runs under: the credential-selection
+// snapshot and variable names handed to the provisioner, plus the AWS account they resolved to
+// immediately before provisioning began.
 //
 // It exists because the create provisioner and the capture that follows it used to resolve AWS
 // independently. The provisioner resolves from the cluster spec's own variable names
@@ -208,25 +219,75 @@ func applyEKSMutationGuard(
 type eksCreateIdentity struct {
 	selection  credentials.AWSResolution
 	awsOptions v1alpha1.OptionsAWS
+	accountID  string
 }
 
-// newEKSCreateIdentity snapshots the AWS selection a create is about to run under.
-//
-// It resolves through the cluster spec's own variable names — the exact source
-// resolveEKSCredentialOptions uses inside the provisioner — so the capture that follows records
-// under the credentials the create actually used rather than under an independently resolved set.
-//
-// Taking the snapshot BEFORE the create is what closes the timing half of the problem: eksctl runs
-// asynchronously, so an operator changing Settings while it works would otherwise move the values
-// the capture later reads. This is a pure read of the process environment; it deliberately does not
-// freeze, because freezing forces concrete credential retrieval (profile chain, IMDS) and a create
-// is entitled to rely on eksctl resolving its own credentials. The freeze happens at capture time,
-// against this snapshot.
+// eksCreateAccountFunc resolves the AWS account selected by one credential snapshot. The default
+// performs exactly one STS GetCallerIdentity call; the seam keeps local lifecycle tests hermetic.
+type eksCreateAccountFunc func(
+	ctx context.Context,
+	selection credentials.AWSResolution,
+) (string, error)
+
+// newEKSCreateIdentity snapshots the AWS selection a create is about to run under. Account
+// resolution is a separate, fallible step in resolveEKSCreateIdentity so selector-only refusal tests
+// can construct the immutable value without AWS credentials.
 func newEKSCreateIdentity(awsOptions v1alpha1.OptionsAWS) *eksCreateIdentity {
 	return &eksCreateIdentity{
 		selection:  credentials.ResolveAWS(credentials.NewAWSOptionsResolver(awsOptions)),
 		awsOptions: awsOptions,
 	}
+}
+
+// resolveEKSCreateIdentity snapshots the AWS selection and resolves its account before create begins.
+//
+// It resolves through the cluster spec's own variable names — the exact source
+// resolveEKSCredentialOptions uses inside the provisioner — so the capture that follows records
+// under the credentials the create actually used rather than under an independently resolved set.
+//
+// Taking both observations BEFORE the create closes the timing gap for mutable profile contents:
+// selector names alone stay equal when a profile is rewritten to point at another account. The
+// selection remains unfrozen so eksctl keeps its normal credential-chain behavior; the read-only STS
+// lookup records only the account identifier needed to verify capture later.
+func (s *Service) resolveEKSCreateIdentity(
+	ctx context.Context,
+	awsOptions v1alpha1.OptionsAWS,
+) (*eksCreateIdentity, error) {
+	identity := newEKSCreateIdentity(awsOptions)
+
+	ctx, cancel := context.WithTimeout(ctx, s.eksOwnershipTimeout)
+	defer cancel()
+
+	accountID, err := s.resolveEKSCreateAccount(ctx, identity.selection)
+	if err != nil {
+		return nil, fmt.Errorf("resolve AWS account before EKS create: %w", err)
+	}
+
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return nil, errEKSCreateAccountMissing
+	}
+
+	identity.accountID = accountID
+
+	return identity, nil
+}
+
+func (s *Service) defaultEKSCreateAccount(
+	ctx context.Context,
+	selection credentials.AWSResolution,
+) (string, error) {
+	client, err := s.eksIdentityClientFor(ctx, selection.Region, selection)
+	if err != nil {
+		return "", err
+	}
+
+	accountID, err := client.CallerAccountID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get AWS caller account for EKS create: %w", err)
+	}
+
+	return accountID, nil
 }
 
 // eksCaptureFunc records the immutable AWS identity of a just-created EKS cluster, under the
@@ -254,7 +315,8 @@ func (s *Service) captureEKSOwnership(
 }
 
 // defaultEKSCapture resolves the just-written binding and records the live identity under the exact
-// credential snapshot the create was pinned to.
+// credential snapshot the create was pinned to. It verifies both the selector and the AWS account:
+// a same-named profile can be rewritten mid-create without changing selector equality.
 func (s *Service) defaultEKSCapture(
 	ctx context.Context,
 	name string,
@@ -308,7 +370,7 @@ func (s *Service) defaultEKSCapture(
 		return err
 	}
 
-	_, err = eksidentity.Capture(
+	err = captureEKSIdentityForCreate(
 		ctx,
 		client,
 		name,
@@ -317,9 +379,45 @@ func (s *Service) defaultEKSCapture(
 		// resolves the same identity this capture observed. Recording the canonical defaults instead
 		// would misdescribe every cluster whose spec names custom variables.
 		credentials.AWSOptionsWithDefaults(identity.awsOptions),
+		identity.accountID,
 	)
 	if err != nil {
 		return fmt.Errorf("capture immutable EKS ownership identity: %w", err)
+	}
+
+	return nil
+}
+
+// captureEKSIdentityForCreate observes the capture-time account and cluster, refuses an account
+// change before any state write, then persists the validated ownership record. Comparing accounts
+// rather than credential bytes permits normal same-account key rotation.
+func captureEKSIdentityForCreate(
+	ctx context.Context,
+	client eksidentity.Client,
+	name, region string,
+	awsOptions v1alpha1.OptionsAWS,
+	createAccountID string,
+) error {
+	ownership, err := eksidentity.Observe(ctx, client, name, region)
+	if err != nil {
+		return fmt.Errorf("observe EKS identity after create: %w", err)
+	}
+
+	if ownership.AccountID != strings.TrimSpace(createAccountID) {
+		return fmt.Errorf(
+			"%w for %q: create account %q, capture account %q",
+			ErrEKSOwnershipAccountChanged,
+			name,
+			strings.TrimSpace(createAccountID),
+			ownership.AccountID,
+		)
+	}
+
+	ownership.AWSOptions = awsOptions
+
+	err = eksidentity.Persist(name, ownership.Region, ownership)
+	if err != nil {
+		return fmt.Errorf("persist EKS identity after create: %w", err)
 	}
 
 	return nil

--- a/pkg/cli/clusterapi/eks_ownership_default_paths_internal_test.go
+++ b/pkg/cli/clusterapi/eks_ownership_default_paths_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/state"
@@ -37,6 +39,89 @@ func markEKSCreated(t *testing.T, name string) {
 	require.NoError(t, state.SaveClusterSpec(name, &v1alpha1.ClusterSpec{
 		Distribution: v1alpha1.DistributionEKS,
 	}))
+}
+
+type captureIdentityClient struct {
+	accountID string
+	cluster   *ekstypes.Cluster
+}
+
+func (c captureIdentityClient) CallerAccountID(context.Context) (string, error) {
+	return c.accountID, nil
+}
+
+func (c captureIdentityClient) DescribeCluster(context.Context, string) (*ekstypes.Cluster, error) {
+	return c.cluster, nil
+}
+
+func liveEKSCluster(name, region, accountID string) *ekstypes.Cluster {
+	createdAt := time.Date(2026, time.August, 25, 0, 0, 0, 0, time.UTC)
+
+	return &ekstypes.Cluster{
+		Name:      aws.String(name),
+		Arn:       aws.String("arn:aws:eks:" + region + ":" + accountID + ":cluster/" + name),
+		CreatedAt: &createdAt,
+	}
+}
+
+//nolint:paralleltest // isolateHome uses t.Setenv and process-global state paths.
+func TestCaptureEKSIdentityForCreateRefusesDifferentAccountBeforePersisting(t *testing.T) {
+	isolateHome(t)
+
+	const (
+		name           = "repointed-profile"
+		region         = "us-east-1"
+		createAccount  = "123456789012"
+		captureAccount = "210987654321"
+	)
+
+	client := captureIdentityClient{
+		accountID: captureAccount,
+		cluster:   liveEKSCluster(name, region, captureAccount),
+	}
+
+	err := captureEKSIdentityForCreate(
+		t.Context(),
+		client,
+		name,
+		region,
+		recordedAliases(),
+		createAccount,
+	)
+	require.ErrorIs(t, err, ErrEKSOwnershipAccountChanged)
+
+	_, loadErr := state.LoadEKSOwnershipState(name, region)
+	require.Error(t, loadErr, "a mismatched capture account was persisted before refusal")
+}
+
+//nolint:paralleltest // isolateHome uses t.Setenv and process-global state paths.
+func TestCaptureEKSIdentityForCreateAcceptsSameAccountCredentialRotation(t *testing.T) {
+	isolateHome(t)
+
+	const (
+		name      = "same-account-rotation"
+		region    = "us-east-1"
+		accountID = "123456789012"
+	)
+
+	client := captureIdentityClient{
+		accountID: accountID,
+		cluster:   liveEKSCluster(name, region, accountID),
+	}
+
+	err := captureEKSIdentityForCreate(
+		t.Context(),
+		client,
+		name,
+		region,
+		recordedAliases(),
+		accountID,
+	)
+	require.NoError(t, err)
+
+	ownership, loadErr := state.LoadEKSOwnershipState(name, region)
+	require.NoError(t, loadErr)
+	require.Equal(t, accountID, ownership.AccountID)
 }
 
 // TestCaptureRefusesWhenTheCreateWroteNoBinding covers the first refusal in the shipped capture

--- a/pkg/cli/clusterapi/export_test.go
+++ b/pkg/cli/clusterapi/export_test.go
@@ -116,6 +116,12 @@ func NewTestService(factory FactoryFunc) *Service {
 	// Point the kubeconfig at nowhere by default so List's endpoint enrichment never reads the
 	// developer's real kubeconfig; tests that need one inject it via SetKubeconfigPathForTest.
 	service.kubeconfigPath = func() string { return "" }
+	service.resolveEKSCreateAccount = func(
+		context.Context,
+		credentials.AWSResolution,
+	) (string, error) {
+		return "123456789012", nil
+	}
 	// Stub the AWS-touching half of the EKS mutation guard so tests stay hermetic. Tests that are
 	// about the guard itself override it with SetEKSOwnershipGuardForTest.
 	service.captureEKSIdentity = func(context.Context, string, *eksCreateIdentity) error { return nil }
@@ -149,7 +155,13 @@ func (s *Service) SetEKSOwnershipCaptureForTest(
 // test asserting on these is asserting the property that matters — that the capture records under
 // the credentials the create actually ran with, not an independently resolved set.
 func (s *Service) SetEKSOwnershipCaptureRecorderForTest(
-	record func(name string, pinned bool, awsOptions v1alpha1.OptionsAWS, selectionRegion string),
+	record func(
+		name string,
+		pinned bool,
+		awsOptions v1alpha1.OptionsAWS,
+		selectionRegion string,
+		accountID string,
+	),
 ) {
 	s.captureEKSIdentity = func(
 		_ context.Context,
@@ -157,15 +169,23 @@ func (s *Service) SetEKSOwnershipCaptureRecorderForTest(
 		identity *eksCreateIdentity,
 	) error {
 		if identity == nil {
-			record(name, false, v1alpha1.OptionsAWS{}, "")
+			record(name, false, v1alpha1.OptionsAWS{}, "", "")
 
 			return nil
 		}
 
-		record(name, true, identity.awsOptions, identity.selection.Region)
+		record(name, true, identity.awsOptions, identity.selection.Region, identity.accountID)
 
 		return nil
 	}
+}
+
+// SetEKSCreateAccountResolverForTest overrides the read-only STS lookup performed before an EKS
+// create, so tests can assert its ordering and failure behavior without AWS credentials.
+func (s *Service) SetEKSCreateAccountResolverForTest(
+	resolve func(context.Context, credentials.AWSResolution) (string, error),
+) {
+	s.resolveEKSCreateAccount = resolve
 }
 
 // SetEKSOwnershipTimeoutForTest shortens the bound on the ownership resolution's network calls, so a

--- a/pkg/cli/clusterapi/local_service.go
+++ b/pkg/cli/clusterapi/local_service.go
@@ -104,6 +104,10 @@ type Service struct {
 	// so the guard above has something to verify against. Injectable alongside resolveEKSGuard.
 	captureEKSIdentity eksCaptureFunc
 
+	// resolveEKSCreateAccount performs the one read-only STS lookup that pins an EKS create to the
+	// AWS account selected before provisioning begins. Injectable so tests stay credential-free.
+	resolveEKSCreateAccount eksCreateAccountFunc
+
 	// discoverer enumerates existing clusters across providers for List/Get; discoverProviders is
 	// the set it queries. NewService queries every provider the machine can reach so cloud clusters
 	// (Hetzner/Omni/EKS) are visible, not just local Docker ones.
@@ -185,6 +189,7 @@ func NewService() *Service {
 	service.resolveEKSGuard = service.defaultEKSGuard
 	service.eksOwnershipTimeout = defaultEKSOwnershipTimeout
 	service.captureEKSIdentity = service.defaultEKSCapture
+	service.resolveEKSCreateAccount = service.defaultEKSCreateAccount
 	service.useDefaultClients()
 
 	return service
@@ -906,20 +911,26 @@ func (s *Service) runCreate(ctx context.Context, name string, spec v1alpha1.Spec
 	// the credentials this create ran with. Re-resolving it after an asynchronous create — from a
 	// different source, and after Settings may have moved — is what let a create in one account be
 	// recorded as a same-named cluster in another.
-	var identity *eksCreateIdentity
+	var (
+		identity *eksCreateIdentity
+		err      error
+	)
 
 	if isEKS {
-		identity = newEKSCreateIdentity(spec.Provider.AWS)
+		identity, err = s.resolveEKSCreateIdentity(ctx, spec.Provider.AWS)
 	}
 
-	err := s.runProvisioner(
-		ctx,
-		name,
-		spec,
-		func(actionCtx context.Context, p clusterprovisioner.Provisioner) error {
-			return p.Create(actionCtx, name)
-		},
-	)
+	if err == nil {
+		err = s.runProvisioner(
+			ctx,
+			name,
+			spec,
+			func(actionCtx context.Context, p clusterprovisioner.Provisioner) error {
+				return p.Create(actionCtx, name)
+			},
+		)
+	}
+
 	if err == nil && isEKS {
 		err = state.SaveClusterSpec(name, &spec.Cluster)
 		if err != nil {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- resolve the selected AWS account once before EKS provisioning starts
- carry that account through create and refuse capture-time account drift before any state write
- preserve same-account credential rotation while closing same-named profile repoints

## Validation

- focused RED: missing account pin and capture-account refusal failed before implementation
- focused GREEN: account ordering, fail-closed resolution, mismatch refusal, and rotation acceptance
- `go test ./pkg/cli/clusterapi`
- `go test -p 1 ./...`
- `golangci-lint run --default=none --enable err113 --enable funlen --enable paralleltest --enable wrapcheck ./pkg/cli/clusterapi`
- `go build -o /private/tmp/ksail-binary-01a035d3 .`

Fixes #6617
