### PR TITLE
chore(web): update nanoid to the patched release

### DIFF
--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -2681,9 +2681,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why
The web UI's build dependencies include a high-severity nanoid advisory.

## What
Update the affected dependency to its compatible patched release while preserving the existing audit controls.

Fixes #6890
