### PR TITLE
feat(eks): add experimental managed nodegroup creation

### DIFF
--- a/charts/ksail-operator/crds/ksail.io_clusters.yaml
+++ b/charts/ksail-operator/crds/ksail.io_clusters.yaml
@@ -361,6 +361,15 @@ spec:
                           and by `cluster update` when the opt-in changes. Not yet validated against
                           a live EKS cluster.
                         type: boolean
+                      experimentalManagedNodegroupCreation:
+                        description: |-
+                          ExperimentalManagedNodegroupCreation allows cluster update to create managed
+                          node groups added to eksctl.yaml. Default false: additions require recreation.
+                          Existing managed node-group scaling does not require this option. Removals
+                          and instance-type changes still require recreation. Creation requires a
+                          verified cluster identity and remains experimental pending live EKS validation.
+                          Graduation: https://github.com/devantler-tech/ksail/issues/6923.
+                        type: boolean
                     type: object
                   gitOpsEngine:
                     description: 'GitOpsEngine selects the GitOps engine KSail bootstraps:

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -157,6 +157,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.79.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eks v1.92.1 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -397,6 +397,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 h1:K0JsbZQj+1h208Ro1zH
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1/go.mod h1:W3/vL6EtCIatICGy9ab29QhMuae+cOKPWcMxv02CO+Q=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1 h1:yhw5KD1phVyP9vijxOUzDfEtJx+bt+L63k+VfuiYFAA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1/go.mod h1:ZW2e0d7DYlRxlS9hEiMXE47gTdX5KRN4byUiNbUpG+Q=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.79.0 h1:QdGV83ods5B0cb1KIc79QhabvneqkRk8FR1bi3w2k30=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.79.0/go.mod h1:Qu13pjg01PcSNWKQVqdC19JK/FkT5q9m+J+dyTwfZjw=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3 h1:RtGctYMmkTerGClvdY6bHXdtly4FeYw9wz/NPz62LF8=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3/go.mod h1:vBfBu24Ka3/5UZtepbTV0gnc9VPLT8ok+0oDDaYAzn4=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.10 h1:1A/sI3LNMi3fhRI5TFLMwwo7ALAALSFVCSGvFlr1Iys=

--- a/docs/src/content/docs/distributions/eks.mdx
+++ b/docs/src/content/docs/distributions/eks.mdx
@@ -127,6 +127,54 @@ KSail invokes eksctl to provision the cluster from `eks.yaml` and waits for comp
 | `ksail cluster list`   | Lists clusters in the configured region (all regions when unset)    |
 | `ksail cluster info`   | Shows cluster details                                               |
 
+### Add a managed node group (experimental)
+
+To create a new managed node group on an existing cluster, enable the opt-in in
+`ksail.yaml`:
+
+```yaml
+spec:
+  cluster:
+    eks:
+      experimentalManagedNodegroupCreation: true
+```
+
+Add the group to `managedNodeGroups` in `eks.yaml`, keeping the existing groups in
+the file. Each group must have a unique name. Review the planned changes before
+applying them:
+
+```bash
+ksail cluster update --dry-run
+ksail cluster update
+```
+
+KSail verifies the existing cluster's ownership and uses
+[`eksctl create nodegroup`](https://docs.aws.amazon.com/eks/latest/eksctl/general-nodegroups.html)
+to create each missing managed group separately. The configuration preserves the
+new group's instance, networking, storage, labels, taints, and IAM settings.
+Self-managed groups under `nodeGroups` are not created by this operation. KSail
+reports an addition as applied only after the live managed group is `ACTIVE` and
+its declared capacity and instance type match. A `ksail.io/nodegroup-creation-id`
+tag identifies the group created by that update.
+
+The selected AWS identity also needs `eks:ListNodegroups`,
+`eks:DescribeNodegroup`, and `cloudformation:ListStacks` read permissions. KSail
+reads every inventory page and refuses creation if a live or unfinished eksctl
+node-group stack already uses the new group's name.
+
+If the source file changes during the update, ownership verification fails, or the
+live inventory is ambiguous, the update stops. After a failed or interrupted
+creation, inspect the group in EKS before retrying. An unfinished or failed group
+blocks the next update; an active group already matching the supported settings
+is not created again. Earlier successful additions remain in place when a later
+addition fails.
+
+This option defaults to `false` and is pending
+[live EKS validation](https://github.com/devantler-tech/ksail/issues/6923). Scaling
+existing groups does not require the option. Removing a managed group or changing
+its instance type still requires recreation and prevents additions in the same
+update. Changes to other settings on existing groups are not currently detected.
+
 ### Concurrent lifecycle operations
 
 EKS `start`, `stop`, and `delete` operations from the CLI and the local web/desktop
@@ -157,7 +205,7 @@ EKS contexts written by eksctl follow the format `<iam-identity>@<name>.<region>
 - EKS is a cloud distribution — **local mirror registries and local registry containers are not supported**. Use external registry URLs (e.g., `docker.io=https://registry-1.docker.io`)
 - EKS only supports the **AWS provider** — the Docker, Hetzner, and Omni providers are not available
 - The control plane keeps running (and billing) while nodegroups are stopped — use `ksail cluster delete` to tear down the cluster and stop its cluster-related charges (resources provisioned by workloads, such as load balancers or persistent volumes, may need separate cleanup)
-- `ksail cluster update` applies `desiredCapacity`, `minSize`, and `maxSize` changes to existing managed node groups in-place. Changing an instance type or adding/removing a managed node group requires cluster recreation. Other managed-node-group fields (including AMI family, volumes, labels, taints, subnets, and IAM) are not currently diffed, so update will not detect those changes.
+- `ksail cluster update` applies `desiredCapacity`, `minSize`, and `maxSize` changes to existing managed node groups in-place. Adding a managed node group requires the experimental opt-in above; without it, additions require cluster recreation. Changing an instance type or removing a managed node group still requires recreation. Other fields on existing groups (including AMI family, volumes, labels, taints, subnets, and IAM) are not currently diffed, so update will not detect those changes.
 - KSail-managed component installation (CNI/CSI/GitOps/security add-ons beyond eksctl's built-ins) is still in progress — the AWS Load Balancer Controller is available behind the experimental `spec.cluster.eks.experimentalAWSLoadBalancerController` opt-in; see [Support Matrix](/support-matrix/)
 
 ## Related

--- a/docs/src/content/docs/distributions/eks.mdx
+++ b/docs/src/content/docs/distributions/eks.mdx
@@ -157,6 +157,15 @@ reports an addition as applied only after the live managed group is `ACTIVE` and
 its declared capacity and instance type match. A `ksail.io/nodegroup-creation-id`
 tag identifies the group created by that update.
 
+Before applying any changes, KSail checks each addition against a conservative
+50-slot tag budget. It counts metadata tags both in the stack and in the merged
+group tags, includes the ownership marker and eksctl node-group identifiers, and
+reserves four slots for eksctl stack identifiers and generated resource names.
+This reserve also applies when an external role or launch template needs fewer
+tags. With no metadata tags, up to 43 distinct user tag keys fit this budget;
+metadata tags reduce that allowance. Existing groups and scaling are unaffected.
+Other AWS and eksctl tag restrictions still apply.
+
 The selected AWS identity also needs `eks:ListNodegroups`,
 `eks:DescribeNodegroup`, and `cloudformation:ListStacks` read permissions. KSail
 reads every inventory page and refuses creation if a live or unfinished eksctl

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.45.1
 	github.com/aws/aws-sdk-go-v2/config v1.33.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.1
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.79.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.92.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.47.1
 	github.com/aws/smithy-go v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -443,6 +443,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 h1:K0JsbZQj+1h208Ro1zH
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1/go.mod h1:W3/vL6EtCIatICGy9ab29QhMuae+cOKPWcMxv02CO+Q=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1 h1:yhw5KD1phVyP9vijxOUzDfEtJx+bt+L63k+VfuiYFAA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1/go.mod h1:ZW2e0d7DYlRxlS9hEiMXE47gTdX5KRN4byUiNbUpG+Q=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.79.0 h1:QdGV83ods5B0cb1KIc79QhabvneqkRk8FR1bi3w2k30=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.79.0/go.mod h1:Qu13pjg01PcSNWKQVqdC19JK/FkT5q9m+J+dyTwfZjw=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3 h1:RtGctYMmkTerGClvdY6bHXdtly4FeYw9wz/NPz62LF8=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3/go.mod h1:vBfBu24Ka3/5UZtepbTV0gnc9VPLT8ok+0oDDaYAzn4=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.10 h1:1A/sI3LNMi3fhRI5TFLMwwo7ALAALSFVCSGvFlr1Iys=

--- a/pkg/apis/cluster/v1alpha1/options.go
+++ b/pkg/apis/cluster/v1alpha1/options.go
@@ -14,6 +14,14 @@ type OptionsVanilla struct {
 
 // OptionsEKS defines options specific to the EKS distribution.
 type OptionsEKS struct {
+	// ExperimentalManagedNodegroupCreation allows cluster update to create managed
+	// node groups added to eksctl.yaml. Default false: additions require recreation.
+	// Existing managed node-group scaling does not require this option. Removals
+	// and instance-type changes still require recreation. Creation requires a
+	// verified cluster identity and remains experimental pending live EKS validation.
+	// Graduation: https://github.com/devantler-tech/ksail/issues/6923.
+	ExperimentalManagedNodegroupCreation bool `json:"experimentalManagedNodegroupCreation,omitzero" jsonschema_description:"Experimental: allow cluster update to create managed node groups added to eksctl.yaml. Default false. Requires verified cluster ownership; removals and instance-type changes still require recreation. Pending live EKS validation."` //nolint:lll // generated-schema description
+
 	// ExperimentalAWSLoadBalancerController enables installing the AWS Load
 	// Balancer Controller as the cluster's LoadBalancer component when
 	// spec.cluster.loadBalancer is Enabled. Default false: EKS keeps its

--- a/pkg/cli/cmd/cluster/eks_lifecycle_test.go
+++ b/pkg/cli/cmd/cluster/eks_lifecycle_test.go
@@ -90,7 +90,7 @@ elif [ "$1 $2" = "get nodegroup" ]; then
 		current_min=2
 	fi
 	printf '[{"Cluster":"%s","Name":"workers","Status":"ACTIVE",' "$KSAIL_EKS_CLUSTER"
-	printf '"DesiredCapacity":%s,"MinSize":%s,"MaxSize":4,"NodeGroupType":"managed"}]\n' \
+	printf '"DesiredCapacity":%s,"MinSize":%s,"MaxSize":4,"Type":"managed"}]\n' \
 		"$current_desired" "$current_min"
 fi
 `
@@ -464,7 +464,7 @@ case "$1 $2" in
   'get nodegroup')
     capacity=$(cat "$KSAIL_EKS_BARRIER_DIR/capacity")
     printf '[{"Cluster":"%s","Name":"workers","Status":"ACTIVE",' "$KSAIL_EKS_CLUSTER"
-    printf '"DesiredCapacity":%s,"MinSize":%s,"MaxSize":4,"NodeGroupType":"managed"}]\n' "$capacity" "$capacity"
+    printf '"DesiredCapacity":%s,"MinSize":%s,"MaxSize":4,"Type":"managed"}]\n' "$capacity" "$capacity"
     ;;
   'scale nodegroup')
     case " $* " in

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -11,6 +11,7 @@ import (
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -79,6 +80,8 @@ type callerIdentityGetter interface {
 // Client reads EKS cluster connection details and mints bearer tokens for
 // them, hiding the SDK's request shapes and the token encoding scheme.
 type Client struct {
+	nodegroupStacks           *cloudformation.Client
+	nodegroups                *awseks.Client
 	describer                 clusterDescriber
 	presigner                 callerIdentityPresigner
 	identityGetter            callerIdentityGetter
@@ -342,6 +345,14 @@ func (c *Client) configureMissingSDKClients(ctx context.Context, region string) 
 
 	if c.describer == nil {
 		c.describer = awseks.NewFromConfig(cfg)
+	}
+
+	if c.nodegroups == nil {
+		c.nodegroups = awseks.NewFromConfig(cfg)
+	}
+
+	if c.nodegroupStacks == nil {
+		c.nodegroupStacks = cloudformation.NewFromConfig(cfg)
 	}
 
 	c.configureMissingSTSClients(cfg)

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -201,7 +201,7 @@ func NewClientWithCredentialRequirement(
 }
 
 // NewClient constructs a Client. Unless the existing DescribeCluster and token-presigning seams are
-// both injected, it resolves the AWS configuration once and builds the missing SDK clients. A
+// both injected without WithAWSConfig, it resolves the AWS configuration once and builds missing SDK clients. A
 // deliberately partial injected client must also provide WithCallerIdentityGetter before using
 // CallerAccountID; preserving that test seam avoids an unexpected config dependency for older
 // consumers that only need DescribeCluster and MintToken.
@@ -303,7 +303,7 @@ func (c *Client) MintToken(ctx context.Context, clusterName string) (string, err
 }
 
 func (c *Client) configureMissingSDKClients(ctx context.Context, region string) error {
-	if c.describer != nil && c.presigner != nil {
+	if c.describer != nil && c.presigner != nil && c.awsConfig == nil {
 		return nil
 	}
 

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -201,7 +201,8 @@ func NewClientWithCredentialRequirement(
 }
 
 // NewClient constructs a Client. Unless the existing DescribeCluster and token-presigning seams are
-// both injected without WithAWSConfig, it resolves the AWS configuration once and builds missing SDK clients. A
+// both injected without explicit AWS configuration or credentials, it resolves the AWS
+// configuration once and builds missing SDK clients. A
 // deliberately partial injected client must also provide WithCallerIdentityGetter before using
 // CallerAccountID; preserving that test seam avoids an unexpected config dependency for older
 // consumers that only need DescribeCluster and MintToken.
@@ -303,7 +304,7 @@ func (c *Client) MintToken(ctx context.Context, clusterName string) (string, err
 }
 
 func (c *Client) configureMissingSDKClients(ctx context.Context, region string) error {
-	if c.describer != nil && c.presigner != nil && c.awsConfig == nil {
+	if c.describer != nil && c.presigner != nil && !c.hasExplicitAWSConfiguration() {
 		return nil
 	}
 
@@ -347,6 +348,10 @@ func (c *Client) configureMissingSDKClients(ctx context.Context, region string) 
 	c.configureMissingSTSClients(cfg)
 
 	return nil
+}
+
+func (c *Client) hasExplicitAWSConfiguration() bool {
+	return c.awsConfig != nil || c.staticCredentialProvider != nil || len(c.loadOptions) > 0
 }
 
 func (c *Client) configureMissingEKSClients(cfg aws.Config) {

--- a/pkg/client/eks/client.go
+++ b/pkg/client/eks/client.go
@@ -343,6 +343,13 @@ func (c *Client) configureMissingSDKClients(ctx context.Context, region string) 
 		}
 	}
 
+	c.configureMissingEKSClients(cfg)
+	c.configureMissingSTSClients(cfg)
+
+	return nil
+}
+
+func (c *Client) configureMissingEKSClients(cfg aws.Config) {
 	if c.describer == nil {
 		c.describer = awseks.NewFromConfig(cfg)
 	}
@@ -354,10 +361,6 @@ func (c *Client) configureMissingSDKClients(ctx context.Context, region string) 
 	if c.nodegroupStacks == nil {
 		c.nodegroupStacks = cloudformation.NewFromConfig(cfg)
 	}
-
-	c.configureMissingSTSClients(cfg)
-
-	return nil
 }
 
 func (c *Client) configureMissingSTSClients(cfg aws.Config) {

--- a/pkg/client/eks/injected_credentials_test.go
+++ b/pkg/client/eks/injected_credentials_test.go
@@ -1,0 +1,118 @@
+package eks_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInjectedClientsKeepExplicitCredentialInventory catches initialization that
+// skips EKS or CloudFormation inventory when only the older seams are injected.
+func TestInjectedClientsKeepExplicitCredentialInventory(t *testing.T) {
+	for _, source := range []string{"static", "profile"} {
+		t.Run(source, func(t *testing.T) {
+			option, accessKey := injectedInventoryCredentials(t, source)
+			calls := 0
+			server := httptest.NewServer(injectedInventoryHandler(t, accessKey, &calls))
+			t.Cleanup(server.Close)
+			t.Setenv("AWS_ENDPOINT_URL", server.URL)
+			t.Setenv("AWS_ENDPOINT_URL_EKS", server.URL)
+			t.Setenv("AWS_ENDPOINT_URL_CLOUDFORMATION", server.URL)
+			t.Setenv("AWS_IGNORE_CONFIGURED_ENDPOINT_URLS", "false")
+			client, err := eksclient.NewClient(t.Context(), "us-east-1",
+				eksclient.WithClusterDescriber(fakeDescriber{}),
+				eksclient.WithCallerIdentityPresigner(fakePresigner{}),
+				option,
+			)
+			require.NoError(t, err)
+			groups, err := client.ListManagedNodegroups(t.Context(), "demo")
+			require.NoError(t, err)
+			assert.Empty(t, groups)
+			exists, err := client.NodegroupStackExists(t.Context(), "demo", "workers")
+			require.NoError(t, err)
+			assert.False(t, exists)
+			assert.Equal(t, 2, calls)
+		})
+	}
+}
+
+func injectedInventoryCredentials(t *testing.T, source string) (eksclient.Option, string) {
+	t.Helper()
+	dir := t.TempDir()
+	credentialsFile := filepath.Join(dir, "credentials")
+	configFile := filepath.Join(dir, "config")
+
+	require.NoError(t, os.WriteFile(
+		credentialsFile,
+		[]byte(
+			"[selected]\naws_access_key_id = PROFILEACCESS\naws_secret_access_key = profile-secret\n",
+		),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(configFile, nil, 0o600))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credentialsFile)
+	t.Setenv("AWS_CONFIG_FILE", configFile)
+	t.Setenv("AWS_PROFILE", "missing-ambient-profile")
+	t.Setenv("AWS_DEFAULT_PROFILE", "missing-ambient-profile")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AMBIENTACCESS")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+
+	if source == "profile" {
+		return eksclient.WithCredentialValues("selected", "", "", ""), "PROFILEACCESS"
+	}
+
+	return eksclient.WithCredentialValues("", "STATICACCESS", "static-secret", ""), "STATICACCESS"
+}
+
+func injectedInventoryHandler(t *testing.T, accessKey string, calls *int) http.HandlerFunc {
+	t.Helper()
+
+	return func(writer http.ResponseWriter, request *http.Request) {
+		(*calls)++
+
+		assert.Contains(
+			t,
+			request.Header.Get("Authorization"),
+			"Credential="+accessKey+"/",
+		)
+		assert.NotContains(t, request.Header.Get("Authorization"), "AMBIENTACCESS")
+
+		if request.Method == http.MethodGet {
+			assert.Equal(t, "/clusters/demo/node-groups", request.URL.Path)
+			assert.Contains(
+				t,
+				request.Header.Get("Authorization"),
+				"/us-east-1/eks/aws4_request",
+			)
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"nodegroups":[]}`))
+
+			return
+		}
+
+		const maxFormBytes = 4096
+
+		request.Body = http.MaxBytesReader(writer, request.Body, maxFormBytes)
+		if !assert.NoError(t, request.ParseForm()) {
+			return
+		}
+
+		assert.Equal(t, "ListStacks", request.PostForm.Get("Action"))
+		assert.Contains(
+			t,
+			request.Header.Get("Authorization"),
+			"/us-east-1/cloudformation/aws4_request",
+		)
+		writer.Header().Set("Content-Type", "text/xml")
+		_, _ = writer.Write(
+			[]byte(stackResponseStart + `<StackSummaries/>` + stackResponseEnd),
+		)
+	}
+}

