### PR TITLE
fix(reconcile): gate argocd app-sync on the application controller too

### DIFF
--- a/pkg/cli/cmd/workload/reconcile.go
+++ b/pkg/cli/cmd/workload/reconcile.go
@@ -716,16 +716,16 @@ func reconcileArgoCD(
 
 	writer := cmd.OutOrStdout()
 
-	// Gate the control-plane readiness on the command's own context, self-bounded
-	// by the gate's internal budget, BEFORE opening the reconcile deadline. If the
-	// gate shared the reconcile deadline, a slow control-plane could consume the
-	// whole timeout budget, leaving TriggerRefresh and the app poll to run on an
-	// already-expired context. Opening deadlineCtx afterwards reserves the full
-	// timeout for the reconcile itself.
-	gateArgoCDControlPlaneReady(cmd.Context(), argoReconciler, timeout, writer)
-
 	deadlineCtx, deadlineCancel := context.WithTimeout(cmd.Context(), timeout)
 	defer deadlineCancel()
+
+	// The readiness gate shares the reconcile deadline so one attempt stays inside
+	// --timeout, and is capped at half of it (ControlPlaneGateBudget) so a slow
+	// control-plane can delay TriggerRefresh and the app poll but never leave them
+	// an already-expired context.
+	gateArgoCDControlPlaneReady(
+		deadlineCtx, argoReconciler, argocd.ControlPlaneGateBudget(timeout), writer,
+	)
 
 	writeActivityNotification("triggering argocd refresh...", writer)
 
@@ -766,9 +766,10 @@ func reconcileArgoCD(
 }
 
 // gateArgoCDControlPlaneReady waits for the ArgoCD control-plane (repo-server /
-// redis / server) to be Ready before the first app-sync poll (issue #5948), so a
-// just-starting control-plane's transient errors ("connection refused", "unable to
-// resolve") are not misclassified as a permanent source-unavailable failure.
+// redis / server / application-controller) to be Ready before the first app-sync
+// poll (issue #5948), so a just-starting control-plane's transient errors
+// ("connection refused", "unable to resolve") are not misclassified as a permanent
+// source-unavailable failure. budget is the gate's share of the reconcile timeout.
 //
 // It is best-effort (fail-open): a control-plane that never becomes ready is not
 // terminal here — reconcile proceeds and any genuine problem surfaces through the
@@ -777,12 +778,12 @@ func reconcileArgoCD(
 func gateArgoCDControlPlaneReady(
 	ctx context.Context,
 	argoReconciler *argocd.Reconciler,
-	timeout time.Duration,
+	budget time.Duration,
 	writer io.Writer,
 ) {
 	writeActivityNotification("waiting for argocd control-plane...", writer)
 
-	err := argoReconciler.WaitForControlPlaneReady(ctx, timeout)
+	err := argoReconciler.WaitForControlPlaneReady(ctx, budget)
 	if err != nil {
 		writeActivityNotification(
 			fmt.Sprintf("warning: argocd control-plane not fully ready, proceeding: %v", err),

--- a/pkg/client/argocd/controlplane.go
+++ b/pkg/client/argocd/controlplane.go
@@ -17,6 +17,9 @@ import (
 // when it is smaller.
 const maxControlPlaneReadyWait = 3 * time.Minute
 
+// controlPlaneBudgetDivisor reserves half the reconcile timeout for app sync.
+const controlPlaneBudgetDivisor = 2
+
 // errControlPlaneReadyBudgetExhausted is returned when the gate's time budget is
 // spent before a component could even be checked. It is handled fail-open by the
 // caller (a warning, then reconcile proceeds), so it never aborts a reconcile.
@@ -90,7 +93,7 @@ func ControlPlaneGateBudget(reconcileTimeout time.Duration) time.Duration {
 		return maxControlPlaneReadyWait
 	}
 
-	return min(reconcileTimeout/2, maxControlPlaneReadyWait)
+	return min(reconcileTimeout/controlPlaneBudgetDivisor, maxControlPlaneReadyWait)
 }
 
 // WaitForControlPlaneReady waits (bounded by timeout, at most
@@ -162,11 +165,19 @@ func waitForComponentReady(
 	switch component.kind {
 	case componentStatefulSet:
 		return readiness.WaitForStatefulSetReadyIfExists( //nolint:wrapcheck // caller wraps with the component
-			ctx, clientset, DefaultNamespace, component.name, remaining,
+			ctx,
+			clientset,
+			DefaultNamespace,
+			component.name,
+			remaining,
 		)
 	case componentDeployment:
 		return readiness.WaitForDeploymentReadyIfExists( //nolint:wrapcheck // caller wraps with the component
-			ctx, clientset, DefaultNamespace, component.name, remaining,
+			ctx,
+			clientset,
+			DefaultNamespace,
+			component.name,
+			remaining,
 		)
 	default:
 		return fmt.Errorf("%w: %q", errUnknownControlPlaneComponentKind, component.kind)

--- a/pkg/client/argocd/controlplane.go
+++ b/pkg/client/argocd/controlplane.go
@@ -24,6 +24,11 @@ var errControlPlaneReadyBudgetExhausted = errors.New(
 	"timeout budget exhausted before checking argocd control-plane readiness",
 )
 
+// errUnknownControlPlaneComponentKind is returned for a component kind the gate
+// has no readiness check for; it can only come from a programming error in
+// controlPlaneComponents.
+var errUnknownControlPlaneComponentKind = errors.New("unknown argocd control-plane component kind")
+
 // newControlPlaneClientset builds a typed clientset for the readiness gate.
 //
 //nolint:gochecknoglobals // Allows mocking for tests.
@@ -41,21 +46,60 @@ var newControlPlaneClientset = func(kubeconfigPath string) (kubernetes.Interface
 	return clientset, nil
 }
 
-// controlPlaneComponents returns the ArgoCD control-plane Deployments whose
+// controlPlaneComponentKind is the workload kind a control-plane component runs as.
+type controlPlaneComponentKind string
+
+const (
+	componentDeployment  controlPlaneComponentKind = "deployment"
+	componentStatefulSet controlPlaneComponentKind = "statefulset"
+)
+
+// controlPlaneComponent names one ArgoCD control-plane workload the gate waits for.
+type controlPlaneComponent struct {
+	kind controlPlaneComponentKind
+	name string
+}
+
+// controlPlaneComponents returns the ArgoCD control-plane workloads whose
 // cold-start (not-yet-Ready) state produces the transient signals — "connection
 // refused" (redis), "unable to resolve"/"failed to fetch" (repo-server) — that the
 // app-sync poll would otherwise misclassify as a permanent source-unavailable
-// failure. The gate waits for them before the first poll so the cold-start window
-// is closed at the root. Absent components (custom or renamed installs, e.g. HA
-// redis) are tolerated and skipped.
-func controlPlaneComponents() []string {
-	return []string{"argocd-repo-server", "argocd-redis", "argocd-server"}
+// failure, plus the application controller, which is the component that writes
+// the Application status the poll reads: until it is Ready a cold-start
+// ComparisonError it recorded earlier stays on the Application and can be
+// classified before it clears. The gate waits for them before the first poll so
+// the cold-start window is closed at the root. Absent components (custom or
+// renamed installs, e.g. HA redis) are tolerated and skipped.
+func controlPlaneComponents() []controlPlaneComponent {
+	return []controlPlaneComponent{
+		{kind: componentDeployment, name: "argocd-repo-server"},
+		{kind: componentDeployment, name: "argocd-redis"},
+		{kind: componentDeployment, name: "argocd-server"},
+		{kind: componentStatefulSet, name: "argocd-application-controller"},
+	}
 }
 
-// WaitForControlPlaneReady waits (bounded) for the ArgoCD control-plane Deployments
-// to be Ready before app-sync polling begins, so a just-started repo-server/redis
-// does not emit transient errors that ksail's poll loop treats as a permanent
-// source-unavailable failure (issue #5948).
+// ControlPlaneGateBudget returns how much of reconcileTimeout the readiness gate
+// may spend before the app-sync poll begins: at most half of it, and never more
+// than maxControlPlaneReadyWait. Sharing the reconcile deadline this way keeps one
+// reconcile attempt inside its --timeout while still reserving at least half of
+// that window for the reconcile itself, so a slow control-plane can delay the poll
+// but never starve it. A non-positive timeout falls back to the gate maximum.
+func ControlPlaneGateBudget(reconcileTimeout time.Duration) time.Duration {
+	if reconcileTimeout <= 0 {
+		return maxControlPlaneReadyWait
+	}
+
+	return min(reconcileTimeout/2, maxControlPlaneReadyWait)
+}
+
+// WaitForControlPlaneReady waits (bounded by timeout, at most
+// maxControlPlaneReadyWait) for the ArgoCD control-plane workloads to be Ready
+// before app-sync polling begins, so a just-started repo-server/redis does not
+// emit transient errors that ksail's poll loop treats as a permanent
+// source-unavailable failure, and a cold-start ComparisonError left on an
+// Application is not read before the application controller has cleared it
+// (issue #5948).
 //
 // It is intended to be used fail-open: the caller treats a returned error as a
 // warning and proceeds with reconcile, so the gate can only reduce the cold-start
@@ -86,25 +130,45 @@ func waitForControlPlaneReady(
 
 	deadline := time.Now().Add(budget)
 
-	for _, name := range controlPlaneComponents() {
+	for _, component := range controlPlaneComponents() {
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			return fmt.Errorf(
 				"%w (last: %s/%s)",
-				errControlPlaneReadyBudgetExhausted, DefaultNamespace, name,
+				errControlPlaneReadyBudgetExhausted, DefaultNamespace, component.name,
 			)
 		}
 
-		err := readiness.WaitForDeploymentReadyIfExists(
-			ctx, clientset, DefaultNamespace, name, remaining,
-		)
+		err := waitForComponentReady(ctx, clientset, component, remaining)
 		if err != nil {
 			return fmt.Errorf(
-				"argocd control-plane component %s/%s not ready: %w",
-				DefaultNamespace, name, err,
+				"argocd control-plane %s %s/%s not ready: %w",
+				component.kind, DefaultNamespace, component.name, err,
 			)
 		}
 	}
 
 	return nil
+}
+
+// waitForComponentReady waits for one control-plane component by its kind,
+// tolerating its absence.
+func waitForComponentReady(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	component controlPlaneComponent,
+	remaining time.Duration,
+) error {
+	switch component.kind {
+	case componentStatefulSet:
+		return readiness.WaitForStatefulSetReadyIfExists( //nolint:wrapcheck // caller wraps with the component
+			ctx, clientset, DefaultNamespace, component.name, remaining,
+		)
+	case componentDeployment:
+		return readiness.WaitForDeploymentReadyIfExists( //nolint:wrapcheck // caller wraps with the component
+			ctx, clientset, DefaultNamespace, component.name, remaining,
+		)
+	default:
+		return fmt.Errorf("%w: %q", errUnknownControlPlaneComponentKind, component.kind)
+	}
 }

--- a/pkg/client/argocd/controlplane_test.go
+++ b/pkg/client/argocd/controlplane_test.go
@@ -38,12 +38,39 @@ func notReadyDeployment(name string) *appsv1.Deployment {
 	}
 }
 
+func readyStatefulSet(name string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: argoCDNamespace},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        1,
+			ReadyReplicas:   1,
+			UpdatedReplicas: 1,
+			CurrentRevision: "rev-1",
+			UpdateRevision:  "rev-1",
+		},
+	}
+}
+
+func notReadyStatefulSet(name string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: argoCDNamespace},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        1,
+			ReadyReplicas:   0,
+			UpdatedReplicas: 0,
+			CurrentRevision: "rev-1",
+			UpdateRevision:  "rev-1",
+		},
+	}
+}
+
 func TestWaitForControlPlaneReady(t *testing.T) {
 	t.Parallel()
 
 	t.Run("AllComponentsReady", testControlPlaneAllReady)
 	t.Run("AbsentComponentsTolerated", testControlPlaneAbsentTolerated)
 	t.Run("PresentButNotReadyReturnsError", testControlPlaneNotReady)
+	t.Run("ApplicationControllerNotReadyReturnsError", testControlPlaneAppControllerNotReady)
 }
 
 // testControlPlaneAllReady covers the healthy case: every control-plane component
@@ -56,6 +83,7 @@ func testControlPlaneAllReady(t *testing.T) {
 		readyDeployment("argocd-repo-server"),
 		readyDeployment("argocd-redis"),
 		readyDeployment("argocd-server"),
+		readyStatefulSet("argocd-application-controller"),
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -154,4 +182,63 @@ func TestReconcilerWaitForControlPlaneReady(t *testing.T) {
 			t.Fatalf("expected clientset-construction error to propagate, got: %v", err)
 		}
 	})
