### PR TITLE
fix(env): resolve the workspace root for env add, list and rm

### DIFF
--- a/pkg/cli/cmd/project/env/add.go
+++ b/pkg/cli/cmd/project/env/add.go
@@ -288,11 +288,7 @@ func loadEnvironmentConfig(cmd *cobra.Command, configFile string) (*v1alpha1.Clu
 // cause's error chain (ErrSourceConfigLoad) and returns it unchanged when discovery
 // fails or finds no other environments.
 func enrichSourceConfigError(cmd *cobra.Command, repoRoot string, cause error) error {
-	loader := func(configFile string) (*v1alpha1.Cluster, error) {
-		return loadEnvironmentConfig(cmd, filepath.Join(repoRoot, configFile))
-	}
-
-	envs, err := environment.DeriveEnvironments(repoRoot, loader)
+	envs, err := discoverWorkspaceEnvironments(cmd, repoRoot)
 	if err != nil || len(envs) == 0 {
 		return cause
 	}
@@ -303,6 +299,24 @@ func enrichSourceConfigError(cmd *cobra.Command, repoRoot string, cause error) e
 	}
 
 	return fmt.Errorf("%w (available environments: %s)", cause, strings.Join(names, ", "))
+}
+
+// discoverWorkspaceEnvironments loads declared environments relative to the resolved
+// workspace root, preserving the same config-loading behavior for listing and errors.
+func discoverWorkspaceEnvironments(
+	cmd *cobra.Command,
+	repoRoot string,
+) ([]environment.Environment, error) {
+	loader := func(configFile string) (*v1alpha1.Cluster, error) {
+		return loadEnvironmentConfig(cmd, filepath.Join(repoRoot, configFile))
+	}
+
+	envs, err := environment.DeriveEnvironments(repoRoot, loader)
+	if err != nil {
+		return nil, fmt.Errorf("discovering environments: %w", err)
+	}
+
+	return envs, nil
 }
 
 // cloneEnvironment derives the structured rewrites and clones the source overlay

--- a/pkg/cli/cmd/project/env/add.go
+++ b/pkg/cli/cmd/project/env/add.go
@@ -156,15 +156,22 @@ func resolveAddEnvironmentParams(
 		return addEnvironmentParams{}, fmt.Errorf("failed to get current directory: %w", err)
 	}
 
-	// Canonicalise the repository root so it matches the symlink-resolved paths the
-	// clone's containment guard derives (on macOS os.Getwd() returns the unresolved
-	// /var/... path while the guard resolves to /private/var/...).
-	repoRoot, err := fsutil.EvalCanonicalPath(workDir)
+	// Canonicalise the working directory so the repository root matches the
+	// symlink-resolved paths the clone's containment guard derives (on macOS
+	// os.Getwd() returns the unresolved /var/... path while the guard resolves to
+	// /private/var/...).
+	canonWorkDir, err := fsutil.EvalCanonicalPath(workDir)
 	if err != nil {
 		return addEnvironmentParams{}, fmt.Errorf("failed to resolve current directory: %w", err)
 	}
 
-	srcCfg, err := loadSourceConfig(cmd, srcName)
+	// The explicit per-file loads below skip the config manager's
+	// parent-directory traversal, so resolve the workspace root the same way it
+	// would — the nearest ancestor holding ksail.yaml — letting the command run
+	// from any subdirectory of the workspace and clone into the real tree.
+	repoRoot := resolveWorkspaceRoot(canonWorkDir)
+
+	srcCfg, err := loadSourceConfig(cmd, repoRoot, srcName)
 	if err != nil {
 		return addEnvironmentParams{}, enrichSourceConfigError(cmd, repoRoot, err)
 	}
@@ -236,18 +243,21 @@ func repoRelativeSourceDir(repoRoot, sourceDir string) (string, error) {
 	return rel, nil
 }
 
