### PR TITLE
fix(talos): retain control-plane nodes after failed etcd cleanup

### DIFF
--- a/pkg/svc/provisioner/cluster/talos/etcd.go
+++ b/pkg/svc/provisioner/cluster/talos/etcd.go
@@ -3,38 +3,68 @@ package talosprovisioner
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"google.golang.org/grpc"
 )
 
-// etcdCleanupBeforeRemoval performs best-effort etcd membership cleanup before
+type etcdMembershipClient interface {
+	EtcdForfeitLeadership(
+		ctx context.Context,
+		request *machineapi.EtcdForfeitLeadershipRequest,
+		options ...grpc.CallOption,
+	) (*machineapi.EtcdForfeitLeadershipResponse, error)
+	EtcdLeaveCluster(
+		ctx context.Context,
+		request *machineapi.EtcdLeaveClusterRequest,
+		options ...grpc.CallOption,
+	) error
+	Close() error
+}
+
+func (p *Provisioner) openEtcdMembershipClient(
+	ctx context.Context,
+	nodeIP string,
+) (etcdMembershipClient, error) {
+	if p.etcdClientFactory != nil {
+		return p.etcdClientFactory(ctx, nodeIP)
+	}
+
+	return p.dialTalosClientWithRetry(ctx, nodeIP, "etcd cleanup connect")
+}
+
+// etcdCleanupBeforeRemoval requires successful etcd membership cleanup before
 // removing a control-plane node. It connects to the node, forfeits leadership
 // if the node is the leader, then tells the node to leave the etcd cluster.
 //