+}
+
+// testControlPlaneAppControllerNotReady covers the slice-2 gap: the application
+// controller (a StatefulSet, not a Deployment) is the component that writes the
+// Application status the poll reads, so the gate must wait for it too. Every
+// Deployment is Ready here; only the controller is still starting.
+func testControlPlaneAppControllerNotReady(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	client := fake.NewClientset(
+		readyDeployment("argocd-repo-server"),
+		readyDeployment("argocd-redis"),
+		readyDeployment("argocd-server"),
+		notReadyStatefulSet("argocd-application-controller"),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := argocd.WaitForControlPlaneReady(ctx, client, 150*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for a not-ready application controller")
+	}
+
+	if !strings.Contains(err.Error(), "statefulset argocd/argocd-application-controller") {
+		t.Fatalf("expected error to name the application-controller statefulset, got: %v", err)
+	}
+}
+
+// TestControlPlaneGateBudget pins the gate's share of the reconcile timeout: half
+// of it, capped at the gate maximum, so one reconcile attempt stays inside
+// --timeout while the reconcile keeps at least half of its window.
+func TestControlPlaneGateBudget(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{name: "small timeout yields half", timeout: 30 * time.Second, want: 15 * time.Second},
+		{name: "half below the cap is used", timeout: 4 * time.Minute, want: 2 * time.Minute},
+		{name: "half equal to the cap", timeout: 6 * time.Minute, want: 3 * time.Minute},
+		{name: "large timeout is capped", timeout: 10 * time.Minute, want: 3 * time.Minute},
+		{name: "zero timeout falls back to the cap", timeout: 0, want: 3 * time.Minute},
+		{name: "negative timeout falls back to the cap", timeout: -time.Second, want: 3 * time.Minute},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := argocd.ControlPlaneGateBudget(testCase.timeout)
+			if got != testCase.want {
+				t.Fatalf("ControlPlaneGateBudget(%v) = %v, want %v", testCase.timeout, got, testCase.want)
+			}
+		})
+	}
 }