--- a/pkg/client/eks/nodegroup_stacks.go
+++ b/pkg/client/eks/nodegroup_stacks.go
@@ -1,0 +1,74 @@
+package eks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+)
+
+// NodegroupStackExists checks every CloudFormation summary page for the exact
+// eksctl stack name. This catches unmanaged groups and unfinished creates even
+// when eksctl's summary silently omits a failed DescribeStack result.
+func (c *Client) NodegroupStackExists(
+	ctx context.Context,
+	clusterName, groupName string,
+) (bool, error) {
+	if c.nodegroupStacks == nil || clusterName == "" || groupName == "" {
+		return false, errNodegroupInventory
+	}
+
+	target := "eksctl-" + clusterName + "-nodegroup-" + groupName
+
+	return c.stackExists(ctx, target)
+}
+
+func (c *Client) stackExists(ctx context.Context, target string) (bool, error) {
+	input := &cloudformation.ListStacksInput{}
+	seen := make(map[string]bool)
+
+	for {
+		page, err := c.nodegroupStacks.ListStacks(ctx, input)
+		if err != nil {
+			return false, fmt.Errorf("list EKS node-group stacks: %w", err)
+		}
+
+		if page == nil || page.StackSummaries == nil {
+			return false, errNodegroupInventory
+		}
+
+		found, err := nodegroupStackPageContains(page.StackSummaries, target)
+		if err != nil || found {
+			return found, err
+		}
+
+		token := aws.ToString(page.NextToken)
+		if token == "" {
+			return false, nil
+		}
+
+		if seen[token] {
+			return false, fmt.Errorf("%w: repeated stack pagination token", errNodegroupInventory)
+		}
+
+		seen[token] = true
+		input.NextToken = page.NextToken
+	}
+}
+
+func nodegroupStackPageContains(stacks []cftypes.StackSummary, target string) (bool, error) {
+	for _, stack := range stacks {
+		if aws.ToString(stack.StackName) == "" || stack.StackStatus == "" {
+			return false, errNodegroupInventory
+		}
+
+		if aws.ToString(stack.StackName) == target &&
+			stack.StackStatus != cftypes.StackStatusDeleteComplete {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/client/eks/nodegroup_stacks_test.go
+++ b/pkg/client/eks/nodegroup_stacks_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	stackResponseStart = `<ListStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">` +
+	maxStackRequestBytes = 1 << 10
+	stackResponseStart   = `<ListStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">` +
 		`<ListStacksResult>`
 	stackResponseEnd = `</ListStacksResult></ListStacksResponse>`
 )
@@ -37,6 +38,8 @@ func TestNodegroupStackExistsFindsCollisionAfterFirstPage(t *testing.T) {
 						request.Header.Get("Authorization"),
 						"/us-east-1/cloudformation/aws4_request",
 					)
+
+					request.Body = http.MaxBytesReader(writer, request.Body, maxStackRequestBytes)
 
 					if !assert.NoError(t, request.ParseForm()) {
 						return

--- a/pkg/client/eks/nodegroup_stacks_test.go
+++ b/pkg/client/eks/nodegroup_stacks_test.go
@@ -1,0 +1,89 @@
+package eks_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	stackResponseStart = `<ListStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">` +
+		`<ListStacksResult>`
+	stackResponseEnd = `</ListStacksResult></ListStacksResponse>`
+)
+
+func TestNodegroupStackExistsFindsCollisionAfterFirstPage(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{"CREATE_COMPLETE", "CREATE_IN_PROGRESS", "CREATE_FAILED", "DELETE_COMPLETE"} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+
+			pages := 0
+			client := newNodegroupHTTPClient(
+				t,
+				func(writer http.ResponseWriter, request *http.Request) {
+					pages++
+
+					assert.Contains(
+						t,
+						request.Header.Get("Authorization"),
+						"Credential=FROZENACCESS/",
+					)
+					assert.Contains(
+						t,
+						request.Header.Get("Authorization"),
+						"/us-east-1/cloudformation/aws4_request",
+					)
+
+					if !assert.NoError(t, request.ParseForm()) {
+						return
+					}
+
+					assert.Equal(t, "ListStacks", request.PostForm.Get("Action"))
+					writer.Header().Set("Content-Type", "text/xml")
+
+					if request.PostForm.Get("NextToken") == "" {
+						_, _ = writer.Write(
+							[]byte(
+								stackResponseStart + `<StackSummaries/><NextToken>next</NextToken>` + stackResponseEnd,
+							),
+						)
+
+						return
+					}
+
+					_, _ = writer.Write([]byte(stackResponseStart + `<StackSummaries><member>` +
+						`<StackName>eksctl-demo-nodegroup-workers</StackName><StackStatus>` + status +
+						`</StackStatus></member></StackSummaries>` + stackResponseEnd))
+				},
+			)
+			exists, err := client.NodegroupStackExists(t.Context(), "demo", "workers")
+			require.NoError(t, err)
+			assert.Equal(t, status != "DELETE_COMPLETE", exists)
+			assert.Equal(t, 2, pages)
+		})
+	}
+}
+
+func TestNodegroupStackExistsRejectsIncompleteInventory(t *testing.T) {
+	t.Parallel()
+
+	for _, response := range []string{
+		``, `<NextToken>repeat</NextToken><StackSummaries/>`,
+		`<StackSummaries><member><StackStatus>CREATE_COMPLETE</StackStatus></member></StackSummaries>`,
+	} {
+		t.Run(response, func(t *testing.T) {
+			t.Parallel()
+			client := newNodegroupHTTPClient(t, func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "text/xml")
+				_, _ = writer.Write([]byte(stackResponseStart + response + stackResponseEnd))
+			})
+			exists, err := client.NodegroupStackExists(t.Context(), "demo", "workers")
+			require.Error(t, err)
+			assert.False(t, exists)
+		})
+	}
+}

--- a/pkg/client/eks/nodegroups.go
+++ b/pkg/client/eks/nodegroups.go
@@ -1,0 +1,106 @@
+package eks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+var errNodegroupInventory = errors.New("EKS managed node-group inventory is incomplete")
+
+// ListManagedNodegroups reads every page and describes every group using the
+// client's frozen AWS configuration. A partial response never authorizes absence.
+// eksctl's bulk summary currently omits EKS pagination, so creation must not use
+// that summary alone to decide which managed groups exist.
+func (c *Client) ListManagedNodegroups(
+	ctx context.Context,
+	clusterName string,
+) ([]ekstypes.Nodegroup, error) {
+	if c.nodegroups == nil || clusterName == "" {
+		return nil, errNodegroupInventory
+	}
+
+	groups := make([]ekstypes.Nodegroup, 0)
+	seenNames := make(map[string]bool)
+	seenTokens := make(map[string]bool)
+
+	input := &awseks.ListNodegroupsInput{ClusterName: aws.String(clusterName)}
+	for {
+		page, err := c.nodegroups.ListNodegroups(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("list EKS managed nodegroups: %w", err)
+		}
+
+		if page == nil || page.Nodegroups == nil {
+			return nil, errNodegroupInventory
+		}
+
+		described, err := c.describeManagedPage(ctx, clusterName, page.Nodegroups, seenNames)
+		if err != nil {
+			return nil, err
+		}
+
+		groups = append(groups, described...)
+
+		token := aws.ToString(page.NextToken)
+		if token == "" {
+			return groups, nil
+		}
+
+		if seenTokens[token] {
+			return nil, fmt.Errorf("%w: repeated pagination token", errNodegroupInventory)
+		}
+
+		seenTokens[token] = true
+		input.NextToken = page.NextToken
+	}
+}
+
+func (c *Client) describeManagedNodegroup(
+	ctx context.Context,
+	clusterName, name string,
+) (*ekstypes.Nodegroup, error) {
+	output, err := c.nodegroups.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName: aws.String(clusterName), NodegroupName: aws.String(name),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe EKS managed nodegroup %s: %w", name, err)
+	}
+
+	if output == nil || output.Nodegroup == nil {
+		return nil, errNodegroupInventory
+	}
+
+	group := output.Nodegroup
+	if aws.ToString(group.ClusterName) != clusterName || aws.ToString(group.NodegroupName) != name {
+		return nil, fmt.Errorf("%w: node-group identity mismatch", errNodegroupInventory)
+	}
+
+	return group, nil
+}
+
+func (c *Client) describeManagedPage(
+	ctx context.Context, clusterName string, names []string, seen map[string]bool,
+) ([]ekstypes.Nodegroup, error) {
+	groups := make([]ekstypes.Nodegroup, 0, len(names))
+	for _, name := range names {
+		if name == "" || seen[name] {
+			return nil, fmt.Errorf("%w: duplicate or empty group name", errNodegroupInventory)
+		}
+
+		seen[name] = true
+
+		group, err := c.describeManagedNodegroup(ctx, clusterName, name)
+		if err != nil {
+			return nil, err
+		}
+
+		groups = append(groups, *group)
+	}
+
+	return groups, nil
+}

