### PR TITLE
fix(ciharness): write PATH stubs without holding a write descriptor

### DIFF
--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -31,6 +31,7 @@ func TestWriteExecutableStub_ProducesRunnableOwnerOnlyStub(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "stub must be owner-only executable")
 
+	//nolint:gosec // stubPath is a test-owned temp file the writer under test just created.
 	output, err := exec.CommandContext(t.Context(), stubPath, "now").CombinedOutput()
 	require.NoError(t, err, "stub must be executable right after it is written: %s", output)
 	assert.Equal(t, "stub ran now\n", string(output))
@@ -67,6 +68,7 @@ func TestWriteExecutableStub_ExecutesUnderConcurrentForks(t *testing.T) {
 				return
 			}
 
+			//nolint:gosec // stubPath is a test-owned temp file the writer under test just created.
 			errs <- exec.CommandContext(t.Context(), stubPath).Run()
 		}()
 	}

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -108,11 +108,12 @@ func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
 	heldPath := filepath.Join(dir, "held-open")
 	require.NoError(t, os.WriteFile(heldPath, []byte(content), 0o700)) //nolint:gosec // Test-owned temp path.
 
-	writer, err := os.OpenFile(heldPath, os.O_WRONLY, 0)
+	writer, err := os.OpenFile(heldPath, os.O_WRONLY, 0) //nolint:gosec // Test-owned temp path.
 	require.NoError(t, err)
 
 	var stderr bytes.Buffer
 
+	//nolint:gosec // heldPath is a test-owned temp file; the shell fragment is a constant.
 	executor := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", heldPath)
 	executor.ExtraFiles = []*os.File{writer}
 	executor.Stderr = &stderr
@@ -138,6 +139,7 @@ func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
 
 	var safeStderr bytes.Buffer
 
+	//nolint:gosec // safePath is a test-owned temp file the writer under test just created.
 	safeExecutor := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", safePath)
 	safeExecutor.Stderr = &safeStderr
 

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -54,11 +54,7 @@ func TestWriteExecutableStub_ExecutesUnderConcurrentForks(t *testing.T) {
 	errs := make(chan error, workers)
 
 	for worker := range workers {
-		waitGroup.Add(1)
-
-		go func() {
-			defer waitGroup.Done()
-
+		waitGroup.Go(func() {
 			stubPath := filepath.Join(dir, "stub-"+strconv.Itoa(worker))
 
 			err := writeExecutableFile(t.Context(), stubPath, "#!/bin/sh\nexit 0\n")
@@ -70,7 +66,7 @@ func TestWriteExecutableStub_ExecutesUnderConcurrentForks(t *testing.T) {
 
 			//nolint:gosec // stubPath is a test-owned temp file the writer under test just created.
 			errs <- exec.CommandContext(t.Context(), stubPath).Run()
-		}()
+		})
 	}
 
 	waitGroup.Wait()

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -1,0 +1,80 @@
+package ciharness_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteExecutableStub_ProducesRunnableOwnerOnlyStub pins the writer's
+// contract: the stub carries exactly the given content, is executable by its
+// owner only, and can be executed immediately after the call returns.
+func TestWriteExecutableStub_ProducesRunnableOwnerOnlyStub(t *testing.T) {
+	t.Parallel()
+
+	stubPath := filepath.Join(t.TempDir(), "stub")
+	content := "#!/bin/sh\nprintf 'stub ran %s\\n' \"$1\"\n"
+
+	writeExecutableStub(t, stubPath, content)
+
+	written, err := os.ReadFile(stubPath) //nolint:gosec // Test-owned temp path.
+	require.NoError(t, err)
+	assert.Equal(t, content, string(written), "stub content must be written verbatim")
+
+	info, err := os.Stat(stubPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "stub must be owner-only executable")
+
+	output, err := exec.CommandContext(t.Context(), stubPath, "now").CombinedOutput()
+	require.NoError(t, err, "stub must be executable right after it is written: %s", output)
+	assert.Equal(t, "stub ran now\n", string(output))
+}
+
+// TestWriteExecutableStub_ExecutesUnderConcurrentForks is the regression
+// signal for #6199: many goroutines write a stub and execute it at once, while
+// every other goroutine's fork is a candidate to inherit a still-open write
+// descriptor. With the descriptor confined to a child shell, no exec can observe
+// the stub open for writing, so this must pass without a single ETXTBSY.
+func TestWriteExecutableStub_ExecutesUnderConcurrentForks(t *testing.T) {
+	t.Parallel()
+
+	const workers = 24
+
+	dir := t.TempDir()
+
+	var waitGroup sync.WaitGroup
+
+	errs := make(chan error, workers)
+
+	for worker := range workers {
+		waitGroup.Add(1)
+
+		go func() {
+			defer waitGroup.Done()
+
+			stubPath := filepath.Join(dir, "stub-"+strconv.Itoa(worker))
+
+			err := writeExecutableFile(t.Context(), stubPath, "#!/bin/sh\nexit 0\n")
+			if err != nil {
+				errs <- err
+
+				return
+			}
+
+			errs <- exec.CommandContext(t.Context(), stubPath).Run()
+		}()
+	}
+
+	waitGroup.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err, "a stub written under concurrent forks must execute cleanly")
+	}
+}

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -1,10 +1,14 @@
 package ciharness_test
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -37,11 +41,12 @@ func TestWriteExecutableStub_ProducesRunnableOwnerOnlyStub(t *testing.T) {
 	assert.Equal(t, "stub ran now\n", string(output))
 }
 
