### PR TITLE
ci: run the workflow contract tests for every file they read

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,15 +177,19 @@ jobs:
             # filter would otherwise not match, so a PR editing only one of them could
             # weaken or delete the gate while the aggregator recorded it as an ordinary
             # skip.
+            # The harness reads far more than those files: every workflow (one test globs the
+            # whole directory), the system-test composite actions, and the EKS cleanup scripts.
+            # Listing them one by one drifted, and ksail#7008 then broke an EKS workflow contract
+            # with every check green (ksail#7009). The patterns below cover the three trees as a
+            # whole, and TestWorkflowContractFilterCoversEveryFileTheHarnessReads fails if a
+            # file the harness reads is ever left out again.
             # ("to-do" is deliberately lowercase and hyphenated here: the scanner keys on the
             # uppercase marker, so spelling it out in prose files an issue against this very
             # comment. ksail#6763 was exactly that — a false positive with no work behind it.)
             todos-contract:
-              - '.github/workflows/todos.yaml'
-              - '.github/workflows/ci.yaml'
-              - '.github/workflows/cd.yaml'
-              - '.github/scripts/validate-release-ref.sh'
-              - '.github/scripts/validate-release-ref.test.sh'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/scripts/**'
               - 'internal/ciharness/**'
             # Deliberately NARROWER than `code`: the job resolves a module graph, so only the
             # module files matter — not every .go file. It also includes THIS workflow, because

--- a/internal/ciharness/ci_contract_filter_test.go
+++ b/internal/ciharness/ci_contract_filter_test.go
@@ -1,6 +1,7 @@
 package ciharness_test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -107,13 +108,18 @@ func harnessReadPaths(t *testing.T) []string {
 	require.NoError(t, err)
 	require.NotEmpty(t, sources)
 
+	// Resolve literals through an fs.FS rooted at the repository: fs.Stat rejects any path
+	// that is not a valid, unrooted, dot-dot-free name, so a literal can never reach a file
+	// outside the repository even though it comes from file contents.
+	repo := os.DirFS(filepath.Join("..", ".."))
+
 	for _, source := range sources {
 		// The glob supplies this package's own test sources, never user input.
 		contents, readErr := os.ReadFile(source) //nolint:gosec
 		require.NoError(t, readErr)
 
 		for _, match := range harnessPathLiteral.FindAllStringSubmatch(string(contents), -1) {
-			if _, statErr := os.Stat(filepath.Join("..", "..", match[1])); statErr == nil {
+			if _, statErr := fs.Stat(repo, match[1]); statErr == nil {
 				paths = append(paths, match[1])
 			}
 		}

--- a/internal/ciharness/ci_contract_filter_test.go
+++ b/internal/ciharness/ci_contract_filter_test.go
@@ -39,23 +39,30 @@ func TestWorkflowContractFilterCoversEveryFileTheHarnessReads(t *testing.T) {
 	t.Parallel()
 
 	patterns := workflowContractFilterPatterns(t)
-	readPaths := harnessReadPaths(t)
+	globbed := globbedWorkflowPaths(t)
+	scanned := scannedLiteralPaths(t)
 
-	// Guard the guard: if discovery ever returned nothing, the loop below would assert nothing.
+	// Guard each discovery source on its own: if either returned nothing, the loop below would
+	// assert less than it claims. The known paths are built by concatenation on purpose. These
+	// test sources are themselves scanned for path literals, and other files in this package
+	// quote the EKS workflow in full, so a merged check could be satisfied by the scanner alone.
+	knownWorkflow := ".github/workflows/" + "system-test-eks.yaml"
 	require.Contains(
 		t,
-		readPaths,
-		".github/workflows/system-test-eks.yaml",
-		"path discovery must find the workflows this package is known to read",
+		globbed,
+		knownWorkflow,
+		"the workflow glob must find the workflows this package is known to read",
 	)
-	// Built by concatenation on purpose: this file is itself scanned for path literals, so a
-	// plain quoted path here would be discovered from this assertion and pass vacuously.
 	require.Contains(
 		t,
-		readPaths,
+		scanned,
 		".github/scripts/"+"delete-old-workflow-runs.test.sh",
-		"path discovery must find scripts the harness executes through a relative ../../ prefix",
+		"literal discovery must find scripts the harness executes through a relative ../../ prefix",
 	)
+
+	readPaths := slices.Concat(globbed, scanned)
+	slices.Sort(readPaths)
+	readPaths = slices.Compact(readPaths)
 
 	var uncovered []string
 
@@ -79,7 +86,7 @@ func TestWorkflowContractFilterCoversEveryFileTheHarnessReads(t *testing.T) {
 	})
 	assert.False(
 		t,
-		contractFilterMatches(t, withoutWorkflows, ".github/workflows/system-test-eks.yaml"),
+		contractFilterMatches(t, withoutWorkflows, knownWorkflow),
 		"negative control: without the workflows pattern the EKS workflow must be uncovered",
 	)
 }
@@ -103,13 +110,12 @@ func workflowContractFilterPatterns(t *testing.T) []string {
 	return patterns
 }
 
-// harnessReadPaths lists the repository files this package reads, sorted and de-duplicated.
-func harnessReadPaths(t *testing.T) []string {
+// globbedWorkflowPaths lists every workflow in the repository as a repository-relative path.
+func globbedWorkflowPaths(t *testing.T) []string {
 	t.Helper()
 
 	workflows, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.y*ml"))
 	require.NoError(t, err)
-	require.NotEmpty(t, workflows)
 
 	repoRoot := filepath.Join("..", "..")
 
@@ -122,6 +128,16 @@ func harnessReadPaths(t *testing.T) []string {
 
 		paths = append(paths, filepath.ToSlash(rel))
 	}
+
+	return paths
+}
+
+// scannedLiteralPaths lists the workflow, action and script paths quoted in this package's test
+// sources that exist in the repository, sorted and de-duplicated.
+func scannedLiteralPaths(t *testing.T) []string {
+	t.Helper()
+
+	var paths []string
 
 	sources, err := filepath.Glob("*_test.go")
 	require.NoError(t, err)

--- a/internal/ciharness/ci_contract_filter_test.go
+++ b/internal/ciharness/ci_contract_filter_test.go
@@ -101,9 +101,16 @@ func harnessReadPaths(t *testing.T) []string {
 	require.NoError(t, err)
 	require.NotEmpty(t, workflows)
 
+	repoRoot := filepath.Join("..", "..")
+
 	paths := make([]string, 0, len(workflows))
 	for _, workflow := range workflows {
-		paths = append(paths, filepath.ToSlash(strings.TrimPrefix(workflow, "../../")))
+		// Rel before ToSlash: on Windows the glob returns ..\..\ prefixes, which a
+		// slash-based TrimPrefix would leave in place.
+		rel, relErr := filepath.Rel(repoRoot, workflow)
+		require.NoError(t, relErr)
+
+		paths = append(paths, filepath.ToSlash(rel))
 	}
 
 	sources, err := filepath.Glob("*_test.go")

--- a/internal/ciharness/ci_contract_filter_test.go
+++ b/internal/ciharness/ci_contract_filter_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 // harnessPathLiteral matches a quoted repository path under the three .github trees this
-// package reads: workflows, composite actions and scripts. Glob characters are excluded so a
-// pattern written in a test (like the filter entries below) is never mistaken for a read path.
+// package reads: workflows, composite actions and scripts. Tests that execute a script do so
+// from this package's directory, so a literal may carry leading ../ segments; the capture group
+// drops them so every match is repository-relative. Glob characters are excluded so a pattern
+// written in a test (like the filter entries below) is never mistaken for a read path.
 var harnessPathLiteral = regexp.MustCompile(
-	`"(\.github/(?:workflows|actions|scripts)/[^"*?\[\]{}]+)"`,
+	`"(?:\.\./)*(\.github/(?:workflows|actions|scripts)/[^"*?\[\]{}]+)"`,
 )
 
 // TestWorkflowContractFilterCoversEveryFileTheHarnessReads keeps the CI gate for this package
@@ -45,6 +47,14 @@ func TestWorkflowContractFilterCoversEveryFileTheHarnessReads(t *testing.T) {
 		readPaths,
 		".github/workflows/system-test-eks.yaml",
 		"path discovery must find the workflows this package is known to read",
+	)
+	// Built by concatenation on purpose: this file is itself scanned for path literals, so a
+	// plain quoted path here would be discovered from this assertion and pass vacuously.
+	require.Contains(
+		t,
+		readPaths,
+		".github/scripts/"+"delete-old-workflow-runs.test.sh",
+		"path discovery must find scripts the harness executes through a relative ../../ prefix",
 	)
 
 	var uncovered []string

--- a/internal/ciharness/ci_contract_filter_test.go
+++ b/internal/ciharness/ci_contract_filter_test.go
@@ -1,0 +1,148 @@
+package ciharness_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// harnessPathLiteral matches a quoted repository path under the three .github trees this
+// package reads: workflows, composite actions and scripts. Glob characters are excluded so a
+// pattern written in a test (like the filter entries below) is never mistaken for a read path.
+var harnessPathLiteral = regexp.MustCompile(`"(\.github/(?:workflows|actions|scripts)/[^"*?\[\]{}]+)"`)
+
+// TestWorkflowContractFilterCoversEveryFileTheHarnessReads keeps the CI gate for this package
+// from drifting away from what the package actually checks.
+//
+// The contract job in ci.yaml only runs when its todos-contract path filter matches. When a
+// file these tests read is missing from that filter, a PR editing only that file skips the
+// tests that guard it, and the aggregator records the skip as success. ksail#7008 hit exactly
+// that: it raised the EKS smoke job timeout in system-test-eks.yaml alone, broke
+// TestEKSSmokeReservesCleanupBudgetAndFreshCredentials, and passed CI (ksail#7009).
+//
+// "Read" covers both ways the package reaches a file: every workflow, because
+// TestNoDefaultBranchWorkflowCancelsRunsInProgress globs the whole workflows directory, and
+// every quoted workflow, action or script path in these test sources that exists on disk.
+func TestWorkflowContractFilterCoversEveryFileTheHarnessReads(t *testing.T) {
+	t.Parallel()
+
+	patterns := workflowContractFilterPatterns(t)
+	readPaths := harnessReadPaths(t)
+
+	// Guard the guard: if discovery ever returned nothing, the loop below would assert nothing.
+	require.Contains(
+		t,
+		readPaths,
+		".github/workflows/system-test-eks.yaml",
+		"path discovery must find the workflows this package is known to read",
+	)
+
+	var uncovered []string
+
+	for _, path := range readPaths {
+		if !contractFilterMatches(t, patterns, path) {
+			uncovered = append(uncovered, path)
+		}
+	}
+
+	assert.Emptyf(
+		t,
+		uncovered,
+		"the todos-contract filter in ci.yaml must match every file internal/ciharness reads, "+
+			"or a PR editing only that file skips these tests; add a pattern covering: %s",
+		strings.Join(uncovered, ", "),
+	)
+
+	// The matcher must be able to say no, or the assertion above could never fail.
+	withoutWorkflows := slices.DeleteFunc(slices.Clone(patterns), func(pattern string) bool {
+		return pattern == ".github/workflows/**"
+	})
+	assert.False(
+		t,
+		contractFilterMatches(t, withoutWorkflows, ".github/workflows/system-test-eks.yaml"),
+		"negative control: without the workflows pattern the EKS workflow must be uncovered",
+	)
+}
+
+// workflowContractFilterPatterns returns the todos-contract entries from the changes job.
+func workflowContractFilterPatterns(t *testing.T) []string {
+	t.Helper()
+
+	workflow := readCIWorkflow(t, ".github/workflows/ci.yaml")
+	changesJob, found := workflow.Jobs["changes"]
+	require.True(t, found, "changes job is missing")
+
+	filterStep := findHarnessStep(t, changesJob.Steps, "🔍 Filter paths")
+
+	var filters map[string][]string
+	require.NoError(t, yaml.Unmarshal([]byte(stringValue(filterStep.With["filters"])), &filters))
+
+	patterns := filters["todos-contract"]
+	require.NotEmpty(t, patterns, "ci.yaml must define a non-empty todos-contract filter")
+
+	return patterns
+}
+
+// harnessReadPaths lists the repository files this package reads, sorted and de-duplicated.
+func harnessReadPaths(t *testing.T) []string {
+	t.Helper()
+
+	workflows, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.y*ml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, workflows)
+
+	paths := make([]string, 0, len(workflows))
+	for _, workflow := range workflows {
+		paths = append(paths, filepath.ToSlash(strings.TrimPrefix(workflow, "../../")))
+	}
+
+	sources, err := filepath.Glob("*_test.go")
+	require.NoError(t, err)
+	require.NotEmpty(t, sources)
+
+	for _, source := range sources {
+		// The glob supplies this package's own test sources, never user input.
+		contents, readErr := os.ReadFile(source) //nolint:gosec
+		require.NoError(t, readErr)
+
+		for _, match := range harnessPathLiteral.FindAllStringSubmatch(string(contents), -1) {
+			if _, statErr := os.Stat(filepath.Join("..", "..", match[1])); statErr == nil {
+				paths = append(paths, match[1])
+			}
+		}
+	}
+
+	slices.Sort(paths)
+
+	return slices.Compact(paths)
+}
+
+// contractFilterMatches reports whether any pattern covers path. It supports exactly the two
+// forms the filter uses, an exact path or a "dir/**" prefix, and fails on any other glob so a
+// pattern it cannot evaluate is never silently treated as a miss or a match.
+func contractFilterMatches(t *testing.T, patterns []string, path string) bool {
+	t.Helper()
+
+	for _, pattern := range patterns {
+		prefix, isTree := strings.CutSuffix(pattern, "/**")
+		require.False(
+			t,
+			strings.ContainsAny(prefix, "*?[]{}!"),
+			"unsupported todos-contract pattern %q: use an exact path or a dir/** prefix",
+			pattern,
+		)
+
+		if pattern == path || (isTree && strings.HasPrefix(path, prefix+"/")) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/ciharness/ci_contract_filter_test.go
+++ b/internal/ciharness/ci_contract_filter_test.go
@@ -17,7 +17,9 @@ import (
 // harnessPathLiteral matches a quoted repository path under the three .github trees this
 // package reads: workflows, composite actions and scripts. Glob characters are excluded so a
 // pattern written in a test (like the filter entries below) is never mistaken for a read path.
-var harnessPathLiteral = regexp.MustCompile(`"(\.github/(?:workflows|actions|scripts)/[^"*?\[\]{}]+)"`)
+var harnessPathLiteral = regexp.MustCompile(
+	`"(\.github/(?:workflows|actions|scripts)/[^"*?\[\]{}]+)"`,
+)
 
 // TestWorkflowContractFilterCoversEveryFileTheHarnessReads keeps the CI gate for this package
 // from drifting away from what the package actually checks.
@@ -119,7 +121,8 @@ func harnessReadPaths(t *testing.T) []string {
 		require.NoError(t, readErr)
 
 		for _, match := range harnessPathLiteral.FindAllStringSubmatch(string(contents), -1) {
-			if _, statErr := fs.Stat(repo, match[1]); statErr == nil {
+			_, statErr := fs.Stat(repo, match[1])
+			if statErr == nil {
 				paths = append(paths, match[1])
 			}
 		}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The CI job that checks our workflows against their written rules only ran when a handful of files changed. Its tests also cover every other workflow, the system-test actions, and the EKS cleanup scripts. So a PR that changed only one of those skipped the tests guarding it, and still showed every check green.

That already happened: #7008 broke an EKS workflow rule and passed CI. A review bot found it, not CI.

### What

The job now runs whenever anything under the workflows, actions, or scripts folders changes. A new test fails if a file these tests read is ever left out of that trigger again, so the list can't drift a second time.

Workflow and script PRs will run this quick test job more often, which is intended.

Fixes #7009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
