### PR TITLE
fix(talos): prepare replacement boot materials before removal

### DIFF
--- a/pkg/svc/provider/hetzner/iso.go
+++ b/pkg/svc/provider/hetzner/iso.go
@@ -43,8 +43,10 @@ func (p *Provider) ValidateISO(ctx context.Context, isoID int64, serverTypeName 
 func (p *Provider) validateISOArchitecture(
 	ctx context.Context, iso *hcloud.ISO, serverTypeName string,
 ) error {
-	// Custom ISOs explicitly support an architecture wildcard in the API.
-	if iso.Architecture == nil && iso.Type == "custom" {
+	// An uploaded (private) ISO carries no architecture and the API treats that
+	// as a wildcard. A public ISO always declares one, so a missing architecture
+	// there is unusable metadata rather than a wildcard.
+	if iso.Architecture == nil && iso.Type == hcloud.ISOTypePrivate {
 		return nil
 	}
 

--- a/pkg/svc/provider/hetzner/iso.go
+++ b/pkg/svc/provider/hetzner/iso.go
@@ -1,0 +1,35 @@
+package hetzner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+)
+
+// ErrISOUnavailable indicates that the selected ISO cannot be resolved by ID.
+var ErrISOUnavailable = errors.New("configured ISO is unavailable")
+
+// ValidateISO checks the selected boot ISO without creating or changing cloud
+// resources. Availability now does not guarantee a later attach will succeed.
+func (p *Provider) ValidateISO(ctx context.Context, isoID int64) error {
+	if p.client == nil {
+		return provider.ErrProviderUnavailable
+	}
+
+	if isoID <= 0 {
+		return ErrISOUnavailable
+	}
+
+	iso, _, err := p.client.ISO.GetByID(ctx, isoID)
+	if err != nil {
+		return fmt.Errorf("look up replacement ISO: %w", err)
+	}
+
+	if iso == nil || iso.ID != isoID {
+		return ErrISOUnavailable
+	}
+
+	return nil
+}

--- a/pkg/svc/provider/hetzner/iso.go
+++ b/pkg/svc/provider/hetzner/iso.go
@@ -6,14 +6,20 @@ import (
 	"fmt"
 
 	"github.com/devantler-tech/ksail/v7/pkg/svc/provider"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 // ErrISOUnavailable indicates that the selected ISO cannot be resolved by ID.
 var ErrISOUnavailable = errors.New("configured ISO is unavailable")
 
+// ErrISOArchitectureMismatch prevents replacing a node with incompatible media.
+var ErrISOArchitectureMismatch = errors.New(
+	"ISO architecture does not match replacement server type",
+)
+
 // ValidateISO checks the selected boot ISO without creating or changing cloud
 // resources. Availability now does not guarantee a later attach will succeed.
-func (p *Provider) ValidateISO(ctx context.Context, isoID int64) error {
+func (p *Provider) ValidateISO(ctx context.Context, isoID int64, serverTypeName string) error {
 	if p.client == nil {
 		return provider.ErrProviderUnavailable
 	}
@@ -29,6 +35,28 @@ func (p *Provider) ValidateISO(ctx context.Context, isoID int64) error {
 
 	if iso == nil || iso.ID != isoID {
 		return ErrISOUnavailable
+	}
+
+	return p.validateISOArchitecture(ctx, iso, serverTypeName)
+}
+
+func (p *Provider) validateISOArchitecture(
+	ctx context.Context, iso *hcloud.ISO, serverTypeName string,
+) error {
+	// Custom ISOs explicitly support an architecture wildcard in the API.
+	if iso.Architecture == nil && iso.Type == "custom" {
+		return nil
+	}
+
+	serverType, _, err := p.client.ServerType.GetByName(ctx, serverTypeName)
+	if err != nil {
+		return fmt.Errorf("look up replacement server type: %w", err)
+	}
+
+	if iso.Architecture == nil || serverType == nil ||
+		serverType.Name != serverTypeName || serverType.Architecture == "" ||
+		*iso.Architecture != serverType.Architecture {
+		return ErrISOArchitectureMismatch
 	}
 
 	return nil

--- a/pkg/svc/provider/hetzner/iso_test.go
+++ b/pkg/svc/provider/hetzner/iso_test.go
@@ -1,0 +1,66 @@
+package hetzner_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateISOArchitecture(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name, isoType, isoArch, serverArch string
+		valid                              bool
+	}{
+		{"matching x86", "public", `"x86"`, "x86", true},
+		{"matching arm", "public", `"arm"`, "arm", true},
+		{"incompatible", "public", `"x86"`, "arm", false},
+		{"custom wildcard", "custom", `null`, "arm", true},
+		{"missing public metadata", "public", `null`, "arm", false},
+		{"missing target metadata", "public", `"x86"`, "", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(
+				http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+					responseWriter.Header().Set("Content-Type", "application/json")
+
+					if request.URL.Path == "/isos/42" {
+						_, _ = fmt.Fprintf(
+							responseWriter,
+							`{"iso":{"id":42,"type":%q,"architecture":%s}}`,
+							test.isoType,
+							test.isoArch,
+						)
+
+						return
+					}
+
+					_, _ = fmt.Fprintf(
+						responseWriter,
+						`{"server_types":[{"id":1,"name":"target","architecture":%q}]}`,
+						test.serverArch,
+					)
+				}),
+			)
+			t.Cleanup(server.Close)
+			provider := hetzner.NewProvider(
+				hcloud.NewClient(hcloud.WithToken("test"), hcloud.WithEndpoint(server.URL)),
+			)
+
+			err := provider.ValidateISO(t.Context(), 42, "target")
+			if test.valid {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, hetzner.ErrISOArchitectureMismatch)
+			}
+		})
+	}
+}

--- a/pkg/svc/provider/hetzner/iso_test.go
+++ b/pkg/svc/provider/hetzner/iso_test.go
@@ -21,8 +21,9 @@ func TestValidateISOArchitecture(t *testing.T) {
 		{"matching x86", "public", `"x86"`, "x86", true},
 		{"matching arm", "public", `"arm"`, "arm", true},
 		{"incompatible", "public", `"x86"`, "arm", false},
-		{"custom wildcard", "custom", `null`, "arm", true},
+		{"private (uploaded) wildcard", "private", `null`, "arm", true},
 		{"missing public metadata", "public", `null`, "arm", false},
+		{"unknown type is not a wildcard", "custom", `null`, "arm", false},
 		{"missing target metadata", "public", `"x86"`, "", false},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/svc/provisioner/cluster/talos/etcd_test.go
+++ b/pkg/svc/provisioner/cluster/talos/etcd_test.go
@@ -217,7 +217,7 @@ func (transport *membershipCloudTransport) isoResponse(request *http.Request) (s
 	body = `{"iso":{"id":` + strings.TrimPrefix(
 		request.URL.Path,
 		"/isos/",
-	) + `,"type":"custom"}}`
+	) + `,"type":"private"}}`
 	if transport.isoArchitecture != "" {
 		body = fmt.Sprintf(
 			`{"iso":{"id":%s,"type":"public","architecture":%q}}`,

--- a/pkg/svc/provisioner/cluster/talos/etcd_test.go
+++ b/pkg/svc/provisioner/cluster/talos/etcd_test.go
@@ -140,8 +140,9 @@ func membershipContainer(index, address string) container.Summary {
 // membershipCloudTransport serves provider reads entirely in memory and records
 // every attempted write, so a forbidden server deletion is directly observable.
 type membershipCloudTransport struct {
-	address string
-	writes  []string
+	address   string
+	writes    []string
+	isoStatus int
 }
 
 func (transport *membershipCloudTransport) RoundTrip(
@@ -157,6 +158,24 @@ func (transport *membershipCloudTransport) RoundTrip(
 		}]}`,
 		transport.address,
 	)
+	if request.Method == http.MethodGet && strings.HasPrefix(request.URL.Path, "/isos/") {
+		body = `{"iso":{"id":` + strings.TrimPrefix(request.URL.Path, "/isos/") + `}}`
+
+		if transport.isoStatus != 0 {
+			statusCode = transport.isoStatus
+
+			code := "forbidden"
+			if statusCode == http.StatusNotFound {
+				code = "not_found"
+			}
+
+			body = fmt.Sprintf(
+				`{"error":{"code":%q,"message":"ISO lookup rejected by fixture"}}`,
+				code,
+			)
+		}
+	}
+
 	if request.Method != http.MethodGet {
 		transport.writes = append(transport.writes, request.Method+" "+request.URL.Path)
 		statusCode = http.StatusForbidden

--- a/pkg/svc/provisioner/cluster/talos/etcd_test.go
+++ b/pkg/svc/provisioner/cluster/talos/etcd_test.go
@@ -140,9 +140,13 @@ func membershipContainer(index, address string) container.Summary {
 // membershipCloudTransport serves provider reads entirely in memory and records
 // every attempted write, so a forbidden server deletion is directly observable.
 type membershipCloudTransport struct {
-	address   string
-	writes    []string
-	isoStatus int
+	address            string
+	writes             []string
+	isoStatus          int
+	isoArchitecture    string
+	serverArchitecture string
+	floatingIPStatus   int
+	serverStatus       int
 }
 
 func (transport *membershipCloudTransport) RoundTrip(
@@ -159,20 +163,29 @@ func (transport *membershipCloudTransport) RoundTrip(
 		transport.address,
 	)
 	if request.Method == http.MethodGet && strings.HasPrefix(request.URL.Path, "/isos/") {
-		body = `{"iso":{"id":` + strings.TrimPrefix(request.URL.Path, "/isos/") + `}}`
+		body, statusCode = transport.isoResponse(request)
+	}
 
-		if transport.isoStatus != 0 {
-			statusCode = transport.isoStatus
+	if request.URL.Path == "/servers" && transport.serverStatus != 0 {
+		statusCode = transport.serverStatus
+		body = `{"error":{"code":"forbidden","message":"server lookup rejected by fixture"}}`
+	}
 
-			code := "forbidden"
-			if statusCode == http.StatusNotFound {
-				code = "not_found"
-			}
+	if request.URL.Path == "/server_types" {
+		body = fmt.Sprintf(
+			`{"server_types":[{"id":1,"name":%q,"architecture":%q}]}`,
+			request.URL.Query().Get("name"),
+			transport.serverArchitecture,
+		)
+	}
 
-			body = fmt.Sprintf(
-				`{"error":{"code":%q,"message":"ISO lookup rejected by fixture"}}`,
-				code,
-			)
+	if request.URL.Path == "/floating_ips" {
+		body = `{"floating_ips":[{"id":7,"name":"scale-cluster-api","ip":"192.0.2.10","type":"ipv4",
+			"labels":{"ksail.owned":"true","ksail.cluster.name":"scale-cluster"}}]}`
+
+		if transport.floatingIPStatus != 0 {
+			statusCode = transport.floatingIPStatus
+			body = `{"error":{"code":"forbidden","message":"floating IP lookup rejected by fixture"}}`
 		}
 	}
 
@@ -194,4 +207,38 @@ func newMembershipCloud(transport *membershipCloudTransport) *hetzner.Provider {
 		hcloud.WithEndpoint("https://membership.invalid"),
 		hcloud.WithHTTPClient(&http.Client{Transport: transport}),
 	))
+}
+
+func (transport *membershipCloudTransport) isoResponse(request *http.Request) (string, int) {
+	var body string
+
+	statusCode := http.StatusOK
+
+	body = `{"iso":{"id":` + strings.TrimPrefix(
+		request.URL.Path,
+		"/isos/",
+	) + `,"type":"custom"}}`
+	if transport.isoArchitecture != "" {
+		body = fmt.Sprintf(
+			`{"iso":{"id":%s,"type":"public","architecture":%q}}`,
+			strings.TrimPrefix(request.URL.Path, "/isos/"),
+			transport.isoArchitecture,
+		)
+	}
+
+	if transport.isoStatus != 0 {
+		statusCode = transport.isoStatus
+
+		code := "forbidden"
+		if statusCode == http.StatusNotFound {
+			code = "not_found"
+		}
+
+		body = fmt.Sprintf(
+			`{"error":{"code":%q,"message":"ISO lookup rejected by fixture"}}`,
+			code,
+		)
+	}
+
+	return body, statusCode
 }

--- a/pkg/svc/provisioner/cluster/talos/export_test.go
+++ b/pkg/svc/provisioner/cluster/talos/export_test.go
@@ -403,9 +403,10 @@ func (p *Provisioner) ReattachFloatingIPAfterControlPlaneReplacementForTest(
 	hzProvider *hetzner.Provider,
 	clusterName string,
 	oldServer, newServer *hcloud.Server,
+	expectedID int64,
 ) error {
 	return p.reattachFloatingIPAfterControlPlaneReplacement(
-		ctx, hzProvider, clusterName, oldServer, newServer,
+		ctx, hzProvider, clusterName, oldServer, newServer, expectedID,
 	)
 }
 
@@ -1124,4 +1125,9 @@ func (p *KubernetesProvisioner) PublishConnectorKubeconfigForTest(
 	raw []byte,
 ) error {
 	return p.publishConnectorKubeconfig(ctx, clusterName, raw)
+}
+
+// AddReplacementCertSANForTest exposes the prepared-config completion step.
+func (p *Provisioner) AddReplacementCertSANForTest(server *hcloud.Server, role string) error {
+	return p.addReplacementCertSAN(server, role)
 }

--- a/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
+++ b/pkg/svc/provisioner/cluster/talos/provisioner_hetzner.go
@@ -246,34 +246,49 @@ func (p *Provisioner) prepareFloatingIPConfigForNewControlPlane(
 		return nil
 	}
 
+	_, err := p.prepareFloatingIPConfig(ctx, hzProvider, clusterName)
+
+	return err
+}
+
+// prepareFloatingIPConfig resolves and renders existing endpoint prerequisites
+// without changing cloud resources. The returned identity can fence later reads.
+func (p *Provisioner) prepareFloatingIPConfig(
+	ctx context.Context, hzProvider *hetzner.Provider, clusterName string,
+) (*hcloud.FloatingIP, error) {
 	floatingIP, err := hzProvider.GetOwnedFloatingIP(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf("looking up floating IP before control-plane config apply: %w", err)
+		return nil, fmt.Errorf("looking up floating IP before control-plane config apply: %w", err)
 	}
 
 	if floatingIP == nil {
-		return fmt.Errorf("%w: %s", ErrFloatingIPMissingForControlPlaneConfig, clusterName)
+		return nil, fmt.Errorf("%w: %s", ErrFloatingIPMissingForControlPlaneConfig, clusterName)
 	}
 
 	controlPlaneServers, err := p.listHetznerNodesByRole(
 		ctx, hzProvider, clusterName, RoleControlPlane,
 	)
 	if err != nil {
-		return fmt.Errorf("listing control planes before config apply: %w", err)
+		return nil, fmt.Errorf("listing control planes before config apply: %w", err)
 	}
 
 	if len(controlPlaneServers) == 0 {
-		return fmt.Errorf("%w: %s", clustererr.ErrNoControlPlaneNodes, clusterName)
+		return nil, fmt.Errorf("%w: %s", clustererr.ErrNoControlPlaneNodes, clusterName)
 	}
 
 	endpointIP := floatingIP.IP.String()
 
 	certSANs, err := hetznerFloatingIPEndpointCertSANs(endpointIP, controlPlaneServers)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return p.regenerateHetznerEndpointConfigs(endpointIP, certSANs)
+	err = p.regenerateHetznerEndpointConfigs(endpointIP, certSANs)
+	if err != nil {
+		return nil, err
+	}
+
+	return floatingIP, nil
 }
 
 // withHetznerVIPIfEnabled renders the Talos VIP block for the floating-IP

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
@@ -228,7 +228,7 @@ func (p *Provisioner) rollingReplaceSingleNode(
 		return fmt.Errorf("resolving address for %s: %w", oldServer.Name, addrErr)
 	}
 
-	imageID, prepareErr := p.prepareReplacementBoot(
+	prepared, prepareErr := p.prepareReplacementBoot(
 		ctx,
 		hzProvider,
 		clusterName,
@@ -274,15 +274,20 @@ func (p *Provisioner) rollingReplaceSingleNode(
 		clusterName,
 		role,
 		infra,
-		imageID,
+		prepared.imageID,
 	)
 	if createErr != nil {
 		return createErr
 	}
 
 	return p.configureAndWaitReplacement(
-		ctx, clientset, hzProvider, clusterName, oldServer, newServer, role,
+		ctx, clientset, hzProvider, clusterName, oldServer, newServer, role, prepared.floatingIPID,
 	)
+}
+
+type replacementBoot struct {
+	imageID      int64
+	floatingIPID int64
 }
 
 // prepareReplacementBoot checks that the loaded role config can be serialized
@@ -293,36 +298,50 @@ func (p *Provisioner) prepareReplacementBoot(
 	ctx context.Context,
 	hzProvider *hetzner.Provider,
 	clusterName, role, serverName string,
-) (int64, error) {
+) (replacementBoot, error) {
+	prepared := replacementBoot{}
+
+	var err error
+
+	prepared.floatingIPID, err = p.prepareReplacementFloatingIP(ctx, hzProvider, clusterName, role)
+	if err != nil {
+		return prepared, err
+	}
+
 	config := p.configForRole(role)
 	if config == nil {
-		return 0, fmt.Errorf("%w: %s", ErrNoConfigForRole, role)
+		return prepared, fmt.Errorf("%w: %s", ErrNoConfigForRole, role)
 	}
 
 	// Exercise the same serialization and hostname patch used at config apply.
 	// The secret-bearing bytes remain in memory and are never written or logged.
 	_, configErr := marshalConfigWithHostname(config, serverName)
 	if configErr != nil {
-		return 0, fmt.Errorf("prepare replacement role config: %w", configErr)
+		return prepared, fmt.Errorf("prepare replacement role config: %w", configErr)
 	}
 
 	imageID, imageErr := p.ensureSnapshotImage(ctx, clusterName)
 	if imageErr != nil {
-		return 0, fmt.Errorf("prepare replacement boot image: %w", imageErr)
+		return prepared, fmt.Errorf("prepare replacement boot image: %w", imageErr)
 	}
 
 	if imageID == 0 && (p.talosOpts == nil || p.talosOpts.ISO <= 0) {
-		return 0, fmt.Errorf("prepare replacement boot image: %w", hetzner.ErrImageOrISORequired)
+		return prepared, fmt.Errorf(
+			"prepare replacement boot image: %w",
+			hetzner.ErrImageOrISORequired,
+		)
 	}
 
 	if imageID == 0 {
-		isoErr := hzProvider.ValidateISO(ctx, p.talosOpts.ISO)
+		isoErr := hzProvider.ValidateISO(ctx, p.talosOpts.ISO, p.hetznerServerType(role))
 		if isoErr != nil {
-			return 0, fmt.Errorf("prepare replacement ISO: %w", isoErr)
+			return prepared, fmt.Errorf("prepare replacement ISO: %w", isoErr)
 		}
 	}
 
-	return imageID, nil
+	prepared.imageID = imageID
+
+	return prepared, nil
 }
 
 // reattachFloatingIPAfterControlPlaneReplacement restores the stable API
@@ -336,6 +355,7 @@ func (p *Provisioner) reattachFloatingIPAfterControlPlaneReplacement(
 	hzProvider *hetzner.Provider,
 	clusterName string,
 	oldServer, newServer *hcloud.Server,
+	expectedFloatingIPID int64,
 ) error {
 	if p.hetznerOpts == nil || !p.hetznerOpts.FloatingIPEnabled {
 		return nil
@@ -344,6 +364,10 @@ func (p *Provisioner) reattachFloatingIPAfterControlPlaneReplacement(
 	floatingIP, lookupErr := hzProvider.GetOwnedFloatingIP(ctx, clusterName)
 	if lookupErr != nil {
 		return fmt.Errorf("looking up floating IP after control-plane replacement: %w", lookupErr)
+	}
+
+	if !replacementFloatingIPMatches(floatingIP, expectedFloatingIPID) {
+		return ErrFloatingIPMissingForControlPlaneConfig
 	}
 
 	if floatingIP == nil {
@@ -387,10 +411,9 @@ func (p *Provisioner) configureAndWaitReplacement(
 	clusterName string,
 	oldServer, newServer *hcloud.Server,
 	role string,
+	expectedFloatingIPID int64,
 ) error {
-	prepareErr := p.prepareFloatingIPConfigForNewControlPlane(
-		ctx, hzProvider, clusterName, role,
-	)
+	prepareErr := p.addReplacementCertSAN(newServer, role)
 	if prepareErr != nil {
 		return prepareErr
 	}
@@ -419,7 +442,7 @@ func (p *Provisioner) configureAndWaitReplacement(
 
 	reattach := func() error {
 		reattachErr := p.reattachFloatingIPAfterControlPlaneReplacement(
-			ctx, hzProvider, clusterName, oldServer, newServer,
+			ctx, hzProvider, clusterName, oldServer, newServer, expectedFloatingIPID,
 		)
 		if reattachErr != nil {
 			_, _ = fmt.Fprintf(p.logWriter,
@@ -669,4 +692,8 @@ func nodeIsReady(node *corev1.Node) bool {
 	}
 
 	return false
+}
+
+func replacementFloatingIPMatches(floatingIP *hcloud.FloatingIP, expectedID int64) bool {
+	return expectedID == 0 || (floatingIP != nil && floatingIP.ID == expectedID)
 }

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate.go
@@ -228,6 +228,17 @@ func (p *Provisioner) rollingReplaceSingleNode(
 		return fmt.Errorf("resolving address for %s: %w", oldServer.Name, addrErr)
 	}
 
+	imageID, prepareErr := p.prepareReplacementBoot(
+		ctx,
+		hzProvider,
+		clusterName,
+		role,
+		oldServer.Name,
+	)
+	if prepareErr != nil {
+		return prepareErr
+	}
+
 	// 1. Cordon and drain the outgoing node before removing it.
 	oldNodeName, drainErr := p.drainResolvedNode(ctx, clientset, oldIP)
 	if drainErr != nil {
@@ -241,11 +252,7 @@ func (p *Provisioner) rollingReplaceSingleNode(
 			// Leave the server and its current scheduling state intact. An
 			// ambiguous leave failure cannot safely authorize either deletion or
 			// automatic uncordon of a node that may already have left etcd.
-			return fmt.Errorf(
-				"retaining control-plane server %s after etcd cleanup failure: %w",
-				oldServer.Name,
-				cleanupErr,
-			)
+			return fmt.Errorf("etcd cleanup failed; retaining %s: %w", oldServer.Name, cleanupErr)
 		}
 	}
 
@@ -261,7 +268,14 @@ func (p *Provisioner) rollingReplaceSingleNode(
 	}
 
 	// 5. Provision the replacement server with the new type and let it rejoin.
-	newServer, createErr := p.createReplacementServer(ctx, hzProvider, clusterName, role, infra)
+	newServer, createErr := p.createReplacementServer(
+		ctx,
+		hzProvider,
+		clusterName,
+		role,
+		infra,
+		imageID,
+	)
 	if createErr != nil {
 		return createErr
 	}
@@ -269,6 +283,46 @@ func (p *Provisioner) rollingReplaceSingleNode(
 	return p.configureAndWaitReplacement(
 		ctx, clientset, hzProvider, clusterName, oldServer, newServer, role,
 	)
+}
+
+// prepareReplacementBoot checks that the loaded role config can be serialized
+// and resolves the boot image before cordon, drain, or membership mutation. A
+// missing snapshot may be built here: this is apply preparation, not a read-only
+// plan. A successfully built image is retained for reuse if a later step fails.
+func (p *Provisioner) prepareReplacementBoot(
+	ctx context.Context,
+	hzProvider *hetzner.Provider,
+	clusterName, role, serverName string,
+) (int64, error) {
+	config := p.configForRole(role)
+	if config == nil {
+		return 0, fmt.Errorf("%w: %s", ErrNoConfigForRole, role)
+	}
+
+	// Exercise the same serialization and hostname patch used at config apply.
+	// The secret-bearing bytes remain in memory and are never written or logged.
+	_, configErr := marshalConfigWithHostname(config, serverName)
+	if configErr != nil {
+		return 0, fmt.Errorf("prepare replacement role config: %w", configErr)
+	}
+
+	imageID, imageErr := p.ensureSnapshotImage(ctx, clusterName)
+	if imageErr != nil {
+		return 0, fmt.Errorf("prepare replacement boot image: %w", imageErr)
+	}
+
+	if imageID == 0 && (p.talosOpts == nil || p.talosOpts.ISO <= 0) {
+		return 0, fmt.Errorf("prepare replacement boot image: %w", hetzner.ErrImageOrISORequired)
+	}
+
+	if imageID == 0 {
+		isoErr := hzProvider.ValidateISO(ctx, p.talosOpts.ISO)
+		if isoErr != nil {
+			return 0, fmt.Errorf("prepare replacement ISO: %w", isoErr)
+		}
+	}
+
+	return imageID, nil
 }
 
 // reattachFloatingIPAfterControlPlaneReplacement restores the stable API
@@ -497,6 +551,7 @@ func (p *Provisioner) createReplacementServer(
 	hzProvider *hetzner.Provider,
 	clusterName, role string,
 	infra HetznerInfra,
+	imageID int64,
 ) (*hcloud.Server, error) {
 	existing, listErr := p.listHetznerNodesByRole(ctx, hzProvider, clusterName, role)
 	if listErr != nil {
@@ -505,14 +560,8 @@ func (p *Provisioner) createReplacementServer(
 
 	indices := availableHetznerNodeIndices(existing, clusterName, role, 1)
 
-	// Boot the replacement from the cluster's Talos snapshot image (when configured)
-	// rather than the maintenance-mode ISO, so it runs the same Talos version as the
-	// node it replaces and can parse the cluster's machine config (see hetznerBootSource).
-	imageID, snapErr := p.ensureSnapshotImage(ctx, clusterName)
-	if snapErr != nil {
-		return nil, snapErr
-	}
-
+	// Use the image resolved before the outgoing server was removed. Do not
+	// perform a late lookup or build that could strand the replacement sequence.
 	creationResults, createErr := p.launchHetznerScaleCreation(
 		ctx, hzProvider, clusterName, role, infra, p.hetznerRetryOpts(), indices, imageID,
 	)

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_config.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_config.go
@@ -1,0 +1,59 @@
+package talosprovisioner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// addReplacementCertSAN uses the endpoint, VIP credentials, PKI and survivor
+// SANs prepared before removal. Only the address allocated by server creation
+// is new; applying it needs no provider lookup or credential reload.
+func (p *Provisioner) addReplacementCertSAN(newServer *hcloud.Server, role string) error {
+	if role != RoleControlPlane || p.hetznerOpts == nil || !p.hetznerOpts.FloatingIPEnabled {
+		return nil
+	}
+
+	address, err := hetznerNodeTalosAddress(newServer)
+	if err != nil {
+		return err
+	}
+
+	config := p.configForRole(role)
+	if config == nil {
+		return ErrNoConfigForRole
+	}
+
+	sans := append([]string{}, config.K8sAPIServerConfig().CertSANs()...)
+	sans = append(sans, address)
+
+	updated, err := p.talosConfigs.WithCertSANs(sans)
+	if err != nil {
+		return fmt.Errorf("add replacement address to prepared config: %w", err)
+	}
+
+	p.talosConfigs = updated
+
+	return nil
+}
+
+func (p *Provisioner) prepareReplacementFloatingIP(
+	ctx context.Context, hzProvider *hetzner.Provider, clusterName, role string,
+) (int64, error) {
+	if role != RoleControlPlane || p.hetznerOpts == nil || !p.hetznerOpts.FloatingIPEnabled {
+		return 0, nil
+	}
+
+	floatingIP, err := p.prepareFloatingIPConfig(ctx, hzProvider, clusterName)
+	if err != nil {
+		return 0, err
+	}
+
+	if floatingIP.ID <= 0 {
+		return 0, ErrFloatingIPMissingForControlPlaneConfig
+	}
+
+	return floatingIP.ID, nil
+}

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_iso_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_iso_test.go
@@ -1,0 +1,63 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRollingReplaceSingleNode_UnavailableISOPreservesNode(t *testing.T) {
+	t.Parallel()
+
+	for _, role := range []string{talosprovisioner.RoleControlPlane, talosprovisioner.RoleWorker} {
+		for _, status := range []int{http.StatusNotFound, http.StatusForbidden} {
+			t.Run(fmt.Sprintf("%s/%d", role, status), func(t *testing.T) {
+				t.Parallel()
+				assertUnavailableISOPreservesNode(t, role, status)
+			})
+		}
+	}
+}
+
+func assertUnavailableISOPreservesNode(t *testing.T, role string, status int) {
+	t.Helper()
+
+	transport := &membershipCloudTransport{address: "192.0.2.1", isoStatus: status}
+	membership := &membershipClient{leaveErr: errMembershipUnavailable}
+	provisioner := newClientErrProvisioner(t).
+		WithTalosConfigsForTest(loadConfigs(t)).
+		WithTalosOptions(v1alpha1.OptionsTalos{ISO: v1alpha1.DefaultTalosISO}).
+		WithEtcdClientFactoryForTest(func(
+			context.Context, string,
+		) (talosprovisioner.EtcdMembershipClientForTest, error) {
+			return membership, nil
+		})
+	server := &hcloud.Server{ID: 1, Name: "scale-cluster-" + role + "-1"}
+	server.PublicNet.IPv4.IP = net.ParseIP(transport.address)
+	clientset := fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: server.Name, UID: "original-node"},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: transport.address},
+		}},
+	})
+
+	err := provisioner.RollingReplaceSingleNodeForTest(
+		t.Context(), clientset, newMembershipCloud(transport), "scale-cluster", role, server,
+	)
+
+	require.ErrorContains(t, err, "ISO")
+	assert.Empty(t, clientset.Actions(), "unavailable ISO must prevent cordon or drain")
+	assert.Empty(t, membership.calls, "unavailable ISO must prevent membership mutation")
+	assert.Empty(t, transport.writes, "unavailable ISO must prevent server deletion")
+}

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_iso_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_iso_test.go
@@ -61,3 +61,62 @@ func assertUnavailableISOPreservesNode(t *testing.T, role string, status int) {
 	assert.Empty(t, membership.calls, "unavailable ISO must prevent membership mutation")
 	assert.Empty(t, transport.writes, "unavailable ISO must prevent server deletion")
 }
+
+func TestRollingReplaceSingleNode_RemainingPrerequisitesPreserveNode(t *testing.T) {
+	t.Parallel()
+
+	for _, failure := range []string{"ISO architecture", "floating IP lookup", "control-plane lookup", "VIP token"} {
+		t.Run(failure, func(t *testing.T) {
+			t.Parallel()
+
+			transport := &membershipCloudTransport{address: "192.0.2.1"}
+			floatingIP := failure != "ISO architecture"
+			expected := "hcloud API token"
+
+			if failure == "ISO architecture" {
+				transport.isoArchitecture = "x86"
+				transport.serverArchitecture = "arm"
+				expected = "architecture"
+			}
+
+			if failure == "floating IP lookup" {
+				transport.floatingIPStatus = http.StatusForbidden
+				expected = "floating IP"
+			}
+
+			if failure == "control-plane lookup" {
+				transport.serverStatus = http.StatusForbidden
+				expected = "listing control planes"
+			}
+
+			membership := &membershipClient{leaveErr: errMembershipUnavailable}
+			missingEnvironmentVariable := "KSAIL_TEST_ABSENT_REPLACEMENT_ENV"
+			provisioner := newClientErrProvisioner(t).
+				WithTalosConfigsForTest(loadConfigs(t)).
+				WithTalosOptions(v1alpha1.OptionsTalos{ISO: v1alpha1.DefaultTalosISO}).
+				WithHetznerOptions(v1alpha1.OptionsHetzner{
+					ControlPlaneServerType: "cax11", FloatingIPEnabled: floatingIP,
+					TokenEnvVar: missingEnvironmentVariable,
+				}).WithEtcdClientFactoryForTest(func(
+				context.Context, string,
+			) (talosprovisioner.EtcdMembershipClientForTest, error) {
+				return membership, nil
+			})
+			server := &hcloud.Server{ID: 1, Name: "scale-cluster-control-plane-1"}
+			server.PublicNet.IPv4.IP = net.ParseIP(transport.address)
+			clientset := fake.NewClientset()
+			err := provisioner.RollingReplaceSingleNodeForTest(
+				t.Context(),
+				clientset,
+				newMembershipCloud(transport),
+				"scale-cluster",
+				talosprovisioner.RoleControlPlane,
+				server,
+			)
+			require.ErrorContains(t, err, expected)
+			assert.Empty(t, clientset.Actions())
+			assert.Empty(t, membership.calls)
+			assert.Empty(t, transport.writes)
+		})
+	}
+}

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_prepare_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_prepare_test.go
@@ -1,0 +1,163 @@
+package talosprovisioner_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	"github.com/devantler-tech/ksail/v7/pkg/svc/provider/hetzner"
+	talosprovisioner "github.com/devantler-tech/ksail/v7/pkg/svc/provisioner/cluster/talos"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRollingReplaceSingleNode_PreparationFailurePreservesNode(t *testing.T) {
+	t.Parallel()
+
+	for _, role := range []string{talosprovisioner.RoleControlPlane, talosprovisioner.RoleWorker} {
+		for _, failure := range []string{
+			"missing role config", "missing snapshot version", "missing boot source",
+		} {
+			t.Run(role+"/"+failure, func(t *testing.T) {
+				t.Parallel()
+				assertReplacementPreparationFailure(t, role, failure)
+			})
+		}
+	}
+}
+
+func TestRollingReplaceSingleNode_UsesImagePreparedBeforeDeletion(t *testing.T) {
+	t.Parallel()
+
+	transport := &preparedReplacementTransport{}
+	cloudClient := hcloud.NewClient(
+		hcloud.WithToken("test-token"), hcloud.WithEndpoint("https://prepare.invalid"),
+		hcloud.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+	provisioner := newClientErrProvisioner(t).
+		WithTalosConfigsForTest(loadConfigs(t)).
+		WithTalosOptions(v1alpha1.OptionsTalos{SchematicID: "test-schematic", Version: "v1.13.3"}).
+		WithHetznerOptions(v1alpha1.OptionsHetzner{Location: "fsn1", ControlPlaneServerType: "cx23"}).
+		WithSnapshotManager(hetzner.NewSnapshotManager(cloudClient, io.Discard)).
+		WithEtcdClientFactoryForTest(func(
+			context.Context, string,
+		) (talosprovisioner.EtcdMembershipClientForTest, error) {
+			return &membershipClient{}, nil
+		})
+	server := &hcloud.Server{ID: 1, Name: "scale-cluster-control-plane-1"}
+	server.PublicNet.IPv4.IP = net.ParseIP("192.0.2.1")
+
+	err := provisioner.RollingReplaceSingleNodeForTest(
+		t.Context(), fake.NewClientset(), hetzner.NewProvider(cloudClient),
+		"scale-cluster", talosprovisioner.RoleControlPlane, server,
+	)
+
+	require.ErrorContains(t, err, "fixture stops after observing prepared image")
+	assert.Equal(t, []string{
+		"GET /images", "DELETE /servers/1", "GET /servers", "POST /servers",
+	}, transport.events, "image resolution must happen once, before deletion")
+	assert.Equal(t, int64(42), transport.createdImageID)
+}
+
+// preparedReplacementTransport permits only the offline provider sequence up
+// to the replacement POST, where it rejects creation after recording the image.
+type preparedReplacementTransport struct {
+	events         []string
+	createdImageID int64
+}
+
+func (transport *preparedReplacementTransport) RoundTrip(
+	request *http.Request,
+) (*http.Response, error) {
+	event := request.Method + " " + request.URL.Path
+	transport.events = append(transport.events, event)
+	statusCode := http.StatusOK
+
+	var response string
+
+	switch event {
+	case "GET /images":
+		response = `{"images":[{"id":42,"status":"available","type":"snapshot"}]}`
+	case "GET /servers":
+		response = `{"servers":[]}`
+	case "DELETE /servers/1":
+		response = `{"action":{"id":1,"status":"success"}}`
+	case "POST /servers":
+		var payload struct {
+			Image int64 `json:"image"`
+		}
+
+		err := json.NewDecoder(request.Body).Decode(&payload)
+		if err != nil {
+			return nil, fmt.Errorf("decode replacement request: %w", err)
+		}
+
+		transport.createdImageID = payload.Image
+		statusCode = http.StatusForbidden
+		response = `{"error":{"code":"forbidden","message":"fixture stops after observing prepared image"}}`
+	default:
+		statusCode = http.StatusForbidden
+		response = `{"error":{"code":"forbidden","message":"unexpected preparation request"}}`
+	}
+
+	return &http.Response{
+		StatusCode: statusCode, Body: io.NopCloser(strings.NewReader(response)),
+		Header: http.Header{"Content-Type": []string{"application/json"}}, Request: request,
+	}, nil
+}
+
+func assertReplacementPreparationFailure(t *testing.T, role, failure string) {
+	t.Helper()
+
+	transport := &membershipCloudTransport{address: "192.0.2.1"}
+	membership := &membershipClient{leaveErr: errMembershipUnavailable}
+	provisioner := newClientErrProvisioner(t).
+		WithSnapshotManager(hetzner.NewSnapshotManager(nil, io.Discard)).
+		WithTalosOptions(v1alpha1.OptionsTalos{SchematicID: "test-schematic"}).
+		WithEtcdClientFactoryForTest(func(
+			context.Context, string,
+		) (talosprovisioner.EtcdMembershipClientForTest, error) {
+			return membership, nil
+		})
+	expectedErr := talosprovisioner.ErrNoConfigForRole
+
+	if failure != "missing role config" {
+		provisioner.WithTalosConfigsForTest(loadConfigs(t))
+
+		expectedErr = talosprovisioner.ErrSchematicRequiresVersion
+	}
+
+	if failure == "missing boot source" {
+		provisioner.WithSnapshotManager(nil).WithTalosOptions(v1alpha1.OptionsTalos{})
+
+		expectedErr = hetzner.ErrImageOrISORequired
+	}
+
+	server := &hcloud.Server{ID: 1, Name: "scale-cluster-" + role + "-1"}
+	server.PublicNet.IPv4.IP = net.ParseIP(transport.address)
+	clientset := fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: server.Name, UID: "original-node"},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: transport.address},
+		}},
+	})
+
+	err := provisioner.RollingReplaceSingleNodeForTest(
+		t.Context(), clientset, newMembershipCloud(transport), "scale-cluster", role, server,
+	)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, clientset.Actions(), "preparation must finish before cordon or drain")
+	assert.Empty(t, membership.calls, "preparation must finish before membership mutation")
+	assert.Empty(t, transport.writes, "preparation failure must retain the server")
+}

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
@@ -2,6 +2,7 @@ package talosprovisioner_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -384,6 +385,7 @@ func TestReattachFloatingIPAfterControlPlaneReplacement_Unassigned(t *testing.T)
 		"fip-cluster",
 		&hcloud.Server{ID: 11, Name: "fip-cluster-cp-0"},
 		&hcloud.Server{ID: 12, Name: "fip-cluster-cp-0"},
+		0,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), assignCalls.Load())
@@ -411,6 +413,7 @@ func TestReattachFloatingIPAfterControlPlaneReplacement_DoesNotCreate(t *testing
 		"fip-cluster",
 		&hcloud.Server{ID: 11, Name: "fip-cluster-cp-0"},
 		&hcloud.Server{ID: 12, Name: "fip-cluster-cp-0"},
+		0,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), calls.create.Load())
@@ -458,6 +461,7 @@ func TestReattachFloatingIPAfterControlPlaneReplacement_PreservesSurvivor(t *tes
 		"fip-cluster",
 		&hcloud.Server{ID: 11, Name: "fip-cluster-cp-0"},
 		&hcloud.Server{ID: 12, Name: "fip-cluster-cp-0"},
+		0,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), assignCalls.Load())
@@ -541,4 +545,27 @@ func TestNodeIsReady(t *testing.T) {
 
 	assert.False(t, talosprovisioner.NodeIsReadyForTest(&corev1.Node{}),
 		"node with no conditions is not ready")
+}
+
+func TestReplacementFloatingIPIdentityDriftPreventsReassignment(t *testing.T) {
+	t.Parallel()
+
+	for _, exists := range []bool{false, true} {
+		t.Run(fmt.Sprintf("exists=%t", exists), func(t *testing.T) {
+			t.Parallel()
+
+			calls := &fipUpdateCalls{}
+			server := fipUpdateTestServer(t, exists, calls)
+			provisioner := talosprovisioner.NewProvisioner(nil, nil).
+				WithHetznerOptions(v1alpha1.OptionsHetzner{FloatingIPEnabled: true}).
+				WithLogWriter(io.Discard)
+			err := provisioner.ReattachFloatingIPAfterControlPlaneReplacementForTest(
+				t.Context(), newFipUpdateProvider(server.URL), "fip-cluster",
+				&hcloud.Server{ID: 11}, &hcloud.Server{ID: 12}, 8,
+			)
+			require.ErrorIs(t, err, talosprovisioner.ErrFloatingIPMissingForControlPlaneConfig)
+			assert.Zero(t, calls.assign.Load())
+			assert.Zero(t, calls.create.Load())
+		})
+	}
 }

--- a/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
+++ b/pkg/svc/provisioner/cluster/talos/rolling_recreate_test.go
@@ -36,7 +36,9 @@ func TestRollingReplaceSingleNode_CleanupFailurePreservesServer(t *testing.T) {
 
 			transport := &membershipCloudTransport{address: "192.0.2.1"}
 
-			provisioner := newClientErrProvisioner(t)
+			provisioner := newClientErrProvisioner(t).
+				WithTalosConfigsForTest(loadConfigs(t)).
+				WithTalosOptions(v1alpha1.OptionsTalos{ISO: v1alpha1.DefaultTalosISO})
 			if leaveFailure {
 				provisioner.WithEtcdClientFactoryForTest(
 					func(context.Context, string) (talosprovisioner.EtcdMembershipClientForTest, error) {

--- a/pkg/svc/provisioner/cluster/talos/update_floating_ip_test.go
+++ b/pkg/svc/provisioner/cluster/talos/update_floating_ip_test.go
@@ -1438,3 +1438,59 @@ func TestAllControlPlanesHaveHetznerFloatingIPConfig_LegacyEth0FormIsDrift(t *te
 		[]talosconfig.Provider{legacy}, "192.0.2.10",
 	), "the legacy eth0 form must read as drift so deployed clusters get migrated")
 }
+
+func TestReplacementCertSANRetainsPreparedConfig(t *testing.T) {
+	t.Setenv(testFloatingIPTokenEnvVar, "vip-test-token")
+
+	calls := &fipUpdateCalls{}
+	server := fipUpdateTestServerWithServers(
+		t,
+		true,
+		calls,
+		fipUpdateControlPlaneServerJSON,
+		fipUpdateSecondControlPlaneServerJSON,
+	)
+	hzProvider := newFipUpdateProvider(server.URL)
+	provisioner := newFloatingIPTestProvisioner(t, v1alpha1.OptionsHetzner{
+		FloatingIPEnabled: true, TokenEnvVar: testFloatingIPTokenEnvVar,
+	})
+	require.NoError(
+		t,
+		provisioner.PrepareFloatingIPConfigForNewControlPlaneForTest(
+			t.Context(),
+			hzProvider,
+			"fip-cluster",
+			talosprovisioner.RoleControlPlane,
+		),
+	)
+	before := provisioner.TalosConfigsForTest().ControlPlane()
+	certificate := before.Machine().Security().IssuingCA().Crt
+	// No provider access or credential reload is available after preparation.
+	server.Close()
+	t.Setenv(testFloatingIPTokenEnvVar, "")
+	require.NoError(
+		t,
+		provisioner.AddReplacementCertSANForTest(
+			controlPlaneServer(13, "fip-cluster-cp-2", "203.0.113.7"),
+			talosprovisioner.RoleControlPlane,
+		),
+	)
+	after := provisioner.TalosConfigsForTest().ControlPlane()
+	assert.Equal(t, "192.0.2.10", after.Cluster().Endpoint().Hostname())
+	assert.Equal(t, certificate, after.Machine().Security().IssuingCA().Crt)
+	assert.Subset(
+		t,
+		after.K8sAPIServerConfig().CertSANs(),
+		[]string{"192.0.2.10", "203.0.113.5", "203.0.113.6", "203.0.113.7"},
+	)
+	assert.Contains(t, after.RawV1Alpha1().MachineConfig.MachineCertSANs, "203.0.113.7")
+	assert.True(
+		t,
+		talosprovisioner.AllControlPlanesHaveHetznerFloatingIPConfigForTest(
+			[]talosconfig.Provider{after},
+			"192.0.2.10",
+		),
+	)
+	assert.Zero(t, calls.assign.Load())
+	assert.Zero(t, calls.create.Load())
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Hetzner rolling replacement can discover missing role configuration, failed image preparation, an unavailable or architecture-incompatible ISO, or floating-IP configuration failure after removing the original node. This change resolves and validates those prerequisites before cordon or removal, then reuses the prepared image and endpoint configuration for the replacement.

The supported custom ISO architecture wildcard is preserved. Floating-IP preparation retains the owned address identity, VIP credentials, existing PKI and control-plane SANs; after creation, config completion adds the actual new server address without repeating prerequisite discovery. The final live assignment refresh rejects an address identity change.

A cache-miss snapshot build still creates temporary cloud resources during preparation. Current availability cannot guarantee a later attachment or capacity, and replacement names retain their existing allocation behavior. Regression tests cover failure-before-mutation, ISO compatibility and wildcard behavior, prepared-config reuse, identity drift, and prepared image reuse. Both affected package suites and scoped lint pass locally; hosted validation runs against the current revision.

Fixes #6935. Part of #6933; the guarded single-target operation and production recreation proof remain separate work.
