### PR TITLE
fix(talos): keep migrated API-server patches off workers

### DIFF
--- a/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patch_set_test.go
@@ -208,7 +208,7 @@ func TestKubernetesPatchSetResolvesRoleCertificateOverrides(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	assertJWTIssuer(t, configs.ControlPlane(), "shared", "control-plane-ca")
-	assertJWTIssuer(t, configs.Worker(), "shared", "shared-ca")
+	assert.Nil(t, configs.Worker().K8sAuthenticationConfig())
 }
 
 func TestKubernetesPatchSetPreservesOIDCCAWithUnrelatedDeletion(t *testing.T) {
@@ -227,7 +227,7 @@ func TestKubernetesPatchSetPreservesOIDCCAWithUnrelatedDeletion(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	assertJWTIssuer(t, configs.ControlPlane(), "shared", "shared-ca")
-	assertJWTIssuer(t, configs.Worker(), "shared", "shared-ca")
+	assert.Nil(t, configs.Worker().K8sAuthenticationConfig())
 
 	files, err := configs.ControlPlane().Machine().Files()
 	require.NoError(t, err)

--- a/pkg/fsutil/configmanager/talos/kubernetes_patches.go
+++ b/pkg/fsutil/configmanager/talos/kubernetes_patches.go
@@ -175,7 +175,71 @@ func migrateKubernetesPatchesForContract(
 		}
 	}
 
-	return nonemptyKubernetesPatches(migrated), nil
+	return scopeClusterControlPlaneKubernetesDocuments(nonemptyKubernetesPatches(migrated))
+}
+
+// scopeClusterControlPlaneKubernetesDocuments preserves the legacy meaning of
+// cluster.apiServer patches. Before Talos 1.14 those fields lived in a shared
+// patch but only affected control-plane machines. Their multi-document
+// replacements are explicitly control-plane-only, so applying the source patch
+// scope verbatim would make every worker config invalid. Non-API-server content
+// from the same patch remains cluster-scoped.
+func scopeClusterControlPlaneKubernetesDocuments(patches []Patch) ([]Patch, error) {
+	scoped := make([]Patch, 0, len(patches))
+
+	for _, patch := range patches {
+		if patch.Scope != PatchScopeCluster {
+			scoped = append(scoped, patch)
+
+			continue
+		}
+
+		documents, err := decodeOrderedPatchDocuments(patch)
+		if err != nil {
+			return nil, err
+		}
+
+		hasControlPlaneDocument := false
+
+		for _, document := range documents {
+			kind, _ := document.document[kindField].(string)
+			if isMigratedControlPlaneKind(kind) {
+				hasControlPlaneDocument = true
+
+				break
+			}
+		}
+
+		if !hasControlPlaneDocument {
+			scoped = append(scoped, patch)
+
+			continue
+		}
+
+		for _, document := range documents {
+			if kind, _ := document.document[kindField].(string); isMigratedControlPlaneKind(kind) {
+				document.patch.Scope = PatchScopeControlPlane
+			}
+
+			scoped = append(scoped, document.patch)
+		}
+	}
+
+	return scoped, nil
+}
+
+func isMigratedControlPlaneKind(kind string) bool {
+	switch kind {
+	case "KubeAPIServerConfig",
+		"KubeAdmissionControlConfig",
+		"KubeAuditPolicyConfig",
+		"KubeAuthenticationConfig",
+		"KubeAuthorizationConfig",
+		"KubeAuthorizerConfig":
+		return true
+	default:
+		return false
+	}
 }
 
 type legacyAPIServerPatchValues struct {

--- a/pkg/fsutil/configmanager/talos/manager_test.go
+++ b/pkg/fsutil/configmanager/talos/manager_test.go
@@ -21,6 +21,22 @@ const registryTokenPatchWithDefault = `machine:
           password: ${REGISTRY_CLUSTER_TOKEN:-forbidden-fallback}
 `
 
+const clusterScopedLegacyAPIServerPatch = `machine:
+  sysctls:
+    net.ipv4.ip_forward: "1"
+cluster:
+  apiServer:
+    extraArgs:
+      audit-log-path: /var/log/audit/kube.log
+      oidc-issuer-url: https://dex.example.com
+      oidc-client-id: ksail
+    auditPolicy:
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      rules:
+        - level: Metadata
+`
+
 func TestNewConfigManager_WithAllParameters(t *testing.T) {
 	t.Parallel()
 
@@ -889,6 +905,80 @@ func TestConfigManager_Load_MigratesLegacyStructuredAPIServerFields(t *testing.T
 	require.NotNil(t, controlPlane)
 	assertMigratedStructuredAPIServerFields(t, controlPlane)
 }
+
+func TestConfigManager_Load_KeepsClusterScopedLegacyAPIServerMigrationOffWorkers(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	clusterDir := filepath.Join(tmpDir, talos.PatchSubdirCluster)
+	require.NoError(t, os.MkdirAll(clusterDir, 0o750))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(clusterDir, "api-server.yaml"),
+			[]byte(clusterScopedLegacyAPIServerPatch),
+			0o600,
+		),
+	)
+
+	manager := talos.NewConfigManager(tmpDir, "talos-114", "1.36.0", "10.5.0.0/24").
+		WithVersionContract(talosconfig.TalosVersion1_14)
+
+	configs, err := manager.Load(configmanager.LoadOptions{})
+	require.NoError(t, err)
+
+	controlPlane := configs.ControlPlane()
+	worker := configs.Worker()
+
+	require.NotNil(t, controlPlane)
+	require.NotNil(t, worker)
+	assert.Equal(
+		t,
+		[]string{"/var/log/audit/kube.log"},
+		controlPlane.K8sAPIServerConfig().ExtraArgs()["audit-log-path"],
+	)
+
+	controlPlaneKinds := talosDocumentKinds(controlPlane)
+	workerKinds := talosDocumentKinds(worker)
+
+	assert.Contains(t, controlPlaneKinds, "KubeAPIServerConfig")
+	assert.Contains(t, controlPlaneKinds, "KubeAuthenticationConfig")
+	assert.Contains(t, controlPlaneKinds, "KubeAuditPolicyConfig")
+
+	for _, kind := range []string{
+		"KubeAPIServerConfig",
+		"KubeAuthenticationConfig",
+		"KubeAuthorizationConfig",
+		"KubeAuditPolicyConfig",
+	} {
+		assert.NotContains(t, workerKinds, kind)
+	}
+
+	assert.Equal(t, "1", controlPlane.Machine().Sysctls()["net.ipv4.ip_forward"])
+	assert.Equal(t, "1", worker.Machine().Sysctls()["net.ipv4.ip_forward"])
+
+	_, err = controlPlane.ValidateAsClient(talosClientValidationMode{})
+	require.NoError(t, err)
+	_, err = worker.ValidateAsClient(talosClientValidationMode{})
+	require.NoError(t, err)
+}
+
+func talosDocumentKinds(provider talosconfig.Provider) []string {
+	documents := provider.Documents()
+
+	kinds := make([]string, 0, len(documents))
+	for _, document := range documents {
+		kinds = append(kinds, document.Kind())
+	}
+
+	return kinds
+}
+
+type talosClientValidationMode struct{}
+
+func (talosClientValidationMode) String() string        { return "test" }
+func (talosClientValidationMode) RequiresInstall() bool { return false }
+func (talosClientValidationMode) InContainer() bool     { return false }
 
 func assertMigratedStructuredAPIServerFields(
 	t *testing.T,


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- split Talos 1.14 control-plane-only documents out of cluster-scoped legacy API-server patches
- keep unrelated shared machine settings applied to both roles
- keep migrated authentication and audit documents off worker configs

## Validation

- RED: regression reproduced KubeAPIServerConfig in the worker and Talos reported an empty API-server image
- GREEN: go test ./pkg/fsutil/configmanager/talos -count=1
- golangci-lint on changed Talos package: 0 issues
- go build -o /private/tmp/ksail-maint-7010 .
- talosctl v1.14.0 validate --strict --mode metal passed for generated control-plane and worker configs
- full go test ./... passed every package except pre-existing timing-sensitive pkg/cli/cmd/open/chat tests; that package passed in isolation

Fixes #7010