### PR TITLE
fix(ui): prevent top pod lists overflowing on small screens

### DIFF
--- a/.github/workflows/web-ui.yaml
+++ b/.github/workflows/web-ui.yaml
@@ -44,3 +44,9 @@ jobs:
 
       - name: 🏗️ Build
         run: npm run build
+
+      - name: 🌐 Install browser
+        run: npx playwright install --with-deps chromium
+
+      - name: 🧪 Test responsive layouts
+        run: npm run test:e2e

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -28,6 +28,7 @@
         "redux": "^5.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "1.61.1",
         "@tailwindcss/vite": "^4.1.13",
         "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.1.10",
@@ -973,6 +974,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2763,6 +2780,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -9,7 +9,8 @@
     "gen:types": "node scripts/gen-types.mjs",
     "build": "npm run gen:types && tsc && vite build",
     "preview": "vite preview",
-    "lint": "npm run gen:types && tsc --noEmit"
+    "lint": "npm run gen:types && tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -32,6 +33,7 @@
     "redux": "^5.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.1",
     "@tailwindcss/vite": "^4.1.13",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.1.10",

--- a/web/ui/playwright.config.ts
+++ b/web/ui/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/web/ui/src/components/ResourceUsage.tsx
+++ b/web/ui/src/components/ResourceUsage.tsx
@@ -300,7 +300,7 @@ export function ResourceUsagePanel({
           </div>
 
           {usage.metricsAvailable && topPods && topPods.length > 0 ? (
-            <div className="grid gap-4 border-t border-slate-100 pt-3 sm:grid-cols-2 dark:border-slate-800">
+            <div className="grid grid-cols-1 gap-4 border-t border-slate-100 pt-3 sm:grid-cols-2 dark:border-slate-800">
               {DIMENSIONS.map((dimension) => (
                 <ConsumerList
                   key={dimension.key}

--- a/web/ui/tests/fixtures/resource-usage.html
+++ b/web/ui/tests/fixtures/resource-usage.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Resource usage fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/tests/fixtures/resource-usage.tsx"></script>
+  </body>
+</html>

--- a/web/ui/tests/fixtures/resource-usage.tsx
+++ b/web/ui/tests/fixtures/resource-usage.tsx
@@ -1,0 +1,51 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { ResourceUsagePanel } from "../../src/components/ResourceUsage.tsx";
+import type { ClusterUsage, PodConsumption, ResourceTotals } from "../../src/lib/usage.ts";
+import "../../src/index.css";
+
+const cpu: ResourceTotals = {
+  capacity: 4,
+  allocatable: 3.5,
+  requests: 1,
+  limits: 2,
+  usage: 1.25,
+};
+
+const memory: ResourceTotals = {
+  capacity: 8 * 1024 ** 3,
+  allocatable: 7 * 1024 ** 3,
+  requests: 2 * 1024 ** 3,
+  limits: 4 * 1024 ** 3,
+  usage: 3 * 1024 ** 3,
+};
+
+const usage: ClusterUsage = {
+  nodes: [
+    {
+      name: "worker-0",
+      controlPlane: false,
+      ready: true,
+      cpu,
+      memory,
+      pods: { allocatable: 110, count: 2 },
+    },
+  ],
+  cpu,
+  memory,
+  pods: { allocatable: 110, count: 2 },
+  metricsAvailable: true,
+};
+
+const longIdentifier =
+  "observability-system/metrics-exporter-with-an-intentionally-long-unbroken-generated-pod-name-7f9c8d6b5f-qwert";
+const [namespace, name] = longIdentifier.split("/");
+const topPods: PodConsumption[] = [{ namespace, name, cpu: 0.95, memory: 900 * 1024 ** 2 }];
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <main data-testid="resource-usage-fixture" className="p-4">
+      <ResourceUsagePanel usage={usage} topPods={topPods} loading={false} />
+    </main>
+  </StrictMode>,
+);

--- a/web/ui/tests/resource-usage.spec.ts
+++ b/web/ui/tests/resource-usage.spec.ts
@@ -32,6 +32,7 @@ test("top pod consumers stay inside a mobile viewport", async ({ page }) => {
   const layout = await page.evaluate(() => {
     const fixture = document.querySelector<HTMLElement>("[data-testid='resource-usage-fixture']")!;
     const podName = document.querySelector<HTMLElement>("[title^='observability-system/']")!;
+    const podNameStyle = getComputedStyle(podName);
 
     return {
       documentClientWidth: document.documentElement.clientWidth,
@@ -40,10 +41,23 @@ test("top pod consumers stay inside a mobile viewport", async ({ page }) => {
       fixtureScrollWidth: fixture.scrollWidth,
       podNameClientWidth: podName.clientWidth,
       podNameScrollWidth: podName.scrollWidth,
+      podNameOverflowX: podNameStyle.overflowX,
+      podNameTextOverflow: podNameStyle.textOverflow,
+      podNameWhiteSpace: podNameStyle.whiteSpace,
     };
   });
 
   expect(layout.documentScrollWidth).toBe(layout.documentClientWidth);
   expect(layout.fixtureScrollWidth).toBe(layout.fixtureClientWidth);
   expect(layout.podNameScrollWidth).toBeGreaterThan(layout.podNameClientWidth);
+
+  // scrollWidth > clientWidth only proves the name is wider than its box -- it is
+  // equally true of a box that clips the overflow with no affordance at all. The
+  // three declarations below are what Tailwind's `truncate` actually applies, and
+  // together they are the property this test claims: the name is kept on one line,
+  // clipped to the box, and marked as continuing with an ellipsis. Dropping any one
+  // of them is a user-visible regression that the width assertion alone cannot see.
+  expect(layout.podNameWhiteSpace).toBe("nowrap");
+  expect(layout.podNameOverflowX).toBe("hidden");
+  expect(layout.podNameTextOverflow).toBe("ellipsis");
 });

--- a/web/ui/tests/resource-usage.spec.ts
+++ b/web/ui/tests/resource-usage.spec.ts
@@ -5,8 +5,18 @@ test.use({ viewport: { width: 320, height: 800 } });
 test("top pod consumers stay inside a mobile viewport", async ({ page }) => {
   await page.goto("/tests/fixtures/resource-usage.html");
 
-  await expect(page.getByText("Top pods by cpu", { exact: true })).toBeVisible();
-  await expect(page.getByText("Top pods by memory", { exact: true })).toBeVisible();
+  const cpuList = page.getByText("Top pods by cpu", { exact: true });
+  const memoryList = page.getByText("Top pods by memory", { exact: true });
+
+  await expect(cpuList).toBeVisible();
+  await expect(memoryList).toBeVisible();
+
+  // The headings alone do not prove the panel is usable: a layout regression can
+  // clip or collapse the metric column while both headings stay visible. These
+  // pin the fixture pod's rendered values -- formatCores(0.95) and
+  // formatBytes(900 MiB) -- inside their own list, so losing a value fails here.
+  await expect(cpuList.locator("..").getByText("950m", { exact: true })).toBeVisible();
+  await expect(memoryList.locator("..").getByText("900 MiB", { exact: true })).toBeVisible();
 
   const layout = await page.evaluate(() => {
     const fixture = document.querySelector<HTMLElement>("[data-testid='resource-usage-fixture']")!;

--- a/web/ui/tests/resource-usage.spec.ts
+++ b/web/ui/tests/resource-usage.spec.ts
@@ -15,8 +15,19 @@ test("top pod consumers stay inside a mobile viewport", async ({ page }) => {
   // clip or collapse the metric column while both headings stay visible. These
   // pin the fixture pod's rendered values -- formatCores(0.95) and
   // formatBytes(900 MiB) -- inside their own list, so losing a value fails here.
-  await expect(cpuList.locator("..").getByText("950m", { exact: true })).toBeVisible();
-  await expect(memoryList.locator("..").getByText("900 MiB", { exact: true })).toBeVisible();
+  const cpuValue = cpuList.locator("..").getByText("950m", { exact: true });
+  const memoryValue = memoryList.locator("..").getByText("900 MiB", { exact: true });
+
+  await expect(cpuValue).toBeVisible();
+  await expect(memoryValue).toBeVisible();
+
+  // toBeVisible() only proves a non-empty box: a value clipped by an
+  // overflow:hidden ancestor, or pushed past the 320px edge, still passes it
+  // -- and the document-level scrollWidth checks below stay green because a
+  // clipping ancestor never extends the document. Requiring the values to sit
+  // ENTIRELY inside the viewport is the property this test actually claims.
+  await expect(cpuValue).toBeInViewport({ ratio: 1 });
+  await expect(memoryValue).toBeInViewport({ ratio: 1 });
 
   const layout = await page.evaluate(() => {
     const fixture = document.querySelector<HTMLElement>("[data-testid='resource-usage-fixture']")!;

--- a/web/ui/tests/resource-usage.spec.ts
+++ b/web/ui/tests/resource-usage.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ viewport: { width: 320, height: 800 } });
+
+test("top pod consumers stay inside a mobile viewport", async ({ page }) => {
+  await page.goto("/tests/fixtures/resource-usage.html");
+
+  await expect(page.getByText("Top pods by cpu", { exact: true })).toBeVisible();
+  await expect(page.getByText("Top pods by memory", { exact: true })).toBeVisible();
+
+  const layout = await page.evaluate(() => {
+    const fixture = document.querySelector<HTMLElement>("[data-testid='resource-usage-fixture']")!;
+    const podName = document.querySelector<HTMLElement>("[title^='observability-system/']")!;
+
+    return {
+      documentClientWidth: document.documentElement.clientWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      fixtureClientWidth: fixture.clientWidth,
+      fixtureScrollWidth: fixture.scrollWidth,
+      podNameClientWidth: podName.clientWidth,
+      podNameScrollWidth: podName.scrollWidth,
+    };
+  });
+
+  expect(layout.documentScrollWidth).toBe(layout.documentClientWidth);
+  expect(layout.fixtureScrollWidth).toBe(layout.fixtureClientWidth);
+  expect(layout.podNameScrollWidth).toBeGreaterThan(layout.podNameClientWidth);
+});


### PR DESCRIPTION
Fixes #6746

## Root cause

Below Tailwind's `sm` breakpoint, the top-consumer wrapper is a grid without an explicit base column. Its implicit `auto` track can take the intrinsic width of a long namespace/pod identifier and widen the Resource usage card beyond the viewport. The `sm:grid-cols-2` tracks are already shrinkable, which is why the defect is limited to small screens.

## Change

- add a real-browser 320 px regression fixture for the Resource usage panel
- run responsive browser tests in the focused Web UI workflow
- define a shrinkable base column for the top-consumer grid

## TDD evidence

- RED: commit `4b7fd47f` adds the browser regression against unchanged production code; hosted CI is expected to fail on horizontal overflow
- GREEN: exact head `785aa9f92517292d2cba8b41f1350053e98b343f` passed the same browser test in [Web UI run 33193033172](https://github.com/devantler-tech/ksail/actions/runs/33193033172), plus the TypeScript/Vite production build