-// All errors are logged but not returned — the node removal should proceed
-// regardless of whether etcd cleanup succeeded.
+// Connection and membership-removal errors retain the infrastructure. A failed
+// membership RPC may have taken effect, so callers must not blindly retry it or
+// assume that deleting the node is safe.
 func (p *Provisioner) etcdCleanupBeforeRemoval(
 	ctx context.Context,
 	nodeIP string,
-) {
+) error {
+	_, addressErr := netip.ParseAddr(nodeIP)
+	if addressErr != nil {
+		return fmt.Errorf("invalid control-plane address for etcd cleanup: %w", addressErr)
+	}
+
 	_, _ = fmt.Fprintf(p.logWriter,
 		"  Cleaning up etcd membership for %s...\n", nodeIP)
 
 	// EtcdForfeitLeadership/EtcdLeaveCluster are not idempotent, so the transient
 	// apid handshake race is absorbed by the Version probe inside
 	// dialTalosClientWithRetry and each membership RPC is issued exactly once.
-	client, err := p.dialTalosClientWithRetry(ctx, nodeIP, "etcd cleanup connect")
+	client, err := p.openEtcdMembershipClient(ctx, nodeIP)
 	if err != nil {
-		_, _ = fmt.Fprintf(p.logWriter,
-			"  ⚠ Could not connect to %s for etcd cleanup: %v\n",
-			nodeIP, err)
-
-		return
+		return fmt.Errorf("connect to %s for etcd cleanup: %w", nodeIP, err)
 	}
 
 	defer client.Close() //nolint:errcheck
 
-	// Step 1: Forfeit leadership if this node is the etcd leader.
+	// Step 1: Attempt leadership transfer. Successful leave below is the required
+	// membership boundary even when this preliminary transfer fails.
 	_, err = client.EtcdForfeitLeadership(
 		ctx,
 		&machineapi.EtcdForfeitLeadershipRequest{},
@@ -51,11 +81,11 @@ func (p *Provisioner) etcdCleanupBeforeRemoval(
 		&machineapi.EtcdLeaveClusterRequest{},
 	)
 	if err != nil {
-		_, _ = fmt.Fprintf(p.logWriter,
-			"  ⚠ Etcd leave failed on %s (best-effort): %v\n",
-			nodeIP, err)
-	} else {
-		_, _ = fmt.Fprintf(p.logWriter,
-			"  ✓ Etcd member removed from cluster (%s)\n", nodeIP)
+		return fmt.Errorf("remove etcd membership on %s: %w", nodeIP, err)
 	}
+
+	_, _ = fmt.Fprintf(p.logWriter,
+		"  ✓ Etcd member removed from cluster (%s)\n", nodeIP)
+
+	return nil
 }

--- a/pkg/svc/provisioner/cluster/talos/etcd_test.go
+++ b/pkg/svc/provisioner/cluster/talos/etcd_test.go
@@ -1,0 +1,178 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/docker"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+var errMembershipUnavailable = errors.New("membership RPC unavailable")
+
+type membershipClient struct {
+	forfeitErr error
+	leaveErr   error
+	calls      []string
+}
+
+func (client *membershipClient) EtcdForfeitLeadership(
+	context.Context, *machineapi.EtcdForfeitLeadershipRequest, ...grpc.CallOption,
+) (*machineapi.EtcdForfeitLeadershipResponse, error) {
+	client.calls = append(client.calls, "forfeit")
+
+	return nil, client.forfeitErr
+}
+
+func (client *membershipClient) EtcdLeaveCluster(
+	context.Context, *machineapi.EtcdLeaveClusterRequest, ...grpc.CallOption,
+) error {
+	client.calls = append(client.calls, "leave")
+
+	return client.leaveErr
+}
+
+func (client *membershipClient) Close() error {
+	client.calls = append(client.calls, "close")
+
+	return nil
+}
+
+//nolint:funlen // Keep each table-driven transition and its safety assertions together.
+func TestEtcdMembershipFailureStopsControlPlaneSequence(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name       string
+		forfeitErr error
+		leaveErr   error
+	}{
+		{name: "membership removal failure", leaveErr: errMembershipUnavailable},
+		{name: "successful removal"},
+		{name: "leadership transfer failure with successful leave", forfeitErr: errMembershipUnavailable},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &membershipClient{
+				forfeitErr: testCase.forfeitErr,
+				leaveErr:   testCase.leaveErr,
+			}
+			mockDocker := docker.NewMockAPIClient(t)
+			mockDocker.On("ContainerList", mock.Anything, mock.Anything).
+				Return([]container.Summary{
+					membershipContainer("1", "192.0.2.1"),
+					membershipContainer("2", "192.0.2.2"),
+				}, nil).Once()
+			mockDocker.On("ContainerStop", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil).Maybe()
+			mockDocker.On("ContainerRemove", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil).Maybe()
+
+			var targets []string
+
+			provisioner := newClientErrProvisioner(t).WithDockerClient(mockDocker).
+				WithEtcdClientFactoryForTest(func(
+					_ context.Context, target string,
+				) (talosprovisioner.EtcdMembershipClientForTest, error) {
+					targets = append(targets, target)
+
+					return client, nil
+				})
+			result := clusterupdate.NewEmptyUpdateResult()
+			err := provisioner.RemoveDockerNodesForTest(
+				t.Context(),
+				"scale-cluster",
+				talosprovisioner.RoleControlPlane,
+				2,
+				result,
+			)
+
+			if testCase.leaveErr != nil {
+				require.ErrorIs(t, err, testCase.leaveErr)
+				assert.Equal(t, []string{"192.0.2.2"}, targets, "must not mutate the next member")
+				assert.Equal(
+					t,
+					[]string{"forfeit", "leave", "close"},
+					client.calls,
+					"membership mutations must not be retried",
+				)
+				assert.Empty(t, result.AppliedChanges)
+				assert.Len(t, result.FailedChanges, 1)
+				mockDocker.AssertNumberOfCalls(t, "ContainerStop", 0)
+				mockDocker.AssertNumberOfCalls(t, "ContainerRemove", 0)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, []string{"192.0.2.2", "192.0.2.1"}, targets)
+				assert.Len(t, result.AppliedChanges, 2)
+				mockDocker.AssertNumberOfCalls(t, "ContainerRemove", 2)
+			}
+		})
+	}
+}
+
+func membershipContainer(index, address string) container.Summary {
+	return container.Summary{
+		ID: "cp-" + index, Names: []string{"/scale-cluster-control-plane-" + index},
+		NetworkSettings: &container.NetworkSettingsSummary{
+			Networks: map[string]*network.EndpointSettings{
+				"scale-cluster": {IPAddress: address},
+			},
+		},
+	}
+}
+
+// membershipCloudTransport serves provider reads entirely in memory and records
+// every attempted write, so a forbidden server deletion is directly observable.
+type membershipCloudTransport struct {
+	address string
+	writes  []string
+}
+
+func (transport *membershipCloudTransport) RoundTrip(
+	request *http.Request,
+) (*http.Response, error) {
+	statusCode := http.StatusOK
+
+	body := fmt.Sprintf(
+		`{"servers":[{
+			"id":1,"name":"scale-cluster-control-plane-1","status":"running",
+			"labels":{"ksail.owned":"true","ksail.cluster.name":"scale-cluster","ksail.node.type":"controlplane"},
+			"public_net":{"ipv4":{"ip":%q}}
+		}]}`,
+		transport.address,
+	)
+	if request.Method != http.MethodGet {
+		transport.writes = append(transport.writes, request.Method+" "+request.URL.Path)
+		statusCode = http.StatusForbidden
+		body = `{"error":{"code":"forbidden","message":"unexpected infrastructure mutation"}}`
+	}
+
+	return &http.Response{
+		StatusCode: statusCode, Body: io.NopCloser(strings.NewReader(body)),
+		Header: http.Header{"Content-Type": []string{"application/json"}}, Request: request,
+	}, nil
+}
+
+func newMembershipCloud(transport *membershipCloudTransport) *hetzner.Provider {
+	return hetzner.NewProvider(hcloud.NewClient(
+		hcloud.WithToken("test-token"),
+		hcloud.WithEndpoint("https://membership.invalid"),
+		hcloud.WithHTTPClient(&http.Client{Transport: transport}),
+	))
+}

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -27,6 +27,41 @@ import (
 
 var errUpdateApplyStepNotFoundForTest = errors.New("update apply step not found")
 
+// EtcdMembershipClientForTest exposes the membership transport boundary.
+type EtcdMembershipClientForTest = etcdMembershipClient
+
+// WithEtcdClientFactoryForTest injects an offline membership RPC client.
+func (p *Provisioner) WithEtcdClientFactoryForTest(
+	factory func(context.Context, string) (EtcdMembershipClientForTest, error),
+) *Provisioner {
+	p.etcdClientFactory = factory
+
+	return p
+}
+
+// RemoveHetznerNodesForTest exposes the scale-down orchestration.
+func (p *Provisioner) RemoveHetznerNodesForTest(
+	ctx context.Context, clusterName, role string, count int, result *clusterupdate.UpdateResult,
+) error {
+	return p.removeHetznerNodes(ctx, clusterName, role, count, result)
+}
+
+// RollingReplaceSingleNodeForTest exposes the destructive replacement boundary.
+func (p *Provisioner) RollingReplaceSingleNodeForTest(
+	ctx context.Context, clientset kubernetes.Interface, hzProvider *hetzner.Provider,
+	clusterName, role string, oldServer *hcloud.Server,
+) error {
+	return p.rollingReplaceSingleNode(
+		ctx,
+		clientset,
+		hzProvider,
+		clusterName,
+		role,
+		oldServer,
+		HetznerInfra{},
+	)
+}
+
 // ErrManagedNodeAnnotationKeysExpectedJSONArrayForTest exposes the stable error
 // identity expected when the persisted ownership marker is JSON null.
 var ErrManagedNodeAnnotationKeysExpectedJSONArrayForTest = errManagedNodeAnnotationKeysExpectedJSONArray

--- a/pkg/svc/provisioner/cluster/talos/provisioner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner.go
@@ -160,6 +160,9 @@ type Provisioner struct {
 	// talosClientFactory creates a Talos client for the given node IP.
 	// Tests can override this via export_test.go to inject a mock.
 	talosClientFactory func(ctx context.Context, ip string) (kubeconfigFetcher, error)
+	// etcdClientFactory optionally supplies the membership RPC client. A nil
+	// factory uses the ordinary authenticated connection and Version probe.
+	etcdClientFactory func(context.Context, string) (etcdMembershipClient, error)
 	// nodeReachabilityCheck reports when a node's Talos API (apid) is accepting
 	// connections at ip:talosAPIPort, retrying until it succeeds or the context is
 	// done. It gates Docker scale-up: a freshly started container returns from

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
@@ -236,7 +236,17 @@ func (p *Provisioner) rollingReplaceSingleNode(
 
 	// 2. Control-plane etcd membership cleanup before removal.
 	if role == RoleControlPlane {
-		p.etcdCleanupBeforeRemoval(ctx, oldIP)
+		cleanupErr := p.etcdCleanupBeforeRemoval(ctx, oldIP)
+		if cleanupErr != nil {
+			// Leave the server and its current scheduling state intact. An
+			// ambiguous leave failure cannot safely authorize either deletion or
+			// automatic uncordon of a node that may already have left etcd.
+			return fmt.Errorf(
+				"retaining control-plane server %s after etcd cleanup failure: %w",
+				oldServer.Name,
+				cleanupErr,
+			)
+		}
 	}
 
 	// 3. Delete the outgoing Hetzner server.

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
@@ -71,22 +71,23 @@ func TestRollingReplaceSingleNode_CleanupFailurePreservesServer(t *testing.T) {
 				)
 			}
 
-			node, getErr := clientset.CoreV1().
-				Nodes().
-				Get(t.Context(), server.Name, metav1.GetOptions{})
-			require.NoError(t, getErr)
-			assert.Equal(t, "original-node", string(node.UID))
-			assert.True(
-				t,
-				node.Spec.Unschedulable,
-				"uncertain membership must not automatically uncordon the node",
-			)
+			assertOriginalNodeRemainsCordoned(t, clientset, server.Name)
 
 			if leaveFailure {
 				assert.ErrorIs(t, err, errMembershipUnavailable)
 			}
 		})
 	}
