### PR TITLE
ci: leave Dependabot branches to Dependabot so bumps can rebase themselves

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -760,7 +760,9 @@ jobs:
       # modes are not expressible. Reject anything other than a regular 0644 file below
       # rather than dereferencing a symlink or silently losing an executable bit.
       - name: 📤 Commit and push generated changes (PR branch)
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           BRANCH: ${{ github.head_ref }}

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -311,8 +311,6 @@ func TestRunsOnDefaultBranch(t *testing.T) {
 
 // autoCommitWorkflow captures the auto-commit job's step surface, which decides
 // whether CI pushes a generated-file commit onto a pull request's own branch.
-//
-//nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
 type autoCommitWorkflow struct {
 	Jobs map[string]struct {
 		Steps []map[string]any `yaml:"steps"`

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -308,3 +308,93 @@ func TestRunsOnDefaultBranch(t *testing.T) {
 		})
 	}
 }
+
+// autoCommitWorkflow captures the auto-commit job's step surface, which decides
+// whether CI pushes a generated-file commit onto a pull request's own branch.
+//
+//nolint:tagliatelle // GitHub Actions defines these external keys in kebab-case.
+type autoCommitWorkflow struct {
+	Jobs map[string]struct {
+		Steps []map[string]any `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+// The exact conditions the two auto-commit delivery paths must carry.
+//
+// The PR-branch push is the one that has to exclude Dependabot; the protected-branch
+// path is asserted alongside it because it is where a skipped Dependabot sync is
+// expected to land instead, and silently losing it would turn this fix into a
+// generated-file correctness regression on the default branch.
+const (
+	approvedAutoCommitPRBranchCondition = "github.event_name == 'pull_request'" +
+		" && github.event.pull_request.user.login != 'dependabot[bot]'"
+	approvedAutoCommitProtectedBranchCondition = "github.event_name != 'pull_request'"
+)
+
+// stepCondition returns the `if:` of the uniquely-named step in the given job.
+//
+// It requires exactly one match rather than taking the first: two steps sharing a
+// name would make the assertion below silently describe whichever came first.
+func stepCondition(t *testing.T, job []map[string]any, stepName string) string {
+	t.Helper()
+
+	var found []map[string]any
+
+	for _, step := range job {
+		if name, ok := step["name"].(string); ok && name == stepName {
+			found = append(found, step)
+		}
+	}
+
+	require.Lenf(t, found, 1, "expected exactly one step named %q", stepName)
+
+	condition, ok := found[0]["if"].(string)
+	require.Truef(t, ok, "step %q must carry a string `if:` condition", stepName)
+
+	return condition
+}
+
+// Pins Dependabot's ownership of its own branches.
+//
+// GitHub permanently revokes Dependabot's ability to rebase a pull request once any
+// other actor pushes to its branch ("this PR has been edited by someone other than
+// Dependabot"). CI's generated-file sync used to push onto every same-repo PR branch,
+// Dependabot's included, so a synced bump could never recover from base drift: the
+// moment anything else merged it went behind base, auto-merge could never fire, and
+// the ordinary `@dependabot rebase` remedy was refused. Roughly half of Dependabot
+// PRs carried the sync commit, and because the ecosystem is capped at an open-PR
+// limit, the stranded ones throttled dependency intake generally (issue #6832).
+//
+// The condition is asserted whole rather than by substring for the reason the
+// concurrency tests above record: a fragment match admits inverted and appended
+// forms that still push to Dependabot's branch. A generated-file change on a
+// Dependabot bump is not lost by this exclusion — it lands through the
+// protected-branch path after the bump merges, which is why that path is pinned here
+// too.
+func TestAutoCommitLeavesDependabotBranchesToDependabot(t *testing.T) {
+	t.Parallel()
+
+	contents := readRepoFile(t, ".github/workflows/ci.yaml")
+
+	var workflow autoCommitWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	job, found := workflow.Jobs["auto-commit"]
+	require.True(t, found, "ci workflow must define the auto-commit job")
+
+	assert.Equal(
+		t,
+		approvedAutoCommitPRBranchCondition,
+		stepCondition(t, job.Steps, "📤 Commit and push generated changes (PR branch)"),
+		"the PR-branch push must skip Dependabot-authored pull requests so Dependabot keeps"+
+			" the ability to rebase its own branch",
+	)
+
+	assert.Equal(
+		t,
+		approvedAutoCommitProtectedBranchCondition,
+		stepCondition(t, job.Steps, "📤 Open PR for generated changes (protected branch)"),
+		"the protected-branch sync must stay reachable: it is where a Dependabot bump's"+
+			" generated changes land once the bump has merged",
+	)
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Dependency bumps keep getting stuck and needing a person to nudge them. GitHub takes
Dependabot's rebase ability away permanently as soon as anything else pushes to its
branch — and our CI was pushing a generated-file sync onto those branches. About half
of all Dependabot PRs were affected: as soon as any other PR merged, they fell behind,
auto-merge could never fire, and the usual "rebase this" remedy was refused. Because
the dependency queue has a cap on how many PRs can be open at once, the stuck ones sat
in that cap and throttled dependency intake generally.

Three PRs are stranded by this right now (#6839, #6845, #6826).

### Change

CI no longer pushes the generated-file sync onto Dependabot's own branches, so
Dependabot keeps ownership and can rebase itself. The generated changes are not lost —
they land through the path we already have, which opens a sync PR once the bump has
merged.

Picks option 1 of the three the issue put forward. It is the only one that removes the
cause rather than reducing how often it bites, and the machinery it depends on already
exists.

Fixes #6832