--- a/pkg/client/eks/nodegroups_test.go
+++ b/pkg/client/eks/nodegroups_test.go
@@ -14,12 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newNodegroupHTTPClient(t *testing.T, handler http.HandlerFunc) *eksclient.Client {
+func newNodegroupHTTPClient(
+	t *testing.T, handler http.HandlerFunc, options ...eksclient.Option,
+) *eksclient.Client {
 	t.Helper()
 
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
-	client, err := eksclient.NewClient(t.Context(), "us-east-1", eksclient.WithAWSConfig(aws.Config{
+	options = append(options, eksclient.WithAWSConfig(aws.Config{
 		Region:       "stale-region",
 		BaseEndpoint: aws.String(server.URL),
 		HTTPClient:   server.Client(),
@@ -30,6 +32,7 @@ func newNodegroupHTTPClient(t *testing.T, handler http.HandlerFunc) *eksclient.C
 		),
 		RetryMaxAttempts: 1,
 	}))
+	client, err := eksclient.NewClient(t.Context(), "us-east-1", options...)
 	require.NoError(t, err)
 
 	return client
@@ -167,4 +170,45 @@ func TestListManagedNodegroupsMissingNamesAreUnknown(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInjectedClientsKeepExplicitInventoryConfiguration checks that optional seams
+// do not suppress frozen EKS and CloudFormation inventory client construction.
+//
+
+func TestInjectedClientsKeepExplicitInventoryConfiguration(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "missing-injected-profile")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AMBIENTACCESS")
+
+	calls := 0
+	client := newNodegroupHTTPClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		calls++
+
+		assert.Contains(t, request.Header.Get("Authorization"), "Credential=FROZENACCESS/")
+
+		if request.Method == http.MethodGet {
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"nodegroups":[]}`))
+
+			return
+		}
+
+		writer.Header().Set("Content-Type", "text/xml")
+		_, _ = writer.Write([]byte(stackResponseStart + `<StackSummaries/>` + stackResponseEnd))
+	}, eksclient.WithClusterDescriber(fakeDescriber{}), eksclient.WithCallerIdentityPresigner(fakePresigner{}))
+	_, err := client.ListManagedNodegroups(t.Context(), "demo")
+	require.NoError(t, err)
+	exists, err := client.NodegroupStackExists(t.Context(), "demo", "workers")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, 2, calls)
+	_, err = eksclient.NewClient(
+		t.Context(),
+		"us-east-1",
+		eksclient.WithClusterDescriber(
+			fakeDescriber{},
+		),
+		eksclient.WithCallerIdentityPresigner(fakePresigner{}),
+	)
+	require.NoError(t, err, "injected-only construction must not load ambient configuration")
 }

--- a/pkg/client/eks/nodegroups_test.go
+++ b/pkg/client/eks/nodegroups_test.go
@@ -1,0 +1,170 @@
+package eks_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	eksclient "github.com/devantler-tech/ksail/v7/pkg/client/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newNodegroupHTTPClient(t *testing.T, handler http.HandlerFunc) *eksclient.Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := eksclient.NewClient(t.Context(), "us-east-1", eksclient.WithAWSConfig(aws.Config{
+		Region:       "stale-region",
+		BaseEndpoint: aws.String(server.URL),
+		HTTPClient:   server.Client(),
+		Credentials: credentials.NewStaticCredentialsProvider(
+			"FROZENACCESS",
+			"test-secret",
+			"",
+		),
+		RetryMaxAttempts: 1,
+	}))
+	require.NoError(t, err)
+
+	return client
+}
+
+func TestListManagedNodegroupsFollowsEveryPageAndPreservesFrozenCredentials(t *testing.T) {
+	t.Parallel()
+
+	var pages, descriptions int
+
+	client := newNodegroupHTTPClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		assert.Contains(t, request.Header.Get("Authorization"), "Credential=FROZENACCESS/")
+		assert.Contains(t, request.Header.Get("Authorization"), "/us-east-1/eks/aws4_request")
+		writer.Header().Set("Content-Type", "application/json")
+
+		switch request.URL.Path {
+		case "/clusters/demo/node-groups":
+			pages++
+
+			if request.URL.Query().Get("nextToken") == "second-page" {
+				_, _ = writer.Write([]byte(`{"nodegroups":["second"]}`))
+			} else {
+				_, _ = writer.Write([]byte(`{"nodegroups":["first"],"nextToken":"second-page"}`))
+			}
+		default:
+			descriptions++
+			name := strings.TrimPrefix(request.URL.Path, "/clusters/demo/node-groups/")
+			_ = json.NewEncoder(writer).Encode(map[string]any{"nodegroup": map[string]any{
+				"clusterName": "demo", "nodegroupName": name, "status": "ACTIVE",
+				"tags": map[string]string{"ksail.io/nodegroup-creation-id": "test-marker"},
+			}})
+		}
+	})
+	groups, err := client.ListManagedNodegroups(t.Context(), "demo")
+	require.NoError(t, err)
+	require.Len(t, groups, 2)
+	assert.Equal(t, 2, pages)
+	assert.Equal(t, 2, descriptions)
+	assert.Equal(t, "second", aws.ToString(groups[1].NodegroupName))
+	assert.Equal(t, "test-marker", groups[1].Tags["ksail.io/nodegroup-creation-id"])
+}
+
+func TestListManagedNodegroupsDoesNotReturnPartialInventory(t *testing.T) {
+	t.Parallel()
+
+	for _, scenario := range []string{
+		"page failure", "repeated token", "duplicate name", "missing describe", "wrong identity",
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			client := newNodegroupHTTPClient(t, nodegroupFailureHandler(scenario))
+			groups, err := client.ListManagedNodegroups(t.Context(), "demo")
+			require.Error(t, err)
+			assert.Nil(t, groups)
+		})
+	}
+}
+
+func nodegroupFailureHandler(scenario string) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+
+		if strings.HasSuffix(request.URL.Path, "/node-groups") {
+			if scenario == "page failure" && request.URL.Query().Get("nextToken") != "" {
+				writer.WriteHeader(http.StatusForbidden)
+
+				return
+			}
+
+			if scenario == "repeated token" {
+				_, _ = writer.Write([]byte(`{"nodegroups":[],"nextToken":"again"}`))
+
+				return
+			}
+
+			_, _ = writer.Write([]byte(`{"nodegroups":["first"],"nextToken":"again"}`))
+
+			return
+		}
+
+		if scenario == "missing describe" {
+			_, _ = writer.Write([]byte(`{}`))
+
+			return
+		}
+
+		clusterName := "demo"
+		if scenario == "wrong identity" {
+			clusterName = "other"
+		}
+
+		_, _ = writer.Write(
+			[]byte(`{"nodegroup":{"clusterName":"` + clusterName + `","nodegroupName":"first"}}`),
+		)
+	}
+}
+
+func TestListManagedNodegroupsEmptyInventoryIsAnExplicitSlice(t *testing.T) {
+	t.Parallel()
+	client := newNodegroupHTTPClient(t, func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"nodegroups":[]}`))
+	})
+	groups, err := client.ListManagedNodegroups(t.Context(), "demo")
+	require.NoError(t, err)
+	assert.NotNil(t, groups)
+	assert.Empty(t, groups)
+}
+
+func TestListManagedNodegroupsMissingNamesAreUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, malformed := range []string{`{}`, `{"nodegroups":null}`} {
+		t.Run(malformed, func(t *testing.T) {
+			t.Parallel()
+
+			for _, laterPage := range []bool{false, true} {
+				client := newNodegroupHTTPClient(
+					t,
+					func(writer http.ResponseWriter, request *http.Request) {
+						writer.Header().Set("Content-Type", "application/json")
+
+						if laterPage && request.URL.Query().Get("nextToken") == "" {
+							_, _ = writer.Write([]byte(`{"nodegroups":[],"nextToken":"later"}`))
+
+							return
+						}
+
+						_, _ = writer.Write([]byte(malformed))
+					},
+				)
+				groups, err := client.ListManagedNodegroups(t.Context(), "demo")
+				require.Error(t, err)
+				assert.Nil(t, groups)
+			}
+		})
+	}
+}

