### PR TITLE
fix(ui): keep operator views within phone-width screens

### DIFF
--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -538,14 +538,14 @@ export function App() {
   const headerActions =
     view === "clusters" ? (
       <>
-        <Button variant="secondary" size="sm" onClick={() => void refresh()} loading={refreshing}>
+        <Button variant="secondary" size="sm" aria-label="Refresh" onClick={() => void refresh()} loading={refreshing}>
           {refreshing ? null : <RotateCw className="size-4" aria-hidden />}
-          Refresh
+          <span className="hidden sm:inline">Refresh</span>
         </Button>
         {!readOnly ? (
-          <Button size="sm" onClick={openCreate}>
+          <Button size="sm" aria-label="New cluster" onClick={openCreate}>
             <Plus className="size-4" aria-hidden />
-            New cluster
+            <span className="hidden sm:inline">New cluster</span>
           </Button>
         ) : null}
       </>

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -375,7 +375,7 @@ export function AppShell({
               </button>
             ) : null}
             {/* Plugin-contributed app-bar actions (Headlamp registerAppBarAction); renders nothing until a plugin adds one. */}
-            <div className="flex min-w-0 max-w-10 shrink items-center overflow-hidden sm:max-w-32 lg:max-w-64">
+            <div className="flex min-w-0 max-w-10 shrink items-center overflow-hidden sm:max-w-32 lg:max-w-64 [&>*]:max-w-full [&>*]:truncate">
               <PluginAppBarActions />
             </div>
             {headerActions}

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -375,7 +375,9 @@ export function AppShell({
               </button>
             ) : null}
             {/* Plugin-contributed app-bar actions (Headlamp registerAppBarAction); renders nothing until a plugin adds one. */}
-            <PluginAppBarActions />
+            <div className="flex min-w-0 max-w-10 shrink items-center overflow-hidden sm:max-w-32 lg:max-w-64">
+              <PluginAppBarActions />
+            </div>
             {headerActions}
             <IconButton
               label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -345,7 +345,7 @@ export function AppShell({
 
       <div className="flex min-w-0 flex-1 flex-col">
         <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white/80 px-4 backdrop-blur md:px-6 dark:border-slate-800 dark:bg-slate-900/80">
-          <div className="flex min-w-0 items-center gap-2 md:gap-3">
+          <div className="flex min-w-0 flex-1 items-center gap-2 md:gap-3">
             <IconButton label="Open navigation" onClick={() => setDrawerOpen(true)} className="md:hidden">
               <MenuIcon className="size-5" />
             </IconButton>
@@ -359,7 +359,7 @@ export function AppShell({
               </span>
             ) : null}
           </div>
-          <div className="flex items-center gap-1.5">
+          <div className="flex shrink-0 items-center gap-1.5">
             {onOpenCommandPalette ? (
               <button
                 type="button"
@@ -396,7 +396,7 @@ export function AppShell({
           </div>
         </header>
 
-        <main id="main-content" className="flex-1 overflow-y-auto p-4 md:p-6">{children}</main>
+        <main id="main-content" className="min-w-0 flex-1 overflow-y-auto p-4 md:p-6">{children}</main>
       </div>
     </div>
   );

--- a/web/ui/src/components/AppShell.tsx
+++ b/web/ui/src/components/AppShell.tsx
@@ -6,8 +6,8 @@ import type { Theme } from "../hooks/useTheme.ts";
 import { clusterViews, globalViews, viewTitle, type RegisteredView, type View, type ViewGates } from "../lib/views.tsx";
 import { PluginAppBarActions } from "../lib/plugins/PluginSlots.tsx";
 import { activeSidebarId } from "../lib/plugins/pluginNavigation.ts";
-import type { SidebarNode } from "../lib/plugins/registry.ts";
-import { usePluginLocation } from "../lib/plugins/usePlugins.ts";
+import { registry, type SidebarNode } from "../lib/plugins/registry.ts";
+import { usePluginLocation, usePluginRegistry } from "../lib/plugins/usePlugins.ts";
 import { ClusterSwitcher } from "./ClusterSwitcher.tsx";
 import { KSailMark } from "./Logo.tsx";
 import { IconButton, NavButton } from "./ui.tsx";
@@ -212,6 +212,8 @@ export function AppShell({
   children: ReactNode;
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
+  usePluginRegistry();
+  const hasPluginActions = registry.getAppBarActions().length > 0;
 
   // The active plugin sidebar item + header title follow the live plugin-router location (so an in-plugin
   // <Link> to a detail page still highlights the right section). activeSidebarId maps the current plugin
@@ -375,9 +377,23 @@ export function AppShell({
               </button>
             ) : null}
             {/* Plugin-contributed app-bar actions (Headlamp registerAppBarAction); renders nothing until a plugin adds one. */}
-            <div className="flex min-w-0 max-w-10 shrink items-center overflow-hidden sm:max-w-32 lg:max-w-64 [&>*]:max-w-full [&>*]:truncate">
-              <PluginAppBarActions />
-            </div>
+            {hasPluginActions ? (
+              <details className="group relative sm:contents">
+                <summary
+                  className="flex size-8 cursor-pointer list-none items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-600 sm:hidden dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200 [&::-webkit-details-marker]:hidden"
+                  role="button"
+                  aria-label="Plugin actions"
+                >
+                  <Puzzle className="size-4" aria-hidden />
+                </summary>
+                <div
+                  className="fixed left-4 right-4 top-14 z-40 hidden flex-col items-stretch gap-1 rounded-lg border border-slate-200 bg-white p-2 shadow-lg group-open:flex sm:static sm:flex sm:w-auto sm:max-w-64 sm:flex-row sm:items-center sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none dark:border-slate-700 dark:bg-slate-900 sm:dark:bg-transparent [&>*]:min-h-10 [&>*]:min-w-0 [&>*]:max-w-full [&>*]:truncate sm:[&>*]:min-h-0"
+                  onClick={(event) => event.currentTarget.closest("details")?.removeAttribute("open")}
+                >
+                  <PluginAppBarActions />
+                </div>
+              </details>
+            ) : null}
             {headerActions}
             <IconButton
               label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}

--- a/web/ui/src/components/Card.tsx
+++ b/web/ui/src/components/Card.tsx
@@ -17,7 +17,7 @@ export function Card({
   return (
     <div
       className={cx(
-        "rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900",
+        "min-w-0 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900",
         className,
       )}
     >

--- a/web/ui/src/components/ClustersTable.tsx
+++ b/web/ui/src/components/ClustersTable.tsx
@@ -92,17 +92,27 @@ export function ClustersTable({
   return (
     <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+        <table className="w-full table-fixed divide-y divide-slate-200 sm:table-auto dark:divide-slate-800">
           <thead className="bg-slate-50 dark:bg-slate-800/50">
             <tr>
               <SortHeader {...headerProps} label="Name" sortKey="name" />
-              <SortHeader {...headerProps} label="Namespace" sortKey="namespace" />
-              <SortHeader {...headerProps} label="Distribution" sortKey="distribution" />
+              <SortHeader
+                {...headerProps}
+                label="Namespace"
+                sortKey="namespace"
+                className="hidden sm:table-cell"
+              />
+              <SortHeader
+                {...headerProps}
+                label="Distribution"
+                sortKey="distribution"
+                className="hidden sm:table-cell"
+              />
               <SortHeader {...headerProps} label="Provider" sortKey="provider" className="hidden sm:table-cell" />
-              <SortHeader {...headerProps} label="Status" sortKey="status" />
-              <SortHeader {...headerProps} label="Nodes" sortKey="nodes" />
-              <SortHeader {...headerProps} label="Age" sortKey="age" />
-              <th className={cx(th, "w-10")}>
+              <SortHeader {...headerProps} label="Status" sortKey="status" className="w-24" />
+              <SortHeader {...headerProps} label="Nodes" sortKey="nodes" className="hidden sm:table-cell" />
+              <SortHeader {...headerProps} label="Age" sortKey="age" className="hidden sm:table-cell" />
+              <th className={cx(th, "w-20 sm:w-10")}>
                 <span className="sr-only">Actions</span>
               </th>
             </tr>
@@ -129,16 +139,24 @@ export function ClustersTable({
                 }}
                 className="cursor-pointer transition-colors hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 dark:hover:bg-slate-800/50"
               >
-                <td className={cx(td, "font-medium text-slate-900 dark:text-white")}>
-                  <span className="inline-flex items-center gap-2">
-                    {cluster.metadata.name}
+                <td className={cx(td, "min-w-0 font-medium text-slate-900 dark:text-white")}>
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="truncate" title={cluster.metadata.name}>
+                      {cluster.metadata.name}
+                    </span>
                     {isHostCluster(cluster) ? <HostBadge /> : null}
                   </span>
+                  <span
+                    className="mt-1 block truncate text-xs font-normal text-slate-500 sm:hidden dark:text-slate-400"
+                    title={cluster.metadata.namespace ?? "default"}
+                  >
+                    {cluster.metadata.namespace ?? "default"}
+                  </span>
                 </td>
-                <td className={cx(td, "text-sm text-slate-600 dark:text-slate-300")}>
+                <td className={cx(td, "hidden text-sm text-slate-600 sm:table-cell dark:text-slate-300")}>
                   {cluster.metadata.namespace ?? "default"}
                 </td>
-                <td className={cx(td, "text-sm text-slate-600 dark:text-slate-300")}>
+                <td className={cx(td, "hidden text-sm text-slate-600 sm:table-cell dark:text-slate-300")}>
                   {cluster.spec?.cluster?.distribution ?? "—"}
                 </td>
                 <td className={cx(td, "hidden text-sm text-slate-600 sm:table-cell dark:text-slate-300")}>
@@ -147,10 +165,10 @@ export function ClustersTable({
                 <td className={td}>
                   <StatusBadge phase={clusterPhase(cluster)} />
                 </td>
-                <td className={cx(td, "text-sm")}>
+                <td className={cx(td, "hidden text-sm sm:table-cell")}>
                   <NodeCount cluster={cluster} />
                 </td>
-                <td className={cx(td, "text-sm text-slate-500 tabular-nums dark:text-slate-400")}>
+                <td className={cx(td, "hidden text-sm text-slate-500 tabular-nums sm:table-cell dark:text-slate-400")}>
                   {format(cluster.metadata.creationTimestamp)}
                 </td>
                 <td className={cx(td, "text-right")}>

--- a/web/ui/src/components/EventList.tsx
+++ b/web/ui/src/components/EventList.tsx
@@ -30,7 +30,7 @@ function EventRow({ event }: { event: EventFields }) {
       <EventTypeBadge type={event.type} />
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-2">
-          <span className="font-medium text-slate-700 dark:text-slate-200">{event.reason || "Event"}</span>
+          <span className="min-w-0 break-words font-medium text-slate-700 dark:text-slate-200">{event.reason || "Event"}</span>
           {event.objectName ? (
             <span className="truncate text-xs text-slate-500 dark:text-slate-400">
               {event.objectKind ? `${event.objectKind}/` : ""}

--- a/web/ui/src/components/EventsView.tsx
+++ b/web/ui/src/components/EventsView.tsx
@@ -80,15 +80,18 @@ export function EventsView({ cluster }: { cluster: Cluster | null }) {
         emptyIcon={<Activity className="size-6" aria-hidden />}
         onRetry={refresh}
       >
-        <TableCard>
+        <TableCard tableClassName="w-full table-fixed sm:table-auto">
           <thead className="bg-slate-50 dark:bg-slate-800/50">
             <tr>
-              <th className={th}>Type</th>
-              <th className={th}>Reason</th>
+              <th className={cx(th, "w-24")}>Type</th>
+              <th className={th}>
+                <span className="sm:hidden">Event</span>
+                <span className="hidden sm:inline">Reason</span>
+              </th>
               <th className={cx(th, "hidden sm:table-cell")}>Object</th>
-              <th className={th}>Message</th>
+              <th className={cx(th, "hidden sm:table-cell")}>Message</th>
               <th className={cx(th, "hidden md:table-cell")}>Count</th>
-              <th className={th}>Last seen</th>
+              <th className={cx(th, "hidden sm:table-cell")}>Last seen</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -97,7 +100,31 @@ export function EventsView({ cluster }: { cluster: Cluster | null }) {
                 <td className={td}>
                   <EventTypeBadge type={event.type} />
                 </td>
-                <td className={cx(td, "font-medium text-slate-900 dark:text-white")}>{event.reason || "—"}</td>
+                <td className={cx(td, "min-w-0 text-slate-900 dark:text-white")}>
+                  <span className="block truncate font-medium" title={event.reason}>
+                    {event.reason || "—"}
+                  </span>
+                  {event.objectName ? (
+                    <span
+                      className="mt-1 block truncate text-xs text-slate-500 sm:hidden dark:text-slate-400"
+                      title={`${event.objectKind ? `${event.objectKind}/` : ""}${event.objectName}`}
+                    >
+                      {event.objectKind ? `${event.objectKind}/` : ""}
+                      {event.objectName}
+                    </span>
+                  ) : null}
+                  {event.message ? (
+                    <p
+                      className="mt-1 line-clamp-3 break-words text-xs font-normal text-slate-500 sm:hidden dark:text-slate-400"
+                      title={event.message}
+                    >
+                      {event.message}
+                    </p>
+                  ) : null}
+                  <span className="mt-1 block text-xs font-normal tabular-nums text-slate-400 sm:hidden">
+                    {format(event.lastSeen)}
+                  </span>
+                </td>
                 <td className={cx(td, "hidden text-sm text-slate-600 sm:table-cell dark:text-slate-300")}>
                   {event.objectName ? (
                     <span className="break-words">
@@ -108,7 +135,7 @@ export function EventsView({ cluster }: { cluster: Cluster | null }) {
                     "—"
                   )}
                 </td>
-                <td className={cx(td, "max-w-md text-sm text-slate-600 dark:text-slate-300")}>
+                <td className={cx(td, "hidden max-w-md text-sm text-slate-600 sm:table-cell dark:text-slate-300")}>
                   <span className="line-clamp-2 break-words" title={event.message}>
                     {event.message || "—"}
                   </span>
@@ -116,7 +143,7 @@ export function EventsView({ cluster }: { cluster: Cluster | null }) {
                 <td className={cx(td, "hidden text-sm tabular-nums text-slate-500 md:table-cell dark:text-slate-400")}>
                   {event.count}
                 </td>
-                <td className={cx(td, "text-sm tabular-nums text-slate-500 dark:text-slate-400")}>
+                <td className={cx(td, "hidden text-sm tabular-nums text-slate-500 sm:table-cell dark:text-slate-400")}>
                   {format(event.lastSeen)}
                 </td>
               </tr>

--- a/web/ui/src/components/EventsView.tsx
+++ b/web/ui/src/components/EventsView.tsx
@@ -101,7 +101,7 @@ export function EventsView({ cluster }: { cluster: Cluster | null }) {
                   <EventTypeBadge type={event.type} />
                 </td>
                 <td className={cx(td, "min-w-0 text-slate-900 dark:text-white")}>
-                  <span className="block truncate font-medium" title={event.reason}>
+                  <span className="block break-words font-medium sm:truncate" title={event.reason}>
                     {event.reason || "—"}
                   </span>
                   {event.objectName ? (

--- a/web/ui/src/components/OverviewView.tsx
+++ b/web/ui/src/components/OverviewView.tsx
@@ -50,7 +50,7 @@ function CopyableEndpoint({ endpoint }: { endpoint: string }) {
           .then(() => toast.success("Endpoint copied"))
           .catch(() => toast.error("Copy failed"));
       }}
-      className="group inline-flex max-w-full items-center gap-1.5"
+      className="group inline-flex min-w-0 max-w-full items-center gap-1.5"
     >
       <span className="truncate font-mono text-xs text-slate-700 dark:text-slate-300">{endpoint}</span>
       <Copy className="size-3.5 shrink-0 text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-200" aria-hidden />
@@ -163,12 +163,14 @@ export function OverviewView({
   const createdAt = cluster.metadata.creationTimestamp ?? health?.createdAt;
 
   return (
-    <div className="mx-auto max-w-6xl space-y-5">
+    <div className="mx-auto min-w-0 max-w-6xl space-y-5">
       {/* Cluster header: identity, status, and lifecycle actions. */}
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="flex items-center gap-2.5">
-            <h2 className="truncate text-xl font-semibold text-slate-900 dark:text-white">{cluster.metadata.name}</h2>
+          <div className="flex min-w-0 items-center gap-2.5">
+            <h2 className="min-w-0 truncate text-xl font-semibold text-slate-900 dark:text-white">
+              {cluster.metadata.name}
+            </h2>
             <StatusBadge phase={clusterPhase(cluster)} />
             {hostCluster ? <HostBadge /> : null}
           </div>
@@ -218,7 +220,7 @@ export function OverviewView({
 
       {/* Live health (workload-read only). */}
       {canBrowse ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           <Card title="Nodes" icon={<Boxes className="size-3.5" aria-hidden />}>
             <div className="flex items-baseline gap-2">
               <span
@@ -273,7 +275,7 @@ export function OverviewView({
       ) : null}
 
       {/* Cluster spec, status, conditions, and (when available) recent warnings. */}
-      <div className="grid gap-4 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <Card title="Spec" icon={<Server className="size-3.5" aria-hidden />}>
           <dl className="divide-y divide-slate-100 dark:divide-slate-800">
             <Field label="Distribution">{distribution}</Field>
@@ -340,7 +342,9 @@ export function OverviewView({
                     {conditionIcon(condition.status)}
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center justify-between gap-2">
-                        <span className="text-sm font-medium text-slate-800 dark:text-slate-100">{condition.type}</span>
+                        <span className="min-w-0 break-words text-sm font-medium text-slate-800 dark:text-slate-100">
+                          {condition.type}
+                        </span>
                         {condition.lastTransitionTime ? (
                           <span className="shrink-0 text-xs tabular-nums text-slate-400">
                             {format(condition.lastTransitionTime)}
@@ -348,10 +352,10 @@ export function OverviewView({
                         ) : null}
                       </div>
                       {condition.reason ? (
-                        <p className="text-xs text-slate-500 dark:text-slate-400">{condition.reason}</p>
+                        <p className="break-words text-xs text-slate-500 dark:text-slate-400">{condition.reason}</p>
                       ) : null}
                       {condition.message ? (
-                        <p className="text-xs text-slate-500 dark:text-slate-400">{condition.message}</p>
+                        <p className="break-words text-xs text-slate-500 dark:text-slate-400">{condition.message}</p>
                       ) : null}
                     </div>
                   </li>

--- a/web/ui/src/components/OverviewView.tsx
+++ b/web/ui/src/components/OverviewView.tsx
@@ -174,7 +174,7 @@ export function OverviewView({
             <StatusBadge phase={clusterPhase(cluster)} />
             {hostCluster ? <HostBadge /> : null}
           </div>
-          <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+          <p className="mt-0.5 break-words text-sm text-slate-500 dark:text-slate-400">
             {distribution} · {provider} · namespace {namespace}
           </p>
         </div>

--- a/web/ui/src/components/ResourcesView.tsx
+++ b/web/ui/src/components/ResourcesView.tsx
@@ -294,7 +294,7 @@ export function ResourcesView({
         emptyIcon={<Layers className="size-6" aria-hidden />}
         onRetry={refresh}
       >
-        <TableCard>
+        <TableCard tableClassName="w-full table-fixed sm:table-auto">
           <thead className="bg-slate-50 dark:bg-slate-800/50">
             <tr>
               <SortHeader label="Name" sortKey="name" activeKey={sortKey} dir={sortDir} onSort={toggleSort} />
@@ -307,7 +307,14 @@ export function ResourcesView({
                 className="hidden sm:table-cell"
               />
               <SortHeader label="Status" sortKey="status" activeKey={sortKey} dir={sortDir} onSort={toggleSort} />
-              <SortHeader label="Age" sortKey="age" activeKey={sortKey} dir={sortDir} onSort={toggleSort} />
+              <SortHeader
+                label="Age"
+                sortKey="age"
+                activeKey={sortKey}
+                dir={sortDir}
+                onSort={toggleSort}
+                className="hidden sm:table-cell"
+              />
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -325,14 +332,26 @@ export function ResourcesView({
                 }}
                 className="cursor-pointer transition-colors hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 dark:hover:bg-slate-800/50"
               >
-                <td className={cx(td, "font-medium text-slate-900 dark:text-white")}>{item.metadata?.name ?? "—"}</td>
+                <td className={cx(td, "min-w-0 font-medium text-slate-900 dark:text-white")}>
+                  <span className="block truncate" title={item.metadata?.name}>
+                    {item.metadata?.name ?? "—"}
+                  </span>
+                  {item.metadata?.namespace ? (
+                    <span
+                      className="mt-1 block truncate text-xs font-normal text-slate-500 sm:hidden dark:text-slate-400"
+                      title={item.metadata.namespace}
+                    >
+                      {item.metadata.namespace}
+                    </span>
+                  ) : null}
+                </td>
                 <td className={cx(td, "hidden text-sm text-slate-600 sm:table-cell dark:text-slate-300")}>
                   {item.metadata?.namespace ?? "—"}
                 </td>
                 <td className={cx(td, "text-sm")}>
                   <ResourceStatusBadge obj={item} />
                 </td>
-                <td className={cx(td, "text-sm text-slate-500 tabular-nums dark:text-slate-400")}>
+                <td className={cx(td, "hidden text-sm text-slate-500 tabular-nums sm:table-cell dark:text-slate-400")}>
                   {format(item.metadata?.creationTimestamp)}
                 </td>
               </tr>

--- a/web/ui/src/components/ResourcesView.tsx
+++ b/web/ui/src/components/ResourcesView.tsx
@@ -34,9 +34,16 @@ function ResourceStatusBadge({ obj }: { obj: K8sObject }) {
   }
 
   return (
-    <span className="inline-flex items-center gap-1.5">
-      <StatusDot tone={status.ok ? "ok" : "warn"} />
-      <span className={status.ok ? "text-slate-600 dark:text-slate-300" : "text-amber-700 dark:text-amber-400"}>
+    <span className="flex min-w-0 max-w-full items-start gap-1.5">
+      <span className="mt-0.5 shrink-0">
+        <StatusDot tone={status.ok ? "ok" : "warn"} />
+      </span>
+      <span
+        className={cx(
+          "min-w-0 break-words",
+          status.ok ? "text-slate-600 dark:text-slate-300" : "text-amber-700 dark:text-amber-400",
+        )}
+      >
         {status.label}
       </span>
     </span>

--- a/web/ui/src/components/StatusBadge.tsx
+++ b/web/ui/src/components/StatusBadge.tsx
@@ -152,12 +152,14 @@ export function StatusBadge({ phase }: { phase?: string }) {
   return (
     <span
       className={cx(
-        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
+        "inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
         meta.badge,
       )}
     >
-      <Icon className={cx("size-3.5", meta.spin && "animate-spin")} aria-hidden />
-      {meta.label}
+      <Icon className={cx("size-3.5 shrink-0", meta.spin && "animate-spin")} aria-hidden />
+      <span className="truncate" title={meta.label}>
+        {meta.label}
+      </span>
     </span>
   );
 }

--- a/web/ui/src/components/table.tsx
+++ b/web/ui/src/components/table.tsx
@@ -158,11 +158,13 @@ export function SortHeader<K extends string>({
 }
 
 // TableCard wraps table markup (thead/tbody) in the standard bordered, horizontally-scrollable card.
-export function TableCard({ children }: { children: ReactNode }) {
+export function TableCard({ children, tableClassName }: { children: ReactNode; tableClassName?: string }) {
   return (
     <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">{children}</table>
+        <table className={cx("min-w-full divide-y divide-slate-200 dark:divide-slate-800", tableClassName)}>
+          {children}
+        </table>
       </div>
     </div>
   );

--- a/web/ui/tests/mobile-layout.spec.ts
+++ b/web/ui/tests/mobile-layout.spec.ts
@@ -1,0 +1,254 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const CLUSTER_NAME = "production-observability-control-plane-with-a-very-long-generated-cluster-name";
+const NAMESPACE = "platform-observability-and-security-services";
+const POD_NAME = "metrics-exporter-with-an-intentionally-long-unbroken-generated-pod-name-7f9c8d6b5f-qwert";
+
+const cluster = {
+  metadata: {
+    name: CLUSTER_NAME,
+    namespace: NAMESPACE,
+    creationTimestamp: "2026-08-01T12:00:00Z",
+  },
+  spec: {
+    cluster: {
+      distribution: "VCluster",
+      provider: "Kubernetes",
+      workers: 12,
+      controlPlanes: 3,
+    },
+  },
+  status: {
+    phase: "Ready",
+    endpoint: `https://${CLUSTER_NAME}.example.invalid:6443`,
+    nodesReady: 15,
+    nodesTotal: 15,
+    lastReconcileTime: "2026-08-29T16:00:00Z",
+    conditions: [
+      {
+        type: "InfrastructureAndWorkloadsRemainHealthyAcrossEveryAvailabilityZone",
+        status: "True",
+        reason: "AllInfrastructureComponentsSuccessfullyReconciled",
+        message:
+          "Every infrastructure component and workload is healthy across all availability zones with no pending remediation.",
+        lastTransitionTime: "2026-08-29T16:00:00Z",
+      },
+    ],
+  },
+};
+
+const node = {
+  apiVersion: "v1",
+  kind: "Node",
+  metadata: {
+    name: "worker-node-with-a-very-long-cloud-provider-generated-identifier-0123456789",
+    creationTimestamp: "2026-08-01T12:00:00Z",
+    labels: { "node-role.kubernetes.io/control-plane": "" },
+  },
+  status: {
+    capacity: { cpu: "8", memory: "16Gi", pods: "110" },
+    allocatable: { cpu: "7500m", memory: "15Gi", pods: "110" },
+    nodeInfo: { kubeletVersion: "v1.37.0", osImage: "Talos Linux v1.12.0" },
+    conditions: [{ type: "Ready", status: "True", lastTransitionTime: "2026-08-29T16:00:00Z" }],
+  },
+};
+
+const pod = {
+  apiVersion: "v1",
+  kind: "Pod",
+  metadata: {
+    name: POD_NAME,
+    namespace: "observability-system-with-a-long-namespace",
+    creationTimestamp: "2026-08-29T12:00:00Z",
+  },
+  spec: {
+    containers: [{ name: "metrics-exporter", resources: { requests: { cpu: "250m", memory: "256Mi" } } }],
+  },
+  status: {
+    phase: "Running",
+    containerStatuses: [{ name: "metrics-exporter", ready: true }],
+  },
+};
+
+const event = {
+  apiVersion: "v1",
+  kind: "Event",
+  metadata: {
+    name: "warning-with-a-long-generated-event-name",
+    namespace: NAMESPACE,
+    creationTimestamp: "2026-08-29T15:55:00Z",
+  },
+  type: "Warning",
+  reason: "BackOffBecauseAContainerWithAnExceptionallyLongNameCouldNotStart",
+  message:
+    "The workload reported an intentionally long diagnostic message without natural break opportunities: abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789.",
+  involvedObject: { kind: "Pod", name: POD_NAME, namespace: pod.metadata.namespace },
+  count: 12345,
+  lastTimestamp: "2026-08-29T15:55:00Z",
+};
+
+function resources(kind: string) {
+  if (kind === "Node") return [node];
+  if (kind === "Pod") return [pod];
+  if (kind === "Event") return [event];
+  if (kind === "NodeMetrics") {
+    return [{ metadata: { name: node.metadata.name }, usage: { cpu: "3200m", memory: "8Gi" } }];
+  }
+  if (kind === "PodMetrics") {
+    return [
+      {
+        metadata: { name: POD_NAME, namespace: pod.metadata.namespace },
+        containers: [{ name: "metrics-exporter", usage: { cpu: "950m", memory: "900Mi" } }],
+      },
+    ];
+  }
+  return [];
+}
+
+async function mockOperatorApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname === "/api/v1/config") {
+      await route.fulfill({
+        json: {
+          readOnly: false,
+          authEnabled: false,
+          mode: "operator",
+          capabilities: {
+            clusterUpdate: true,
+            workloadRead: true,
+            workloadWrite: true,
+            kubeconfigDownload: true,
+            applyManifests: true,
+            secretsCipher: false,
+            workloadLogs: true,
+            workloadExec: true,
+            clusterStartStop: false,
+            componentsInstall: true,
+            plugins: false,
+            aiChat: false,
+            kubeProxy: false,
+            pluginInstall: false,
+            aiChatWrite: false,
+            pluginCatalog: false,
+            kubeWatch: false,
+            wsMultiplexer: false,
+          },
+        },
+      });
+      return;
+    }
+
+    if (url.pathname === "/api/v1/meta") {
+      await route.fulfill({
+        json: {
+          distributions: ["VCluster"],
+          providers: { VCluster: ["Kubernetes"] },
+          components: [],
+          resourceKinds: ["Pod", "Deployment", "StatefulSet", "DaemonSet", "Event", "Node", "Namespace"].map(
+            (kind) => ({
+              kind,
+              namespaced: !["Node", "Namespace"].includes(kind),
+              scalable: ["Deployment", "StatefulSet"].includes(kind),
+              restartable: ["Deployment", "StatefulSet", "DaemonSet"].includes(kind),
+              reconcilable: false,
+              deletable: !["Node", "Namespace"].includes(kind),
+              browsable: true,
+            }),
+          ),
+        },
+      });
+      return;
+    }
+
+    if (url.pathname === "/api/v1/clusters") {
+      await route.fulfill({ json: { items: [cluster] } });
+      return;
+    }
+
+    if (url.pathname.endsWith("/resources")) {
+      await route.fulfill({ json: { items: resources(url.searchParams.get("kind") ?? "") } });
+      return;
+    }
+
+    if (url.pathname === "/api/v1/events") {
+      await route.fulfill({ status: 204 });
+      return;
+    }
+
+    await route.fulfill({ status: 404, json: { error: `No mock route for ${url.pathname}` } });
+  });
+}
+
+async function expectPageAndTableToFit(page: Page) {
+  const widths = await page.evaluate(() => {
+    const table = document.querySelector("table");
+    const scroller = table?.parentElement;
+
+    return {
+      documentClientWidth: document.documentElement.clientWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      tableScrollerClientWidth: scroller?.clientWidth ?? 0,
+      tableScrollerScrollWidth: scroller?.scrollWidth ?? 0,
+    };
+  });
+
+  expect(widths.documentScrollWidth).toBe(widths.documentClientWidth);
+  expect(widths.tableScrollerScrollWidth).toBe(widths.tableScrollerClientWidth);
+}
+
+async function navigateFromDrawer(page: Page, label: "Resources" | "Events") {
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await page.getByRole("dialog").getByRole("button", { name: label, exact: true }).click();
+}
+
+test.use({ viewport: { width: 320, height: 800 } });
+
+test("operator views remain usable without horizontal overflow on a phone", async ({ page }) => {
+  await mockOperatorApi(page);
+  await page.goto("/");
+
+  const pageTitle = page.getByRole("heading", { name: "Clusters", level: 1 });
+  await expect(pageTitle).toBeVisible();
+  await expect(pageTitle).toBeInViewport({ ratio: 1 });
+  await expect(page.getByRole("button", { name: "Refresh", exact: true })).toBeInViewport({ ratio: 1 });
+  await expect(page.getByRole("button", { name: "New cluster", exact: true })).toBeInViewport({ ratio: 1 });
+  await expectPageAndTableToFit(page);
+
+  await expect(page.getByRole("columnheader", { name: "Name" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Status" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Namespace" })).toBeHidden();
+  await page.getByText(CLUSTER_NAME, { exact: true }).click();
+
+  const specCard = page.getByText("Spec", { exact: true }).locator("..");
+  const statusCard = page.getByText("Status", { exact: true }).locator("..");
+  const conditionsCard = page.getByText("Conditions", { exact: true }).locator("..");
+  await expect(specCard).toBeInViewport({ ratio: 1 });
+  await expect(statusCard).toBeInViewport({ ratio: 1 });
+  await expect(conditionsCard).toBeInViewport({ ratio: 1 });
+
+  const overviewWidth = await page.evaluate(() => {
+    const mainContent = document.querySelector<HTMLElement>("#main-content")!;
+    return {
+      documentClientWidth: document.documentElement.clientWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      mainClientWidth: mainContent.clientWidth,
+      mainScrollWidth: mainContent.scrollWidth,
+    };
+  });
+  expect(overviewWidth.documentScrollWidth).toBe(overviewWidth.documentClientWidth);
+  expect(overviewWidth.mainScrollWidth).toBe(overviewWidth.mainClientWidth);
+
+  await navigateFromDrawer(page, "Resources");
+  await expect(page.getByText(POD_NAME, { exact: true })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Name" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Status" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Age" })).toBeHidden();
+  await expectPageAndTableToFit(page);
+
+  await navigateFromDrawer(page, "Events");
+  await expect(page.getByText(event.reason, { exact: true })).toBeVisible();
+  await expect(page.getByText(event.message, { exact: true })).toBeVisible();
+  await expectPageAndTableToFit(page);
+});

--- a/web/ui/tests/mobile-layout.spec.ts
+++ b/web/ui/tests/mobile-layout.spec.ts
@@ -3,7 +3,12 @@ import { expect, test, type Page } from "@playwright/test";
 const CLUSTER_NAME = "production-observability-control-plane-with-a-very-long-generated-cluster-name";
 const NAMESPACE = "n".repeat(63);
 const POD_NAME = "metrics-exporter-with-an-intentionally-long-unbroken-generated-pod-name-7f9c8d6b5f-qwert";
-const PLUGIN_ACTION_LABEL = "PluginActionWithoutAnyNaturalBreakOpportunity".repeat(3);
+const PLUGIN_ACTION_LABELS = [
+  "PluginActionWithoutAnyNaturalBreakOpportunity".repeat(3),
+  "SecondPluginActionWithoutAnyNaturalBreakOpportunity".repeat(3),
+];
+const RESOURCE_READY_REASON = "ControllerReportedAnExceptionallyLongUnbrokenReadinessFailureReason".repeat(2);
+const RESOURCE_STATUS_LABEL = `Not Ready: ${RESOURCE_READY_REASON}`;
 
 const cluster = {
   metadata: {
@@ -20,7 +25,7 @@ const cluster = {
     },
   },
   status: {
-    phase: "Ready",
+    phase: "Provisioning",
     endpoint: `https://${CLUSTER_NAME}.example.invalid:6443`,
     nodesReady: 15,
     nodesTotal: 15,
@@ -67,6 +72,7 @@ const pod = {
   },
   status: {
     phase: "Running",
+    conditions: [{ type: "Ready", status: "False", reason: RESOURCE_READY_REASON }],
     containerStatuses: [{ name: "metrics-exporter", ready: true }],
   },
 };
@@ -149,7 +155,10 @@ async function mockOperatorApi(page: Page) {
     if (url.pathname === "/api/v1/plugins/wide-action/main.js") {
       await route.fulfill({
         contentType: "application/javascript",
-        body: `window.pluginLib.registerAppBarAction(window.pluginLib.React.createElement("button", { type: "button", "aria-label": "${PLUGIN_ACTION_LABEL}" }, "${PLUGIN_ACTION_LABEL}"));`,
+        body: PLUGIN_ACTION_LABELS.map(
+          (label) =>
+            `window.pluginLib.registerAppBarAction(window.pluginLib.React.createElement("button", { type: "button", "aria-label": "${label}" }, "${label}"));`,
+        ).join("\n"),
       });
       return;
     }
@@ -226,9 +235,15 @@ test("operator views remain usable without horizontal overflow on a phone", asyn
   const pageTitle = page.getByRole("heading", { name: "Clusters", level: 1 });
   await expect(pageTitle).toBeVisible();
   await expect(pageTitle).toBeInViewport({ ratio: 1 });
-  const pluginAction = page.getByRole("button", { name: PLUGIN_ACTION_LABEL });
-  await expect(pluginAction).toBeVisible();
-  await expect(pluginAction).toBeInViewport({ ratio: 1 });
+  const pluginActions = page.getByRole("button", { name: "Plugin actions" });
+  await expect(pluginActions).toBeInViewport({ ratio: 1 });
+  await pluginActions.click();
+  for (const label of PLUGIN_ACTION_LABELS) {
+    const action = page.getByRole("button", { name: label });
+    await expect(action).toBeVisible();
+    await expect(action).toBeInViewport({ ratio: 1 });
+  }
+  await pluginActions.click();
   await expect(page.getByRole("button", { name: "Refresh", exact: true })).toBeInViewport({ ratio: 1 });
   await expect(page.getByRole("button", { name: "New cluster", exact: true })).toBeInViewport({ ratio: 1 });
   await expectPageAndTableToFit(page);
@@ -236,6 +251,8 @@ test("operator views remain usable without horizontal overflow on a phone", asyn
   await expect(page.getByRole("columnheader", { name: "Name" })).toBeVisible();
   await expect(page.getByRole("columnheader", { name: "Status" })).toBeVisible();
   await expect(page.getByRole("columnheader", { name: "Namespace" })).toBeHidden();
+  const clusterStatusCell = page.getByRole("cell", { name: "Provisioning" });
+  expect(await clusterStatusCell.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
   await page.getByText(CLUSTER_NAME, { exact: true }).click();
 
   const specCard = page.getByText("Spec", { exact: true }).locator("..");
@@ -265,10 +282,20 @@ test("operator views remain usable without horizontal overflow on a phone", asyn
   await expect(page.getByRole("columnheader", { name: "Name" })).toBeVisible();
   await expect(page.getByRole("columnheader", { name: "Status" })).toBeVisible();
   await expect(page.getByRole("columnheader", { name: "Age" })).toBeHidden();
+  const resourceStatusCell = page.getByRole("cell", {
+    name: RESOURCE_STATUS_LABEL,
+  });
+  expect(await resourceStatusCell.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
   await expectPageAndTableToFit(page);
 
   await navigateFromDrawer(page, "Events");
-  await expect(page.getByText(event.reason, { exact: true })).toBeVisible();
+  const eventReason = page.getByText(event.reason, { exact: true });
+  await expect(eventReason).toBeVisible();
+  expect(
+    await eventReason.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight,
+    ),
+  ).toBe(true);
   await expect(page.getByText(event.message, { exact: true }).filter({ visible: true })).toBeVisible();
   await expectPageAndTableToFit(page);
 });

--- a/web/ui/tests/mobile-layout.spec.ts
+++ b/web/ui/tests/mobile-layout.spec.ts
@@ -226,7 +226,9 @@ test("operator views remain usable without horizontal overflow on a phone", asyn
   const pageTitle = page.getByRole("heading", { name: "Clusters", level: 1 });
   await expect(pageTitle).toBeVisible();
   await expect(pageTitle).toBeInViewport({ ratio: 1 });
-  await expect(page.getByRole("button", { name: PLUGIN_ACTION_LABEL })).toBeVisible();
+  const pluginAction = page.getByRole("button", { name: PLUGIN_ACTION_LABEL });
+  await expect(pluginAction).toBeVisible();
+  await expect(pluginAction).toBeInViewport({ ratio: 1 });
   await expect(page.getByRole("button", { name: "Refresh", exact: true })).toBeInViewport({ ratio: 1 });
   await expect(page.getByRole("button", { name: "New cluster", exact: true })).toBeInViewport({ ratio: 1 });
   await expectPageAndTableToFit(page);

--- a/web/ui/tests/mobile-layout.spec.ts
+++ b/web/ui/tests/mobile-layout.spec.ts
@@ -224,8 +224,11 @@ test("operator views remain usable without horizontal overflow on a phone", asyn
   const specCard = page.getByText("Spec", { exact: true }).locator("..");
   const statusCard = page.getByText("Status", { exact: true }).locator("..");
   const conditionsCard = page.getByText("Conditions", { exact: true }).locator("..");
+  await specCard.scrollIntoViewIfNeeded();
   await expect(specCard).toBeInViewport({ ratio: 1 });
+  await statusCard.scrollIntoViewIfNeeded();
   await expect(statusCard).toBeInViewport({ ratio: 1 });
+  await conditionsCard.scrollIntoViewIfNeeded();
   await expect(conditionsCard).toBeInViewport({ ratio: 1 });
 
   const overviewWidth = await page.evaluate(() => {
@@ -249,6 +252,6 @@ test("operator views remain usable without horizontal overflow on a phone", asyn
 
   await navigateFromDrawer(page, "Events");
   await expect(page.getByText(event.reason, { exact: true })).toBeVisible();
-  await expect(page.getByText(event.message, { exact: true })).toBeVisible();
+  await expect(page.getByText(event.message, { exact: true }).filter({ visible: true })).toBeVisible();
   await expectPageAndTableToFit(page);
 });

--- a/web/ui/tests/mobile-layout.spec.ts
+++ b/web/ui/tests/mobile-layout.spec.ts
@@ -205,6 +205,8 @@ async function mockOperatorApi(page: Page) {
 }
 
 async function expectPageAndTableToFit(page: Page) {
+  await expect(page.locator("table")).toBeVisible();
+
   const widths = await page.evaluate(() => {
     const table = document.querySelector("table");
     const scroller = table?.parentElement;

--- a/web/ui/tests/mobile-layout.spec.ts
+++ b/web/ui/tests/mobile-layout.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
 
 const CLUSTER_NAME = "production-observability-control-plane-with-a-very-long-generated-cluster-name";
-const NAMESPACE = "platform-observability-and-security-services";
+const NAMESPACE = "n".repeat(63);
 const POD_NAME = "metrics-exporter-with-an-intentionally-long-unbroken-generated-pod-name-7f9c8d6b5f-qwert";
+const PLUGIN_ACTION_LABEL = "PluginActionWithoutAnyNaturalBreakOpportunity".repeat(3);
 
 const cluster = {
   metadata: {
@@ -126,7 +127,7 @@ async function mockOperatorApi(page: Page) {
             workloadExec: true,
             clusterStartStop: false,
             componentsInstall: true,
-            plugins: false,
+            plugins: true,
             aiChat: false,
             kubeProxy: false,
             pluginInstall: false,
@@ -136,6 +137,19 @@ async function mockOperatorApi(page: Page) {
             wsMultiplexer: false,
           },
         },
+      });
+      return;
+    }
+
+    if (url.pathname === "/api/v1/plugins") {
+      await route.fulfill({ json: { plugins: [{ name: "wide-action", main: "main.js" }] } });
+      return;
+    }
+
+    if (url.pathname === "/api/v1/plugins/wide-action/main.js") {
+      await route.fulfill({
+        contentType: "application/javascript",
+        body: `window.pluginLib.registerAppBarAction(window.pluginLib.React.createElement("button", { type: "button", "aria-label": "${PLUGIN_ACTION_LABEL}" }, "${PLUGIN_ACTION_LABEL}"));`,
       });
       return;
     }
@@ -212,6 +226,7 @@ test("operator views remain usable without horizontal overflow on a phone", asyn
   const pageTitle = page.getByRole("heading", { name: "Clusters", level: 1 });
   await expect(pageTitle).toBeVisible();
   await expect(pageTitle).toBeInViewport({ ratio: 1 });
+  await expect(page.getByRole("button", { name: PLUGIN_ACTION_LABEL })).toBeVisible();
   await expect(page.getByRole("button", { name: "Refresh", exact: true })).toBeInViewport({ ratio: 1 });
   await expect(page.getByRole("button", { name: "New cluster", exact: true })).toBeInViewport({ ratio: 1 });
   await expectPageAndTableToFit(page);


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The operator workspace currently becomes clipped or horizontally scrollable on phone-width screens when real Kubernetes names and diagnostic messages are present. Operators can lose the page title, status details, and event context.

## What

- adds a real-SPA Playwright regression at 320 × 800 with populated operator responses;
- keeps app-bar identity and actions visible on narrow screens;
- bounds overview grids and long identifiers to the viewport;
- presents mobile cluster, resource, and event data without sideways component scrolling.

## Validation

- [x] Reproduced live in the in-app browser at 320 × 800.
- [x] Playwright regression observed RED on the collapsed Clusters heading.
- [x] Focused Playwright regression GREEN.
- [x] UI lint/build GREEN.
- [x] Live browser evaluation GREEN on Clusters, Overview, Resources, and Events.

At 320 × 800, document, main-content, and table-scroller widths now match their client widths on all four views; overview detail cards render at 273 px instead of the 889 px baseline.

Fixes #6773
