### PR TITLE
ci(k3k): assert the k3k server pod's creating principal in the sentinel

### DIFF
--- a/.github/actions/ksail-system-test/action.yaml
+++ b/.github/actions/ksail-system-test/action.yaml
@@ -100,6 +100,13 @@ inputs:
       "Calico"). Only used when test-kubernetes-provider is 'true'.
     required: false
     default: ""
+  assert-k3k-server-creator:
+    description: |
+      Assert the k3k server pod creating principal after each nested K3s create and
+      record the evidence (see the ksail-test-kubernetes-provider action). Only used
+      when test-kubernetes-provider is 'true'.
+    required: false
+    default: "false"
   rolling-resize-server-type:
     description: |
       Hetzner only. When set to a server type (e.g. "cx33"), runs an additional
@@ -616,6 +623,7 @@ runs:
       with:
         distributions: ${{ inputs.kubernetes-provider-distributions }}
         cni: ${{ inputs.kubernetes-provider-cni }}
+        assert-k3k-server-creator: ${{ inputs.assert-k3k-server-creator }}
         dockerhub-user: ${{ inputs.dockerhub-user }}
         dockerhub-token: ${{ inputs.dockerhub-token }}
         ghcr-user: ${{ inputs.ghcr-user }}

--- a/.github/actions/ksail-test-kubernetes-provider/action.yaml
+++ b/.github/actions/ksail-test-kubernetes-provider/action.yaml
@@ -180,12 +180,19 @@ runs:
           # created by the StatefulSet controller. Runs while the nested cluster is still
           # up, and a failure adds to FAILED rather than masking an earlier one.
           if [ "$create_ok" = "true" ] && [ "$ASSERT_K3K_SERVER_CREATOR" = "true" ] && [ "${DIST,,}" = "k3s" ]; then
-            echo "  ⏳ Asserting the k3k server pod creating principal..."
-            CREATOR_LOG="$LOG_DIR/${DIST,,}-server-creator.log"
-            if "$GITHUB_WORKSPACE/.github/scripts/assert-k3k-server-creator.sh" "$NESTED_NAME" "$LOG_DIR" 2>&1 | tee "$CREATOR_LOG"; then
-              echo "  ✅ $DIST server pod creator matches the guard pinned principal"
+            # An explicit host context can leave the nested cluster selected after
+            # creation. The server pod lives on the host, so bind the query first.
+            if kubectl config use-context "$HOST_CONTEXT"; then
+              echo "  ⏳ Asserting the k3k server pod creating principal..."
+              CREATOR_LOG="$LOG_DIR/${DIST,,}-server-creator.log"
+              if "$GITHUB_WORKSPACE/.github/scripts/assert-k3k-server-creator.sh" "$NESTED_NAME" "$LOG_DIR" 2>&1 | tee "$CREATOR_LOG"; then
+                echo "  ✅ $DIST server pod creator matches the guard pinned principal"
+              else
+                echo "  ❌ $DIST server pod creator assertion FAILED"
+                FAILED=$((FAILED + 1))
+              fi
             else
-              echo "  ❌ $DIST server pod creator assertion FAILED"
+              echo "  ❌ $DIST host context restoration FAILED; skipping server pod creator assertion"
               FAILED=$((FAILED + 1))
             fi
           fi

--- a/.github/actions/ksail-test-kubernetes-provider/action.yaml
+++ b/.github/actions/ksail-test-kubernetes-provider/action.yaml
@@ -42,6 +42,17 @@ inputs:
       that enables the MutatingAdmissionPolicy / v1beta1 admissionregistration API.
     required: false
     default: ""
+  assert-k3k-server-creator:
+    description: |
+      After each successful nested K3s (k3k) create, assert that the k3k server pod
+      is owned by a StatefulSet and written by kube-controller-manager, and record
+      that evidence in the kubernetes-provider log directory. The k3k privileged-pod
+      guard pins exactly that principal with FailurePolicy Fail, so a k3k release that
+      changed who creates the pod would make every k3k cluster unprovisionable; this
+      keeps the premise asserted by CI rather than by a comment. A failed assertion
+      counts as a failed distribution. Off by default.
+    required: false
+    default: "false"
   dockerhub-user:
     description: Docker Hub username for authenticated nested pull-through mirrors.
     required: false
