### PR TITLE
fix(clusterapi): give apiserver calls their own connection pool

### DIFF
--- a/pkg/cli/clusterapi/apiserver_transport.go
+++ b/pkg/cli/clusterapi/apiserver_transport.go
@@ -1,6 +1,7 @@
 package clusterapi
 
 import (
+	"fmt"
 	"net/http"
 
 	"k8s.io/client-go/rest"
@@ -20,7 +21,7 @@ import (
 func apiserverTransportFor(config *rest.Config) (http.RoundTripper, error) {
 	transport, err := rest.TransportFor(config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build apiserver transport: %w", err)
 	}
 
 	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok &&

--- a/pkg/cli/clusterapi/apiserver_transport.go
+++ b/pkg/cli/clusterapi/apiserver_transport.go
@@ -1,0 +1,32 @@
+package clusterapi
+
+import (
+	"net/http"
+
+	"k8s.io/client-go/rest"
+)
+
+// apiserverTransportFor builds the HTTP transport used for direct apiserver calls (watch, proxy).
+//
+// client-go's transport cache returns the process-global http.DefaultTransport whenever the config
+// needs no custom TLS, dialer or proxy — which is every plain-HTTP apiserver config. A watch is
+// long-lived, so sharing that pool means any goroutine calling
+// http.DefaultTransport.CloseIdleConnections() can break the stream with
+// "http: CloseIdleConnections called". Give apiserver calls their own connection pool instead.
+//
+// Only the process-global case is cloned. A config that needs a custom transport already gets a
+// per-config cached one from client-go (not the process global), and may be wrapped in an auth
+// RoundTripper that must not be copied, so it is passed through untouched.
+func apiserverTransportFor(config *rest.Config) (http.RoundTripper, error) {
+	transport, err := rest.TransportFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok &&
+		transport == http.DefaultTransport {
+		return defaultTransport.Clone(), nil
+	}
+
+	return transport, nil
+}

--- a/pkg/cli/clusterapi/apiserver_transport_internal_test.go
+++ b/pkg/cli/clusterapi/apiserver_transport_internal_test.go
@@ -86,9 +86,8 @@ func TestWatchKubeSurvivesDefaultTransportCloseIdleConnections(t *testing.T) {
 
 	// Put an idle keep-alive connection on the process-global pool, so closing it below is a real
 	// event rather than a no-op.
-	warm, err := http.DefaultClient.Get(
-		server.URL,
-	) //nolint:noctx // fixture warm-up, not production code
+	//nolint:noctx // fixture warm-up, not production code
+	warm, err := http.DefaultClient.Get(server.URL)
 	if err != nil {
 		t.Fatalf("warm-up request: %v", err)
 	}

--- a/pkg/cli/clusterapi/apiserver_transport_internal_test.go
+++ b/pkg/cli/clusterapi/apiserver_transport_internal_test.go
@@ -86,7 +86,9 @@ func TestWatchKubeSurvivesDefaultTransportCloseIdleConnections(t *testing.T) {
 
 	// Put an idle keep-alive connection on the process-global pool, so closing it below is a real
 	// event rather than a no-op.
-	warm, err := http.DefaultClient.Get(server.URL) //nolint:noctx // fixture warm-up, not production code
+	warm, err := http.DefaultClient.Get(
+		server.URL,
+	) //nolint:noctx // fixture warm-up, not production code
 	if err != nil {
 		t.Fatalf("warm-up request: %v", err)
 	}
@@ -107,7 +109,11 @@ func TestWatchKubeSurvivesDefaultTransportCloseIdleConnections(t *testing.T) {
 			url.Values{"labelSelector": {"app=x"}},
 		)
 		if err != nil {
-			t.Fatalf("iteration %d: WatchKube broken by an unrelated CloseIdleConnections: %v", iteration, err)
+			t.Fatalf(
+				"iteration %d: WatchKube broken by an unrelated CloseIdleConnections: %v",
+				iteration,
+				err,
+			)
 		}
 
 		_, _ = io.Copy(io.Discard, stream)

--- a/pkg/cli/clusterapi/apiserver_transport_internal_test.go
+++ b/pkg/cli/clusterapi/apiserver_transport_internal_test.go
@@ -1,0 +1,114 @@
+package clusterapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// A plain rest.Config needs no custom TLS, dialer or proxy, so client-go's transport cache hands
+// back the process-global http.DefaultTransport. An apiserver watch is long-lived, so sharing that
+// pool means any goroutine calling http.DefaultTransport.CloseIdleConnections() can break the
+// stream. The apiserver transport must therefore have its own pool.
+func TestApiserverTransportIsNotTheProcessGlobalPool(t *testing.T) {
+	t.Parallel()
+
+	transport, err := apiserverTransportFor(&rest.Config{Host: "http://127.0.0.1:1"})
+	if err != nil {
+		t.Fatalf("apiserverTransportFor: %v", err)
+	}
+
+	if transport == http.DefaultTransport {
+		t.Fatal("apiserver transport is the process-global http.DefaultTransport: " +
+			"an unrelated CloseIdleConnections() can break a live watch")
+	}
+}
+
+// Negative control: a config that genuinely needs a custom transport must be left on client-go's
+// own cached transport. Without this, the fix could pass by cloning unconditionally, which would
+// silently discard client-go's per-config caching and any wrapped auth RoundTripper.
+func TestApiserverTransportLeavesCustomConfigsOnClientGoCache(t *testing.T) {
+	t.Parallel()
+
+	config := &rest.Config{
+		Host:            "https://127.0.0.1:1",
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	}
+
+	first, err := apiserverTransportFor(config)
+	if err != nil {
+		t.Fatalf("apiserverTransportFor: %v", err)
+	}
+
+	second, err := apiserverTransportFor(config)
+	if err != nil {
+		t.Fatalf("apiserverTransportFor: %v", err)
+	}
+
+	if first == http.DefaultTransport {
+		t.Fatal("a TLS config must not resolve to the process-global transport")
+	}
+
+	if first != second {
+		t.Fatal("a custom-TLS config was cloned per call: client-go's transport cache is bypassed")
+	}
+}
+
+// Behavioural regression guard for the failure actually observed in CI:
+//
+//	WatchKube: open apiserver watch: Get "http://…/api/v1/pods?…&watch=true":
+//	net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
+//
+// A watch must not be broken by an unrelated goroutine closing the process-global pool's idle
+// connections. The loop reuses keep-alive connections and interleaves the close, which is the
+// sequence that produced the CI failure.
+func TestWatchKubeSurvivesDefaultTransportCloseIdleConnections(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte("{}\n"))
+		}),
+	)
+	defer server.Close()
+
+	service := &Service{
+		restConfigForCluster: func(string) (*rest.Config, error) {
+			return &rest.Config{Host: server.URL}, nil
+		},
+	}
+
+	// Put an idle keep-alive connection on the process-global pool, so closing it below is a real
+	// event rather than a no-op.
+	warm, err := http.DefaultClient.Get(server.URL) //nolint:noctx // fixture warm-up, not production code
+	if err != nil {
+		t.Fatalf("warm-up request: %v", err)
+	}
+
+	_, _ = io.Copy(io.Discard, warm.Body)
+	_ = warm.Body.Close()
+
+	for i := range 25 {
+		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+			defaultTransport.CloseIdleConnections()
+		}
+
+		stream, err := service.WatchKube(
+			context.Background(),
+			"default",
+			"kind",
+			"api/v1/pods",
+			url.Values{"labelSelector": {"app=x"}},
+		)
+		if err != nil {
+			t.Fatalf("iteration %d: WatchKube broken by an unrelated CloseIdleConnections: %v", i, err)
+		}
+
+		_, _ = io.Copy(io.Discard, stream)
+		_ = stream.Close()
+	}
+}

