### PR TITLE
fix(security): pin the k3k privileged-pod exemption to the controller identity

### DIFF
--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go
@@ -726,20 +726,33 @@ const unsafePodExpression = "object.spec.hostPID == true || " +
 	"(has(object.spec.ephemeralContainers) && object.spec.ephemeralContainers.exists(c, " +
 	unsafeContainerPredicate + "))"
 
+// statefulSetControllerPrincipals are the identities that can create the k3k server pod.
+//
+// k3k runs the server as a StatefulSet (rancher/k3k pkg/controller/cluster/server: StatefulServer
+// builds an appsv1.StatefulSet named <cluster>-server), and a StatefulSet controller creates its
+// pods directly rather than through an intermediate ReplicaSet. The creator is therefore always
+// kube-controller-manager's StatefulSet controller, under one of two spellings: the per-controller
+// service account when the host runs with --use-service-account-credentials, and the shared
+// component identity when it does not. Both are populated by the API server from the authenticated
+// request, so neither can be forged, and neither is obtainable by a namespace user.
+const statefulSetControllerPrincipals = "['system:serviceaccount:kube-system:statefulset-controller', " +
+	"'system:kube-controller-manager']"
+
 // serverPodExemptionTemplate is the CEL expression admitting an unsafe pod only when it is a
 // KSail-managed k3k server pod. Formatted with the server pod name prefix and the cluster name.
 //
 // The pod name and labels are attacker-controlled: anyone able to create a Pod in this namespace
 // can reproduce them. They are therefore paired with `request.userInfo`, which the API server
 // populates from the authenticated request and a requester cannot forge, so a pod hand-crafted by
-// a namespace user no longer satisfies the exemption. The k3k server pod is created by a
-// controller acting as a service account, which is what this admits.
+// a namespace user no longer satisfies the exemption. The username is additionally pinned to the
+// exact principals in statefulSetControllerPrincipals, so a compromised or hostile service account
+// that merely holds pod-create in this namespace no longer reaches the exemption either.
 //
 // Every map lookup is key-guarded. CEL raises "no such key" on a missing map key, and because
 // FailurePolicy is Fail an evaluation error becomes a rejection carrying that error instead of the
 // guard's own message.
 const serverPodExemptionTemplate = "!variables.isUnsafePod || " +