--- a/pkg/client/eksctl/client_test.go
+++ b/pkg/client/eksctl/client_test.go
@@ -491,7 +491,7 @@ func TestListNodegroups_HappyPath(t *testing.T) {
 	runner := &fakeRunner{
 		stdout: []byte(`[{"Cluster":"demo","Name":"ng-1","Status":"ACTIVE",
 			"DesiredCapacity":2,"MinSize":1,"MaxSize":3,
-			"InstanceType":"t3.medium","NodeGroupType":"managed","Version":"1.31"}]`),
+			"InstanceType":"t3.medium","Type":"managed","Version":"1.31"}]`),
 	}
 	client := newTestClient(runner)
 

--- a/pkg/client/eksctl/commands.go
+++ b/pkg/client/eksctl/commands.go
@@ -49,7 +49,7 @@ type NodegroupSummary struct {
 	InstanceType  string `json:"InstanceType"`
 	ImageID       string `json:"ImageID"`
 	CreationTime  string `json:"CreationTime"`
-	NodeGroupType string `json:"NodeGroupType"`
+	NodeGroupType string `json:"Type"`
 	Version       string `json:"Version"`
 }
 
@@ -83,6 +83,18 @@ func (c *Client) createCluster(
 	}
 
 	_, _, err := c.Exec(ctx, args...)
+
+	return err
+}
+
+// CreateNodegroup creates the node groups in a config file. The caller supplies
+// a config containing only the intended additions and the verified target.
+func (c *Client) CreateNodegroup(ctx context.Context, configPath string) error {
+	if strings.TrimSpace(configPath) == "" {
+		return ErrEmptyConfigPath
+	}
+
+	_, _, err := c.Exec(ctx, "create", "nodegroup", "--config-file", configPath)
 
 	return err
 }

--- a/pkg/svc/provider/aws/provider_test.go
+++ b/pkg/svc/provider/aws/provider_test.go
@@ -166,9 +166,9 @@ func TestListNodes_MapsNodegroupsToNodeInfo(t *testing.T) {
 	prov, _ := newProvider(t, map[string][]response{
 		"get nodegroup": {{stdout: []byte(`[
 			{"Cluster":"demo","Name":"ng-1","Status":"ACTIVE","DesiredCapacity":2,
-			 "MinSize":1,"MaxSize":3,"NodeGroupType":"managed"},
+			 "MinSize":1,"MaxSize":3,"Type":"managed"},
 			{"Cluster":"demo","Name":"ng-2","Status":"CREATING","DesiredCapacity":1,
-			 "MinSize":1,"MaxSize":2,"NodeGroupType":"managed"}
+			 "MinSize":1,"MaxSize":2,"Type":"managed"}
 		]`)}},
 	})
 

--- a/pkg/svc/provisioner/cluster/eks/creation.go
+++ b/pkg/svc/provisioner/cluster/eks/creation.go
@@ -1,0 +1,388 @@
+package eksprovisioner
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"maps"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	errInvalidNodegroupConfig = errors.New("invalid managed node-group creation config")
+	errUnknownNodegroupState  = errors.New("managed node-group state is not authoritative")
+	errNodegroupPlanChanged   = errors.New(
+		"EKS node-group update plan changed; run cluster update again",
+	)
+	errNodegroupIdentityRequired = errors.New(
+		"managed node-group creation requires a verified cluster name and region",
+	)
+	errNodegroupNotConverged = errors.New(
+		"created managed node group is not ACTIVE with the declared settings",
+	)
+	managedNodegroupName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$`)
+)
+
+// nodegroupCreationPlan holds the exact source read for this Update invocation.
+// Full group objects preserve advanced eksctl settings; the typed subset drives
+// the diff. No later read can silently replace the declaration being applied.
+type nodegroupCreationPlan struct {
+	path        string
+	source      []byte
+	config      map[string]any
+	desired     []managedNodeGroupConfig
+	groups      map[string]map[string]any
+	additions   map[string]bool
+	operationID string
+}
+
+func (u *UpdatableProvisioner) updateWithNodegroupCreation(
+	ctx context.Context,
+	name string,
+	oldSpec, newSpec *v1alpha1.ClusterSpec,
+	opts clusterupdate.UpdateOptions,
+) (*clusterupdate.UpdateResult, error) {
+	var plan *nodegroupCreationPlan
+
+	diff := func(ctx context.Context, name string, _, _ *v1alpha1.ClusterSpec) (*clusterupdate.UpdateResult, error) {
+		var (
+			result *clusterupdate.UpdateResult
+			err    error
+		)
+
+		plan, result, err = u.planNodegroupCreation(ctx, name)
+
+		return result, err
+	}
+	apply := func(ctx context.Context, name string, result *clusterupdate.UpdateResult) error {
+		if plan == nil || !result.HasInPlaceChanges() {
+			return nil
+		}
+
+		return u.applyNodegroupPlan(ctx, name, plan, result)
+	}
+
+	//nolint:wrapcheck // RunUpdate adds the operation context.
+	return clusterupdate.RunUpdate(ctx, name, oldSpec, newSpec, opts,
+		clustererr.ErrRecreationRequired, diff, apply, "failed to update managed nodegroups")
+}
+
+func (u *UpdatableProvisioner) planNodegroupCreation(
+	ctx context.Context, name string,
+) (*nodegroupCreationPlan, *clusterupdate.UpdateResult, error) {
+	result := clusterupdate.NewEmptyUpdateResult()
+	if strings.TrimSpace(u.configPath) == "" {
+		return nil, result, nil
+	}
+
+	plan, err := readNodegroupCreationPlan(u.configPath)
+	if err != nil {
+		return nil, result, err
+	}
+
+	live, err := u.listCreationNodegroups(ctx, name, plan.desired)
+	if err != nil {
+		return nil, result, err
+	}
+
+	for _, group := range plan.desired {
+		_, exists := live.groups[group.Name]
+		plan.additions[group.Name] = !exists
+	}
+
+	return plan, diffManagedNodegroups(plan.desired, live.groups, true), nil
+}
+
+func readNodegroupCreationPlan(path string) (*nodegroupCreationPlan, error) {
+	canonical, err := fsutil.EvalCanonicalPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize EKS node-group config: %w", err)
+	}
+
+	data, err := fsutil.ReadFileSafe(filepath.Dir(canonical), canonical)
+	if err != nil {
+		return nil, fmt.Errorf("read EKS node-group config: %w", err)
+	}
+
+	plan := &nodegroupCreationPlan{
+		path: canonical, source: data, groups: make(map[string]map[string]any),
+		additions: make(map[string]bool), operationID: rand.Text(),
+	}
+
+	err = plan.parse()
+	if err != nil {
+		return nil, err
+	}
+
+	return plan, nil
+}
+
+func (p *nodegroupCreationPlan) parse() error {
+	err := yaml.UnmarshalStrict(p.source, &p.config)
+	if err != nil {
+		return fmt.Errorf("parse EKS node-group config: %w", err)
+	}
+
+	_, metadataOK := p.config["metadata"].(map[string]any)
+	if !metadataOK || p.config["apiVersion"] != "eksctl.io/v1alpha5" ||
+		p.config["kind"] != "ClusterConfig" {
+		return errInvalidNodegroupConfig
+	}
+
+	var typed struct {
+		ManagedNodeGroups []managedNodeGroupConfig `json:"managedNodeGroups"`
+	}
+
+	err = yaml.Unmarshal(p.source, &typed)
+	if err != nil {
+		return fmt.Errorf("parse managed node-group settings: %w", err)
+	}
+
+	p.desired = typed.ManagedNodeGroups
+
+	return p.indexDesiredGroups()
+}
+
+func (p *nodegroupCreationPlan) indexDesiredGroups() error {
+	rawGroups, _ := p.config["managedNodeGroups"].([]any)
+	if len(rawGroups) != len(p.desired) {
+		return errInvalidNodegroupConfig
+	}
+
+	for index, group := range p.desired {
+		if !managedNodegroupName.MatchString(group.Name) || p.groups[group.Name] != nil {
+			return fmt.Errorf(
+				"%w: invalid or duplicate name %q",
+				errInvalidNodegroupConfig,
+				group.Name,
+			)
+		}
+
+		rawGroup, valid := rawGroups[index].(map[string]any)
+		if !valid || rawGroup["name"] != group.Name {
+			return errInvalidNodegroupConfig
+		}
+
+		if tags, declared := rawGroup["tags"]; declared {
+			if _, valid := tags.(map[string]any); !valid {
+				return errInvalidNodegroupConfig
+			}
+		}
+
+		p.groups[group.Name] = rawGroup
+	}
+
+	return nil
+}
+
+func (u *UpdatableProvisioner) applyNodegroupPlan(
+	ctx context.Context,
+	name string,
+	plan *nodegroupCreationPlan,
+	result *clusterupdate.UpdateResult,
+) error {
+	for _, group := range plan.desired {
+		changes, err := u.refreshAndApplyNodegroup(ctx, name, plan, group)
+		if err != nil {
+			result.FailedChanges = append(result.FailedChanges, clusterupdate.Change{
+				Field: nodegroupField(group.Name), Reason: err.Error(),
+			})
+
+			return fmt.Errorf("update nodegroup %s: %w", group.Name, err)
+		}
+
+		result.AppliedChanges = append(result.AppliedChanges, changes...)
+	}
+
+	return nil
+}
+
+func (u *UpdatableProvisioner) refreshAndApplyNodegroup(
+	ctx context.Context, name string, plan *nodegroupCreationPlan, group managedNodeGroupConfig,
+) ([]clusterupdate.Change, error) {
+	live, err := u.listCreationNodegroups(ctx, name, plan.desired)
+	if err != nil {
+		return nil, err
+	}
+
+	if diffManagedNodegroups(plan.desired, maps.Clone(live.groups), true).HasRecreateRequired() {
+		return nil, errNodegroupPlanChanged
+	}
+
+	for _, desired := range plan.desired {
+		if _, exists := live.groups[desired.Name]; !exists && !plan.additions[desired.Name] {
+			return nil, fmt.Errorf("%w: %s disappeared", errNodegroupPlanChanged, desired.Name)
+		}
+	}
+
+	return u.applyPlannedNodegroup(ctx, name, plan, group, live)
+}
+
+func (u *UpdatableProvisioner) applyPlannedNodegroup(
+	ctx context.Context, name string, plan *nodegroupCreationPlan,
+	group managedNodeGroupConfig, live *creationInventory,
+) ([]clusterupdate.Change, error) {
+	liveGroup, exists := live.groups[group.Name]
+	if !exists {
+		err := u.createPlannedNodegroup(ctx, name, plan, group)
+		if err != nil {
+			return nil, err
+		}
+
+		return []clusterupdate.Change{nodegroupCreationChange(group.Name)}, nil
+	}
+
+	if plan.additions[group.Name] {
+		return nil, fmt.Errorf(
+			"%w: %s appeared after planning",
+			errNodegroupPlanChanged,
+			group.Name,
+		)
+	}
+
+	changes := scalingChanges(group, liveGroup)
+	if len(changes) == 0 {
+		return nil, nil
+	}
+
+	err := u.verifyNodegroupPlan(ctx, name, plan)
+	if err != nil {
+		return nil, err
+	}
+
+	desired, minimum, maximum := nodegroupScaleTargets(group, liveGroup)
+
+	err = u.client.ScaleNodegroup(ctx, u.name, group.Name, u.region, desired, minimum, maximum)
+	if err != nil {
+		return nil, fmt.Errorf("scale managed nodegroup: %w", err)
+	}
+
+	return changes, nil
+}
+
+func (u *UpdatableProvisioner) createPlannedNodegroup(
+	ctx context.Context, name string, plan *nodegroupCreationPlan, group managedNodeGroupConfig,
+) error {
+	config := maps.Clone(plan.config)
+	metadata, _ := config["metadata"].(map[string]any)
+	metadata = maps.Clone(metadata)
+	metadata["name"], metadata["region"] = u.name, u.region
+	config["metadata"] = metadata
+	rawGroup := plan.groups[group.Name]
+	effectiveGroup := maps.Clone(rawGroup)
+	tags, _ := rawGroup["tags"].(map[string]any)
+	effectiveTags := make(map[string]any, len(tags)+1)
+	maps.Copy(effectiveTags, tags)
+	effectiveTags[nodegroupCreationTag] = plan.operationID
+	effectiveGroup["tags"] = effectiveTags
+	config["managedNodeGroups"] = []any{effectiveGroup}
+	delete(config, "nodeGroups")
+
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal managed node-group creation config: %w", err)
+	}
+
+	path, cleanup, err := writeEffectiveCreateConfig(data)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	err = u.verifyCreationStackAbsent(ctx, name, group.Name)
+	if err != nil {
+		return err
+	}
+
+	// The private snapshot is complete before the identity check. The same
+	// credential-bound client used for the read executes this exact file.
+	err = u.verifyNodegroupPlan(ctx, name, plan)
+	if err != nil {
+		return err
+	}
+
+	err = u.client.CreateNodegroup(ctx, path)
+	if err != nil {
+		return fmt.Errorf("create managed nodegroup: %w", err)
+	}
+
+	live, err := u.listCreationNodegroups(ctx, name, plan.desired)
+	if err != nil {
+		return err
+	}
+
+	created, exists := live.groups[group.Name]
+	if !exists || !nodegroupConverged(group, created) ||
+		live.creationIDs[group.Name] != plan.operationID {
+		return fmt.Errorf(
+			"%w: %s; inspect EKS before retrying",
+			errNodegroupNotConverged,
+			group.Name,
+		)
+	}
+
+	return nil
+}
+
+func (u *UpdatableProvisioner) verifyNodegroupPlan(
+	ctx context.Context, name string, plan *nodegroupCreationPlan,
+) error {
+	if u.ownershipVerifier == nil || u.name == "" || u.region == "" ||
+		u.resolveName(name) != u.name {
+		return errNodegroupIdentityRequired
+	}
+
+	err := eksidentity.VerifyBeforeMutation(ctx, u.ownershipVerifier)
+	if err != nil {
+		return fmt.Errorf("verify EKS ownership before node-group update: %w", err)
+	}
+
+	return plan.verifySource(ctx, u.configPath)
+}
+
+func (p *nodegroupCreationPlan) verifySource(ctx context.Context, sourcePath string) error {
+	canonical, err := fsutil.EvalCanonicalPath(sourcePath)
+	if err != nil {
+		return fmt.Errorf("recheck EKS config path: %w", err)
+	}
+
+	data, err := fsutil.ReadFileSafe(filepath.Dir(canonical), canonical)
+	if err != nil {
+		return fmt.Errorf("recheck EKS config: %w", err)
+	}
+
+	if canonical != p.path || !bytes.Equal(data, p.source) {
+		return errNodegroupPlanChanged
+	}
+
+	err = ctx.Err()
+	if err != nil {
+		return fmt.Errorf("node-group update canceled: %w", err)
+	}
+
+	return nil
+}
+
+func nodegroupConverged(group managedNodeGroupConfig, live eksctl.NodegroupSummary) bool {
+	return live.Status == "ACTIVE" && len(scalingChanges(group, live)) == 0 &&
+		(group.InstanceType == "" || group.InstanceType == live.InstanceType)
+}
+
+func nodegroupCreationChange(name string) clusterupdate.Change {
+	return clusterupdate.Change{
+		Field: nodegroupField(name), NewValue: name, Category: clusterupdate.ChangeCategoryInPlace,
+		Reason: "experimental managed node-group creation is enabled",
+	}
+}

