### PR TITLE
fix(release): validate release refs before publishing

### DIFF
--- a/.github/scripts/validate-release-ref.sh
+++ b/.github/scripts/validate-release-ref.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Release tags must be semantic versions that can also be used as OCI tags.
+set -euo pipefail
+export LC_ALL=C
+
+ref=${GITHUB_REF-}
+tag=${ref#refs/tags/}
+number='(0|[1-9][0-9]*)'
+# Numeric prerelease identifiers cannot have leading zeros; identifiers containing
+# a letter or hyphen may contain them. OCI tags do not permit '+' build metadata.
+identifier='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+pattern="^refs/tags/v${number}\\.${number}\\.${number}(-${identifier}(\\.${identifier})*)?$"
+
+if [[ ${#tag} -gt 128 || ! $ref =~ $pattern ]]; then
+	printf 'Invalid release ref %q: expected refs/tags/v<semver> with an OCI-compatible tag of at most 128 characters.\n' "$ref" >&2
+	exit 1
+fi
+
+printf 'Validated release tag: %s\n' "$tag"

--- a/.github/scripts/validate-release-ref.test.sh
+++ b/.github/scripts/validate-release-ref.test.sh
@@ -6,6 +6,7 @@ script_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 validator="$script_dir/validate-release-ref.sh"
 checks=0
 
+# expect_accept checks that a valid ref passes the production validator.
 expect_accept() {
 	local ref=$1 output
 	if ! output=$(GITHUB_REF="$ref" bash "$validator" 2>&1); then
@@ -15,6 +16,7 @@ expect_accept() {
 	checks=$((checks + 1))
 }
 
+# expect_reject checks rejection and a safe, single-line diagnostic naming the ref.
 expect_reject() {
 	local ref=$1 output quoted
 	if output=$(GITHUB_REF="$ref" bash "$validator" 2>&1); then

--- a/.github/scripts/validate-release-ref.test.sh
+++ b/.github/scripts/validate-release-ref.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+validator="$script_dir/validate-release-ref.sh"
+checks=0
+
+expect_accept() {
+	local ref=$1 output
+	if ! output=$(GITHUB_REF="$ref" bash "$validator" 2>&1); then
+		printf 'FAIL: valid release ref %q rejected: %s\n' "$ref" "$output" >&2
+		exit 1
+	fi
+	checks=$((checks + 1))
+}
+
+expect_reject() {
+	local ref=$1 output quoted
+	if output=$(GITHUB_REF="$ref" bash "$validator" 2>&1); then
+		printf 'FAIL: invalid release ref %q accepted\n' "$ref" >&2
+		exit 1
+	fi
+	printf -v quoted '%q' "$ref"
+	if [[ $output != *"$quoted"* || $output == *$'\n'* ]]; then
+		printf 'FAIL: rejected ref must be reported safely on one line: %q\n' "$output" >&2
+		exit 1
+	fi
+	checks=$((checks + 1))
+}
+
+for tag in v7.181.8 v8.0.0-beta.1 v0.0.0 v1.2.3-0 v1.2.3-01a v1.2.3-RC.1 v1.2.3-alpha-beta; do
+	expect_accept "refs/tags/$tag"
+done
+
+for tag in vanything v/../evil v1latest v01.0.0 v1.01.0 v1.0.01 \
+	v1.2 v1.2.3.4 v1.2.3- v1.2.3-01 v1.2.3-beta.01 v1.2.3-alpha..1 \
+	v1.2.3+build v1.2.3-alpha_1 V1.2.3 v1.2.3-é; do
+	expect_reject "refs/tags/$tag"
+done
+
+for ref in '' v1.2.3 refs/heads/v1.2.3 refs/pull/1/merge 'refs/tags/v1.2.3 ' \
+	$'refs/tags/v1.2.3\n::error::injected'; do
+	expect_reject "$ref"
+done
+
+# The OCI limit includes the leading v and prerelease separator.
+printf -v suffix '%121s' ''
+suffix=${suffix// /a}
+expect_accept "refs/tags/v1.2.3-$suffix"
+expect_reject "refs/tags/v1.2.3-${suffix}a"
+
+if (
+	unset GITHUB_REF
+	bash "$validator"
+) >/dev/null 2>&1; then
+	printf 'FAIL: missing GITHUB_REF accepted\n' >&2
+	exit 1
+fi
+
+printf 'PASS: release ref validation (%s cases plus missing environment)\n' "$checks"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,6 +22,20 @@ permissions:
   contents: read
 
 jobs:
+  validate-release-ref:
+    name: 🏷️ Validate release ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: 🏷️ Validate release ref
+        run: .github/scripts/validate-release-ref.sh
+
   # A reused evergreen cask PR can still be ready-for-review (auto-merge armed by the tap) from a
   # previous release that never merged. Demote it to draft BEFORE GoReleaser rewrites its branch —
   # otherwise the tap could auto-merge freshly rewritten, not-yet-validated cask content while this
@@ -29,6 +43,7 @@ jobs:
   # safe and the release run is simply re-run after the wedge is cleared.
   cask-checkpoint:
     name: 🍺 Re-arm cask PR draft checkpoint
+    needs: [validate-release-ref]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -163,6 +178,7 @@ jobs:
 
   vscode-extension:
     name: 🧩 Release VSCode Extension
+    needs: [validate-release-ref]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -281,6 +297,7 @@ jobs:
   # is present before the release is locked by immutable releases (see #4874).
   desktop:
     name: 🧩 Release Desktop App
+    needs: [validate-release-ref]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     permissions:
@@ -342,6 +359,7 @@ jobs:
 
   copilot-plugin:
     name: 🧩 Release Copilot CLI Plugin
+    needs: [validate-release-ref]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Runs in parallel with the other releases — it only opens an auto-merging version-bump
@@ -667,6 +685,7 @@ jobs:
 
   pages-build:
     name: 📄 Build Pages
+    needs: [validate-release-ref]
     runs-on: ubuntu-latest
     # Runs in parallel with the other releases (no GoReleaser artifact dependency). The
     # gated `pages-deploy` and `publish-release` jobs both list it in `needs`, so a docs
@@ -1236,8 +1255,8 @@ jobs:
     name: 🧹 Clean up incomplete release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [publish-release]
-    if: always() && needs.publish-release.result != 'success'
+    needs: [validate-release-ref, publish-release]
+    if: always() && needs.publish-release.result != 'success' && needs.validate-release-ref.result == 'success'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,7 +164,7 @@ jobs:
               - 'go.sum'
               - '.govulncheck-allow.txt'
               - '.github/actions/**'
-            # The Go harness in internal/ciharness asserts the shape of the to-do scanner
+            # The Go harness in internal/ciharness checks release-ref safety and the to-do scanner
             # caller. Its subject is a WORKFLOW file, not a Go file, so the org-required
             # validate-go-project run cannot reach it: that workflow gates its own test job
             # on a `go` filter of **/*.go|go.mod|go.sum|.golangci.* and skips everything
@@ -183,6 +183,9 @@ jobs:
             todos-contract:
               - '.github/workflows/todos.yaml'
               - '.github/workflows/ci.yaml'
+              - '.github/workflows/cd.yaml'
+              - '.github/scripts/validate-release-ref.sh'
+              - '.github/scripts/validate-release-ref.test.sh'
               - 'internal/ciharness/**'
             # Deliberately NARROWER than `code`: the job resolves a module graph, so only the
             # module files matter — not every .go file. It also includes THIS workflow, because
@@ -1728,7 +1731,7 @@ jobs:
           echo "Dependency test graph resolves."
 
   verify-todos-workflow-contract:
-    name: 🧾 Verify TODO Workflow Contract
+    name: 🧾 Verify Workflow Contracts
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes]
@@ -1752,11 +1755,11 @@ jobs:
       # -count=1 is load-bearing: this test's real subject is a YAML file the Go build graph
       # cannot see, so a cached PASS from an earlier run would be replayed over a changed
       # workflow and report success without executing anything.
-      - name: 🧾 Verify TODO workflow contract
+      - name: 🧾 Verify workflow contracts
         run: |
           if ! go test ./internal/ciharness/... -count=1; then
-            echo "::error::The TODO scanner workflow no longer matches the contract in internal/ciharness."
-            echo "Fix: reconcile .github/workflows/todos.yaml with the assertions, or update the assertions if the contract itself changed."
+            echo "::error::A workflow no longer matches its contract in internal/ciharness."
+            echo "Fix the reported workflow or script failure while preserving its safety properties."
             exit 1
           fi
 

--- a/internal/ciharness/release_workflow_test.go
+++ b/internal/ciharness/release_workflow_test.go
@@ -21,6 +21,7 @@ type releaseJob struct {
 	Steps           []harnessStep     `yaml:"steps"`
 }
 
+// readReleaseJobs loads the release dependency graph from the real CD workflow.
 func readReleaseJobs(t *testing.T) map[string]releaseJob {
 	t.Helper()
 
@@ -34,6 +35,7 @@ func readReleaseJobs(t *testing.T) map[string]releaseJob {
 	return workflow.Jobs
 }
 
+// TestReleaseJobsRequireValidatedRef prevents publish or cleanup paths from bypassing validation.
 func TestReleaseJobsRequireValidatedRef(t *testing.T) {
 	t.Parallel()
 
@@ -70,6 +72,7 @@ func TestReleaseJobsRequireValidatedRef(t *testing.T) {
 	}
 }
 
+// releaseDependsOnValidation follows dependencies without looping through cyclic graphs.
 func releaseDependsOnValidation(
 	jobs map[string]releaseJob,
 	name string,
@@ -94,6 +97,7 @@ func releaseDependsOnValidation(
 	return false
 }
 
+// TestReleaseRefValidationStep verifies the runner executes validation and propagates rejection.
 func TestReleaseRefValidationStep(t *testing.T) {
 	t.Parallel()
 	requireTestExecutable(t, "bash")
@@ -139,6 +143,7 @@ func TestReleaseRefValidationStep(t *testing.T) {
 	}
 }
 
+// envWithoutReleaseRef isolates each fixture from a release ref inherited from CI.
 func envWithoutReleaseRef() []string {
 	var result []string
 
@@ -151,6 +156,7 @@ func envWithoutReleaseRef() []string {
 	return result
 }
 
+// TestReleaseRefScript exercises valid, malformed, and boundary refs through the shell validator.
 func TestReleaseRefScript(t *testing.T) {
 	t.Parallel()
 	requireTestExecutable(t, "bash")

--- a/internal/ciharness/release_workflow_test.go
+++ b/internal/ciharness/release_workflow_test.go
@@ -1,0 +1,165 @@
+package ciharness_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+//nolint:tagliatelle // GitHub Actions defines this external key in kebab-case.
+type releaseJob struct {
+	Needs           []string          `yaml:"needs"`
+	If              string            `yaml:"if"`
+	ContinueOnError bool              `yaml:"continue-on-error"`
+	Permissions     map[string]string `yaml:"permissions"`
+	Steps           []harnessStep     `yaml:"steps"`
+}
+
+func readReleaseJobs(t *testing.T) map[string]releaseJob {
+	t.Helper()
+
+	var workflow struct {
+		Jobs map[string]releaseJob `yaml:"jobs"`
+	}
+
+	require.NoError(t, yaml.Unmarshal(readRepoFile(t, ".github/workflows/cd.yaml"), &workflow))
+	require.NotEmpty(t, workflow.Jobs)
+
+	return workflow.Jobs
+}
+
+func TestReleaseJobsRequireValidatedRef(t *testing.T) {
+	t.Parallel()
+
+	jobs := readReleaseJobs(t)
+	gate, exists := jobs["validate-release-ref"]
+	require.True(t, exists, "release must validate its ref before any build or mutation")
+	assert.Empty(t, gate.Needs)
+	assert.Empty(t, gate.If)
+	assert.False(t, gate.ContinueOnError)
+	assert.Equal(t, map[string]string{"contents": "read"}, gate.Permissions)
+
+	for name, job := range jobs {
+		if name == "validate-release-ref" {
+			continue
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, releaseDependsOnValidation(jobs, name, map[string]bool{}),
+				"release job must be downstream of ref validation")
+
+			if name == "cleanup-failed-release" {
+				assert.Contains(t, job.Needs, "validate-release-ref")
+				assert.Contains(t, job.Needs, "publish-release")
+				// This approved condition allows cleanup after a valid release fails,
+				// but never lets always() delete a ref that failed validation.
+				assert.Equal(t, "always() && needs.publish-release.result != 'success' && "+
+					"needs.validate-release-ref.result == 'success'", job.If)
+			} else {
+				assert.Empty(t, job.If,
+					"release jobs must retain the default success dependency gate")
+			}
+		})
+	}
+}
+
+func releaseDependsOnValidation(
+	jobs map[string]releaseJob,
+	name string,
+	visited map[string]bool,
+) bool {
+	if name == "validate-release-ref" {
+		return true
+	}
+
+	if visited[name] {
+		return false
+	}
+
+	visited[name] = true
+
+	for _, dependency := range jobs[name].Needs {
+		if releaseDependsOnValidation(jobs, dependency, visited) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestReleaseRefValidationStep(t *testing.T) {
+	t.Parallel()
+	requireTestExecutable(t, "bash")
+
+	gate, exists := readReleaseJobs(t)["validate-release-ref"]
+	require.True(t, exists)
+	require.Len(t, gate.Steps, 2, "checkout followed immediately by validation")
+	assert.Contains(t, gate.Steps[0].Uses, "actions/checkout@")
+	assert.Equal(t, false, gate.Steps[0].With["persist-credentials"])
+	validation := gate.Steps[1]
+	require.Equal(t, ".github/scripts/validate-release-ref.sh", validation.Run)
+	assert.Empty(t, validation.If)
+	assert.False(t, validation.ContinueOnError, "a rejected ref must fail the validation job")
+	assert.Empty(t, validation.Env, "validation must read the actual runner ref")
+
+	for _, test := range []struct {
+		ref   string
+		valid bool
+	}{
+		{ref: "refs/tags/v7.181.8", valid: true},
+		{ref: "refs/tags/vanything", valid: false},
+	} {
+		t.Run(test.ref, func(t *testing.T) {
+			t.Parallel()
+
+			command := exec.CommandContext(
+				t.Context(),
+				"bash",
+				".github/scripts/validate-release-ref.sh",
+			)
+			command.Dir = filepath.Join("..", "..")
+
+			command.Env = append(envWithoutReleaseRef(), "GITHUB_REF="+test.ref)
+
+			output, err := command.CombinedOutput()
+			if test.valid {
+				require.NoErrorf(t, err, "valid release rejected: %s", output)
+			} else {
+				require.Error(t, err, "malformed ref reached release work")
+				assert.Contains(t, string(output), test.ref)
+			}
+		})
+	}
+}
+
+func envWithoutReleaseRef() []string {
+	var result []string
+
+	for _, value := range os.Environ() {
+		if !strings.HasPrefix(value, "GITHUB_REF=") {
+			result = append(result, value)
+		}
+	}
+
+	return result
+}
+
+func TestReleaseRefScript(t *testing.T) {
+	t.Parallel()
+	requireTestExecutable(t, "bash")
+
+	command := exec.CommandContext(
+		t.Context(),
+		"bash",
+		"../../.github/scripts/validate-release-ref.test.sh",
+	)
+	output, err := command.CombinedOutput()
+	require.NoErrorf(t, err, "release ref validation failed:\n%s", output)
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why
The release pipeline accepts any tag beginning with v, allowing malformed versions to reach publishing and signing.

## What
Require an OCI-compatible semantic release version before any release work begins. Reject malformed tags without running publishing or cleanup, while preserving normal releases and recovery from valid failed releases.

Fixes #6895