-// loadSourceConfig reads the source environment's root config (ksail.<src>.yaml)
-// to resolve its provider, distribution and source directory. Validation and
-// distribution-specific config (e.g. Talos PKI) are skipped because the clone only
-// needs the structured identity, not a provisioning-ready config.
-func loadSourceConfig(cmd *cobra.Command, srcName string) (*v1alpha1.Cluster, error) {
-	return loadEnvironmentConfig(cmd, "ksail."+srcName+".yaml")
+// loadSourceConfig reads the source environment's root config
+// (<repoRoot>/ksail.<src>.yaml) to resolve its provider, distribution and source
+// directory. Validation and distribution-specific config (e.g. Talos PKI) are
+// skipped because the clone only needs the structured identity, not a
+// provisioning-ready config.
+func loadSourceConfig(cmd *cobra.Command, repoRoot, srcName string) (*v1alpha1.Cluster, error) {
+	return loadEnvironmentConfig(cmd, filepath.Join(repoRoot, "ksail."+srcName+".yaml"))
 }
 
-// loadEnvironmentConfig loads a single ksail.<name>.yaml root config by file name.
+// loadEnvironmentConfig loads a single ksail.<name>.yaml root config by path.
 // It is the shared loader behind loadSourceConfig and the environment.ConfigLoader
 // that enrichSourceConfigError feeds to DeriveEnvironments, so both resolve a config
-// the same silent, validation-skipping way.
+// the same silent, validation-skipping way. The path is loaded as given — it does
+// not traverse parent directories — so callers join it onto the resolved workspace
+// root (see resolveWorkspaceRoot) rather than passing a bare file name.
 func loadEnvironmentConfig(cmd *cobra.Command, configFile string) (*v1alpha1.Cluster, error) {
 	manager := ksailconfigmanager.NewConfigManager(cmd.OutOrStdout(), configFile)
 
@@ -279,7 +289,7 @@ func loadEnvironmentConfig(cmd *cobra.Command, configFile string) (*v1alpha1.Clu
 // fails or finds no other environments.
 func enrichSourceConfigError(cmd *cobra.Command, repoRoot string, cause error) error {
 	loader := func(configFile string) (*v1alpha1.Cluster, error) {
-		return loadEnvironmentConfig(cmd, configFile)
+		return loadEnvironmentConfig(cmd, filepath.Join(repoRoot, configFile))
 	}
 
 	envs, err := environment.DeriveEnvironments(repoRoot, loader)

--- a/pkg/cli/cmd/project/env/add_test.go
+++ b/pkg/cli/cmd/project/env/add_test.go
@@ -279,3 +279,68 @@ func TestNewAddCmd_Structure(t *testing.T) {
 	// The write annotation marks the command as state-modifying.
 	assert.Equal(t, "write", cmd.Annotations[annotations.AnnotationPermission])
 }
+
+// addEnvBaseConfig is the workspace base config (ksail.yaml) whose presence marks
+// the repository root for the env verbs' upward traversal.
+const addEnvBaseConfig = `apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  name: base
+spec:
+  cluster:
+    distribution: Vanilla
+    provider: Docker
+  workload:
+    sourceDirectory: k8s
+`
+
+// writeAddEnvWorkspace materialises the source "prod" environment plus the base
+// ksail.yaml that marks the workspace root, and returns the repo root.
+func writeAddEnvWorkspace(t *testing.T) string {
+	t.Helper()
+
+	repoRoot := writeAddEnvSourceRepo(t)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "ksail.yaml"), []byte(addEnvBaseConfig), 0o600,
+	))
+
+	return repoRoot
+}
+
+//nolint:paralleltest // uses t.Chdir to set the working directory
+func TestHandleAddEnvironmentRunE_RunsFromSubdirectory(t *testing.T) {
+	repoRoot := writeAddEnvWorkspace(t)
+	subDir := filepath.Join(repoRoot, "k8s", "clusters", "prod")
+	t.Chdir(subDir)
+
+	_, err := runAddEnvironment(t, "staging", "--from", "prod")
+	require.NoError(t, err)
+
+	// The workspace root was resolved by upward traversal, so the source config
+	// was found and the clone landed at the repo root — not relative to the
+	// subdirectory.
+	config := readAddEnv(t, repoRoot, "ksail.staging.yaml")
+	assert.Contains(t, config, "name: staging")
+
+	overlay := readAddEnv(t, repoRoot, "k8s/clusters/staging/kustomization.yaml")
+	assert.Contains(t, overlay, "cluster_name: staging")
+
+	_, statErr := os.Stat(filepath.Join(subDir, "ksail.staging.yaml"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+
+	_, statErr = os.Stat(filepath.Join(subDir, "k8s"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+//nolint:paralleltest // uses t.Chdir to set the working directory
+func TestHandleAddEnvironmentRunE_MissingSourceFromSubdirectoryListsAvailable(t *testing.T) {
+	repoRoot := writeAddEnvWorkspace(t)
+	t.Chdir(filepath.Join(repoRoot, "k8s"))
+
+	_, err := runAddEnvironment(t, "staging", "--from", "ghost")
+	require.ErrorIs(t, err, env.ErrSourceConfigLoad)
+
+	// The available-environments hint is discovered at the workspace root, so a
+	// mistyped --from still reports what exists from a subdirectory.
+	assert.Contains(t, err.Error(), "available environments: prod")
+}

--- a/pkg/cli/cmd/project/env/list.go
+++ b/pkg/cli/cmd/project/env/list.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"text/tabwriter"
 
-	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
 	"github.com/devantler-tech/ksail/v7/pkg/notify"
 	"github.com/devantler-tech/ksail/v7/pkg/svc/environment"
@@ -130,13 +128,9 @@ func HandleListRunE(cmd *cobra.Command) error {
 	// ancestor holding ksail.yaml — the traversal the config manager would do).
 	repoRoot := resolveWorkspaceRoot(canonWorkDir)
 
-	loader := func(configFile string) (*v1alpha1.Cluster, error) {
-		return loadEnvironmentConfig(cmd, filepath.Join(repoRoot, configFile))
-	}
-
-	envs, err := environment.DeriveEnvironments(repoRoot, loader)
+	envs, err := discoverWorkspaceEnvironments(cmd, repoRoot)
 	if err != nil {
-		return fmt.Errorf("discovering environments: %w", err)
+		return err
 	}
 
 	if output == listEnvOutputJSON {

--- a/pkg/cli/cmd/project/env/list.go
+++ b/pkg/cli/cmd/project/env/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
@@ -119,13 +120,18 @@ func HandleListRunE(cmd *cobra.Command) error {
 
 	// Canonicalise so the workspace root matches the symlink-resolved paths the
 	// config loader derives, mirroring `env add`.
-	repoRoot, err := fsutil.EvalCanonicalPath(workDir)
+	canonWorkDir, err := fsutil.EvalCanonicalPath(workDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve current directory: %w", err)
 	}
 
+	// Discovery enumerates the workspace root, not the current directory, so the
+	// list is the same from any subdirectory of the workspace (the nearest
+	// ancestor holding ksail.yaml — the traversal the config manager would do).
+	repoRoot := resolveWorkspaceRoot(canonWorkDir)
+
 	loader := func(configFile string) (*v1alpha1.Cluster, error) {
-		return loadEnvironmentConfig(cmd, configFile)
+		return loadEnvironmentConfig(cmd, filepath.Join(repoRoot, configFile))
 	}
 
 	envs, err := environment.DeriveEnvironments(repoRoot, loader)

--- a/pkg/cli/cmd/project/env/list_test.go
+++ b/pkg/cli/cmd/project/env/list_test.go
@@ -184,3 +184,20 @@ func TestNewListCmd_Structure(t *testing.T) {
 	assert.False(t, cmd.Hidden)
 	assert.Empty(t, cmd.Annotations[annotations.AnnotationPermission])
 }
+
+//nolint:paralleltest // uses t.Chdir to set the working directory
+func TestHandleListEnvironmentsRunE_RunsFromSubdirectory(t *testing.T) {
+	repoRoot := writeListEnvRepo(t)
+	subDir := filepath.Join(repoRoot, "k8s", "clusters", "prod")
+	require.NoError(t, os.MkdirAll(subDir, 0o750))
+	t.Chdir(subDir)
+
+	out, err := runListEnvironments(t)
+	require.NoError(t, err)
+
+	// Discovery enumerates the workspace root (resolved by upward traversal), so
+	// the list is identical to running at the root rather than empty.
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "staging")
+	assert.NotContains(t, out, "no environments declared")
+}

--- a/pkg/cli/cmd/project/env/reconcile.go
+++ b/pkg/cli/cmd/project/env/reconcile.go
@@ -116,9 +116,13 @@ func HandleReconcileRunE(cmd *cobra.Command) error {
 
 // resolveWorkspaceRoot walks upward from workDir to the nearest directory
 // containing the workspace base config (ksail.yaml), mirroring the config
-// manager's parent-directory traversal that the explicit per-file loads here
-// skip. It returns workDir unchanged when no ksail.yaml exists on the walk —
-// the base-config load then fails with its normal error.
+// manager's parent-directory traversal that the env verbs' explicit per-file
+// loads (loadEnvironmentConfig) skip. Every env verb resolves its repository
+// root through it so add, list, rm and reconcile all operate on the same tree
+// from any subdirectory of the workspace. It returns workDir unchanged when no
+// ksail.yaml exists on the walk — a workspace declaring only ksail.<name>.yaml
+// files keeps resolving against the current directory, and a base-config load
+// then fails with its normal error.
 func resolveWorkspaceRoot(workDir string) string {
 	for dir := workDir; ; dir = filepath.Dir(dir) {
 		_, statErr := os.Stat(filepath.Join(dir, "ksail.yaml"))

--- a/pkg/cli/cmd/project/env/rm.go
+++ b/pkg/cli/cmd/project/env/rm.go
@@ -82,10 +82,15 @@ func HandleRmRunE(cmd *cobra.Command, name string) error {
 
 	// Canonicalise so the repository root matches the symlink-resolved paths the
 	// config loader derives, mirroring `env add`.
-	repoRoot, err := fsutil.EvalCanonicalPath(workDir)
+	canonWorkDir, err := fsutil.EvalCanonicalPath(workDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve current directory: %w", err)
 	}
+
+	// The removal targets the workspace root, not the current directory, so the
+	// command finds (and deletes) the same files from any subdirectory of the
+	// workspace — the nearest ancestor holding ksail.yaml.
+	repoRoot := resolveWorkspaceRoot(canonWorkDir)
 
 	configRel := "ksail." + name + ".yaml"
 
@@ -107,7 +112,7 @@ func HandleRmRunE(cmd *cobra.Command, name string) error {
 // directory (sourceDirectory/clusters/<name>) relative to the repository root,
 // enriching a load failure with the environments that are actually declared.
 func resolveOverlayRel(cmd *cobra.Command, repoRoot, name string) (string, error) {
-	cfg, err := loadEnvironmentConfig(cmd, "ksail."+name+".yaml")
+	cfg, err := loadEnvironmentConfig(cmd, filepath.Join(repoRoot, "ksail."+name+".yaml"))
 	if err != nil {
 		return "", enrichSourceConfigError(cmd, repoRoot, err)
 	}

--- a/pkg/cli/cmd/project/env/rm_test.go
+++ b/pkg/cli/cmd/project/env/rm_test.go
@@ -245,3 +245,27 @@ func TestHandleRmRunE_PurgeAppliesDefaultSourceDirectory(t *testing.T) {
 	_, statErr := os.Stat(filepath.Join(repoRoot, "k8s", "clusters", "prod"))
 	require.ErrorIs(t, statErr, os.ErrNotExist, "the real overlay must be purged")
 }
+
+//nolint:paralleltest // uses t.Chdir to set the working directory
+func TestHandleRmRunE_RunsFromSubdirectory(t *testing.T) {
+	repoRoot := writeAddEnvWorkspace(t)
+	t.Chdir(filepath.Join(repoRoot, "k8s"))
+
+	out, err := runRm(t, "prod", "--purge")
+	require.NoError(t, err)
+
+	// The removal targets the workspace root (resolved by upward traversal), so
+	// both the root config and its overlay are gone even though the command ran
+	// from a subdirectory.
+	_, statErr := os.Stat(filepath.Join(repoRoot, "ksail.prod.yaml"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+
+	_, statErr = os.Stat(filepath.Join(repoRoot, "k8s", "clusters", "prod"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+
+	// The base config that marks the root is untouched.
+	_, statErr = os.Stat(filepath.Join(repoRoot, "ksail.yaml"))
+	require.NoError(t, statErr)
+
+	assert.Contains(t, out, "removed environment")
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

`ksail project env add`, `env list` and `env rm` only worked when run from the workspace root. From any subdirectory they could not find the environment configs that a plain `ksail up` resolves fine, and `env add` would clone the new environment into the wrong directory. `env reconcile` already handled this correctly, so the four verbs disagreed about where the workspace is.

### What

All four env verbs now find the workspace root the same way (the nearest parent directory holding `ksail.yaml`) and read, write and delete environment files there, so they behave identically from anywhere inside the workspace. Each verb gains a run-from-subdirectory regression test.

Fixes #6088