--- a/pkg/svc/provisioner/cluster/eks/creation.go
+++ b/pkg/svc/provisioner/cluster/eks/creation.go
@@ -104,7 +104,16 @@ func (u *UpdatableProvisioner) planNodegroupCreation(
 
 	for _, group := range plan.desired {
 		_, exists := live.groups[group.Name]
+
 		plan.additions[group.Name] = !exists
+		if exists {
+			continue
+		}
+
+		err = plan.validateCreationTagBudget(group.Name)
+		if err != nil {
+			return nil, result, err
+		}
 	}
 
 	return plan, diffManagedNodegroups(plan.desired, live.groups, true), nil

--- a/pkg/svc/provisioner/cluster/eks/creation.go
+++ b/pkg/svc/provisioner/cluster/eks/creation.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -88,6 +89,10 @@ func (u *UpdatableProvisioner) planNodegroupCreation(
 	}
 
 	plan, err := readNodegroupCreationPlan(u.configPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, result, nil
+	}
+
 	if err != nil {
 		return nil, result, err
 	}

--- a/pkg/svc/provisioner/cluster/eks/creation_inventory.go
+++ b/pkg/svc/provisioner/cluster/eks/creation_inventory.go
@@ -1,0 +1,218 @@
+package eksprovisioner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+)
+
+const nodegroupCreationTag = "ksail.io/nodegroup-creation-id"
+
+type managedNodegroupReader interface {
+	ListManagedNodegroups(ctx context.Context, name string) ([]ekstypes.Nodegroup, error)
+}
+
+type creationInventory struct {
+	groups      map[string]eksctl.NodegroupSummary
+	creationIDs map[string]string
+}
+
+// listCreationNodegroups uses paginated SDK results for managed groups. eksctl
+// supplies additional names to cross-check. Its summary can be incomplete, so
+// absence also requires a direct CloudFormation stack check before creation.
+func (u *UpdatableProvisioner) listCreationNodegroups(
+	ctx context.Context, name string, desired []managedNodeGroupConfig,
+) (*creationInventory, error) {
+	clusterName := u.resolveName(name)
+
+	live, err := u.client.ListNodegroups(ctx, clusterName, u.region)
+	if err != nil {
+		return nil, fmt.Errorf("list nodegroups: %w", err)
+	}
+
+	listed, err := indexCreationSummary(live, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	inventory, err := u.readManagedInventory(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	for groupName, group := range listed {
+		_, managed := inventory.groups[groupName]
+		if managed != strings.EqualFold(group.NodeGroupType, "managed") {
+			return nil, fmt.Errorf(
+				"%w: inventory disagrees about %s",
+				errUnknownNodegroupState,
+				groupName,
+			)
+		}
+	}
+
+	for _, group := range desired {
+		if entry, exists := listed[group.Name]; exists &&
+			strings.EqualFold(entry.NodeGroupType, "unmanaged") {
+			return nil, fmt.Errorf(
+				"%w: %s already exists as an unmanaged group",
+				errUnknownNodegroupState,
+				group.Name,
+			)
+		}
+	}
+
+	return inventory, nil
+}
+
+func (u *UpdatableProvisioner) verifyCreationStackAbsent(
+	ctx context.Context,
+	name, groupName string,
+) error {
+	api, err := u.resolveAWSClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	reader, supported := api.(interface {
+		NodegroupStackExists(ctx context.Context, clusterName, groupName string) (bool, error)
+	})
+	if !supported {
+		return errUnknownNodegroupState
+	}
+
+	exists, err := reader.NodegroupStackExists(ctx, u.resolveName(name), groupName)
+	if err != nil {
+		return fmt.Errorf("verify node-group stack absence: %w", err)
+	}
+
+	if exists {
+		return fmt.Errorf("%w: a stack already exists for %s", errNodegroupPlanChanged, groupName)
+	}
+
+	return nil
+}
+
+func indexCreationSummary(
+	live []eksctl.NodegroupSummary,
+	clusterName string,
+) (map[string]eksctl.NodegroupSummary, error) {
+	if live == nil {
+		return nil, fmt.Errorf(
+			"%w: expected a JSON array, received empty or null output",
+			errUnknownNodegroupState,
+		)
+	}
+
+	seen := make(map[string]eksctl.NodegroupSummary, len(live))
+	for _, group := range live {
+		_, duplicate := seen[group.Name]
+		if group.Name == "" || duplicate || group.Cluster != clusterName {
+			return nil, fmt.Errorf(
+				"%w: invalid, duplicate or wrong-cluster entry %q",
+				errUnknownNodegroupState,
+				group.Name,
+			)
+		}
+
+		if !strings.EqualFold(group.NodeGroupType, "managed") &&
+			!strings.EqualFold(group.NodeGroupType, "unmanaged") {
+			return nil, fmt.Errorf(
+				"%w: unknown group type for %s",
+				errUnknownNodegroupState,
+				group.Name,
+			)
+		}
+
+		seen[group.Name] = group
+	}
+
+	return seen, nil
+}
+
+func (u *UpdatableProvisioner) readManagedInventory(
+	ctx context.Context,
+	clusterName string,
+) (*creationInventory, error) {
+	api, err := u.resolveAWSClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	reader, supported := api.(managedNodegroupReader)
+	if !supported {
+		return nil, errUnknownNodegroupState
+	}
+
+	groups, err := reader.ListManagedNodegroups(ctx, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("read complete managed node-group inventory: %w", err)
+	}
+
+	if groups == nil {
+		return nil, errUnknownNodegroupState
+	}
+
+	inventory := &creationInventory{
+		groups:      make(map[string]eksctl.NodegroupSummary, len(groups)),
+		creationIDs: make(map[string]string, len(groups)),
+	}
+	for _, group := range groups {
+		summary, err := managedCreationSummary(group, clusterName)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, duplicate := inventory.groups[summary.Name]; duplicate {
+			return nil, errUnknownNodegroupState
+		}
+
+		inventory.groups[summary.Name] = summary
+		inventory.creationIDs[summary.Name] = group.Tags[nodegroupCreationTag]
+	}
+
+	return inventory, nil
+}
+
+func managedCreationSummary(
+	group ekstypes.Nodegroup,
+	clusterName string,
+) (eksctl.NodegroupSummary, error) {
+	name := aws.ToString(group.NodegroupName)
+	if name == "" || aws.ToString(group.ClusterName) != clusterName ||
+		group.Status != ekstypes.NodegroupStatusActive {
+		return eksctl.NodegroupSummary{}, fmt.Errorf(
+			"%w: %s has status %q or wrong identity",
+			errUnknownNodegroupState,
+			name,
+			group.Status,
+		)
+	}
+
+	scaling := group.ScalingConfig
+	if scaling == nil || scaling.DesiredSize == nil || scaling.MinSize == nil ||
+		scaling.MaxSize == nil {
+		return eksctl.NodegroupSummary{}, fmt.Errorf(
+			"%w: %s has incomplete scaling settings",
+			errUnknownNodegroupState,
+			name,
+		)
+	}
+
+	return eksctl.NodegroupSummary{
+		Cluster:       clusterName,
+		Name:          name,
+		NodeGroupType: "managed",
+		Status:        string(group.Status),
+		DesiredCap: int(
+			*scaling.DesiredSize,
+		),
+		MinSize:      int(*scaling.MinSize),
+		MaxSize:      int(*scaling.MaxSize),
+		InstanceType: strings.Join(group.InstanceTypes, ","),
+	}, nil
+}

--- a/pkg/svc/provisioner/cluster/eks/creation_tags.go
+++ b/pkg/svc/provisioner/cluster/eks/creation_tags.go
@@ -1,0 +1,47 @@
+package eksprovisioner
+
+import "fmt"
+
+const (
+	// Reserve the three eksctl stack identifiers and generated resource Name tag,
+	// including when a particular external role/template would use fewer slots.
+	nodegroupCreationReservedTagSlots = 4
+	nodegroupCreationTagLimit         = 50
+)
+
+// validateCreationTagBudget bounds the supported experimental creation payload.
+// eksctl merges metadata into node-group tags, then appends metadata and group
+// tags separately to the CloudFormation tag array. Counting metadata twice is
+// intentional; an extra slot also reserves generated resource Name tags.
+func (p *nodegroupCreationPlan) validateCreationTagBudget(name string) error {
+	metadata, _ := p.config["metadata"].(map[string]any)
+
+	metadataTags, valid := metadata["tags"].(map[string]any)
+	if metadata["tags"] != nil && !valid {
+		return fmt.Errorf("%w: metadata.tags must be a mapping", errInvalidNodegroupConfig)
+	}
+
+	groupTags, _ := p.groups[name]["tags"].(map[string]any)
+	keys := map[string]struct{}{
+		nodegroupCreationTag:             {},
+		"alpha.eksctl.io/nodegroup-name": {},
+		"alpha.eksctl.io/nodegroup-type": {},
+	}
+
+	for _, tags := range []map[string]any{metadataTags, groupTags} {
+		for key := range tags {
+			keys[key] = struct{}{}
+		}
+	}
+
+	slots := len(metadataTags) + len(keys) + nodegroupCreationReservedTagSlots
+	if slots > nodegroupCreationTagLimit {
+		return fmt.Errorf(
+			"%w: nodegroup %q exceeds the creation tag budget: %d slots, maximum %d "+
+				"including metadata, KSail and eksctl reserved tags",
+			errInvalidNodegroupConfig, name, slots, nodegroupCreationTagLimit,
+		)
+	}
+
+	return nil
+}

--- a/pkg/svc/provisioner/cluster/eks/creation_tags_test.go
+++ b/pkg/svc/provisioner/cluster/eks/creation_tags_test.go
@@ -1,0 +1,189 @@
+package eksprovisioner_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// TestManagedNodegroupCreationReservesTagCapacity accounts for metadata
+// propagation, eksctl identifiers, the ownership marker and generated Name tags.
+func TestManagedNodegroupCreationReservesTagCapacity(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name                     string
+		metadata, group          int
+		overlap, marker, wantErr bool
+	}{
+		{name: "group_boundary", group: 43},
+		{name: "group_overflow", group: 44, wantErr: true},
+		{name: "metadata_boundary", metadata: 1, group: 41},
+		{name: "metadata_overflow", metadata: 1, group: 42, wantErr: true},
+		{name: "overlap_boundary", metadata: 1, group: 42, overlap: true},
+		{name: "overlap_overflow", metadata: 1, group: 43, overlap: true, wantErr: true},
+		{name: "existing_marker", group: 43, marker: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			config := creationConfigWithTags(
+				t,
+				testCase.metadata,
+				testCase.group,
+				testCase.overlap,
+				testCase.marker,
+			)
+			provisioner, runner, _ := newCreationProvisioner(t, config, allowCreation)
+
+			for _, dryRun := range []bool{false, true} {
+				if testCase.wantErr {
+					_, err := runCreationUpdate(t, provisioner, dryRun)
+					require.ErrorContains(t, err, "tag budget")
+					assert.Zero(t, runner.creates)
+					assert.Zero(t, runner.scales)
+				} else {
+					result, err := provisioner.DiffConfig(
+						t.Context(),
+						"",
+						&v1alpha1.ClusterSpec{},
+						&v1alpha1.ClusterSpec{},
+					)
+					require.NoError(t, err)
+					assert.True(t, result.HasInPlaceChanges())
+				}
+			}
+		})
+	}
+}
+
+func creationConfigWithTags(
+	t *testing.T,
+	metadataCount, groupCount int,
+	overlap, marker bool,
+) string {
+	t.Helper()
+
+	var config map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(creationConfig), &config))
+	metadata, valid := config["metadata"].(map[string]any)
+	require.True(t, valid)
+
+	metadataTags := make(map[string]any)
+	for index := range metadataCount {
+		metadataTags[fmt.Sprintf("metadata-%d", index)] = "value"
+	}
+
+	metadata["tags"] = metadataTags
+	groups, valid := config["managedNodeGroups"].([]any)
+	require.True(t, valid)
+	group, valid := groups[0].(map[string]any)
+	require.True(t, valid)
+
+	tags := make(map[string]any)
+	for index := range groupCount {
+		tags[fmt.Sprintf("tag-%d", index)] = "value"
+	}
+
+	if overlap {
+		delete(tags, "tag-0")
+		tags["metadata-0"] = "override"
+	}
+
+	if marker {
+		tags["ksail.io/nodegroup-creation-id"] = "old-marker"
+	}
+
+	group["tags"] = tags
+	data, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+// TestExistingManagedNodegroupBypassesCreationTagBudget preserves scaling for
+// existing groups even when their source declarations exceed the creation reserve.
+func TestExistingManagedNodegroupBypassesCreationTagBudget(t *testing.T) {
+	t.Parallel()
+	provisioner, runner, _ := newCreationProvisioner(
+		t,
+		creationConfigWithTags(t, 0, 50, false, false),
+		allowCreation,
+	)
+	live := activeCreationGroup("workers")
+	live.DesiredCap = 2
+	runner.live = []eksctl.NodegroupSummary{live}
+	result, err := provisioner.DiffConfig(
+		t.Context(),
+		"",
+		&v1alpha1.ClusterSpec{},
+		&v1alpha1.ClusterSpec{},
+	)
+	require.NoError(t, err)
+	assert.True(t, result.HasInPlaceChanges())
+	_, err = runCreationUpdate(t, provisioner, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, runner.scales)
+	assert.Zero(t, runner.creates)
+}
+
+// TestCreationTagBudgetPreflightsAllAdditions prevents earlier scaling changes
+// from being applied before discovering an oversized later addition.
+func TestCreationTagBudgetPreflightsAllAdditions(t *testing.T) {
+	t.Parallel()
+
+	var config map[string]any
+	require.NoError(
+		t,
+		yaml.Unmarshal([]byte(creationConfigWithTags(t, 0, 44, false, false)), &config),
+	)
+	groups, ok := config["managedNodeGroups"].([]any)
+	require.True(t, ok)
+
+	config["managedNodeGroups"] = append([]any{map[string]any{
+		"name": "existing", "desiredCapacity": 2, "minSize": 1, "maxSize": 3,
+	}}, groups...)
+	data, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	provisioner, runner, _ := newCreationProvisioner(t, string(data), allowCreation)
+	runner.live = []eksctl.NodegroupSummary{activeCreationGroup("existing")}
+
+	for _, dryRun := range []bool{false, true} {
+		_, err = runCreationUpdate(t, provisioner, dryRun)
+		require.ErrorContains(t, err, "tag budget")
+		assert.Zero(t, runner.scales)
+		assert.Zero(t, runner.creates)
+	}
+}
+
+// TestCreationMarkerReplacesExistingMarker reserves one slot while preventing
+// a caller-provided value from claiming ownership of the newly created group.
+func TestCreationMarkerReplacesExistingMarker(t *testing.T) {
+	t.Parallel()
+	provisioner, runner, _ := newCreationProvisioner(
+		t,
+		creationConfigWithTags(t, 0, 43, false, true),
+		allowCreation,
+	)
+	runner.create = func(config map[string]any) error {
+		groups, ok := config["managedNodeGroups"].([]any)
+		require.True(t, ok)
+		group, ok := groups[0].(map[string]any)
+		require.True(t, ok)
+		tags, ok := group["tags"].(map[string]any)
+		require.True(t, ok)
+		assert.NotEmpty(t, tags["ksail.io/nodegroup-creation-id"])
+		assert.NotEqual(t, "old-marker", tags["ksail.io/nodegroup-creation-id"])
+
+		runner.live = []eksctl.NodegroupSummary{activeCreationGroup("workers")}
+
+		return nil
+	}
+	_, err := runCreationUpdate(t, provisioner, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, runner.creates)
+}