+}
+
+func assertOriginalNodeRemainsCordoned(t *testing.T, clientset *fake.Clientset, name string) {
+	t.Helper()
+
+	node, err := clientset.CoreV1().Nodes().Get(t.Context(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "original-node", string(node.UID))
+	assert.True(t, node.Spec.Unschedulable,
+		"uncertain membership must not automatically uncordon the node")
 }
 
 const (

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
@@ -3,6 +3,7 @@ package talosprovisioner_test
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,7 +18,76 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestRollingReplaceSingleNode_CleanupFailurePreservesServer(t *testing.T) {
+	t.Parallel()
+
+	for _, leaveFailure := range []bool{false, true} {
+		name := "connection failure"
+		if leaveFailure {
+			name = "leave failure"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			transport := &membershipCloudTransport{address: "192.0.2.1"}
+
+			provisioner := newClientErrProvisioner(t)
+			if leaveFailure {
+				provisioner.WithEtcdClientFactoryForTest(
+					func(context.Context, string) (talosprovisioner.EtcdMembershipClientForTest, error) {
+						return &membershipClient{leaveErr: errMembershipUnavailable}, nil
+					},
+				)
+			}
+
+			server := &hcloud.Server{ID: 1, Name: "scale-cluster-control-plane-1"}
+			server.PublicNet.IPv4.IP = net.ParseIP(transport.address)
+			clientset := fake.NewClientset(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: server.Name, UID: "original-node"},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: transport.address},
+				}},
+			})
+
+			err := provisioner.RollingReplaceSingleNodeForTest(
+				t.Context(), clientset, newMembershipCloud(transport), "scale-cluster",
+				talosprovisioner.RoleControlPlane, server,
+			)
+
+			require.Error(t, err)
+			assert.Empty(t, transport.writes, "failed cleanup must prevent server replacement")
+
+			for _, action := range clientset.Actions() {
+				assert.NotEqual(
+					t,
+					"delete",
+					action.GetVerb(),
+					"must preserve the Kubernetes node object",
+				)
+			}
+
+			node, getErr := clientset.CoreV1().
+				Nodes().
+				Get(t.Context(), server.Name, metav1.GetOptions{})
+			require.NoError(t, getErr)
+			assert.Equal(t, "original-node", string(node.UID))
+			assert.True(
+				t,
+				node.Spec.Unschedulable,
+				"uncertain membership must not automatically uncordon the node",
+			)
+
+			if leaveFailure {
+				assert.ErrorIs(t, err, errMembershipUnavailable)
+			}
+		})
+	}
+}
 
 const (
 	testTypeCX22                 = "cx22"

--- a/pkg/svc/provisioner/cluster/talos/scale_docker.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_docker.go
@@ -327,7 +327,17 @@ func (p *Provisioner) removeControlPlaneNodesSequentially(
 		ctr := existing[idx]
 		nodeName := containerName(ctr)
 		nodeIP := containerIP(ctr, clusterName)
-		p.etcdCleanupBeforeRemoval(ctx, nodeIP)
+
+		cleanupErr := p.etcdCleanupBeforeRemoval(ctx, nodeIP)
+		if cleanupErr != nil {
+			recordFailedChange(result, RoleControlPlane, nodeName, cleanupErr)
+
+			return fmt.Errorf(
+				"retaining control-plane node %s after etcd cleanup failure: %w",
+				nodeName,
+				cleanupErr,
+			)
+		}
 
 		removeErr := p.removeDockerContainer(ctx, ctr.ID)
 		if removeErr != nil {

--- a/pkg/svc/provisioner/cluster/talos/scale_docker_test.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_docker_test.go
@@ -12,12 +12,91 @@ import (
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 var errDockerDaemonUnavailable = errors.New("docker: connection refused")
+
+//nolint:funlen // Keep the table-driven input, transport, and deletion assertions together.
+func TestRemoveDockerNodes_ControlPlaneCleanupFailurePreservesContainers(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name    string
+		address string
+	}{
+		{name: "missing address"},
+		{name: "invalid address", address: "not-an-ip"},
+		{name: "connection failure", address: "192.0.2.2"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockClient := docker.NewMockAPIClient(t)
+			mockClient.On("ContainerList", mock.Anything, mock.Anything).
+				Return([]container.Summary{
+					{ID: "cp-1", Names: []string{"/scale-cluster-control-plane-1"}},
+					{
+						ID: "cp-2", Names: []string{"/scale-cluster-control-plane-2"},
+						NetworkSettings: &container.NetworkSettingsSummary{
+							Networks: map[string]*network.EndpointSettings{
+								"scale-cluster": {IPAddress: testCase.address},
+							},
+						},
+					},
+				}, nil).Once()
+			mockClient.On("ContainerStop", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil).Maybe()
+			mockClient.On("ContainerRemove", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil).Maybe()
+
+			provisioner := newClientErrProvisioner(t).WithDockerClient(mockClient)
+
+			var cleanupTargets []string
+
+			if testCase.name != "connection failure" {
+				provisioner.WithEtcdClientFactoryForTest(
+					func(_ context.Context, target string) (talosprovisioner.EtcdMembershipClientForTest, error) {
+						cleanupTargets = append(cleanupTargets, target)
+
+						return &membershipClient{}, nil
+					},
+				)
+			}
+
+			result := clusterupdate.NewEmptyUpdateResult()
+			err := provisioner.RemoveDockerNodesForTest(
+				t.Context(), "scale-cluster", talosprovisioner.RoleControlPlane, 2, result,
+			)
+
+			require.Error(t, err)
+			assert.Empty(t, result.AppliedChanges)
+			assert.Len(t, result.FailedChanges, 1)
+			assert.Empty(
+				t,
+				cleanupTargets,
+				"invalid target must not fall back to a default endpoint",
+			)
+			mockClient.AssertNotCalled(
+				t,
+				"ContainerStop",
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			)
+			mockClient.AssertNotCalled(
+				t,
+				"ContainerRemove",
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			)
+		})
+	}
+}
 
 // newScaleProvisioner builds a Provisioner wired with the given mock Docker client.
 // TalosConfigs are generated fresh so every test has valid CP/worker configs.

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner.go
@@ -338,11 +338,21 @@ func (p *Provisioner) removeHetznerNodes(
 	for i := len(existing) - 1; i >= len(existing)-count; i-- {
 		server := existing[i]
 
-		// Best-effort etcd cleanup for control-plane nodes
+		// Address resolution and etcd cleanup must succeed before destruction.
 		if role == RoleControlPlane {
-			serverIP, addrErr := hetznerNodeTalosAddress(server)
-			if addrErr == nil {
-				p.etcdCleanupBeforeRemoval(ctx, serverIP)
+			serverIP, cleanupErr := hetznerNodeTalosAddress(server)
+			if cleanupErr == nil {
+				cleanupErr = p.etcdCleanupBeforeRemoval(ctx, serverIP)
+			}
+
+			if cleanupErr != nil {
+				recordFailedChange(result, role, server.Name, cleanupErr)
+
+				return fmt.Errorf(
+					"retaining control-plane server %s after etcd cleanup failure: %w",
+					server.Name,
+					cleanupErr,
+				)
 			}
 		}
 

--- a/pkg/svc/provisioner/cluster/talos/scale_hetzner_test.go
+++ b/pkg/svc/provisioner/cluster/talos/scale_hetzner_test.go
@@ -6,11 +6,66 @@ import (
 	"net"
 	"testing"
 
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/clusterupdate"
 	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRemoveHetznerNodes_CleanupFailurePreservesServer(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name         string
+		address      string
+		leaveFailure bool
+	}{
+		{name: "missing target address"},
+		{name: "connection failure", address: "192.0.2.1"},
+		{name: "leave failure", address: "192.0.2.1", leaveFailure: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			transport := &membershipCloudTransport{address: testCase.address}
+
+			provisioner := newClientErrProvisioner(
+				t,
+			).WithInfraProvider(newMembershipCloud(transport))
+			if testCase.leaveFailure {
+				provisioner.WithEtcdClientFactoryForTest(
+					func(context.Context, string) (talosprovisioner.EtcdMembershipClientForTest, error) {
+						return &membershipClient{leaveErr: errMembershipUnavailable}, nil
+					},
+				)
+			}
+
+			result := clusterupdate.NewEmptyUpdateResult()
+
+			err := provisioner.RemoveHetznerNodesForTest(
+				t.Context(),
+				"scale-cluster",
+				talosprovisioner.RoleControlPlane,
+				1,
+				result,
+			)
+
+			require.Error(t, err)
+			assert.Empty(
+				t,
+				transport.writes,
+				"membership failure must precede every infrastructure mutation",
+			)
+			assert.Empty(t, result.AppliedChanges)
+			assert.Len(t, result.FailedChanges, 1)
+
+			if testCase.leaveFailure {
+				assert.ErrorIs(t, err, errMembershipUnavailable)
+			}
+		})
+	}
+}
 
 // TestWaitForNewHetznerNodesReachable_NoServersIsNoOp verifies the post-config
 // reachability wait is a no-op (no dialing, no error) when there are no new nodes.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

A failed Talos connection or etcd leave RPC previously logged a warning and still deleted the control-plane server/container. This change returns the error and stops Docker/Hetzner scale-down and Hetzner rolling replacement before infrastructure deletion or the next member. Invalid target addresses are rejected before opening a Talos client.

Membership mutations remain single-attempt; a successful leave still permits removal when the preliminary leadership-transfer attempt fails. An uncertain leave failure preserves the node and its existing cordon so recovery does not assume whether the operation took effect.

Validation: real-caller regression tests failed before the fix, observing cloud DELETE attempts and successful Docker removal after cleanup errors. The final Talos package suite passes on Go1.26.6, and scoped golangci-lint reports zero issues. Tests cover connection/leave/address failure, retained node UID and cordon, no next-member mutation, successful removals, and unchanged worker behavior. Full build and repository checks remain with CI; no destructive cluster drill was run.

Fixes #6931.

This is a bounded prerequisite for the replacement-verification work tracked by devantler-tech/platform#2120 and devantler-tech/platform#2764. It does not introduce or enable a production drill; target identity, survivor quorum, recovery-material, stable-endpoint, and deployment-lock requirements remain separately outstanding.
