### PR TITLE
fix(deps): migrate cel-go to its cel.dev module path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,9 +222,10 @@ linters:
             - google.golang.org/grpc
             - google.golang.org/protobuf
             # cel-go powers the native CEL rule validation of rendered GitOps
-            # manifests in pkg/svc/gitops/celrules (#5693, epic #5344). Already
+            # manifests in pkg/svc/gitops/celrules (#5693, epic #5344). The module
+            # renamed its path from github.com/google/cel-go in v0.32.0. Already
             # linked transitively via the Kubernetes apiserver stack.
-            - github.com/google/cel-go
+            - cel.dev/cel-go
             - gopkg.in/yaml.v3
             - helm.sh/helm
             - k8s.io

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -26,6 +26,7 @@ require (
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
+	cel.dev/cel-go v0.32.0 // indirect
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.22.0 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -2,6 +2,8 @@ al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeX
 al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
 c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
+cel.dev/cel-go v0.32.0 h1:irvpFKr5EuGPyxeME03ERh0rii1TX+BDAnB9eL3IvNk=
+cel.dev/cel-go v0.32.0/go.mod h1:DnVip7tpJSsgZymwfT+m1tnEVy3ivAjSMXPx12YrMkU=
 cel.dev/expr v0.25.2 h1:K6j46C81hXtZQfuX60cVWQFBJahKSE2gfRbNuvr5bFs=
 cel.dev/expr v0.25.2/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 )
 
 require (
+	cel.dev/cel-go v0.32.0
 	cloud.google.com/go/container v1.53.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
@@ -77,7 +78,6 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/github/copilot-sdk/go v1.0.11
 	github.com/go-jose/go-jose/v4 v4.1.4
-	github.com/google/cel-go v0.31.0
 	github.com/google/go-github/v72 v72.0.0
 	github.com/googleapis/gax-go/v2 v2.23.0
 	github.com/gopacket/gopacket v1.7.1
@@ -479,6 +479,7 @@ require (
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/goodhosts/hostsfile v0.1.7 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/google/cel-go v0.31.0 // indirect
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeX
 al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
 c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
+cel.dev/cel-go v0.32.0 h1:irvpFKr5EuGPyxeME03ERh0rii1TX+BDAnB9eL3IvNk=
+cel.dev/cel-go v0.32.0/go.mod h1:DnVip7tpJSsgZymwfT+m1tnEVy3ivAjSMXPx12YrMkU=
 cel.dev/expr v0.25.2 h1:K6j46C81hXtZQfuX60cVWQFBJahKSE2gfRbNuvr5bFs=
 cel.dev/expr v0.25.2/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/pkg/client/celrules/client.go
+++ b/pkg/client/celrules/client.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/ext"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/svc/gitops/celrules/celrules.go
+++ b/pkg/svc/gitops/celrules/celrules.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/ext"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/common/types"
+	"cel.dev/cel-go/ext"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_guardcel_test.go
+++ b/pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner_guardcel_test.go
@@ -6,8 +6,8 @@ import (
 	"maps"
 	"testing"
 
+	"cel.dev/cel-go/cel"
 	k3dprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/k3d"
-	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Automatic dependency updates for KSail's main Go module have been **completely dead since 2026-08-24** — every daily run has failed, so no Go dependency update has landed in six days, security patches included. CI stays green throughout, so this is invisible without reading the Dependabot logs.

The cause is that one library, `cel-go`, moved to a new home and renamed itself. The old name simply cannot be resolved any more, and that single unresolvable name aborts the whole update job for every other dependency with it.

### What

Point KSail at the library's new name. The update job stops hitting the dead name, so the other ~100 Go dependencies can flow again.

The old name stays in the dependency graph indirectly, because around twenty upstream projects (Kubernetes, Cilium, Talos, vCluster) have not moved yet — that is expected and harmless, and it does not re-block the job.

Also covers the desktop module, which shares the main module's code and would otherwise stop building.

Fixes #6732
