### PR TITLE
fix(ci): deliver the desktop tidy to Dependabot branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -747,11 +747,31 @@ jobs:
           path: /tmp/patches
 
       - name: 📋 Apply patches
+        env:
+          # Dependabot loses its rebase ability permanently once anything else pushes to
+          # its branch, so its branches are left alone (#6832) — with one exception.
+          #
+          # That exclusion assumed every patch here is cosmetic drift the protected-branch
+          # sync repairs after the bump merges. The desktop tidy is not: desktop/ is a
+          # separate module vendoring the root via `replace => ../`, so a root bump leaves
+          # desktop/go.{mod,sum} stale and fails the bump's OWN required checks. Deferring
+          # it means the bump can never merge, so the post-merge path it was deferred to is
+          # never reached, and the PR sits red in the ecosystem's open-PR cap (#6974).
+          #
+          # Apply only the desktop tidy on a Dependabot branch: the one patch Dependabot
+          # cannot produce itself and cannot merge without. When desktop is already tidy
+          # this patch is empty, nothing is staged, and the branch is never touched — so
+          # Dependabot keeps its rebase ability in exactly the cases #6832 was about.
+          DESKTOP_TIDY_ONLY: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
         run: |
           set -euo pipefail
           shopt -s nullglob
 
           for patch in /tmp/patches/*.patch; do
+            if [ "${DESKTOP_TIDY_ONLY}" = "true" ] && [ "$(basename "$patch")" != "desktop-tidy.patch" ]; then
+              echo "Skipping $(basename "$patch"): Dependabot branch — only the desktop tidy is applied here."
+              continue
+            fi
             if [ -s "$patch" ]; then
               patch_name="$(basename "$patch")"
               echo "Applying ${patch_name}..."
@@ -790,9 +810,12 @@ jobs:
       # modes are not expressible. Reject anything other than a regular 0644 file below
       # rather than dereferencing a symlink or silently losing an executable bit.
       - name: 📤 Commit and push generated changes (PR branch)
-        if: >-
-          github.event_name == 'pull_request'
-          && github.event.pull_request.user.login != 'dependabot[bot]'
+        # Dependabot is no longer excluded here; the exclusion moved into 📋 Apply patches,
+        # which restricts a Dependabot branch to the desktop tidy. That keeps the decision
+        # about WHAT may be pushed in one place and lets this step stay a plain "commit
+        # whatever was applied" — on a Dependabot bump with a tidy desktop module nothing
+        # is applied, so this step finds no changes and pushes nothing (#6974).
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           BRANCH: ${{ github.head_ref }}

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -317,17 +317,30 @@ type autoCommitWorkflow struct {
 	} `yaml:"jobs"`
 }
 
-// The exact conditions the two auto-commit delivery paths must carry.
+// The exact conditions the two auto-commit delivery paths must carry, plus the
+// restriction that decides what may be applied on a Dependabot branch.
 //
-// The PR-branch push is the one that has to exclude Dependabot; the protected-branch
-// path is asserted alongside it because it is where a skipped Dependabot sync is
-// expected to land instead, and silently losing it would turn this fix into a
-// generated-file correctness regression on the default branch.
+// Dependabot's exclusion lives in 📋 Apply patches rather than on the PR-branch push:
+// what may reach a Dependabot branch is a per-patch question, not a per-step one, and
+// pinning it on the push could only express "all patches or none". The protected-branch
+// path is asserted alongside because it is where a skipped generated-file sync lands
+// instead, and silently losing it would turn this into a generated-file correctness
+// regression on the default branch.
 const (
-	approvedAutoCommitPRBranchCondition = "github.event_name == 'pull_request'" +
-		" && github.event.pull_request.user.login != 'dependabot[bot]'"
+	approvedAutoCommitPRBranchCondition        = "github.event_name == 'pull_request'"
 	approvedAutoCommitProtectedBranchCondition = "github.event_name != 'pull_request'"
+	approvedDesktopTidyOnlyRestriction         = "${{ github.event_name == 'pull_request'" +
+		" && github.event.pull_request.user.login == 'dependabot[bot]' }}"
 )
+
+// The guard 📋 Apply patches must carry, pinned as a whole block.
+//
+// A substring match on the variable name alone would pass against an inverted test, a
+// negated comparison, or a guard that logs without skipping — each of which pushes a
+// generated-file commit onto a Dependabot branch and re-opens #6832. Requiring the
+// `continue` in the same block is what makes this an assertion about behaviour.
+const approvedDesktopTidyOnlyGuard = `if [ "${DESKTOP_TIDY_ONLY}" = "true" ] && ` +
+	`[ "$(basename "$patch")" != "desktop-tidy.patch" ]; then`
 
 // stepCondition returns the `if:` of the uniquely-named step in the given job.
 //
@@ -350,6 +363,26 @@ func stepCondition(t *testing.T, job []map[string]any, stepName string) string {
 	require.Truef(t, ok, "step %q must carry a string `if:` condition", stepName)
 
 	return condition
+}
+
+// step returns the uniquely-named step in the given job.
+//
+// Same uniqueness requirement as stepCondition, and for the same reason: two steps
+// sharing a name would make the caller silently assert against whichever came first.
+func step(t *testing.T, job []map[string]any, stepName string) map[string]any {
+	t.Helper()
+
+	var found []map[string]any
+
+	for _, candidate := range job {
+		if name, ok := candidate["name"].(string); ok && name == stepName {
+			found = append(found, candidate)
+		}
+	}
+
+	require.Lenf(t, found, 1, "expected exactly one step named %q", stepName)
+
+	return found[0]
 }
 
 // Pins Dependabot's ownership of its own branches.
@@ -384,8 +417,8 @@ func TestAutoCommitLeavesDependabotBranchesToDependabot(t *testing.T) {
 		t,
 		approvedAutoCommitPRBranchCondition,
 		stepCondition(t, job.Steps, "📤 Commit and push generated changes (PR branch)"),
-		"the PR-branch push must skip Dependabot-authored pull requests so Dependabot keeps"+
-			" the ability to rebase its own branch",
+		"the PR-branch push must commit whatever was applied; restricting WHICH patches"+
+			" reach a Dependabot branch is 📋 Apply patches' job, asserted below",
 	)
 
 	assert.Equal(
@@ -394,5 +427,91 @@ func TestAutoCommitLeavesDependabotBranchesToDependabot(t *testing.T) {
 		stepCondition(t, job.Steps, "📤 Open PR for generated changes (protected branch)"),
 		"the protected-branch sync must stay reachable: it is where a Dependabot bump's"+
 			" generated changes land once the bump has merged",
+	)
+
+	applyPatches := step(t, job.Steps, "📋 Apply patches")
+
+	env, ok := applyPatches["env"].(map[string]any)
+	require.True(t, ok, "📋 Apply patches must carry an `env:` mapping")
+
+	assert.Equal(
+		t,
+		approvedDesktopTidyOnlyRestriction,
+		env["DESKTOP_TIDY_ONLY"],
+		"the Dependabot restriction must key on the pull request's author; any other"+
+			" expression either leaks generated-file commits onto Dependabot branches"+
+			" (#6832) or withholds the desktop tidy from everyone (#6974)",
+	)
+
+	run, ok := applyPatches["run"].(string)
+	require.True(t, ok, "📋 Apply patches must carry a string `run:` script")
+
+	assert.Contains(
+		t,
+		run,
+		approvedDesktopTidyOnlyGuard,
+		"📋 Apply patches must actually skip non-desktop patches when the restriction is"+
+			" set — an unread DESKTOP_TIDY_ONLY is a restriction in name only",
+	)
+
+	assert.Contains(
+		t,
+		run,
+		"continue",
+		"the guard must skip the patch rather than only logging about it",
+	)
+}
+
+// Pins the desktop tidy's delivery onto Dependabot branches.
+//
+// desktop/ is a separate Go module that vendors the root via `replace => ../`, so a root
+// dependency bump leaves desktop/go.{mod,sum} stale. ci.yaml's verify-desktop-tidy job
+// computes the fix and uploads it as desktop-tidy.patch, and desktop.yaml deliberately
+// SKIPS its own hard `go mod tidy -diff` gate on same-repo PRs on the stated grounds that
+// this self-heal covers them.
+//
+// Between 2026-09-03 and 2026-09-08 it did not: the PR-branch push excluded Dependabot,
+// so on a bump the patch was computed, uploaded, applied — and then never committed, while
+// the job reported success. The bump's own required checks failed on the stale module, so
+// it could never merge, and the protected-branch path that was supposed to repair it only
+// runs after a merge. Three bumps (#6971, #6972, #6973) stalled on one root cause, with a
+// clean before/after: every bump merged before the exclusion carried an automated tidy
+// commit, every one after needed a hand-pushed one.
+//
+// The two workflows defer to each other, so this test exists to keep at least one of them
+// honest: if the self-heal is ever restricted away from Dependabot again, desktop.yaml's
+// skipped gate means nothing catches it until a bump goes red.
+func TestApplyPatchesDeliversDesktopTidyToDependabotBranches(t *testing.T) {
+	t.Parallel()
+
+	contents := readRepoFile(t, ".github/workflows/ci.yaml")
+
+	var workflow autoCommitWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	job, found := workflow.Jobs["auto-commit"]
+	require.True(t, found, "ci workflow must define the auto-commit job")
+
+	run, ok := step(t, job.Steps, "📋 Apply patches")["run"].(string)
+	require.True(t, ok, "📋 Apply patches must carry a string `run:` script")
+
+	// The restriction names the one patch that survives it. If verify-desktop-tidy's
+	// artifact is ever renamed, the guard silently starts skipping every patch on a
+	// Dependabot branch — including the desktop tidy — and the stall returns.
+	assert.Contains(
+		t,
+		run,
+		`!= "desktop-tidy.patch"`,
+		"the guard must admit desktop-tidy.patch by name; a rename of the uploaded"+
+			" artifact must break this test rather than silently restore the stall",
+	)
+
+	desktopTidy := readRepoFile(t, ".github/workflows/ci.yaml")
+	assert.Contains(
+		t,
+		string(desktopTidy),
+		"name: desktop-tidy-patch",
+		"verify-desktop-tidy must keep uploading the artifact under the name the guard"+
+			" admits; the two are only connected by this string",
 	)
 }

--- a/internal/ciharness/ci_workflow_test.go
+++ b/internal/ciharness/ci_workflow_test.go
@@ -431,8 +431,8 @@ func TestAutoCommitLeavesDependabotBranchesToDependabot(t *testing.T) {
 
 	applyPatches := step(t, job.Steps, "📋 Apply patches")
 
-	env, ok := applyPatches["env"].(map[string]any)
-	require.True(t, ok, "📋 Apply patches must carry an `env:` mapping")
+	env, hasEnv := applyPatches["env"].(map[string]any)
+	require.True(t, hasEnv, "📋 Apply patches must carry an `env:` mapping")
 
 	assert.Equal(
 		t,
@@ -443,8 +443,8 @@ func TestAutoCommitLeavesDependabotBranchesToDependabot(t *testing.T) {
 			" (#6832) or withholds the desktop tidy from everyone (#6974)",
 	)
 
-	run, ok := applyPatches["run"].(string)
-	require.True(t, ok, "📋 Apply patches must carry a string `run:` script")
+	run, hasRun := applyPatches["run"].(string)
+	require.True(t, hasRun, "📋 Apply patches must carry a string `run:` script")
 
 	assert.Contains(
 		t,
@@ -492,8 +492,8 @@ func TestApplyPatchesDeliversDesktopTidyToDependabotBranches(t *testing.T) {
 	job, found := workflow.Jobs["auto-commit"]
 	require.True(t, found, "ci workflow must define the auto-commit job")
 
-	run, ok := step(t, job.Steps, "📋 Apply patches")["run"].(string)
-	require.True(t, ok, "📋 Apply patches must carry a string `run:` script")
+	run, hasRun := step(t, job.Steps, "📋 Apply patches")["run"].(string)
+	require.True(t, hasRun, "📋 Apply patches must carry a string `run:` script")
 
 	// The restriction names the one patch that survives it. If verify-desktop-tidy's
 	// artifact is ever renamed, the guard silently starts skipping every patch on a


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Dependency bumps keep stalling. Three are stuck right now (#6971, #6972, #6973), all failing the same four checks for the same reason, and the queue has a cap on how many can be open at once — so stuck ones throttle dependency intake generally.

CI already knows how to fix this and was computing the fix on every one of them, then throwing it away and reporting success.

### What

The desktop app is a second Go module that tracks the main one, so a dependency bump has to update it too. CI works that out automatically and is supposed to commit it back to the bump's branch. Since #6851 it stopped doing so on Dependabot's branches — correctly for generated files like schemas and docs, which are tidied up later after the bump merges, and which cost Dependabot its ability to keep a branch up to date if we push them.

The desktop update is not that kind of change: without it the bump's own checks fail, so it can never merge, and "we'll fix it after it merges" never arrives.

Now Dependabot's branch receives the desktop update and nothing else. When the desktop module is already up to date the branch is not touched at all, so #6851's benefit is kept in every case it was actually about.

Fixes #6974

<details>
<summary>Merge-order note</summary>

The three stalled bumps need a rerun (or a rebase) after this lands to pick up the repaired job. They are not fixed by this PR merging on its own.
</details>
