### PR TITLE
fix(ci): treat an already-deleted workflow run as cleanup success

### DIFF
--- a/.github/fixtures/workflow-run-cleanup/fake-bin/gh
+++ b/.github/fixtures/workflow-run-cleanup/fake-bin/gh
@@ -37,6 +37,13 @@ case "$*" in
 		printf 'fixture deletion failure\n' >&2
 		exit 42
 	fi
+	if [[ "${scenario}" == already-deleted ]]; then
+		# Mirrors real gh when the run vanished between listing and deletion:
+		# the same 404 body on stdout and the same marker on stderr.
+		printf '%s' '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/actions/workflow-runs#delete-a-workflow-run","status":"404"}'
+		printf 'gh: Not Found (HTTP 404)\n' >&2
+		exit 1
+	fi
 	printf '1005\n' >>"${state_dir}/deleted"
 	;;
 *"api --method DELETE repos/devantler-tech/ksail/actions/runs/1006"*)

--- a/.github/fixtures/workflow-run-cleanup/fake-bin/gh
+++ b/.github/fixtures/workflow-run-cleanup/fake-bin/gh
@@ -38,10 +38,26 @@ case "$*" in
 		exit 42
 	fi
 	if [[ "${scenario}" == already-deleted ]]; then
-		# Mirrors real gh when the run vanished between listing and deletion:
-		# the same 404 body on stdout and the same marker on stderr.
+		# Mirrors real `gh api --include` when the run vanished between listing
+		# and deletion: the response status line and headers on stdout ahead of
+		# the 404 body, and the human-readable marker on stderr.
+		printf 'HTTP/2.0 404 Not Found\n'
+		printf 'Content-Type: application/json; charset=utf-8\n'
+		printf '\n'
 		printf '%s' '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/actions/workflow-runs#delete-a-workflow-run","status":"404"}'
 		printf 'gh: Not Found (HTTP 404)\n' >&2
+		exit 1
+	fi
+	if [[ "${scenario}" == misleading-body ]]; then
+		# A genuine NON-404 failure whose response body happens to contain the
+		# text "(HTTP 404)". Matching that string anywhere in the combined
+		# output would misread this as an absent run; only the status line
+		# distinguishes it.
+		printf 'HTTP/2.0 500 Internal Server Error\n'
+		printf 'Content-Type: application/json; charset=utf-8\n'
+		printf '\n'
+		printf '%s' '{"message":"upstream said (HTTP 404) while proxying","status":"500"}'
+		printf 'gh: Internal Server Error (HTTP 500)\n' >&2
 		exit 1
 	fi
 	printf '1005\n' >>"${state_dir}/deleted"

--- a/.github/scripts/delete-old-workflow-runs.sh
+++ b/.github/scripts/delete-old-workflow-runs.sh
@@ -166,15 +166,22 @@ for workflow_id in "${workflow_ids[@]}"; do
 
 		((deletion_attempts += 1))
 		if delete_output="$(
-			gh api --method DELETE "repos/${repository}/actions/runs/${run_id}" 2>&1
+			gh api --method DELETE "repos/${repository}/actions/runs/${run_id}" \
+				--include 2>&1
 		)"; then
 			((deletions += 1))
 			printf 'Deleted workflow run %s (%s)\n' "${run_id}" "${workflow_id}"
-		elif [[ "${delete_output}" == *"(HTTP 404)"* ]]; then
+		elif grep -qE '^HTTP/[0-9.]+ 404( |$)' <<<"${delete_output}"; then
 			# The run vanished between the listing above and this delete — a
 			# concurrent cleanup pass or GitHub's own retention got there first.
 			# The run is gone, which is the outcome this script wanted, so it is
 			# not a failed attempt. Reported so the batch stays auditable.