--- a/pkg/client/argocd/controlplane_test.go
+++ b/pkg/client/argocd/controlplane_test.go
@@ -228,7 +228,11 @@ func TestControlPlaneGateBudget(t *testing.T) {
 		{name: "half equal to the cap", timeout: 6 * time.Minute, want: 3 * time.Minute},
 		{name: "large timeout is capped", timeout: 10 * time.Minute, want: 3 * time.Minute},
 		{name: "zero timeout falls back to the cap", timeout: 0, want: 3 * time.Minute},
-		{name: "negative timeout falls back to the cap", timeout: -time.Second, want: 3 * time.Minute},
+		{
+			name:    "negative timeout falls back to the cap",
+			timeout: -time.Second,
+			want:    3 * time.Minute,
+		},
 	}
 
 	for _, testCase := range cases {
@@ -237,7 +241,12 @@ func TestControlPlaneGateBudget(t *testing.T) {
 
 			got := argocd.ControlPlaneGateBudget(testCase.timeout)
 			if got != testCase.want {
-				t.Fatalf("ControlPlaneGateBudget(%v) = %v, want %v", testCase.timeout, got, testCase.want)
+				t.Fatalf(
+					"ControlPlaneGateBudget(%v) = %v, want %v",
+					testCase.timeout,
+					got,
+					testCase.want,
+				)
 			}
 		})
 	}