--- a/pkg/svc/provisioner/cluster/eks/creation_test.go
+++ b/pkg/svc/provisioner/cluster/eks/creation_test.go
@@ -1,0 +1,608 @@
+package eksprovisioner_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/client/eksctl"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/eksidentity"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clustererr"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	eksprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+const creationConfig = `apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata: {name: stale-name, region: stale-region}
+iam: {withOIDC: true}
+vpc: {id: vpc-existing}
+nodeGroups:
+  - name: unmanaged-do-not-create
+managedNodeGroups:
+  - name: workers
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 3
+    instanceType: t3.medium
+    privateNetworking: true
+    labels: {workload: batch}
+    iam: {instanceRoleARN: arn:aws:iam::123456789012:role/workers}
+`
+
+var errCreationFailed = errors.New("node-group creation failed")
+
+type creationRunner struct {
+	eksprovisioner.AWSClusterAPI
+
+	stackExists bool
+	stackErr    error
+	markers     map[string]string
+	t           *testing.T
+	live        []eksctl.NodegroupSummary
+	output      *string
+	gets        int
+	creates     int
+	scales      int
+	scaleArgs   []string
+	paths       []string
+	beforeGet   func(int)
+	create      func(map[string]any) error
+	environment []string
+}
+
+func (r *creationRunner) NodegroupStackExists(context.Context, string, string) (bool, error) {
+	return r.stackExists, r.stackErr
+}
+
+func (r *creationRunner) Run(
+	ctx context.Context, binary string, args []string, stdin io.Reader,
+) ([]byte, []byte, error) {
+	return r.RunWithEnvironment(ctx, binary, args, stdin, nil)
+}
+
+func (r *creationRunner) RunWithEnvironment(
+	_ context.Context, _ string, args []string, _ io.Reader, environment []string,
+) ([]byte, []byte, error) {
+	r.t.Helper()
+	assert.Equal(r.t, r.environment, environment, "every read and mutation uses the frozen client")
+
+	switch args[0] {
+	case "get":
+		r.gets++
+		if r.beforeGet != nil {
+			r.beforeGet(r.gets)
+		}
+
+		if r.output != nil {
+			return []byte(*r.output), nil, nil
+		}
+
+		data, err := json.Marshal(r.live)
+		require.NoError(r.t, err)
+
+		return data, nil, nil
+	case "create":
+		r.creates++
+		require.Len(r.t, args, 4)
+		assert.Equal(r.t, []string{"create", "nodegroup", "--config-file"}, args[:3])
+		path := args[3]
+		r.paths = append(r.paths, path)
+		info, err := os.Stat(path)
+		require.NoError(r.t, err)
+		assert.Equal(r.t, os.FileMode(0o600), info.Mode().Perm())
+		//nolint:gosec // the provisioner creates this private temporary config.
+		data, err := os.ReadFile(path)
+		require.NoError(r.t, err)
+
+		var config map[string]any
+		require.NoError(r.t, yaml.Unmarshal(data, &config))
+
+		if r.create != nil {
+			groups, _ := config["managedNodeGroups"].([]any)
+			group, _ := groups[0].(map[string]any)
+			tags, _ := group["tags"].(map[string]any)
+			name, _ := group["name"].(string)
+			marker, _ := tags["ksail.io/nodegroup-creation-id"].(string)
+			r.markers[name] = marker
+
+			return nil, nil, r.create(config)
+		}
+	case "scale":
+		r.scales++
+		r.scaleArgs = args
+	default:
+		r.t.Fatalf("unexpected eksctl command: %v", args)
+	}
+
+	return nil, nil, nil
+}
+
+func activeCreationGroup(name string) eksctl.NodegroupSummary {
+	return eksctl.NodegroupSummary{
+		Cluster: "ksail-test", Name: name, Status: "ACTIVE", NodeGroupType: "managed",
+		DesiredCap: 1, MinSize: 1, MaxSize: 3, InstanceType: "t3.medium",
+	}
+}
+
+func newCreationProvisioner(
+	t *testing.T, config string, verifier eksidentity.Verifier,
+) (*eksprovisioner.UpdatableProvisioner, *creationRunner, string) {
+	t.Helper()
+
+	path := writeUpdateTestConfig(t, config)
+	runner := &creationRunner{
+		markers: make(map[string]string),
+		t:       t,
+		live:    []eksctl.NodegroupSummary{},
+		environment: []string{
+			"AWS_ACCESS_KEY_ID=frozen-test-key", "AWS_SECRET_ACCESS_KEY=frozen-test-secret",
+			"AWS_REGION=us-east-1",
+		},
+	}
+	client := eksctl.NewClient(eksctl.WithBinary(testBinary), eksctl.WithRunner(runner),
+		eksctl.WithEnvironment(runner.environment))
+	base, err := eksprovisioner.NewProvisioner("ksail-test", "us-east-1", path, client, nil,
+		eksprovisioner.WithOwnershipVerifier(verifier), eksprovisioner.WithAWSClusterAPI(runner))
+	require.NoError(t, err)
+
+	return eksprovisioner.NewUpdatableProvisioner(
+		base,
+		eksprovisioner.WithManagedNodegroupCreation(true),
+	), runner, path
+}
+
+func allowCreation(context.Context) error { return nil }
+
+func runCreationUpdate(
+	t *testing.T, provisioner *eksprovisioner.UpdatableProvisioner, dryRun bool,
+) (*clusterupdate.UpdateResult, error) {
+	t.Helper()
+
+	//nolint:wrapcheck // test helper preserves the production error for assertions.
+	return provisioner.Update(t.Context(), "", &v1alpha1.ClusterSpec{}, &v1alpha1.ClusterSpec{},
+		clusterupdate.UpdateOptions{DryRun: dryRun})
+}
+
+func TestManagedNodegroupCreationUsesPrivateVerifiedSnapshotAndRetryIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	verified := 0
+	provisioner, runner, source := newCreationProvisioner(
+		t,
+		creationConfig,
+		func(context.Context) error {
+			verified++
+
+			return nil
+		},
+	)
+	runner.create = func(config map[string]any) error {
+		assert.Equal(t, 1, verified)
+		assert.Equal(
+			t,
+			map[string]any{"name": "ksail-test", "region": "us-east-1"},
+			config["metadata"],
+		)
+		assert.Equal(t, map[string]any{"withOIDC": true}, config["iam"])
+		assert.Equal(t, map[string]any{"id": "vpc-existing"}, config["vpc"])
+		assert.NotContains(t, config, "nodeGroups")
+		groups, groupsOK := config["managedNodeGroups"].([]any)
+		require.True(t, groupsOK)
+		require.Len(t, groups, 1)
+		group, groupOK := groups[0].(map[string]any)
+		require.True(t, groupOK)
+		assert.Equal(t, "workers", group["name"])
+		assert.Equal(t, true, group["privateNetworking"])
+		assert.Equal(t, map[string]any{"workload": "batch"}, group["labels"])
+		assert.Equal(
+			t,
+			map[string]any{"instanceRoleARN": "arn:aws:iam::123456789012:role/workers"},
+			group["iam"],
+		)
+
+		runner.live = append(runner.live, activeCreationGroup("workers"))
+
+		return nil
+	}
+
+	result, err := runCreationUpdate(t, provisioner, false)
+	require.NoError(t, err)
+	require.Len(t, result.AppliedChanges, 1)
+	assert.Equal(t, "eks.managedNodeGroups[workers]", result.AppliedChanges[0].Field)
+	assert.Empty(t, result.FailedChanges)
+	assert.Equal(t, 3, runner.gets, "plan, refresh, then verify actual creation")
+	require.Len(t, runner.paths, 1)
+	assert.NoFileExists(t, runner.paths[0])
+	//nolint:gosec // source is a fixture in this test's private directory.
+	unchanged, err := os.ReadFile(source)
+	require.NoError(t, err)
+	assert.Equal(t, creationConfig, string(unchanged))
+
+	result, err = runCreationUpdate(t, provisioner, false)
+	require.NoError(t, err)
+	assert.Zero(t, result.TotalChanges())
+	assert.Empty(t, result.AppliedChanges)
+	assert.Equal(t, 1, runner.creates)
+}
+
+func TestManagedNodegroupCreationRejectsAmbiguousInventory(t *testing.T) {
+	t.Parallel()
+
+	for _, output := range []string{
+		"", "null", "{", `[{"Cluster":"other","Name":"workers","Type":"managed","Status":"ACTIVE"}]`,
+		`[{"Cluster":"ksail-test","Name":"workers","Type":"unmanaged"}]`,
+		`[{"Cluster":"ksail-test","Name":"workers","Type":"managed","Status":"CREATING"}]`,
+		`[{"Cluster":"ksail-test","Name":"workers","Type":"managed","Status":"CREATE_FAILED"}]`,
+		`[{"Cluster":"ksail-test","Name":"workers","Status":"ACTIVE"}]`,
+		`[{"Cluster":"ksail-test","Name":"workers","Type":"managed","Status":"ACTIVE"},` +
+			`{"Cluster":"ksail-test","Name":"workers","Type":"managed","Status":"ACTIVE"}]`,
+	} {
+		t.Run(output, func(t *testing.T) {
+			t.Parallel()
+			provisioner, runner, _ := newCreationProvisioner(t, creationConfig, allowCreation)
+			runner.output = &output
+			_, err := runCreationUpdate(t, provisioner, false)
+			require.Error(t, err)
+			assert.Zero(t, runner.creates)
+			assert.Zero(t, runner.scales)
+		})
+	}
+}
+
+func TestManagedNodegroupCreationRejectsInvalidDeclarationBeforeEksctl(t *testing.T) {
+	t.Parallel()
+
+	for name, config := range map[string]string{
+		"duplicate names": creationConfig + "  - name: workers\n",
+		"duplicate YAML key": strings.Replace(creationConfig, "    desiredCapacity: 1",
+			"    desiredCapacity: 1\n    desiredCapacity: 2", 1),
+		"glob name":    strings.Replace(creationConfig, "name: workers", "name: 'workers*'", 1),
+		"empty name":   strings.Replace(creationConfig, "name: workers", "name: ''", 1),
+		"numeric name": strings.Replace(creationConfig, "name: workers", "name: 123", 1),
+		"malformed tags": strings.Replace(creationConfig, "    desiredCapacity: 1",
+			"    tags: invalid\n    desiredCapacity: 1", 1),
+		"wrong group shape": "apiVersion: eksctl.io/v1alpha5\nkind: ClusterConfig\nmetadata: {}\nmanagedNodeGroups: {}\n",
+		"missing metadata":  "managedNodeGroups: []\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			provisioner, runner, _ := newCreationProvisioner(t, config, allowCreation)
+			_, err := runCreationUpdate(t, provisioner, false)
+			require.Error(t, err)
+			assert.Zero(t, runner.gets)
+			assert.Zero(t, runner.creates)
+		})
+	}
+}
+
+func TestManagedNodegroupCreationPreservesUpdateGates(t *testing.T) {
+	t.Parallel()
+
+	for _, scenario := range []string{"dry run", "removal", "immutable", "nil spec"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+
+			provisioner, runner, _ := newCreationProvisioner(t, creationConfig, nil)
+			if scenario == "removal" {
+				runner.live = append(runner.live, activeCreationGroup("old"))
+			}
+
+			if scenario == "immutable" {
+				old := activeCreationGroup("workers")
+				old.InstanceType = "t3.large"
+				runner.live = append(runner.live, old)
+			}
+
+			if scenario == "nil spec" {
+				_, err := provisioner.Update(
+					t.Context(),
+					"",
+					nil,
+					nil,
+					clusterupdate.UpdateOptions{},
+				)
+				require.NoError(t, err)
+				assert.Zero(t, runner.gets)
+			} else {
+				result, err := runCreationUpdate(t, provisioner, scenario == "dry run")
+				if scenario == "dry run" {
+					require.NoError(t, err)
+					assert.Len(t, result.InPlaceChanges, 1)
+				} else {
+					require.ErrorIs(t, err, clustererr.ErrRecreationRequired)
+				}
+			}
+
+			assert.Zero(t, runner.creates)
+			assert.Zero(t, runner.scales)
+		})
+	}
+}
+
+func TestManagedNodegroupCreationVerificationFailuresDoNotMutate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		verifier func(*string) eksidentity.Verifier
+		wantErr  error
+	}{
+		{name: "missing verifier", verifier: func(*string) eksidentity.Verifier { return nil }},
+		{
+			name: "ownership changed", wantErr: eksidentity.ErrIdentityMismatch,
+			verifier: func(*string) eksidentity.Verifier {
+				return func(context.Context) error { return eksidentity.ErrIdentityMismatch }
+			},
+		},
+		{name: "source changed", verifier: func(path *string) eksidentity.Verifier {
+			return func(context.Context) error { return os.WriteFile(*path, []byte(creationConfig+"# changed\n"), 0o600) }
+		}},
+		{
+			name:     "canceled",
+			wantErr:  context.Canceled,
+			verifier: func(*string) eksidentity.Verifier { return func(context.Context) error { return context.Canceled } },
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var source string
+
+			provisioner, runner, path := newCreationProvisioner(
+				t,
+				creationConfig,
+				testCase.verifier(&source),
+			)
+			source = path
+			result, err := runCreationUpdate(t, provisioner, false)
+			require.Error(t, err)
+
+			if testCase.wantErr != nil {
+				require.ErrorIs(t, err, testCase.wantErr)
+			}
+
+			assert.Empty(t, result.AppliedChanges)
+			assert.Len(t, result.FailedChanges, 1)
+			assert.Zero(t, runner.creates)
+		})
+	}
+}
+
+func TestManagedNodegroupCreationCommandFailuresDoNotReportApplied(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		change func(*creationRunner)
+		err    error
+	}{
+		{name: "command failure", err: errCreationFailed},
+		{name: "missing after create"},
+		{name: "settings differ", change: func(runner *creationRunner) {
+			group := activeCreationGroup("workers")
+			group.DesiredCap = 2
+			runner.live = append(runner.live, group)
+		}},
+		{name: "concurrent creation lacks our marker", change: func(runner *creationRunner) {
+			runner.live = append(runner.live, activeCreationGroup("workers"))
+			delete(runner.markers, "workers")
+		}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			provisioner, runner, _ := newCreationProvisioner(t, creationConfig, allowCreation)
+			runner.create = func(map[string]any) error {
+				if testCase.change != nil {
+					testCase.change(runner)
+				}
+
+				return testCase.err
+			}
+			result, err := runCreationUpdate(t, provisioner, false)
+			require.Error(t, err)
+			assert.Empty(t, result.AppliedChanges)
+			assert.Len(t, result.FailedChanges, 1)
+
+			for _, path := range runner.paths {
+				assert.NoFileExists(t, path)
+			}
+		})
+	}
+}
+
+func TestManagedNodegroupCreationReportsPartialSuccessAndRetriesOnlyMissingGroup(t *testing.T) {
+	t.Parallel()
+
+	config := creationConfig + "  - name: second\n    desiredCapacity: 1\n"
+	provisioner, runner, _ := newCreationProvisioner(t, config, allowCreation)
+	runner.create = func(config map[string]any) error {
+		groups, groupsOK := config["managedNodeGroups"].([]any)
+		require.True(t, groupsOK)
+		require.Len(t, groups, 1)
+		group, groupOK := groups[0].(map[string]any)
+		require.True(t, groupOK)
+
+		name, nameOK := group["name"].(string)
+		require.True(t, nameOK)
+
+		if name == "second" && runner.creates == 2 {
+			return errCreationFailed
+		}
+
+		runner.live = append(runner.live, activeCreationGroup(name))
+
+		return nil
+	}
+	result, err := runCreationUpdate(t, provisioner, false)
+	require.ErrorIs(t, err, errCreationFailed)
+	require.Len(t, result.AppliedChanges, 1)
+	assert.Equal(t, "workers", result.AppliedChanges[0].NewValue)
+	require.Len(t, result.FailedChanges, 1)
+	assert.Equal(t, "eks.managedNodeGroups[second]", result.FailedChanges[0].Field)
+
+	result, err = runCreationUpdate(t, provisioner, false)
+	require.NoError(t, err)
+	require.Len(t, result.AppliedChanges, 1)
+	assert.Equal(t, "second", result.AppliedChanges[0].NewValue)
+	assert.Equal(t, 3, runner.creates)
+
+	for _, path := range runner.paths {
+		assert.NoFileExists(t, path)
+	}
+}
+
+func TestManagedNodegroupCreationRejectsExistingGroupDisappearance(t *testing.T) {
+	t.Parallel()
+
+	provisioner, runner, _ := newCreationProvisioner(t,
+		creationConfig+"  - name: new\n    desiredCapacity: 1\n", allowCreation)
+	runner.live = append(runner.live, activeCreationGroup("workers"))
+	runner.beforeGet = func(call int) {
+		if call == 2 {
+			runner.live = []eksctl.NodegroupSummary{}
+		}
+	}
+	_, err := runCreationUpdate(t, provisioner, false)
+	require.ErrorContains(t, err, "disappeared")
+	assert.Zero(t, runner.creates)
+}
+
+func TestManagedNodegroupCreationRefreshesAutoscalerCapacityAfterSlowCreate(t *testing.T) {
+	t.Parallel()
+
+	config := creationConfig + "  - name: autoscaled\n    minSize: 1\n    maxSize: 10\n"
+	provisioner, runner, _ := newCreationProvisioner(t, config, allowCreation)
+	runner.live = append(runner.live, activeCreationGroup("autoscaled"))
+	runner.create = func(map[string]any) error {
+		// An autoscaler can change this group while eksctl creates another one.
+		runner.live[0].DesiredCap = 3
+		runner.live = append(runner.live, activeCreationGroup("workers"))
+
+		return nil
+	}
+	_, err := runCreationUpdate(t, provisioner, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"scale", "nodegroup", "--cluster", "ksail-test",
+		"--name", "autoscaled", "--nodes", "3", "--nodes-max", "10", "--region", "us-east-1",
+	}, runner.scaleArgs)
+}
+
+func (r *creationRunner) ListManagedNodegroups(
+	context.Context,
+	string,
+) ([]ekstypes.Nodegroup, error) {
+	groups := make([]ekstypes.Nodegroup, 0, len(r.live))
+	for _, summary := range r.live {
+		if summary.NodeGroupType != "managed" {
+			continue
+		}
+
+		groups = append(groups, ekstypes.Nodegroup{
+			ClusterName:   aws.String(summary.Cluster),
+			NodegroupName: aws.String(summary.Name),
+			Status: ekstypes.NodegroupStatus(
+				summary.Status,
+			),
+			InstanceTypes: []string{summary.InstanceType},
+			ScalingConfig: &ekstypes.NodegroupScalingConfig{
+				DesiredSize: fixtureCapacity(
+					summary.DesiredCap,
+				),
+				MinSize: fixtureCapacity(summary.MinSize),
+				MaxSize: fixtureCapacity(summary.MaxSize),
+			},
+			Tags: map[string]string{"ksail.io/nodegroup-creation-id": r.markers[summary.Name]},
+		})
+	}
+
+	return groups, nil
+}
+
+func TestManagedNodegroupCreationRejectsUnexpectedAppearance(t *testing.T) {
+	t.Parallel()
+	provisioner, runner, _ := newCreationProvisioner(t, creationConfig, allowCreation)
+	runner.beforeGet = func(call int) {
+		if call == 2 {
+			runner.live = append(runner.live, activeCreationGroup("workers"))
+		}
+	}
+	result, err := runCreationUpdate(t, provisioner, false)
+	require.ErrorContains(t, err, "appeared after planning")
+	assert.Empty(t, result.AppliedChanges)
+	assert.Zero(t, runner.creates)
+}
+
+func TestManagedNodegroupCreationCleansSnapshotOnOwnershipRefusal(t *testing.T) {
+	provisioner, runner, _ := newCreationProvisioner(
+		t,
+		creationConfig,
+		func(context.Context) error {
+			return eksidentity.ErrIdentityMismatch
+		},
+	)
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv("TMP", tempRoot)
+	t.Setenv("TEMP", tempRoot)
+	_, err := runCreationUpdate(t, provisioner, false)
+	require.ErrorIs(t, err, eksidentity.ErrIdentityMismatch)
+	files, err := os.ReadDir(tempRoot)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+	assert.Zero(t, runner.creates)
+}
+
+func fixtureCapacity(value int) *int32 {
+	//nolint:gosec // fixture capacities range from zero to ten.
+	converted := int32(value)
+
+	return &converted
+}
+
+func TestManagedNodegroupCreationUsesSDKWhenEksctlOmitsManagedGroups(t *testing.T) {
+	t.Parallel()
+	provisioner, runner, _ := newCreationProvisioner(t, creationConfig, allowCreation)
+	empty := "[]"
+	runner.output = &empty
+	runner.live = append(runner.live, activeCreationGroup("workers"))
+	result, err := runCreationUpdate(t, provisioner, false)
+	require.NoError(t, err)
+	assert.Zero(t, result.TotalChanges())
+	assert.Zero(t, runner.creates)
+}
+
+func TestManagedNodegroupCreationRequiresAuthoritativeStackAbsence(t *testing.T) {
+	t.Parallel()
+
+	for _, lookupFailure := range []bool{false, true} {
+		t.Run(strconv.FormatBool(lookupFailure), func(t *testing.T) {
+			t.Parallel()
+			provisioner, runner, _ := newCreationProvisioner(t, creationConfig, allowCreation)
+
+			runner.stackExists = !lookupFailure
+			if lookupFailure {
+				runner.stackErr = errCreationFailed
+			}
+
+			result, err := runCreationUpdate(t, provisioner, false)
+			require.Error(t, err)
+			assert.Empty(t, result.AppliedChanges)
+			assert.Zero(t, runner.creates)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/eks/creation_test.go
+++ b/pkg/svc/provisioner/cluster/eks/creation_test.go
@@ -606,3 +606,31 @@ func TestManagedNodegroupCreationRequiresAuthoritativeStackAbsence(t *testing.T)
 		})
 	}
 }
+
+// TestManagedNodegroupCreationMissingConfigIsNoOp preserves the optional-config
+// behavior for both planning and update without making inventory or mutation calls.
+func TestManagedNodegroupCreationMissingConfigIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	for _, dryRun := range []bool{false, true} {
+		t.Run(strconv.FormatBool(dryRun), func(t *testing.T) {
+			t.Parallel()
+			provisioner, runner, path := newCreationProvisioner(t, creationConfig, allowCreation)
+			require.NoError(t, os.Remove(path))
+			result, err := provisioner.DiffConfig(
+				t.Context(),
+				"",
+				&v1alpha1.ClusterSpec{},
+				&v1alpha1.ClusterSpec{},
+			)
+			require.NoError(t, err)
+			assert.Zero(t, result.TotalChanges())
+			result, err = runCreationUpdate(t, provisioner, dryRun)
+			require.NoError(t, err)
+			assert.Zero(t, result.TotalChanges())
+			assert.Zero(t, runner.gets)
+			assert.Zero(t, runner.creates)
+			assert.Zero(t, runner.scales)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -98,9 +98,9 @@ type managedNodeGroupConfig struct {
 }
 
 // Update applies configuration changes to a running EKS cluster.
-// The first supported in-place dimension is managed node-group scaling
-// (desiredCapacity/minSize/maxSize); everything else reports as
-// recreate-required and is handled by the orchestrator's recreate flow.
+// Managed node-group scaling is in-place. Experimental managed node-group
+// creation additionally permits verified additions; removals and immutable
+// field changes require the orchestrator's recreate flow.
 func (u *UpdatableProvisioner) Update(
 	ctx context.Context,
 	name string,

--- a/pkg/svc/provisioner/cluster/eks/update.go
+++ b/pkg/svc/provisioner/cluster/eks/update.go
@@ -28,7 +28,8 @@ import (
 type UpdatableProvisioner struct {
 	*Provisioner
 
-	managedNodegroupUpdates bool
+	managedNodegroupUpdates  bool
+	managedNodegroupCreation bool
 
 	// componentDetector probes the running cluster's components for the
 	// update baseline; injected by the orchestrator via SetComponentDetector.
@@ -46,9 +47,17 @@ func WithManagedNodegroupUpdates(enabled bool) UpdatableOption {
 	}
 }
 
+// WithManagedNodegroupCreation enables experimental in-place additions. It
+// defaults to false and does not enable updates without a declared config.
+func WithManagedNodegroupCreation(enabled bool) UpdatableOption {
+	return func(provisioner *UpdatableProvisioner) {
+		provisioner.managedNodegroupCreation = enabled
+	}
+}
+
 // NewUpdatableProvisioner wraps an EKS provisioner with component update
-// support. Managed node-group updates default to enabled for compatibility;
-// the cluster factory supplies the user's explicit experimental opt-in.
+// support. Managed node-group scaling defaults to enabled; additions require
+// the separate experimental opt-in supplied by the cluster factory.
 func NewUpdatableProvisioner(
 	provisioner *Provisioner,
 	options ...UpdatableOption,
@@ -98,6 +107,10 @@ func (u *UpdatableProvisioner) Update(
 	oldSpec, newSpec *v1alpha1.ClusterSpec,
 	opts clusterupdate.UpdateOptions,
 ) (*clusterupdate.UpdateResult, error) {
+	if u.managedNodegroupUpdates && u.managedNodegroupCreation {
+		return u.updateWithNodegroupCreation(ctx, name, oldSpec, newSpec, opts)
+	}
+
 	//nolint:wrapcheck // error context added inside RunUpdate.
 	return clusterupdate.RunUpdate(
 		ctx, name, oldSpec, newSpec, opts, clustererr.ErrRecreationRequired,
@@ -107,8 +120,8 @@ func (u *UpdatableProvisioner) Update(
 
 // DiffConfig computes the differences between the declared eksctl.yaml
 // managed node groups and the live cluster state. Scaling changes on an
-// existing managed node group are in-place; adding or removing node groups
-// is classified recreate-required (not supported in-place yet).
+// existing managed node group are in-place. Additions require the experimental
+// opt-in; removals and supported immutable-field changes require recreation.
 func (u *UpdatableProvisioner) DiffConfig(
 	ctx context.Context,
 	name string,
@@ -117,6 +130,12 @@ func (u *UpdatableProvisioner) DiffConfig(
 	result := clusterupdate.NewEmptyUpdateResult()
 	if !u.managedNodegroupUpdates {
 		return result, nil
+	}
+
+	if u.managedNodegroupCreation {
+		_, diff, err := u.planNodegroupCreation(ctx, name)
+
+		return diff, err
 	}
 
 	desired, declared, err := u.desiredNodegroups()
@@ -135,11 +154,28 @@ func (u *UpdatableProvisioner) DiffConfig(
 		return result, fmt.Errorf("failed to list nodegroups: %w", err)
 	}
 
-	liveByName := liveManagedNodegroups(live)
+	return diffManagedNodegroups(desired, liveManagedNodegroups(live), false), nil
+}
+
+func diffManagedNodegroups(
+	desired []managedNodeGroupConfig,
+	liveByName map[string]eksctl.NodegroupSummary,
+	allowCreation bool,
+) *clusterupdate.UpdateResult {
+	result := clusterupdate.NewEmptyUpdateResult()
 
 	for _, group := range desired {
 		liveGroup, exists := liveByName[group.Name]
 		if !exists {
+			if allowCreation {
+				result.InPlaceChanges = append(
+					result.InPlaceChanges,
+					nodegroupCreationChange(group.Name),
+				)
+
+				continue
+			}
+
 			result.RecreateRequired = append(result.RecreateRequired, clusterupdate.Change{
 				Field:    nodegroupField(group.Name),
 				NewValue: group.Name,
@@ -171,7 +207,7 @@ func (u *UpdatableProvisioner) DiffConfig(
 		})
 	}
 
-	return result, nil
+	return result
 }
 
 // GetCurrentConfig retrieves the current cluster configuration: component

--- a/pkg/svc/provisioner/cluster/eks/update_test.go
+++ b/pkg/svc/provisioner/cluster/eks/update_test.go
@@ -41,7 +41,7 @@ managedNodeGroups:
 
 const liveNodegroupsJSON = `[{"Cluster":"ksail-test","Name":"ng-1","Status":"ACTIVE",` +
 	`"DesiredCapacity":2,"MinSize":1,"MaxSize":3,"InstanceType":"t3.medium",` +
-	`"NodeGroupType":"managed"}]`
+	`"Type":"managed"}]`
 
 // writeUpdateTestConfig writes an eksctl.yaml into a temp dir and returns its path.
 func writeUpdateTestConfig(t *testing.T, content string) string {
@@ -163,8 +163,8 @@ func TestDiffConfig_RemovedNodegroupRequiresRecreate(t *testing.T) {
 	t.Parallel()
 
 	liveTwoGroups := `[{"Name":"ng-1","DesiredCapacity":3,"MinSize":1,"MaxSize":3,` +
-		`"NodeGroupType":"managed"},{"Name":"ng-old","DesiredCapacity":1,"MinSize":1,` +
-		`"MaxSize":1,"NodeGroupType":"managed"}]`
+		`"Type":"managed"},{"Name":"ng-old","DesiredCapacity":1,"MinSize":1,` +
+		`"MaxSize":1,"Type":"managed"}]`
 
 	configPath := writeUpdateTestConfig(t, updateTestConfig)
 	prov, _ := newTestProvisioner(t, map[string][]response{
@@ -185,8 +185,8 @@ func TestDiffConfig_UnmanagedLiveGroupIsIgnored(t *testing.T) {
 	t.Parallel()
 
 	liveWithUnmanaged := `[{"Name":"ng-1","DesiredCapacity":3,"MinSize":1,"MaxSize":3,` +
-		`"NodeGroupType":"managed"},{"Name":"legacy","DesiredCapacity":1,"MinSize":1,` +
-		`"MaxSize":1,"NodeGroupType":"unmanaged"}]`
+		`"Type":"managed"},{"Name":"legacy","DesiredCapacity":1,"MinSize":1,` +
+		`"MaxSize":1,"Type":"unmanaged"}]`
 
 	configPath := writeUpdateTestConfig(t, updateTestConfig)
 	prov, _ := newTestProvisioner(t, map[string][]response{
@@ -341,7 +341,7 @@ func TestUpdate_NoChangesIsANoOp(t *testing.T) {
 	t.Parallel()
 
 	liveMatchingConfig := `[{"Name":"ng-1","DesiredCapacity":3,"MinSize":1,"MaxSize":3,` +
-		`"NodeGroupType":"managed"}]`
+		`"Type":"managed"}]`
 
 	configPath := writeUpdateTestConfig(t, updateTestConfig)
 	prov, runner := newTestProvisioner(t, map[string][]response{
@@ -369,7 +369,7 @@ func TestDiffConfig_InstanceTypeChangeRequiresRecreate(t *testing.T) {
 	t.Parallel()
 
 	liveOtherType := `[{"Name":"ng-1","DesiredCapacity":3,"MinSize":1,"MaxSize":3,` +
-		`"InstanceType":"t3.large","NodeGroupType":"managed"}]`
+		`"InstanceType":"t3.large","Type":"managed"}]`
 
 	configPath := writeUpdateTestConfig(t, updateTestConfig)
 	prov, _ := newTestProvisioner(t, map[string][]response{
@@ -429,7 +429,7 @@ managedNodeGroups:
 `
 
 	liveBelowNewMin := `[{"Name":"ng-1","DesiredCapacity":2,"MinSize":1,"MaxSize":3,` +