+			#
+			# Classified on the response status line that --include puts on
+			# stdout, anchored to the start of a line. A failure's response BODY
+			# can itself contain the text "(HTTP 404)", so matching that string
+			# anywhere in the combined output would count a genuine failure as an
+			# absent run and let the batch exit 0 with the run still present.
 			((already_absent += 1))
 			printf 'Already absent: workflow run %s (%s)\n' "${run_id}" "${workflow_id}"
 		else

--- a/.github/scripts/delete-old-workflow-runs.sh
+++ b/.github/scripts/delete-old-workflow-runs.sh
@@ -125,6 +125,7 @@ done <<<"${workflow_output}"
 deletion_attempts=0
 deletion_failures=0
 deletions=0
+already_absent=0
 for workflow_id in "${workflow_ids[@]}"; do
 	keep_output="$(
 		gh api --method GET "repos/${repository}/actions/workflows/${workflow_id}/runs" \
@@ -164,13 +165,22 @@ for workflow_id in "${workflow_ids[@]}"; do
 		fi
 
 		((deletion_attempts += 1))
-		if gh api --method DELETE "repos/${repository}/actions/runs/${run_id}"; then
+		if delete_output="$(
+			gh api --method DELETE "repos/${repository}/actions/runs/${run_id}" 2>&1
+		)"; then
 			((deletions += 1))
 			printf 'Deleted workflow run %s (%s)\n' "${run_id}" "${workflow_id}"
+		elif [[ "${delete_output}" == *"(HTTP 404)"* ]]; then
+			# The run vanished between the listing above and this delete — a
+			# concurrent cleanup pass or GitHub's own retention got there first.
+			# The run is gone, which is the outcome this script wanted, so it is
+			# not a failed attempt. Reported so the batch stays auditable.
+			((already_absent += 1))
+			printf 'Already absent: workflow run %s (%s)\n' "${run_id}" "${workflow_id}"
 		else
 			((deletion_failures += 1))
-			printf 'ERROR: failed to delete workflow run %s (%s)\n' \
-				"${run_id}" "${workflow_id}" >&2
+			printf 'ERROR: failed to delete workflow run %s (%s): %s\n' \
+				"${run_id}" "${workflow_id}" "${delete_output}" >&2
 		fi
 
 		if ((deletion_attempts == max_deletions)); then
@@ -186,4 +196,5 @@ if ((deletion_failures > 0)); then
 	exit 1
 fi
 
-printf 'Cleanup complete: %s workflow run(s) deleted\n' "${deletions}"
+printf 'Cleanup complete: %s workflow run(s) deleted, %s already absent\n' \
+	"${deletions}" "${already_absent}"

--- a/.github/scripts/delete-old-workflow-runs.test.sh
+++ b/.github/scripts/delete-old-workflow-runs.test.sh
@@ -69,3 +69,32 @@ grep -Fq 'ERROR: failed to delete workflow run 1005 (101)' "${tmp_dir}/delete-fa
 grep -Fq 'Deletion limit reached: 2' "${tmp_dir}/delete-failure-output"
 grep -Fq 'Cleanup completed with 1 failed deletion attempt(s)' "${tmp_dir}/delete-failure-output"
 printf 'PASS: cleanup continues its bounded batch and reports deletion failures\n'
