### PR TITLE
fix(ci): stop the path-filter comment self-triggering the to-do scanner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
               - 'go.sum'
               - '.govulncheck-allow.txt'
               - '.github/actions/**'
-            # The Go harness in internal/ciharness asserts the shape of the TODO scanner
+            # The Go harness in internal/ciharness asserts the shape of the to-do scanner
             # caller. Its subject is a WORKFLOW file, not a Go file, so the org-required
             # validate-go-project run cannot reach it: that workflow gates its own test job
             # on a `go` filter of **/*.go|go.mod|go.sum|.golangci.* and skips everything
@@ -176,6 +176,9 @@ jobs:
             # filter would otherwise not match, so a PR editing only one of them could
             # weaken or delete the gate while the aggregator recorded it as an ordinary
             # skip.
+            # ("to-do" is deliberately lowercase and hyphenated here: the scanner keys on the
+            # uppercase marker, so spelling it out in prose files an issue against this very
+            # comment. ksail#6763 was exactly that — a false positive with no work behind it.)
             todos-contract:
               - '.github/workflows/todos.yaml'
               - '.github/workflows/ci.yaml'

--- a/internal/ciharness/todos_workflow_test.go
+++ b/internal/ciharness/todos_workflow_test.go
@@ -23,7 +23,12 @@ type todosWorkflow struct {
 	} `yaml:"jobs"`
 }
 
-// TestTODOScannerExcludesOnlyVendoredSources pins the scanner's delegation and its blast radius.
+// Pins the shared scanner's delegation and the blast radius of its ignore pattern.
+//
+// This comment deliberately does not open with the function's own name, the way a doc comment
+// normally would: that name embeds the uppercase marker, and the scanner keys on the marker
+// wherever it appears in a comment. See TestCIFilterCommentDoesNotSpellTheScannerMarker below,
+// which pins the same trap after it fired once for real.
 //
 // KSail calls the shared scanner in devantler-tech/actions instead of carrying its own copy, so the
 // job must stay a bare reusable-workflow call: a runs-on or steps key here would mean the

--- a/internal/ciharness/todos_workflow_test.go
+++ b/internal/ciharness/todos_workflow_test.go
@@ -2,6 +2,7 @@ package ciharness_test
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,4 +57,53 @@ func TestTODOScannerExcludesOnlyVendoredSources(t *testing.T) {
 		string(contents),
 		"workflow pin must retain its release annotation",
 	)
+}
+
+// TestCIFilterCommentDoesNotSpellTheScannerMarker pins a trap that has already fired once.
+//
+// The shared scanner keys on the uppercase marker wherever it appears in a comment, so prose
+// that merely NAMES the marker files an issue against itself. ksail#6763 was exactly that: a
+// false positive whose entire body was the ci.yaml comment block below, with no work behind
+// it. The shared workflow in devantler-tech/actions guards itself the same way and says so in
+// its own source.
+//
+// The marker is assembled at runtime rather than written out, because spelling it in this
+// file would reintroduce the very defect the test exists to prevent.
+func TestCIFilterCommentDoesNotSpellTheScannerMarker(t *testing.T) {
+	t.Parallel()
+
+	contents := readRepoFile(t, ".github/workflows/ci.yaml")
+	lines := strings.Split(string(contents), "\n")
+
+	anchor := -1
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "todos-contract:" {
+			anchor = i
+
+			break
+		}
+	}
+
+	require.GreaterOrEqual(t, anchor, 0, "ci.yaml must still define the todos-contract filter")
+
+	// Walk back over the contiguous comment block that documents the filter. Asserting the
+	// block is non-empty stops this test passing vacuously if the comment is ever deleted.
+	var block []string
+
+	for i := anchor - 1; i >= 0 && strings.HasPrefix(strings.TrimSpace(lines[i]), "#"); i-- {
+		block = append(block, lines[i])
+	}
+
+	require.NotEmpty(t, block, "the todos-contract filter must keep its explanatory comment")
+
+	marker := "TO" + "DO"
+	for _, line := range block {
+		assert.NotContains(
+			t,
+			line,
+			marker,
+			"comment must not spell the scanner marker: doing so files a spurious issue (ksail#6763)",
+		)
+	}
 }

--- a/internal/ciharness/todos_workflow_test.go
+++ b/internal/ciharness/todos_workflow_test.go
@@ -23,6 +23,18 @@ type todosWorkflow struct {
 	} `yaml:"jobs"`
 }
 
+// TestTODOScannerExcludesOnlyVendoredSources pins the scanner's delegation and its blast radius.
+//
+// KSail calls the shared scanner in devantler-tech/actions instead of carrying its own copy, so the
+// job must stay a bare reusable-workflow call: a runs-on or steps key here would mean the
+// implementation had been forked and could drift from the reviewed one. The pin is required to be an
+// immutable 40-character commit that keeps its release annotation, so the workflow KSail runs is
+// always the workflow that was reviewed.
+//
+// The ignore pattern is asserted exactly rather than loosely, because widening it fails silently: a
+// pattern that also swallowed first-party paths would leave real to-do comments unscanned with no
+// check going red anywhere. third_party/ is vendored source KSail does not own; internal/ is its own
+// code and must stay covered.
 func TestTODOScannerExcludesOnlyVendoredSources(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Our to-do scanner files a GitHub issue whenever it sees the uppercase marker in a comment. That is exactly what it is for — but it means a comment that merely *talks about* the scanner files an issue about itself. One landed yesterday and produced #6763: an issue whose entire body was a comment block, with no work behind it. It was also the only issue in the whole portfolio missing an Issue Type, so it showed up as triage debt on top of being noise.

### What

Refers to the marker as "to-do" in that one explanatory comment — the same convention the shared workflow in `devantler-tech/actions` already applies to its own source, for this exact reason — and adds a test so the trap cannot come back unnoticed.

The guard is deliberately narrow: filing issues from real markers is the scanner's job, so it checks only that this one comment block stays clean rather than banning the marker repository-wide.

Fixes #6763
