### PR TITLE
fix(talos): preserve patch settings and tolerate upgrade API restarts

### DIFF
--- a/docs/src/content/docs/guides/talos-native-patches.mdx
+++ b/docs/src/content/docs/guides/talos-native-patches.mdx
@@ -104,6 +104,39 @@ When you run `ksail cluster update`, KSail:
    - **Wipe-required** — requires partition wipe (disk encryption migration)
 4. Applies changes using the appropriate Talos SDK mode
 
+## Talos 1.14 Kubernetes Patch Migration
+
+When generating a Talos 1.14 or newer configuration, KSail converts supported legacy
+`cluster.apiServer` settings into native Kubernetes configuration documents. Patches
+for older Talos version contracts keep their original content.
+
+Files are applied in filename order within each directory. Shared `cluster/` patches
+are applied before `control-planes/` and `workers/` patches, including shared patches
+supplied at runtime. Documents separated by `---` are applied in their original order
+as separate patches, so repeated API-server settings follow Talos's native merge rules.
+
+Legacy OIDC flags may be split across files or documents in the same scope. KSail
+resolves the complete issuer, client, claim mappings, and CA before emitting structured
+authentication. Role patches override shared settings without changing the other role.
+A shared OIDC configuration must be complete on its own; put settings intended only for
+control planes together in `control-planes/`.
+
+Some layouts require an explicit conversion:
+
+- **RFC 6902 YAML or JSON lists:** Talos cannot apply these to its multi-document
+  configuration. Convert them to strategic-merge Talos configuration documents. KSail
+  reports the source file during migration, including for operations on unrelated fields.
+- **YAML aliases in multi-document files:** expand aliases to explicit values before
+  migration so each resulting patch is self-contained.
+- **Mixed authentication formats:** consolidate legacy OIDC flags and an explicit
+  `KubeAuthenticationConfig` into one structured configuration.
+- **OIDC CA appends or deletions:** provide the complete CA as literal file content
+  using `create` or `overwrite`. KSail cannot resolve a CA from existing machine state.
+  An empty final CA does not fall back to earlier content.
+- **Deletion selectors overlapping OIDC:** consolidate the remaining authentication
+  settings before migration. Multi-key list deletions in a legacy document being
+  converted must be moved to a separate strategic-merge patch to preserve their selector.
+
 ## Backward Compatibility
 
 Deprecated fields continue to work. When a deprecated field is set:

--- a/docs/src/content/docs/guides/talos-native-patches.mdx
+++ b/docs/src/content/docs/guides/talos-native-patches.mdx
@@ -136,6 +136,9 @@ Some layouts require an explicit conversion:
 - **Deletion selectors overlapping OIDC:** consolidate the remaining authentication
   settings before migration. Multi-key list deletions in a legacy document being
   converted must be moved to a separate strategic-merge patch to preserve their selector.
+  When OIDC references a CA file, a deletion selected only by another file's `path`
+  is preserved. Deletions of the CA, the whole file list, or the machine remain
+  unsupported, as do selectors without a path or with additional selector fields.
 
 ## Backward Compatibility
 

--- a/go.mod
+++ b/go.mod
@@ -933,7 +933,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/image v0.45.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/sys v0.47.0
 	golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