+
+# A run can disappear between the listing and the deletion — a concurrent
+# cleanup pass or GitHub's own retention removes it first. The delete then
+# 404s, but the run is gone, which is exactly what this script wanted, so it
+# must not be reported as a failed deletion attempt.
+already_deleted_state="${tmp_dir}/already-deleted"
+mkdir -p "${already_deleted_state}"
+if ! PATH="${fake_bin}:${PATH}" \
+	GH_TOKEN=fixture \
+	FAKE_GH_SCENARIO=already-deleted \
+	FAKE_GH_STATE_DIR="${already_deleted_state}" \
+	KSAIL_MAINTENANCE_CUTOFF_DATE=2026-07-02 \
+	"${cleanup}" \
+	--repository devantler-tech/ksail \
+	--retain-days 30 \
+	--keep-minimum-runs 2 \
+	--max-deletions 2 >"${tmp_dir}/already-deleted-output" 2>&1; then
+	printf 'FAIL: cleanup treated an already-deleted run as a failure\n' >&2
+	cat "${tmp_dir}/already-deleted-output" >&2
+	exit 1
+fi
+printf '1006\n' >"${tmp_dir}/expected-already-deleted-deletions"
+diff -u "${tmp_dir}/expected-already-deleted-deletions" "${already_deleted_state}/deleted"
+grep -Fq 'Already absent: workflow run 1005 (101)' "${tmp_dir}/already-deleted-output"
+if grep -Fq 'failed deletion attempt(s)' "${tmp_dir}/already-deleted-output"; then
+	printf 'FAIL: cleanup counted an already-absent run as a failed deletion\n' >&2
+	exit 1
+fi
+printf 'PASS: cleanup treats an already-deleted run as success\n'

--- a/.github/scripts/delete-old-workflow-runs.test.sh
+++ b/.github/scripts/delete-old-workflow-runs.test.sh
@@ -97,4 +97,34 @@ if grep -Fq 'failed deletion attempt(s)' "${tmp_dir}/already-deleted-output"; th
 	printf 'FAIL: cleanup counted an already-absent run as a failed deletion\n' >&2
 	exit 1
 fi
+grep -Fq 'Cleanup complete: 1 workflow run(s) deleted, 1 already absent' \
+	"${tmp_dir}/already-deleted-output"
 printf 'PASS: cleanup treats an already-deleted run as success\n'
+
+# Only the response STATUS LINE may classify a run as already absent. A genuine
+# non-404 failure whose response body happens to contain the text "(HTTP 404)"
+# must still fail the batch — otherwise cleanup exits 0 while the run it failed
+# to delete is still there.
+misleading_state="${tmp_dir}/misleading-body"
+mkdir -p "${misleading_state}"
+if PATH="${fake_bin}:${PATH}" \
+	GH_TOKEN=fixture \
+	FAKE_GH_SCENARIO=misleading-body \
+	FAKE_GH_STATE_DIR="${misleading_state}" \
+	KSAIL_MAINTENANCE_CUTOFF_DATE=2026-07-02 \
+	"${cleanup}" \
+	--repository devantler-tech/ksail \
+	--retain-days 30 \
+	--keep-minimum-runs 2 \
+	--max-deletions 2 >"${tmp_dir}/misleading-body-output" 2>&1; then
+	printf 'FAIL: cleanup accepted a non-404 failure as an already-absent run\n' >&2
+	cat "${tmp_dir}/misleading-body-output" >&2
+	exit 1
+fi
+if grep -Fq 'Already absent: workflow run 1005 (101)' "${tmp_dir}/misleading-body-output"; then
+	printf 'FAIL: a non-404 body containing "(HTTP 404)" was read as already absent\n' >&2
+	exit 1
+fi
+grep -Fq 'ERROR: failed to delete workflow run 1005 (101)' "${tmp_dir}/misleading-body-output"
+grep -Fq 'Cleanup completed with 1 failed deletion attempt(s)' "${tmp_dir}/misleading-body-output"
+printf 'PASS: a non-404 failure mentioning "(HTTP 404)" still fails the batch\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The nightly `Maintenance` workflow went red on `main` — the first failure after 26 consecutive successes. It deleted 20 old workflow runs successfully and then failed the whole job because one run returned `404 Not Found`.

That run had already been deleted. A run disappearing between the listing and the delete is a benign race — a concurrent pass or GitHub's own retention gets there first — and the run being gone is exactly the outcome the cleanup wanted. Counting it as a failure meant routine housekeeping could red the default branch at any time, for nothing.

### What

Only a non-404 failure now counts as a failed deletion. Already-absent runs are reported per run and included in the summary line, so the batch stays auditable rather than silently ignoring them. A genuine deletion failure still fails the job exactly as before.


Fixes #6683
