### PR TITLE
fix(deps): prevent partial Kubernetes minor bumps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -48,6 +48,14 @@ updates:
           - "github.com/siderolabs/talos"
           - "github.com/siderolabs/talos/pkg/machinery"
           - "github.com/siderolabs/omni/client"
+    # Kubernetes modules share APIs across repositories but Dependabot groups
+    # only the updates eligible in a given run. A minor-line bump can therefore
+    # move one module ahead of the rest and make the graph uncompilable
+    # (ksail#6837). Keep automated patch and security updates; minor upgrades
+    # are deliberate compatibility work that moves the coupled set together.
+    ignore:
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-minor"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary
- keep Dependabot Kubernetes patch updates automated
- keep security updates unaffected
- reserve Kubernetes minor-line upgrades for a coordinated compatibility change

## Why
Dependabot groups only dependencies eligible in a particular run; grouping `k8s.io/*` does not guarantee lockstep versions. #6837 moved only `k8s.io/apimachinery` to 0.37.0 while the rest of the Kubernetes graph remained on 0.36.x, producing deterministic upstream type errors across the build.

A local experiment moving the coupled Kubernetes set to 1.37/0.37 removed that version skew but exposed additional compatibility changes in KSail test doubles and `github.com/loft-sh/apiserver`. Expanding the dependency PR into that product upgrade would not be a minimal repair.

GitHub's Dependabot options reference documents that wildcard dependency names and `version-update:semver-minor` exclusions apply to version updates, while security updates remain unaffected.

## Verification
- RED: `go test ./...` on #6837 at `a10a2cce3ffd0544e7b3051ee07d78555d2daf93` reproduced the CI failures in `k8s.io/api@v0.36.4` and `k8s.io/apiserver@v0.36.4` against `k8s.io/apimachinery@v0.37.0`
- YAML parse: `yq eval '.' .github/dependabot.yaml`
- effective rule: `yq eval '.updates[] | select(."package-ecosystem" == "gomod" and .directory == "/") | .ignore' .github/dependabot.yaml`
- whitespace: `git diff --check origin/main...HEAD`

Fixes #6841
Related: #6837