--- a/pkg/k8s/readiness/deployment.go
+++ b/pkg/k8s/readiness/deployment.go
@@ -92,19 +92,16 @@ func WaitForDeploymentReadyIfExists(
 	namespace, name string,
 	deadline time.Duration,
 ) error {
-	deadlineCtx, cancel := context.WithTimeout(ctx, deadline)
-	defer cancel()
-
-	_, err := clientset.AppsV1().
-		Deployments(namespace).
-		Get(deadlineCtx, name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
+	lookup := func(lookupCtx context.Context) error {
+		_, err := clientset.AppsV1().
+			Deployments(namespace).
+			Get(lookupCtx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to check deployment %s/%s: %w", namespace, name, err)
 		}
 
-		return fmt.Errorf("failed to check deployment %s/%s: %w", namespace, name, err)
+		return nil
 	}
 
-	return PollForReadiness(deadlineCtx, 0, deploymentReadyCheck(clientset, namespace, name))
+	return pollIfExists(ctx, deadline, lookup, deploymentReadyCheck(clientset, namespace, name))
 }

--- a/pkg/k8s/readiness/doc.go
+++ b/pkg/k8s/readiness/doc.go
@@ -1,13 +1,14 @@
 // Package readiness provides Kubernetes resource readiness polling utilities.
 //
 // This package offers reusable utilities for waiting until Kubernetes resources
-// become ready. It supports deployments, daemonsets, nodes, and the API server,
+// become ready. It supports deployments, daemonsets, statefulsets, nodes, and the API server,
 // and provides a generic polling mechanism that can be extended.
 //
 // Key features:
 //   - Generic polling mechanism (PollForReadiness)
 //   - Deployment readiness polling (WaitForDeploymentReady)
 //   - DaemonSet readiness polling (WaitForDaemonSetReady)
+//   - StatefulSet readiness polling (WaitForStatefulSetReady)
 //   - Node readiness polling (WaitForNodeReady)
 //   - API server readiness and stability polling (WaitForAPIServerReady, WaitForAPIServerStable)
 //   - In-cluster API connectivity verification (WaitForInClusterAPIConnectivity)

--- a/pkg/k8s/readiness/multi_resource.go
+++ b/pkg/k8s/readiness/multi_resource.go
@@ -11,7 +11,7 @@ import (
 // Check defines a check to perform for a Kubernetes resource.
 type Check struct {
 	// Type specifies the kind of Kubernetes resource to check for readiness.
-	// Valid values are "deployment" or "daemonset".
+	// Valid values are "deployment", "daemonset" or "statefulset".
 	Type string
 	// Namespace is the Kubernetes namespace where the resource resides.
 	Namespace string
@@ -58,6 +58,10 @@ func WaitForMultipleResources(
 			)
 		case "daemonset":
 			err = WaitForDaemonSetReady(
+				resourceCtx, clientset, check.Namespace, check.Name, remainingTimeout,
+			)
+		case "statefulset":
+			err = WaitForStatefulSetReady(
 				resourceCtx, clientset, check.Namespace, check.Name, remainingTimeout,
 			)
 		default:

--- a/pkg/k8s/readiness/multi_resource_test.go
+++ b/pkg/k8s/readiness/multi_resource_test.go
@@ -284,3 +284,35 @@ func TestWaitForMultipleResources_MixedTypes(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+// TestWaitForMultipleResources_SingleStatefulSetReady tests single ready statefulset.
+func TestWaitForMultipleResources_SingleStatefulSetReady(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace = "argocd"
+		name      = "argocd-application-controller"
+	)
+
+	client := fake.NewClientset(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        1,
+			ReadyReplicas:   1,
+			UpdatedReplicas: 1,
+			CurrentRevision: "rev-1",
+			UpdateRevision:  "rev-1",
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	checks := []readiness.Check{
+		{Type: "statefulset", Namespace: namespace, Name: name},
+	}
+
+	err := readiness.WaitForMultipleResources(ctx, client, checks, 500*time.Millisecond)
+
+	require.NoError(t, err)
+}

--- a/pkg/k8s/readiness/polling.go
+++ b/pkg/k8s/readiness/polling.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -14,6 +15,29 @@ const (
 	// readinessPollInterval is the interval between readiness checks.
 	readinessPollInterval = 2 * time.Second
 )
+
+// pollIfExists shares one deadline between the initial lookup and readiness polling.
+// The lookup supplies resource-specific error context; a missing resource is skipped.
+func pollIfExists(
+	ctx context.Context,
+	deadline time.Duration,
+	lookup func(context.Context) error,
+	poll func(context.Context) (bool, error),
+) error {
+	deadlineCtx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
+	err := lookup(deadlineCtx)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return PollForReadiness(deadlineCtx, 0, poll)
+}
 
 // PollForReadiness polls a check function until ready or timeout.
 //

--- a/pkg/k8s/readiness/statefulset.go
+++ b/pkg/k8s/readiness/statefulset.go
@@ -13,8 +13,8 @@ import (
 
 // statefulSetReadyCheck returns a poll function that checks whether a StatefulSet is ready.
 // A StatefulSet is considered ready when the controller has observed the current spec, it
-// has at least one replica, every replica is Ready, and its rollout is complete. NotFound
-// errors are tolerated (returns false to continue polling).
+// wants at least one replica, every desired replica is Ready, and its rollout is complete.
+// NotFound errors are tolerated (returns false to continue polling).
 func statefulSetReadyCheck(
 	clientset kubernetes.Interface,
 	namespace, name string,
@@ -38,15 +38,20 @@ func statefulSetReadyCheck(
 			return false, nil
 		}
 
-		if statefulSet.Status.Replicas == 0 {
+		// Compare against the DESIRED count, not Status.Replicas: during a scale-up
+		// the controller creates pods one ordinal at a time, so Status.Replicas trails
+		// Spec.Replicas and a partially created StatefulSet would otherwise read as
+		// ready once its first pod is.
+		desired := desiredStatefulSetReplicas(statefulSet)
+		if desired == 0 || statefulSet.Status.Replicas == 0 {
 			return false, nil
 		}
 
-		if statefulSet.Status.ReadyReplicas < statefulSet.Status.Replicas {
+		if statefulSet.Status.ReadyReplicas < desired {
 			return false, nil
 		}
 
-		return isStatefulSetRolloutComplete(statefulSet), nil
+		return isStatefulSetRolloutComplete(statefulSet, desired), nil
 	}
 }
 
@@ -56,7 +61,7 @@ func statefulSetReadyCheck(
 // so revisions are not compared there. A partitioned RollingUpdate deliberately
 // leaves the ordinals below the partition on the old revision, so only the pods
 // above it are required to be updated.
-func isStatefulSetRolloutComplete(statefulSet *appsv1.StatefulSet) bool {
+func isStatefulSetRolloutComplete(statefulSet *appsv1.StatefulSet, desired int32) bool {
 	strategy := statefulSet.Spec.UpdateStrategy
 	if strategy.Type == appsv1.OnDeleteStatefulSetStrategyType {
 		return true
@@ -64,8 +69,7 @@ func isStatefulSetRolloutComplete(statefulSet *appsv1.StatefulSet) bool {
 
 	if strategy.RollingUpdate != nil && strategy.RollingUpdate.Partition != nil &&
 		*strategy.RollingUpdate.Partition > 0 {
-		return statefulSet.Status.UpdatedReplicas >=
-			statefulSet.Status.Replicas-*strategy.RollingUpdate.Partition
+		return statefulSet.Status.UpdatedReplicas >= desired-*strategy.RollingUpdate.Partition
 	}
 
 	return statefulSet.Status.UpdateRevision == statefulSet.Status.CurrentRevision
@@ -124,4 +128,15 @@ func WaitForStatefulSetReadyIfExists(
 	}
 
 	return pollIfExists(ctx, deadline, lookup, statefulSetReadyCheck(clientset, namespace, name))
+}
+
+// desiredStatefulSetReplicas returns the replica count the StatefulSet is meant
+// to reach. Spec.Replicas is a pointer that the API server defaults to 1 when
+// unset, so a nil value means one replica, not zero.
+func desiredStatefulSetReplicas(statefulSet *appsv1.StatefulSet) int32 {
+	if statefulSet.Spec.Replicas == nil {
+		return 1
+	}
+
+	return *statefulSet.Spec.Replicas
 }

--- a/pkg/k8s/readiness/statefulset.go
+++ b/pkg/k8s/readiness/statefulset.go
@@ -112,19 +112,16 @@ func WaitForStatefulSetReadyIfExists(
 	namespace, name string,
 	deadline time.Duration,
 ) error {
-	deadlineCtx, cancel := context.WithTimeout(ctx, deadline)
-	defer cancel()
-
-	_, err := clientset.AppsV1().
-		StatefulSets(namespace).
-		Get(deadlineCtx, name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
+	lookup := func(lookupCtx context.Context) error {
+		_, err := clientset.AppsV1().
+			StatefulSets(namespace).
+			Get(lookupCtx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to check statefulset %s/%s: %w", namespace, name, err)
 		}
 
-		return fmt.Errorf("failed to check statefulset %s/%s: %w", namespace, name, err)
+		return nil
 	}
 
-	return PollForReadiness(deadlineCtx, 0, statefulSetReadyCheck(clientset, namespace, name))
+	return pollIfExists(ctx, deadline, lookup, statefulSetReadyCheck(clientset, namespace, name))
 }

--- a/pkg/k8s/readiness/statefulset.go
+++ b/pkg/k8s/readiness/statefulset.go
@@ -1,0 +1,130 @@
+package readiness
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// statefulSetReadyCheck returns a poll function that checks whether a StatefulSet is ready.
+// A StatefulSet is considered ready when the controller has observed the current spec, it
+// has at least one replica, every replica is Ready, and its rollout is complete. NotFound
+// errors are tolerated (returns false to continue polling).
+func statefulSetReadyCheck(
+	clientset kubernetes.Interface,
+	namespace, name string,
+) func(context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		statefulSet, err := clientset.AppsV1().
+			StatefulSets(namespace).
+			Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to get statefulset %s/%s: %w", namespace, name, err)
+		}
+
+		// The controller must have observed the current spec before its status
+		// counters and revisions can be trusted: right after a spec change the
+		// Status still describes the previous generation's (possibly ready) pods.
+		if statefulSet.Status.ObservedGeneration < statefulSet.Generation {
+			return false, nil
+		}
+
+		if statefulSet.Status.Replicas == 0 {
+			return false, nil
+		}
+
+		if statefulSet.Status.ReadyReplicas < statefulSet.Status.Replicas {
+			return false, nil
+		}
+
+		return isStatefulSetRolloutComplete(statefulSet), nil
+	}
+}
+
+// isStatefulSetRolloutComplete reports whether every pod the rollout is meant to
+// reach runs the update revision, mirroring `kubectl rollout status`. Under the
+// OnDelete strategy the operator moves pods to the new revision by deleting them,
+// so revisions are not compared there. A partitioned RollingUpdate deliberately
+// leaves the ordinals below the partition on the old revision, so only the pods
+// above it are required to be updated.
+func isStatefulSetRolloutComplete(statefulSet *appsv1.StatefulSet) bool {
+	strategy := statefulSet.Spec.UpdateStrategy
+	if strategy.Type == appsv1.OnDeleteStatefulSetStrategyType {
+		return true
+	}
+
+	if strategy.RollingUpdate != nil && strategy.RollingUpdate.Partition != nil &&
+		*strategy.RollingUpdate.Partition > 0 {
+		return statefulSet.Status.UpdatedReplicas >=
+			statefulSet.Status.Replicas-*strategy.RollingUpdate.Partition
+	}
+
+	return statefulSet.Status.UpdateRevision == statefulSet.Status.CurrentRevision
+}
+
+// WaitForStatefulSetReady waits for a StatefulSet to be ready.
+//
+// This function polls the specified StatefulSet until it is ready or the deadline is reached.
+// A StatefulSet is considered ready when:
+//   - The controller has observed the current spec
+//   - It has at least one replica
+//   - All replicas are Ready
+//   - Its rollout is complete (see isStatefulSetRolloutComplete)
+//
+// The function tolerates NotFound errors and continues polling. Other API errors
+// are returned immediately.
+//
+// Returns an error if the StatefulSet is not ready within the deadline or if an API error occurs.
+func WaitForStatefulSetReady(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, name string,
+	deadline time.Duration,
+) error {
+	return PollForReadiness(ctx, deadline, statefulSetReadyCheck(clientset, namespace, name))
+}
+
+// WaitForStatefulSetReadyIfExists waits for a StatefulSet to be ready, but returns
+// immediately if the StatefulSet does not exist.
+//
+// This is useful when a component may or may not be installed, or may be installed
+// under another name (e.g. a renamed ArgoCD application controller). If the
+// StatefulSet is absent, there is nothing to wait for. If it exists, this function
+// waits for it to be fully ready using the same criteria as WaitForStatefulSetReady.
+//
+// A single deadline bounds the total wall-clock time for both the initial existence
+// check and the subsequent readiness polling.
+//
+// Returns nil if the StatefulSet does not exist (including when the namespace does not exist).
+// Returns an error if the StatefulSet exists but is not ready within the deadline.
+func WaitForStatefulSetReadyIfExists(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, name string,
+	deadline time.Duration,
+) error {
+	deadlineCtx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
+	_, err := clientset.AppsV1().
+		StatefulSets(namespace).
+		Get(deadlineCtx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to check statefulset %s/%s: %w", namespace, name, err)
+	}
+
+	return PollForReadiness(deadlineCtx, 0, statefulSetReadyCheck(clientset, namespace, name))
+}

--- a/pkg/k8s/readiness/statefulset_test.go
+++ b/pkg/k8s/readiness/statefulset_test.go
@@ -1,0 +1,189 @@
+package readiness_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/k8s/readiness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const (
+	statefulSetNamespace = "argocd"
+	statefulSetName      = "argocd-application-controller"
+	statefulSetShortWait = 150 * time.Millisecond
+)
+
+var errStatefulSetAPI = errors.New("apiserver unavailable")
+
+// statefulSetFixture builds a StatefulSet whose controller has observed the
+// current generation, with the given replica counters and revisions.
+func statefulSetFixture(replicas, ready, updated int32, current, update string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: statefulSetName, Namespace: statefulSetNamespace, Generation: 1,
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           replicas,
+			ReadyReplicas:      ready,
+			UpdatedReplicas:    updated,
+			CurrentRevision:    current,
+			UpdateRevision:     update,
+		},
+	}
+}
+
+func readyStatefulSet() *appsv1.StatefulSet {
+	return statefulSetFixture(1, 1, 1, "rev-1", "rev-1")
+}
+
+func waitIfExists(t *testing.T, objects ...runtime.Object) error {
+	t.Helper()
+
+	client := fake.NewClientset(objects...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	return readiness.WaitForStatefulSetReadyIfExists(
+		ctx, client, statefulSetNamespace, statefulSetName, statefulSetShortWait,
+	)
+}
+
+// TestWaitForStatefulSetReadyIfExists_Absent verifies an absent StatefulSet is
+// nothing to wait for: a renamed or custom install must not stall the caller.
+func TestWaitForStatefulSetReadyIfExists_Absent(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, waitIfExists(t), "absent statefulset must be tolerated")
+}
+
+// TestWaitForStatefulSetReadyIfExists_Ready verifies the healthy shape reads as
+// ready: current generation observed, every replica Ready, revisions converged.
+func TestWaitForStatefulSetReadyIfExists_Ready(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, waitIfExists(t, readyStatefulSet()))
+}
+
+// TestWaitForStatefulSetReadyIfExists_NotReady verifies a StatefulSet whose pods
+// are not yet Ready is reported, which is the cold-start window the ArgoCD gate
+// exists to wait out.
+func TestWaitForStatefulSetReadyIfExists_NotReady(t *testing.T) {
+	t.Parallel()
+
+	err := waitIfExists(t, statefulSetFixture(1, 0, 1, "rev-1", "rev-1"))
+
+	require.Error(t, err, "a statefulset with no Ready replicas must not read as ready")
+}
+
+// TestWaitForStatefulSetReadyIfExists_StaleObservedGeneration verifies that
+// healthy-looking counters from a previous generation are not trusted before the
+// controller has observed the current spec.
+func TestWaitForStatefulSetReadyIfExists_StaleObservedGeneration(t *testing.T) {
+	t.Parallel()
+
+	stale := readyStatefulSet()
+	stale.Generation = 2
+	stale.Status.ObservedGeneration = 1
+
+	err := waitIfExists(t, stale)
+
+	require.Error(t, err, "stale observedGeneration must not read as ready")
+}
+
+// TestWaitForStatefulSetReadyIfExists_RollingUpdateInProgress verifies that a
+// rollout still moving pods to the update revision is not ready even though every
+// pod is currently Ready — the old-revision pods are about to be replaced.
+func TestWaitForStatefulSetReadyIfExists_RollingUpdateInProgress(t *testing.T) {
+	t.Parallel()
+
+	err := waitIfExists(t, statefulSetFixture(2, 2, 1, "rev-1", "rev-2"))
+
+	require.Error(t, err, "diverged revisions under RollingUpdate must not read as ready")
+}
+
+// TestWaitForStatefulSetReadyIfExists_OnDeleteIgnoresRevisions verifies that the
+// OnDelete strategy, where the operator decides when pods move revision, does not
+// hold readiness hostage to a revision that will never converge on its own.
+func TestWaitForStatefulSetReadyIfExists_OnDeleteIgnoresRevisions(t *testing.T) {
+	t.Parallel()
+
+	onDelete := statefulSetFixture(2, 2, 0, "rev-1", "rev-2")
+	onDelete.Spec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
+
+	require.NoError(t, waitIfExists(t, onDelete))
+}
+
+// TestWaitForStatefulSetReadyIfExists_PartitionedRollout verifies that a
+// partitioned RollingUpdate is complete once the ordinals above the partition run
+// the update revision, and not before.
+func TestWaitForStatefulSetReadyIfExists_PartitionedRollout(t *testing.T) {
+	t.Parallel()
+
+	partition := int32(1)
+
+	complete := statefulSetFixture(3, 3, 2, "rev-1", "rev-2")
+	complete.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type:          appsv1.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{Partition: &partition},
+	}
+
+	require.NoError(t, waitIfExists(t, complete), "2 of 3 updated satisfies partition 1")
+
+	incomplete := statefulSetFixture(3, 3, 1, "rev-1", "rev-2")
+	incomplete.Spec.UpdateStrategy = complete.Spec.UpdateStrategy
+
+	require.Error(t, waitIfExists(t, incomplete), "1 of 3 updated does not satisfy partition 1")
+}
+
+// TestWaitForStatefulSetReady_Ready verifies the non-IfExists variant polls the
+// same readiness criteria.
+func TestWaitForStatefulSetReady_Ready(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewClientset(readyStatefulSet())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := readiness.WaitForStatefulSetReady(
+		ctx, client, statefulSetNamespace, statefulSetName, time.Second,
+	)
+
+	require.NoError(t, err)
+}
+
+// TestWaitForStatefulSetReady_APIErrorPropagates verifies that a non-NotFound API
+// error is surfaced immediately rather than polled until the deadline, so an
+// unreachable API server is reported as such and not as "not ready".
+func TestWaitForStatefulSetReady_APIErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewClientset()
+	client.PrependReactor(
+		"get", "statefulsets",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errStatefulSetAPI
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := readiness.WaitForStatefulSetReadyIfExists(
+		ctx, client, statefulSetNamespace, statefulSetName, time.Second,
+	)
+
+	require.ErrorIs(t, err, errStatefulSetAPI)
+	assert.Contains(t, err.Error(), "failed to check statefulset argocd/argocd-application-controller")
+}

--- a/pkg/k8s/readiness/statefulset_test.go
+++ b/pkg/k8s/readiness/statefulset_test.go
@@ -3,6 +3,7 @@ package readiness_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -25,8 +26,8 @@ const (
 var errStatefulSetAPI = errors.New("apiserver unavailable")
 
 // statefulSetFixture builds a StatefulSet whose controller has observed the
-// current generation, with the given replica counters and revisions.
-func statefulSetFixture(replicas, ready, updated int32, current, update string) *appsv1.StatefulSet {
+// current generation, with the given replica counters and update revision.
+func statefulSetFixture(replicas, ready, updated int32, update string) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: statefulSetName, Namespace: statefulSetNamespace, Generation: 1,
@@ -36,14 +37,14 @@ func statefulSetFixture(replicas, ready, updated int32, current, update string) 
 			Replicas:           replicas,
 			ReadyReplicas:      ready,
 			UpdatedReplicas:    updated,
-			CurrentRevision:    current,
+			CurrentRevision:    "rev-1",
 			UpdateRevision:     update,
 		},
 	}
 }
 
 func readyStatefulSet() *appsv1.StatefulSet {
-	return statefulSetFixture(1, 1, 1, "rev-1", "rev-1")
+	return statefulSetFixture(1, 1, 1, "rev-1")
 }
 
 func waitIfExists(t *testing.T, objects ...runtime.Object) error {
@@ -54,9 +55,14 @@ func waitIfExists(t *testing.T, objects ...runtime.Object) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	return readiness.WaitForStatefulSetReadyIfExists(
+	err := readiness.WaitForStatefulSetReadyIfExists(
 		ctx, client, statefulSetNamespace, statefulSetName, statefulSetShortWait,
 	)
+	if err != nil {
+		return fmt.Errorf("wait for test statefulset: %w", err)
+	}
+
+	return nil
 }
 
 // TestWaitForStatefulSetReadyIfExists_Absent verifies an absent StatefulSet is
@@ -81,7 +87,7 @@ func TestWaitForStatefulSetReadyIfExists_Ready(t *testing.T) {
 func TestWaitForStatefulSetReadyIfExists_NotReady(t *testing.T) {
 	t.Parallel()
 
-	err := waitIfExists(t, statefulSetFixture(1, 0, 1, "rev-1", "rev-1"))
+	err := waitIfExists(t, statefulSetFixture(1, 0, 1, "rev-1"))
 
 	require.Error(t, err, "a statefulset with no Ready replicas must not read as ready")
 }
@@ -107,7 +113,7 @@ func TestWaitForStatefulSetReadyIfExists_StaleObservedGeneration(t *testing.T) {
 func TestWaitForStatefulSetReadyIfExists_RollingUpdateInProgress(t *testing.T) {
 	t.Parallel()
 
-	err := waitIfExists(t, statefulSetFixture(2, 2, 1, "rev-1", "rev-2"))
+	err := waitIfExists(t, statefulSetFixture(2, 2, 1, "rev-2"))
 
 	require.Error(t, err, "diverged revisions under RollingUpdate must not read as ready")
 }
@@ -118,7 +124,7 @@ func TestWaitForStatefulSetReadyIfExists_RollingUpdateInProgress(t *testing.T) {
 func TestWaitForStatefulSetReadyIfExists_OnDeleteIgnoresRevisions(t *testing.T) {
 	t.Parallel()
 
-	onDelete := statefulSetFixture(2, 2, 0, "rev-1", "rev-2")
+	onDelete := statefulSetFixture(2, 2, 0, "rev-2")
 	onDelete.Spec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
 
 	require.NoError(t, waitIfExists(t, onDelete))
@@ -132,7 +138,7 @@ func TestWaitForStatefulSetReadyIfExists_PartitionedRollout(t *testing.T) {
 
 	partition := int32(1)
 
-	complete := statefulSetFixture(3, 3, 2, "rev-1", "rev-2")
+	complete := statefulSetFixture(3, 3, 2, "rev-2")
 	complete.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
 		Type:          appsv1.RollingUpdateStatefulSetStrategyType,
 		RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{Partition: &partition},
@@ -140,7 +146,7 @@ func TestWaitForStatefulSetReadyIfExists_PartitionedRollout(t *testing.T) {
 
 	require.NoError(t, waitIfExists(t, complete), "2 of 3 updated satisfies partition 1")
 
-	incomplete := statefulSetFixture(3, 3, 1, "rev-1", "rev-2")
+	incomplete := statefulSetFixture(3, 3, 1, "rev-2")
 	incomplete.Spec.UpdateStrategy = complete.Spec.UpdateStrategy
 
 	require.Error(t, waitIfExists(t, incomplete), "1 of 3 updated does not satisfy partition 1")
@@ -185,5 +191,9 @@ func TestWaitForStatefulSetReady_APIErrorPropagates(t *testing.T) {
 	)
 
 	require.ErrorIs(t, err, errStatefulSetAPI)
-	assert.Contains(t, err.Error(), "failed to check statefulset argocd/argocd-application-controller")
+	assert.Contains(
+		t,
+		err.Error(),
+		"failed to check statefulset argocd/argocd-application-controller",
+	)
 }

--- a/pkg/k8s/readiness/statefulset_test.go
+++ b/pkg/k8s/readiness/statefulset_test.go
@@ -28,10 +28,21 @@ var errStatefulSetAPI = errors.New("apiserver unavailable")
 // statefulSetFixture builds a StatefulSet whose controller has observed the
 // current generation, with the given replica counters and update revision.
 func statefulSetFixture(replicas, ready, updated int32, update string) *appsv1.StatefulSet {
+	return statefulSetFixtureWithDesired(replicas, replicas, ready, updated, update)
+}
+
+// statefulSetFixtureWithDesired is statefulSetFixture with an explicit
+// Spec.Replicas, for the scale-up case where the pods created so far
+// (Status.Replicas) trail the desired count.
+func statefulSetFixtureWithDesired(
+	desired, replicas, ready, updated int32,
+	update string,
+) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: statefulSetName, Namespace: statefulSetNamespace, Generation: 1,
 		},
+		Spec: appsv1.StatefulSetSpec{Replicas: &desired},
 		Status: appsv1.StatefulSetStatus{
 			ObservedGeneration: 1,
 			Replicas:           replicas,
@@ -196,4 +207,28 @@ func TestWaitForStatefulSetReady_APIErrorPropagates(t *testing.T) {
 		err.Error(),
 		"failed to check statefulset argocd/argocd-application-controller",
 	)
+}
+
+// TestWaitForStatefulSetReadyIfExists_ScaleUpInProgress verifies that a
+// StatefulSet whose controller has only created some of the desired pods is not
+// ready even though every pod created so far is Ready: readiness is judged
+// against Spec.Replicas, not against the pods that happen to exist yet.
+func TestWaitForStatefulSetReadyIfExists_ScaleUpInProgress(t *testing.T) {
+	t.Parallel()
+
+	err := waitIfExists(t, statefulSetFixtureWithDesired(3, 1, 1, 1, "rev-1"))
+
+	require.Error(t, err, "1 of 3 desired pods ready must not read as ready")
+}
+
+// TestWaitForStatefulSetReadyIfExists_NilSpecReplicasDefaultsToOne verifies the
+// API-server default: a nil Spec.Replicas means one desired pod, so a single
+// Ready pod satisfies it.
+func TestWaitForStatefulSetReadyIfExists_NilSpecReplicasDefaultsToOne(t *testing.T) {
+	t.Parallel()
+
+	unset := readyStatefulSet()
+	unset.Spec.Replicas = nil
+
+	require.NoError(t, waitIfExists(t, unset))
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`ksail workload reconcile` against ArgoCD still flakes on slow cold starts: the readiness gate added for #5948 waits for the repo-server, redis and server, but not for the application controller — the component that actually writes the sync status the reconcile reads. A stale cold-start error it recorded can therefore be judged permanent before it has had the chance to clear. The gate could also overrun a short `--timeout`, because it ran on its own clock before the reconcile's.

## What

The gate now also waits for the application controller (a StatefulSet, which the readiness helpers did not support before), and it shares the reconcile deadline with a half-of-timeout cap, so one reconcile attempt always stays inside `--timeout` while the reconcile itself keeps at least half of that window. Behaviour is unchanged when every component is already ready; absent components are still tolerated.

Part of #5948

