### PR TITLE
ci(eks): give cluster create a budget EKS provisioning can actually fit

### DIFF
--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -259,7 +259,7 @@ jobs:
 
       - name: 🧪 ksail cluster create
         id: create
-        timeout-minutes: 30
+        timeout-minutes: 60
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -107,9 +107,11 @@ jobs:
     runs-on: ubuntu-latest
     # Must cover every step budget below, or a worst-case run is cancelled while
     # the always-run cleanup is still deleting the cluster. Worst case (GitOps
-    # engine enabled): 172 minutes of steps before cleanup + 45 for cleanup = 217.
-    # Re-check this sum whenever a step's timeout-minutes changes.
-    timeout-minutes: 230
+    # engine enabled): 172 minutes of steps before cleanup + 45 for cleanup = 217,
+    # plus at least 15 minutes of job-level headroom = 232, rounded up to 235.
+    # Re-check this sum whenever a step's timeout-minutes changes; the ciharness
+    # test TestEKSSmokeReservesCleanupBudgetAndFreshCredentials enforces it.
+    timeout-minutes: 235
     needs: [preflight, build-artifact]
     if: needs.preflight.outputs.aws-credentials == 'true'
     environment: ci

--- a/.github/workflows/system-test-eks.yaml
+++ b/.github/workflows/system-test-eks.yaml
@@ -105,7 +105,11 @@ jobs:
   smoke-test:
     name: 🧪 EKS Smoke Test
     runs-on: ubuntu-latest
-    timeout-minutes: 210
+    # Must cover every step budget below, or a worst-case run is cancelled while
+    # the always-run cleanup is still deleting the cluster. Worst case (GitOps
+    # engine enabled): 172 minutes of steps before cleanup + 45 for cleanup = 217.
+    # Re-check this sum whenever a step's timeout-minutes changes.
+    timeout-minutes: 230
     needs: [preflight, build-artifact]
     if: needs.preflight.outputs.aws-credentials == 'true'
     environment: ci

--- a/internal/ciharness/system_test_harness_test.go
+++ b/internal/ciharness/system_test_harness_test.go
@@ -678,7 +678,7 @@ func TestEKSSmokeReservesCleanupBudgetAndFreshCredentials(t *testing.T) {
 	workflow := readCIWorkflow(t, ".github/workflows/system-test-eks.yaml")
 	smokeJob, ok := workflow.Jobs["smoke-test"]
 	require.True(t, ok, "smoke-test job is missing")
-	assert.Equal(t, 210, smokeJob.TimeoutMinutes)
+	assert.Equal(t, 235, smokeJob.TimeoutMinutes)
 
 	boundedStepNames := []string{
 		"📄 Checkout",


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The EKS smoke test cannot pass as configured. Its `ksail cluster create` step was capped at 30
minutes, which is less time than provisioning an EKS control plane and node group takes — so the
test fails on the clock regardless of whether KSail works.

It also fails misleadingly: the symptom is a red `ksail cluster create`, which reads as "KSail can't
create EKS clusters" and sends investigation to the provisioner instead of the workflow.

This is the current blocker for the EKS smoke-test criterion on #4328.

### What

Raises the create step's budget from 30 to 60 minutes, and raises the job's overall budget from 210
to 235 minutes so a worst-case run can still finish its cleanup instead of being cancelled while
deleting the cluster. The existing workflow test now pins the new job budget.

The 60 is derived, not round: teardown already budgets 45 minutes against ~23 observed, and the same
margin applied to create's observed floor gives 60.

**Proven by a live dispatch before merge** — see the evaluation comment for the run and its result.

Fixes #7007
Part of #4328