@@ -72,6 +83,7 @@ runs:
         # runner contention is not failed prematurely at the 10m default. See #4891.
         KSAIL_NESTED_READY_TIMEOUT: ${{ inputs.ready-timeout }}
         CNI: ${{ inputs.cni }}
+        ASSERT_K3K_SERVER_CREATOR: ${{ inputs.assert-k3k-server-creator }}
         # Mirror proxy credentials. Exported here so ksail expands the ${...}
         # placeholders in the --mirror-registry specs from its own process env,
         # keeping the secret values out of argv and the command log.
@@ -160,6 +172,20 @@ runs:
               PASSED=$((PASSED + 1))
             else
               echo "  ❌ $DIST info FAILED"
+              FAILED=$((FAILED + 1))
+            fi
+          fi
+
+          # Pin the premise the k3k privileged-pod guard depends on: the server pod is
+          # created by the StatefulSet controller. Runs while the nested cluster is still
+          # up, and a failure adds to FAILED rather than masking an earlier one.
+          if [ "$create_ok" = "true" ] && [ "$ASSERT_K3K_SERVER_CREATOR" = "true" ] && [ "${DIST,,}" = "k3s" ]; then
+            echo "  ⏳ Asserting the k3k server pod creating principal..."
+            CREATOR_LOG="$LOG_DIR/${DIST,,}-server-creator.log"
+            if "$GITHUB_WORKSPACE/.github/scripts/assert-k3k-server-creator.sh" "$NESTED_NAME" "$LOG_DIR" 2>&1 | tee "$CREATOR_LOG"; then
+              echo "  ✅ $DIST server pod creator matches the guard pinned principal"
+            else
+              echo "  ❌ $DIST server pod creator assertion FAILED"
               FAILED=$((FAILED + 1))
             fi
           fi

--- a/.github/scripts/assert-k3k-server-creator.sh
+++ b/.github/scripts/assert-k3k-server-creator.sh
@@ -27,6 +27,7 @@
 
 set -euo pipefail
 
