### PR TITLE
fix(argocd): distinguish transport failures during reconciliation

### DIFF
--- a/pkg/cli/cmd/workload/export_test.go
+++ b/pkg/cli/cmd/workload/export_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	v1alpha1 "github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
 	"github.com/devantler-tech/ksail/v7/pkg/client/flux"
 	"github.com/devantler-tech/ksail/v7/pkg/client/helm"
 	"github.com/devantler-tech/ksail/v7/pkg/client/hubble"
@@ -28,6 +29,15 @@ import (
 // These seams cover validation/expansion helpers, debounce/watch behavior, and
 // source/Flux path resolution and formatting. They are only compiled during
 // testing and should be changed together with the tests that depend on them.
+
+// ExportPollUntilApplicationReady exposes the production ArgoCD polling path.
+func ExportPollUntilApplicationReady(
+	ctx context.Context,
+	client *argocd.Reconciler,
+	name string,
+) error {
+	return pollUntilApplicationReady(ctx, client, name)
+}
 
 // The Flux-substitution engine now lives in pkg/svc/fluxsubst; these shims
 // delegate to its exported API so existing command-package tests keep working.

--- a/pkg/cli/cmd/workload/reconcile.go
+++ b/pkg/cli/cmd/workload/reconcile.go
@@ -813,9 +813,8 @@ func buildArgoCDApplicationTasks(
 // pollUntilApplicationReady polls a named ArgoCD Application until it is
 // synced and healthy, or the context's deadline expires. On permanent failure,
 // it returns an actionable error including the resource name and failure details.
-// A source-availability error inside the cold-start warm-up window is treated as
-// "not ready yet" rather than a permanent failure, because ArgoCD resolves those
-// itself within seconds of the control plane coming up.
+// Recognized transport failures are retried inside the cold-start warm-up window;
+// a timeout retains the latest failure so the user can diagnose the unavailable source.
 //
 // The caller is expected to provide a context with a deadline (shared across all
 // application tasks) so that the total reconcile time is bounded.
@@ -833,17 +832,16 @@ func pollUntilApplicationReady(
 			ready, err := argoReconciler.CheckNamedApplicationReady(ctx, name)
 			if err != nil {
 				if argocd.IsColdStartTransient(err, time.Since(start), argoCDSourceWarmupGrace) {
-					return reconcilerclient.CheckResult{Ready: false}, nil
+					return reconcilerclient.CheckResult{Status: err.Error()}, nil
 				}
 
-				return reconcilerclient.CheckResult{}, err //nolint:wrapcheck // identity preserved
+				return reconcilerclient.CheckResult{}, fmt.Errorf("application %q: %w", name, err)
 			}
 
-			// ArgoCD exposes no per-poll status, so Status is left empty.
 			return reconcilerclient.CheckResult{Ready: ready}, nil
 		},
-		func(string) error {
-			return applicationReadinessTimeoutError(name)
+		func(lastStatus string) error {
+			return applicationReadinessTimeoutError(name, lastStatus)
 		},
 	)
 }
@@ -851,10 +849,14 @@ func pollUntilApplicationReady(
 // applicationReadinessTimeoutError returns the actionable error for an ArgoCD
 // Application that did not become ready within the timeout. Hoisted out of the
 // poll loop so the message is defined once instead of duplicated per branch.
-func applicationReadinessTimeoutError(name string) error {
+func applicationReadinessTimeoutError(name, lastStatus string) error {
+	if lastStatus != "" {
+		lastStatus = ": " + lastStatus
+	}
+
 	return fmt.Errorf(
-		"%w — "+
+		"%w%s — "+
 			"run 'ksail workload get applications.argoproj.io %s -n argocd' to inspect",
-		argocd.ErrReconcileTimeout, name,
+		argocd.ErrReconcileTimeout, lastStatus, name,
 	)
 }

--- a/pkg/cli/cmd/workload/reconcile_test.go
+++ b/pkg/cli/cmd/workload/reconcile_test.go
@@ -2,6 +2,8 @@ package workload_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -9,6 +11,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/workload"
 	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
 	"github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -135,4 +138,54 @@ func TestPollArgoCDApplicationCancellation(t *testing.T) {
 	err := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
 	require.ErrorIs(t, err, context.Canceled)
 	assert.NotErrorIs(t, err, argocd.ErrReconcileTimeout)
+}
+
+func TestPermanentArgoCDPollFailureDoesNotEscapeIntoOuterRetries(t *testing.T) {
+	t.Parallel()
+
+	for _, message := range []string{
+		"manifest unknown (previous attempt: i/o timeout)",
+		"permission denied (previous attempt: connection refused)",
+	} {
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
+			client := newArgoCDPollClient(func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, argoCDPollApplication(message), nil
+			})
+			permanent := workload.ExportPollUntilApplicationReady(t.Context(), client, "test-app")
+			require.Error(t, permanent)
+
+			transientClient := newArgoCDPollClient(
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, argoCDPollApplication("connection refused"), nil
+				},
+			)
+			_, transient := transientClient.CheckNamedApplicationReady(t.Context(), "test-app")
+			require.Error(t, transient)
+
+			for _, failure := range []error{
+				permanent, errors.Join(transient, permanent), errors.Join(permanent, transient),
+			} {
+				attempts := 0
+				cmd := &cobra.Command{}
+				cmd.SetOut(io.Discard)
+				cmd.SetErr(io.Discard)
+				err := workload.ExportRetryOnTransientError(
+					t.Context(),
+					cmd,
+					3,
+					0,
+					0,
+					func() error {
+						attempts++
+
+						return failure
+					},
+				)
+				require.ErrorIs(t, err, permanent)
+				assert.Equal(t, 1, attempts)
+			}
+		})
+	}
 }

