### PR TITLE
ci: run the operator chart lint in the merge queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1185,7 +1185,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes]
-    if: github.event_name != 'merge_group' && needs.changes.outputs.operator-chart == 'true'
+    # The merge queue is the one run that validates the MERGED tree, and `changes` is skipped there
+    # (no PR diff for its path filter to inspect), so gate on the event rather than on the filter:
+    # helm lint plus a handful of template renders cost seconds, cheap enough to re-validate every
+    # queued merge against whatever landed before it. Without this the required aggregate check
+    # counted the skipped job as a pass, so a chart change was never validated at the point it
+    # merged. `!cancelled()` is what lets the job run when its `changes` dependency was skipped
+    # instead of being skipped along with it (mirrors operator-chart-e2e).
+    if: >-
+      !cancelled()
+      && (
+        github.event_name == 'merge_group'
+        || needs.changes.outputs.operator-chart == 'true'
+      )
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The operator Helm chart's lint and template checks were skipped in the merge queue, and the required aggregate check counts a skipped job as a pass. The queue is the one place the merged tree is actually tested, so a chart change could pass every check on its PR and then merge through a queue run that never re-validated it against whatever landed before it.

### What

The chart lint now runs on every merge-queue run (it takes seconds) while keeping its path filter on pull requests, so a chart change is validated at the point it merges. No other job changes.

Fixes #6123