+# Print the required arguments to stderr and reject an invalid invocation with exit 2.
 usage() {
 	printf 'usage: %s <cluster-name> <evidence-dir>\n' "${0##*/}" >&2
 	exit 2

--- a/.github/scripts/assert-k3k-server-creator.sh
+++ b/.github/scripts/assert-k3k-server-creator.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Asserts who creates the k3k server pod, and records the evidence.
+#
+# The k3k privileged-pod guard (pkg/svc/provisioner/cluster/k3d/kubernetes_provisioner.go,
+# serverPodExemptionTemplate) admits the privileged k3k server pod only when the request
+# principal is kube-controller-manager's StatefulSet controller. The guard runs with
+# FailurePolicy Fail, so if a k3k release ever changed who creates that pod, every k3k
+# cluster would become unprovisionable. This script pins that premise against a live
+# cluster: the server pod must be owned by a StatefulSet and managed by
+# kube-controller-manager.
+#
+# Usage: assert-k3k-server-creator.sh <cluster-name> <evidence-dir>
+#
+#   <cluster-name>  The KSail cluster name. The k3k server pod lives in namespace
+#                   k3k-<cluster-name> and carries the labels role=server,cluster=<cluster-name>.
+#   <evidence-dir>  Directory that receives k3k-server-pod-creator.json — the pod's
+#                   ownerReferences and managedFields managers — so the evidence survives the run.
+#
+# Environment:
+#   KUBECTL                     kubectl command to use (default: kubectl).
+#   KSAIL_K3K_SERVER_POD_JSON   Test seam: path to a file holding the `kubectl get pods -o json`
+#                               list to evaluate instead of reading a live cluster.
+#
+# Exit status: 0 when every server pod satisfies both assertions; 1 otherwise, with a message
+# naming what was found instead.
+
+set -euo pipefail
+
+usage() {
+	printf 'usage: %s <cluster-name> <evidence-dir>\n' "${0##*/}" >&2
+	exit 2
+}
+
+[ "$#" -eq 2 ] || usage
+
+cluster="$1"
+evidence_dir="$2"
+namespace="k3k-${cluster}"
+selector="role=server,cluster=${cluster}"
+kubectl_cmd="${KUBECTL:-kubectl}"
+
+expected_owner_kind="StatefulSet"
+expected_manager="kube-controller-manager"
+
+mkdir -p "${evidence_dir}"
+evidence_file="${evidence_dir}/k3k-server-pod-creator.json"
+
+if [ -n "${KSAIL_K3K_SERVER_POD_JSON:-}" ]; then
+	pods_json="$(cat "${KSAIL_K3K_SERVER_POD_JSON}")"
+else
+	pods_json="$("${kubectl_cmd}" get pods -n "${namespace}" -l "${selector}" -o json)"
+fi
+
+# Keep only what the assertion reads (and what a reader needs to re-derive it): the
+# controller owner and the managers that wrote the pod. The fieldsV1 blobs are dropped
+# so the evidence stays legible.
+evidence_json="$(
+	jq '{
+		namespace: "'"${namespace}"'",
+		selector: "'"${selector}"'",
+		pods: [ .items[] | {
+			name: .metadata.name,
+			ownerReferences: (.metadata.ownerReferences // []),
+			managedFields: [ (.metadata.managedFields // [])[]
+				| {manager, operation, subresource: (.subresource // ""), time: (.time // "")} ]
+		} ]
+	}' <<<"${pods_json}"
+)"
+
+printf '%s\n' "${evidence_json}" >"${evidence_file}"
+
+pod_count="$(jq '.pods | length' <<<"${evidence_json}")"
+if [ "${pod_count}" -eq 0 ]; then
+	printf 'FAIL: no pod with labels %s found in namespace %s — the guard'"'"'s label assumptions do not match this k3k release\n' \
+		"${selector}" "${namespace}" >&2
+	exit 1
+fi
+
+failures=0
+
+while IFS= read -r pod_name; do
+	pod_query='.pods[] | select(.name == "'"${pod_name}"'")'
+
+	# The controller owner: exactly one ownerReference flagged controller=true, of the expected kind.
+	controller_kinds="$(jq -r "${pod_query}"' | [.ownerReferences[] | select(.controller == true) | .kind] | join(",")' <<<"${evidence_json}")"
+	if [ "${controller_kinds}" != "${expected_owner_kind}" ]; then
+		printf 'FAIL: pod %s/%s is controlled by [%s], expected exactly one %s owner\n' \
+			"${namespace}" "${pod_name}" "${controller_kinds:-none}" "${expected_owner_kind}" >&2
+		failures=$((failures + 1))
+	fi
+
+	# The managing component: the managers that wrote the pod object itself (not a
+	# subresource such as status, which the kubelet owns) must include the StatefulSet
+	# controller's component identity.
+	managers="$(jq -r "${pod_query}"' | [.managedFields[] | select(.operation == "Update" and .subresource == "") | .manager] | unique | join(",")' <<<"${evidence_json}")"
+	if ! printf '%s\n' "${managers}" | tr ',' '\n' | grep -qx -- "${expected_manager}"; then
+		printf 'FAIL: pod %s/%s was written by managers [%s], expected %s among them\n' \
+			"${namespace}" "${pod_name}" "${managers:-none}" "${expected_manager}" >&2
+		failures=$((failures + 1))
+	fi
+done < <(jq -r '.pods[].name' <<<"${evidence_json}")
+
+if [ "${failures}" -gt 0 ]; then
+	printf 'FAIL: %d assertion(s) failed for %d server pod(s); evidence at %s\n' \
+		"${failures}" "${pod_count}" "${evidence_file}" >&2
+	exit 1
+fi
+
+printf 'OK: %d k3k server pod(s) in %s owned by a %s and written by %s; evidence at %s\n' \
+	"${pod_count}" "${namespace}" "${expected_owner_kind}" "${expected_manager}" "${evidence_file}"

--- a/.github/scripts/assert-k3k-server-creator.sh
+++ b/.github/scripts/assert-k3k-server-creator.sh
@@ -49,7 +49,8 @@ evidence_file="${evidence_dir}/k3k-server-pod-creator.json"
 if [ -n "${KSAIL_K3K_SERVER_POD_JSON:-}" ]; then
 	pods_json="$(cat "${KSAIL_K3K_SERVER_POD_JSON}")"
 else
-	pods_json="$("${kubectl_cmd}" get pods -n "${namespace}" -l "${selector}" -o json)"
+	# kubectl strips managedFields from JSON by default; retain the creator evidence.
+	pods_json="$("${kubectl_cmd}" get pods -n "${namespace}" -l "${selector}" -o json --show-managed-fields=true)"
 fi
 
 # Keep only what the assertion reads (and what a reader needs to re-derive it): the

--- a/.github/scripts/assert-k3k-server-creator.test.sh
+++ b/.github/scripts/assert-k3k-server-creator.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# RED/GREEN proof for assert-k3k-server-creator.sh. Each fixture is a
+# `kubectl get pods -o json` list; the positive control passes, and every
+# negative control must be REJECTED with a message naming what was found.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+assert="${script_dir}/assert-k3k-server-creator.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+cluster="nested-k3s"
+
+# pod_json NAME OWNER_KIND MANAGERS... — one server pod. MANAGERS are
+# "<manager>[:<subresource>]" entries, all recorded as operation Update.
+pod_json() {
+	local name="$1" owner_kind="$2"
+	shift 2
+
+	local managed=""
+	local entry manager subresource
+	for entry in "$@"; do
+		manager="${entry%%:*}"
+		subresource=""
+		case "${entry}" in
+		*:*) subresource="${entry#*:}" ;;
+		esac
+		managed="${managed}{\"manager\":\"${manager}\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2026-09-05T00:00:00Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{}"
+		if [ -n "${subresource}" ]; then
+			managed="${managed},\"subresource\":\"${subresource}\""
+		fi
+		managed="${managed}},"
+	done
+	managed="${managed%,}"
+
+	local owners='[]'
+	if [ -n "${owner_kind}" ]; then
+		owners="[{\"apiVersion\":\"apps/v1\",\"kind\":\"${owner_kind}\",\"name\":\"k3k-${cluster}-server\",\"uid\":\"u\",\"controller\":true,\"blockOwnerDeletion\":true}]"
+	fi
+
+	printf '{"metadata":{"name":"%s","namespace":"k3k-%s","labels":{"role":"server","cluster":"%s"},"ownerReferences":%s,"managedFields":[%s]}}' \
+		"${name}" "${cluster}" "${cluster}" "${owners}" "${managed}"
+}
+
+# list_json POD_JSON... — wraps pods into a kubectl List.
+list_json() {
+	local items
+	items="$(printf '%s,' "$@")"
+	printf '{"apiVersion":"v1","kind":"List","items":[%s]}' "${items%,}"
+}
+
+good_pod="$(pod_json "k3k-${cluster}-server-0" StatefulSet kube-controller-manager kubelet:status)"
+
+fixture() {
+	local name="$1"
+	shift
+	local file="${tmp_dir}/${name}.json"
+	list_json "$@" >"${file}"
+	printf '%s' "${file}"
+}
+
+expect_pass() {
+	local label="$1" file="$2" evidence="${tmp_dir}/evidence-$1"
+	if ! KSAIL_K3K_SERVER_POD_JSON="${file}" "${assert}" "${cluster}" "${evidence}" >"${tmp_dir}/${label}.out" 2>&1; then
+		printf 'FAIL: %s was rejected:\n' "${label}" >&2
+		cat "${tmp_dir}/${label}.out" >&2
+		exit 1
+	fi
+	[ -s "${evidence}/k3k-server-pod-creator.json" ] || {
+		printf 'FAIL: %s wrote no evidence file\n' "${label}" >&2
+		exit 1
+	}
+}
+
+expect_fail() {
+	local label="$1" file="$2" needle="$3" evidence="${tmp_dir}/evidence-$1"
+	if KSAIL_K3K_SERVER_POD_JSON="${file}" "${assert}" "${cluster}" "${evidence}" >"${tmp_dir}/${label}.out" 2>&1; then
+		printf 'FAIL: %s passed the assertion\n' "${label}" >&2
+		exit 1
+	fi
+	if ! grep -qF -- "${needle}" "${tmp_dir}/${label}.out"; then
+		printf 'FAIL: %s was rejected without naming %q:\n' "${label}" "${needle}" >&2
+		cat "${tmp_dir}/${label}.out" >&2
+		exit 1
+	fi
+}
+
+# GREEN — the premise the guard depends on: a StatefulSet-owned pod written by
+# kube-controller-manager (the kubelet writes only the status subresource).
+expect_pass "statefulset-owned" "$(fixture good "${good_pod}")"
+
+# The evidence must record what the assertion read, so a later reader can
+# re-derive it without a cluster.
+evidence="${tmp_dir}/evidence-statefulset-owned/k3k-server-pod-creator.json"
+jq -e '.namespace == "k3k-nested-k3s"
+	and .pods[0].ownerReferences[0].kind == "StatefulSet"
+	and ([.pods[0].managedFields[].manager] | index("kube-controller-manager") != null)
+	and (.pods[0].managedFields | map(has("fieldsV1")) | any | not)' "${evidence}" >/dev/null
+
+# RED — owner is a ReplicaSet (a Deployment-shaped k3k server would break the guard).
+expect_fail "replicaset-owned" \
+	"$(fixture rs "$(pod_json "k3k-${cluster}-server-0" ReplicaSet kube-controller-manager)")" \
+	"controlled by [ReplicaSet]"
+
+# RED — no controller owner at all (a bare pod created by some other actor).
+expect_fail "unowned" \
+	"$(fixture unowned "$(pod_json "k3k-${cluster}-server-0" "" kube-controller-manager)")" \
+	"controlled by [none]"
+
+# RED — a StatefulSet owner but a different writer: a k3k controller creating the
+# pod itself would carry its own manager and never satisfy the pinned principal.
+expect_fail "foreign-manager" \
+	"$(fixture foreign "$(pod_json "k3k-${cluster}-server-0" StatefulSet k3k-controller kubelet:status)")" \
+	"written by managers [k3k-controller]"
+
+# RED — kube-controller-manager appears only on a subresource write; the pod
+# object itself was written by someone else, so the creator is not proven.
+expect_fail "kcm-status-only" \
+	"$(fixture kcmstatus "$(pod_json "k3k-${cluster}-server-0" StatefulSet k3k-controller kube-controller-manager:status)")" \
+	"written by managers [k3k-controller]"
+
+# RED — no pod matched the labels: the guard's label assumptions no longer hold.
+expect_fail "no-pods" "$(fixture empty)" "no pod with labels role=server,cluster=${cluster}"
+
+# RED — every server pod is checked, not only the first (multi-replica servers).
+expect_fail "second-pod-bad" \
+	"$(fixture second "${good_pod}" "$(pod_json "k3k-${cluster}-server-1" ReplicaSet kube-controller-manager)")" \
+	"k3k-${cluster}-server-1 is controlled by [ReplicaSet]"
+
+# Live path — the real read goes through kubectl with the namespace and label
+# selector the guard's exemption is written against. A fake kubectl records
+# its arguments and serves the GREEN fixture.
+fake_bin="${tmp_dir}/bin"
+mkdir -p "${fake_bin}"
+cat >"${fake_bin}/kubectl" <<FAKE
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >"${tmp_dir}/kubectl.args"
+cat "${tmp_dir}/good.json"
+FAKE
+chmod +x "${fake_bin}/kubectl"
+
+if ! KUBECTL="${fake_bin}/kubectl" "${assert}" "${cluster}" "${tmp_dir}/evidence-live" >"${tmp_dir}/live.out" 2>&1; then
+	printf 'FAIL: live path rejected the GREEN fixture:\n' >&2
+	cat "${tmp_dir}/live.out" >&2
+	exit 1
+fi
+expected_args="get pods -n k3k-${cluster} -l role=server,cluster=${cluster} -o json"
+if [ "$(cat "${tmp_dir}/kubectl.args")" != "${expected_args}" ]; then
+	printf 'FAIL: kubectl was invoked as %q, expected %q\n' "$(cat "${tmp_dir}/kubectl.args")" "${expected_args}" >&2
+	exit 1
+fi
+
+# Usage guard: a missing argument is an error, never a silent pass.
+if "${assert}" "${cluster}" >/dev/null 2>&1; then
+	printf 'FAIL: missing evidence-dir argument passed\n' >&2
+	exit 1
+fi
+
+printf 'OK: assert-k3k-server-creator.sh — 1 positive control, 7 negative controls, live-path arguments pinned\n'

--- a/.github/scripts/assert-k3k-server-creator.test.sh
+++ b/.github/scripts/assert-k3k-server-creator.test.sh
@@ -53,6 +53,7 @@ list_json() {
 
 good_pod="$(pod_json "k3k-${cluster}-server-0" StatefulSet kube-controller-manager kubelet:status)"
 
+# fixture NAME POD_JSON... — write a temporary pod list and print its path.
 fixture() {
 	local name="$1"
 	shift
@@ -61,6 +62,7 @@ fixture() {
 	printf '%s' "${file}"
 }
 
+# expect_pass LABEL FILE — require a successful assertion and a nonempty evidence file.
 expect_pass() {
 	local label="$1" file="$2" evidence="${tmp_dir}/evidence-$1"
 	if ! KSAIL_K3K_SERVER_POD_JSON="${file}" "${assert}" "${cluster}" "${evidence}" >"${tmp_dir}/${label}.out" 2>&1; then
@@ -74,6 +76,7 @@ expect_pass() {
 	}
 }
 
+# expect_fail LABEL FILE NEEDLE — require rejection with the expected diagnostic.
 expect_fail() {
 	local label="$1" file="$2" needle="$3" evidence="${tmp_dir}/evidence-$1"
 	if KSAIL_K3K_SERVER_POD_JSON="${file}" "${assert}" "${cluster}" "${evidence}" >"${tmp_dir}/${label}.out" 2>&1; then

--- a/.github/scripts/assert-k3k-server-creator.test.sh
+++ b/.github/scripts/assert-k3k-server-creator.test.sh
@@ -130,14 +130,18 @@ expect_fail "second-pod-bad" \
 	"k3k-${cluster}-server-1 is controlled by [ReplicaSet]"
 
 # Live path — the real read goes through kubectl with the namespace and label
-# selector the guard's exemption is written against. A fake kubectl records
-# its arguments and serves the GREEN fixture.
+# selector the guard's exemption is written against. Like real kubectl, the fake
+# omits managedFields unless the caller explicitly requests them. Without that
+# flag, even the valid StatefulSet pod must fail the creator assertion.
 fake_bin="${tmp_dir}/bin"
 mkdir -p "${fake_bin}"
 cat >"${fake_bin}/kubectl" <<FAKE
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >"${tmp_dir}/kubectl.args"
-cat "${tmp_dir}/good.json"
+case " \$* " in
+*" --show-managed-fields=true "*) cat "${tmp_dir}/good.json" ;;
+*) jq 'del(.items[].metadata.managedFields)' "${tmp_dir}/good.json" ;;
+esac
 FAKE
 chmod +x "${fake_bin}/kubectl"
 
@@ -146,7 +150,7 @@ if ! KUBECTL="${fake_bin}/kubectl" "${assert}" "${cluster}" "${tmp_dir}/evidence
 	cat "${tmp_dir}/live.out" >&2
 	exit 1
 fi
-expected_args="get pods -n k3k-${cluster} -l role=server,cluster=${cluster} -o json"
+expected_args="get pods -n k3k-${cluster} -l role=server,cluster=${cluster} -o json --show-managed-fields=true"
 if [ "$(cat "${tmp_dir}/kubectl.args")" != "${expected_args}" ]; then
 	printf 'FAIL: kubectl was invoked as %q, expected %q\n' "$(cat "${tmp_dir}/kubectl.args")" "${expected_args}" >&2
 	exit 1

--- a/.github/scripts/assert-k3k-server-creator.test.sh
+++ b/.github/scripts/assert-k3k-server-creator.test.sh
@@ -165,4 +165,76 @@ if "${assert}" "${cluster}" >/dev/null 2>&1; then
 	exit 1
 fi
 
-printf 'OK: assert-k3k-server-creator.sh — 1 positive control, 7 negative controls, live-path arguments pinned\n'
+# Exercise the real composite-action assertion block after nested creation has
+# selected its own context. Only kubectl is faked; the creator assertion is real.
+action="${script_dir}/../actions/ksail-test-kubernetes-provider/action.yaml"
+awk -v bash_version="${BASH_VERSINFO[0]}" '
+  /# Pin the premise the k3k privileged-pod guard depends on/ { block = 1 }
+  /# Always attempt delete/ { block = 0 }
+  block {
+    sub(/^        /, "")
+    # macOS Bash 3 lacks case conversion; this fixture always selects K3s.
+    if (bash_version < 4) gsub(/\$\{DIST,,\}/, "k3s")
+    print
+  }
+' "${action}" >"${tmp_dir}/creator-block.sh"
+[ -s "${tmp_dir}/creator-block.sh" ]
+
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+"config use-context custom-host")
+  [ "${RESTORE_FAIL}" = "false" ] || exit 1
+  printf 'custom-host\n' >"${CASE_DIR}/context"
+  ;;
+"get pods -n k3k-nested-k3s -l role=server,cluster=nested-k3s -o json --show-managed-fields=true")
+  cat "${CASE_DIR}/context" >"${CASE_DIR}/queried-context"
+  if [ "$(cat "${CASE_DIR}/context")" = "custom-host" ]; then
+    cat "${POD_FIXTURE}"
+  else
+    printf '{"items":[]}\n'
+  fi
+  ;;
+*) printf 'unexpected kubectl request: %s\n' "$*" >&2; exit 2 ;;
+esac
+FAKE
+chmod +x "${fake_bin}/kubectl"
+
+for restore_fail in false true; do
+	case_dir="${tmp_dir}/host-context-${restore_fail}"
+	mkdir -p "${case_dir}"
+	printf 'nested-context\n' >"${case_dir}/context"
+	if ! PATH="${fake_bin}:${PATH}" KUBECTL="${fake_bin}/kubectl" \
+		RESTORE_FAIL="${restore_fail}" CASE_DIR="${case_dir}" POD_FIXTURE="${tmp_dir}/good.json" \
+		GITHUB_WORKSPACE="$(cd "${script_dir}/../.." && pwd)" \
+		bash -euo pipefail -c '
+          create_ok=true
+          ASSERT_K3K_SERVER_CREATOR=true
+          DIST=K3s
+          NESTED_NAME=nested-k3s
+          HOST_CONTEXT=custom-host
+          LOG_DIR="$CASE_DIR"
+          FAILED=0
+          source "$1"
+          printf "%s\n" "$FAILED" >"$CASE_DIR/failed"
+        ' bash "${tmp_dir}/creator-block.sh" >"${case_dir}/output" 2>&1; then
+		cat "${case_dir}/output" >&2
+		exit 1
+	fi
+	if [ "${restore_fail}" = false ]; then
+		if [ "$(cat "${case_dir}/failed")" != 0 ] ||
+			[ "$(cat "${case_dir}/queried-context")" != custom-host ]; then
+			printf 'FAIL: creator assertion did not query the restored host context\n' >&2
+			cat "${case_dir}/output" >&2
+			exit 1
+		fi
+	else
+		if [ "$(cat "${case_dir}/failed")" != 1 ] || [ -e "${case_dir}/queried-context" ]; then
+			printf 'FAIL: failed host-context restoration must fail and skip the creator assertion\n' >&2
+			exit 1
+		fi
+	fi
+done
+
+printf 'OK: creator fixtures, live-path arguments, and composite-action host-context handling\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,6 +146,7 @@ jobs:
       calico-cni: ${{ steps.filter.outputs.calico-cni }}
       cask-pr-handoff: ${{ steps.filter.outputs.cask-pr-handoff }}
       eks-smoke-scripts: ${{ steps.filter.outputs.eks-smoke-scripts }}
+      k3k-sentinel-scripts: ${{ steps.filter.outputs.k3k-sentinel-scripts }}
     steps:
       - name: 📄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -328,6 +329,10 @@ jobs:
               - '.github/scripts/delete-eks-smoke-cluster.test.sh'
               - '.github/workflows/system-test-eks.yaml'
               - '.github/workflows/ci.yaml'
+            k3k-sentinel-scripts:
+              - '.github/scripts/assert-k3k-server-creator.sh'
+              - '.github/scripts/assert-k3k-server-creator.test.sh'
+              - '.github/workflows/ci.yaml'
 
   eks-smoke-scripts:
     name: 🧹 Validate EKS Smoke Teardown
@@ -349,6 +354,27 @@ jobs:
             .github/scripts/delete-eks-smoke-cluster.sh \
             .github/scripts/delete-eks-smoke-cluster.test.sh
           .github/scripts/delete-eks-smoke-cluster.test.sh
+
+  k3k-sentinel-scripts:
+    name: 🔐 Validate k3k Sentinel Scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes]
+    if: needs.changes.outputs.k3k-sentinel-scripts == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: 🔐 Verify the k3k server-creator assertion rejects every wrong principal
+        run: |
+          shellcheck \
+            .github/scripts/assert-k3k-server-creator.sh \
+            .github/scripts/assert-k3k-server-creator.test.sh
+          .github/scripts/assert-k3k-server-creator.test.sh
 
   cask-pr-handoff:
     name: 🔐 Validate Cask PR Handoff