-	"(request.userInfo.username.startsWith('system:serviceaccount:') && " +
+	"(request.userInfo.username in " + statefulSetControllerPrincipals + " && " +
 	"object.metadata.name.startsWith('%s') && " +
 	"has(object.metadata.labels) && " +
 	"'cluster' in object.metadata.labels && " +

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_guardcel_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_guardcel_test.go
@@ -19,11 +19,19 @@ import (
 // provisioner actually ships and check the admit/reject decision for concrete pods.
 
 const (
-	guardTestCluster    = "nested-k3s"
-	guardTestNamespace  = "k3k-nested-k3s"
-	guardServerPodName  = "k3k-nested-k3s-server-0"
-	controllerUsername  = "system:serviceaccount:kube-system:statefulset-controller"
-	regularUserUsername = "kubernetes-admin"
+	guardTestCluster   = "nested-k3s"
+	guardTestNamespace = "k3k-nested-k3s"
+	guardServerPodName = "k3k-nested-k3s-server-0"
+	controllerUsername = "system:serviceaccount:kube-system:statefulset-controller"
+	// kubeControllerManagerUsername is the identity kube-controller-manager presents when it runs
+	// without --use-service-account-credentials, where every built-in controller shares one
+	// identity instead of getting a per-controller service account.
+	kubeControllerManagerUsername = "system:kube-controller-manager"
+	// hostileServiceAccountUsername is a service account any user able to create a pod in the
+	// namespace can obtain a token for. It satisfies the class-level startsWith check while not
+	// being the StatefulSet controller.
+	hostileServiceAccountUsername = "system:serviceaccount:k3k-nested-k3s:default"
+	regularUserUsername           = "kubernetes-admin"
 )
 
 // guardExpressions returns the isUnsafePod variable expression and the validation expression from
@@ -266,6 +274,25 @@ func exemptionCases(t *testing.T) []exemptionCase {
 
 	return []exemptionCase{
 		{
+			// The StatefulSet controller shares one identity with every other built-in
+			// controller when --use-service-account-credentials is off, so the guard admits
+			// that spelling too rather than letting the host distribution decide whether
+			// k3k provisions at all.
+			name:     "server pod created by a shared kube-controller-manager identity is admitted",
+			object:   unsafePodNamed(t, guardServerPodName, serverLabels),
+			username: kubeControllerManagerUsername,
+			admitted: true,
+		},
+		{
+			// The residual #6261 left behind: the class-level startsWith check proves only
+			// that some service account made the request, so any service account holding
+			// pod-create in this namespace reached the privileged exemption.
+			name:     "non-controller service account spoofing the server pod is rejected",
+			object:   unsafePodNamed(t, guardServerPodName, serverLabels),
+			username: hostileServiceAccountUsername,
+			admitted: false,
+		},
+		{
 			name:     "controller-created server pod is admitted",
 			object:   unsafePodNamed(t, guardServerPodName, serverLabels),
 			username: controllerUsername,
@@ -394,4 +421,53 @@ func TestGuardCEL_UnlabelledUnsafePodIsRejectedNotErrored(t *testing.T) {
 	_, err = evalGuardExpr(t, env, unguarded, input)
 	require.Error(t, err, "control must reproduce the missing-key failure the guards prevent")
 	assert.Contains(t, err.Error(), "no such key")
+}
+
+// Identity-narrowing regression. #6261 proved only that *a* service account made the request, so
+// every service account holding pod-create in the namespace reached the privileged exemption. The
+// negative control pins that the class-level form really did admit a hostile service account, so
+// this test fails if the exemption is ever widened back to a startsWith check.
+func TestGuardCEL_ExemptionPinsTheStatefulSetControllerIdentity(t *testing.T) {
+	t.Parallel()
+
+	_, validationExpr := guardExpressions(t)
+	env := guardEnv(t)
+
+	input := map[string]any{
+		"object": unsafePodNamed(
+			t,
+			guardServerPodName,
+			map[string]any{"cluster": guardTestCluster, "role": "server"},
+		),
+		"request": map[string]any{
+			"userInfo": map[string]any{"username": hostileServiceAccountUsername},
+		},
+		"variables": map[string]any{"isUnsafePod": true},
+	}
+
+	got, err := evalGuardExpr(t, env, validationExpr, input)
+	require.NoError(t, err)
+	assert.False(t, got, "a non-controller service account must not reach the exemption")
+
+	// Negative control: the class-level form this replaced admitted the same pod.
+	classLevel := fmt.Sprintf(
+		"!variables.isUnsafePod || "+
+			"(request.userInfo.username.startsWith('system:serviceaccount:') && "+
+			"object.metadata.name.startsWith('%s') && "+
+			"has(object.metadata.labels) && "+
+			"'cluster' in object.metadata.labels && "+
+			"object.metadata.labels['cluster'] == '%s' && "+
+			"'role' in object.metadata.labels && "+
+			"object.metadata.labels['role'] == 'server')",
+		"k3k-"+guardTestCluster+"-server-",
+		guardTestCluster,
+	)
+
+	admittedByControl, err := evalGuardExpr(t, env, classLevel, input)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		admittedByControl,
+		"control must reproduce the residual the narrowed identity check closes",
+	)
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The k3k namespace carries a blanket `privileged` Pod Security exemption, and an admission guard is what keeps that exemption reachable only by the cluster's own server pod. Until now the guard only checked that *a* service account made the request — not *which* one. Any service account able to create a pod in that namespace could copy the server pod's name and labels and obtain a privileged pod.

While pinning it, a second problem surfaced: the old check would have **rejected the real server pod outright** on any host cluster that runs its controllers under a single shared identity. Because the guard fails closed, that would have made k3k clusters impossible to create on those hosts.

### What

Narrows the exemption from "any service account" to the specific controller that actually creates the server pod, and accepts both spellings that controller can present depending on how the host cluster is configured — closing the escalation path without introducing the availability risk above.

The blocker recorded on the issue was that the creator could not be confirmed without a live cluster. It could: k3k is a direct dependency of this repository, and its source settles the question.

Fixes #6586
