### PR TITLE
test(localpathstorage): serve the installer manifest from a fixture

### DIFF
--- a/pkg/svc/installer/localpathstorage/export_test.go
+++ b/pkg/svc/installer/localpathstorage/export_test.go
@@ -1,0 +1,20 @@
+package localpathstorageinstaller
+
+// SetManifestURLForTest overrides the upstream manifest location so unit tests can
+// serve the manifest from a local test server instead of reaching the network.
+func SetManifestURLForTest(installer *Installer, url string) {
+	installer.manifestURL = url
+}
+
+// ManifestURLForTest exposes the configured manifest location so a test can assert
+// the production default still points at the pinned upstream manifest.
+func ManifestURLForTest(installer *Installer) string {
+	return installer.manifestURL
+}
+
+// LocalPathProvisionerVersionForTest exposes the version pinned in the embedded
+// Dockerfile, so a test can assert the manifest URL tracks it across dependency
+// bumps instead of hard-coding a version that Dependabot will move.
+func LocalPathProvisionerVersionForTest() string {
+	return localPathProvisionerVersion()
+}

--- a/pkg/svc/installer/localpathstorage/installer.go
+++ b/pkg/svc/installer/localpathstorage/installer.go
@@ -49,6 +49,9 @@ type Installer struct {
 	context      string
 	timeout      time.Duration
 	distribution v1alpha1.Distribution
+	// manifestURL is the upstream manifest location. It is a field rather than a
+	// package function call so unit tests can serve the manifest locally.
+	manifestURL string
 }
 
 // NewInstaller creates a new local-path-storage installer instance.
@@ -62,6 +65,7 @@ func NewInstaller(
 		context:      context,
 		timeout:      timeout,
 		distribution: distribution,
+		manifestURL:  localPathProvisionerManifestURL(),
 	}
 }
 
