### PR TITLE
ci(deps): ignore the unsatisfiable k3k 1.2.0 bump

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -56,6 +56,14 @@ updates:
     ignore:
       - dependency-name: "k8s.io/*"
         update-types: ["version-update:semver-minor"]
+      # k3k v1.2.0 splits pkg/apis into its own module but publishes a go.mod that
+      # requires it at v0.0.0-00010101000000-000000000000, resolved only by k3k's OWN
+      # `replace ... => ./pkg/apis`. Go honours replace only in the main module, so every
+      # consumer gets `unknown revision 000000000000`, and pkg/apis publishes no version
+      # to require instead — the bump is unsatisfiable for anyone, not a compatibility
+      # gap here (ksail#6607). Scoped to 1.2.0 so a fixed 1.2.1 still comes through.
+      - dependency-name: "github.com/rancher/k3k"
+        versions: ["1.2.0"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

KSail's root dependency-update job has been failing on every cycle. It keeps trying to take a new version of one upstream component, and that version cannot be installed by anyone — the people who published it shipped it referring to a piece of itself that they never released. Nothing we can change on our side makes it installable.

While that failure repeats, real dependency updates are harder to see, because a red result is the normal state.

### What

Tells the update job to skip that one broken version, with the reasoning recorded next to it. Any later fixed version still comes through automatically, so this does not freeze the component — it skips exactly the release that is broken.

No product behaviour changes; this is dependency-update configuration only.

Part of #6607 — that issue's recorded cause was a different component and has since been resolved; the current cause is this one, and the evidence is on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