--- a/pkg/cli/clusterapi/apiserver_transport_internal_test.go
+++ b/pkg/cli/clusterapi/apiserver_transport_internal_test.go
@@ -67,6 +67,8 @@ func TestApiserverTransportLeavesCustomConfigsOnClientGoCache(t *testing.T) {
 // A watch must not be broken by an unrelated goroutine closing the process-global pool's idle
 // connections. The loop reuses keep-alive connections and interleaves the close, which is the
 // sequence that produced the CI failure.
+//
+//nolint:paralleltest // Mutates the process-global http.DefaultTransport; cannot run in parallel.
 func TestWatchKubeSurvivesDefaultTransportCloseIdleConnections(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -92,7 +94,7 @@ func TestWatchKubeSurvivesDefaultTransportCloseIdleConnections(t *testing.T) {
 	_, _ = io.Copy(io.Discard, warm.Body)
 	_ = warm.Body.Close()
 
-	for i := range 25 {
+	for iteration := range 25 {
 		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
 			defaultTransport.CloseIdleConnections()
 		}
@@ -105,7 +107,7 @@ func TestWatchKubeSurvivesDefaultTransportCloseIdleConnections(t *testing.T) {
 			url.Values{"labelSelector": {"app=x"}},
 		)
 		if err != nil {
-			t.Fatalf("iteration %d: WatchKube broken by an unrelated CloseIdleConnections: %v", i, err)
+			t.Fatalf("iteration %d: WatchKube broken by an unrelated CloseIdleConnections: %v", iteration, err)
 		}
 
 		_, _ = io.Copy(io.Discard, stream)

--- a/pkg/cli/clusterapi/kubeproxy.go
+++ b/pkg/cli/clusterapi/kubeproxy.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/devantler-tech/ksail/v7/pkg/webui/api"
-	"k8s.io/client-go/rest"
 )
 
 // kubeProxyTimeout bounds a single proxied apiserver read.
@@ -33,7 +32,7 @@ func (s *Service) ProxyKubeGet(
 		return api.KubeProxyResponse{}, fmt.Errorf("resolve cluster %q: %w", name, err)
 	}
 
-	transport, err := rest.TransportFor(config)
+	transport, err := apiserverTransportFor(config)
 	if err != nil {
 		return api.KubeProxyResponse{}, fmt.Errorf("build apiserver transport: %w", err)
 	}

--- a/pkg/cli/clusterapi/kubewatch.go
+++ b/pkg/cli/clusterapi/kubewatch.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	"github.com/devantler-tech/ksail/v7/pkg/webui/api"
-	"k8s.io/client-go/rest"
 )
 
 // Ensure the local backend exposes the read-only kube-apiserver watch alongside the kube-proxy.
@@ -36,7 +35,7 @@ func (s *Service) WatchKube(
 		return nil, fmt.Errorf("resolve cluster %q: %w", name, err)
 	}
 
-	transport, err := rest.TransportFor(config)
+	transport, err := apiserverTransportFor(config)
 	if err != nil {
 		return nil, fmt.Errorf("build apiserver transport: %w", err)
 	}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The resource browser's live cluster views are served by long-lived apiserver watches. Those watches were sharing one process-wide connection pool with everything else in the process, so unrelated activity elsewhere could drop a watch mid-stream and blank a user's view for no visible reason.

It also showed up as an intermittent test failure that was blocking dependency updates from merging, which is how it was found.

### What

Apiserver watches and proxied reads now get their own connection pool, so unrelated work can no longer break them. Clusters that use custom credentials or TLS are left exactly as they were.

This applies the same pattern the Cilium Gateway API fetcher already uses for the identical problem.

Fixes #6953
