### PR TITLE
fix(homebrew): generate structured postflight steps

### DIFF
--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -112,8 +112,7 @@ homebrew_casks:
       uninstall quit: "tech.devantler.ksail.desktop"
       postflight_steps do
         on_macos do
-          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{appdir}}" }}/KSail.app"],
-                               must_succeed: false
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{appdir}}" }}/KSail.app"]
         end
       end
     # Symlink the CLI from inside the installed app (the canonical GUI-app-with-CLI cask pattern),

--- a/.goreleaser.desktop.yaml
+++ b/.goreleaser.desktop.yaml
@@ -105,18 +105,19 @@ homebrew_casks:
     # `<version>.upgrading` staging dir that blocks every subsequent `brew upgrade` (a real cascade
     # observed in the field). The cd.yaml `homebrew` job runs `brew style --fix`, which reorders these
     # stanzas into canonical position before the cask lands in the tap.
+    # Escape Homebrew's install-time token through GoReleaser's template pass.
     custom_block: |
       depends_on macos: :big_sur
       app "KSail.app"
       uninstall quit: "tech.devantler.ksail.desktop"
+      postflight_steps do
+        on_macos do
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{appdir}}" }}/KSail.app"],
+                               must_succeed: false
+        end
+      end
     # Symlink the CLI from inside the installed app (the canonical GUI-app-with-CLI cask pattern),
     # so `ksail-desktop` is on PATH and `ksail open desktop` finds it. Without this, GoReleaser would
     # default the symlink to the bare basename, which does not exist at the archive root.
     binaries:
       - "#{appdir}/KSail.app/Contents/MacOS/ksail-desktop"
-    hooks:
-      post:
-        # Single-line body: use the modifier form so `brew style`
-        # (Style/IfUnlessModifier) is satisfied.
-        install: |
-          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/KSail.app"] if OS.mac?

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,12 +66,14 @@ homebrew_casks:
         # release (tap#1172 — GoReleaser tolerates an existing ref and soft-skips the duplicate PR;
         # the tap deletes the branch on merge, so it is recreated fresh from main next release).
         draft: true
-    hooks:
-      post:
-        # Single-line body: use the modifier form so `brew style`
-        # (Style/IfUnlessModifier) is satisfied.
-        install: |
-          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ksail"] if OS.mac?
+    # Escape Homebrew's install-time token through GoReleaser's template pass.
+    custom_block: |
+      postflight_steps do
+        on_macos do
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{staged_path}}" }}/ksail"],
+                               must_succeed: false
+        end
+      end
     commit_author:
       signing:
         enabled: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,8 +70,7 @@ homebrew_casks:
     custom_block: |
       postflight_steps do
         on_macos do
-          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{staged_path}}" }}/ksail"],
-                               must_succeed: false
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{staged_path}}" }}/ksail"]
         end
       end
     commit_author:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Homebrew warns that both KSail casks use deprecated installation hooks, and its current style check rejects them.

## What

Generate supported installation steps while retaining macOS quarantine cleanup. The desktop cleanup targets the installed app, and both casks preserve Homebrew's install-time paths through release generation.

The next KSail release will refresh both generated tap casks.