-// TestWriteExecutableStub_ExecutesUnderConcurrentForks is the regression
-// signal for #6199: many goroutines write a stub and execute it at once, while
-// every other goroutine's fork is a candidate to inherit a still-open write
-// descriptor. With the descriptor confined to a child shell, no exec can observe
-// the stub open for writing, so this must pass without a single ETXTBSY.
+// TestWriteExecutableStub_ExecutesUnderConcurrentForks is a load smoke for #6199:
+// many goroutines write a stub and execute it at once, so every other goroutine's
+// fork is a candidate to inherit a still-open write descriptor. It samples the
+// race rather than forcing it — the deterministic reproduction is
+// TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec — so it must simply
+// never fail, however the scheduler interleaves the workers.
 func TestWriteExecutableStub_ExecutesUnderConcurrentForks(t *testing.T) {
 	t.Parallel()
 
@@ -75,4 +80,74 @@ func TestWriteExecutableStub_ExecutesUnderConcurrentForks(t *testing.T) {
 	for err := range errs {
 		require.NoError(t, err, "a stub written under concurrent forks must execute cleanly")
 	}
+}
+
+// TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec is the coordinated
+// regression behind #6199. It forces the race instead of sampling it: this
+// process holds a stub open for writing while it starts a child that inherits
+// that descriptor (ExtraFiles survives exec, unlike Go's default close-on-exec
+// descriptors), then closes its own copy and only then lets the child execute
+// the stub. The child still holds the inherited descriptor, so the kernel refuses
+// the exec with ETXTBSY — the exact "bad interpreter: Text file busy" the
+// harness hit. A stub written by writeExecutableFile leaves this process with no
+// descriptor to inherit, so the same executor runs it cleanly.
+func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
+	t.Parallel()
+
+	// Linux refuses to execute a file that any process holds open for writing;
+	// macOS does not (verified: the control below succeeds there), and the CI
+	// runners that hit #6199 are Linux.
+	if runtime.GOOS != "linux" {
+		t.Skip("ETXTBSY on exec of a file open for writing is Linux semantics")
+	}
+
+	dir := t.TempDir()
+	content := "#!/bin/sh\nexit 0\n"
+
+	// The hazard: an open writer in this process at the moment a child is forked.
+	heldPath := filepath.Join(dir, "held-open")
+	require.NoError(t, os.WriteFile(heldPath, []byte(content), 0o700)) //nolint:gosec // Test-owned temp path.
+
+	writer, err := os.OpenFile(heldPath, os.O_WRONLY, 0)
+	require.NoError(t, err)
+
+	var stderr bytes.Buffer
+
+	executor := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", heldPath)
+	executor.ExtraFiles = []*os.File{writer}
+	executor.Stderr = &stderr
+
+	stdin, err := executor.StdinPipe()
+	require.NoError(t, err)
+	require.NoError(t, executor.Start())
+
+	// This process releases the writer first; only the child's inherited copy remains.
+	require.NoError(t, writer.Close())
+
+	_, err = io.WriteString(stdin, "go\n")
+	require.NoError(t, err)
+	require.NoError(t, stdin.Close())
+
+	err = executor.Wait()
+	require.Error(t, err, "a child holding an inherited write descriptor must not execute the stub")
+	assert.Contains(t, strings.ToLower(stderr.String()), "text file busy")
+
+	// The fix: the helper never gives this process a descriptor a child could inherit.
+	safePath := filepath.Join(dir, "helper-written")
+	require.NoError(t, writeExecutableFile(t.Context(), safePath, content))
+
+	var safeStderr bytes.Buffer
+
+	safeExecutor := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", safePath)
+	safeExecutor.Stderr = &safeStderr
+
+	safeStdin, err := safeExecutor.StdinPipe()
+	require.NoError(t, err)
+	require.NoError(t, safeExecutor.Start())
+
+	_, err = io.WriteString(safeStdin, "go\n")
+	require.NoError(t, err)
+	require.NoError(t, safeStdin.Close())
+
+	require.NoError(t, safeExecutor.Wait(), "helper-written stub must execute: %s", safeStderr.String())
 }

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -106,7 +106,10 @@ func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
 
 	// The hazard: an open writer in this process at the moment a child is forked.
 	heldPath := filepath.Join(dir, "held-open")
