### PR TITLE
fix(ci): validate TODO workflow contract updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,6 +132,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       dependency-test-graph: ${{ steps.filter.outputs.dependency-test-graph }}
       govuln-allowlist: ${{ steps.filter.outputs.govuln-allowlist }}
+      todos-contract: ${{ steps.filter.outputs.todos-contract }}
       system-test: ${{ steps.filter.outputs.system-test }}
       schema: ${{ steps.filter.outputs.schema }}
       cli: ${{ steps.filter.outputs.cli }}
@@ -162,10 +163,19 @@ jobs:
               - 'go.sum'
               - '.govulncheck-allow.txt'
               - '.github/actions/**'
-              # The Go CI harness validates the reusable scanner boundary and its
-              # repository-specific ignore selector. Run that contract before a
-              # workflow-only scanner update can merge.
+            # The Go harness in internal/ciharness asserts the shape of the TODO scanner
+            # caller. Its subject is a WORKFLOW file, not a Go file, so the org-required
+            # validate-go-project run cannot reach it: that workflow gates its own test job
+            # on a `go` filter of **/*.go|go.mod|go.sum|.golangci.* and skips everything
+            # else. A scanner-only bump therefore merges with the contract unexecuted and
+            # reddens main instead (ksail#6750 merged 2026-08-28T17:17Z with its test job
+            # `skipped`; main went red 94 minutes later). This filter feeds a job of its own
+            # so that class of change is gated on the PR that makes it. The harness sources
+            # are included for the same reason ci.yaml is included below -- otherwise a PR
+            # could weaken or delete the assertion without ever running it.
+            todos-contract:
               - '.github/workflows/todos.yaml'
+              - 'internal/ciharness/**'
             # Deliberately NARROWER than `code`: the job resolves a module graph, so only the
             # module files matter — not every .go file. It also includes THIS workflow, because
             # the check lives here and a workflow-only PR would otherwise be able to weaken or
@@ -1681,6 +1691,39 @@ jobs:
           fi
           echo "Dependency test graph resolves."
 
+  verify-todos-workflow-contract:
+    name: 🧾 Verify TODO Workflow Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [changes]
+    if: github.event_name != 'merge_group' && needs.changes.outputs.todos-contract == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      # -count=1 is load-bearing: this test's real subject is a YAML file the Go build graph
+      # cannot see, so a cached PASS from an earlier run would be replayed over a changed
+      # workflow and report success without executing anything.
+      - name: 🧾 Verify TODO workflow contract
+        run: |
+          if ! go test ./internal/ciharness/... -count=1; then
+            echo "::error::The TODO scanner workflow no longer matches the contract in internal/ciharness."
+            echo "Fix: reconcile .github/workflows/todos.yaml with the assertions, or update the assertions if the contract itself changed."
+            exit 1
+          fi
+
   require-checks-in-pr:
     name: CI - Required Checks
     runs-on: ubuntu-latest
@@ -1709,6 +1752,7 @@ jobs:
         verify-desktop-tidy,
         validate-calico-chart,
         verify-dependency-test-graph,
+        verify-todos-workflow-contract,
         cask-pr-handoff,
       ]
     if: ${{ always() }}
@@ -1738,4 +1782,5 @@ jobs:
             ${{ needs.verify-desktop-tidy.result }}
             ${{ needs.validate-calico-chart.result }}
             ${{ needs.verify-dependency-test-graph.result }}