@@ -1763,6 +1789,7 @@ jobs:
         verify-dependency-test-graph,
         verify-todos-workflow-contract,
         cask-pr-handoff,
+        k3k-sentinel-scripts,
       ]
     if: ${{ always() }}
     steps:
@@ -1793,3 +1820,4 @@ jobs:
             ${{ needs.verify-dependency-test-graph.result }}
             ${{ needs.verify-todos-workflow-contract.result }}
             ${{ needs.cask-pr-handoff.result }}
+            ${{ needs.k3k-sentinel-scripts.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,6 +332,7 @@ jobs:
             k3k-sentinel-scripts:
               - '.github/scripts/assert-k3k-server-creator.sh'
               - '.github/scripts/assert-k3k-server-creator.test.sh'
+              - '.github/actions/ksail-test-kubernetes-provider/action.yaml'
               - '.github/workflows/ci.yaml'
 
   eks-smoke-scripts:

--- a/.github/workflows/system-test-k3k-calico.yaml
+++ b/.github/workflows/system-test-k3k-calico.yaml
@@ -83,6 +83,7 @@ jobs:
           test-kubernetes-provider: "true"
           kubernetes-provider-distributions: K3s
           kubernetes-provider-cni: Calico
+          assert-k3k-server-creator: "true"
           ghcr-user: ${{ github.actor }}
           ghcr-token: >-
             ${{ github.event_name != 'pull_request'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The k3k privileged-pod guard only lets the k3k server pod run privileged when the request comes from Kubernetes' own StatefulSet controller, and it rejects everything else outright. That works only while k3k keeps creating the server pod that way — and until now nothing checked it. A k3k release that changed how the pod is created would make every k3k cluster impossible to provision, with the reason living in a code comment rather than in a test.

## What

The weekly k3k sentinel now asserts, while the nested cluster is still up, that the live server pod is owned by a StatefulSet and was written by kube-controller-manager, records that evidence in the run's log artifact, and fails naming what it found instead. The check is opt-in on the shared system-test action (off by default), so the main CI matrix is unchanged. A self-contained test pins seven wrong-principal shapes and runs in CI whenever the script changes.

Fixes #6744