-	require.NoError(t, os.WriteFile(heldPath, []byte(content), 0o700)) //nolint:gosec // Test-owned temp path.
+	require.NoError(
+		t,
+		os.WriteFile(heldPath, []byte(content), 0o700),
+	) //nolint:gosec // Test-owned temp path.
 
 	writer, err := os.OpenFile(heldPath, os.O_WRONLY, 0) //nolint:gosec // Test-owned temp path.
 	require.NoError(t, err)
@@ -114,7 +117,14 @@ func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
 	var stderr bytes.Buffer
 
 	//nolint:gosec // heldPath is a test-owned temp file; the shell fragment is a constant.
-	executor := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", heldPath)
+	executor := exec.CommandContext(
+		t.Context(),
+		"sh",
+		"-c",
+		`read -r line && exec "$1"`,
+		"sh",
+		heldPath,
+	)
 	executor.ExtraFiles = []*os.File{writer}
 	executor.Stderr = &stderr
 
@@ -140,7 +150,14 @@ func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
 	var safeStderr bytes.Buffer
 
 	//nolint:gosec // safePath is a test-owned temp file the writer under test just created.
-	safeExecutor := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", safePath)
+	safeExecutor := exec.CommandContext(
+		t.Context(),
+		"sh",
+		"-c",
+		`read -r line && exec "$1"`,
+		"sh",
+		safePath,
+	)
 	safeExecutor.Stderr = &safeStderr
 
 	safeStdin, err := safeExecutor.StdinPipe()
@@ -151,5 +168,10 @@ func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, safeStdin.Close())
 
