### PR TITLE
fix(desktop): mirror the parent module's runc replace

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -17,6 +17,13 @@ replace (
 	github.com/loft-sh/log => github.com/devantler/log v0.0.0-20260407144227-16cc61ebdb79
 	// Mirrors the parent module's local v0.3.0 compatibility module.
 	github.com/moby/go-archive => ../third_party/go-archive
+
+	// dockertest imports runc's libcontainer/user, removed in runc v1.4.0, through the tests
+	// of a dependency (sops/v3/hcvault.test). `go mod tidy` resolves that graph, so without
+	// this pin it falls back to runc@latest, which no longer provides the package, and tidy
+	// fails. Mirrors the parent module's replace, where the full rationale and its security
+	// trade-off are recorded.
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.3.6
 )
 
 require (


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The desktop app is a separate Go module, so it has to keep its own copy of the compatibility
pins the main module uses — Go does not share them across modules. One of those pins was
missing from the copy, which makes dependency updates fail while the main build stays green.
That is why it went unnoticed: it only bites when an update shifts which dependency versions
get picked, and then it blocks the update rather than the product.

### What

Adds the missing pin to the desktop module so its dependency housekeeping resolves again, with
a note explaining why it has to be duplicated. No dependency versions actually change — the
lockfile is untouched — so this carries no product risk and only removes a recurring blocker
from dependency updates.

Verified by reproducing the failure on the currently-stuck talos update, confirming the fix
clears it, and confirming the desktop app still builds.

Part of the same blocker chain as #6816 — that issue makes grouped updates refresh the
desktop module; this makes that refresh actually succeed. Neither alone is sufficient.