@@ -261,9 +261,9 @@ func resolveScopeOIDC(records []kubernetesPatchDocument, scope PatchScope) (Patc
 	config, err := resolvedOIDCConfig(arguments, records, source)
 	if err != nil {
 		return Patch{}, false, fmt.Errorf(
-			"resolve OIDC scope %d (shared settings must be complete; "+
+			"resolve OIDC scope %s/ (shared settings must be complete; "+
 				"put role-only settings together in control-planes/ or workers/): %w",
-			scope,
+			patchScopeDirectory(scope),
 			err,
 		)
 	}
@@ -503,4 +503,17 @@ func containsYAMLAlias(node *yamlv3.Node) bool {
 	}
 
 	return slices.ContainsFunc(node.Content, containsYAMLAlias)
+}
+
+func patchScopeDirectory(scope PatchScope) string {
+	switch scope {
+	case PatchScopeCluster:
+		return PatchSubdirCluster
+	case PatchScopeControlPlane:
+		return PatchSubdirControlPlanes
+	case PatchScopeWorker:
+		return PatchSubdirWorkers
+	default:
+		return "unknown"
+	}
 }

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
@@ -75,43 +75,98 @@ func prepareKubernetesPatchSet(patches []Patch) ([]Patch, error) {
 func decodeKubernetesPatchSet(patches []Patch) ([]kubernetesPatchDocument, error) {
 	records := make([]kubernetesPatchDocument, 0, len(patches))
 	for _, patch := range patches {
-		documents, mapDocuments, err := decodeLegacyKubernetesDocuments(patch)
+		documents, err := decodeOrderedPatchDocuments(patch)
 		if err != nil {
 			return nil, err
 		}
 
-		if !mapDocuments {
-			return nil, fmt.Errorf(
-				"migrate Kubernetes patch %q: %w",
-				patch.Path,
-				errRFC6902Migration,
-			)
-		}
-
-		contents, err := orderedKubernetesDocuments(patch, len(documents))
-		if err != nil {
-			return nil, err
-		}
-
-		for idx, document := range documents {
-			if hasLegacyKubernetesValues(document) && ambiguousListDeletion(document) {
-				return nil, fmt.Errorf(
-					"migrate Kubernetes patch %q: %w",
-					patch.Path,
-					errMigrationDeletion,
-				)
-			}
-
-			part := patch
-			if len(documents) > 1 {
-				part.Content = contents[idx]
-			}
-
-			records = append(records, kubernetesPatchDocument{patch: part, document: document})
-		}
+		records = append(records, documents...)
 	}
 
 	return records, nil
+}
+
+// Derive the decoded map and ordered YAML from the same document. Empty merge
+// documents and aliases must never shift a separate content index.
+func decodeOrderedPatchDocuments(patch Patch) ([]kubernetesPatchDocument, error) {
+	decoder := yamlv3.NewDecoder(bytes.NewReader(patch.Content))
+
+	var (
+		records []kubernetesPatchDocument
+		nodes   []*yamlv3.Node
+	)
+
+	documentCount := 0
+
+	for {
+		var node yamlv3.Node
+
+		err := decoder.Decode(&node)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("decode Kubernetes patch %q: %w", patch.Path, err)
+		}
+
+		documentCount++
+
+		document, err := decodeKubernetesDocument(&node, patch.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(document) == 0 {
+			continue
+		}
+
+		records = append(records, kubernetesPatchDocument{patch: patch, document: document})
+		nodes = append(nodes, &node)
+	}
+
+	if documentCount <= 1 {
+		return records, nil
+	}
+
+	for idx, node := range nodes {
+		if containsYAMLAlias(node) {
+			return nil, fmt.Errorf("migrate Kubernetes patch %q: %w", patch.Path, errMigrationAlias)
+		}
+
+		content, err := yamlv3.Marshal(node)
+		if err != nil {
+			return nil, fmt.Errorf("encode Kubernetes patch %q: %w", patch.Path, err)
+		}
+
+		records[idx].patch.Content = content
+	}
+
+	return records, nil
+}
+
+func decodeKubernetesDocument(node *yamlv3.Node, path string) (map[string]any, error) {
+	var value any
+
+	err := node.Decode(&value)
+	if err != nil {
+		return nil, fmt.Errorf("decode Kubernetes patch %q: %w", path, err)
+	}
+
+	if value == nil {
+		return map[string]any{}, nil
+	}
+
+	document, isMap := value.(map[string]any)
+	if !isMap {
+		return nil, fmt.Errorf("migrate Kubernetes patch %q: %w", path, errRFC6902Migration)
+	}
+
+	if hasLegacyKubernetesValues(document) && ambiguousListDeletion(document) {
+		return nil, fmt.Errorf("migrate Kubernetes patch %q: %w", path, errMigrationDeletion)
+	}
+
+	return document, nil
 }
 
 func resolvePatchSetOIDC(records []kubernetesPatchDocument) ([]Patch, error) {
@@ -364,46 +419,6 @@ func nonemptyKubernetesPatches(patches []Patch) []Patch {
 	return nonempty
 }
 
-// Keep YAML key order when splitting documents: Talos deletion selectors can
-// depend on the first field of a list entry.
-func orderedKubernetesDocuments(patch Patch, count int) ([][]byte, error) {
-	if count <= 1 {
-		return nil, nil
-	}
-
-	decoder := yamlv3.NewDecoder(bytes.NewReader(patch.Content))
-	contents := make([][]byte, 0, count)
-
-	for {
-		var document yamlv3.Node
-
-		err := decoder.Decode(&document)
-		if errors.Is(err, io.EOF) {
-			return contents, nil
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("decode Kubernetes patch %q: %w", patch.Path, err)
-		}
-
-		if containsYAMLAlias(&document) {
-			return nil, fmt.Errorf("migrate Kubernetes patch %q: %w", patch.Path, errMigrationAlias)
-		}
-
-		if len(document.Content) == 0 || document.Content[0].Kind != yamlv3.MappingNode ||
-			len(document.Content[0].Content) == 0 {
-			continue
-		}
-
-		content, err := yamlv3.Marshal(&document)
-		if err != nil {
-			return nil, fmt.Errorf("encode Kubernetes patch %q: %w", patch.Path, err)
-		}
-
-		contents = append(contents, content)
-	}
-}
-
 func rejectOIDCDeletions(records []kubernetesPatchDocument) error {
 	for _, record := range records {
 		cluster, _ := mapValue(record.document, "cluster")
@@ -487,11 +502,5 @@ func containsYAMLAlias(node *yamlv3.Node) bool {
 		return true
 	}
 
-	for _, child := range node.Content {
-		if containsYAMLAlias(child) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(node.Content, containsYAMLAlias)
 }

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
@@ -382,7 +382,7 @@ func resolveOIDCCA(records []kubernetesPatchDocument, path string) (string, erro
 
 	for _, record := range records {
 		machine, _ := mapValue(record.document, "machine")
-		if machine["$patch"] != nil || containsDeletion(machine["files"]) {
+		if machine["$patch"] != nil || containsOIDCCADeletion(machine["files"], path) {
 			return "", fmt.Errorf("CA patch %q: %w", record.patch.Path, errOIDCDeletion)
 		}
 
@@ -406,6 +406,30 @@ func resolveOIDCCA(records []kubernetesPatchDocument, path string) (string, erro
 	}
 
 	return content, nil
+}
+
+// containsOIDCCADeletion permits only an unambiguous selector for another path.
+// Talos selects by the first non-$patch key, whose order a decoded map cannot retain.
+func containsOIDCCADeletion(value any, path string) bool {
+	files, ok := value.([]any)
+	if !ok {
+		return containsDeletion(value)
+	}
+
+	for _, item := range files {
+		if !containsDeletion(item) {
+			continue
+		}
+
+		file, _ := item.(map[string]any)
+
+		filePath, _ := file["path"].(string)
+		if len(file) != 2 || file["$patch"] == nil || filePath == "" || filePath == path {
+			return true
+		}
+	}
+
+	return false
 }
 
 func nonemptyKubernetesPatches(patches []Patch) []Patch {

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set.go
@@ -1,0 +1,497 @@
+package talos
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	errMigrationAlias = errors.New("expand YAML aliases before migrating a multi-document patch")
+	errOIDCDeletion   = errors.New(
+		"deletion selectors overlap legacy OIDC configuration; consolidate authentication and CA content before migrating",
+	)
+	errMigrationDeletion = errors.New(
+		"multi-key list deletion cannot be normalized safely; move the deletion into a separate strategic-merge patch",
+	)
+	errRFC6902Migration = errors.New(
+		"RFC 6902 patches cannot target Talos 1.14 multi-document configurations; " +
+			"convert this patch to strategic-merge Talos configuration documents",
+	)
+	errMixedOIDCAuthentication = errors.New(
+		"legacy OIDC flags overlap KubeAuthenticationConfig; consolidate authentication into one structured configuration",
+	)
+	errOIDCArgumentType = errors.New("legacy OIDC arguments must be strings")
+	errOIDCCAOperation  = errors.New(
+		"OIDC CA cannot be resolved from this file operation; provide the complete CA content with create or overwrite",
+	)
+)
+
+// A record retains application scope and source order while each document is
+// migrated independently. The SDK rejects duplicate document kinds in one patch.
+type kubernetesPatchDocument struct {
+	patch    Patch
+	document map[string]any
+}
+
+func prepareKubernetesPatchSet(patches []Patch) ([]Patch, error) {
+	records, err := decodeKubernetesPatchSet(patches)
+	if err != nil {
+		return nil, err
+	}
+
+	authentication, err := resolvePatchSetOIDC(records)
+	if err != nil {
+		return nil, err
+	}
+
+	prepared := make([]Patch, 0, len(records)+len(authentication))
+	for _, record := range records {
+		changed := removePatchOIDCArguments(record.document)
+
+		patch := record.patch
+		if changed {
+			content, marshalErr := yaml.Marshal(record.document)
+			if marshalErr != nil {
+				return nil, fmt.Errorf("marshal Kubernetes patch %q: %w", patch.Path, marshalErr)
+			}
+
+			patch.Content = content
+		}
+
+		prepared = append(prepared, patch)
+	}
+
+	return append(prepared, authentication...), nil
+}
+
+func decodeKubernetesPatchSet(patches []Patch) ([]kubernetesPatchDocument, error) {
+	records := make([]kubernetesPatchDocument, 0, len(patches))
+	for _, patch := range patches {
+		documents, mapDocuments, err := decodeLegacyKubernetesDocuments(patch)
+		if err != nil {
+			return nil, err
+		}
+
+		if !mapDocuments {
+			return nil, fmt.Errorf(
+				"migrate Kubernetes patch %q: %w",
+				patch.Path,
+				errRFC6902Migration,
+			)
+		}
+
+		contents, err := orderedKubernetesDocuments(patch, len(documents))
+		if err != nil {
+			return nil, err
+		}
+
+		for idx, document := range documents {
+			if hasLegacyKubernetesValues(document) && ambiguousListDeletion(document) {
+				return nil, fmt.Errorf(
+					"migrate Kubernetes patch %q: %w",
+					patch.Path,
+					errMigrationDeletion,
+				)
+			}
+
+			part := patch
+			if len(documents) > 1 {
+				part.Content = contents[idx]
+			}
+
+			records = append(records, kubernetesPatchDocument{patch: part, document: document})
+		}
+	}
+
+	return records, nil
+}
+
+func resolvePatchSetOIDC(records []kubernetesPatchDocument) ([]Patch, error) {
+	var (
+		authentication []Patch
+		sharedContent  []byte
+	)
+
+	for _, scope := range []PatchScope{PatchScopeCluster, PatchScopeControlPlane, PatchScopeWorker} {
+		applicable := patchDocumentsForScope(records, scope)
+
+		patch, found, err := resolveScopeOIDC(applicable, scope)
+		if err != nil {
+			return nil, err
+		}
+
+		if !found {
+			continue
+		}
+
+		if scope == PatchScopeCluster {
+			sharedContent = patch.Content
+		} else if bytes.Equal(sharedContent, patch.Content) {
+			continue
+		}
+
+		authentication = append(authentication, patch)
+	}
+
+	return authentication, nil
+}
+
+// Bundle applies all shared patches before the role patches, even when a runtime
+// shared patch was appended after files from control-planes/ or workers/.
+func patchDocumentsForScope(
+	records []kubernetesPatchDocument,
+	scope PatchScope,
+) []kubernetesPatchDocument {
+	applicable := make([]kubernetesPatchDocument, 0, len(records))
+	for _, record := range records {
+		if record.patch.Scope == PatchScopeCluster {
+			applicable = append(applicable, record)
+		}
+	}
+
+	if scope != PatchScopeCluster {
+		for _, record := range records {
+			if record.patch.Scope == scope {
+				applicable = append(applicable, record)
+			}
+		}
+	}
+
+	return applicable
+}
+
+func resolveScopeOIDC(records []kubernetesPatchDocument, scope PatchScope) (Patch, bool, error) {
+	arguments := map[string]any{}
+	source := ""
+	structured := false
+
+	for _, record := range records {
+		if record.document[kindField] == kubeAuthenticationConfigKind {
+			structured = true
+		}
+
+		local := patchOIDCArguments(record.document)
+		if len(local) > 0 {
+			source = record.patch.Path
+
+			maps.Copy(arguments, local)
+		}
+	}
+
+	if len(arguments) == 0 {
+		return Patch{}, false, nil
+	}
+
+	if structured {
+		return Patch{}, false, fmt.Errorf(
+			"migrate legacy OIDC patch %q: %w",
+			source,
+			errMixedOIDCAuthentication,
+		)
+	}
+
+	err := rejectOIDCDeletions(records)
+	if err != nil {
+		return Patch{}, false, err
+	}
+
+	config, err := resolvedOIDCConfig(arguments, records, source)
+	if err != nil {
+		return Patch{}, false, fmt.Errorf(
+			"resolve OIDC scope %d (shared settings must be complete; "+
+				"put role-only settings together in control-planes/ or workers/): %w",
+			scope,
+			err,
+		)
+	}
+
+	return Patch{Path: source, Scope: scope, Content: StructuredOIDCPatchYAML(config)}, true, nil
+}
+
+func resolvedOIDCConfig(
+	arguments map[string]any,
+	records []kubernetesPatchDocument,
+	source string,
+) (OIDCPatchConfig, error) {
+	for key, value := range arguments {
+		if _, ok := value.(string); !ok {
+			return OIDCPatchConfig{}, fmt.Errorf(
+				"migrate legacy OIDC patch %q argument %q: %w",
+				source,
+				key,
+				errOIDCArgumentType,
+			)
+		}
+	}
+
+	config := OIDCPatchConfig{
+		IssuerURL: popString(
+			arguments,
+			"oidc-issuer-url",
+		),
+		ClientID: popString(arguments, "oidc-client-id"),
+		UsernameClaim: popString(
+			arguments,
+			"oidc-username-claim",
+		),
+		UsernamePrefix: popString(arguments, "oidc-username-prefix"),
+		GroupsClaim: popString(
+			arguments,
+			"oidc-groups-claim",
+		),
+		GroupsPrefix: popString(arguments, "oidc-groups-prefix"),
+	}
+	if config.IssuerURL == "" || config.ClientID == "" {
+		return OIDCPatchConfig{}, fmt.Errorf(
+			"migrate legacy OIDC patch %q: %w",
+			source,
+			errLegacyOIDCRequiredFields,
+		)
+	}
+
+	caPath := popString(arguments, "oidc-ca-file")
+	if caPath != "" {
+		content, err := resolveOIDCCA(records, caPath)
+		if err != nil {
+			return OIDCPatchConfig{}, fmt.Errorf(
+				"migrate legacy OIDC patch %q for %q: %w",
+				source,
+				caPath,
+				err,
+			)
+		}
+
+		config.CertificateAuthority = content
+	}
+
+	return config, nil
+}
+
+func patchOIDCArguments(document map[string]any) map[string]any {
+	cluster, _ := mapValue(document, "cluster")
+	apiServer, _ := mapValue(cluster, "apiServer")
+	arguments, _ := mapValue(apiServer, "extraArgs")
+	oidc := map[string]any{}
+
+	for key, value := range arguments {
+		if supportedOIDCArgument(key) {
+			oidc[key] = value
+		}
+	}
+
+	return oidc
+}
+
+func supportedOIDCArgument(key string) bool {
+	switch key {
+	case "oidc-issuer-url",
+		"oidc-client-id",
+		"oidc-username-claim",
+		"oidc-username-prefix",
+		"oidc-groups-claim",
+		"oidc-groups-prefix",
+		"oidc-ca-file":
+		return true
+	default:
+		return false
+	}
+}
+
+func removePatchOIDCArguments(document map[string]any) bool {
+	cluster, _ := mapValue(document, "cluster")
+	apiServer, _ := mapValue(cluster, "apiServer")
+	arguments, _ := mapValue(apiServer, "extraArgs")
+	changed := false
+
+	for key := range arguments {
+		if supportedOIDCArgument(key) {
+			delete(arguments, key)
+
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+func resolveOIDCCA(records []kubernetesPatchDocument, path string) (string, error) {
+	content := ""
+
+	for _, record := range records {
+		machine, _ := mapValue(record.document, "machine")
+		if machine["$patch"] != nil || containsDeletion(machine["files"]) {
+			return "", fmt.Errorf("CA patch %q: %w", record.patch.Path, errOIDCDeletion)
+		}
+
+		files, _ := machine["files"].([]any)
+		for _, item := range files {
+			file, ok := item.(map[string]any)
+			if !ok || file["path"] != path {
+				continue
+			}
+
+			if !literalCAOperation(file) {
+				return "", fmt.Errorf("CA patch %q: %w", record.patch.Path, errOIDCCAOperation)
+			}
+
+			content, _ = file["content"].(string)
+		}
+	}
+
+	if strings.TrimSpace(content) == "" {
+		return "", errLegacyOIDCCAMissing
+	}
+
+	return content, nil
+}
+
+func nonemptyKubernetesPatches(patches []Patch) []Patch {
+	nonempty := patches[:0]
+	for _, patch := range patches {
+		if len(bytes.TrimSpace(patch.Content)) > 0 {
+			nonempty = append(nonempty, patch)
+		}
+	}
+
+	return nonempty
+}
+
+// Keep YAML key order when splitting documents: Talos deletion selectors can
+// depend on the first field of a list entry.
+func orderedKubernetesDocuments(patch Patch, count int) ([][]byte, error) {
+	if count <= 1 {
+		return nil, nil
+	}
+
+	decoder := yamlv3.NewDecoder(bytes.NewReader(patch.Content))
+	contents := make([][]byte, 0, count)
+
+	for {
+		var document yamlv3.Node
+
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			return contents, nil
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("decode Kubernetes patch %q: %w", patch.Path, err)
+		}
+
+		if containsYAMLAlias(&document) {
+			return nil, fmt.Errorf("migrate Kubernetes patch %q: %w", patch.Path, errMigrationAlias)
+		}
+
+		if len(document.Content) == 0 || document.Content[0].Kind != yamlv3.MappingNode ||
+			len(document.Content[0].Content) == 0 {
+			continue
+		}
+
+		content, err := yamlv3.Marshal(&document)
+		if err != nil {
+			return nil, fmt.Errorf("encode Kubernetes patch %q: %w", patch.Path, err)
+		}
+
+		contents = append(contents, content)
+	}
+}
+
+func rejectOIDCDeletions(records []kubernetesPatchDocument) error {
+	for _, record := range records {
+		cluster, _ := mapValue(record.document, "cluster")
+
+		apiServer, _ := mapValue(cluster, "apiServer")
+		if cluster["$patch"] != nil || apiServer["$patch"] != nil ||
+			containsDeletion(apiServer["extraArgs"]) {
+			return fmt.Errorf("OIDC patch %q: %w", record.patch.Path, errOIDCDeletion)
+		}
+	}
+
+	return nil
+}
+
+func containsDeletion(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		if typed["$patch"] != nil {
+			return true
+		}
+
+		for _, child := range typed {
+			if containsDeletion(child) {
+				return true
+			}
+		}
+	case []any:
+		if slices.ContainsFunc(typed, containsDeletion) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ambiguousListDeletion(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		for _, child := range typed {
+			if ambiguousListDeletion(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if entry, ok := child.(map[string]any); ok && entry["$patch"] != nil && len(entry) > 2 {
+				return true
+			}
+
+			if ambiguousListDeletion(child) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func hasLegacyKubernetesValues(document map[string]any) bool {
+	cluster, _ := mapValue(document, "cluster")
+	if _, found := mapValue(cluster, "apiServer"); found {
+		return true
+	}
+
+	network, _ := mapValue(cluster, "network")
+	cni, _ := mapValue(network, "cni")
+
+	return cni["name"] == "none"
+}
+
+func literalCAOperation(file map[string]any) bool {
+	operation, _ := file["op"].(string)
+	// Preserve legacy migration of omitted operations. Append requires machine
+	// state, which is unavailable while generating configuration.
+	return (operation == "" || operation == "create" || operation == "overwrite") &&
+		file["$patch"] == nil
+}
+
+func containsYAMLAlias(node *yamlv3.Node) bool {
+	if node.Kind == yamlv3.AliasNode {
+		return true
+	}
+
+	for _, child := range node.Content {
+		if containsYAMLAlias(child) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
@@ -211,6 +211,35 @@ func TestKubernetesPatchSetResolvesRoleCertificateOverrides(t *testing.T) {
 	assertJWTIssuer(t, configs.Worker(), "shared", "shared-ca")
 }
 
+func TestKubernetesPatchSetPreservesOIDCCAWithUnrelatedDeletion(t *testing.T) {
+	t.Parallel()
+	configs, err := loadVariantPatches(t, map[string]string{
+		"cluster/oidc.yaml": legacyOIDCArgs(sharedOIDCWithCA),
+		"cluster/files.yaml": oidcCAFile("shared-ca", "overwrite") + `    - path: /etc/obsolete.conf
+      op: overwrite
+      content: obsolete
+`,
+		"control-planes/delete.yaml": `machine:
+  files:
+    - path: /etc/obsolete.conf
+      $patch: delete
+`,
+	}, nil)
+	require.NoError(t, err)
+	assertJWTIssuer(t, configs.ControlPlane(), "shared", "shared-ca")
+	assertJWTIssuer(t, configs.Worker(), "shared", "shared-ca")
+
+	files, err := configs.ControlPlane().Machine().Files()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "/etc/oidc.crt", files[0].Path())
+	assert.Equal(t, "shared-ca", files[0].Content())
+
+	workerFiles, err := configs.Worker().Machine().Files()
+	require.NoError(t, err)
+	require.Len(t, workerFiles, 2)
+}
+
 func TestKubernetesPatchSetRejectsAmbiguousOIDC(t *testing.T) {
 	t.Parallel()
 
@@ -230,8 +259,28 @@ func TestKubernetesPatchSetRejectsAmbiguousOIDC(t *testing.T) {
 		{"empty CA", oidcCAFile("", "overwrite"), "CA content is missing"},
 		{"delete API server", "cluster:\n  apiServer:\n    $patch: delete\n", "deletion"},
 		{
+			"delete referenced CA",
+			"machine:\n  files:\n    - path: /etc/oidc.crt\n      $patch: delete\n",
+			"deletion",
+		},
+		{
 			"delete CA by selector",
 			"machine:\n  files:\n    - op: overwrite\n      $patch: delete\n",
+			"deletion",
+		},
+		{
+			"operation selector before unrelated path",
+			"machine:\n  files:\n    - op: overwrite\n      path: /etc/obsolete.conf\n      $patch: delete\n",
+			"deletion",
+		},
+		{
+			"path selector before operation",
+			"machine:\n  files:\n    - path: /etc/obsolete.conf\n      op: overwrite\n      $patch: delete\n",
+			"deletion",
+		},
+		{
+			"delete files",
+			"machine:\n  files:\n    $patch: delete\n",
 			"deletion",
 		},
 		{"delete machine", "machine:\n  $patch: delete\n", "deletion"},

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
@@ -1,0 +1,369 @@
+package talos_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager"
+	talos "github.com/devantler-tech/ksail/v7/pkg/fsutil/configmanager/talos"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sharedOIDCWithCA = "oidc-issuer-url: https://dex.example.com\n      oidc-client-id: shared\n" +
+	"      oidc-ca-file: /etc/oidc.crt"
+
+func TestKubernetesPatchSetRejectsJSON6902AtMigration(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"yaml":                "- op: replace\n  path: /cluster/network/cni/name\n  value: none\n",
+		"json":                `[{"op":"replace","path":"/cluster/apiServer/extraArgs","value":{"audit-log-maxage":"30"}}]`,
+		"move":                `[{"op":"move","from":"/cluster/apiServer","path":"/machine/ignored"}]`,
+		"copy root":           `[{"op":"copy","from":"","path":"/copy"}]`,
+		"replace root":        `[{"op":"replace","path":"","value":{}}]`,
+		"hostname":            `[{"op":"add","path":"/machine/network/hostname","value":"node"}]`,
+		"malformed operation": `[{"op":"invalid"}]`,
+	}
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			patches := []talos.Patch{{Path: "variant.yaml", Content: []byte(content)}}
+			_, err := talos.MigrateKubernetesPatchesForContract(
+				patches,
+				talosconfig.TalosVersion1_14,
+			)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "variant.yaml")
+			require.ErrorContains(t, err, "RFC 6902")
+			require.ErrorContains(t, err, "strategic-merge")
+			preserved, err := talos.MigrateKubernetesPatchesForContract(
+				patches,
+				talosconfig.TalosVersion1_13,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, patches, preserved)
+		})
+	}
+}
+
+func TestKubernetesPatchSetPreservesDocumentOrder(t *testing.T) {
+	t.Parallel()
+	configs, err := loadVariantPatches(t, map[string]string{
+		"cluster/api.yaml": `cluster:
+  apiServer:
+    certSANs: [first.example.com]
+    extraArgs:
+      audit-log-maxage: "10"
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+extraArgs:
+  audit-log-maxage: "20"
+  audit-log-maxbackup: "5"
+---
+cluster:
+  apiServer:
+    certSANs: [last.example.com]
+    extraArgs:
+      audit-log-maxage: "30"
+`,
+	}, nil)
+	require.NoError(t, err)
+
+	api := configs.ControlPlane().K8sAPIServerConfig()
+	assert.Contains(t, api.CertSANs(), "first.example.com")
+	assert.Contains(t, api.CertSANs(), "last.example.com")
+	assert.Equal(t, []string{"30"}, api.ExtraArgs()["audit-log-maxage"])
+	assert.Equal(t, []string{"5"}, api.ExtraArgs()["audit-log-maxbackup"])
+}
+
+func TestKubernetesPatchSetResolvesSplitOIDC(t *testing.T) {
+	t.Parallel()
+
+	for _, reverse := range []bool{false, true} {
+		name := "issuer first"
+		if reverse {
+			name = "client first"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			issuer := legacyOIDCArgs("oidc-issuer-url: https://dex.example.com")
+
+			client := legacyOIDCArgs("oidc-client-id: ksail\n      oidc-username-claim: email")
+			if reverse {
+				issuer, client = client, issuer
+			}
+
+			configs, err := loadVariantPatches(t, map[string]string{
+				"control-planes/01.yaml": issuer, "control-planes/02.yaml": client,
+			}, nil)
+			require.NoError(t, err)
+			assertJWTIssuer(t, configs.ControlPlane(), "ksail", "")
+			assert.Empty(t, configs.ControlPlane().K8sAPIServerConfig().ExtraArgs())
+			assert.Nil(t, configs.Worker().K8sAuthenticationConfig())
+		})
+	}
+}
+
+func TestKubernetesPatchSetResolvesOIDCByScopeAndRuntimeOrder(t *testing.T) {
+	t.Parallel()
+	configs, err := loadVariantPatches(t, map[string]string{
+		"cluster/oidc.yaml": legacyOIDCArgs(
+			"oidc-issuer-url: https://dex.example.com\n      oidc-client-id: shared",
+		),
+		"control-planes/client.yaml": legacyOIDCArgs("oidc-client-id: control-plane"),
+		"workers/client.yaml":        legacyOIDCArgs("oidc-client-id: worker"),
+	}, []talos.Patch{{
+		Path: "runtime shared", Scope: talos.PatchScopeCluster,
+		Content: []byte(legacyOIDCArgs("oidc-client-id: runtime")),
+	}})
+	require.NoError(t, err)
+	assertJWTIssuer(t, configs.ControlPlane(), "control-plane", "")
+	assertJWTIssuer(t, configs.Worker(), "worker", "")
+}
+
+func TestKubernetesPatchSetRejectsCrossScopeOIDCCompletion(t *testing.T) {
+	t.Parallel()
+	_, err := loadVariantPatches(t, map[string]string{
+		"control-planes/issuer.yaml": legacyOIDCArgs("oidc-issuer-url: https://dex.example.com"),
+		"workers/client.yaml":        legacyOIDCArgs("oidc-client-id: worker"),
+	}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "issuer URL and client ID are required")
+}
+
+func loadVariantPatches(
+	t *testing.T,
+	files map[string]string,
+	additional []talos.Patch,
+) (*talos.Configs, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	}
+
+	configs, err := talos.NewConfigManager(dir, "variants", "1.36.0", "10.5.0.0/24").
+		WithVersionContract(talosconfig.TalosVersion1_14).WithAdditionalPatches(additional).
+		Load(configmanager.LoadOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("load variant patches: %w", err)
+	}
+
+	return configs, nil
+}
+
+func legacyOIDCArgs(args string) string {
+	return "cluster:\n  apiServer:\n    extraArgs:\n      " + args + "\n"
+}
+
+func assertJWTIssuer(
+	t *testing.T,
+	provider talosconfig.Provider,
+	audience, certificateAuthority string,
+) {
+	t.Helper()
+
+	auth := provider.K8sAuthenticationConfig().Configuration()
+	jwt, found := auth["jwt"].([]any)
+	require.True(t, found)
+	require.Len(t, jwt, 1)
+	authenticator, found := jwt[0].(map[string]any)
+	require.True(t, found)
+	issuer, found := authenticator["issuer"].(map[string]any)
+	require.True(t, found)
+	assert.Equal(t, "https://dex.example.com", issuer["url"])
+	assert.Equal(t, []any{audience}, issuer["audiences"])
+
+	if certificateAuthority != "" {
+		assert.Equal(t, certificateAuthority+"\n", issuer["certificateAuthority"])
+	}
+}
+
+func TestKubernetesPatchSetResolvesRoleCertificateOverrides(t *testing.T) {
+	t.Parallel()
+	configs, err := loadVariantPatches(t, map[string]string{
+		"cluster/oidc.yaml": legacyOIDCArgs(
+			sharedOIDCWithCA,
+		),
+		"cluster/ca.yaml": oidcCAFile(
+			"shared-ca",
+			"overwrite",
+		),
+		"control-planes/ca.yaml": oidcCAFile(
+			"control-plane-ca",
+			"overwrite",
+		),
+	}, nil)
+	require.NoError(t, err)
+	assertJWTIssuer(t, configs.ControlPlane(), "shared", "control-plane-ca")
+	assertJWTIssuer(t, configs.Worker(), "shared", "shared-ca")
+}
+
+func TestKubernetesPatchSetRejectsAmbiguousOIDC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ name, patch, want string }{
+		{
+			"empty client",
+			legacyOIDCArgs(`oidc-client-id: ""`),
+			"issuer URL and client ID are required",
+		},
+		{"list client", legacyOIDCArgs(`oidc-client-id: [one, two]`), "must be strings"},
+		{
+			"structured auth",
+			"apiVersion: v1alpha1\nkind: KubeAuthenticationConfig\nconfiguration: {}\n",
+			"overlap KubeAuthenticationConfig",
+		},
+		{"append CA", oidcCAFile("appended", "append"), "complete CA content"},
+		{"empty CA", oidcCAFile("", "overwrite"), "CA content is missing"},
+		{"delete API server", "cluster:\n  apiServer:\n    $patch: delete\n", "deletion"},
+		{
+			"delete CA by selector",
+			"machine:\n  files:\n    - op: overwrite\n      $patch: delete\n",
+			"deletion",
+		},
+		{"delete machine", "machine:\n  $patch: delete\n", "deletion"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := loadVariantPatches(t, map[string]string{
+				"cluster/oidc.yaml": legacyOIDCArgs(
+					sharedOIDCWithCA,
+				),
+				"cluster/ca.yaml": oidcCAFile(
+					"shared-ca",
+					"overwrite",
+				),
+				"control-planes/override.yaml": testCase.patch,
+			}, nil)
+			require.ErrorContains(t, err, testCase.want)
+		})
+	}
+}
+
+func TestKubernetesPatchSetPreservesEmptyFileList(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"null", "[]"} {
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+			configs, err := loadVariantPatches(t, map[string]string{
+				"cluster/oidc.yaml": legacyOIDCArgs(
+					sharedOIDCWithCA,
+				),
+				"cluster/ca.yaml": oidcCAFile(
+					"shared-ca",
+					"overwrite",
+				),
+				"control-planes/empty.yaml": "machine:\n  files: " + value + "\n",
+			}, nil)
+			require.NoError(t, err)
+			assertJWTIssuer(t, configs.ControlPlane(), "shared", "shared-ca")
+		})
+	}
+}
+
+func TestKubernetesPatchSetPreservesInputAndSplitDocumentOIDC(t *testing.T) {
+	t.Parallel()
+
+	content := legacyOIDCArgs(
+		"oidc-client-id: shared",
+	) + "---\n" + legacyOIDCArgs(
+		"oidc-issuer-url: https://dex.example.com",
+	)
+	original := []talos.Patch{{Path: "split.yaml", Content: []byte(content)}}
+	first, err := talos.MigrateKubernetesPatchesForContract(original, talosconfig.TalosVersion1_14)
+	require.NoError(t, err)
+	second, err := talos.MigrateKubernetesPatchesForContract(original, talosconfig.TalosVersion1_14)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, content, string(original[0].Content))
+	configs, err := loadVariantPatches(
+		t,
+		map[string]string{"control-planes/split.yaml": content},
+		nil,
+	)
+	require.NoError(t, err)
+	assertJWTIssuer(t, configs.ControlPlane(), "shared", "")
+}
+
+func oidcCAFile(content, operation string) string {
+	return "machine:\n  files:\n    - path: /etc/oidc.crt\n      op: " + operation +
+		"\n      content: \"" + content + "\"\n"
+}
+
+func TestKubernetesPatchSetPreservesDeletionSelectorOrder(t *testing.T) {
+	t.Parallel()
+	configs, err := loadVariantPatches(t, map[string]string{
+		"cluster/files.yaml": `machine:
+  files:
+    - path: /first
+      op: overwrite
+      content: first
+    - path: /second
+      op: create
+      content: second
+---
+machine:
+  files:
+    - op: create
+      path: /first
+      $patch: delete
+`,
+	}, nil)
+	require.NoError(t, err)
+	files, err := configs.ControlPlane().Machine().Files()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "/first", files[0].Path())
+}
+
+func TestKubernetesPatchSetRejectsWorkerOnlyCertificate(t *testing.T) {
+	t.Parallel()
+	_, err := loadVariantPatches(t, map[string]string{
+		"control-planes/oidc.yaml": legacyOIDCArgs(sharedOIDCWithCA),
+		"workers/ca.yaml":          oidcCAFile("worker-ca", "overwrite"),
+	}, nil)
+	require.ErrorContains(t, err, "CA content is missing")
+}
+
+func TestKubernetesPatchSetRejectsIncompleteSharedOIDC(t *testing.T) {
+	t.Parallel()
+	_, err := loadVariantPatches(t, map[string]string{
+		"cluster/issuer.yaml":        legacyOIDCArgs("oidc-issuer-url: https://dex.example.com"),
+		"control-planes/client.yaml": legacyOIDCArgs("oidc-client-id: control-plane"),
+	}, nil)
+	require.ErrorContains(t, err, "shared settings must be complete")
+	require.ErrorContains(t, err, "control-planes/")
+}
+
+func TestKubernetesPatchSetRejectsCrossDocumentAliases(t *testing.T) {
+	t.Parallel()
+
+	patches := []talos.Patch{{Path: "aliases.yaml", Content: []byte(`&base
+cluster:
+  apiServer:
+    extraArgs:
+      audit-log-maxage: "10"
+---
+*base
+`)}}
+
+	require.NotPanics(t, func() {
+		_, err := talos.MigrateKubernetesPatchesForContract(patches, talosconfig.TalosVersion1_14)
+		require.ErrorContains(t, err, "aliases.yaml")
+		require.ErrorContains(t, err, "alias")
+	})
+}

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
@@ -367,3 +367,31 @@ cluster:
 		require.ErrorContains(t, err, "alias")
 	})
 }