-		`"NodeGroupType":"managed"}]`
+		`"Type":"managed"}]`
 
 	configPath := writeUpdateTestConfig(t, minOnlyConfig)
 	prov, runner := newTestProvisioner(t, map[string][]response{
@@ -462,9 +462,9 @@ func TestDiffConfig_RemovalsAreEmittedInSortedOrder(t *testing.T) {
 	t.Parallel()
 
 	liveThreeGroups := `[{"Name":"ng-1","DesiredCapacity":3,"MinSize":1,"MaxSize":3,` +
-		`"InstanceType":"t3.medium","NodeGroupType":"managed"},` +
-		`{"Name":"zeta","DesiredCapacity":1,"MinSize":1,"MaxSize":1,"NodeGroupType":"managed"},` +
-		`{"Name":"alpha","DesiredCapacity":1,"MinSize":1,"MaxSize":1,"NodeGroupType":"managed"}]`
+		`"InstanceType":"t3.medium","Type":"managed"},` +
+		`{"Name":"zeta","DesiredCapacity":1,"MinSize":1,"MaxSize":1,"Type":"managed"},` +
+		`{"Name":"alpha","DesiredCapacity":1,"MinSize":1,"MaxSize":1,"Type":"managed"}]`
 
 	configPath := writeUpdateTestConfig(t, updateTestConfig)
 	prov, _ := newTestProvisioner(t, map[string][]response{

--- a/pkg/svc/provisioner/cluster/factory_eks.go
+++ b/pkg/svc/provisioner/cluster/factory_eks.go
@@ -66,9 +66,9 @@ func (f DefaultFactory) createEKSProvisioner(
 		return nil, nil, fmt.Errorf("failed to create EKS provisioner: %w", err)
 	}
 
-	// EKS always exposes Updater so component-only changes can reconcile. Managed
-	// node-group mutation is graduated out of its experimental flag and now needs
-	// only a declared eksctl config path, which is what the diff is computed from.
+	// EKS always exposes Updater so component-only changes can reconcile. Scaling
+	// existing managed node groups requires a declared eksctl config path. Creating
+	// missing groups additionally requires the experimental creation option below.
 	managedNodegroupUpdates := eksConfig.ConfigPath != ""
 
 	return eksprovisioner.NewUpdatableProvisioner(

--- a/pkg/svc/provisioner/cluster/factory_eks.go
+++ b/pkg/svc/provisioner/cluster/factory_eks.go
@@ -78,6 +78,9 @@ func (f DefaultFactory) createEKSProvisioner(
 	return eksprovisioner.NewUpdatableProvisioner(
 		provisioner,
 		eksprovisioner.WithManagedNodegroupUpdates(managedNodegroupUpdates),
+		eksprovisioner.WithManagedNodegroupCreation(
+			cluster.Spec.Cluster.EKS.ExperimentalManagedNodegroupCreation,
+		),
 	), eksConfig, nil
 }
 

--- a/pkg/svc/provisioner/cluster/factory_eks.go
+++ b/pkg/svc/provisioner/cluster/factory_eks.go
@@ -49,11 +49,7 @@ func (f DefaultFactory) createEKSProvisioner(
 		)
 	}
 
-	infraProvider, err := awsprovider.NewProvider(
-		client,
-		eksConfig.Region,
-		providerOptions...,
-	)
+	infraProvider, err := awsprovider.NewProvider(client, eksConfig.Region, providerOptions...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create AWS provider: %w", err)
 	}

--- a/pkg/svc/provisioner/cluster/factory_eks_test.go
+++ b/pkg/svc/provisioner/cluster/factory_eks_test.go
@@ -2,13 +2,17 @@ package clusterprovisioner_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/credentials"
 	clusterprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster"
 	eksprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/eks"
 	"github.com/stretchr/testify/assert"
@@ -299,4 +303,83 @@ func TestCreateEKSProvisionerRejectsOwnershipVerifierWithoutResolution(t *testin
 	provisioner, _, err := factory.Create(context.Background(), eksTestCluster())
 	require.ErrorIs(t, err, clusterprovisioner.ErrUnfrozenAWSResolution)
 	assert.Nil(t, provisioner)
+}
+
+// TestEKSNodegroupCreationOptInReachesUpdater checks both configuration states through the real factory.
+//
+//nolint:paralleltest // the eksctl fixture uses a private PATH for this process.
+func TestEKSNodegroupCreationOptInReachesUpdater(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script eksctl fixture is not portable to Windows")
+	}
+
+	frozen := configureEKSNodegroupInventory(t)
+
+	binDir := t.TempDir()
+	writeExecutableFixture(t, filepath.Join(binDir, "eksctl"), "#!/bin/sh\nprintf '[]\\n'\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	configPath := filepath.Join(t.TempDir(), "eks.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata: {name: test-eks, region: eu-west-1}
+managedNodeGroups:
+  - name: workers
+    desiredCapacity: 1
+`), 0o600))
+
+	for _, enabled := range []bool{false, true} {
+		t.Run(strconv.FormatBool(enabled), func(t *testing.T) {
+			cluster := eksTestCluster()
+			require.NoError(t, yaml.Unmarshal([]byte(
+				"experimentalManagedNodegroupCreation: "+strconv.FormatBool(enabled),
+			), &cluster.Spec.Cluster.EKS))
+			factory := clusterprovisioner.DefaultFactory{
+				AWSResolution: &frozen,
+				DistributionConfig: &clusterprovisioner.DistributionConfig{
+					EKS: &clusterprovisioner.EKSConfig{
+						Name: "test-eks", Region: "eu-west-1", ConfigPath: configPath,
+					},
+				},
+			}
+			provisioner, _, err := factory.Create(t.Context(), cluster)
+			require.NoError(t, err)
+
+			updater, ok := provisioner.(*eksprovisioner.UpdatableProvisioner)
+			require.True(t, ok)
+			diff, err := updater.DiffConfig(
+				t.Context(),
+				"test-eks",
+				&cluster.Spec.Cluster,
+				&cluster.Spec.Cluster,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, enabled, diff.HasInPlaceChanges())
+			assert.Equal(t, !enabled, diff.HasRecreateRequired())
+		})
+	}
+}
+
+func configureEKSNodegroupInventory(t *testing.T) credentials.AWSResolution {
+	t.Helper()
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, "/clusters/test-eks/node-groups", request.URL.Path)
+			assert.Contains(t, request.Header.Get("Authorization"), "Credential=factory-test-key/")
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"nodegroups":[]}`))
+		}),
+	)
+	t.Cleanup(server.Close)
+	t.Setenv("AWS_ENDPOINT_URL_EKS", server.URL)
+	t.Setenv("AWS_IGNORE_CONFIGURED_ENDPOINT_URLS", "false")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials"))
+	frozen, err := credentials.FreezeAWS(t.Context(), credentials.AWSResolution{
+		AccessKeyID: "factory-test-key", SecretAccessKey: "factory-test-secret",
+	}, "eu-west-1")
+	require.NoError(t, err)
+
+	return frozen
 }