-	require.NoError(t, safeExecutor.Wait(), "helper-written stub must execute: %s", safeStderr.String())
+	require.NoError(
+		t,
+		safeExecutor.Wait(),
+		"helper-written stub must execute: %s",
+		safeStderr.String(),
+	)
 }

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -251,6 +251,10 @@ func TestWriteExecutableStub_ConcurrentWriteBlocksExec(t *testing.T) {
 	require.NoError(t, <-closeErr)
 
 	require.Error(t, err, "exec must fail while a writer holds the stub open: %s", output)
+	// Specifically ETXTBSY: any other execution failure would pass a bare
+	// Error check while hiding a regression in this exact behaviour.
+	assert.Contains(t, strings.ToLower(err.Error()), "text file busy",
+		"the failure must be ETXTBSY, got: %v (output: %s)", err, output)
 
 	// The fix: writeExecutableFile leaves no writer anywhere once it returns.
 	viaHelper := filepath.Join(dir, "helper-writer")

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -156,5 +156,31 @@ func execAfterSignal(t *testing.T, stubPath string, inherit *os.File) (string, e
 	require.NoError(t, err)
 	require.NoError(t, stdin.Close())
 
-	return stderr.String(), child.Wait()
+	// Wait first: the child is still writing to stderr until it exits, so reading
+	// the buffer in the same return statement would race the exec failure message
+	// (Go evaluates the operands left to right).
+	waitErr := child.Wait()
+
+	return stderr.String(), waitErr
+}
+
+// TestExecAfterSignal_CapturesStderrAfterExit pins the helper's contract on any
+// platform: the child is still writing while it runs, so the returned stderr
+// must be read after it exits. Reading it in the same return statement as
+// Wait() captures an empty buffer, which silently turns the ETXTBSY assertion
+// above into a vacuous one.
+func TestExecAfterSignal_CapturesStderrAfterExit(t *testing.T) {
+	t.Parallel()
+
+	stubPath := filepath.Join(t.TempDir(), "late-writer")
+	require.NoError(t, writeExecutableFile(
+		t.Context(), stubPath,
+		"#!/bin/sh\nsleep 0.2\necho 'stub failed late' >&2\nexit 3\n",
+	))
+
+	stderr, err := execAfterSignal(t, stubPath, nil)
+
+	require.Error(t, err, "the stub exits non-zero")
+	assert.Contains(t, stderr, "stub failed late",
+		"stderr must be read after the child exits, not while it is still running")
 }

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -137,7 +137,14 @@ func execAfterSignal(t *testing.T, stubPath string, inherit *os.File) (string, e
 	var stderr bytes.Buffer
 
 	//nolint:gosec // stubPath is a test-owned temp file; the shell fragment is a constant.
-	child := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", stubPath)
+	child := exec.CommandContext(
+		t.Context(),
+		"sh",
+		"-c",
+		`read -r line && exec "$1"`,
+		"sh",
+		stubPath,
+	)
 	child.Stderr = &stderr
 
 	if inherit != nil {

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -226,11 +226,8 @@ func TestWriteExecutableStub_ConcurrentWriteBlocksExec(t *testing.T) {
 	closeErr := make(chan error, 1)
 
 	go func() {
-		handle, err := os.OpenFile(
-			inProcess,
-			os.O_WRONLY,
-			0,
-		) //nolint:gosec // Test-owned temp path.
+		//nolint:gosec // inProcess is a test-owned temp file this test just created.
+		handle, err := os.OpenFile(inProcess, os.O_WRONLY, 0)
 
 		openErr <- err
 

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -226,7 +226,11 @@ func TestWriteExecutableStub_ConcurrentWriteBlocksExec(t *testing.T) {
 	closeErr := make(chan error, 1)
 
 	go func() {
-		handle, err := os.OpenFile(inProcess, os.O_WRONLY, 0) //nolint:gosec // Test-owned temp path.
+		handle, err := os.OpenFile(
+			inProcess,
+			os.O_WRONLY,
+			0,
+		) //nolint:gosec // Test-owned temp path.
 
 		openErr <- err
 
@@ -237,6 +241,7 @@ func TestWriteExecutableStub_ConcurrentWriteBlocksExec(t *testing.T) {
 		}
 
 		<-execDone
+
 		closeErr <- handle.Close()
 	}()
 
@@ -244,6 +249,7 @@ func TestWriteExecutableStub_ConcurrentWriteBlocksExec(t *testing.T) {
 
 	//nolint:gosec // inProcess is a test-owned temp file this test just created.
 	output, err := exec.CommandContext(t.Context(), inProcess).CombinedOutput()
+
 	close(execDone)
 	require.NoError(t, <-closeErr)
 

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -104,74 +104,57 @@ func TestWriteExecutableStub_InheritedWriteDescriptorBlocksExec(t *testing.T) {
 	dir := t.TempDir()
 	content := "#!/bin/sh\nexit 0\n"
 
-	// The hazard: an open writer in this process at the moment a child is forked.
+	// The hazard: a writer this process opened, inherited by the child that execs.
 	heldPath := filepath.Join(dir, "held-open")
-	require.NoError(
-		t,
-		os.WriteFile(heldPath, []byte(content), 0o700),
-	) //nolint:gosec // Test-owned temp path.
+	require.NoError(t, os.WriteFile(heldPath, []byte(content), 0o600))
+	//nolint:gosec // Owner execute is required for a PATH stub in a private temp dir.
+	require.NoError(t, os.Chmod(heldPath, 0o700))
 
 	writer, err := os.OpenFile(heldPath, os.O_WRONLY, 0) //nolint:gosec // Test-owned temp path.
 	require.NoError(t, err)
 
-	var stderr bytes.Buffer
-
-	//nolint:gosec // heldPath is a test-owned temp file; the shell fragment is a constant.
-	executor := exec.CommandContext(
-		t.Context(),
-		"sh",
-		"-c",
-		`read -r line && exec "$1"`,
-		"sh",
-		heldPath,
-	)
-	executor.ExtraFiles = []*os.File{writer}
-	executor.Stderr = &stderr
-
-	stdin, err := executor.StdinPipe()
-	require.NoError(t, err)
-	require.NoError(t, executor.Start())
-
-	// This process releases the writer first; only the child's inherited copy remains.
-	require.NoError(t, writer.Close())
-
-	_, err = io.WriteString(stdin, "go\n")
-	require.NoError(t, err)
-	require.NoError(t, stdin.Close())
-
-	err = executor.Wait()
+	stderr, err := execAfterSignal(t, heldPath, writer)
 	require.Error(t, err, "a child holding an inherited write descriptor must not execute the stub")
-	assert.Contains(t, strings.ToLower(stderr.String()), "text file busy")
+	assert.Contains(t, strings.ToLower(stderr), "text file busy")
 
 	// The fix: the helper never gives this process a descriptor a child could inherit.
 	safePath := filepath.Join(dir, "helper-written")
 	require.NoError(t, writeExecutableFile(t.Context(), safePath, content))
 
-	var safeStderr bytes.Buffer
+	stderr, err = execAfterSignal(t, safePath, nil)
+	require.NoError(t, err, "helper-written stub must execute: %s", stderr)
+}
 
-	//nolint:gosec // safePath is a test-owned temp file the writer under test just created.
-	safeExecutor := exec.CommandContext(
-		t.Context(),
-		"sh",
-		"-c",
-		`read -r line && exec "$1"`,
-		"sh",
-		safePath,
-	)
-	safeExecutor.Stderr = &safeStderr
+// execAfterSignal starts a child that waits for a line on stdin before exec'ing
+// stubPath, so the caller controls exactly when the exec happens. When inherit is
+// non-nil the child receives it as an extra descriptor (ExtraFiles survives exec,
+// unlike Go's default close-on-exec descriptors) and this process closes its own
+// copy before releasing the child, leaving the child's inherited descriptor as the
+// only writer open on the stub. It returns the child's stderr and its wait error.
+func execAfterSignal(t *testing.T, stubPath string, inherit *os.File) (string, error) {
+	t.Helper()
 
-	safeStdin, err := safeExecutor.StdinPipe()
+	var stderr bytes.Buffer
+
+	//nolint:gosec // stubPath is a test-owned temp file; the shell fragment is a constant.
+	child := exec.CommandContext(t.Context(), "sh", "-c", `read -r line && exec "$1"`, "sh", stubPath)
+	child.Stderr = &stderr
+
+	if inherit != nil {
+		child.ExtraFiles = []*os.File{inherit}
+	}
+
+	stdin, err := child.StdinPipe()
 	require.NoError(t, err)
-	require.NoError(t, safeExecutor.Start())
+	require.NoError(t, child.Start())
 
-	_, err = io.WriteString(safeStdin, "go\n")
+	if inherit != nil {
+		require.NoError(t, inherit.Close())
+	}
+
+	_, err = io.WriteString(stdin, "go\n")
 	require.NoError(t, err)
-	require.NoError(t, safeStdin.Close())
+	require.NoError(t, stdin.Close())
 
-	require.NoError(
-		t,
-		safeExecutor.Wait(),
-		"helper-written stub must execute: %s",
-		safeStderr.String(),
-	)
+	return stderr.String(), child.Wait()
 }

--- a/internal/ciharness/executable_stub_test.go
+++ b/internal/ciharness/executable_stub_test.go
@@ -191,3 +191,69 @@ func TestExecAfterSignal_CapturesStderrAfterExit(t *testing.T) {
 	assert.Contains(t, stderr, "stub failed late",
 		"stderr must be read after the child exits, not while it is still running")
 }
+
+// TestWriteExecutableStub_ConcurrentWriteBlocksExec is the regression that
+// separates the two writers, and the reason writeExecutableFile exists.
+//
+// The kernel refuses to exec a file while any process holds it open for writing.
+// An in-process writer therefore poisons every concurrent exec of that stub for
+// as long as it is open — and the harness's tests fork constantly, which is how
+// #6199 surfaced. The control below makes that window explicit: a goroutine holds
+// the descriptor while this test execs the same path, and the exec fails.
+// writeExecutableFile cannot reproduce it, because the only descriptor lives in a
+// child shell that has exited by the time the call returns, so the same exec of
+// the same path succeeds.
+func TestWriteExecutableStub_ConcurrentWriteBlocksExec(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("ETXTBSY on exec of a file open for writing is Linux semantics")
+	}
+
+	dir := t.TempDir()
+	content := "#!/bin/sh\nexit 0\n"
+
+	// Control: this process holds the write descriptor across the exec.
+	inProcess := filepath.Join(dir, "in-process-writer")
+	require.NoError(t, os.WriteFile(inProcess, []byte(content), 0o600))
+	//nolint:gosec // Owner execute is required for a PATH stub in a private temp dir.
+	require.NoError(t, os.Chmod(inProcess, 0o700))
+
+	// The writer goroutine reports through channels rather than asserting:
+	// testify's require must only run on the test goroutine.
+	execDone := make(chan struct{})
+	openErr := make(chan error, 1)
+	closeErr := make(chan error, 1)
+
+	go func() {
+		handle, err := os.OpenFile(inProcess, os.O_WRONLY, 0) //nolint:gosec // Test-owned temp path.
+
+		openErr <- err
+
+		if err != nil {
+			closeErr <- nil
+
+			return
+		}
+
+		<-execDone
+		closeErr <- handle.Close()
+	}()
+
+	require.NoError(t, <-openErr, "could not hold the stub open for writing")
+
+	//nolint:gosec // inProcess is a test-owned temp file this test just created.
+	output, err := exec.CommandContext(t.Context(), inProcess).CombinedOutput()
+	close(execDone)
+	require.NoError(t, <-closeErr)
+
+	require.Error(t, err, "exec must fail while a writer holds the stub open: %s", output)
+
+	// The fix: writeExecutableFile leaves no writer anywhere once it returns.
+	viaHelper := filepath.Join(dir, "helper-writer")
+	require.NoError(t, writeExecutableFile(t.Context(), viaHelper, content))
+
+	//nolint:gosec // viaHelper is a test-owned temp file the writer under test just created.
+	output, err = exec.CommandContext(t.Context(), viaHelper).CombinedOutput()
+	require.NoError(t, err, "helper-written stub must exec cleanly: %s", output)
+}

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -1,6 +1,8 @@
 package ciharness_test
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,11 +263,7 @@ func runCleanupScriptWithoutCreate(t *testing.T) (string, []string) {
 	// Any of these running at all means the guard let execution through.
 	for _, name := range []string{"ksail", "eksctl", "aws"} {
 		stub := "#!/bin/sh\nprintf '%s\\n' '" + name + "' >> \"$KSAIL_CLEANUP_CALL_LOG\"\nexit 0\n"
-		stubPath := filepath.Join(binDir, name)
-
-		require.NoError(t, os.WriteFile(stubPath, []byte(stub), 0o600))
-		//nolint:gosec // Owner execute is required for a PATH stub in a private temp dir.
-		require.NoError(t, os.Chmod(stubPath, 0o700))
+		writeExecutableStub(t, filepath.Join(binDir, name), stub)
 	}
 
 	scriptPath := filepath.Join("..", "..", ".github", "scripts", "delete-eks-smoke-cluster.sh")
@@ -809,10 +807,7 @@ esac
 	awsPath := filepath.Join(tempDir, "aws")
 	outputPath := filepath.Join(tempDir, "github-output")
 
-	require.NoError(
-		t,
-		os.WriteFile(awsPath, []byte(awsStub), 0o700), //nolint:gosec // Test-owned path.
-	)
+	writeExecutableStub(t, awsPath, awsStub)
 	require.NoError(
 		t,
 		os.WriteFile(outputPath, nil, 0o600),
@@ -1045,4 +1040,39 @@ func stringValue(value any) string {
 	}
 
 	return strings.TrimSpace(text)
+}
+
+// writeExecutableStub writes an executable PATH stub without this process ever
+// holding a write descriptor on it.
+//
+// Tests in this package run in parallel and fork subprocesses constantly. On
+// Linux a child forked while another goroutine still holds a file open for
+// writing inherits that descriptor until its own exec completes, and executing
+// the file inside that window fails with ETXTBSY ("bad interpreter: Text file
+// busy", #6199). os.WriteFile closes before it returns, but it cannot stop a
+// concurrent fork from copying the descriptor first. Writing through a
+// short-lived child shell moves the write descriptor into a process nothing
+// here forks from, so no sibling subprocess can inherit it, and the file is
+// closed by the time the child has exited.
+func writeExecutableStub(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, writeExecutableFile(t.Context(), path, content))
+}
+
+// writeExecutableFile is the fork-safe writer behind writeExecutableStub, kept
+// free of testing assertions so it can run inside worker goroutines.
+func writeExecutableFile(ctx context.Context, path, content string) error {
+	//nolint:gosec // path is a test-owned temp file; the shell fragment is a constant.
+	command := exec.CommandContext(
+		ctx, "sh", "-c", `umask 077 && cat >"$1" && chmod 0700 "$1"`, "sh", path,
+	)
+	command.Stdin = strings.NewReader(content)
+
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("write executable stub %s: %w (%s)", path, err, output)
+	}
+
+	return nil
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The CI harness tests occasionally fail with "bad interpreter: Text file busy" on a fake `aws` binary they had just written. It is a timing race under parallel test load, not a real defect in the code under test, and it makes a required check flaky.

## What

Fake binaries are now written in a way that never leaves a write handle open in the test process, so no concurrently started subprocess can hold the file open at the moment it is executed. Both places that write such stubs use the new helper, and two tests pin its behaviour, including under concurrent process starts.

Fixes #6199