+
+func TestKubernetesPatchSetSkipsEmptyMergeDocuments(t *testing.T) {
+	t.Parallel()
+	configs, err := loadVariantPatches(t, map[string]string{"cluster/api.yaml": `<<: {}
+---
+cluster:
+  apiServer:
+    certSANs: [retained.example.com]
+    extraArgs:
+      audit-log-maxage: "10"
+---
+cluster:
+  apiServer:
+    extraArgs:
+      audit-log-maxage: "30"
+`}, nil)
+	require.NoError(t, err)
+	assert.Contains(
+		t,
+		configs.ControlPlane().K8sAPIServerConfig().CertSANs(),
+		"retained.example.com",
+	)
+	assert.Equal(
+		t,
+		[]string{"30"},
+		configs.ControlPlane().K8sAPIServerConfig().ExtraArgs()["audit-log-maxage"],
+	)
+}

--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
@@ -137,6 +137,7 @@ func TestKubernetesPatchSetRejectsCrossScopeOIDCCompletion(t *testing.T) {
 	}, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "issuer URL and client ID are required")
+	require.ErrorContains(t, err, "resolve OIDC scope control-planes/")
 }
 
 func loadVariantPatches(
@@ -346,26 +347,56 @@ func TestKubernetesPatchSetRejectsIncompleteSharedOIDC(t *testing.T) {
 		"control-planes/client.yaml": legacyOIDCArgs("oidc-client-id: control-plane"),
 	}, nil)
 	require.ErrorContains(t, err, "shared settings must be complete")