--- a/pkg/cli/cmd/workload/reconcile_test.go
+++ b/pkg/cli/cmd/workload/reconcile_test.go
@@ -1,0 +1,138 @@
+package workload_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/cli/cmd/workload"
+	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
+	"github.com/devantler-tech/ksail/v7/pkg/client/reconciler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newArgoCDPollClient serves scripted API responses to the real polling loop.
+func newArgoCDPollClient(
+	reactor k8stesting.ReactionFunc,
+) *argocd.Reconciler {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "applications", reactor)
+
+	return &argocd.Reconciler{Base: reconciler.NewBaseWithClient(client)}
+}
+
+// argoCDPollApplication retains healthy status alongside an optional active comparison error.
+func argoCDPollApplication(message string) *unstructured.Unstructured {
+	conditions := []any{}
+	if message != "" {
+		conditions = append(conditions, map[string]any{
+			"type": "ComparisonError", "message": message,
+		})
+	}
+
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "test-app", "namespace": "argocd"},
+		"status": map[string]any{
+			"sync":       map[string]any{"status": "Synced"},
+			"health":     map[string]any{"status": "Healthy"},
+			"conditions": conditions,
+		},
+	}}
+}
+
+// TestPollArgoCDApplicationRecoversFromTransportFailure waits for an error-free comparison.
+func TestPollArgoCDApplicationRecoversFromTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	client := newArgoCDPollClient(func(action k8stesting.Action) (bool, runtime.Object, error) {
+		assert.Equal(t, "argocd", action.GetNamespace())
+		getAction, ok := action.(k8stesting.GetAction)
+		require.True(t, ok)
+		assert.Equal(t, "test-app", getAction.GetName())
+
+		if calls.Add(1) == 1 {
+			return true, argoCDPollApplication("lookup registry.example: no such host"), nil
+		}
+
+		return true, argoCDPollApplication(""), nil
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	err := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load(), "stale healthy status must not finish the first poll")
+}
+
+// TestPollArgoCDApplicationFailsFastOnMissingArtifact rejects permanent failures on the first poll.
+func TestPollArgoCDApplicationFailsFastOnMissingArtifact(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	client := newArgoCDPollClient(func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		calls.Add(1)
+
+		return true, argoCDPollApplication("manifest unknown"), nil
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	err := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
+	require.ErrorIs(t, err, argocd.ErrSourceNotAvailable)
+	require.NotErrorIs(t, err, argocd.ErrReconcileTimeout)
+	assert.Contains(t, err.Error(), "test-app")
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+// TestPollArgoCDApplicationTimeoutPreservesTransportCause keeps failure details and an inspection command.
+func TestPollArgoCDApplicationTimeoutPreservesTransportCause(t *testing.T) {
+	t.Parallel()
+
+	client := newArgoCDPollClient(func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, argoCDPollApplication("connection refused"), nil
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	err := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
+	require.ErrorIs(t, err, argocd.ErrReconcileTimeout)
+	assert.Contains(t, err.Error(), "test-app")
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.Contains(
+		t,
+		err.Error(),
+		"ksail workload get applications.argoproj.io test-app -n argocd",
+	)
+}
+
+// TestPollArgoCDApplicationCancellation preserves cancellation during a transient failure.
+func TestPollArgoCDApplicationCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	client := newArgoCDPollClient(func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		cancel()
+
+		return true, argoCDPollApplication("connection refused"), nil
+	})
+
+	err := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, argocd.ErrReconcileTimeout)
+}

--- a/pkg/cli/cmd/workload/reconcile_test.go
+++ b/pkg/cli/cmd/workload/reconcile_test.go
@@ -3,6 +3,7 @@ package workload_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync/atomic"
 	"testing"