@@ -92,7 +96,7 @@ func (l *Installer) Images(ctx context.Context) ([]string, error) {
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
-		localPathProvisionerManifestURL(),
+		l.manifestURL,
 		nil,
 	)
 	if err != nil {

--- a/pkg/svc/installer/localpathstorage/installer_coverage_test.go
+++ b/pkg/svc/installer/localpathstorage/installer_coverage_test.go
@@ -35,7 +35,12 @@ func TestInstaller_Images_VClusterDistribution(t *testing.T) {
 	images, err := installer.Images(context.Background())
 
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
+	assert.Equal(
+		t,
+		int64(1),
+		hits.Load(),
+		"manifest must come from the test server, not the network",
+	)
 	assert.NotEmpty(t, images, "VCluster should fetch images (same as Vanilla)")
 }
 

--- a/pkg/svc/installer/localpathstorage/installer_coverage_test.go
+++ b/pkg/svc/installer/localpathstorage/installer_coverage_test.go
@@ -30,15 +30,12 @@ func TestInstaller_Install_VClusterDistribution(t *testing.T) {
 func TestInstaller_Images_VClusterDistribution(t *testing.T) {
 	t.Parallel()
 
-	installer := localpathstorageinstaller.NewInstaller(
-		"/path/to/kubeconfig",
-		"test-context",
-		30*time.Second,
-		v1alpha1.DistributionVCluster,
-	)
+	installer, hits := newFixtureInstaller(t, v1alpha1.DistributionVCluster)
 
 	images, err := installer.Images(context.Background())
+
 	require.NoError(t, err)
+	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
 	assert.NotEmpty(t, images, "VCluster should fetch images (same as Vanilla)")
 }
 
@@ -74,12 +71,7 @@ func TestInstaller_Uninstall_CanceledContext(t *testing.T) {
 func TestInstaller_Images_CanceledContext_VCluster(t *testing.T) {
 	t.Parallel()
 
-	installer := localpathstorageinstaller.NewInstaller(
-		"/path/to/kubeconfig",
-		"test-context",
-		30*time.Second,
-		v1alpha1.DistributionVCluster,
-	)
+	installer, _ := newFixtureInstaller(t, v1alpha1.DistributionVCluster)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/pkg/svc/installer/localpathstorage/installer_manifest_test.go
+++ b/pkg/svc/installer/localpathstorage/installer_manifest_test.go
@@ -81,7 +81,12 @@ func TestInstaller_Images_ServesManifestFromFixture(t *testing.T) {
 	images, err := installer.Images(context.Background())
 
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
+	assert.Equal(
+		t,
+		int64(1),
+		hits.Load(),
+		"manifest must come from the test server, not the network",
+	)
 	assert.Contains(t, images, "docker.io/rancher/local-path-provisioner:v0.0.37")
 	assert.Contains(t, images, "docker.io/library/busybox:latest")
 }

--- a/pkg/svc/installer/localpathstorage/installer_manifest_test.go
+++ b/pkg/svc/installer/localpathstorage/installer_manifest_test.go
@@ -1,0 +1,133 @@
+package localpathstorageinstaller_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/devantler-tech/ksail/v7/pkg/apis/cluster/v1alpha1"
+	localpathstorageinstaller "github.com/devantler-tech/ksail/v7/pkg/svc/installer/localpathstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newManifestServer serves the checked-in local-path-storage fixture and reports how
+// many times it was called, so a test can prove the installer fetched from here and
+// not from the upstream host.
+func newManifestServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	manifest, err := os.ReadFile(filepath.Join("testdata", "local-path-storage.yaml"))
+	require.NoError(t, err, "fixture manifest must be readable")
+
+	var hits atomic.Int64
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+
+			writer.Header().Set("Content-Type", "text/plain")
+			_, _ = writer.Write(manifest)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	return server, &hits
+}
+
+// newFixtureInstallerWithTimeout returns an installer for distribution that reads its
+// manifest from a local test server rather than the network.
+func newFixtureInstallerWithTimeout(
+	t *testing.T,
+	distribution v1alpha1.Distribution,
+	timeout time.Duration,
+) (*localpathstorageinstaller.Installer, *atomic.Int64) {
+	t.Helper()
+
+	server, hits := newManifestServer(t)
+
+	installer := localpathstorageinstaller.NewInstaller(
+		"/path/to/kubeconfig",
+		"test-context",
+		timeout,
+		distribution,
+	)
+	localpathstorageinstaller.SetManifestURLForTest(installer, server.URL)
+
+	return installer, hits
+}
+
+// newFixtureInstaller returns an installer for distribution that reads its manifest
+// from a local test server rather than the network.
+func newFixtureInstaller(
+	t *testing.T,
+	distribution v1alpha1.Distribution,
+) (*localpathstorageinstaller.Installer, *atomic.Int64) {
+	t.Helper()
+
+	return newFixtureInstallerWithTimeout(t, distribution, 30*time.Second)
+}
+
+func TestInstaller_Images_ServesManifestFromFixture(t *testing.T) {
+	t.Parallel()
+
+	installer, hits := newFixtureInstaller(t, v1alpha1.DistributionVanilla)
+
+	images, err := installer.Images(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
+	assert.Contains(t, images, "docker.io/rancher/local-path-provisioner:v0.0.37")
+	assert.Contains(t, images, "docker.io/library/busybox:latest")
+}
+
+func TestInstaller_Images_PropagatesNonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusNotFound)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	installer := localpathstorageinstaller.NewInstaller(
+		"/path/to/kubeconfig",
+		"test-context",
+		30*time.Second,
+		v1alpha1.DistributionVanilla,
+	)
+	localpathstorageinstaller.SetManifestURLForTest(installer, server.URL)
+
+	images, err := installer.Images(context.Background())
+
+	require.ErrorIs(t, err, localpathstorageinstaller.ErrManifestFetchFailed)
+	assert.Empty(t, images)
+}
+
+func TestInstaller_ManifestURLDefaultsToUpstream(t *testing.T) {
+	t.Parallel()
+
+	installer := localpathstorageinstaller.NewInstaller(
+		"/path/to/kubeconfig",
+		"test-context",
+		30*time.Second,
+		v1alpha1.DistributionVanilla,
+	)
+
+	version := localpathstorageinstaller.LocalPathProvisionerVersionForTest()
+	require.NotEmpty(t, version, "the Dockerfile pin must resolve to a version")
+
+	assert.Equal(
+		t,
+		"https://raw.githubusercontent.com/rancher/local-path-provisioner/"+
+			version+"/deploy/local-path-storage.yaml",
+		localpathstorageinstaller.ManifestURLForTest(installer),
+		"the production default must track the version pinned in the embedded Dockerfile",
+	)
+}

--- a/pkg/svc/installer/localpathstorage/installer_test.go
+++ b/pkg/svc/installer/localpathstorage/installer_test.go
@@ -164,19 +164,15 @@ func TestInstaller_Images_K3s(t *testing.T) {
 func TestInstaller_Images_Success(t *testing.T) {
 	t.Parallel()
 
-	installer := localpathstorageinstaller.NewInstaller(
-		"/path/to/kubeconfig",
-		"test-context",
-		30*time.Second,
-		v1alpha1.DistributionVanilla,
-	)
+	installer, hits := newFixtureInstaller(t, v1alpha1.DistributionVanilla)
 
 	ctx := context.Background()
 	images, err := installer.Images(ctx)
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, images, "Should extract images from real manifest")
-	// The real manifest should contain the local-path-provisioner image
+	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
+	assert.NotEmpty(t, images, "Should extract images from the manifest")
+	// The manifest should contain the local-path-provisioner image
 	foundProvisionerImage := false
 
 	for _, img := range images {
@@ -193,28 +189,23 @@ func TestInstaller_Images_Success(t *testing.T) {
 func TestInstaller_Images_Talos(t *testing.T) {
 	t.Parallel()
 
-	installer := localpathstorageinstaller.NewInstaller(
-		"/path/to/kubeconfig",
-		"test-context",
-		30*time.Second,
-		v1alpha1.DistributionTalos,
-	)
+	installer, hits := newFixtureInstaller(t, v1alpha1.DistributionTalos)
 
 	ctx := context.Background()
 	images, err := installer.Images(ctx)
 
 	require.NoError(t, err)
+	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
 	assert.NotEmpty(t, images, "Talos should also fetch images from manifest")
 }
 
 func TestInstaller_Images_ShortTimeout(t *testing.T) {
 	t.Parallel()
 
-	installer := localpathstorageinstaller.NewInstaller(
-		"/path/to/kubeconfig",
-		"test-context",
-		1*time.Nanosecond,
+	installer, _ := newFixtureInstallerWithTimeout(
+		t,
 		v1alpha1.DistributionVanilla,
+		1*time.Nanosecond,
 	)
 
 	ctx := context.Background()
@@ -227,12 +218,7 @@ func TestInstaller_Images_ShortTimeout(t *testing.T) {
 func TestInstaller_Images_CanceledContext(t *testing.T) {
 	t.Parallel()
 
-	installer := localpathstorageinstaller.NewInstaller(
-		"/path/to/kubeconfig",
-		"test-context",
-		30*time.Second,
-		v1alpha1.DistributionVanilla,
-	)
+	installer, _ := newFixtureInstaller(t, v1alpha1.DistributionVanilla)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/pkg/svc/installer/localpathstorage/installer_test.go
+++ b/pkg/svc/installer/localpathstorage/installer_test.go
@@ -170,7 +170,12 @@ func TestInstaller_Images_Success(t *testing.T) {
 	images, err := installer.Images(ctx)
 
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
+	assert.Equal(
+		t,
+		int64(1),
+		hits.Load(),
+		"manifest must come from the test server, not the network",
+	)
 	assert.NotEmpty(t, images, "Should extract images from the manifest")
 	// The manifest should contain the local-path-provisioner image
 	foundProvisionerImage := false
@@ -195,7 +200,12 @@ func TestInstaller_Images_Talos(t *testing.T) {
 	images, err := installer.Images(ctx)
 
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), hits.Load(), "manifest must come from the test server, not the network")
+	assert.Equal(
+		t,
+		int64(1),
+		hits.Load(),
+		"manifest must come from the test server, not the network",
+	)
 	assert.NotEmpty(t, images, "Talos should also fetch images from manifest")
 }
 

--- a/pkg/svc/installer/localpathstorage/testdata/local-path-storage.yaml
+++ b/pkg/svc/installer/localpathstorage/testdata/local-path-storage.yaml
@@ -1,0 +1,57 @@
+# Structurally faithful sample of the upstream Rancher local-path-provisioner deploy
+# manifest. It exists so the Images unit tests exercise the fetch-and-extract path
+# without reaching raw.githubusercontent.com. The image tags below are fixture data
+# only; they intentionally do not track the Dockerfile pin.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: rancher/local-path-provisioner:v0.0.37
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      containers:
+        - name: helper-pod
+          image: busybox


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

A unit test in the storage installer downloaded a file from GitHub every time it ran. Whenever GitHub had a brief network hiccup, that test failed — turning completely unrelated pull requests red and forcing someone to re-run the build by hand. It also meant the test suite could not run offline.

This is not hypothetical: it red-checked a PR earlier today, and the same failure was recorded on two others.

### What this changes

The test now serves that file from inside the test itself, so it no longer depends on GitHub being reachable. The real download path is unchanged for users — only the tests stopped reaching the network.

Verified by running the suite with network access blocked: it passes now, and the previous tests fail on all three cases under the same conditions.

Fixes #6901