+	require.ErrorContains(t, err, "resolve OIDC scope cluster/")
 	require.ErrorContains(t, err, "control-planes/")
 }
 
 func TestKubernetesPatchSetRejectsCrossDocumentAliases(t *testing.T) {
 	t.Parallel()
 
-	patches := []talos.Patch{{Path: "aliases.yaml", Content: []byte(`&base
+	tests := map[string]string{
+		"cross-document": `&base
 cluster:
   apiServer:
     extraArgs:
       audit-log-maxage: "10"
 ---
 *base
-`)}}
+`,
+		"within-document": `cluster:
+  apiServer:
+    certSANs: &names [api.example.com]
+    env:
+      EXAMPLE: example
+machine:
+  certSANs: *names
+---
+cluster:
+  apiServer:
+    extraArgs:
+      audit-log-maxage: "30"
+`,
+	}
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	require.NotPanics(t, func() {
-		_, err := talos.MigrateKubernetesPatchesForContract(patches, talosconfig.TalosVersion1_14)
-		require.ErrorContains(t, err, "aliases.yaml")
-		require.ErrorContains(t, err, "alias")
-	})
+			patches := []talos.Patch{{Path: "shared.yaml", Content: []byte(content)}}
+
+			require.NotPanics(t, func() {
+				_, err := talos.MigrateKubernetesPatchesForContract(
+					patches,
+					talosconfig.TalosVersion1_14,
+				)
+				require.ErrorContains(t, err, "shared.yaml")
+				require.ErrorContains(
+					t,
+					err,
+					"expand YAML aliases before migrating a multi-document patch",
+				)
+			})
+		})
+	}
 }
 
 func TestKubernetesPatchSetSkipsEmptyMergeDocuments(t *testing.T) {

--- a/pkg/fsutil/configmanager/talos/kubernetes_patches.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patches.go
@@ -13,9 +13,6 @@ import (
 )
 
 var (
-	errLegacyAPIServerMultipleDocuments = errors.New(
-		"multiple legacy cluster.apiServer documents are not supported",
-	)
 	errLegacyOIDCRequiredFields        = errors.New("issuer URL and client ID are required")
 	errLegacyOIDCCAMissing             = errors.New("CA content is missing")
 	errLegacyOIDCUnsupportedExtraArg   = errors.New("unsupported legacy OIDC extra argument")
@@ -203,14 +200,7 @@ func migrateLegacyKubernetesPatch(
 
 	cniMigrated := migrateDisableDefaultCNIDocuments(documents)
 
-	values, found, err := findLegacyAPIServerValues(documents)
-	if err != nil {
-		return nil, false, fmt.Errorf(
-			"migrate legacy Kubernetes patch %q: %w",
-			patch.Path,
-			err,
-		)
-	}
+	values, found := findLegacyAPIServerValues(documents)
 
 	if !found && !cniMigrated {
 		return patch.Content, false, nil
@@ -361,11 +351,8 @@ func decodeLegacyKubernetesDocuments(patch Patch) ([]map[string]any, bool, error
 	return documents, true, nil
 }
 
-func findLegacyAPIServerValues(
-	documents []map[string]any,
-) (*legacyAPIServerPatchValues, bool, error) {
-	var values *legacyAPIServerPatchValues
-
+// Each input patch has already been split into independent documents.
+func findLegacyAPIServerValues(documents []map[string]any) (*legacyAPIServerPatchValues, bool) {
 	for _, document := range documents {
 		cluster, found := mapValue(document, "cluster")
 		if !found {
@@ -379,19 +366,12 @@ func findLegacyAPIServerValues(
 
 		extraArgs, _ := mapValue(apiServer, "extraArgs")
 
-		if values != nil {
-			return nil, false, errLegacyAPIServerMultipleDocuments
-		}
-
-		values = &legacyAPIServerPatchValues{
-			clusterDocument: document,
-			cluster:         cluster,
-			apiServer:       apiServer,
-			extraArgs:       extraArgs,
-		}
+		return &legacyAPIServerPatchValues{
+			clusterDocument: document, cluster: cluster, apiServer: apiServer, extraArgs: extraArgs,
+		}, true
 	}
 
-	return values, values != nil, nil
+	return nil, false
 }
 
 func (values *legacyAPIServerPatchValues) rejectUnsupportedOIDCArgument(patchPath string) error {

--- a/pkg/fsutil/configmanager/talos/kubernetes_patches.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patches.go
@@ -152,14 +152,10 @@ func migrateKubernetesPatchesForContract(
 		return patches, nil
 	}
 
-	migrated := make([]Patch, len(patches))
-	copy(migrated, patches)
-
-	// Legacy patches may split a value across files — most notably an OIDC CA whose
-	// machine.files entry lives in a different patch than the kube-apiserver args that
-	// reference it. Decode the whole set up front so per-patch migration can resolve
-	// against every patch, not just the one being migrated.
-	patchSetDocuments := decodePatchSetDocuments(patches)
+	migrated, err := prepareKubernetesPatchSet(patches)
+	if err != nil {
+		return nil, err
+	}
 
 	for idx := range migrated {
 		content := strings.TrimSpace(string(migrated[idx].Content))
@@ -172,7 +168,6 @@ func migrateKubernetesPatchesForContract(
 		default:
 			content, found, migrationErr := migrateLegacyKubernetesPatch(
 				migrated[idx],
-				patchSetDocuments,
 			)
 			if migrationErr != nil {
 				return nil, migrationErr
@@ -184,40 +179,18 @@ func migrateKubernetesPatchesForContract(
 		}
 	}
 
-	return migrated, nil
+	return nonemptyKubernetesPatches(migrated), nil
 }
 
 type legacyAPIServerPatchValues struct {
-	documents         []map[string]any
-	patchSetDocuments []map[string]any
-	clusterDocument   map[string]any
-	cluster           map[string]any
-	apiServer         map[string]any
-	extraArgs         map[string]any
-}
-
-// decodePatchSetDocuments decodes every patch in the set into a flat document list,
-// used to resolve references that span patches. Patches that fail to decode, or that
-// are not map documents, are skipped: migrating each patch reports its own decode
-// error, and this lookup must not turn an unrelated malformed patch into a failure.
-func decodePatchSetDocuments(patches []Patch) []map[string]any {
-	documents := []map[string]any{}
-
-	for _, patch := range patches {
-		patchDocuments, mapDocuments, err := decodeLegacyKubernetesDocuments(patch)
-		if err != nil || !mapDocuments {
-			continue
-		}
-
-		documents = append(documents, patchDocuments...)
-	}
-
-	return documents
+	clusterDocument map[string]any
+	cluster         map[string]any
+	apiServer       map[string]any
+	extraArgs       map[string]any
 }
 
 func migrateLegacyKubernetesPatch(
 	patch Patch,
-	patchSetDocuments []map[string]any,
 ) ([]byte, bool, error) {
 	documents, mapDocuments, err := decodeLegacyKubernetesDocuments(patch)
 	if err != nil {
@@ -239,15 +212,11 @@ func migrateLegacyKubernetesPatch(
 		)
 	}
 
-	if values != nil {
-		values.patchSetDocuments = patchSetDocuments
-	}
-
 	if !found && !cniMigrated {
 		return patch.Content, false, nil
 	}
 
-	apiServerDocument, structuredDocuments, authenticationDocument, err := migrateAPIServerDocuments(
+	apiServerDocument, structuredDocuments, err := migrateAPIServerDocuments(
 		values,
 		found,
 		patch.Path,
@@ -266,7 +235,6 @@ func migrateLegacyKubernetesPatch(
 		documents,
 		apiServerDocument,
 		structuredDocuments,
-		authenticationDocument,
 		cniDeleteDocument,
 	)
 	if err != nil {
@@ -276,41 +244,41 @@ func migrateLegacyKubernetesPatch(
 	return content, true, nil
 }
 
-// migrateAPIServerDocuments migrates the OIDC/authentication, structured, and API-server
+// migrateAPIServerDocuments migrates structured and API-server
 // documents for a legacy kube-apiserver patch, returning them for marshaling. It is a no-op
 // (all-nil) when the patch carries no legacy API-server values.
 func migrateAPIServerDocuments(
 	values *legacyAPIServerPatchValues,
 	found bool,
 	patchPath string,
-) (map[string]any, []map[string]any, []byte, error) {
+) (map[string]any, []map[string]any, error) {
 	if !found {
-		return nil, nil, nil, nil
+		return nil, nil, nil
 	}
 
-	authenticationDocument, err := values.migrateOIDCAuthenticationDocument(patchPath)
+	err := values.rejectUnsupportedOIDCArgument(patchPath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	err = values.rejectDeniedAPIServerExtraArgs(patchPath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	structuredDocuments, err := values.migrateStructuredAPIServerDocuments(patchPath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	apiServerDocument, err := values.migrateAPIServerDocument(patchPath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	values.removeMigratedValues()
 
-	return apiServerDocument, structuredDocuments, authenticationDocument, nil
+	return apiServerDocument, structuredDocuments, nil
 }
 
 // migrateDisableDefaultCNIDocuments structurally detects a disable-default-CNI edit
@@ -416,7 +384,6 @@ func findLegacyAPIServerValues(
 		}
 
 		values = &legacyAPIServerPatchValues{
-			documents:       documents,
 			clusterDocument: document,
 			cluster:         cluster,
 			apiServer:       apiServer,
@@ -427,22 +394,9 @@ func findLegacyAPIServerValues(
 	return values, values != nil, nil
 }
 
-func (values *legacyAPIServerPatchValues) migrateOIDCAuthenticationDocument(
-	patchPath string,
-) ([]byte, error) {
-	var authenticationDocument []byte
-
-	if _, hasOIDCIssuer := values.extraArgs["oidc-issuer-url"]; hasOIDCIssuer {
-		config, err := values.oidcConfig(patchPath)
-		if err != nil {
-			return nil, err
-		}
-
-		authenticationDocument = StructuredOIDCPatchYAML(config)
-	}
-
+func (values *legacyAPIServerPatchValues) rejectUnsupportedOIDCArgument(patchPath string) error {
 	if extraArg := unsupportedLegacyOIDCExtraArg(values.extraArgs); extraArg != "" {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"migrate legacy OIDC patch %q: %w %q",
 			patchPath,
 			errLegacyOIDCUnsupportedExtraArg,
@@ -450,47 +404,7 @@ func (values *legacyAPIServerPatchValues) migrateOIDCAuthenticationDocument(
 		)
 	}
 
-	return authenticationDocument, nil
-}
-
-func (values *legacyAPIServerPatchValues) oidcConfig(patchPath string) (OIDCPatchConfig, error) {
-	config := OIDCPatchConfig{
-		IssuerURL:      popString(values.extraArgs, "oidc-issuer-url"),
-		ClientID:       popString(values.extraArgs, "oidc-client-id"),
-		UsernameClaim:  popString(values.extraArgs, "oidc-username-claim"),
-		UsernamePrefix: popString(values.extraArgs, "oidc-username-prefix"),
-		GroupsClaim:    popString(values.extraArgs, "oidc-groups-claim"),
-		GroupsPrefix:   popString(values.extraArgs, "oidc-groups-prefix"),
-	}
-	caPath := popString(values.extraArgs, "oidc-ca-file")
-
-	if config.IssuerURL == "" || config.ClientID == "" {
-		return OIDCPatchConfig{}, fmt.Errorf(
-			"migrate legacy OIDC patch %q: %w",
-			patchPath,
-			errLegacyOIDCRequiredFields,
-		)
-	}
-
-	if caPath != "" {
-		// Prefer the patch being migrated, then fall back to the rest of the set: the
-		// machine.files entry backing oidc-ca-file may live in a different patch.
-		config.CertificateAuthority = machineFileContent(values.documents, caPath)
-		if config.CertificateAuthority == "" {
-			config.CertificateAuthority = machineFileContent(values.patchSetDocuments, caPath)
-		}
-
-		if config.CertificateAuthority == "" {
-			return OIDCPatchConfig{}, fmt.Errorf(
-				"migrate legacy OIDC patch %q for %q: %w",
-				patchPath,
-				caPath,
-				errLegacyOIDCCAMissing,
-			)
-		}
-	}
-
-	return config, nil
+	return nil
 }
 
 // rejectDeniedAPIServerExtraArgs fails the migration when extraArgs still carries an
@@ -775,7 +689,6 @@ func marshalMigratedKubernetesDocuments(
 	legacyDocuments []map[string]any,
 	apiServerDocument map[string]any,
 	structuredDocuments []map[string]any,
-	authenticationDocument []byte,
 	cniDeleteDocument []byte,
 ) ([]byte, error) {
 	documents := make(
@@ -823,10 +736,6 @@ func marshalMigratedKubernetesDocuments(
 		documents = append(documents, bytes.TrimSpace(encoded))
 	}
 
-	if len(authenticationDocument) > 0 {
-		documents = append(documents, bytes.TrimSpace(authenticationDocument))
-	}
-
 	return append(bytes.Join(documents, []byte("\n---\n")), '\n'), nil
 }
 
@@ -858,44 +767,4 @@ func removeEmptyMap(parent map[string]any, key string, value map[string]any) {
 	if len(value) == 0 {
 		delete(parent, key)
 	}
-}
-
-func machineFileContent(documents []map[string]any, path string) string {
-	for _, document := range documents {
-		if content := machineFileContentInDocument(document, path); content != "" {
-			return content
-		}
-	}
-
-	return ""
-}
-
-func machineFileContentInDocument(document map[string]any, path string) string {
-	machine, found := mapValue(document, "machine")
-	if !found {
-		return ""
-	}
-
-	files, found := machine["files"].([]any)
-	if !found {
-		return ""
-	}
-
-	for _, item := range files {
-		file, isMap := item.(map[string]any)
-		if !isMap {
-			continue
-		}
-
-		filePath, _ := file["path"].(string)
-		if filePath != path {
-			continue
-		}
-
-		content, _ := file["content"].(string)
-
-		return content
-	}
-
-	return ""
 }

--- a/pkg/fsutil/configmanager/talos/kubernetes_patches.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patches.go
@@ -33,7 +33,6 @@ const (
 
 const (
 	multiDocumentAPIVersion  = "v1alpha1"
-	migratedDocumentSlack    = 2
 	kubeAuthorizerConfigKind = "KubeAuthorizerConfig"
 	apiVersionField          = "apiVersion"
 	kindField                = "kind"
@@ -671,11 +670,7 @@ func marshalMigratedKubernetesDocuments(
 	structuredDocuments []map[string]any,
 	cniDeleteDocument []byte,
 ) ([]byte, error) {
-	documents := make(
-		[][]byte,
-		0,
-		len(legacyDocuments)+len(structuredDocuments)+migratedDocumentSlack,
-	)
+	documents := make([][]byte, 0, len(legacyDocuments))
 
 	for _, document := range legacyDocuments {
 		if len(document) == 0 {

--- a/pkg/fsutil/configmanager/talos/manager_test.go
+++ b/pkg/fsutil/configmanager/talos/manager_test.go
@@ -440,7 +440,7 @@ func TestConfigManager_Load_MigratesLegacyAPIServerPatchWithoutOIDC(t *testing.T
 	assert.Equal(t, map[string][]string{"audit-log-maxage": {"30"}}, apiServer.ExtraArgs())
 }
 
-func TestConfigManager_Load_RejectsDuplicateLegacyAPIServerDocuments(t *testing.T) {
+func TestConfigManager_Load_MigratesDuplicateLegacyAPIServerDocuments(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -466,9 +466,14 @@ cluster:
 	manager := talos.NewConfigManager(tmpDir, "talos-114", "1.36.0", "10.5.0.0/24").
 		WithVersionContract(talosconfig.TalosVersion1_14)
 
-	_, err := manager.Load(configmanager.LoadOptions{})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "multiple legacy cluster.apiServer documents are not supported")
+	configs, err := manager.Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, configs.ControlPlane().K8sAPIServerConfig().CertSANs(), "api.example.com")
+	assert.Equal(
+		t,
+		[]string{"30"},
+		configs.ControlPlane().K8sAPIServerConfig().ExtraArgs()["audit-log-maxage"],
+	)
 }
 
 func TestConfigManager_Load_PreservesLegacyAPIServerPatchBeforeMultiDocumentConfig(t *testing.T) {

--- a/pkg/svc/provider/hetzner/autoscaler_nodes_test.go
+++ b/pkg/svc/provider/hetzner/autoscaler_nodes_test.go
@@ -107,7 +107,7 @@ func TestListAutoscalerNodes_MissingNetworkReturnsNothing(t *testing.T) {
 	srv := newAutoscalerNodesTestServer(t, map[string][]schema.Server{
 		autoscalerPoolA: {schemaServer(1, "as-1", autoscalerNetworkID)},
 	})
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	servers, err := prov.ListAutoscalerNodes(
 		context.Background(), "absent-cluster", []string{autoscalerPoolA},
@@ -133,7 +133,7 @@ func TestListAutoscalerNodes_FiltersByNetworkAndDedupes(t *testing.T) {
 			schemaServer(4, "as-4", autoscalerNetworkID),
 		},
 	})
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	servers, err := prov.ListAutoscalerNodes(
 		context.Background(), autoscalerTestCluster, []string{autoscalerPoolA, autoscalerPoolB},

--- a/pkg/svc/provider/hetzner/availability_retry_test.go
+++ b/pkg/svc/provider/hetzner/availability_retry_test.go
@@ -67,7 +67,7 @@ func TestCheckServerAvailabilityWithRetry_SucceedsAfterRetry(t *testing.T) {
 	var calls atomic.Int32
 
 	srv := newCountingAvailabilityServer(t, 3, &calls)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	err := prov.CheckServerAvailabilityWithRetryForTest(
 		context.Background(),
@@ -90,7 +90,7 @@ func TestCheckServerAvailabilityWithRetry_ExhaustsRetries(t *testing.T) {
 
 	// availableAfter 0 => never available, so every attempt fails.
 	srv := newCountingAvailabilityServer(t, 0, &calls)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	err := prov.CheckServerAvailabilityWithRetryForTest(
 		context.Background(),
@@ -113,7 +113,7 @@ func TestCheckServerAvailabilityWithRetry_PermanentErrorNotRetried(t *testing.T)
 
 	// The queried type is never returned, so the lookup yields ErrServerTypeNotFound.
 	srv := newCountingAvailabilityServer(t, 1, &calls)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	err := prov.CheckServerAvailabilityWithRetryForTest(
 		context.Background(),
@@ -135,7 +135,7 @@ func TestCheckServerAvailabilityWithRetry_ContextCancelledDuringWait(t *testing.
 	var calls atomic.Int32
 
 	srv := newCountingAvailabilityServer(t, 0, &calls)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Cancel the context during the backoff wait of the first attempt.
@@ -165,7 +165,7 @@ func TestCheckServerAvailabilityWithRetry_ClampsNonPositiveMaxAttempts(t *testin
 	var calls atomic.Int32
 
 	srv := newCountingAvailabilityServer(t, 0, &calls)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	err := prov.CheckServerAvailabilityWithRetryForTest(
 		context.Background(),
@@ -187,7 +187,7 @@ func TestCheckServerAvailabilityWithRetry_PublicWrapperSucceeds(t *testing.T) {
 	var calls atomic.Int32
 
 	srv := newCountingAvailabilityServer(t, 1, &calls)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	// maxAttempts of 1 means the public wrapper never sleeps even though it uses
 	// the real backoff delay function.

--- a/pkg/svc/provider/hetzner/availability_test.go
+++ b/pkg/svc/provider/hetzner/availability_test.go
@@ -142,7 +142,7 @@ func TestCheckServerAvailability(t *testing.T) {
 			t.Parallel()
 
 			srv := newAvailabilityTestServer(t, testCase.types)
-			prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+			prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 			err := prov.CheckServerAvailability(
 				context.Background(),

--- a/pkg/svc/provider/hetzner/create_server_test.go
+++ b/pkg/svc/provider/hetzner/create_server_test.go
@@ -105,7 +105,7 @@ func TestCreateServer_ISOBoot(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 	_, err := prov.CreateServer(context.Background(), hetzner.CreateServerOpts{
 		Name:       "test-node",
 		ServerType: "cx22",

--- a/pkg/svc/provider/hetzner/floating_ip_test.go
+++ b/pkg/svc/provider/hetzner/floating_ip_test.go
@@ -129,7 +129,7 @@ func newFloatingIPProvider(
 		&counters.lastCreateBody,
 	)
 
-	return hetzner.NewProvider(newTestHcloudClient(srv.URL)), counters
+	return hetzner.NewProvider(newTestHcloudClient(t, srv.URL)), counters
 }
 
 // TestEnsureFloatingIP_CreatesWhenAbsent verifies the full create request and
@@ -413,7 +413,7 @@ func TestDeleteFloatingIP_PropagatesLookupError(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	err := prov.DeleteFloatingIPForTest(t.Context(), "test-cluster")
 

--- a/pkg/svc/provider/hetzner/infrastructure_reconcile_test.go
+++ b/pkg/svc/provider/hetzner/infrastructure_reconcile_test.go
@@ -74,7 +74,7 @@ func TestEnsureNetwork_ReconcilesMissingSubnetOnExisting(t *testing.T) {
 		&addSubnetCalls,
 		&lastAddSubnetBody,
 	)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", defaultNetworkCIDR)
 
@@ -101,7 +101,7 @@ func TestEnsureNetwork_SkipsSubnetWhenPresent(t *testing.T) {
 	srv := newNetworkReconcileServer(
 		t, defaultNetworkCIDR, existingSubnet, &addSubnetCalls, &lastAddSubnetBody,
 	)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", defaultNetworkCIDR)
 
@@ -124,7 +124,7 @@ func TestEnsureNetwork_CustomCIDRAddsFirstSlash24(t *testing.T) {
 	)
 
 	srv := newNetworkReconcileServer(t, "10.100.0.0/16", `[]`, &addSubnetCalls, &lastAddSubnetBody)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", "10.100.0.0/16")
 
@@ -150,7 +150,7 @@ func TestEnsureNetwork_CustomCIDRSkipsWhenFirstSlash24Present(t *testing.T) {
 	srv := newNetworkReconcileServer(
 		t, "10.100.0.0/16", existingSubnet, &addSubnetCalls, &lastAddSubnetBody,
 	)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", "10.100.0.0/16")
 
@@ -172,7 +172,7 @@ func TestEnsureNetwork_CustomSlash24UsesWholeRange(t *testing.T) {
 	)
 
 	srv := newNetworkReconcileServer(t, "10.200.5.0/24", `[]`, &addSubnetCalls, &lastAddSubnetBody)
-	prov := hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	prov := hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 
 	network, err := prov.EnsureNetwork(context.Background(), "test-cluster", "10.200.5.0/24")
 

--- a/pkg/svc/provider/hetzner/iso_test.go
+++ b/pkg/svc/provider/hetzner/iso_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +52,7 @@ func TestValidateISOArchitecture(t *testing.T) {
 			)
 			t.Cleanup(server.Close)
 			provider := hetzner.NewProvider(
-				hcloud.NewClient(hcloud.WithToken("test"), hcloud.WithEndpoint(server.URL)),
+				newTestHcloudClient(t, server.URL),
 			)
 
 			err := provider.ValidateISO(t.Context(), 42, "target")

--- a/pkg/svc/provider/hetzner/server_retry_orchestration_test.go
+++ b/pkg/svc/provider/hetzner/server_retry_orchestration_test.go
@@ -69,7 +69,7 @@ func newRetryTestProvider(t *testing.T, handler http.Handler) *hetzner.Provider 
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	return hetzner.NewProvider(newTestHcloudClient(srv.URL))
+	return hetzner.NewProvider(newTestHcloudClient(t, srv.URL))
 }
 
 // decodeServerCreateBody parses a POST /servers request body into a generic map.

--- a/pkg/svc/provider/hetzner/snapshot_test.go
+++ b/pkg/svc/provider/hetzner/snapshot_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/apricote/hcloud-upload-image/hcloudimages"
@@ -49,11 +51,68 @@ type hcloudImageSchema struct {
 var errServerQuotaExceeded = errors.New("server quota exceeded")
 
 // newTestHcloudClient creates an hcloud.Client pointing at a test HTTP server.
-func newTestHcloudClient(serverURL string) *hcloudtest.Client {
+func newTestHcloudClient(t *testing.T, serverURL string) *hcloudtest.Client {
+	t.Helper()
+
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok, "the default HTTP transport must support cloning")
+
+	transport := defaultTransport.Clone()
+	t.Cleanup(transport.CloseIdleConnections)
+
 	return hcloudtest.NewClient(
 		hcloudtest.WithToken("test-token"),
 		hcloudtest.WithEndpoint(serverURL),
+		hcloudtest.WithHTTPClient(&http.Client{Transport: transport}),
 	)
+}
+
+// Test clients must own their pools while retaining keep-alive within each client.
+// This test runs alone because parallel httptest cleanup closes the global pool.
+//
+//nolint:paralleltest // The regression observes ownership of process-global idle connections.
+func TestNewTestHcloudClientIsolatesConnectionPools(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodGet, request.Method)
+			assert.Equal(t, "/images", request.URL.Path)
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"images":[{"id":10}]}`))
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	firstClient := newTestHcloudClient(t, server.URL)
+	secondClient := newTestHcloudClient(t, server.URL)
+
+	listImages := func(client *hcloudtest.Client) bool {
+		var connection atomic.Pointer[httptrace.GotConnInfo]
+
+		ctx := httptrace.WithClientTrace(t.Context(), &httptrace.ClientTrace{
+			GotConn: func(info httptrace.GotConnInfo) {
+				connection.Store(&info)
+			},
+		})
+
+		images, _, err := client.Image.List(ctx, hcloudtest.ImageListOpts{})
+		require.NoError(t, err)
+		require.Len(t, images, 1)
+		assert.Equal(t, int64(10), images[0].ID)
+
+		info := connection.Load()
+		require.NotNil(t, info, "the SDK request must acquire an HTTP connection")
+
+		return info.Reused
+	}
+
+	assert.False(t, listImages(firstClient), "the first request must establish a connection")
+	assert.True(t, listImages(firstClient), "one client must reuse its own idle connection")
+	assert.False(
+		t,
+		listImages(secondClient),
+		"independent clients must not share an idle connection",
+	)
+	assert.True(t, listImages(secondClient), "the second client must reuse its own idle connection")
 }
 
 func marshalJSON(t *testing.T, v any) []byte {
@@ -99,7 +158,7 @@ func TestSnapshotManager_EnsureTalosSnapshot_ExistingFound(t *testing.T) {
 		_, _ = responseWriter.Write(marshalJSON(t, resp))
 	})
 
-	client := newTestHcloudClient(srv.URL)
+	client := newTestHcloudClient(t, srv.URL)
 	uploader := &mockUploader{}
 
 	var logBuf bytes.Buffer
@@ -135,7 +194,7 @@ func TestSnapshotManager_EnsureTalosSnapshot_BuildsNew(t *testing.T) {
 		_, _ = w.Write(marshalJSON(t, hcloudImageListResponse{Images: []hcloudImageSchema{}}))
 	})
 
-	client := newTestHcloudClient(srv.URL)
+	client := newTestHcloudClient(t, srv.URL)
 	uploader := &mockUploader{
 		image: &hcloudtest.Image{ID: builtID},
 	}
@@ -172,7 +231,7 @@ func TestSnapshotManager_EnsureTalosSnapshot_UploaderError(t *testing.T) {
 		)
 	})
 
-	client := newTestHcloudClient(srv.URL)
+	client := newTestHcloudClient(t, srv.URL)
 	uploader := &mockUploader{err: errServerQuotaExceeded}
 
 	var logBuf bytes.Buffer
@@ -246,7 +305,7 @@ func TestSnapshotManager_DeleteTalosSnapshots_DeletesImages(t *testing.T) {
 
 	registerDeleteTestHandlers(t, mux, clusterName, deletedIDs)
 
-	client := newTestHcloudClient(srv.URL)
+	client := newTestHcloudClient(t, srv.URL)
 	uploader := &mockUploader{}
 
 	var logBuf bytes.Buffer
@@ -281,7 +340,7 @@ func TestSnapshotManager_DeleteTalosSnapshots_NoOp(t *testing.T) {
 		_, _ = w.Write(marshalJSON(t, hcloudImageListResponse{Images: []hcloudImageSchema{}}))
 	})
 
-	client := newTestHcloudClient(srv.URL)
+	client := newTestHcloudClient(t, srv.URL)
 	uploader := &mockUploader{}
 
 	var logBuf bytes.Buffer
@@ -363,7 +422,7 @@ func TestSnapshotManager_EnsureTalosSnapshot_SkipsNonAvailableSnapshot(t *testin
 		_, _ = responseWriter.Write(marshalJSON(t, resp))
 	})
 
-	client := newTestHcloudClient(srv.URL)
+	client := newTestHcloudClient(t, srv.URL)
 	uploader := &mockUploader{image: &hcloudtest.Image{ID: builtID}}
 
 	var logBuf bytes.Buffer
@@ -423,7 +482,7 @@ func TestSnapshotManager_EnsureTalosSnapshot_SHA256SchematicID(t *testing.T) {
 		_, _ = responseWriter.Write(marshalJSON(t, resp))
 	})
 
-	client := newTestHcloudClient(srv.URL)
+	client := newTestHcloudClient(t, srv.URL)
 	uploader := &mockUploader{}
 
 	var logBuf bytes.Buffer

--- a/pkg/svc/provisioner/cluster/talos/upgrade_errno_unix.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_errno_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package talosprovisioner
+
+import "syscall"
+
+const errKubernetesUpgradeConnectionRefused = syscall.ECONNREFUSED

--- a/pkg/svc/provisioner/cluster/talos/upgrade_errno_windows.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_errno_windows.go
@@ -1,0 +1,6 @@
+package talosprovisioner
+
+import "golang.org/x/sys/windows"
+
+// Windows sockets return a Winsock error, not syscall.ECONNREFUSED.
+const errKubernetesUpgradeConnectionRefused = windows.WSAECONNREFUSED

--- a/pkg/svc/provisioner/cluster/talos/upgrade_transport.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_transport.go
@@ -1,0 +1,83 @@
+package talosprovisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/client/netretry"
+	"github.com/siderolabs/talos/pkg/cluster"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	kubernetesUpgradeReadAttempts = 6
+	kubernetesUpgradeReadWait     = time.Second
+	kubernetesUpgradeReadMaxWait  = 5 * time.Second
+)
+
+type upgradeKubernetesProvider struct {
+	cluster.K8sProvider
+}
+
+func kubernetesUpgradeProvider(provider cluster.K8sProvider) cluster.K8sProvider {
+	return upgradeKubernetesProvider{K8sProvider: provider}
+}
+
+// K8sRestConfig covers the SSA inventory read, which precedes the SDK's
+// reconciliation retry loop. Copy the config and compose its transport wrapper
+// so the original provider and its authentication remain intact.
+func (provider upgradeKubernetesProvider) K8sRestConfig(ctx context.Context) (*rest.Config, error) {
+	config, err := provider.K8sProvider.K8sRestConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting Kubernetes upgrade REST config: %w", err)
+	}
+
+	config = rest.CopyConfig(config)
+	config.Wrap(func(transport http.RoundTripper) http.RoundTripper {
+		return upgradeReadTransport{transport: transport}
+	})
+
+	return config, nil
+}
+
+type upgradeReadTransport struct {
+	transport http.RoundTripper
+}
+
+//nolint:wrapcheck // A transport decorator preserves the underlying request errors.
+func (transport upgradeReadTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	// Never replay a mutation or a request body. client-go already handles EOF
+	// and connection resets for reads; add only the observed API restart gap.
+	if request.Method != http.MethodGet || (request.Body != nil && request.Body != http.NoBody) {
+		return transport.transport.RoundTrip(request)
+	}
+
+	var response *http.Response
+
+	err := netretry.Do(request.Context(), kubernetesUpgradeReadAttempts,
+		kubernetesUpgradeReadWait, kubernetesUpgradeReadMaxWait, func() error {
+			err := request.Context().Err()
+			if err != nil {
+				return err
+			}
+
+			//nolint:bodyclose // Successful response is returned to the caller.
+			response, err = transport.transport.RoundTrip(request)
+			if err != nil && response != nil {
+				if response.Body != nil {
+					_ = response.Body.Close()
+				}
+
+				response = nil
+			}
+
+			return err
+		}, netretry.WithRetryable(func(err error) bool {
+			return errors.Is(err, errKubernetesUpgradeConnectionRefused)
+		}))
+
+	return response, err
+}

--- a/pkg/svc/provisioner/cluster/talos/upgrade_transport_internal_test.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrade_transport_internal_test.go
@@ -1,0 +1,322 @@
+package talosprovisioner
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/go-kubernetes/kubernetes/ssa"
+	"github.com/siderolabs/talos/pkg/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type upgradeRoundTripper func(*http.Request) (*http.Response, error)
+
+func (roundTrip upgradeRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func TestKubernetesUpgradeReadTransportDoesNotReplayOtherRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		body   string
+		err    error
+	}{
+		{name: "create", method: http.MethodPost, err: refusedUpgradeConnection()},
+		{name: "update", method: http.MethodPut, err: refusedUpgradeConnection()},
+		{name: "apply", method: http.MethodPatch, err: refusedUpgradeConnection()},
+		{name: "delete", method: http.MethodDelete, err: refusedUpgradeConnection()},
+		{
+			name:   "read with body",
+			method: http.MethodGet,
+			body:   "body",
+			err:    refusedUpgradeConnection(),
+		},
+		{name: "permanent error", method: http.MethodGet, err: syscall.EACCES},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			transport := upgradeReadTransport{transport: upgradeRoundTripper(
+				func(*http.Request) (*http.Response, error) {
+					calls++
+
+					return nil, test.err
+				})}
+			request, err := http.NewRequestWithContext(t.Context(), test.method,
+				"https://upgrade.invalid", strings.NewReader(test.body))
+			require.NoError(t, err)
+
+			response, err := transport.RoundTrip(request)
+			if response != nil {
+				require.NoError(t, response.Body.Close())
+			}
+
+			require.ErrorIs(t, err, test.err)
+			assert.Nil(t, response)
+			assert.Equal(t, 1, calls)
+		})
+	}
+}
+
+func TestKubernetesUpgradeReadTransportPreservesHTTPFailure(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	transport := upgradeReadTransport{transport: upgradeRoundTripper(
+		func(request *http.Request) (*http.Response, error) {
+			calls++
+			response := upgradeJSONResponse(request, "forbidden")
+			response.StatusCode = http.StatusForbidden
+
+			return response, nil
+		})}
+	request, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"https://upgrade.invalid",
+		nil,
+	)
+	require.NoError(t, err)
+
+	response, err := transport.RoundTrip(request)
+	require.NoError(t, err)
+
+	defer response.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
+	assert.Equal(t, 1, calls)
+}
+
+func TestKubernetesUpgradeReadTransportStopsAtRetryLimit(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	transport := upgradeReadTransport{transport: upgradeRoundTripper(
+		func(*http.Request) (*http.Response, error) {
+			calls++
+
+			return nil, refusedUpgradeConnection()
+		})}
+	request, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"https://upgrade.invalid",
+		nil,
+	)
+	require.NoError(t, err)
+
+	response, err := transport.RoundTrip(request)
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+
+	require.ErrorIs(t, err, refusedUpgradeErrno())
+	assert.Nil(t, response)
+	assert.Equal(t, 6, calls)
+}
+
+func TestKubernetesUpgradeReadTransportStopsOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	for _, beforeRequest := range []bool{false, true} {
+		t.Run(
+			map[bool]string{false: "during backoff", true: "before request"}[beforeRequest],
+			func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+
+				if beforeRequest {
+					cancel()
+				}
+
+				calls := 0
+				transport := upgradeReadTransport{transport: upgradeRoundTripper(
+					func(*http.Request) (*http.Response, error) {
+						calls++
+
+						cancel()
+
+						return nil, refusedUpgradeConnection()
+					})}
+				request, err := http.NewRequestWithContext(
+					ctx,
+					http.MethodGet,
+					"https://upgrade.invalid",
+					nil,
+				)
+				require.NoError(t, err)
+
+				started := time.Now()
+
+				response, err := transport.RoundTrip(request)
+				if response != nil {
+					require.NoError(t, response.Body.Close())
+				}
+
+				require.ErrorIs(t, err, context.Canceled)
+				assert.Nil(t, response)
+				assert.Less(t, time.Since(started), time.Second)
+
+				if beforeRequest {
+					assert.Zero(t, calls)
+				} else {
+					assert.Equal(t, 1, calls)
+				}
+			},
+		)
+	}
+}
+
+func TestKubernetesUpgradeProviderPreservesOriginalTransport(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	config := &rest.Config{
+		Host: "https://upgrade.invalid",
+		Transport: upgradeRoundTripper(func(request *http.Request) (*http.Response, error) {
+			calls++
+
+			assert.Equal(t, "preserved", request.Header.Get("X-Upgrade-Test"))
+
+			return nil, refusedUpgradeConnection()
+		}),
+		WrapTransport: func(transport http.RoundTripper) http.RoundTripper {
+			return upgradeRoundTripper(func(request *http.Request) (*http.Response, error) {
+				request = request.Clone(request.Context())
+				request.Header.Set("X-Upgrade-Test", "preserved")
+
+				return transport.RoundTrip(request)
+			})
+		},
+	}
+	provider := kubernetesUpgradeProvider(upgradeConfigProvider{config: config})
+	upgradeConfig, err := provider.K8sRestConfig(t.Context())
+	require.NoError(t, err)
+	require.NotSame(t, config, upgradeConfig)
+
+	// The source config must retain its single-attempt behavior.
+	client, err := rest.HTTPClientFor(config)
+	require.NoError(t, err)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, config.Host, nil)
+	require.NoError(t, err)
+
+	response, err := client.Do(request)
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+
+	require.ErrorIs(t, err, refusedUpgradeErrno())
+	assert.Equal(t, 1, calls)
+
+	// The decorated config must still invoke the original wrapper.
+	client, err = rest.HTTPClientFor(upgradeConfig)
+	require.NoError(t, err)
+
+	request.Method = http.MethodPatch
+
+	response, err = client.Do(request)
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+
+	require.ErrorIs(t, err, refusedUpgradeErrno())
+	assert.Equal(t, 2, calls)
+}
+
+type upgradeConfigProvider struct {
+	cluster.K8sProvider
+
+	config *rest.Config
+}
+
+func (provider upgradeConfigProvider) K8sRestConfig(context.Context) (*rest.Config, error) {
+	return provider.config, nil
+}
+
+func refusedUpgradeConnection() error {
+	return &net.OpError{Op: "dial", Net: "tcp", Err: refusedUpgradeErrno()}
+}
+
+func refusedUpgradeErrno() syscall.Errno {
+	if runtime.GOOS == "windows" {
+		// Real Winsock connection refusal. syscall.ECONNREFUSED is synthetic on Windows.
+		const winsockConnectionRefused = 10061
+
+		return syscall.Errno(winsockConnectionRefused)
+	}
+
+	return syscall.ECONNREFUSED
+}
+
+func upgradeJSONResponse(request *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}
+}
+
+func TestKubernetesUpgradeInventoryRecoversAfterConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	inventoryReads := 0
+	config := &rest.Config{
+		Host: "https://upgrade.invalid",
+		Transport: upgradeRoundTripper(func(request *http.Request) (*http.Response, error) {
+			require.Equal(t, http.MethodGet, request.Method)
+
+			if request.URL.Path == "/api/v1/namespaces/kube-system" {
+				return upgradeJSONResponse(request,
+					`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"kube-system"}}`), nil
+			}
+
+			require.Equal(
+				t,
+				"/api/v1/namespaces/kube-system/configmaps/talos-manifests",
+				request.URL.Path,
+			)
+
+			inventoryReads++
+
+			if inventoryReads == 1 {
+				return nil, refusedUpgradeConnection()
+			}
+
+			return upgradeJSONResponse(
+				request,
+				`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"talos-manifests","namespace":"kube-system"}}`,
+			), nil
+		}),
+	}
+	provider := kubernetesUpgradeProvider(upgradeConfigProvider{config: config})
+	upgradeConfig, err := provider.K8sRestConfig(t.Context())
+	require.NoError(t, err)
+
+	client, err := kubernetes.NewForConfig(upgradeConfig)
+	require.NoError(t, err)
+
+	inventory, err := ssa.GetInventory(t.Context(), client, "kube-system", "talos-manifests")
+	require.NoError(t, err)
+	assert.Equal(t, "talos-manifests", inventory.ID())
+	assert.Empty(t, inventory.Get())
+	assert.Equal(t, 2, inventoryReads)
+}

--- a/pkg/svc/provisioner/cluster/talos/upgrader.go
+++ b/pkg/svc/provisioner/cluster/talos/upgrader.go
@@ -191,9 +191,9 @@ func (p *Provisioner) UpgradeKubernetes(
 		cluster.K8sProvider
 	}{
 		ClientProvider: clientProvider,
-		K8sProvider: &cluster.KubernetesClient{
+		K8sProvider: kubernetesUpgradeProvider(&cluster.KubernetesClient{
 			ClientProvider: clientProvider,
-		},
+		}),
 	}
 
 	_, _ = fmt.Fprintf(p.logWriter,


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Talos patch migration must preserve ordered documents and authentication settings split across files. This change keeps shared and role-specific authentication independent, retains compatibility with earlier Talos contracts, and gives conversion guidance for unsupported layouts. Hetzner test clients are isolated so one test cannot interrupt another during cleanup.

Kubernetes upgrades also tolerate brief API-server connection refusals while loading their manifest inventory. Read-only requests are retried on Unix and Windows; upgrade writes keep their existing behavior.

The separate dry-run PATCH failure remains tracked in #6848.

Fixes #6170. Fixes #6955. Fixes #6958.
