### PR TITLE
fix(ci): add weekly k3k Calico sentinel

### DIFF
--- a/.github/workflows/system-test-k3k-calico.yaml
+++ b/.github/workflows/system-test-k3k-calico.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 120
     permissions:
       contents: read
-      packages: write
+      packages: read
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,11 +37,13 @@ jobs:
           docker-prune: "true"
 
       - name: 🔐 Login to Docker Hub
-        if: ${{ vars.DOCKERHUB_USERNAME != '' }}
+        if: ${{ github.event_name != 'pull_request' && vars.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }} # zizmor: ignore[secrets-outside-env] - third-party action input, no environment scoping available
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: ⚙️ Setup Go
         id: setup-go
@@ -77,9 +79,9 @@ jobs:
           kubernetes-provider-distributions: K3s
           kubernetes-provider-cni: Calico
           ghcr-user: ${{ github.actor }}
-          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          ghcr-token: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}
           dockerhub-user: ${{ vars.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          dockerhub-token: ${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN || '' }}
           upload-artifacts: "false"
           cleanup: "false"
 

--- a/.github/workflows/system-test-k3k-calico.yaml
+++ b/.github/workflows/system-test-k3k-calico.yaml
@@ -1,6 +1,9 @@
 name: 🧪 System Test - k3k + Calico Sentinel
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/system-test-k3k-calico.yaml"
   workflow_dispatch:
   schedule:
     # This third-party compatibility path can regress without a repository diff.

--- a/.github/workflows/system-test-k3k-calico.yaml
+++ b/.github/workflows/system-test-k3k-calico.yaml
@@ -1,0 +1,111 @@
+name: 🧪 System Test - k3k + Calico Sentinel
+
+on:
+  workflow_dispatch:
+  schedule:
+    # This third-party compatibility path can regress without a repository diff.
+    # Run one bounded sentinel weekly on the default branch instead of the full matrix.
+    - cron: "30 2 * * 1"
+
+concurrency:
+  group: "system-test-k3k-calico-${{ github.ref }}"
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  k3k-calico-sentinel:
+    name: 🧪 k3k + Calico Sentinel
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: 🧹 Free disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          docker-prune: "true"
+
+      - name: 🔐 Login to Docker Hub
+        if: ${{ vars.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }} # zizmor: ignore[secrets-outside-env] - third-party action input, no environment scoping available
+
+      - name: ⚙️ Setup Go
+        id: setup-go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: 📦 Cache KSail Binary
+        uses: ./.github/actions/cache-ksail-binary
+        with:
+          go-version: ${{ steps.setup-go.outputs.go-version }}
+          source-hash: ${{ hashFiles('go.mod', 'go.sum', '**/*.go') }}
+          output-path: /usr/local/bin/ksail
+          save: "false"
+
+      - name: 📥 Restore Helm Cache
+        uses: ./.github/actions/restore-helm-cache
+
+      - name: 📥 Restore Mirror Cache
+        uses: ./.github/actions/restore-mirror-cache
+
+      - name: 🧪 Run k3k + Calico Sentinel
+        id: system-test
+        uses: ./.github/actions/ksail-system-test
+        with:
+          distribution: Vanilla
+          provider: Docker
+          init: "true"
+          args: "--name k3k-calico-host"
+          apply-overlay-path: ".github/fixtures/podinfo-overlay"
+          test-kubernetes-provider: "true"
+          kubernetes-provider-distributions: K3s
+          kubernetes-provider-cni: Calico
+          ghcr-user: ${{ github.actor }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub-user: ${{ vars.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          upload-artifacts: "false"
+          cleanup: "false"
+
+      - name: 📤 Upload system test diagnostics
+        if: ${{ failure() && steps.system-test.outcome == 'failure' }}
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: k3k-calico-system-test-diagnostics
+          path: /tmp/system-test-diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: 🧪 Cleanup KSail System Test
+        if: ${{ always() && steps.system-test.outcome != 'skipped' && steps.system-test.outcome != '' }}
+        uses: ./.github/actions/ksail-system-test-cleanup
+        with:
+          distribution: Vanilla
+          provider: Docker
+          args: "--name k3k-calico-host"
+
+      - name: 📤 Upload system test logs
+        if: ${{ always() && steps.system-test.outcome != 'skipped' && steps.system-test.outcome != '' }}
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: k3k-calico-system-test-logs
+          path: /tmp/ksail-system-test-logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/system-test-k3k-calico.yaml
+++ b/.github/workflows/system-test-k3k-calico.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: 🔐 Login to Docker Hub
         if: >-
           ${{ github.event_name != 'pull_request'
+          && github.ref_type == 'branch'
           && github.ref_name == github.event.repository.default_branch
           && vars.DOCKERHUB_USERNAME != ''
           && env.DOCKERHUB_TOKEN != '' }}
@@ -83,9 +84,17 @@ jobs:
           kubernetes-provider-distributions: K3s
           kubernetes-provider-cni: Calico
           ghcr-user: ${{ github.actor }}
-          ghcr-token: ${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.GITHUB_TOKEN || '' }}
+          ghcr-token: >-
+            ${{ github.event_name != 'pull_request'
+            && github.ref_type == 'branch'
+            && github.ref_name == github.event.repository.default_branch
+            && secrets.GITHUB_TOKEN || '' }}
           dockerhub-user: ${{ vars.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.DOCKERHUB_TOKEN || '' }}
+          dockerhub-token: >-
+            ${{ github.event_name != 'pull_request'
+            && github.ref_type == 'branch'
+            && github.ref_name == github.event.repository.default_branch
+            && secrets.DOCKERHUB_TOKEN || '' }}
           upload-artifacts: "false"
           cleanup: "false"
 
@@ -101,7 +110,10 @@ jobs:
           if-no-files-found: ignore
 
       - name: 🧪 Cleanup KSail System Test
-        if: ${{ always() && steps.system-test.outcome != 'skipped' && steps.system-test.outcome != '' }}
+        if: >-
+          ${{ always()
+          && steps.system-test.outcome != 'skipped'
+          && steps.system-test.outcome != '' }}
         uses: ./.github/actions/ksail-system-test-cleanup
         with:
           distribution: Vanilla
@@ -109,7 +121,10 @@ jobs:
           args: "--name k3k-calico-host"
 
       - name: 📤 Upload system test logs
-        if: ${{ always() && steps.system-test.outcome != 'skipped' && steps.system-test.outcome != '' }}
+        if: >-
+          ${{ always()
+          && steps.system-test.outcome != 'skipped'
+          && steps.system-test.outcome != '' }}
         continue-on-error: true
         timeout-minutes: 5
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/system-test-k3k-calico.yaml
+++ b/.github/workflows/system-test-k3k-calico.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/system-test-k3k-calico.yaml"
-  workflow_dispatch:
+  workflow_dispatch: {}
   schedule:
     # This third-party compatibility path can regress without a repository diff.
     # Run one bounded sentinel weekly on the default branch instead of the full matrix.
@@ -37,7 +37,11 @@ jobs:
           docker-prune: "true"
 
       - name: 🔐 Login to Docker Hub
-        if: ${{ github.event_name != 'pull_request' && vars.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: >-
+          ${{ github.event_name != 'pull_request'
+          && github.ref_name == github.event.repository.default_branch
+          && vars.DOCKERHUB_USERNAME != ''
+          && env.DOCKERHUB_TOKEN != '' }}
         env:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -79,9 +83,9 @@ jobs:
           kubernetes-provider-distributions: K3s
           kubernetes-provider-cni: Calico
           ghcr-user: ${{ github.actor }}
-          ghcr-token: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}
+          ghcr-token: ${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.GITHUB_TOKEN || '' }}
           dockerhub-user: ${{ vars.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN || '' }}
+          dockerhub-token: ${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.DOCKERHUB_TOKEN || '' }}
           upload-artifacts: "false"
           cleanup: "false"
 

--- a/internal/ciharness/k3k_calico_workflow_test.go
+++ b/internal/ciharness/k3k_calico_workflow_test.go
@@ -10,9 +10,11 @@ import (
 
 const (
 	defaultBranchGHCRToken = "${{ github.event_name != 'pull_request' && " +
-		"github.ref_name == github.event.repository.default_branch && secrets.GITHUB_TOKEN || '' }}"
+		"github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch && " +
+		"secrets.GITHUB_TOKEN || '' }}"
 	defaultBranchDockerHubToken = "${{ github.event_name != 'pull_request' && " +
-		"github.ref_name == github.event.repository.default_branch && secrets.DOCKERHUB_TOKEN || '' }}"
+		"github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch && " +
+		"secrets.DOCKERHUB_TOKEN || '' }}"
 )
 
 //nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
@@ -100,6 +102,7 @@ func assertDockerHubLoginGuard(t *testing.T, steps []harnessStep) {
 	dockerHubLogin := findHarnessStep(t, steps, "🔐 Login to Docker Hub")
 	assert.Equal(t, "${{ secrets.DOCKERHUB_TOKEN }}", dockerHubLogin.Env["DOCKERHUB_TOKEN"])
 	assert.Contains(t, dockerHubLogin.If, "github.event_name != 'pull_request'")
+	assert.Contains(t, dockerHubLogin.If, "github.ref_type == 'branch'")
 	assert.Contains(
 		t,
 		dockerHubLogin.If,

--- a/internal/ciharness/k3k_calico_workflow_test.go
+++ b/internal/ciharness/k3k_calico_workflow_test.go
@@ -8,6 +8,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	defaultBranchGHCRToken = "${{ github.event_name != 'pull_request' && " +
+		"github.ref_name == github.event.repository.default_branch && secrets.GITHUB_TOKEN || '' }}"
+	defaultBranchDockerHubToken = "${{ github.event_name != 'pull_request' && " +
+		"github.ref_name == github.event.repository.default_branch && secrets.DOCKERHUB_TOKEN || '' }}"
+)
+
 //nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
 type k3kCalicoWorkflow struct {
 	On struct {
@@ -58,13 +65,7 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 	checkout := findHarnessStep(t, job.Steps, "📄 Checkout")
 	assert.Equal(t, false, checkout.With["persist-credentials"])
 
-	dockerHubLogin := findHarnessStep(t, job.Steps, "🔐 Login to Docker Hub")
-	assert.Equal(t, "${{ secrets.DOCKERHUB_TOKEN }}", dockerHubLogin.Env["DOCKERHUB_TOKEN"])
-	assert.Contains(t, dockerHubLogin.If, "github.event_name != 'pull_request'")
-	assert.Contains(t, dockerHubLogin.If, "github.ref_name == github.event.repository.default_branch")
-	assert.Contains(t, dockerHubLogin.If, "vars.DOCKERHUB_USERNAME != ''")
-	assert.Contains(t, dockerHubLogin.If, "env.DOCKERHUB_TOKEN != ''")
-	assert.Equal(t, "${{ env.DOCKERHUB_TOKEN }}", dockerHubLogin.With["password"])
+	assertDockerHubLoginGuard(t, job.Steps)
 
 	systemTest := findHarnessStep(t, job.Steps, "🧪 Run k3k + Calico Sentinel")
 	assert.Equal(t, "./.github/actions/ksail-system-test", systemTest.Uses)
@@ -77,12 +78,12 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 	assert.Equal(t, "Calico", systemTest.With["kubernetes-provider-cni"])
 	assert.Equal(
 		t,
-		"${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.GITHUB_TOKEN || '' }}",
+		defaultBranchGHCRToken,
 		systemTest.With["ghcr-token"],
 	)
 	assert.Equal(
 		t,
-		"${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.DOCKERHUB_TOKEN || '' }}",
+		defaultBranchDockerHubToken,
 		systemTest.With["dockerhub-token"],
 	)
 	assert.Equal(t, "false", systemTest.With["cleanup"])
@@ -91,4 +92,16 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 	cleanup := findHarnessStep(t, job.Steps, "🧪 Cleanup KSail System Test")
 	assert.Equal(t, "./.github/actions/ksail-system-test-cleanup", cleanup.Uses)
 	assert.Contains(t, cleanup.If, "always()")
+}
+
+func assertDockerHubLoginGuard(t *testing.T, steps []harnessStep) {
+	t.Helper()
+
+	dockerHubLogin := findHarnessStep(t, steps, "🔐 Login to Docker Hub")
+	assert.Equal(t, "${{ secrets.DOCKERHUB_TOKEN }}", dockerHubLogin.Env["DOCKERHUB_TOKEN"])
+	assert.Contains(t, dockerHubLogin.If, "github.event_name != 'pull_request'")
+	assert.Contains(t, dockerHubLogin.If, "github.ref_name == github.event.repository.default_branch")
+	assert.Contains(t, dockerHubLogin.If, "vars.DOCKERHUB_USERNAME != ''")
+	assert.Contains(t, dockerHubLogin.If, "env.DOCKERHUB_TOKEN != ''")
+	assert.Equal(t, "${{ env.DOCKERHUB_TOKEN }}", dockerHubLogin.With["password"])
 }

--- a/internal/ciharness/k3k_calico_workflow_test.go
+++ b/internal/ciharness/k3k_calico_workflow_test.go
@@ -51,10 +51,17 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 	assert.Equal(t, 120, job.TimeoutMinutes)
 	assert.Nil(t, job.Strategy, "sentinel must not expand into a system-test matrix")
 	assert.Equal(t, "read", job.Permissions["contents"])
-	assert.Equal(t, "write", job.Permissions["packages"])
+	assert.Equal(t, "read", job.Permissions["packages"])
 
 	checkout := findHarnessStep(t, job.Steps, "📄 Checkout")
 	assert.Equal(t, false, checkout.With["persist-credentials"])
+
+	dockerHubLogin := findHarnessStep(t, job.Steps, "🔐 Login to Docker Hub")
+	assert.Equal(t, "${{ secrets.DOCKERHUB_TOKEN }}", dockerHubLogin.Env["DOCKERHUB_TOKEN"])
+	assert.Contains(t, dockerHubLogin.If, "github.event_name != 'pull_request'")
+	assert.Contains(t, dockerHubLogin.If, "vars.DOCKERHUB_USERNAME != ''")
+	assert.Contains(t, dockerHubLogin.If, "env.DOCKERHUB_TOKEN != ''")
+	assert.Equal(t, "${{ env.DOCKERHUB_TOKEN }}", dockerHubLogin.With["password"])
 
 	systemTest := findHarnessStep(t, job.Steps, "🧪 Run k3k + Calico Sentinel")
 	assert.Equal(t, "./.github/actions/ksail-system-test", systemTest.Uses)
@@ -65,6 +72,16 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 	assert.Equal(t, "true", systemTest.With["test-kubernetes-provider"])
 	assert.Equal(t, "K3s", systemTest.With["kubernetes-provider-distributions"])
 	assert.Equal(t, "Calico", systemTest.With["kubernetes-provider-cni"])
+	assert.Equal(
+		t,
+		"${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}",
+		systemTest.With["ghcr-token"],
+	)
+	assert.Equal(
+		t,
+		"${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN || '' }}",
+		systemTest.With["dockerhub-token"],
+	)
 	assert.Equal(t, "false", systemTest.With["cleanup"])
 	assert.Equal(t, "false", systemTest.With["upload-artifacts"])
 

--- a/internal/ciharness/k3k_calico_workflow_test.go
+++ b/internal/ciharness/k3k_calico_workflow_test.go
@@ -1,0 +1,65 @@
+package ciharness_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+//nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
+type k3kCalicoWorkflow struct {
+	On struct {
+		Schedule []struct {
+			Cron string `yaml:"cron"`
+		} `yaml:"schedule"`
+	} `yaml:"on"`
+	Permissions map[string]string `yaml:"permissions"`
+	Jobs        map[string]struct {
+		TimeoutMinutes int               `yaml:"timeout-minutes"`
+		Permissions    map[string]string `yaml:"permissions"`
+		Strategy       any               `yaml:"strategy"`
+		Steps          []harnessStep     `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
+	t.Parallel()
+
+	contents := readRepoFile(t, ".github/workflows/system-test-k3k-calico.yaml")
+
+	var workflow k3kCalicoWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	require.Len(t, workflow.On.Schedule, 1, "sentinel must have one weekly schedule")
+	assert.Equal(t, "30 2 * * 1", workflow.On.Schedule[0].Cron)
+	assert.Equal(t, "read", workflow.Permissions["contents"])
+
+	require.Len(t, workflow.Jobs, 1, "scheduled sentinel must remain one bounded test leg")
+	job, found := workflow.Jobs["k3k-calico-sentinel"]
+	require.True(t, found, "k3k+Calico sentinel job is missing")
+	assert.Equal(t, 120, job.TimeoutMinutes)
+	assert.Nil(t, job.Strategy, "sentinel must not expand into a system-test matrix")
+	assert.Equal(t, "read", job.Permissions["contents"])
+	assert.Equal(t, "write", job.Permissions["packages"])
+
+	checkout := findHarnessStep(t, job.Steps, "📄 Checkout")
+	assert.Equal(t, false, checkout.With["persist-credentials"])
+
+	systemTest := findHarnessStep(t, job.Steps, "🧪 Run k3k + Calico Sentinel")
+	assert.Equal(t, "./.github/actions/ksail-system-test", systemTest.Uses)
+	assert.Equal(t, "Vanilla", systemTest.With["distribution"])
+	assert.Equal(t, "Docker", systemTest.With["provider"])
+	assert.Equal(t, "true", systemTest.With["init"])
+	assert.Equal(t, "--name k3k-calico-host", systemTest.With["args"])
+	assert.Equal(t, "true", systemTest.With["test-kubernetes-provider"])
+	assert.Equal(t, "K3s", systemTest.With["kubernetes-provider-distributions"])
+	assert.Equal(t, "Calico", systemTest.With["kubernetes-provider-cni"])
+	assert.Equal(t, "false", systemTest.With["cleanup"])
+	assert.Equal(t, "false", systemTest.With["upload-artifacts"])
+
+	cleanup := findHarnessStep(t, job.Steps, "🧪 Cleanup KSail System Test")
+	assert.Equal(t, "./.github/actions/ksail-system-test-cleanup", cleanup.Uses)
+	assert.Contains(t, cleanup.If, "always()")
+}

--- a/internal/ciharness/k3k_calico_workflow_test.go
+++ b/internal/ciharness/k3k_calico_workflow_test.go
@@ -11,7 +11,8 @@ import (
 //nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
 type k3kCalicoWorkflow struct {
 	On struct {
-		PullRequest struct {
+		WorkflowDispatch map[string]any `yaml:"workflow_dispatch"`
+		PullRequest      struct {
 			Paths []string `yaml:"paths"`
 		} `yaml:"pull_request"`
 		Schedule []struct {
@@ -37,6 +38,7 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 
 	require.Len(t, workflow.On.Schedule, 1, "sentinel must have one weekly schedule")
 	assert.Equal(t, "30 2 * * 1", workflow.On.Schedule[0].Cron)
+	assert.NotNil(t, workflow.On.WorkflowDispatch, "sentinel must remain manually dispatchable")
 	assert.Contains(
 		t,
 		workflow.On.PullRequest.Paths,
@@ -59,6 +61,7 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 	dockerHubLogin := findHarnessStep(t, job.Steps, "🔐 Login to Docker Hub")
 	assert.Equal(t, "${{ secrets.DOCKERHUB_TOKEN }}", dockerHubLogin.Env["DOCKERHUB_TOKEN"])
 	assert.Contains(t, dockerHubLogin.If, "github.event_name != 'pull_request'")
+	assert.Contains(t, dockerHubLogin.If, "github.ref_name == github.event.repository.default_branch")
 	assert.Contains(t, dockerHubLogin.If, "vars.DOCKERHUB_USERNAME != ''")
 	assert.Contains(t, dockerHubLogin.If, "env.DOCKERHUB_TOKEN != ''")
 	assert.Equal(t, "${{ env.DOCKERHUB_TOKEN }}", dockerHubLogin.With["password"])
@@ -74,12 +77,12 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 	assert.Equal(t, "Calico", systemTest.With["kubernetes-provider-cni"])
 	assert.Equal(
 		t,
-		"${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}",
+		"${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.GITHUB_TOKEN || '' }}",
 		systemTest.With["ghcr-token"],
 	)
 	assert.Equal(
 		t,
-		"${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN || '' }}",
+		"${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch && secrets.DOCKERHUB_TOKEN || '' }}",
 		systemTest.With["dockerhub-token"],
 	)
 	assert.Equal(t, "false", systemTest.With["cleanup"])

--- a/internal/ciharness/k3k_calico_workflow_test.go
+++ b/internal/ciharness/k3k_calico_workflow_test.go
@@ -11,6 +11,9 @@ import (
 //nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
 type k3kCalicoWorkflow struct {
 	On struct {
+		PullRequest struct {
+			Paths []string `yaml:"paths"`
+		} `yaml:"pull_request"`
 		Schedule []struct {
 			Cron string `yaml:"cron"`
 		} `yaml:"schedule"`
@@ -34,6 +37,12 @@ func TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests(t *testing.T) {
 
 	require.Len(t, workflow.On.Schedule, 1, "sentinel must have one weekly schedule")
 	assert.Equal(t, "30 2 * * 1", workflow.On.Schedule[0].Cron)
+	assert.Contains(
+		t,
+		workflow.On.PullRequest.Paths,
+		".github/workflows/system-test-k3k-calico.yaml",
+		"workflow changes must exercise the real sentinel before merge",
+	)
 	assert.Equal(t, "read", workflow.Permissions["contents"])
 
 	require.Len(t, workflow.Jobs, 1, "scheduled sentinel must remain one bounded test leg")

--- a/internal/ciharness/k3k_calico_workflow_test.go
+++ b/internal/ciharness/k3k_calico_workflow_test.go
@@ -100,7 +100,11 @@ func assertDockerHubLoginGuard(t *testing.T, steps []harnessStep) {
 	dockerHubLogin := findHarnessStep(t, steps, "🔐 Login to Docker Hub")
 	assert.Equal(t, "${{ secrets.DOCKERHUB_TOKEN }}", dockerHubLogin.Env["DOCKERHUB_TOKEN"])
 	assert.Contains(t, dockerHubLogin.If, "github.event_name != 'pull_request'")
-	assert.Contains(t, dockerHubLogin.If, "github.ref_name == github.event.repository.default_branch")
+	assert.Contains(
+		t,
+		dockerHubLogin.If,
+		"github.ref_name == github.event.repository.default_branch",
+	)
 	assert.Contains(t, dockerHubLogin.If, "vars.DOCKERHUB_USERNAME != ''")
 	assert.Contains(t, dockerHubLogin.If, "env.DOCKERHUB_TOKEN != ''")
 	assert.Equal(t, "${{ env.DOCKERHUB_TOKEN }}", dockerHubLogin.With["password"])


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- run the k3k + Calico compatibility path weekly on the default branch
- keep the scheduled check to one bounded system-test leg instead of the full matrix
- add a CI-harness contract test for cadence, scope, permissions, and cleanup

Fixes #6733

## Root cause

The `k3k-calico-host` leg only ran inside the pull-request matrix or by manual dispatch. Its dependencies can change behavior without a KSail diff, so the default branch had no recurring signal after merge. The runtime incompatibility originally reported by #6733 was fixed by #6709; this PR closes the remaining detection gap without scheduling the entire system-test matrix.

## Verification

RED at `5bb1a9256a11bd47a6869265ecde8c5b9b54cdc4`:

```text
go test ./internal/ciharness -run TestK3KCalicoSentinelRunsWeeklyOutsidePullRequests -count=1
open ../../.github/workflows/system-test-k3k-calico.yaml: no such file or directory
```

Initial GREEN at `03361da03fe695f089f406ed1df9cdd53d37facc`:

```text
go test -race ./internal/ciharness
ok github.com/devantler-tech/ksail/v7/internal/ciharness

go vet ./internal/ciharness
PASS

actionlint .github/workflows/system-test-k3k-calico.yaml
PASS

zizmor .github/workflows/system-test-k3k-calico.yaml
PASS
```

The workflow also self-validates when its own file changes. That contract was RED at `ed0418b1f3512874ffb3c7d1ab0447ca5a2e5431` because the pull-request path list was empty, then GREEN at the current head after adding the narrow workflow-file trigger. This makes the real sentinel run on this PR without adding it to unrelated pull requests.

The first substantive review exposed a credential edge case for fork/Dependabot pull requests. The workflow contract was RED at `03361da03fe695f089f406ed1df9cdd53d37facc` because the login checked only the username, PR self-runs received registry-token inputs, and the job requested package-write. It was GREEN at `86c71df92a1b37c045b6edd91efc6e2dabc75625`: PR runs are credential-free with `packages: read`, while non-PR runs retain optional registry authentication.

The restarted review then found that a manual dispatch from a non-default ref could still receive credentials and that the contract did not assert the manual trigger. Both cases were RED at `86c71df92a1b37c045b6edd91efc6e2dabc75625` and GREEN from `a8c81336cbb3148d579dfe62fc032dd107f6d00d`: credential inputs require the repository default branch, and the parsed-workflow contract asserts `workflow_dispatch`.

Repository lint then caught a long test function and an overlong condition. Those gates were RED at `a8c81336cbb3148d579dfe62fc032dd107f6d00d`, then GREEN at `6ff6354fe53ca7452b54ac508c72af151afb52ff` after a structural test-helper extraction and the repository formatter's exact wrap.

The next review identified a tag-ref collision: a manual dispatch from a tag whose short name matched the default branch could satisfy the name-only credential guard. All three credential-path assertions were RED at `6ff6354fe53ca7452b54ac508c72af151afb52ff`, then GREEN at the final `31d08d265565a3fcacd9f6b191f94f995a5ec810` after requiring `github.ref_type == 'branch'`. The focused contract also passed 10 consecutive runs.

The final current-head suite is 26 checks passed and zero failed, including build, race tests, coverage, vulnerability scanning, golangci-lint, MegaLinter, CodeQL, dependency review, zizmor, home isolation, provenance, and the required-check aggregate. CodeRabbit's restarted exact-head review reported no actionable issues after verifying the branch provenance guard and live result.

Local full-build and lint gates were unavailable: two full `go build` attempts exhausted the host filesystem while compiling the existing dependency graph; local `golangci-lint` panicked in its Go 1.26 analyzer on a file requiring Go 1.27; and `mega-linter-runner` is not installed. Current-head repository CI supplied those gates.

The real `k3k-calico-host` sentinel passed at the final exact head in [run 33166270876](https://github.com/devantler-tech/ksail/actions/runs/33166270876), including binary build, Helm/mirror cache restore, the credential-free PR k3k + Calico user path, diagnostics, logs, and always-run cleanup.
