### PR TITLE
fix(talos): cap Hetzner default Kubernetes version

### DIFF
--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -91,6 +91,10 @@ func DefaultHetznerFallbackLocations() []string {
 
 // Talos default values — canonical source for OptionsTalos struct tag defaults.
 const (
+	// DefaultHetznerTalosVersion is the Talos release provided by
+	// DefaultTalosISO. Config generation uses this version as a bootstrap
+	// compatibility ceiling when the default ISO is selected.
+	DefaultHetznerTalosVersion = "v1.12.4"
 	// DefaultTalosISO is the default Hetzner ISO/image ID for booting Talos
 	// Linux 1.12.4 x86 (matches `default:"125127"` struct tag). The prior default
 	// (122630, Talos 1.11.2) was deprecated and removed from Hetzner on 2026-03-18.

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -317,10 +317,7 @@ func (m *ConfigManager) removeWorkerRoleLabelPatch(patchesDir string) {
 // existing cluster the provisioner further prefers the running version when unpinned,
 // so an unrelated update never forces a Kubernetes upgrade.
 func (m *ConfigManager) resolveTalosKubernetesVersion() string {
-	version := talosconfigmanager.ResolveKubernetesVersion(
-		m.Config.Spec.Cluster.Talos.Version,
-		m.Config.Spec.Cluster.KubernetesVersion,
-	)
+	version := talosconfigmanager.ResolveClusterKubernetesVersion(m.Config)
 	warnKubernetesVersionCapped(m.Config, version, m.Writer)
 
 	return version

--- a/pkg/fsutil/configmanager/ksail/distribution.go
+++ b/pkg/fsutil/configmanager/ksail/distribution.go
@@ -333,7 +333,8 @@ func warnKubernetesVersionCapped(cfg *v1alpha1.Cluster, resolvedVersion string, 
 		return
 	}
 
-	if strings.TrimSpace(cfg.Spec.Cluster.Talos.Version) == "" {
+	talosVersion := talosconfigmanager.ResolveClusterTalosCompatibilityVersion(cfg)
+	if strings.TrimSpace(talosVersion) == "" {
 		return
 	}
 
@@ -344,11 +345,11 @@ func warnKubernetesVersionCapped(cfg *v1alpha1.Cluster, resolvedVersion string, 
 	notify.WriteMessage(notify.Message{
 		Type: notify.WarningType,
 		Content: fmt.Sprintf(
-			"Kubernetes %s is too new for the pinned Talos version %s; "+
+			"Kubernetes %s is too new for Talos compatibility version %s; "+
 				"defaulting to compatible Kubernetes %s. "+
 				"Set spec.cluster.kubernetesVersion to choose a different version.",
 			talosconfigmanager.DefaultKubernetesVersion,
-			cfg.Spec.Cluster.Talos.Version,
+			talosVersion,
 			resolvedVersion,
 		),
 		Writer: out,

--- a/pkg/fsutil/configmanager/ksail/talos_kubernetes_version_test.go
+++ b/pkg/fsutil/configmanager/ksail/talos_kubernetes_version_test.go
@@ -15,6 +15,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestLoadConfig_TalosUnpinnedHetznerUsesCompatibleKubernetesVersion guards the
+// project-init path where neither Talos nor Kubernetes is explicitly pinned.
+// Hetzner boots the built-in Talos 1.12 ISO, so the generated machine config
+// must stay within that release's Kubernetes support window.
+//
+//nolint:paralleltest // Uses t.Chdir to isolate filesystem state for config loading.
+func TestLoadConfig_TalosUnpinnedHetznerUsesCompatibleKubernetesVersion(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	ksailConfig := "apiVersion: ksail.io/v1alpha1\n" +
+		"kind: Cluster\n" +
+		"spec:\n" +
+		"  cluster:\n" +
+		"    distribution: Talos\n" +
+		"    provider: Hetzner\n" +
+		"    cni: Cilium\n"
+	require.NoError(t, os.WriteFile("ksail.yaml", []byte(ksailConfig), 0o600))
+
+	manager := configmanager.NewConfigManager(io.Discard, "")
+	manager.Viper.SetConfigFile("ksail.yaml")
+
+	_, err := manager.Load(configmanagerinterface.LoadOptions{})
+	require.NoError(t, err)
+
+	require.NotNil(t, manager.DistributionConfig)
+	require.NotNil(t, manager.DistributionConfig.Talos)
+	assert.Equal(t, "1.35.0", manager.DistributionConfig.Talos.KubernetesVersion())
+}
+
 // TestLoadConfig_TalosFallbackCapsKubernetesVersion guards the regression where the
 // no-scaffolded-talos-dir fallback in cacheTalosConfig ignored the resolved version:
 // with an older Talos version pinned and no talos/ patches dir, the default config

--- a/pkg/fsutil/configmanager/ksail/talos_kubernetes_version_test.go
+++ b/pkg/fsutil/configmanager/ksail/talos_kubernetes_version_test.go
@@ -169,9 +169,24 @@ func TestWarnKubernetesVersionCapped_WarnsWhenDefaultCapped(t *testing.T) {
 	// Resolved version differs from the built-in default => the default was capped.
 	configmanager.WarnKubernetesVersionCappedForTest(cfg, "1.35.0", &out)
 
-	assert.Contains(t, out.String(), "too new for the pinned Talos version v1.12.4")
+	assert.Contains(t, out.String(), "too new for Talos compatibility version v1.12.4")
 	assert.Contains(t, out.String(), "1.35.0")
 	assert.Contains(t, out.String(), "spec.cluster.kubernetesVersion")
+}
+
+func TestWarnKubernetesVersionCapped_ReportsDefaultHetznerISOConstraint(t *testing.T) {
+	t.Parallel()
+
+	cfg := v1alpha1.NewCluster()
+	cfg.Spec.Cluster.Distribution = v1alpha1.DistributionTalos
+	cfg.Spec.Cluster.Provider = v1alpha1.ProviderHetzner
+	cfg.Spec.Cluster.Talos.Version = "v1.13.2"
+
+	var out bytes.Buffer
+	configmanager.WarnKubernetesVersionCappedForTest(cfg, "1.35.0", &out)
+
+	assert.Contains(t, out.String(), v1alpha1.DefaultHetznerTalosVersion)
+	assert.NotContains(t, out.String(), cfg.Spec.Cluster.Talos.Version)
 }
 
 func TestWarnKubernetesVersionCapped_SilentWhenExplicitlyPinned(t *testing.T) {

--- a/pkg/fsutil/configmanager/talos/version.go
+++ b/pkg/fsutil/configmanager/talos/version.go
@@ -18,6 +18,17 @@ import (
 // valid for that maintenance environment even when the installed Talos target
 // is newer.
 func ResolveClusterKubernetesVersion(cluster *v1alpha1.Cluster) string {
+	return ResolveKubernetesVersion(
+		ResolveClusterTalosCompatibilityVersion(cluster),
+		cluster.Spec.Cluster.KubernetesVersion,
+	)
+}
+
+// ResolveClusterTalosCompatibilityVersion returns the Talos version that
+// constrains generated Kubernetes configuration. For Hetzner's default ISO,
+// this is the older of the requested Talos target and the bootstrap ISO's Talos
+// release. Other providers and custom Hetzner ISOs retain the requested target.
+func ResolveClusterTalosCompatibilityVersion(cluster *v1alpha1.Cluster) string {
 	talosVersion := cluster.Spec.Cluster.Talos.Version
 
 	if cluster.Spec.Cluster.Provider == v1alpha1.ProviderHetzner &&
@@ -29,10 +40,7 @@ func ResolveClusterKubernetesVersion(cluster *v1alpha1.Cluster) string {
 		)
 	}
 
-	return ResolveKubernetesVersion(
-		talosVersion,
-		cluster.Spec.Cluster.KubernetesVersion,
-	)
+	return talosVersion
 }
 
 // olderTalosVersion returns the older of two Talos versions. An empty primary

--- a/pkg/fsutil/configmanager/talos/version.go
+++ b/pkg/fsutil/configmanager/talos/version.go
@@ -5,10 +5,58 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
 )
+
+// ResolveClusterKubernetesVersion determines the Kubernetes version for a
+// cluster while accounting for provider-specific Talos bootstrap constraints.
+// Hetzner's default ISO boots Talos 1.12.4, so generated configuration must be
+// valid for that maintenance environment even when the installed Talos target
+// is newer.
+func ResolveClusterKubernetesVersion(cluster *v1alpha1.Cluster) string {
+	talosVersion := cluster.Spec.Cluster.Talos.Version
+
+	if cluster.Spec.Cluster.Provider == v1alpha1.ProviderHetzner &&
+		(cluster.Spec.Cluster.Talos.ISO == 0 ||
+			cluster.Spec.Cluster.Talos.ISO == v1alpha1.DefaultTalosISO) {
+		talosVersion = olderTalosVersion(
+			talosVersion,
+			v1alpha1.DefaultHetznerTalosVersion,
+		)
+	}
+
+	return ResolveKubernetesVersion(
+		talosVersion,
+		cluster.Spec.Cluster.KubernetesVersion,
+	)
+}
+
+// olderTalosVersion returns the older of two Talos versions. An empty primary
+// version means the fallback is the only known compatibility constraint. An
+// invalid primary is preserved so the existing version-contract validation can
+// report it to the user.
+func olderTalosVersion(primary, fallback string) string {
+	primary = strings.TrimSpace(primary)
+	if primary == "" {
+		return fallback
+	}
+
+	primaryVersion, err := semver.NewVersion(strings.TrimPrefix(primary, "v"))
+	if err != nil {
+		return primary
+	}
+
+	fallbackVersion, err := semver.NewVersion(strings.TrimPrefix(fallback, "v"))
+	if err != nil || primaryVersion.LessThan(fallbackVersion) {
+		return primary
+	}
+
+	return fallback
+}
 
 // normalizeKubernetesVersion trims surrounding whitespace and any leading "v" so
 // the value matches the form the Talos bundle expects for KubeVersion ("1.32.0",

--- a/pkg/operator/provisioner.go
+++ b/pkg/operator/provisioner.go
@@ -128,10 +128,7 @@ func buildDistributionConfig(
 		// Honor the Kubernetes version pin / cap the default to the pinned Talos
 		// version, matching the CLI so the operator never deploys an incompatible
 		// Kubernetes version.
-		kubernetesVersion := talosconfigmanager.ResolveKubernetesVersion(
-			cluster.Spec.Cluster.Talos.Version,
-			cluster.Spec.Cluster.KubernetesVersion,
-		)
+		kubernetesVersion := talosconfigmanager.ResolveClusterKubernetesVersion(cluster)
 
 		talosConfig, err := newTalosConfig(
 			name,

--- a/pkg/operator/provisioner_test.go
+++ b/pkg/operator/provisioner_test.go
@@ -53,18 +53,17 @@ func TestBuildDistributionConfig_Vanilla(t *testing.T) {
 	assert.Equal(t, "c1", config.Kind.Name)
 }
 
-func TestBuildDistributionConfig_TalosCapsKubernetesVersion(t *testing.T) {
+func TestBuildDistributionConfig_TalosHetznerDefaultsToCompatibleKubernetesVersion(t *testing.T) {
 	t.Parallel()
 
-	// Talos 1.12 supports Kubernetes <= 1.35, so the built-in default must be capped.
 	cluster := clusterWithDistribution("c1", v1alpha1.DistributionTalos)
-	cluster.Spec.Cluster.Talos.Version = "v1.12.4"
+	cluster.Spec.Cluster.Provider = v1alpha1.ProviderHetzner
 
 	config, err := operator.BuildDistributionConfig(cluster)
 	require.NoError(t, err)
 	require.NotNil(t, config.Talos)
 	assert.Equal(t, "1.35.0", config.Talos.KubernetesVersion(),
-		"operator must cap the default Kubernetes version to the pinned Talos version")
+		"operator must stay compatible with the default Hetzner Talos ISO")
 }
 
 func TestBuildDistributionConfig_TalosHonorsKubernetesVersionPin(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/builddistconfig_test.go
+++ b/pkg/svc/provisioner/cluster/builddistconfig_test.go
@@ -73,6 +73,18 @@ func TestBuildDistributionConfigTalosHonorsVersionPin(t *testing.T) {
 	assert.Equal(t, buildClusterName, config.Talos.Name, "the bundle is named after the cluster")
 }
 
+func TestBuildDistributionConfigTalosHetznerDefaultsToCompatibleKubernetesVersion(t *testing.T) {
+	t.Parallel()
+
+	cluster := clusterWith(v1alpha1.DistributionTalos)
+	cluster.Spec.Cluster.Provider = v1alpha1.ProviderHetzner
+
+	config, err := clusterprovisioner.BuildDistributionConfig(cluster, buildClusterName, false)
+	require.NoError(t, err)
+	require.NotNil(t, config.Talos)
+	assert.Equal(t, "1.35.0", config.Talos.KubernetesVersion())
+}
+
 // TestBuildDistributionConfigTalosUsesPinnedVersionContract verifies the shared
 // web/local builder emits Talos 1.14's multi-document configuration shape.
 func TestBuildDistributionConfigTalosUsesPinnedVersionContract(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/distconfig.go
+++ b/pkg/svc/provisioner/cluster/distconfig.go
@@ -112,10 +112,7 @@ func newTalosDistributionConfig(
 	cluster *v1alpha1.Cluster,
 	name string,
 ) (*DistributionConfig, error) {
-	kubernetesVersion := talosconfigmanager.ResolveKubernetesVersion(
-		cluster.Spec.Cluster.Talos.Version,
-		cluster.Spec.Cluster.KubernetesVersion,
-	)
+	kubernetesVersion := talosconfigmanager.ResolveClusterKubernetesVersion(cluster)
 
 	versionContract, err := talosconfigmanager.ParseVersionContract(
 		cluster.Spec.Cluster.Talos.Version,


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Root cause

`ksail project init` leaves Talos and Kubernetes versions unpinned. The Talos config resolver therefore selected KSail's global Kubernetes 1.36.0 default, even though Hetzner's default ISO boots Talos 1.12.4, which supports Kubernetes only through 1.35. The incompatibility was discovered only when Talos rejected the generated machine configuration during node apply.

## Fix

- Treat the Talos version supplied by Hetzner's default ISO as a bootstrap compatibility ceiling.
- Use the older constraint when a user explicitly targets an older Talos release.
- Preserve explicit Kubernetes pins and custom Hetzner ISO behavior.
- Route CLI config loading, local/web provisioning, and operator provisioning through the same resolver.

## Validation

- RED: the unpinned Talos + Hetzner config-loader regression expected `1.35.0` and received `1.36.0` before the implementation.
- GREEN: the regression passes and resolves `1.35.0` after the implementation.
- All tests pass in the four affected packages: Talos config management, KSail config loading, operator provisioning, and cluster provisioning.
- `go mod tidy -diff` is clean.
- Dependency-policy lint reports `0 issues` for every affected package.
- The repository-wide local test run passed every package except two unrelated `open web` tests that fail identically on untouched `main` in this sandbox; hosted required checks remain authoritative.

Fixes #6680