@@ -201,4 +202,96 @@ func TestPermanentArgoCDPollFailureDoesNotEscapeIntoOuterRetries(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestArgoCDReadinessTimeoutIsNotRetried preserves the completed polling budget
+// even when retained diagnostics contain an earlier transient transport failure.
+func TestArgoCDReadinessTimeoutIsNotRetried(t *testing.T) {
+	t.Parallel()
+	timeoutErr := expiredArgoCDPollingError(t)
+	client := newArgoCDPollClient(func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, argoCDPollApplication("connection refused"), nil
+	})
+	_, transient := client.CheckNamedApplicationReady(t.Context(), "test-app")
+	require.Error(t, transient)
+
+	for _, testCase := range []struct {
+		name         string
+		failure      error
+		wantAttempts int
+	}{
+		{"timeout", timeoutErr, 1},
+		{"wrapped", fmt.Errorf("reconcile application: %w", timeoutErr), 1},
+		{"joined_first", errors.Join(timeoutErr, transient), 1},
+		{"joined_last", errors.Join(transient, timeoutErr), 1},
+		{"active_transient", transient, 3},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assertReconcileRetryAttempts(t, testCase.failure, testCase.wantAttempts)
+		})
+	}
+}
+
+// expiredArgoCDPollingError exercises a transient failure followed by clean but
+// unsynced status and an expired read, retaining the earlier diagnostic.
+func expiredArgoCDPollingError(t *testing.T) error {
+	t.Helper()
+
+	calls := 0
+	client := newArgoCDPollClient(func(k8stesting.Action) (bool, runtime.Object, error) {
+		calls++
+		switch calls {
+		case 1:
+			return true, argoCDPollApplication("connection refused"), nil
+		case 2:
+			application := argoCDPollApplication("")
+			require.NoError(
+				t,
+				unstructured.SetNestedField(
+					application.Object,
+					"OutOfSync",
+					"status",
+					"sync",
+					"status",
+				),
+			)
+
+			return true, application, nil
+		default:
+			return true, nil, context.DeadlineExceeded
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	failure := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
+	require.ErrorIs(t, failure, argocd.ErrReconcileTimeout)
+	require.ErrorContains(t, failure, "connection refused")
+	require.ErrorContains(
+		t,
+		failure,
+		"ksail workload get applications.argoproj.io test-app -n argocd",
+	)
+	require.Equal(t, 3, calls)
+
+	//nolint:wrapcheck // Preserve the real polling error for wrapping and joining regressions.
+	return failure
+}
+
+func assertReconcileRetryAttempts(t *testing.T, failure error, want int) {
+	t.Helper()
+
+	attempts := 0
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := workload.ExportRetryOnTransientError(t.Context(), cmd, 3, 0, 0, func() error {
+		attempts++
+
+		return failure
+	})
+	require.ErrorIs(t, err, failure)
+	assert.Equal(t, want, attempts)
 }

--- a/pkg/cli/cmd/workload/reconcile_test.go
+++ b/pkg/cli/cmd/workload/reconcile_test.go
@@ -55,27 +55,40 @@ func argoCDPollApplication(message string) *unstructured.Unstructured {
 func TestPollArgoCDApplicationRecoversFromTransportFailure(t *testing.T) {
 	t.Parallel()
 
-	var calls atomic.Int32
+	for _, message := range []string{
+		"lookup registry.example: no such host", "429 Too Many Requests", "503 Service Unavailable",
+	} {
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
 
-	client := newArgoCDPollClient(func(action k8stesting.Action) (bool, runtime.Object, error) {
-		assert.Equal(t, "argocd", action.GetNamespace())
-		getAction, ok := action.(k8stesting.GetAction)
-		require.True(t, ok)
-		assert.Equal(t, "test-app", getAction.GetName())
+			var calls atomic.Int32
 
-		if calls.Add(1) == 1 {
-			return true, argoCDPollApplication("lookup registry.example: no such host"), nil
-		}
+			client := newArgoCDPollClient(
+				func(action k8stesting.Action) (bool, runtime.Object, error) {
+					assert.Equal(t, "argocd", action.GetNamespace())
+					getAction, ok := action.(k8stesting.GetAction)
+					require.True(t, ok)
+					assert.Equal(t, "test-app", getAction.GetName())
 
-		return true, argoCDPollApplication(""), nil
-	})
+					if calls.Add(1) == 1 {
+						return true, argoCDPollApplication(message), nil
+					}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+					return true, argoCDPollApplication(""), nil
+				},
+			)
 
-	err := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
-	require.NoError(t, err)
-	assert.Equal(t, int32(2), calls.Load(), "stale healthy status must not finish the first poll")
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			err := workload.ExportPollUntilApplicationReady(ctx, client, "test-app")
+			require.NoError(t, err)
+			assert.Equal(
+				t, int32(2), calls.Load(),
+				"stale healthy status must not finish the first poll",
+			)
+		})
+	}
 }
 
 // TestPollArgoCDApplicationFailsFastOnMissingArtifact rejects permanent failures on the first poll.

--- a/pkg/cli/cmd/workload/shared.go
+++ b/pkg/cli/cmd/workload/shared.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/cli/flags"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/kubeconfig"
 	"github.com/devantler-tech/ksail/v7/pkg/cli/kubeconfighook"
+	"github.com/devantler-tech/ksail/v7/pkg/client/argocd"
 	"github.com/devantler-tech/ksail/v7/pkg/client/kubectl"
 	"github.com/devantler-tech/ksail/v7/pkg/client/netretry"
 	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
@@ -348,7 +349,7 @@ func retryOnTransientError(
 
 		lastErr = err
 
-		if !netretry.IsRetryable(lastErr) || attempt == maxAttempts {
+		if !isRetryableReconcileError(lastErr) || attempt == maxAttempts {
 			break
 		}
 
@@ -358,11 +359,17 @@ func retryOnTransientError(
 		}
 	}
 
-	if !netretry.IsRetryable(lastErr) {
+	if !isRetryableReconcileError(lastErr) {
 		return lastErr
 	}
 
 	return fmt.Errorf("failed after %d attempts: %w", maxAttempts, lastErr)
+}
+
+// isRetryableReconcileError preserves ArgoCD's permanent classification even
+// when an aggregated diagnostic also contains an earlier transport failure.
+func isRetryableReconcileError(err error) bool {
+	return !argocd.IsPermanentApplicationError(err) && netretry.IsRetryable(err)
 }
 
 // waitBeforeRetry blocks for the exponential backoff delay before the next

--- a/pkg/cli/cmd/workload/shared.go
+++ b/pkg/cli/cmd/workload/shared.go
@@ -366,10 +366,11 @@ func retryOnTransientError(
 	return fmt.Errorf("failed after %d attempts: %w", maxAttempts, lastErr)
 }
 
-// isRetryableReconcileError preserves ArgoCD's permanent classification even
-// when an aggregated diagnostic also contains an earlier transport failure.
+// isRetryableReconcileError preserves ArgoCD's permanent and timeout outcomes
+// even when an aggregated diagnostic contains an earlier transport failure.
 func isRetryableReconcileError(err error) bool {
-	return !argocd.IsPermanentApplicationError(err) && netretry.IsRetryable(err)
+	return !errors.Is(err, argocd.ErrReconcileTimeout) &&
+		!argocd.IsPermanentApplicationError(err) && netretry.IsRetryable(err)
 }
 
 // waitBeforeRetry blocks for the exponential backoff delay before the next

--- a/pkg/cli/cmd/workload/shared.go
+++ b/pkg/cli/cmd/workload/shared.go
@@ -290,10 +290,9 @@ const (
 	defaultReconcileTimeout       = 5 * time.Minute
 	fluxKustomizationPollInterval = 500 * time.Millisecond
 	argoCDApplicationPollInterval = 500 * time.Millisecond
-	// argoCDSourceWarmupGrace bounds how long a source-availability error is
-	// treated as a control-plane cold start rather than a real failure. ArgoCD
-	// self-heals these within seconds; a source still unavailable after this
-	// window is a genuine misconfiguration and fails with an actionable error.
+	// argoCDSourceWarmupGrace bounds retries for recognized source transport
+	// failures while the control plane starts. Missing sources, access failures,
+	// and unclassified operation failures remain terminal throughout the window.
 	argoCDSourceWarmupGrace = 90 * time.Second
 	reconcileConcurrency    = 5
 	reconcileCmdLong        = "Trigger reconciliation/sync and wait for completion. " +

--- a/pkg/client/argocd/reconciler.go
+++ b/pkg/client/argocd/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -189,6 +190,12 @@ type sourceAvailabilityError struct {
 
 var errPermanentApplicationFailure = errors.New("permanent ArgoCD application failure")
 
+// comparisonHTTPStatus requires an HTTP/status label so line numbers and ports
+// do not turn invalid manifests into transient transport failures.
+var comparisonHTTPStatus = regexp.MustCompile(
+	`\b(?:http(?:/[0-9.]+)?|status(?:\s+code)?)[\s:=]+(?:429|5[0-9]{2})\b`,
+)
+
 // Error includes the source failure and the public sentinel's existing guidance.
 func (e *sourceAvailabilityError) Error() string {
 	return fmt.Sprintf("%s: %s", ErrSourceNotAvailable, e.message)
@@ -248,7 +255,9 @@ func classifyApplicationError(message string, comparison bool) error {
 func comparisonTransportError(message string) bool {
 	lower := strings.TrimSpace(message)
 
-	return strings.Contains(lower, "context deadline exceeded") || lower == "eof" ||
+	return containsAny(lower, "context deadline exceeded", "too many requests",
+		"internal server error", "bad gateway", "service unavailable", "gateway timeout") ||
+		comparisonHTTPStatus.MatchString(lower) || lower == "eof" ||
 		strings.HasSuffix(lower, "unexpected eof") || strings.HasSuffix(lower, ": eof") ||
 		strings.HasSuffix(lower, "= eof")
 }

--- a/pkg/client/argocd/reconciler.go
+++ b/pkg/client/argocd/reconciler.go
@@ -158,7 +158,7 @@ func (r *Reconciler) checkOperationState(app *unstructured.Unstructured) error {
 	message, _, _ := unstructured.NestedString(operationState, "message")
 
 	if phase == "Error" || phase == "Failed" {
-		return classifyApplicationError(message)
+		return classifyApplicationError(message, false)
 	}
 
 	return nil
@@ -170,7 +170,10 @@ func (r *Reconciler) checkConditions(app *unstructured.Unstructured) error {
 
 	for _, cond := range reconciler.ParseConditions(app) {
 		if cond.Type == "ComparisonError" || cond.Type == "SyncError" {
-			failure = preferPermanentFailure(failure, classifyApplicationError(cond.Message))
+			failure = preferPermanentFailure(
+				failure,
+				classifyApplicationError(cond.Message, cond.Type == "ComparisonError"),
+			)
 		}
 	}
 
@@ -184,6 +187,8 @@ type sourceAvailabilityError struct {
 	transient bool
 }
 
+var errPermanentApplicationFailure = errors.New("permanent ArgoCD application failure")
+
 // Error includes the source failure and the public sentinel's existing guidance.
 func (e *sourceAvailabilityError) Error() string {
 	return fmt.Sprintf("%s: %s", ErrSourceNotAvailable, e.message)
@@ -194,8 +199,20 @@ func (e *sourceAvailabilityError) Unwrap() error {
 	return ErrSourceNotAvailable
 }
 
+// Is exposes permanent classification through wrappers and errors.Join without
+// changing the diagnostic text or the existing source-availability sentinel.
+func (e *sourceAvailabilityError) Is(target error) bool {
+	return target == errPermanentApplicationFailure && !e.transient
+}
+
+// IsPermanentApplicationError reports whether any wrapped or joined application
+// error is permanent. Outer retries must honor this before matching network text.
+func IsPermanentApplicationError(err error) bool {
+	return errors.Is(err, errPermanentApplicationFailure) || errors.Is(err, ErrOperationFailed)
+}
+
 // classifyApplicationError retries only recognized transport failures and rejects ambiguous errors.
-func classifyApplicationError(message string) error {
+func classifyApplicationError(message string, comparison bool) error {
 	lower := strings.ToLower(message)
 
 	// Explicit absence and denied access stay terminal even when the message also
@@ -215,11 +232,25 @@ func classifyApplicationError(message string) error {
 		return &sourceAvailabilityError{message: message, transient: true}
 	}
 
+	if comparison && comparisonTransportError(lower) {
+		return &sourceAvailabilityError{message: message, transient: true}
+	}
+
 	if containsAny(lower, "failed to fetch", "unable to resolve") {
 		return &sourceAvailabilityError{message: message}
 	}
 
 	return fmt.Errorf("%w: %s", ErrOperationFailed, message)
+}
+
+// comparisonTransportError recognizes transport details whose meaning is
+// ambiguous in sync hooks or failed operation states. EOF must end the detail.
+func comparisonTransportError(message string) bool {
+	lower := strings.TrimSpace(message)
+
+	return strings.Contains(lower, "context deadline exceeded") || lower == "eof" ||
+		strings.HasSuffix(lower, "unexpected eof") || strings.HasSuffix(lower, ": eof") ||
+		strings.HasSuffix(lower, "= eof")
 }
 
 // containsAny matches normalized ArgoCD diagnostics against recognized failure descriptions.
@@ -246,7 +277,7 @@ func preferPermanentFailure(current, candidate error) error {
 func isTransientSourceError(err error) bool {
 	var sourceErr *sourceAvailabilityError
 
-	return errors.As(err, &sourceErr) && sourceErr.transient
+	return !IsPermanentApplicationError(err) && errors.As(err, &sourceErr) && sourceErr.transient
 }
 
 // isApplicationSynced checks if the application is synced and healthy.

--- a/pkg/client/argocd/reconciler.go
+++ b/pkg/client/argocd/reconciler.go
@@ -120,7 +120,9 @@ func (r *Reconciler) ListApplications(
 
 // CheckNamedApplicationReady performs a single-poll readiness check for
 // a specific ArgoCD Application CR identified by name.
-// Returns (ready, error) where error is non-nil for permanent failures.
+// Active operation and comparison failures return an error even when sync and
+// health fields still describe a successful comparison. Callers may use
+// IsColdStartTransient to retry recognized transport failures within a deadline.
 func (r *Reconciler) CheckNamedApplicationReady(
 	ctx context.Context,
 	name string,
@@ -132,12 +134,7 @@ func (r *Reconciler) CheckNamedApplicationReady(
 		return false, fmt.Errorf("get argocd application %q: %w", name, err)
 	}
 
-	err = r.checkOperationState(app)
-	if err != nil {
-		return false, err
-	}
-
-	err = r.checkConditions(app)
+	err = preferPermanentFailure(r.checkOperationState(app), r.checkConditions(app))
 	if err != nil {
 		return false, err
 	}
@@ -161,12 +158,7 @@ func (r *Reconciler) checkOperationState(app *unstructured.Unstructured) error {
 	message, _, _ := unstructured.NestedString(operationState, "message")
 
 	if phase == "Error" || phase == "Failed" {
-		// Check if this is a source-related error
-		if isSourceRelatedError(message) {
-			return fmt.Errorf("%w: %s", ErrSourceNotAvailable, message)
-		}
-
-		return fmt.Errorf("%w: %s", ErrOperationFailed, message)
+		return classifyApplicationError(message)
 	}
 
 	return nil
@@ -174,38 +166,87 @@ func (r *Reconciler) checkOperationState(app *unstructured.Unstructured) error {
 
 // checkConditions checks for error conditions.
 func (r *Reconciler) checkConditions(app *unstructured.Unstructured) error {
+	var failure error
+
 	for _, cond := range reconciler.ParseConditions(app) {
-		// Look for error conditions
 		if cond.Type == "ComparisonError" || cond.Type == "SyncError" {
-			if isSourceRelatedError(cond.Message) {
-				return fmt.Errorf("%w: %s", ErrSourceNotAvailable, cond.Message)
-			}
+			failure = preferPermanentFailure(failure, classifyApplicationError(cond.Message))
 		}
 	}
 
-	return nil
+	return failure
 }
 
-// isSourceRelatedError checks if the error message indicates a source availability issue.
-func isSourceRelatedError(message string) bool {
-	sourceProblemPatterns := []string{
-		"manifest unknown",
-		"not found",
-		"does not exist",
-		"failed to fetch",
-		"repository not found",
-		"unable to resolve",
-		"connection refused",
+// sourceAvailabilityError preserves the public sentinel while recording whether
+// the source failed for a recognized transport reason.
+type sourceAvailabilityError struct {
+	message   string
+	transient bool
+}
+
+// Error includes the source failure and the public sentinel's existing guidance.
+func (e *sourceAvailabilityError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrSourceNotAvailable, e.message)
+}
+
+// Unwrap preserves errors.Is compatibility for callers checking source availability.
+func (e *sourceAvailabilityError) Unwrap() error {
+	return ErrSourceNotAvailable
+}
+
+// classifyApplicationError retries only recognized transport failures and rejects ambiguous errors.
+func classifyApplicationError(message string) error {
+	lower := strings.ToLower(message)
+
+	// Explicit absence and denied access stay terminal even when the message also
+	// contains a transport failure from an earlier attempt.
+	if containsAny(lower, "manifest unknown", "not found", "does not exist") {
+		return &sourceAvailabilityError{message: message}
 	}
 
-	lowerMessage := strings.ToLower(message)
-	for _, pattern := range sourceProblemPatterns {
-		if strings.Contains(lowerMessage, pattern) {
+	if containsAny(lower, "unauthorized", "unauthenticated", "authentication required",
+		"permission denied", "permissiondenied", "access denied", "forbidden", "x509:") {
+		return fmt.Errorf("%w: %s", ErrOperationFailed, message)
+	}
+
+	if containsAny(lower, "connection refused", "connection reset by peer", "i/o timeout",
+		"no such host", "temporary failure in name resolution", "network is unreachable",
+		"tls handshake timeout") {
+		return &sourceAvailabilityError{message: message, transient: true}
+	}
+
+	if containsAny(lower, "failed to fetch", "unable to resolve") {
+		return &sourceAvailabilityError{message: message}
+	}
+
+	return fmt.Errorf("%w: %s", ErrOperationFailed, message)
+}
+
+// containsAny matches normalized ArgoCD diagnostics against recognized failure descriptions.
+func containsAny(message string, patterns ...string) bool {
+	for _, pattern := range patterns {
+		if strings.Contains(message, pattern) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// preferPermanentFailure prevents a retryable error from hiding another failure on the same Application.
+func preferPermanentFailure(current, candidate error) error {
+	if candidate != nil && (current == nil || isTransientSourceError(current)) {
+		return candidate
+	}
+
+	return current
+}
+
+// isTransientSourceError accepts only source failures classified as transport errors.
+func isTransientSourceError(err error) bool {
+	var sourceErr *sourceAvailabilityError
+
+	return errors.As(err, &sourceErr) && sourceErr.transient
 }
 
 // isApplicationSynced checks if the application is synced and healthy.
@@ -225,24 +266,10 @@ func isApplicationSynced(app *unstructured.Unstructured) bool {
 	return true
 }
 
-// IsColdStartTransient reports whether err is a source-availability failure
-// that ArgoCD is expected to resolve on its own, given how long the caller has
-// been polling.
-//
-// During a control-plane cold start ArgoCD's repo-server and redis are still
-// coming up, so the first comparison of the root Application briefly reports a
-// connection failure. ArgoCD retries internally and self-heals seconds later,
-// but the message is indistinguishable from a genuinely unreachable source, so
-// the classifier cannot tell the two apart from the text alone. Elapsed poll
-// time is what separates them: a source that is still unavailable once the
-// warm-up window has passed is a real misconfiguration.
-//
-// Only ErrSourceNotAvailable is eligible. A failed operation, or any other
-// error, stays terminal so a genuine failure is never masked into a timeout.
+// IsColdStartTransient reports whether err is a recognized transport failure
+// within the caller's cold-start grace period. ArgoCD retries these failures as
+// its services start. Explicit source absence, access failures, and unclassified
+// errors remain terminal; elapsed time never makes those failures retryable.
 func IsColdStartTransient(err error, elapsed, grace time.Duration) bool {
-	if err == nil {
-		return false
-	}
-
-	return errors.Is(err, ErrSourceNotAvailable) && elapsed < grace
+	return isTransientSourceError(err) && elapsed < grace
 }

--- a/pkg/client/argocd/reconciler_test.go
+++ b/pkg/client/argocd/reconciler_test.go
@@ -506,13 +506,11 @@ func TestIsColdStartTransient(t *testing.T) {
 			name:    "source unavailable outside the warm-up window stays terminal",
 			err:     fmt.Errorf("%w: %s", argocd.ErrSourceNotAvailable, "repository not found"),
 			elapsed: grace + time.Second,
-			want:    false,
 		},
 		{
 			name:    "a failed operation is never masked, even inside the window",
 			err:     fmt.Errorf("%w: %s", argocd.ErrOperationFailed, "sync operation failed"),
 			elapsed: time.Second,
-			want:    false,
 		},
 		{
 			name:    "an unrelated error is never masked",
@@ -524,13 +522,11 @@ func TestIsColdStartTransient(t *testing.T) {
 			name:    "the window boundary itself is already terminal",
 			err:     transportErr,
 			elapsed: grace,
-			want:    false,
 		},
 		{
 			name:    "an unclassified source sentinel does not authorize retry",
 			err:     argocd.ErrSourceNotAvailable,
 			elapsed: time.Second,
-			want:    false,
 		},
 	}
 

--- a/pkg/client/argocd/reconciler_test.go
+++ b/pkg/client/argocd/reconciler_test.go
@@ -484,6 +484,12 @@ func TestIsColdStartTransient(t *testing.T) {
 
 	const grace = 90 * time.Second
 
+	client := newTestArgoCDReconciler(newFakeApplicationWithConditions("warming", []map[string]any{
+		{"type": "ComparisonError", "message": "connection refused"},
+	}))
+	_, transportErr := client.CheckNamedApplicationReady(t.Context(), "warming")
+	require.ErrorIs(t, transportErr, argocd.ErrSourceNotAvailable)
+
 	tests := []struct {
 		name    string
 		err     error
@@ -492,7 +498,7 @@ func TestIsColdStartTransient(t *testing.T) {
 	}{
 		{
 			name:    "source unavailable inside the warm-up window is retryable",
-			err:     fmt.Errorf("%w: %s", argocd.ErrSourceNotAvailable, "connection refused"),
+			err:     fmt.Errorf("wrapped: %w", transportErr),
 			elapsed: 5 * time.Second,
 			want:    true,
 		},
@@ -512,18 +518,18 @@ func TestIsColdStartTransient(t *testing.T) {
 			name:    "an unrelated error is never masked",
 			err:     errSimulatedAPIFailure,
 			elapsed: time.Second,
-			want:    false,
 		},
-		{
-			name:    "no error is not a transient",
-			err:     nil,
-			elapsed: time.Second,
-			want:    false,
-		},
+		{name: "no error is not a transient", elapsed: time.Second},
 		{
 			name:    "the window boundary itself is already terminal",
-			err:     fmt.Errorf("%w: %s", argocd.ErrSourceNotAvailable, "connection refused"),
+			err:     transportErr,
 			elapsed: grace,
+			want:    false,
+		},
+		{
+			name:    "an unclassified source sentinel does not authorize retry",
+			err:     argocd.ErrSourceNotAvailable,
+			elapsed: time.Second,
 			want:    false,
 		},
 	}
@@ -535,5 +541,126 @@ func TestIsColdStartTransient(t *testing.T) {
 			got := argocd.IsColdStartTransient(testCase.err, testCase.elapsed, grace)
 			assert.Equal(t, testCase.want, got)
 		})
+	}
+}
+
+// TestApplicationTransportErrors identifies retryable network failures in every error location.
+func TestApplicationTransportErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, message := range []string{
+		"lookup registry.example: no such host",
+		"read tcp: i/o timeout",
+		"failed to fetch: connection refused",
+		"read tcp: connection reset by peer",
+		"temporary failure in name resolution",
+	} {
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+			assertApplicationErrorClassification(t, message, true, true)
+		})
+	}
+}
+
+// TestApplicationPermanentErrors keeps absence, denied access, and ambiguous failures terminal.
+func TestApplicationPermanentErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		message string
+		source  bool
+	}{
+		{message: "sync hook failed: context deadline exceeded"},
+		{message: "rpc error: code = DeadlineExceeded desc = context deadline exceeded"},
+		{message: "failed to fetch: manifest unknown", source: true},
+		{message: "repository not found", source: true},
+		{message: "unable to resolve revision: does not exist", source: true},
+		{message: "failed to fetch repository", source: true},
+		{message: "unable to resolve revision", source: true},
+		{message: "authentication required"},
+		{message: "permission denied (previous attempt: connection refused)"},
+		{message: "manifest unknown (previous attempt: i/o timeout)", source: true},
+		{message: "invalid manifest: unknown resource kind"},
+		{message: "comparison failed"},
+		{message: ""},
+	} {
+		t.Run(testCase.message, func(t *testing.T) {
+			t.Parallel()
+			assertApplicationErrorClassification(t, testCase.message, false, testCase.source)
+		})
+	}
+}
+
+// assertApplicationErrorClassification checks readiness, sentinel compatibility, and retry bounds.
+func assertApplicationErrorClassification(t *testing.T, message string, transient, source bool) {
+	t.Helper()
+
+	for _, location := range []string{"ComparisonError", "SyncError", "Failed", "Error"} {
+		t.Run(location, func(t *testing.T) {
+			t.Parallel()
+
+			var app *unstructured.Unstructured
+			if location == "Failed" || location == "Error" {
+				app = newFakeApplicationWithOperation("test-app", location, message)
+			} else {
+				// Synced/Healthy fields may outlive the failed comparison.
+				app = newFakeApplicationWithConditions("test-app", []map[string]any{
+					{"type": location, "message": message},
+				})
+			}
+
+			client := newTestArgoCDReconciler(app)
+			ready, err := client.CheckNamedApplicationReady(t.Context(), "test-app")
+			require.Error(t, err)
+			assert.False(t, ready)
+			assert.Contains(t, err.Error(), message)
+
+			if source {
+				require.ErrorIs(t, err, argocd.ErrSourceNotAvailable)
+			} else {
+				require.ErrorIs(t, err, argocd.ErrOperationFailed)
+			}
+
+			assert.Equal(t, transient, argocd.IsColdStartTransient(err, 0, time.Second))
+			assert.False(t, argocd.IsColdStartTransient(err, time.Second, time.Second))
+		})
+	}
+}
+
+// TestApplicationPermanentErrorTakesPrecedence checks mixed errors in both condition orders.
+func TestApplicationPermanentErrorTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	for _, operationMessage := range []string{"", "connection refused", "manifest unknown"} {
+		for _, reverse := range []bool{false, true} {
+			t.Run(
+				fmt.Sprintf("operation=%s/reverse=%t", operationMessage, reverse),
+				func(t *testing.T) {
+					t.Parallel()
+
+					conditions := []map[string]any{
+						{"type": "ComparisonError", "message": "connection refused"},
+						{"type": "SyncError", "message": "manifest unknown"},
+					}
+					if reverse {
+						conditions[0], conditions[1] = conditions[1], conditions[0]
+					}
+
+					app := newFakeApplicationWithConditions("mixed", conditions)
+					if operationMessage != "" {
+						require.NoError(t, unstructured.SetNestedMap(app.Object, map[string]any{
+							"phase": "Error", "message": operationMessage,
+						}, "status", "operationState"))
+					}
+
+					client := newTestArgoCDReconciler(app)
+					ready, err := client.CheckNamedApplicationReady(t.Context(), "mixed")
+					require.ErrorIs(t, err, argocd.ErrSourceNotAvailable)
+					assert.False(t, ready)
+					assert.Contains(t, err.Error(), "manifest unknown")
+					assert.False(t, argocd.IsColdStartTransient(err, 0, time.Minute))
+				},
+			)
+		}
 	}
 }

--- a/pkg/client/argocd/reconciler_test.go
+++ b/pkg/client/argocd/reconciler_test.go
@@ -558,6 +558,42 @@ func TestApplicationTransportErrors(t *testing.T) {
 	}
 }
 
+func TestComparisonTransportFormsPreserveTheirLocationContext(t *testing.T) {
+	t.Parallel()
+
+	for _, message := range []string{
+		"unexpected EOF", "rpc error: desc = EOF", "EOF", "context deadline exceeded",
+		"rpc error: code = DeadlineExceeded desc = context deadline exceeded",
+	} {
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
+			for _, location := range []string{"ComparisonError", "SyncError", "Failed", "Error"} {
+				t.Run(location, func(t *testing.T) {
+					t.Parallel()
+
+					app := newFakeApplicationWithOperation("test-app", location, message)
+					if location == "ComparisonError" || location == "SyncError" {
+						app = newFakeApplicationWithConditions("test-app", []map[string]any{
+							{"type": location, "message": message},
+						})
+					}
+
+					client := newTestArgoCDReconciler(app)
+					_, err := client.CheckNamedApplicationReady(t.Context(), "test-app")
+					require.Error(t, err)
+					assert.Equal(
+						t,
+						location == "ComparisonError",
+						argocd.IsColdStartTransient(err, 0, time.Minute),
+					)
+					assert.False(t, argocd.IsColdStartTransient(err, time.Minute, time.Minute))
+				})
+			}
+		})
+	}
+}
+
 // TestApplicationPermanentErrors keeps absence, denied access, and ambiguous failures terminal.
 func TestApplicationPermanentErrors(t *testing.T) {
 	t.Parallel()
@@ -566,8 +602,6 @@ func TestApplicationPermanentErrors(t *testing.T) {
 		message string
 		source  bool
 	}{
-		{message: "sync hook failed: context deadline exceeded"},
-		{message: "rpc error: code = DeadlineExceeded desc = context deadline exceeded"},
 		{message: "failed to fetch: manifest unknown", source: true},
 		{message: "repository not found", source: true},
 		{message: "unable to resolve revision: does not exist", source: true},
@@ -578,6 +612,7 @@ func TestApplicationPermanentErrors(t *testing.T) {
 		{message: "manifest unknown (previous attempt: i/o timeout)", source: true},
 		{message: "invalid manifest: unknown resource kind"},
 		{message: "comparison failed"},
+		{message: "EOF is not allowed in this manifest"},
 		{message: ""},
 	} {
 		t.Run(testCase.message, func(t *testing.T) {

--- a/pkg/client/argocd/reconciler_test.go
+++ b/pkg/client/argocd/reconciler_test.go
@@ -564,6 +564,9 @@ func TestComparisonTransportFormsPreserveTheirLocationContext(t *testing.T) {
 	for _, message := range []string{
 		"unexpected EOF", "rpc error: desc = EOF", "EOF", "context deadline exceeded",
 		"rpc error: code = DeadlineExceeded desc = context deadline exceeded",
+		"429 Too Many Requests", "503 Service Unavailable", "Bad Gateway", "Gateway Timeout",
+		"Internal Server Error", "unexpected status code: 502", "HTTP/2 504", "HTTP 500",
+		"response status: 429",
 	} {
 		t.Run(message, func(t *testing.T) {
 			t.Parallel()
@@ -610,6 +613,10 @@ func TestApplicationPermanentErrors(t *testing.T) {
 		{message: "authentication required"},
 		{message: "permission denied (previous attempt: connection refused)"},
 		{message: "manifest unknown (previous attempt: i/o timeout)", source: true},
+		{message: "manifest unknown (previous attempt: 503 Service Unavailable)", source: true},
+		{message: "forbidden (previous attempt: 429 Too Many Requests)"},
+		{message: "invalid manifest at line 503"},
+		{message: "fetch registry.example:5000 failed"},
 		{message: "invalid manifest: unknown resource kind"},
 		{message: "comparison failed"},
 		{message: "EOF is not allowed in this manifest"},

--- a/pkg/client/reconciler/poll.go
+++ b/pkg/client/reconciler/poll.go
@@ -81,7 +81,9 @@ func PollUntilReady(
 			return nil
 		}
 
-		lastStatus = result.Status
+		if result.Status != "" {
+			lastStatus = result.Status
+		}
 
 		select {
 		case <-ctx.Done():

--- a/pkg/client/reconciler/poll_test.go
+++ b/pkg/client/reconciler/poll_test.go
@@ -118,3 +118,28 @@ func TestPollUntilReadyTimeoutUsesLastStatus(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "last status: Progressing")
 }
+
+func TestPollUntilReadyRetainsMostRecentNonEmptyStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, statuses := range [][]string{{"connection refused", ""}, {"connection refused", "recovering", ""}} {
+		t.Run(statuses[len(statuses)-2], func(t *testing.T) {
+			t.Parallel()
+
+			index := 0
+			err := reconciler.PollUntilReady(t.Context(), testPollInterval,
+				func(context.Context) (reconciler.CheckResult, error) {
+					if index == len(statuses) {
+						return reconciler.CheckResult{}, context.DeadlineExceeded
+					}
+
+					status := statuses[index]
+					index++
+
+					return reconciler.CheckResult{Status: status}, nil
+				}, timeoutErr)
+			require.ErrorIs(t, err, errTimeoutPoll)
+			assert.Contains(t, err.Error(), statuses[len(statuses)-2])
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

ArgoCD reconciliation can report success from stale healthy status despite an active comparison error, or spend its warm-up window retrying a missing artifact. When a connection failure times out, its cause is lost.

### What

Retry recognized transport failures within the existing warm-up window, fail immediately on permanent errors, and give permanent failures priority when both are present. Readiness requires an error-free comparison; failures and timeouts retain the application name and useful diagnostics.

Fixes #6917
Part of #5948