--- a/schemas/ksail-config.schema.json
+++ b/schemas/ksail-config.schema.json
@@ -765,6 +765,10 @@
             },
             "eks": {
               "properties": {
+                "experimentalManagedNodegroupCreation": {
+                  "type": "boolean",
+                  "description": "Experimental: allow cluster update to create managed node groups added to eksctl.yaml. Default false. Requires verified cluster ownership; removals and instance-type changes still require recreation. Pending live EKS validation."
+                },
                 "experimentalAWSLoadBalancerController": {
                   "type": "boolean",
                   "description": "Experimental: install the AWS Load Balancer Controller when spec.cluster.loadBalancer is Enabled, replacing the default in-tree Classic Load Balancer path. Default false (nothing is installed). IAM permissions and subnet tags are prerequisites KSail does not create."

--- a/web/ui/src/generated/ksail-config.ts
+++ b/web/ui/src/generated/ksail-config.ts
@@ -488,6 +488,10 @@ export interface KSailClusterConfiguration {
        */
       eks?: {
         /**
+         * Experimental: allow cluster update to create managed node groups added to eksctl.yaml. Default false. Requires verified cluster ownership; removals and instance-type changes still require recreation. Pending live EKS validation.
+         */
+        experimentalManagedNodegroupCreation?: boolean;
+        /**
          * Experimental: install the AWS Load Balancer Controller when spec.cluster.loadBalancer is Enabled, replacing the default in-tree Classic Load Balancer path. Default false (nothing is installed). IAM permissions and subnet tags are prerequisites KSail does not create.
          */
         experimentalAWSLoadBalancerController?: boolean;


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why
Adding worker capacity to an existing EKS cluster currently requires recreation even when a separate managed node group would be sufficient.

## What
Allow cluster update to create newly declared managed node groups through an experimental option that defaults to off. Preserve each new group's networking, storage, IAM, labels, and other eksctl settings, and create groups individually so a retry keeps earlier successes.

Verify cluster ownership and complete AWS inventory before creation, stop on ambiguous state or changed configuration, and report success only after the created group is active with the declared settings. Existing scaling remains available without the option; removals and instance-type changes still require recreation.

The option remains experimental until the live AWS validation in #6923 is complete.

Fixes #6921
Part of #4328
