### PR TITLE
ci: check published installer URL

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -20,10 +20,6 @@ https://kubernetes.default.svc/
 # GoReleaser template URL (not a real URL)
 https://github.com/devantler-tech/ksail/releases/download/
 
-# Release bootstrap: this URL becomes valid when the first installer-bearing
-# release is published. Remove this exact exception after that release exists.
-https://github.com/devantler-tech/ksail/releases/latest/download/install.sh
-
 # pkg.go.dev may lag behind newly published major versions (returns 404 until indexed)
 https://pkg.go.dev/github.com/devantler-tech/ksail/
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

PR #6709 temporarily excluded the future `releases/latest/download/install.sh`
URL from Lychee because no release contained that asset yet. Release v7.180.7
is now public and installer-bearing, so retaining the exception would hide a
real regression in the documented Quick Install path.

## Change

Remove only the installer bootstrap comment and URL exception. Lychee will now
check the public latest-release installer like every other maintained link.

## Verification

- `https://github.com/devantler-tech/ksail/releases/latest/download/install.sh`
  resolves publicly with HTTP 200
- executing that public installer in an isolated temporary directory installed
  KSail v7.180.7
- the installed binary reported build SHA
  `cb0d750c53f15ae6b69aa64f60a839b5afdccd5c`
- `git diff --check`
- exact commit `d6fb75f38423ce430cbaebac1b5e379a8c40f98b` is PGP verified by GitHub

Follow-up to #6709.