+            ${{ needs.verify-todos-workflow-contract.result }}
             ${{ needs.cask-pr-handoff.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,6 +162,10 @@ jobs:
               - 'go.sum'
               - '.govulncheck-allow.txt'
               - '.github/actions/**'
+              # The Go CI harness validates the reusable scanner boundary and its
+              # repository-specific ignore selector. Run that contract before a
+              # workflow-only scanner update can merge.
+              - '.github/workflows/todos.yaml'
             # Deliberately NARROWER than `code`: the job resolves a module graph, so only the
             # module files matter — not every .go file. It also includes THIS workflow, because
             # the check lives here and a workflow-only PR would otherwise be able to weaken or

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,10 +171,14 @@ jobs:
             # reddens main instead (ksail#6750 merged 2026-08-28T17:17Z with its test job
             # `skipped`; main went red 94 minutes later). This filter feeds a job of its own
             # so that class of change is gated on the PR that makes it. The harness sources
-            # are included for the same reason ci.yaml is included below -- otherwise a PR
-            # could weaken or delete the assertion without ever running it.
+            # and THIS workflow are included for the same reason dependency-test-graph
+            # includes ci.yaml below: the job and its assertions both live in files this
+            # filter would otherwise not match, so a PR editing only one of them could
+            # weaken or delete the gate while the aggregator recorded it as an ordinary
+            # skip.
             todos-contract:
               - '.github/workflows/todos.yaml'
+              - '.github/workflows/ci.yaml'
               - 'internal/ciharness/**'
             # Deliberately NARROWER than `code`: the job resolves a module graph, so only the
             # module files matter — not every .go file. It also includes THIS workflow, because

--- a/internal/ciharness/todos_workflow_test.go
+++ b/internal/ciharness/todos_workflow_test.go
@@ -49,5 +49,10 @@ func TestTODOScannerExcludesOnlyVendoredSources(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, compiled.MatchString("third_party/go-archive/archive/tar/reader.go"))
 	assert.False(t, compiled.MatchString("internal/maintenance/todos.go"))
-	assert.Regexp(t, `# v\d+\.\d+\.\d+`, string(contents), "workflow pin must retain its release annotation")
+	assert.Regexp(
+		t,
+		`# v\d+\.\d+\.\d+`,
+		string(contents),
+		"workflow pin must retain its release annotation",
+	)
 }

--- a/internal/ciharness/todos_workflow_test.go
+++ b/internal/ciharness/todos_workflow_test.go
@@ -51,7 +51,8 @@ func TestTODOScannerExcludesOnlyVendoredSources(t *testing.T) {
 	assert.False(t, compiled.MatchString("internal/maintenance/todos.go"))
 	assert.Regexp(
 		t,
-		`# v\d+\.\d+\.\d+`,
+		`(?m)^\s*uses:\s+devantler-tech/actions/\.github/workflows/`+
+			`scan-for-todo-comments\.yaml@[0-9a-f]{40}\s+# v\d+\.\d+\.\d+\s*$`,
 		string(contents),
 		"workflow pin must retain its release annotation",
 	)

--- a/internal/ciharness/todos_workflow_test.go
+++ b/internal/ciharness/todos_workflow_test.go
@@ -32,11 +32,11 @@ func TestTODOScannerExcludesOnlyVendoredSources(t *testing.T) {
 
 	job, found := workflow.Jobs["todos"]
 	require.True(t, found, "TODO workflow must define the todos job")
-	require.Equal(
+	require.Regexp(
 		t,
-		"devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@"+
-			"56665ea3f455622d6ff0cc0fb2b90fc3be6e41e7",
+		`^devantler-tech/actions/\.github/workflows/scan-for-todo-comments\.yaml@[0-9a-f]{40}$`,
 		job.Uses,
+		"shared scanner must use the reviewed workflow pinned to an immutable commit",
 	)
 	assert.Empty(t, job.RunsOn, "reusable workflow callers cannot configure runs-on")
 	assert.Empty(t, job.Steps, "KSail must not copy the shared scanner implementation")
@@ -49,5 +49,5 @@ func TestTODOScannerExcludesOnlyVendoredSources(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, compiled.MatchString("third_party/go-archive/archive/tar/reader.go"))
 	assert.False(t, compiled.MatchString("internal/maintenance/todos.go"))
-	assert.Contains(t, string(contents), "# v13.2.2")
+	assert.Regexp(t, `# v\d+\.\d+\.\d+`, string(contents), "workflow pin must retain its release annotation")
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A routine dependency update to the shared TODO scanner broke the default branch. The
regression test pinned one specific release of that shared workflow, so every legitimate
bump made `main` go red — and the check that would have caught it did not run on the
update itself. The red default branch also blocks the wider pull-request queue.

## What

The test now checks what actually matters — that KSail calls the reviewed shared scanner,
that the reference is pinned to an immutable commit rather than a movable tag, and that the
pin keeps its release annotation — instead of one hard-coded release. A change to the TODO
workflow now runs that contract check in its own pull request, so this cannot merge
unnoticed again.

Security posture is unchanged: the immutable-pin requirement is kept, only the "which
release" part is relaxed to what dependency automation is allowed to advance.
