### PR TITLE
fix(deps): group the co-dependent siderolabs Talos modules

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -37,6 +37,12 @@ updates:
       # set because it constrains machinery transitively and drags it forward on its
       # own bumps. The standalone siderolabs utility modules (crypto, gen, go-retry,
       # net, ...) version independently and are deliberately NOT grouped.
+      # Scope: grouping batches whichever of these modules have an update available
+      # into ONE pull request. It does not enforce version equality and does not
+      # require every module to move, so a partial bump is still possible and would
+      # fail to build exactly as an ungrouped one does. What this buys is fewer
+      # duplicate failing PRs and a failure that reads for the real reason - not a
+      # lockstep guarantee. The standing upstream ceiling is tracked in ksail#6728.
       talos:
         patterns:
           - "github.com/siderolabs/talos"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -30,6 +30,18 @@ updates:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+      # The Talos module and its machinery module are released together from one
+      # repository and share a version tag, and talos itself compiles against
+      # machinery's config API - so bumping either alone leaves a skew that fails to
+      # build inside the dependency's own source (ksail#6801). omni/client joins the
+      # set because it constrains machinery transitively and drags it forward on its
+      # own bumps. The standalone siderolabs utility modules (crypto, gen, go-retry,
+      # net, ...) version independently and are deliberately NOT grouped.
+      talos:
+        patterns:
+          - "github.com/siderolabs/talos"
+          - "github.com/siderolabs/talos/pkg/machinery"
+          - "github.com/siderolabs/omni/client"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The Talos module and its machinery module ship together as a matched pair, but Dependabot treats them
as unrelated dependencies and bumps them separately. Today that produces **two** permanently-failing
PRs (#6796 and #6724) instead of one, each burning a full CI run — lint, unit tests and the entire
System Test matrix — and each failing with a confusing error inside the dependency's own source
rather than the real reason.

**This does not unblock the Talos line, and is not claimed to.** #6728 is the standing ceiling: a
lockstep bump pulls `k8s.io/*` to 0.37, which breaks the vcluster stack (pinned to 0.36), and
`alpha.2` is the last Talos release on the 0.36 line. That is an upstream problem and stays tracked
there.

What this buys is narrower and still worth having:

- one failing PR instead of two while the ceiling holds, so less repeated CI spend and less noise;
- the failure surfaces for the real reason rather than as a version-skew red herring — which has
  already cost re-derivation more than once;
- when upstream does align, the co-dependent bumps arrive as one PR instead of several.

**Scope, stated plainly:** grouping batches whichever of these modules have an update available
into one PR. It does **not** enforce version equality and does not require every module to move,
so a partial bump stays possible and would fail to build exactly as an ungrouped one does. This
reduces duplicate failing PRs and makes the failure read for the real reason; it is not a lockstep
guarantee. Rejecting partial updates in CI is a separate, larger change — filed as its own issue.

This repository already groups two other matched sets for the same reason: the Astro docs set (#5600)
and the Flux operator pair (#5595).

### What

Groups the three co-dependent modules so Dependabot moves them in one PR. The dozen-plus standalone
Siderolabs utility libraries are deliberately excluded so they keep updating independently and
failures stay easy to isolate.

Config only — no product code changes.

Part of #6728

